### PR TITLE
🔧 chore: Drop duplicate `getAppConfig` import in `set-balance.js`

### DIFF
--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -6,7 +6,6 @@ require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { getAppConfig } = require('~/server/services/Config');
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');
-const { getAppConfig } = require('~/server/services/Config');
 
 (async () => {
   await connect();


### PR DESCRIPTION
## Summary

[#12669](https://github.com/danny-avila/LibreChat/pull/12669) added `const { getAppConfig } = require('~/server/services/Config');` near the top of `config/set-balance.js` but the same import already existed lower in the file:

```js
const { getAppConfig } = require('~/server/services/Config');  // ← line 6 (added by #12669)
const { askQuestion, silentExit } = require('./helpers');
const connect = require('./connect');
const { getAppConfig } = require('~/server/services/Config');  // ← line 9 (pre-existing)
```

ESLint flags this as:

```
config/set-balance.js
  9:9  error  'getAppConfig' is already defined  no-redeclare
```

## Why CI didn't catch it

`.github/workflows/eslint-ci.yml` is path-filtered on `^(api|client|packages)/.*\.(js|jsx|ts|tsx)$` — `config/**` files are out of scope. The duplicate slipped through.

I caught it in a downstream fork's sync CI where the pre-commit hook (`lint-staged` → `eslint`) ran over the file because it was part of a merge.

## Fix

Drop the second declaration (line 9). One-line change, functionally identical, lint clean.

## Test plan

- [x] `npx eslint config/set-balance.js` → no errors.
- [ ] Optional: add `config/**` to the `eslint-ci.yml` path filter so future drift in this directory gets caught. Out of scope for this PR.