### PR TITLE
🌐 chore: Guard Locize Reviewer Request

### DIFF
--- a/.github/workflows/locize-i18n-sync.yml
+++ b/.github/workflows/locize-i18n-sync.yml
@@ -65,6 +65,7 @@ jobs:
       # 3. Create a Pull Request using a dedicated fine-grained PAT so this
       # workflow does not depend on the global GITHUB_TOKEN PR-creation setting.
       - name: Create Pull Request
+        id: create-pull-request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.LOCIZE_PR_TOKEN }}
@@ -73,7 +74,6 @@ jobs:
           commit-message: "🌍 i18n: Update translation.json with latest translations"
           base: main
           branch: i18n/locize-translation-update
-          reviewers: danny-avila
           title: "🌍 i18n: Update translation.json with latest translations"
           body: |
             **Description**:
@@ -81,3 +81,19 @@ jobs:
             - 🔍 **Details**: This PR is automatically generated upon receiving a versionPublished event with version "latest". It reflects the newest translations provided by locize.
             - ✅ **Status**: Ready for review.
           labels: "🌍 i18n"
+
+      - name: Request Reviewer
+        if: ${{ steps.create-pull-request.outputs.pull-request-number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.LOCIZE_PR_TOKEN }}
+          PR_NUMBER: ${{ steps.create-pull-request.outputs.pull-request-number }}
+          REVIEWER: danny-avila
+        run: |
+          author="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')"
+
+          if [ "$author" = "$REVIEWER" ]; then
+            echo "Skipping reviewer request because $REVIEWER authored PR #$PR_NUMBER."
+            exit 0
+          fi
+
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-reviewer "$REVIEWER"


### PR DESCRIPTION
## Summary

I guarded the Locize translation PR reviewer request so the workflow no longer fails when the dedicated token creates a PR authored by the same user it tries to request for review.

- Added an explicit step id to the Locize `create-pull-request` action so later steps can read the generated PR number.
- Removed the inline `reviewers` input from `peter-evans/create-pull-request`, which caused the action to fail after creating PR #13283.
- Added a separate reviewer request step that checks the PR author first and skips requesting `danny-avila` when that user authored the PR.
- Preserved `LOCIZE_PR_TOKEN` so translation PRs can still trigger downstream workflows; if the token is later swapped to a machine user or GitHub App, the reviewer request will run normally.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/locize-i18n-sync.yml"); puts "YAML OK"'`.
- Reviewed the failed Actions log for run `26345092975`, which failed on `Review cannot be requested from pull request author.`

### **Test Configuration**:

- macOS local worktree
- Ruby YAML parser

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings