### PR TITLE
🧯 fix: Suppress Google Service Key Noise

### DIFF
--- a/api/server/services/Config/loadAsyncEndpoints.js
+++ b/api/server/services/Config/loadAsyncEndpoints.js
@@ -1,7 +1,30 @@
 const path = require('path');
+const fs = require('fs/promises');
 const { logger } = require('@librechat/data-schemas');
 const { loadServiceKey, isUserProvided } = require('@librechat/api');
 const { config } = require('./EndpointService');
+
+const defaultServiceKeyPath = path.join(__dirname, '../../..', 'data', 'auth.json');
+
+async function getServiceKeyPath() {
+  const serviceKeyPath = process.env.GOOGLE_SERVICE_KEY_FILE?.trim();
+  if (serviceKeyPath) {
+    return serviceKeyPath;
+  }
+
+  try {
+    await fs.access(defaultServiceKeyPath);
+    return defaultServiceKeyPath;
+  } catch (error) {
+    if (error?.code && error.code !== 'ENOENT') {
+      logger.warn(
+        `Unable to access default Google service key file: ${defaultServiceKeyPath}`,
+        error,
+      );
+    }
+    return null;
+  }
+}
 
 async function loadAsyncEndpoints() {
   let serviceKey, googleUserProvides;
@@ -14,15 +37,15 @@ async function loadAsyncEndpoints() {
     /** If GOOGLE_KEY is provided, check if it's user_provided */
     googleUserProvides = isUserProvided(googleKey);
   } else {
-    /** Only attempt to load service key if GOOGLE_KEY is not provided */
-    const serviceKeyPath =
-      process.env.GOOGLE_SERVICE_KEY_FILE || path.join(__dirname, '../../..', 'data', 'auth.json');
+    const serviceKeyPath = await getServiceKeyPath();
 
-    try {
-      serviceKey = await loadServiceKey(serviceKeyPath);
-    } catch (error) {
-      logger.error('Error loading service key', error);
-      serviceKey = null;
+    if (serviceKeyPath) {
+      try {
+        serviceKey = await loadServiceKey(serviceKeyPath);
+      } catch (error) {
+        logger.warn('Error loading Google service key', error);
+        serviceKey = null;
+      }
     }
   }
 

--- a/api/server/services/Config/loadAsyncEndpoints.js
+++ b/api/server/services/Config/loadAsyncEndpoints.js
@@ -16,7 +16,7 @@ async function getServiceKeyPath() {
     await fs.access(defaultServiceKeyPath);
     return defaultServiceKeyPath;
   } catch (error) {
-    if (error?.code && error.code !== 'ENOENT') {
+    if (error?.code !== 'ENOENT') {
       logger.warn(
         `Unable to access default Google service key file: ${defaultServiceKeyPath}`,
         error,
@@ -27,7 +27,8 @@ async function getServiceKeyPath() {
 }
 
 async function loadAsyncEndpoints() {
-  let serviceKey, googleUserProvides;
+  let serviceKey;
+  let googleUserProvides = false;
   const { googleKey } = config;
 
   /** Check if GOOGLE_KEY is provided at all(including 'user_provided') */

--- a/api/server/services/Config/loadAsyncEndpoints.spec.js
+++ b/api/server/services/Config/loadAsyncEndpoints.spec.js
@@ -89,7 +89,7 @@ describe('loadAsyncEndpoints', () => {
 
     const result = await loadAsyncEndpoints();
 
-    expect(result).toEqual({ google: { userProvide: undefined } });
+    expect(result).toEqual({ google: { userProvide: false } });
     expect(mockLoadServiceKey).toHaveBeenCalledWith(expect.stringContaining('api/data/auth.json'));
   });
 
@@ -102,7 +102,7 @@ describe('loadAsyncEndpoints', () => {
 
     const result = await loadAsyncEndpoints();
 
-    expect(result).toEqual({ google: { userProvide: undefined } });
+    expect(result).toEqual({ google: { userProvide: false } });
     expect(mockAccess).not.toHaveBeenCalled();
     expect(mockLoadServiceKey).toHaveBeenCalledWith('/secrets/google-service-account.json');
   });

--- a/api/server/services/Config/loadAsyncEndpoints.spec.js
+++ b/api/server/services/Config/loadAsyncEndpoints.spec.js
@@ -1,0 +1,119 @@
+const mockAccess = jest.fn();
+const mockLoadServiceKey = jest.fn();
+const mockIsUserProvided = jest.fn((value) => value === 'user_provided');
+const mockLogger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+};
+
+jest.mock('fs/promises', () => ({
+  access: mockAccess,
+}));
+
+jest.mock(
+  '@librechat/api',
+  () => ({
+    isEnabled: (value) => value === true || value === 'true' || value === '1',
+    isUserProvided: mockIsUserProvided,
+    loadServiceKey: mockLoadServiceKey,
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@librechat/data-schemas',
+  () => ({
+    logger: mockLogger,
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'librechat-data-provider',
+  () => ({
+    EModelEndpoint: {
+      agents: 'agents',
+      anthropic: 'anthropic',
+      assistants: 'assistants',
+      azureAssistants: 'azureAssistants',
+      azureOpenAI: 'azureOpenAI',
+      bedrock: 'bedrock',
+      google: 'google',
+      openAI: 'openAI',
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock('~/server/utils/handleText', () => ({
+  generateConfig: (key) => (key ? { userProvide: key === 'user_provided' } : false),
+}));
+
+describe('loadAsyncEndpoints', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.GOOGLE_KEY;
+    delete process.env.GOOGLE_SERVICE_KEY_FILE;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  function loadModule(env = {}) {
+    process.env = { ...process.env, ...env };
+    return require('./loadAsyncEndpoints');
+  }
+
+  it('does not load the default Google service key when the default file is missing', async () => {
+    mockAccess.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+    const loadAsyncEndpoints = loadModule();
+
+    const result = await loadAsyncEndpoints();
+
+    expect(result).toEqual({ google: false });
+    expect(mockLoadServiceKey).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('loads the default Google service key when the default file exists', async () => {
+    const serviceKey = { project_id: 'test-project' };
+    mockAccess.mockResolvedValue();
+    mockLoadServiceKey.mockResolvedValue(serviceKey);
+    const loadAsyncEndpoints = loadModule();
+
+    const result = await loadAsyncEndpoints();
+
+    expect(result).toEqual({ google: { userProvide: undefined } });
+    expect(mockLoadServiceKey).toHaveBeenCalledWith(expect.stringContaining('api/data/auth.json'));
+  });
+
+  it('loads an explicitly configured Google service key path without probing the default file', async () => {
+    const serviceKey = { project_id: 'test-project' };
+    mockLoadServiceKey.mockResolvedValue(serviceKey);
+    const loadAsyncEndpoints = loadModule({
+      GOOGLE_SERVICE_KEY_FILE: '/secrets/google-service-account.json',
+    });
+
+    const result = await loadAsyncEndpoints();
+
+    expect(result).toEqual({ google: { userProvide: undefined } });
+    expect(mockAccess).not.toHaveBeenCalled();
+    expect(mockLoadServiceKey).toHaveBeenCalledWith('/secrets/google-service-account.json');
+  });
+
+  it('uses GOOGLE_KEY without probing for a service key', async () => {
+    const loadAsyncEndpoints = loadModule({ GOOGLE_KEY: 'user_provided' });
+
+    const result = await loadAsyncEndpoints();
+
+    expect(result).toEqual({ google: { userProvide: true } });
+    expect(mockAccess).not.toHaveBeenCalled();
+    expect(mockLoadServiceKey).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/services/Config/loadAsyncEndpoints.spec.js
+++ b/api/server/services/Config/loadAsyncEndpoints.spec.js
@@ -7,31 +7,31 @@ const mockLogger = {
   warn: jest.fn(),
 };
 
-jest.mock('fs/promises', () => ({
-  access: mockAccess,
-}));
+function mockOptionalModule(moduleName, factory) {
+  try {
+    require.resolve(moduleName);
+    jest.doMock(moduleName, factory);
+  } catch {
+    jest.doMock(moduleName, factory, { virtual: true });
+  }
+}
 
-jest.mock(
-  '@librechat/api',
-  () => ({
+function mockDependencies() {
+  jest.doMock('fs/promises', () => ({
+    access: mockAccess,
+  }));
+
+  mockOptionalModule('@librechat/api', () => ({
     isEnabled: (value) => value === true || value === 'true' || value === '1',
     isUserProvided: mockIsUserProvided,
     loadServiceKey: mockLoadServiceKey,
-  }),
-  { virtual: true },
-);
+  }));
 
-jest.mock(
-  '@librechat/data-schemas',
-  () => ({
+  mockOptionalModule('@librechat/data-schemas', () => ({
     logger: mockLogger,
-  }),
-  { virtual: true },
-);
+  }));
 
-jest.mock(
-  'librechat-data-provider',
-  () => ({
+  mockOptionalModule('librechat-data-provider', () => ({
     EModelEndpoint: {
       agents: 'agents',
       anthropic: 'anthropic',
@@ -42,13 +42,12 @@ jest.mock(
       google: 'google',
       openAI: 'openAI',
     },
-  }),
-  { virtual: true },
-);
+  }));
 
-jest.mock('~/server/utils/handleText', () => ({
-  generateConfig: (key) => (key ? { userProvide: key === 'user_provided' } : false),
-}));
+  jest.doMock('~/server/utils/handleText', () => ({
+    generateConfig: (key) => (key ? { userProvide: key === 'user_provided' } : false),
+  }));
+}
 
 describe('loadAsyncEndpoints', () => {
   const originalEnv = process.env;
@@ -56,6 +55,7 @@ describe('loadAsyncEndpoints', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
+    mockDependencies();
     process.env = { ...originalEnv };
     delete process.env.GOOGLE_KEY;
     delete process.env.GOOGLE_SERVICE_KEY_FILE;

--- a/api/server/services/Config/loadDefaultEConfig.js
+++ b/api/server/services/Config/loadDefaultEConfig.js
@@ -8,10 +8,12 @@ const { config } = require('./EndpointService');
  * @returns {Promise<Object.<string, EndpointWithOrder>>} An object whose keys are endpoint names and values are objects that contain the endpoint configuration and an order.
  */
 async function loadDefaultEndpointsConfig(appConfig) {
-  const { google } = await loadAsyncEndpoints(appConfig);
   const { assistants, azureAssistants, azureOpenAI } = config;
 
   const enabledEndpoints = getEnabledEndpoints();
+  const { google } = enabledEndpoints.includes(EModelEndpoint.google)
+    ? await loadAsyncEndpoints(appConfig)
+    : { google: false };
 
   const endpointConfig = {
     [EModelEndpoint.openAI]: config[EModelEndpoint.openAI],

--- a/api/server/services/Config/loadDefaultEConfig.spec.js
+++ b/api/server/services/Config/loadDefaultEConfig.spec.js
@@ -1,0 +1,66 @@
+const mockGetEnabledEndpoints = jest.fn();
+const mockLoadAsyncEndpoints = jest.fn();
+
+jest.mock(
+  'librechat-data-provider',
+  () => ({
+    EModelEndpoint: {
+      agents: 'agents',
+      anthropic: 'anthropic',
+      assistants: 'assistants',
+      azureAssistants: 'azureAssistants',
+      azureOpenAI: 'azureOpenAI',
+      bedrock: 'bedrock',
+      google: 'google',
+      openAI: 'openAI',
+    },
+    getEnabledEndpoints: mockGetEnabledEndpoints,
+  }),
+  { virtual: true },
+);
+
+jest.mock('./loadAsyncEndpoints', () => mockLoadAsyncEndpoints);
+
+jest.mock('./EndpointService', () => ({
+  config: {
+    agents: { userProvide: false },
+    anthropic: false,
+    assistants: false,
+    azureAssistants: false,
+    azureOpenAI: false,
+    bedrock: false,
+    openAI: { userProvide: false },
+  },
+}));
+
+describe('loadDefaultEndpointsConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it('does not probe async Google credentials when Google is excluded from enabled endpoints', async () => {
+    mockGetEnabledEndpoints.mockReturnValue(['openAI']);
+    const loadDefaultEndpointsConfig = require('./loadDefaultEConfig');
+
+    const result = await loadDefaultEndpointsConfig();
+
+    expect(mockLoadAsyncEndpoints).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      openAI: { userProvide: false, order: 0 },
+    });
+  });
+
+  it('loads async Google credentials when Google is enabled', async () => {
+    mockGetEnabledEndpoints.mockReturnValue(['google']);
+    mockLoadAsyncEndpoints.mockResolvedValue({ google: { userProvide: false } });
+    const loadDefaultEndpointsConfig = require('./loadDefaultEConfig');
+
+    const result = await loadDefaultEndpointsConfig();
+
+    expect(mockLoadAsyncEndpoints).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      google: { userProvide: false, order: 0 },
+    });
+  });
+});

--- a/api/server/services/Config/loadDefaultEConfig.spec.js
+++ b/api/server/services/Config/loadDefaultEConfig.spec.js
@@ -1,9 +1,17 @@
 const mockGetEnabledEndpoints = jest.fn();
 const mockLoadAsyncEndpoints = jest.fn();
 
-jest.mock(
-  'librechat-data-provider',
-  () => ({
+function mockOptionalModule(moduleName, factory) {
+  try {
+    require.resolve(moduleName);
+    jest.doMock(moduleName, factory);
+  } catch {
+    jest.doMock(moduleName, factory, { virtual: true });
+  }
+}
+
+function mockDependencies() {
+  mockOptionalModule('librechat-data-provider', () => ({
     EModelEndpoint: {
       agents: 'agents',
       anthropic: 'anthropic',
@@ -15,28 +23,28 @@ jest.mock(
       openAI: 'openAI',
     },
     getEnabledEndpoints: mockGetEnabledEndpoints,
-  }),
-  { virtual: true },
-);
+  }));
 
-jest.mock('./loadAsyncEndpoints', () => mockLoadAsyncEndpoints);
+  jest.doMock('./loadAsyncEndpoints', () => mockLoadAsyncEndpoints);
 
-jest.mock('./EndpointService', () => ({
-  config: {
-    agents: { userProvide: false },
-    anthropic: false,
-    assistants: false,
-    azureAssistants: false,
-    azureOpenAI: false,
-    bedrock: false,
-    openAI: { userProvide: false },
-  },
-}));
+  jest.doMock('./EndpointService', () => ({
+    config: {
+      agents: { userProvide: false },
+      anthropic: false,
+      assistants: false,
+      azureAssistants: false,
+      azureOpenAI: false,
+      bedrock: false,
+      openAI: { userProvide: false },
+    },
+  }));
+}
 
 describe('loadDefaultEndpointsConfig', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
+    mockDependencies();
   });
 
   it('does not probe async Google credentials when Google is excluded from enabled endpoints', async () => {


### PR DESCRIPTION
## Summary

I suppressed the expected missing Google service key fallback so unused Google provider checks no longer produce production error noise.

- Skipped async Google credential probing when the Google endpoint is excluded from enabled endpoints.
- Checked for the legacy `api/data/auth.json` file before calling `loadServiceKey`, so a missing default file disables Google quietly.
- Preserved explicit `GOOGLE_SERVICE_KEY_FILE` behavior for deployments that intentionally configure service account credentials.
- Downgraded unexpected Google service key loading failures in startup endpoint config from `error` to `warn`.
- Added focused regression coverage for missing default key files, explicit key paths, user-provided Google keys, and Google endpoint exclusion.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest server/services/Config/loadAsyncEndpoints.spec.js server/services/Config/loadDefaultEConfig.spec.js --runInBand` from `api`.
- Ran `npx prettier --check api/server/services/Config/loadAsyncEndpoints.js api/server/services/Config/loadDefaultEConfig.js api/server/services/Config/loadAsyncEndpoints.spec.js api/server/services/Config/loadDefaultEConfig.spec.js`.
- Ran `npx eslint api/server/services/Config/loadAsyncEndpoints.js api/server/services/Config/loadDefaultEConfig.js api/server/services/Config/loadAsyncEndpoints.spec.js api/server/services/Config/loadDefaultEConfig.spec.js`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node/Jest through the local LibreChat workspace dependencies.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes