### PR TITLE
🏣 fix: Reject System Tenant In Auth Context

### DIFF
--- a/packages/api/src/middleware/__tests__/tenant.spec.ts
+++ b/packages/api/src/middleware/__tests__/tenant.spec.ts
@@ -168,6 +168,20 @@ describe('tenantContextMiddleware', () => {
     expect(tenantId).toBe('tenant-y');
   });
 
+  it('rejects a normalized system tenant sentinel for authenticated requests', async () => {
+    const req = mockReq({ tenantId: ` ${SYSTEM_TENANT_ID} `, role: 'user' });
+    const res = mockRes();
+    const next: NextFunction = jest.fn();
+
+    await tenantContextMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'System tenant is not allowed for request-scoped routes',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('different requests get independent tenant contexts', async () => {
     const runRequest = (tid: string) => {
       const req = mockReq({ tenantId: tid, role: 'user' });

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -20,6 +20,7 @@ type ContextRequest = {
 };
 
 const REQUEST_ID_HEADERS = ['x-request-id', 'x-correlation-id'] as const;
+const SYSTEM_TENANT_REJECTION_MESSAGE = 'System tenant is not allowed for request-scoped routes';
 
 let _checkedThread = false;
 
@@ -119,13 +120,20 @@ export function tenantContextMiddleware(
 
   const user = req.user;
   const context = buildTenantContext(req);
+  const { tenantId } = context;
+
+  if (tenantId === SYSTEM_TENANT_ID) {
+    logger.warn('[tenantContextMiddleware] Rejected system tenant for request route', {
+      path: req.path,
+    });
+    res.status(403).json({ error: SYSTEM_TENANT_REJECTION_MESSAGE });
+    return;
+  }
 
   if (!user) {
     runWithTenantContext(context, next);
     return;
   }
-
-  const { tenantId } = context;
 
   if (!tenantId) {
     if (isStrict()) {
@@ -255,7 +263,7 @@ export function restoreTenantContextFromReq(
     return rejectRequestWithUploadCleanup(
       req,
       res,
-      'System tenant is not allowed for request-scoped routes',
+      SYSTEM_TENANT_REJECTION_MESSAGE,
     );
   }
 


### PR DESCRIPTION
## Summary

I fixed the authenticated tenant context path so request-scoped middleware rejects the reserved system tenant sentinel before downstream tenant-isolated queries can observe it.

- Reject normalized `SYSTEM_TENANT_ID` values in `tenantContextMiddleware` with a 403 response.
- Reuse the existing request-scoped system tenant rejection message for the authenticated and upload restore paths.
- Add regression coverage for whitespace-padded stored tenant IDs such as ` __SYSTEM__ `.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`
- Ran `npm run build:data-schemas`
- Ran `cd packages/api && npx jest src/middleware/__tests__/tenant.spec.ts --runInBand --coverage=false`
- Ran `npm run build:api`

### **Test Configuration**:

- Node/Jest workspace dependencies installed with `npm install --ignore-scripts --no-audit --no-fund`
- Targeted package: `@librechat/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
