### PR TITLE
🧰 feat: Add MCP Tool Filtering to Reduce Context Consumption and Improve Security

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -315,6 +315,15 @@ actions:
 #     url: http://localhost:3001/sse
 #     # proxy: "${MCP_PROXY_URL}"  # optional outbound proxy (http/https/socks/socks5)
 #     timeout: 60000  # 1 minute timeout for this server, this is the default timeout for MCP servers.
+#     # (optional) Limit which tools this server exposes to the model to save context tokens or security.
+#     # `include` (allowlist) is applied first, then `exclude` removes matches from the result.
+#     # Each entry is an exact tool name or a regex pattern `{ regex: "..." }`. Omit to expose all.
+#     # toolFilter:
+#     #   include:
+#     #     - "search"
+#     #     - { regex: ".*Jira.*" }
+#     #   exclude:
+#     #     - "lookupJiraAccountId"
 #   puppeteer:
 #     type: stdio
 #     command: npx

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -173,7 +173,11 @@ export class MCPManager extends UserConnectionManager {
       //try get the appConnection (if the config is not in the app level anymore any existing connection will disconnect and get will return null)
       const existingAppConnection = await this.appConnections?.get(serverName);
       if (existingAppConnection) {
-        return MCPServerInspector.getToolFunctions(serverName, existingAppConnection);
+        return MCPServerInspector.getToolFunctions(
+          serverName,
+          existingAppConnection,
+          existingAppConnection.toolFilter,
+        );
       }
 
       const userConnections = this.getUserConnections(userId);
@@ -184,7 +188,12 @@ export class MCPManager extends UserConnectionManager {
         return null;
       }
 
-      return MCPServerInspector.getToolFunctions(serverName, userConnections.get(serverName)!);
+      const userConnection = userConnections.get(serverName)!;
+      return MCPServerInspector.getToolFunctions(
+        serverName,
+        userConnection,
+        userConnection.toolFilter,
+      );
     } catch (error) {
       logger.warn(
         `[getServerToolFunctions] Error getting tool functions for server ${serverName}`,

--- a/packages/api/src/mcp/__tests__/MCPConnectionToolFilter.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionToolFilter.test.ts
@@ -1,0 +1,74 @@
+import { MCPConnection } from '~/mcp/connection';
+import type { MCPOptions } from 'librechat-data-provider';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('~/auth', () => ({
+  createSSRFSafeUndiciConnect: jest.fn(() => undefined),
+  isOAuthUrlAllowed: jest.fn(() => false),
+  isSSRFTarget: jest.fn(() => false),
+  resolveHostnameSSRF: jest.fn(async () => false),
+}));
+
+jest.mock('~/mcp/mcpConfig', () => ({
+  mcpConfig: { CONNECTION_CHECK_TTL: 0 },
+}));
+
+const SERVER_TOOLS = [
+  { name: 'searchJira', description: '', inputSchema: { type: 'object' } },
+  { name: 'createJiraIssue', description: '', inputSchema: { type: 'object' } },
+  { name: 'lookupJiraAccountId', description: '', inputSchema: { type: 'object' } },
+  { name: 'searchConfluence', description: '', inputSchema: { type: 'object' } },
+];
+
+function createConnection(toolFilter?: MCPOptions['toolFilter']): MCPConnection {
+  const serverConfig = {
+    type: 'streamable-http',
+    url: 'http://127.0.0.1:9/',
+    toolFilter,
+  } as MCPOptions;
+  const conn = new MCPConnection({
+    serverName: 'atlassian',
+    serverConfig,
+    useSSRFProtection: false,
+  });
+  conn.client.listTools = jest.fn().mockResolvedValue({ tools: SERVER_TOOLS });
+  return conn;
+}
+
+describe('MCPConnection.fetchTools toolFilter', () => {
+  const toolNames = (tools: Array<{ name: string }>) => tools.map((t) => t.name).sort();
+
+  it('returns all tools when no filter is configured', async () => {
+    const conn = createConnection();
+    const tools = await conn.fetchTools();
+    expect(toolNames(tools)).toEqual([
+      'createJiraIssue',
+      'lookupJiraAccountId',
+      'searchConfluence',
+      'searchJira',
+    ]);
+  });
+
+  it('keeps only tools matching the include allowlist', async () => {
+    const conn = createConnection({ include: [{ regex: '.*Jira.*' }] });
+    const tools = await conn.fetchTools();
+    expect(toolNames(tools)).toEqual(['createJiraIssue', 'lookupJiraAccountId', 'searchJira']);
+  });
+
+  it('applies exclude after include', async () => {
+    const conn = createConnection({
+      include: [{ regex: '.*Jira.*' }],
+      exclude: ['lookupJiraAccountId'],
+    });
+    const tools = await conn.fetchTools();
+    expect(toolNames(tools)).toEqual(['createJiraIssue', 'searchJira']);
+  });
+});

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -8,6 +8,7 @@ import {
   getMissingCustomUserVars,
   hasCustomUserVars,
   isUserSourced,
+  isToolAllowed,
 } from '~/mcp/utils';
 import type { ParsedServerConfig } from '~/mcp/types';
 
@@ -392,5 +393,55 @@ describe('getMissingCustomUserVars', () => {
     expect(
       getMissingCustomUserVars(config, { THINGY_TOKEN: 'abc123', UNRELATED: 'value' }),
     ).toEqual([]);
+  });
+});
+
+describe('isToolAllowed', () => {
+  it('allows every tool when no filter is provided', () => {
+    expect(isToolAllowed('anyTool')).toBe(true);
+    expect(isToolAllowed('anyTool', undefined)).toBe(true);
+  });
+
+  it('allows every tool when include and exclude are empty', () => {
+    expect(isToolAllowed('anyTool', { include: [], exclude: [] })).toBe(true);
+  });
+
+  it('keeps only tools matching an exact-name include entry', () => {
+    const filter = { include: ['search'] };
+    expect(isToolAllowed('search', filter)).toBe(true);
+    expect(isToolAllowed('searchJira', filter)).toBe(false);
+  });
+
+  it('keeps tools matching a regex include entry', () => {
+    const filter = { include: [{ regex: '.*Jira.*' }] };
+    expect(isToolAllowed('searchJira', filter)).toBe(true);
+    expect(isToolAllowed('createJiraIssue', filter)).toBe(true);
+    expect(isToolAllowed('searchConfluence', filter)).toBe(false);
+  });
+
+  it('combines string and regex include entries', () => {
+    const filter = { include: ['search', { regex: '.*Jira.*' }] };
+    expect(isToolAllowed('search', filter)).toBe(true);
+    expect(isToolAllowed('createJiraIssue', filter)).toBe(true);
+    expect(isToolAllowed('deleteConfluencePage', filter)).toBe(false);
+  });
+
+  it('removes tools matching an exclude entry', () => {
+    const filter = { exclude: ['lookupJiraAccountId'] };
+    expect(isToolAllowed('lookupJiraAccountId', filter)).toBe(false);
+    expect(isToolAllowed('searchJira', filter)).toBe(true);
+  });
+
+  it('applies include before exclude', () => {
+    const filter = { include: [{ regex: '.*Jira.*' }], exclude: ['lookupJiraAccountId'] };
+    expect(isToolAllowed('searchJira', filter)).toBe(true);
+    expect(isToolAllowed('lookupJiraAccountId', filter)).toBe(false);
+    expect(isToolAllowed('searchConfluence', filter)).toBe(false);
+  });
+
+  it('treats an invalid regex as a non-match rather than throwing', () => {
+    const filter = { include: [{ regex: '[' }] };
+    expect(() => isToolAllowed('search', filter)).not.toThrow();
+    expect(isToolAllowed('search', filter)).toBe(false);
   });
 });

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -23,7 +23,7 @@ import type * as t from './types';
 import { createSSRFSafeUndiciConnect, isSSRFTarget, resolveHostnameSSRF } from '~/auth';
 import { isAddressAllowed } from '~/auth/domain';
 import { runOutsideTracing } from '~/utils/tracing';
-import { sanitizeUrlForLogging } from './utils';
+import { sanitizeUrlForLogging, isToolAllowed } from './utils';
 import { withTimeout } from '~/utils/promise';
 import { mcpConfig } from './mcpConfig';
 
@@ -1254,6 +1254,11 @@ export class MCPConnection extends EventEmitter {
     this.setupEventListeners();
   }
 
+  /** Optional include/exclude tool filter configured for this server. */
+  public get toolFilter(): t.MCPOptions['toolFilter'] {
+    return this.options.toolFilter;
+  }
+
   /** Helper to generate consistent log prefixes */
   private getLogPrefix(): string {
     const userPart = this.userId ? `[User: ${this.userId}]` : '';
@@ -2186,7 +2191,11 @@ export class MCPConnection extends EventEmitter {
   async fetchTools() {
     try {
       const { tools } = await this.client.listTools();
-      return tools;
+      const filter = this.options.toolFilter;
+      if (!filter) {
+        return tools;
+      }
+      return tools.filter((tool) => isToolAllowed(tool.name, filter));
     } catch (error) {
       this.emitError(error, 'Failed to fetch tools');
       return [];

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -2191,11 +2191,7 @@ export class MCPConnection extends EventEmitter {
   async fetchTools() {
     try {
       const { tools } = await this.client.listTools();
-      const filter = this.options.toolFilter;
-      if (!filter) {
-        return tools;
-      }
-      return tools.filter((tool) => isToolAllowed(tool.name, filter));
+      return tools.filter((tool) => isToolAllowed(tool.name, this.options.toolFilter));
     } catch (error) {
       this.emitError(error, 'Failed to fetch tools');
       return [];

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -4,7 +4,7 @@ import type { MCPConnection } from '~/mcp/connection';
 import type * as t from '~/mcp/types';
 import { isMCPDomainAllowed, extractMCPServerDomain } from '~/auth/domain';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
-import { hasCustomUserVars, isUserSourced } from '~/mcp/utils';
+import { hasCustomUserVars, isUserSourced, isToolAllowed } from '~/mcp/utils';
 import { MCPDomainNotAllowedError } from '~/mcp/errors';
 import { detectOAuthRequirement } from '~/mcp/oauth';
 import { isEnabled } from '~/utils';
@@ -125,13 +125,17 @@ export class MCPServerInspector {
     const capabilities = this.connection!.client.getServerCapabilities();
     this.config.capabilities = JSON.stringify(capabilities);
     const tools = await this.connection!.client.listTools();
-    this.config.tools = tools.tools.map((tool) => tool.name).join(', ');
+    this.config.tools = tools.tools
+      .filter((tool) => isToolAllowed(tool.name, this.config.toolFilter))
+      .map((tool) => tool.name)
+      .join(', ');
   }
 
   private async fetchToolFunctions(): Promise<void> {
     this.config.toolFunctions = await MCPServerInspector.getToolFunctions(
       this.serverName,
       this.connection!,
+      this.config.toolFilter,
     );
   }
 
@@ -139,16 +143,21 @@ export class MCPServerInspector {
    * Converts server tools to LibreChat-compatible tool functions format.
    * @param serverName - The name of the server
    * @param connection - The MCP connection
+   * @param toolFilter - Optional include/exclude filter applied to the server's tools
    * @returns Tool functions formatted for LibreChat
    */
   public static async getToolFunctions(
     serverName: string,
     connection: MCPConnection,
+    toolFilter?: t.MCPOptions['toolFilter'],
   ): Promise<t.LCAvailableTools> {
     const { tools }: t.MCPToolListResponse = await connection.client.listTools();
 
     const toolFunctions: t.LCAvailableTools = {};
     tools.forEach((tool) => {
+      if (!isToolAllowed(tool.name, toolFilter)) {
+        return;
+      }
       const name = `${tool.name}${Constants.mcp_delimiter}${serverName}`;
       toolFunctions[name] = {
         type: 'function',

--- a/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
@@ -433,5 +433,70 @@ describe('MCPServerInspector', () => {
 
       expect(result).toEqual({});
     });
+
+    describe('toolFilter', () => {
+      beforeEach(() => {
+        mockConnection.client.listTools = jest.fn().mockResolvedValue({
+          tools: [
+            { name: 'searchJira', description: '', inputSchema: { type: 'object' } },
+            { name: 'createJiraIssue', description: '', inputSchema: { type: 'object' } },
+            { name: 'lookupJiraAccountId', description: '', inputSchema: { type: 'object' } },
+            { name: 'searchConfluence', description: '', inputSchema: { type: 'object' } },
+          ],
+        });
+      });
+
+      it('keeps only tools matching the include allowlist', async () => {
+        const result = await MCPServerInspector.getToolFunctions('atlassian', mockConnection, {
+          include: ['searchConfluence'],
+        });
+
+        expect(Object.keys(result)).toEqual(['searchConfluence_mcp_atlassian']);
+      });
+
+      it('supports regex include patterns', async () => {
+        const result = await MCPServerInspector.getToolFunctions('atlassian', mockConnection, {
+          include: [{ regex: '.*Jira.*' }],
+        });
+
+        expect(Object.keys(result).sort()).toEqual([
+          'createJiraIssue_mcp_atlassian',
+          'lookupJiraAccountId_mcp_atlassian',
+          'searchJira_mcp_atlassian',
+        ]);
+      });
+
+      it('removes tools matching the exclude blocklist', async () => {
+        const result = await MCPServerInspector.getToolFunctions('atlassian', mockConnection, {
+          exclude: ['lookupJiraAccountId'],
+        });
+
+        expect(Object.keys(result)).not.toContain('lookupJiraAccountId_mcp_atlassian');
+        expect(Object.keys(result)).toHaveLength(3);
+      });
+
+      it('applies include before exclude', async () => {
+        const result = await MCPServerInspector.getToolFunctions('atlassian', mockConnection, {
+          include: [{ regex: '.*Jira.*' }],
+          exclude: ['lookupJiraAccountId'],
+        });
+
+        expect(Object.keys(result).sort()).toEqual([
+          'createJiraIssue_mcp_atlassian',
+          'searchJira_mcp_atlassian',
+        ]);
+      });
+
+      it('exposes all tools when filter is undefined or empty', async () => {
+        const noFilter = await MCPServerInspector.getToolFunctions('atlassian', mockConnection);
+        const emptyFilter = await MCPServerInspector.getToolFunctions('atlassian', mockConnection, {
+          include: [],
+          exclude: [],
+        });
+
+        expect(Object.keys(noFilter)).toHaveLength(4);
+        expect(Object.keys(emptyFilter)).toHaveLength(4);
+      });
+    });
   });
 });

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -1,4 +1,5 @@
 import { Constants } from 'librechat-data-provider';
+import type { ToolFilter, ToolFilterPattern } from 'librechat-data-provider';
 import type { ParsedServerConfig } from '~/mcp/types';
 
 export const mcpToolPattern = new RegExp(`^.+${Constants.mcp_delimiter}.+$`);
@@ -108,6 +109,38 @@ export function redactAllServerSecrets(
     result[key] = redactServerSecrets(config);
   }
   return result;
+}
+
+/** Tests a single tool name against one filter pattern (exact match or regex). */
+function matchesToolPattern(toolName: string, pattern: ToolFilterPattern): boolean {
+  if (typeof pattern === 'string') {
+    return toolName === pattern;
+  }
+  try {
+    return new RegExp(pattern.regex).test(toolName);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Determines whether a tool should be exposed given an optional `toolFilter`.
+ * `include` (allowlist) is applied first: when present and non-empty, the tool
+ * must match at least one entry. `exclude` (blocklist) is applied after: a tool
+ * matching any entry is rejected. An absent or empty filter allows every tool.
+ */
+export function isToolAllowed(toolName: string, filter?: ToolFilter): boolean {
+  if (!filter) {
+    return true;
+  }
+  const { include, exclude } = filter;
+  if (include && include.length > 0 && !include.some((p) => matchesToolPattern(toolName, p))) {
+    return false;
+  }
+  if (exclude && exclude.length > 0 && exclude.some((p) => matchesToolPattern(toolName, p))) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -1,4 +1,5 @@
 import { Constants } from 'librechat-data-provider';
+import { logger } from '@librechat/data-schemas';
 import type { ToolFilter, ToolFilterPattern } from 'librechat-data-provider';
 import type { ParsedServerConfig } from '~/mcp/types';
 
@@ -111,16 +112,39 @@ export function redactAllServerSecrets(
   return result;
 }
 
+/**
+ * Caches compiled tool-filter regexes so repeated checks (every tool against
+ * every pattern, on each `fetchTools`/`getToolFunctions` call) don't recompile.
+ * Patterns originate from admin config, so the set is bounded. A `null` entry
+ * marks a pattern that failed to compile — it is logged once and never retried.
+ */
+const compiledToolFilterRegexes = new Map<string, RegExp | null>();
+
+function getToolFilterRegex(pattern: string): RegExp | null {
+  const cached = compiledToolFilterRegexes.get(pattern);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let regex: RegExp | null;
+  try {
+    regex = new RegExp(pattern);
+  } catch {
+    regex = null;
+    logger.warn(
+      `[MCP] Ignoring invalid toolFilter regex pattern "${pattern}"; it will not match any tool.`,
+    );
+  }
+  compiledToolFilterRegexes.set(pattern, regex);
+  return regex;
+}
+
 /** Tests a single tool name against one filter pattern (exact match or regex). */
 function matchesToolPattern(toolName: string, pattern: ToolFilterPattern): boolean {
   if (typeof pattern === 'string') {
     return toolName === pattern;
   }
-  try {
-    return new RegExp(pattern.regex).test(toolName);
-  } catch {
-    return false;
-  }
+  const regex = getToolFilterRegex(pattern.regex);
+  return regex != null && regex.test(toolName);
 }
 
 /**

--- a/packages/data-provider/specs/mcp.spec.ts
+++ b/packages/data-provider/specs/mcp.spec.ts
@@ -273,4 +273,37 @@ describe('MCP schemas', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  describe('toolFilter', () => {
+    const withFilter = (toolFilter: unknown) =>
+      MCPOptionsSchema.safeParse({
+        type: 'streamable-http',
+        url: 'https://mcp-server.com/http',
+        toolFilter,
+      });
+
+    it('accepts string and regex include/exclude entries', () => {
+      const result = withFilter({
+        include: ['search', { regex: '.*Jira.*' }],
+        exclude: ['lookupJiraAccountId'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a config with no toolFilter', () => {
+      const result = MCPOptionsSchema.safeParse({
+        type: 'streamable-http',
+        url: 'https://mcp-server.com/http',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an invalid regex pattern at parse time', () => {
+      const result = withFilter({ include: [{ regex: '[' }] });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Invalid regular expression pattern');
+      }
+    });
+  });
 });

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -51,6 +51,28 @@ const OAuthOptionsSchema = z
     }
   });
 
+/**
+ * A single tool-filter matcher: either an exact tool name or a regular
+ * expression wrapped in `{ regex: "..." }`. Matching is performed against the
+ * server's original (un-prefixed) tool names.
+ */
+export const ToolFilterPatternSchema = z.union([z.string(), z.object({ regex: z.string() })]);
+
+/**
+ * Optional allow/block filtering of the tools an MCP server exposes.
+ * `include` is applied first (allowlist), then `exclude` (blocklist).
+ * An absent or empty filter exposes every tool (backward compatible).
+ */
+export const ToolFilterSchema = z.object({
+  /** Allowlist — only tools matching at least one entry are kept. */
+  include: z.array(ToolFilterPatternSchema).optional(),
+  /** Blocklist — tools matching any entry are removed (after `include`). */
+  exclude: z.array(ToolFilterPatternSchema).optional(),
+});
+
+export type ToolFilterPattern = z.infer<typeof ToolFilterPatternSchema>;
+export type ToolFilter = z.infer<typeof ToolFilterSchema>;
+
 const BaseOptionsSchema = z.object({
   /** Display name for the MCP server - only letters, numbers, and spaces allowed */
   title: z
@@ -73,6 +95,13 @@ const BaseOptionsSchema = z.object({
   initTimeout: z.number().int().nonnegative().optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */
   chatMenu: z.boolean().optional(),
+  /**
+   * Optional filtering of the tools this server exposes to the model, used to
+   * reduce context-window consumption from large tool sets. `include` (allowlist)
+   * is applied first, then `exclude` (blocklist). Each entry is an exact tool
+   * name or a `{ regex: "..." }` pattern. Omitting this exposes all tools.
+   */
+  toolFilter: ToolFilterSchema.optional(),
   /**
    * Controls server instruction behavior:
    * - undefined/not set: No instructions included (default)
@@ -262,6 +291,7 @@ const omitServerManagedFields = <T extends z.ZodObject<z.ZodRawShape>>(schema: T
     requiresOAuth: true,
     customUserVars: true,
     oauth_headers: true,
+    toolFilter: true,
   });
 
 const envVarPattern = /\$\{[^}]+\}/;

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -51,12 +51,28 @@ const OAuthOptionsSchema = z
     }
   });
 
+/** Validates that a string compiles to a valid regular expression. */
+const isValidRegex = (value: string): boolean => {
+  try {
+    new RegExp(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * A single tool-filter matcher: either an exact tool name or a regular
  * expression wrapped in `{ regex: "..." }`. Matching is performed against the
- * server's original (un-prefixed) tool names.
+ * server's original (un-prefixed) tool names. Regex patterns are validated at
+ * parse time so misconfigurations surface immediately on config load.
  */
-export const ToolFilterPatternSchema = z.union([z.string(), z.object({ regex: z.string() })]);
+export const ToolFilterPatternSchema = z.union([
+  z.string(),
+  z.object({
+    regex: z.string().refine(isValidRegex, { message: 'Invalid regular expression pattern' }),
+  }),
+]);
 
 /**
  * Optional allow/block filtering of the tools an MCP server exposes.


### PR DESCRIPTION
## Summary

Resolves #11088.

MCP tool definitions can consume a large share of the context window before a conversation even begins — e.g. the Atlassian MCP server's 28 tools take ~24.6k tokens (~12% of context). Most users only need a subset.

This PR adds an optional **`toolFilter`** to each MCP server config so operators can include/exclude tools, reclaiming tokens, reducing cost, and improving the model's tool selection.

```yaml
mcpServers:
  atlassian:
    url: https://mcp.atlassian.com/v1/sse
    toolFilter:
      include:
        - "search"
        - { regex: ".*Jira.*" }
      exclude:
        - "lookupJiraAccountId"
```

**Semantics**
- `include` (allowlist) is applied first; when present and non-empty, a tool must match at least one entry.
- `exclude` (blocklist) is applied next; any match is removed.
- Each entry is an exact tool name or a `{ regex: "..." }` pattern (matched against the server's original, un-prefixed tool names).
- An absent or empty filter exposes all tools (fully backward compatible).
- The field is **admin-only** — it is omitted from the user MCP-creation input schema, so end users cannot define regex tool filters.

**Implementation**
- Schema + types in `packages/data-provider/src/mcp.ts` (`ToolFilterSchema`, `ToolFilter`).
- A single `isToolAllowed()` matcher in `packages/api/src/mcp/utils.ts` (invalid regex degrades to a non-match rather than throwing).
- Applied at every tool-exposure path so no path leaks filtered tools:
  - `MCPServerInspector.getToolFunctions` and the `tools` capability string (boot-time inspection / cached tool functions).
  - `MCPManager.getServerToolFunctions` (on-demand listing), via a new `MCPConnection.toolFilter` getter.
  - `MCPConnection.fetchTools()` — covers OAuth / `startup: false` servers whose tools are registered through the discovery + reinitialize flow, which bypasses `getToolFunctions`.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Unit tests added/updated (run per-workspace with Jest):

- `packages/api/src/mcp/__tests__/utils.test.ts` — `isToolAllowed`: include/exclude, exact + regex, ordering, empty/undefined filter, invalid-regex safety.
- `packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts` — `getToolFunctions` filtering (allowlist, regex, exclude, include-before-exclude, no-filter).
- `packages/api/src/mcp/__tests__/MCPConnectionToolFilter.test.ts` (new) — `MCPConnection.fetchTools()` filtering.

```bash
cd packages/api && npx jest src/mcp/__tests__/utils.test.ts \
  src/mcp/registry/__tests__/MCPServerInspector.test.ts \
  src/mcp/__tests__/MCPConnectionToolFilter.test.ts
```

All pass; existing MCPManager/MCPConnection suites remain green. ESLint clean on all changed files. (Pre-existing cache-integration specs that require a local Redis are unaffected by this change.)

### **Test Configuration**:
Node 22, Jest per workspace.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes (example in `librechat.example.yaml`)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
