### PR TITLE
⛑️ ci: Fix Helm Tag Sync Workflow Planning

### DIFF
--- a/.github/workflows/helmcharts.yml
+++ b/.github/workflows/helmcharts.yml
@@ -25,7 +25,7 @@ jobs:
         id: chart-version
         env:
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_CHART_TAG: ${{ inputs.chart_tag || '' }}
+          INPUT_CHART_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.chart_tag || '' }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -41,9 +41,11 @@ jobs:
             exit 1
           fi
 
-          printf 'CHART_REF=refs/tags/%s\n' "$CHART_TAG" >> "$GITHUB_OUTPUT"
-          printf 'CHART_TAG=%s\n' "$CHART_TAG" >> "$GITHUB_OUTPUT"
-          printf 'CHART_VERSION=%s\n' "$CHART_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            printf 'CHART_REF=refs/tags/%s\n' "$CHART_TAG"
+            printf 'CHART_TAG=%s\n' "$CHART_TAG"
+            printf 'CHART_VERSION=%s\n' "$CHART_VERSION"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sync-helm-chart-tags.yml
+++ b/.github/workflows/sync-helm-chart-tags.yml
@@ -12,19 +12,30 @@ on:
         type: string
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
 
 concurrency:
   group: sync-helm-chart-tags
   cancel-in-progress: false
 
 jobs:
+  noop:
+    name: Ignore non-main push
+    if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Skip tag sync
+        run: echo "Helm chart tag sync only runs on main pushes or manual dispatch."
+
   sync:
     name: Sync chart tags
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: write
+      contents: write
     env:
       BASE_REF: refs/remotes/origin/main
       BACKFILL_FROM_VERSION: 1.9.0
@@ -34,8 +45,8 @@ jobs:
       GITHUB_SERVER_URL: ${{ github.server_url }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPOSITORY: ${{ github.repository }}
-      RELEASE_EXISTING_TAG: ${{ inputs.release_existing_tag || '' }}
-      REPO_DIR: ${{ runner.temp }}/librechat
+      RELEASE_EXISTING_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_existing_tag || '' }}
+      REPO_DIR: /tmp/librechat-sync
       TAG_PREFIX: chart-
     steps:
       - name: Fetch main and tags


### PR DESCRIPTION
## Summary

I fixed the Helm chart tag sync workflow so GitHub Actions can plan it without producing empty 0-second failures on branch pushes.

- Replaced the job-level `runner.temp` expression with a static temp path because `runner` is not available in job `env` during workflow planning.
- Moved write permissions from the workflow default to the privileged sync job, leaving non-sync executions with read-only contents permission.
- Added a read-only no-op job for unexpected non-main push evaluations so the workflow never fails with `jobs: []` while still only running tag sync on `main` pushes or manual dispatch.
- Switched manual input expressions to `github.event.inputs` guarded by `github.event_name` in both Helm workflows.
- Cleaned up `GITHUB_OUTPUT` writes in the chart release workflow so `actionlint` passes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/sync-helm-chart-tags.yml .github/workflows/helmcharts.yml`.
- Ran `bash -n .github/scripts/sync-helm-chart-tags.sh`.
- Ran `.github/scripts/sync-helm-chart-tags.sh` in dry-run mode and confirmed it still identifies `chart-2.0.4` and `chart-2.0.5` as missing.
- Parsed `.github/workflows/sync-helm-chart-tags.yml` and `.github/workflows/helmcharts.yml` with Ruby YAML loading.
- Ran `git diff --check`.
- Pushed this branch and confirmed it did not create another empty failed `sync-helm-chart-tags.yml` run.

### **Test Configuration**:

- macOS local worktree
- Docker actionlint image `rhysd/actionlint:latest`
- Ruby YAML parser from local environment

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
