### PR TITLE
fix: URL-decode S3 keys for special character support

### DIFF
--- a/packages/api/src/storage/s3/crud.ts
+++ b/packages/api/src/storage/s3/crud.ts
@@ -643,7 +643,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
         (endpointUrl.pathname.endsWith('/') ? 0 : 1) +
         bucketName.length +
         1;
-      const key = url.pathname.substring(startPos);
+      const key = decodeURIComponent(url.pathname.substring(startPos));
       if (!key) {
         logger.warn(
           `[extractKeyFromS3Url] Extracted key is empty for endpoint path-style URL: ${fileUrlOrKey}`,
@@ -661,7 +661,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
     ) {
       const firstSlashIndex = pathname.indexOf('/');
       if (firstSlashIndex > 0) {
-        const key = pathname.substring(firstSlashIndex + 1);
+        const key = decodeURIComponent(pathname.substring(firstSlashIndex + 1));
         if (key === '') {
           logger.warn(
             `[extractKeyFromS3Url] Extracted key is empty after removing bucket name from URL: ${fileUrlOrKey}`,
@@ -679,8 +679,9 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
       return '';
     }
 
-    logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${pathname}`);
-    return pathname;
+    const decodedPathname = decodeURIComponent(pathname);
+    logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${decodedPathname}`);
+    return decodedPathname;
   } catch (error) {
     if (fileUrlOrKey.startsWith('http://') || fileUrlOrKey.startsWith('https://')) {
       logger.error(


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

  `extractKeyFromS3Url` in `packages/api/src/storage/s3/crud.ts` returns the raw URL pathname when parsing an S3 URL into a bucket key. URL pathnames are percent-encoded, so any object key containing characters that get percent-encoded in a URL (spaces, parentheses, non-ASCII characters, `+`, `#`, etc.) is returned with its encoded form (e.g. `My%20File.pdf`) instead of the actual key (`My File.pdf`). Subsequent S3 operations that use that returned key against the SDK — which expects the decoded key — fail with `NoSuchKey` even though the object exists.

  Fix wraps the three return paths in `extractKeyFromS3Url` with `decodeURIComponent`:

  - Endpoint-based path-style URLs (path is `/{bucket}/{key}`)
  - Virtual-hosted-style URLs (`{bucket}.s3...amazonaws.com/{key}`)
  - The fallback that returns the raw pathname when neither path-style nor virtual-hosted matches

No interface change; same function signature, same call sites, same behavior for keys without special characters. The debug log line in the fallback path is updated to show the decoded key so log diagnostics match the value returned.

## Change Type

Please delete any irrelevant options.

- [ x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

1. On a build without this fix:
     - Configured S3 (`fileStrategies.document: s3`, valid credentials).
     - Uploaded a file whose name contains a space, parentheses, or a non-ASCII character (e.g. `Quarterly Report (Q1).pdf`.
     - Attached to a new chat, ran an agent context fetch).
     - Observed a `NoSuchKey` / 404 error in backend logs even though `aws s3 ls s3://<bucket>/<prefix>` shows the object present.
  2. On a build with this fix:
     - Repeat the same upload and operations. The file resolves correctly, no `NoSuchKey` error, and the preview / context fetch succeeds.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

 - [x] My code adheres to this project's style guidelines
 - [x] I have performed a self-review of my own code
 - [x] I have commented in any complex areas of my code
 - [x] My changes do not introduce new warnings
 - [x] Local unit tests pass with my changes
 - [x] Any changes dependent on mine have been merged and published in downstream modules.
