### PR TITLE
if meilisearch.enabled  we should set SEARCH: "true"

### DIFF
--- a/helm/librechat/templates/configmap-env.yaml
+++ b/helm/librechat/templates/configmap-env.yaml
@@ -12,6 +12,9 @@ data:
   {{- if and (not (dig "configEnv" "MEILI_HOST" "" .Values.librechat)) .Values.meilisearch.enabled }}
   MEILI_HOST: http://{{ include "meilisearch.fullname" .Subcharts.meilisearch }}.{{ .Release.Namespace | lower }}.svc.cluster.local:7700
   {{- end }}
+  {{- if and (not (dig "configEnv" "SEARCH" "" .Values.librechat)) .Values.meilisearch.enabled }}
+  SEARCH: "true"
+  {{- end }}
   {{- if and (not (dig "configEnv" "MONGO_URI" "" .Values.librechat)) .Values.mongodb.enabled }}
   MONGO_URI: mongodb://{{ include "mongodb.service.nameOverride" .Subcharts.mongodb }}.{{ .Release.Namespace | lower }}.svc.cluster.local:27017/LibreChat
   {{- end }}


### PR DESCRIPTION
## Summary

If meilisearch.enabled is true and config.Env.Search is not set then default to true so that search is enabled.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run `helm template helm/librechat --show-only templates/configmap-env.yaml` and verify `SEARCH: "true"` is set

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings