### PR TITLE
🪪 feat: Accept Multiple OpenID JWT Audiences

### DIFF
--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -15,7 +15,11 @@ const {
 const { updateUser, findUser } = require('~/models');
 
 const getOpenIdJwtAudience = () => {
-  const audiences = [process.env.OPENID_CLIENT_ID, process.env.OPENID_AUDIENCE].filter(Boolean);
+  const parsedAudience = (process.env.OPENID_AUDIENCE ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const audiences = [process.env.OPENID_CLIENT_ID, ...parsedAudience].filter(Boolean);
   const uniqueAudiences = [...new Set(audiences)];
 
   return uniqueAudiences.length > 1 ? uniqueAudiences : uniqueAudiences[0];

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -119,6 +119,52 @@ describe('openIdJwtStrategy – token validation', () => {
     });
   });
 
+  it('uses a single OPENID_AUDIENCE value when no client ID is configured', () => {
+    withEnv({ OPENID_CLIENT_ID: undefined, OPENID_AUDIENCE: 'librechat' }, () => {
+      openIdJwtLogin(mockOpenIdConfig);
+    });
+
+    expect(capturedStrategyOptions.audience).toBe('librechat');
+  });
+
+  it('splits comma-separated OPENID_AUDIENCE values into multiple accepted audiences', () => {
+    withEnv({ OPENID_CLIENT_ID: undefined, OPENID_AUDIENCE: 'librechat,control-plane-web' }, () => {
+      openIdJwtLogin(mockOpenIdConfig);
+    });
+
+    expect(capturedStrategyOptions.audience).toEqual(['librechat', 'control-plane-web']);
+  });
+
+  it('trims whitespace around comma-separated OPENID_AUDIENCE values', () => {
+    withEnv(
+      { OPENID_CLIENT_ID: undefined, OPENID_AUDIENCE: ' librechat , control-plane-web ' },
+      () => {
+        openIdJwtLogin(mockOpenIdConfig);
+      },
+    );
+
+    expect(capturedStrategyOptions.audience).toEqual(['librechat', 'control-plane-web']);
+  });
+
+  it('falls back to OPENID_CLIENT_ID when OPENID_AUDIENCE is empty', () => {
+    withEnv({ OPENID_CLIENT_ID: 'client-id-only', OPENID_AUDIENCE: '' }, () => {
+      openIdJwtLogin(mockOpenIdConfig);
+    });
+
+    expect(capturedStrategyOptions.audience).toBe('client-id-only');
+  });
+
+  it('combines OPENID_CLIENT_ID with comma-separated OPENID_AUDIENCE values and deduplicates', () => {
+    withEnv(
+      { OPENID_CLIENT_ID: 'librechat', OPENID_AUDIENCE: 'librechat,control-plane-web' },
+      () => {
+        openIdJwtLogin(mockOpenIdConfig);
+      },
+    );
+
+    expect(capturedStrategyOptions.audience).toEqual(['librechat', 'control-plane-web']);
+  });
+
   it('rejects OpenID JWTs whose issuer does not match the configured issuer', async () => {
     findOpenIDUser.mockResolvedValue({ user: null, error: null, migration: false });
     openIdJwtLogin(mockOpenIdConfig);


### PR DESCRIPTION
## Summary

I ported Alexey Korepanov's ClickHouse LibreChat change for multiple OpenID JWT audiences into upstream LibreChat. The original commit could not be reused byte-for-byte because it is based on ClickHouse fork history and includes CHC-only context, so I preserved Alexey as the commit author and adapted the generic OpenID audience parsing/tests to current `main`.

- Parse `OPENID_AUDIENCE` as a comma-separated list with whitespace trimming and empty-value filtering.
- Preserve the existing `OPENID_CLIENT_ID` fallback and deduplicate combined client/audience values before passing them to `passport-jwt`.
- Add upstream spec coverage for single audience values, comma-separated audiences, whitespace tolerance, empty audience fallback, and deduplication.
- Reference the source ClickHouse change: https://github.com/ClickHouse/LibreChat/commit/2e8f9f541d3616a89c75c8bc91d50fe1cae0cb16.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npm run smart-reinstall` to install dependencies and build the workspace.
- Ran `npx turbo run build --filter=@librechat/data-schemas --filter=@librechat/api --force` so Jest could resolve built workspace packages.
- Ran `npx prettier --check api/strategies/openIdJwtStrategy.js api/strategies/openIdJwtStrategy.spec.js`.
- Ran `npx eslint api/strategies/openIdJwtStrategy.js api/strategies/openIdJwtStrategy.spec.js`.
- Ran `cd api && npx jest strategies/openIdJwtStrategy.spec.js --runInBand`.

### **Test Configuration**:

- Node.js: v20.19.5
- npm: 10.8.2
- macOS local worktree

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes