### PR TITLE
🤫 chore: Quiet Repetitive Log Noise from Balance, CloudFront, and Capability Paths

### DIFF
--- a/api/server/controllers/Balance.js
+++ b/api/server/controllers/Balance.js
@@ -1,7 +1,7 @@
 const { findBalanceByUser } = require('~/models');
 
 async function balanceController(req, res) {
-  const balanceData = await findBalanceByUser(req.user.id);
+  const balanceData = req.balanceData ?? (await findBalanceByUser(req.user.id));
 
   if (!balanceData) {
     return res.status(404).json({ error: 'Balance not found' });

--- a/api/server/controllers/Balance.js
+++ b/api/server/controllers/Balance.js
@@ -1,6 +1,10 @@
 const { findBalanceByUser } = require('~/models');
 
 async function balanceController(req, res) {
+  if (req.balanceConfigEnabled === false) {
+    return res.sendStatus(204);
+  }
+
   const balanceData = req.balanceData ?? (await findBalanceByUser(req.user.id));
 
   if (!balanceData) {

--- a/api/server/controllers/Balance.js
+++ b/api/server/controllers/Balance.js
@@ -1,11 +1,13 @@
 const { findBalanceByUser } = require('~/models');
 
 async function balanceController(req, res) {
-  if (req.balanceConfigEnabled === false) {
+  const balanceLocals = res.locals || {};
+
+  if (balanceLocals.balanceConfigEnabled === false) {
     return res.sendStatus(204);
   }
 
-  const balanceData = req.balanceData ?? (await findBalanceByUser(req.user.id));
+  const balanceData = balanceLocals.balanceData ?? (await findBalanceByUser(req.user.id));
 
   if (!balanceData) {
     return res.status(404).json({ error: 'Balance not found' });

--- a/api/server/controllers/Balance.spec.js
+++ b/api/server/controllers/Balance.spec.js
@@ -1,0 +1,71 @@
+jest.mock('~/models', () => ({
+  findBalanceByUser: jest.fn(),
+}));
+
+const { findBalanceByUser } = require('~/models');
+const balanceController = require('./Balance');
+
+describe('balanceController', () => {
+  const createResponse = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    sendStatus: jest.fn().mockReturnThis(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns no content without reading balance when balance config is disabled', async () => {
+    const req = {
+      user: { id: 'user-1' },
+      balanceConfigEnabled: false,
+    };
+    const res = createResponse();
+
+    await balanceController(req, res);
+
+    expect(findBalanceByUser).not.toHaveBeenCalled();
+    expect(res.sendStatus).toHaveBeenCalledWith(204);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('uses balance data attached by middleware without a second read', async () => {
+    const req = {
+      user: { id: 'user-1' },
+      balanceConfigEnabled: true,
+      balanceData: {
+        _id: 'balance-1',
+        user: 'user-1',
+        tokenCredits: 100,
+        autoRefillEnabled: false,
+      },
+    };
+    const res = createResponse();
+
+    await balanceController(req, res);
+
+    expect(findBalanceByUser).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      user: 'user-1',
+      tokenCredits: 100,
+      autoRefillEnabled: false,
+    });
+  });
+
+  it('returns not found when balance is enabled and no record exists', async () => {
+    findBalanceByUser.mockResolvedValue(null);
+    const req = {
+      user: { id: 'user-1' },
+      balanceConfigEnabled: true,
+    };
+    const res = createResponse();
+
+    await balanceController(req, res);
+
+    expect(findBalanceByUser).toHaveBeenCalledWith('user-1');
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Balance not found' });
+  });
+});

--- a/api/server/controllers/Balance.spec.js
+++ b/api/server/controllers/Balance.spec.js
@@ -7,6 +7,7 @@ const balanceController = require('./Balance');
 
 describe('balanceController', () => {
   const createResponse = () => ({
+    locals: {},
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
     sendStatus: jest.fn().mockReturnThis(),
@@ -19,9 +20,9 @@ describe('balanceController', () => {
   it('returns no content without reading balance when balance config is disabled', async () => {
     const req = {
       user: { id: 'user-1' },
-      balanceConfigEnabled: false,
     };
     const res = createResponse();
+    res.locals.balanceConfigEnabled = false;
 
     await balanceController(req, res);
 
@@ -33,15 +34,15 @@ describe('balanceController', () => {
   it('uses balance data attached by middleware without a second read', async () => {
     const req = {
       user: { id: 'user-1' },
-      balanceConfigEnabled: true,
-      balanceData: {
-        _id: 'balance-1',
-        user: 'user-1',
-        tokenCredits: 100,
-        autoRefillEnabled: false,
-      },
     };
     const res = createResponse();
+    res.locals.balanceConfigEnabled = true;
+    res.locals.balanceData = {
+      _id: 'balance-1',
+      user: 'user-1',
+      tokenCredits: 100,
+      autoRefillEnabled: false,
+    };
 
     await balanceController(req, res);
 
@@ -58,9 +59,9 @@ describe('balanceController', () => {
     findBalanceByUser.mockResolvedValue(null);
     const req = {
       user: { id: 'user-1' },
-      balanceConfigEnabled: true,
     };
     const res = createResponse();
+    res.locals.balanceConfigEnabled = true;
 
     await balanceController(req, res);
 

--- a/api/server/routes/balance.js
+++ b/api/server/routes/balance.js
@@ -1,8 +1,17 @@
 const express = require('express');
+const { createSetBalanceConfig } = require('@librechat/api');
 const router = express.Router();
 const controller = require('../controllers/Balance');
 const { requireJwtAuth } = require('../middleware/');
+const { findBalanceByUser, upsertBalanceFields } = require('~/models');
+const { getAppConfig } = require('~/server/services/Config');
 
-router.get('/', requireJwtAuth, controller);
+const setBalanceConfig = createSetBalanceConfig({
+  getAppConfig,
+  findBalanceByUser,
+  upsertBalanceFields,
+});
+
+router.get('/', requireJwtAuth, setBalanceConfig, controller);
 
 module.exports = router;

--- a/packages/api/src/cdn/cloudfront-cookies.ts
+++ b/packages/api/src/cdn/cloudfront-cookies.ts
@@ -520,10 +520,6 @@ export function setCloudFrontCookies(
       path: '/',
     });
 
-    logger.debug(
-      `[setCloudFrontCookies] Issued signed CloudFront cookies (paths=${signedCookieSets.length}, expiresInSec=${cookieExpiry}).`,
-    );
-
     return true;
   } catch (error) {
     logger.error('[setCloudFrontCookies] Failed to generate signed cookies:', error);
@@ -571,12 +567,6 @@ export function maybeRefreshCloudFrontAuthCookies(
       : getScopeRefreshReason(previousScope, effectiveScope, refreshWindowSec);
 
     if (!refreshReason) {
-      logger.debug('[maybeRefreshCloudFrontAuthCookies] CloudFront auth cookies still fresh', {
-        attempted: false,
-        refreshed: false,
-        reason: 'fresh',
-        refresh_window_sec: refreshWindowSec,
-      });
       return {
         enabled: true,
         attempted: false,
@@ -599,10 +589,14 @@ export function maybeRefreshCloudFrontAuthCookies(
     };
 
     if (cookiesSet) {
-      logger.debug(
-        '[maybeRefreshCloudFrontAuthCookies] CloudFront auth cookies refreshed',
-        logPayload,
-      );
+      return {
+        enabled: true,
+        attempted: true,
+        refreshed: true,
+        reason: refreshReason,
+        expiresInSec: timing.expiresInSec,
+        refreshAfterSec: timing.refreshAfterSec,
+      };
     } else {
       logger.warn(
         '[maybeRefreshCloudFrontAuthCookies] CloudFront auth cookie refresh failed',
@@ -613,8 +607,8 @@ export function maybeRefreshCloudFrontAuthCookies(
     return {
       enabled: true,
       attempted: true,
-      refreshed: cookiesSet,
-      reason: cookiesSet ? refreshReason : 'set_failed',
+      refreshed: false,
+      reason: 'set_failed',
       expiresInSec: timing.expiresInSec,
       refreshAfterSec: timing.refreshAfterSec,
     };

--- a/packages/api/src/middleware/balance.spec.ts
+++ b/packages/api/src/middleware/balance.spec.ts
@@ -52,6 +52,7 @@ describe('createSetBalanceConfig', () => {
   });
 
   const createMockResponse = (): Partial<ServerResponse> => ({
+    locals: {},
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
   });
@@ -93,12 +94,8 @@ describe('createSetBalanceConfig', () => {
       expect(balanceRecord?.refillIntervalUnit).toBe('days');
       expect(balanceRecord?.refillAmount).toBe(500);
       expect(balanceRecord?.lastRefill).toBeInstanceOf(Date);
-      expect((req as ServerRequest & { balanceConfigEnabled?: boolean }).balanceConfigEnabled).toBe(
-        true,
-      );
-      expect((req as ServerRequest & { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(
-        1000,
-      );
+      expect((res.locals as { balanceConfigEnabled?: boolean }).balanceConfigEnabled).toBe(true);
+      expect((res.locals as { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(1000);
     });
 
     test('should skip if balance config is not enabled', async () => {
@@ -121,9 +118,7 @@ describe('createSetBalanceConfig', () => {
       await middleware(req as ServerRequest, res as ServerResponse, mockNext);
 
       expect(mockNext).toHaveBeenCalled();
-      expect((req as ServerRequest & { balanceConfigEnabled?: boolean }).balanceConfigEnabled).toBe(
-        false,
-      );
+      expect((res.locals as { balanceConfigEnabled?: boolean }).balanceConfigEnabled).toBe(false);
 
       const balanceRecord = await Balance.findOne({ user: userId });
       expect(balanceRecord).toBeNull();
@@ -504,9 +499,7 @@ describe('createSetBalanceConfig', () => {
 
       expect(mockNext).toHaveBeenCalled();
       expect(upsertSpy).not.toHaveBeenCalled();
-      expect((req as ServerRequest & { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(
-        1000,
-      );
+      expect((res.locals as { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(1000);
     });
 
     test('should set tokenCredits for user with null tokenCredits', async () => {

--- a/packages/api/src/middleware/balance.spec.ts
+++ b/packages/api/src/middleware/balance.spec.ts
@@ -93,6 +93,9 @@ describe('createSetBalanceConfig', () => {
       expect(balanceRecord?.refillIntervalUnit).toBe('days');
       expect(balanceRecord?.refillAmount).toBe(500);
       expect(balanceRecord?.lastRefill).toBeInstanceOf(Date);
+      expect((req as ServerRequest & { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(
+        1000,
+      );
     });
 
     test('should skip if balance config is not enabled', async () => {
@@ -495,6 +498,9 @@ describe('createSetBalanceConfig', () => {
 
       expect(mockNext).toHaveBeenCalled();
       expect(upsertSpy).not.toHaveBeenCalled();
+      expect((req as ServerRequest & { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(
+        1000,
+      );
     });
 
     test('should set tokenCredits for user with null tokenCredits', async () => {

--- a/packages/api/src/middleware/balance.spec.ts
+++ b/packages/api/src/middleware/balance.spec.ts
@@ -93,6 +93,9 @@ describe('createSetBalanceConfig', () => {
       expect(balanceRecord?.refillIntervalUnit).toBe('days');
       expect(balanceRecord?.refillAmount).toBe(500);
       expect(balanceRecord?.lastRefill).toBeInstanceOf(Date);
+      expect((req as ServerRequest & { balanceConfigEnabled?: boolean }).balanceConfigEnabled).toBe(
+        true,
+      );
       expect((req as ServerRequest & { balanceData?: IBalance }).balanceData?.tokenCredits).toBe(
         1000,
       );
@@ -118,6 +121,9 @@ describe('createSetBalanceConfig', () => {
       await middleware(req as ServerRequest, res as ServerResponse, mockNext);
 
       expect(mockNext).toHaveBeenCalled();
+      expect((req as ServerRequest & { balanceConfigEnabled?: boolean }).balanceConfigEnabled).toBe(
+        false,
+      );
 
       const balanceRecord = await Balance.findOne({ user: userId });
       expect(balanceRecord).toBeNull();

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -24,6 +24,7 @@ export interface BalanceMiddlewareOptions {
 
 type BalanceRequest = ServerRequest & {
   balanceData?: IBalance | null;
+  balanceConfigEnabled?: boolean;
 };
 
 const balanceUpdateLocks = new Map<string, Promise<void>>();
@@ -129,6 +130,7 @@ export function createSetBalanceConfig({
         tenantId: user?.tenantId,
       });
       const balanceConfig = getBalanceConfig(appConfig);
+      balanceReq.balanceConfigEnabled = balanceConfig?.enabled === true;
       if (!balanceConfig?.enabled) {
         return next();
       }

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -22,6 +22,10 @@ export interface BalanceMiddlewareOptions {
   upsertBalanceFields: (userId: string, fields: IBalanceUpdate) => Promise<IBalance | null>;
 }
 
+type BalanceRequest = ServerRequest & {
+  balanceData?: IBalance | null;
+};
+
 const balanceUpdateLocks = new Map<string, Promise<void>>();
 
 async function runBalanceUpdate(userId: string, task: () => Promise<void>): Promise<void> {
@@ -117,6 +121,7 @@ export function createSetBalanceConfig({
 ) => Promise<void> {
   return async (req: ServerRequest, res: ServerResponse, next: NextFunction): Promise<void> => {
     try {
+      const balanceReq = req as BalanceRequest;
       const user = req.user as IUser & { _id: string | ObjectId };
       const appConfig = await getAppConfig({
         role: user?.role,
@@ -140,10 +145,11 @@ export function createSetBalanceConfig({
         const updateFields = buildUpdateFields(balanceConfig, userBalanceRecord, userId);
 
         if (Object.keys(updateFields).length === 0) {
+          balanceReq.balanceData = userBalanceRecord;
           return;
         }
 
-        await upsertBalanceFields(userId, updateFields);
+        balanceReq.balanceData = await upsertBalanceFields(userId, updateFields);
       });
 
       next();

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -22,7 +22,7 @@ export interface BalanceMiddlewareOptions {
   upsertBalanceFields: (userId: string, fields: IBalanceUpdate) => Promise<IBalance | null>;
 }
 
-type BalanceRequest = ServerRequest & {
+type BalanceLocals = {
   balanceData?: IBalance | null;
   balanceConfigEnabled?: boolean;
 };
@@ -122,7 +122,7 @@ export function createSetBalanceConfig({
 ) => Promise<void> {
   return async (req: ServerRequest, res: ServerResponse, next: NextFunction): Promise<void> => {
     try {
-      const balanceReq = req as BalanceRequest;
+      const balanceLocals = res.locals as BalanceLocals;
       const user = req.user as IUser & { _id: string | ObjectId };
       const appConfig = await getAppConfig({
         role: user?.role,
@@ -130,7 +130,7 @@ export function createSetBalanceConfig({
         tenantId: user?.tenantId,
       });
       const balanceConfig = getBalanceConfig(appConfig);
-      balanceReq.balanceConfigEnabled = balanceConfig?.enabled === true;
+      balanceLocals.balanceConfigEnabled = balanceConfig?.enabled === true;
       if (!balanceConfig?.enabled) {
         return next();
       }
@@ -147,11 +147,11 @@ export function createSetBalanceConfig({
         const updateFields = buildUpdateFields(balanceConfig, userBalanceRecord, userId);
 
         if (Object.keys(updateFields).length === 0) {
-          balanceReq.balanceData = userBalanceRecord;
+          balanceLocals.balanceData = userBalanceRecord;
           return;
         }
 
-        balanceReq.balanceData = await upsertBalanceFields(userId, updateFields);
+        balanceLocals.balanceData = await upsertBalanceFields(userId, updateFields);
       });
 
       next();

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -35,6 +35,10 @@ interface CapabilityStore {
   results: Map<string, boolean>;
 }
 
+const DENIAL_WARN_INTERVAL_MS = 5 * 60 * 1000;
+const MAX_DENIAL_WARN_KEYS = 1000;
+const recentDenialWarnings = new Map<string, number>();
+
 export type HasCapabilityFn = (
   user: CapabilityUser,
   capability: SystemCapability,
@@ -73,6 +77,21 @@ export function capabilityContextMiddleware(
     );
   }
   capabilityStore.run({ principals: new Map(), results: new Map() }, next);
+}
+
+function warnDeniedCapabilityOnce(key: string, message: string): void {
+  const now = Date.now();
+  const lastLoggedAt = recentDenialWarnings.get(key);
+  if (lastLoggedAt !== undefined && now - lastLoggedAt < DENIAL_WARN_INTERVAL_MS) {
+    return;
+  }
+
+  if (recentDenialWarnings.size >= MAX_DENIAL_WARN_KEYS) {
+    recentDenialWarnings.clear();
+  }
+
+  recentDenialWarnings.set(key, now);
+  logger.warn(message);
 }
 
 /**
@@ -191,7 +210,10 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
           return;
         }
 
-        logger.warn(`[requireCapability] Forbidden: user ${id} missing capability '${capability}'`);
+        warnDeniedCapabilityOnce(
+          `missing-capability:${id}:${capability}`,
+          `[requireCapability] Forbidden: user ${id} missing capability '${capability}'`,
+        );
         res.status(403).json({ message: 'Forbidden' });
       } catch (err) {
         logger.error(`[requireCapability] Error checking capability: ${capability}`, err);

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -87,7 +87,10 @@ function warnDeniedCapabilityOnce(key: string, message: string): void {
   }
 
   if (recentDenialWarnings.size >= MAX_DENIAL_WARN_KEYS) {
-    recentDenialWarnings.clear();
+    const oldestKey = recentDenialWarnings.keys().next().value;
+    if (oldestKey !== undefined) {
+      recentDenialWarnings.delete(oldestKey);
+    }
   }
 
   recentDenialWarnings.set(key, now);


### PR DESCRIPTION
## Summary
- hydrate missing balance records before `/api/balance` reads so user polling does not produce repeated 404 noise
- stop debug logging for healthy CloudFront signed-cookie issue, fresh, and refresh paths while preserving warnings/errors
- throttle repeated `requireCapability` forbidden warnings per user/capability

## Validation
- `../../node_modules/.bin/jest src/cdn/__tests__/cloudfront-cookies.test.ts src/middleware/capabilities.spec.ts --runInBand --coverage=false` from `packages/api`
- `./node_modules/.bin/eslint api/server/routes/balance.js packages/api/src/cdn/cloudfront-cookies.ts packages/api/src/middleware/capabilities.ts`