### PR TITLE
fix: parse <think> tags in custom endpoint streaming messages

### DIFF
--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -11,20 +11,13 @@ import Thinking from './Parts/Thinking';
 import { useLocalize } from '~/hooks';
 import Container from './Container';
 import Markdown from './Markdown';
+import { parseThinkingContent } from '~/utils/parseThinking';
 import { cn } from '~/utils';
 import store from '~/store';
 
 const ERROR_CONNECTION_TEXT = 'Error connecting to server, try refreshing the page.';
 const DELAYED_ERROR_TIMEOUT = 5500;
 const UNFINISHED_DELAY = 250;
-
-const parseThinkingContent = (text: string) => {
-  const thinkingMatch = text.match(/:::thinking([\s\S]*?):::/);
-  return {
-    thinkingContent: thinkingMatch ? thinkingMatch[1].trim() : '',
-    regularContent: thinkingMatch ? text.replace(/:::thinking[\s\S]*?:::/, '').trim() : text,
-  };
-};
 
 const LoadingFallback = () => (
   <div className="text-message mb-[0.625rem] flex min-h-[20px] flex-col items-start gap-3 overflow-visible">

--- a/client/src/components/Chat/Messages/Content/__tests__/MessageContent.parseThinking.test.ts
+++ b/client/src/components/Chat/Messages/Content/__tests__/MessageContent.parseThinking.test.ts
@@ -1,0 +1,85 @@
+import { parseThinkingContent } from '~/utils/parseThinking';
+
+describe('parseThinkingContent', () => {
+  describe(':::thinking::: directive format (legacy)', () => {
+    it('extracts thinking and regular content', () => {
+      const text = ':::thinking\nsome reasoning\n:::\nActual response';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('some reasoning');
+      expect(result.regularContent).toBe('Actual response');
+    });
+
+    it('returns empty thinking when no match', () => {
+      const text = 'No thinking here';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('');
+      expect(result.regularContent).toBe('No thinking here');
+    });
+  });
+
+  describe('<think> tag format (custom endpoints)', () => {
+    it('extracts full thinking and response when both tags present', () => {
+      const text = '<think>reasoning text</think>\n\nActual response';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('reasoning text');
+      expect(result.regularContent).toBe('Actual response');
+    });
+
+    it('shows partial thinking when </think> not yet received (mid-stream)', () => {
+      const text = '<think>partial reasoning...';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('partial reasoning...');
+      expect(result.regularContent).toBe('');
+    });
+
+    it('handles empty response after </think>', () => {
+      const text = '<think>reasoning</think>';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('reasoning');
+      expect(result.regularContent).toBe('');
+    });
+
+    it('is case-insensitive for <THINK> tags', () => {
+      const text = '<THINK>reasoning</THINK>\n\nResponse';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('reasoning');
+      expect(result.regularContent).toBe('Response');
+    });
+
+    it('trims whitespace from thinking and response', () => {
+      const text = '<think>\n  reasoning content  \n</think>\n\n  response text  ';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('reasoning content');
+      expect(result.regularContent).toBe('response text');
+    });
+
+    it('does not match <think> in the middle of text', () => {
+      const text = 'Regular text <think>not at start</think>';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('');
+      expect(result.regularContent).toBe('Regular text <think>not at start</think>');
+    });
+
+    it('handles multiline reasoning content', () => {
+      const text = '<think>\nLine one\nLine two\nLine three\n</think>\n\nThe answer';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('Line one\nLine two\nLine three');
+      expect(result.regularContent).toBe('The answer');
+    });
+  });
+
+  describe('plain text', () => {
+    it('returns empty thinking and original text for plain content', () => {
+      const text = 'Just a plain response';
+      const result = parseThinkingContent(text);
+      expect(result.thinkingContent).toBe('');
+      expect(result.regularContent).toBe('Just a plain response');
+    });
+
+    it('handles empty string', () => {
+      const result = parseThinkingContent('');
+      expect(result.thinkingContent).toBe('');
+      expect(result.regularContent).toBe('');
+    });
+  });
+});

--- a/client/src/utils/parseThinking.ts
+++ b/client/src/utils/parseThinking.ts
@@ -1,0 +1,35 @@
+const THINK_CLOSE_TAG = '</think>';
+
+/**
+ * Parses thinking/reasoning content embedded in a message text.
+ *
+ * Supports two formats:
+ * - `:::thinking\ncontent\n:::` — directive format used for `reasoning_content` streams
+ * - `<think>content</think>` — inline tag format used by models like MiniMax, QwQ
+ *
+ * During streaming, if `</think>` has not yet arrived, all text after `<think>`
+ * is returned as `thinkingContent` with an empty `regularContent`.
+ */
+export const parseThinkingContent = (text: string) => {
+  const directiveMatch = text.match(/:::thinking([\s\S]*?):::/);
+  if (directiveMatch) {
+    return {
+      thinkingContent: directiveMatch[1].trim(),
+      regularContent: text.replace(/:::thinking[\s\S]*?:::/, '').trim(),
+    };
+  }
+
+  if (/^<think>/i.test(text)) {
+    const afterOpen = text.slice('<think>'.length);
+    const closeIdx = afterOpen.toLowerCase().indexOf(THINK_CLOSE_TAG);
+    if (closeIdx === -1) {
+      return { thinkingContent: afterOpen, regularContent: '' };
+    }
+    return {
+      thinkingContent: afterOpen.slice(0, closeIdx).trim(),
+      regularContent: afterOpen.slice(closeIdx + THINK_CLOSE_TAG.length).trim(),
+    };
+  }
+
+  return { thinkingContent: '', regularContent: text };
+};


### PR DESCRIPTION
## Problem
Models that embed reasoning inline as `<think>reasoning...</think>\nActual response` (e.g. MiniMax M2.7, QwQ, and other custom endpoints) were broken in two ways:

1. **Thoughts box never closed during streaming** — `parseThinkingContent` only matched `:::thinking:::` directive format, so `<think>` tags fell through to the Markdown renderer. ReactMarkdown rendered `<think>` as raw HTML, causing the Thoughts box to open on `<think>` but never close when `</think>` arrived.

2. **Response swallowed** — After `</think>`, the actual response was also rendered inside the Thoughts box since the parser didn't split the text.

Reported in: #13360

## Solution
Extracted `parseThinkingContent` into a standalone utility (`utils/parseThinking.ts`) and added `<think>` tag support alongside the existing `:::thinking:::` directive format:

- Detects `<think>` at the start of the response (case-insensitive)
- Extracts content between tags into the Thinking box
- Shows the text after `</think>` as the regular response
- Handles mid-stream correctly: when `</think>` hasn't arrived yet, all text after `<think>` is shown as thinking content with empty response

## Testing
- 11 unit tests covering both `:::thinking:::` and `<think>` formats, mid-stream case, case-insensitivity, whitespace trimming, and edge cases
- All pass: `cd client && npx jest MessageContent.parseThinking`