### PR TITLE
fix: resolve previous_response_id conversation lookup in Responses API

### DIFF
--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -251,6 +251,7 @@ jest.mock('~/models', () => ({
   getConvoFiles: jest.fn().mockResolvedValue([]),
   saveConvo: jest.fn().mockResolvedValue({}),
   getConvo: jest.fn().mockResolvedValue(null),
+  getConvoByResponseId: jest.fn().mockResolvedValue(null),
 }));
 
 describe('createResponse controller', () => {
@@ -317,7 +318,7 @@ describe('createResponse controller', () => {
 
     it('should return 404 when conversation is not owned by user', async () => {
       const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
-      const { getConvo } = require('~/models');
+      const { getConvoByResponseId } = require('~/models');
       validateResponseRequest.mockReturnValueOnce({
         request: {
           model: 'agent-123',
@@ -326,10 +327,10 @@ describe('createResponse controller', () => {
           previous_response_id: 'resp_abc',
         },
       });
-      getConvo.mockResolvedValueOnce(null);
+      getConvoByResponseId.mockResolvedValueOnce(null);
 
       await createResponse(req, res);
-      expect(getConvo).toHaveBeenCalledWith('user-123', 'resp_abc');
+      expect(getConvoByResponseId).toHaveBeenCalledWith('user-123', 'resp_abc');
       expect(sendResponsesErrorResponse).toHaveBeenCalledWith(
         res,
         404,
@@ -340,7 +341,7 @@ describe('createResponse controller', () => {
 
     it('should proceed when conversation is owned by user', async () => {
       const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
-      const { getConvo } = require('~/models');
+      const { getConvoByResponseId } = require('~/models');
       validateResponseRequest.mockReturnValueOnce({
         request: {
           model: 'agent-123',
@@ -349,10 +350,13 @@ describe('createResponse controller', () => {
           previous_response_id: 'resp_abc',
         },
       });
-      getConvo.mockResolvedValueOnce({ conversationId: 'resp_abc', user: 'user-123' });
+      getConvoByResponseId.mockResolvedValueOnce({
+        conversationId: 'mock-uuid-456',
+        user: 'user-123',
+      });
 
       await createResponse(req, res);
-      expect(getConvo).toHaveBeenCalledWith('user-123', 'resp_abc');
+      expect(getConvoByResponseId).toHaveBeenCalledWith('user-123', 'resp_abc');
       expect(sendResponsesErrorResponse).not.toHaveBeenCalledWith(
         res,
         404,
@@ -363,7 +367,7 @@ describe('createResponse controller', () => {
 
     it('should return 500 when getConvo throws a DB error', async () => {
       const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
-      const { getConvo } = require('~/models');
+      const { getConvoByResponseId } = require('~/models');
       validateResponseRequest.mockReturnValueOnce({
         request: {
           model: 'agent-123',
@@ -372,13 +376,57 @@ describe('createResponse controller', () => {
           previous_response_id: 'resp_abc',
         },
       });
-      getConvo.mockRejectedValueOnce(new Error('DB connection failed'));
+      getConvoByResponseId.mockRejectedValueOnce(new Error('DB connection failed'));
 
       await createResponse(req, res);
       expect(sendResponsesErrorResponse).toHaveBeenCalledWith(
         res,
         500,
         expect.any(String),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('conversation history loading', () => {
+    it('should use conversationId from DB record, not previous_response_id, when loading history', async () => {
+      const { validateResponseRequest } = require('@librechat/api');
+      const { getConvoByResponseId, getMessages } = require('~/models');
+
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Hello',
+          stream: false,
+          previous_response_id: 'resp_abc',
+        },
+      });
+      // responseId and conversationId are different — this is the key assertion
+      getConvoByResponseId.mockResolvedValueOnce({
+        conversationId: 'internal-uuid-xyz',
+        user: 'user-123',
+      });
+
+      await createResponse(req, res);
+
+      expect(getMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: 'internal-uuid-xyz' }),
+      );
+    });
+  });
+
+  describe('response context', () => {
+    it('should reflect store flag from request in response context', async () => {
+      const { validateResponseRequest, createResponseContext } = require('@librechat/api');
+
+      validateResponseRequest.mockReturnValueOnce({
+        request: { model: 'agent-123', input: 'Hello', stream: false, store: true },
+      });
+
+      await createResponse(req, res);
+
+      expect(createResponseContext).toHaveBeenCalledWith(
+        expect.objectContaining({ store: true }),
         expect.any(String),
       );
     });

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -162,7 +162,11 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId) {
   for (const msg of inputMessages) {
     if (msg.role === 'user') {
       await db.saveMessage(
-        req,
+        {
+          userId: req.user.id,
+          isTemporary: req.body?.isTemporary,
+          interfaceConfig: req?.config?.interfaceConfig,
+        },
         {
           messageId: msg.messageId || nanoid(),
           conversationId,
@@ -203,7 +207,11 @@ async function saveResponseOutput(req, conversationId, responseId, response, age
 
   // Save the assistant message
   await db.saveMessage(
-    req,
+    {
+      userId: req.user.id,
+      isTemporary: req.body?.isTemporary,
+      interfaceConfig: req?.config?.interfaceConfig,
+    },
     {
       messageId: responseId,
       conversationId,
@@ -224,11 +232,12 @@ async function saveResponseOutput(req, conversationId, responseId, response, age
  * Save or update conversation
  * @param {import('express').Request} req
  * @param {string} conversationId
+ * @param {string} responseId
  * @param {string} agentId
  * @param {object} agent
  * @returns {Promise<void>}
  */
-async function saveConversation(req, conversationId, agentId, agent) {
+async function saveConversation(req, conversationId, responseId, agentId, agent) {
   await db.saveConvo(
     {
       userId: req?.user?.id,
@@ -237,6 +246,7 @@ async function saveConversation(req, conversationId, agentId, agent) {
     },
     {
       conversationId,
+      responseId,
       endpoint: EModelEndpoint.agents,
       agentId,
       title: agent?.name || 'Open Responses Conversation',
@@ -330,6 +340,7 @@ const createResponse = async (req, res) => {
     }
   });
 
+  let conversationId;
   try {
     if (request.previous_response_id != null) {
       if (typeof request.previous_response_id !== 'string') {
@@ -340,12 +351,15 @@ const createResponse = async (req, res) => {
           'invalid_request',
         );
       }
-      if (!(await db.getConvo(req.user?.id, request.previous_response_id))) {
+      const convo = await db.getConvoByResponseId(req.user.id, request.previous_response_id);
+      if (!convo) {
         return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
       }
+      conversationId = convo.conversationId;
+    } else {
+      conversationId = uuidv4();
     }
 
-    const conversationId = request.previous_response_id ?? uuidv4();
     const parentMessageId = null;
 
     // Build allowed providers set
@@ -570,7 +584,7 @@ const createResponse = async (req, res) => {
     let previousMessages = [];
     if (request.previous_response_id) {
       const userId = req.user?.id ?? 'api-user';
-      previousMessages = await loadPreviousMessages(request.previous_response_id, userId);
+      previousMessages = await loadPreviousMessages(conversationId, userId);
     }
 
     // Convert input to internal messages
@@ -821,7 +835,7 @@ const createResponse = async (req, res) => {
       if (request.store === true) {
         try {
           // Save conversation
-          await saveConversation(req, conversationId, agentId, agent);
+          await saveConversation(req, conversationId, responseId, agentId, agent);
 
           // Save input messages
           await saveInputMessages(req, conversationId, inputMessages, agentId);
@@ -999,7 +1013,7 @@ const createResponse = async (req, res) => {
 
       if (request.store === true) {
         try {
-          await saveConversation(req, conversationId, agentId, agent);
+          await saveConversation(req, conversationId, responseId, agentId, agent);
 
           await saveInputMessages(req, conversationId, inputMessages, agentId);
 

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -295,6 +295,7 @@ export function createResponseContext(
     createdAt: Math.floor(Date.now() / 1000),
     previousResponseId: request.previous_response_id,
     instructions: request.instructions,
+    store: request.store ?? false,
   };
 }
 
@@ -738,7 +739,7 @@ export function buildAggregatedResponse(
     },
     max_output_tokens: null,
     max_tool_calls: null,
-    store: false,
+    store: context.store ?? false,
     background: false,
     service_tier: 'default',
     metadata: {},

--- a/packages/api/src/agents/responses/types.ts
+++ b/packages/api/src/agents/responses/types.ts
@@ -769,6 +769,8 @@ export interface ResponseContext {
   previousResponseId?: string;
   /** Instructions */
   instructions?: string;
+  /** Store flag */
+  store?: boolean;
 }
 
 /** Validation result for requests */

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -888,6 +888,7 @@ const DocumentType: z.ZodType<DocumentTypeValue> = z.lazy(() =>
 
 export const tConversationSchema = z.object({
   conversationId: z.string().nullable(),
+  responseId: z.string().nullable().optional(),
   endpoint: eModelEndpointSchema.nullable(),
   endpointType: eModelEndpointSchema.nullable().optional(),
   isArchived: z.boolean().optional(),
@@ -982,6 +983,7 @@ export const tPresetSchema = tConversationSchema
   .omit({
     conversationId: true,
     chatProjectId: true,
+    responseId: true,
     createdAt: true,
     updatedAt: true,
     title: true,

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -61,6 +61,7 @@ export interface ConversationMethods {
     conversationId: string,
   ): Promise<Pick<IConversation, 'expiredAt'> | null>;
   getConvoTitle(user: string, conversationId: string): Promise<string | null>;
+  getConvoByResponseId(user: string, responseId: string): Promise<IConversation | null>;
   deleteConvos(
     user: string,
     filter: FilterQuery<IConversation>,
@@ -741,6 +742,19 @@ export function createConversationMethods(
   }
 
   /**
+   * Fetches specific conversation by response id.
+   */
+  async function getConvoByResponseId(user: string, responseId: string) {
+    try {
+      const Conversation = mongoose.models.Conversation as Model<IConversation>;
+      return await Conversation.findOne({ user, responseId }).lean<IConversation>();
+    } catch (error) {
+      logger.error('[getConvoByResponseId] Error getting conversation by responseId', error);
+      throw new Error('Error getting conversation by responseId');
+    }
+  }
+
+  /**
    * Deletes conversations and their associated messages for a given user and filter.
    */
   async function deleteConvos(user: string, filter: FilterQuery<IConversation>) {
@@ -829,6 +843,7 @@ export function createConversationMethods(
     getConvo,
     getConvoRetention,
     getConvoTitle,
+    getConvoByResponseId,
     deleteConvos,
   };
 }

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -10,6 +10,11 @@ const convoSchema: Schema<IConversation> = new Schema(
       index: true,
       meiliIndex: true,
     },
+    responseId: {
+      type: String,
+      required: false,
+      index: true,
+    },
     title: {
       type: String,
       default: 'New Chat',
@@ -60,7 +65,7 @@ convoSchema.index({ expiredAt: 1 }, { expireAfterSeconds: 0 });
 convoSchema.index({ createdAt: 1, updatedAt: 1 });
 convoSchema.index({ conversationId: 1, user: 1, tenantId: 1 }, { unique: true });
 convoSchema.index({ user: 1, chatProjectId: 1, updatedAt: -1, _id: -1 });
-convoSchema.index({ user: 1, chatProjectId: 1, createdAt: -1, _id: -1 });
+convoSchema.index({ user: 1, responseId: 1 }, { sparse: true });
 
 convoSchema.index({ user: 1, isTemporary: 1, expiredAt: 1 });
 // index for MeiliSearch sync operations

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -3,6 +3,7 @@ import type { Document, Types } from 'mongoose';
 // @ts-ignore
 export interface IConversation extends Document {
   conversationId: string;
+  responseId?: string;
   title?: string;
   user?: string;
   messages?: Types.ObjectId[];


### PR DESCRIPTION
## Summary

`previous_response_id` in the Responses API was always returning "Conversation not found" because conversations were saved using an internal UUID as the key, while lookups used the response ID. This fix stores `responseId` on the conversation document and introduces `getConvoByResponseId` to resolve the correct `conversationId` before loading message history.

Also fixes `store` being hardcoded to false in the response body regardless of the request value.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

0. Send a `POST` to `/api/agents/v1/responses` with `store: true`, note the response id
0. Send a second `POST` with `previous_response_id` set to that id
0. Verify the agent recalls context from the first turn

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
