### PR TITLE
🧾 fix: Validate Bedrock User Credentials

### DIFF
--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -483,6 +483,26 @@ describe('initializeBedrock', () => {
       expect(result.llmConfig).not.toHaveProperty('credentials');
     });
 
+    it('should reject a non-string user-provided Bedrock API key', async () => {
+      process.env.BEDROCK_AWS_BEARER_TOKEN = AuthType.USER_PROVIDED;
+      process.env.BEDROCK_AWS_ACCESS_KEY_ID = AuthType.USER_PROVIDED;
+      process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = AuthType.USER_PROVIDED;
+      const params = createMockParams();
+      (params.db.getUserKey as jest.Mock).mockResolvedValue(
+        JSON.stringify({
+          apiKey: JSON.stringify({
+            bearerToken: {},
+            accessKeyId: 'user-access-key',
+            secretAccessKey: 'user-secret-key',
+          }),
+        }),
+      );
+
+      await expect(initializeBedrock(params)).rejects.toThrow(
+        'Bedrock credentials not provided. Please provide them again.',
+      );
+    });
+
     it('should not use stored access keys when only bearer token mode is configured', async () => {
       process.env.BEDROCK_AWS_BEARER_TOKEN = AuthType.USER_PROVIDED;
       const params = createMockParams();
@@ -512,6 +532,24 @@ describe('initializeBedrock', () => {
         secretAccessKey: 'static-secret-key',
       });
       expect(result.llmConfig).not.toHaveProperty('client');
+    });
+
+    it('should reject non-string user-provided access key values', async () => {
+      process.env.BEDROCK_AWS_ACCESS_KEY_ID = AuthType.USER_PROVIDED;
+      process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = AuthType.USER_PROVIDED;
+      const params = createMockParams();
+      (params.db.getUserKey as jest.Mock).mockResolvedValue(
+        JSON.stringify({
+          apiKey: JSON.stringify({
+            accessKeyId: {},
+            secretAccessKey: 'user-secret-key',
+          }),
+        }),
+      );
+
+      await expect(initializeBedrock(params)).rejects.toThrow(
+        'Bedrock credentials not provided. Please provide them again.',
+      );
     });
   });
 

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -15,11 +15,60 @@ import type {
   BaseInitializeParams,
   InitializeResultBase,
   BedrockCredentials,
-  BedrockUserCredentials,
   GuardrailConfiguration,
   InferenceProfileConfig,
 } from '~/types';
 import { checkUserKeyExpiry } from '~/utils';
+
+const BEDROCK_CREDENTIALS_ERROR = 'Bedrock credentials not provided. Please provide them again.';
+
+type UserCredentialKey = 'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'bearerToken';
+type UserCredentialValue = string | number | boolean | object | null;
+type ParsedBedrockUserCredentials = Partial<Record<UserCredentialKey, UserCredentialValue>> & {
+  apiKey?: string;
+};
+
+function isParsedBedrockUserCredentials(value: unknown): value is ParsedBedrockUserCredentials {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseBedrockUserCredentials(userKey: string): ParsedBedrockUserCredentials {
+  const storedCredentials = JSON.parse(userKey) as unknown;
+  if (!isParsedBedrockUserCredentials(storedCredentials)) {
+    throw new Error(BEDROCK_CREDENTIALS_ERROR);
+  }
+
+  if (typeof storedCredentials.apiKey !== 'string') {
+    return storedCredentials;
+  }
+
+  const nestedCredentials = JSON.parse(storedCredentials.apiKey) as unknown;
+  if (!isParsedBedrockUserCredentials(nestedCredentials)) {
+    throw new Error(BEDROCK_CREDENTIALS_ERROR);
+  }
+
+  return nestedCredentials;
+}
+
+function getUserCredentialValue(
+  credentials: ParsedBedrockUserCredentials,
+  key: UserCredentialKey,
+): string | undefined {
+  if (!Object.prototype.hasOwnProperty.call(credentials, key)) {
+    return undefined;
+  }
+
+  const value = credentials[key];
+  if (value === '') {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(BEDROCK_CREDENTIALS_ERROR);
+  }
+
+  return value;
+}
 
 /**
  * Initializes Bedrock endpoint configuration.
@@ -101,35 +150,37 @@ export async function initializeBedrock({
     });
 
     if (!userKey) {
-      throw new Error('Bedrock credentials not provided. Please provide them again.');
+      throw new Error(BEDROCK_CREDENTIALS_ERROR);
     }
 
-    let userCredentials: BedrockUserCredentials;
+    let userCredentials: ParsedBedrockUserCredentials;
     try {
-      const storedCredentials = JSON.parse(userKey) as BedrockUserCredentials & { apiKey?: string };
-      userCredentials =
-        typeof storedCredentials.apiKey === 'string'
-          ? (JSON.parse(storedCredentials.apiKey) as BedrockUserCredentials)
-          : storedCredentials;
+      userCredentials = parseBedrockUserCredentials(userKey);
     } catch {
-      throw new Error('Bedrock credentials not provided. Please provide them again.');
+      throw new Error(BEDROCK_CREDENTIALS_ERROR);
     }
 
-    if (userProvidesBearerToken && userCredentials.bearerToken) {
-      bearerToken = userCredentials.bearerToken;
+    const userBearerToken = userProvidesBearerToken
+      ? getUserCredentialValue(userCredentials, 'bearerToken')
+      : undefined;
+
+    if (userBearerToken) {
+      bearerToken = userBearerToken;
     } else {
       const canUseAccessKeys =
         userProvidesAccessKeyId || userProvidesSecretAccessKey || userProvidesSessionToken;
-      const accessKeyId = userProvidesAccessKeyId ? userCredentials.accessKeyId : staticAccessKeyId;
+      const accessKeyId = userProvidesAccessKeyId
+        ? getUserCredentialValue(userCredentials, 'accessKeyId')
+        : staticAccessKeyId;
       const secretAccessKey = userProvidesSecretAccessKey
-        ? userCredentials.secretAccessKey
+        ? getUserCredentialValue(userCredentials, 'secretAccessKey')
         : staticSecretAccessKey;
       const sessionToken = userProvidesSessionToken
-        ? userCredentials.sessionToken
+        ? getUserCredentialValue(userCredentials, 'sessionToken')
         : staticSessionToken;
 
       if (!canUseAccessKeys || !accessKeyId || !secretAccessKey) {
-        throw new Error('Bedrock credentials not provided. Please provide them again.');
+        throw new Error(BEDROCK_CREDENTIALS_ERROR);
       }
 
       credentials = {


### PR DESCRIPTION
## Summary

I fixed Bedrock user-provided credential handling so malformed stored credential values fail closed before the AWS SDK can fall back to server-side default credentials.

- Added explicit parsing and shape checks for stored Bedrock user credentials, including the nested `apiKey` JSON form used by the key dialog.
- Validated configured user-provided Bedrock credential fields as strings before selecting bearer-token or access-key authentication.
- Preserved empty-string handling as missing credentials so existing credential-required errors continue to behave consistently.
- Added regression coverage for non-string bearer tokens and non-string access key values.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider` to make the local workspace package importable for API tests.
- Ran `npm run build:data-schemas` to make the local schema package importable for the API build.
- Ran `npx jest src/endpoints/bedrock/initialize.spec.ts --runInBand --coverage=false` from `packages/api`.
- Ran `npm run build:api`.
- Ran `npx eslint packages/api/src/endpoints/bedrock/initialize.ts packages/api/src/endpoints/bedrock/initialize.spec.ts`.

### **Test Configuration**:

- Node/npm workspace install from `npm ci --include=dev`
- Target branch: `danny-avila/fix-bedrock-bearer-token-validation-main`
- Base branch: `main`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
