### PR TITLE
🧵 fix: Preserve Streaming Messages During Stale Refetch

### DIFF
--- a/client/src/data-provider/Messages/__tests__/queries.test.ts
+++ b/client/src/data-provider/Messages/__tests__/queries.test.ts
@@ -1,0 +1,82 @@
+import type { TMessage } from 'librechat-data-provider';
+import { getStableMessages } from '../queries';
+
+const message = (overrides: Partial<TMessage>): TMessage =>
+  ({
+    messageId: 'message-id',
+    conversationId: 'convo-id',
+    parentMessageId: '00000000-0000-0000-0000-000000000000',
+    text: '',
+    sender: 'User',
+    isCreatedByUser: true,
+    createdAt: '2026-05-21T12:00:00.000Z',
+    updatedAt: '2026-05-21T12:00:00.000Z',
+    ...overrides,
+  }) as TMessage;
+
+describe('getStableMessages', () => {
+  it('keeps cache when an empty result races with unhydrated stream messages', () => {
+    const currentMessages = [
+      message({ messageId: 'persisted-1' }),
+      message({ messageId: 'user-2', createdAt: undefined, updatedAt: undefined }),
+      message({
+        messageId: 'user-2_',
+        isCreatedByUser: false,
+        createdAt: undefined,
+        updatedAt: undefined,
+      }),
+    ];
+
+    const result = getStableMessages({
+      pathname: '/c/convo-id',
+      result: [],
+      currentMessages,
+    });
+
+    expect(result).toBe(currentMessages);
+  });
+
+  it('keeps cache when a one-message result returns for a larger cache', () => {
+    const currentMessages = [
+      message({ messageId: 'persisted-1' }),
+      message({ messageId: 'persisted-2' }),
+    ];
+
+    const result = getStableMessages({
+      pathname: '/c/convo-id',
+      result: [currentMessages[0]],
+      currentMessages,
+    });
+
+    expect(result).toBe(currentMessages);
+  });
+
+  it('accepts fewer persisted messages when the cache is fully hydrated', () => {
+    const currentMessages = [
+      message({ messageId: 'persisted-1' }),
+      message({ messageId: 'persisted-2' }),
+      message({ messageId: 'persisted-3' }),
+    ];
+    const serverMessages = [currentMessages[0], currentMessages[1]];
+
+    const result = getStableMessages({
+      pathname: '/c/convo-id',
+      result: serverMessages,
+      currentMessages,
+    });
+
+    expect(result).toBe(serverMessages);
+  });
+
+  it('does not preserve cache on the new conversation route', () => {
+    const currentMessages = [message({ messageId: 'user-1', createdAt: undefined })];
+
+    const result = getStableMessages({
+      pathname: '/c/new',
+      result: [],
+      currentMessages,
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/client/src/data-provider/Messages/queries.ts
+++ b/client/src/data-provider/Messages/queries.ts
@@ -5,6 +5,39 @@ import { QueryKeys, dataService } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import { logger } from '~/utils';
 
+type StableMessagesParams = {
+  pathname: string;
+  result: t.TMessage[];
+  currentMessages?: t.TMessage[];
+};
+
+function hasUnhydratedMessage(messages: t.TMessage[]) {
+  return messages.some((message) => {
+    const messageId = message.messageId ?? '';
+    return message.createdAt == null || message.updatedAt == null || messageId.endsWith('_');
+  });
+}
+
+export function getStableMessages({
+  pathname,
+  result,
+  currentMessages,
+}: StableMessagesParams): t.TMessage[] {
+  if (pathname.includes('/c/new') || !currentMessages?.length) {
+    return result;
+  }
+
+  if (result.length >= currentMessages.length) {
+    return result;
+  }
+
+  if (result.length === 1 || hasUnhydratedMessage(currentMessages)) {
+    return currentMessages;
+  }
+
+  return result;
+}
+
 export const useGetMessagesByConvoId = <TData = t.TMessage[]>(
   id: string,
   config?: UseQueryOptions<t.TMessage[], unknown, TData>,
@@ -15,22 +48,23 @@ export const useGetMessagesByConvoId = <TData = t.TMessage[]>(
     [QueryKeys.messages, id],
     async () => {
       const result = await dataService.getMessagesByConvoId(id);
-      if (!location.pathname.includes('/c/new') && result?.length === 1) {
-        const currentMessages = queryClient.getQueryData<t.TMessage[]>([QueryKeys.messages, id]);
-        if (currentMessages?.length === 1) {
-          return result;
-        }
-        if (currentMessages && currentMessages?.length > 1) {
-          logger.warn(
-            'messages',
-            `Messages query for convo ${id} returned fewer than cache; path: "${location.pathname}"`,
-            result,
-            currentMessages,
-          );
-          return currentMessages;
-        }
+      const currentMessages = queryClient.getQueryData<t.TMessage[]>([QueryKeys.messages, id]);
+      const stableMessages = getStableMessages({
+        pathname: location.pathname,
+        result,
+        currentMessages,
+      });
+
+      if (stableMessages === currentMessages) {
+        logger.warn(
+          'messages',
+          `Messages query for convo ${id} returned fewer than cache; path: "${location.pathname}"`,
+          result,
+          currentMessages,
+        );
       }
-      return result;
+
+      return stableMessages;
     },
     {
       refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary

I fixed a race where a lagging messages refetch could overwrite optimistic or streaming chat state with an empty or shorter result before persisted messages became visible.

- Preserve the current messages cache when a refetch returns fewer messages while the cache still contains unhydrated stream messages.
- Keep the existing one-message stale-result protection through a reusable `getStableMessages` helper.
- Add focused coverage for empty-result races, one-message stale responses, fully hydrated shorter results, and `/c/new` behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm test -- --watch=false --runInBand src/data-provider/Messages/__tests__/queries.test.ts`
- Ran `npx eslint client/src/data-provider/Messages/queries.ts client/src/data-provider/Messages/__tests__/queries.test.ts`
- Ran `npx prettier --check client/src/data-provider/Messages/queries.ts client/src/data-provider/Messages/__tests__/queries.test.ts`

### **Test Configuration**:

- Node.js: `v20.19.5`
- npm: `10.8.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes