### PR TITLE
fix(agents): include conversation_starters in agents list projection

### DIFF
--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -764,6 +764,7 @@ export function createAgentMethods(mongoose: typeof import('mongoose'), deps: Ag
       category: 1,
       support_contact: 1,
       is_promoted: 1,
+      conversation_starters: 1,
     };
 
     if (includeSkillConfig) {


### PR DESCRIPTION
## Problem

The `/api/agents` list endpoint omits `conversation_starters` from each agent in the response. As a consequence the frontend Landing page never renders the starter chips, even when `conversation_starters` is set on the agent and visible in Agent Builder.

## Root cause

In `packages/data-schemas/src/methods/agent.ts`, the `getListAgentsByAccess` function builds the Mongoose projection without `conversation_starters`:

```ts
const projection: Record<string, 1> = {
  id: 1, _id: 1, name: 1, avatar: 1, author: 1, description: 1,
  updatedAt: 1, category: 1, support_contact: 1, is_promoted: 1,
};
```

The detail endpoint `/api/agents/:id` returns the full document including `conversation_starters`, but the Landing page never refetches the detail — it reads from the `agentsMap` cache populated by the list response. With the field missing the chip render condition (`agent?.conversation_starters?.length`) is always falsy, so chips never appear for any agent regardless of how they are configured.

## Fix

One line: include `conversation_starters: 1` in the base projection. The field is small (an array of short strings), part of the agent schema by design, and already exposed by the detail endpoint. No new ACL, no new query parameter, no behavioural change other than the chips becoming visible as users would already expect them to.

## Verification

Reproduced and verified against v0.8.6 in a multi-agent deployment with public ACL:

- Before: `/api/agents` items omit `conversation_starters`. Chips never rendered on Landing.
- After: `/api/agents` items include `conversation_starters`. Chips render as expected.

Detail endpoint behaviour unchanged. No schema migration.