### PR TITLE
🪪 fix: Preserve Trusted Registration Provider Overrides

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -191,13 +191,13 @@ const verifyEmail = async (req) => {
 /**
  * Register a new user.
  * @param {IUser} user <email, password, name, username>
- * @param {Partial<IUser>} [additionalData={}]
+ * @param {Partial<IUser>} [additionalData={}] Trusted server-provided fields, such as CLI overrides.
  * @returns {Promise<{status: number, message: string, user?: IUser}>}
  */
 const registerUser = async (user, additionalData = {}) => {
-  const { error } = registerSchema.safeParse(user);
-  if (error) {
-    const errorMessage = errorsToString(error.errors);
+  const result = registerSchema.safeParse(user);
+  if (!result.success) {
+    const errorMessage = errorsToString(result.error.errors);
     logger.info(
       'Route: register - Validation Error',
       { name: 'Request params:', value: user },
@@ -207,7 +207,8 @@ const registerUser = async (user, additionalData = {}) => {
     return { status: 404, message: errorMessage };
   }
 
-  const { email, password, name, username, provider } = user;
+  const { email, password, name, username } = result.data;
+  const { provider, ...trustedAdditionalData } = additionalData ?? {};
 
   let newUserId;
   try {
@@ -245,7 +246,7 @@ const registerUser = async (user, additionalData = {}) => {
       avatar: null,
       role: isFirstRegisteredUser ? SystemRoles.ADMIN : SystemRoles.USER,
       password: bcrypt.hashSync(password, salt),
-      ...additionalData,
+      ...trustedAdditionalData,
     };
 
     const emailEnabled = checkEmailConfig();

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -42,11 +42,25 @@ jest.mock('~/models', () => ({
   deleteUserById: jest.fn(),
   generateRefreshToken: jest.fn(),
 }));
-jest.mock('~/strategies/validators', () => ({ registerSchema: { parse: jest.fn() } }));
+jest.mock('~/strategies/validators', () => ({
+  registerSchema: {
+    safeParse: jest.fn((user) => ({
+      success: true,
+      data: {
+        name: user.name,
+        username: user.username,
+        email: user.email,
+        password: user.password,
+        confirm_password: user.confirm_password,
+      },
+    })),
+  },
+}));
 jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
 jest.mock('~/server/utils', () => ({ sendEmail: jest.fn() }));
 
 const {
+  checkEmailConfig,
   shouldUseSecureCookie,
   isEmailDomainAllowed,
   resolveAppConfigForUser,
@@ -58,6 +72,9 @@ const jwt = require('jsonwebtoken');
 const { logger } = require('@librechat/data-schemas');
 const {
   findUser,
+  createUser,
+  updateUser,
+  countUsers,
   getUserById,
   generateToken,
   generateRefreshToken,
@@ -67,6 +84,7 @@ const { getAppConfig } = require('~/server/services/Config');
 const {
   setOpenIDAuthTokens,
   requestPasswordReset,
+  registerUser,
   setAuthTokens,
   setCloudFrontAuthCookies,
 } = require('./AuthService');
@@ -378,6 +396,59 @@ describe('setOpenIDAuthTokens', () => {
       expect(result).toBe('the-id-token');
       expect(req.session.openidTokens.refreshToken).toBe('existing-refresh');
     });
+  });
+});
+
+describe('registerUser', () => {
+  const registrationPayload = {
+    name: 'Test User',
+    username: 'testuser',
+    email: 'test@example.com',
+    password: 'Password123!',
+    confirm_password: 'Password123!',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ALLOW_UNVERIFIED_EMAIL_LOGIN = 'false';
+    checkEmailConfig.mockReturnValue(false);
+    isEmailDomainAllowed.mockReturnValue(true);
+    getAppConfig.mockResolvedValue({
+      balance: { enabled: false },
+      registration: { allowedDomains: [] },
+    });
+    findUser.mockResolvedValue(null);
+    countUsers.mockResolvedValue(1);
+    createUser.mockResolvedValue({ _id: 'new-user-id' });
+    updateUser.mockResolvedValue({ _id: 'new-user-id' });
+  });
+
+  it('ignores provider values from the public registration payload', async () => {
+    const result = await registerUser({ ...registrationPayload, provider: 'google' });
+
+    expect(result.status).toBe(200);
+    expect(createUser.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        email: registrationPayload.email,
+        provider: 'local',
+      }),
+    );
+  });
+
+  it('allows trusted callers to set provider through additional data', async () => {
+    const result = await registerUser(registrationPayload, {
+      emailVerified: true,
+      provider: 'google',
+    });
+
+    expect(result.status).toBe(200);
+    expect(createUser.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        email: registrationPayload.email,
+        emailVerified: true,
+        provider: 'google',
+      }),
+    );
   });
 });
 

--- a/config/create-user.js
+++ b/config/create-user.js
@@ -103,10 +103,11 @@ or the user will need to attempt logging in to have a verification link sent to 
     silentExit(1);
   }
 
-  const user = { email, password, name, username, confirm_password: password, provider };
+  const user = { email, password, name, username, confirm_password: password };
+  const additionalData = { emailVerified, ...(provider !== undefined ? { provider } : {}) };
   let result;
   try {
-    result = await registerUser(user, { emailVerified });
+    result = await registerUser(user, additionalData);
   } catch (error) {
     console.red('Error: ' + error.message);
     silentExit(1);


### PR DESCRIPTION
## Summary

I updated registration handling so validated registration fields and trusted server-provided overrides stay separate, while preserving provider selection for the create-user script.

- Use the parsed registration schema payload when building a new user.
- Keep provider overrides available through trusted additional data for operator-created users.
- Pass create-user provider values through additional data instead of the registration payload.
- Add regression coverage for ignored payload provider values and trusted provider overrides.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `node --check api/server/services/AuthService.js`.
- Ran `node --check config/create-user.js`.
- Ran `node --check api/server/services/AuthService.spec.js`.
- Ran `git diff --cached --check`.
- Attempted `cd api && npx jest server/services/AuthService.spec.js --runInBand`, but this worktree has no installed dependencies and Jest could not resolve `dotenv` from `api/test/jestSetup.js`.

### **Test Configuration**:

- Local worktree: `/Users/danny/.codex/worktrees/7e19/LibreChat`
- Branch: `danny-avila/trusted-registration-provider`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
