### PR TITLE
🩺 feat: Add Explicit Readiness Endpoints

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -53,6 +53,7 @@ const host = HOST || 'localhost';
 const trusted_proxy = Number(TRUST_PROXY) || 1; /* trust first proxy by default */
 
 const app = express();
+let serverReady = false;
 
 const startServer = async () => {
   const { metricsMiddleware, metricsRouter } = createMetrics();
@@ -113,6 +114,13 @@ const startServer = async () => {
   }
 
   app.get('/health', (_req, res) => res.status(200).send('OK'));
+  app.get('/livez', (_req, res) => res.status(200).send('OK'));
+  app.get('/readyz', (_req, res) => {
+    if (!serverReady) {
+      return res.status(503).send('NOT_READY');
+    }
+    return res.status(200).send('OK');
+  });
 
   /* Middleware */
   app.use(metricsMiddleware);
@@ -278,7 +286,10 @@ const startServer = async () => {
       if (inspectFlags || isEnabled(process.env.MEM_DIAG)) {
         memoryDiagnostics.start();
       }
+      serverReady = true;
+      logger.info('Server readiness checks passing.');
     } catch (initErr) {
+      serverReady = false;
       logger.error('Post-listen initialization failed:', initErr);
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

I added explicit Kubernetes health endpoints so liveness can stay cheap while readiness waits for post-listen initialization to finish. This complements #13211, which handles graceful shutdown, but does not duplicate that work.

- Added `/livez` as a cheap liveness endpoint that always returns `200 OK` once the HTTP server is serving requests.
- Added `/readyz` as a readiness endpoint that returns `503 NOT_READY` until MCP initialization, OAuth reconnect initialization, migrations, stream service setup, and memory diagnostics startup have completed.
- Kept `/health` unchanged for existing probes and backward compatibility.
- Logged when server readiness checks begin passing.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `node --check api/server/index.js`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node syntax verification only; this worktree does not have dependencies installed, so I did not run the Jest suite locally.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
