### PR TITLE
🪪 ci: Fix Helm Tag Sync Git Auth

### DIFF
--- a/.github/scripts/sync-helm-chart-tags.sh
+++ b/.github/scripts/sync-helm-chart-tags.sh
@@ -17,9 +17,14 @@ fail() {
   exit 1
 }
 
+git_auth_header() {
+  token="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+  printf 'AUTHORIZATION: basic %s' "$token"
+}
+
 git_with_auth() {
   if [ -n "${GITHUB_TOKEN:-}" ]; then
-    git -c "http.${GITHUB_SERVER_URL}/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" "$@"
+    git -c "http.extraheader=$(git_auth_header)" "$@"
     return
   fi
 

--- a/.github/workflows/sync-helm-chart-tags.yml
+++ b/.github/workflows/sync-helm-chart-tags.yml
@@ -68,7 +68,8 @@ jobs:
           git init "$REPO_DIR"
           cd "$REPO_DIR"
           git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
-          git -c "http.${GITHUB_SERVER_URL}/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
+          AUTH_HEADER="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')"
+          git -c "http.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
             fetch --prune --force --tags origin \
             "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
           git checkout --detach "$BASE_REF"


### PR DESCRIPTION
## Summary

I fixed the Helm chart tag sync workflow failure from run `26785694164`, where the `Fetch main and tags` step failed with `fatal: could not read Username for 'https://github.com'`.

- Replaced the Git HTTP `bearer` header with GitHub's Basic auth format using `x-access-token:<token>` for the initial workflow fetch.
- Updated the shared script helper so later `ls-remote` and `push` calls use the same authenticated Git header.
- Kept the token scoped to per-command `git -c http.extraheader=...` usage instead of persisting credentials in repository config.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/sync-helm-chart-tags.yml .github/workflows/helmcharts.yml`.
- Ran `bash -n .github/scripts/sync-helm-chart-tags.sh`.
- Ran `.github/scripts/sync-helm-chart-tags.sh` in dry-run mode and confirmed it still identifies `chart-2.0.4` and `chart-2.0.5` as missing.
- Parsed `.github/workflows/sync-helm-chart-tags.yml` and `.github/workflows/helmcharts.yml` with Ruby YAML loading.
- Ran `git diff --check`.
- Verified the exact Basic auth header format with an authenticated temp-repo `git fetch` against `https://github.com/danny-avila/LibreChat.git`.

### **Test Configuration**:

- macOS local worktree
- Docker actionlint image `rhysd/actionlint:latest`
- GitHub CLI token used for the temp authenticated fetch test
- Ruby YAML parser from local environment

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
