### PR TITLE
🍞 fix: don't show 'deleting file' toast on attached files

### DIFF
--- a/client/src/components/Chat/Input/Files/FileRow.tsx
+++ b/client/src/components/Chat/Input/Files/FileRow.tsx
@@ -115,7 +115,7 @@ export default function FileRow({
               if (abortUpload && file.progress < 1) {
                 abortUpload();
               }
-              if (file.progress >= 1) {
+              if (file.progress >= 1 && !file.attached) {
                 showToast({
                   message: localize('com_ui_deleting_file'),
                   status: 'info',


### PR DESCRIPTION
## Summary

There are two ways to add a file to a conversation:

1. Uploading a new file.
2. Using an existing file (from the side panel).

If you decide to remove the file, the behavior differs depending on how it was added. If you just uploaded a new file, it gets deleted from the conversation & the system. But if it's an existing file, then it only gets removed from the conversation (but not deleted).

However, in both cases, it would show a toast saying that the file was deleted, which is incorrect for the "existing file" case.

Now we check whether the file is `attached` (to the system) before showing the deletion toast, and skip showing it if we're not actually deleting the file.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tried deleting files after uploading them & after selecting them from the side panel, to make sure the toast still showed up when deleting new uploads.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes