### PR TITLE
feat: Allow Scope Overrides To Tombstone Inherited MCP Server Entries

### DIFF
--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -428,6 +428,81 @@ describe('mergeConfigOverrides', () => {
   });
 });
 
+describe('mergeConfigOverrides — mcpServers tombstones', () => {
+  const baseWithMcp = {
+    interfaceConfig: { modelSelect: true },
+    mcpConfig: {
+      inherited: { type: 'sse', url: 'https://base.example.com' },
+      other: { type: 'sse', url: 'https://other.example.com', title: 'Other' },
+    },
+  } as unknown as AppConfig;
+
+  it('drops an inherited mcpServers entry when the override sets it to null', () => {
+    const configs = [fakeConfig({ mcpServers: { inherited: null } }, 10)];
+    const result = mergeConfigOverrides(baseWithMcp, configs) as unknown as Record<string, unknown>;
+    const mcpConfig = result.mcpConfig as Record<string, unknown>;
+    expect(mcpConfig.inherited).toBeUndefined();
+    expect(mcpConfig.other).toEqual({
+      type: 'sse',
+      url: 'https://other.example.com',
+      title: 'Other',
+    });
+  });
+
+  it('preserves other inherited entries and applies partial overrides alongside a tombstone', () => {
+    const configs = [
+      fakeConfig({ mcpServers: { inherited: null, other: { title: 'Edited' } } }, 10),
+    ];
+    const result = mergeConfigOverrides(baseWithMcp, configs) as unknown as Record<string, unknown>;
+    const mcpConfig = result.mcpConfig as Record<string, unknown>;
+    expect(mcpConfig.inherited).toBeUndefined();
+    expect(mcpConfig.other).toEqual({
+      type: 'sse',
+      url: 'https://other.example.com',
+      title: 'Edited',
+    });
+  });
+
+  it('lets a higher-priority override re-assert an entry tombstoned at lower priority', () => {
+    const configs = [
+      fakeConfig({ mcpServers: { inherited: null } }, 5),
+      fakeConfig(
+        { mcpServers: { inherited: { type: 'sse', url: 'https://reassert.example.com' } } },
+        10,
+      ),
+    ];
+    const result = mergeConfigOverrides(baseWithMcp, configs) as unknown as Record<string, unknown>;
+    const mcpConfig = result.mcpConfig as Record<string, unknown>;
+    expect(mcpConfig.inherited).toEqual({ type: 'sse', url: 'https://reassert.example.com' });
+  });
+
+  it('treats null at the section root as a normal merge replacement, not a tombstone', () => {
+    const configs = [fakeConfig({ mcpServers: null }, 10)];
+    const result = mergeConfigOverrides(baseWithMcp, configs) as unknown as Record<string, unknown>;
+    expect(result.mcpConfig).toBeNull();
+  });
+
+  it('does not tombstone null values nested beneath an entry key', () => {
+    const configs = [fakeConfig({ mcpServers: { other: { title: null } } }, 10)];
+    const result = mergeConfigOverrides(baseWithMcp, configs) as unknown as Record<string, unknown>;
+    const mcpConfig = result.mcpConfig as Record<string, unknown>;
+    expect(mcpConfig.other).toEqual({
+      type: 'sse',
+      url: 'https://other.example.com',
+      title: null,
+    });
+  });
+
+  it('is a no-op tombstone for an entry that does not exist in base', () => {
+    const configs = [fakeConfig({ mcpServers: { neverExisted: null } }, 10)];
+    const result = mergeConfigOverrides(baseWithMcp, configs) as unknown as Record<string, unknown>;
+    const mcpConfig = result.mcpConfig as Record<string, unknown>;
+    expect('neverExisted' in mcpConfig).toBe(false);
+    expect(mcpConfig.inherited).toBeDefined();
+    expect(mcpConfig.other).toBeDefined();
+  });
+});
+
 describe('INTERFACE_PERMISSION_FIELDS', () => {
   it('contains all expected permission fields', () => {
     const expected = [

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -21,6 +21,16 @@ const ARRAY_MERGE_KEYS: Record<string, string> = {
 };
 
 /**
+ * Record-type sections whose override layer interprets a `null` value at a child
+ * key as a tombstone: the entry inherited from base (or a lower-priority layer)
+ * is removed from the effective config for this scope. Without this, a scope
+ * can only add or amend entries, never subtract inherited ones, because the
+ * per-field PATCH path has no way to express "for this scope, pretend the
+ * inherited entry does not exist."
+ */
+const TOMBSTONE_SUPPORTED_PARENTS = new Set<string>(['mcpConfig']);
+
+/**
  * Maps YAML-level override keys (TCustomConfig) to their AppConfig equivalents.
  * Overrides are stored with YAML keys but merged into the already-processed AppConfig
  * where some fields have been renamed by AppService.
@@ -122,6 +132,8 @@ function deepMerge<T extends AnyObject>(target: T, source: AnyObject, depth = 0,
         depth,
         currentPath,
       );
+    } else if (sourceVal === null && TOMBSTONE_SUPPORTED_PARENTS.has(path)) {
+      delete result[key];
     } else {
       result[key] = sourceVal;
     }


### PR DESCRIPTION
## Summary

Scope overrides (role/group profiles) on `mcpServers` can already add new entries and edit individual fields on inherited entries, but cannot remove an inherited entry for a single scope. The per-leaf save path uses DELETE-field-path semantics, which only unsets an existing override row; for an entry that exists only in the base YAML/file config there is no scope-tier row to unset, so the DELETE silently no-ops and the entry remains visible in the merged config for that scope. The admin panel worked around this by hiding scope-mode rename/delete affordances entirely, stripping a feature most operators expect.

Add tombstone semantics to the config merge layer: a scope override storing `null` at `mcpServers.<entryKey>` is interpreted as "hide this inherited entry from the effective config for this scope" instead of as a literal null value or a no-op.

## What was happening

`mergeConfigOverrides` in `packages/data-schemas/src/app/resolution.ts` sorts each tenant's scope `configs` by priority and deep-merges their `overrides` payloads onto the base AppConfig. Inside `deepMerge`, a non-object source value at an entry path replaces the target value verbatim; there was no way for a scope to express "remove this key that the lower-priority layer (base) put in the merged result." The per-field PATCH path on the admin side could write any leaf, but the entry-level DELETE could only unset an existing override row, so an inherited-only entry was effectively immortal at the scope tier.

## Fix

Single change in the merge layer, gated to record-type sections that can grow scope-specific deletions:

1. `TOMBSTONE_SUPPORTED_PARENTS` is a new constant set containing `mcpConfig` (the remapped name for the YAML-level `mcpServers` section).
2. `deepMerge` checks for `sourceVal === null` AND the parent path being in `TOMBSTONE_SUPPORTED_PARENTS` before its existing non-object branch. When the check matches, the key is deleted from the result rather than assigned `null`.

Behaviors preserved:

- A `null` at the section root (`mcpServers: null`) keeps the existing replacement behavior; only nested entry-key paths are tombstone-eligible.
- Nested `null` values beneath an entry key (`mcpServers.foo.title: null`) keep their literal meaning, so tombstones do not accidentally recurse into leaf fields.
- A higher-priority layer can re-assert an entry that a lower-priority layer tombstoned by writing a non-null value at the same path; the later assignment wins by the usual priority order.
- Tombstoning an entry that does not exist in base is a silent no-op (nothing to delete), matching the intuition for "this scope does not have this entry."

## Change Type

- [x] New feature (small): scope-override tombstone semantics for MCP server entries

## Testing

`cd packages/data-schemas && npx tsc --noEmit -p tsconfig.json` clean.

`cd packages/data-schemas && npx jest src/app/resolution.spec.ts` covers 32 tests including 6 new tombstone cases: drops an inherited entry when override is null, preserves other inherited entries alongside a tombstone, higher-priority re-assertion beats a lower-priority tombstone, section-root null stays a replacement, nested null is not a tombstone, and tombstone of a non-existent entry is a no-op.

`cd packages/api && npm run test:ci`: 5428 pass, 10 skipped — no regressions from the merge layer change.

Full `cd packages/data-schemas && npm run test:ci` matches CI behavior: suite-level passes apart from a known flake in `mongodb-memory-server` parallel-worker index timing (manifests in different specs on different runs; isolated runs all pass on this branch and on `origin/dev`).

### Test Configuration

```
cd packages/data-schemas
npx jest src/app/resolution.spec.ts
```

## Companion PR

The companion admin-panel change writes the `null` sentinel where it previously sent a DELETE that could only remove an existing override. Until that ships, this code path is dormant; the merge layer accepts the tombstone shape but no client emits it.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
