### PR TITLE
🧩 fix: Add REDIS_CLUSTER_SAFE_DELETE Flag for ElastiCache Serverless CROSSSLOT Errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -766,6 +766,12 @@ HELP_AND_FAQ_URL=https://librechat.ai
 
 # Redis cluster (multiple nodes)
 # REDIS_URI=redis://127.0.0.1:7001,redis://127.0.0.1:7002,redis://127.0.0.1:7003
+# Enable Redis cluster mode when connecting to a cluster through a single URI
+# USE_REDIS_CLUSTER=true
+
+# Managed Redis services with a single endpoint may shard keys internally and reject multi-key DEL
+# Set to true to delete keys individually and avoid CROSSSLOT errors while keeping single-node mode
+# REDIS_CLUSTER_SAFE_DELETE=true
 
 # Redis with TLS/SSL encryption and CA certificate
 # REDIS_URI=rediss://127.0.0.1:6380

--- a/packages/api/src/cache/__tests__/cacheConfig.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheConfig.spec.ts
@@ -12,6 +12,7 @@ describe('cacheConfig', () => {
     delete process.env.USE_REDIS;
     delete process.env.USE_REDIS_STREAMS;
     delete process.env.USE_REDIS_CLUSTER;
+    delete process.env.REDIS_CLUSTER_SAFE_DELETE;
     delete process.env.REDIS_PING_INTERVAL;
     delete process.env.FORCED_IN_MEMORY_CACHE_NAMESPACES;
 
@@ -128,6 +129,27 @@ describe('cacheConfig', () => {
       expect(cacheConfig.USE_REDIS_CLUSTER).toBe(true);
       expect(cacheConfig.USE_REDIS).toBe(true);
       expect(cacheConfig.REDIS_URI).toBe('redis://localhost:6379');
+    });
+  });
+
+  describe('REDIS_CLUSTER_SAFE_DELETE configuration', () => {
+    test('should default to false when REDIS_CLUSTER_SAFE_DELETE is not set', async () => {
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.REDIS_CLUSTER_SAFE_DELETE).toBe(false);
+    });
+
+    test('should be false when REDIS_CLUSTER_SAFE_DELETE is set to false', async () => {
+      process.env.REDIS_CLUSTER_SAFE_DELETE = 'false';
+
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.REDIS_CLUSTER_SAFE_DELETE).toBe(false);
+    });
+
+    test('should be true when REDIS_CLUSTER_SAFE_DELETE is set to true', async () => {
+      process.env.REDIS_CLUSTER_SAFE_DELETE = 'true';
+
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.REDIS_CLUSTER_SAFE_DELETE).toBe(true);
     });
   });
 

--- a/packages/api/src/cache/cacheConfig.ts
+++ b/packages/api/src/cache/cacheConfig.ts
@@ -95,6 +95,13 @@ const cacheConfig = {
   REDIS_USE_ALTERNATIVE_DNS_LOOKUP: isEnabled(process.env.REDIS_USE_ALTERNATIVE_DNS_LOOKUP),
   /** Enable redis cluster without the need of multiple URIs */
   USE_REDIS_CLUSTER: isEnabled(process.env.USE_REDIS_CLUSTER ?? 'false'),
+  /**
+   * Force cluster-safe (key-by-key) deletion even when connecting as a single-node Redis instance.
+   * Needed for managed services like ElastiCache Serverless that present a single endpoint
+   * but shard keys internally, causing CROSSSLOT errors on multi-key DEL commands.
+   * Has no effect when USE_REDIS_CLUSTER is already true.
+   */
+  REDIS_CLUSTER_SAFE_DELETE: isEnabled(process.env.REDIS_CLUSTER_SAFE_DELETE ?? 'false'),
   CI: isEnabled(process.env.CI),
   DEBUG_MEMORY_CACHE: isEnabled(process.env.DEBUG_MEMORY_CACHE),
 

--- a/packages/api/src/cache/redisUtils.ts
+++ b/packages/api/src/cache/redisUtils.ts
@@ -31,11 +31,14 @@ export async function batchDeleteKeys(
   }
 
   const size = chunkSize ?? cacheConfig.REDIS_DELETE_CHUNK_SIZE;
-  const mode = cacheConfig.USE_REDIS_CLUSTER ? 'cluster' : 'single-node';
+  const clusterSafe = cacheConfig.USE_REDIS_CLUSTER || cacheConfig.REDIS_CLUSTER_SAFE_DELETE;
+  const mode = cacheConfig.USE_REDIS_CLUSTER ? 'cluster' : clusterSafe ? 'cluster-safe' : 'single-node';
   const deletePromises = [];
 
-  if (cacheConfig.USE_REDIS_CLUSTER) {
-    // Cluster mode: Delete each key individually in parallel chunks to avoid CROSSSLOT errors
+  if (clusterSafe) {
+    // Cluster / cluster-safe mode: Delete each key individually in parallel chunks to avoid CROSSSLOT errors.
+    // Also used when REDIS_CLUSTER_SAFE_DELETE=true for managed services like ElastiCache Serverless that
+    // shard keys internally while presenting a single-node connection endpoint.
     for (let i = 0; i < keys.length; i += size) {
       const chunk = keys.slice(i, i + size);
       deletePromises.push(Promise.all(chunk.map((key) => client.del(key))));

--- a/packages/api/src/cache/redisUtils.ts
+++ b/packages/api/src/cache/redisUtils.ts
@@ -32,7 +32,14 @@ export async function batchDeleteKeys(
 
   const size = chunkSize ?? cacheConfig.REDIS_DELETE_CHUNK_SIZE;
   const clusterSafe = cacheConfig.USE_REDIS_CLUSTER || cacheConfig.REDIS_CLUSTER_SAFE_DELETE;
-  const mode = cacheConfig.USE_REDIS_CLUSTER ? 'cluster' : clusterSafe ? 'cluster-safe' : 'single-node';
+  let mode = 'single-node';
+
+  if (cacheConfig.USE_REDIS_CLUSTER) {
+    mode = 'cluster';
+  } else if (cacheConfig.REDIS_CLUSTER_SAFE_DELETE) {
+    mode = 'cluster-safe';
+  }
+
   const deletePromises = [];
 
   if (clusterSafe) {


### PR DESCRIPTION
## Problem

ElastiCache Serverless and similar managed Redis services (e.g. Redis Enterprise Cloud on AWS) present a **single-node connection endpoint** but shard keys internally across multiple nodes. This means:

- `USE_REDIS_CLUSTER=false` is required (only one endpoint to connect to)
- But multi-key `DEL` commands still fail with `CROSSSLOT Keys in request don't hash to the same slot`

The result is that `clear()` calls on any cache namespace fail with errors like:

```
{"level":"error","message":"[MCP] Failed to initialize MCPManager: CROSSSLOT Keys in request don't hash to the same slot"}
```

Reported in #13261. A previous attempt (#11269) was never merged.

## Solution

Adds a new `REDIS_CLUSTER_SAFE_DELETE=true` environment variable that forces per-key deletion (the same code path used by `USE_REDIS_CLUSTER`) without changing the connection mode.

**Before:**
```
batchDeleteKeys → USE_REDIS_CLUSTER ? per-key : multi-key DEL
```

**After:**
```
batchDeleteKeys → (USE_REDIS_CLUSTER || REDIS_CLUSTER_SAFE_DELETE) ? per-key : multi-key DEL
```

The mode string in logs also reflects this: single-node / cluster-safe / cluster.

## What this changes

- `packages/api/src/cache/cacheConfig.ts` — adds `REDIS_CLUSTER_SAFE_DELETE` boolean config (defaults `false`)
- `packages/api/src/cache/redisUtils.ts` — `batchDeleteKeys` uses the new flag as a fallback cluster-safe path
- `packages/api/src/cache/__tests__/cacheConfig.spec.ts` — 3 tests for the new config flag following the same pattern as `USE_REDIS_CLUSTER`

## Testing

Set `REDIS_CLUSTER_SAFE_DELETE=true` when using ElastiCache Serverless and call any cache `clear()` — previously failing with CROSSSLOT, now succeeds. Standard Redis single-node and `USE_REDIS_CLUSTER=true` deployments are unaffected.