### PR TITLE
Fix Agent endpoint maxContextTokens fallback

### DIFF
--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -666,6 +666,144 @@ describe('initializeAgent — maxContextTokens', () => {
     expect(result.maxContextTokens).toBe(userValue);
   });
 
+  it('uses endpoint-level maxContextTokens when initial model_parameters omit it', async () => {
+    const endpointValue = 64000;
+    const { agent, req, res, loadTools, db } = createMocks({
+      maxContextTokens: undefined,
+      modelDefault: 200000,
+      maxOutputTokens: 4096,
+    });
+    mockExtractLibreChatParams.mockImplementation(realUtils.extractLibreChatParams);
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: {
+          endpoint: EModelEndpoint.agents,
+          maxContextTokens: endpointValue,
+          model_parameters: { model: 'custom-long-context-model' },
+        },
+        allowedProviders: new Set([Providers.OPENAI]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    expect(mockExtractLibreChatParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'custom-long-context-model',
+        maxContextTokens: endpointValue,
+      }),
+    );
+    expect(result.maxContextTokens).toBe(endpointValue);
+  });
+
+  it('keeps model_parameters maxContextTokens ahead of endpoint-level fallback', async () => {
+    const endpointValue = 128000;
+    const modelParameterValue = 64000;
+    const { agent, req, res, loadTools, db } = createMocks({
+      maxContextTokens: undefined,
+      modelDefault: 200000,
+      maxOutputTokens: 4096,
+    });
+    mockExtractLibreChatParams.mockImplementation(realUtils.extractLibreChatParams);
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: {
+          endpoint: EModelEndpoint.agents,
+          maxContextTokens: endpointValue,
+          model_parameters: {
+            model: 'custom-long-context-model',
+            maxContextTokens: modelParameterValue,
+          },
+        },
+        allowedProviders: new Set([Providers.OPENAI]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    expect(mockExtractLibreChatParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'custom-long-context-model',
+        maxContextTokens: modelParameterValue,
+      }),
+    );
+    expect(result.maxContextTokens).toBe(modelParameterValue);
+  });
+
+  it('ignores nullish model_parameters maxContextTokens when endpoint-level fallback is set', async () => {
+    const endpointValue = 64000;
+    const { agent, req, res, loadTools, db } = createMocks({
+      maxContextTokens: undefined,
+      modelDefault: 200000,
+      maxOutputTokens: 4096,
+    });
+    mockExtractLibreChatParams.mockImplementation(realUtils.extractLibreChatParams);
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: {
+          endpoint: EModelEndpoint.agents,
+          maxContextTokens: endpointValue,
+          model_parameters: {
+            model: 'custom-long-context-model',
+            maxContextTokens: undefined,
+          },
+        },
+        allowedProviders: new Set([Providers.OPENAI]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    expect(result.maxContextTokens).toBe(endpointValue);
+  });
+
+  it('does not apply endpoint-level maxContextTokens to non-initial agents', async () => {
+    const endpointValue = 64000;
+    const modelDefault = 200000;
+    const maxOutputTokens = 4096;
+    const { agent, req, res, loadTools, db } = createMocks({
+      maxContextTokens: undefined,
+      modelDefault,
+      maxOutputTokens,
+    });
+    mockExtractLibreChatParams.mockImplementation(realUtils.extractLibreChatParams);
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: {
+          endpoint: EModelEndpoint.agents,
+          maxContextTokens: endpointValue,
+          model_parameters: { model: 'custom-long-context-model' },
+        },
+        allowedProviders: new Set([Providers.OPENAI]),
+        isInitialAgent: false,
+      },
+      db,
+    );
+
+    const expected = Math.round((modelDefault - maxOutputTokens) * 0.95);
+    expect(result.maxContextTokens).toBe(expected);
+  });
+
   it('falls back to formula when maxContextTokens is NOT provided', async () => {
     const modelDefault = 200000;
     const maxOutputTokens = 4096;

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -462,11 +462,21 @@ export async function initializeAgent(
 
   let currentFiles: IMongoFile[] | undefined;
 
+  const endpointModelOptions =
+    isInitialAgent === true ? (endpointOption?.model_parameters ?? {}) : {};
+  const agentModelOptions = agent.model_parameters ?? { model: agent.model };
+  const resolvedMaxContextTokens = optionalChainWithEmptyCheck(
+    endpointModelOptions.maxContextTokens as number | undefined,
+    agentModelOptions.maxContextTokens as number | undefined,
+    isInitialAgent === true ? endpointOption?.maxContextTokens : undefined,
+  );
+
   const _modelOptions = structuredClone(
     Object.assign(
       { model: agent.model },
-      agent.model_parameters ?? { model: agent.model },
-      isInitialAgent === true ? endpointOption?.model_parameters : {},
+      agentModelOptions,
+      endpointModelOptions,
+      resolvedMaxContextTokens != null ? { maxContextTokens: resolvedMaxContextTokens } : {},
     ),
   );
 


### PR DESCRIPTION
## Summary

Fixes an Agent initialization path where an endpoint-level `maxContextTokens` value could be dropped before `extractLibreChatParams` runs.

When a custom long-context endpoint provides `maxContextTokens` at the endpoint level, but the initial request `model_parameters` omit it, the Agent path could fall back to the default context budget for models not present in the built-in token map. For example, a custom endpoint intended to use a 1M-class model with a 64K+ per-request context budget could be reduced to the default budget path.

This change resolves `maxContextTokens` before building `_modelOptions`, preserving the intended precedence:

1. `endpointOption.model_parameters.maxContextTokens`
2. `agent.model_parameters.maxContextTokens`
3. `endpointOption.maxContextTokens` for the initial agent

It also ignores nullish model-parameter values so they do not erase the endpoint-level fallback.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm --workspace packages/api run test:ci -- --runTestsByPath src/agents/__tests__/initialize.test.ts --runInBand --coverage=false`

### **Test Configuration**:

- OS: Windows
- Node.js: v24.15.0
- npm: 11.12.1

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes