### PR TITLE
🪤 chore: Prevent CI Path Argument Injection

### DIFF
--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -44,14 +44,17 @@ jobs:
           echo "Base commit SHA: $BASE_SHA"
 
           # Get changed files (only JS/TS files in api/, client/, or packages/)
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD | grep -E '^(api|client|packages)/.*\.(js|jsx|ts|tsx)$' || true)
+          mapfile -d '' -t CHANGED_FILES < <(
+            git diff -z --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD |
+              grep -zE '^(api|client|packages)/.*\.(js|jsx|ts|tsx)$' || true
+          )
 
           # Debug output
           echo "Changed files:"
-          echo "$CHANGED_FILES"
+          printf '%s\n' "${CHANGED_FILES[@]}"
 
           # Ensure there are files to lint before running ESLint
-          if [[ -z "$CHANGED_FILES" ]]; then
+          if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
             echo "No matching files changed. Skipping ESLint."
             exit 0
           fi
@@ -60,7 +63,7 @@ jobs:
           npx eslint --no-error-on-unmatched-pattern \
             --config eslint.config.mjs \
             --max-warnings=0 \
-            $CHANGED_FILES
+            -- "${CHANGED_FILES[@]}"
 
       # Run Prettier --check on the same set of changed files to catch
       # formatting drift in PRs that bypassed the local pre-commit hook
@@ -68,20 +71,23 @@ jobs:
       - name: Run Prettier --check on changed files
         run: |
           BASE_SHA=$(jq --raw-output .pull_request.base.sha "$GITHUB_EVENT_PATH")
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD | grep -E '^(api|client|packages)/.*\.(js|jsx|ts|tsx)$' || true)
+          mapfile -d '' -t CHANGED_FILES < <(
+            git diff -z --name-only --diff-filter=ACMRTUXB "$BASE_SHA" HEAD |
+              grep -zE '^(api|client|packages)/.*\.(js|jsx|ts|tsx)$' || true
+          )
 
-          if [[ -z "$CHANGED_FILES" ]]; then
+          if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
             echo "No matching files changed. Skipping Prettier."
             exit 0
           fi
 
           echo "Files to check:"
-          echo "$CHANGED_FILES"
+          printf '%s\n' "${CHANGED_FILES[@]}"
 
           # `prettier --check` exits non-zero if any file would be reformatted.
           # Suggest the local fix in the failure message so contributors aren't
           # left guessing how to resolve.
-          if ! npx prettier --check --no-error-on-unmatched-pattern $CHANGED_FILES; then
+          if ! npx prettier --check --no-error-on-unmatched-pattern -- "${CHANGED_FILES[@]}"; then
             echo ""
             echo "::error::Prettier formatting drift detected. Fix locally with:"
             echo "::error::  npx prettier --write <files>"


### PR DESCRIPTION
## Summary

I hardened the ESLint CI workflow so PR-controlled filenames cannot be interpreted as CLI options by ESLint or Prettier.

- Replaced newline-separated scalar filename handling with NUL-delimited `git diff -z` output and bash arrays.
- Passed changed files after `--` with `"${CHANGED_FILES[@]}"` so filenames containing spaces or option-looking substrings stay data.
- Updated debug output and empty-file checks to work with arrays.
- Fixed the newly reported Prettier injection sink and the adjacent ESLint sink that used the same unsafe pattern.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Parsed `.github/workflows/eslint-ci.yml` with Ruby YAML loading.
- Extracted workflow `run` blocks and checked them with `bash -n`.
- Ran a local shell PoC showing the vulnerable scalar expansion split `--config=...` into a separate argv entry, while the patched array invocation preserved the crafted name as a single path argument after `--`.
- Did not run unit tests because this only changes the GitHub Actions shell workflow.

### **Test Configuration**:

- macOS local worktree
- Ruby YAML parser
- Bash shell syntax check

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
