### PR TITLE
🧵 chore: Raise MCP SSE Line Default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -898,8 +898,8 @@ OPENWEATHER_API_KEY=
 # MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES=16777216
 
 # Max bytes allowed in a single SSE line for non-GET streamable HTTP MCP responses.
-# Set to 0 to disable. Default: 1048576 (1 MiB)
-# MCP_STREAMABLE_HTTP_MAX_LINE_BYTES=1048576
+# Set to 0 to disable. Default: 5242880 (5 MiB)
+# MCP_STREAMABLE_HTTP_MAX_LINE_BYTES=5242880
 
 # Skip code challenge method validation (e.g., for AWS Cognito that supports S256 but doesn't advertise it)
 # When set to true, forces S256 code challenge even if not advertised in .well-known/openid-configuration

--- a/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
@@ -1185,6 +1185,33 @@ describe('MCP SSRF protection – customFetch input shapes', () => {
     }
   });
 
+  it('should allow SSE lines above the old 1 MiB default when no line override is set', async () => {
+    delete process.env.MCP_STREAMABLE_HTTP_MAX_LINE_BYTES;
+    const payload = 'x'.repeat(2 * 1024 * 1024);
+    const server = await createRawResponseServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      res.end(`data: ${payload}\n\n`);
+    });
+    try {
+      conn = new MCPConnection({
+        serverName: 'customfetch-sse-default-line-limit',
+        serverConfig: { type: 'streamable-http', url: server.url },
+        useSSRFProtection: false,
+      });
+
+      const customFetch = getGuardedStreamableHTTPCustomFetch(conn);
+      const response = await customFetch(server.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/cancelled' }),
+      });
+
+      await expect(response.text()).resolves.toContain(payload.slice(0, 128));
+    } finally {
+      await server.close();
+    }
+  });
+
   it('should fail an actual streamable HTTP tool call promptly with a clear oversized SSE line error', async () => {
     process.env.MCP_STREAMABLE_HTTP_MAX_LINE_BYTES = '512';
     target = await createOversizedToolResultStreamableServer(2048);

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -75,7 +75,7 @@ const DEFAULT_INIT_TIMEOUT = 30000;
 /** Max 307/308 redirects to follow per request (prevents redirect loops) */
 const MAX_REDIRECTS = 5;
 const DEFAULT_MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
-const DEFAULT_MCP_STREAMABLE_HTTP_MAX_LINE_BYTES = 1024 * 1024;
+const DEFAULT_MCP_STREAMABLE_HTTP_MAX_LINE_BYTES = 5 * 1024 * 1024;
 
 function getNonNegativeIntegerEnv(name: string, defaultValue: number): number {
   const raw = process.env[name];


### PR DESCRIPTION
## Summary

I raised the default streamable HTTP MCP SSE line guard from 1 MiB to 5 MiB so legitimate larger MCP payloads are less surprising while the guard still blocks pathological single-line responses before parser heap growth.

- Changed `DEFAULT_MCP_STREAMABLE_HTTP_MAX_LINE_BYTES` to `5 * 1024 * 1024`.
- Updated `.env.example` to document the new `5242880` byte default.
- Added regression coverage proving an SSE line above the old 1 MiB default passes without an env override.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Ran `npx jest src/mcp/__tests__/MCPConnectionSSRF.test.ts --runInBand --watch=false` from `packages/api`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node/Jest via existing LibreChat workspace dependencies
- Branch: `danny-avila/mcp-default-line-limit-5mb`

## Checklist

- [x] My code adheres to this project's style guidelines\n- [x] I have performed a self-review of my own code\n- [x] I have made pertinent documentation changes\n- [x] My changes do not introduce new warnings\n- [x] I have written tests demonstrating that my changes are effective or that my feature works\n- [x] Local unit tests pass with my changes\n