### PR TITLE
⚡ feat: Add Gemini 3.5 Flash Support

### DIFF
--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -333,6 +333,9 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gemini-3.1-pro-preview-customtools', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-3.1'],
     );
+    expect(getModelMaxTokens('gemini-3.5-flash', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemini-3.5-flash'],
+    );
     expect(getModelMaxTokens('gemini-2.5-pro', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-2.5-pro'],
     );

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -628,6 +628,78 @@ describe('getGoogleConfig', () => {
       });
     });
 
+    it('should default Gemini 3.5 Flash to medium thinkingLevel', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.5-flash',
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'MEDIUM',
+      });
+    });
+
+    it('should preserve explicit Gemini 3.5 Flash thinkingLevel', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.5-flash',
+          thinkingLevel: ThinkingLevel.low,
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'LOW',
+      });
+    });
+
+    it('should remove legacy sampling params for Gemini 3.5 Flash', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const modelOptions = {
+        model: 'gemini-3.5-flash',
+        temperature: 0.7,
+        topP: 0.9,
+        topK: 40,
+        top_p: 0.9,
+        top_k: 40,
+        thinking_budget: 5000,
+      } as unknown as t.GoogleParameters;
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions,
+        defaultParams: {
+          temperature: 0.5,
+          topP: 0.8,
+          topK: 20,
+        },
+        addParams: {
+          temperature: 0.2,
+          topP: 0.6,
+          topK: 10,
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect(result.llmConfig).not.toHaveProperty('topP');
+      expect(result.llmConfig).not.toHaveProperty('topK');
+      expect(result.llmConfig).not.toHaveProperty('top_p');
+      expect(result.llmConfig).not.toHaveProperty('top_k');
+      expect(result.llmConfig).not.toHaveProperty('thinking_budget');
+    });
+
     it('should omit thinkingLevel when unset (empty string) for Gemini 3', () => {
       const credentials = {
         [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -663,6 +663,25 @@ describe('getGoogleConfig', () => {
       });
     });
 
+    it('should apply Gemini 3.5 Flash overrides to versioned aliases', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'google/gemini-3.5-flash-latest',
+          temperature: 0.7,
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'MEDIUM',
+      });
+    });
+
     it('should remove legacy sampling params for Gemini 3.5 Flash', () => {
       const credentials = {
         [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
@@ -698,6 +717,44 @@ describe('getGoogleConfig', () => {
       expect(result.llmConfig).not.toHaveProperty('top_p');
       expect(result.llmConfig).not.toHaveProperty('top_k');
       expect(result.llmConfig).not.toHaveProperty('thinking_budget');
+    });
+
+    it('should respect dropParams for Gemini 3.5 Flash thinkingConfig', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.5-flash',
+        },
+        dropParams: ['thinkingConfig'],
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('thinkingConfig');
+    });
+
+    it('should respect dropParams for Gemini 3.5 Flash includeThoughts', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_SERVICE_KEY]: {
+          project_id: 'test-project',
+        },
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.5-flash',
+        },
+        dropParams: ['includeThoughts'],
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('includeThoughts');
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        thinkingLevel: 'MEDIUM',
+      });
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).not.toHaveProperty(
+        'includeThoughts',
+      );
     });
 
     it('should omit thinkingLevel when unset (empty string) for Gemini 3', () => {

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -757,6 +757,21 @@ describe('getGoogleConfig', () => {
       );
     });
 
+    it('should remove empty Gemini 3.5 Flash thinkingConfig when all fields are dropped', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.5-flash',
+        },
+        dropParams: ['includeThoughts', 'thinkingLevel'],
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('thinkingConfig');
+    });
+
     it('should omit thinkingLevel when unset (empty string) for Gemini 3', () => {
       const credentials = {
         [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -11,6 +11,18 @@ type GoogleThinkingConfig = {
   thinkingLevel?: GoogleThinkingLevel;
 };
 
+const GEMINI_3_5_FLASH = 'gemini-3.5-flash';
+const GEMINI_3_5_FLASH_DEFAULT_THINKING_LEVEL: GoogleThinkingLevel = 'MEDIUM';
+const gemini35FlashLegacyParams = [
+  'temperature',
+  'topP',
+  'topK',
+  'top_p',
+  'top_k',
+  'thinkingBudget',
+  'thinking_budget',
+] as const;
+
 const googleThinkingLevels = new Set<GoogleThinkingLevel>([
   'THINKING_LEVEL_UNSPECIFIED',
   'MINIMAL',
@@ -116,6 +128,11 @@ function normalizeGoogleThinkingLevel(value: unknown): GoogleThinkingLevel | und
   return normalized;
 }
 
+function isGemini35Flash(model: string) {
+  const normalized = model.toLowerCase();
+  return normalized === GEMINI_3_5_FLASH || normalized.endsWith(`/${GEMINI_3_5_FLASH}`);
+}
+
 function getVertexMultiRegionEndpoint(location: string): string | undefined {
   return vertexMultiRegionEndpoints.get(location);
 }
@@ -126,6 +143,43 @@ function sanitizeModelOptions(modelOptions: Partial<t.GoogleParameters> | undefi
     delete sanitizedOptions[param];
   });
   return sanitizedOptions;
+}
+
+function applyGemini35FlashOverrides({
+  config,
+  provider,
+  thinking,
+}: {
+  config: GoogleClientOptions | VertexAIClientOptions;
+  provider: Providers;
+  thinking: boolean;
+}) {
+  const mutableConfig = config as Record<string, unknown>;
+  const model = mutableConfig.model;
+  if (typeof model !== 'string' || !isGemini35Flash(model)) {
+    return;
+  }
+
+  gemini35FlashLegacyParams.forEach((param) => {
+    delete mutableConfig[param];
+  });
+
+  if (!thinking) {
+    return;
+  }
+
+  const configWithThinking = config as { thinkingConfig?: GoogleThinkingConfig };
+  if (!configWithThinking.thinkingConfig) {
+    configWithThinking.thinkingConfig = { includeThoughts: true };
+  }
+
+  if (!configWithThinking.thinkingConfig.thinkingLevel) {
+    configWithThinking.thinkingConfig.thinkingLevel = GEMINI_3_5_FLASH_DEFAULT_THINKING_LEVEL;
+  }
+
+  if (provider === Providers.VERTEXAI) {
+    (config as VertexAIClientOptions).includeThoughts = true;
+  }
 }
 
 function isAllowedVertexEndpoint(endpoint: string): boolean {
@@ -452,6 +506,12 @@ export function getGoogleConfig(
       }
     });
   }
+
+  applyGemini35FlashOverrides({
+    config: llmConfig,
+    provider,
+    thinking,
+  });
 
   if (provider === Providers.VERTEXAI && shouldSyncVertexEndpoint && !hasCustomVertexEndpoint) {
     applyVertexMultiRegionEndpoint(llmConfig as VertexAIClientOptions & { endpoint?: string });

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -130,7 +130,8 @@ function normalizeGoogleThinkingLevel(value: unknown): GoogleThinkingLevel | und
 
 function isGemini35Flash(model: string) {
   const normalized = model.toLowerCase();
-  return normalized === GEMINI_3_5_FLASH || normalized.endsWith(`/${GEMINI_3_5_FLASH}`);
+  const modelId = normalized.split('/').pop() ?? normalized;
+  return modelId === GEMINI_3_5_FLASH || modelId.startsWith(`${GEMINI_3_5_FLASH}-`);
 }
 
 function getVertexMultiRegionEndpoint(location: string): string | undefined {
@@ -149,10 +150,12 @@ function applyGemini35FlashOverrides({
   config,
   provider,
   thinking,
+  dropParams,
 }: {
   config: GoogleClientOptions | VertexAIClientOptions;
   provider: Providers;
   thinking: boolean;
+  dropParams?: string[];
 }) {
   const mutableConfig = config as Record<string, unknown>;
   const model = mutableConfig.model;
@@ -168,16 +171,37 @@ function applyGemini35FlashOverrides({
     return;
   }
 
+  const droppedParams = new Set(dropParams ?? []);
+  if (droppedParams.has('thinkingConfig')) {
+    return;
+  }
+
+  const shouldDropIncludeThoughts = droppedParams.has('includeThoughts');
+  const shouldDropThinkingLevel = droppedParams.has('thinkingLevel');
   const configWithThinking = config as { thinkingConfig?: GoogleThinkingConfig };
-  if (!configWithThinking.thinkingConfig) {
-    configWithThinking.thinkingConfig = { includeThoughts: true };
+  const thinkingConfig = configWithThinking.thinkingConfig ?? {};
+
+  if (shouldDropIncludeThoughts) {
+    delete thinkingConfig.includeThoughts;
   }
 
-  if (!configWithThinking.thinkingConfig.thinkingLevel) {
-    configWithThinking.thinkingConfig.thinkingLevel = GEMINI_3_5_FLASH_DEFAULT_THINKING_LEVEL;
+  if (shouldDropThinkingLevel) {
+    delete thinkingConfig.thinkingLevel;
   }
 
-  if (provider === Providers.VERTEXAI) {
+  if (!shouldDropIncludeThoughts && thinkingConfig.includeThoughts == null) {
+    thinkingConfig.includeThoughts = true;
+  }
+
+  if (!shouldDropThinkingLevel && !thinkingConfig.thinkingLevel) {
+    thinkingConfig.thinkingLevel = GEMINI_3_5_FLASH_DEFAULT_THINKING_LEVEL;
+  }
+
+  if (Object.keys(thinkingConfig).length > 0) {
+    configWithThinking.thinkingConfig = thinkingConfig;
+  }
+
+  if (provider === Providers.VERTEXAI && !shouldDropIncludeThoughts) {
     (config as VertexAIClientOptions).includeThoughts = true;
   }
 }
@@ -511,6 +535,7 @@ export function getGoogleConfig(
     config: llmConfig,
     provider,
     thinking,
+    dropParams: Array.isArray(options.dropParams) ? options.dropParams : undefined,
   });
 
   if (provider === Providers.VERTEXAI && shouldSyncVertexEndpoint && !hasCustomVertexEndpoint) {

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -7,7 +7,7 @@ import { isEnabled } from '~/utils';
 
 type GoogleThinkingLevel = 'THINKING_LEVEL_UNSPECIFIED' | 'MINIMAL' | 'LOW' | 'MEDIUM' | 'HIGH';
 type GoogleThinkingConfig = {
-  includeThoughts: boolean;
+  includeThoughts?: boolean;
   thinkingLevel?: GoogleThinkingLevel;
 };
 
@@ -179,7 +179,7 @@ function applyGemini35FlashOverrides({
   const shouldDropIncludeThoughts = droppedParams.has('includeThoughts');
   const shouldDropThinkingLevel = droppedParams.has('thinkingLevel');
   const configWithThinking = config as { thinkingConfig?: GoogleThinkingConfig };
-  const thinkingConfig = configWithThinking.thinkingConfig ?? {};
+  const thinkingConfig: GoogleThinkingConfig = { ...(configWithThinking.thinkingConfig ?? {}) };
 
   if (shouldDropIncludeThoughts) {
     delete thinkingConfig.includeThoughts;

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -199,6 +199,8 @@ function applyGemini35FlashOverrides({
 
   if (Object.keys(thinkingConfig).length > 0) {
     configWithThinking.thinkingConfig = thinkingConfig;
+  } else {
+    delete configWithThinking.thinkingConfig;
   }
 
   if (provider === Providers.VERTEXAI && !shouldDropIncludeThoughts) {

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -117,6 +117,7 @@ const googleModels = {
   'gemini-3-pro-image': 1000000,
   'gemini-3.1': 1000000,
   'gemini-3.1-flash-lite': 1000000,
+  'gemini-3.5-flash': 1048576,
 };
 
 const anthropicModels = {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1595,6 +1595,8 @@ export const defaultModels = {
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
   [EModelEndpoint.google]: [
+    // Gemini 3.5 Models
+    'gemini-3.5-flash',
     // Gemini 3.1 Models
     'gemini-3.1-pro-preview',
     'gemini-3.1-pro-preview-customtools',

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -372,7 +372,7 @@ export const googleSettings = {
   },
   maxOutputTokens: {
     min: 1 as const,
-    max: 64000 as const,
+    max: 65536 as const,
     step: 1 as const,
     default: 8192 as const,
   },

--- a/packages/data-schemas/src/methods/tx.spec.ts
+++ b/packages/data-schemas/src/methods/tx.spec.ts
@@ -1497,6 +1497,7 @@ describe('Google Model Tests', () => {
     'gemini-3.1-pro-preview',
     'gemini-3.1-pro-preview-customtools',
     'gemini-3.1-flash-lite-preview',
+    'gemini-3.5-flash',
     'gemini-2.5-pro',
     'gemini-2.5-flash',
     'gemini-2.5-flash-lite',
@@ -1544,6 +1545,7 @@ describe('Google Model Tests', () => {
       'gemini-3.1-pro-preview': 'gemini-3.1',
       'gemini-3.1-pro-preview-customtools': 'gemini-3.1',
       'gemini-3.1-flash-lite-preview': 'gemini-3.1-flash-lite',
+      'gemini-3.5-flash': 'gemini-3.5-flash',
       'gemini-2.5-pro': 'gemini-2.5-pro',
       'gemini-2.5-flash': 'gemini-2.5-flash',
       'gemini-2.5-flash-lite': 'gemini-2.5-flash-lite',
@@ -1643,6 +1645,22 @@ describe('Google Model Tests', () => {
     );
     expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(
       cacheTokenValues['gemini-3.1-flash-lite'].read,
+    );
+  });
+
+  it('should return correct rates for Gemini 3.5 Flash', () => {
+    const model = 'gemini-3.5-flash';
+    expect(getMultiplier({ model, tokenType: 'prompt', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.5-flash'].prompt,
+    );
+    expect(getMultiplier({ model, tokenType: 'completion', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.5-flash'].completion,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'write' })).toBe(
+      cacheTokenValues['gemini-3.5-flash'].write,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(
+      cacheTokenValues['gemini-3.5-flash'].read,
     );
   });
 });

--- a/packages/data-schemas/src/methods/tx.ts
+++ b/packages/data-schemas/src/methods/tx.ts
@@ -186,6 +186,7 @@ export const tokenValues: Record<string, { prompt: number; completion: number }>
     'gemini-3-pro-image': { prompt: 2, completion: 120 },
     'gemini-3.1': { prompt: 2, completion: 12 },
     'gemini-3.1-flash-lite': { prompt: 0.25, completion: 1.5 },
+    'gemini-3.5-flash': { prompt: 1.5, completion: 9 },
     'gemini-pro-vision': { prompt: 0.5, completion: 1.5 },
     grok: { prompt: 2.0, completion: 10.0 },
     'grok-beta': { prompt: 5.0, completion: 15.0 },
@@ -329,6 +330,8 @@ export const cacheTokenValues: Record<string, { write: number; read: number }> =
   'gemini-3.1': { write: 2, read: 0.2 },
   // Gemini 3.1 Flash-Lite - cache write: $0.25/1M, cache read: $0.025/1M
   'gemini-3.1-flash-lite': { write: 0.25, read: 0.025 },
+  // Gemini 3.5 Flash - cache write: $1.50/1M, cache read: $0.15/1M
+  'gemini-3.5-flash': { write: 1.5, read: 0.15 },
 };
 
 /**


### PR DESCRIPTION
## Summary

I added native Google/Vertex support for Gemini 3.5 Flash and wired its model metadata, request defaults, and pricing behavior.

- Added `gemini-3.5-flash` to the default Google model list.
- Set Gemini 3.5 Flash context metadata to 1,048,576 tokens and raised Google max output configuration to 65,536 tokens.
- Defaulted Gemini 3.5 Flash requests to `MEDIUM` thinking level while preserving explicit thinking levels.
- Removed legacy sampling and thinking-budget parameters from native Gemini 3.5 Flash request config.
- Added token pricing, cache pricing, and focused regression tests for model matching and request shaping.

Closes #13199

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] `npm run build:data-provider`
- [x] `npm run build:data-schemas`
- [x] `npm run build:api`
- [x] `cd packages/api && npx jest src/endpoints/google/llm.spec.ts --runInBand --coverage=false`
- [x] `cd packages/data-schemas && npx jest src/methods/tx.spec.ts --runInBand --coverage=false`
- [x] `cd api && npx jest utils/tokens.spec.js --runInBand --coverage=false`
- [x] `npx prettier --check packages/api/src/endpoints/google/llm.ts packages/api/src/endpoints/google/llm.spec.ts packages/api/src/utils/tokens.ts api/utils/tokens.spec.js packages/data-provider/src/config.ts packages/data-provider/src/schemas.ts packages/data-schemas/src/methods/tx.ts packages/data-schemas/src/methods/tx.spec.ts`

### **Test Configuration**:

- Node.js v20.19.5
- macOS local worktree

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes