### PR TITLE
🪪 fix: Consolidate MCP OAuth Policy

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -7,7 +7,7 @@ import type { FlowStateManager } from '~/flow/manager';
 import type * as t from './types';
 import { MCPTokenStorage, MCPOAuthHandler, ReauthenticationRequiredError } from '~/mcp/oauth';
 import { PENDING_STALE_MS, normalizeExpiresAt } from '~/flow/manager';
-import { sanitizeUrlForLogging, isClientRejectionMessage } from './utils';
+import { sanitizeUrlForLogging, isClientRejectionMessage, isOAuthServer } from './utils';
 import { withTimeout } from '~/utils/promise';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils';
@@ -46,7 +46,7 @@ export class MCPConnectionFactory {
   /** Creates a new MCP connection with optional OAuth support */
   static async create(
     basic: t.BasicConnectionOptions,
-    oauth?: t.OAuthConnectionOptions,
+    oauth?: t.OAuthConnectionOptions | t.UserConnectionContext,
   ): Promise<MCPConnection> {
     const factory = new this(basic, oauth);
     return factory.createConnection();
@@ -237,6 +237,17 @@ export class MCPConnectionFactory {
     let cleanupOAuthHandlers: (() => void) | null = null;
     if (this.useOAuth) {
       cleanupOAuthHandlers = this.handleOAuthEvents(connection);
+    } else {
+      const nonOAuthHandler = () => {
+        logger.info(
+          `${this.logPrefix} Server does not use OAuth; treating 401/403 as auth failure`,
+        );
+        connection.emit('oauthFailed', new Error('Server does not use OAuth'));
+      };
+      connection.on('oauthRequired', nonOAuthHandler);
+      cleanupOAuthHandlers = () => {
+        connection.removeListener('oauthRequired', nonOAuthHandler);
+      };
     }
 
     try {
@@ -260,10 +271,7 @@ export class MCPConnectionFactory {
     if (!this.useOAuth || oauthTokens) {
       return false;
     }
-    if (this.serverConfig.requiresOAuth === false) {
-      return false;
-    }
-    return this.serverConfig.requiresOAuth === true;
+    return isOAuthServer(this.serverConfig);
   }
 
   private getServerUrl(): string | undefined {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -225,16 +225,6 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
-    const requiresOAuth = (this.serverConfig as t.ParsedServerConfig).requiresOAuth === true;
-
-    /** Only trigger proactive OAuth when the server explicitly requires it AND no stored
-     *  tokens exist. Some servers (e.g. BigQuery MCP) accept anonymous connections and
-     *  never return a 401 during initialize/tools/list, so we cannot rely on the server
-     *  to emit the oauthRequired event — we must trigger the flow proactively.
-     *  We gate on `requiresOAuth` (not just `useOAuth`) because user connections always
-     *  pass `useOAuth: true` even for servers that don't need OAuth. */
-    const needsProactiveOAuth = this.useOAuth && requiresOAuth && !oauthTokens;
-
     const connection = new MCPConnection({
       serverName: this.serverName,
       serverConfig: this.serverConfig,
@@ -250,44 +240,10 @@ export class MCPConnectionFactory {
     }
 
     try {
-      if (needsProactiveOAuth) {
-        const serverUrl = (this.serverConfig as t.ParsedServerConfig).url;
-        if (!serverUrl) {
-          throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
-        }
-
-        const oauthTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
-        logger.info(
-          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting (timeout: ${oauthTimeout}ms)`,
-        );
-
-        await withTimeout(
-          new Promise<void>((resolve, reject) => {
-            const handleSuccess = () => {
-              connection.off('oauthFailed', handleFailure);
-              resolve();
-            };
-            const handleFailure = (err: Error) => {
-              connection.off('oauthHandled', handleSuccess);
-              reject(err);
-            };
-            connection.once('oauthHandled', handleSuccess);
-            connection.once('oauthFailed', handleFailure);
-            connection.emit('oauthRequired', {
-              serverUrl,
-              serverName: this.serverName,
-              userId: this.userId,
-            });
-          }),
-          oauthTimeout,
-          `Proactive OAuth flow timeout after ${oauthTimeout}ms`,
-        );
-
-        await this.attemptToConnect(connection);
-      } else {
-        await this.attemptToConnect(connection);
+      if (this.shouldInitiateOAuthBeforeConnect(oauthTokens)) {
+        await this.initiateOAuthBeforeConnect(connection);
       }
-
+      await this.attemptToConnect(connection);
       if (cleanupOAuthHandlers) {
         cleanupOAuthHandlers();
       }
@@ -298,6 +254,84 @@ export class MCPConnectionFactory {
       }
       throw error;
     }
+  }
+
+  private shouldInitiateOAuthBeforeConnect(oauthTokens: MCPOAuthTokens | null): boolean {
+    if (!this.useOAuth || oauthTokens) {
+      return false;
+    }
+    if (this.serverConfig.requiresOAuth === false) {
+      return false;
+    }
+    return (
+      this.serverConfig.requiresOAuth === true ||
+      this.serverConfig.oauth != null ||
+      ('oauthMetadata' in this.serverConfig && this.serverConfig.oauthMetadata != null)
+    );
+  }
+
+  private getServerUrl(): string | undefined {
+    return 'url' in this.serverConfig ? this.serverConfig.url : undefined;
+  }
+
+  private async initiateOAuthBeforeConnect(connection: MCPConnection): Promise<void> {
+    const serverUrl = this.getServerUrl();
+    if (!serverUrl) {
+      throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
+    }
+
+    const oauthTimeout = this.connectionTimeout ?? 60000 * 2;
+    logger.info(
+      `${this.logPrefix} No stored tokens, proactively triggering OAuth flow before connecting (timeout: ${oauthTimeout}ms)`,
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      let oauthHandledListener: (() => void) | null = null;
+      let oauthFailedListener: ((error: Error) => void) | null = null;
+
+      const cleanup = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        if (oauthHandledListener) {
+          connection.off('oauthHandled', oauthHandledListener);
+        }
+        if (oauthFailedListener) {
+          connection.off('oauthFailed', oauthFailedListener);
+        }
+      };
+
+      oauthHandledListener = () => {
+        cleanup();
+        resolve();
+      };
+
+      oauthFailedListener = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error(`Proactive OAuth flow timeout after ${oauthTimeout}ms`));
+      }, oauthTimeout);
+
+      connection.once('oauthHandled', oauthHandledListener);
+      connection.once('oauthFailed', oauthFailedListener);
+
+      const emitted = connection.emit('oauthRequired', {
+        serverName: this.serverName,
+        error: new Error('OAuth tokens missing before connection'),
+        serverUrl,
+        userId: this.userId,
+      });
+
+      if (!emitted) {
+        cleanup();
+        reject(new Error('OAuth required but no handler is registered'));
+      }
+    });
   }
 
   /** Retrieves existing OAuth tokens from storage or returns null */

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -225,6 +225,13 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+
+    /** True when OAuth is required but no stored tokens exist yet.
+     *  Some servers (e.g. BigQuery MCP) accept anonymous connections and never
+     *  return a 401 during initialize/tools/list, so we cannot rely on the server
+     *  to emit the oauthRequired event — we must trigger the flow proactively. */
+    const needsProactiveOAuth = this.useOAuth && !oauthTokens;
+
     const connection = new MCPConnection({
       serverName: this.serverName,
       serverConfig: this.serverConfig,
@@ -240,7 +247,30 @@ export class MCPConnectionFactory {
     }
 
     try {
-      await this.attemptToConnect(connection);
+      if (needsProactiveOAuth) {
+        logger.info(
+          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
+        );
+        const serverUrl =
+          (this.serverConfig as t.SSEOptions | t.StreamableHTTPOptions).url ?? '';
+
+        await new Promise<void>((resolve, reject) => {
+          connection.once('oauthHandled', resolve);
+          connection.once('oauthFailed', (err: Error) => reject(err));
+          connection.emit('oauthRequired', {
+            serverUrl,
+            serverName: this.serverName,
+            userId: this.userId,
+          });
+        });
+
+        // OAuth completed successfully — connection now has tokens set by handleOAuthEvents.
+        // Proceed to establish the actual MCP connection.
+        await this.attemptToConnect(connection);
+      } else {
+        await this.attemptToConnect(connection);
+      }
+
       if (cleanupOAuthHandlers) {
         cleanupOAuthHandlers();
       }

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -263,11 +263,7 @@ export class MCPConnectionFactory {
     if (this.serverConfig.requiresOAuth === false) {
       return false;
     }
-    return (
-      this.serverConfig.requiresOAuth === true ||
-      this.serverConfig.oauth != null ||
-      ('oauthMetadata' in this.serverConfig && this.serverConfig.oauthMetadata != null)
-    );
+    return this.serverConfig.requiresOAuth === true;
   }
 
   private getServerUrl(): string | undefined {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -256,27 +256,32 @@ export class MCPConnectionFactory {
           throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
         }
 
+        const oauthTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
         logger.info(
-          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
+          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting (timeout: ${oauthTimeout}ms)`,
         );
 
-        await new Promise<void>((resolve, reject) => {
-          const handleSuccess = () => {
-            connection.off('oauthFailed', handleFailure);
-            resolve();
-          };
-          const handleFailure = (err: Error) => {
-            connection.off('oauthHandled', handleSuccess);
-            reject(err);
-          };
-          connection.once('oauthHandled', handleSuccess);
-          connection.once('oauthFailed', handleFailure);
-          connection.emit('oauthRequired', {
-            serverUrl,
-            serverName: this.serverName,
-            userId: this.userId,
-          });
-        });
+        await withTimeout(
+          new Promise<void>((resolve, reject) => {
+            const handleSuccess = () => {
+              connection.off('oauthFailed', handleFailure);
+              resolve();
+            };
+            const handleFailure = (err: Error) => {
+              connection.off('oauthHandled', handleSuccess);
+              reject(err);
+            };
+            connection.once('oauthHandled', handleSuccess);
+            connection.once('oauthFailed', handleFailure);
+            connection.emit('oauthRequired', {
+              serverUrl,
+              serverName: this.serverName,
+              userId: this.userId,
+            });
+          }),
+          oauthTimeout,
+          `Proactive OAuth flow timeout after ${oauthTimeout}ms`,
+        );
 
         await this.attemptToConnect(connection);
       } else {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -225,12 +225,15 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+    const requiresOAuth = (this.serverConfig as t.ParsedServerConfig).requiresOAuth === true;
 
-    /** True when OAuth is required but no stored tokens exist yet.
-     *  Some servers (e.g. BigQuery MCP) accept anonymous connections and never
-     *  return a 401 during initialize/tools/list, so we cannot rely on the server
-     *  to emit the oauthRequired event — we must trigger the flow proactively. */
-    const needsProactiveOAuth = this.useOAuth && !oauthTokens;
+    /** Only trigger proactive OAuth when the server explicitly requires it AND no stored
+     *  tokens exist. Some servers (e.g. BigQuery MCP) accept anonymous connections and
+     *  never return a 401 during initialize/tools/list, so we cannot rely on the server
+     *  to emit the oauthRequired event — we must trigger the flow proactively.
+     *  We gate on `requiresOAuth` (not just `useOAuth`) because user connections always
+     *  pass `useOAuth: true` even for servers that don't need OAuth. */
+    const needsProactiveOAuth = this.useOAuth && requiresOAuth && !oauthTokens;
 
     const connection = new MCPConnection({
       serverName: this.serverName,
@@ -248,15 +251,26 @@ export class MCPConnectionFactory {
 
     try {
       if (needsProactiveOAuth) {
+        const serverUrl = (this.serverConfig as t.ParsedServerConfig).url;
+        if (!serverUrl) {
+          throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
+        }
+
         logger.info(
           `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
         );
-        const serverUrl =
-          (this.serverConfig as t.SSEOptions | t.StreamableHTTPOptions).url ?? '';
 
         await new Promise<void>((resolve, reject) => {
-          connection.once('oauthHandled', resolve);
-          connection.once('oauthFailed', (err: Error) => reject(err));
+          const handleSuccess = () => {
+            connection.off('oauthFailed', handleFailure);
+            resolve();
+          };
+          const handleFailure = (err: Error) => {
+            connection.off('oauthHandled', handleSuccess);
+            reject(err);
+          };
+          connection.once('oauthHandled', handleSuccess);
+          connection.once('oauthFailed', handleFailure);
           connection.emit('oauthRequired', {
             serverUrl,
             serverName: this.serverName,
@@ -264,8 +278,6 @@ export class MCPConnectionFactory {
           });
         });
 
-        // OAuth completed successfully — connection now has tokens set by handleOAuthEvents.
-        // Proceed to establish the actual MCP connection.
         await this.attemptToConnect(connection);
       } else {
         await this.attemptToConnect(connection);

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -18,7 +18,7 @@ import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils/env';
-import { isUserSourced } from './utils';
+import { isUserSourced, isOAuthServer } from './utils';
 
 /**
  * Centralized manager for MCP server connections and tool execution.
@@ -102,7 +102,7 @@ export class MCPManager extends UserConnectionManager {
       return { tools: null, oauthRequired: false, oauthUrl: null };
     }
 
-    const useOAuth = Boolean(serverConfig.requiresOAuth || serverConfig.oauthMetadata);
+    const useOAuth = isOAuthServer(serverConfig);
 
     const registry = MCPServersRegistry.getInstance();
     const useSSRFProtection = registry.shouldEnableSSRFProtection();

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -4,7 +4,7 @@ import type * as t from './types';
 import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
-import { isUserSourced } from './utils';
+import { isUserSourced, isOAuthServer } from './utils';
 import { MCPConnection } from './connection';
 import { mcpConfig } from './mcpConfig';
 
@@ -35,14 +35,7 @@ export abstract class UserConnectionManager {
   }
 
   /** Gets or creates a connection for a specific user, coalescing concurrent attempts */
-  public async getUserConnection(
-    opts: {
-      serverName: string;
-      forceNew?: boolean;
-      /** Pre-resolved config for config-source servers not in YAML/DB */
-      serverConfig?: t.ParsedServerConfig;
-    } & Omit<t.OAuthConnectionOptions, 'useOAuth'>,
-  ): Promise<MCPConnection> {
+  public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
     const { serverName, forceNew, user } = opts;
     const userId = user?.id;
     if (!userId) {
@@ -89,11 +82,7 @@ export abstract class UserConnectionManager {
       returnOnOAuth = false,
       connectionTimeout,
       serverConfig: providedConfig,
-    }: {
-      serverName: string;
-      forceNew?: boolean;
-      serverConfig?: t.ParsedServerConfig;
-    } & Omit<t.OAuthConnectionOptions, 'useOAuth'>,
+    }: t.UserMCPConnectionOptions,
     userId: string,
   ): Promise<MCPConnection> {
     if (await this.appConnections!.has(serverName)) {
@@ -161,16 +150,26 @@ export abstract class UserConnectionManager {
 
     try {
       const registry = MCPServersRegistry.getInstance();
-      connection = await MCPConnectionFactory.create(
-        {
-          serverConfig: config,
-          serverName: serverName,
-          dbSourced: isUserSourced(config),
-          useSSRFProtection: registry.shouldEnableSSRFProtection(),
-          allowedDomains: registry.getAllowedDomains(),
-          allowedAddresses: registry.getAllowedAddresses(),
-        },
-        {
+      const basic: t.BasicConnectionOptions = {
+        serverConfig: config,
+        serverName: serverName,
+        dbSourced: isUserSourced(config),
+        useSSRFProtection: registry.shouldEnableSSRFProtection(),
+        allowedDomains: registry.getAllowedDomains(),
+        allowedAddresses: registry.getAllowedAddresses(),
+      };
+
+      const useOAuth = isOAuthServer(config);
+      let connectionOptions: t.OAuthConnectionOptions | t.UserConnectionContext;
+      if (useOAuth) {
+        if (!flowManager) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            `[MCP][User: ${userId}] OAuth server "${serverName}" requires a flowManager`,
+          );
+        }
+
+        connectionOptions = {
           useOAuth: true,
           user: user,
           customUserVars: customUserVars,
@@ -182,8 +181,17 @@ export abstract class UserConnectionManager {
           returnOnOAuth: returnOnOAuth,
           requestBody: requestBody,
           connectionTimeout: connectionTimeout,
-        },
-      );
+        };
+      } else {
+        connectionOptions = {
+          user,
+          customUserVars,
+          requestBody,
+          connectionTimeout,
+        };
+      }
+
+      connection = await MCPConnectionFactory.create(basic, connectionOptions);
 
       if (!(await connection?.isConnected())) {
         throw new Error('Failed to establish connection after initialization attempt.');

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1002,4 +1002,272 @@ describe('MCPConnectionFactory', () => {
       expect(mockLogger.debug).toHaveBeenCalled();
     });
   });
+
+  describe('proactive OAuth flow', () => {
+    const makeOAuthServerConfig = (): t.MCPOptions =>
+      ({
+        type: 'streamable-http' as const,
+        url: 'https://bigquery.googleapis.com/mcp',
+        initTimeout: 5000,
+        requiresOAuth: true,
+      }) as unknown as t.MCPOptions;
+
+    const makeOAuthOptions = () => ({
+      useOAuth: true as const,
+      user: mockUser,
+      flowManager: mockFlowManager,
+      tokenMethods: {
+        findToken: jest.fn(),
+        createToken: jest.fn(),
+        updateToken: jest.fn(),
+        deleteTokens: jest.fn(),
+      },
+    });
+
+    /**
+     * Wires mock EventEmitter so `emit('oauthRequired', ...)` dispatches to
+     * the handler registered via `on('oauthRequired', ...)`, and
+     * `emit('oauthHandled')` / `emit('oauthFailed', err)` dispatch to the
+     * matching `once(...)` handler registered on the connection.
+     */
+    function wireEventHandlers(instance: jest.Mocked<MCPConnection>) {
+      const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+      const key = (event: string | symbol): string =>
+        typeof event === 'symbol' ? event.toString() : event;
+
+      instance.on.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          (handlers[key(event)] ??= []).push(handler);
+          return instance;
+        },
+      );
+
+      instance.once.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          (handlers[key(event)] ??= []).push(handler);
+          return instance;
+        },
+      );
+
+      instance.off.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          const list = handlers[key(event)];
+          if (list) {
+            const idx = list.indexOf(handler);
+            if (idx !== -1) list.splice(idx, 1);
+          }
+          return instance;
+        },
+      );
+
+      instance.removeListener.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          const list = handlers[key(event)];
+          if (list) {
+            const idx = list.indexOf(handler);
+            if (idx !== -1) list.splice(idx, 1);
+          }
+          return instance;
+        },
+      );
+
+      instance.emit.mockImplementation((event: string | symbol, ...args: unknown[]) => {
+        const list = handlers[key(event)];
+        if (list) {
+          for (const fn of [...list]) fn(...args);
+        }
+        return true;
+      });
+
+      return handlers;
+    }
+
+    it('should trigger proactive OAuth when requiresOAuth and no tokens', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      const mockTokens: MCPOAuthTokens = {
+        access_token: 'bq-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+
+      const mockFlowData = {
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth?state=xyz',
+        flowId: 'flow-bq',
+        flowMetadata: {
+          serverName: 'bigquery',
+          userId: 'user123',
+          serverUrl: 'https://bigquery.googleapis.com/mcp',
+          state: 'state-xyz',
+          clientInfo: { client_id: 'bq-client' },
+        },
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-bq');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'bigquery', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(mockTokens);
+      expect(mockConnectionInstance.connect).toHaveBeenCalled();
+    });
+
+    it('should NOT trigger proactive OAuth when useOAuth is true but requiresOAuth is absent', async () => {
+      const serverConfig = {
+        command: 'node',
+        args: ['server.js'],
+        initTimeout: 5000,
+      } as t.MCPOptions;
+
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'test-server', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+    });
+
+    it('should skip proactive OAuth when tokens already exist', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      const existingTokens: MCPOAuthTokens = {
+        access_token: 'existing-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(existingTokens);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'bigquery', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+    });
+
+    it('should reject when proactive OAuth flow fails', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = {
+        ...makeOAuthOptions(),
+        returnOnOAuth: true,
+        oauthStart: jest.fn(),
+      };
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      const mockFlowData = {
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth',
+        flowId: 'flow-bq',
+        flowMetadata: {
+          serverName: 'bigquery',
+          userId: 'user123',
+          serverUrl: 'https://bigquery.googleapis.com/mcp',
+          state: 'state-xyz',
+        },
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-bq');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockReturnValue(new Promise(() => {}));
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      await expect(
+        MCPConnectionFactory.create({ serverName: 'bigquery', serverConfig }, oauthOptions),
+      ).rejects.toThrow('OAuth flow initiated - return early');
+    });
+
+    it('should throw when requiresOAuth is true but url is missing', async () => {
+      const serverConfig = {
+        type: 'streamable-http' as const,
+        initTimeout: 5000,
+        requiresOAuth: true,
+      } as unknown as t.MCPOptions;
+
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      await expect(
+        MCPConnectionFactory.create({ serverName: 'no-url', serverConfig }, oauthOptions),
+      ).rejects.toThrow('server URL is missing');
+    });
+
+    it('should clean up cross-listeners when oauthHandled fires', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      const mockTokens: MCPOAuthTokens = {
+        access_token: 'cleanup-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-cleanup');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com',
+        flowId: 'flow-cleanup',
+        flowMetadata: {
+          serverName: 'bigquery',
+          userId: 'user123',
+          serverUrl: 'https://bigquery.googleapis.com/mcp',
+          state: 'state-cleanup',
+          clientInfo: { client_id: 'client-cleanup' },
+        },
+      });
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
+
+      const handlers = wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      await MCPConnectionFactory.create({ serverName: 'bigquery', serverConfig }, oauthOptions);
+
+      // After oauthHandled resolved, the oauthFailed listener should have been removed
+      const failedListeners = handlers['oauthFailed'] ?? [];
+      expect(failedListeners.length).toBe(0);
+    });
+  });
 });

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -95,6 +95,34 @@ describe('MCPConnectionFactory', () => {
       expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
 
+    it('should register fallback oauthRequired handler for non-OAuth connections', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      await MCPConnectionFactory.create(basicOptions);
+
+      expect(mockConnectionInstance.on).toHaveBeenCalledWith('oauthRequired', expect.any(Function));
+
+      const onCall = (mockConnectionInstance.on as jest.Mock).mock.calls.find(
+        ([event]: [string]) => event === 'oauthRequired',
+      );
+      const handler = onCall![1] as () => void;
+      handler();
+
+      expect(mockConnectionInstance.emit).toHaveBeenCalledWith(
+        'oauthFailed',
+        expect.objectContaining({ message: 'Server does not use OAuth' }),
+      );
+      expect(mockConnectionInstance.removeListener).toHaveBeenCalledWith(
+        'oauthRequired',
+        expect.any(Function),
+      );
+    });
+
     it('should create a connection with OAuth', async () => {
       const basicOptions = {
         serverName: 'test-server',
@@ -1135,7 +1163,7 @@ describe('MCPConnectionFactory', () => {
       expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
 
-    it('should not trigger proactive OAuth when OAuth metadata is present without requiresOAuth', async () => {
+    it('should trigger proactive OAuth when oauth is configured without requiresOAuth', async () => {
       const serverConfig = {
         type: 'streamable-http' as const,
         url: 'https://drivemcp.googleapis.com/mcp/v1',
@@ -1144,8 +1172,53 @@ describe('MCPConnectionFactory', () => {
           authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth',
           token_url: 'https://oauth2.googleapis.com/token',
         },
+      } as t.ParsedServerConfig;
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(null);
+
+      const mockTokens: MCPOAuthTokens = {
+        access_token: 'drive-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-drive');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue({
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth?state=drive',
+        flowId: 'flow-drive',
+        flowMetadata: {
+          serverName: 'drive',
+          userId: 'user123',
+          serverUrl: 'https://drivemcp.googleapis.com/mcp/v1',
+          state: 'state-drive',
+        },
+      });
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'drive', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockMCPOAuthHandler.initiateOAuthFlow).toHaveBeenCalled();
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(mockTokens);
+      expect(mockConnectionInstance.connect).toHaveBeenCalled();
+    });
+
+    it('should not trigger proactive OAuth when only OAuth metadata is present', async () => {
+      const serverConfig = {
+        type: 'streamable-http' as const,
+        url: 'https://metadata-only.example.com/mcp',
+        initTimeout: 5000,
         oauthMetadata: {
-          authorization_servers: ['https://accounts.google.com/'],
+          authorization_servers: ['https://auth.example.com/'],
         },
       } as t.ParsedServerConfig;
       const oauthOptions = makeOAuthOptions();
@@ -1155,7 +1228,7 @@ describe('MCPConnectionFactory', () => {
       mockConnectionInstance.isConnected.mockResolvedValue(true);
 
       const connection = await MCPConnectionFactory.create(
-        { serverName: 'drive', serverConfig },
+        { serverName: 'metadata-only', serverConfig },
         oauthOptions,
       );
 

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1077,8 +1077,11 @@ describe('MCPConnectionFactory', () => {
 
       instance.emit.mockImplementation((event: string | symbol, ...args: unknown[]) => {
         const list = handlers[key(event)];
-        if (list) {
-          for (const fn of [...list]) fn(...args);
+        if (!list || list.length === 0) {
+          return false;
+        }
+        for (const fn of [...list]) {
+          fn(...args);
         }
         return true;
       });
@@ -1309,6 +1312,24 @@ describe('MCPConnectionFactory', () => {
       await expect(
         MCPConnectionFactory.create({ serverName: 'no-url', serverConfig }, oauthOptions),
       ).rejects.toThrow('server URL is missing');
+    });
+
+    it('should reject when proactive OAuth has no registered handler', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(null);
+      mockConnectionInstance.on.mockReturnValue(mockConnectionInstance);
+      mockConnectionInstance.once.mockReturnValue(mockConnectionInstance);
+      mockConnectionInstance.off.mockReturnValue(mockConnectionInstance);
+      mockConnectionInstance.emit.mockReturnValue(false);
+
+      await expect(
+        MCPConnectionFactory.create({ serverName: 'bigquery', serverConfig }, oauthOptions),
+      ).rejects.toThrow('OAuth required but no handler is registered');
+
+      expect(mockConnectionInstance.connect).not.toHaveBeenCalled();
     });
 
     it('should clean up cross-listeners when oauthHandled fires', async () => {

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1024,53 +1024,56 @@ describe('MCPConnectionFactory', () => {
       },
     });
 
-    /**
-     * Wires mock EventEmitter so `emit('oauthRequired', ...)` dispatches to
-     * the handler registered via `on('oauthRequired', ...)`, and
-     * `emit('oauthHandled')` / `emit('oauthFailed', err)` dispatch to the
-     * matching `once(...)` handler registered on the connection.
-     */
     function wireEventHandlers(instance: jest.Mocked<MCPConnection>) {
-      const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+      type Listener = (...args: unknown[]) => void;
 
+      const handlers: Record<string, Listener[]> = {};
+      const onceWrappers = new Map<Listener, Listener>();
       const key = (event: string | symbol): string =>
         typeof event === 'symbol' ? event.toString() : event;
+      const addHandler = (event: string | symbol, handler: Listener) => {
+        (handlers[key(event)] ??= []).push(handler);
+      };
+      const removeHandler = (event: string | symbol, handler: Listener) => {
+        const list = handlers[key(event)];
+        if (!list) {
+          return;
+        }
+        const wrapped = onceWrappers.get(handler);
+        const handlerToRemove = wrapped ?? handler;
+        const index = list.indexOf(handlerToRemove);
+        if (index !== -1) {
+          list.splice(index, 1);
+        }
+        if (wrapped) {
+          onceWrappers.delete(handler);
+        }
+      };
 
-      instance.on.mockImplementation(
-        (event: string | symbol, handler: (...args: unknown[]) => void) => {
-          (handlers[key(event)] ??= []).push(handler);
-          return instance;
-        },
-      );
+      instance.on.mockImplementation((event: string | symbol, handler: Listener) => {
+        addHandler(event, handler);
+        return instance;
+      });
 
-      instance.once.mockImplementation(
-        (event: string | symbol, handler: (...args: unknown[]) => void) => {
-          (handlers[key(event)] ??= []).push(handler);
-          return instance;
-        },
-      );
+      instance.once.mockImplementation((event: string | symbol, handler: Listener) => {
+        const wrapped: Listener = (...args) => {
+          removeHandler(event, handler);
+          handler(...args);
+        };
+        onceWrappers.set(handler, wrapped);
+        addHandler(event, wrapped);
+        return instance;
+      });
 
-      instance.off.mockImplementation(
-        (event: string | symbol, handler: (...args: unknown[]) => void) => {
-          const list = handlers[key(event)];
-          if (list) {
-            const idx = list.indexOf(handler);
-            if (idx !== -1) list.splice(idx, 1);
-          }
-          return instance;
-        },
-      );
+      instance.off.mockImplementation((event: string | symbol, handler: Listener) => {
+        removeHandler(event, handler);
+        return instance;
+      });
 
-      instance.removeListener.mockImplementation(
-        (event: string | symbol, handler: (...args: unknown[]) => void) => {
-          const list = handlers[key(event)];
-          if (list) {
-            const idx = list.indexOf(handler);
-            if (idx !== -1) list.splice(idx, 1);
-          }
-          return instance;
-        },
-      );
+      instance.removeListener.mockImplementation((event: string | symbol, handler: Listener) => {
+        removeHandler(event, handler);
+        return instance;
+      });
 
       instance.emit.mockImplementation((event: string | symbol, ...args: unknown[]) => {
         const list = handlers[key(event)];
@@ -1129,6 +1132,53 @@ describe('MCPConnectionFactory', () => {
       expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
 
+    it('should trigger proactive OAuth when protected resource metadata is present', async () => {
+      const serverConfig = {
+        type: 'streamable-http' as const,
+        url: 'https://drivemcp.googleapis.com/mcp/v1',
+        initTimeout: 5000,
+        oauthMetadata: {
+          authorization_servers: ['https://accounts.google.com/'],
+        },
+      } as t.ParsedServerConfig;
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(null);
+
+      const mockTokens: MCPOAuthTokens = {
+        access_token: 'drive-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-drive');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue({
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth?state=drive',
+        flowId: 'flow-drive',
+        flowMetadata: {
+          serverName: 'drive',
+          userId: 'user123',
+          serverUrl: 'https://drivemcp.googleapis.com/mcp/v1',
+          state: 'state-drive',
+        },
+      });
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'drive', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockMCPOAuthHandler.initiateOAuthFlow).toHaveBeenCalled();
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(mockTokens);
+    });
+
     it('should NOT trigger proactive OAuth when useOAuth is true but requiresOAuth is absent', async () => {
       const serverConfig = {
         command: 'node',
@@ -1148,6 +1198,35 @@ describe('MCPConnectionFactory', () => {
       );
 
       expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+    });
+
+    it('should not trigger proactive OAuth when requiresOAuth is explicitly false', async () => {
+      const serverConfig = {
+        type: 'streamable-http' as const,
+        url: 'https://api.example.com/mcp',
+        initTimeout: 5000,
+        requiresOAuth: false,
+        oauth: {
+          authorization_url: 'https://auth.example.com/oauth/authorize',
+          token_url: 'https://auth.example.com/oauth/token',
+        },
+      } as t.MCPOptions;
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(null);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'test-server', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockMCPOAuthHandler.initiateOAuthFlow).not.toHaveBeenCalled();
       expect(mockLogger.info).not.toHaveBeenCalledWith(
         expect.stringContaining('proactively triggering OAuth flow'),
       );
@@ -1268,6 +1347,33 @@ describe('MCPConnectionFactory', () => {
       // After oauthHandled resolved, the oauthFailed listener should have been removed
       const failedListeners = handlers['oauthFailed'] ?? [];
       expect(failedListeners.length).toBe(0);
+    });
+
+    it('should not trigger proactive OAuth during tool discovery', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = {
+        ...makeOAuthOptions(),
+        oauthStart: jest.fn(),
+      };
+      const mockTools = [
+        { name: 'tool1', description: 'First tool', inputSchema: { type: 'object' } },
+      ];
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(null);
+      mockConnectionInstance.connect.mockResolvedValue(undefined);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+      mockConnectionInstance.fetchTools = jest.fn().mockResolvedValue(mockTools);
+
+      const result = await MCPConnectionFactory.discoverTools(
+        { serverName: 'bigquery', serverConfig },
+        oauthOptions,
+      );
+
+      expect(result.tools).toEqual(mockTools);
+      expect(result.oauthRequired).toBe(false);
+      expect(oauthOptions.oauthStart).not.toHaveBeenCalled();
+      expect(mockMCPOAuthHandler.initiateOAuthFlow).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1135,11 +1135,15 @@ describe('MCPConnectionFactory', () => {
       expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
 
-    it('should trigger proactive OAuth when protected resource metadata is present', async () => {
+    it('should not trigger proactive OAuth when OAuth metadata is present without requiresOAuth', async () => {
       const serverConfig = {
         type: 'streamable-http' as const,
         url: 'https://drivemcp.googleapis.com/mcp/v1',
         initTimeout: 5000,
+        oauth: {
+          authorization_url: 'https://accounts.google.com/o/oauth2/v2/auth',
+          token_url: 'https://oauth2.googleapis.com/token',
+        },
         oauthMetadata: {
           authorization_servers: ['https://accounts.google.com/'],
         },
@@ -1148,28 +1152,6 @@ describe('MCPConnectionFactory', () => {
 
       mockProcessMCPEnv.mockReturnValue(serverConfig);
       mockFlowManager.createFlowWithHandler.mockResolvedValue(null);
-
-      const mockTokens: MCPOAuthTokens = {
-        access_token: 'drive-token',
-        token_type: 'Bearer',
-        obtained_at: Date.now(),
-      };
-
-      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-drive');
-      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue({
-        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth?state=drive',
-        flowId: 'flow-drive',
-        flowMetadata: {
-          serverName: 'drive',
-          userId: 'user123',
-          serverUrl: 'https://drivemcp.googleapis.com/mcp/v1',
-          state: 'state-drive',
-        },
-      });
-      mockFlowManager.getFlowState.mockResolvedValue(null);
-      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
-
-      wireEventHandlers(mockConnectionInstance);
       mockConnectionInstance.isConnected.mockResolvedValue(true);
 
       const connection = await MCPConnectionFactory.create(
@@ -1178,8 +1160,8 @@ describe('MCPConnectionFactory', () => {
       );
 
       expect(connection).toBe(mockConnectionInstance);
-      expect(mockMCPOAuthHandler.initiateOAuthFlow).toHaveBeenCalled();
-      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(mockTokens);
+      expect(mockMCPOAuthHandler.initiateOAuthFlow).not.toHaveBeenCalled();
+      expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
 
     it('should NOT trigger proactive OAuth when useOAuth is true but requiresOAuth is absent', async () => {

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -905,6 +905,28 @@ describe('MCPManager', () => {
       );
     });
 
+    it('should treat configured oauth as OAuth when requiresOAuth is unset', async () => {
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(null),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'sse',
+        url: 'https://api.example.com',
+        oauth: {
+          authorization_url: 'https://auth.example.com/oauth/authorize',
+          token_url: 'https://auth.example.com/oauth/token',
+        },
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const result = await manager.discoverServerTools({ serverName });
+
+      expect(result.tools).toBeNull();
+      expect(result.oauthRequired).toBe(true);
+      expect(MCPConnectionFactory.discoverTools).not.toHaveBeenCalled();
+    });
+
     it('should return OAuth info when server requires OAuth but no user provided', async () => {
       mockAppConnections({
         get: jest.fn().mockResolvedValue(null),
@@ -965,6 +987,98 @@ describe('MCPManager', () => {
         expect.objectContaining({ serverName }),
         expect.objectContaining({ user: mockUser, useOAuth: true }),
       );
+    });
+  });
+
+  describe('getUserConnection - useOAuth derivation', () => {
+    const mockUser = { id: userId, email: 'test@example.com' } as unknown as IUser;
+    const mockFlowManager = {
+      createFlow: jest.fn(),
+      getFlowState: jest.fn(),
+      deleteFlow: jest.fn(),
+    };
+    const mockConnection = {
+      isConnected: jest.fn().mockResolvedValue(true),
+      isStale: jest.fn().mockReturnValue(false),
+      disconnect: jest.fn(),
+    } as unknown as MCPConnection;
+
+    it('should pass useOAuth for servers with configured oauth and no requiresOAuth value', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'sse',
+        url: 'https://oauth-mcp.example.com',
+        oauth: {
+          authorization_url: 'https://auth.example.com/oauth/authorize',
+          token_url: 'https://auth.example.com/oauth/token',
+        },
+      });
+
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(mockConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        flowManager: mockFlowManager as unknown as t.UserMCPConnectionOptions['flowManager'],
+      });
+
+      expect(MCPConnectionFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.objectContaining({ useOAuth: true }),
+      );
+    });
+
+    it('should not pass useOAuth for servers with requiresOAuth: false', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'http://private-mcp.svc:5446/mcp',
+        requiresOAuth: false,
+        oauth: {
+          authorization_url: 'https://auth.example.com/oauth/authorize',
+          token_url: 'https://auth.example.com/oauth/token',
+        },
+      });
+
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(mockConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({
+        serverName,
+        user: mockUser,
+      });
+
+      expect(MCPConnectionFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.not.objectContaining({ useOAuth: true }),
+      );
+    });
+
+    it('should throw when OAuth server lacks flowManager', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'sse',
+        url: 'https://oauth-mcp.example.com',
+        requiresOAuth: true,
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await expect(
+        manager.getUserConnection({
+          serverName,
+          user: mockUser,
+        }),
+      ).rejects.toThrow('requires a flowManager');
     });
   });
 });

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -204,6 +204,19 @@ export interface OAuthConnectionOptions extends UserConnectionContext {
   returnOnOAuth?: boolean;
 }
 
+/** Options accepted by UserConnectionManager.getUserConnection. OAuth fields are optional. */
+export interface UserMCPConnectionOptions extends UserConnectionContext {
+  serverName: string;
+  forceNew?: boolean;
+  serverConfig?: ParsedServerConfig;
+  flowManager?: FlowStateManager<o.MCPOAuthTokens | null>;
+  tokenMethods?: TokenMethods;
+  signal?: AbortSignal;
+  oauthStart?: (authURL: string) => Promise<void>;
+  oauthEnd?: () => Promise<void>;
+  returnOnOAuth?: boolean;
+}
+
 export interface ToolDiscoveryOptions {
   serverName: string;
   user?: IUser;

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -3,6 +3,16 @@ import type { ParsedServerConfig } from '~/mcp/types';
 
 export const mcpToolPattern = new RegExp(`^.+${Constants.mcp_delimiter}.+$`);
 
+/** Whether a server should use MCP OAuth handling. */
+export function isOAuthServer(
+  config: Pick<ParsedServerConfig, 'requiresOAuth' | 'oauth'>,
+): boolean {
+  if (config.requiresOAuth === false) {
+    return false;
+  }
+  return config.requiresOAuth === true || config.oauth != null;
+}
+
 /** Checks that `customUserVars` is present AND non-empty (guards against truthy `{}`) */
 export function hasCustomUserVars(config: Pick<ParsedServerConfig, 'customUserVars'>): boolean {
   return !!config.customUserVars && Object.keys(config.customUserVars).length > 0;


### PR DESCRIPTION
I built on #12759 and folded in the policy-layer fix from #12511 to make MCP OAuth decisions consistent across proactive connection, discovery, and user connection setup. This supersedes #12759 and #12511.

- Consolidated MCP OAuth detection around a shared policy: `requiresOAuth: false` opts out, `requiresOAuth: true` opts in, and configured `oauth` opts in when `requiresOAuth` is unset.
- Improved the OAuth UX for MCP servers that need user authorization by prompting before the first protected tool call when no tokens exist, instead of letting the server appear connected and then failing later with a delayed auth error.
- Preserved `requiresOAuth: false` as an explicit escape hatch so private/OIDC pass-through MCP servers do not show unwanted OAuth prompts and continue to fail promptly on normal auth failures.
- Refined proactive OAuth so missing tokens start OAuth before connect when the shared policy marks the server as OAuth-enabled.
- Updated user-specific MCP connections to derive `useOAuth` from server config instead of hardcoding OAuth for every user connection.
- Added a non-OAuth fallback `oauthRequired` handler so 401/403 responses from non-OAuth servers fail promptly instead of waiting for OAuth handling timeouts.
- Added regression coverage for configured OAuth, explicit opt-out, metadata-only behavior, non-OAuth fallback cleanup, user-connection policy derivation, missing flowManager guards, listener cleanup, missing handlers, and discovery mode continuing to list tools without initiating OAuth.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest src/mcp/__tests__/MCPConnectionFactory.test.ts src/mcp/__tests__/MCPManager.test.ts --runInBand` from `packages/api`.
- Ran `npx eslint packages/api/src/mcp/MCPConnectionFactory.ts packages/api/src/mcp/UserConnectionManager.ts packages/api/src/mcp/MCPManager.ts packages/api/src/mcp/utils.ts packages/api/src/mcp/types/index.ts packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts packages/api/src/mcp/__tests__/MCPManager.test.ts`.
- Ran `npm run build:api`.
- Ran `git diff --check`.

### **Test Configuration**:
- Node.js v20.19.5
- npm 10.8.2
- Branch based on #12759 head with #12511 policy changes folded in, targeting `dev`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
