### PR TITLE
✂️ fix: Truncate Long MCP Server Titles In Builder Panel

### DIFF
--- a/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
@@ -123,7 +123,7 @@ export default function MCPServerCard({
 
         {/* Server Info */}
         <div className="min-w-0 flex-1">
-          <span className="truncate text-sm font-medium text-text-primary">{displayName}</span>
+          <div className="truncate text-sm font-medium text-text-primary">{displayName}</div>
           {description && <p className="truncate text-xs text-text-secondary">{description}</p>}
         </div>
 


### PR DESCRIPTION
## Summary

In `SidePanel/MCPBuilder/MCPServerCard` the server title was rendered in a `<span>` carrying the Tailwind `truncate` utility. `overflow: hidden` does not apply to inline boxes, so long server names overflowed their slot and ran underneath the Edit / Reconnect / Revoke icons.

The title now renders in a `<div>` so `truncate` actually clips with an ellipsis. No other styling changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification on the frontend dev server with an MCP server whose display name exceeds the panel width: the title now truncates with an ellipsis and the trailing action icons no longer overlap the title text.

### Before
<img width="310" height="67" alt="Screenshot 2026-05-26 at 8 27 50 AM" src="https://github.com/user-attachments/assets/f61adeb5-d366-43f6-b379-a23d05718a8e" />

### After
<img width="302" height="109" alt="Screenshot 2026-05-26 at 9 52 42 AM" src="https://github.com/user-attachments/assets/63902fe4-4944-489c-8e24-8a3b15e90df6" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes