### PR TITLE
🎨 ci: Check Prettier Formatting Drift on Package Changes

### DIFF
--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -61,3 +61,30 @@ jobs:
             --config eslint.config.mjs \
             --max-warnings=0 \
             $CHANGED_FILES
+
+      # Run Prettier --check on the same set of changed files to catch
+      # formatting drift in PRs that bypassed the local pre-commit hook
+      # (e.g. GitHub UI edit-and-merge, `git commit --no-verify`).
+      - name: Run Prettier --check on changed files
+        run: |
+          BASE_SHA=$(jq --raw-output .pull_request.base.sha "$GITHUB_EVENT_PATH")
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD | grep -E '^(api|client|packages)/.*\.(js|jsx|ts|tsx)$' || true)
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "No matching files changed. Skipping Prettier."
+            exit 0
+          fi
+
+          echo "Files to check:"
+          echo "$CHANGED_FILES"
+
+          # `prettier --check` exits non-zero if any file would be reformatted.
+          # Suggest the local fix in the failure message so contributors aren't
+          # left guessing how to resolve.
+          if ! npx prettier --check --no-error-on-unmatched-pattern $CHANGED_FILES; then
+            echo ""
+            echo "::error::Prettier formatting drift detected. Fix locally with:"
+            echo "::error::  npx prettier --write <files>"
+            echo "::error::Or rely on the lint-staged pre-commit hook (do not bypass with --no-verify)."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a `Run Prettier --check on changed files` step to the existing `eslint-ci.yml` workflow so formatting drift is caught in CI, not just by the local pre-commit hook.

## Why

Today there is no `prettier --check` step in CI — only the local `lint-staged` pre-commit hook runs `prettier --write`. When a PR is merged with the hook bypassed (GitHub UI edit-and-merge, `git commit --no-verify`, certain rebase flows), a file can land in a non-prettier-canonical state and nobody notices. The next contributor who stages an unrelated change in that file then ends up with a "drive-by" prettier diff in their PR.

`packages/api/src` had 14 such files accumulated; [#13281](https://github.com/danny-avila/LibreChat/pull/13281) fixes the existing drift. This PR closes the gap so it doesn't regrow.

## What the step does

- Detects changed JS/TS files under `api/**`, `client/**`, or `packages/**` against the PR base (same logic as the ESLint step).
- Runs `npx prettier --check $CHANGED_FILES`.
- On failure, prints `::error::` annotations telling the contributor how to fix it locally (`npx prettier --write <files>`) and reminds them not to bypass the pre-commit hook.

Same one-step shape as the existing ESLint check — no extra workflow file, no extra `npm ci`, no extra checkout.

## Ordering

[#13281](https://github.com/danny-avila/LibreChat/pull/13281) (`chore: prettier --write packages/api/src`) should land first so the existing drift is cleared. After both PRs merge, the pre-commit hook + this CI check together prevent drift from re-accumulating.

## Test plan

- [x] `js-yaml .github/workflows/eslint-ci.yml` validates.
- [ ] CI green on this PR itself (touches only `.github/workflows/eslint-ci.yml`, which the path filter includes, so the workflow runs on itself with no changed JS/TS files → both steps skip cleanly).
- [ ] Once merged: a synthetic PR introducing prettier drift should fail the new step with the diagnostic message.