### PR TITLE
🖱️ fix: Add MCP Hover Action Background

### DIFF
--- a/client/src/components/SidePanel/Agents/MCPTool.tsx
+++ b/client/src/components/SidePanel/Agents/MCPTool.tsx
@@ -102,7 +102,7 @@ export default function MCPTool({ serverInfo }: { serverInfo?: MCPServerInfo }) 
       <Accordion type="single" value={accordionValue} onValueChange={setAccordionValue} collapsible>
         <AccordionItem value={currentServerName} className="group relative w-full border-none">
           <div
-            className="relative flex w-full items-center gap-1 rounded-lg p-1 text-sm hover:bg-surface-primary-alt"
+            className="relative flex w-full items-center gap-1 rounded-lg p-1 text-sm focus-within:bg-surface-primary-alt hover:bg-surface-primary-alt"
             onMouseEnter={() => setIsHovering(true)}
             onMouseLeave={() => setIsHovering(false)}
             onFocus={() => setIsFocused(true)}
@@ -140,7 +140,7 @@ export default function MCPTool({ serverInfo }: { serverInfo?: MCPServerInfo }) 
                   <div className="relative flex items-center">
                     <div
                       className={cn(
-                        'absolute right-0 transition-all duration-300',
+                        'absolute right-0 rounded-md bg-surface-primary-alt py-0.5 pl-1 transition-all duration-300',
                         isHovering || isFocused
                           ? 'translate-x-0 opacity-100'
                           : 'translate-x-8 opacity-0',


### PR DESCRIPTION
## Summary

I fixed the MCP server action buttons in the agent builder so the hover controls render on a solid row-matched background instead of floating transparently over the server name.

- Added the same `bg-surface-primary-alt` treatment to the hover action tray used for MCP server row controls.
- Applied the row hover background during keyboard focus so focused action buttons match the hover presentation.
- Kept the fix scoped to the existing `MCPTool` layout and styling classes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I validated the touched file with ESLint and checked the committed diff for whitespace issues.

### **Test Configuration**:

- `npx eslint client/src/components/SidePanel/Agents/MCPTool.tsx`
- `git diff --check HEAD~1..HEAD`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings