### PR TITLE
🧮 chore: Update Gemma Context Token Defaults

### DIFF
--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -356,6 +356,37 @@ describe('getModelMaxTokens', () => {
     );
   });
 
+  test('should return correct context tokens for Gemma models', () => {
+    expect(maxTokensMap[EModelEndpoint.google].gemma).toBe(32768);
+    expect(getModelMaxTokens('gemma', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google].gemma,
+    );
+    expect(getModelMaxTokens('gemma-2-9b-it', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemma-2'],
+    );
+    expect(getModelMaxTokens('gemma-3-27b-it', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemma-3-27b'],
+    );
+    expect(getModelMaxTokens('gemma4:latest', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google].gemma4,
+    );
+    expect(getModelMaxTokens('gemma4:e4b', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google].gemma4,
+    );
+    expect(getModelMaxTokens('Gemma4:31B', EModelEndpoint.custom)).toBe(
+      maxTokensMap[EModelEndpoint.custom]['gemma4:31b'],
+    );
+    expect(getModelMaxTokens('ollama/gemma4:31b', EModelEndpoint.custom)).toBe(
+      maxTokensMap[EModelEndpoint.custom]['gemma4:31b'],
+    );
+    expect(getModelMaxTokens('google/gemma-4-31B-it', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemma-4-31b'],
+    );
+    expect(getModelMaxTokens('google/gemma-4-26B-A4B-it', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemma-4-26b-a4b'],
+    );
+  });
+
   test('should return correct tokens for partial match - Cohere models', () => {
     expect(getModelMaxTokens('command', EModelEndpoint.custom)).toBe(
       maxTokensMap[EModelEndpoint.custom]['command'],

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -95,10 +95,19 @@ const cohereModels = {
 
 const googleModels = {
   /* Max I/O is combined so we subtract the amount from max response tokens for actual total */
-  gemma: 8196,
+  gemma: 32768,
   'gemma-2': 32768,
   'gemma-3': 32768,
   'gemma-3-27b': 131072,
+  'gemma4:31b': 256000,
+  'gemma4-31b': 256000,
+  'gemma-4-31b': 256000,
+  'gemma4:26b': 256000,
+  'gemma4-26b': 256000,
+  'gemma-4-26b-a4b': 256000,
+  'gemma-4-26b': 256000,
+  gemma4: 128000,
+  'gemma-4': 128000,
   gemini: 30720, // -2048 from max
   'gemini-pro-vision': 12288,
   'gemini-1.5': 1000000,


### PR DESCRIPTION
## Summary

I updated Gemma context token defaults so Gemma and Gemma 4 models stop inheriting the old 8K budget called out in #13409.

- Raised the baseline `gemma` context token default to 32K.
- Added Gemma 4 context entries for Ollama-style `gemma4:*` and Google/Hugging Face-style `gemma-4-*` names.
- Mapped Gemma 4 default and small variants to 128K, and 26B/31B variants to 256K.
- Covered case-insensitive, provider-prefixed, and size-specific Gemma lookups in the token spec.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm ci`
- `npm run build:data-provider`
- `npm run build:data-schemas`
- `npm run build:api`
- `cd api && npx jest utils/tokens.spec.js --runInBand`
- `npx prettier --check packages/api/src/utils/tokens.ts api/utils/tokens.spec.js`

### **Test Configuration**:

- Node.js: v20.19.5
- npm: 10.8.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
