### PR TITLE
feat: Trace resumable stream lifecycle

### DIFF
--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -90,18 +90,20 @@ router.get('/chat/stream/:streamId', async (req, res) => {
   logger.debug(`[AgentStream] Client subscribed to ${streamId}, resume: ${isResume}`);
 
   const writeEvent = (event, options = {}) => {
-    if (!res.writableEnded) {
-      const eventName = options.eventName ?? 'message';
-      const payload = `event: ${eventName}\ndata: ${JSON.stringify(event)}\n\n`;
-      res.write(payload);
-      streamTelemetry.recordWrite(payload, { final: options.final });
-      if (typeof res.flush === 'function') {
-        res.flush();
+    return streamTelemetry.runWithContext(() => {
+      if (!res.writableEnded) {
+        const eventName = options.eventName ?? 'message';
+        const payload = `event: ${eventName}\ndata: ${JSON.stringify(event)}\n\n`;
+        res.write(payload);
+        streamTelemetry.recordWrite(payload, { final: options.final });
+        if (typeof res.flush === 'function') {
+          res.flush();
+        }
+        return true;
       }
-      return true;
-    }
 
-    return false;
+      return false;
+    });
   };
 
   const onDone = (event) => {
@@ -121,8 +123,9 @@ router.get('/chat/stream/:streamId', async (req, res) => {
   let result;
 
   if (isResume) {
-    const { subscription, resumeState, pendingEvents } =
-      await GenerationJobManager.subscribeWithResume(streamId, writeEvent, onDone, onError);
+    const { subscription, resumeState, pendingEvents } = await streamTelemetry.runWithContext(() =>
+      GenerationJobManager.subscribeWithResume(streamId, writeEvent, onDone, onError),
+    );
 
     if (!res.writableEnded) {
       if (resumeState) {
@@ -143,7 +146,9 @@ router.get('/chat/stream/:streamId', async (req, res) => {
 
     result = subscription;
   } else {
-    result = await GenerationJobManager.subscribe(streamId, writeEvent, onDone, onError);
+    result = await streamTelemetry.runWithContext(() =>
+      GenerationJobManager.subscribe(streamId, writeEvent, onDone, onError),
+    );
   }
 
   if (!result) {

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -16,6 +16,7 @@ import {
   recordGenerationStreamSubscription,
   setGenerationJobsInFlight,
 } from '~/app/metrics';
+import { withTelemetrySpan } from '~/telemetry/tracer';
 import type { GenerationJobStore } from '~/app/metrics';
 import { InMemoryEventTransport } from './implementations/InMemoryEventTransport';
 import { InMemoryJobStore } from './implementations/InMemoryJobStore';
@@ -225,98 +226,118 @@ class GenerationJobManagerClass {
   ): Promise<t.GenerationJob> {
     const tenantId = getTenantId();
     const safeTenantId = tenantId && tenantId !== SYSTEM_TENANT_ID ? tenantId : undefined;
-    const jobData = await this.jobStore.createJob(streamId, userId, conversationId, safeTenantId);
+    return await withTelemetrySpan(
+      'librechat.generation.job.create',
+      {
+        attributes: {
+          'librechat.stream.store': this.storeLabel,
+          'librechat.generation.new_conversation': !conversationId || conversationId === 'new',
+          'librechat.tenant.present': safeTenantId != null,
+        },
+      },
+      async () => {
+        const jobData = await this.jobStore.createJob(
+          streamId,
+          userId,
+          conversationId,
+          safeTenantId,
+        );
 
-    /**
-     * Create runtime state with readyPromise.
-     *
-     * With the resumable stream architecture, we no longer need to wait for the
-     * first subscriber before starting generation:
-     * - Redis mode: Events are persisted and can be replayed via sync
-     * - In-memory mode: Content is aggregated and sent via sync on connect
-     *
-     * We resolve readyPromise immediately to eliminate startup latency.
-     * The sync mechanism handles late-connecting clients.
-     */
-    let resolveReady: () => void;
-    const readyPromise = new Promise<void>((resolve) => {
-      resolveReady = resolve;
-    });
-
-    const runtime: RuntimeJobState = {
-      abortController: new AbortController(),
-      readyPromise,
-      resolveReady: resolveReady!,
-      syncSent: false,
-      earlyEventBuffer: [],
-      hasSubscriber: false,
-    };
-    this.runtimeState.set(streamId, runtime);
-    this.runningJobs.add(streamId);
-    this.syncRunningJobMetrics();
-    recordGenerationJob(this.storeLabel, 'created');
-
-    // Resolve immediately - early event buffer handles late subscribers
-    resolveReady!();
-
-    /**
-     * Set up all-subscribers-left callback.
-     * When all SSE clients disconnect, this:
-     * 1. Resets syncSent so reconnecting clients get sync event (persisted to Redis)
-     * 2. Calls any registered allSubscribersLeft handlers (e.g., to save partial responses)
-     */
-    this.eventTransport.onAllSubscribersLeft(streamId, () => {
-      const currentRuntime = this.runtimeState.get(streamId);
-      if (currentRuntime) {
-        currentRuntime.syncSent = false;
-        currentRuntime.hasSubscriber = false;
-        // Persist syncSent=false to Redis for cross-replica consistency
-        this.jobStore.updateJob(streamId, { syncSent: false }).catch((err) => {
-          logger.error(`[GenerationJobManager] Failed to persist syncSent=false:`, err);
+        /**
+         * Create runtime state with readyPromise.
+         *
+         * With the resumable stream architecture, we no longer need to wait for the
+         * first subscriber before starting generation:
+         * - Redis mode: Events are persisted and can be replayed via sync
+         * - In-memory mode: Content is aggregated and sent via sync on connect
+         *
+         * We resolve readyPromise immediately to eliminate startup latency.
+         * The sync mechanism handles late-connecting clients.
+         */
+        let resolveReady: () => void;
+        const readyPromise = new Promise<void>((resolve) => {
+          resolveReady = resolve;
         });
-        // Call registered handlers (from job.emitter.on('allSubscribersLeft', ...))
-        if (currentRuntime.allSubscribersLeftHandlers) {
-          this.jobStore
-            .getContentParts(streamId)
-            .then((result) => {
-              const parts = result?.content ?? [];
-              for (const handler of currentRuntime.allSubscribersLeftHandlers ?? []) {
-                try {
-                  handler(parts);
-                } catch (err) {
-                  logger.error(`[GenerationJobManager] Error in allSubscribersLeft handler:`, err);
-                }
-              }
-            })
-            .catch((err) => {
-              logger.error(
-                `[GenerationJobManager] Failed to get content parts for allSubscribersLeft handlers:`,
-                err,
-              );
+
+        const runtime: RuntimeJobState = {
+          abortController: new AbortController(),
+          readyPromise,
+          resolveReady: resolveReady!,
+          syncSent: false,
+          earlyEventBuffer: [],
+          hasSubscriber: false,
+        };
+        this.runtimeState.set(streamId, runtime);
+        this.runningJobs.add(streamId);
+        this.syncRunningJobMetrics();
+        recordGenerationJob(this.storeLabel, 'created');
+
+        // Resolve immediately - early event buffer handles late subscribers
+        resolveReady!();
+
+        /**
+         * Set up all-subscribers-left callback.
+         * When all SSE clients disconnect, this:
+         * 1. Resets syncSent so reconnecting clients get sync event (persisted to Redis)
+         * 2. Calls any registered allSubscribersLeft handlers (e.g., to save partial responses)
+         */
+        this.eventTransport.onAllSubscribersLeft(streamId, () => {
+          const currentRuntime = this.runtimeState.get(streamId);
+          if (currentRuntime) {
+            currentRuntime.syncSent = false;
+            currentRuntime.hasSubscriber = false;
+            // Persist syncSent=false to Redis for cross-replica consistency
+            this.jobStore.updateJob(streamId, { syncSent: false }).catch((err) => {
+              logger.error(`[GenerationJobManager] Failed to persist syncSent=false:`, err);
             });
+            // Call registered handlers (from job.emitter.on('allSubscribersLeft', ...))
+            if (currentRuntime.allSubscribersLeftHandlers) {
+              this.jobStore
+                .getContentParts(streamId)
+                .then((result) => {
+                  const parts = result?.content ?? [];
+                  for (const handler of currentRuntime.allSubscribersLeftHandlers ?? []) {
+                    try {
+                      handler(parts);
+                    } catch (err) {
+                      logger.error(
+                        `[GenerationJobManager] Error in allSubscribersLeft handler:`,
+                        err,
+                      );
+                    }
+                  }
+                })
+                .catch((err) => {
+                  logger.error(
+                    `[GenerationJobManager] Failed to get content parts for allSubscribersLeft handlers:`,
+                    err,
+                  );
+                });
+            }
+          }
+        });
+
+        /**
+         * Set up cross-replica abort listener (Redis mode only).
+         * When abort is triggered on ANY replica, this replica receives the signal
+         * and aborts its local AbortController (if it's the one running generation).
+         */
+        if (this.eventTransport.onAbort) {
+          this.eventTransport.onAbort(streamId, () => {
+            const currentRuntime = this.runtimeState.get(streamId);
+            if (currentRuntime && !currentRuntime.abortController.signal.aborted) {
+              logger.debug(`[GenerationJobManager] Received cross-replica abort for ${streamId}`);
+              currentRuntime.abortController.abort();
+            }
+          });
         }
-      }
-    });
 
-    /**
-     * Set up cross-replica abort listener (Redis mode only).
-     * When abort is triggered on ANY replica, this replica receives the signal
-     * and aborts its local AbortController (if it's the one running generation).
-     */
-    if (this.eventTransport.onAbort) {
-      this.eventTransport.onAbort(streamId, () => {
-        const currentRuntime = this.runtimeState.get(streamId);
-        if (currentRuntime && !currentRuntime.abortController.signal.aborted) {
-          logger.debug(`[GenerationJobManager] Received cross-replica abort for ${streamId}`);
-          currentRuntime.abortController.abort();
-        }
-      });
-    }
+        logger.debug(`[GenerationJobManager] Created job: ${streamId}`);
 
-    logger.debug(`[GenerationJobManager] Created job: ${streamId}`);
-
-    // Return facade for backwards compatibility
-    return this.buildJobFacade(streamId, jobData, runtime);
+        // Return facade for backwards compatibility
+        return this.buildJobFacade(streamId, jobData, runtime);
+      },
+    );
   }
 
   /**
@@ -622,115 +643,137 @@ class GenerationJobManagerClass {
    * - The replica running generation receives signal and aborts its AbortController
    */
   async abortJob(streamId: string): Promise<AbortResult> {
-    const jobData = await this.jobStore.getJob(streamId);
-    const runtime = this.runtimeState.get(streamId);
+    return await withTelemetrySpan(
+      'librechat.generation.job.abort',
+      {
+        attributes: {
+          'librechat.stream.store': this.storeLabel,
+        },
+      },
+      async (span) => {
+        const jobData = await this.jobStore.getJob(streamId);
+        const runtime = this.runtimeState.get(streamId);
 
-    if (!jobData) {
-      logger.warn(`[GenerationJobManager] Cannot abort - job not found: ${streamId}`);
-      recordGenerationJob(this.storeLabel, 'abort_failed');
-      return {
-        text: '',
-        content: [],
-        jobData: null,
-        success: false,
-        finalEvent: null,
-        collectedUsage: [],
-      };
-    }
+        if (!jobData) {
+          logger.warn(`[GenerationJobManager] Cannot abort - job not found: ${streamId}`);
+          recordGenerationJob(this.storeLabel, 'abort_failed');
+          span.setAttributes({
+            'librechat.job.status': 'not_found',
+            'librechat.job.abort.success': false,
+          });
+          return {
+            text: '',
+            content: [],
+            jobData: null,
+            success: false,
+            finalEvent: null,
+            collectedUsage: [],
+          };
+        }
 
-    // Emit abort signal for cross-replica support (Redis mode)
-    // This ensures the generating replica receives the abort signal
-    if (this.eventTransport.emitAbort) {
-      this.eventTransport.emitAbort(streamId);
-    }
+        // Emit abort signal for cross-replica support (Redis mode)
+        // This ensures the generating replica receives the abort signal
+        if (this.eventTransport.emitAbort) {
+          this.eventTransport.emitAbort(streamId);
+        }
 
-    // Also abort local controller if we have it (same-replica abort)
-    if (runtime) {
-      runtime.abortController.abort();
-    }
+        // Also abort local controller if we have it (same-replica abort)
+        if (runtime) {
+          runtime.abortController.abort();
+        }
 
-    /** Content before clearing state */
-    const result = await this.jobStore.getContentParts(streamId);
-    const content = result?.content ?? [];
+        /** Content before clearing state */
+        const result = await this.jobStore.getContentParts(streamId);
+        const content = result?.content ?? [];
 
-    /** Collected usage for all models */
-    const collectedUsage = this.jobStore.getCollectedUsage(streamId);
+        /** Collected usage for all models */
+        const collectedUsage = this.jobStore.getCollectedUsage(streamId);
 
-    /** Text from content parts for fallback token counting */
-    const text = parseTextParts(content as TMessageContentParts[]);
+        /** Text from content parts for fallback token counting */
+        const text = parseTextParts(content as TMessageContentParts[]);
 
-    /** Detect "early abort" - aborted before any generation happened (e.g., during tool loading)
-    In this case, no messages were saved to DB, so frontend shouldn't navigate to conversation */
-    const isEarlyAbort = content.length === 0 && !jobData.responseMessageId;
+        /**
+         * Detect "early abort" - aborted before any generation happened (e.g., during tool loading).
+         * In this case, no messages were saved to DB, so frontend shouldn't navigate to conversation.
+         */
+        const isEarlyAbort = content.length === 0 && !jobData.responseMessageId;
+        span.setAttributes({
+          'librechat.job.abort.early': isEarlyAbort,
+          'librechat.stream.content_parts.count': content.length,
+          'librechat.usage.records.count': collectedUsage.length,
+        });
 
-    /** Final event for abort */
-    const userMessageId = jobData.userMessage?.messageId;
+        /** Final event for abort */
+        const userMessageId = jobData.userMessage?.messageId;
 
-    const abortFinalEvent: t.ServerSentEvent = {
-      final: true,
-      // Don't include conversation for early aborts - it doesn't exist in DB
-      conversation: isEarlyAbort ? null : { conversationId: jobData.conversationId },
-      title: 'New Chat',
-      requestMessage: jobData.userMessage
-        ? {
-            messageId: userMessageId,
-            parentMessageId: jobData.userMessage.parentMessageId,
-            conversationId: jobData.conversationId,
-            text: jobData.userMessage.text ?? '',
-            isCreatedByUser: true,
-          }
-        : null,
-      responseMessage: isEarlyAbort
-        ? null
-        : {
-            messageId: jobData.responseMessageId ?? `${userMessageId ?? 'aborted'}_`,
-            parentMessageId: userMessageId,
-            conversationId: jobData.conversationId,
-            content,
-            sender: jobData.sender ?? 'AI',
-            unfinished: true,
-            error: false,
-            isCreatedByUser: false,
-          },
-      aborted: true,
-      // Flag for early abort - no messages saved, frontend should go to new chat
-      earlyAbort: isEarlyAbort,
-    } satisfies t.FinalEvent as t.ServerSentEvent;
+        const abortFinalEvent: t.ServerSentEvent = {
+          final: true,
+          // Don't include conversation for early aborts - it doesn't exist in DB
+          conversation: isEarlyAbort ? null : { conversationId: jobData.conversationId },
+          title: 'New Chat',
+          requestMessage: jobData.userMessage
+            ? {
+                messageId: userMessageId,
+                parentMessageId: jobData.userMessage.parentMessageId,
+                conversationId: jobData.conversationId,
+                text: jobData.userMessage.text ?? '',
+                isCreatedByUser: true,
+              }
+            : null,
+          responseMessage: isEarlyAbort
+            ? null
+            : {
+                messageId: jobData.responseMessageId ?? `${userMessageId ?? 'aborted'}_`,
+                parentMessageId: userMessageId,
+                conversationId: jobData.conversationId,
+                content,
+                sender: jobData.sender ?? 'AI',
+                unfinished: true,
+                error: false,
+                isCreatedByUser: false,
+              },
+          aborted: true,
+          // Flag for early abort - no messages saved, frontend should go to new chat
+          earlyAbort: isEarlyAbort,
+        } satisfies t.FinalEvent as t.ServerSentEvent;
 
-    if (runtime) {
-      runtime.finalEvent = abortFinalEvent;
-    }
+        if (runtime) {
+          runtime.finalEvent = abortFinalEvent;
+        }
 
-    await this.eventTransport.emitDone(streamId, abortFinalEvent);
-    this.jobStore.clearContentState(streamId);
-    this.runStepBuffers?.delete(streamId);
+        await this.eventTransport.emitDone(streamId, abortFinalEvent);
+        this.jobStore.clearContentState(streamId);
+        this.runStepBuffers?.delete(streamId);
 
-    // Immediate cleanup if configured (default: true)
-    if (this._cleanupOnComplete) {
-      this.runtimeState.delete(streamId);
-      // Don't cleanup eventTransport here - let the abort event fully transmit first.
-      await this.jobStore.deleteJob(streamId);
-    } else {
-      // Only update status if keeping the job around
-      await this.jobStore.updateJob(streamId, {
-        status: 'aborted',
-        completedAt: Date.now(),
-      });
-    }
+        // Immediate cleanup if configured (default: true)
+        if (this._cleanupOnComplete) {
+          this.runtimeState.delete(streamId);
+          // Don't cleanup eventTransport here - let the abort event fully transmit first.
+          await this.jobStore.deleteJob(streamId);
+        } else {
+          // Only update status if keeping the job around
+          await this.jobStore.updateJob(streamId, {
+            status: 'aborted',
+            completedAt: Date.now(),
+          });
+        }
 
-    this.runningJobs.delete(streamId);
-    this.syncRunningJobMetrics();
-    recordGenerationJob(this.storeLabel, 'aborted');
-    logger.debug(`[GenerationJobManager] Job aborted: ${streamId}`);
+        this.runningJobs.delete(streamId);
+        this.syncRunningJobMetrics();
+        recordGenerationJob(this.storeLabel, 'aborted');
+        span.setAttribute('librechat.job.abort.success', true);
+        logger.debug(`[GenerationJobManager] Job aborted: ${streamId}`);
 
-    return {
-      success: true,
-      jobData,
-      content,
-      finalEvent: abortFinalEvent,
-      text,
-      collectedUsage,
-    };
+        return {
+          success: true,
+          jobData,
+          content,
+          finalEvent: abortFinalEvent,
+          text,
+          collectedUsage,
+        };
+      },
+    );
   }
 
   /**
@@ -906,37 +949,56 @@ class GenerationJobManagerClass {
     onDone?: t.DoneHandler,
     onError?: t.ErrorHandler,
   ): Promise<t.SubscribeWithResumeResult> {
-    const bufferLengthAtSnapshot = !this._isRedis
-      ? (this.runtimeState.get(streamId)?.earlyEventBuffer.length ?? 0)
-      : 0;
+    return await withTelemetrySpan(
+      'librechat.stream.resume',
+      {
+        attributes: {
+          'librechat.stream.store': this.storeLabel,
+          'librechat.stream.resume': true,
+        },
+      },
+      async (span) => {
+        const bufferLengthAtSnapshot = !this._isRedis
+          ? (this.runtimeState.get(streamId)?.earlyEventBuffer.length ?? 0)
+          : 0;
 
-    const resumeState = await this.getResumeState(streamId);
-    recordGenerationStreamSubscription(
-      this.storeLabel,
-      'resume_state',
-      resumeState ? 'found' : 'missing',
-    );
+        const resumeState = await this.getResumeState(streamId);
+        recordGenerationStreamSubscription(
+          this.storeLabel,
+          'resume_state',
+          resumeState ? 'found' : 'missing',
+        );
 
-    let pendingEvents: t.ServerSentEvent[] = [];
-    if (!this._isRedis) {
-      const runtime = this.runtimeState.get(streamId);
-      if (runtime) {
-        pendingEvents = runtime.earlyEventBuffer.slice(bufferLengthAtSnapshot);
-        runtime.earlyEventBuffer = [];
-        if (pendingEvents.length > 0) {
-          recordGenerationStreamResumePendingEvents(this.storeLabel, pendingEvents.length);
-          logger.debug(
-            `[GenerationJobManager] Captured ${pendingEvents.length} gap events for ${streamId}`,
-          );
+        let pendingEvents: t.ServerSentEvent[] = [];
+        if (!this._isRedis) {
+          const runtime = this.runtimeState.get(streamId);
+          if (runtime) {
+            pendingEvents = runtime.earlyEventBuffer.slice(bufferLengthAtSnapshot);
+            runtime.earlyEventBuffer = [];
+            if (pendingEvents.length > 0) {
+              recordGenerationStreamResumePendingEvents(this.storeLabel, pendingEvents.length);
+              logger.debug(
+                `[GenerationJobManager] Captured ${pendingEvents.length} gap events for ${streamId}`,
+              );
+            }
+          }
         }
-      }
-    }
 
-    const subscription = await this.subscribe(streamId, onChunk, onDone, onError, {
-      skipBufferReplay: true,
-    });
+        const subscription = await this.subscribe(streamId, onChunk, onDone, onError, {
+          skipBufferReplay: true,
+        });
 
-    return { subscription, resumeState, pendingEvents };
+        span.setAttributes({
+          'librechat.stream.resume_state_found': resumeState != null,
+          'librechat.stream.pending_events.count': pendingEvents.length,
+          'librechat.stream.run_steps.count': resumeState?.runSteps?.length ?? 0,
+          'librechat.stream.aggregated_content.count': resumeState?.aggregatedContent?.length ?? 0,
+          'librechat.stream.subscribed': subscription != null,
+        });
+
+        return { subscription, resumeState, pendingEvents };
+      },
+    );
   }
 
   /**

--- a/packages/api/src/telemetry/index.ts
+++ b/packages/api/src/telemetry/index.ts
@@ -2,6 +2,8 @@ export { getTelemetryConfig } from './config';
 export { initializeTelemetry, shutdownTelemetry } from './sdk';
 export { telemetryErrorMiddleware, telemetryMiddleware } from './middleware';
 export { createSseStreamTelemetry } from './stream';
+export { withTelemetrySpan } from './tracer';
 export type { SseStreamTelemetry } from './stream';
 export type { TelemetryConfig, TelemetryStatus } from './config';
 export type { TelemetryController } from './sdk';
+export type { TelemetrySpanOptions } from './tracer';

--- a/packages/api/src/telemetry/stream.spec.ts
+++ b/packages/api/src/telemetry/stream.spec.ts
@@ -107,6 +107,26 @@ describe('createSseStreamTelemetry', () => {
     expect(span.end).toHaveBeenCalledTimes(1);
   });
 
+  it('runs callbacks through the stream context', () => {
+    const span = createSpan();
+    mockTracer(span);
+    const contextWith = jest
+      .spyOn(context, 'with')
+      .mockImplementation((_telemetryContext, fn) => fn());
+    const res = createResponse();
+    const telemetry = createSseStreamTelemetry({
+      isResume: false,
+      req: createRequest(),
+      res: res as Response,
+      streamId: 'stream-context',
+    });
+
+    const result = telemetry.runWithContext(() => 'ok');
+
+    expect(result).toBe('ok');
+    expect(contextWith).toHaveBeenCalledWith(expect.any(Object), expect.any(Function));
+  });
+
   it('records client aborts on close before writableEnded', () => {
     const span = createSpan();
     mockTracer(span);

--- a/packages/api/src/telemetry/stream.ts
+++ b/packages/api/src/telemetry/stream.ts
@@ -1,6 +1,6 @@
 import { performance } from 'node:perf_hooks';
 import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
-import type { Attributes, Span } from '@opentelemetry/api';
+import type { Attributes, Context, Span } from '@opentelemetry/api';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types';
 
@@ -10,6 +10,7 @@ const STREAM_ROUTE = '/api/agents/chat/stream/:streamId';
 type StreamEndReason = 'done' | 'client_aborted' | 'server_error' | 'subscribe_failed';
 
 export interface SseStreamTelemetry {
+  runWithContext: <T>(fn: () => T) => T;
   recordHeadersFlushed: () => void;
   recordWrite: (payload: string, options?: { final?: boolean }) => void;
   recordFinalEventEmitted: () => void;
@@ -26,6 +27,7 @@ interface SseStreamTelemetryOptions {
 
 class SseStreamSpanTelemetry implements SseStreamTelemetry {
   private readonly span: Span;
+  private readonly streamContext: Context;
   private readonly startTimeMs = performance.now();
   private bytesSent = 0;
   private chunksCount = 0;
@@ -51,6 +53,7 @@ class SseStreamSpanTelemetry implements SseStreamTelemetry {
       },
       context.active(),
     );
+    this.streamContext = trace.setSpan(context.active(), this.span);
 
     res.once('finish', () => {
       this.end(this.plannedEndReason ?? (this.errorEventEmitted ? 'server_error' : 'done'));
@@ -65,6 +68,10 @@ class SseStreamSpanTelemetry implements SseStreamTelemetry {
       this.span.addEvent('client_aborted');
       this.end('client_aborted');
     });
+  }
+
+  runWithContext<T>(fn: () => T): T {
+    return context.with(this.streamContext, fn);
   }
 
   recordHeadersFlushed(): void {

--- a/packages/api/src/telemetry/tracer.spec.ts
+++ b/packages/api/src/telemetry/tracer.spec.ts
@@ -1,0 +1,118 @@
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Span, Tracer } from '@opentelemetry/api';
+import { withTelemetrySpan } from './tracer';
+
+function createSpan(): jest.Mocked<Span> {
+  const span = {} as jest.Mocked<Span>;
+  span.addEvent = jest.fn<jest.Mocked<Span>, Parameters<Span['addEvent']>>(() => span);
+  span.addLink = jest.fn<jest.Mocked<Span>, Parameters<Span['addLink']>>(() => span);
+  span.addLinks = jest.fn<jest.Mocked<Span>, Parameters<Span['addLinks']>>(() => span);
+  span.end = jest.fn<void, Parameters<Span['end']>>();
+  span.isRecording = jest.fn<boolean, Parameters<Span['isRecording']>>(() => true);
+  span.recordException = jest.fn<void, Parameters<Span['recordException']>>();
+  span.setAttribute = jest.fn<jest.Mocked<Span>, Parameters<Span['setAttribute']>>(() => span);
+  span.setAttributes = jest.fn<jest.Mocked<Span>, Parameters<Span['setAttributes']>>(() => span);
+  span.setStatus = jest.fn<jest.Mocked<Span>, Parameters<Span['setStatus']>>(() => span);
+  span.spanContext = jest.fn<ReturnType<Span['spanContext']>, Parameters<Span['spanContext']>>(
+    () => ({
+      spanId: '0000000000000000',
+      traceFlags: 0,
+      traceId: '00000000000000000000000000000000',
+    }),
+  );
+  span.updateName = jest.fn<jest.Mocked<Span>, Parameters<Span['updateName']>>(() => span);
+  return span;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('telemetry tracer helpers', () => {
+  it('ends successful active spans', () => {
+    const span = createSpan();
+    jest.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan: (_name: string, _options: unknown, fn: (span: Span) => unknown) => fn(span),
+    } as unknown as Tracer);
+
+    const result = withTelemetrySpan('librechat.test', undefined, () => 42);
+
+    expect(result).toBe(42);
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters undefined attributes when starting active spans', () => {
+    const span = createSpan();
+    const startActiveSpan = jest.fn(
+      (_name: string, _options: unknown, fn: (span: Span) => unknown) => fn(span),
+    );
+    jest.spyOn(trace, 'getTracer').mockReturnValue({ startActiveSpan } as unknown as Tracer);
+
+    withTelemetrySpan(
+      'librechat.test',
+      {
+        attributes: {
+          keep: 'value',
+          drop: undefined,
+        },
+      },
+      () => undefined,
+    );
+
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      'librechat.test',
+      {
+        kind: SpanKind.INTERNAL,
+        attributes: { keep: 'value' },
+      },
+      expect.any(Function),
+    );
+  });
+
+  it('ends successful async active spans after resolution', async () => {
+    const span = createSpan();
+    jest.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan: (_name: string, _options: unknown, fn: (span: Span) => unknown) => fn(span),
+    } as unknown as Tracer);
+
+    await expect(withTelemetrySpan('librechat.test', undefined, async () => 42)).resolves.toBe(42);
+
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('records and rethrows span errors', () => {
+    const span = createSpan();
+    const error = new Error('boom');
+    jest.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan: (_name: string, _options: unknown, fn: (span: Span) => unknown) => fn(span),
+    } as unknown as Tracer);
+
+    expect(() =>
+      withTelemetrySpan('librechat.test', undefined, () => {
+        throw error;
+      }),
+    ).toThrow(error);
+
+    expect(span.recordException).toHaveBeenCalledWith(error);
+    expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR });
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('records async span errors before rethrowing', async () => {
+    const span = createSpan();
+    const error = new Error('boom');
+    jest.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan: (_name: string, _options: unknown, fn: (span: Span) => unknown) => fn(span),
+    } as unknown as Tracer);
+
+    await expect(
+      withTelemetrySpan('librechat.test', undefined, async () => {
+        throw error;
+      }),
+    ).rejects.toThrow(error);
+
+    expect(span.recordException).toHaveBeenCalledWith(error);
+    expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR });
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/telemetry/tracer.ts
+++ b/packages/api/src/telemetry/tracer.ts
@@ -1,0 +1,77 @@
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Attributes, Span, SpanOptions } from '@opentelemetry/api';
+
+const TRACER_NAME = 'librechat.telemetry';
+
+export interface TelemetrySpanOptions {
+  attributes?: Attributes;
+  kind?: SpanKind;
+}
+
+function getTracer() {
+  return trace.getTracer(TRACER_NAME);
+}
+
+function recordSpanError(span: Span, error: unknown): void {
+  span.recordException(error instanceof Error ? error : String(error));
+  span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>)?.then === 'function';
+}
+
+function toSpanOptions(options?: TelemetrySpanOptions): SpanOptions {
+  return {
+    kind: options?.kind ?? SpanKind.INTERNAL,
+    attributes: filterAttributes(options?.attributes),
+  };
+}
+
+function filterAttributes(attributes?: Attributes): Attributes | undefined {
+  if (!attributes) {
+    return undefined;
+  }
+
+  const entries = Object.entries(attributes).filter((entry) => entry[1] !== undefined);
+  return entries.length > 0 ? (Object.fromEntries(entries) as Attributes) : undefined;
+}
+
+export function withTelemetrySpan<T>(
+  name: string,
+  options: TelemetrySpanOptions | undefined,
+  fn: (span: Span) => Promise<T>,
+): Promise<T>;
+export function withTelemetrySpan<T>(
+  name: string,
+  options: TelemetrySpanOptions | undefined,
+  fn: (span: Span) => T,
+): T;
+export function withTelemetrySpan<T>(
+  name: string,
+  options: TelemetrySpanOptions | undefined,
+  fn: (span: Span) => T | Promise<T>,
+): T | Promise<T> {
+  return getTracer().startActiveSpan(name, toSpanOptions(options), (span) => {
+    try {
+      const result = fn(span);
+      if (!isPromiseLike(result)) {
+        span.end();
+        return result;
+      }
+
+      return result
+        .catch((error: unknown) => {
+          recordSpanError(span, error);
+          throw error;
+        })
+        .finally(() => {
+          span.end();
+        });
+    } catch (error) {
+      recordSpanError(span, error);
+      span.end();
+      throw error;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/danny-avila/LibreChat/pull/13266. Adds focused OpenTelemetry spans for resumable stream and generation job lifecycle paths

## Testing

- jest packages/api/src/telemetry/tracer.spec.ts packages/api/src/telemetry/stream.spec.ts --config packages/api/jest.config.mjs --coverage=false --runInBand
- node --check api/server/routes/agents/index.js
- git diff --check