### PR TITLE
fix(auth): resolve admin-panel allowedDomains override in registerUser

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -211,7 +211,7 @@ const registerUser = async (user, additionalData = {}) => {
 
   let newUserId;
   try {
-    const appConfig = await getAppConfig({ baseOnly: true });
+    const appConfig = await getAppConfig();
     if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
       const errorMessage =
         'The email address provided cannot be used. Please use a different email address.';

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -42,7 +42,9 @@ jest.mock('~/models', () => ({
   deleteUserById: jest.fn(),
   generateRefreshToken: jest.fn(),
 }));
-jest.mock('~/strategies/validators', () => ({ registerSchema: { parse: jest.fn() } }));
+jest.mock('~/strategies/validators', () => ({
+  registerSchema: { parse: jest.fn(), safeParse: jest.fn().mockReturnValue({ error: null }) },
+}));
 jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
 jest.mock('~/server/utils', () => ({ sendEmail: jest.fn() }));
 
@@ -67,6 +69,7 @@ const { getAppConfig } = require('~/server/services/Config');
 const {
   setOpenIDAuthTokens,
   requestPasswordReset,
+  registerUser,
   setAuthTokens,
   setCloudFrontAuthCookies,
 } = require('./AuthService');
@@ -378,6 +381,35 @@ describe('setOpenIDAuthTokens', () => {
       expect(result).toBe('the-id-token');
       expect(req.session.openidTokens.refreshToken).toBe('existing-refresh');
     });
+  });
+});
+
+describe('registerUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isEmailDomainAllowed.mockReturnValue(true);
+    getAppConfig.mockResolvedValue({});
+  });
+
+  it('calls getAppConfig without baseOnly to include admin-panel __base__ override', async () => {
+    isEmailDomainAllowed.mockReturnValue(false);
+
+    const user = { email: 'user@blocked.com', password: 'pass123', name: 'Test', username: 'test' };
+    const result = await registerUser(user);
+
+    expect(getAppConfig).toHaveBeenCalledWith();
+    expect(result.status).toBe(403);
+  });
+
+  it('rejects registration when admin-panel allowedDomains blocks the email domain', async () => {
+    isEmailDomainAllowed.mockReturnValue(false);
+    getAppConfig.mockResolvedValue({ registration: { allowedDomains: ['allowed.com'] } });
+
+    const user = { email: 'user@blocked.com', password: 'pass123', name: 'Test', username: 'test' };
+    const result = await registerUser(user);
+
+    expect(result.status).toBe(403);
+    expect(result.message).toContain('email address provided cannot be used');
   });
 });
 


### PR DESCRIPTION
## Problem

Admin-panel edits to `registration.allowedDomains` are silently ignored at native email/password registration (`/register`). Domains that an admin explicitly blocks via the admin panel can still be used to create accounts.

**Root cause:** `registerUser` in `api/server/services/AuthService.js` calls `getAppConfig({ baseOnly: true })`, which short-circuits DB override resolution and returns only the YAML-derived config. The admin panel writes `registration.allowedDomains` to the `__base__` principal in the configs collection. `getApplicableConfigs` unconditionally injects `__base__` — it requires no user identity — so the override is always available through a plain `getAppConfig()` call, but is never reached with `baseOnly: true`.

**Steps to reproduce:**
1. Leave `registration.allowedDomains` unset in `librechat.yaml`.
2. Boot the server. In the admin panel, set `registration.allowedDomains` to `['example.com']`.
3. Register with `email@pm.me` (not `@example.com`).
4. **Expected:** HTTP 403 — email domain not allowed.
5. **Actual:** Registration succeeds; admin override was bypassed.

Closes #13203

## Solution

Remove `baseOnly: true` from the `getAppConfig()` call in `registerUser`. Without that flag, `getApplicableConfigs` is called with an empty principals list, which unconditionally includes the `__base__` principal and returns the admin-panel override. The result is cached (default 60 s TTL), so the database is not queried on every registration attempt.

## Testing

- Added `registerUser` tests to `AuthService.spec.js`:
  - Verifies `getAppConfig` is called without `baseOnly`.
  - Verifies registration is blocked (HTTP 403) when the admin-panel `allowedDomains` override is active.