### PR TITLE
🚦 ci: Enforce ESLint on Package Changes

### DIFF
--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'api/**'
       - 'client/**'
+      - 'packages/**'
+      - '.github/workflows/eslint-ci.yml'
 
 jobs:
   eslint_checks:
@@ -34,15 +36,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Run ESLint on changed files within the api/ and client/ directories.
+      # Run ESLint on changed files within the api/, client/, and packages/ directories.
       - name: Run ESLint on changed files
         run: |
           # Extract the base commit SHA from the pull_request event payload.
           BASE_SHA=$(jq --raw-output .pull_request.base.sha "$GITHUB_EVENT_PATH")
           echo "Base commit SHA: $BASE_SHA"
 
-          # Get changed files (only JS/TS files in api/ or client/)
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD | grep -E '^(api|client)/.*\.(js|jsx|ts|tsx)$' || true)
+          # Get changed files (only JS/TS files in api/, client/, or packages/)
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD | grep -E '^(api|client|packages)/.*\.(js|jsx|ts|tsx)$' || true)
 
           # Debug output
           echo "Changed files:"
@@ -57,4 +59,5 @@ jobs:
           # Run ESLint
           npx eslint --no-error-on-unmatched-pattern \
             --config eslint.config.mjs \
+            --max-warnings=0 \
             $CHANGED_FILES


### PR DESCRIPTION
## Summary

I fixed the ESLint CI workflow so package workspace changes are linted and warning-level rules fail CI.

- Included `packages/**` in the ESLint workflow trigger so package-only PRs run the lint job.
- Updated the changed-file filter to lint JavaScript and TypeScript files under `packages/` alongside `api/` and `client/`.
- Added `--max-warnings=0` so warning-level rules like `no-nested-ternary` block CI instead of passing silently.
- Included the ESLint workflow file in the trigger paths so future workflow edits can exercise the job.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Parsed `.github/workflows/eslint-ci.yml` with Ruby YAML loading.
- Verified the updated changed-file regex matches the `packages/api` files from PR #13275.

### **Test Configuration**:

- macOS local worktree
- GitHub CLI 2.92.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
