### PR TITLE
♊ feat: Model-Aware Max Output Tokens for Google/Gemini

### DIFF
--- a/client/src/components/Endpoints/Settings/Google.tsx
+++ b/client/src/components/Endpoints/Settings/Google.tsx
@@ -49,6 +49,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   const setTopP = setOption('topP');
   const setTopK = setOption('topK');
   const setMaxOutputTokens = setOption('maxOutputTokens');
+  const maxOutputTokensDefault = google.maxOutputTokens.reset(model ?? '');
 
   return (
     <div className="grid grid-cols-5 gap-6">
@@ -267,7 +268,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
                 <small className="opacity-40">
                   (
                   {localize('com_endpoint_default_with_num', {
-                    0: google.maxOutputTokens.default + '',
+                    0: maxOutputTokensDefault + '',
                   })}
                   )
                 </small>
@@ -292,9 +293,9 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[maxOutputTokens ?? google.maxOutputTokens.default]}
+              value={[maxOutputTokens ?? maxOutputTokensDefault]}
               onValueChange={(value) => setMaxOutputTokens(value[0])}
-              onDoubleClick={() => setMaxOutputTokens(google.maxOutputTokens.default)}
+              onDoubleClick={() => setMaxOutputTokens(maxOutputTokensDefault)}
               max={google.maxOutputTokens.max}
               min={google.maxOutputTokens.min}
               step={google.maxOutputTokens.step}

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -86,7 +86,7 @@ export default function ModelPanel({
     const resolvedParams = defaultParams
       .filter((param) => param != null)
       .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
-    return applyModelAwareDefaults(resolvedParams, endpointType ?? provider, model ?? '');
+    return applyModelAwareDefaults(resolvedParams, overriddenEndpointKey, model ?? '');
   }, [endpointType, endpointsConfig, model, provider]);
 
   const setOption = (optionKey: keyof t.AgentModelParameters) => (value: t.AgentParameterValue) => {

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -11,6 +11,7 @@ import {
   LocalStorageKeys,
   SettingDefinition,
   agentParamSettings,
+  applyModelAwareDefaults,
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';
@@ -82,9 +83,10 @@ export default function ModelPanel({
       agentParamSettings[combinedKey] ?? agentParamSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
     const overriddenParamsMap = keyBy(overriddenParams, 'key');
-    return defaultParams
+    const resolvedParams = defaultParams
       .filter((param) => param != null)
       .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
+    return applyModelAwareDefaults(resolvedParams, endpointType ?? provider, model ?? '');
   }, [endpointType, endpointsConfig, model, provider]);
 
   const setOption = (optionKey: keyof t.AgentModelParameters) => (value: t.AgentParameterValue) => {

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -83,10 +83,14 @@ export default function ModelPanel({
       agentParamSettings[combinedKey] ?? agentParamSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
     const overriddenParamsMap = keyBy(overriddenParams, 'key');
-    const resolvedParams = defaultParams
-      .filter((param) => param != null)
-      .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
-    return applyModelAwareDefaults(resolvedParams, overriddenEndpointKey, model ?? '');
+    const modelAwareParams = applyModelAwareDefaults(
+      defaultParams.filter((param) => param != null),
+      overriddenEndpointKey,
+      model ?? '',
+    );
+    return modelAwareParams.map(
+      (param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param,
+    );
   }, [endpointType, endpointsConfig, model, provider]);
 
   const setOption = (optionKey: keyof t.AgentModelParameters) => (value: t.AgentParameterValue) => {

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -8,6 +8,7 @@ import {
   getEndpointField,
   SettingDefinition,
   tConvoUpdateSchema,
+  applyModelAwareDefaults,
 } from 'librechat-data-provider';
 import type { TPreset } from 'librechat-data-provider';
 import { SaveAsPresetDialog } from '~/components/Endpoints';
@@ -45,9 +46,10 @@ export default function Parameters() {
     const defaultParams = paramSettings[combinedKey] ?? paramSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
     const overriddenParamsMap = keyBy(overriddenParams, 'key');
-    return defaultParams
+    const resolvedParams = defaultParams
       .filter((param) => param != null)
       .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
+    return applyModelAwareDefaults(resolvedParams, endpointType ?? provider, model);
   }, [endpointType, endpointsConfig, model, provider]);
 
   useEffect(() => {

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -49,7 +49,7 @@ export default function Parameters() {
     const resolvedParams = defaultParams
       .filter((param) => param != null)
       .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
-    return applyModelAwareDefaults(resolvedParams, endpointType ?? provider, model);
+    return applyModelAwareDefaults(resolvedParams, overriddenEndpointKey, model);
   }, [endpointType, endpointsConfig, model, provider]);
 
   useEffect(() => {

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -46,10 +46,14 @@ export default function Parameters() {
     const defaultParams = paramSettings[combinedKey] ?? paramSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
     const overriddenParamsMap = keyBy(overriddenParams, 'key');
-    const resolvedParams = defaultParams
-      .filter((param) => param != null)
-      .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
-    return applyModelAwareDefaults(resolvedParams, overriddenEndpointKey, model);
+    const modelAwareParams = applyModelAwareDefaults(
+      defaultParams.filter((param) => param != null),
+      overriddenEndpointKey,
+      model,
+    );
+    return modelAwareParams.map(
+      (param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param,
+    );
   }, [endpointType, endpointsConfig, model, provider]);
 
   useEffect(() => {

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -99,6 +99,40 @@ describe('getGoogleConfig', () => {
     });
   });
 
+  describe('Model-aware maxOutputTokens default', () => {
+    const credentials = {
+      [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+    };
+
+    it('defaults current Gemini models to 65536 when unset', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-2.5-pro' },
+      });
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65536);
+    });
+
+    it('defaults Gemini 3.5 Flash to 65536 when unset', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-3.5-flash' },
+      });
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65536);
+    });
+
+    it('defaults legacy Gemini models to 8192 when unset', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-2.0-flash' },
+      });
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 8192);
+    });
+
+    it('preserves an explicit maxOutputTokens value', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-2.5-pro', maxOutputTokens: 1024 },
+      });
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 1024);
+    });
+  });
+
   describe('Empty String Handling (Issue Fix)', () => {
     it('should remove empty string maxOutputTokens from config', () => {
       const credentials = {

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -103,19 +103,33 @@ describe('getGoogleConfig', () => {
     const credentials = {
       [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
     };
+    const vertexCredentials = {
+      [AuthKeys.GOOGLE_SERVICE_KEY]: {
+        project_id: 'test-project',
+        client_email: 'test@test-project.iam.gserviceaccount.com',
+        private_key: 'test-private-key',
+      },
+    };
 
-    it('defaults current Gemini models to 65536 when unset', () => {
+    it('defaults current Gemini models to 65535 when unset', () => {
       const result = getGoogleConfig(credentials, {
         modelOptions: { model: 'gemini-2.5-pro' },
       });
-      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65536);
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65535);
     });
 
-    it('defaults Gemini 3.5 Flash to 65536 when unset', () => {
+    it('defaults Gemini 3.5 Flash to 65535 when unset', () => {
       const result = getGoogleConfig(credentials, {
         modelOptions: { model: 'gemini-3.5-flash' },
       });
-      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65536);
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65535);
+    });
+
+    it('defaults Gemini image models to 32768 when unset', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-2.5-flash-image' },
+      });
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 32768);
     });
 
     it('defaults legacy Gemini models to 8192 when unset', () => {
@@ -123,6 +137,14 @@ describe('getGoogleConfig', () => {
         modelOptions: { model: 'gemini-2.0-flash' },
       });
       expect(result.llmConfig).toHaveProperty('maxOutputTokens', 8192);
+    });
+
+    it('keeps the Vertex default within the model output limit', () => {
+      const result = getGoogleConfig(vertexCredentials, {
+        modelOptions: { model: 'gemini-2.5-flash' },
+      });
+      expect(result.provider).toBe(Providers.VERTEXAI);
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65535);
     });
 
     it('preserves an explicit maxOutputTokens value', () => {

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -153,6 +153,22 @@ describe('getGoogleConfig', () => {
       });
       expect(result.llmConfig).toHaveProperty('maxOutputTokens', 1024);
     });
+
+    it('lets a configured defaultParams maxOutputTokens take precedence over the model default', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-2.5-pro' },
+        defaultParams: { maxOutputTokens: 2048 },
+      });
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 2048);
+    });
+
+    it('omits maxOutputTokens when listed in dropParams', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-2.5-pro' },
+        dropParams: ['maxOutputTokens'],
+      });
+      expect(result.llmConfig).not.toHaveProperty('maxOutputTokens');
+    });
   });
 
   describe('Empty String Handling (Issue Fix)', () => {

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -169,6 +169,15 @@ describe('getGoogleConfig', () => {
       });
       expect(result.llmConfig).not.toHaveProperty('maxOutputTokens');
     });
+
+    it('bases the default on the final model after an addParams override', () => {
+      const result = getGoogleConfig(credentials, {
+        modelOptions: { model: 'gemini-1.5-flash' },
+        addParams: { model: 'gemini-2.5-pro' },
+      });
+      expect(result.llmConfig).toHaveProperty('model', 'gemini-2.5-pro');
+      expect(result.llmConfig).toHaveProperty('maxOutputTokens', 65535);
+    });
   });
 
   describe('Empty String Handling (Issue Fix)', () => {

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -360,7 +360,9 @@ export function getGoogleConfig(
       topP: modelOptions?.topP ?? undefined,
       topK: modelOptions?.topK ?? undefined,
       temperature: modelOptions?.temperature ?? undefined,
-      maxOutputTokens: modelOptions?.maxOutputTokens ?? undefined,
+      maxOutputTokens:
+        modelOptions?.maxOutputTokens ??
+        googleSettings.maxOutputTokens.reset(modelOptions?.model ?? ''),
     },
     true,
   ) as GoogleClientOptions | VertexAIClientOptions;

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -360,9 +360,7 @@ export function getGoogleConfig(
       topP: modelOptions?.topP ?? undefined,
       topK: modelOptions?.topK ?? undefined,
       temperature: modelOptions?.temperature ?? undefined,
-      maxOutputTokens:
-        modelOptions?.maxOutputTokens ??
-        googleSettings.maxOutputTokens.reset(modelOptions?.model ?? ''),
+      maxOutputTokens: modelOptions?.maxOutputTokens ?? undefined,
     },
     true,
   ) as GoogleClientOptions | VertexAIClientOptions;
@@ -533,6 +531,25 @@ export function getGoogleConfig(
         delete (llmConfig as Record<string, unknown>)[param];
       }
     });
+  }
+
+  /**
+   * Apply the model-aware `maxOutputTokens` default last, so an explicit value,
+   * `defaultParams`, and `addParams` all take precedence and a `dropParams` entry
+   * is respected. Only fill in when the field is genuinely unset (`undefined`/`null`);
+   * an empty-string value stays stripped per Gemini empty-payload handling. Without
+   * this, current Gemini models would inherit the legacy 8K default instead of their
+   * documented limit.
+   */
+  const maxOutputDropped =
+    Array.isArray(options.dropParams) && options.dropParams.includes('maxOutputTokens');
+  if (
+    !maxOutputDropped &&
+    modelOptions?.maxOutputTokens == null &&
+    (llmConfig as Record<string, unknown>).maxOutputTokens == null
+  ) {
+    (llmConfig as GoogleClientOptions).maxOutputTokens =
+      googleSettings.maxOutputTokens.reset(modelName);
   }
 
   applyGemini35FlashOverrides({

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -548,8 +548,9 @@ export function getGoogleConfig(
     modelOptions?.maxOutputTokens == null &&
     (llmConfig as Record<string, unknown>).maxOutputTokens == null
   ) {
+    const resolvedModel = (llmConfig as { model?: string }).model || modelName;
     (llmConfig as GoogleClientOptions).maxOutputTokens =
-      googleSettings.maxOutputTokens.reset(modelName);
+      googleSettings.maxOutputTokens.reset(resolvedModel);
   }
 
   applyGemini35FlashOverrides({

--- a/packages/data-provider/src/generate.ts
+++ b/packages/data-provider/src/generate.ts
@@ -614,7 +614,9 @@ export const generateGoogleSchema = (customGoogle: GoogleSettings) => {
         promptPrefix: obj.promptPrefix ?? null,
         examples: obj.examples ?? [{ input: { content: '' }, output: { content: '' } }],
         temperature: obj.temperature ?? defaults.temperature.default,
-        maxOutputTokens: obj.maxOutputTokens ?? defaults.maxOutputTokens.default,
+        maxOutputTokens:
+          obj.maxOutputTokens ??
+          defaults.maxOutputTokens.reset(obj.model ?? defaults.model.default),
         topP: obj.topP ?? defaults.topP.default,
         topK: obj.topK ?? defaults.topK.default,
         maxContextTokens: obj.maxContextTokens ?? undefined,

--- a/packages/data-provider/src/parameterSettings.spec.ts
+++ b/packages/data-provider/src/parameterSettings.spec.ts
@@ -1,0 +1,57 @@
+import { EModelEndpoint } from './types';
+import { applyModelAwareDefaults, paramSettings } from './parameterSettings';
+import type { SettingDefinition } from './generate';
+
+const googleParams = paramSettings[EModelEndpoint.google] as SettingDefinition[];
+const maxOut = (params: SettingDefinition[]) => params.find((p) => p.key === 'maxOutputTokens');
+
+describe('applyModelAwareDefaults', () => {
+  it('resolves the Google maxOutputTokens default for current Gemini models', () => {
+    const result = applyModelAwareDefaults(googleParams, EModelEndpoint.google, 'gemini-2.5-pro');
+    expect(maxOut(result)?.default).toBe(65535);
+  });
+
+  it('resolves the legacy default for older Gemini models', () => {
+    const result = applyModelAwareDefaults(googleParams, EModelEndpoint.google, 'gemini-1.5-flash');
+    expect(maxOut(result)?.default).toBe(8192);
+  });
+
+  it('resolves the image default for Gemini image models', () => {
+    const result = applyModelAwareDefaults(
+      googleParams,
+      EModelEndpoint.google,
+      'gemini-2.5-flash-image',
+    );
+    expect(maxOut(result)?.default).toBe(32768);
+  });
+
+  it('returns settings unchanged for non-Google endpoints', () => {
+    const result = applyModelAwareDefaults(
+      googleParams,
+      EModelEndpoint.anthropic,
+      'gemini-2.5-pro',
+    );
+    expect(result).toBe(googleParams);
+  });
+
+  it('returns settings unchanged when no model is provided', () => {
+    expect(applyModelAwareDefaults(googleParams, EModelEndpoint.google, '')).toBe(googleParams);
+  });
+
+  it('does not mutate the original settings', () => {
+    const before = maxOut(googleParams)?.default;
+    applyModelAwareDefaults(googleParams, EModelEndpoint.google, 'gemini-2.5-pro');
+    expect(maxOut(googleParams)?.default).toBe(before);
+  });
+
+  it('lets a configured override applied afterward take precedence', () => {
+    const modelAware = applyModelAwareDefaults(
+      googleParams,
+      EModelEndpoint.google,
+      'gemini-2.5-pro',
+    );
+    const override = { ...maxOut(modelAware), default: 2048 } as SettingDefinition;
+    const final = modelAware.map((p) => (p.key === 'maxOutputTokens' ? override : p));
+    expect(maxOut(final)?.default).toBe(2048);
+  });
+});

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -1141,3 +1141,23 @@ export const agentParamSettings: Record<string, SettingsConfiguration | undefine
   }
   return acc;
 }, {});
+
+/**
+ * Resolves model-aware defaults for a settings configuration before rendering.
+ * Google's `maxOutputTokens` default depends on the selected Gemini model so that
+ * current models (2.5 and 3+) surface their 64K output limit instead of the legacy 8K value.
+ */
+export function applyModelAwareDefaults(
+  settings: SettingsConfiguration,
+  endpoint: string,
+  model?: string,
+): SettingsConfiguration {
+  if (endpoint !== EModelEndpoint.google || !model) {
+    return settings;
+  }
+  return settings.map((setting) =>
+    setting.key === 'maxOutputTokens'
+      ? { ...setting, default: googleSettings.maxOutputTokens.reset(model) }
+      : setting,
+  );
+}

--- a/packages/data-provider/src/schemas.spec.ts
+++ b/packages/data-provider/src/schemas.spec.ts
@@ -1,4 +1,10 @@
-import { AnthropicEffort, anthropicSettings, eAnthropicEffortSchema } from './schemas';
+import {
+  AnthropicEffort,
+  googleSettings,
+  anthropicSettings,
+  compactGoogleSchema,
+  eAnthropicEffortSchema,
+} from './schemas';
 
 describe('anthropicSettings', () => {
   describe('maxOutputTokens.reset()', () => {
@@ -350,6 +356,101 @@ describe('anthropicSettings', () => {
       it('should allow 128K exactly', () => {
         expect(set(128000, 'claude-3-opus')).toBe(128000);
       });
+    });
+  });
+});
+
+describe('googleSettings', () => {
+  describe('maxOutputTokens.reset()', () => {
+    const { reset } = googleSettings.maxOutputTokens;
+
+    describe('current Gemini text models (64K)', () => {
+      it.each([
+        'gemini-2.5-pro',
+        'gemini-2.5-flash',
+        'gemini-2.5-flash-lite',
+        'gemini-2.5-flash-image',
+        'gemini-2.5-pro-preview-05-06',
+        'gemini-3',
+        'gemini-3-pro',
+        'gemini-3.1',
+        'gemini-3.1-flash-lite',
+        'gemini-3.5-flash',
+        'models/gemini-3.5-flash',
+        'gemini-4-pro',
+        'gemini-10-flash',
+      ])('returns 65536 for %s', (model) => {
+        expect(reset(model)).toBe(65536);
+      });
+    });
+
+    describe('legacy/deprecated Gemini and Gemma models (8K)', () => {
+      it.each([
+        'gemini',
+        'gemini-pro',
+        'gemini-pro-vision',
+        'gemini-1.0-pro',
+        'gemini-1.5-pro',
+        'gemini-1.5-flash',
+        'gemini-1.5-flash-latest',
+        'gemini-1.5-flash-8b',
+        'gemini-2.0-flash',
+        'gemini-2.0-flash-lite',
+        'gemini-exp-1206',
+        'gemma-3-27b',
+      ])('returns 8192 for %s', (model) => {
+        expect(reset(model)).toBe(8192);
+      });
+    });
+  });
+
+  describe('maxOutputTokens.set()', () => {
+    const { set } = googleSettings.maxOutputTokens;
+
+    it('caps current Gemini models at 65536', () => {
+      expect(set(100000, 'gemini-2.5-pro')).toBe(65536);
+      expect(set(100000, 'gemini-3.5-flash')).toBe(65536);
+    });
+
+    it('allows values within the current 64K limit', () => {
+      expect(set(32000, 'gemini-2.5-flash')).toBe(32000);
+      expect(set(65536, 'gemini-3.5-flash')).toBe(65536);
+    });
+
+    it('caps legacy Gemini models at 8192', () => {
+      expect(set(65536, 'gemini-2.0-flash')).toBe(8192);
+      expect(set(20000, 'gemini-1.5-flash')).toBe(8192);
+    });
+
+    it('allows values within the legacy 8K limit', () => {
+      expect(set(4096, 'gemini-1.5-flash')).toBe(4096);
+      expect(set(8192, 'gemini-2.0-flash')).toBe(8192);
+    });
+  });
+
+  describe('compactGoogleSchema (model-aware maxOutputTokens)', () => {
+    it('strips the model default for current Gemini models', () => {
+      const result = compactGoogleSchema.parse({
+        model: 'gemini-2.5-pro',
+        maxOutputTokens: 65536,
+      });
+      expect(result.maxOutputTokens).toBeUndefined();
+    });
+
+    it('preserves a deliberate below-default value for current Gemini models', () => {
+      const result = compactGoogleSchema.parse({
+        model: 'gemini-2.5-pro',
+        maxOutputTokens: 8192,
+      });
+      expect(result.maxOutputTokens).toBe(8192);
+    });
+
+    it('strips the legacy default for legacy Gemini models', () => {
+      const result = compactGoogleSchema.parse({
+        model: 'gemini-1.5-flash',
+        maxOutputTokens: 8192,
+      });
+      expect(result.maxOutputTokens).toBeUndefined();
     });
   });
 });

--- a/packages/data-provider/src/schemas.spec.ts
+++ b/packages/data-provider/src/schemas.spec.ts
@@ -364,12 +364,11 @@ describe('googleSettings', () => {
   describe('maxOutputTokens.reset()', () => {
     const { reset } = googleSettings.maxOutputTokens;
 
-    describe('current Gemini text models (64K)', () => {
+    describe('current Gemini text models (64K, Vertex-safe)', () => {
       it.each([
         'gemini-2.5-pro',
         'gemini-2.5-flash',
         'gemini-2.5-flash-lite',
-        'gemini-2.5-flash-image',
         'gemini-2.5-pro-preview-05-06',
         'gemini-3',
         'gemini-3-pro',
@@ -379,8 +378,14 @@ describe('googleSettings', () => {
         'models/gemini-3.5-flash',
         'gemini-4-pro',
         'gemini-10-flash',
-      ])('returns 65536 for %s', (model) => {
-        expect(reset(model)).toBe(65536);
+      ])('returns 65535 for %s', (model) => {
+        expect(reset(model)).toBe(65535);
+      });
+    });
+
+    describe('Gemini image models (32K)', () => {
+      it.each(['gemini-2.5-flash-image', 'gemini-3-pro-image'])('returns 32768 for %s', (model) => {
+        expect(reset(model)).toBe(32768);
       });
     });
 
@@ -407,18 +412,23 @@ describe('googleSettings', () => {
   describe('maxOutputTokens.set()', () => {
     const { set } = googleSettings.maxOutputTokens;
 
-    it('caps current Gemini models at 65536', () => {
-      expect(set(100000, 'gemini-2.5-pro')).toBe(65536);
-      expect(set(100000, 'gemini-3.5-flash')).toBe(65536);
+    it('caps current Gemini models at 65535', () => {
+      expect(set(100000, 'gemini-2.5-pro')).toBe(65535);
+      expect(set(100000, 'gemini-3.5-flash')).toBe(65535);
     });
 
     it('allows values within the current 64K limit', () => {
       expect(set(32000, 'gemini-2.5-flash')).toBe(32000);
-      expect(set(65536, 'gemini-3.5-flash')).toBe(65536);
+      expect(set(65535, 'gemini-3.5-flash')).toBe(65535);
+    });
+
+    it('caps Gemini image models at 32768', () => {
+      expect(set(65535, 'gemini-2.5-flash-image')).toBe(32768);
+      expect(set(32768, 'gemini-2.5-flash-image')).toBe(32768);
     });
 
     it('caps legacy Gemini models at 8192', () => {
-      expect(set(65536, 'gemini-2.0-flash')).toBe(8192);
+      expect(set(65535, 'gemini-2.0-flash')).toBe(8192);
       expect(set(20000, 'gemini-1.5-flash')).toBe(8192);
     });
 
@@ -432,7 +442,7 @@ describe('googleSettings', () => {
     it('strips the model default for current Gemini models', () => {
       const result = compactGoogleSchema.parse({
         model: 'gemini-2.5-pro',
-        maxOutputTokens: 65536,
+        maxOutputTokens: 65535,
       });
       expect(result.maxOutputTokens).toBeUndefined();
     });

--- a/packages/data-provider/src/schemas.spec.ts
+++ b/packages/data-provider/src/schemas.spec.ts
@@ -401,6 +401,7 @@ describe('googleSettings', () => {
         'gemini-1.5-flash-8b',
         'gemini-2.0-flash',
         'gemini-2.0-flash-lite',
+        'gemini-2.0-flash-preview-image-generation',
         'gemini-exp-1206',
         'gemma-3-27b',
       ])('returns 8192 for %s', (model) => {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -366,15 +366,35 @@ export const openAISettings = {
   },
 };
 
+const GOOGLE_MAX_OUTPUT = 65536 as const;
+const GOOGLE_LEGACY_MAX_OUTPUT = 8192 as const;
+
+/**
+ * Resolves the documented max output-token limit for a Google/Gemini model.
+ * Current Gemini text models (2.5 and 3+) support 64K output tokens, while
+ * legacy/deprecated models (2.0 and earlier) and Gemma retain the 8K limit.
+ */
+const getGoogleMaxOutputTokens = (modelName: string): number => {
+  if (/gemini-(?:2\.5|[3-9]|\d{2,})/i.test(modelName)) {
+    return GOOGLE_MAX_OUTPUT;
+  }
+  return GOOGLE_LEGACY_MAX_OUTPUT;
+};
+
 export const googleSettings = {
   model: {
     default: 'gemini-1.5-flash-latest' as const,
   },
   maxOutputTokens: {
     min: 1 as const,
-    max: 65536 as const,
+    max: GOOGLE_MAX_OUTPUT,
     step: 1 as const,
-    default: 8192 as const,
+    default: GOOGLE_LEGACY_MAX_OUTPUT,
+    reset: (modelName: string): number => getGoogleMaxOutputTokens(modelName),
+    set: (value: number, modelName: string): number => {
+      const max = getGoogleMaxOutputTokens(modelName);
+      return value > max ? max : value;
+    },
   },
   temperature: {
     min: 0 as const,
@@ -1265,7 +1285,7 @@ export const compactGoogleSchema = googleBaseSchema
     if (newObj.temperature === google.temperature.default) {
       delete newObj.temperature;
     }
-    if (newObj.maxOutputTokens === google.maxOutputTokens.default) {
+    if (newObj.maxOutputTokens === google.maxOutputTokens.reset(newObj.model ?? '')) {
       delete newObj.maxOutputTokens;
     }
     if (newObj.topP === google.topP.default) {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -366,15 +366,25 @@ export const openAISettings = {
   },
 };
 
-const GOOGLE_MAX_OUTPUT = 65536 as const;
+/**
+ * `65535` (not 65536) is the value valid on both Google AI Studio and Vertex AI:
+ * Vertex caps current Gemini text models at 65,535 output tokens, so defaulting to
+ * 65,536 would make otherwise-default Vertex requests fail validation.
+ */
+const GOOGLE_MAX_OUTPUT = 65535 as const;
+const GOOGLE_IMAGE_MAX_OUTPUT = 32768 as const;
 const GOOGLE_LEGACY_MAX_OUTPUT = 8192 as const;
 
 /**
  * Resolves the documented max output-token limit for a Google/Gemini model.
- * Current Gemini text models (2.5 and 3+) support 64K output tokens, while
- * legacy/deprecated models (2.0 and earlier) and Gemma retain the 8K limit.
+ * Current Gemini text models (2.5 and 3+) support 64K output tokens; image models
+ * (e.g. `gemini-2.5-flash-image`) cap at 32K; legacy/deprecated models (2.0 and
+ * earlier) and Gemma retain the 8K limit.
  */
 const getGoogleMaxOutputTokens = (modelName: string): number => {
+  if (/gemini-.*image/i.test(modelName)) {
+    return GOOGLE_IMAGE_MAX_OUTPUT;
+  }
   if (/gemini-(?:2\.5|[3-9]|\d{2,})/i.test(modelName)) {
     return GOOGLE_MAX_OUTPUT;
   }

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -377,15 +377,15 @@ const GOOGLE_LEGACY_MAX_OUTPUT = 8192 as const;
 
 /**
  * Resolves the documented max output-token limit for a Google/Gemini model.
- * Current Gemini text models (2.5 and 3+) support 64K output tokens; image models
- * (e.g. `gemini-2.5-flash-image`) cap at 32K; legacy/deprecated models (2.0 and
- * earlier) and Gemma retain the 8K limit.
+ * Current Gemini text models (2.5 and 3+) support 64K output tokens; their image
+ * variants (e.g. `gemini-2.5-flash-image`) cap at 32K; legacy/deprecated models
+ * (2.0 and earlier, including legacy image models) and Gemma retain the 8K limit.
  */
 const getGoogleMaxOutputTokens = (modelName: string): number => {
-  if (/gemini-.*image/i.test(modelName)) {
-    return GOOGLE_IMAGE_MAX_OUTPUT;
-  }
   if (/gemini-(?:2\.5|[3-9]|\d{2,})/i.test(modelName)) {
+    if (/image/i.test(modelName)) {
+      return GOOGLE_IMAGE_MAX_OUTPUT;
+    }
     return GOOGLE_MAX_OUTPUT;
   }
   return GOOGLE_LEGACY_MAX_OUTPUT;


### PR DESCRIPTION
## Summary

Resolves #13384. Current Gemini text models (2.5 and 3+, including the newly released Gemini 3.5 Flash) support 64K output tokens, but LibreChat defaulted every Google model to the legacy `8192` value — most visibly in the Agents model-parameter panel, where modern Gemini agents appeared far more limited than the underlying model actually is. I made the Google `maxOutputTokens` default model-aware, mirroring the existing Anthropic `reset`/`set` pattern.

- Added model-aware `reset(model)` and `set(value, model)` to `googleSettings.maxOutputTokens`: current Gemini text models (`2.5`, `3`, `3.x`, and newer) resolve to `65536`, while legacy/deprecated models (`2.0` and earlier) and Gemma retain `8192`.
- Resolved the default server-side in `getGoogleConfig`, so a request without an explicit value receives the model's documented limit (matching `anthropic/llm.ts`).
- Added a shared `applyModelAwareDefaults` helper and wired it into the Agents (`ModelPanel`), preset/conversation (`Parameters/Panel`), and standard Google settings panels so the displayed default reflects the selected model.
- Made `compactGoogleSchema` and `generateGoogleSchema` model-aware, so a deliberate user value (e.g. `8192` on a modern model) is preserved instead of being stripped and reset to the new default.
- Verified Gemini 3.5 Flash is fully recognized: it already carried the correct context window, pricing, default-model-list, vision, and thinking-level handling, and now resolves to its `65536` output limit.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I verified the change end-to-end with unit tests across the affected workspaces plus a standalone check of the model-matching regex.

- `packages/data-provider`: added `googleSettings.maxOutputTokens.reset()/set()` and `compactGoogleSchema` cases (Gemini 1.5/2.0 → `8192`; 2.5/3/3.1/3.5-flash/4+ → `65536`; deliberate sub-default values preserved). Schema, parser, and config suites pass.
- `packages/api`: added `getGoogleConfig` cases (defaults `gemini-2.5-pro` and `gemini-3.5-flash` to `65536`, `gemini-2.0-flash` to `8192`, preserves explicit values). All 74 `endpoints/google/llm` tests pass.
- `client`: `buildDefaultConvo` and `cleanupPreset` suites pass; `tsc --noEmit` reports no errors in the changed files.

### **Test Configuration**:

- Node 20; monorepo Jest run per workspace (`npx jest` in `packages/data-provider`, `packages/api`, and `client`).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
