### PR TITLE
🗂️ feat: Allow Disabling File Log Transports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,8 @@ CONSOLE_JSON=false
 
 DEBUG_LOGGING=true
 DEBUG_CONSOLE=false
+# Set to false to disable file-backed Winston transports.
+LOG_TO_FILE=true
 # Set to true to enable agent debug logging
 AGENT_DEBUG_LOGGING=false
 

--- a/api/config/__tests__/logToFile.spec.js
+++ b/api/config/__tests__/logToFile.spec.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+
+const ORIGINAL_ENV = process.env;
+
+const mockDataSchemas = () => {
+  jest.doMock('@librechat/data-schemas', () => ({
+    getTenantId: jest.fn(),
+    getUserId: jest.fn(),
+    getRequestId: jest.fn(),
+    SYSTEM_TENANT_ID: 'system',
+  }));
+};
+
+const mockReadOnlyDockerLogDir = () => {
+  const originalExistsSync = fs.existsSync;
+  const originalMkdirSync = fs.mkdirSync;
+
+  jest.spyOn(process, 'cwd').mockReturnValue('/app');
+  jest
+    .spyOn(fs, 'existsSync')
+    .mockImplementation((target) =>
+      target === '/app/logs' ? false : originalExistsSync.call(fs, target),
+    );
+
+  return jest.spyOn(fs, 'mkdirSync').mockImplementation((target, options) => {
+    if (target === '/app/logs') {
+      throw new Error('Attempted to create Docker log directory');
+    }
+    return originalMkdirSync.call(fs, target, options);
+  });
+};
+
+const prepareLoggerWithoutFileLogging = () => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  mockDataSchemas();
+
+  process.env = {
+    ...ORIGINAL_ENV,
+    DEBUG_LOGGING: 'true',
+    LOG_TO_FILE: 'false',
+  };
+
+  return mockReadOnlyDockerLogDir();
+};
+
+describe('LOG_TO_FILE', () => {
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it('does not create the API log directory when winston file logging is disabled', () => {
+    const mkdirSyncSpy = prepareLoggerWithoutFileLogging();
+
+    expect(() => require('../winston')).not.toThrow();
+
+    const winston = require('winston');
+    expect(winston.transports.DailyRotateFile).not.toHaveBeenCalled();
+    expect(mkdirSyncSpy).not.toHaveBeenCalledWith('/app/logs', expect.anything());
+  });
+
+  it('does not create the API log directory when Meili file logging is disabled', () => {
+    const mkdirSyncSpy = prepareLoggerWithoutFileLogging();
+
+    expect(() => require('../meiliLogger')).not.toThrow();
+
+    const winston = require('winston');
+    expect(winston.transports.DailyRotateFile).not.toHaveBeenCalled();
+    expect(mkdirSyncSpy).not.toHaveBeenCalledWith('/app/logs', expect.anything());
+  });
+});

--- a/api/config/meiliLogger.js
+++ b/api/config/meiliLogger.js
@@ -29,8 +29,6 @@ const getLogDir = () => {
   return path.join(__dirname, '..', 'logs');
 };
 
-const logDir = getLogDir();
-
 const { NODE_ENV, DEBUG_LOGGING = false, LOG_TO_FILE = true } = process.env;
 
 const useDebugLogging =
@@ -75,6 +73,8 @@ const logLevel = useDebugLogging ? 'debug' : 'error';
 const transports = [];
 
 if (useFileLogging) {
+  const logDir = getLogDir();
+
   transports.push(
     new winston.transports.DailyRotateFile({
       level: logLevel,

--- a/api/config/meiliLogger.js
+++ b/api/config/meiliLogger.js
@@ -31,11 +31,15 @@ const getLogDir = () => {
 
 const logDir = getLogDir();
 
-const { NODE_ENV, DEBUG_LOGGING = false } = process.env;
+const { NODE_ENV, DEBUG_LOGGING = false, LOG_TO_FILE = true } = process.env;
 
 const useDebugLogging =
   (typeof DEBUG_LOGGING === 'string' && DEBUG_LOGGING?.toLowerCase() === 'true') ||
   DEBUG_LOGGING === true;
+
+const useFileLogging =
+  (typeof LOG_TO_FILE === 'string' && LOG_TO_FILE?.toLowerCase() !== 'false') ||
+  LOG_TO_FILE === true;
 
 const levels = {
   error: 0,
@@ -68,17 +72,21 @@ const fileFormat = winston.format.combine(
 );
 
 const logLevel = useDebugLogging ? 'debug' : 'error';
-const transports = [
-  new winston.transports.DailyRotateFile({
-    level: logLevel,
-    filename: `${logDir}/meiliSync-%DATE%.log`,
-    datePattern: 'YYYY-MM-DD',
-    zippedArchive: true,
-    maxSize: '20m',
-    maxFiles: '14d',
-    format: fileFormat,
-  }),
-];
+const transports = [];
+
+if (useFileLogging) {
+  transports.push(
+    new winston.transports.DailyRotateFile({
+      level: logLevel,
+      filename: `${logDir}/meiliSync-%DATE%.log`,
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
+      format: fileFormat,
+    }),
+  );
+}
 
 const consoleFormat = winston.format.combine(
   winston.format.colorize({ all: true }),

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -44,7 +44,13 @@ const getLogDir = () => {
 
 const logDir = getLogDir();
 
-const { NODE_ENV, DEBUG_LOGGING = true, CONSOLE_JSON = false, DEBUG_CONSOLE = false } = process.env;
+const {
+  NODE_ENV,
+  DEBUG_LOGGING = true,
+  CONSOLE_JSON = false,
+  DEBUG_CONSOLE = false,
+  LOG_TO_FILE = true,
+} = process.env;
 
 const useConsoleJson =
   (typeof CONSOLE_JSON === 'string' && CONSOLE_JSON?.toLowerCase() === 'true') ||
@@ -57,6 +63,10 @@ const useDebugConsole =
 const useDebugLogging =
   (typeof DEBUG_LOGGING === 'string' && DEBUG_LOGGING?.toLowerCase() === 'true') ||
   DEBUG_LOGGING === true;
+
+const useFileLogging =
+  (typeof LOG_TO_FILE === 'string' && LOG_TO_FILE?.toLowerCase() !== 'false') ||
+  LOG_TO_FILE === true;
 
 const levels = {
   error: 0,
@@ -129,19 +139,23 @@ const fileFormat = winston.format.combine(
   // redactErrors(),
 );
 
-const transports = [
-  new winston.transports.DailyRotateFile({
-    level: 'error',
-    filename: `${logDir}/error-%DATE%.log`,
-    datePattern: 'YYYY-MM-DD',
-    zippedArchive: true,
-    maxSize: '20m',
-    maxFiles: '14d',
-    format: fileFormat,
-  }),
-];
+const transports = [];
 
-if (useDebugLogging) {
+if (useFileLogging) {
+  transports.push(
+    new winston.transports.DailyRotateFile({
+      level: 'error',
+      filename: `${logDir}/error-%DATE%.log`,
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
+      format: fileFormat,
+    }),
+  );
+}
+
+if (useFileLogging && useDebugLogging) {
   transports.push(
     new winston.transports.DailyRotateFile({
       level: 'debug',

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -42,8 +42,6 @@ const getLogDir = () => {
   return path.join(__dirname, '..', 'logs');
 };
 
-const logDir = getLogDir();
-
 const {
   NODE_ENV,
   DEBUG_LOGGING = true,
@@ -142,6 +140,8 @@ const fileFormat = winston.format.combine(
 const transports = [];
 
 if (useFileLogging) {
+  const logDir = getLogDir();
+
   transports.push(
     new winston.transports.DailyRotateFile({
       level: 'error',
@@ -153,20 +153,20 @@ if (useFileLogging) {
       format: fileFormat,
     }),
   );
-}
 
-if (useFileLogging && useDebugLogging) {
-  transports.push(
-    new winston.transports.DailyRotateFile({
-      level: 'debug',
-      filename: `${logDir}/debug-%DATE%.log`,
-      datePattern: 'YYYY-MM-DD',
-      zippedArchive: true,
-      maxSize: '20m',
-      maxFiles: '14d',
-      format: winston.format.combine(fileFormat, debugTraverse),
-    }),
-  );
+  if (useDebugLogging) {
+    transports.push(
+      new winston.transports.DailyRotateFile({
+        level: 'debug',
+        filename: `${logDir}/debug-%DATE%.log`,
+        datePattern: 'YYYY-MM-DD',
+        zippedArchive: true,
+        maxSize: '20m',
+        maxFiles: '14d',
+        format: winston.format.combine(fileFormat, debugTraverse),
+      }),
+    );
+  }
 }
 
 const consoleFormat = winston.format.combine(

--- a/api/utils/logger.js
+++ b/api/utils/logger.js
@@ -1,12 +1,18 @@
 const winston = require('winston');
 
+const useFileLogging =
+  typeof process.env.LOG_TO_FILE !== 'string' || process.env.LOG_TO_FILE.toLowerCase() !== 'false';
+
+const transports = [new winston.transports.Console()];
+
+if (useFileLogging) {
+  transports.push(new winston.transports.File({ filename: 'login-logs.log' }));
+}
+
 const logger = winston.createLogger({
   level: 'info',
   format: winston.format.combine(winston.format.timestamp(), winston.format.json()),
-  transports: [
-    new winston.transports.Console(),
-    new winston.transports.File({ filename: 'login-logs.log' }),
-  ],
+  transports,
 });
 
 module.exports = logger;

--- a/packages/data-schemas/src/config/meiliLogger.ts
+++ b/packages/data-schemas/src/config/meiliLogger.ts
@@ -2,8 +2,6 @@ import winston from 'winston';
 import 'winston-daily-rotate-file';
 import { getLogDirectory } from './utils';
 
-const logDir = getLogDirectory();
-
 const { NODE_ENV, DEBUG_LOGGING = 'false', LOG_TO_FILE } = process.env;
 
 const useDebugLogging =
@@ -46,6 +44,8 @@ const logLevel = useDebugLogging ? 'debug' : 'error';
 const transports: winston.transport[] = [];
 
 if (useFileLogging) {
+  const logDir = getLogDirectory();
+
   transports.push(
     new winston.transports.DailyRotateFile({
       level: logLevel,

--- a/packages/data-schemas/src/config/meiliLogger.ts
+++ b/packages/data-schemas/src/config/meiliLogger.ts
@@ -4,11 +4,13 @@ import { getLogDirectory } from './utils';
 
 const logDir = getLogDirectory();
 
-const { NODE_ENV, DEBUG_LOGGING = 'false' } = process.env;
+const { NODE_ENV, DEBUG_LOGGING = 'false', LOG_TO_FILE } = process.env;
 
 const useDebugLogging =
   (typeof DEBUG_LOGGING === 'string' && DEBUG_LOGGING.toLowerCase() === 'true') ||
   DEBUG_LOGGING === 'true';
+
+const useFileLogging = typeof LOG_TO_FILE !== 'string' || LOG_TO_FILE.toLowerCase() !== 'false';
 
 const levels: winston.config.AbstractConfigSetLevels = {
   error: 0,
@@ -41,17 +43,21 @@ const fileFormat = winston.format.combine(
 );
 
 const logLevel = useDebugLogging ? 'debug' : 'error';
-const transports: winston.transport[] = [
-  new winston.transports.DailyRotateFile({
-    level: logLevel,
-    filename: `${logDir}/meiliSync-%DATE%.log`,
-    datePattern: 'YYYY-MM-DD',
-    zippedArchive: true,
-    maxSize: '20m',
-    maxFiles: '14d',
-    format: fileFormat,
-  }),
-];
+const transports: winston.transport[] = [];
+
+if (useFileLogging) {
+  transports.push(
+    new winston.transports.DailyRotateFile({
+      level: logLevel,
+      filename: `${logDir}/meiliSync-%DATE%.log`,
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
+      format: fileFormat,
+    }),
+  );
+}
 
 const consoleFormat = winston.format.combine(
   winston.format.colorize({ all: true }),

--- a/packages/data-schemas/src/config/winston.ts
+++ b/packages/data-schemas/src/config/winston.ts
@@ -6,13 +6,15 @@ import { getLogDirectory } from './utils';
 
 const logDir = getLogDirectory();
 
-const { NODE_ENV, DEBUG_LOGGING, CONSOLE_JSON, DEBUG_CONSOLE } = process.env;
+const { NODE_ENV, DEBUG_LOGGING, CONSOLE_JSON, DEBUG_CONSOLE, LOG_TO_FILE } = process.env;
 
 const useConsoleJson = typeof CONSOLE_JSON === 'string' && CONSOLE_JSON.toLowerCase() === 'true';
 
 const useDebugConsole = typeof DEBUG_CONSOLE === 'string' && DEBUG_CONSOLE.toLowerCase() === 'true';
 
 const useDebugLogging = typeof DEBUG_LOGGING === 'string' && DEBUG_LOGGING.toLowerCase() === 'true';
+
+const useFileLogging = typeof LOG_TO_FILE !== 'string' || LOG_TO_FILE.toLowerCase() !== 'false';
 
 const levels: winston.config.AbstractConfigSetLevels = {
   error: 0,
@@ -88,19 +90,23 @@ const fileFormat = winston.format.combine(
   requestContextFormat(),
 );
 
-const transports: winston.transport[] = [
-  new winston.transports.DailyRotateFile({
-    level: 'error',
-    filename: `${logDir}/error-%DATE%.log`,
-    datePattern: 'YYYY-MM-DD',
-    zippedArchive: true,
-    maxSize: '20m',
-    maxFiles: '14d',
-    format: winston.format.combine(fileFormat, winston.format.json()),
-  }),
-];
+const transports: winston.transport[] = [];
 
-if (useDebugLogging) {
+if (useFileLogging) {
+  transports.push(
+    new winston.transports.DailyRotateFile({
+      level: 'error',
+      filename: `${logDir}/error-%DATE%.log`,
+      datePattern: 'YYYY-MM-DD',
+      zippedArchive: true,
+      maxSize: '20m',
+      maxFiles: '14d',
+      format: winston.format.combine(fileFormat, winston.format.json()),
+    }),
+  );
+}
+
+if (useFileLogging && useDebugLogging) {
   transports.push(
     new winston.transports.DailyRotateFile({
       level: 'debug',

--- a/packages/data-schemas/src/config/winston.ts
+++ b/packages/data-schemas/src/config/winston.ts
@@ -4,8 +4,6 @@ import { redactFormat, redactMessage, debugTraverse, jsonTruncateFormat } from '
 import { getTenantId, getUserId, getRequestId, SYSTEM_TENANT_ID } from './tenantContext';
 import { getLogDirectory } from './utils';
 
-const logDir = getLogDirectory();
-
 const { NODE_ENV, DEBUG_LOGGING, CONSOLE_JSON, DEBUG_CONSOLE, LOG_TO_FILE } = process.env;
 
 const useConsoleJson = typeof CONSOLE_JSON === 'string' && CONSOLE_JSON.toLowerCase() === 'true';
@@ -93,6 +91,8 @@ const fileFormat = winston.format.combine(
 const transports: winston.transport[] = [];
 
 if (useFileLogging) {
+  const logDir = getLogDirectory();
+
   transports.push(
     new winston.transports.DailyRotateFile({
       level: 'error',
@@ -104,20 +104,20 @@ if (useFileLogging) {
       format: winston.format.combine(fileFormat, winston.format.json()),
     }),
   );
-}
 
-if (useFileLogging && useDebugLogging) {
-  transports.push(
-    new winston.transports.DailyRotateFile({
-      level: 'debug',
-      filename: `${logDir}/debug-%DATE%.log`,
-      datePattern: 'YYYY-MM-DD',
-      zippedArchive: true,
-      maxSize: '20m',
-      maxFiles: '14d',
-      format: winston.format.combine(fileFormat, debugTraverse),
-    }),
-  );
+  if (useDebugLogging) {
+    transports.push(
+      new winston.transports.DailyRotateFile({
+        level: 'debug',
+        filename: `${logDir}/debug-%DATE%.log`,
+        datePattern: 'YYYY-MM-DD',
+        zippedArchive: true,
+        maxSize: '20m',
+        maxFiles: '14d',
+        format: winston.format.combine(fileFormat, debugTraverse),
+      }),
+    );
+  }
 }
 
 const consoleFormat = winston.format.combine(


### PR DESCRIPTION
## Summary

I added a `LOG_TO_FILE` switch so deployments can disable Winston file transports while keeping console logging available for Kubernetes collection.

- Gate the primary API Winston error and debug rotate-file transports behind `LOG_TO_FILE`.
- Gate the Meili sync rotate-file transports behind the same flag in both API and data-schemas logger copies.
- Gate the legacy `login-logs.log` file transport behind the same flag.
- Document `LOG_TO_FILE=true` in `.env.example` while preserving current default behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Ran `node -c api/config/winston.js`.
- Ran `node -c api/config/meiliLogger.js`.
- Ran `node -c api/utils/logger.js`.

### **Test Configuration**:

- Node syntax checks for changed CommonJS logger files.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have made pertinent documentation changes
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.