### PR TITLE
fix: Resolve User Field Placeholders In External Agents API Headers

### DIFF
--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -690,7 +690,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         messageId: responseId,
         conversationId,
       },
-      user: { id: userId },
+      user: createSafeUser(req.user),
     });
 
     if (!run) {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -698,7 +698,7 @@ const createResponse = async (req, res) => {
           messageId: responseId,
           conversationId,
         },
-        user: { id: userId },
+        user: createSafeUser(req.user),
       });
 
       if (!run) {
@@ -872,7 +872,7 @@ const createResponse = async (req, res) => {
           messageId: responseId,
           conversationId,
         },
-        user: { id: userId },
+        user: createSafeUser(req.user),
       });
 
       if (!run) {


### PR DESCRIPTION
## Summary

The External Agents API controllers (`POST /api/agents/v1/chat/completions` and `POST /api/agents/v1/responses`) currently pass `user: { id: userId }` to `createRun`, stripping every user field except `id`.

The agent runtime then calls `resolveHeaders` to substitute `{{LIBRECHAT_USER_<FIELD>}}` placeholders configured on custom-endpoint headers — but [`resolveValue` in `packages/api/src/utils/env.ts:140`](https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/utils/env.ts#L140) silently skips any field not present on the user object:

```ts
if (!(field in user)) {
  continue;
}
```

So a custom endpoint configured with the documented header-substitution pattern:

```yaml
endpoints:
  custom:
    - name: "my-gateway"
      baseURL: "https://gateway.example.com/v1"
      headers:
        X-User-Email:    "{{LIBRECHAT_USER_EMAIL}}"
        X-User-Username: "{{LIBRECHAT_USER_USERNAME}}"
        X-User-Name:     "{{LIBRECHAT_USER_NAME}}"
```

…works correctly for the **UI chat** path (because [`controllers/agents/client.js`](https://github.com/danny-avila/LibreChat/blob/main/api/server/controllers/agents/client.js) already passes `createSafeUser(req.user)` to `createRun`), but breaks for the **external API** path — outbound requests ship the **literal placeholder string** as the header value, or (after intermediary HTTP normalization) an empty value, with no warning logged.

This is an inconsistency bug: the same agent invoked the same way emits different outbound headers depending on whether the caller arrived via the UI or the API. Downstream gateways/proxies (LiteLLM, Helicone, Langfuse, custom auth proxies) that key per-user attribution off these headers cannot attribute external-API traffic today.

### Fix

Align the three `createRun` call sites in the external API controllers with the UI path's pattern:

```diff
- user: { id: userId },
+ user: createSafeUser(req.user),
```

`createSafeUser` is already imported in both files (used today for `configurable.user` two lines below each site) — this change just uses the same helper one level up on the `user` field that the runtime reads when resolving header placeholders.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Reproduction

1. Configure any custom endpoint with a placeholder-bearing header (example above).
2. Send a message via the UI — header arrives with the user's real email/username on the gateway side.
3. Call the same agent via `POST /api/agents/v1/chat/completions` — header arrives as the literal `{{LIBRECHAT_USER_EMAIL}}` (or empty, depending on intermediary normalization).

After this fix both paths produce identical outbound headers.

### Existing test coverage

The contract this fix relies on is already proven by [`packages/api/src/utils/env.spec.ts`](https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/utils/env.spec.ts):

- `'should process full user object placeholders'` (line 199) — full `createSafeUser`-shaped user resolves correctly.
- `'should handle missing user fields gracefully'` (line 229) — fields absent from the user object are skipped (which is exactly what was happening to the external API path).

No new test is strictly necessary — the unit tests already prove that the substitution behavior depends on which fields are present on the user object, and this fix simply ensures the same shape gets passed in both paths.

### **Test Configuration**:

Reproduced and verified against `main` (commit fetched 2026-05). No new dependencies, no schema changes, no API contract changes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Existing tests in `packages/api/src/utils/env.spec.ts` cover the fixed contract
- [x] Local smoke test passes (UI chat unchanged; external API now resolves placeholders identically)

### Notes for reviewers

- Behaviour change is zero for callers; strictly enables more placeholder substitutions in outbound headers (impossible to break existing ones — substitution rule is opt-in per field and the only state passed to `resolveHeaders` is the user object).
- The patch touches three call sites only; `responses.js` has two because both the streaming and non-streaming Open Responses paths construct their own `createRun`.
- I'd also be happy to add a dedicated regression test in `env.spec.ts` if you'd prefer — something like `'should leave placeholder unresolved when user object only has id'` that asserts the buggy shape explicitly. Let me know.
