### PR TITLE
🪝 fix: Apply Isolation Plugin to Distinct Queries

### DIFF
--- a/packages/data-schemas/src/methods/aclEntry.tenant.spec.ts
+++ b/packages/data-schemas/src/methods/aclEntry.tenant.spec.ts
@@ -1,0 +1,114 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { PrincipalType, PrincipalModel, PermissionBits } from 'librechat-data-provider';
+import type { IAclEntry } from '..';
+import { createAclEntryMethods } from './aclEntry';
+import { createModels } from '../models';
+import { tenantStorage } from '../config/tenantContext';
+
+jest.mock('~/config/winston', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const TENANT_A = 'tenant-aaaaaaaaaaaaaaaaaaaa';
+const TENANT_B = 'tenant-bbbbbbbbbbbbbbbbbbbb';
+const RESOURCE_TYPE = 'agent';
+
+let mongoServer: MongoMemoryServer;
+let AclEntry: mongoose.Model<IAclEntry>;
+let methods: ReturnType<typeof createAclEntryMethods>;
+
+function runAs<T>(tenantId: string, fn: () => Promise<T>): Promise<T> {
+  return tenantStorage.run({ tenantId }, fn);
+}
+
+async function seedAcl(tenantId: string, doc: Record<string, unknown>): Promise<void> {
+  await runAs(tenantId, async () => {
+    await new AclEntry(doc).save();
+  });
+}
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  AclEntry = mongoose.models.AclEntry as mongoose.Model<IAclEntry>;
+  methods = createAclEntryMethods(mongoose);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await AclEntry.deleteMany({});
+});
+
+describe('AclEntry resource lookups are scoped to the active tenant', () => {
+  it('findAccessibleResources returns only the current tenant resources', async () => {
+    const principalId = new mongoose.Types.ObjectId();
+    const resourceA = new mongoose.Types.ObjectId();
+    const resourceB = new mongoose.Types.ObjectId();
+
+    await seedAcl(TENANT_A, {
+      principalType: PrincipalType.USER,
+      principalModel: PrincipalModel.USER,
+      principalId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: resourceA,
+      permBits: PermissionBits.VIEW,
+    });
+    await seedAcl(TENANT_B, {
+      principalType: PrincipalType.USER,
+      principalModel: PrincipalModel.USER,
+      principalId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: resourceB,
+      permBits: PermissionBits.VIEW,
+    });
+
+    const principals = [{ principalType: PrincipalType.USER, principalId }];
+
+    const aResources = await runAs(TENANT_A, () =>
+      methods.findAccessibleResources(principals, RESOURCE_TYPE, PermissionBits.VIEW),
+    );
+    expect(aResources.map(String)).toEqual([String(resourceA)]);
+
+    const bResources = await runAs(TENANT_B, () =>
+      methods.findAccessibleResources(principals, RESOURCE_TYPE, PermissionBits.VIEW),
+    );
+    expect(bResources.map(String)).toEqual([String(resourceB)]);
+  });
+
+  it('findPublicResourceIds returns only the current tenant public resources', async () => {
+    const publicA = new mongoose.Types.ObjectId();
+    const publicB = new mongoose.Types.ObjectId();
+
+    await seedAcl(TENANT_A, {
+      principalType: PrincipalType.PUBLIC,
+      resourceType: RESOURCE_TYPE,
+      resourceId: publicA,
+      permBits: PermissionBits.VIEW,
+    });
+    await seedAcl(TENANT_B, {
+      principalType: PrincipalType.PUBLIC,
+      resourceType: RESOURCE_TYPE,
+      resourceId: publicB,
+      permBits: PermissionBits.VIEW,
+    });
+
+    const aPublic = await runAs(TENANT_A, () =>
+      methods.findPublicResourceIds(RESOURCE_TYPE, PermissionBits.VIEW),
+    );
+    expect(aPublic.map(String)).toEqual([String(publicA)]);
+
+    const bPublic = await runAs(TENANT_B, () =>
+      methods.findPublicResourceIds(RESOURCE_TYPE, PermissionBits.VIEW),
+    );
+    expect(bPublic.map(String)).toEqual([String(publicB)]);
+  });
+});

--- a/packages/data-schemas/src/methods/agentCategory.tenant.spec.ts
+++ b/packages/data-schemas/src/methods/agentCategory.tenant.spec.ts
@@ -1,0 +1,60 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import type { IAgentCategory } from '..';
+import { createAgentCategoryMethods } from './agentCategory';
+import { createModels } from '../models';
+import { tenantStorage } from '../config/tenantContext';
+
+jest.mock('~/config/winston', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const TENANT_A = 'tenant-aaaaaaaaaaaaaaaaaaaa';
+const TENANT_B = 'tenant-bbbbbbbbbbbbbbbbbbbb';
+
+let mongoServer: MongoMemoryServer;
+let AgentCategory: mongoose.Model<IAgentCategory>;
+let methods: ReturnType<typeof createAgentCategoryMethods>;
+
+function runAs<T>(tenantId: string, fn: () => Promise<T>): Promise<T> {
+  return tenantStorage.run({ tenantId }, fn);
+}
+
+async function seedCategory(tenantId: string, value: string): Promise<void> {
+  await runAs(tenantId, async () => {
+    await new AgentCategory({ value, label: value, isActive: true }).save();
+  });
+}
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  AgentCategory = mongoose.models.AgentCategory as mongoose.Model<IAgentCategory>;
+  methods = createAgentCategoryMethods(mongoose);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await AgentCategory.deleteMany({});
+});
+
+describe('getValidCategoryValues is scoped to the active tenant', () => {
+  it('returns only the current tenant category values', async () => {
+    await seedCategory(TENANT_A, 'alpha');
+    await seedCategory(TENANT_B, 'beta');
+
+    const aValues = await runAs(TENANT_A, () => methods.getValidCategoryValues());
+    expect(aValues).toEqual(['alpha']);
+
+    const bValues = await runAs(TENANT_B, () => methods.getValidCategoryValues());
+    expect(bValues).toEqual(['beta']);
+  });
+});

--- a/packages/data-schemas/src/models/plugins/tenantIsolation.spec.ts
+++ b/packages/data-schemas/src/models/plugins/tenantIsolation.spec.ts
@@ -154,6 +154,35 @@ describe('applyTenantIsolation', () => {
       const tenantADoc = await TestModel.findOne({ tenantId: 'tenant-a' }).lean();
       expect(tenantADoc!.name).toBe('updated');
     });
+
+    it('injects tenantId filter into distinct', async () => {
+      const names = await tenantStorage.run({ tenantId: 'tenant-a' }, async () =>
+        TestModel.distinct('name'),
+      );
+
+      expect(names).toEqual(['tenant-a-doc']);
+    });
+
+    it('injects tenantId filter into find().distinct() (op switches to distinct)', async () => {
+      const names = await tenantStorage.run({ tenantId: 'tenant-b' }, async () =>
+        TestModel.find().distinct('name'),
+      );
+
+      expect(names).toEqual(['tenant-b-doc']);
+    });
+
+    it('does not scope distinct when context is absent (non-strict)', async () => {
+      const names = await TestModel.distinct('name');
+      expect(names.sort()).toEqual(['no-tenant-doc', 'tenant-a-doc', 'tenant-b-doc']);
+    });
+
+    it('bypasses distinct filter for SYSTEM_TENANT_ID', async () => {
+      const names = await tenantStorage.run({ tenantId: SYSTEM_TENANT_ID }, async () =>
+        TestModel.distinct('name'),
+      );
+
+      expect(names).toHaveLength(3);
+    });
   });
 
   describe('aggregate filtering', () => {

--- a/packages/data-schemas/src/models/plugins/tenantIsolation.ts
+++ b/packages/data-schemas/src/models/plugins/tenantIsolation.ts
@@ -137,6 +137,7 @@ export function applyTenantIsolation(schema: Schema): void {
 
   schema.pre('find', queryMiddleware);
   schema.pre('findOne', queryMiddleware);
+  schema.pre('distinct', queryMiddleware);
   schema.pre('findOneAndUpdate', queryMiddleware);
   schema.pre('findOneAndDelete', queryMiddleware);
   schema.pre('findOneAndReplace', queryMiddleware);


### PR DESCRIPTION
## Summary

The tenant-isolation plugin scopes queries by injecting `tenantId`, but `distinct` was **not in its hooked-operation list**. So `Model.distinct(field, filter)` — and `Model.find(filter).distinct(field)`, whose op switches to `distinct` — ran **unscoped, across all tenants**.

Affected request-path lookups (all back the resource-visibility / category surfaces):

| Method | Returns | Bypass impact |
|---|---|---|
| `aclEntry.findAccessibleResources` | resource IDs a set of principals can access | cross-tenant resource IDs |
| `aclEntry.findPublicResourceIds` | `PUBLIC` ("shared-to-all") resource IDs | **other tenants' public agents/prompts/files** can surface |
| `agentCategory.getValidCategoryValues` | active category values | category enumeration across tenants |
| `prompt.getRandomPromptGroups` | distinct prompt categories | category enumeration across tenants |

## Fix (one line in the plugin)

`distinct` **is** a registerable query-middleware hook in Mongoose 8 (it's in `queryOperations`). So the fix is to register the plugin's existing `queryMiddleware` for it:

```js
schema.pre('distinct', queryMiddleware);
```

This is strictly better than rewriting each call site to an aggregation:

- **Systemic** — every `.distinct()` on every tenant-scoped model is now scoped, including any future ones, with the same `SYSTEM_TENANT_ID` bypass and strict-mode fail-closed behavior as `find`/`findOne`/etc.
- **No query-shape change** — call sites stay `.distinct()`, which is the **established FerretDB-compatible pattern**. `getRandomPromptGroups` was deliberately built on `.distinct()` (not a `$sample`/aggregation stage) precisely for FerretDB support (see `misc/ferretdb/randomPrompts.ferretdb.spec.ts`); this fix preserves that. The existing `misc/ferretdb/aclBitops.ferretdb.spec.ts` exercises `findAccessibleResources`, so the scoped `.distinct()` is covered on FerretDB.
- Intentional cross-tenant `distinct` in the one-time migration scripts is unaffected — they run outside request tenant context (same as their sibling `find` calls), so the `SYSTEM`/no-context paths apply.

## Tests

- Plugin spec (`tenantIsolation.spec.ts`): `distinct` is scoped, the `find().distinct()` op-switch is scoped, `SYSTEM_TENANT_ID` bypasses, and no-context (non-strict) stays unscoped.
- Behavioral specs (`aclEntry.tenant.spec.ts`, `agentCategory.tenant.spec.ts`): two tenants, real `createModels` (plugin applied) — the ACL and category lookups return only the current tenant's data.

Verified all fail without the hook and pass with it.