### PR TITLE
📡 fix: Respect Custom Endpoint Stream Usage Opt-In

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -206,6 +206,39 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+// Suite: custom endpoint stream usage defaults
+// ---------------------------------------------------------------------------
+describe('custom endpoint stream usage defaults', () => {
+  it('disables streamUsage by default for OpenAI-compatible custom endpoints', async () => {
+    const agents = await callAndCapture({
+      agents: [makeAgent({ endpoint: 'LiteLLM' })],
+    });
+    const clientOptions = agents[0].clientOptions as Record<string, unknown>;
+
+    expect(clientOptions.streamUsage).toBe(false);
+    expect(clientOptions.usage).toBe(true);
+  });
+
+  it('respects explicit streamUsage from endpoint-resolved model parameters', async () => {
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          endpoint: 'LiteLLM',
+          model_parameters: {
+            model: 'gpt-4o',
+            streamUsage: true,
+          },
+        }),
+      ],
+    });
+    const clientOptions = agents[0].clientOptions as Record<string, unknown>;
+
+    expect(clientOptions.streamUsage).toBe(true);
+    expect(clientOptions.usage).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Suite 1: reserveRatio
 // ---------------------------------------------------------------------------
 describe('reserveRatio', () => {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -804,6 +804,10 @@ export async function createRun({
     );
 
     const modelParameters = normalizeAgentModelParameters(agent.model_parameters);
+    const hasExplicitStreamUsage = Object.prototype.hasOwnProperty.call(
+      modelParameters ?? {},
+      'streamUsage',
+    );
     const llmConfig = Object.assign(
       {
         provider,
@@ -847,7 +851,9 @@ export async function createRun({
       customProviders.has(agent.provider) ||
       (agent.provider === Providers.OPENAI && agent.endpoint !== agent.provider)
     ) {
-      llmConfig.streamUsage = false;
+      if (!hasExplicitStreamUsage) {
+        llmConfig.streamUsage = false;
+      }
       llmConfig.usage = true;
     }
 


### PR DESCRIPTION
## Summary

I fixed custom/OpenAI-compatible agent runs so an explicit endpoint `streamUsage` opt-in survives the compatibility default.

- Preserve `streamUsage` when endpoint-resolved model parameters explicitly define it.
- Keep the default compatibility behavior for custom/OpenAI-compatible endpoints by disabling streamed usage when no explicit opt-in is present.
- Add focused `createRun` tests for the default behavior and the explicit opt-in path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `NODE_PATH=/Users/danny/Projects/LibreChat/node_modules /Users/danny/Projects/LibreChat/node_modules/.bin/jest src/agents/__tests__/run-summarization.test.ts --runInBand --coverage=false` from `packages/api`.

### **Test Configuration**:

- Node.js v20.19.5
- Jest focused package test in `packages/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
