### PR TITLE
🌎 ci: Fix Locize Sync CDN Mode

### DIFF
--- a/.github/workflows/locize-i18n-sync.yml
+++ b/.github/workflows/locize-i18n-sync.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '24.16.0'
 
       - name: Install locize CLI
-        run: npm install -g locize-cli
+        run: npm install -g locize-cli@12.2.0 --ignore-scripts --no-audit --no-fund
 
       # Sync translations (Push missing keys & remove deleted ones)
       - name: Sync Locize with Repository
@@ -35,7 +35,7 @@ jobs:
           LOCIZE_PROJECT_ID: ${{ secrets.LOCIZE_PROJECT_ID }}
         run: |
           cd client/src/locales
-          locize sync --api-key "$LOCIZE_API_KEY" --project-id "$LOCIZE_PROJECT_ID" --language en
+          locize sync --cdn-type pro --api-key "$LOCIZE_API_KEY" --project-id "$LOCIZE_PROJECT_ID" --language en
 
       # When triggered by repository_dispatch, skip sync step.
       - name: Skip sync step on non-push events


### PR DESCRIPTION
## Summary

I fixed the Locize translation sync workflow so the Node 24 upgrade no longer changes which Locize CDN endpoint the sync command uses.

- Pin `locize-cli` to `12.2.0` so the workflow does not pull a moving global CLI version on each run.
- Disable npm install scripts for the transient global CLI install and suppress audit/funding noise in CI.
- Pass `--cdn-type pro` explicitly so the workflow keeps using the endpoint expected by the existing LibreChat Locize project.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/locize-i18n-sync.yml"); puts "yaml ok"'`.
- Ran official `actionlint v1.7.12` against `.github/workflows/locize-i18n-sync.yml`.
- Ran `git diff --check`.
- Verified `locize-cli@12.2.0` installs with `--ignore-scripts` and still reports `12.2.0`.
- Verified `locize-cli@12.2.0 sync --help` exposes `--cdn-type <standard|pro>`.
- Ran `npm audit --omit=dev --audit-level=high` for `locize-cli@12.2.0`; it reported `found 0 vulnerabilities`.

### **Test Configuration**:

- Node.js: v24.16.0
- npm: local npm via the current workspace shell
- actionlint: v1.7.12 darwin/arm64

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local workflow lint/sanity checks pass with my changes