### PR TITLE
📎 fix: Preserve Gemini PDF Media Blocks

### DIFF
--- a/packages/api/src/files/encode/document.spec.ts
+++ b/packages/api/src/files/encode/document.spec.ts
@@ -749,6 +749,38 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         file_data: `data:application/pdf;base64,${mockContent}`,
       });
     });
+
+    it.each([Providers.GOOGLE, Providers.VERTEXAI] as const)(
+      'should format %s PDF as media block when responses API is enabled',
+      async (provider) => {
+        const req = createMockRequest(15, provider) as ServerRequest;
+        const file = createMockFile(10);
+
+        const mockContent = Buffer.from('test-pdf-content').toString('base64');
+        mockedGetFileStream.mockResolvedValue({
+          file,
+          content: mockContent,
+          metadata: file,
+        });
+
+        mockedValidatePdf.mockResolvedValue({ isValid: true });
+
+        const result = await encodeAndFormatDocuments(
+          req,
+          [file],
+          { provider, useResponsesApi: true },
+          mockStrategyFunctions,
+        );
+
+        expect(result.documents).toHaveLength(1);
+        expect(result.documents[0]).toMatchObject({
+          type: 'media',
+          mimeType: 'application/pdf',
+          data: mockContent,
+        });
+        expect(result.documents[0]).not.toHaveProperty('type', 'input_file');
+      },
+    );
   });
 
   describe('Generic document encoding path', () => {

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -55,6 +55,14 @@ function formatDocumentBlock(
     return document;
   }
 
+  if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
+    return {
+      type: 'media',
+      mimeType,
+      data: content,
+    };
+  }
+
   const resolvedFilename = filename ?? 'document';
 
   if (useResponsesApi) {
@@ -62,14 +70,6 @@ function formatDocumentBlock(
       type: 'input_file',
       filename: resolvedFilename,
       file_data: `data:${mimeType};base64,${content}`,
-    };
-  }
-
-  if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
-    return {
-      type: 'media',
-      mimeType,
-      data: content,
     };
   }
 
@@ -84,6 +84,18 @@ function formatDocumentBlock(
   }
 
   return null;
+}
+
+function getBase64DecodedByteCount(content: string): number {
+  let paddingChars = 0;
+
+  if (content.endsWith('==')) {
+    paddingChars = 2;
+  } else if (content.endsWith('=')) {
+    paddingChars = 1;
+  }
+
+  return Math.floor((content.length * 3) / 4) - paddingChars;
 }
 
 /**
@@ -208,8 +220,7 @@ export async function encodeAndFormatDocuments(
         result.files.push(metadata);
       }
     } else if (isDocSupported && !isBedrock) {
-      const paddingChars = content.endsWith('==') ? 2 : content.endsWith('=') ? 1 : 0;
-      const decodedByteCount = Math.floor((content.length * 3) / 4) - paddingChars;
+      const decodedByteCount = getBase64DecodedByteCount(content);
       if (configuredFileSizeLimit && decodedByteCount > configuredFileSizeLimit) {
         throw new Error(
           `File size (~${(decodedByteCount / 1024 / 1024).toFixed(1)}MB) exceeds the configured limit for ${provider}`,


### PR DESCRIPTION
## Summary

I fixed Vertex AI / Google Gemini agent PDF uploads so provider-uploaded documents stay in Gemini-compatible media blocks instead of being converted to OpenAI Responses `input_file` blocks. Closes #13314.

- Moved Google and Vertex AI document formatting ahead of the generic Responses API formatting branch.
- Preserved OpenAI Responses `input_file` behavior for OpenAI while preventing it from leaking into Gemini agent requests.
- Added regression coverage for both Google and Vertex AI PDF encoding when `useResponsesApi` is enabled.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`.
- Ran `cd packages/api && npx jest src/files/encode/document.spec.ts --runInBand`.
- Ran `npx prettier --check packages/api/src/files/encode/document.ts packages/api/src/files/encode/document.spec.ts`.

### **Test Configuration**:

- Node/npm workspace dependencies installed with `npm ci --ignore-scripts` from `package-lock.json`.
- Focused package: `packages/api`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes