### PR TITLE
🗼 ci: Guard Scoped Model Applies the Isolation Plugin

### DIFF
--- a/packages/data-schemas/src/models/plugins/tenantIsolation.coverage.spec.ts
+++ b/packages/data-schemas/src/models/plugins/tenantIsolation.coverage.spec.ts
@@ -1,0 +1,52 @@
+import mongoose from 'mongoose';
+import { createModels } from '../index';
+
+/**
+ * Global symbol set by applyTenantIsolation() on every schema it processes.
+ * Recreated here via Symbol.for (the global registry) so the guard can detect
+ * plugin application without the plugin exporting anything.
+ */
+const TENANT_ISOLATION_APPLIED = Symbol.for('librechat:tenantIsolation');
+
+/**
+ * Models that carry a `tenantId` field but intentionally do NOT use the
+ * tenant-isolation plugin. SystemGrant scopes tenancy manually inside its
+ * methods (see models/systemGrant). Adding an entry here must be a deliberate,
+ * reviewed decision — that is the whole point of this guard.
+ */
+const MANUAL_TENANT_SCOPING = new Set<string>(['SystemGrant']);
+
+function isPluginApplied(schema: mongoose.Schema): boolean {
+  return (schema as unknown as { [key: symbol]: boolean })[TENANT_ISOLATION_APPLIED] === true;
+}
+
+describe('tenant-isolation plugin coverage', () => {
+  beforeAll(() => {
+    createModels(mongoose);
+  });
+
+  it('applies the tenant-isolation plugin to every model that has a tenantId field', () => {
+    const missing: string[] = [];
+
+    for (const [name, model] of Object.entries(mongoose.models)) {
+      const hasTenantId = Boolean(model.schema.path('tenantId'));
+      if (!hasTenantId || MANUAL_TENANT_SCOPING.has(name)) {
+        continue;
+      }
+      if (!isPluginApplied(model.schema)) {
+        missing.push(name);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the manual-scoping allowlist accurate (tenantId field, no plugin)', () => {
+    for (const name of MANUAL_TENANT_SCOPING) {
+      const model = mongoose.models[name];
+      expect(model).toBeDefined();
+      expect(Boolean(model.schema.path('tenantId'))).toBe(true);
+      expect(isPluginApplied(model.schema)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Tenant isolation depends on every Mongoose model that stores a `tenantId` having `applyTenantIsolation` applied. That application is a manual, per-model call (`applyTenantIsolation(schema)` in the model factory) — so a new model that ships a `tenantId` field but forgets the plugin would silently read/write across **all** tenants, with no failing test.

This adds a coverage guard that closes that gap.

## How it works

`applyTenantIsolation` already stamps each schema it processes with a global marker, `Symbol.for('librechat:tenantIsolation')`. The test recreates that symbol (the global registry returns the same symbol) and, after `createModels`, asserts:

- every registered model whose schema has a `tenantId` path has the plugin applied;
- the only exemption is an explicit allowlist — currently just `SystemGrant`, which scopes tenancy manually in its methods.

No production code changes; no DB connection needed (schema registration only). A future model with a `tenantId` field and no plugin now fails CI by name, and intentionally exempting a model requires editing the documented allowlist.

The two passing assertions also confirm the detection works in both directions: all plugged models read `true`, and the manually-scoped `SystemGrant` reads `false`.