### PR TITLE
📌 fix: Preserve Ephemeral Agent Selections on Optimistic Hydration

### DIFF
--- a/client/src/store/__tests__/agents.spec.tsx
+++ b/client/src/store/__tests__/agents.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { RecoilRoot, useRecoilValue } from 'recoil';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { ephemeralAgentByConvoId, useApplyNewAgentTemplate } from '../agents';
+
+jest.mock('~/utils', () => ({
+  logger: {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <RecoilRoot>{children}</RecoilRoot>
+);
+
+const useAgentTemplateHarness = (conversationId: string) => {
+  const applyTemplate = useApplyNewAgentTemplate();
+  const ephemeralAgent = useRecoilValue(ephemeralAgentByConvoId(conversationId));
+  return { applyTemplate, ephemeralAgent };
+};
+
+describe('useApplyNewAgentTemplate', () => {
+  it('applies an explicit ephemeral agent when optimistic hydration makes source and target match', async () => {
+    const conversationId = 'convo-123';
+    const agent = {
+      mcp: ['chrome-devtools'],
+      skills: true,
+      artifacts: 'default',
+      web_search: true,
+      file_search: true,
+      execute_code: true,
+    };
+    const { result } = renderHook(() => useAgentTemplateHarness(conversationId), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.applyTemplate(conversationId, conversationId, agent);
+    });
+
+    await waitFor(() => {
+      expect(result.current.ephemeralAgent).toEqual(agent);
+    });
+  });
+});

--- a/client/src/store/agents.ts
+++ b/client/src/store/agents.ts
@@ -43,7 +43,7 @@ export function useApplyNewAgentTemplate() {
         const sourceId = _sourceId || Constants.NEW_CONVO;
         logger.log('agents', `Attempting to apply template from "${sourceId}" to "${targetId}"`);
 
-        if (targetId === sourceId) {
+        if (targetId === sourceId && ephemeralAgentState == null) {
           logger.warn('agents', `Attempted to apply template to itself ("${sourceId}"). Skipping.`);
           return;
         }


### PR DESCRIPTION
## Summary

I fixed the new-chat optimistic update path so explicit ephemeral agent selections survive when a generated conversation receives its persisted conversation ID.

- Preserved an explicit `ephemeralAgent` when `useApplyNewAgentTemplate` is asked to apply state to the same conversation ID after optimistic hydration.
- Kept the existing same-ID short circuit for cases that do not provide an explicit ephemeral agent, so the helper still avoids pointless self-copy reads.
- Added a focused regression test covering MCP selections and the other ephemeral agent flags carried by the same state object.

Root cause: resumable SSE optimistic hydration updates the submission to the persisted conversation ID before `created`/`final` applies the ephemeral agent template. That made `sourceId` and `targetId` match, so the helper skipped writing the request-time `ephemeralAgent` into the saved conversation state.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`
- Did not run local tests per request

### **Test Configuration**:

- Local worktree: `/Users/danny/.codex/worktrees/99d4/LibreChat`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works