### PR TITLE
✨ v0.8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# v0.8.6-rc1
+# v0.8.6
 
 # Base node image
 FROM node:20-alpine AS node

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,5 @@
 # Dockerfile.multi
-# v0.8.6-rc1
+# v0.8.6
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "v0.8.6-rc1",
+  "version": "v0.8.6",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.6-rc1",
+      "version": "0.8.6",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.14.3",
         "@aws-sdk/client-bedrock-runtime": "^3.980.0",
@@ -130,7 +130,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.6-rc1",
+      "version": "0.8.6",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@ariakit/react-core": "^0.4.17",
@@ -264,7 +264,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.30",
+      "version": "1.7.31",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
@@ -345,7 +345,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.59",
+      "version": "0.4.60",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
@@ -433,7 +433,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.502",
+      "version": "0.8.503",
       "dependencies": {
         "axios": "^1.13.5",
         "dayjs": "^1.11.13",
@@ -470,7 +470,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,4 @@
-/** v0.8.6-rc1 */
+/** v0.8.6 */
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "v0.8.6-rc1",
+  "version": "v0.8.6",
   "description": "",
   "type": "module",
   "scripts": {

--- a/e2e/jestSetup.js
+++ b/e2e/jestSetup.js
@@ -1,3 +1,3 @@
-// v0.8.6-rc1
+// v0.8.6
 // See .env.test.example for an example of the '.env.test' file.
 require('dotenv').config({ path: './e2e/.env.test' });

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.4
+version: 2.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,7 +23,7 @@ version: 2.0.4
 # It is recommended to use it with quotes.
 
 # renovate: image=registry.librechat.ai/danny-avila/librechat
-appVersion: "v0.8.6-rc1"
+appVersion: "v0.8.6"
 
 home: https://www.librechat.ai
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -2,7 +2,7 @@
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.11
+version: 1.3.12
 
 # Cache settings: Set to true to enable caching
 cache: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.6-rc1",
+  "version": "v0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.6-rc1",
+      "version": "v0.8.6",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -46,7 +46,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.6-rc1",
+      "version": "v0.8.6",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -407,7 +407,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.6-rc1",
+      "version": "v0.8.6",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
@@ -44017,7 +44017,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.30",
+      "version": "1.7.31",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",
@@ -44157,7 +44157,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.59",
+      "version": "0.4.60",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44633,7 +44633,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.502",
+      "version": "0.8.503",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -44714,7 +44714,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.6-rc1",
+  "version": "v0.8.6",
   "description": "",
   "packageManager": "npm@11.10.0",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.30",
+  "version": "1.7.31",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.59",
+  "version": "0.4.60",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.502",
+  "version": "0.8.503",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2191,7 +2191,7 @@ export enum Constants {
    */
   VERSION = '__LIBRECHAT_VERSION__',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.3.11',
+  CONFIG_VERSION = '1.3.12',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value to use whatever the submission prelim. `responseMessageId` is */

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

I refreshed the v0.8.6 release branch on the latest `dev` and kept the release bump scoped to version metadata.

- Rebuilt the release branch from current `dev` after the branch moved again, now including the latest post-RC changes through #13424.
- Updated main app version strings from `v0.8.6-rc1` to `v0.8.6` across Dockerfiles, workspace package manifests, Jest setup comments, Helm `appVersion`, and lockfiles.
- Bumped the Helm chart version from `2.0.4` to `2.0.5` because the chart packages the updated app version.
- Incremented the custom config schema version from `1.3.11` to `1.3.12` in the example YAML and data-provider constants.
- Incremented internal package versions for `@librechat/api`, `@librechat/client`, `librechat-data-provider`, and `@librechat/data-schemas`, and mirrored them in both lockfiles.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

CI will validate this mechanical version bump.

### **Test Configuration**:

- Verified targeted version strings and lockfile entries locally with grep and Node checks.
- Ran `git diff --check`.
- Ran `npm exec -- prettier --check temp-changelog.md` for the local release-note temp file.
- Did not run local unit tests; this release bump relies on CI as requested.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
