### PR TITLE
fix(auth): stop retrying OAuth failures

### DIFF
--- a/api/server/routes/oauth.error.test.js
+++ b/api/server/routes/oauth.error.test.js
@@ -1,0 +1,108 @@
+const express = require('express');
+const request = require('supertest');
+const { OAuthErrorCodes } = require('@librechat/api');
+
+jest.mock('passport', () => ({
+  authenticate: jest.fn(() => (_req, _res, next) => next()),
+}));
+
+jest.mock('openid-client', () => ({
+  randomState: jest.fn(() => 'state'),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  createSetBalanceConfig: jest.fn(() => (_req, _res, next) => next()),
+}));
+
+jest.mock('~/server/middleware', () => ({
+  checkDomainAllowed: (_req, _res, next) => next(),
+  loginLimiter: (_req, _res, next) => next(),
+  logHeaders: (_req, _res, next) => next(),
+}));
+
+jest.mock('~/server/controllers/auth/oauth', () => ({
+  createOAuthHandler: jest.fn(() => (_req, _res, next) => next()),
+}));
+
+jest.mock('~/models', () => ({
+  findBalanceByUser: jest.fn(),
+  upsertBalanceFields: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: jest.fn(),
+}));
+
+process.env.DOMAIN_CLIENT = 'http://client.example';
+
+const oauthRouter = require('./oauth');
+
+function buildApp(sessionMessages) {
+  const app = express();
+  app.use((req, _res, next) => {
+    req.session = { messages: [...sessionMessages] };
+    next();
+  });
+  app.use('/oauth', oauthRouter);
+  return app;
+}
+
+describe('GET /oauth/error', () => {
+  it('logs known OAuth failure codes without exposing them on the login redirect', async () => {
+    const response = await request(buildApp([OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH]))
+      .get('/oauth/error')
+      .expect(302);
+
+    expect(response.headers.location).toBe(
+      'http://client.example/login?redirect=false&error=auth_failed',
+    );
+    expect(require('@librechat/data-schemas').logger.error).toHaveBeenCalledWith(
+      'Error in OAuth authentication:',
+      {
+        message: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
+        errorCode: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
+        clientErrorCode: OAuthErrorCodes.AUTH_FAILED,
+      },
+    );
+  });
+
+  it.each([
+    ['Email domain not allowed', OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED],
+    ['Social registration is disabled', OAuthErrorCodes.OAUTH_REGISTRATION_DISABLED],
+    ['User does not exist', OAuthErrorCodes.OAUTH_USER_NOT_FOUND],
+    ['You must have "requiredRole" role to log in.', OAuthErrorCodes.OPENID_ROLE_REQUIRED],
+  ])('maps legacy OAuth failure message "%s" to %s', async (message, expectedCode) => {
+    const response = await request(buildApp([message]))
+      .get('/oauth/error')
+      .expect(302);
+
+    expect(response.headers.location).toBe(
+      'http://client.example/login?redirect=false&error=auth_failed',
+    );
+    expect(require('@librechat/data-schemas').logger.error).toHaveBeenCalledWith(
+      'Error in OAuth authentication:',
+      {
+        message,
+        errorCode: expectedCode,
+        clientErrorCode: OAuthErrorCodes.AUTH_FAILED,
+      },
+    );
+  });
+
+  it('falls back to generic auth_failed for unknown OAuth errors', async () => {
+    const response = await request(buildApp(['Unexpected provider error']))
+      .get('/oauth/error')
+      .expect(302);
+
+    expect(response.headers.location).toBe(
+      'http://client.example/login?redirect=false&error=auth_failed',
+    );
+  });
+});

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -3,8 +3,7 @@ const express = require('express');
 const passport = require('passport');
 const { randomState } = require('openid-client');
 const { logger } = require('@librechat/data-schemas');
-const { ErrorTypes } = require('librechat-data-provider');
-const { createSetBalanceConfig } = require('@librechat/api');
+const { createSetBalanceConfig, getOAuthErrorCode, OAuthErrorCodes } = require('@librechat/api');
 const { checkDomainAllowed, loginLimiter, logHeaders } = require('~/server/middleware');
 const { createOAuthHandler } = require('~/server/controllers/auth/oauth');
 const { findBalanceByUser, upsertBalanceFields } = require('~/models');
@@ -31,11 +30,19 @@ const oauthHandler = createOAuthHandler();
 router.get('/error', (req, res) => {
   /** A single error message is pushed by passport when authentication fails. */
   const errorMessage = req.session?.messages?.pop() || 'Unknown OAuth error';
+  const errorCode = getOAuthErrorCode(errorMessage);
+  const clientErrorCode = OAuthErrorCodes.AUTH_FAILED;
   logger.error('Error in OAuth authentication:', {
     message: errorMessage,
+    errorCode,
+    clientErrorCode,
   });
 
-  res.redirect(`${domains.client}/login?redirect=false&error=${ErrorTypes.AUTH_FAILED}`);
+  /** Keep detailed OAuth failure codes server-side; the browser only receives a generic auth error. */
+  const errorUrl = new URL('/login', domains.client || 'http://localhost:3080');
+  errorUrl.searchParams.set('redirect', 'false');
+  errorUrl.searchParams.set('error', clientErrorCode);
+  res.redirect(errorUrl.toString());
 });
 
 /**

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -1,4 +1,5 @@
 const { SystemRoles } = require('librechat-data-provider');
+const { OAuthErrorCodes } = jest.requireActual('@librechat/api');
 
 // --- Capture JwtStrategy inputs ---
 let capturedStrategyOptions;
@@ -310,6 +311,13 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     iss: 'https://issuer.example.com',
     exp: 9999999999,
   };
+  const isOpenIdLookup = (query) =>
+    (query.openidId === payload.sub && query.openidIssuer === 'https://issuer.example.com') ||
+    query.$or?.some(
+      (condition) =>
+        condition.openidId === payload.sub &&
+        condition.openidIssuer === 'https://issuer.example.com',
+    );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -339,7 +347,7 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
       role: SystemRoles.USER,
     };
     findUser.mockImplementation(async (query) => {
-      if (query.openidId === payload.sub && query.openidIssuer === 'https://issuer.example.com') {
+      if (isOpenIdLookup(query)) {
         return existingUser;
       }
       return null;
@@ -348,10 +356,7 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     const req = { headers: { authorization: 'Bearer tok' }, session: {} };
     await invokeVerify(req, payload);
 
-    expect(findUser).toHaveBeenCalledWith({
-      openidId: payload.sub,
-      openidIssuer: 'https://issuer.example.com',
-    });
+    expect(findUser.mock.calls.some(([query]) => isOpenIdLookup(query))).toBe(true);
   });
 
   it('should use OPENID_EMAIL_CLAIM when set for email lookup', async () => {
@@ -362,10 +367,7 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     const { user } = await invokeVerify(req, payload);
 
     expect(findUser).toHaveBeenCalledTimes(2);
-    expect(findUser.mock.calls[0][0]).toEqual({
-      openidId: payload.sub,
-      openidIssuer: 'https://issuer.example.com',
-    });
+    expect(isOpenIdLookup(findUser.mock.calls[0][0])).toBe(true);
     expect(findUser.mock.calls[1][0]).toEqual({
       email: 'test@corp.example.com',
     });
@@ -406,7 +408,7 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     const { user, info } = await invokeVerify(req, payload);
 
     expect(user).toBe(false);
-    expect(info).toEqual({ message: 'auth_failed' });
+    expect(info).toEqual({ message: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH });
   });
 
   it('should trim whitespace from OPENID_EMAIL_CLAIM', async () => {

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -7,7 +7,7 @@ const jwtDecode = require('jsonwebtoken/decode');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { hashToken, logger } = require('@librechat/data-schemas');
 const { Strategy: OpenIDStrategy } = require('openid-client/passport');
-const { CacheKeys, ErrorTypes, SystemRoles } = require('librechat-data-provider');
+const { CacheKeys, SystemRoles } = require('librechat-data-provider');
 const {
   isEnabled,
   logHeaders,
@@ -20,6 +20,8 @@ const {
   getAvatarFileStrategy,
   getAvatarSaveParams,
   resolveAppConfigForUser,
+  isKnownOAuthErrorCode,
+  OAuthErrorCodes,
 } = require('@librechat/api');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { findUser, createUser, updateUser } = require('~/models');
@@ -468,7 +470,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
   const error = result.error;
 
   if (error) {
-    throw new Error(ErrorTypes.AUTH_FAILED);
+    throw new Error(error);
   }
 
   const appConfig = user?.tenantId ? await resolveAppConfigForUser(getAppConfig, user) : baseConfig;
@@ -554,7 +556,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
   }
 
   if (existingUsersOnly && !user) {
-    throw new Error('User does not exist');
+    throw new Error(OAuthErrorCodes.OAUTH_USER_NOT_FOUND);
   }
 
   if (!user) {
@@ -713,10 +715,10 @@ function createOpenIDCallback(existingUsersOnly) {
       const user = await processOpenIDAuth(tokenset, existingUsersOnly);
       done(null, user);
     } catch (err) {
-      if (err.message === 'Email domain not allowed') {
+      if (isKnownOAuthErrorCode(err.message)) {
         return done(null, false, { message: err.message });
       }
-      if (err.message === ErrorTypes.AUTH_FAILED) {
+      if (err.message === 'Email domain not allowed') {
         return done(null, false, { message: err.message });
       }
       if (err.message && err.message.includes('role to log in')) {

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -1,9 +1,14 @@
 const undici = require('undici');
 const fetch = require('node-fetch');
 const jwtDecode = require('jsonwebtoken/decode');
-const { ErrorTypes, FileSources } = require('librechat-data-provider');
+const { FileSources } = require('librechat-data-provider');
 const { findUser, createUser, updateUser } = require('~/models');
-const { getOpenIdIssuer, resolveAppConfigForUser, isEnabled } = require('@librechat/api');
+const {
+  getOpenIdIssuer,
+  OAuthErrorCodes,
+  resolveAppConfigForUser,
+  isEnabled,
+} = require('@librechat/api');
 const { getAppConfig } = require('~/server/services/Config');
 const { setupOpenId } = require('./openidStrategy');
 
@@ -170,6 +175,17 @@ describe('setupOpenId', () => {
   const validate = (tokenset) =>
     new Promise((resolve, reject) => {
       verifyCallback(tokenset, (err, user, details) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ user, details });
+        }
+      });
+    });
+  const validateStrategy = (strategyName, tokenset) =>
+    new Promise((resolve, reject) => {
+      const callback = require('openid-client/passport').__getVerifyCallbackByName(strategyName);
+      callback(tokenset, (err, user, details) => {
         if (err) {
           reject(err);
         } else {
@@ -483,7 +499,7 @@ describe('setupOpenId', () => {
 
     // Assert – verify that the strategy rejects login
     expect(result.user).toBe(false);
-    expect(result.details.message).toBe(ErrorTypes.AUTH_FAILED);
+    expect(result.details.message).toBe(OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH);
     expect(createUser).not.toHaveBeenCalled();
     expect(updateUser).not.toHaveBeenCalled();
   });
@@ -510,7 +526,18 @@ describe('setupOpenId', () => {
     const result = await validate(tokenset);
 
     expect(result.user).toBe(false);
-    expect(result.details.message).toBe(ErrorTypes.AUTH_FAILED);
+    expect(result.details.message).toBe(OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH);
+    expect(createUser).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it('should return known OAuth failure code when admin OpenID login requires an existing user', async () => {
+    findUser.mockResolvedValue(null);
+
+    const result = await validateStrategy('openidAdmin', tokenset);
+
+    expect(result.user).toBe(false);
+    expect(result.details.message).toBe(OAuthErrorCodes.OAUTH_USER_NOT_FOUND);
     expect(createUser).not.toHaveBeenCalled();
     expect(updateUser).not.toHaveBeenCalled();
   });

--- a/api/strategies/socialLogin.js
+++ b/api/strategies/socialLogin.js
@@ -1,6 +1,10 @@
 const { logger } = require('@librechat/data-schemas');
-const { ErrorTypes } = require('librechat-data-provider');
-const { isEnabled, isEmailDomainAllowed, resolveAppConfigForUser } = require('@librechat/api');
+const {
+  isEnabled,
+  isEmailDomainAllowed,
+  OAuthErrorCodes,
+  resolveAppConfigForUser,
+} = require('@librechat/api');
 const { createSocialUser, handleExistingUser } = require('./process');
 const { getAppConfig } = require('~/server/services/Config');
 const { findUser } = require('~/models');
@@ -19,8 +23,8 @@ const socialLogin =
         logger.error(
           `[${provider}Login] Authentication blocked - email domain not allowed [Email: ${email}]`,
         );
-        const error = new Error(ErrorTypes.AUTH_FAILED);
-        error.code = ErrorTypes.AUTH_FAILED;
+        const error = new Error(OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED);
+        error.code = OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED;
         error.message = 'Email domain not allowed';
         return cb(error);
       }
@@ -49,8 +53,8 @@ const socialLogin =
         logger.error(
           `[${provider}Login] Authentication blocked - email domain not allowed [Email: ${email}]`,
         );
-        const error = new Error(ErrorTypes.AUTH_FAILED);
-        error.code = ErrorTypes.AUTH_FAILED;
+        const error = new Error(OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED);
+        error.code = OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED;
         error.message = 'Email domain not allowed';
         return cb(error);
       }
@@ -62,8 +66,8 @@ const socialLogin =
         logger.info(
           `[${provider}Login] User ${email} already exists with provider ${existingUser.provider}`,
         );
-        const error = new Error(ErrorTypes.AUTH_FAILED);
-        error.code = ErrorTypes.AUTH_FAILED;
+        const error = new Error(OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH);
+        error.code = OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH;
         error.provider = existingUser.provider;
         return cb(error);
       }
@@ -80,8 +84,8 @@ const socialLogin =
         logger.error(
           `[${provider}Login] Registration blocked - social registration is disabled [Email: ${email}]`,
         );
-        const error = new Error(ErrorTypes.AUTH_FAILED);
-        error.code = ErrorTypes.AUTH_FAILED;
+        const error = new Error(OAuthErrorCodes.OAUTH_REGISTRATION_DISABLED);
+        error.code = OAuthErrorCodes.OAUTH_REGISTRATION_DISABLED;
         error.message = 'Social registration is disabled';
         return cb(error);
       }

--- a/api/strategies/socialLogin.test.js
+++ b/api/strategies/socialLogin.test.js
@@ -1,9 +1,13 @@
 const { logger } = require('@librechat/data-schemas');
-const { ErrorTypes } = require('librechat-data-provider');
 const { createSocialUser, handleExistingUser } = require('./process');
 const socialLogin = require('./socialLogin');
 const { findUser } = require('~/models');
-const { resolveAppConfigForUser } = require('@librechat/api');
+const {
+  isEmailDomainAllowed,
+  isEnabled,
+  OAuthErrorCodes,
+  resolveAppConfigForUser,
+} = require('@librechat/api');
 const { getAppConfig } = require('~/server/services/Config');
 
 jest.mock('@librechat/data-schemas', () => {
@@ -52,6 +56,17 @@ describe('socialLogin', () => {
     username: profile.name?.givenName || 'user',
     name: `${profile.name?.givenName || ''} ${profile.name?.familyName || ''}`.trim(),
     emailVerified: profile.emails[0].verified || false,
+  });
+  const buildProfile = ({
+    id = 'google-user',
+    email = 'user@example.com',
+    givenName = 'John',
+    familyName = 'Doe',
+  } = {}) => ({
+    id,
+    emails: [{ value: email, verified: true }],
+    photos: [{ value: 'https://example.com/avatar.png' }],
+    name: { givenName, familyName },
   });
 
   beforeEach(() => {
@@ -222,6 +237,33 @@ describe('socialLogin', () => {
   });
 
   describe('Error handling', () => {
+    it('should return known OAuth failure code when base config blocks the email domain', async () => {
+      const provider = 'google';
+      const email = 'blocked@example.com';
+
+      isEmailDomainAllowed.mockReturnValueOnce(false);
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(
+        null,
+        null,
+        null,
+        buildProfile({ id: 'google-blocked-domain', email, givenName: 'Blocked' }),
+        callback,
+      );
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED,
+          message: 'Email domain not allowed',
+        }),
+      );
+      expect(findUser).not.toHaveBeenCalled();
+      expect(createSocialUser).not.toHaveBeenCalled();
+    });
+
     it('should return error if user exists with different provider', async () => {
       const provider = 'google';
       const googleId = 'google-user-123';
@@ -235,21 +277,14 @@ describe('socialLogin', () => {
 
       findUser.mockResolvedValueOnce(null).mockResolvedValueOnce(existingUser);
 
-      const mockProfile = {
-        id: googleId,
-        emails: [{ value: email, verified: true }],
-        photos: [{ value: 'https://example.com/avatar.png' }],
-        name: { givenName: 'John', familyName: 'Doe' },
-      };
-
       const loginFn = socialLogin(provider, mockGetProfileDetails);
       const callback = jest.fn();
 
-      await loginFn(null, null, null, mockProfile, callback);
+      await loginFn(null, null, null, buildProfile({ id: googleId, email }), callback);
 
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          code: ErrorTypes.AUTH_FAILED,
+          code: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
           provider: 'local',
         }),
       );
@@ -257,6 +292,33 @@ describe('socialLogin', () => {
       expect(logger.info).toHaveBeenCalledWith(
         `[${provider}Login] User ${email} already exists with provider local`,
       );
+    });
+
+    it('should return known OAuth failure code when social registration is disabled', async () => {
+      const provider = 'google';
+      const email = 'newuser@example.com';
+
+      findUser.mockResolvedValue(null);
+      isEnabled.mockReturnValueOnce(false);
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(
+        null,
+        null,
+        null,
+        buildProfile({ id: 'google-new-user', email, givenName: 'New', familyName: 'User' }),
+        callback,
+      );
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: OAuthErrorCodes.OAUTH_REGISTRATION_DISABLED,
+          message: 'Social registration is disabled',
+        }),
+      );
+      expect(createSocialUser).not.toHaveBeenCalled();
     });
   });
 
@@ -342,20 +404,22 @@ describe('socialLogin', () => {
       });
       isEmailDomainAllowed.mockReturnValueOnce(true).mockReturnValueOnce(false);
 
-      const mockProfile = {
-        id: googleId,
-        emails: [{ value: email, verified: true }],
-        photos: [{ value: 'https://example.com/avatar.png' }],
-        name: { givenName: 'Blocked', familyName: 'User' },
-      };
-
       const loginFn = socialLogin(provider, mockGetProfileDetails);
       const callback = jest.fn();
 
-      await loginFn(null, null, null, mockProfile, callback);
+      await loginFn(
+        null,
+        null,
+        null,
+        buildProfile({ id: googleId, email, givenName: 'Blocked' }),
+        callback,
+      );
 
       expect(callback).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Email domain not allowed' }),
+        expect.objectContaining({
+          code: OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED,
+          message: 'Email domain not allowed',
+        }),
       );
     });
   });

--- a/client/src/components/Auth/Login.tsx
+++ b/client/src/components/Auth/Login.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ErrorTypes, registerPage } from 'librechat-data-provider';
+import { registerPage } from 'librechat-data-provider';
 import { OpenIDIcon, useToastContext } from '@librechat/client';
 import { useOutletContext, useSearchParams, useLocation } from 'react-router-dom';
 import type { TLoginLayoutContext } from '~/common';
@@ -23,8 +23,11 @@ function Login() {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const disableAutoRedirect = searchParams.get('redirect') === 'false';
+  const initialOauthError = searchParams.get('error');
 
-  const [isAutoRedirectDisabled, setIsAutoRedirectDisabled] = useState(disableAutoRedirect);
+  const [isAutoRedirectDisabled, setIsAutoRedirectDisabled] = useState(
+    disableAutoRedirect || !!initialOauthError,
+  );
 
   useEffect(() => {
     const redirectTo = searchParams.get('redirect_to');
@@ -38,7 +41,8 @@ function Login() {
     }
 
     const oauthError = searchParams?.get('error');
-    if (oauthError && oauthError === ErrorTypes.AUTH_FAILED) {
+    if (oauthError) {
+      setIsAutoRedirectDisabled(true);
       showToast({
         message: localize('com_auth_error_oauth_failed'),
         status: 'error',
@@ -67,6 +71,7 @@ function Login() {
   useEffect(() => {
     if (shouldAutoRedirect) {
       console.log('Auto-redirecting to OpenID provider...');
+      setIsAutoRedirectDisabled(true);
       window.location.href = `${startupConfig.serverDomain}/oauth/openid`;
     }
   }, [shouldAutoRedirect, startupConfig]);

--- a/client/src/components/Auth/__tests__/Login.spec.tsx
+++ b/client/src/components/Auth/__tests__/Login.spec.tsx
@@ -1,7 +1,7 @@
 import reactRouter from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { getByTestId, render, waitFor } from 'test/layout-test-utils';
-import type { TStartupConfig } from 'librechat-data-provider';
+import { ErrorTypes, type TStartupConfig } from 'librechat-data-provider';
 import * as endpointQueries from '~/data-provider/Endpoints/queries';
 import * as miscDataProvider from '~/data-provider/Misc/queries';
 import * as authMutations from '~/data-provider/Auth/mutations';
@@ -9,7 +9,15 @@ import * as authQueries from '~/data-provider/Auth/queries';
 import AuthLayout from '~/components/Auth/AuthLayout';
 import Login from '~/components/Auth/Login';
 
+const mockShowToast = jest.fn();
+
 jest.mock('librechat-data-provider/react-query');
+jest.mock('@librechat/client', () => ({
+  ...jest.requireActual('@librechat/client'),
+  useToastContext: () => ({
+    showToast: mockShowToast,
+  }),
+}));
 
 const mockStartupConfig = {
   isFetching: false,
@@ -22,6 +30,7 @@ const mockStartupConfig = {
     githubLoginEnabled: true,
     googleLoginEnabled: true,
     openidLoginEnabled: true,
+    openidAutoRedirect: false,
     openidLabel: 'Test OpenID',
     openidImageUrl: 'http://test-server.com',
     samlLoginEnabled: true,
@@ -112,12 +121,36 @@ const setup = ({
   };
 };
 
+const setupWithOpenIdAutoRedirect = (data: Partial<TStartupConfig> = {}) =>
+  setup({
+    useGetStartupConfigReturnValue: {
+      ...mockStartupConfig,
+      data: {
+        ...mockStartupConfig.data,
+        openidAutoRedirect: true,
+        ...data,
+      },
+    },
+  });
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useOutletContext: () => ({
     startupConfig: mockStartupConfig,
   }),
 }));
+
+beforeEach(() => {
+  sessionStorage.clear();
+  window.history.replaceState({}, '', '/login');
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+  window.history.replaceState({}, '', '/');
+  mockShowToast.mockClear();
+  jest.restoreAllMocks();
+});
 
 test('renders login form', () => {
   const { getByLabelText, getByRole } = setup();
@@ -151,6 +184,24 @@ test('renders login form', () => {
     'href',
     'mock-server/oauth/saml',
   );
+});
+
+it.each([
+  ['legacy leaked OAuth account mismatch', 'oauth_account_mismatch'],
+  ['generic OAuth auth failure', ErrorTypes.AUTH_FAILED],
+  ['unknown OAuth auth failure', 'unexpected_provider_error'],
+])('does not auto redirect when the login URL has %s', async (_label, errorCode) => {
+  window.history.replaceState({}, '', `/login?error=${errorCode}`);
+
+  setupWithOpenIdAutoRedirect();
+
+  await waitFor(() => {
+    expect(getByTestId(document.body, 'login-button')).toBeInTheDocument();
+  });
+  expect(mockShowToast).toHaveBeenCalledWith({
+    message: 'Authentication failed. Please check your login method and try again.',
+    status: 'error',
+  });
 });
 
 test('calls loginUser.mutate on login', async () => {

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -98,7 +98,11 @@ const AuthContextProvider = ({
       }, 50),
     [navigate, setUser, setQueriesEnabled],
   );
-  const doSetError = useTimeout({ callback: (error) => setError(error as string | undefined) });
+  const setErrorOnTimeout = useCallback(
+    (error: string | number | boolean | null) => setError(error as string | undefined),
+    [],
+  );
+  const doSetError = useTimeout({ callback: setErrorOnTimeout });
 
   const loginUser = useLoginUserMutation({
     onSuccess: (data: t.TLoginResponse) => {
@@ -167,9 +171,12 @@ const AuthContextProvider = ({
 
   const userQuery = useGetUserQuery({ enabled: !!(token ?? '') });
 
-  const login = (data: t.TLoginUser) => {
-    loginUser.mutate(data);
-  };
+  const login = useCallback(
+    (data: t.TLoginUser) => {
+      loginUser.mutate(data);
+    },
+    [loginUser],
+  );
 
   const silentRefresh = useCallback(() => {
     if (authConfig?.test === true) {
@@ -244,6 +251,7 @@ const AuthContextProvider = ({
     userQuery.isError,
     userQuery.error,
     error,
+    doSetError,
     setUser,
     navigate,
     silentRefresh,
@@ -293,6 +301,8 @@ const AuthContextProvider = ({
       isCustomRole,
       userRoleName,
       customRole,
+      login,
+      logout,
     ],
   );
 

--- a/client/src/hooks/useTimeout.tsx
+++ b/client/src/hooks/useTimeout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 type TUseTimeoutParams = {
   callback: (error: string | number | boolean | null) => void;
@@ -9,20 +9,23 @@ type TTimeout = ReturnType<typeof setTimeout> | null;
 function useTimeout({ callback, delay = 400 }: TUseTimeoutParams) {
   const timeout = useRef<TTimeout>(null);
 
-  const callOnTimeout = (value?: string) => {
-    // Clear existing timeout
-    if (timeout.current !== null) {
-      clearTimeout(timeout.current);
-    }
+  const callOnTimeout = useCallback(
+    (value?: string) => {
+      // Clear existing timeout
+      if (timeout.current !== null) {
+        clearTimeout(timeout.current);
+      }
 
-    // Set new timeout
-    if (value != null && value) {
-      console.log(value);
-      timeout.current = setTimeout(() => {
-        callback(value);
-      }, delay);
-    }
-  };
+      // Set new timeout
+      if (value != null && value) {
+        console.log(value);
+        timeout.current = setTimeout(() => {
+          callback(value);
+        }, delay);
+      }
+    },
+    [callback, delay],
+  );
 
   // Clear timeout when the component unmounts
   useEffect(() => {

--- a/packages/api/src/auth/errors.ts
+++ b/packages/api/src/auth/errors.ts
@@ -1,0 +1,38 @@
+import { ErrorTypes } from 'librechat-data-provider';
+
+export const OAuthErrorCodes = {
+  AUTH_FAILED: ErrorTypes.AUTH_FAILED,
+  OAUTH_ACCOUNT_MISMATCH: 'oauth_account_mismatch',
+  OAUTH_EMAIL_DOMAIN_BLOCKED: 'oauth_email_domain_blocked',
+  OAUTH_REGISTRATION_DISABLED: 'oauth_registration_disabled',
+  OAUTH_USER_NOT_FOUND: 'oauth_user_not_found',
+  OPENID_ISSUER_MISMATCH: 'openid_issuer_mismatch',
+  OPENID_ROLE_REQUIRED: 'openid_role_required',
+} as const;
+
+export type OAuthErrorCode = (typeof OAuthErrorCodes)[keyof typeof OAuthErrorCodes];
+
+const KNOWN_OAUTH_FAILURE_CODES = new Set<string>(Object.values(OAuthErrorCodes));
+
+export function isKnownOAuthErrorCode(value: unknown): value is OAuthErrorCode {
+  return typeof value === 'string' && KNOWN_OAUTH_FAILURE_CODES.has(value);
+}
+
+export function getOAuthErrorCode(message: unknown): OAuthErrorCode {
+  if (isKnownOAuthErrorCode(message)) {
+    return message;
+  }
+  if (message === 'Email domain not allowed') {
+    return OAuthErrorCodes.OAUTH_EMAIL_DOMAIN_BLOCKED;
+  }
+  if (message === 'Social registration is disabled') {
+    return OAuthErrorCodes.OAUTH_REGISTRATION_DISABLED;
+  }
+  if (message === 'User does not exist') {
+    return OAuthErrorCodes.OAUTH_USER_NOT_FOUND;
+  }
+  if (typeof message === 'string' && message.includes('role to log in')) {
+    return OAuthErrorCodes.OPENID_ROLE_REQUIRED;
+  }
+  return OAuthErrorCodes.AUTH_FAILED;
+}

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,4 +1,5 @@
 export * from './domain';
+export * from './errors';
 export * from './openid';
 export * from './exchange';
 export * from './refresh';

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -1,11 +1,11 @@
 import mongoose, { Types } from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { logger, createMethods, createModels } from '@librechat/data-schemas';
-import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
 import type { CommandStartedEvent } from 'mongodb';
 import type { FilterQuery } from 'mongoose';
 import { recordOpenIDUserLookup } from '~/app/metrics';
+import { OAuthErrorCodes } from './errors';
 import { findOpenIDUser, getOpenIdEmail, getOpenIdIssuer, normalizeOpenIdIssuer } from './openid';
 
 function newId() {
@@ -400,7 +400,7 @@ describe('findOpenIDUser', () => {
 
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
         migration: false,
       });
     });
@@ -425,7 +425,7 @@ describe('findOpenIDUser', () => {
 
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
         migration: false,
       });
     });
@@ -477,7 +477,7 @@ describe('findOpenIDUser', () => {
 
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OPENID_ISSUER_MISMATCH,
         migration: false,
       });
     });
@@ -503,7 +503,7 @@ describe('findOpenIDUser', () => {
 
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OPENID_ISSUER_MISMATCH,
         migration: false,
       });
     });
@@ -589,7 +589,7 @@ describe('findOpenIDUser', () => {
 
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
         migration: false,
       });
     });
@@ -614,7 +614,7 @@ describe('findOpenIDUser', () => {
 
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
         migration: false,
       });
     });
@@ -765,7 +765,7 @@ describe('findOpenIDUser', () => {
       expect(mockFindUser).toHaveBeenCalledWith({ email: 'user@example.com' });
       expect(result).toEqual({
         user: null,
-        error: ErrorTypes.AUTH_FAILED,
+        error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
         migration: false,
       });
     });

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -1,9 +1,9 @@
 import { logger } from '@librechat/data-schemas';
-import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
 import { isMetricsConfigured, recordOpenIDUserLookup } from '~/app/metrics';
 import type { OpenIDUserLookupResult } from '~/app/metrics';
+import { OAuthErrorCodes } from './errors';
 
 export type OpenIdEmailClaims = {
   email?: unknown;
@@ -159,7 +159,7 @@ function resolveIssuerBoundUser(
     logger.warn(
       `[${strategyName}] Rejected ${context} for ${user.email}: stored openidIssuer does not match token issuer`,
     );
-    return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
+    return { user: null, error: OAuthErrorCodes.OPENID_ISSUER_MISMATCH, migration: false };
   }
 
   if (normalizedIssuer && !normalizeOpenIdIssuer(user.openidIssuer)) {
@@ -260,14 +260,22 @@ export async function findOpenIDUser({
         logger.warn(
           `[${strategyName}] Attempted OpenID login by user ${user.email}, was registered with "${user.provider}" provider`,
         );
-        return finish({ user: null, error: ErrorTypes.AUTH_FAILED, migration: false });
+        return finish({
+          user: null,
+          error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
+          migration: false,
+        });
       }
 
       if (user?.openidId && user.openidId !== openidId) {
         logger.warn(
           `[${strategyName}] Rejected email fallback for ${user.email}: stored openidId does not match token sub`,
         );
-        return finish({ user: null, error: ErrorTypes.AUTH_FAILED, migration: false });
+        return finish({
+          user: null,
+          error: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
+          migration: false,
+        });
       }
 
       const emailIssuerResolution = resolveIssuerBoundUser(

--- a/packages/api/src/middleware/error.spec.ts
+++ b/packages/api/src/middleware/error.spec.ts
@@ -2,6 +2,7 @@ import { logger } from '@librechat/data-schemas';
 import { ErrorController } from './error';
 import type { Request, Response } from 'express';
 import type { ValidationError, MongoServerError, CustomError } from '~/types';
+import { OAuthErrorCodes } from '~/auth/errors';
 
 // Mock the logger
 jest.mock('@librechat/data-schemas', () => ({
@@ -24,6 +25,7 @@ describe('ErrorController', () => {
     mockRes = {
       status: jest.fn().mockReturnThis(),
       send: jest.fn(),
+      redirect: jest.fn(),
     } as unknown as Response;
     (logger.error as jest.Mock).mockClear();
     mockNext = jest.fn();
@@ -230,6 +232,65 @@ describe('ErrorController', () => {
       expect(mockRes.status).toHaveBeenCalledWith(500);
       expect(mockRes.send).toHaveBeenCalledWith('An unknown error occurred.');
       expect(logger.error).toHaveBeenCalledWith('ErrorController => error', genericError);
+    });
+  });
+
+  describe('OAuth callback error handling', () => {
+    const originalDomainClient = process.env.DOMAIN_CLIENT;
+
+    beforeEach(() => {
+      process.env.DOMAIN_CLIENT = 'https://client.example.com';
+      mockReq.originalUrl = '/oauth/google/callback';
+    });
+
+    afterEach(() => {
+      if (originalDomainClient == null) {
+        delete process.env.DOMAIN_CLIENT;
+        return;
+      }
+      process.env.DOMAIN_CLIENT = originalDomainClient;
+    });
+
+    it.each([
+      [
+        'code',
+        () =>
+          Object.assign(new Error('provider mismatch'), {
+            code: OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
+          }),
+        OAuthErrorCodes.OAUTH_ACCOUNT_MISMATCH,
+      ],
+      [
+        'message',
+        () => new Error(OAuthErrorCodes.OPENID_ISSUER_MISMATCH),
+        OAuthErrorCodes.OPENID_ISSUER_MISMATCH,
+      ],
+    ])(
+      'redirects known OAuth callback failures by %s with redirect disabled',
+      (_source, buildError, expectedCode) => {
+        const error = buildError() as CustomError;
+
+        ErrorController(error, mockReq, mockRes, mockNext);
+
+        expect(mockRes.redirect).toHaveBeenCalledWith(
+          'https://client.example.com/login?redirect=false&error=auth_failed',
+        );
+        expect(logger.error).toHaveBeenCalledWith('OAuth callback authentication failed', {
+          errorCode: expectedCode,
+          clientErrorCode: 'auth_failed',
+        });
+        expect(mockRes.status).not.toHaveBeenCalled();
+      },
+    );
+
+    it('does not redirect auth failures outside OAuth callbacks', () => {
+      mockReq.originalUrl = '/api/auth/login';
+      const error = new Error('auth_failed');
+
+      ErrorController(error, mockReq, mockRes, mockNext);
+
+      expect(mockRes.redirect).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(500);
     });
   });
 

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -2,6 +2,7 @@ import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { NextFunction, Request, Response } from 'express';
 import type { MongoServerError, ValidationError, CustomError } from '~/types';
+import { isKnownOAuthErrorCode } from '~/auth/errors';
 
 const handleDuplicateKeyError = (err: MongoServerError, res: Response) => {
   logger.warn('Duplicate key error: ' + (err.errmsg || err.message));
@@ -40,6 +41,16 @@ function isCustomError(err: unknown): err is CustomError {
   return err !== null && typeof err === 'object' && 'statusCode' in err && 'body' in err;
 }
 
+function getOAuthErrorCode(error: CustomError): string | null {
+  if (isKnownOAuthErrorCode(error.code)) {
+    return error.code;
+  }
+  if (isKnownOAuthErrorCode(error.message)) {
+    return error.message;
+  }
+  return null;
+}
+
 export const ErrorController = (
   err: Error | CustomError,
   req: Request,
@@ -52,14 +63,24 @@ export const ErrorController = (
     }
     const error = err as CustomError;
 
+    const oauthErrorCode = getOAuthErrorCode(error);
+
     if (
-      (error.message === ErrorTypes.AUTH_FAILED || error.code === ErrorTypes.AUTH_FAILED) &&
-      req.originalUrl &&
-      req.originalUrl.includes('/oauth/') &&
+      oauthErrorCode &&
+      req.originalUrl?.includes('/oauth/') &&
       req.originalUrl.includes('/callback')
     ) {
+      const clientErrorCode = ErrorTypes.AUTH_FAILED;
+      logger.error('OAuth callback authentication failed', {
+        errorCode: oauthErrorCode,
+        clientErrorCode,
+      });
       const domain = process.env.DOMAIN_CLIENT || 'http://localhost:3080';
-      return res.redirect(`${domain}/login?redirect=false&error=${ErrorTypes.AUTH_FAILED}`);
+      const errorUrl = new URL('/login', domain);
+      errorUrl.searchParams.set('redirect', 'false');
+      /** Keep detailed OAuth failure codes server-side; the browser only receives a generic auth error. */
+      errorUrl.searchParams.set('error', clientErrorCode);
+      return res.redirect(errorUrl.toString());
     }
 
     if (isValidationError(error)) {


### PR DESCRIPTION
## Summary

Prevents deterministic OAuth/OpenID failures from looping back into automatic OpenID login.

- adds server-side OAuth/OpenID failure codes for account/provider mismatches, blocked domains, disabled registration, missing users, issuer mismatches, and required-role failures
- preserves those codes in server-side handling and logs while redirecting users with redirect=false and generic error=auth_failed
- disables OpenID auto-redirect whenever the login URL carries an error, so failed auth returns to the login UI instead of immediately retrying
- shows a generic OAuth failure message for callback errors without exposing account/provider mismatch details in the browser URL

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- client: npm run test:ci -- Login.spec.tsx AuthContext.spec.tsx --runInBand
- client: npm run test:ci -- Login.spec.tsx --runInBand
- api: npm run test:ci -- strategies/openIdJwtStrategy.spec.js --runInBand
- api: npm run test:ci -- strategies/openidStrategy.spec.js strategies/socialLogin.test.js server/routes/oauth.error.test.js --runInBand
- packages/api: npx jest src/auth/openid.spec.ts src/middleware/error.spec.ts --runInBand --coverage=false
- eslint: npx eslint --no-error-on-unmatched-pattern --config eslint.config.mjs --max-warnings=0 -- client/src/components/Auth/Login.tsx client/src/components/Auth/__tests__/Login.spec.tsx client/src/hooks/AuthContext.tsx client/src/hooks/__tests__/AuthContext.spec.tsx client/src/hooks/useTimeout.tsx api/server/routes/oauth.js api/server/routes/oauth.error.test.js api/strategies/openidStrategy.js api/strategies/openidStrategy.spec.js api/strategies/socialLogin.js api/strategies/socialLogin.test.js packages/api/src/auth/openid.ts packages/api/src/auth/openid.spec.ts packages/api/src/middleware/error.ts packages/api/src/middleware/error.spec.ts packages/data-provider/src/config.ts

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
