### PR TITLE
🪨 fix: Preserve Bedrock Guardrail Config

### DIFF
--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -29,6 +29,34 @@ describe('excludedKeys', () => {
   });
 });
 
+describe('bedrockEndpointSchema', () => {
+  it('preserves guardrailConfig from configSchema parsing', () => {
+    const guardrailConfig = {
+      guardrailIdentifier: '${BEDROCK_GUARDRAIL_ID}',
+      guardrailVersion: '${BEDROCK_GUARDRAIL_VERSION}',
+      trace: 'enabled_full',
+      streamProcessingMode: 'sync',
+    };
+
+    const result = configSchema.safeParse({
+      version: '1.0',
+      endpoints: {
+        bedrock: {
+          streamRate: 25,
+          availableRegions: ['us-west-2'],
+          guardrailConfig,
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.data.endpoints?.bedrock?.guardrailConfig).toEqual(guardrailConfig);
+  });
+});
+
 describe('resolveEndpointType', () => {
   describe('non-agents endpoints', () => {
     it('returns the config type for a custom endpoint', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -403,10 +403,18 @@ export const baseEndpointSchema = z.object({
 
 export type TBaseEndpoint = z.infer<typeof baseEndpointSchema>;
 
+export const bedrockGuardrailConfigSchema = z.object({
+  guardrailIdentifier: z.string(),
+  guardrailVersion: z.string(),
+  trace: z.enum(['enabled', 'disabled', 'enabled_full']).optional(),
+  streamProcessingMode: z.enum(['sync', 'async']).optional(),
+});
+
 export const bedrockEndpointSchema = baseEndpointSchema.merge(
   z.object({
     availableRegions: z.array(z.string()).optional(),
     models: z.array(z.string()).optional(),
+    guardrailConfig: bedrockGuardrailConfigSchema.optional(),
     inferenceProfiles: z.record(z.string(), z.string()).optional(),
   }),
 );


### PR DESCRIPTION
## Summary

I fixed Bedrock guardrail configuration loading so `guardrailConfig` survives `librechat.yaml` schema parsing and reaches the existing Bedrock initializer path.

- Added a Bedrock guardrail config schema with `guardrailIdentifier`, `guardrailVersion`, `trace`, and `streamProcessingMode` support.
- Preserved `endpoints.bedrock.guardrailConfig` during `configSchema` parsing instead of silently stripping it from YAML config.
- Added a regression test covering YAML-style guardrail config with environment-variable references.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest --runTestsByPath src/config.spec.ts --runInBand --coverage=false --ci` from `packages/data-provider`.
- Ran `npx jest --runTestsByPath src/endpoints/bedrock/initialize.spec.ts --runInBand --coverage=false --ci` from `packages/api`.
- Ran `npm run build` from `packages/data-provider`.
- Verified a local `librechat.yaml` with `endpoints.bedrock.guardrailConfig` now keeps the guardrail config after `configSchema` parsing.

### **Test Configuration**:

- Node.js `v20.19.5`
- Bedrock test guardrail configured locally through ignored `.env` and `librechat.yaml` files

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that this feature works
- [x] Local unit tests pass with my changes