### PR TITLE
🐢 ci: Raise test-packages-api timeout to 20 min

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -367,7 +367,11 @@ jobs:
     name: 'Tests: @librechat/api'
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Suite typically completes in ~5 min on a warm runner, but tail-latency
+    # cancellations have started showing up: tests are actively passing right
+    # up to the timeout, then the job is killed mid-suite. Bump headroom to
+    # absorb GitHub Actions runner variance.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Bump `timeout-minutes` on the `test-packages-api` job in `.github/workflows/backend-review.yml` from `10` to `20`.

## Why

This job has started getting cancelled mid-suite. Looking at a real cancelled run (10m18s wall, killed at exactly the 10-minute mark with `PASS …` lines still streaming up to the final second):

```
2026-05-26T22:55:46Z  job started
2026-05-26T23:05:59Z  PASS src/agents/openai/handlers.spec.ts          ← last test (passing)
2026-05-26T23:06:00Z  ##[error]The operation was canceled.             ← timeout fired
2026-05-26T23:06:04Z  job ended (cancelled)
```

Tests aren't hanging — the suite simply outgrew the 10-minute ceiling.

## Suite has grown

Over the last few months the `packages/api` test surface has expanded substantially:

- OpenTelemetry SDK + instrumentation tests (#12909, #13266)
- Operational Prometheus Metrics (#13265 — 29 new tests in `metrics.spec.ts` alone)
- MCP OAuth hardening + name-collision + JWT exp tests (#13254 #13256 #13264 #13248 #12460 #5d393ad7)
- AWS Bedrock validation tests (#13277 #13279)
- Agents + responses + handoff + skills (#13167 #13119)

Most recent run pre-timeout had ~150 suites running with mongodb-memory-server bootstrap costs.

## What this changes

Single line:

```yaml
   test-packages-api:
     name: 'Tests: @librechat/api'
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
```

Plus a brief comment above explaining why, so a future reviewer doesn't drop it back to 10.

## Why 20 and not 15

A warm runner finishes the suite in ~4–5 minutes. A cold/busy runner can take 10+. 20 minutes gives 4–5x headroom over the typical run, which leaves room for both runner variance and continued suite growth between PRs that touch this job's config. A genuinely stuck job will still get killed eventually rather than billing CI minutes forever — 20 min is well below the runner's 6h hard cap.

## Test plan

- [x] No code change; one config line.
- [ ] CI green on this PR.