### PR TITLE
🪪 fix: Add Admin Panel SSO URL Config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ MONGO_AUTO_CREATE=
 DOMAIN_CLIENT=http://localhost:3080
 DOMAIN_SERVER=http://localhost:3080
 
+# External admin panel origin used for admin OAuth/SSO redirects.
+# Required when the admin panel is hosted separately from LibreChat.
+# Example: https://admin.example.com
+ADMIN_PANEL_URL=
+
 NO_INDEX=true
 # Use the address that is at most n number of hops away from the Express application.
 # req.socket.remoteAddress is the first hop, and the rest are looked for in the X-Forwarded-For header from right to left.
@@ -533,6 +538,8 @@ OPENID_ISSUER=
 OPENID_SESSION_SECRET=
 OPENID_SCOPE="openid profile email"
 OPENID_CALLBACK_URL=/oauth/openid/callback
+# Admin panel SSO uses ${DOMAIN_SERVER}/api/admin/oauth/openid/callback as the
+# OpenID provider redirect URI.
 OPENID_REQUIRED_ROLE=
 OPENID_REQUIRED_ROLE_TOKEN_KIND=
 OPENID_REQUIRED_ROLE_PARAMETER_PATH=

--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,10 @@ MONGO_AUTO_CREATE=
 DOMAIN_CLIENT=http://localhost:3080
 DOMAIN_SERVER=http://localhost:3080
 
-# External admin panel origin used for admin OAuth/SSO redirects.
+# External admin panel base URL used for admin OAuth/SSO redirects.
 # Required when the admin panel is hosted separately from LibreChat.
-# Example: https://admin.example.com
+# May include a path. Do not include a trailing slash.
+# Example: https://admin.example.com/admin
 ADMIN_PANEL_URL=
 
 NO_INDEX=true

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/librechat/readme.md
+++ b/helm/librechat/readme.md
@@ -35,3 +35,20 @@ kind: Secret
 3. Apply the Secret to the Cluster
 
 4. Fill out values.yaml and apply the Chart to the Cluster
+
+## Admin Panel SSO
+
+When deploying the admin panel at a separate URL, set `librechat.adminPanelUrl`
+to the external admin panel origin:
+
+```yaml
+librechat:
+  adminPanelUrl: https://admin.example.com
+```
+
+This renders `ADMIN_PANEL_URL` for LibreChat's admin OAuth flow. For OpenID SSO,
+also register this LibreChat callback URL with your identity provider:
+
+```text
+https://<librechat-domain>/api/admin/oauth/openid/callback
+```

--- a/helm/librechat/readme.md
+++ b/helm/librechat/readme.md
@@ -39,11 +39,12 @@ kind: Secret
 ## Admin Panel SSO
 
 When deploying the admin panel at a separate URL, set `librechat.adminPanelUrl`
-to the external admin panel origin:
+to the external admin panel base URL. It may include a path, but it should not
+end with a trailing `/` because LibreChat appends `/auth/...` callback paths.
 
 ```yaml
 librechat:
-  adminPanelUrl: https://admin.example.com
+  adminPanelUrl: https://admin.example.com/admin
 ```
 
 This renders `ADMIN_PANEL_URL` for LibreChat's admin OAuth flow. For OpenID SSO,

--- a/helm/librechat/templates/configmap-env.yaml
+++ b/helm/librechat/templates/configmap-env.yaml
@@ -18,7 +18,7 @@ data:
   {{- if and (not (dig "configEnv" "REDIS_URI" "" .Values.librechat)) .Values.redis.enabled }}
   REDIS_URI: redis://{{ include "common.names.fullname" .Subcharts.redis }}-master.{{ .Release.Namespace | lower }}.svc.cluster.local:6379
   {{- end }}
-  {{- if and .Values.librechat.adminPanelUrl (not (hasKey (default dict .Values.librechat.configEnv) "ADMIN_PANEL_URL")) }}
+  {{- if and .Values.librechat.adminPanelUrl (not (dig "configEnv" "ADMIN_PANEL_URL" "" .Values.librechat)) }}
   ADMIN_PANEL_URL: {{ .Values.librechat.adminPanelUrl | quote }}
   {{- end }}
   {{- if .Values.librechat.configEnv }}

--- a/helm/librechat/templates/configmap-env.yaml
+++ b/helm/librechat/templates/configmap-env.yaml
@@ -18,6 +18,9 @@ data:
   {{- if and (not (dig "configEnv" "REDIS_URI" "" .Values.librechat)) .Values.redis.enabled }}
   REDIS_URI: redis://{{ include "common.names.fullname" .Subcharts.redis }}-master.{{ .Release.Namespace | lower }}.svc.cluster.local:6379
   {{- end }}
+  {{- if and .Values.librechat.adminPanelUrl (not (hasKey (default dict .Values.librechat.configEnv) "ADMIN_PANEL_URL")) }}
+  ADMIN_PANEL_URL: {{ .Values.librechat.adminPanelUrl | quote }}
+  {{- end }}
   {{- if .Values.librechat.configEnv }}
   {{- toYaml .Values.librechat.configEnv | nindent 2 }}
   {{- end }}

--- a/helm/librechat/templates/configmap-env.yaml
+++ b/helm/librechat/templates/configmap-env.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 metadata:
   name: {{ include "librechat.fullname" $ }}-configenv
 data:
+  {{- $configEnv := default dict .Values.librechat.configEnv }}
+  {{- $adminPanelUrl := .Values.librechat.adminPanelUrl }}
+  {{- $configAdminPanelUrl := dig "configEnv" "ADMIN_PANEL_URL" "" .Values.librechat }}
   {{- if (index .Values "librechat-rag-api" "enabled") }}
   RAG_API_URL: http://{{ include "rag.fullname" (index .Subcharts "librechat-rag-api") | lower }}.{{ .Release.Namespace | lower }}.svc.cluster.local:8000 
   {{- end }}
@@ -18,9 +21,15 @@ data:
   {{- if and (not (dig "configEnv" "REDIS_URI" "" .Values.librechat)) .Values.redis.enabled }}
   REDIS_URI: redis://{{ include "common.names.fullname" .Subcharts.redis }}-master.{{ .Release.Namespace | lower }}.svc.cluster.local:6379
   {{- end }}
-  {{- if and .Values.librechat.adminPanelUrl (not (dig "configEnv" "ADMIN_PANEL_URL" "" .Values.librechat)) }}
-  ADMIN_PANEL_URL: {{ .Values.librechat.adminPanelUrl | quote }}
+  {{- if and $adminPanelUrl (not $configAdminPanelUrl) }}
+  ADMIN_PANEL_URL: {{ $adminPanelUrl | quote }}
   {{- end }}
-  {{- if .Values.librechat.configEnv }}
-  {{- toYaml .Values.librechat.configEnv | nindent 2 }}
+  {{- if $configEnv }}
+  {{- $renderedConfigEnv := $configEnv }}
+  {{- if and $adminPanelUrl (hasKey $configEnv "ADMIN_PANEL_URL") (not $configAdminPanelUrl) }}
+  {{- $renderedConfigEnv = omit $configEnv "ADMIN_PANEL_URL" }}
+  {{- end }}
+  {{- if $renderedConfigEnv }}
+  {{- toYaml $renderedConfigEnv | nindent 2 }}
+  {{- end }}
   {{- end }}

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -33,9 +33,10 @@ global:
     #        key: client_id
 
 librechat:
-  # External admin panel origin used for admin OAuth/SSO redirects.
+  # External admin panel base URL used for admin OAuth/SSO redirects.
   # Required when deploying the admin panel on a separate URL.
-  # Example: https://admin.example.com
+  # May include a path. Do not include a trailing slash.
+  # Example: https://admin.example.com/admin
   adminPanelUrl: ""
 
   configEnv:

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -33,6 +33,11 @@ global:
     #        key: client_id
 
 librechat:
+  # External admin panel origin used for admin OAuth/SSO redirects.
+  # Required when deploying the admin panel on a separate URL.
+  # Example: https://admin.example.com
+  adminPanelUrl: ""
+
   configEnv:
     # IMPORTANT -- GENERATE your own: openssl rand -hex 32 and openssl rand -hex 16 for CREDS_IV. Best Practise: Put into Secret. See global.librechat.existingSecretName
     CREDS_KEY: 9e95d9894da7e68dd69c0046caf5343c8b1e80c89609b5a1e40e6568b5b23ce6


### PR DESCRIPTION
## Summary

I added explicit admin panel URL configuration for Helm deployments and documented the OpenID SSO callback requirements so separate admin panel deployments do not fall back to the localhost callback target.

- Added `ADMIN_PANEL_URL` to `.env.example` with guidance for separately hosted admin panels.
- Added `librechat.adminPanelUrl` to Helm values and rendered it into `ADMIN_PANEL_URL` unless `librechat.configEnv.ADMIN_PANEL_URL` is already provided with a non-empty value.
- Documented the admin panel SSO setup, required OpenID provider callback URL, optional admin panel base paths, and the no-trailing-slash requirement.
- Bumped the LibreChat Helm chart version to `2.0.4`.

Closes #13218

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Ran `git diff --check`.
- Ran `helm lint helm/librechat --set mongodb.enabled=false --set meilisearch.enabled=false --set redis.enabled=false --set librechat-rag-api.enabled=false`.
- Rendered a dependency-built temp chart to confirm `librechat.adminPanelUrl` emits `ADMIN_PANEL_URL`, `configEnv.ADMIN_PANEL_URL` overrides it when non-empty, and an empty `configEnv.ADMIN_PANEL_URL` still falls back to `librechat.adminPanelUrl`.

### **Test Configuration**:

- Helm CLI from local environment
- Chart: `helm/librechat`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
