### PR TITLE
🧮 feat: Add Per-User File Storage Limits

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -28,6 +28,7 @@ const {
   isCodeSessionToolName,
   shouldSignalSandboxStart,
   getToolInputValidationDetails,
+  isFileStorageLimitError,
 } = require('@librechat/api');
 const { processFileCitations } = require('~/server/services/Files/Citations');
 const { processCodeOutput, runPreviewFinalize } = require('~/server/services/Files/Code/process');
@@ -73,7 +74,14 @@ async function enqueueCodeOutputBatch({
   for (const entry of entries) {
     const current = persistenceChain
       .then(() => processEntry(entry))
-      .catch(() => {
+      .catch((error) => {
+        /* Quota rejections are a user condition, not a transport fault — name
+         * them so operators can tell "over storage limit" apart from a failed
+         * download. The attachment is still dropped; the turn continues. */
+        if (isFileStorageLimitError(error)) {
+          logger.warn(`[enqueueCodeOutputBatch] Artifact dropped: ${error.message}`);
+          return null;
+        }
         logger.error('Error processing code output');
         return null;
       });

--- a/api/server/controllers/tools.js
+++ b/api/server/controllers/tools.js
@@ -5,6 +5,7 @@ const {
   assertDirectToolOutputAllowed,
   loadWebSearchAuth,
   isContentFilterError,
+  isFileStorageLimitError,
 } = require('@librechat/api');
 const {
   Tools,
@@ -224,8 +225,14 @@ const callTool = async (req, res) => {
           previewRevision: result?.previewRevision,
         });
         attachments.push(fileMetadata);
-      } catch {
-        logger.error('Error processing code output');
+      } catch (error) {
+        /* Same split as the streaming path: an over-quota user needs the
+         * storage condition named in the logs, not a generic artifact error. */
+        if (isFileStorageLimitError(error)) {
+          logger.warn(`[processCodeOutput] Artifact dropped: ${error.message}`);
+        } else {
+          logger.error('Error processing code output');
+        }
         attachments.push(null);
       }
     }

--- a/api/server/routes/files/files.agents.test.js
+++ b/api/server/routes/files/files.agents.test.js
@@ -474,6 +474,33 @@ describe('File Routes - Agent Files Endpoint', () => {
       expect(processAgentFileUpload).toHaveBeenCalled();
     });
 
+    it('should preserve storage-limit status when agent upload is over quota', async () => {
+      await createAgent({
+        id: agentCustomId,
+        name: 'Test Agent',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: authorId,
+      });
+      processAgentFileUpload.mockRejectedValueOnce(
+        Object.assign(new Error('storage limit exceeded. Delete files first.'), {
+          code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+          status: 413,
+        }),
+      );
+      const testApp = createAppWithUser(authorId);
+
+      const response = await request(testApp).post('/files').send({
+        endpoint: 'agents',
+        agent_id: agentCustomId,
+        tool_resource: 'context',
+        file_id: uuidv4(),
+      });
+
+      expect(response.status).toBe(413);
+      expect(response.body.message).toBe('storage limit exceeded. Delete files first.');
+    });
+
     it('should allow file upload to agent for user with EDIT permission', async () => {
       // Create an agent owned by authorId
       const agent = await createAgent({

--- a/api/server/routes/files/files.agents.test.js
+++ b/api/server/routes/files/files.agents.test.js
@@ -1013,6 +1013,33 @@ describe('File Routes - Agent Files Endpoint', () => {
       });
     });
 
+    it('should preserve storage-limit status when agent upload is over quota', async () => {
+      await createAgent({
+        id: agentCustomId,
+        name: 'Test Agent',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: authorId,
+      });
+      processAgentFileUpload.mockRejectedValueOnce(
+        Object.assign(new Error('storage limit exceeded. Delete files first.'), {
+          code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+          status: 413,
+        }),
+      );
+      const testApp = createAppWithUser(authorId);
+
+      const response = await request(testApp).post('/files').send({
+        endpoint: 'agents',
+        agent_id: agentCustomId,
+        tool_resource: 'context',
+        file_id: uuidv4(),
+      });
+
+      expect(response.status).toBe(413);
+      expect(response.body.message).toBe('storage limit exceeded. Delete files first.');
+    });
+
     it('should allow file upload to agent for user with EDIT permission', async () => {
       // Create an agent owned by authorId
       const agent = await createAgent({

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -654,7 +654,8 @@ router.post('/', async (req, res) => {
     } catch (error) {
       logger.error('[/files] Error deleting file:', error);
     }
-    res.status(500).json({ message });
+    const status = Number(error?.status ?? error?.statusCode) || 500;
+    res.status(status).json({ message });
   } finally {
     if (cleanup) {
       try {

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -11,6 +11,7 @@ const {
   startUploadSseStream,
   sendUploadPolicyError,
   resolveUploadErrorMessage,
+  resolveUploadErrorStatus,
   verifyAgentUploadPermission,
   getCodeExecutionBaseUrl,
   assertUploadContentAllowed,
@@ -774,13 +775,7 @@ router.post('/', async (req, res) => {
       logger.error('[/files] Error deleting file:', getSafeErrorMetadata(cleanupError));
     }
 
-    const userErrorStatusCode = error?.userErrorStatusCode;
-    const errorStatusCode =
-      Number.isInteger(userErrorStatusCode) &&
-      userErrorStatusCode >= 400 &&
-      userErrorStatusCode <= 599
-        ? userErrorStatusCode
-        : 500;
+    const errorStatusCode = resolveUploadErrorStatus(error);
 
     if (sseStream) {
       sseStream.sendError({

--- a/api/server/routes/files/images.agents.test.js
+++ b/api/server/routes/files/images.agents.test.js
@@ -34,7 +34,7 @@ jest.mock('fs', () => {
 });
 
 const fs = require('fs');
-const { processAgentFileUpload } = require('~/server/services/Files/process');
+const { processAgentFileUpload, processImageFile } = require('~/server/services/Files/process');
 
 const router = require('~/server/routes/files/images');
 
@@ -259,6 +259,24 @@ describe('POST /images - Agent Upload Permission Check (Integration)', () => {
     });
 
     expect(response.status).toBe(200);
+  });
+
+  it('should preserve storage-limit status for regular image uploads', async () => {
+    processImageFile.mockRejectedValueOnce(
+      Object.assign(new Error('storage limit exceeded. Delete files first.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      }),
+    );
+    const app = createAppWithUser(otherUserId);
+
+    const response = await request(app).post('/images').send({
+      endpoint: 'agents',
+      file_id: uuidv4(),
+    });
+
+    expect(response.status).toBe(413);
+    expect(response.body.message).toBe('storage limit exceeded. Delete files first.');
   });
 
   it('should return 404 for non-existent agent', async () => {

--- a/api/server/routes/files/images.agents.test.js
+++ b/api/server/routes/files/images.agents.test.js
@@ -580,6 +580,24 @@ describe('POST /images - Agent Upload Permission Check (Integration)', () => {
     expect(JSON.stringify(response.body)).not.toContain(rawProviderDetail);
   });
 
+  it('should preserve storage-limit status for regular image uploads', async () => {
+    processImageFile.mockRejectedValueOnce(
+      Object.assign(new Error('storage limit exceeded. Delete files first.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      }),
+    );
+    const app = createAppWithUser(otherUserId);
+
+    const response = await request(app).post('/images').send({
+      endpoint: 'agents',
+      file_id: uuidv4(),
+    });
+
+    expect(response.status).toBe(413);
+    expect(response.body.message).toBe('storage limit exceeded. Delete files first.');
+  });
+
   it('should return 404 for non-existent agent', async () => {
     const app = createAppWithUser(otherUserId);
     const response = await request(app).post('/images').send({

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -55,7 +55,8 @@ router.post('/', async (req, res) => {
     } catch (error) {
       logger.error('[/files/images] Error deleting file:', error);
     }
-    res.status(500).json({ message });
+    const status = Number(error?.status ?? error?.statusCode) || 500;
+    res.status(status).json({ message });
   } finally {
     try {
       await fs.unlink(req.file.path);

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -8,6 +8,7 @@ const {
   startUploadSseStream,
   sendUploadPolicyError,
   resolveUploadErrorMessage,
+  resolveUploadErrorStatus,
   verifyAgentUploadPermission,
   assertUploadContentAllowed,
   hasActiveFilePolicy,
@@ -106,16 +107,17 @@ router.post('/', async (req, res) => {
       'Error processing file',
       contentProtectionActive,
     );
+    const errorStatusCode = resolveUploadErrorStatus(error);
     if (sseStream) {
       sseStream.sendError({
         message,
-        code: 500,
+        code: errorStatusCode,
         temp_file_id: metadata.temp_file_id,
         tool_resource: metadata.tool_resource,
         display_to_user: true,
       });
     } else {
-      res.status(500).json({ message });
+      res.status(errorStatusCode).json({ message });
     }
   } finally {
     try {

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -267,7 +267,9 @@ async function uploadFileHandler(req, res) {
         author: req.user._id,
         tenantId,
       });
-      recordFileStorageUsage(req, file.size);
+      recordFileStorageUsage(req, file.size, {
+        skillFile: { id: result?._id, skillId, relativePath },
+      });
     } catch (dbError) {
       // Clean up the stored blob so it doesn't leak on DB failure
       try {

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -7,6 +7,8 @@ const {
   createImportHandler,
   generateCheckAccess,
   getStorageMetadata,
+  isFileStorageLimitError,
+  assertFileStorageLimit,
   resolveRequestTenantId,
   restoreTenantContextFromReq,
 } = require('@librechat/api');
@@ -30,6 +32,7 @@ const {
   getSkillFileByPath,
   updateSkillFileContent,
   getRoleByName,
+  getUserStorageUsage,
 } = require('~/models');
 const { requireJwtAuth, canAccessSkillResource } = require('~/server/middleware');
 const {
@@ -138,6 +141,26 @@ function resolveSkillStorage(req, { isImage = false } = {}) {
   return { saveBuffer: strategy.saveBuffer, source };
 }
 
+const assertSkillFileStorageLimit = (req, incomingBytes, excludeSkillFile) =>
+  assertFileStorageLimit({
+    req,
+    incomingBytes,
+    excludeSkillFile,
+    getUserStorageUsage,
+  });
+
+function getReplacementExclusion(req, existingFile, skillId, relativePath) {
+  if (!existingFile) {
+    return undefined;
+  }
+
+  if (existingFile.author?.toString() !== req.user._id?.toString()) {
+    return undefined;
+  }
+
+  return { skillId, relativePath };
+}
+
 // ---------------------------------------------------------------------------
 // Import handler (zip/md/skill → create skill + files)
 // ---------------------------------------------------------------------------
@@ -149,16 +172,22 @@ const importHandler = createImportHandler({
   getSkillById,
   deleteSkill,
   upsertSkillFile,
-  saveBuffer: (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
+  saveBuffer: async (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
     const requestTenantId = tenantId ?? resolveRequestTenantId(req);
     const storage = resolveSkillStorage(req, { isImage });
-    return storage
-      .saveBuffer({ userId, buffer, fileName, basePath, tenantId: requestTenantId })
-      .then((filepath) => ({
-        filepath,
-        source: storage.source,
-        ...getStorageMetadata({ filepath, source: storage.source }),
-      }));
+    await assertSkillFileStorageLimit(req, buffer.length);
+    const filepath = await storage.saveBuffer({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      tenantId: requestTenantId,
+    });
+    return {
+      filepath,
+      source: storage.source,
+      ...getStorageMetadata({ filepath, source: storage.source }),
+    };
   },
   deleteFile: (req, file) => {
     const { deleteFile } = getStrategyFunctions(file.source);
@@ -202,6 +231,7 @@ async function uploadFileHandler(req, res) {
 
     // Look up existing file before saving — needed to clean up old blob on replace
     const existingFile = await getSkillFileByPath(skillId, relativePath);
+    const excludeSkillFile = getReplacementExclusion(req, existingFile, skillId, relativePath);
 
     const fileId = crypto.randomUUID();
     const filename = file.originalname;
@@ -209,6 +239,7 @@ async function uploadFileHandler(req, res) {
 
     const isImage = (file.mimetype || '').startsWith('image/');
     const storage = resolveSkillStorage(req, { isImage });
+    await assertSkillFileStorageLimit(req, file.size, excludeSkillFile);
     const filepath = await storage.saveBuffer({
       userId: req.user.id,
       buffer: file.buffer,
@@ -220,6 +251,7 @@ async function uploadFileHandler(req, res) {
 
     let result;
     try {
+      await assertSkillFileStorageLimit(req, file.size, excludeSkillFile);
       result = await upsertSkillFile({
         skillId,
         relativePath,
@@ -261,6 +293,10 @@ async function uploadFileHandler(req, res) {
 
     return res.status(200).json(result);
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      return res.status(error.status ?? 413).json({ error: error.message });
+    }
+
     if (error.code === 'SKILL_FILE_VALIDATION_FAILED') {
       return res.status(400).json({ error: error.message });
     }

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -252,7 +252,6 @@ async function uploadFileHandler(req, res) {
 
     let result;
     try {
-      await assertSkillFileStorageLimit(req, file.size, excludeSkillFile);
       result = await upsertSkillFile({
         skillId,
         relativePath,

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -9,6 +9,7 @@ const {
   getStorageMetadata,
   isFileStorageLimitError,
   assertFileStorageLimit,
+  recordFileStorageUsage,
   resolveRequestTenantId,
   restoreTenantContextFromReq,
 } = require('@librechat/api');
@@ -266,6 +267,7 @@ async function uploadFileHandler(req, res) {
         author: req.user._id,
         tenantId,
       });
+      recordFileStorageUsage(req, file.size);
     } catch (dbError) {
       // Clean up the stored blob so it doesn't leak on DB failure
       try {

--- a/api/server/routes/skills.js
+++ b/api/server/routes/skills.js
@@ -8,6 +8,10 @@ const {
   blockFilteredSkillFile,
   generateCheckAccess,
   getStorageMetadata,
+  isFileStorageLimitError,
+  assertFileStorageLimit,
+  recordFileStorageUsage,
+  getSkillFileReplacementExclusion,
   resolveRequestTenantId,
   restoreTenantContextFromReq,
 } = require('@librechat/api');
@@ -28,6 +32,7 @@ const {
   deleteSkillFile,
   getSkillFileByPath,
   getRoleByName,
+  getUserStorageUsage,
 } = require('~/models');
 const { requireJwtAuth, canAccessSkillResource } = require('~/server/middleware');
 const {
@@ -153,6 +158,14 @@ function resolveSkillStorage(req, { isImage = false } = {}) {
   return { saveBuffer: strategy.saveBuffer, source };
 }
 
+const assertSkillFileStorageLimit = (req, incomingBytes, excludeSkillFile) =>
+  assertFileStorageLimit({
+    req,
+    incomingBytes,
+    excludeSkillFile,
+    getUserStorageUsage,
+  });
+
 // ---------------------------------------------------------------------------
 // Import handler (zip/md/skill → create skill + files)
 // ---------------------------------------------------------------------------
@@ -164,16 +177,22 @@ const importHandler = createImportHandler({
   getSkillById,
   deleteSkill,
   upsertSkillFile,
-  saveBuffer: (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
+  saveBuffer: async (req, { userId, buffer, fileName, basePath, isImage, tenantId }) => {
     const requestTenantId = tenantId ?? resolveRequestTenantId(req);
     const storage = resolveSkillStorage(req, { isImage });
-    return storage
-      .saveBuffer({ userId, buffer, fileName, basePath, tenantId: requestTenantId })
-      .then((filepath) => ({
-        filepath,
-        source: storage.source,
-        ...getStorageMetadata({ filepath, source: storage.source }),
-      }));
+    await assertSkillFileStorageLimit(req, buffer.length);
+    const filepath = await storage.saveBuffer({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      tenantId: requestTenantId,
+    });
+    return {
+      filepath,
+      source: storage.source,
+      ...getStorageMetadata({ filepath, source: storage.source }),
+    };
   },
   deleteFile: (req, file) => {
     const { deleteFile } = getStrategyFunctions(file.source);
@@ -226,6 +245,12 @@ async function uploadFileHandler(req, res) {
 
     // Look up existing file before saving — needed to clean up old blob on replace
     const existingFile = await getSkillFileByPath(skillId, relativePath);
+    const excludeSkillFile = getSkillFileReplacementExclusion({
+      existingFile,
+      requesterId: req.user._id,
+      skillId,
+      relativePath,
+    });
 
     const fileId = crypto.randomUUID();
     const filename = file.originalname;
@@ -233,6 +258,7 @@ async function uploadFileHandler(req, res) {
 
     const isImage = (file.mimetype || '').startsWith('image/');
     const storage = resolveSkillStorage(req, { isImage });
+    await assertSkillFileStorageLimit(req, file.size, excludeSkillFile);
     const filepath = await storage.saveBuffer({
       userId: req.user.id,
       buffer: file.buffer,
@@ -257,6 +283,9 @@ async function uploadFileHandler(req, res) {
         isExecutable: false,
         author: req.user._id,
         tenantId,
+      });
+      recordFileStorageUsage(req, file.size, {
+        skillFile: { id: result?._id, skillId, relativePath },
       });
     } catch (dbError) {
       // Clean up the stored blob so it doesn't leak on DB failure
@@ -285,6 +314,10 @@ async function uploadFileHandler(req, res) {
 
     return res.status(200).json(result);
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      return res.status(error.status ?? 413).json({ error: error.message });
+    }
+
     if (error.code === 'SKILL_FILE_VALIDATION_FAILED') {
       return res.status(400).json({ error: error.message });
     }

--- a/api/server/routes/skills.test.js
+++ b/api/server/routes/skills.test.js
@@ -10,9 +10,11 @@ jest.mock('librechat-data-provider', () => {
     ...actual,
     mergeFileConfig: jest.fn((dynamic) => {
       const skillFileSizeLimit = dynamic?.skills?.fileSizeLimit;
+      const storageLimit = dynamic?.storageLimit;
       return {
         ...actual.fileConfig,
         ...dynamic,
+        ...(storageLimit !== undefined ? { storageLimit: storageLimit * 1024 * 1024 } : {}),
         skills: {
           ...(actual.fileConfig.skills ?? { fileSizeLimit: 50 * 1024 * 1024 }),
           ...(skillFileSizeLimit !== undefined
@@ -393,6 +395,37 @@ describe('Skill routes', () => {
         }),
       );
     });
+
+    it('rejects over-limit imported skill files before saving blobs', async () => {
+      mockFileConfig = { storageLimit: 0 };
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/should-not-save.sh');
+      const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+      getStrategyFunctions.mockReturnValueOnce({ saveBuffer });
+
+      const zip = new JSZip();
+      zip.file(
+        'SKILL.md',
+        [
+          '---',
+          'name: over-limit-skill',
+          'description: Storage limit import test.',
+          '---',
+          '# Over Limit',
+        ].join('\n'),
+      );
+      zip.file('scripts/imported-script.sh', 'echo imported');
+      const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+
+      const res = await request(app).post('/api/skills/import').attach('file', buffer, {
+        filename: 'over-limit-skill.skill',
+        contentType: 'application/zip',
+      });
+
+      expect(res.status).toBe(413);
+      expect(res.body.error).toMatch(/storage limit/i);
+      expect(saveBuffer).not.toHaveBeenCalled();
+      await expect(Skill.findOne({ name: 'over-limit-skill' })).resolves.toBeNull();
+    });
   });
 
   describe('GET /api/skills', () => {
@@ -513,6 +546,29 @@ describe('Skill routes', () => {
       const res = await request(app).post(`/api/skills/${created.body._id}/files`);
       expect(res.status).toBe(400);
       expect(res.body.error).toMatch(/no file/i);
+    });
+
+    it('rejects over-limit single skill-file uploads before saving blobs', async () => {
+      mockFileConfig = { storageLimit: 0 };
+      const created = await createSkillAsOwner();
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/should-not-save.sh');
+      const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+      getStrategyFunctions.mockReturnValueOnce({ saveBuffer });
+
+      const res = await request(app)
+        .post(`/api/skills/${created.body._id}/files`)
+        .field('relativePath', 'scripts/new.sh')
+        .attach('file', Buffer.from('echo no'), {
+          filename: 'new.sh',
+          contentType: 'text/x-shellscript',
+        });
+
+      expect(res.status).toBe(413);
+      expect(res.body.error).toMatch(/storage limit/i);
+      expect(saveBuffer).not.toHaveBeenCalled();
+      await expect(
+        SkillFile.findOne({ skillId: created.body._id, relativePath: 'scripts/new.sh' }),
+      ).resolves.toBeNull();
     });
   });
 

--- a/api/server/routes/skills.test.js
+++ b/api/server/routes/skills.test.js
@@ -10,9 +10,11 @@ jest.mock('librechat-data-provider', () => {
     ...actual,
     mergeFileConfig: jest.fn((dynamic) => {
       const skillFileSizeLimit = dynamic?.skills?.fileSizeLimit;
+      const storageLimit = dynamic?.storageLimit;
       return {
         ...actual.fileConfig,
         ...dynamic,
+        ...(storageLimit !== undefined ? { storageLimit: storageLimit * 1024 * 1024 } : {}),
         skills: {
           ...(actual.fileConfig.skills ?? { fileSizeLimit: 50 * 1024 * 1024 }),
           ...(skillFileSizeLimit !== undefined
@@ -591,6 +593,37 @@ describe('Skill routes', () => {
       expect(await Skill.countDocuments()).toBe(0);
       expect(await SkillFile.countDocuments()).toBe(0);
     });
+
+    it('rejects over-limit imported skill files before saving blobs', async () => {
+      mockFileConfig = { storageLimit: 0 };
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/should-not-save.sh');
+      const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+      getStrategyFunctions.mockReturnValueOnce({ saveBuffer });
+
+      const zip = new JSZip();
+      zip.file(
+        'SKILL.md',
+        [
+          '---',
+          'name: over-limit-skill',
+          'description: Storage limit import test.',
+          '---',
+          '# Over Limit',
+        ].join('\n'),
+      );
+      zip.file('scripts/imported-script.sh', 'echo imported');
+      const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+
+      const res = await request(app).post('/api/skills/import').attach('file', buffer, {
+        filename: 'over-limit-skill.skill',
+        contentType: 'application/zip',
+      });
+
+      expect(res.status).toBe(413);
+      expect(res.body.error).toMatch(/storage limit/i);
+      expect(saveBuffer).not.toHaveBeenCalled();
+      await expect(Skill.findOne({ name: 'over-limit-skill' })).resolves.toBeNull();
+    });
   });
 
   describe('GET /api/skills', () => {
@@ -875,6 +908,29 @@ describe('Skill routes', () => {
         }),
       );
       expect(await SkillFile.countDocuments()).toBe(0);
+    });
+
+    it('rejects over-limit single skill-file uploads before saving blobs', async () => {
+      mockFileConfig = { storageLimit: 0 };
+      const created = await createSkillAsOwner();
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/should-not-save.sh');
+      const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+      getStrategyFunctions.mockReturnValueOnce({ saveBuffer });
+
+      const res = await request(app)
+        .post(`/api/skills/${created.body._id}/files`)
+        .field('relativePath', 'scripts/new.sh')
+        .attach('file', Buffer.from('echo no'), {
+          filename: 'new.sh',
+          contentType: 'text/x-shellscript',
+        });
+
+      expect(res.status).toBe(413);
+      expect(res.body.error).toMatch(/storage limit/i);
+      expect(saveBuffer).not.toHaveBeenCalled();
+      await expect(
+        SkillFile.findOne({ skillId: created.body._id, relativePath: 'scripts/new.sh' }),
+      ).resolves.toBeNull();
     });
   });
 

--- a/api/server/services/Endpoints/agents/skillDeps.js
+++ b/api/server/services/Endpoints/agents/skillDeps.js
@@ -13,6 +13,9 @@ const {
   isMemoryEnabled,
   getStorageMetadata,
   resolveRequestTenantId,
+  assertFileStorageLimit,
+  recordFileStorageUsage,
+  getSkillFileReplacementExclusion,
   enrichWithSkillConfigurable,
   mergeDeploymentSkillIds,
   createDeploymentSkillMethods,
@@ -84,6 +87,21 @@ async function saveSkillFileContent({ req, skillId, relativePath, content, mimeT
   const storageFileName = `${fileId}__${filename}`;
   const buffer = Buffer.from(content, 'utf8');
   const storage = resolveSkillStorage(req, { isImage: mimeType.startsWith('image/') });
+  /* Agent-authored skill files land in the same `SkillFile` ledger the HTTP
+   * upload path writes to, so they must clear the same per-user quota — an
+   * editable skill would otherwise be an unmetered way past the cap. */
+  const excludeSkillFile = getSkillFileReplacementExclusion({
+    existingFile,
+    requesterId: req.user._id,
+    skillId,
+    relativePath,
+  });
+  await assertFileStorageLimit({
+    req,
+    incomingBytes: buffer.length,
+    excludeSkillFile,
+    getUserStorageUsage: db.getUserStorageUsage,
+  });
   const filepath = await storage.saveBuffer({
     userId: req.user.id,
     buffer,
@@ -114,6 +132,9 @@ async function saveSkillFileContent({ req, skillId, relativePath, content, mimeT
       error.code = 'SKILL_FILE_UPSERT_NOT_FOUND';
       throw error;
     }
+    recordFileStorageUsage(req, buffer.length, {
+      skillFile: { id: result._id, skillId, relativePath },
+    });
   } catch (error) {
     const { deleteFile } = getStrategyFunctions(storage.source);
     if (deleteFile) {

--- a/api/server/services/Endpoints/agents/skillDeps.spec.js
+++ b/api/server/services/Endpoints/agents/skillDeps.spec.js
@@ -22,6 +22,11 @@ jest.mock('~/server/services/Files/Code/process', () => ({
 }));
 
 jest.mock('@librechat/api', () => ({
+  assertFileStorageLimit: (...args) => mockAssertFileStorageLimit(...args),
+  recordFileStorageUsage: (...args) => mockRecordFileStorageUsage(...args),
+  getSkillFileReplacementExclusion: jest.fn(({ existingFile, skillId, relativePath }) =>
+    existingFile ? { skillId, relativePath } : undefined,
+  ),
   checkAccess: jest.fn(),
   createDeploymentSkillMethods: (...args) => mockCreateDeploymentSkillMethods(...args),
   enrichWithSkillConfigurable: jest.fn(),
@@ -52,9 +57,13 @@ jest.mock('~/server/utils/getFileStrategy', () => ({
   getFileStrategy: (...args) => mockGetFileStrategy(...args),
 }));
 
+const mockAssertFileStorageLimit = jest.fn();
+const mockRecordFileStorageUsage = jest.fn();
+
 const mockDb = {
   getSkillFileByPath: jest.fn(),
   upsertSkillFile: jest.fn(),
+  getUserStorageUsage: jest.fn(),
 };
 
 jest.mock('~/models', () => mockDb);
@@ -77,6 +86,7 @@ describe('skillDeps saveSkillFileContent', () => {
     });
     mockResolveRequestTenantId.mockReturnValue('tenant-1');
     mockDb.getSkillFileByPath.mockResolvedValue(null);
+    mockAssertFileStorageLimit.mockResolvedValue(undefined);
   });
 
   it('cleans up the uploaded object when metadata upsert returns no row', async () => {
@@ -103,5 +113,52 @@ describe('skillDeps saveSkillFileContent', () => {
         tenantId: 'tenant-1',
       },
     );
+  });
+
+  /* Agent-authored skill files write the same `SkillFile` rows the HTTP upload
+   * path does, so they have to clear the same per-user quota — otherwise an
+   * editable skill is an unmetered way past the cap. */
+  it('charges agent-authored skill files against the storage quota', async () => {
+    mockDb.upsertSkillFile.mockResolvedValue({ _id: 'skill-file-1', bytes: 13, relativePath: 'x' });
+
+    await getSkillToolDeps().saveSkillFileContent({
+      req: { user: { id: 'user-1', _id: 'user-1' }, config: {} },
+      skillId: 'skill-1',
+      relativePath: 'references/template.html',
+      content: '<html></html>',
+      mimeType: 'text/html',
+    });
+
+    expect(mockAssertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ incomingBytes: 13 }),
+    );
+    expect(mockRecordFileStorageUsage).toHaveBeenCalledWith(
+      expect.anything(),
+      13,
+      expect.objectContaining({
+        skillFile: expect.objectContaining({ id: 'skill-file-1', skillId: 'skill-1' }),
+      }),
+    );
+  });
+
+  it('rejects before writing any bytes when the author is over quota', async () => {
+    const overLimit = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    mockAssertFileStorageLimit.mockRejectedValueOnce(overLimit);
+
+    await expect(
+      getSkillToolDeps().saveSkillFileContent({
+        req: { user: { id: 'user-1', _id: 'user-1' }, config: {} },
+        skillId: 'skill-1',
+        relativePath: 'references/template.html',
+        content: '<html></html>',
+        mimeType: 'text/html',
+      }),
+    ).rejects.toMatchObject({ code: 'FILE_STORAGE_LIMIT_EXCEEDED' });
+
+    expect(mockSaveBuffer).not.toHaveBeenCalled();
+    expect(mockDb.upsertSkillFile).not.toHaveBeenCalled();
   });
 });

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 const fetch = require('node-fetch');
 const { logger } = require('@librechat/data-schemas');
 const { getAzureContainerClient, deleteRagFile } = require('@librechat/api');
+const { getBufferMetadata } = require('~/server/utils');
 
 const defaultBasePath = 'images';
 const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } = process.env;
@@ -53,7 +54,7 @@ async function saveBufferToAzure({
  * @param {string} params.fileName - The name of the file.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
- * @returns {Promise<string>} The URL of the uploaded blob.
+ * @returns {Promise<{ filepath: string, bytes: number, type: string, dimensions: Record<string, number> }>} The uploaded blob metadata.
  */
 async function saveURLToAzure({
   userId,
@@ -65,7 +66,9 @@ async function saveURLToAzure({
   try {
     const response = await fetch(URL);
     const buffer = await response.buffer();
-    return await saveBufferToAzure({ userId, buffer, fileName, basePath, containerName });
+    const metadata = await getBufferMetadata(buffer);
+    const filepath = await saveBufferToAzure({ userId, buffer, fileName, basePath, containerName });
+    return { filepath, ...metadata };
   } catch (error) {
     logger.error('[saveURLToAzure] Error uploading file from URL:', error);
     throw error;

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -12,6 +12,7 @@ const {
   getRemoteFileFetchTimeoutMs,
   assertRemoteFileContentLength,
 } = require('@librechat/api');
+const { getBufferMetadata } = require('~/server/utils');
 
 const defaultBasePath = 'images';
 const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } = process.env;
@@ -60,7 +61,7 @@ async function saveBufferToAzure({
  * @param {string} params.fileName - The name of the file.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
- * @returns {Promise<string>} The URL of the uploaded blob.
+ * @returns {Promise<{ filepath: string, bytes: number, type: string, dimensions: Record<string, number> }>} The uploaded blob metadata.
  */
 async function saveURLToAzure({
   userId,
@@ -84,7 +85,9 @@ async function saveURLToAzure({
       throw new Error(`Remote file response too large: ${buffer.length} bytes`);
     }
 
-    return await saveBufferToAzure({ userId, buffer, fileName, basePath, containerName });
+    const metadata = await getBufferMetadata(buffer);
+    const filepath = await saveBufferToAzure({ userId, buffer, fileName, basePath, containerName });
+    return { filepath, ...metadata };
   } catch (error) {
     logger.error('[saveURLToAzure] Error uploading file from URL:', error);
     throw error;

--- a/api/server/services/Files/Azure/crud.spec.js
+++ b/api/server/services/Files/Azure/crud.spec.js
@@ -1,0 +1,60 @@
+jest.mock('node-fetch', () => jest.fn());
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('@librechat/api', () => ({
+  getAzureContainerClient: jest.fn(),
+  deleteRagFile: jest.fn(),
+}));
+
+jest.mock('~/server/utils', () => ({
+  getBufferMetadata: jest.fn(),
+}));
+
+const fetch = require('node-fetch');
+const { getAzureContainerClient } = require('@librechat/api');
+const { getBufferMetadata } = require('~/server/utils');
+const { saveURLToAzure } = require('./crud');
+
+describe('saveURLToAzure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns byte metadata for URL uploads so storage limits can be enforced', async () => {
+    const buffer = Buffer.from('azure-url-upload');
+    const uploadData = jest.fn().mockResolvedValue(undefined);
+    getAzureContainerClient.mockResolvedValue({
+      createIfNotExists: jest.fn().mockResolvedValue(undefined),
+      getBlockBlobClient: jest.fn().mockReturnValue({
+        uploadData,
+        url: 'https://storage.example.com/files/images/user-123/image.png',
+      }),
+    });
+    fetch.mockResolvedValue({
+      buffer: jest.fn().mockResolvedValue(buffer),
+    });
+    getBufferMetadata.mockResolvedValue({
+      bytes: buffer.byteLength,
+      type: 'image/png',
+      dimensions: { width: 16, height: 16 },
+    });
+
+    const result = await saveURLToAzure({
+      userId: 'user-123',
+      URL: 'https://example.com/image.png',
+      fileName: 'image.png',
+      basePath: 'images',
+    });
+
+    expect(uploadData).toHaveBeenCalledWith(buffer);
+    expect(result).toEqual({
+      filepath: 'https://storage.example.com/files/images/user-123/image.png',
+      bytes: buffer.byteLength,
+      type: 'image/png',
+      dimensions: { width: 16, height: 16 },
+    });
+  });
+});

--- a/api/server/services/Files/Azure/crud.spec.js
+++ b/api/server/services/Files/Azure/crud.spec.js
@@ -1,0 +1,66 @@
+jest.mock('node-fetch', () => jest.fn());
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+jest.mock('@librechat/api', () => ({
+  getAzureContainerClient: jest.fn(),
+  deleteRagFile: jest.fn(),
+  assertRemoteFileURL: jest.fn((url) => url),
+  getRemoteFileFetchMaxBytes: jest.fn(() => 20 * 1024 * 1024),
+  getRemoteFileFetchTimeoutMs: jest.fn(() => 10000),
+  assertRemoteFileContentLength: jest.fn(),
+}));
+
+jest.mock('~/server/utils', () => ({
+  getBufferMetadata: jest.fn(),
+}));
+
+const fetch = require('node-fetch');
+const { getAzureContainerClient } = require('@librechat/api');
+const { getBufferMetadata } = require('~/server/utils');
+const { saveURLToAzure } = require('./crud');
+
+describe('saveURLToAzure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns byte metadata for URL uploads so storage limits can be enforced', async () => {
+    const buffer = Buffer.from('azure-url-upload');
+    const uploadData = jest.fn().mockResolvedValue(undefined);
+    getAzureContainerClient.mockResolvedValue({
+      createIfNotExists: jest.fn().mockResolvedValue(undefined),
+      getBlockBlobClient: jest.fn().mockReturnValue({
+        uploadData,
+        url: 'https://storage.example.com/files/images/user-123/image.png',
+      }),
+    });
+    fetch.mockResolvedValue({
+      ok: true,
+      headers: new Map(),
+      buffer: jest.fn().mockResolvedValue(buffer),
+    });
+    getBufferMetadata.mockResolvedValue({
+      bytes: buffer.byteLength,
+      type: 'image/png',
+      dimensions: { width: 16, height: 16 },
+    });
+
+    const result = await saveURLToAzure({
+      userId: 'user-123',
+      URL: 'https://example.com/image.png',
+      fileName: 'image.png',
+      basePath: 'images',
+    });
+
+    expect(uploadData).toHaveBeenCalledWith(buffer);
+    expect(result).toEqual({
+      filepath: 'https://storage.example.com/files/images/user-123/image.png',
+      bytes: buffer.byteLength,
+      type: 'image/png',
+      dimensions: { width: 16, height: 16 },
+    });
+  });
+});

--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -36,6 +36,7 @@ jest.mock('@librechat/api', () => {
     getStorageMetadata: jest.fn(() => ({})),
     isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
     assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
+    recordFileStorageUsage: jest.fn(),
     /* Pass-through `withTimeout`: this suite asserts traversal sanitization,
      * not deferred preview timing. */
     withTimeout: async (promise) => promise,

--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -34,6 +34,8 @@ jest.mock('@librechat/api', () => {
      * downstream consumers don't see a phantom format. */
     getExtractedTextFormat: jest.fn(() => null),
     getStorageMetadata: jest.fn(() => ({})),
+    isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
+    assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
     /* Pass-through `withTimeout`: this suite asserts traversal sanitization,
      * not deferred preview timing. */
     withTimeout: async (promise) => promise,
@@ -67,8 +69,10 @@ jest.mock('librechat-data-provider', () => ({
 
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({}),
+  deleteFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn().mockResolvedValue([]),
   updateFile: jest.fn(),
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
   claimCodeFile: jest.fn().mockResolvedValue({ file_id: 'mock-uuid', usage: 0 }),
 }));
 

--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -40,6 +40,10 @@ jest.mock('@librechat/api', () => {
      * downstream consumers don't see a phantom format. */
     getExtractedTextFormat: jest.fn(() => null),
     getStorageMetadata: jest.fn(() => ({})),
+    isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
+    assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
+    recordFileStorageUsage: jest.fn(),
+    resolveRequestTenantId: jest.fn((req) => req?.tenantId ?? req?.user?.tenantId),
     /* Pass-through `withTimeout`: this suite asserts traversal sanitization,
      * not deferred preview timing. */
     withTimeout: async (promise) => promise,
@@ -73,8 +77,10 @@ jest.mock('librechat-data-provider', () => ({
 
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({}),
+  deleteFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn().mockResolvedValue([]),
   updateFile: jest.fn(),
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
   claimCodeFile: jest.fn().mockResolvedValue({ file_id: 'mock-uuid', usage: 0 }),
 }));
 

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -128,6 +128,49 @@ async function uploadCodeEnvFile({ req, stream, filename, kind, id, version }) {
 }
 
 /**
+ * Deletes a file from the Code Environment server.
+ *
+ * @param {ServerRequest} req - The authenticated request used for Code API auth.
+ * @param {import('librechat-data-provider').CodeEnvRef | { metadata?: { codeEnvRef?: import('librechat-data-provider').CodeEnvRef } }} file
+ *   The code environment reference, or a file object containing one.
+ * @returns {Promise<void>}
+ */
+async function deleteCodeEnvFile(req, file) {
+  const ref = file?.metadata?.codeEnvRef ?? file;
+  if (!ref?.storage_session_id || !ref?.file_id) {
+    return;
+  }
+
+  try {
+    const baseURL = getCodeBaseURL();
+    const query = buildCodeEnvDownloadQuery({
+      kind: ref.kind,
+      id: ref.id,
+      ...(ref.kind === 'skill' ? { version: ref.version } : {}),
+    });
+    const authHeaders = await getCodeApiAuthHeaders(req);
+    await axios({
+      method: 'delete',
+      url: `${baseURL}/files/${ref.storage_session_id}/${ref.file_id}${query}`,
+      headers: {
+        'User-Agent': 'LibreChat/1.0',
+        ...authHeaders,
+      },
+      httpAgent: codeServerHttpAgent,
+      httpsAgent: codeServerHttpsAgent,
+      timeout: 15000,
+    });
+  } catch (error) {
+    throw new Error(
+      logAxiosError({
+        message: `Error deleting code environment file: ${error.message}`,
+        error,
+      }),
+    );
+  }
+}
+
+/**
  * Uploads multiple files to the code execution environment in a single request.
  * Uses the /upload/batch endpoint which shares one session_id across all files.
  *
@@ -211,5 +254,6 @@ async function batchUploadCodeEnvFiles({ req, files, kind, id, version, read_onl
 module.exports = {
   getCodeOutputDownloadStream,
   uploadCodeEnvFile,
+  deleteCodeEnvFile,
   batchUploadCodeEnvFiles,
 };

--- a/api/server/services/Files/Code/crud.spec.js
+++ b/api/server/services/Files/Code/crud.spec.js
@@ -61,7 +61,7 @@ const {
   codeServerHttpsAgent,
   getCodeApiAuthHeaders,
 } = require('@librechat/api');
-const { getCodeOutputDownloadStream, uploadCodeEnvFile } = require('./crud');
+const { getCodeOutputDownloadStream, uploadCodeEnvFile, deleteCodeEnvFile } = require('./crud');
 
 describe('Code CRUD', () => {
   beforeEach(() => {
@@ -325,6 +325,56 @@ describe('Code CRUD', () => {
       mockAxios.post.mockRejectedValue(new Error('ECONNREFUSED'));
 
       await expect(uploadCodeEnvFile(baseUploadParams)).rejects.toThrow();
+    });
+  });
+
+  describe('deleteCodeEnvFile', () => {
+    const req = { user: { id: 'user-123' } };
+    const ref = {
+      kind: 'agent',
+      id: 'agent-123',
+      storage_session_id: 'sess-1',
+      file_id: 'fid-1',
+    };
+
+    it('deletes through the Code API with identity and auth headers', async () => {
+      getCodeApiAuthHeaders.mockResolvedValue({ Authorization: 'Bearer codeapi-token' });
+      mockAxios.mockResolvedValue({ data: { message: 'File deleted successfully' } });
+
+      await deleteCodeEnvFile(req, ref);
+
+      expect(getCodeApiAuthHeaders).toHaveBeenCalledWith(req);
+      expect(mockAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'delete',
+          url: 'https://code-api.example.com/files/sess-1/fid-1?kind=agent&id=agent-123',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer codeapi-token',
+            'User-Agent': 'LibreChat/1.0',
+          }),
+          httpAgent: codeServerHttpAgent,
+          httpsAgent: codeServerHttpsAgent,
+          timeout: 15000,
+        }),
+      );
+    });
+
+    it('accepts a file object containing metadata.codeEnvRef', async () => {
+      mockAxios.mockResolvedValue({ data: { message: 'File deleted successfully' } });
+
+      await deleteCodeEnvFile(req, { metadata: { codeEnvRef: ref } });
+
+      expect(mockAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://code-api.example.com/files/sess-1/fid-1?kind=agent&id=agent-123',
+        }),
+      );
+    });
+
+    it('no-ops when a code environment ref is missing', async () => {
+      await deleteCodeEnvFile(req, { metadata: {} });
+
+      expect(mockAxios).not.toHaveBeenCalled();
     });
   });
 });

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -17,6 +17,8 @@ const {
   extractCodeArtifactText,
   getExtractedTextFormat,
   getStorageMetadata,
+  isFileStorageLimitError,
+  assertFileStorageLimit,
   buildCodeEnvDownloadQuery,
 } = require('@librechat/api');
 const {
@@ -33,13 +35,70 @@ const {
   getEndpointFileConfig,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
-const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
+const {
+  createFile,
+  deleteFile,
+  getFiles,
+  updateFile,
+  claimCodeFile,
+  getUserStorageUsage,
+} = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
 const { determineFileType } = require('~/server/utils');
 
 const axios = createAxiosInstance();
+
+const assertCodeOutputStorageLimit = (req, incomingBytes, options = {}) =>
+  assertFileStorageLimit({
+    req,
+    incomingBytes,
+    getUserStorageUsage,
+    ...options,
+  });
+
+const cleanupStoredCodeFile = async (req, file) => {
+  const { deleteFile: deleteStoredFile } = getStrategyFunctions(file.source ?? FileSources.local);
+  if (!deleteStoredFile) {
+    return;
+  }
+
+  try {
+    await deleteStoredFile(req, {
+      ...file,
+      user: file.user ?? req.user.id,
+      tenantId: file.tenantId ?? req.user.tenantId,
+    });
+  } catch (cleanupError) {
+    logger.error('[processCodeOutput] Failed to clean up over-limit artifact:', cleanupError);
+  }
+};
+
+const deleteClaimedCodeFile = async (fileId) => {
+  try {
+    await deleteFile(fileId);
+  } catch (cleanupError) {
+    logger.error('[processCodeOutput] Failed to clean up over-limit file claim:', cleanupError);
+  }
+};
+
+const createCodeFileWithStorageLimit = async (req, file, options = {}) => {
+  try {
+    await assertCodeOutputStorageLimit(req, file.bytes, { excludeFileId: file.file_id });
+    await createFile(file, true);
+  } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      if (options.cleanupStorage !== false) {
+        await cleanupStoredCodeFile(req, options.cleanupFile ?? file);
+      }
+      if (options.deleteClaimOnFailure) {
+        await deleteClaimedCodeFile(file.file_id);
+      }
+    }
+    throw error;
+  }
+};
 
 /**
  * Creates a fallback download URL response when file cannot be processed locally.
@@ -427,6 +486,15 @@ const processCodeOutput = async ({
       );
     }
 
+    try {
+      await assertCodeOutputStorageLimit(req, buffer.length, { excludeFileId: file_id });
+    } catch (error) {
+      if (isFileStorageLimitError(error) && !isUpdate) {
+        await deleteClaimedCodeFile(file_id);
+      }
+      throw error;
+    }
+
     /**
      * Preserve the original `messageId` on update. Each `processCodeOutput`
      * call would otherwise overwrite it with the current run's run id, which
@@ -466,7 +534,10 @@ const processCodeOutput = async ({
         metadata: { codeEnvRef },
         ...(await getRetentionExpiry(req)),
       };
-      await createFile(file, true);
+      await createCodeFileWithStorageLimit(req, file, {
+        cleanupFile: { ...file, filepath: _file.filepath },
+        deleteClaimOnFailure: !isUpdate,
+      });
       return { file: Object.assign(file, { messageId, toolCallId }) };
     }
 
@@ -592,7 +663,7 @@ const processCodeOutput = async ({
         previewError: null,
         previewRevision,
       };
-      await createFile(file, true);
+      await createCodeFileWithStorageLimit(req, file, { deleteClaimOnFailure: !isUpdate });
       return {
         file: Object.assign(file, { messageId, toolCallId }),
         finalize: () =>
@@ -630,9 +701,14 @@ const processCodeOutput = async ({
       previewRevision: null,
     };
 
-    await createFile(file, true);
+    await createCodeFileWithStorageLimit(req, file, { deleteClaimOnFailure: !isUpdate });
     return { file: Object.assign(file, { messageId, toolCallId }) };
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      logger.warn(`[processCodeOutput] Storage limit blocked artifact "${name}"`);
+      throw error;
+    }
+
     if (error?.message === 'Path traversal detected in filename') {
       logger.warn(
         `[processCodeOutput] Path traversal blocked for file "${name}" | conv=${conversationId}`,

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -486,15 +486,6 @@ const processCodeOutput = async ({
       );
     }
 
-    try {
-      await assertCodeOutputStorageLimit(req, buffer.length, { excludeFileId: file_id });
-    } catch (error) {
-      if (isFileStorageLimitError(error) && !isUpdate) {
-        await deleteClaimedCodeFile(file_id);
-      }
-      throw error;
-    }
-
     /**
      * Preserve the original `messageId` on update. Each `processCodeOutput`
      * call would otherwise overwrite it with the current run's run id, which
@@ -557,6 +548,15 @@ const processCodeOutput = async ({
           expiresAt: currentDate.getTime() + 86400000,
         }),
       };
+    }
+
+    try {
+      await assertCodeOutputStorageLimit(req, buffer.length, { excludeFileId: file_id });
+    } catch (error) {
+      if (isFileStorageLimitError(error) && !isUpdate) {
+        await deleteClaimedCodeFile(file_id);
+      }
+      throw error;
     }
 
     const detectedType = await determineFileType(buffer, true);

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -88,6 +88,8 @@ const removeCacheBuster = (filepath) =>
   typeof filepath === 'string' ? filepath.replace(/\?v=\d+$/, '') : filepath;
 
 const getStorageFileId = (fileId, isUpdate) => (isUpdate ? `${fileId}-${v4()}` : fileId);
+const getStorageLimitOptions = (fileId, isUpdate) =>
+  isUpdate ? { excludeFileId: fileId } : undefined;
 
 const cleanupReplacedCodeFile = async (req, previousFile, nextFile) => {
   const previousPath = removeCacheBuster(previousFile?.filepath);
@@ -101,9 +103,10 @@ const cleanupReplacedCodeFile = async (req, previousFile, nextFile) => {
 
 const createCodeFileWithStorageLimit = async (req, file, options = {}) => {
   try {
-    await assertCodeOutputStorageLimit(req, file.bytes, { excludeFileId: file.file_id });
-    await createFile(file, true);
+    await assertCodeOutputStorageLimit(req, file.bytes, options.limitOptions);
+    const result = await createFile(file, true);
     recordFileStorageUsage(req, file.bytes, { fileId: file.file_id });
+    return result;
   } catch (error) {
     if (isFileStorageLimitError(error)) {
       if (options.cleanupStorage !== false) {
@@ -496,6 +499,7 @@ const processCodeOutput = async ({
     });
     const file_id = claimed.file_id;
     const isUpdate = file_id !== newFileId;
+    const limitOptions = getStorageLimitOptions(file_id, isUpdate);
 
     if (isUpdate) {
       logger.debug(
@@ -546,6 +550,7 @@ const processCodeOutput = async ({
       await createCodeFileWithStorageLimit(req, file, {
         cleanupFile: { ...file, filepath: _file.filepath },
         deleteClaimOnFailure: !isUpdate,
+        limitOptions,
       });
       if (isUpdate) {
         await cleanupReplacedCodeFile(req, claimed, { ...file, filepath: _file.filepath });
@@ -572,7 +577,7 @@ const processCodeOutput = async ({
     }
 
     try {
-      await assertCodeOutputStorageLimit(req, buffer.length, { excludeFileId: file_id });
+      await assertCodeOutputStorageLimit(req, buffer.length, limitOptions);
     } catch (error) {
       if (isFileStorageLimitError(error) && !isUpdate) {
         await deleteClaimedCodeFile(file_id);
@@ -685,7 +690,10 @@ const processCodeOutput = async ({
         previewError: null,
         previewRevision,
       };
-      await createCodeFileWithStorageLimit(req, file, { deleteClaimOnFailure: !isUpdate });
+      await createCodeFileWithStorageLimit(req, file, {
+        deleteClaimOnFailure: !isUpdate,
+        limitOptions,
+      });
       if (isUpdate) {
         await cleanupReplacedCodeFile(req, claimed, file);
       }
@@ -726,7 +734,10 @@ const processCodeOutput = async ({
       previewRevision: null,
     };
 
-    await createCodeFileWithStorageLimit(req, file, { deleteClaimOnFailure: !isUpdate });
+    await createCodeFileWithStorageLimit(req, file, {
+      deleteClaimOnFailure: !isUpdate,
+      limitOptions,
+    });
     if (isUpdate) {
       await cleanupReplacedCodeFile(req, claimed, file);
     }

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -19,6 +19,7 @@ const {
   getStorageMetadata,
   isFileStorageLimitError,
   assertFileStorageLimit,
+  recordFileStorageUsage,
   buildCodeEnvDownloadQuery,
 } = require('@librechat/api');
 const {
@@ -87,6 +88,7 @@ const createCodeFileWithStorageLimit = async (req, file, options = {}) => {
   try {
     await assertCodeOutputStorageLimit(req, file.bytes, { excludeFileId: file.file_id });
     await createFile(file, true);
+    recordFileStorageUsage(req, file.bytes);
   } catch (error) {
     if (isFileStorageLimitError(error)) {
       if (options.cleanupStorage !== false) {

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -88,8 +88,7 @@ const removeCacheBuster = (filepath) =>
   typeof filepath === 'string' ? filepath.replace(/\?v=\d+$/, '') : filepath;
 
 const getStorageFileId = (fileId, isUpdate) => (isUpdate ? `${fileId}-${v4()}` : fileId);
-const getStorageLimitOptions = (fileId, isUpdate) =>
-  isUpdate ? { excludeFileId: fileId } : undefined;
+const getStorageLimitOptions = (fileId, isUpdate) => (isUpdate ? { excludeFileId: fileId } : {});
 
 const cleanupReplacedCodeFile = async (req, previousFile, nextFile) => {
   const previousPath = removeCacheBuster(previousFile?.filepath);

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -84,11 +84,26 @@ const deleteClaimedCodeFile = async (fileId) => {
   }
 };
 
+const removeCacheBuster = (filepath) =>
+  typeof filepath === 'string' ? filepath.replace(/\?v=\d+$/, '') : filepath;
+
+const getStorageFileId = (fileId, isUpdate) => (isUpdate ? `${fileId}-${v4()}` : fileId);
+
+const cleanupReplacedCodeFile = async (req, previousFile, nextFile) => {
+  const previousPath = removeCacheBuster(previousFile?.filepath);
+  const nextPath = removeCacheBuster(nextFile?.filepath);
+  if (!previousPath || previousPath === nextPath) {
+    return;
+  }
+
+  await cleanupStoredCodeFile(req, { ...previousFile, filepath: previousPath });
+};
+
 const createCodeFileWithStorageLimit = async (req, file, options = {}) => {
   try {
     await assertCodeOutputStorageLimit(req, file.bytes, { excludeFileId: file.file_id });
     await createFile(file, true);
-    recordFileStorageUsage(req, file.bytes);
+    recordFileStorageUsage(req, file.bytes, { fileId: file.file_id });
   } catch (error) {
     if (isFileStorageLimitError(error)) {
       if (options.cleanupStorage !== false) {
@@ -500,7 +515,8 @@ const processCodeOutput = async ({
 
     if (isImage) {
       const usage = isUpdate ? (claimed.usage ?? 0) + 1 : 1;
-      const _file = await convertImage(req, buffer, 'high', `${file_id}${fileExt}`);
+      const storageFileId = getStorageFileId(file_id, isUpdate);
+      const _file = await convertImage(req, buffer, 'high', `${storageFileId}${fileExt}`);
       const filepath = usage > 1 ? `${_file.filepath}?v=${Date.now()}` : _file.filepath;
       const storageMetadata = getStorageMetadata({
         filepath: _file.filepath,
@@ -531,6 +547,9 @@ const processCodeOutput = async ({
         cleanupFile: { ...file, filepath: _file.filepath },
         deleteClaimOnFailure: !isUpdate,
       });
+      if (isUpdate) {
+        await cleanupReplacedCodeFile(req, claimed, { ...file, filepath: _file.filepath });
+      }
       return { file: Object.assign(file, { messageId, toolCallId }) };
     }
 
@@ -586,8 +605,9 @@ const processCodeOutput = async ({
      * the conservative cross-platform NAME_MAX (Linux ext4, NTFS, APFS).
      */
     const NAME_MAX = 255;
-    const flatName = flattenArtifactPath(safeName, NAME_MAX - file_id.length - 2);
-    const fileName = `${file_id}__${flatName}`;
+    const storageFileId = getStorageFileId(file_id, isUpdate);
+    const flatName = flattenArtifactPath(safeName, NAME_MAX - storageFileId.length - 2);
+    const fileName = `${storageFileId}__${flatName}`;
     const filepath = await saveBuffer({
       userId: req.user.id,
       buffer,
@@ -666,6 +686,9 @@ const processCodeOutput = async ({
         previewRevision,
       };
       await createCodeFileWithStorageLimit(req, file, { deleteClaimOnFailure: !isUpdate });
+      if (isUpdate) {
+        await cleanupReplacedCodeFile(req, claimed, file);
+      }
       return {
         file: Object.assign(file, { messageId, toolCallId }),
         finalize: () =>
@@ -704,6 +727,9 @@ const processCodeOutput = async ({
     };
 
     await createCodeFileWithStorageLimit(req, file, { deleteClaimOnFailure: !isUpdate });
+    if (isUpdate) {
+      await cleanupReplacedCodeFile(req, claimed, file);
+    }
     return { file: Object.assign(file, { messageId, toolCallId }) };
   } catch (error) {
     if (isFileStorageLimitError(error)) {

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -21,6 +21,10 @@ const {
   getExtractedTextFormat,
   getStorageMetadata,
   getCodeExecutionBaseUrl,
+  isFileStorageLimitError,
+  assertFileStorageLimit,
+  recordFileStorageUsage,
+  resolveRequestTenantId,
   buildCodeEnvDownloadQuery,
   CODE_API_EXPECTED_PROFILE_HEADER,
 } = require('@librechat/api');
@@ -42,7 +46,14 @@ const {
   getEndpointFileConfig,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
-const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
+const {
+  createFile,
+  deleteFile,
+  getFiles,
+  updateFile,
+  claimCodeFile,
+  getUserStorageUsage,
+} = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
@@ -215,6 +226,94 @@ const prepareCodeOutputForInspection = async ({
       extractedText: extractedText.text ?? undefined,
     },
   };
+};
+
+const assertCodeOutputStorageLimit = (req, incomingBytes, options = {}) =>
+  assertFileStorageLimit({
+    req,
+    incomingBytes,
+    getUserStorageUsage,
+    ...options,
+  });
+
+const cleanupStoredCodeFile = async (req, file) => {
+  const { deleteFile: deleteStoredFile } = getStrategyFunctions(file.source ?? FileSources.local);
+  if (!deleteStoredFile) {
+    return;
+  }
+
+  try {
+    await deleteStoredFile(req, {
+      ...file,
+      user: file.user ?? req.user.id,
+      tenantId: file.tenantId ?? req.user.tenantId,
+    });
+  } catch (cleanupError) {
+    logger.error('[processCodeOutput] Failed to clean up over-limit artifact:', cleanupError);
+  }
+};
+
+const deleteClaimedCodeFile = async (fileId) => {
+  try {
+    await deleteFile(fileId);
+  } catch (cleanupError) {
+    logger.error('[processCodeOutput] Failed to clean up over-limit file claim:', cleanupError);
+  }
+};
+
+const removeCacheBuster = (filepath) =>
+  typeof filepath === 'string' ? filepath.replace(/\?v=\d+$/, '') : filepath;
+
+const getStorageFileId = (fileId, isUpdate) => (isUpdate ? `${fileId}-${v4()}` : fileId);
+const getStorageLimitOptions = (fileId, isUpdate) => (isUpdate ? { excludeFileId: fileId } : {});
+
+const cleanupReplacedCodeFile = async (req, previousFile, nextFile) => {
+  const previousPath = removeCacheBuster(previousFile?.filepath);
+  const nextPath = removeCacheBuster(nextFile?.filepath);
+  if (!previousPath || previousPath === nextPath) {
+    return;
+  }
+
+  await cleanupStoredCodeFile(req, { ...previousFile, filepath: previousPath });
+};
+
+/**
+ * Gates a generated-artifact write on the per-user storage quota, then commits it
+ * through the caller's ownership-aware writer. Usage is only charged once the
+ * commit actually lands, so a stale background harvest never consumes quota.
+ */
+const commitCodeFileWithStorageLimit = async (req, file, commit, options = {}) => {
+  /* Same invariant as the upload ledger: charge and write under one tenant, or the
+   * row falls outside the scope later checks query and the cap stops applying.
+   * Stamped in place so the persisted row and the attachment returned to the caller
+   * cannot disagree. */
+  file.tenantId = resolveRequestTenantId(req);
+  try {
+    await assertCodeOutputStorageLimit(req, file.bytes, options.limitOptions);
+    const committed = await commit(file);
+    if (!committed) {
+      /* A newer writer owns this filename slot. Updates write to a
+       * UUID-suffixed storage key, so the bytes this loser just uploaded are
+       * referenced by nothing once the winner's filepath lands — drop them.
+       * The claimed row itself now belongs to the winner and is left alone. */
+      if (options.cleanupStorage !== false) {
+        await cleanupStoredCodeFile(req, options.cleanupFile ?? file);
+      }
+      return committed;
+    }
+    recordFileStorageUsage(req, file.bytes, { fileId: file.file_id });
+    return committed;
+  } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      if (options.cleanupStorage !== false) {
+        await cleanupStoredCodeFile(req, options.cleanupFile ?? file);
+      }
+      if (options.deleteClaimOnFailure) {
+        await deleteClaimedCodeFile(file.file_id);
+      }
+    }
+    throw error;
+  }
 };
 
 /**
@@ -625,6 +724,7 @@ const processCodeOutput = async ({
     });
     const file_id = claimed.file_id;
     const isUpdate = file_id !== newFileId;
+    const limitOptions = getStorageLimitOptions(file_id, isUpdate);
 
     /**
      * Out-of-order guard for detached (background) harvests: when the claimed
@@ -703,7 +803,8 @@ const processCodeOutput = async ({
 
     if (isImage) {
       const usage = isUpdate ? (claimed.usage ?? 0) + 1 : 1;
-      const _file = await convertImage(req, buffer, 'high', `${file_id}${fileExt}`);
+      const storageFileId = getStorageFileId(file_id, isUpdate);
+      const _file = await convertImage(req, buffer, 'high', `${storageFileId}${fileExt}`);
       const filepath = usage > 1 ? `${_file.filepath}?v=${Date.now()}` : _file.filepath;
       const storageMetadata = getStorageMetadata({
         filepath: _file.filepath,
@@ -731,8 +832,16 @@ const processCodeOutput = async ({
         metadata: codeEnvMetadata,
         ...(await getRetentionExpiry(req)),
       };
-      if (!(await commitCodeFile(file))) {
+      const committed = await commitCodeFileWithStorageLimit(req, file, commitCodeFile, {
+        cleanupFile: { ...file, filepath: _file.filepath },
+        deleteClaimOnFailure: !isUpdate,
+        limitOptions,
+      });
+      if (!committed) {
         return null;
+      }
+      if (isUpdate) {
+        await cleanupReplacedCodeFile(req, claimed, { ...file, filepath: _file.filepath });
       }
       return { file: Object.assign(file, { messageId, toolCallId, agentId }) };
     }
@@ -755,6 +864,15 @@ const processCodeOutput = async ({
           expiresAt: currentDate.getTime() + 86400000,
         }),
       };
+    }
+
+    try {
+      await assertCodeOutputStorageLimit(req, buffer.length, limitOptions);
+    } catch (error) {
+      if (isFileStorageLimitError(error) && !isUpdate) {
+        await deleteClaimedCodeFile(file_id);
+      }
+      throw error;
     }
 
     const detectedType = await determineFileType(buffer, true);
@@ -782,8 +900,9 @@ const processCodeOutput = async ({
      * the conservative cross-platform NAME_MAX (Linux ext4, NTFS, APFS).
      */
     const NAME_MAX = 255;
-    const flatName = flattenArtifactPath(safeName, NAME_MAX - file_id.length - 2);
-    const fileName = `${file_id}__${flatName}`;
+    const storageFileId = getStorageFileId(file_id, isUpdate);
+    const flatName = flattenArtifactPath(safeName, NAME_MAX - storageFileId.length - 2);
+    const fileName = `${storageFileId}__${flatName}`;
     const filepath = await saveBuffer({
       userId: req.user.id,
       buffer,
@@ -861,8 +980,15 @@ const processCodeOutput = async ({
         previewError: null,
         previewRevision,
       };
-      if (!(await commitCodeFile(file))) {
+      const committed = await commitCodeFileWithStorageLimit(req, file, commitCodeFile, {
+        deleteClaimOnFailure: !isUpdate,
+        limitOptions,
+      });
+      if (!committed) {
         return null;
+      }
+      if (isUpdate) {
+        await cleanupReplacedCodeFile(req, claimed, file);
       }
       return {
         file: Object.assign(file, { messageId, toolCallId, agentId }),
@@ -901,11 +1027,23 @@ const processCodeOutput = async ({
       previewRevision: null,
     };
 
-    if (!(await commitCodeFile(file))) {
+    const committed = await commitCodeFileWithStorageLimit(req, file, commitCodeFile, {
+      deleteClaimOnFailure: !isUpdate,
+      limitOptions,
+    });
+    if (!committed) {
       return null;
+    }
+    if (isUpdate) {
+      await cleanupReplacedCodeFile(req, claimed, file);
     }
     return { file: Object.assign(file, { messageId, toolCallId, agentId }) };
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      logger.warn(`[processCodeOutput] Storage limit blocked artifact "${name}"`);
+      throw error;
+    }
+
     if (error?.code === 'CODE_OUTPUT_DOWNLOAD_LIMIT') {
       logger.warn(
         `[processCodeOutput] Generated file exceeds size limit of ${(fileSizeLimit / megabyte).toFixed(2)} MB, falling back to download URL`,

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -333,12 +333,15 @@ describe('Code Process', () => {
         const { file: result } = await processCodeOutput(imageParams);
 
         expect(result.bytes).toBe(convertedBytes);
+        expect(assertFileStorageLimit).toHaveBeenCalledTimes(1);
         expect(assertFileStorageLimit).toHaveBeenCalledWith(
           expect.objectContaining({
             incomingBytes: convertedBytes,
           }),
         );
-        expect(assertFileStorageLimit.mock.calls[0][0]).not.toHaveProperty('excludeFileId');
+        expect(assertFileStorageLimit).toHaveBeenCalledWith(
+          expect.not.objectContaining({ excludeFileId: expect.anything() }),
+        );
         expect(createFile).toHaveBeenCalled();
       });
 

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -367,15 +367,21 @@ describe('Code Process', () => {
 
       it('should update existing image file with cache-busted filepath', async () => {
         const imageParams = { ...baseParams, name: 'chart.png' };
+        const deleteStoredFile = jest.fn();
+        getStrategyFunctions.mockReturnValue({ deleteFile: deleteStoredFile });
         mockClaimCodeFile.mockResolvedValue({
           file_id: 'existing-img-id',
           usage: 1,
           createdAt: '2024-01-01T00:00:00.000Z',
+          filepath: '/images/user-123/existing-img-id.webp',
+          source: 'local',
         });
 
         const imageBuffer = Buffer.alloc(500);
         mockAxios.mockResolvedValue({ data: imageBuffer });
-        convertImage.mockResolvedValue({ filepath: '/images/user-123/existing-img-id.webp' });
+        convertImage.mockResolvedValue({
+          filepath: '/images/user-123/existing-img-id-mock-uuid-1234.webp',
+        });
 
         const { file: result } = await processCodeOutput(imageParams);
 
@@ -383,14 +389,50 @@ describe('Code Process', () => {
           mockReq,
           imageBuffer,
           'high',
-          'existing-img-id.png',
+          'existing-img-id-mock-uuid-1234.png',
         );
         expect(result.file_id).toBe('existing-img-id');
         expect(result.usage).toBe(2);
-        expect(result.filepath).toMatch(/^\/images\/user-123\/existing-img-id\.webp\?v=\d+$/);
+        expect(result.filepath).toMatch(
+          /^\/images\/user-123\/existing-img-id-mock-uuid-1234\.webp\?v=\d+$/,
+        );
+        expect(deleteStoredFile).toHaveBeenCalledWith(
+          mockReq,
+          expect.objectContaining({ filepath: '/images/user-123/existing-img-id.webp' }),
+        );
         expect(logger.debug).toHaveBeenCalledWith(
           expect.stringContaining('Updating existing file'),
         );
+      });
+
+      it('cleans only the new image blob when an over-limit image update fails', async () => {
+        const imageParams = { ...baseParams, name: 'chart.png' };
+        const error = Object.assign(new Error('storage limit exceeded.'), {
+          code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+          status: 413,
+        });
+        const deleteStoredFile = jest.fn();
+        getStrategyFunctions.mockReturnValue({ deleteFile: deleteStoredFile });
+        mockClaimCodeFile.mockResolvedValue({
+          file_id: 'existing-img-id',
+          usage: 1,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          filepath: '/images/user-123/existing-img-id.webp',
+          source: 'local',
+        });
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(500) });
+        convertImage.mockResolvedValue({
+          filepath: '/images/user-123/existing-img-id-mock-uuid-1234.webp',
+          bytes: 400,
+        });
+        assertFileStorageLimit.mockRejectedValueOnce(error);
+
+        await expect(processCodeOutput(imageParams)).rejects.toThrow('storage limit exceeded');
+
+        expect(deleteFile).not.toHaveBeenCalledWith('existing-img-id');
+        expect(deleteStoredFile.mock.calls.map(([, file]) => file.filepath)).toEqual([
+          '/images/user-123/existing-img-id-mock-uuid-1234.webp',
+        ]);
       });
     });
 

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -309,6 +309,38 @@ describe('Code Process', () => {
         expect(result.filename).toBe('chart.png');
       });
 
+      it('checks storage quota against converted image bytes, not raw artifact bytes', async () => {
+        const imageParams = { ...baseParams, name: 'chart.png' };
+        const rawArtifactBytes = 10 * 1024 * 1024;
+        const convertedBytes = 512;
+        const rawBytesError = Object.assign(new Error('storage limit exceeded.'), {
+          code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+          status: 413,
+        });
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(rawArtifactBytes) });
+        convertImage.mockResolvedValue({
+          filepath: '/uploads/converted-image.webp',
+          bytes: convertedBytes,
+        });
+        assertFileStorageLimit.mockImplementation(({ incomingBytes }) => {
+          if (incomingBytes === rawArtifactBytes) {
+            return Promise.reject(rawBytesError);
+          }
+          return Promise.resolve();
+        });
+
+        const { file: result } = await processCodeOutput(imageParams);
+
+        expect(result.bytes).toBe(convertedBytes);
+        expect(assertFileStorageLimit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            incomingBytes: convertedBytes,
+            excludeFileId: 'mock-uuid-1234',
+          }),
+        );
+        expect(createFile).toHaveBeenCalled();
+      });
+
       it('persists tenantId on image code output records when present', async () => {
         const tenantReq = { ...mockReq, user: { ...mockReq.user, tenantId: 'tenantA' } };
         const imageBuffer = Buffer.alloc(500);

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -88,6 +88,7 @@ jest.mock('@librechat/api', () => {
     getStorageMetadata: jest.fn(() => ({})),
     isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
     assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
+    recordFileStorageUsage: jest.fn(),
     /* Identity helpers mirror codeapi's validator. The real impl
      * lives in `packages/api/src/files/code/identity.ts` with its
      * own dedicated `identity.spec.ts`; here we just stub the

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -336,9 +336,9 @@ describe('Code Process', () => {
         expect(assertFileStorageLimit).toHaveBeenCalledWith(
           expect.objectContaining({
             incomingBytes: convertedBytes,
-            excludeFileId: 'mock-uuid-1234',
           }),
         );
+        expect(assertFileStorageLimit.mock.calls[0][0]).not.toHaveProperty('excludeFileId');
         expect(createFile).toHaveBeenCalled();
       });
 

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -86,6 +86,8 @@ jest.mock('@librechat/api', () => {
      * if a case needs to assert the 'html' value. */
     getExtractedTextFormat: (...args) => mockGetExtractedTextFormat(...args),
     getStorageMetadata: jest.fn(() => ({})),
+    isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
+    assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
     /* Identity helpers mirror codeapi's validator. The real impl
      * lives in `packages/api/src/files/code/identity.ts` with its
      * own dedicated `identity.spec.ts`; here we just stub the
@@ -117,8 +119,10 @@ jest.mock('@librechat/agents', () => ({
 const mockClaimCodeFile = jest.fn();
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({}),
+  deleteFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn(),
   updateFile: jest.fn(),
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
   claimCodeFile: (...args) => mockClaimCodeFile(...args),
 }));
 
@@ -148,7 +152,7 @@ jest.mock('~/server/utils', () => ({
 
 const http = require('http');
 const https = require('https');
-const { createFile, getFiles } = require('~/models');
+const { createFile, deleteFile, getFiles } = require('~/models');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
@@ -159,6 +163,7 @@ const {
   codeServerHttpsAgent,
   getCodeApiAuthHeaders,
   getStorageMetadata,
+  assertFileStorageLimit,
 } = require('@librechat/api');
 
 const { processCodeOutput, getSessionInfo, readSandboxFile, primeFiles } = require('./process');
@@ -186,6 +191,7 @@ describe('Code Process', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
     // Default mock: atomic claim returns a new file record (no existing file)
     mockClaimCodeFile.mockResolvedValue({
       file_id: 'mock-uuid-1234',
@@ -243,6 +249,23 @@ describe('Code Process', () => {
   });
 
   describe('processCodeOutput', () => {
+    it('rejects over-limit artifacts before saving or persisting them', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/should-not-save.txt');
+      getStrategyFunctions.mockReturnValue({ saveBuffer });
+      mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+      assertFileStorageLimit.mockRejectedValueOnce(error);
+
+      await expect(processCodeOutput(baseParams)).rejects.toThrow('storage limit exceeded');
+
+      expect(saveBuffer).not.toHaveBeenCalled();
+      expect(createFile).not.toHaveBeenCalled();
+      expect(deleteFile).toHaveBeenCalledWith('mock-uuid-1234');
+    });
+
     it('forwards Code API auth headers when downloading generated output', async () => {
       getCodeApiAuthHeaders.mockResolvedValueOnce({ Authorization: 'Bearer codeapi-token' });
       mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -101,6 +101,10 @@ jest.mock('@librechat/api', () => {
      * if a case needs to assert the 'html' value. */
     getExtractedTextFormat: (...args) => mockGetExtractedTextFormat(...args),
     getStorageMetadata: jest.fn(() => ({})),
+    isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
+    assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
+    recordFileStorageUsage: jest.fn(),
+    resolveRequestTenantId: jest.fn((req) => req?.tenantId ?? req?.user?.tenantId),
     /* Identity helpers mirror codeapi's validator. The real impl
      * lives in `packages/api/src/files/code/identity.ts` with its
      * own dedicated `identity.spec.ts`; here we just stub the
@@ -133,8 +137,10 @@ const mockClaimCodeFile = jest.fn();
 const mockUpdateFile = jest.fn();
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({}),
+  deleteFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn(),
   updateFile: mockUpdateFile,
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
   claimCodeFile: (...args) => mockClaimCodeFile(...args),
 }));
 
@@ -164,7 +170,7 @@ jest.mock('~/server/utils', () => ({
 
 const http = require('http');
 const https = require('https');
-const { createFile, getFiles } = require('~/models');
+const { createFile, deleteFile, getFiles } = require('~/models');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
@@ -175,6 +181,7 @@ const {
   codeServerHttpsAgent,
   getCodeApiAuthHeaders,
   getStorageMetadata,
+  assertFileStorageLimit,
 } = require('@librechat/api');
 
 const {
@@ -211,6 +218,7 @@ describe('Code Process', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fileSizeLimitConfig.value = 20 * 1024 * 1024;
+    assertFileStorageLimit.mockResolvedValue(undefined);
     // Default mock: atomic claim returns a new file record (no existing file)
     mockClaimCodeFile.mockResolvedValue({
       file_id: 'mock-uuid-1234',
@@ -456,6 +464,39 @@ describe('Code Process', () => {
       );
     });
 
+    it('deletes the bytes it just wrote when its conditional commit loses the race', async () => {
+      /* Updates write to a UUID-suffixed storage key, so a loser's object is
+       * referenced by nothing once the winner's filepath lands. Drop it rather
+       * than leak — but leave the claimed row, which the winner now owns. */
+      const deleteStoredFile = jest.fn().mockResolvedValue(undefined);
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/overtaken.txt');
+      getStrategyFunctions.mockReturnValue({ saveBuffer, deleteFile: deleteStoredFile });
+      mockClaimCodeFile.mockResolvedValue({
+        file_id: 'existing-file-id',
+        user: 'user-123',
+        filepath: '/uploads/previous.txt',
+      });
+      mockUpdateFile.mockResolvedValueOnce(null);
+      mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+
+      const result = await processCodeOutput({
+        ...baseParams,
+        freshClaimAfter: new Date('2024-01-01T00:00:00.000Z').getTime(),
+      });
+
+      expect(result).toBeNull();
+      expect(deleteStoredFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/overtaken.txt' }),
+      );
+      /* The previously claimed artifact belongs to the winner now. */
+      expect(deleteStoredFile).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/previous.txt' }),
+      );
+      expect(deleteFile).not.toHaveBeenCalled();
+    });
+
     it('commits when the conditional write matches (ownership held through the write)', async () => {
       mockClaimCodeFile.mockResolvedValue({
         file_id: 'existing-file-id',
@@ -501,6 +542,23 @@ describe('Code Process', () => {
   });
 
   describe('processCodeOutput', () => {
+    it('rejects over-limit artifacts before saving or persisting them', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const saveBuffer = jest.fn().mockResolvedValue('/uploads/should-not-save.txt');
+      getStrategyFunctions.mockReturnValue({ saveBuffer });
+      mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+      assertFileStorageLimit.mockRejectedValueOnce(error);
+
+      await expect(processCodeOutput(baseParams)).rejects.toThrow('storage limit exceeded');
+
+      expect(saveBuffer).not.toHaveBeenCalled();
+      expect(createFile).not.toHaveBeenCalled();
+      expect(deleteFile).toHaveBeenCalledWith('mock-uuid-1234');
+    });
+
     it('forwards Code API auth headers when downloading generated output', async () => {
       getCodeApiAuthHeaders.mockResolvedValueOnce({ Authorization: 'Bearer codeapi-token' });
       mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
@@ -544,6 +602,41 @@ describe('Code Process', () => {
         expect(result.filename).toBe('chart.png');
       });
 
+      it('checks storage quota against converted image bytes, not raw artifact bytes', async () => {
+        const imageParams = { ...baseParams, name: 'chart.png' };
+        const rawArtifactBytes = 10 * 1024 * 1024;
+        const convertedBytes = 512;
+        const rawBytesError = Object.assign(new Error('storage limit exceeded.'), {
+          code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+          status: 413,
+        });
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(rawArtifactBytes) });
+        convertImage.mockResolvedValue({
+          filepath: '/uploads/converted-image.webp',
+          bytes: convertedBytes,
+        });
+        assertFileStorageLimit.mockImplementation(({ incomingBytes }) => {
+          if (incomingBytes === rawArtifactBytes) {
+            return Promise.reject(rawBytesError);
+          }
+          return Promise.resolve();
+        });
+
+        const { file: result } = await processCodeOutput(imageParams);
+
+        expect(result.bytes).toBe(convertedBytes);
+        expect(assertFileStorageLimit).toHaveBeenCalledTimes(1);
+        expect(assertFileStorageLimit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            incomingBytes: convertedBytes,
+          }),
+        );
+        expect(assertFileStorageLimit).toHaveBeenCalledWith(
+          expect.not.objectContaining({ excludeFileId: expect.anything() }),
+        );
+        expect(createFile).toHaveBeenCalled();
+      });
+
       it('persists tenantId on image code output records when present', async () => {
         const tenantReq = { ...mockReq, user: { ...mockReq.user, tenantId: 'tenantA' } };
         const imageBuffer = Buffer.alloc(500);
@@ -567,17 +660,42 @@ describe('Code Process', () => {
         );
       });
 
+      it('persists artifacts under the resolved request tenant, not the user tenant', async () => {
+        /* Remote-agent auth sets `req.tenantId` for users with no `user.tenantId`.
+         * The artifact row has to land in the tenant the quota aggregates, or the
+         * cap silently stops applying to generated files. */
+        const tenantReq = { ...mockReq, tenantId: 'request-tenant', user: { ...mockReq.user } };
+        delete tenantReq.user.tenantId;
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(500) });
+        convertImage.mockResolvedValue({
+          filepath: '/t/request-tenant/images/user-123/mock-uuid-1234.webp',
+        });
+
+        await processCodeOutput({ ...baseParams, req: tenantReq, name: 'chart.png' });
+
+        expect(createFile).toHaveBeenCalledWith(
+          expect.objectContaining({ tenantId: 'request-tenant' }),
+          true,
+        );
+      });
+
       it('should update existing image file with cache-busted filepath', async () => {
         const imageParams = { ...baseParams, name: 'chart.png' };
+        const deleteStoredFile = jest.fn();
+        getStrategyFunctions.mockReturnValue({ deleteFile: deleteStoredFile });
         mockClaimCodeFile.mockResolvedValue({
           file_id: 'existing-img-id',
           usage: 1,
           createdAt: '2024-01-01T00:00:00.000Z',
+          filepath: '/images/user-123/existing-img-id.webp',
+          source: 'local',
         });
 
         const imageBuffer = Buffer.alloc(500);
         mockAxios.mockResolvedValue({ data: imageBuffer });
-        convertImage.mockResolvedValue({ filepath: '/images/user-123/existing-img-id.webp' });
+        convertImage.mockResolvedValue({
+          filepath: '/images/user-123/existing-img-id-mock-uuid-1234.webp',
+        });
 
         const { file: result } = await processCodeOutput(imageParams);
 
@@ -585,14 +703,50 @@ describe('Code Process', () => {
           mockReq,
           imageBuffer,
           'high',
-          'existing-img-id.png',
+          'existing-img-id-mock-uuid-1234.png',
         );
         expect(result.file_id).toBe('existing-img-id');
         expect(result.usage).toBe(2);
-        expect(result.filepath).toMatch(/^\/images\/user-123\/existing-img-id\.webp\?v=\d+$/);
+        expect(result.filepath).toMatch(
+          /^\/images\/user-123\/existing-img-id-mock-uuid-1234\.webp\?v=\d+$/,
+        );
+        expect(deleteStoredFile).toHaveBeenCalledWith(
+          mockReq,
+          expect.objectContaining({ filepath: '/images/user-123/existing-img-id.webp' }),
+        );
         expect(logger.debug).toHaveBeenCalledWith(
           expect.stringContaining('Updating existing file'),
         );
+      });
+
+      it('cleans only the new image blob when an over-limit image update fails', async () => {
+        const imageParams = { ...baseParams, name: 'chart.png' };
+        const error = Object.assign(new Error('storage limit exceeded.'), {
+          code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+          status: 413,
+        });
+        const deleteStoredFile = jest.fn();
+        getStrategyFunctions.mockReturnValue({ deleteFile: deleteStoredFile });
+        mockClaimCodeFile.mockResolvedValue({
+          file_id: 'existing-img-id',
+          usage: 1,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          filepath: '/images/user-123/existing-img-id.webp',
+          source: 'local',
+        });
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(500) });
+        convertImage.mockResolvedValue({
+          filepath: '/images/user-123/existing-img-id-mock-uuid-1234.webp',
+          bytes: 400,
+        });
+        assertFileStorageLimit.mockRejectedValueOnce(error);
+
+        await expect(processCodeOutput(imageParams)).rejects.toThrow('storage limit exceeded');
+
+        expect(deleteFile).not.toHaveBeenCalledWith('existing-img-id');
+        expect(deleteStoredFile.mock.calls.map(([, file]) => file.filepath)).toEqual([
+          '/images/user-123/existing-img-id-mock-uuid-1234.webp',
+        ]);
       });
     });
 

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -524,8 +524,6 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
   const { handleImageUpload } = getStrategyFunctions(source);
   const { file_id, temp_file_id, endpoint } = metadata;
 
-  await assertUploadStorageLimit(req, file?.size);
-
   const { filepath, bytes, width, height, storageKey, storageRegion } = await handleImageUpload({
     req,
     file,
@@ -776,7 +774,9 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   const appConfig = req.config;
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
 
-  await assertUploadStorageLimit(req, file?.size);
+  if (tool_resource !== EToolResources.context) {
+    await assertUploadStorageLimit(req, file?.size);
+  }
 
   let messageAttachment = !!metadata.message_file;
 

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -620,7 +620,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     }`;
   }
   const fileName = `${file_id}-${filename}`;
-  await assertUploadStorageLimit(req, bytes);
+  await assertUploadStorageLimit(req, bytes, { excludeFileId: file_id });
   const filepath = await saveBuffer({
     userId: req.user.id,
     fileName,
@@ -671,7 +671,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
   const { file_id, temp_file_id = null } = metadata;
   const { file } = req;
 
-  await assertUploadStorageLimit(req, file?.size);
+  await assertUploadStorageLimit(req, file?.size, { excludeFileId: file_id });
 
   /** @type {OpenAI | undefined} */
   let openai;
@@ -808,7 +808,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
 
   if (tool_resource !== EToolResources.context) {
-    await assertUploadStorageLimit(req, file?.size);
+    await assertUploadStorageLimit(req, file?.size, { excludeFileId: file_id });
   }
 
   let messageAttachment = !!metadata.message_file;
@@ -1101,12 +1101,19 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
 
   let imageFile;
   if (isImage) {
-    imageFile = await processImageFile({
-      req,
-      file,
-      metadata: { file_id: v4() },
-      returnFile: true,
-    });
+    try {
+      imageFile = await processImageFile({
+        req,
+        file,
+        metadata: { file_id: v4() },
+        returnFile: true,
+      });
+    } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupStoredFile({ req, file: originalStoredFile });
+      }
+      throw error;
+    }
     filepath = imageFile.filepath;
     storageMetadata = getStorageMetadata({
       filepath,
@@ -1407,7 +1414,7 @@ async function saveBase64Image(
   const image = await resizeImageBuffer(inputBuffer, effectiveResolution, endpoint);
   const source = getFileStrategy(appConfig, { isImage: true });
   const { saveBuffer } = getStrategyFunctions(source);
-  await assertUploadStorageLimit(req, image.bytes);
+  await assertUploadStorageLimit(req, image.bytes, { excludeFileId: file_id });
   const filepath = await saveBuffer({
     userId: req.user.id,
     fileName: filename,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -24,6 +24,8 @@ const {
   parseText,
   processAudioFile,
   getStorageMetadata,
+  isFileStorageLimitError,
+  assertFileStorageLimit,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
 } = require('@librechat/api');
@@ -65,6 +67,52 @@ const createSanitizedUploadWrapper = (uploadFunction) => {
 
     return uploadFunction({ req, file: sanitizedFile, file_id, ...restParams });
   };
+};
+
+const assertUploadStorageLimit = (req, incomingBytes, options = {}) =>
+  assertFileStorageLimit({
+    req,
+    incomingBytes,
+    getUserStorageUsage: db.getUserStorageUsage,
+    ...options,
+  });
+
+const cleanupStoredFile = async ({ req, file, openai }) => {
+  const source = file?.source ?? FileSources.local;
+  if (source === FileSources.text) {
+    return;
+  }
+
+  const { deleteFile } = getStrategyFunctions(source);
+  if (!deleteFile) {
+    return;
+  }
+
+  try {
+    await deleteFile(
+      req,
+      {
+        ...file,
+        user: file.user ?? req.user.id,
+        tenantId: file.tenantId ?? req.user.tenantId,
+      },
+      openai,
+    );
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit file storage:', cleanupError);
+  }
+};
+
+const createFileWithStorageLimit = async (req, fileInfo, disableTTL, options = {}) => {
+  try {
+    await assertUploadStorageLimit(req, fileInfo.bytes, { excludeFileId: fileInfo.file_id });
+    return await db.createFile(fileInfo, disableTTL);
+  } catch (error) {
+    if (isFileStorageLimitError(error) && options.cleanup !== false) {
+      await cleanupStoredFile({ req, file: fileInfo, openai: options.openai });
+    }
+    throw error;
+  }
 };
 
 const isMissingStorageError = (err) => {
@@ -386,25 +434,28 @@ const processFileURL = async ({
       storageRegion: typeof savedFile === 'string' ? undefined : savedFile.storageRegion,
     });
 
-    return await db.createFile(
-      {
-        user: userId,
-        file_id: v4(),
-        bytes,
-        filepath,
-        ...storageMetadata,
-        filename: fileName,
-        source: fileStrategy,
-        type,
-        context,
-        ...(await getRetentionExpiry(req)),
-        tenantId,
-        width: dimensions.width,
-        height: dimensions.height,
-      },
-      true,
-    );
+    const fileInfo = {
+      user: userId,
+      file_id: v4(),
+      bytes,
+      filepath,
+      ...storageMetadata,
+      filename: fileName,
+      source: fileStrategy,
+      type,
+      context,
+      ...(await getRetentionExpiry(req)),
+      tenantId,
+      width: dimensions.width,
+      height: dimensions.height,
+    };
+    return req
+      ? await createFileWithStorageLimit(req, fileInfo, true)
+      : await db.createFile(fileInfo, true);
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      throw error;
+    }
     logger.error(`Error while processing the image with ${fileStrategy}:`, error);
     throw new Error(`Failed to process the image with ${fileStrategy}. ${error.message}`);
   }
@@ -428,6 +479,8 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
   const { handleImageUpload } = getStrategyFunctions(source);
   const { file_id, temp_file_id, endpoint } = metadata;
 
+  await assertUploadStorageLimit(req, file?.size);
+
   const { filepath, bytes, width, height, storageKey, storageRegion } = await handleImageUpload({
     req,
     file,
@@ -436,7 +489,8 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
   });
   const storageMetadata = getStorageMetadata({ filepath, source, storageKey, storageRegion });
 
-  const result = await db.createFile(
+  const result = await createFileWithStorageLimit(
+    req,
     {
       user: req.user.id,
       file_id,
@@ -490,6 +544,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     }`;
   }
   const fileName = `${file_id}-${filename}`;
+  await assertUploadStorageLimit(req, bytes);
   const filepath = await saveBuffer({
     userId: req.user.id,
     fileName,
@@ -497,7 +552,8 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     tenantId: req.user.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
-  return await db.createFile(
+  return await createFileWithStorageLimit(
+    req,
     {
       user: req.user.id,
       file_id,
@@ -537,6 +593,9 @@ const processFileUpload = async ({ req, res, metadata }) => {
   const source = isAssistantUpload ? assistantSource : appConfig.fileStrategy;
   const { handleFileUpload } = getStrategyFunctions(source);
   const { file_id, temp_file_id = null } = metadata;
+  const { file } = req;
+
+  await assertUploadStorageLimit(req, file?.size);
 
   /** @type {OpenAI | undefined} */
   let openai;
@@ -544,7 +603,6 @@ const processFileUpload = async ({ req, res, metadata }) => {
     ({ openai } = await getOpenAIClient({ req }));
   }
 
-  const { file } = req;
   const sanitizedUploadFn = createSanitizedUploadWrapper(handleFileUpload);
   const {
     id,
@@ -600,7 +658,8 @@ const processFileUpload = async ({ req, res, metadata }) => {
     });
   }
 
-  const result = await db.createFile(
+  const result = await createFileWithStorageLimit(
+    req,
     {
       user: req.user.id,
       file_id: id ?? file_id,
@@ -620,6 +679,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
       tenantId: req.user.tenantId,
     },
     true,
+    { openai },
   );
   res.status(200).json({ message: 'File uploaded and processed successfully', ...result });
 };
@@ -639,6 +699,8 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   const { file } = req;
   const appConfig = req.config;
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
+
+  await assertUploadStorageLimit(req, file?.size);
 
   let messageAttachment = !!metadata.message_file;
 
@@ -746,6 +808,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
         ...retentionExpiry,
       };
 
+      const result = await createFileWithStorageLimit(req, fileInfo, true, { cleanup: false });
       if (!messageAttachment && tool_resource) {
         await db.addAgentResourceFile({
           file_id,
@@ -754,7 +817,6 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
           updatingUserId: req?.user?.id,
         });
       }
-      const result = await db.createFile(fileInfo, true);
       return res
         .status(200)
         .json({ message: 'Agent file uploaded and processed successfully', ...result });
@@ -851,6 +913,25 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       entity_id,
     });
 
+    try {
+      await assertUploadStorageLimit(req, storageResult.bytes, { excludeFileId: file_id });
+    } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupStoredFile({
+          req,
+          file: {
+            file_id,
+            filepath: storageResult.filepath,
+            storageKey: storageResult.storageKey,
+            storageRegion: storageResult.storageRegion,
+            source,
+            tenantId: req.user.tenantId,
+          },
+        });
+      }
+      throw error;
+    }
+
     // SECOND: Upload to Vector DB
     const { uploadVectors } = require('./VectorDB/crud');
 
@@ -900,15 +981,6 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     storageRegion: _storageRegion,
   });
 
-  if (!messageAttachment && tool_resource) {
-    await db.addAgentResourceFile({
-      file_id,
-      agent_id,
-      tool_resource,
-      updatingUserId: req?.user?.id,
-    });
-  }
-
   if (isImage) {
     const result = await processImageFile({
       req,
@@ -948,7 +1020,15 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     ...retentionExpiry,
   };
 
-  const result = await db.createFile(fileInfo, true);
+  const result = await createFileWithStorageLimit(req, fileInfo, true);
+  if (!messageAttachment && tool_resource) {
+    await db.addAgentResourceFile({
+      file_id,
+      agent_id,
+      tool_resource,
+      updatingUserId: req?.user?.id,
+    });
+  }
 
   res.status(200).json({ message: 'Agent file uploaded and processed successfully', ...result });
 };
@@ -996,7 +1076,7 @@ const processOpenAIFile = async ({
   };
 
   if (saveFile) {
-    await db.createFile(file, true);
+    await createFileWithStorageLimit(openai.req, file, true, { openai });
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({ file_id });
@@ -1022,6 +1102,7 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
   const currentDate = new Date();
   const formattedDate = currentDate.toISOString();
   const appConfig = req.config;
+  await assertUploadStorageLimit(req, buffer.length, { excludeFileId: file_id });
   const _file = await convertImage(req, buffer, undefined, `${file_id}${fileExt}`);
 
   // Create only one file record with the correct information
@@ -1040,8 +1121,11 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     tenantId: req.user.tenantId,
   };
   try {
-    await db.createFile(file, true);
+    await createFileWithStorageLimit(req, file, true);
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      throw error;
+    }
     logger.warn('Error saving OpenAI image output file metadata', error);
   }
   return file;
@@ -1182,6 +1266,7 @@ async function saveBase64Image(
   const image = await resizeImageBuffer(inputBuffer, effectiveResolution, endpoint);
   const source = getFileStrategy(appConfig, { isImage: true });
   const { saveBuffer } = getStrategyFunctions(source);
+  await assertUploadStorageLimit(req, image.bytes);
   const filepath = await saveBuffer({
     userId: req.user.id,
     fileName: filename,
@@ -1189,7 +1274,8 @@ async function saveBase64Image(
     tenantId: req.user.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
-  return await db.createFile(
+  return await createFileWithStorageLimit(
+    req,
     {
       type,
       source,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -123,6 +123,18 @@ const cleanupVectorFile = async ({ req, file }) => {
   }
 };
 
+const cleanupFileMetadata = async ({ fileId }) => {
+  if (!fileId) {
+    return;
+  }
+
+  try {
+    await db.deleteFiles([fileId]);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit file metadata:', cleanupError);
+  }
+};
+
 const cleanupCodeEnvFile = async ({ req, file }) => {
   if (!file?.metadata?.codeEnvRef) {
     return;
@@ -146,11 +158,7 @@ const cleanupPersistedFile = async ({ req, file, openai }) => {
     return;
   }
 
-  try {
-    await db.deleteFiles([file.file_id]);
-  } catch (cleanupError) {
-    logger.error('[fileStorageLimit] Failed to clean up over-limit file metadata:', cleanupError);
-  }
+  await cleanupFileMetadata({ fileId: file.file_id });
 };
 
 const detachAssistantStoredFile = async ({ req, metadata, openai, fileId }) => {
@@ -936,12 +944,17 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
 
       const result = await createFileWithStorageLimit(req, fileInfo, true, { cleanup: false });
       if (!messageAttachment && tool_resource) {
-        await db.addAgentResourceFile({
-          file_id,
-          agent_id,
-          tool_resource,
-          updatingUserId: req?.user?.id,
-        });
+        try {
+          await db.addAgentResourceFile({
+            file_id,
+            agent_id,
+            tool_resource,
+            updatingUserId: req?.user?.id,
+          });
+        } catch (error) {
+          await cleanupFileMetadata({ fileId: file_id });
+          throw error;
+        }
       }
       return res
         .status(200)
@@ -1100,6 +1113,8 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   }
 
   let filepath = _filepath;
+  let fileSource = source;
+  let fileType = file.mimetype;
   const originalStoredFile = {
     file_id,
     bytes,
@@ -1132,9 +1147,14 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       throw error;
     }
     filepath = imageFile.filepath;
+    bytes = imageFile.bytes ?? bytes;
+    height = imageFile.height ?? height;
+    width = imageFile.width ?? width;
+    fileSource = imageFile.source ?? source;
+    fileType = imageFile.type ?? file.mimetype;
     storageMetadata = getStorageMetadata({
       filepath,
-      source: imageFile.source,
+      source: fileSource,
       storageKey: imageFile.storageKey,
       storageRegion: imageFile.storageRegion,
     });
@@ -1153,9 +1173,9 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       context: messageAttachment ? FileContext.message_attachment : FileContext.agents,
       model: messageAttachment ? undefined : req.body.model,
       metadata: fileInfoMetadata,
-      type: file.mimetype,
+      type: fileType,
       embedded,
-      source,
+      source: fileSource,
       height,
       width,
       tenantId: req.user.tenantId,
@@ -1182,12 +1202,29 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     throw error;
   }
   if (!messageAttachment && tool_resource) {
-    await db.addAgentResourceFile({
-      file_id,
-      agent_id,
-      tool_resource,
-      updatingUserId: req?.user?.id,
-    });
+    try {
+      await db.addAgentResourceFile({
+        file_id,
+        agent_id,
+        tool_resource,
+        updatingUserId: req?.user?.id,
+      });
+    } catch (error) {
+      if (imageFile) {
+        await cleanupFileMetadata({ fileId: fileInfo.file_id });
+        await cleanupPersistedFile({ req, file: imageFile });
+        await cleanupStoredFile({ req, file: originalStoredFile });
+      } else {
+        await cleanupPersistedFile({ req, file: fileInfo });
+      }
+      if (tool_resource === EToolResources.file_search && embedded) {
+        await cleanupVectorFile({ req, file: fileInfo });
+      }
+      if (tool_resource === EToolResources.execute_code) {
+        await cleanupCodeEnvFile({ req, file: fileInfo });
+      }
+      throw error;
+    }
   }
 
   res.status(200).json({ message: 'Agent file uploaded and processed successfully', ...result });
@@ -1275,7 +1312,7 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     type: mime.getType(fileExt),
     createdAt: formattedDate,
     updatedAt: formattedDate,
-    source: getFileStrategy(appConfig, { isImage: true }),
+    source: appConfig.fileStrategy,
     context: FileContext.assistants_output,
     file_id,
     filename,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -103,6 +103,51 @@ const cleanupStoredFile = async ({ req, file, openai }) => {
   }
 };
 
+const cleanupPersistedFile = async ({ req, file, openai }) => {
+  await cleanupStoredFile({ req, file, openai });
+  if (!file?.file_id) {
+    return;
+  }
+
+  try {
+    await db.deleteFiles([file.file_id]);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit file metadata:', cleanupError);
+  }
+};
+
+const detachAssistantStoredFile = async ({ req, metadata, openai, fileId }) => {
+  if (!openai || !metadata?.assistant_id || metadata.message_file) {
+    return;
+  }
+
+  try {
+    if (metadata.tool_resource) {
+      await deleteResourceFileId({
+        req,
+        openai,
+        file_id: fileId,
+        assistant_id: metadata.assistant_id,
+        tool_resource: metadata.tool_resource,
+      });
+      return;
+    }
+
+    await openai.beta.assistants.files.del(metadata.assistant_id, fileId);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to detach over-limit assistant file:', cleanupError);
+  }
+};
+
+const cleanupAssistantStoredFile = async ({ req, metadata, openai, file }) => {
+  if (!file?.file_id) {
+    return;
+  }
+
+  await detachAssistantStoredFile({ req, metadata, openai, fileId: file.file_id });
+  await cleanupStoredFile({ req, file, openai });
+};
+
 const createFileWithStorageLimit = async (req, fileInfo, disableTTL, options = {}) => {
   try {
     await assertUploadStorageLimit(req, fileInfo.bytes, { excludeFileId: fileInfo.file_id });
@@ -621,66 +666,97 @@ const processFileUpload = async ({ req, res, metadata }) => {
     openai,
   });
 
+  const assistantFileId = id ?? file_id;
   if (isAssistantUpload && !metadata.message_file && !metadata.tool_resource) {
     await openai.beta.assistants.files.create(metadata.assistant_id, {
-      file_id: id,
+      file_id: assistantFileId,
     });
   } else if (isAssistantUpload && !metadata.message_file) {
     await addResourceFileId({
       req,
       openai,
-      file_id: id,
+      file_id: assistantFileId,
       assistant_id: metadata.assistant_id,
       tool_resource: metadata.tool_resource,
     });
   }
 
-  let filepath = isAssistantUpload ? `${openai.baseURL}/files/${id}` : _filepath;
+  const assistantStoredFile = isAssistantUpload
+    ? {
+        user: req.user.id,
+        file_id: assistantFileId,
+        bytes,
+        filepath: `${openai.baseURL}/files/${assistantFileId}`,
+        filename: filename ?? sanitizeFilename(file.originalname),
+        source,
+        tenantId: req.user.tenantId,
+      }
+    : null;
+  let filepath = isAssistantUpload ? `${openai.baseURL}/files/${assistantFileId}` : _filepath;
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
     storageKey: _storageKey,
     storageRegion: _storageRegion,
   });
+  let imageFile;
   if (isAssistantUpload && file.mimetype.startsWith('image')) {
-    const result = await processImageFile({
-      req,
-      file,
-      metadata: { file_id: v4() },
-      returnFile: true,
-    });
-    filepath = result.filepath;
+    try {
+      imageFile = await processImageFile({
+        req,
+        file,
+        metadata: { file_id: v4() },
+        returnFile: true,
+      });
+    } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupAssistantStoredFile({ req, metadata, openai, file: assistantStoredFile });
+      }
+      throw error;
+    }
+    filepath = imageFile.filepath;
     storageMetadata = getStorageMetadata({
       filepath,
-      source: result.source,
-      storageKey: result.storageKey,
-      storageRegion: result.storageRegion,
+      source: imageFile.source,
+      storageKey: imageFile.storageKey,
+      storageRegion: imageFile.storageRegion,
     });
   }
 
-  const result = await createFileWithStorageLimit(
-    req,
-    {
-      user: req.user.id,
-      file_id: id ?? file_id,
-      temp_file_id,
-      bytes,
-      filepath,
-      ...storageMetadata,
-      filename: filename ?? sanitizeFilename(file.originalname),
-      context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
-      model: isAssistantUpload ? req.body.model : undefined,
-      type: file.mimetype,
-      ...(await getRetentionExpiry(req)),
-      embedded,
-      source,
-      height,
-      width,
-      tenantId: req.user.tenantId,
-    },
-    true,
-    { openai },
-  );
+  const fileInfo = {
+    user: req.user.id,
+    file_id: assistantFileId,
+    temp_file_id,
+    bytes,
+    filepath,
+    ...storageMetadata,
+    filename: filename ?? sanitizeFilename(file.originalname),
+    context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
+    model: isAssistantUpload ? req.body.model : undefined,
+    type: file.mimetype,
+    ...(await getRetentionExpiry(req)),
+    embedded,
+    source,
+    height,
+    width,
+    tenantId: req.user.tenantId,
+  };
+
+  let result;
+  try {
+    result = await createFileWithStorageLimit(req, fileInfo, true, {
+      openai,
+      cleanup: !isAssistantUpload,
+    });
+  } catch (error) {
+    if (isFileStorageLimitError(error) && isAssistantUpload) {
+      if (imageFile) {
+        await cleanupPersistedFile({ req, file: imageFile });
+      }
+      await cleanupAssistantStoredFile({ req, metadata, openai, file: fileInfo });
+    }
+    throw error;
+  }
   res.status(200).json({ message: 'File uploaded and processed successfully', ...result });
 };
 

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -1219,7 +1219,7 @@ const processOpenAIFile = async ({
   };
 
   if (saveFile) {
-    await createFileWithStorageLimit(request, file, true, { openai });
+    await createFileWithStorageLimit(request, file, true, { cleanup: false });
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({ file_id });

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -26,6 +26,7 @@ const {
   getStorageMetadata,
   isFileStorageLimitError,
   assertFileStorageLimit,
+  recordFileStorageUsage,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
 } = require('@librechat/api');
@@ -103,6 +104,25 @@ const cleanupStoredFile = async ({ req, file, openai }) => {
   }
 };
 
+const cleanupVectorFile = async ({ req, file }) => {
+  const { deleteFile } = getStrategyFunctions(FileSources.vectordb);
+  if (!deleteFile) {
+    return;
+  }
+
+  try {
+    await deleteFile(req, {
+      ...file,
+      source: FileSources.vectordb,
+      embedded: true,
+      user: file.user ?? req.user.id,
+      tenantId: file.tenantId ?? req.user.tenantId,
+    });
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit vector storage:', cleanupError);
+  }
+};
+
 const cleanupPersistedFile = async ({ req, file, openai }) => {
   await cleanupStoredFile({ req, file, openai });
   if (!file?.file_id) {
@@ -151,7 +171,9 @@ const cleanupAssistantStoredFile = async ({ req, metadata, openai, file }) => {
 const createFileWithStorageLimit = async (req, fileInfo, disableTTL, options = {}) => {
   try {
     await assertUploadStorageLimit(req, fileInfo.bytes, { excludeFileId: fileInfo.file_id });
-    return await db.createFile(fileInfo, disableTTL);
+    const result = await db.createFile(fileInfo, disableTTL);
+    recordFileStorageUsage(req, fileInfo.bytes);
+    return result;
   } catch (error) {
     if (isFileStorageLimitError(error) && options.cleanup !== false) {
       await cleanupStoredFile({ req, file: fileInfo, openai: options.openai });
@@ -455,11 +477,7 @@ const processFileURL = async ({
       throw new Error(`Strategy "${fileStrategy}" did not save "${fileName}"`);
     }
 
-    const {
-      bytes = 0,
-      type = '',
-      dimensions = {},
-    } = typeof savedFile === 'string' ? {} : savedFile;
+    const { bytes, type = '', dimensions = {} } = typeof savedFile === 'string' ? {} : savedFile;
     const fallbackFileName =
       fileStrategy === FileSources.local || fileStrategy === FileSources.firebase
         ? `${userId}/${fileName}`
@@ -478,11 +496,24 @@ const processFileURL = async ({
       storageKey: typeof savedFile === 'string' ? undefined : savedFile.storageKey,
       storageRegion: typeof savedFile === 'string' ? undefined : savedFile.storageRegion,
     });
+    if (req && !Number.isFinite(bytes)) {
+      await cleanupStoredFile({
+        req,
+        file: {
+          filepath,
+          ...storageMetadata,
+          source: fileStrategy,
+          user: userId,
+          tenantId,
+        },
+      });
+      throw new Error(`Strategy "${fileStrategy}" did not return byte metadata for "${fileName}"`);
+    }
 
     const fileInfo = {
       user: userId,
       file_id: v4(),
-      bytes,
+      bytes: Math.max(0, bytes ?? 0),
       filepath,
       ...storageMetadata,
       filename: fileName,
@@ -494,6 +525,8 @@ const processFileURL = async ({
       width: dimensions.width,
       height: dimensions.height,
     };
+    // Some legacy tool tests call this helper without an Express request; runtime callers pass req
+    // so generated files go through retention and storage quota enforcement.
     return req
       ? await createFileWithStorageLimit(req, fileInfo, true)
       : await db.createFile(fileInfo, true);
@@ -1050,6 +1083,15 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   }
 
   let filepath = _filepath;
+  const originalStoredFile = {
+    file_id,
+    bytes,
+    filepath,
+    storageKey: _storageKey,
+    storageRegion: _storageRegion,
+    source,
+    tenantId: req.user.tenantId,
+  };
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
@@ -1057,19 +1099,20 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     storageRegion: _storageRegion,
   });
 
+  let imageFile;
   if (isImage) {
-    const result = await processImageFile({
+    imageFile = await processImageFile({
       req,
       file,
       metadata: { file_id: v4() },
       returnFile: true,
     });
-    filepath = result.filepath;
+    filepath = imageFile.filepath;
     storageMetadata = getStorageMetadata({
       filepath,
-      source: result.source,
-      storageKey: result.storageKey,
-      storageRegion: result.storageRegion,
+      source: imageFile.source,
+      storageKey: imageFile.storageKey,
+      storageRegion: imageFile.storageRegion,
     });
   }
 
@@ -1096,7 +1139,21 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     ...retentionExpiry,
   };
 
-  const result = await createFileWithStorageLimit(req, fileInfo, true);
+  let result;
+  try {
+    result = await createFileWithStorageLimit(req, fileInfo, true);
+  } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      if (imageFile) {
+        await cleanupPersistedFile({ req, file: imageFile });
+        await cleanupStoredFile({ req, file: originalStoredFile });
+      }
+      if (tool_resource === EToolResources.file_search && embedded) {
+        await cleanupVectorFile({ req, file: fileInfo });
+      }
+    }
+    throw error;
+  }
   if (!messageAttachment && tool_resource) {
     await db.addAgentResourceFile({
       file_id,
@@ -1112,6 +1169,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
 /**
  * @param {object} params - The params object.
  * @param {OpenAI} params.openai - The OpenAI client instance.
+ * @param {ServerRequest} params.req - The Express request object associated with the client.
  * @param {string} params.file_id - The ID of the file to retrieve.
  * @param {string} params.userId - The user ID.
  * @param {string} [params.filename] - The name of the file. `undefined` for `file_citation` annotations.
@@ -1120,12 +1178,14 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
  */
 const processOpenAIFile = async ({
   openai,
+  req,
   file_id,
   userId,
   filename,
   saveFile = false,
   updateUsage = false,
 }) => {
+  const request = req ?? openai.req;
   const _file = await openai.files.retrieve(file_id);
   const originalName = filename ?? (_file.filename ? path.basename(_file.filename) : undefined);
   const filepath = `${openai.baseURL}/files/${userId}/${file_id}${
@@ -1133,7 +1193,7 @@ const processOpenAIFile = async ({
   }`;
   const type = mime.getType(originalName ?? file_id);
   const source =
-    openai.req.body.endpoint === EModelEndpoint.azureAssistants
+    request.body.endpoint === EModelEndpoint.azureAssistants
       ? FileSources.azure
       : FileSources.openai;
   const file = {
@@ -1145,14 +1205,14 @@ const processOpenAIFile = async ({
     user: userId,
     context: _file.purpose,
     source,
-    model: openai.req.body.model,
+    model: request.body.model,
     filename: originalName ?? file_id,
-    ...(await getRetentionExpiry(openai.req)),
-    tenantId: openai.req?.user?.tenantId,
+    ...(await getRetentionExpiry(request)),
+    tenantId: request.user?.tenantId,
   };
 
   if (saveFile) {
-    await createFileWithStorageLimit(openai.req, file, true, { openai });
+    await createFileWithStorageLimit(request, file, true, { openai });
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({ file_id });
@@ -1178,7 +1238,6 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
   const currentDate = new Date();
   const formattedDate = currentDate.toISOString();
   const appConfig = req.config;
-  await assertUploadStorageLimit(req, buffer.length, { excludeFileId: file_id });
   const _file = await convertImage(req, buffer, undefined, `${file_id}${fileExt}`);
 
   // Create only one file record with the correct information
@@ -1231,7 +1290,13 @@ async function retrieveAndProcessFile({
   }
 
   let basename = _basename;
-  const processArgs = { openai, file_id, filename: basename, userId: client.req.user.id };
+  const processArgs = {
+    openai,
+    req: client.req,
+    file_id,
+    filename: basename,
+    userId: client.req.user.id,
+  };
 
   // If no basename provided, return only the file metadata
   if (!basename) {

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -172,7 +172,7 @@ const createFileWithStorageLimit = async (req, fileInfo, disableTTL, options = {
   try {
     await assertUploadStorageLimit(req, fileInfo.bytes, { excludeFileId: fileInfo.file_id });
     const result = await db.createFile(fileInfo, disableTTL);
-    recordFileStorageUsage(req, fileInfo.bytes);
+    recordFileStorageUsage(req, fileInfo.bytes, { fileId: fileInfo.file_id });
     return result;
   } catch (error) {
     if (isFileStorageLimitError(error) && options.cleanup !== false) {

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -123,6 +123,23 @@ const cleanupVectorFile = async ({ req, file }) => {
   }
 };
 
+const cleanupCodeEnvFile = async ({ req, file }) => {
+  if (!file?.metadata?.codeEnvRef) {
+    return;
+  }
+
+  const { deleteFile } = getStrategyFunctions(FileSources.execute_code);
+  if (!deleteFile) {
+    return;
+  }
+
+  try {
+    await deleteFile(req, file);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit code env file:', cleanupError);
+  }
+};
+
 const cleanupPersistedFile = async ({ req, file, openai }) => {
   await cleanupStoredFile({ req, file, openai });
   if (!file?.file_id) {
@@ -1157,6 +1174,9 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       }
       if (tool_resource === EToolResources.file_search && embedded) {
         await cleanupVectorFile({ req, file: fileInfo });
+      }
+      if (tool_resource === EToolResources.execute_code) {
+        await cleanupCodeEnvFile({ req, file: fileInfo });
       }
     }
     throw error;

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -34,6 +34,10 @@ const {
   sendUploadSuccess,
   getStorageMetadata,
   contentFilterBlockResponse,
+  isFileStorageLimitError,
+  assertFileStorageLimit,
+  recordFileStorageUsage,
+  resolveRequestTenantId,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
 } = require('@librechat/api');
@@ -79,6 +83,152 @@ const createSanitizedUploadWrapper = (uploadFunction) => {
 
 const hasCodeEnvRef = (file) =>
   file?.metadata?.codeEnvRef != null || file?.metadata?.codeEnvRefs != null;
+
+const assertUploadStorageLimit = (req, incomingBytes, options = {}) =>
+  assertFileStorageLimit({
+    req,
+    incomingBytes,
+    getUserStorageUsage: db.getUserStorageUsage,
+    ...options,
+  });
+
+const cleanupStoredFile = async ({ req, file, openai }) => {
+  const source = file?.source ?? FileSources.local;
+  if (source === FileSources.text) {
+    return;
+  }
+
+  const { deleteFile } = getStrategyFunctions(source);
+  if (!deleteFile) {
+    return;
+  }
+
+  try {
+    await deleteFile(
+      req,
+      {
+        ...file,
+        user: file.user ?? req.user.id,
+        tenantId: file.tenantId ?? req.user.tenantId,
+      },
+      openai,
+    );
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit file storage:', cleanupError);
+  }
+};
+
+const cleanupVectorFile = async ({ req, file }) => {
+  const { deleteFile } = getStrategyFunctions(FileSources.vectordb);
+  if (!deleteFile) {
+    return;
+  }
+
+  try {
+    await deleteFile(req, {
+      ...file,
+      source: FileSources.vectordb,
+      embedded: true,
+      user: file.user ?? req.user.id,
+      tenantId: file.tenantId ?? req.user.tenantId,
+    });
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit vector storage:', cleanupError);
+  }
+};
+
+const cleanupFileMetadata = async ({ fileId }) => {
+  if (!fileId) {
+    return;
+  }
+
+  try {
+    await db.deleteFiles([fileId]);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit file metadata:', cleanupError);
+  }
+};
+
+const cleanupCodeEnvFile = async ({ req, file }) => {
+  if (!file?.metadata?.codeEnvRef) {
+    return;
+  }
+
+  const { deleteFile } = getStrategyFunctions(FileSources.execute_code);
+  if (!deleteFile) {
+    return;
+  }
+
+  try {
+    await deleteFile(req, file);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to clean up over-limit code env file:', cleanupError);
+  }
+};
+
+const cleanupPersistedFile = async ({ req, file, openai }) => {
+  await cleanupStoredFile({ req, file, openai });
+  if (!file?.file_id) {
+    return;
+  }
+
+  await cleanupFileMetadata({ fileId: file.file_id });
+};
+
+const detachAssistantStoredFile = async ({ req, metadata, openai, fileId }) => {
+  if (!openai || !metadata?.assistant_id || metadata.message_file) {
+    return;
+  }
+
+  try {
+    if (metadata.tool_resource) {
+      await deleteResourceFileId({
+        req,
+        openai,
+        file_id: fileId,
+        assistant_id: metadata.assistant_id,
+        tool_resource: metadata.tool_resource,
+      });
+      return;
+    }
+
+    await openai.beta.assistants.files.del(metadata.assistant_id, fileId);
+  } catch (cleanupError) {
+    logger.error('[fileStorageLimit] Failed to detach over-limit assistant file:', cleanupError);
+  }
+};
+
+const cleanupAssistantStoredFile = async ({ req, metadata, openai, file }) => {
+  if (!file?.file_id) {
+    return;
+  }
+
+  await detachAssistantStoredFile({ req, metadata, openai, fileId: file.file_id });
+  await cleanupStoredFile({ req, file, openai });
+};
+
+/**
+ * Sole quota-checked path to the `File` ledger. Usage is aggregated under the
+ * resolved request tenant, so the row must be stamped with that same tenant or it
+ * is never counted again and the cap silently stops applying — remote-agent auth
+ * sets `req.tenantId` for users that carry no `user.tenantId` of their own. Owning
+ * the stamp here keeps query scope and write scope equal by construction instead of
+ * relying on every call site to pass a matching value.
+ */
+const createFileWithStorageLimit = async (req, fileInfo, disableTTL, options = {}) => {
+  fileInfo.tenantId = resolveRequestTenantId(req);
+  try {
+    await assertUploadStorageLimit(req, fileInfo.bytes, { excludeFileId: fileInfo.file_id });
+    const result = await db.createFile(fileInfo, disableTTL);
+    recordFileStorageUsage(req, fileInfo.bytes, { fileId: fileInfo.file_id });
+    return result;
+  } catch (error) {
+    if (isFileStorageLimitError(error) && options.cleanup !== false) {
+      await cleanupStoredFile({ req, file: fileInfo, openai: options.openai });
+    }
+    throw error;
+  }
+};
 
 const isMissingStorageError = (err) => {
   const code = err?.code ?? err?.status ?? err?.statusCode ?? err?.response?.status;
@@ -400,11 +550,7 @@ const processFileURL = async ({
       throw new Error(`Strategy "${fileStrategy}" did not save "${fileName}"`);
     }
 
-    const {
-      bytes = 0,
-      type = '',
-      dimensions = {},
-    } = typeof savedFile === 'string' ? {} : savedFile;
+    const { bytes, type = '', dimensions = {} } = typeof savedFile === 'string' ? {} : savedFile;
     const fallbackFileName =
       fileStrategy === FileSources.local || fileStrategy === FileSources.firebase
         ? `${userId}/${fileName}`
@@ -423,26 +569,44 @@ const processFileURL = async ({
       storageKey: typeof savedFile === 'string' ? undefined : savedFile.storageKey,
       storageRegion: typeof savedFile === 'string' ? undefined : savedFile.storageRegion,
     });
+    if (req && !Number.isFinite(bytes)) {
+      await cleanupStoredFile({
+        req,
+        file: {
+          filepath,
+          ...storageMetadata,
+          source: fileStrategy,
+          user: userId,
+          tenantId,
+        },
+      });
+      throw new Error(`Strategy "${fileStrategy}" did not return byte metadata for "${fileName}"`);
+    }
 
-    return await db.createFile(
-      {
-        user: userId,
-        file_id: v4(),
-        bytes,
-        filepath,
-        ...storageMetadata,
-        filename: fileName,
-        source: fileStrategy,
-        type,
-        context,
-        ...(await getRetentionExpiry(req)),
-        tenantId,
-        width: dimensions.width,
-        height: dimensions.height,
-      },
-      true,
-    );
+    const fileInfo = {
+      user: userId,
+      file_id: v4(),
+      bytes: Math.max(0, bytes ?? 0),
+      filepath,
+      ...storageMetadata,
+      filename: fileName,
+      source: fileStrategy,
+      type,
+      context,
+      ...(await getRetentionExpiry(req)),
+      tenantId,
+      width: dimensions.width,
+      height: dimensions.height,
+    };
+    // Some legacy tool tests call this helper without an Express request; runtime callers pass req
+    // so generated files go through retention and storage quota enforcement.
+    return req
+      ? await createFileWithStorageLimit(req, fileInfo, true)
+      : await db.createFile(fileInfo, true);
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      throw error;
+    }
     logger.error(`Error while processing the image with ${fileStrategy}:`, error);
     throw new Error(`Failed to process the image with ${fileStrategy}. ${error.message}`);
   }
@@ -475,7 +639,8 @@ const processImageFile = async ({ req, res, metadata, returnFile = false, sseStr
   });
   const storageMetadata = getStorageMetadata({ filepath, source, storageKey, storageRegion });
 
-  const result = await db.createFile(
+  const result = await createFileWithStorageLimit(
+    req,
     {
       user: req.user.id,
       file_id,
@@ -529,6 +694,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     }`;
   }
   const fileName = `${file_id}-${filename}`;
+  await assertUploadStorageLimit(req, bytes, { excludeFileId: file_id });
   const filepath = await saveBuffer({
     userId: req.user.id,
     fileName,
@@ -536,7 +702,8 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     tenantId: req.user.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
-  return await db.createFile(
+  return await createFileWithStorageLimit(
+    req,
     {
       user: req.user.id,
       file_id,
@@ -577,6 +744,9 @@ const processFileUpload = async ({ req, res, metadata, sseStream }) => {
   const source = isAssistantUpload ? assistantSource : appConfig.fileStrategy;
   const { handleFileUpload } = getStrategyFunctions(source);
   const { file_id, temp_file_id = null } = metadata;
+  const { file } = req;
+
+  await assertUploadStorageLimit(req, file?.size, { excludeFileId: file_id });
 
   /** @type {OpenAI | undefined} */
   let openai;
@@ -584,7 +754,6 @@ const processFileUpload = async ({ req, res, metadata, sseStream }) => {
     ({ openai } = await getOpenAIClient({ req }));
   }
 
-  const { file } = req;
   const sanitizedUploadFn = createSanitizedUploadWrapper(handleFileUpload);
   const {
     id,
@@ -603,64 +772,97 @@ const processFileUpload = async ({ req, res, metadata, sseStream }) => {
     openai,
   });
 
+  const assistantFileId = id ?? file_id;
   if (isAssistantUpload && !metadata.message_file && !metadata.tool_resource) {
     await openai.beta.assistants.files.create(metadata.assistant_id, {
-      file_id: id,
+      file_id: assistantFileId,
     });
   } else if (isAssistantUpload && !metadata.message_file) {
     await addResourceFileId({
       req,
       openai,
-      file_id: id,
+      file_id: assistantFileId,
       assistant_id: metadata.assistant_id,
       tool_resource: metadata.tool_resource,
     });
   }
 
-  let filepath = isAssistantUpload ? `${openai.baseURL}/files/${id}` : _filepath;
+  const assistantStoredFile = isAssistantUpload
+    ? {
+        user: req.user.id,
+        file_id: assistantFileId,
+        bytes,
+        filepath: `${openai.baseURL}/files/${assistantFileId}`,
+        filename: filename ?? sanitizeFilename(file.originalname),
+        source,
+        tenantId: req.user.tenantId,
+      }
+    : null;
+  let filepath = isAssistantUpload ? `${openai.baseURL}/files/${assistantFileId}` : _filepath;
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
     storageKey: _storageKey,
     storageRegion: _storageRegion,
   });
+  let imageFile;
   if (isAssistantUpload && file.mimetype.startsWith('image')) {
-    const result = await processImageFile({
-      req,
-      file,
-      metadata: { file_id: v4() },
-      returnFile: true,
-    });
-    filepath = result.filepath;
+    try {
+      imageFile = await processImageFile({
+        req,
+        file,
+        metadata: { file_id: v4() },
+        returnFile: true,
+      });
+    } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupAssistantStoredFile({ req, metadata, openai, file: assistantStoredFile });
+      }
+      throw error;
+    }
+    filepath = imageFile.filepath;
     storageMetadata = getStorageMetadata({
       filepath,
-      source: result.source,
-      storageKey: result.storageKey,
-      storageRegion: result.storageRegion,
+      source: imageFile.source,
+      storageKey: imageFile.storageKey,
+      storageRegion: imageFile.storageRegion,
     });
   }
 
-  const result = await db.createFile(
-    {
-      user: req.user.id,
-      file_id: id ?? file_id,
-      temp_file_id,
-      bytes,
-      filepath,
-      ...storageMetadata,
-      filename: filename ?? sanitizeFilename(file.originalname),
-      context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
-      model: isAssistantUpload ? req.body.model : undefined,
-      type: file.mimetype,
-      ...(await getRetentionExpiry(req)),
-      embedded,
-      source,
-      height,
-      width,
-      tenantId: req.user.tenantId,
-    },
-    true,
-  );
+  const fileInfo = {
+    user: req.user.id,
+    file_id: assistantFileId,
+    temp_file_id,
+    bytes,
+    filepath,
+    ...storageMetadata,
+    filename: filename ?? sanitizeFilename(file.originalname),
+    context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
+    model: isAssistantUpload ? req.body.model : undefined,
+    type: file.mimetype,
+    ...(await getRetentionExpiry(req)),
+    embedded,
+    source,
+    height,
+    width,
+    tenantId: req.user.tenantId,
+  };
+
+  let result;
+  try {
+    result = await createFileWithStorageLimit(req, fileInfo, true, {
+      openai,
+      cleanup: !isAssistantUpload,
+    });
+  } catch (error) {
+    if (isFileStorageLimitError(error) && isAssistantUpload) {
+      if (imageFile) {
+        await cleanupPersistedFile({ req, file: imageFile });
+      }
+      await cleanupAssistantStoredFile({ req, metadata, openai, file: fileInfo });
+    }
+    throw error;
+  }
   sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
 
@@ -680,6 +882,10 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
   const { file } = req;
   const appConfig = req.config;
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
+
+  if (tool_resource !== EToolResources.context) {
+    await assertUploadStorageLimit(req, file?.size, { excludeFileId: file_id });
+  }
 
   let messageAttachment = !!metadata.message_file;
 
@@ -763,7 +969,6 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     /**
      * @param {object} params
      * @param {string} params.text
-     * @param {number} params.bytes
      * @param {string} params.filepath
      * @param {string} params.type
      * @param {boolean} params.isTranscript
@@ -771,7 +976,6 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
      */
     const createTextFile = async ({
       text,
-      bytes,
       filepath,
       type = 'text/plain',
       isTranscript = false,
@@ -821,7 +1025,9 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       const fileInfo = {
         ...removeNullishValues({
           text,
-          bytes,
+          /* `bytes` may be a provider estimate (Mistral OCR reports `text.length * 4`).
+           * Persist and charge the size actually written. */
+          bytes: textBytes,
           file_id,
           temp_file_id,
           user: req.user.id,
@@ -836,15 +1042,20 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
         ...retentionExpiry,
       };
 
+      const result = await createFileWithStorageLimit(req, fileInfo, true, { cleanup: false });
       if (!messageAttachment && tool_resource) {
-        await db.addAgentResourceFile({
-          file_id,
-          agent_id,
-          tool_resource,
-          updatingUserId: req?.user?.id,
-        });
+        try {
+          await db.addAgentResourceFile({
+            file_id,
+            agent_id,
+            tool_resource,
+            updatingUserId: req?.user?.id,
+          });
+        } catch (error) {
+          await cleanupFileMetadata({ fileId: file_id });
+          throw error;
+        }
       }
-      const result = await db.createFile(fileInfo, true);
       sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
     };
 
@@ -900,8 +1111,8 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
         extract: resolveDocumentText,
       });
       if (ocrResult) {
-        const { text, bytes, filepath: ocrFileURL } = ocrResult;
-        return await createTextFile({ text, bytes, filepath: ocrFileURL });
+        const { text, filepath: ocrFileURL } = ocrResult;
+        return await createTextFile({ text, filepath: ocrFileURL });
       }
       throw new Error(
         `Unable to extract text from "${file.originalname}". The document may be image-based and requires an OCR service to process.`,
@@ -915,8 +1126,8 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
 
     if (shouldUseSTT) {
       const sttService = await STTService.getInstance();
-      const { text, bytes } = await processAudioFile({ req, file, sttService });
-      return await createTextFile({ text, bytes, type: file.mimetype, isTranscript: true });
+      const { text } = await processAudioFile({ req, file, sttService });
+      return await createTextFile({ text, type: file.mimetype, isTranscript: true });
     }
 
     const shouldUseText = fileConfig.checkType(
@@ -954,21 +1165,17 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
             `Unable to extract text from "${file.originalname}". RAG text extraction was unavailable and the built-in parser produced no result.`,
           );
         }
-        const { text, bytes, filepath: docFileURL } = documentText;
-        return await createTextFile({ text, bytes, filepath: docFileURL });
+        const { text, filepath: docFileURL } = documentText;
+        return await createTextFile({ text, filepath: docFileURL });
       }
-      return await createTextFile({
-        text: configuredText.text,
-        bytes: configuredText.bytes,
-        type: file.mimetype,
-      });
+      return await createTextFile({ text: configuredText.text, type: file.mimetype });
     }
 
-    const { text, bytes } = await extractInspectableFileText({
+    const { text } = await extractInspectableFileText({
       filters: appConfig?.filters,
       extract: () => parseText({ req, file, file_id }),
     });
-    return await createTextFile({ text, bytes, type: file.mimetype });
+    return await createTextFile({ text, type: file.mimetype });
   }
 
   // Dual storage pattern for RAG files: Storage + Vector DB
@@ -987,6 +1194,25 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       basePath,
       entity_id,
     });
+
+    try {
+      await assertUploadStorageLimit(req, storageResult.bytes, { excludeFileId: file_id });
+    } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupStoredFile({
+          req,
+          file: {
+            file_id,
+            filepath: storageResult.filepath,
+            storageKey: storageResult.storageKey,
+            storageRegion: storageResult.storageRegion,
+            source,
+            tenantId: req.user.tenantId,
+          },
+        });
+      }
+      throw error;
+    }
 
     // SECOND: Upload to Vector DB
     const { uploadVectors } = require('./VectorDB/crud');
@@ -1030,6 +1256,17 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
   }
 
   let filepath = _filepath;
+  let fileSource = source;
+  let fileType = file.mimetype;
+  const originalStoredFile = {
+    file_id,
+    bytes,
+    filepath,
+    storageKey: _storageKey,
+    storageRegion: _storageRegion,
+    source,
+    tenantId: req.user.tenantId,
+  };
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
@@ -1037,28 +1274,32 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     storageRegion: _storageRegion,
   });
 
-  if (!messageAttachment && tool_resource) {
-    await db.addAgentResourceFile({
-      file_id,
-      agent_id,
-      tool_resource,
-      updatingUserId: req?.user?.id,
-    });
-  }
-
+  let imageFile;
   if (isImage) {
-    const result = await processImageFile({
-      req,
-      file,
-      metadata: { file_id: v4() },
-      returnFile: true,
-    });
-    filepath = result.filepath;
+    try {
+      imageFile = await processImageFile({
+        req,
+        file,
+        metadata: { file_id: v4() },
+        returnFile: true,
+      });
+    } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupStoredFile({ req, file: originalStoredFile });
+      }
+      throw error;
+    }
+    filepath = imageFile.filepath;
+    bytes = imageFile.bytes ?? bytes;
+    height = imageFile.height ?? height;
+    width = imageFile.width ?? width;
+    fileSource = imageFile.source ?? source;
+    fileType = imageFile.type ?? file.mimetype;
     storageMetadata = getStorageMetadata({
       filepath,
-      source: result.source,
-      storageKey: result.storageKey,
-      storageRegion: result.storageRegion,
+      source: fileSource,
+      storageKey: imageFile.storageKey,
+      storageRegion: imageFile.storageRegion,
     });
   }
 
@@ -1079,9 +1320,9 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       context: messageAttachment ? FileContext.message_attachment : FileContext.agents,
       model: messageAttachment ? undefined : req.body.model,
       metadata: fileInfoMetadata,
-      type: file.mimetype,
+      type: fileType,
       embedded,
-      source,
+      source: fileSource,
       height,
       width,
       tenantId: req.user.tenantId,
@@ -1089,7 +1330,49 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     ...retentionExpiry,
   };
 
-  const result = await db.createFile(fileInfo, true);
+  let result;
+  try {
+    result = await createFileWithStorageLimit(req, fileInfo, true);
+  } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      if (imageFile) {
+        await cleanupPersistedFile({ req, file: imageFile });
+        await cleanupStoredFile({ req, file: originalStoredFile });
+      }
+      if (tool_resource === EToolResources.file_search && embedded) {
+        await cleanupVectorFile({ req, file: fileInfo });
+      }
+      if (tool_resource === EToolResources.execute_code) {
+        await cleanupCodeEnvFile({ req, file: fileInfo });
+      }
+    }
+    throw error;
+  }
+  if (!messageAttachment && tool_resource) {
+    try {
+      await db.addAgentResourceFile({
+        file_id,
+        agent_id,
+        tool_resource,
+        updatingUserId: req?.user?.id,
+      });
+    } catch (error) {
+      if (imageFile) {
+        await cleanupFileMetadata({ fileId: fileInfo.file_id });
+        await cleanupPersistedFile({ req, file: imageFile });
+        await cleanupStoredFile({ req, file: originalStoredFile });
+      } else {
+        await cleanupPersistedFile({ req, file: fileInfo });
+      }
+      if (tool_resource === EToolResources.file_search && embedded) {
+        await cleanupVectorFile({ req, file: fileInfo });
+      }
+      if (tool_resource === EToolResources.execute_code) {
+        await cleanupCodeEnvFile({ req, file: fileInfo });
+      }
+      throw error;
+    }
+  }
 
   sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
 };
@@ -1097,6 +1380,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
 /**
  * @param {object} params - The params object.
  * @param {OpenAI} params.openai - The OpenAI client instance.
+ * @param {ServerRequest} params.req - The Express request object associated with the client.
  * @param {string} params.file_id - The ID of the file to retrieve.
  * @param {string} params.userId - The user ID.
  * @param {string} [params.filename] - The name of the file. `undefined` for `file_citation` annotations.
@@ -1105,12 +1389,14 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
  */
 const processOpenAIFile = async ({
   openai,
+  req,
   file_id,
   userId,
   filename,
   saveFile = false,
   updateUsage = false,
 }) => {
+  const request = req ?? openai.req;
   const _file = await openai.files.retrieve(file_id);
   const originalName = filename ?? (_file.filename ? path.basename(_file.filename) : undefined);
   const filepath = `${openai.baseURL}/files/${userId}/${file_id}${
@@ -1118,7 +1404,7 @@ const processOpenAIFile = async ({
   }`;
   const type = mime.getType(originalName ?? file_id);
   const source =
-    openai.req.body.endpoint === EModelEndpoint.azureAssistants
+    request.body.endpoint === EModelEndpoint.azureAssistants
       ? FileSources.azure
       : FileSources.openai;
   const file = {
@@ -1130,14 +1416,14 @@ const processOpenAIFile = async ({
     user: userId,
     context: _file.purpose,
     source,
-    model: openai.req.body.model,
+    model: request.body.model,
     filename: originalName ?? file_id,
-    ...(await getRetentionExpiry(openai.req)),
-    tenantId: openai.req?.user?.tenantId,
+    ...(await getRetentionExpiry(request)),
+    tenantId: request.user?.tenantId,
   };
 
   if (saveFile) {
-    await db.createFile(file, true);
+    await createFileWithStorageLimit(request, file, true, { cleanup: false });
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({
@@ -1177,7 +1463,7 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     type: mime.getType(fileExt),
     createdAt: formattedDate,
     updatedAt: formattedDate,
-    source: getFileStrategy(appConfig, { isImage: true }),
+    source: appConfig.fileStrategy,
     context: FileContext.assistants_output,
     file_id,
     filename,
@@ -1185,8 +1471,11 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     tenantId: req.user.tenantId,
   };
   try {
-    await db.createFile(file, true);
+    await createFileWithStorageLimit(req, file, true);
   } catch (error) {
+    if (isFileStorageLimitError(error)) {
+      throw error;
+    }
     logger.warn('Error saving OpenAI image output file metadata', error);
   }
   return file;
@@ -1216,7 +1505,13 @@ async function retrieveAndProcessFile({
   }
 
   let basename = _basename;
-  const processArgs = { openai, file_id, filename: basename, userId: client.req.user.id };
+  const processArgs = {
+    openai,
+    req: client.req,
+    file_id,
+    filename: basename,
+    userId: client.req.user.id,
+  };
 
   // If no basename provided, return only the file metadata
   if (!basename) {
@@ -1327,6 +1622,7 @@ async function saveBase64Image(
   const image = await resizeImageBuffer(inputBuffer, effectiveResolution, endpoint);
   const source = getFileStrategy(appConfig, { isImage: true });
   const { saveBuffer } = getStrategyFunctions(source);
+  await assertUploadStorageLimit(req, image.bytes, { excludeFileId: file_id });
   const filepath = await saveBuffer({
     userId: req.user.id,
     fileName: filename,
@@ -1334,7 +1630,8 @@ async function saveBase64Image(
     tenantId: req.user.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
-  return await db.createFile(
+  return await createFileWithStorageLimit(
+    req,
     {
       type,
       source,

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -33,6 +33,7 @@ jest.mock('@librechat/api', () => {
     getStorageMetadata: jest.fn(() => ({})),
     isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
     assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
+    recordFileStorageUsage: jest.fn(),
     getRetentionExpiry: jest.fn(() => ({})),
     sweepExpiredFiles: jest.fn().mockResolvedValue({ scanned: 0, deleted: 0, failed: 0 }),
     startExpiredFileSweep: jest.fn().mockReturnValue('sweep-interval'),
@@ -87,6 +88,10 @@ jest.mock('~/server/services/Files/strategies', () => ({
   getStrategyFunctions: jest.fn(),
 }));
 
+jest.mock('./VectorDB/crud', () => ({
+  uploadVectors: jest.fn(),
+}));
+
 jest.mock('~/server/utils', () => ({
   determineFileType: jest.fn(),
 }));
@@ -114,6 +119,8 @@ const { checkCapability } = require('~/server/services/Config');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 const { addResourceFileId, deleteResourceFileId } = require('~/server/controllers/assistants/v2');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { uploadVectors } = require('./VectorDB/crud');
+const { convertImage, resizeImageBuffer } = require('~/server/services/Files/images');
 const db = require('~/models');
 const {
   processAgentFileUpload,
@@ -121,8 +128,11 @@ const {
   processFileURL,
   processImageFile,
   processFileUpload,
+  retrieveAndProcessFile,
+  saveBase64Image,
   sweepExpiredFiles,
   startExpiredFileSweep,
+  uploadImageBuffer,
 } = require('./process');
 
 const PDF_MIME = 'application/pdf';
@@ -462,6 +472,112 @@ describe('processAgentFileUpload', () => {
       await expect(
         processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe('storage-limit cleanup after secondary processing', () => {
+    it('cleans up agent image side effects when final metadata quota check fails', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 700,
+        filename: 'image.png',
+        filepath: '/uploads/user-123/original.png',
+      });
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/resized.png',
+        bytes: 100,
+        width: 32,
+        height: 32,
+      });
+      const deleteFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({ handleFileUpload, handleImageUpload, deleteFile });
+      db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+      db.deleteFiles.mockResolvedValue({ deletedCount: 1 });
+      assertFileStorageLimit
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(error);
+      const req = makeReq({ mimetype: 'image/png' });
+      req.config.imageOutputType = 'png';
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: { file_id: 'agent-file-id', message_file: true },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(db.deleteFiles).toHaveBeenCalledWith(['mock-uuid']);
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/user-123/original.png' }),
+        undefined,
+      );
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/images/user-123/resized.png' }),
+        undefined,
+      );
+    });
+
+    it('cleans up vector embeddings when file_search metadata quota check fails', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 700,
+        filename: 'doc.pdf',
+        filepath: '/uploads/user-123/doc.pdf',
+      });
+      const deleteStoredFile = jest.fn().mockResolvedValue(undefined);
+      const deleteVectorFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockImplementation((source) =>
+        source === FileSources.vectordb
+          ? { deleteFile: deleteVectorFile }
+          : { handleFileUpload, deleteFile: deleteStoredFile },
+      );
+      uploadVectors.mockResolvedValue({
+        bytes: 700,
+        filename: 'doc.pdf',
+        filepath: FileSources.vectordb,
+        embedded: true,
+      });
+      assertFileStorageLimit
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(error);
+
+      await expect(
+        processAgentFileUpload({
+          req: makeReq(),
+          res: mockRes,
+          metadata: {
+            agent_id: 'agent-abc',
+            tool_resource: EToolResources.file_search,
+            file_id: 'agent-file-id',
+          },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(deleteStoredFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/user-123/doc.pdf' }),
+        undefined,
+      );
+      expect(deleteVectorFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          file_id: 'agent-file-id',
+          source: FileSources.vectordb,
+          embedded: true,
+        }),
+      );
+      expect(db.createFile).not.toHaveBeenCalled();
     });
   });
 
@@ -1080,6 +1196,209 @@ describe('processFileURL', () => {
       }),
       true,
     );
+  });
+
+  it('cleans up and rejects request-scoped URL saves without byte metadata', async () => {
+    const saveURL = jest.fn().mockResolvedValue('/images/user-123/image.png');
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockReturnValue({ saveURL, deleteFile });
+
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.local,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: 'tenant-a',
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 } },
+        },
+      }),
+    ).rejects.toThrow('did not return byte metadata');
+
+    expect(deleteFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filepath: '/images/user-123/image.png',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('generated image quota paths', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockResolvedValue({ file_id: 'created-file-id' });
+  });
+
+  it('uploadImageBuffer rejects over-limit images before saving the buffer', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const saveBuffer = jest.fn();
+    getStrategyFunctions.mockReturnValue({ saveBuffer });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      uploadImageBuffer({
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          file: { originalname: 'input.png' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 }, imageOutputType: 'webp' },
+        },
+        context: FileContext.image_generation,
+        resize: false,
+        metadata: {
+          buffer: Buffer.from('image'),
+          bytes: 512,
+          width: 10,
+          height: 10,
+          filename: 'image.webp',
+          file_id: 'image-file-id',
+          type: 'image/webp',
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(saveBuffer).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('saveBase64Image rejects over-limit resized images before saving the buffer', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const saveBuffer = jest.fn();
+    getStrategyFunctions.mockReturnValue({ saveBuffer });
+    resizeImageBuffer.mockResolvedValue({
+      buffer: Buffer.from('resized'),
+      bytes: 512,
+      width: 10,
+      height: 10,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      saveBase64Image('data:image/png;base64,aW1hZ2U=', {
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: {
+            fileConfig: { storageLimit: 1, imageGeneration: 'low' },
+            imageOutputType: 'webp',
+          },
+        },
+        filename: 'image.png',
+        endpoint: EModelEndpoint.openAI,
+        context: FileContext.image_generation,
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(saveBuffer).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('retrieveAndProcessFile applies quota to OpenAI file metadata with explicit req', async () => {
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: { fileConfig: { storageLimit: 1 } },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 512,
+          filename: 'remote.txt',
+          purpose: 'assistants_output',
+        }),
+      },
+    };
+
+    await retrieveAndProcessFile({
+      openai,
+      client: { req },
+      file_id: 'openai-file-id',
+    });
+
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req,
+        incomingBytes: 512,
+        excludeFileId: 'openai-file-id',
+      }),
+    );
+    expect(db.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_id: 'openai-file-id',
+        tenantId: 'tenant-a',
+        source: FileSources.openai,
+      }),
+      true,
+    );
+  });
+
+  it('retrieveAndProcessFile rejects over-limit OpenAI image outputs before metadata persistence', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: {
+        fileConfig: { storageLimit: 1 },
+        fileStrategy: FileSources.local,
+        imageOutputType: 'webp',
+      },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 1024,
+          filename: 'image.png',
+          purpose: 'assistants_output',
+        }),
+        content: jest.fn().mockResolvedValue({
+          arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('raw-image')),
+        }),
+      },
+    };
+    convertImage.mockResolvedValue({
+      filepath: '/images/user-123/openai-file-id.webp',
+      bytes: 512,
+      width: 10,
+      height: 10,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      retrieveAndProcessFile({
+        openai,
+        client: {
+          req,
+          attachedFileIds: new Set(),
+          processedFileIds: new Set(),
+        },
+        file_id: 'openai-file-id',
+        basename: 'image.png',
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(convertImage).toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
   });
 });
 

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -31,6 +31,8 @@ jest.mock('@librechat/api', () => {
     parseText: jest.fn().mockResolvedValue({ text: '', bytes: 0 }),
     processAudioFile: jest.fn(),
     getStorageMetadata: jest.fn(() => ({})),
+    isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
+    assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
     getRetentionExpiry: jest.fn(() => ({})),
     sweepExpiredFiles: jest.fn().mockResolvedValue({ scanned: 0, deleted: 0, failed: 0 }),
     startExpiredFileSweep: jest.fn().mockReturnValue('sweep-interval'),
@@ -58,6 +60,7 @@ jest.mock('~/server/services/Tools/credentials', () => ({
 
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({ file_id: 'created-file-id' }),
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
   updateFileUsage: jest.fn(),
   deleteFiles: jest.fn(),
   findFileById: jest.fn(),
@@ -93,6 +96,7 @@ jest.mock('~/server/services/Files/Audio/STTService', () => ({
 }));
 
 const {
+  assertFileStorageLimit,
   getRetentionExpiry,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
@@ -162,6 +166,7 @@ const makeFileConfig = ({ ocrSupportedMimeTypes = [] } = {}) => ({
 describe('processAgentFileUpload', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
     mockRes.status.mockReturnThis();
     mockRes.json.mockReturnValue({});
     checkCapability.mockResolvedValue(true);
@@ -171,6 +176,40 @@ describe('processAgentFileUpload', () => {
         .mockResolvedValue({ text: 'extracted text', bytes: 42, filepath: 'doc://result' }),
     });
     mergeFileConfig.mockReturnValue(makeFileConfig());
+  });
+
+  test('rejects over-limit uploads before storage processing starts', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.file.size = 1024;
+
+    await expect(
+      processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(getStrategyFunctions).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  test('does not attach an agent resource when the final storage check rejects', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.file.size = 16;
+
+    await expect(
+      processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(db.createFile).not.toHaveBeenCalled();
+    expect(db.addAgentResourceFile).not.toHaveBeenCalled();
   });
 
   describe('OCR strategy selection', () => {
@@ -567,6 +606,49 @@ describe('processFileURL', () => {
       }),
       true,
     );
+  });
+
+  it('cleans up URL-saved files when the final storage limit check fails', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const saveURL = jest.fn().mockResolvedValue({
+      filepath: 'https://cdn.example.com/t/tenant-a/images/user-123/image.png',
+      bytes: 512,
+      type: 'image/png',
+    });
+    const getFileURL = jest.fn();
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockReturnValue({ saveURL, getFileURL, deleteFile });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.cloudfront,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: 'tenant-a',
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 } },
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filepath: 'https://cdn.example.com/t/tenant-a/images/user-123/image.png',
+        source: FileSources.cloudfront,
+      }),
+      undefined,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
   });
 
   it('applies retention metadata for generated images when retention mode is all', async () => {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -476,6 +476,49 @@ describe('processAgentFileUpload', () => {
   });
 
   describe('storage-limit cleanup after secondary processing', () => {
+    it('cleans up original agent image storage when image persistence quota fails', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 700,
+        filename: 'image.png',
+        filepath: '/uploads/user-123/original.png',
+      });
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/resized.png',
+        bytes: 100,
+        width: 32,
+        height: 32,
+      });
+      const deleteFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({ handleFileUpload, handleImageUpload, deleteFile });
+      assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+      const req = makeReq({ mimetype: 'image/png' });
+      req.config.imageOutputType = 'png';
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: { file_id: 'agent-file-id', message_file: true },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/images/user-123/resized.png' }),
+        undefined,
+      );
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/user-123/original.png' }),
+        undefined,
+      );
+      expect(db.createFile).not.toHaveBeenCalled();
+    });
+
     it('cleans up agent image side effects when final metadata quota check fails', async () => {
       const error = Object.assign(new Error('storage limit exceeded.'), {
         code: 'FILE_STORAGE_LIMIT_EXCEEDED',

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -1392,6 +1392,42 @@ describe('generated image quota paths', () => {
     );
   });
 
+  it('retrieveAndProcessFile does not delete existing OpenAI files when metadata quota rejects', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: { fileConfig: { storageLimit: 1 } },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 512,
+          filename: 'remote.txt',
+          purpose: 'assistants_output',
+        }),
+      },
+    };
+    const deleteFile = jest.fn();
+    getStrategyFunctions.mockReturnValue({ deleteFile });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      retrieveAndProcessFile({
+        openai,
+        client: { req },
+        file_id: 'openai-file-id',
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteFile).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
   it('retrieveAndProcessFile rejects over-limit OpenAI image outputs before metadata persistence', async () => {
     const error = Object.assign(new Error('storage limit exceeded.'), {
       code: 'FILE_STORAGE_LIMIT_EXCEEDED',

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -119,6 +119,7 @@ const { checkCapability } = require('~/server/services/Config');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 const { addResourceFileId, deleteResourceFileId } = require('~/server/controllers/assistants/v2');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { getFileStrategy } = require('~/server/utils/getFileStrategy');
 const { uploadVectors } = require('./VectorDB/crud');
 const { convertImage, resizeImageBuffer } = require('~/server/services/Files/images');
 const db = require('~/models');
@@ -567,6 +568,50 @@ describe('processAgentFileUpload', () => {
       );
     });
 
+    it('uses converted image metadata for the final agent image record', async () => {
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 100,
+        filename: 'image.jpg',
+        filepath: '/uploads/user-123/original.jpg',
+      });
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/resized.png',
+        bytes: 700,
+        width: 32,
+        height: 64,
+      });
+      getStrategyFunctions.mockReturnValue({ handleFileUpload, handleImageUpload });
+      db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+      const req = makeReq({ mimetype: 'image/jpeg' });
+      req.config.imageOutputType = 'png';
+
+      await processAgentFileUpload({
+        req,
+        res: mockRes,
+        metadata: { file_id: 'agent-file-id', message_file: true },
+      });
+
+      const [finalFile] = db.createFile.mock.calls.find(
+        ([fileInfo]) => fileInfo.file_id === 'agent-file-id',
+      );
+      expect(finalFile).toEqual(
+        expect.objectContaining({
+          bytes: 700,
+          filepath: '/images/user-123/resized.png',
+          source: FileSources.local,
+          type: 'image/png',
+          width: 32,
+          height: 64,
+        }),
+      );
+      expect(assertFileStorageLimit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          incomingBytes: 700,
+          excludeFileId: 'agent-file-id',
+        }),
+      );
+    });
+
     it('cleans up vector embeddings when file_search metadata quota check fails', async () => {
       const error = Object.assign(new Error('storage limit exceeded.'), {
         code: 'FILE_STORAGE_LIMIT_EXCEEDED',
@@ -790,6 +835,48 @@ describe('processAgentFileUpload', () => {
         }),
       );
       expect(db.createFile).not.toHaveBeenCalled();
+    });
+
+    it('rolls back persisted execute_code uploads when agent resource linking fails', async () => {
+      const { codeEnvDelete, localDelete } = setupCodeEnvUpload({
+        storage_session_id: 'sess-link',
+        file_id: 'fid-link',
+      });
+      db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+      db.addAgentResourceFile.mockRejectedValueOnce(new Error('link failed'));
+      const req = makeReq();
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: {
+            agent_id: 'agent-abc',
+            tool_resource: EToolResources.execute_code,
+            file_id: 'file-uuid',
+          },
+        }),
+      ).rejects.toThrow('link failed');
+
+      expect(db.deleteFiles).toHaveBeenCalledWith(['file-uuid']);
+      expect(localDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/upload.bin' }),
+        undefined,
+      );
+      expect(codeEnvDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: {
+            codeEnvRef: {
+              kind: 'agent',
+              id: 'agent-abc',
+              storage_session_id: 'sess-link',
+              file_id: 'fid-link',
+            },
+          },
+        }),
+      );
     });
   });
 });
@@ -1567,6 +1654,74 @@ describe('generated image quota paths', () => {
     ).rejects.toThrow('storage limit exceeded');
 
     expect(convertImage).toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('cleans over-limit OpenAI image outputs with the file strategy used by conversion', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: {
+        fileConfig: { storageLimit: 1 },
+        fileStrategy: FileSources.local,
+        imageOutputType: 'webp',
+      },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 1024,
+          filename: 'image.png',
+          purpose: 'assistants_output',
+        }),
+        content: jest.fn().mockResolvedValue({
+          arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('raw-image')),
+        }),
+      },
+    };
+    const deleteLocalFile = jest.fn().mockResolvedValue(undefined);
+    const deleteImageStrategyFile = jest.fn().mockResolvedValue(undefined);
+    getFileStrategy.mockReturnValueOnce('image-strategy');
+    getStrategyFunctions.mockImplementation((source) =>
+      source === FileSources.local
+        ? { deleteFile: deleteLocalFile }
+        : { deleteFile: deleteImageStrategyFile },
+    );
+    convertImage.mockResolvedValue({
+      filepath: '/images/user-123/openai-file-id.webp',
+      bytes: 512,
+      width: 10,
+      height: 10,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      retrieveAndProcessFile({
+        openai,
+        client: {
+          req,
+          attachedFileIds: new Set(),
+          processedFileIds: new Set(),
+        },
+        file_id: 'openai-file-id',
+        basename: 'image.png',
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteLocalFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filepath: '/images/user-123/openai-file-id.webp',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(deleteImageStrategyFile).not.toHaveBeenCalled();
     expect(db.createFile).not.toHaveBeenCalled();
   });
 });

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -119,6 +119,7 @@ const {
   processAgentFileUpload,
   processDeleteRequest,
   processFileURL,
+  processImageFile,
   processFileUpload,
   sweepExpiredFiles,
   startExpiredFileSweep,
@@ -192,7 +193,11 @@ describe('processAgentFileUpload', () => {
     req.file.size = 1024;
 
     await expect(
-      processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
+      processAgentFileUpload({
+        req,
+        res: mockRes,
+        metadata: { ...makeMetadata(), tool_resource: EToolResources.file_search },
+      }),
     ).rejects.toThrow('storage limit exceeded');
 
     expect(getStrategyFunctions).not.toHaveBeenCalled();
@@ -204,7 +209,7 @@ describe('processAgentFileUpload', () => {
       code: 'FILE_STORAGE_LIMIT_EXCEEDED',
       status: 413,
     });
-    assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+    assertFileStorageLimit.mockRejectedValueOnce(error);
     const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
     req.file.size = 16;
 
@@ -214,6 +219,41 @@ describe('processAgentFileUpload', () => {
 
     expect(db.createFile).not.toHaveBeenCalled();
     expect(db.addAgentResourceFile).not.toHaveBeenCalled();
+  });
+
+  test('checks context upload quota against extracted text bytes, not raw upload bytes', async () => {
+    const rawUploadBytes = 10 * 1024 * 1024;
+    const extractedBytes = 42;
+    const rawBytesError = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockImplementation(({ incomingBytes }) => {
+      if (incomingBytes === rawUploadBytes) {
+        return Promise.reject(rawBytesError);
+      }
+      return Promise.resolve();
+    });
+    getStrategyFunctions.mockReturnValue({
+      handleFileUpload: jest.fn().mockResolvedValue({
+        text: 'small extracted text',
+        bytes: extractedBytes,
+        filepath: 'doc://result',
+      }),
+    });
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.file.size = rawUploadBytes;
+
+    await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+    expect(assertFileStorageLimit).toHaveBeenCalledTimes(1);
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ incomingBytes: extractedBytes }),
+    );
+    expect(db.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({ bytes: extractedBytes, source: FileSources.text }),
+      true,
+    );
   });
 
   describe('OCR strategy selection', () => {
@@ -548,6 +588,56 @@ describe('processAgentFileUpload', () => {
   });
 });
 
+describe('processImageFile storage-limit checks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+    mockRes.status.mockReturnThis();
+    mockRes.json.mockReturnValue({});
+  });
+
+  it('checks quota against persisted image bytes, not raw upload bytes', async () => {
+    const rawUploadBytes = 10 * 1024 * 1024;
+    const persistedBytes = 256;
+    const rawBytesError = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockImplementation(({ incomingBytes }) => {
+      if (incomingBytes === rawUploadBytes) {
+        return Promise.reject(rawBytesError);
+      }
+      return Promise.resolve();
+    });
+    const handleImageUpload = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/image.png',
+      bytes: persistedBytes,
+      width: 32,
+      height: 32,
+    });
+    getStrategyFunctions.mockReturnValue({ handleImageUpload });
+    const req = makeReq({ mimetype: 'image/png' });
+    req.file.size = rawUploadBytes;
+    req.config.imageOutputType = 'png';
+
+    await processImageFile({
+      req,
+      res: mockRes,
+      metadata: { file_id: 'image-file-id', endpoint: 'agents' },
+    });
+
+    expect(handleImageUpload).toHaveBeenCalled();
+    expect(assertFileStorageLimit).toHaveBeenCalledTimes(1);
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        incomingBytes: persistedBytes,
+        excludeFileId: 'image-file-id',
+      }),
+    );
+  });
+});
+
 describe('processFileUpload assistant storage-limit cleanup', () => {
   const makeAssistantImageReq = () => ({
     user: { id: 'user-123', tenantId: 'tenant-a' },
@@ -627,10 +717,7 @@ describe('processFileUpload assistant storage-limit cleanup', () => {
     const openai = makeOpenAI();
     const { deleteOpenAIFile } = setupAssistantStrategies();
     getOpenAIClient.mockResolvedValue({ openai });
-    assertFileStorageLimit
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(error);
+    assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
 
     await expect(
       processFileUpload({
@@ -680,7 +767,6 @@ describe('processFileUpload assistant storage-limit cleanup', () => {
     assertFileStorageLimit
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(error);
 
     await expect(
@@ -718,6 +804,8 @@ describe('processFileUpload assistant storage-limit cleanup', () => {
 describe('processFileURL', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockResolvedValue({ file_id: 'created-file-id' });
   });
 
   it('throws and skips DB persistence when saveURL returns null', async () => {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -657,17 +657,19 @@ describe('processAgentFileUpload', () => {
        * runs in the same flow. Both must return a working
        * `handleFileUpload`. */
       const codeEnvUpload = jest.fn().mockResolvedValue(uploaded);
+      const codeEnvDelete = jest.fn().mockResolvedValue(undefined);
       const localUpload = jest.fn().mockResolvedValue({
         bytes: 0,
         filename: 'upload.bin',
         filepath: '/uploads/upload.bin',
       });
+      const localDelete = jest.fn().mockResolvedValue(undefined);
       getStrategyFunctions.mockImplementation((src) =>
         src === FileSources.execute_code
-          ? { handleFileUpload: codeEnvUpload }
-          : { handleFileUpload: localUpload, saveBuffer: jest.fn() },
+          ? { handleFileUpload: codeEnvUpload, deleteFile: codeEnvDelete }
+          : { handleFileUpload: localUpload, deleteFile: localDelete, saveBuffer: jest.fn() },
       );
-      return codeEnvUpload;
+      return { codeEnvUpload, codeEnvDelete, localDelete };
     };
 
     it('persists kind:user codeEnvRef for chat attachments (messageAttachment=true)', async () => {
@@ -743,6 +745,51 @@ describe('processAgentFileUpload', () => {
 
       const persisted = db.createFile.mock.calls[0][0];
       expect(persisted.metadata).not.toHaveProperty('fileIdentifier');
+    });
+
+    it('rolls back code env uploads when final storage quota rejects', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const { codeEnvDelete, localDelete } = setupCodeEnvUpload({
+        storage_session_id: 'sess-4',
+        file_id: 'fid-4',
+      });
+      assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+      const req = makeReq();
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: {
+            agent_id: 'agent-abc',
+            tool_resource: EToolResources.execute_code,
+            file_id: 'file-uuid',
+          },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(localDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/upload.bin' }),
+        undefined,
+      );
+      expect(codeEnvDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: {
+            codeEnvRef: {
+              kind: 'agent',
+              id: 'agent-abc',
+              storage_session_id: 'sess-4',
+              file_id: 'fid-4',
+            },
+          },
+        }),
+      );
+      expect(db.createFile).not.toHaveBeenCalled();
     });
   });
 });
@@ -1063,6 +1110,49 @@ describe('processFileURL', () => {
       expect.objectContaining({
         filepath: 'https://cdn.example.com/t/tenant-a/images/user-123/image.png',
         source: FileSources.cloudfront,
+      }),
+      undefined,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('passes request path config to local URL cleanup on storage limit failure', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const paths = { publicPath: '/srv/public', uploads: '/srv/uploads' };
+    const saveURL = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/image.png',
+      bytes: 512,
+      type: 'image/png',
+    });
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockReturnValue({ saveURL, deleteFile });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.local,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: 'tenant-a',
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 }, paths },
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteFile).toHaveBeenCalledWith(
+      expect.objectContaining({ config: expect.objectContaining({ paths }) }),
+      expect.objectContaining({
+        filepath: '/images/user-123/image.png',
+        source: FileSources.local,
       }),
       undefined,
     );

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -105,17 +105,21 @@ const {
   EToolResources,
   FileSources,
   FileContext,
+  EModelEndpoint,
   RetentionMode,
   AgentCapabilities,
 } = require('librechat-data-provider');
 const { mergeFileConfig } = require('librechat-data-provider');
 const { checkCapability } = require('~/server/services/Config');
+const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
+const { addResourceFileId, deleteResourceFileId } = require('~/server/controllers/assistants/v2');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const db = require('~/models');
 const {
   processAgentFileUpload,
   processDeleteRequest,
   processFileURL,
+  processFileUpload,
   sweepExpiredFiles,
   startExpiredFileSweep,
 } = require('./process');
@@ -541,6 +545,173 @@ describe('processAgentFileUpload', () => {
       const persisted = db.createFile.mock.calls[0][0];
       expect(persisted.metadata).not.toHaveProperty('fileIdentifier');
     });
+  });
+});
+
+describe('processFileUpload assistant storage-limit cleanup', () => {
+  const makeAssistantImageReq = () => ({
+    user: { id: 'user-123', tenantId: 'tenant-a' },
+    file: {
+      path: '/tmp/image.png',
+      originalname: 'image.png',
+      filename: 'image.png',
+      mimetype: 'image/png',
+      size: 128,
+    },
+    body: { model: 'gpt-4o' },
+    config: {
+      fileConfig: { storageLimit: 1 },
+      fileStrategy: FileSources.local,
+      imageOutputType: 'png',
+    },
+  });
+
+  const makeOpenAI = () => ({
+    baseURL: 'https://api.openai.test/v1',
+    files: {
+      del: jest.fn().mockResolvedValue({ deleted: true }),
+    },
+    beta: {
+      assistants: {
+        files: {
+          create: jest.fn().mockResolvedValue({}),
+          del: jest.fn().mockResolvedValue({ deleted: true }),
+        },
+      },
+    },
+  });
+
+  const setupAssistantStrategies = () => {
+    const deleteOpenAIFile = jest.fn((req, file, openai) => openai.files.del(file.file_id));
+    const deleteLocalFile = jest.fn().mockResolvedValue(undefined);
+    const uploadAssistantFile = jest.fn().mockResolvedValue({
+      id: 'file-openai',
+      bytes: 200,
+      filename: 'image.png',
+    });
+    const uploadLocalImage = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/local-image.png',
+      bytes: 300,
+      width: 32,
+      height: 32,
+    });
+
+    getStrategyFunctions.mockImplementation((source) =>
+      source === FileSources.openai
+        ? { handleFileUpload: uploadAssistantFile, deleteFile: deleteOpenAIFile }
+        : { handleImageUpload: uploadLocalImage, deleteFile: deleteLocalFile },
+    );
+
+    return {
+      deleteOpenAIFile,
+      deleteLocalFile,
+      uploadAssistantFile,
+      uploadLocalImage,
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockResolvedValue({ file_id: 'created-file-id' });
+    db.deleteFiles.mockResolvedValue(undefined);
+    mockRes.status.mockReturnThis();
+    mockRes.json.mockReturnValue({});
+  });
+
+  it('removes an assistant tool-resource file when image persistence fails quota after upload', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const openai = makeOpenAI();
+    const { deleteOpenAIFile } = setupAssistantStrategies();
+    getOpenAIClient.mockResolvedValue({ openai });
+    assertFileStorageLimit
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      processFileUpload({
+        req: makeAssistantImageReq(),
+        res: mockRes,
+        metadata: {
+          endpoint: EModelEndpoint.assistants,
+          assistant_id: 'asst-1',
+          tool_resource: EToolResources.file_search,
+          file_id: 'metadata-file-id',
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(addResourceFileId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_id: 'file-openai',
+        assistant_id: 'asst-1',
+        tool_resource: EToolResources.file_search,
+      }),
+    );
+    expect(deleteResourceFileId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_id: 'file-openai',
+        assistant_id: 'asst-1',
+        tool_resource: EToolResources.file_search,
+      }),
+    );
+    expect(deleteOpenAIFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ file_id: 'file-openai', source: FileSources.openai }),
+      openai,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the local assistant image record when assistant metadata persistence fails quota', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const openai = makeOpenAI();
+    const { deleteOpenAIFile, deleteLocalFile } = setupAssistantStrategies();
+    getOpenAIClient.mockResolvedValue({ openai });
+    db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+    db.deleteFiles.mockResolvedValue({ deletedCount: 1 });
+    assertFileStorageLimit
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      processFileUpload({
+        req: makeAssistantImageReq(),
+        res: mockRes,
+        metadata: {
+          endpoint: EModelEndpoint.assistants,
+          assistant_id: 'asst-1',
+          file_id: 'metadata-file-id',
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(openai.beta.assistants.files.del).toHaveBeenCalledWith('asst-1', 'file-openai');
+    expect(deleteOpenAIFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ file_id: 'file-openai', source: FileSources.openai }),
+      openai,
+    );
+    expect(deleteLocalFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        file_id: 'mock-uuid',
+        filepath: '/images/user-123/local-image.png',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(db.deleteFiles).toHaveBeenCalledWith(['mock-uuid']);
+    expect(db.createFile).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -128,6 +128,10 @@ jest.mock('@librechat/api', () => {
       res.status(200).json({ message, ...result });
     }),
     getStorageMetadata: jest.fn(() => ({})),
+    isFileStorageLimitError: jest.fn((error) => error?.code === 'FILE_STORAGE_LIMIT_EXCEEDED'),
+    assertFileStorageLimit: jest.fn().mockResolvedValue(undefined),
+    recordFileStorageUsage: jest.fn(),
+    resolveRequestTenantId: jest.fn((req) => req?.tenantId ?? req?.user?.tenantId),
     getRetentionExpiry,
     getAgentFileRetentionExpiry: jest.fn(({ req, messageAttachment, toolResource }) => {
       const interfaceConfig = req?.config?.interfaceConfig;
@@ -167,6 +171,7 @@ jest.mock('~/server/services/Tools/credentials', () => ({
 
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({ file_id: 'created-file-id' }),
+  getUserStorageUsage: jest.fn().mockResolvedValue(0),
   updateFileUsage: jest.fn(),
   deleteFiles: jest.fn(),
   findFileById: jest.fn(),
@@ -212,6 +217,7 @@ jest.mock('~/server/services/Files/Audio/STTService', () => ({
 }));
 
 const {
+  assertFileStorageLimit,
   getRetentionExpiry,
   getAgentFileRetentionExpiry,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
@@ -221,21 +227,31 @@ const {
   EToolResources,
   FileSources,
   FileContext,
+  EModelEndpoint,
   RetentionMode,
   AgentCapabilities,
 } = require('librechat-data-provider');
 const { mergeFileConfig } = require('librechat-data-provider');
 const { checkCapability } = require('~/server/services/Config');
+const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
+const { addResourceFileId, deleteResourceFileId } = require('~/server/controllers/assistants/v2');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { getFileStrategy } = require('~/server/utils/getFileStrategy');
 const { uploadVectors } = require('./VectorDB/crud');
 const { logger } = require('@librechat/data-schemas');
+const { convertImage, resizeImageBuffer } = require('~/server/services/Files/images');
 const db = require('~/models');
 const {
   processAgentFileUpload,
   processDeleteRequest,
   processFileURL,
+  processImageFile,
+  processFileUpload,
+  retrieveAndProcessFile,
+  saveBase64Image,
   sweepExpiredFiles,
   startExpiredFileSweep,
+  uploadImageBuffer,
 } = require('./process');
 const {
   inspectContent,
@@ -328,6 +344,7 @@ const setupStoredFileUpload = (result = {}) => {
 describe('processAgentFileUpload', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
     mockRes.status.mockReturnThis();
     mockRes.json.mockReturnValue({});
     checkCapability.mockResolvedValue(true);
@@ -492,6 +509,108 @@ describe('processAgentFileUpload', () => {
       expect(db.addAgentResourceFile).toHaveBeenCalledTimes(1);
       expect(db.createFile).toHaveBeenCalledTimes(1);
     });
+  });
+
+  test('rejects over-limit uploads before storage processing starts', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.file.size = 1024;
+
+    await expect(
+      processAgentFileUpload({
+        req,
+        res: mockRes,
+        metadata: { ...makeMetadata(), tool_resource: EToolResources.file_search },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(getStrategyFunctions).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  test('does not attach an agent resource when the final storage check rejects', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.file.size = 16;
+
+    await expect(
+      processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(db.createFile).not.toHaveBeenCalled();
+    expect(db.addAgentResourceFile).not.toHaveBeenCalled();
+  });
+
+  test('checks context upload quota against extracted text bytes, not raw upload bytes', async () => {
+    const rawUploadBytes = 10 * 1024 * 1024;
+    const extractedText = 'small extracted text';
+    /* Mistral OCR reports a conservative `text.length * 4` estimate; the row must be
+     * charged and persisted at the size actually written. */
+    const extractedBytes = Buffer.byteLength(extractedText, 'utf8');
+    const rawBytesError = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockImplementation(({ incomingBytes }) => {
+      if (incomingBytes === rawUploadBytes) {
+        return Promise.reject(rawBytesError);
+      }
+      return Promise.resolve();
+    });
+    getStrategyFunctions.mockReturnValue({
+      handleFileUpload: jest.fn().mockResolvedValue({
+        text: extractedText,
+        bytes: extractedText.length * 4,
+        filepath: 'doc://result',
+      }),
+    });
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.file.size = rawUploadBytes;
+
+    await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+    expect(assertFileStorageLimit).toHaveBeenCalledTimes(1);
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ incomingBytes: extractedBytes }),
+    );
+    expect(db.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({ bytes: extractedBytes, source: FileSources.text }),
+      true,
+    );
+  });
+
+  test('persists the ledger row under the resolved request tenant, not the user tenant', async () => {
+    /* Remote-agent auth sets `req.tenantId` for users carrying no `user.tenantId`.
+     * Usage aggregates under the resolved tenant, so a row written under the user
+     * tenant would never be counted again and the cap would stop applying. */
+    getStrategyFunctions.mockReturnValue({
+      handleFileUpload: jest.fn().mockResolvedValue({
+        text: 'extracted',
+        bytes: 9,
+        filepath: 'doc://result',
+      }),
+    });
+    const req = makeReq({ mimetype: PDF_MIME, ocrConfig: null });
+    req.user.tenantId = undefined;
+    req.tenantId = 'request-tenant';
+
+    await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ req: expect.objectContaining({ tenantId: 'request-tenant' }) }),
+    );
+    expect(db.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'request-tenant' }),
+      true,
+    );
   });
 
   describe('OCR strategy selection', () => {
@@ -1133,6 +1252,199 @@ describe('processAgentFileUpload', () => {
     });
   });
 
+  describe('storage-limit cleanup after secondary processing', () => {
+    it('cleans up original agent image storage when image persistence quota fails', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 700,
+        filename: 'image.png',
+        filepath: '/uploads/user-123/original.png',
+      });
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/resized.png',
+        bytes: 100,
+        width: 32,
+        height: 32,
+      });
+      const deleteFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({ handleFileUpload, handleImageUpload, deleteFile });
+      assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+      const req = makeReq({ mimetype: 'image/png' });
+      req.config.imageOutputType = 'png';
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: { file_id: 'agent-file-id', message_file: true },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/images/user-123/resized.png' }),
+        undefined,
+      );
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/user-123/original.png' }),
+        undefined,
+      );
+      expect(db.createFile).not.toHaveBeenCalled();
+    });
+
+    it('cleans up agent image side effects when final metadata quota check fails', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 700,
+        filename: 'image.png',
+        filepath: '/uploads/user-123/original.png',
+      });
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/resized.png',
+        bytes: 100,
+        width: 32,
+        height: 32,
+      });
+      const deleteFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockReturnValue({ handleFileUpload, handleImageUpload, deleteFile });
+      db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+      db.deleteFiles.mockResolvedValue({ deletedCount: 1 });
+      assertFileStorageLimit
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(error);
+      const req = makeReq({ mimetype: 'image/png' });
+      req.config.imageOutputType = 'png';
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: { file_id: 'agent-file-id', message_file: true },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(db.deleteFiles).toHaveBeenCalledWith(['mock-uuid']);
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/user-123/original.png' }),
+        undefined,
+      );
+      expect(deleteFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/images/user-123/resized.png' }),
+        undefined,
+      );
+    });
+
+    it('uses converted image metadata for the final agent image record', async () => {
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 100,
+        filename: 'image.jpg',
+        filepath: '/uploads/user-123/original.jpg',
+      });
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/resized.png',
+        bytes: 700,
+        width: 32,
+        height: 64,
+      });
+      getStrategyFunctions.mockReturnValue({ handleFileUpload, handleImageUpload });
+      db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+      const req = makeReq({ mimetype: 'image/jpeg' });
+      req.config.imageOutputType = 'png';
+
+      await processAgentFileUpload({
+        req,
+        res: mockRes,
+        metadata: { file_id: 'agent-file-id', message_file: true },
+      });
+
+      const [finalFile] = db.createFile.mock.calls.find(
+        ([fileInfo]) => fileInfo.file_id === 'agent-file-id',
+      );
+      expect(finalFile).toEqual(
+        expect.objectContaining({
+          bytes: 700,
+          filepath: '/images/user-123/resized.png',
+          source: FileSources.local,
+          type: 'image/png',
+          width: 32,
+          height: 64,
+        }),
+      );
+      expect(assertFileStorageLimit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          incomingBytes: 700,
+          excludeFileId: 'agent-file-id',
+        }),
+      );
+    });
+
+    it('cleans up vector embeddings when file_search metadata quota check fails', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const handleFileUpload = jest.fn().mockResolvedValue({
+        bytes: 700,
+        filename: 'doc.pdf',
+        filepath: '/uploads/user-123/doc.pdf',
+      });
+      const deleteStoredFile = jest.fn().mockResolvedValue(undefined);
+      const deleteVectorFile = jest.fn().mockResolvedValue(undefined);
+      getStrategyFunctions.mockImplementation((source) =>
+        source === FileSources.vectordb
+          ? { deleteFile: deleteVectorFile }
+          : { handleFileUpload, deleteFile: deleteStoredFile },
+      );
+      uploadVectors.mockResolvedValue({
+        bytes: 700,
+        filename: 'doc.pdf',
+        filepath: FileSources.vectordb,
+        embedded: true,
+      });
+      assertFileStorageLimit
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(error);
+
+      await expect(
+        processAgentFileUpload({
+          req: makeReq(),
+          res: mockRes,
+          metadata: {
+            agent_id: 'agent-abc',
+            tool_resource: EToolResources.file_search,
+            file_id: 'agent-file-id',
+          },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(deleteStoredFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/user-123/doc.pdf' }),
+        undefined,
+      );
+      expect(deleteVectorFile).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          file_id: 'agent-file-id',
+          source: FileSources.vectordb,
+          embedded: true,
+        }),
+      );
+      expect(db.createFile).not.toHaveBeenCalled();
+    });
+  });
+
   /* Phase C / option α regression: the upload must persist its sandbox
    * pointer under `metadata.codeEnvRef` (the post-cutover schema). The
    * legacy `metadata.fileIdentifier` key is silently stripped by mongoose
@@ -1166,17 +1478,19 @@ describe('processAgentFileUpload', () => {
        * runs in the same flow. Both must return a working
        * `handleFileUpload`. */
       const codeEnvUpload = jest.fn().mockResolvedValue(uploaded);
+      const codeEnvDelete = jest.fn().mockResolvedValue(undefined);
       const localUpload = jest.fn().mockResolvedValue({
         bytes: 0,
         filename: 'upload.bin',
         filepath: '/uploads/upload.bin',
       });
+      const localDelete = jest.fn().mockResolvedValue(undefined);
       getStrategyFunctions.mockImplementation((src) =>
         src === FileSources.execute_code
-          ? { handleFileUpload: codeEnvUpload }
-          : { handleFileUpload: localUpload, saveBuffer: jest.fn() },
+          ? { handleFileUpload: codeEnvUpload, deleteFile: codeEnvDelete }
+          : { handleFileUpload: localUpload, deleteFile: localDelete, saveBuffer: jest.fn() },
       );
-      return codeEnvUpload;
+      return { codeEnvUpload, codeEnvDelete, localDelete };
     };
 
     it('persists kind:user codeEnvRef for chat attachments (messageAttachment=true)', async () => {
@@ -1349,12 +1663,314 @@ describe('processAgentFileUpload', () => {
       const persisted = db.createFile.mock.calls[0][0];
       expect(persisted.metadata).not.toHaveProperty('fileIdentifier');
     });
+
+    it('rolls back code env uploads when final storage quota rejects', async () => {
+      const error = Object.assign(new Error('storage limit exceeded.'), {
+        code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+        status: 413,
+      });
+      const { codeEnvDelete, localDelete } = setupCodeEnvUpload({
+        storage_session_id: 'sess-4',
+        file_id: 'fid-4',
+      });
+      assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+      const req = makeReq();
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: {
+            agent_id: 'agent-abc',
+            tool_resource: EToolResources.execute_code,
+            file_id: 'file-uuid',
+          },
+        }),
+      ).rejects.toThrow('storage limit exceeded');
+
+      expect(localDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/upload.bin' }),
+        undefined,
+      );
+      expect(codeEnvDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            codeEnvRef: expect.objectContaining({
+              kind: 'agent',
+              id: 'agent-abc',
+              storage_session_id: 'sess-4',
+              file_id: 'fid-4',
+            }),
+          }),
+        }),
+      );
+      expect(db.createFile).not.toHaveBeenCalled();
+    });
+
+    it('rolls back persisted execute_code uploads when agent resource linking fails', async () => {
+      const { codeEnvDelete, localDelete } = setupCodeEnvUpload({
+        storage_session_id: 'sess-link',
+        file_id: 'fid-link',
+      });
+      db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+      db.addAgentResourceFile.mockRejectedValueOnce(new Error('link failed'));
+      const req = makeReq();
+
+      await expect(
+        processAgentFileUpload({
+          req,
+          res: mockRes,
+          metadata: {
+            agent_id: 'agent-abc',
+            tool_resource: EToolResources.execute_code,
+            file_id: 'file-uuid',
+          },
+        }),
+      ).rejects.toThrow('link failed');
+
+      expect(db.deleteFiles).toHaveBeenCalledWith(['file-uuid']);
+      expect(localDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ filepath: '/uploads/upload.bin' }),
+        undefined,
+      );
+      expect(codeEnvDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            codeEnvRef: expect.objectContaining({
+              kind: 'agent',
+              id: 'agent-abc',
+              storage_session_id: 'sess-link',
+              file_id: 'fid-link',
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});
+
+describe('processImageFile storage-limit checks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+    mockRes.status.mockReturnThis();
+    mockRes.json.mockReturnValue({});
+  });
+
+  it('checks quota against persisted image bytes, not raw upload bytes', async () => {
+    const rawUploadBytes = 10 * 1024 * 1024;
+    const persistedBytes = 256;
+    const rawBytesError = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    assertFileStorageLimit.mockImplementation(({ incomingBytes }) => {
+      if (incomingBytes === rawUploadBytes) {
+        return Promise.reject(rawBytesError);
+      }
+      return Promise.resolve();
+    });
+    const handleImageUpload = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/image.png',
+      bytes: persistedBytes,
+      width: 32,
+      height: 32,
+    });
+    getStrategyFunctions.mockReturnValue({ handleImageUpload });
+    const req = makeReq({ mimetype: 'image/png' });
+    req.file.size = rawUploadBytes;
+    req.config.imageOutputType = 'png';
+
+    await processImageFile({
+      req,
+      res: mockRes,
+      metadata: { file_id: 'image-file-id', endpoint: 'agents' },
+    });
+
+    expect(handleImageUpload).toHaveBeenCalled();
+    expect(assertFileStorageLimit).toHaveBeenCalledTimes(1);
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        incomingBytes: persistedBytes,
+        excludeFileId: 'image-file-id',
+      }),
+    );
+  });
+});
+
+describe('processFileUpload assistant storage-limit cleanup', () => {
+  const makeAssistantImageReq = () => ({
+    user: { id: 'user-123', tenantId: 'tenant-a' },
+    file: {
+      path: '/tmp/image.png',
+      originalname: 'image.png',
+      filename: 'image.png',
+      mimetype: 'image/png',
+      size: 128,
+    },
+    body: { model: 'gpt-4o' },
+    config: {
+      fileConfig: { storageLimit: 1 },
+      fileStrategy: FileSources.local,
+      imageOutputType: 'png',
+    },
+  });
+
+  const makeOpenAI = () => ({
+    baseURL: 'https://api.openai.test/v1',
+    files: {
+      del: jest.fn().mockResolvedValue({ deleted: true }),
+    },
+    beta: {
+      assistants: {
+        files: {
+          create: jest.fn().mockResolvedValue({}),
+          del: jest.fn().mockResolvedValue({ deleted: true }),
+        },
+      },
+    },
+  });
+
+  const setupAssistantStrategies = () => {
+    const deleteOpenAIFile = jest.fn((req, file, openai) => openai.files.del(file.file_id));
+    const deleteLocalFile = jest.fn().mockResolvedValue(undefined);
+    const uploadAssistantFile = jest.fn().mockResolvedValue({
+      id: 'file-openai',
+      bytes: 200,
+      filename: 'image.png',
+    });
+    const uploadLocalImage = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/local-image.png',
+      bytes: 300,
+      width: 32,
+      height: 32,
+    });
+
+    getStrategyFunctions.mockImplementation((source) =>
+      source === FileSources.openai
+        ? { handleFileUpload: uploadAssistantFile, deleteFile: deleteOpenAIFile }
+        : { handleImageUpload: uploadLocalImage, deleteFile: deleteLocalFile },
+    );
+
+    return {
+      deleteOpenAIFile,
+      deleteLocalFile,
+      uploadAssistantFile,
+      uploadLocalImage,
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockResolvedValue({ file_id: 'created-file-id' });
+    db.deleteFiles.mockResolvedValue(undefined);
+    mockRes.status.mockReturnThis();
+    mockRes.json.mockReturnValue({});
+  });
+
+  it('removes an assistant tool-resource file when image persistence fails quota after upload', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const openai = makeOpenAI();
+    const { deleteOpenAIFile } = setupAssistantStrategies();
+    getOpenAIClient.mockResolvedValue({ openai });
+    assertFileStorageLimit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(error);
+
+    await expect(
+      processFileUpload({
+        req: makeAssistantImageReq(),
+        res: mockRes,
+        metadata: {
+          endpoint: EModelEndpoint.assistants,
+          assistant_id: 'asst-1',
+          tool_resource: EToolResources.file_search,
+          file_id: 'metadata-file-id',
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(addResourceFileId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_id: 'file-openai',
+        assistant_id: 'asst-1',
+        tool_resource: EToolResources.file_search,
+      }),
+    );
+    expect(deleteResourceFileId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_id: 'file-openai',
+        assistant_id: 'asst-1',
+        tool_resource: EToolResources.file_search,
+      }),
+    );
+    expect(deleteOpenAIFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ file_id: 'file-openai', source: FileSources.openai }),
+      openai,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the local assistant image record when assistant metadata persistence fails quota', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const openai = makeOpenAI();
+    const { deleteOpenAIFile, deleteLocalFile } = setupAssistantStrategies();
+    getOpenAIClient.mockResolvedValue({ openai });
+    db.createFile.mockImplementation((fileInfo) => Promise.resolve(fileInfo));
+    db.deleteFiles.mockResolvedValue({ deletedCount: 1 });
+    assertFileStorageLimit
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+
+    await expect(
+      processFileUpload({
+        req: makeAssistantImageReq(),
+        res: mockRes,
+        metadata: {
+          endpoint: EModelEndpoint.assistants,
+          assistant_id: 'asst-1',
+          file_id: 'metadata-file-id',
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(openai.beta.assistants.files.del).toHaveBeenCalledWith('asst-1', 'file-openai');
+    expect(deleteOpenAIFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ file_id: 'file-openai', source: FileSources.openai }),
+      openai,
+    );
+    expect(deleteLocalFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        file_id: 'mock-uuid',
+        filepath: '/images/user-123/local-image.png',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(db.deleteFiles).toHaveBeenCalledWith(['mock-uuid']);
+    expect(db.createFile).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('processFileURL', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockResolvedValue({ file_id: 'created-file-id' });
   });
 
   it('throws and skips DB persistence when saveURL returns null', async () => {
@@ -1414,6 +2030,92 @@ describe('processFileURL', () => {
       }),
       true,
     );
+  });
+
+  it('cleans up URL-saved files when the final storage limit check fails', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const saveURL = jest.fn().mockResolvedValue({
+      filepath: 'https://cdn.example.com/t/tenant-a/images/user-123/image.png',
+      bytes: 512,
+      type: 'image/png',
+    });
+    const getFileURL = jest.fn();
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockReturnValue({ saveURL, getFileURL, deleteFile });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.cloudfront,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: 'tenant-a',
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 } },
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filepath: 'https://cdn.example.com/t/tenant-a/images/user-123/image.png',
+        source: FileSources.cloudfront,
+      }),
+      undefined,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('passes request path config to local URL cleanup on storage limit failure', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const paths = { publicPath: '/srv/public', uploads: '/srv/uploads' };
+    const saveURL = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/image.png',
+      bytes: 512,
+      type: 'image/png',
+    });
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockReturnValue({ saveURL, deleteFile });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.local,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: 'tenant-a',
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 }, paths },
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteFile).toHaveBeenCalledWith(
+      expect.objectContaining({ config: expect.objectContaining({ paths }) }),
+      expect.objectContaining({
+        filepath: '/images/user-123/image.png',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
   });
 
   it('applies retention metadata for generated images when retention mode is all', async () => {
@@ -1586,6 +2288,313 @@ describe('processFileURL', () => {
       }),
       true,
     );
+  });
+
+  it('cleans up and rejects request-scoped URL saves without byte metadata', async () => {
+    const saveURL = jest.fn().mockResolvedValue('/images/user-123/image.png');
+    const deleteFile = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockReturnValue({ saveURL, deleteFile });
+
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.local,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: 'tenant-a',
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 } },
+        },
+      }),
+    ).rejects.toThrow('did not return byte metadata');
+
+    expect(deleteFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filepath: '/images/user-123/image.png',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('generated image quota paths', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    assertFileStorageLimit.mockResolvedValue(undefined);
+    db.createFile.mockResolvedValue({ file_id: 'created-file-id' });
+  });
+
+  it('uploadImageBuffer rejects over-limit images before saving the buffer', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const saveBuffer = jest.fn();
+    getStrategyFunctions.mockReturnValue({ saveBuffer });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      uploadImageBuffer({
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          file: { originalname: 'input.png' },
+          body: {},
+          config: { fileConfig: { storageLimit: 1 }, imageOutputType: 'webp' },
+        },
+        context: FileContext.image_generation,
+        resize: false,
+        metadata: {
+          buffer: Buffer.from('image'),
+          bytes: 512,
+          width: 10,
+          height: 10,
+          filename: 'image.webp',
+          file_id: 'image-file-id',
+          type: 'image/webp',
+        },
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(saveBuffer).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('saveBase64Image rejects over-limit resized images before saving the buffer', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const saveBuffer = jest.fn();
+    getStrategyFunctions.mockReturnValue({ saveBuffer });
+    resizeImageBuffer.mockResolvedValue({
+      buffer: Buffer.from('resized'),
+      bytes: 512,
+      width: 10,
+      height: 10,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      saveBase64Image('data:image/png;base64,aW1hZ2U=', {
+        req: {
+          user: { id: 'user-123', tenantId: 'tenant-a' },
+          body: {},
+          config: {
+            fileConfig: { storageLimit: 1, imageGeneration: 'low' },
+            imageOutputType: 'webp',
+          },
+        },
+        filename: 'image.png',
+        endpoint: EModelEndpoint.openAI,
+        context: FileContext.image_generation,
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(saveBuffer).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('retrieveAndProcessFile applies quota to OpenAI file metadata with explicit req', async () => {
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: { fileConfig: { storageLimit: 1 } },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 512,
+          filename: 'remote.txt',
+          purpose: 'assistants_output',
+        }),
+      },
+    };
+
+    await retrieveAndProcessFile({
+      openai,
+      client: { req },
+      file_id: 'openai-file-id',
+    });
+
+    expect(assertFileStorageLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        req,
+        incomingBytes: 512,
+        excludeFileId: 'openai-file-id',
+      }),
+    );
+    expect(db.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_id: 'openai-file-id',
+        tenantId: 'tenant-a',
+        source: FileSources.openai,
+      }),
+      true,
+    );
+  });
+
+  it('retrieveAndProcessFile does not delete existing OpenAI files when metadata quota rejects', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: { fileConfig: { storageLimit: 1 } },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 512,
+          filename: 'remote.txt',
+          purpose: 'assistants_output',
+        }),
+      },
+    };
+    const deleteFile = jest.fn();
+    getStrategyFunctions.mockReturnValue({ deleteFile });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      retrieveAndProcessFile({
+        openai,
+        client: { req },
+        file_id: 'openai-file-id',
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteFile).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('retrieveAndProcessFile rejects over-limit OpenAI image outputs before metadata persistence', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: {
+        fileConfig: { storageLimit: 1 },
+        fileStrategy: FileSources.local,
+        imageOutputType: 'webp',
+      },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 1024,
+          filename: 'image.png',
+          purpose: 'assistants_output',
+        }),
+        content: jest.fn().mockResolvedValue({
+          arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('raw-image')),
+        }),
+      },
+    };
+    convertImage.mockResolvedValue({
+      filepath: '/images/user-123/openai-file-id.webp',
+      bytes: 512,
+      width: 10,
+      height: 10,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      retrieveAndProcessFile({
+        openai,
+        client: {
+          req,
+          attachedFileIds: new Set(),
+          processedFileIds: new Set(),
+        },
+        file_id: 'openai-file-id',
+        basename: 'image.png',
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(convertImage).toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('cleans over-limit OpenAI image outputs with the file strategy used by conversion', async () => {
+    const error = Object.assign(new Error('storage limit exceeded.'), {
+      code: 'FILE_STORAGE_LIMIT_EXCEEDED',
+      status: 413,
+    });
+    const req = {
+      user: { id: 'user-123', tenantId: 'tenant-a' },
+      body: { endpoint: EModelEndpoint.assistants, model: 'gpt-4o' },
+      config: {
+        fileConfig: { storageLimit: 1 },
+        fileStrategy: FileSources.local,
+        imageOutputType: 'webp',
+      },
+    };
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: {
+        retrieve: jest.fn().mockResolvedValue({
+          bytes: 1024,
+          filename: 'image.png',
+          purpose: 'assistants_output',
+        }),
+        content: jest.fn().mockResolvedValue({
+          arrayBuffer: jest.fn().mockResolvedValue(Buffer.from('raw-image')),
+        }),
+      },
+    };
+    const deleteLocalFile = jest.fn().mockResolvedValue(undefined);
+    const deleteImageStrategyFile = jest.fn().mockResolvedValue(undefined);
+    getFileStrategy.mockReturnValueOnce('image-strategy');
+    getStrategyFunctions.mockImplementation((source) =>
+      source === FileSources.local
+        ? { deleteFile: deleteLocalFile }
+        : { deleteFile: deleteImageStrategyFile },
+    );
+    convertImage.mockResolvedValue({
+      filepath: '/images/user-123/openai-file-id.webp',
+      bytes: 512,
+      width: 10,
+      height: 10,
+    });
+    assertFileStorageLimit.mockRejectedValueOnce(error);
+
+    await expect(
+      retrieveAndProcessFile({
+        openai,
+        client: {
+          req,
+          attachedFileIds: new Set(),
+          processedFileIds: new Set(),
+        },
+        file_id: 'openai-file-id',
+        basename: 'image.png',
+      }),
+    ).rejects.toThrow('storage limit exceeded');
+
+    expect(deleteLocalFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filepath: '/images/user-123/openai-file-id.webp',
+        source: FileSources.local,
+      }),
+      undefined,
+    );
+    expect(deleteImageStrategyFile).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
   });
 });
 

--- a/api/server/services/Files/strategies.js
+++ b/api/server/services/Files/strategies.js
@@ -72,7 +72,7 @@ const {
   processAzureAvatar,
 } = require('./Azure');
 const { uploadOpenAIFile, deleteOpenAIFile, getOpenAIFileStream } = require('./OpenAI');
-const { getCodeOutputDownloadStream, uploadCodeEnvFile } = require('./Code');
+const { getCodeOutputDownloadStream, uploadCodeEnvFile, deleteCodeEnvFile } = require('./Code');
 const { uploadVectors, deleteVectors } = require('./VectorDB');
 
 /**
@@ -222,7 +222,7 @@ const codeOutputStrategy = () => ({
   /** @type {typeof prepareImagesLocal | null} */
   prepareImagePayload: null,
   /** @type {typeof deleteLocalFile | null} */
-  deleteFile: null,
+  deleteFile: deleteCodeEnvFile,
   handleFileUpload: uploadCodeEnvFile,
   getDownloadStream: getCodeOutputDownloadStream,
 });

--- a/api/server/services/Files/strategies.js
+++ b/api/server/services/Files/strategies.js
@@ -221,6 +221,7 @@ const codeOutputStrategy = () => ({
   handleImageUpload: null,
   /** @type {typeof prepareImagesLocal | null} */
   prepareImagePayload: null,
+  /** @type {typeof deleteLocalFile | null} */
   deleteFile: deleteCodeEnvFile,
   handleFileUpload: uploadCodeEnvFile,
   getDownloadStream: getCodeOutputDownloadStream,

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -655,6 +655,7 @@ endpoints:
 #       fileLimit: 2
 #       fileSizeLimit: 5
 #   serverFileSizeLimit: 100  # Global server file size limit in MB
+#   storageLimit: 1000  # Per-user total persisted file storage limit in MB
 #   avatarSizeLimit: 2  # Limit for user avatar image size in MB
 #   imageGeneration: # Image Gen settings, either percentage or px
 #     percentage: 100

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -983,6 +983,11 @@ endpoints:
 #       fileLimit: 2
 #       fileSizeLimit: 5
 #   serverFileSizeLimit: 100  # Global server file size limit in MB
+#   # Per-user total persisted file storage limit in MB. Enforced on writes only:
+#   # users already above the limit (e.g. after lowering it) keep their files and
+#   # read access, but every new upload or generated artifact is rejected until
+#   # they delete enough to fall back under it.
+#   storageLimit: 1000
 #   avatarSizeLimit: 2  # Limit for user avatar image size in MB
 #   imageGeneration: # Image Gen settings, either percentage or px
 #     percentage: 100

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -5,6 +5,7 @@ export * from './context';
 export * from './documents/crud';
 export * from './encode';
 export * from './filter';
+export * from './limits';
 export * from './mistral/crud';
 export * from './ocr';
 export * from './parse';

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -6,6 +6,7 @@ export * from './extract';
 export * from './documents/crud';
 export * from './encode';
 export * from './filter';
+export * from './limits';
 export * from './mistral/crud';
 export * from './ocr';
 export * from './parse';

--- a/packages/api/src/files/limits.spec.ts
+++ b/packages/api/src/files/limits.spec.ts
@@ -4,6 +4,7 @@ import {
   FILE_STORAGE_LIMIT_ERROR_CODE,
   assertFileStorageLimit,
   isFileStorageLimitError,
+  recordFileStorageUsage,
 } from './limits';
 
 const megabyte = 1024 * 1024;
@@ -97,20 +98,63 @@ describe('assertFileStorageLimit', () => {
       excludeSkillFile,
     });
   });
+
+  it('reuses request-scoped usage and includes bytes recorded after persistence', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+    const req = createReq(1);
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 100,
+      getUserStorageUsage,
+    });
+    recordFileStorageUsage(req, 200);
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: megabyte - 200,
+      getUserStorageUsage,
+    });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte - 199,
+        getUserStorageUsage,
+      }),
+    ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats NaN incoming bytes as zero bytes', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: Number.NaN,
+        getUserStorageUsage,
+      }),
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe('isFileStorageLimitError', () => {
   it('matches storage limit errors by code', async () => {
     const getUserStorageUsage = createUsageMock(megabyte);
 
-    try {
-      await assertFileStorageLimit({
-        req: createReq(1),
-        incomingBytes: 1,
-        getUserStorageUsage,
-      });
-    } catch (error) {
-      expect(isFileStorageLimitError(error)).toBe(true);
-    }
+    const error = await assertFileStorageLimit({
+      req: createReq(1),
+      incomingBytes: 1,
+      getUserStorageUsage,
+    }).catch((caught) => caught);
+
+    expect(isFileStorageLimitError(error)).toBe(true);
+  });
+
+  it('rejects non-storage-limit errors', () => {
+    expect(isFileStorageLimitError(new Error('plain'))).toBe(false);
+    expect(isFileStorageLimitError(null)).toBe(false);
+    expect(isFileStorageLimitError(undefined)).toBe(false);
+    expect(isFileStorageLimitError({ code: 'SOMETHING_ELSE' })).toBe(false);
   });
 });

--- a/packages/api/src/files/limits.spec.ts
+++ b/packages/api/src/files/limits.spec.ts
@@ -1,0 +1,116 @@
+import type { UserStorageUsageParams } from '@librechat/data-schemas';
+import type { ServerRequest } from '~/types';
+import {
+  FILE_STORAGE_LIMIT_ERROR_CODE,
+  assertFileStorageLimit,
+  isFileStorageLimitError,
+} from './limits';
+
+const megabyte = 1024 * 1024;
+
+function createReq(storageLimit?: number, tenantId?: string): ServerRequest {
+  return {
+    config: {
+      fileConfig: storageLimit === undefined ? {} : { storageLimit },
+    },
+    user: {
+      id: '64f000000000000000000001',
+      tenantId,
+    },
+  } as ServerRequest;
+}
+
+function createUsageMock(currentUsage: number) {
+  return jest.fn<Promise<number>, [UserStorageUsageParams]>(async () => currentUsage);
+}
+
+describe('assertFileStorageLimit', () => {
+  it('no-ops when storageLimit is undefined', async () => {
+    const getUserStorageUsage = createUsageMock(10 * megabyte);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(getUserStorageUsage).not.toHaveBeenCalled();
+  });
+
+  it('allows usage equal to the limit', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte - 10);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: 10,
+        getUserStorageUsage,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects usage above the limit with a user-facing storage limit error', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }),
+    ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE, status: 413 });
+  });
+
+  it('treats 0 as no new positive-byte storage', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(0),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }),
+    ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+  });
+
+  it('passes tenant and replacement exclusions to the usage lookup', async () => {
+    const getUserStorageUsage = createUsageMock(1);
+    const excludeSkillFile = {
+      skillId: '64f000000000000000000002',
+      relativePath: 'scripts/run.sh',
+    };
+
+    await assertFileStorageLimit({
+      req: createReq(1, 'tenant-a'),
+      incomingBytes: 1,
+      getUserStorageUsage,
+      excludeFileId: 'file-1',
+      excludeSkillFile,
+    });
+
+    expect(getUserStorageUsage).toHaveBeenCalledWith({
+      userId: '64f000000000000000000001',
+      tenantId: 'tenant-a',
+      excludeFileId: 'file-1',
+      excludeSkillFile,
+    });
+  });
+});
+
+describe('isFileStorageLimitError', () => {
+  it('matches storage limit errors by code', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte);
+
+    try {
+      await assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      });
+    } catch (error) {
+      expect(isFileStorageLimitError(error)).toBe(true);
+    }
+  });
+});

--- a/packages/api/src/files/limits.spec.ts
+++ b/packages/api/src/files/limits.spec.ts
@@ -192,6 +192,33 @@ describe('assertFileStorageLimit', () => {
     expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
   });
 
+  it('does not add recorded bytes to cache scopes that exclude that skill file', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+    const req = createReq(1);
+    const excludeSkillFile = {
+      skillId: '64f0000000000000000000aa',
+      relativePath: 'actions/run.ts',
+    };
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 1,
+      getUserStorageUsage,
+      excludeSkillFile,
+    });
+    recordFileStorageUsage(req, 200, { skillFile: excludeSkillFile });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte,
+        getUserStorageUsage,
+        excludeSkillFile,
+      }),
+    ).resolves.toBeUndefined();
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+  });
+
   it('treats NaN incoming bytes as zero bytes', async () => {
     const getUserStorageUsage = createUsageMock(megabyte);
 
@@ -223,5 +250,8 @@ describe('isFileStorageLimitError', () => {
     expect(isFileStorageLimitError(null)).toBe(false);
     expect(isFileStorageLimitError(undefined)).toBe(false);
     expect(isFileStorageLimitError({ code: 'SOMETHING_ELSE' })).toBe(false);
+    expect(isFileStorageLimitError(Object.assign(new Error('coded'), { code: 'OTHER' }))).toBe(
+      false,
+    );
   });
 });

--- a/packages/api/src/files/limits.spec.ts
+++ b/packages/api/src/files/limits.spec.ts
@@ -9,8 +9,13 @@ import {
 
 const megabyte = 1024 * 1024;
 
-function createReq(storageLimit?: number, tenantId?: string): ServerRequest {
+function createReq(
+  storageLimit?: number,
+  tenantId?: string,
+  requestTenantId?: string,
+): ServerRequest {
   return {
+    tenantId: requestTenantId,
     config: {
       fileConfig: storageLimit === undefined ? {} : { storageLimit },
     },
@@ -18,7 +23,7 @@ function createReq(storageLimit?: number, tenantId?: string): ServerRequest {
       id: '64f000000000000000000001',
       tenantId,
     },
-  } as ServerRequest;
+  } as unknown as ServerRequest;
 }
 
 function createUsageMock(currentUsage: number) {
@@ -99,6 +104,20 @@ describe('assertFileStorageLimit', () => {
     });
   });
 
+  it('uses the resolved request tenant for the usage lookup', async () => {
+    const getUserStorageUsage = createUsageMock(1);
+
+    await assertFileStorageLimit({
+      req: createReq(1, 'tenant-user', 'tenant-request'),
+      incomingBytes: 1,
+      getUserStorageUsage,
+    });
+
+    expect(getUserStorageUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant-request' }),
+    );
+  });
+
   it('reuses request-scoped usage and includes bytes recorded after persistence', async () => {
     const getUserStorageUsage = createUsageMock(0);
     const req = createReq(1);
@@ -122,6 +141,54 @@ describe('assertFileStorageLimit', () => {
         getUserStorageUsage,
       }),
     ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-count recorded bytes when a fresh exclusion scope reads persisted usage', async () => {
+    const getUserStorageUsage = jest
+      .fn<Promise<number>, [UserStorageUsageParams]>()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(200);
+    const req = createReq(1);
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 100,
+      getUserStorageUsage,
+    });
+    recordFileStorageUsage(req, 200, { fileId: 'image-file-id' });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte - 200,
+        getUserStorageUsage,
+        excludeFileId: 'assistant-file-id',
+      }),
+    ).resolves.toBeUndefined();
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not add recorded bytes to cache scopes that exclude that file', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+    const req = createReq(1);
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 1,
+      getUserStorageUsage,
+      excludeFileId: 'file-1',
+    });
+    recordFileStorageUsage(req, 200, { fileId: 'file-1' });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte,
+        getUserStorageUsage,
+        excludeFileId: 'file-1',
+      }),
+    ).resolves.toBeUndefined();
     expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/api/src/files/limits.spec.ts
+++ b/packages/api/src/files/limits.spec.ts
@@ -1,0 +1,324 @@
+import type { UserStorageUsageParams } from '@librechat/data-schemas';
+import type { ServerRequest } from '~/types';
+import {
+  FILE_STORAGE_LIMIT_ERROR_CODE,
+  assertFileStorageLimit,
+  isFileStorageLimitError,
+  recordFileStorageUsage,
+} from './limits';
+
+const megabyte = 1024 * 1024;
+
+function createReq(
+  storageLimit?: number,
+  tenantId?: string,
+  requestTenantId?: string,
+): ServerRequest {
+  return {
+    tenantId: requestTenantId,
+    config: {
+      fileConfig: storageLimit === undefined ? {} : { storageLimit },
+    },
+    user: {
+      id: '64f000000000000000000001',
+      tenantId,
+    },
+  } as unknown as ServerRequest;
+}
+
+function createUsageMock(currentUsage: number) {
+  return jest.fn<Promise<number>, [UserStorageUsageParams]>(async () => currentUsage);
+}
+
+describe('assertFileStorageLimit', () => {
+  it('no-ops when storageLimit is undefined', async () => {
+    const getUserStorageUsage = createUsageMock(10 * megabyte);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(getUserStorageUsage).not.toHaveBeenCalled();
+  });
+
+  it('allows usage equal to the limit', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte - 10);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: 10,
+        getUserStorageUsage,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects usage above the limit with a user-facing storage limit error', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }),
+    ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE, status: 413 });
+  });
+
+  it('treats 0 as no new positive-byte storage', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(0),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }),
+    ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+  });
+
+  it('passes tenant and replacement exclusions to the usage lookup', async () => {
+    const getUserStorageUsage = createUsageMock(1);
+    const excludeSkillFile = {
+      skillId: '64f000000000000000000002',
+      relativePath: 'scripts/run.sh',
+    };
+
+    await assertFileStorageLimit({
+      req: createReq(1, 'tenant-a'),
+      incomingBytes: 1,
+      getUserStorageUsage,
+      excludeFileId: 'file-1',
+      excludeSkillFile,
+    });
+
+    expect(getUserStorageUsage).toHaveBeenCalledWith({
+      userId: '64f000000000000000000001',
+      tenantId: 'tenant-a',
+      excludeFileId: 'file-1',
+      excludeSkillFile,
+    });
+  });
+
+  it('uses the resolved request tenant for the usage lookup', async () => {
+    const getUserStorageUsage = createUsageMock(1);
+
+    await assertFileStorageLimit({
+      req: createReq(1, 'tenant-user', 'tenant-request'),
+      incomingBytes: 1,
+      getUserStorageUsage,
+    });
+
+    expect(getUserStorageUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant-request' }),
+    );
+  });
+
+  it('reuses request-scoped usage and includes bytes recorded after persistence', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+    const req = createReq(1);
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 100,
+      getUserStorageUsage,
+    });
+    recordFileStorageUsage(req, 200);
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: megabyte - 200,
+      getUserStorageUsage,
+    });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte - 199,
+        getUserStorageUsage,
+      }),
+    ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-count recorded bytes when a fresh exclusion scope reads persisted usage', async () => {
+    const getUserStorageUsage = jest
+      .fn<Promise<number>, [UserStorageUsageParams]>()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(200);
+    const req = createReq(1);
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 100,
+      getUserStorageUsage,
+    });
+    recordFileStorageUsage(req, 200, { fileId: 'image-file-id' });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte - 200,
+        getUserStorageUsage,
+        excludeFileId: 'assistant-file-id',
+      }),
+    ).resolves.toBeUndefined();
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not add recorded bytes to cache scopes that exclude that file', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+    const req = createReq(1);
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 1,
+      getUserStorageUsage,
+      excludeFileId: 'file-1',
+    });
+    recordFileStorageUsage(req, 200, { fileId: 'file-1' });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte,
+        getUserStorageUsage,
+        excludeFileId: 'file-1',
+      }),
+    ).resolves.toBeUndefined();
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not add recorded bytes to cache scopes that exclude that skill file', async () => {
+    const getUserStorageUsage = createUsageMock(0);
+    const req = createReq(1);
+    const excludeSkillFile = {
+      skillId: '64f0000000000000000000aa',
+      relativePath: 'actions/run.ts',
+    };
+
+    await assertFileStorageLimit({
+      req,
+      incomingBytes: 1,
+      getUserStorageUsage,
+      excludeSkillFile,
+    });
+    recordFileStorageUsage(req, 200, { skillFile: excludeSkillFile });
+
+    await expect(
+      assertFileStorageLimit({
+        req,
+        incomingBytes: megabyte,
+        getUserStorageUsage,
+        excludeSkillFile,
+      }),
+    ).resolves.toBeUndefined();
+    expect(getUserStorageUsage).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when the user is already over the limit', () => {
+    /** Quotas can be switched on — or lowered — for accounts that already hold
+     * more than the new cap. Every write must stop until they free space, and
+     * the failure has to tell them how far over they are. */
+    it('rejects a new upload and reports observed usage against the cap', async () => {
+      const getUserStorageUsage = createUsageMock(5 * megabyte);
+
+      const error = await assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: 1,
+        getUserStorageUsage,
+      }).catch((caught) => caught);
+
+      expect(isFileStorageLimitError(error)).toBe(true);
+      expect(error).toMatchObject({
+        status: 413,
+        storageLimit: megabyte,
+        currentUsage: 5 * megabyte,
+      });
+      expect(error.message).toContain('5MB');
+      expect(error.message).toContain('1MB');
+    });
+
+    it('rejects storage-neutral writes too, so nothing new lands while over', async () => {
+      const getUserStorageUsage = createUsageMock(5 * megabyte);
+
+      await expect(
+        assertFileStorageLimit({
+          req: createReq(1),
+          incomingBytes: 0,
+          getUserStorageUsage,
+        }),
+      ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+    });
+
+    it('still rejects a smaller replacement while the retained files alone exceed the cap', async () => {
+      const getUserStorageUsage = createUsageMock(5 * megabyte);
+
+      await expect(
+        assertFileStorageLimit({
+          req: createReq(1),
+          incomingBytes: 1,
+          excludeFileId: 'file-being-replaced',
+          getUserStorageUsage,
+        }),
+      ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+    });
+
+    it('accepts writes again once deletions bring usage back under the cap', async () => {
+      await expect(
+        assertFileStorageLimit({
+          req: createReq(1),
+          incomingBytes: 1,
+          getUserStorageUsage: createUsageMock(5 * megabyte),
+        }),
+      ).rejects.toMatchObject({ code: FILE_STORAGE_LIMIT_ERROR_CODE });
+
+      await expect(
+        assertFileStorageLimit({
+          req: createReq(1),
+          incomingBytes: 1,
+          getUserStorageUsage: createUsageMock(megabyte / 2),
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it('treats NaN incoming bytes as zero bytes', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte);
+
+    await expect(
+      assertFileStorageLimit({
+        req: createReq(1),
+        incomingBytes: Number.NaN,
+        getUserStorageUsage,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('isFileStorageLimitError', () => {
+  it('matches storage limit errors by code', async () => {
+    const getUserStorageUsage = createUsageMock(megabyte);
+
+    const error = await assertFileStorageLimit({
+      req: createReq(1),
+      incomingBytes: 1,
+      getUserStorageUsage,
+    }).catch((caught) => caught);
+
+    expect(isFileStorageLimitError(error)).toBe(true);
+  });
+
+  it('rejects non-storage-limit errors', () => {
+    expect(isFileStorageLimitError(new Error('plain'))).toBe(false);
+    expect(isFileStorageLimitError(null)).toBe(false);
+    expect(isFileStorageLimitError(undefined)).toBe(false);
+    expect(isFileStorageLimitError({ code: 'SOMETHING_ELSE' })).toBe(false);
+    expect(isFileStorageLimitError(Object.assign(new Error('coded'), { code: 'OTHER' }))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/api/src/files/limits.ts
+++ b/packages/api/src/files/limits.ts
@@ -1,0 +1,74 @@
+import { megabyte, mergeFileConfig } from 'librechat-data-provider';
+import type { UserStorageUsageParams } from '@librechat/data-schemas';
+import type { ServerRequest } from '~/types';
+
+export const FILE_STORAGE_LIMIT_ERROR_CODE = 'FILE_STORAGE_LIMIT_EXCEEDED';
+
+export class FileStorageLimitError extends Error {
+  code = FILE_STORAGE_LIMIT_ERROR_CODE;
+  status = 413;
+
+  constructor(storageLimit: number) {
+    super(
+      `storage limit exceeded. Delete files or ask an admin to raise your storage limit (${formatStorageLimit(storageLimit)}).`,
+    );
+    this.name = 'FileStorageLimitError';
+  }
+}
+
+export type GetUserStorageUsage = (params: UserStorageUsageParams) => Promise<number>;
+
+export type AssertFileStorageLimitParams = {
+  req: ServerRequest;
+  incomingBytes?: number | null;
+  getUserStorageUsage: GetUserStorageUsage;
+  excludeFileId?: UserStorageUsageParams['excludeFileId'];
+  excludeSkillFile?: UserStorageUsageParams['excludeSkillFile'];
+};
+
+function formatStorageLimit(bytes: number): string {
+  if (bytes >= megabyte) {
+    return `${Math.floor(bytes / megabyte)}MB`;
+  }
+
+  return `${bytes} bytes`;
+}
+
+export function isFileStorageLimitError(error: unknown): error is FileStorageLimitError {
+  return (
+    error instanceof Error &&
+    (error as Error & { code?: string }).code === FILE_STORAGE_LIMIT_ERROR_CODE
+  );
+}
+
+export async function assertFileStorageLimit({
+  req,
+  incomingBytes,
+  getUserStorageUsage,
+  excludeFileId,
+  excludeSkillFile,
+}: AssertFileStorageLimitParams): Promise<void> {
+  const storageLimit = mergeFileConfig(req.config?.fileConfig).storageLimit;
+  if (storageLimit === undefined) {
+    return;
+  }
+
+  const bytes = Math.max(0, incomingBytes ?? 0);
+  const userId = req.user?.id;
+  if (!userId) {
+    throw new Error('Unable to determine user for storage limit check');
+  }
+
+  const currentUsage = await getUserStorageUsage({
+    userId,
+    tenantId: req.user?.tenantId,
+    excludeFileId,
+    excludeSkillFile,
+  });
+
+  if (currentUsage + bytes <= storageLimit) {
+    return;
+  }
+
+  throw new FileStorageLimitError(storageLimit);
+}

--- a/packages/api/src/files/limits.ts
+++ b/packages/api/src/files/limits.ts
@@ -5,8 +5,8 @@ import type { ServerRequest } from '~/types';
 export const FILE_STORAGE_LIMIT_ERROR_CODE = 'FILE_STORAGE_LIMIT_EXCEEDED';
 
 export class FileStorageLimitError extends Error {
-  code = FILE_STORAGE_LIMIT_ERROR_CODE;
-  status = 413;
+  readonly code = FILE_STORAGE_LIMIT_ERROR_CODE;
+  readonly status = 413;
 
   constructor(storageLimit: number) {
     super(
@@ -26,12 +26,70 @@ export type AssertFileStorageLimitParams = {
   excludeSkillFile?: UserStorageUsageParams['excludeSkillFile'];
 };
 
+type FileStorageLimitCache = {
+  storageLimitLoaded: boolean;
+  storageLimit?: number;
+  committedBytes: number;
+  usageByScope: Map<string, number>;
+};
+
+type StorageLimitRequest = {
+  config?: ServerRequest['config'];
+  user?: {
+    id?: string;
+    tenantId?: string;
+  };
+  fileStorageLimitCache?: FileStorageLimitCache;
+};
+
 function formatStorageLimit(bytes: number): string {
   if (bytes >= megabyte) {
     return `${Math.floor(bytes / megabyte)}MB`;
   }
 
   return `${bytes} bytes`;
+}
+
+function normalizeIncomingBytes(incomingBytes?: number | null): number {
+  const bytes = Number(incomingBytes ?? 0);
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return 0;
+  }
+  return bytes;
+}
+
+function getStorageLimitCache(req: StorageLimitRequest): FileStorageLimitCache {
+  const storageReq = req as StorageLimitRequest;
+  storageReq.fileStorageLimitCache ??= {
+    storageLimitLoaded: false,
+    committedBytes: 0,
+    usageByScope: new Map<string, number>(),
+  };
+  return storageReq.fileStorageLimitCache;
+}
+
+function getStorageLimit(req: StorageLimitRequest): number | undefined {
+  const cache = getStorageLimitCache(req);
+  if (!cache.storageLimitLoaded) {
+    cache.storageLimit = mergeFileConfig(req.config?.fileConfig).storageLimit;
+    cache.storageLimitLoaded = true;
+  }
+  return cache.storageLimit;
+}
+
+function getUsageCacheKey(params: UserStorageUsageParams): string {
+  return JSON.stringify({
+    userId: params.userId.toString(),
+    tenantId: params.tenantId ?? null,
+    excludeFileId: params.excludeFileId ?? null,
+    excludeSkillFile: params.excludeSkillFile
+      ? {
+          id: params.excludeSkillFile.id?.toString() ?? null,
+          skillId: params.excludeSkillFile.skillId?.toString() ?? null,
+          relativePath: params.excludeSkillFile.relativePath ?? null,
+        }
+      : null,
+  });
 }
 
 export function isFileStorageLimitError(error: unknown): error is FileStorageLimitError {
@@ -41,6 +99,10 @@ export function isFileStorageLimitError(error: unknown): error is FileStorageLim
   );
 }
 
+/**
+ * Soft quota gate: prevents writes once observed usage reaches the cap.
+ * Concurrent requests can still pass before each has committed its ledger row.
+ */
 export async function assertFileStorageLimit({
   req,
   incomingBytes,
@@ -48,27 +110,47 @@ export async function assertFileStorageLimit({
   excludeFileId,
   excludeSkillFile,
 }: AssertFileStorageLimitParams): Promise<void> {
-  const storageLimit = mergeFileConfig(req.config?.fileConfig).storageLimit;
+  const storageLimit = getStorageLimit(req);
   if (storageLimit === undefined) {
     return;
   }
 
-  const bytes = Math.max(0, incomingBytes ?? 0);
+  const bytes = normalizeIncomingBytes(incomingBytes);
   const userId = req.user?.id;
   if (!userId) {
     throw new Error('Unable to determine user for storage limit check');
   }
 
-  const currentUsage = await getUserStorageUsage({
+  const usageParams: UserStorageUsageParams = {
     userId,
     tenantId: req.user?.tenantId,
     excludeFileId,
     excludeSkillFile,
-  });
+  };
+  const cache = getStorageLimitCache(req);
+  const usageCacheKey = getUsageCacheKey(usageParams);
+  let currentUsage = cache.usageByScope.get(usageCacheKey);
+  if (currentUsage === undefined) {
+    currentUsage = await getUserStorageUsage(usageParams);
+    cache.usageByScope.set(usageCacheKey, currentUsage);
+  }
 
-  if (currentUsage + bytes <= storageLimit) {
+  if (currentUsage + cache.committedBytes + bytes <= storageLimit) {
     return;
   }
 
   throw new FileStorageLimitError(storageLimit);
+}
+
+export function recordFileStorageUsage(
+  req: StorageLimitRequest,
+  incomingBytes?: number | null,
+): void {
+  const bytes = normalizeIncomingBytes(incomingBytes);
+  if (bytes === 0) {
+    return;
+  }
+
+  const cache = getStorageLimitCache(req);
+  cache.committedBytes += bytes;
 }

--- a/packages/api/src/files/limits.ts
+++ b/packages/api/src/files/limits.ts
@@ -1,6 +1,7 @@
 import { megabyte, mergeFileConfig } from 'librechat-data-provider';
 import type { UserStorageUsageParams } from '@librechat/data-schemas';
 import type { ServerRequest } from '~/types';
+import { resolveRequestTenantId } from '~/middleware/tenant';
 
 export const FILE_STORAGE_LIMIT_ERROR_CODE = 'FILE_STORAGE_LIMIT_EXCEEDED';
 
@@ -29,12 +30,22 @@ export type AssertFileStorageLimitParams = {
 type FileStorageLimitCache = {
   storageLimitLoaded: boolean;
   storageLimit?: number;
-  committedBytes: number;
-  usageByScope: Map<string, number>;
+  usageByScope: Map<string, StorageUsageEntry>;
+};
+
+type StorageUsageEntry = {
+  params: UserStorageUsageParams;
+  currentUsage: number;
+};
+
+type RecordFileStorageUsageOptions = {
+  fileId?: UserStorageUsageParams['excludeFileId'];
+  skillFile?: UserStorageUsageParams['excludeSkillFile'];
 };
 
 type StorageLimitRequest = {
   config?: ServerRequest['config'];
+  tenantId?: string;
   user?: {
     id?: string;
     tenantId?: string;
@@ -62,8 +73,7 @@ function getStorageLimitCache(req: StorageLimitRequest): FileStorageLimitCache {
   const storageReq = req as StorageLimitRequest;
   storageReq.fileStorageLimitCache ??= {
     storageLimitLoaded: false,
-    committedBytes: 0,
-    usageByScope: new Map<string, number>(),
+    usageByScope: new Map<string, StorageUsageEntry>(),
   };
   return storageReq.fileStorageLimitCache;
 }
@@ -90,6 +100,40 @@ function getUsageCacheKey(params: UserStorageUsageParams): string {
         }
       : null,
   });
+}
+
+function idsMatch(
+  left?: { toString: () => string } | string | null,
+  right?: { toString: () => string } | string | null,
+): boolean {
+  return left != null && right != null && left.toString() === right.toString();
+}
+
+function skillFilesMatch(
+  excludeSkillFile: UserStorageUsageParams['excludeSkillFile'],
+  skillFile: UserStorageUsageParams['excludeSkillFile'],
+): boolean {
+  if (!excludeSkillFile || !skillFile) {
+    return false;
+  }
+  if (idsMatch(excludeSkillFile.id, skillFile.id)) {
+    return true;
+  }
+  return (
+    idsMatch(excludeSkillFile.skillId, skillFile.skillId) &&
+    excludeSkillFile.relativePath != null &&
+    excludeSkillFile.relativePath === skillFile.relativePath
+  );
+}
+
+function isExcludedFromScope(
+  params: UserStorageUsageParams,
+  options: RecordFileStorageUsageOptions,
+): boolean {
+  return (
+    idsMatch(params.excludeFileId, options.fileId) ||
+    skillFilesMatch(params.excludeSkillFile, options.skillFile)
+  );
 }
 
 export function isFileStorageLimitError(error: unknown): error is FileStorageLimitError {
@@ -123,19 +167,22 @@ export async function assertFileStorageLimit({
 
   const usageParams: UserStorageUsageParams = {
     userId,
-    tenantId: req.user?.tenantId,
+    tenantId: resolveRequestTenantId(req),
     excludeFileId,
     excludeSkillFile,
   };
   const cache = getStorageLimitCache(req);
   const usageCacheKey = getUsageCacheKey(usageParams);
-  let currentUsage = cache.usageByScope.get(usageCacheKey);
-  if (currentUsage === undefined) {
-    currentUsage = await getUserStorageUsage(usageParams);
-    cache.usageByScope.set(usageCacheKey, currentUsage);
+  let usageEntry = cache.usageByScope.get(usageCacheKey);
+  if (usageEntry === undefined) {
+    usageEntry = {
+      params: usageParams,
+      currentUsage: await getUserStorageUsage(usageParams),
+    };
+    cache.usageByScope.set(usageCacheKey, usageEntry);
   }
 
-  if (currentUsage + cache.committedBytes + bytes <= storageLimit) {
+  if (usageEntry.currentUsage + bytes <= storageLimit) {
     return;
   }
 
@@ -145,6 +192,7 @@ export async function assertFileStorageLimit({
 export function recordFileStorageUsage(
   req: StorageLimitRequest,
   incomingBytes?: number | null,
+  options: RecordFileStorageUsageOptions = {},
 ): void {
   const bytes = normalizeIncomingBytes(incomingBytes);
   if (bytes === 0) {
@@ -152,5 +200,10 @@ export function recordFileStorageUsage(
   }
 
   const cache = getStorageLimitCache(req);
-  cache.committedBytes += bytes;
+  cache.usageByScope.forEach((entry) => {
+    if (isExcludedFromScope(entry.params, options)) {
+      return;
+    }
+    entry.currentUsage += bytes;
+  });
 }

--- a/packages/api/src/files/limits.ts
+++ b/packages/api/src/files/limits.ts
@@ -45,6 +45,7 @@ type RecordFileStorageUsageOptions = {
 
 type StorageLimitRequest = {
   config?: ServerRequest['config'];
+  /** Tenant resolved by request middleware; preferred over user.tenantId when present. */
   tenantId?: string;
   user?: {
     id?: string;
@@ -70,12 +71,11 @@ function normalizeIncomingBytes(incomingBytes?: number | null): number {
 }
 
 function getStorageLimitCache(req: StorageLimitRequest): FileStorageLimitCache {
-  const storageReq = req as StorageLimitRequest;
-  storageReq.fileStorageLimitCache ??= {
+  req.fileStorageLimitCache ??= {
     storageLimitLoaded: false,
     usageByScope: new Map<string, StorageUsageEntry>(),
   };
-  return storageReq.fileStorageLimitCache;
+  return req.fileStorageLimitCache;
 }
 
 function getStorageLimit(req: StorageLimitRequest): number | undefined {

--- a/packages/api/src/files/limits.ts
+++ b/packages/api/src/files/limits.ts
@@ -1,0 +1,257 @@
+import { megabyte, mergeFileConfig } from 'librechat-data-provider';
+import type { UserStorageUsageParams } from '@librechat/data-schemas';
+import type { RequestTenantSource } from '~/middleware/tenant';
+import type { ServerRequest } from '~/types';
+import { resolveRequestTenantId } from '~/middleware/tenant';
+
+export const FILE_STORAGE_LIMIT_ERROR_CODE = 'FILE_STORAGE_LIMIT_EXCEEDED';
+
+export class FileStorageLimitError extends Error {
+  readonly code: typeof FILE_STORAGE_LIMIT_ERROR_CODE = FILE_STORAGE_LIMIT_ERROR_CODE;
+  readonly status = 413 as const;
+  readonly storageLimit: number;
+  readonly currentUsage: number;
+
+  /**
+   * Reports observed usage alongside the cap. A user who is already over the
+   * limit — because an admin lowered it or enabled quotas on an existing
+   * account — otherwise has no way to tell how much they must free before any
+   * write succeeds again.
+   */
+  constructor(storageLimit: number, currentUsage: number) {
+    super(
+      `storage limit exceeded. You are using ${formatBytes(currentUsage)} of your ${formatBytes(storageLimit)} storage limit. Delete files or ask an admin to raise the limit.`,
+    );
+    this.name = 'FileStorageLimitError';
+    this.storageLimit = storageLimit;
+    this.currentUsage = currentUsage;
+  }
+}
+
+export type GetUserStorageUsage = (params: UserStorageUsageParams) => Promise<number>;
+
+export type AssertFileStorageLimitParams = {
+  req: ServerRequest;
+  incomingBytes?: number | null;
+  getUserStorageUsage: GetUserStorageUsage;
+  excludeFileId?: UserStorageUsageParams['excludeFileId'];
+  excludeSkillFile?: UserStorageUsageParams['excludeSkillFile'];
+};
+
+type FileStorageLimitCache = {
+  storageLimitLoaded: boolean;
+  storageLimit?: number;
+  usageByScope: Map<string, StorageUsageEntry>;
+};
+
+type StorageUsageEntry = {
+  params: UserStorageUsageParams;
+  currentUsage: number;
+};
+
+type RecordFileStorageUsageOptions = {
+  fileId?: UserStorageUsageParams['excludeFileId'];
+  skillFile?: UserStorageUsageParams['excludeSkillFile'];
+};
+
+type StorageLimitRequest = {
+  config?: ServerRequest['config'];
+  /** Tenant resolved by request middleware; preferred over user.tenantId when present. */
+  tenantId?: string;
+  user?: {
+    id?: string;
+    tenantId?: string;
+  };
+  fileStorageLimitCache?: FileStorageLimitCache;
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes >= megabyte) {
+    return `${Math.floor(bytes / megabyte)}MB`;
+  }
+
+  return `${bytes} bytes`;
+}
+
+function normalizeIncomingBytes(incomingBytes?: number | null): number {
+  const bytes = Number(incomingBytes ?? 0);
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return 0;
+  }
+  return bytes;
+}
+
+function getStorageLimitCache(req: StorageLimitRequest): FileStorageLimitCache {
+  req.fileStorageLimitCache ??= {
+    storageLimitLoaded: false,
+    usageByScope: new Map<string, StorageUsageEntry>(),
+  };
+  return req.fileStorageLimitCache;
+}
+
+function getStorageLimit(req: StorageLimitRequest): number | undefined {
+  const cache = getStorageLimitCache(req);
+  if (!cache.storageLimitLoaded) {
+    cache.storageLimit = mergeFileConfig(req.config?.fileConfig).storageLimit;
+    cache.storageLimitLoaded = true;
+  }
+  return cache.storageLimit;
+}
+
+function getUsageCacheKey(params: UserStorageUsageParams): string {
+  return JSON.stringify({
+    userId: params.userId.toString(),
+    tenantId: params.tenantId ?? null,
+    excludeFileId: params.excludeFileId ?? null,
+    excludeSkillFile: params.excludeSkillFile
+      ? {
+          id: params.excludeSkillFile.id?.toString() ?? null,
+          skillId: params.excludeSkillFile.skillId?.toString() ?? null,
+          relativePath: params.excludeSkillFile.relativePath ?? null,
+        }
+      : null,
+  });
+}
+
+function idsMatch(
+  left?: { toString: () => string } | string | null,
+  right?: { toString: () => string } | string | null,
+): boolean {
+  return left != null && right != null && left.toString() === right.toString();
+}
+
+function skillFilesMatch(
+  excludeSkillFile: UserStorageUsageParams['excludeSkillFile'],
+  skillFile: UserStorageUsageParams['excludeSkillFile'],
+): boolean {
+  if (!excludeSkillFile || !skillFile) {
+    return false;
+  }
+  if (idsMatch(excludeSkillFile.id, skillFile.id)) {
+    return true;
+  }
+  return (
+    idsMatch(excludeSkillFile.skillId, skillFile.skillId) &&
+    excludeSkillFile.relativePath != null &&
+    excludeSkillFile.relativePath === skillFile.relativePath
+  );
+}
+
+function isExcludedFromScope(
+  params: UserStorageUsageParams,
+  options: RecordFileStorageUsageOptions,
+): boolean {
+  return (
+    idsMatch(params.excludeFileId, options.fileId) ||
+    skillFilesMatch(params.excludeSkillFile, options.skillFile)
+  );
+}
+
+type SkillFileReplacementParams = {
+  /** Row about to be overwritten, or null/undefined when this is a fresh write. */
+  existingFile?: { author?: { toString(): string } | null } | null;
+  /** Authenticated requester, whose ledger the replaced row is charged to. */
+  requesterId?: { toString(): string } | null;
+  skillId: NonNullable<UserStorageUsageParams['excludeSkillFile']>['skillId'];
+  relativePath: string;
+};
+
+/**
+ * Exclusion for a skill file the requester is replacing. Only the requester's own
+ * rows may be discounted — a file authored by someone else is charged to that
+ * author and stays in the usage total.
+ */
+export function getSkillFileReplacementExclusion({
+  existingFile,
+  requesterId,
+  skillId,
+  relativePath,
+}: SkillFileReplacementParams): UserStorageUsageParams['excludeSkillFile'] {
+  const author = existingFile?.author;
+  if (author == null || requesterId == null) {
+    return undefined;
+  }
+
+  if (author.toString() !== requesterId.toString()) {
+    return undefined;
+  }
+
+  return { skillId, relativePath };
+}
+
+export function isFileStorageLimitError(error: unknown): error is FileStorageLimitError {
+  return (
+    error instanceof Error &&
+    (error as Error & { code?: string }).code === FILE_STORAGE_LIMIT_ERROR_CODE
+  );
+}
+
+/**
+ * Soft quota gate: prevents writes once observed usage reaches the cap.
+ * Concurrent requests can still pass before each has committed its ledger row.
+ */
+export async function assertFileStorageLimit({
+  req,
+  incomingBytes,
+  getUserStorageUsage,
+  excludeFileId,
+  excludeSkillFile,
+}: AssertFileStorageLimitParams): Promise<void> {
+  const storageLimit = getStorageLimit(req);
+  if (storageLimit === undefined) {
+    return;
+  }
+
+  const bytes = normalizeIncomingBytes(incomingBytes);
+  const userId = req.user?.id;
+  if (!userId) {
+    throw new Error('Unable to determine user for storage limit check');
+  }
+
+  /**
+   * Ledger writes stamp this same resolved tenant (see `createFileWithStorageLimit`),
+   * so query scope and write scope stay equal even when remote-agent auth supplies
+   * `req.tenantId` for a user carrying no tenant of their own.
+   */
+  const usageParams: UserStorageUsageParams = {
+    userId,
+    tenantId: resolveRequestTenantId(req as RequestTenantSource),
+    excludeFileId,
+    excludeSkillFile,
+  };
+  const cache = getStorageLimitCache(req);
+  const usageCacheKey = getUsageCacheKey(usageParams);
+  let usageEntry = cache.usageByScope.get(usageCacheKey);
+  if (usageEntry === undefined) {
+    usageEntry = {
+      params: usageParams,
+      currentUsage: await getUserStorageUsage(usageParams),
+    };
+    cache.usageByScope.set(usageCacheKey, usageEntry);
+  }
+
+  if (usageEntry.currentUsage + bytes <= storageLimit) {
+    return;
+  }
+
+  throw new FileStorageLimitError(storageLimit, usageEntry.currentUsage);
+}
+
+export function recordFileStorageUsage(
+  req: StorageLimitRequest,
+  incomingBytes?: number | null,
+  options: RecordFileStorageUsageOptions = {},
+): void {
+  const bytes = normalizeIncomingBytes(incomingBytes);
+  if (bytes === 0) {
+    return;
+  }
+
+  const cache = getStorageLimitCache(req);
+  cache.usageByScope.forEach((entry) => {
+    if (isExcludedFromScope(entry.params, options)) {
+      return;
+    }
+    entry.currentUsage += bytes;
+  });
+}

--- a/packages/api/src/files/retention.spec.ts
+++ b/packages/api/src/files/retention.spec.ts
@@ -215,16 +215,22 @@ describe('retention helpers', () => {
   });
 
   it('creates minimal retention requests for tool calls', () => {
+    const paths = {
+      imageOutput: '/srv/public/images',
+      publicPath: '/srv/public',
+      uploads: '/srv/uploads',
+    };
+
     expect(
       createMinimalRetentionRequest({
         user: { id: 'user-1', tenantId: 'tenant-1' },
         body: { conversationId: 'convo-1', isTemporary: 'true' },
-        config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY } },
+        config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY }, paths },
       }),
     ).toEqual({
       user: { id: 'user-1', tenantId: 'tenant-1' },
       body: { conversationId: 'convo-1', isTemporary: 'true' },
-      config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY } },
+      config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY }, paths },
     });
 
     expect(createMinimalRetentionRequest()).toBeUndefined();

--- a/packages/api/src/files/retention.spec.ts
+++ b/packages/api/src/files/retention.spec.ts
@@ -339,19 +339,44 @@ describe('retention helpers', () => {
   });
 
   it('creates minimal retention requests for tool calls', () => {
+    const paths = {
+      imageOutput: '/srv/public/images',
+      publicPath: '/srv/public',
+      uploads: '/srv/uploads',
+    };
+
     expect(
       createMinimalRetentionRequest({
         user: { id: 'user-1', tenantId: 'tenant-1' },
         body: { conversationId: 'convo-1', isTemporary: 'true' },
-        config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY } },
+        config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY }, paths },
       }),
     ).toEqual({
+      tenantId: undefined,
       user: { id: 'user-1', tenantId: 'tenant-1' },
       body: { conversationId: 'convo-1', isTemporary: 'true' },
-      config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY } },
+      config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY }, paths },
     });
 
     expect(createMinimalRetentionRequest()).toBeUndefined();
+  });
+
+  it('carries the resolved request tenant, not just the user tenant', () => {
+    /* Remote-agent auth places the tenant only on `req.tenantId`. Dropping it here
+     * makes downstream quota checks resolve a null tenant, billing generated images
+     * to a second ledger and handing the user a duplicate allowance. */
+    expect(
+      createMinimalRetentionRequest({
+        tenantId: 'request-tenant',
+        user: { id: 'user-1' },
+        body: { conversationId: 'convo-1' },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        tenantId: 'request-tenant',
+        user: { id: 'user-1', tenantId: undefined },
+      }),
+    );
   });
 
   describe('getSharedLinkExpiration', () => {

--- a/packages/api/src/files/retention.ts
+++ b/packages/api/src/files/retention.ts
@@ -4,6 +4,7 @@ import type { AppConfig } from '@librechat/data-schemas';
 
 type InterfaceConfig = AppConfig['interfaceConfig'];
 type FileConfig = AppConfig['fileConfig'];
+type PathsConfig = AppConfig['paths'];
 
 const retentionExpiryCache = new WeakMap<
   RetentionRequest,
@@ -28,6 +29,7 @@ export type RetentionRequest = {
   };
   config?: {
     interfaceConfig?: InterfaceConfig;
+    paths?: PathsConfig;
     fileConfig?: FileConfig;
   };
 };
@@ -228,6 +230,7 @@ export const createMinimalRetentionRequest = (
     },
     config: {
       interfaceConfig: req.config?.interfaceConfig,
+      ...(req.config?.paths ? { paths: req.config.paths } : {}),
       ...(req.config?.fileConfig ? { fileConfig: req.config.fileConfig } : {}),
     },
   };

--- a/packages/api/src/files/retention.ts
+++ b/packages/api/src/files/retention.ts
@@ -3,6 +3,7 @@ import { createFallbackRetentionDate } from '@librechat/data-schemas';
 import type { AppConfig } from '@librechat/data-schemas';
 
 type InterfaceConfig = AppConfig['interfaceConfig'];
+type FileConfig = AppConfig['fileConfig'];
 
 const retentionExpiryCache = new WeakMap<
   RetentionRequest,
@@ -27,6 +28,7 @@ export type RetentionRequest = {
   };
   config?: {
     interfaceConfig?: InterfaceConfig;
+    fileConfig?: FileConfig;
   };
 };
 
@@ -226,6 +228,7 @@ export const createMinimalRetentionRequest = (
     },
     config: {
       interfaceConfig: req.config?.interfaceConfig,
+      ...(req.config?.fileConfig ? { fileConfig: req.config.fileConfig } : {}),
     },
   };
 };

--- a/packages/api/src/files/retention.ts
+++ b/packages/api/src/files/retention.ts
@@ -3,6 +3,8 @@ import { createFallbackRetentionDate } from '@librechat/data-schemas';
 import type { AppConfig } from '@librechat/data-schemas';
 
 type InterfaceConfig = AppConfig['interfaceConfig'];
+type FileConfig = AppConfig['fileConfig'];
+type PathsConfig = AppConfig['paths'];
 
 const retentionExpiryCache = new WeakMap<
   RetentionRequest,
@@ -17,6 +19,8 @@ export type RetentionConversation = {
 };
 
 export type RetentionRequest = {
+  /** Tenant resolved by request middleware; outranks `user.tenantId` when present. */
+  tenantId?: string;
   user?: {
     id?: string;
     tenantId?: string;
@@ -27,6 +31,8 @@ export type RetentionRequest = {
   };
   config?: {
     interfaceConfig?: InterfaceConfig;
+    paths?: PathsConfig;
+    fileConfig?: FileConfig;
   };
 };
 
@@ -249,6 +255,11 @@ export const createMinimalRetentionRequest = (
   }
 
   return {
+    /* Carry the resolved request tenant, not just the user's. Remote-agent auth puts
+     * the tenant only on `req.tenantId`; dropping it here would make quota checks
+     * downstream of this request resolve a null tenant and bill generated images to a
+     * second, separate ledger. */
+    tenantId: req.tenantId,
     user: req.user
       ? {
           id: req.user.id,
@@ -261,6 +272,8 @@ export const createMinimalRetentionRequest = (
     },
     config: {
       interfaceConfig: req.config?.interfaceConfig,
+      ...(req.config?.paths ? { paths: req.config.paths } : {}),
+      ...(req.config?.fileConfig ? { fileConfig: req.config.fileConfig } : {}),
     },
   };
 };

--- a/packages/api/src/skills/import.ts
+++ b/packages/api/src/skills/import.ts
@@ -641,6 +641,7 @@ async function handleZip(
     } catch (error) {
       if (isFileStorageLimitError(error)) {
         await cleanupStoredImportFiles(deps, req, savedFiles);
+        // Runtime deleteSkill cascades SkillFile rows; blob cleanup above handles saved storage.
         await deps
           .deleteSkill(skill._id.toString())
           .catch((rollbackError) =>

--- a/packages/api/src/skills/import.ts
+++ b/packages/api/src/skills/import.ts
@@ -593,7 +593,7 @@ async function handleZip(
       // Upsert the SkillFile DB record (runs path validation internally).
       // If the DB write fails, clean up the stored blob to prevent orphans.
       try {
-        await deps.upsertSkillFile({
+        const savedSkillFile = await deps.upsertSkillFile({
           skillId: skill._id,
           relativePath,
           file_id: fileId,
@@ -608,7 +608,9 @@ async function handleZip(
           author: authorId,
           tenantId,
         });
-        recordFileStorageUsage(req, fileBuffer.length);
+        recordFileStorageUsage(req, fileBuffer.length, {
+          skillFile: { id: savedSkillFile?._id, skillId: skill._id, relativePath },
+        });
         savedFiles.push({
           filepath,
           storageKey,

--- a/packages/api/src/skills/import.ts
+++ b/packages/api/src/skills/import.ts
@@ -12,7 +12,7 @@ import type {
   CreateSkillResult,
   UpsertSkillFileInput,
 } from '@librechat/data-schemas';
-import { isFileStorageLimitError } from '~/files/limits';
+import { isFileStorageLimitError, recordFileStorageUsage } from '~/files/limits';
 import { resolveRequestTenantId } from '~/middleware/tenant';
 
 /** Security limits for zip processing. */
@@ -183,7 +183,7 @@ async function cleanupStoredImportFiles(
     return;
   }
 
-  await Promise.allSettled(
+  await Promise.all(
     files.map((file) =>
       deleteFile(req, file).catch((error) =>
         logger.error(`[importSkill] Import rollback cleanup failed:`, error),
@@ -608,6 +608,7 @@ async function handleZip(
           author: authorId,
           tenantId,
         });
+        recordFileStorageUsage(req, fileBuffer.length);
         savedFiles.push({
           filepath,
           storageKey,

--- a/packages/api/src/skills/import.ts
+++ b/packages/api/src/skills/import.ts
@@ -12,6 +12,7 @@ import type {
   CreateSkillResult,
   UpsertSkillFileInput,
 } from '@librechat/data-schemas';
+import { isFileStorageLimitError } from '~/files/limits';
 import { resolveRequestTenantId } from '~/middleware/tenant';
 
 /** Security limits for zip processing. */
@@ -20,6 +21,15 @@ const MAX_DECOMPRESSED_BYTES = 500 * 1024 * 1024; // 500 MB total decompressed
 const MAX_ENTRIES = 500;
 const MAX_SINGLE_FILE_BYTES = 10 * 1024 * 1024; // 10 MB per file
 const SKILL_MD = 'SKILL.md';
+
+type StoredImportFile = {
+  filepath: string;
+  source: string;
+  storageKey?: string;
+  storageRegion?: string;
+  user: Types.ObjectId;
+  tenantId?: string;
+};
 
 export interface ImportLimits {
   maxZipBytes: number;
@@ -160,6 +170,25 @@ function isDuplicateKeyError(error: unknown): boolean {
     typeof error === 'object' &&
     'code' in error &&
     (error as { code: unknown }).code === 11000
+  );
+}
+
+async function cleanupStoredImportFiles(
+  deps: ImportSkillDeps,
+  req: Request,
+  files: StoredImportFile[],
+): Promise<void> {
+  const deleteFile = deps.deleteFile;
+  if (!deleteFile || files.length === 0) {
+    return;
+  }
+
+  await Promise.allSettled(
+    files.map((file) =>
+      deleteFile(req, file).catch((error) =>
+        logger.error(`[importSkill] Import rollback cleanup failed:`, error),
+      ),
+    ),
   );
 }
 
@@ -465,6 +494,7 @@ async function handleZip(
 
   // Process additional files (everything except SKILL.md)
   const fileResults: Array<{ path: string; status: 'ok' | 'error'; error?: string }> = [];
+  const savedFiles: StoredImportFile[] = [];
   let totalDecompressed = 0;
 
   for (const [entryPath, zipEntry] of Object.entries(zip.files)) {
@@ -578,6 +608,14 @@ async function handleZip(
           author: authorId,
           tenantId,
         });
+        savedFiles.push({
+          filepath,
+          storageKey,
+          storageRegion,
+          source,
+          user: authorId,
+          tenantId,
+        });
       } catch (dbError) {
         if (deps.deleteFile) {
           await deps
@@ -598,6 +636,19 @@ async function handleZip(
 
       fileResults.push({ path: relativePath, status: 'ok' });
     } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        await cleanupStoredImportFiles(deps, req, savedFiles);
+        await deps
+          .deleteSkill(skill._id.toString())
+          .catch((rollbackError) =>
+            logger.error(
+              `[importSkill] Failed to roll back over-limit skill import:`,
+              rollbackError,
+            ),
+          );
+        return res.status(error.status).json({ error: error.message });
+      }
+
       logger.error(`[importSkill] Failed to process file ${relativePath}:`, error);
       fileResults.push({
         path: relativePath,

--- a/packages/api/src/skills/import.ts
+++ b/packages/api/src/skills/import.ts
@@ -37,6 +37,7 @@ import {
   contentFilterUninspectableResponse,
   getBlockedUninspectableSkillFileField,
 } from '~/protection';
+import { isFileStorageLimitError, recordFileStorageUsage } from '~/files/limits';
 import { contentFilterBlockResponse } from '~/middleware/contentFilter';
 import { resolveRequestTenantId } from '~/middleware/tenant';
 import { DEFAULT_SKILL_IMPORT_LIMITS } from './limits';
@@ -47,6 +48,15 @@ import { isBinaryBuffer } from './binary';
 const SKILL_MD = 'SKILL.md';
 
 export type { ImportLimits } from './limits';
+
+type StoredImportFile = {
+  filepath: string;
+  source: string;
+  storageKey?: string;
+  storageRegion?: string;
+  user: Types.ObjectId;
+  tenantId?: string;
+};
 
 /**
  * YAML frontmatter parser — extracts the first-class fields LibreChat
@@ -123,6 +133,25 @@ function isDuplicateKeyError(error: unknown): boolean {
     typeof error === 'object' &&
     'code' in error &&
     (error as { code: unknown }).code === 11000
+  );
+}
+
+async function cleanupStoredImportFiles(
+  deps: ImportSkillDeps,
+  req: Request,
+  files: StoredImportFile[],
+): Promise<void> {
+  const deleteFile = deps.deleteFile;
+  if (!deleteFile || files.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    files.map((file) =>
+      deleteFile(req, file).catch((error) =>
+        logger.error(`[importSkill] Import rollback cleanup failed:`, error),
+      ),
+    ),
   );
 }
 
@@ -599,6 +628,9 @@ async function scanArchiveFiles(
       files.push(fileDescriptor);
       results.push({ path: relativePath, status: 'ok' });
     } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        throw error;
+      }
       logger.error(`[importSkill] Failed to read file ${relativePath}:`, error);
       results.push({
         path: relativePath,
@@ -638,6 +670,8 @@ interface ArchivePersistenceContext {
   readonly skillId: Types.ObjectId;
   readonly authorId: Types.ObjectId;
   readonly tenantId?: string;
+  /** Blobs written so far, so an over-quota abort can roll the whole import back. */
+  readonly savedFiles: StoredImportFile[];
 }
 
 async function persistArchiveFile(
@@ -659,7 +693,7 @@ async function persistArchiveFile(
   });
 
   try {
-    await deps.upsertSkillFile({
+    const savedSkillFile = await deps.upsertSkillFile({
       skillId: context.skillId,
       relativePath: file.relativePath,
       file_id: fileId,
@@ -672,6 +706,21 @@ async function persistArchiveFile(
       bytes: buffer.length,
       isExecutable: false,
       author: context.authorId,
+      tenantId: context.tenantId,
+    });
+    recordFileStorageUsage(req, buffer.length, {
+      skillFile: {
+        id: savedSkillFile?._id,
+        skillId: context.skillId,
+        relativePath: file.relativePath,
+      },
+    });
+    context.savedFiles.push({
+      filepath,
+      storageKey,
+      storageRegion,
+      source,
+      user: context.authorId,
       tenantId: context.tenantId,
     });
   } catch (dbError) {
@@ -737,6 +786,9 @@ async function persistPreflightedArchiveFiles(
       await persistArchiveFile(req, deps, file, buffer, context);
       results.push({ path: file.relativePath, status: 'ok' });
     } catch (error) {
+      if (isFileStorageLimitError(error)) {
+        throw error;
+      }
       logger.error(`[importSkill] Failed to process file ${file.relativePath}:`, error);
       results.push({
         path: file.relativePath,
@@ -950,39 +1002,55 @@ async function handleZip(
     return res.status(500).json({ error: grant.error });
   }
 
+  const savedFiles: StoredImportFile[] = [];
   const persistenceContext: ArchivePersistenceContext = {
     userId,
     skillId: skill._id,
     authorId,
     tenantId,
+    savedFiles,
   };
   let fileResults: ImportFileResult[];
-  if (preflight == null) {
-    const processing = await scanArchiveFiles(
-      zip,
-      prefix,
-      limits,
-      {
-        onFile: async (archiveFile, buffer) => {
-          await persistArchiveFile(req, deps, archiveFile, buffer, persistenceContext);
-          return false;
+  try {
+    if (preflight == null) {
+      const processing = await scanArchiveFiles(
+        zip,
+        prefix,
+        limits,
+        {
+          onFile: async (archiveFile, buffer) => {
+            await persistArchiveFile(req, deps, archiveFile, buffer, persistenceContext);
+            return false;
+          },
         },
-      },
-      skillMdBytes,
-    );
-    fileResults = processing.results;
-  } else {
-    const preflightErrors = preflight.results.filter((result) => result.status === 'error');
-    const persisted = await persistPreflightedArchiveFiles(
-      req,
-      deps,
-      zip,
-      preflight.files,
-      limits,
-      persistenceContext,
-      skillMdBytes,
-    );
-    fileResults = [...preflightErrors, ...persisted];
+        skillMdBytes,
+      );
+      fileResults = processing.results;
+    } else {
+      const preflightErrors = preflight.results.filter((result) => result.status === 'error');
+      const persisted = await persistPreflightedArchiveFiles(
+        req,
+        deps,
+        zip,
+        preflight.files,
+        limits,
+        persistenceContext,
+        skillMdBytes,
+      );
+      fileResults = [...preflightErrors, ...persisted];
+    }
+  } catch (error) {
+    if (!isFileStorageLimitError(error)) {
+      throw error;
+    }
+    await cleanupStoredImportFiles(deps, req, savedFiles);
+    /** Runtime `deleteSkill` cascades SkillFile rows; the blob cleanup above covers storage. */
+    await deps
+      .deleteSkill(skill._id.toString())
+      .catch((rollbackError) =>
+        logger.error(`[importSkill] Failed to roll back over-limit skill import:`, rollbackError),
+      );
+    return res.status(error.status).json({ error: error.message });
   }
 
   const errors: typeof fileResults = [];

--- a/packages/api/src/utils/files.spec.ts
+++ b/packages/api/src/utils/files.spec.ts
@@ -539,6 +539,11 @@ describe('resolveUploadErrorMessage', () => {
     );
   });
 
+  test('surfaces storage limit errors', () => {
+    const msg = 'storage limit exceeded. Delete files before uploading more.';
+    expect(resolveUploadErrorMessage({ message: msg })).toBe(msg);
+  });
+
   test('surfaces "Unable to extract text from" errors', () => {
     const msg = 'Unable to extract text from "doc.pdf". The document may be image-based.';
     expect(resolveUploadErrorMessage({ message: msg })).toBe(msg);

--- a/packages/api/src/utils/files.spec.ts
+++ b/packages/api/src/utils/files.spec.ts
@@ -573,6 +573,25 @@ describe('resolveUploadErrorMessage', () => {
     expect(result).not.toContain('PRIVATE-UPLOAD');
   });
 
+  test('surfaces storage limit errors', () => {
+    const msg = 'storage limit exceeded. Delete files before uploading more.';
+    expect(resolveUploadErrorMessage({ message: msg })).toBe(msg);
+  });
+
+  test('maps storage limit errors to a fixed message when redaction is enabled', () => {
+    const result = resolveUploadErrorMessage(
+      {
+        message: 'storage limit exceeded. Delete files or ask an admin to raise it (100MB).',
+      },
+      undefined,
+      true,
+    );
+
+    expect(result).toBe(
+      'Storage limit reached. Delete files or ask an admin to raise your storage limit.',
+    );
+  });
+
   test('preserves legacy "Unable to extract text from" details by default', () => {
     const msg = 'Unable to extract text from "doc.pdf". The document may be image-based.';
     expect(resolveUploadErrorMessage({ message: msg })).toBe(msg);

--- a/packages/api/src/utils/files.ts
+++ b/packages/api/src/utils/files.ts
@@ -6,6 +6,7 @@ import { readFile, stat } from 'fs/promises';
 const USER_FACING_UPLOAD_ERRORS = [
   'Invalid file format',
   'exceeds token limit',
+  'storage limit',
   'Unable to extract text from',
 ] as const;
 

--- a/packages/api/src/utils/files.ts
+++ b/packages/api/src/utils/files.ts
@@ -6,6 +6,10 @@ import { readFile, stat } from 'fs/promises';
 const USER_FACING_UPLOAD_ERRORS = [
   ['Invalid file format', 'Invalid file format'],
   ['exceeds token limit', 'File content exceeds token limit'],
+  [
+    'storage limit',
+    'Storage limit reached. Delete files or ask an admin to raise your storage limit.',
+  ],
   ['Unable to extract text from', 'Unable to extract text from file'],
 ] as const;
 
@@ -91,6 +95,28 @@ export function resolveUploadErrorMessage(
   }
 
   return defaultMessage;
+}
+
+/**
+ * Resolves the HTTP status an upload error should surface with. Honors the
+ * `userErrorStatusCode` convention first, then the `status`/`statusCode` carried by
+ * typed errors such as `FileStorageLimitError`, falling back to 500.
+ */
+export function resolveUploadErrorStatus(
+  error:
+    | { userErrorStatusCode?: unknown; status?: unknown; statusCode?: unknown }
+    | null
+    | undefined,
+  defaultStatus = 500,
+): number {
+  for (const candidate of [error?.userErrorStatusCode, error?.status, error?.statusCode]) {
+    const status = Number(candidate);
+    if (Number.isInteger(status) && status >= 400 && status <= 599) {
+      return status;
+    }
+  }
+
+  return defaultStatus;
 }
 
 /**

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -8,6 +8,7 @@ import {
   applicationMimeTypes,
   defaultOCRMimeTypes,
   supportedMimeTypes,
+  fileConfigSchema,
   mergeFileConfig,
   inferMimeType,
   textMimeTypes,
@@ -846,6 +847,20 @@ describe('getEndpointFileConfig', () => {
       expect(merged.skills?.fileSizeLimit).toBe(15 * 1024 * 1024);
     });
 
+    it('should convert storageLimit from MB to bytes', () => {
+      const merged = mergeFileConfig({
+        storageLimit: 25,
+      });
+
+      expect(merged.storageLimit).toBe(25 * 1024 * 1024);
+    });
+
+    it('should leave storageLimit unset by default', () => {
+      const merged = mergeFileConfig(undefined);
+
+      expect(merged.storageLimit).toBeUndefined();
+    });
+
     it('should default skills fileSizeLimit to 50 MB', () => {
       const merged = mergeFileConfig(undefined);
 
@@ -1275,6 +1290,16 @@ describe('getEndpointFileConfig', () => {
       expect(result.totalSizeLimit).toBe(0);
       expect(result.supportedMimeTypes).toEqual([]);
     });
+  });
+});
+
+describe('fileConfigSchema', () => {
+  it('should accept storageLimit', () => {
+    expect(fileConfigSchema.safeParse({ storageLimit: 100 }).success).toBe(true);
+  });
+
+  it('should reject negative storageLimit', () => {
+    expect(fileConfigSchema.safeParse({ storageLimit: -1 }).success).toBe(false);
   });
 });
 

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -965,6 +965,20 @@ describe('getEndpointFileConfig', () => {
       expect(merged.skills?.fileSizeLimit).toBe(15 * 1024 * 1024);
     });
 
+    it('should convert storageLimit from MB to bytes', () => {
+      const merged = mergeFileConfig({
+        storageLimit: 25,
+      });
+
+      expect(merged.storageLimit).toBe(25 * 1024 * 1024);
+    });
+
+    it('should leave storageLimit unset by default', () => {
+      const merged = mergeFileConfig(undefined);
+
+      expect(merged.storageLimit).toBeUndefined();
+    });
+
     it('should default skills fileSizeLimit to 50 MB', () => {
       const merged = mergeFileConfig(undefined);
 
@@ -1394,6 +1408,16 @@ describe('getEndpointFileConfig', () => {
       expect(result.totalSizeLimit).toBe(0);
       expect(result.supportedMimeTypes).toEqual([]);
     });
+  });
+});
+
+describe('fileConfigSchema', () => {
+  it('should accept storageLimit', () => {
+    expect(fileConfigSchema.safeParse({ storageLimit: 100 }).success).toBe(true);
+  });
+
+  it('should reject negative storageLimit', () => {
+    expect(fileConfigSchema.safeParse({ storageLimit: -1 }).success).toBe(false);
   });
 });
 

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -471,6 +471,7 @@ export const fileConfigSchema = z.object({
   endpoints: z.record(endpointFileConfigSchema).optional(),
   skills: skillFileConfigSchema.optional(),
   serverFileSizeLimit: z.number().min(0).optional(),
+  storageLimit: z.number().min(0).optional(),
   avatarSizeLimit: z.number().min(0).optional(),
   fileTokenLimit: z.number().min(0).optional(),
   imageGeneration: z
@@ -683,6 +684,10 @@ export function mergeFileConfig(dynamic: z.infer<typeof fileConfigSchema> | unde
 
   if (dynamic.serverFileSizeLimit !== undefined) {
     mergedConfig.serverFileSizeLimit = mbToBytes(dynamic.serverFileSizeLimit);
+  }
+
+  if (dynamic.storageLimit !== undefined) {
+    mergedConfig.storageLimit = mbToBytes(dynamic.storageLimit);
   }
 
   if (dynamic.avatarSizeLimit !== undefined) {

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -523,6 +523,7 @@ export const fileConfigSchema = z.object({
   endpoints: z.record(endpointFileConfigSchema).optional(),
   skills: skillFileConfigSchema.optional(),
   serverFileSizeLimit: z.number().min(0).optional(),
+  storageLimit: z.number().min(0).optional(),
   avatarSizeLimit: z.number().min(0).optional(),
   fileTokenLimit: z.number().min(0).optional(),
   imageGeneration: z
@@ -1004,6 +1005,10 @@ export function mergeFileConfig(dynamic: z.infer<typeof fileConfigSchema> | unde
 
   if (dynamic.serverFileSizeLimit !== undefined) {
     mergedConfig.serverFileSizeLimit = mbToBytes(dynamic.serverFileSizeLimit);
+  }
+
+  if (dynamic.storageLimit !== undefined) {
+    mergedConfig.storageLimit = mbToBytes(dynamic.storageLimit);
   }
 
   if (dynamic.avatarSizeLimit !== undefined) {

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -55,6 +55,7 @@ export type FileConfig = {
     fileSizeLimit?: number;
   };
   fileTokenLimit?: number;
+  storageLimit?: number;
   serverFileSizeLimit?: number;
   avatarSizeLimit?: number;
   clientImageResize?: {
@@ -83,6 +84,7 @@ export type FileConfigInput = {
     fileSizeLimit?: number;
   };
   serverFileSizeLimit?: number;
+  storageLimit?: number;
   avatarSizeLimit?: number;
   clientImageResize?: {
     enabled?: boolean;

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -58,6 +58,7 @@ export type FileConfig = {
     fileSizeLimit?: number;
   };
   fileTokenLimit?: number;
+  storageLimit?: number;
   serverFileSizeLimit?: number;
   avatarSizeLimit?: number;
   clientImageResize?: {
@@ -88,6 +89,7 @@ export type FileConfigInput = {
     fileSizeLimit?: number;
   };
   serverFileSizeLimit?: number;
+  storageLimit?: number;
   avatarSizeLimit?: number;
   clientImageResize?: {
     enabled?: boolean;

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -254,6 +254,14 @@ describe('File Methods', () => {
       await expect(fileMethods.getUserStorageUsage({ userId, tenantId: 't1' })).resolves.toBe(150);
     });
 
+    it('defines compound indexes for storage usage lookups', () => {
+      const fileIndexes = File.schema.indexes().map(([fields]) => fields);
+      const skillFileIndexes = SkillFile.schema.indexes().map(([fields]) => fields);
+
+      expect(fileIndexes).toContainEqual({ user: 1, tenantId: 1 });
+      expect(skillFileIndexes).toContainEqual({ author: 1, tenantId: 1 });
+    });
+
     it('uses legacy no-tenant scope when tenantId is absent', async () => {
       const userId = new mongoose.Types.ObjectId();
       const skillId = new mongoose.Types.ObjectId();
@@ -313,6 +321,19 @@ describe('File Methods', () => {
           excludeSkillFile: { skillId, relativePath: 'replace.txt' },
         }),
       ).resolves.toBe(50);
+    });
+
+    it('rejects invalid ObjectId inputs instead of under-counting usage', async () => {
+      await expect(fileMethods.getUserStorageUsage({ userId: 'not-an-object-id' })).rejects.toThrow(
+        'Invalid userId',
+      );
+
+      await expect(
+        fileMethods.getUserStorageUsage({
+          userId: new mongoose.Types.ObjectId(),
+          excludeSkillFile: { skillId: 'not-an-object-id', relativePath: 'replace.txt' },
+        }),
+      ).rejects.toThrow('Invalid excludeSkillFile.skillId');
     });
   });
 

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { EToolResources, FileContext } from 'librechat-data-provider';
@@ -8,6 +9,7 @@ import { runAsSystem } from '~/config/tenantContext';
 import { _resetStrictCache } from '~/models/plugins/tenantIsolation';
 
 let File: mongoose.Model<unknown>;
+let SkillFile: mongoose.Model<unknown>;
 let fileMethods: ReturnType<typeof createFileMethods>;
 let mongoServer: MongoMemoryServer;
 let modelsToCleanup: string[] = [];
@@ -23,6 +25,7 @@ describe('File Methods', () => {
     Object.assign(mongoose.models, models);
 
     File = mongoose.models.File as mongoose.Model<unknown>;
+    SkillFile = mongoose.models.SkillFile as mongoose.Model<unknown>;
     fileMethods = createFileMethods(mongoose);
   });
 
@@ -44,6 +47,7 @@ describe('File Methods', () => {
 
   beforeEach(async () => {
     await File.deleteMany({});
+    await SkillFile.deleteMany({});
   });
 
   describe('createFile', () => {
@@ -163,6 +167,150 @@ describe('File Methods', () => {
 
       expect(legacy.file_id).toBe('legacy-null-file');
       expect(legacyAgain.file_id).toBe('legacy-null-file');
+    });
+  });
+
+  describe('getUserStorageUsage', () => {
+    const createStoredFile = async ({
+      user,
+      file_id,
+      bytes,
+      tenantId,
+    }: {
+      user: mongoose.Types.ObjectId;
+      file_id: string;
+      bytes: number;
+      tenantId?: string;
+    }) =>
+      runAsSystem(() =>
+        File.create({
+          file_id,
+          user,
+          filename: `${file_id}.txt`,
+          filepath: `/uploads/${file_id}.txt`,
+          type: 'text/plain',
+          bytes,
+          tenantId,
+        }),
+      );
+
+    const createSkillFile = ({
+      author,
+      skillId,
+      relativePath,
+      bytes,
+      tenantId,
+    }: {
+      author: mongoose.Types.ObjectId;
+      skillId: mongoose.Types.ObjectId;
+      relativePath: string;
+      bytes: number;
+      tenantId?: string;
+    }) =>
+      SkillFile.create({
+        skillId,
+        relativePath,
+        file_id: uuidv4(),
+        filename: path.basename(relativePath),
+        filepath: `/uploads/${relativePath}`,
+        source: 'local',
+        mimeType: 'text/plain',
+        bytes,
+        isExecutable: false,
+        author,
+        tenantId,
+      });
+
+    it('sums File and authored SkillFile bytes by user and tenant', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const otherUserId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'tenant-file', bytes: 100, tenantId: 't1' });
+      await createStoredFile({ user: userId, file_id: 'other-tenant', bytes: 200, tenantId: 't2' });
+      await createStoredFile({
+        user: otherUserId,
+        file_id: 'other-user',
+        bytes: 300,
+        tenantId: 't1',
+      });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'scripts/run.sh',
+        bytes: 50,
+        tenantId: 't1',
+      });
+      await createSkillFile({
+        author: otherUserId,
+        skillId,
+        relativePath: 'scripts/other.sh',
+        bytes: 75,
+        tenantId: 't1',
+      });
+
+      await expect(fileMethods.getUserStorageUsage({ userId, tenantId: 't1' })).resolves.toBe(150);
+    });
+
+    it('uses legacy no-tenant scope when tenantId is absent', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'legacy-file', bytes: 100 });
+      await createStoredFile({ user: userId, file_id: 'tenant-file', bytes: 200, tenantId: 't1' });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'legacy.txt',
+        bytes: 25,
+      });
+
+      await expect(fileMethods.getUserStorageUsage({ userId })).resolves.toBe(125);
+    });
+
+    it('ignores non-positive bytes', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'positive', bytes: 10 });
+      await createStoredFile({ user: userId, file_id: 'zero', bytes: 0 });
+      await createStoredFile({ user: userId, file_id: 'negative', bytes: -10 });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'empty.txt',
+        bytes: 0,
+      });
+
+      await expect(fileMethods.getUserStorageUsage({ userId })).resolves.toBe(10);
+    });
+
+    it('excludes replacement File and SkillFile rows', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'replace-me', bytes: 100 });
+      await createStoredFile({ user: userId, file_id: 'keep-me', bytes: 30 });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'replace.txt',
+        bytes: 40,
+      });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'keep.txt',
+        bytes: 20,
+      });
+
+      await expect(
+        fileMethods.getUserStorageUsage({
+          userId,
+          excludeFileId: 'replace-me',
+          excludeSkillFile: { skillId, relativePath: 'replace.txt' },
+        }),
+      ).resolves.toBe(50);
     });
   });
 

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -207,19 +207,21 @@ describe('File Methods', () => {
       bytes: number;
       tenantId?: string;
     }) =>
-      SkillFile.create({
-        skillId,
-        relativePath,
-        file_id: uuidv4(),
-        filename: path.basename(relativePath),
-        filepath: `/uploads/${relativePath}`,
-        source: 'local',
-        mimeType: 'text/plain',
-        bytes,
-        isExecutable: false,
-        author,
-        tenantId,
-      });
+      runAsSystem(() =>
+        SkillFile.create({
+          skillId,
+          relativePath,
+          file_id: uuidv4(),
+          filename: path.basename(relativePath),
+          filepath: `/uploads/${relativePath}`,
+          source: 'local',
+          mimeType: 'text/plain',
+          bytes,
+          isExecutable: false,
+          author,
+          tenantId,
+        }),
+      );
 
     it('sums File and authored SkillFile bytes by user and tenant', async () => {
       const userId = new mongoose.Types.ObjectId();

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import mongoose from 'mongoose';
 import { v4 as uuidv4 } from 'uuid';
 import { MongoMemoryServer } from 'mongodb-memory-server';
@@ -8,6 +9,7 @@ import { createFileMethods } from './file';
 import { createModels } from '~/models';
 
 let File: mongoose.Model<unknown>;
+let SkillFile: mongoose.Model<unknown>;
 let fileMethods: ReturnType<typeof createFileMethods>;
 let mongoServer: MongoMemoryServer;
 let modelsToCleanup: string[] = [];
@@ -23,6 +25,7 @@ describe('File Methods', () => {
     Object.assign(mongoose.models, models);
 
     File = mongoose.models.File as mongoose.Model<unknown>;
+    SkillFile = mongoose.models.SkillFile as mongoose.Model<unknown>;
     fileMethods = createFileMethods(mongoose);
   });
 
@@ -44,6 +47,7 @@ describe('File Methods', () => {
 
   beforeEach(async () => {
     await File.deleteMany({});
+    await SkillFile.deleteMany({});
   });
 
   describe('createFile', () => {
@@ -253,6 +257,173 @@ describe('File Methods', () => {
 
       expect(legacy.file_id).toBe('legacy-null-file');
       expect(legacyAgain.file_id).toBe('legacy-null-file');
+    });
+  });
+
+  describe('getUserStorageUsage', () => {
+    const createStoredFile = async ({
+      user,
+      file_id,
+      bytes,
+      tenantId,
+    }: {
+      user: mongoose.Types.ObjectId;
+      file_id: string;
+      bytes: number;
+      tenantId?: string;
+    }) =>
+      runAsSystem(() =>
+        File.create({
+          file_id,
+          user,
+          filename: `${file_id}.txt`,
+          filepath: `/uploads/${file_id}.txt`,
+          type: 'text/plain',
+          bytes,
+          tenantId,
+        }),
+      );
+
+    const createSkillFile = ({
+      author,
+      skillId,
+      relativePath,
+      bytes,
+      tenantId,
+    }: {
+      author: mongoose.Types.ObjectId;
+      skillId: mongoose.Types.ObjectId;
+      relativePath: string;
+      bytes: number;
+      tenantId?: string;
+    }) =>
+      runAsSystem(() =>
+        SkillFile.create({
+          skillId,
+          relativePath,
+          file_id: uuidv4(),
+          filename: path.basename(relativePath),
+          filepath: `/uploads/${relativePath}`,
+          source: 'local',
+          mimeType: 'text/plain',
+          bytes,
+          isExecutable: false,
+          author,
+          tenantId,
+        }),
+      );
+
+    it('sums File and authored SkillFile bytes by user and tenant', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const otherUserId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'tenant-file', bytes: 100, tenantId: 't1' });
+      await createStoredFile({ user: userId, file_id: 'other-tenant', bytes: 200, tenantId: 't2' });
+      await createStoredFile({
+        user: otherUserId,
+        file_id: 'other-user',
+        bytes: 300,
+        tenantId: 't1',
+      });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'scripts/run.sh',
+        bytes: 50,
+        tenantId: 't1',
+      });
+      await createSkillFile({
+        author: otherUserId,
+        skillId,
+        relativePath: 'scripts/other.sh',
+        bytes: 75,
+        tenantId: 't1',
+      });
+
+      await expect(fileMethods.getUserStorageUsage({ userId, tenantId: 't1' })).resolves.toBe(150);
+    });
+
+    it('defines compound indexes for storage usage lookups', () => {
+      const fileIndexes = File.schema.indexes().map(([fields]) => fields);
+      const skillFileIndexes = SkillFile.schema.indexes().map(([fields]) => fields);
+
+      expect(fileIndexes).toContainEqual({ user: 1, tenantId: 1 });
+      expect(skillFileIndexes).toContainEqual({ author: 1, tenantId: 1 });
+    });
+
+    it('uses legacy no-tenant scope when tenantId is absent', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'legacy-file', bytes: 100 });
+      await createStoredFile({ user: userId, file_id: 'tenant-file', bytes: 200, tenantId: 't1' });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'legacy.txt',
+        bytes: 25,
+      });
+
+      await expect(fileMethods.getUserStorageUsage({ userId })).resolves.toBe(125);
+    });
+
+    it('ignores non-positive bytes', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'positive', bytes: 10 });
+      await createStoredFile({ user: userId, file_id: 'zero', bytes: 0 });
+      await createStoredFile({ user: userId, file_id: 'negative', bytes: -10 });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'empty.txt',
+        bytes: 0,
+      });
+
+      await expect(fileMethods.getUserStorageUsage({ userId })).resolves.toBe(10);
+    });
+
+    it('excludes replacement File and SkillFile rows', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const skillId = new mongoose.Types.ObjectId();
+
+      await createStoredFile({ user: userId, file_id: 'replace-me', bytes: 100 });
+      await createStoredFile({ user: userId, file_id: 'keep-me', bytes: 30 });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'replace.txt',
+        bytes: 40,
+      });
+      await createSkillFile({
+        author: userId,
+        skillId,
+        relativePath: 'keep.txt',
+        bytes: 20,
+      });
+
+      await expect(
+        fileMethods.getUserStorageUsage({
+          userId,
+          excludeFileId: 'replace-me',
+          excludeSkillFile: { skillId, relativePath: 'replace.txt' },
+        }),
+      ).resolves.toBe(50);
+    });
+
+    it('rejects invalid ObjectId inputs instead of under-counting usage', async () => {
+      await expect(fileMethods.getUserStorageUsage({ userId: 'not-an-object-id' })).rejects.toThrow(
+        'Invalid userId',
+      );
+
+      await expect(
+        fileMethods.getUserStorageUsage({
+          userId: new mongoose.Types.ObjectId(),
+          excludeSkillFile: { skillId: 'not-an-object-id', relativePath: 'replace.txt' },
+        }),
+      ).rejects.toThrow('Invalid excludeSkillFile.skillId');
     });
   });
 

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -1,11 +1,94 @@
 import logger from '../config/winston';
 import { EToolResources, FileContext } from 'librechat-data-provider';
-import type { FilterQuery, SortOrder, Model } from 'mongoose';
+import type { FilterQuery, SortOrder, Model, Types } from 'mongoose';
 import type { IMongoFile } from '~/types/file';
+import type { ISkillFileDocument } from '~/types/skill';
+import { runAsSystem } from '~/config/tenantContext';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
+
+type ObjectIdInput = string | Types.ObjectId;
+
+export type SkillFileStorageExclusion = {
+  id?: ObjectIdInput;
+  skillId?: ObjectIdInput;
+  relativePath?: string;
+};
+
+export type UserStorageUsageParams = {
+  userId: ObjectIdInput;
+  tenantId?: string | null;
+  excludeFileId?: string | null;
+  excludeSkillFile?: SkillFileStorageExclusion | null;
+};
 
 /** Factory function that takes mongoose instance and returns the file methods */
 export function createFileMethods(mongoose: typeof import('mongoose')) {
+  function toObjectId(value: ObjectIdInput): string | Types.ObjectId {
+    if (value instanceof mongoose.Types.ObjectId) {
+      return value;
+    }
+
+    return mongoose.Types.ObjectId.isValid(value) ? new mongoose.Types.ObjectId(value) : value;
+  }
+
+  async function sumFileBytes(match: FilterQuery<IMongoFile>): Promise<number> {
+    const File = mongoose.models.File as Model<IMongoFile>;
+    const [result] = await File.aggregate<{ total: number }>([
+      { $match: match },
+      { $group: { _id: null, total: { $sum: '$bytes' } } },
+    ]);
+    return result?.total ?? 0;
+  }
+
+  async function sumSkillFileBytes(match: FilterQuery<ISkillFileDocument>): Promise<number> {
+    const SkillFile = mongoose.models.SkillFile as Model<ISkillFileDocument>;
+    const [result] = await SkillFile.aggregate<{ total: number }>([
+      { $match: match },
+      { $group: { _id: null, total: { $sum: '$bytes' } } },
+    ]);
+    return result?.total ?? 0;
+  }
+
+  async function getUserStorageUsage({
+    userId,
+    tenantId,
+    excludeFileId,
+    excludeSkillFile,
+  }: UserStorageUsageParams): Promise<number> {
+    const userObjectId = toObjectId(userId);
+    const scopedTenantId = tenantId ?? null;
+    const fileMatch: FilterQuery<IMongoFile> = {
+      user: userObjectId,
+      tenantId: scopedTenantId,
+      bytes: { $gt: 0 },
+    };
+    const skillFileMatch: FilterQuery<ISkillFileDocument> = {
+      author: userObjectId,
+      tenantId: scopedTenantId,
+      bytes: { $gt: 0 },
+    };
+
+    if (excludeFileId) {
+      fileMatch.file_id = { $ne: excludeFileId };
+    }
+
+    if (excludeSkillFile?.id) {
+      skillFileMatch._id = { $ne: toObjectId(excludeSkillFile.id) };
+    } else if (excludeSkillFile?.skillId && excludeSkillFile.relativePath) {
+      skillFileMatch.$nor = [
+        {
+          skillId: toObjectId(excludeSkillFile.skillId),
+          relativePath: excludeSkillFile.relativePath,
+        },
+      ];
+    }
+
+    const [fileBytes, skillFileBytes] = await runAsSystem(() =>
+      Promise.all([sumFileBytes(fileMatch), sumSkillFileBytes(skillFileMatch)]),
+    );
+    return fileBytes + skillFileBytes;
+  }
+
   /**
    * Finds a file by its file_id with additional query options.
    * @param file_id - The unique identifier of the file
@@ -464,6 +547,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')) {
 
   return {
     findFileById,
+    getUserStorageUsage,
     getFiles,
     getExpiredFiles,
     getToolFilesByIds,

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -23,12 +23,16 @@ export type UserStorageUsageParams = {
 
 /** Factory function that takes mongoose instance and returns the file methods */
 export function createFileMethods(mongoose: typeof import('mongoose')) {
-  function toObjectId(value: ObjectIdInput): string | Types.ObjectId {
+  function toObjectId(value: ObjectIdInput, label: string): Types.ObjectId {
     if (value instanceof mongoose.Types.ObjectId) {
       return value;
     }
 
-    return mongoose.Types.ObjectId.isValid(value) ? new mongoose.Types.ObjectId(value) : value;
+    if (mongoose.Types.ObjectId.isValid(value)) {
+      return new mongoose.Types.ObjectId(value);
+    }
+
+    throw new Error(`Invalid ${label}`);
   }
 
   async function sumFileBytes(match: FilterQuery<IMongoFile>): Promise<number> {
@@ -55,7 +59,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')) {
     excludeFileId,
     excludeSkillFile,
   }: UserStorageUsageParams): Promise<number> {
-    const userObjectId = toObjectId(userId);
+    const userObjectId = toObjectId(userId, 'userId');
     const scopedTenantId = tenantId ?? null;
     const fileMatch: FilterQuery<IMongoFile> = {
       user: userObjectId,
@@ -73,11 +77,11 @@ export function createFileMethods(mongoose: typeof import('mongoose')) {
     }
 
     if (excludeSkillFile?.id) {
-      skillFileMatch._id = { $ne: toObjectId(excludeSkillFile.id) };
+      skillFileMatch._id = { $ne: toObjectId(excludeSkillFile.id, 'excludeSkillFile.id') };
     } else if (excludeSkillFile?.skillId && excludeSkillFile.relativePath) {
       skillFileMatch.$nor = [
         {
-          skillId: toObjectId(excludeSkillFile.skillId),
+          skillId: toObjectId(excludeSkillFile.skillId, 'excludeSkillFile.skillId'),
           relativePath: excludeSkillFile.relativePath,
         },
       ];

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -1,7 +1,9 @@
 import { EToolResources, FileContext } from 'librechat-data-provider';
-import type { FilterQuery, SortOrder, Model } from 'mongoose';
+import type { FilterQuery, SortOrder, Model, Types } from 'mongoose';
+import type { ISkillFileDocument } from '~/types/skill';
 import type { IMongoFile } from '~/types/file';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
+import { runAsSystem } from '~/config/tenantContext';
 import logger from '../config/winston';
 
 export type FileOwnerScope = {
@@ -26,6 +28,21 @@ function withOwnerScope<T extends FilterQuery<IMongoFile>>(
   }
   return scopedFilter;
 }
+
+type ObjectIdInput = string | Types.ObjectId;
+
+export type SkillFileStorageExclusion = {
+  id?: ObjectIdInput;
+  skillId?: ObjectIdInput;
+  relativePath?: string;
+};
+
+export type UserStorageUsageParams = {
+  userId: ObjectIdInput;
+  tenantId?: string | null;
+  excludeFileId?: string | null;
+  excludeSkillFile?: SkillFileStorageExclusion | null;
+};
 
 /** Factory function that takes mongoose instance and returns the file methods */
 export function createFileMethods(mongoose: typeof import('mongoose')): {
@@ -88,7 +105,78 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
     owner: { user: string; tenantId?: string | null },
   ) => Promise<number>;
   sweepOrphanedPreviews: (maxAgeMs?: number) => Promise<number>;
+  getUserStorageUsage: (params: UserStorageUsageParams) => Promise<number>;
 } {
+  function toObjectId(value: ObjectIdInput, label: string): Types.ObjectId {
+    if (value instanceof mongoose.Types.ObjectId) {
+      return value;
+    }
+
+    if (mongoose.Types.ObjectId.isValid(value)) {
+      return new mongoose.Types.ObjectId(value);
+    }
+
+    throw new Error(`Invalid ${label}`);
+  }
+
+  async function sumFileBytes(match: FilterQuery<IMongoFile>): Promise<number> {
+    const File = mongoose.models.File as Model<IMongoFile>;
+    const [result] = await File.aggregate<{ total: number }>([
+      { $match: match },
+      { $group: { _id: null, total: { $sum: '$bytes' } } },
+    ]);
+    return result?.total ?? 0;
+  }
+
+  async function sumSkillFileBytes(match: FilterQuery<ISkillFileDocument>): Promise<number> {
+    const SkillFile = mongoose.models.SkillFile as Model<ISkillFileDocument>;
+    const [result] = await SkillFile.aggregate<{ total: number }>([
+      { $match: match },
+      { $group: { _id: null, total: { $sum: '$bytes' } } },
+    ]);
+    return result?.total ?? 0;
+  }
+
+  async function getUserStorageUsage({
+    userId,
+    tenantId,
+    excludeFileId,
+    excludeSkillFile,
+  }: UserStorageUsageParams): Promise<number> {
+    const userObjectId = toObjectId(userId, 'userId');
+    const scopedTenantId = tenantId ?? null;
+    const fileMatch: FilterQuery<IMongoFile> = {
+      user: userObjectId,
+      tenantId: scopedTenantId,
+      bytes: { $gt: 0 },
+    };
+    const skillFileMatch: FilterQuery<ISkillFileDocument> = {
+      author: userObjectId,
+      tenantId: scopedTenantId,
+      bytes: { $gt: 0 },
+    };
+
+    if (excludeFileId) {
+      fileMatch.file_id = { $ne: excludeFileId };
+    }
+
+    if (excludeSkillFile?.id) {
+      skillFileMatch._id = { $ne: toObjectId(excludeSkillFile.id, 'excludeSkillFile.id') };
+    } else if (excludeSkillFile?.skillId && excludeSkillFile.relativePath) {
+      skillFileMatch.$nor = [
+        {
+          skillId: toObjectId(excludeSkillFile.skillId, 'excludeSkillFile.skillId'),
+          relativePath: excludeSkillFile.relativePath,
+        },
+      ];
+    }
+
+    const [fileBytes, skillFileBytes] = await runAsSystem(() =>
+      Promise.all([sumFileBytes(fileMatch), sumSkillFileBytes(skillFileMatch)]),
+    );
+    return fileBytes + skillFileBytes;
+  }
+
   /**
    * Finds a file by its file_id with additional query options.
    * @param file_id - The unique identifier of the file
@@ -677,6 +765,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')): {
 
   return {
     findFileById,
+    getUserStorageUsage,
     getFiles,
     getExpiredFiles,
     getToolFilesByIds,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -4,7 +4,7 @@ import { createRoleMethods, RoleConflictError } from './role';
 import type { RoleMethods, RoleDeps } from './role';
 import { createUserMethods, DEFAULT_SESSION_EXPIRY, type UserMethods } from './user';
 import { createKeyMethods, type KeyMethods } from './key';
-import { createFileMethods, type FileMethods } from './file';
+import { createFileMethods, type FileMethods, type UserStorageUsageParams } from './file';
 /* Memories */
 import { createMemoryMethods, type MemoryMethods } from './memory';
 /* Agent Categories */
@@ -238,6 +238,7 @@ export type {
   RoleMethods,
   KeyMethods,
   FileMethods,
+  UserStorageUsageParams,
   MemoryMethods,
   AgentCategoryMethods,
   AgentApiKeyMethods,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -1,7 +1,12 @@
 import type { RoleMethods, RoleDeps } from './role';
+import {
+  createFileMethods,
+  type FileMethods,
+  type FileOwnerScope,
+  type UserStorageUsageParams,
+} from './file';
 import { createSessionMethods, DEFAULT_REFRESH_TOKEN_EXPIRY, type SessionMethods } from './session';
 import { createUserMethods, DEFAULT_SESSION_EXPIRY, type UserMethods } from './user';
-import { createFileMethods, type FileMethods, type FileOwnerScope } from './file';
 import { createTokenMethods, type TokenMethods } from './token';
 import { createRoleMethods, RoleConflictError } from './role';
 import { createKeyMethods, type KeyMethods } from './key';
@@ -363,6 +368,7 @@ export type {
   KeyMethods,
   FileMethods,
   FileOwnerScope,
+  UserStorageUsageParams,
   MemoryMethods,
   ToolFavoriteMethods,
   AgentCategoryMethods,

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -160,6 +160,7 @@ const file: Schema<IMongoFile> = new Schema(
 
 file.index({ expiredAt: 1 });
 file.index({ createdAt: 1, updatedAt: 1 });
+file.index({ user: 1, tenantId: 1 });
 file.index(
   { filename: 1, conversationId: 1, context: 1, tenantId: 1 },
   { unique: true, partialFilterExpression: { context: FileContext.execute_code } },

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -7,7 +7,6 @@ const file: Schema<IMongoFile> = new Schema(
     user: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
-      index: true,
       required: true,
     },
     conversationId: {

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -8,7 +8,6 @@ const file: Schema<IMongoFile> = new Schema(
     user: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
-      index: true,
       required: true,
     },
     conversationId: {
@@ -160,6 +159,7 @@ const file: Schema<IMongoFile> = new Schema(
 
 file.index({ expiredAt: 1 });
 file.index({ createdAt: 1, updatedAt: 1 });
+file.index({ user: 1, tenantId: 1 });
 file.index(
   { filename: 1, conversationId: 1, context: 1, tenantId: 1 },
   { unique: true, partialFilterExpression: { context: FileContext.execute_code } },

--- a/packages/data-schemas/src/schema/skillFile.ts
+++ b/packages/data-schemas/src/schema/skillFile.ts
@@ -127,5 +127,6 @@ const skillFileSchema: Schema<ISkillFileDocument> = new Schema(
 
 skillFileSchema.index({ skillId: 1, relativePath: 1 }, { unique: true });
 skillFileSchema.index({ skillId: 1, category: 1 });
+skillFileSchema.index({ author: 1, tenantId: 1 });
 
 export default skillFileSchema;

--- a/packages/data-schemas/src/schema/skillFile.ts
+++ b/packages/data-schemas/src/schema/skillFile.ts
@@ -122,5 +122,6 @@ const skillFileSchema: Schema<ISkillFileDocument> = new Schema(
 
 skillFileSchema.index({ skillId: 1, relativePath: 1 }, { unique: true });
 skillFileSchema.index({ skillId: 1, category: 1 });
+skillFileSchema.index({ author: 1, tenantId: 1 });
 
 export default skillFileSchema;


### PR DESCRIPTION
## Summary

I added a per-user persisted file storage quota driven by `fileConfig.storageLimit`, including runtime enforcement across upload, generated-file, agent artifact, and skill-file paths.

- Added `fileConfig.storageLimit` to shared config types, validation, merge conversion, and `librechat.example.yaml`.
- Added a shared usage lookup that sums positive-byte `File` rows for the requester and authored `SkillFile` rows within the current tenant scope.
- Added an exported storage-limit helper in `@librechat/api` with preflight/final checks, replacement exclusions, and user-facing upload errors.
- Wrapped normal file persistence, generated image/file outputs, OpenAI/assistant metadata, code-output artifacts, agent attachments, and agent tool resources with quota checks and best-effort cleanup.
- Included skill imports and single skill-file uploads while charging authored skill files to the uploader/author, not skill consumers.
- Left avatar/profile-image storage and whole-server quota behavior for follow-up work because they do not write `File` or `SkillFile` ledger rows today.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- `npm run build:data-provider`
- `npm run build:data-schemas`
- `npm run build:api` (completed; existing Rollup TypeScript warnings still print)
- `npx eslint api/server/routes/skills.js api/server/routes/skills.test.js api/server/services/Files/Code/__tests__/process-traversal.spec.js api/server/services/Files/Code/process.js api/server/services/Files/Code/process.spec.js api/server/services/Files/process.js api/server/services/Files/process.spec.js packages/api/src/files/index.ts packages/api/src/files/limits.ts packages/api/src/files/limits.spec.ts packages/api/src/files/retention.ts packages/api/src/skills/import.ts packages/api/src/utils/files.ts packages/api/src/utils/files.spec.ts packages/data-provider/src/file-config.ts packages/data-provider/src/file-config.spec.ts packages/data-provider/src/types/files.ts packages/data-schemas/src/methods/file.ts packages/data-schemas/src/methods/file.spec.ts packages/data-schemas/src/methods/index.ts`
- `cd packages/data-provider && npx jest src/file-config.spec.ts --runInBand`
- `cd packages/api && npx jest src/files/limits.spec.ts src/utils/files.spec.ts src/files/retention.spec.ts --runInBand`
- `cd packages/data-schemas && npx jest src/methods/file.spec.ts --runInBand`
- `cd api && npx jest server/services/Files/process.spec.js server/services/Files/Code/process.spec.js server/services/Files/Code/__tests__/process-traversal.spec.js server/routes/skills.test.js --runInBand`

### **Test Configuration**:

- Node.js v20.19.5
- MongoDB memory server via Jest suites

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
