### PR TITLE
⏭️ fix: Avoid False Resume Submission Stale Detection

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -62,18 +62,20 @@ function buildSubmission(conversationId: string | null | undefined): TSubmission
 
 function renderUseResumeOnLoad({
   messages = [],
+  getMessages: getMessagesOverride,
   submission = null,
   conversationId = CONVERSATION_ID,
   messagesLoaded = true,
   onSubmission,
 }: {
   messages?: TMessage[];
+  getMessages?: () => TMessage[] | undefined;
   submission?: TSubmission | null;
   conversationId?: string;
   messagesLoaded?: boolean;
   onSubmission?: (submission: TSubmission | null) => void;
 }) {
-  const getMessages = jest.fn(() => messages);
+  const getMessages = jest.fn(getMessagesOverride ?? (() => messages));
   const initializeState = (snapshot: MutableSnapshot) => {
     snapshot.set(store.conversationByIndex(0), buildConversation(conversationId));
     snapshot.set(store.submissionByIndex(0), submission);
@@ -140,6 +142,22 @@ describe('useResumeOnLoad', () => {
     });
 
     expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, true);
+  });
+
+  it('stops checking for resume after loaded messages prove a null-conversation submission belongs to the route', () => {
+    const submission = buildSubmission(null);
+    let messages: TMessage[] = [];
+    const { rerender } = renderUseResumeOnLoad({
+      submission,
+      getMessages: () => messages,
+    });
+
+    expect(mockUseStreamStatus).toHaveBeenLastCalledWith(CONVERSATION_ID, true);
+
+    messages = [buildUserMessage(CONVERSATION_ID)];
+    rerender();
+
+    expect(mockUseStreamStatus).toHaveBeenLastCalledWith(CONVERSATION_ID, false);
   });
 
   it('does not replace a null-conversation submission when stream status matches its resume state', async () => {

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -1,0 +1,177 @@
+import { RecoilRoot, useRecoilValue } from 'recoil';
+import { Constants } from 'librechat-data-provider';
+import { renderHook, act } from '@testing-library/react';
+
+import type { TMessage, TConversation, TSubmission } from 'librechat-data-provider';
+import type { MutableSnapshot } from 'recoil';
+import type { ReactNode } from 'react';
+
+import useResumeOnLoad from '../useResumeOnLoad';
+import store from '~/store';
+
+const mockUseStreamStatus = jest.fn();
+
+jest.mock('~/data-provider', () => ({
+  useStreamStatus: (conversationId: string | undefined, enabled: boolean) =>
+    mockUseStreamStatus(conversationId, enabled),
+}));
+
+const CONVERSATION_ID = 'conv-current';
+const STALE_CONVERSATION_ID = 'conv-stale';
+const USER_MESSAGE_ID = 'user-message-1';
+const RESPONSE_MESSAGE_ID = 'user-message-1_';
+
+function buildConversation(conversationId = CONVERSATION_ID): TConversation {
+  return {
+    conversationId,
+    endpoint: 'agents',
+  } as TConversation;
+}
+
+function buildUserMessage(
+  conversationId: string | null = CONVERSATION_ID,
+  messageId = USER_MESSAGE_ID,
+): TMessage {
+  return {
+    text: 'Hello',
+    sender: 'User',
+    messageId,
+    conversationId,
+    isCreatedByUser: true,
+    parentMessageId: Constants.NO_PARENT,
+  } as TMessage;
+}
+
+function buildSubmission(conversationId: string | null | undefined): TSubmission {
+  return {
+    messages: [],
+    isTemporary: false,
+    endpointOption: { endpoint: 'agents' },
+    conversation: { conversationId },
+    userMessage: buildUserMessage(null),
+    initialResponse: {
+      text: '',
+      sender: 'Assistant',
+      messageId: RESPONSE_MESSAGE_ID,
+      conversationId,
+      isCreatedByUser: false,
+      parentMessageId: USER_MESSAGE_ID,
+    } as TMessage,
+  } as unknown as TSubmission;
+}
+
+function renderUseResumeOnLoad({
+  messages = [],
+  submission = null,
+  conversationId = CONVERSATION_ID,
+  messagesLoaded = true,
+  onSubmission,
+}: {
+  messages?: TMessage[];
+  submission?: TSubmission | null;
+  conversationId?: string;
+  messagesLoaded?: boolean;
+  onSubmission?: (submission: TSubmission | null) => void;
+}) {
+  const getMessages = jest.fn(() => messages);
+  const initializeState = (snapshot: MutableSnapshot) => {
+    snapshot.set(store.conversationByIndex(0), buildConversation(conversationId));
+    snapshot.set(store.submissionByIndex(0), submission);
+  };
+
+  const SubmissionProbe = () => {
+    const currentSubmission = useRecoilValue(store.submissionByIndex(0));
+    onSubmission?.(currentSubmission);
+    return null;
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <RecoilRoot initializeState={initializeState}>
+      <SubmissionProbe />
+      {children}
+    </RecoilRoot>
+  );
+
+  return {
+    getMessages,
+    ...renderHook(
+      () => useResumeOnLoad(conversationId, getMessages, 0, messagesLoaded),
+      { wrapper },
+    ),
+  };
+}
+
+describe('useResumeOnLoad', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    mockUseStreamStatus.mockReset();
+    mockUseStreamStatus.mockReturnValue({
+      data: undefined,
+      isSuccess: false,
+      isFetching: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not check for resume when a null-conversation submission matches a loaded user message', () => {
+    renderUseResumeOnLoad({
+      submission: buildSubmission(null),
+      messages: [buildUserMessage(CONVERSATION_ID)],
+    });
+
+    expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, false);
+  });
+
+  it('checks for resume when the active submission belongs to a different conversation', () => {
+    renderUseResumeOnLoad({
+      submission: buildSubmission(STALE_CONVERSATION_ID),
+      messages: [buildUserMessage(CONVERSATION_ID)],
+    });
+
+    expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, true);
+  });
+
+  it('checks for resume when a null-conversation submission cannot be matched to loaded messages', () => {
+    renderUseResumeOnLoad({
+      submission: buildSubmission(null),
+      messages: [buildUserMessage(CONVERSATION_ID, 'different-user-message')],
+    });
+
+    expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, true);
+  });
+
+  it('does not replace a null-conversation submission when stream status matches its resume state', async () => {
+    const submission = buildSubmission(null);
+    const observedSubmissions: Array<TSubmission | null> = [];
+    mockUseStreamStatus.mockReturnValue({
+      isSuccess: true,
+      isFetching: false,
+      data: {
+        active: true,
+        status: 'running',
+        streamId: 'stream-1',
+        resumeState: {
+          aggregatedContent: [],
+          responseMessageId: RESPONSE_MESSAGE_ID,
+          userMessage: { messageId: USER_MESSAGE_ID },
+        },
+      },
+    });
+
+    renderUseResumeOnLoad({
+      submission,
+      messages: [],
+      onSubmission: (currentSubmission) => observedSubmissions.push(currentSubmission),
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, true);
+    expect(observedSubmissions[observedSubmissions.length - 1]).toBe(submission);
+  });
+});

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -94,10 +94,9 @@ function renderUseResumeOnLoad({
 
   return {
     getMessages,
-    ...renderHook(
-      () => useResumeOnLoad(conversationId, getMessages, 0, messagesLoaded),
-      { wrapper },
-    ),
+    ...renderHook(() => useResumeOnLoad(conversationId, getMessages, 0, messagesLoaded), {
+      wrapper,
+    }),
   };
 }
 

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -2,8 +2,45 @@ import { useEffect, useRef } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { Constants, tMessageSchema, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TMessage, TConversation, TSubmission, Agents } from 'librechat-data-provider';
+import type { StreamStatusResponse } from '~/data-provider';
 import { useStreamStatus } from '~/data-provider';
 import store from '~/store';
+
+function hasSubmissionUserMessage(
+  submission: TSubmission | null,
+  messages: TMessage[] | undefined,
+  conversationId: string | undefined,
+): boolean {
+  const userMessageId = submission?.userMessage?.messageId;
+  if (!userMessageId || !conversationId || !messages?.length) {
+    return false;
+  }
+
+  return messages.some(
+    (message) =>
+      message.isCreatedByUser === true &&
+      message.messageId === userMessageId &&
+      message.conversationId === conversationId,
+  );
+}
+
+function resumeStateMatchesSubmission(
+  streamStatus: StreamStatusResponse | undefined,
+  submission: TSubmission | null,
+): boolean {
+  const resumeState = streamStatus?.resumeState;
+  if (!resumeState || !submission) {
+    return false;
+  }
+
+  const userMessageId = submission.userMessage?.messageId;
+  if (userMessageId && resumeState.userMessage?.messageId === userMessageId) {
+    return true;
+  }
+
+  const responseMessageId = submission.initialResponse?.messageId;
+  return !!responseMessageId && resumeState.responseMessageId === responseMessageId;
+}
 
 /**
  * Build a submission object from resume state for reconnected streams.
@@ -113,14 +150,21 @@ export default function useResumeOnLoad(
   const processedConvoRef = useRef<string | null>(null);
 
   // Check for active stream when conversation changes
-  // Allow check if no submission OR submission is for a different conversation (stale)
   const submissionConvoId = currentSubmission?.conversation?.conversationId;
-  const hasActiveSubmissionForThisConvo = currentSubmission && submissionConvoId === conversationId;
+  const loadedMessages = messagesLoaded ? getMessages() : undefined;
+  const hasExplicitSubmissionMatch = !!conversationId && submissionConvoId === conversationId;
+  const hasHydratedMessageMatch =
+    submissionConvoId == null &&
+    hasSubmissionUserMessage(currentSubmission, loadedMessages, conversationId);
+  const hasActiveSubmissionForThisConvo =
+    !!currentSubmission && (hasExplicitSubmissionMatch || hasHydratedMessageMatch);
+  const hasStaleSubmissionForDifferentConvo =
+    !!currentSubmission && submissionConvoId != null && submissionConvoId !== conversationId;
 
   const shouldCheck =
     resumableEnabled &&
     messagesLoaded && // Wait for messages to load before checking
-    !hasActiveSubmissionForThisConvo && // Allow if no submission or stale submission
+    !hasActiveSubmissionForThisConvo && // Allow if no submission or a confirmed stale submission
     !!conversationId &&
     conversationId !== Constants.NEW_CONVO &&
     processedConvoRef.current !== conversationId; // Don't re-check processed convos
@@ -166,7 +210,7 @@ export default function useResumeOnLoad(
     }
 
     // If there's a stale submission for a different conversation, log it but continue
-    if (currentSubmission && submissionConvoId !== conversationId) {
+    if (hasStaleSubmissionForDifferentConvo) {
       console.log(
         '[ResumeOnLoad] Found stale submission for different conversation, will check for resume',
         {
@@ -180,6 +224,21 @@ export default function useResumeOnLoad(
     // that may replace a stale cached result with fresh data)
     if (!isSuccess || !streamStatus || isFetching) {
       console.log('[ResumeOnLoad] Waiting for stream status query');
+      return;
+    }
+
+    if (
+      streamStatus.active &&
+      streamStatus.streamId &&
+      submissionConvoId == null &&
+      resumeStateMatchesSubmission(streamStatus, currentSubmission)
+    ) {
+      console.log('[ResumeOnLoad] Skipping - active submission matches stream status', {
+        streamId: streamStatus.streamId,
+        currentConvoId: conversationId,
+        userMessageId: currentSubmission?.userMessage?.messageId,
+      });
+      processedConvoRef.current = conversationId;
       return;
     }
 
@@ -242,6 +301,7 @@ export default function useResumeOnLoad(
     messagesLoaded,
     hasActiveSubmissionForThisConvo,
     submissionConvoId,
+    hasStaleSubmissionForDifferentConvo,
     currentSubmission,
     isSuccess,
     isFetching,


### PR DESCRIPTION
## Summary

I fixed the `useResumeOnLoad` identity race from #13296 so active submissions are no longer treated as stale only because their conversation id has not hydrated yet.

- Added null-safe active-submission detection that treats missing submission conversation ids as unknown and confirms identity through the loaded user message for the current route.
- Added resume-state matching by user message id or response message id so an active stream status response does not replace the live local submission during hydration.
- Preserved existing stale-submission behavior for submissions with a concrete different conversation id.
- Added focused hook coverage for the null-conversation timing window, genuine stale submissions, unmatched unknown submissions, and matching resume-state responses.

Closes #13296.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci` to install the workspace dependencies in this worktree.
- Ran `npm run build:data-provider` and `npm run build:client-package` so the focused frontend test could resolve local workspace packages.
- Ran focused Jest coverage for the new hook spec:
  `cd client && npx jest src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx --runInBand --coverage=false`
- Ran ESLint on the changed files:
  `npx eslint --no-error-on-unmatched-pattern --config eslint.config.mjs --max-warnings=0 -- client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx client/src/hooks/SSE/useResumeOnLoad.ts`
- Ran `git diff --check`.

### **Test Configuration**:

- Local macOS worktree based on `origin/dev` at `f2be5baec`.
- Node/npm dependencies installed with the repository lockfile via `npm ci`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
