### PR TITLE
Track cache usage by agent

### DIFF
--- a/api/server/controllers/agents/__tests__/modelEndHandler.spec.js
+++ b/api/server/controllers/agents/__tests__/modelEndHandler.spec.js
@@ -22,6 +22,7 @@ const { ModelEndHandler } = require('../callbacks');
 
 const buildGraph = () => ({
   getAgentContext: () => ({
+    agentId: 'agent_insights',
     provider: 'vertexai',
     clientOptions: { model: 'gemini-3.1-flash-lite-preview' },
   }),
@@ -51,6 +52,13 @@ describe('ModelEndHandler — Vertex thoughtSignature capture (issue #13006 foll
 
     expect(collectedThoughtSignatures).toEqual({ tc_a: 'SIG_A', tc_b: 'SIG_B' });
     expect(collectedUsage).toHaveLength(1);
+    expect(collectedUsage[0]).toEqual(
+      expect.objectContaining({
+        agentId: 'agent_insights',
+        model: 'gemini-3.1-flash-lite-preview',
+        provider: 'vertexai',
+      }),
+    );
   });
 
   it('accumulates per-id across multiple model_end events (multi-step tool turn)', async () => {

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -83,15 +83,7 @@ class ModelEndHandler {
       if (!usage) {
         return this.finalize(errorMessage);
       }
-      const modelName = metadata?.ls_model_name || agentContext.clientOptions?.model;
-      if (modelName) {
-        usage.model = modelName;
-      }
-      if (agentContext.provider) {
-        usage.provider = agentContext.provider;
-      }
-
-      const taggedUsage = markSummarizationUsage(usage, metadata);
+      const taggedUsage = tagUsageAttribution(usage, metadata, agentContext);
 
       this.collectedUsage.push(taggedUsage);
 
@@ -1032,6 +1024,40 @@ function markSummarizationUsage(usage, metadata) {
   return usage;
 }
 
+function resolveUsageAgentId(agentContext, metadata) {
+  const candidates = [
+    agentContext?.agentId,
+    agentContext?.id,
+    agentContext?.agent?.id,
+    metadata?.agentId,
+    metadata?.agent_id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  if (checkIfLastAgent(metadata?.last_agent_id, metadata?.langgraph_node)) {
+    return metadata.last_agent_id;
+  }
+  return undefined;
+}
+
+function tagUsageAttribution(usage, metadata, agentContext = {}) {
+  const modelName = metadata?.ls_model_name || agentContext.clientOptions?.model;
+  if (modelName) {
+    usage.model = modelName;
+  }
+  if (agentContext.provider) {
+    usage.provider = agentContext.provider;
+  }
+  const agentId = resolveUsageAgentId(agentContext, metadata);
+  if (agentId) {
+    usage.agentId = agentId;
+  }
+  return markSummarizationUsage(usage, metadata);
+}
+
 const agentLogHandlerObj = { handle: agentLogHandler };
 
 /**
@@ -1067,6 +1093,8 @@ module.exports = {
   createToolEndCallback,
   isStreamWritable,
   markSummarizationUsage,
+  tagUsageAttribution,
+  resolveUsageAgentId,
   buildSummarizationHandlers,
   createResponsesToolEndCallback,
 };

--- a/packages/api/src/agents/transactions.ts
+++ b/packages/api/src/agents/transactions.ts
@@ -27,6 +27,7 @@ export interface PricingFns {
 interface BaseTxData {
   user: string;
   model?: string;
+  agentId?: string;
   context: string;
   messageId?: string;
   conversationId: string;
@@ -76,6 +77,7 @@ export interface StructuredTokenUsage {
 export interface TxMetadata {
   user: string;
   model?: string;
+  agentId?: string;
   context: string;
   messageId?: string;
   conversationId: string;

--- a/packages/api/src/agents/usage.bulk-parity.spec.ts
+++ b/packages/api/src/agents/usage.bulk-parity.spec.ts
@@ -237,6 +237,8 @@ describe('recordCollectedUsage — bulk path parity', () => {
       const result = await recordCollectedUsage(deps, { ...baseParams, collectedUsage });
 
       expect(result?.input_tokens).toBe(140); // 100 + 25 + 15
+      expect(result?.cache_creation_input_tokens).toBe(25);
+      expect(result?.cache_read_input_tokens).toBe(15);
       expect(mockInsertMany).toHaveBeenCalledTimes(1);
       expect(mockSpendStructuredTokens).not.toHaveBeenCalled();
 
@@ -387,7 +389,7 @@ describe('recordCollectedUsage — bulk path parity', () => {
   describe('transaction metadata — doc fields match what legacy would pass to spendTokens', () => {
     it('should pass all metadata fields to docs', async () => {
       const collectedUsage: UsageMetadata[] = [
-        { input_tokens: 100, output_tokens: 50, model: 'gpt-4' },
+        { input_tokens: 100, output_tokens: 50, model: 'gpt-4', agentId: 'agent_insights' },
       ];
       const endpointTokenConfig = { 'gpt-4': { prompt: 0.01, completion: 0.03, context: 8192 } };
 
@@ -403,6 +405,7 @@ describe('recordCollectedUsage — bulk path parity', () => {
         expect(doc.user).toBe('user-123');
         expect(doc.conversationId).toBe('convo-123');
         expect(doc.model).toBe('gpt-4');
+        expect(doc.agentId).toBe('agent_insights');
         expect(doc.context).toBe('message');
         expect(doc.messageId).toBe('msg-123');
       }

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -72,6 +72,30 @@ describe('recordCollectedUsage', () => {
       expect(result).toEqual({ input_tokens: 100, output_tokens: 50 });
     });
 
+    it('passes agentId from usage metadata to token spend metadata', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 100,
+          output_tokens: 50,
+          model: 'claude-sonnet-4-6',
+          agentId: 'agent_insights',
+        },
+      ];
+
+      await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'agent_insights',
+          model: 'claude-sonnet-4-6',
+        }),
+        { promptTokens: 100, completionTokens: 50 },
+      );
+    });
+
     it('should skip null entries in collectedUsage', async () => {
       const collectedUsage = [
         { input_tokens: 100, output_tokens: 50, model: 'gpt-4' },
@@ -361,6 +385,8 @@ describe('recordCollectedUsage', () => {
         },
       );
       expect(result?.input_tokens).toBe(140); // 100 + 25 + 15
+      expect(result?.cache_creation_input_tokens).toBe(25);
+      expect(result?.cache_read_input_tokens).toBe(15);
     });
   });
 
@@ -635,7 +661,12 @@ describe('recordCollectedUsage', () => {
       });
 
       // openAI is a subset provider → input_tokens already includes cache
-      expect(result).toEqual({ input_tokens: 100, output_tokens: 50 });
+      expect(result).toEqual({
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 10,
+      });
     });
   });
 

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -138,6 +138,8 @@ export interface RecordUsageParams {
 export interface RecordUsageResult {
   input_tokens: number;
   output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
 }
 
 /**
@@ -180,6 +182,8 @@ export async function recordCollectedUsage(
   const input_tokens = firstUsage == null ? 0 : splitUsage(firstUsage).totalInput;
 
   let total_output_tokens = 0;
+  let total_cache_creation_input_tokens = 0;
+  let total_cache_read_input_tokens = 0;
 
   const { pricing, bulkWriteOps } = deps;
   const useBulk = pricing && bulkWriteOps;
@@ -197,6 +201,8 @@ export async function recordCollectedUsage(
       const { inputOnly, cacheCreation, cacheRead, completion } = splitUsage(usage);
 
       total_output_tokens += completion;
+      total_cache_creation_input_tokens += cacheCreation;
+      total_cache_read_input_tokens += cacheRead;
 
       const txMetadata: TxMetadata = {
         user,
@@ -207,6 +213,7 @@ export async function recordCollectedUsage(
         endpointTokenConfig,
         context: usageContext,
         model: usage.model ?? model,
+        ...(usage.agentId && { agentId: usage.agentId }),
       };
 
       if (useBulk) {
@@ -283,5 +290,11 @@ export async function recordCollectedUsage(
   return {
     input_tokens,
     output_tokens: total_output_tokens,
+    ...(total_cache_creation_input_tokens > 0 && {
+      cache_creation_input_tokens: total_cache_creation_input_tokens,
+    }),
+    ...(total_cache_read_input_tokens > 0 && {
+      cache_read_input_tokens: total_cache_read_input_tokens,
+    }),
   };
 }

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -78,6 +78,8 @@ export interface UsageMetadata {
   model?: string;
   /** Provider identifier that generated this usage */
   provider?: string;
+  /** Agent identifier that generated this usage */
+  agentId?: string;
   /**
    * OpenAI-style cache token details.
    * Present for OpenAI models (GPT-4, o1, etc.)

--- a/packages/data-schemas/src/schema/transaction.ts
+++ b/packages/data-schemas/src/schema/transaction.ts
@@ -6,6 +6,7 @@ export interface ITransaction extends Document {
   conversationId?: string;
   tokenType: 'prompt' | 'completion' | 'credits';
   model?: string;
+  agentId?: string;
   context?: string;
   valueKey?: string;
   rate?: number;
@@ -39,6 +40,10 @@ const transactionSchema: Schema<ITransaction> = new Schema(
       required: true,
     },
     model: {
+      type: String,
+      index: true,
+    },
+    agentId: {
       type: String,
       index: true,
     },

--- a/packages/data-schemas/src/types/transaction.ts
+++ b/packages/data-schemas/src/types/transaction.ts
@@ -3,6 +3,7 @@ export interface TransactionData {
   conversationId: string;
   tokenType: string;
   model?: string;
+  agentId?: string;
   context?: string;
   valueKey?: string;
   rate?: number;


### PR DESCRIPTION
## What changed

- Tags collected agent usage metadata with the agent id resolved from the graph agent context.
- Persists `agentId` on token transaction documents, including structured prompt cache transactions.
- Carries aggregate `cache_creation_input_tokens` and `cache_read_input_tokens` through `recordCollectedUsage` results when cache tokens are present.
- Adds `agentId` to transaction schema/types and usage metadata types.
- Covers the callback attribution path plus legacy and bulk usage accounting tests.

## Why

Claude prompt caching is already enabled in the Anthropic/Vertex path, but cache write/read spend is hard to attribute back to a specific LibreChat agent. Without agent-level attribution, we cannot safely tell whether high cache-write cost is coming from one large agent, subagent fan-out, summarization, or broad production traffic.

This change makes cache cost analysis actionable by preserving the agent id alongside model/provider/cache token fields in the existing accounting path. That gives us a concrete way to group prompt cache writes and reads per agent before changing TTL or prompt-cache breakpoint behavior.

## Validation

- `git diff --check`
- `npm run build:data-schemas && npm run build:data-provider`
- `npm run build:api` (completed with existing TypeScript warnings)
- `npm exec --workspace packages/api -- jest src/agents/usage.spec.ts src/agents/usage.bulk-parity.spec.ts --runInBand --coverage=false`
- `npm exec --workspace api -- jest server/controllers/agents/__tests__/modelEndHandler.spec.js --runInBand --coverage=false`

Related issue: #13372