### PR TITLE
🎛️ refactor: Scope App-Config Override Cache by Isolation Context

### DIFF
--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -327,6 +327,51 @@ describe('createAppConfigService', () => {
 
         expect(deps.getApplicableConfigs).toHaveBeenCalledWith([]);
       });
+
+      it('scopes the override cache key to the ALS tenant when no tenantId param is given', async () => {
+        const { tenantStorage } = jest.requireActual('@librechat/data-schemas');
+        const deps = createDeps({
+          getApplicableConfigs: jest
+            .fn()
+            .mockResolvedValue([{ priority: 10, overrides: { x: 1 }, isActive: true }]),
+        });
+        const { getAppConfig } = createAppConfigService(deps);
+
+        await tenantStorage.run({ tenantId: 'tenant-a' }, async () =>
+          getAppConfig({ role: 'USER' }),
+        );
+
+        const overrideKey = [...deps._cache._store.keys()].find((k: string) =>
+          k.includes('_OVERRIDE_:'),
+        );
+        expect(overrideKey).toBe('app_config:_OVERRIDE_:tenant-a:USER');
+        expect(overrideKey).not.toContain('__default__');
+      });
+
+      it('does not serve one tenant a cached config built for another tenant', async () => {
+        const { tenantStorage, getTenantId } = jest.requireActual('@librechat/data-schemas');
+        // Each tenant's DB overrides carry a marker derived from the active ALS tenant.
+        const deps = createDeps({
+          getApplicableConfigs: jest
+            .fn()
+            .mockImplementation(async () => [
+              { priority: 10, overrides: { whoami: getTenantId() }, isActive: true },
+            ]),
+        });
+        const { getAppConfig } = createAppConfigService(deps);
+
+        const configA = (await tenantStorage.run({ tenantId: 'tenant-a' }, async () =>
+          getAppConfig({ role: 'USER' }),
+        )) as TestConfig & { whoami?: string };
+        const configB = (await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
+          getAppConfig({ role: 'USER' }),
+        )) as TestConfig & { whoami?: string };
+
+        expect(configA.whoami).toBe('tenant-a');
+        expect(configB.whoami).toBe('tenant-b');
+        // A cache collision would short-circuit the second tenant's DB read.
+        expect(deps.getApplicableConfigs).toHaveBeenCalledTimes(2);
+      });
     });
 
     it('does not cache on buildPrincipals error — retries on next request', async () => {

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -73,7 +73,10 @@ export function _resetOverrideStrictCache(): void {
 }
 
 function overrideCacheKey(role?: string, userId?: string, tenantId?: string): string {
-  const tenant = tenantId || '__default__';
+  // Fall back to the ALS tenant context before `__default__`: callers that rely on the
+  // tenant middleware (the common path) pass no explicit tenantId, so without this the
+  // entry is keyed under the shared `__default__` bucket and leaks across tenants.
+  const tenant = tenantId || getTenantId() || '__default__';
   if (userId && role) {
     return `_OVERRIDE_:${tenant}:${role}:${userId}`;
   }
@@ -174,16 +177,16 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
       return baseConfig;
     }
 
-    // Strict-isolation + no tenant (param or ALS) = pathological path (middleware bypass or
-    // unauthenticated startup). Pre-tenant calls use baseOnly:true; admin calls carry tenantId.
-    // If ALS has a tenant, Mongoose scopes queries to that tenant's overrides — must fall through.
-    // Not cached: the cache key doesn't include ALS context, so a cached __default__ entry would
-    // be served to later ALS-scoped calls that share the same param-derived key.
+    // Strict isolation + no tenant anywhere (neither param nor ALS) is pathological: a
+    // middleware bypass or an unauthenticated startup call. Pre-tenant calls should use
+    // baseOnly:true and admin calls carry an explicit tenantId. Return the base config
+    // without caching it under the shared `__default__` bucket. When ALS has a tenant,
+    // overrideCacheKey scopes the key to it, so we fall through and cache per-tenant.
     if (principals.length === 0 && !tenantId && !getTenantId() && isStrictOverrideMode()) {
       return baseConfig;
     }
 
-    if (!tenantId && isStrictOverrideMode() && !_warnedNoTenantInStrictMode) {
+    if (!tenantId && !getTenantId() && isStrictOverrideMode() && !_warnedNoTenantInStrictMode) {
       _warnedNoTenantInStrictMode = true;
       logger.warn(
         '[getAppConfig] No tenantId in strict mode — falling back to __default__. ' +


### PR DESCRIPTION
## Summary

`getAppConfig` caches per-principal merged config overrides (model specs, endpoints, interface flags) under a key produced by `overrideCacheKey(role, userId, tenantId)`:

```js
const tenant = tenantId || '__default__';   // ← only the tenantId *argument*
```

The key derives the tenant from the `tenantId` **argument** only. But callers that go through the tenant-context middleware — the common request path — pass no explicit `tenantId` and rely on the `AsyncLocalStorage` tenant context. Those calls are keyed under the shared `__default__` bucket:

1. Tenant A request (no `tenantId` arg, ALS = A) → `getApplicableConfigs` runs under A's context (the Mongoose plugin scopes the DB query to A), the merged result is cached under `_OVERRIDE_:__default__:USER`.
2. Tenant B request (no `tenantId` arg, ALS = B) → same `__default__` key → **cache hit** → tenant A's merged config is served to tenant B.

So the cache key disagreed with the DB scoping, leaking config across tenants. (This affects strict mode too whenever principals are non-empty — the existing empty-principals early-return doesn't cover the role/user case.)

## Fix

Fall back to `getTenantId()` (the ALS tenant) before `__default__`, so the cache key reflects the actual scope the DB query already uses:

```js
const tenant = tenantId || getTenantId() || '__default__';
```

`getTenantId()` is undefined for single-tenant deployments (no ALS context, no `DEFAULT_TENANT_ID`), so the key stays `__default__` and behavior is unchanged there. The strict-mode "no tenantId" warning is also tightened to fire only when there's genuinely no tenant anywhere (neither argument nor ALS), since the ALS case is now scoped rather than defaulted.

## Tests

Adds two tests to the existing `service.spec.ts` (real `Map`-backed cache):

- the override cache key is scoped to the ALS tenant (`_OVERRIDE_:tenant-a:USER`, never `__default__`) when no `tenantId` argument is passed;
- two tenants resolving the same role each receive their own merged config, and the second tenant's request is **not** short-circuited by a cache collision (`getApplicableConfigs` called once per tenant).

Verified both fail without the fix and pass with it. The existing 27 `service.spec.ts` tests are unchanged and green.