### PR TITLE
🪡 fix: Prevent Hover Actions Flash While Streaming

### DIFF
--- a/client/src/hooks/Messages/__tests__/useMemoizedChatContext.spec.tsx
+++ b/client/src/hooks/Messages/__tests__/useMemoizedChatContext.spec.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import type { TConversation, TMessage } from 'librechat-data-provider';
+import { useChatContext } from '~/Providers';
+import useMemoizedChatContext from '../useMemoizedChatContext';
+
+jest.mock('~/Providers', () => ({
+  useChatContext: jest.fn(),
+}));
+
+const mockUseChatContext = useChatContext as jest.MockedFunction<typeof useChatContext>;
+
+const conversation = {
+  conversationId: 'convo-id',
+  endpoint: 'openAI',
+  model: 'gpt-4',
+} as TConversation;
+
+const message = (overrides: Partial<TMessage> = {}) =>
+  ({
+    messageId: 'assistant-response_',
+    parentMessageId: 'user-message',
+    conversationId: 'convo-id',
+    sender: 'Assistant',
+    text: '',
+    isCreatedByUser: false,
+    children: [],
+    ...overrides,
+  }) as TMessage;
+
+function mockChatContext(latestMessageId: string | undefined) {
+  mockUseChatContext.mockReturnValue({
+    ask: jest.fn(),
+    index: 0,
+    regenerate: jest.fn(),
+    conversation,
+    latestMessageId,
+    latestMessageDepth: -1,
+    handleContinue: jest.fn(),
+    isSubmitting: true,
+  } as unknown as ReturnType<typeof useChatContext>);
+}
+
+describe('useMemoizedChatContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('treats the latest message as submitting while streaming', () => {
+    mockChatContext('assistant-response_');
+
+    const { result } = renderHook(() => useMemoizedChatContext(message(), true));
+
+    expect(result.current.effectiveIsSubmitting).toBe(true);
+  });
+
+  it('requires latestMessageId alignment before marking a row as submitting', () => {
+    mockChatContext(undefined);
+
+    const { result } = renderHook(() => useMemoizedChatContext(message(), true));
+
+    expect(result.current.effectiveIsSubmitting).toBe(false);
+    expect(result.current.chatContext.isSubmitting).toBe(true);
+  });
+});

--- a/client/src/hooks/SSE/__tests__/useEventHandlers.latestMessage.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useEventHandlers.latestMessage.spec.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Constants } from 'librechat-data-provider';
+import type { TConversation, TMessage, EventSubmission } from 'librechat-data-provider';
+import useEventHandlers, { type EventHandlerParams } from '../useEventHandlers';
+import { renderHook, act } from '@testing-library/react';
+
+const mockAnnouncePolite = jest.fn();
+const mockApplyAgentTemplate = jest.fn();
+const mockContentHandler = jest.fn();
+const mockResetContentHandler = jest.fn();
+const mockStepHandler = jest.fn();
+const mockClearStepMaps = jest.fn();
+const mockResetSubagentAtoms = jest.fn();
+const mockSyncStepMessage = jest.fn();
+const mockAttachmentHandler = jest.fn();
+
+jest.mock('~/Providers', () => ({
+  useLiveAnnouncer: () => ({ announcePolite: mockAnnouncePolite }),
+}));
+
+jest.mock('~/hooks/AuthContext', () => ({
+  useAuthContext: () => ({ token: 'token' }),
+}));
+
+jest.mock('~/hooks/Agents', () => ({
+  useApplyAgentTemplate: () => mockApplyAgentTemplate,
+}));
+
+jest.mock('~/hooks/SSE/useContentHandler', () => () => ({
+  contentHandler: mockContentHandler,
+  resetContentHandler: mockResetContentHandler,
+}));
+
+jest.mock('~/hooks/SSE/useStepHandler', () => () => ({
+  stepHandler: mockStepHandler,
+  clearStepMaps: mockClearStepMaps,
+  resetSubagentAtoms: mockResetSubagentAtoms,
+  syncStepMessage: mockSyncStepMessage,
+}));
+
+jest.mock('~/hooks/SSE/useAttachmentHandler', () => () => mockAttachmentHandler);
+
+const conversation = {
+  conversationId: 'convo-id',
+  endpoint: 'openAI',
+  model: 'gpt-4',
+  title: 'New Chat',
+} as TConversation;
+
+const userMessage = {
+  messageId: 'user-message',
+  parentMessageId: Constants.NO_PARENT,
+  conversationId: 'convo-id',
+  sender: 'User',
+  text: 'hello',
+  isCreatedByUser: true,
+} as TMessage;
+
+const initialResponse = {
+  messageId: 'user-message_',
+  parentMessageId: 'user-message',
+  conversationId: 'convo-id',
+  sender: 'Assistant',
+  text: '',
+  isCreatedByUser: false,
+} as TMessage;
+
+const submission = {
+  conversation,
+  messages: [] as TMessage[],
+  userMessage,
+  initialResponse,
+} as unknown as EventSubmission;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <MemoryRouter initialEntries={['/c/convo-id']}>{children}</MemoryRouter>
+      </RecoilRoot>
+    </QueryClientProvider>
+  );
+}
+
+const expectedCreatedAssistantResponse = () =>
+  expect.objectContaining({
+    messageId: 'user-message_',
+    parentMessageId: 'user-message',
+    isCreatedByUser: false,
+  });
+
+type EventHandlerSpies = Omit<
+  EventHandlerParams,
+  | 'setMessages'
+  | 'setLatestMessage'
+  | 'getMessages'
+  | 'setCompleted'
+  | 'setIsSubmitting'
+  | 'setShowStopButton'
+> & {
+  setMessages: jest.Mock;
+  setLatestMessage: jest.Mock;
+  getMessages: jest.Mock;
+  setCompleted: jest.Mock;
+  setIsSubmitting: jest.Mock;
+  setShowStopButton: jest.Mock;
+};
+
+function renderEventHandlersWithSpies(overrides: Partial<EventHandlerSpies> = {}) {
+  const defaultSpies: EventHandlerSpies = {
+    setMessages: jest.fn(),
+    setLatestMessage: jest.fn(),
+    getMessages: jest.fn(() => []),
+    setCompleted: jest.fn(),
+    setIsSubmitting: jest.fn(),
+    setShowStopButton: jest.fn(),
+  };
+  const spies: EventHandlerSpies = { ...defaultSpies, ...overrides };
+
+  const { result } = renderHook(() => useEventHandlers(spies), { wrapper });
+
+  return { result, ...spies };
+}
+
+describe('useEventHandlers latest-message transitions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps latestMessage aligned after replacing optimistic messages in createdHandler', () => {
+    const { result, setMessages, setLatestMessage } = renderEventHandlersWithSpies();
+
+    act(() => {
+      result.current.createdHandler(
+        { created: true } as unknown as Parameters<typeof result.current.createdHandler>[0],
+        submission,
+      );
+    });
+
+    expect(setMessages).toHaveBeenCalledWith([userMessage, expectedCreatedAssistantResponse()]);
+    expect(setLatestMessage).toHaveBeenCalledWith(expectedCreatedAssistantResponse());
+    expect(setLatestMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      setMessages.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps latestMessage aligned when createdHandler starts a regeneration', () => {
+    const previousMessage = {
+      ...userMessage,
+      messageId: 'previous-message',
+    } as TMessage;
+    const regenerateSubmission = {
+      ...submission,
+      messages: [previousMessage],
+      isRegenerate: true,
+    } as unknown as EventSubmission;
+    const { result, setMessages, setLatestMessage } = renderEventHandlersWithSpies({
+      getMessages: jest.fn(() => [previousMessage]),
+    });
+
+    act(() => {
+      result.current.createdHandler(
+        { created: true } as unknown as Parameters<typeof result.current.createdHandler>[0],
+        regenerateSubmission,
+      );
+    });
+
+    expect(setMessages).toHaveBeenCalledWith([previousMessage, expectedCreatedAssistantResponse()]);
+    expect(setLatestMessage).toHaveBeenCalledWith(expectedCreatedAssistantResponse());
+    expect(setLatestMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      setMessages.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps latestMessage aligned after replacing optimistic messages in syncHandler', () => {
+    const requestMessage = { ...userMessage, messageId: 'server-user-message' } as TMessage;
+    const responseMessage = {
+      ...initialResponse,
+      messageId: 'server-assistant-response',
+      parentMessageId: 'server-user-message',
+    } as TMessage;
+    const setShowStopButton = jest.fn();
+    const { result, setMessages, setLatestMessage } = renderEventHandlersWithSpies({
+      getMessages: jest.fn(() => [userMessage, initialResponse]),
+      setShowStopButton,
+    });
+
+    act(() => {
+      result.current.syncHandler(
+        {
+          sync: true,
+          conversationId: 'convo-id',
+          thread_id: 'thread-id',
+          requestMessage,
+          responseMessage,
+        },
+        submission,
+      );
+    });
+
+    expect(setMessages).toHaveBeenCalledWith([requestMessage, responseMessage]);
+    expect(setShowStopButton).toHaveBeenCalledWith(true);
+    expect(setLatestMessage).toHaveBeenCalledWith(responseMessage);
+    expect(setLatestMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      setMessages.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -156,7 +156,7 @@ const buildChatHelpers = () => ({
   setConversation: jest.fn(),
   setIsSubmitting: mockSetIsSubmitting,
   newConversation: jest.fn(),
-  resetLatestMessage: jest.fn(),
+  setLatestMessage: jest.fn(),
 });
 
 const getLastSSE = (): MockSSEInstance => {

--- a/client/src/hooks/SSE/useAdaptiveSSE.ts
+++ b/client/src/hooks/SSE/useAdaptiveSSE.ts
@@ -11,7 +11,7 @@ type ChatHelpers = Pick<
   | 'setConversation'
   | 'setIsSubmitting'
   | 'newConversation'
-  | 'resetLatestMessage'
+  | 'setLatestMessage'
 >;
 
 /**

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -21,7 +21,7 @@ import type {
 } from 'librechat-data-provider';
 import type { TResData, TFinalResData, ConvoGenerator } from '~/common';
 import type { InfiniteData } from '@tanstack/react-query';
-import type { SetterOrUpdater, Resetter } from 'recoil';
+import type { SetterOrUpdater } from 'recoil';
 import type { ConversationCursorData } from '~/utils';
 import {
   logger,
@@ -62,7 +62,7 @@ export type EventHandlerParams = {
   setConversation?: SetterOrUpdater<TConversation | null>;
   newConversation?: ConvoGenerator;
   setShowStopButton: SetterOrUpdater<boolean>;
-  resetLatestMessage?: Resetter;
+  setLatestMessage: SetterOrUpdater<TMessage | null>;
 };
 
 const createErrorMessage = ({
@@ -175,7 +175,7 @@ export default function useEventHandlers({
   setIsSubmitting,
   newConversation,
   setShowStopButton,
-  resetLatestMessage,
+  setLatestMessage,
 }: EventHandlerParams) {
   const queryClient = useQueryClient();
   const { announcePolite } = useLiveAnnouncer();
@@ -323,14 +323,14 @@ export default function useEventHandlers({
       const { initialResponse, messages: _messages, userMessage } = submission;
       const messages = _messages.filter((msg) => msg.messageId !== userMessage.messageId);
 
-      setMessages([
-        ...messages,
-        requestMessage,
-        {
-          ...initialResponse,
-          ...responseMessage,
-        },
-      ]);
+      const nextResponseMessage = {
+        ...initialResponse,
+        ...responseMessage,
+      };
+
+      logger.log('latest_message', 'syncHandler: setting latest message');
+      setLatestMessage(nextResponseMessage);
+      setMessages([...messages, requestMessage, nextResponseMessage]);
 
       announcePolite({
         message: 'start',
@@ -375,10 +375,6 @@ export default function useEventHandlers({
       }
 
       setShowStopButton(true);
-      if (resetLatestMessage) {
-        logger.log('latest_message', 'syncHandler: resetting latest message');
-        resetLatestMessage();
-      }
     },
     [
       queryClient,
@@ -387,7 +383,7 @@ export default function useEventHandlers({
       announcePolite,
       setConversation,
       setShowStopButton,
-      resetLatestMessage,
+      setLatestMessage,
     ],
   );
 
@@ -410,7 +406,10 @@ export default function useEventHandlers({
         ...submission.initialResponse,
         parentMessageId: userMessage.messageId,
         messageId: userMessage.messageId + '_',
+        conversationId: userMessage.conversationId ?? submission.initialResponse.conversationId,
       };
+      logger.log('latest_message', 'createdHandler: setting latest message');
+      setLatestMessage(initialResponse);
       if (isRegenerate) {
         setMessages([...messages, initialResponse]);
       } else {
@@ -469,10 +468,6 @@ export default function useEventHandlers({
         });
       }
 
-      if (resetLatestMessage) {
-        logger.log('latest_message', 'createdHandler: resetting latest message');
-        resetLatestMessage();
-      }
       scrollToEnd(() => setAbortScroll(false));
     },
     [
@@ -482,7 +477,7 @@ export default function useEventHandlers({
       isAddedRequest,
       announcePolite,
       setConversation,
-      resetLatestMessage,
+      setLatestMessage,
       applyAgentTemplate,
     ],
   );

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -35,7 +35,7 @@ type ChatHelpers = Pick<
   | 'setConversation'
   | 'setIsSubmitting'
   | 'newConversation'
-  | 'resetLatestMessage'
+  | 'setLatestMessage'
 >;
 
 const MAX_RETRIES = 5;
@@ -102,7 +102,7 @@ export default function useResumableSSE(
     setConversation,
     setIsSubmitting,
     newConversation,
-    resetLatestMessage,
+    setLatestMessage,
   } = chatHelpers;
 
   const {
@@ -125,7 +125,7 @@ export default function useResumableSSE(
     setIsSubmitting,
     newConversation,
     setShowStopButton,
-    resetLatestMessage,
+    setLatestMessage,
   });
 
   const { data: startupConfig } = useGetStartupConfig();

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -19,7 +19,7 @@ type ChatHelpers = Pick<
   | 'setConversation'
   | 'setIsSubmitting'
   | 'newConversation'
-  | 'resetLatestMessage'
+  | 'setLatestMessage'
 >;
 
 export default function useSSE(
@@ -41,7 +41,7 @@ export default function useSSE(
     setConversation,
     setIsSubmitting,
     newConversation,
-    resetLatestMessage,
+    setLatestMessage,
   } = chatHelpers;
 
   const {
@@ -64,7 +64,7 @@ export default function useSSE(
     setIsSubmitting,
     newConversation,
     setShowStopButton,
-    resetLatestMessage,
+    setLatestMessage,
   });
 
   const { data: startupConfig } = useGetStartupConfig();


### PR DESCRIPTION
## Summary

I fixed the streaming hover-action flash by keeping the active assistant response aligned as the latest message during SSE message replacement.

- Preserved `latestMessage` through `created` and `sync` events instead of clearing it while the replacement assistant message is inserted.
- Set the replacement assistant message as latest before updating the message list, so an unbatched SSE callback cannot produce a one-render window where the streaming row is treated as non-latest.
- Made `setLatestMessage` required at the SSE event-handler boundary and removed the old reset fallback, since resetting latest was the behavior that allowed the hover flash.
- Threaded `setLatestMessage` through standard, resumable, and adaptive SSE hooks.
- Preserved the server user message `conversationId` on the created assistant placeholder when available; this keeps the newly aligned `latestMessage` and rendered placeholder tied to the real conversation during new-conversation streaming.
- Added regression coverage for `createdHandler`, `createdHandler` regeneration, `syncHandler`, and the `useMemoizedChatContext` render invariant that only the aligned latest row should receive `effectiveIsSubmitting`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/hooks/SSE/__tests__/useEventHandlers.latestMessage.spec.tsx src/hooks/Messages/__tests__/useMemoizedChatContext.spec.tsx src/hooks/SSE/__tests__/useResumableSSE.spec.ts --runInBand --coverage=false`
- `npx jest src/hooks/SSE/__tests__ src/hooks/Messages/__tests__ src/components/Chat/Messages/__tests__ src/Providers/__tests__/MessagesViewContext.spec.tsx src/data-provider/Messages/__tests__/queries.test.ts --runInBand --coverage=false`
- `npx prettier --check client/src/hooks/SSE/useEventHandlers.ts client/src/hooks/SSE/useSSE.ts client/src/hooks/SSE/useResumableSSE.ts client/src/hooks/SSE/useAdaptiveSSE.ts client/src/hooks/SSE/__tests__/useEventHandlers.latestMessage.spec.tsx client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts client/src/hooks/Messages/__tests__/useMemoizedChatContext.spec.tsx`
- `git diff --check`
- `npm run typecheck -- --pretty false` was attempted; the repo currently reports pre-existing unrelated type errors outside the touched files.

### **Test Configuration**:

- Frontend workspace: `client`
- Jest run mode: `--runInBand`
- Branch base: `main`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes