### PR TITLE
feat: add configurable retention for uploaded files

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -38,7 +38,7 @@ const { loadAuthValues } = require('~/server/services/Tools/credentials');
 const { getFileStrategy } = require('~/server/utils/getFileStrategy');
 const { checkCapability } = require('~/server/services/Config');
 const { LB_QueueAsyncCall } = require('~/server/utils/queue');
-const { getRetentionExpiry, getAgentFileRetentionExpiry } = require('./retention');
+const { getFileRetentionExpiry, getAgentFileRetentionExpiry } = require('./retention');
 const { getStrategyFunctions } = require('./strategies');
 const { determineFileType } = require('~/server/utils');
 const { STTService } = require('./Audio/STTService');
@@ -424,7 +424,7 @@ const processFileURL = async ({
         source: fileStrategy,
         type,
         context,
-        ...(await getRetentionExpiry(req)),
+        ...(await getFileRetentionExpiry(req)),
         tenantId,
         width: dimensions.width,
         height: dimensions.height,
@@ -475,7 +475,7 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
       context: FileContext.message_attachment,
       source,
       type: `image/${appConfig.imageOutputType}`,
-      ...(await getRetentionExpiry(req)),
+      ...(await getFileRetentionExpiry(req)),
       width,
       height,
       tenantId: req.user.tenantId,
@@ -536,7 +536,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
       source,
       type,
       width,
-      ...(await getRetentionExpiry(req)),
+      ...(await getFileRetentionExpiry(req)),
       height,
       tenantId: req.user.tenantId,
     },
@@ -639,7 +639,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
       context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
       model: isAssistantUpload ? req.body.model : undefined,
       type: file.mimetype,
-      ...(await getRetentionExpiry(req)),
+      ...(await getFileRetentionExpiry(req)),
       embedded,
       source,
       height,
@@ -1026,7 +1026,7 @@ const processOpenAIFile = async ({
     source,
     model: openai.req.body.model,
     filename: originalName ?? file_id,
-    ...(await getRetentionExpiry(openai.req)),
+    ...(await getFileRetentionExpiry(openai.req)),
     tenantId: openai.req?.user?.tenantId,
   };
 
@@ -1071,7 +1071,7 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     context: FileContext.assistants_output,
     file_id,
     filename,
-    ...(await getRetentionExpiry(req)),
+    ...(await getFileRetentionExpiry(req)),
     tenantId: req.user.tenantId,
   };
   try {
@@ -1236,7 +1236,7 @@ async function saveBase64Image(
       user: req.user.id,
       bytes: image.bytes,
       width: image.width,
-      ...(await getRetentionExpiry(req)),
+      ...(await getFileRetentionExpiry(req)),
       height: image.height,
       tenantId: req.user.tenantId,
     },

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -4,6 +4,7 @@ jest.mock('@librechat/data-schemas', () => ({
   logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
   runAsSystem: jest.fn((fn) => fn()),
   createTempChatExpirationDate: jest.fn(() => new Date('2030-01-01T00:00:00.000Z')),
+  createFileExpirationDate: jest.fn(() => new Date('2030-01-01T00:00:00.000Z')),
 }));
 
 jest.mock('@librechat/agents', () => ({

--- a/api/server/services/Files/retention.js
+++ b/api/server/services/Files/retention.js
@@ -2,12 +2,22 @@ const {
   getRetentionExpiry: getRetentionExpiryWithDeps,
   getAgentFileRetentionExpiry: getAgentFileRetentionExpiryWithDeps,
 } = require('@librechat/api');
-const { logger, createTempChatExpirationDate } = require('@librechat/data-schemas');
+const {
+  logger,
+  createTempChatExpirationDate,
+  createFileExpirationDate,
+} = require('@librechat/data-schemas');
 const db = require('~/models');
 
 const getRetentionDependencies = () => ({
   getConvo: db.getConvoRetention ?? db.getConvo,
   createExpirationDate: createTempChatExpirationDate,
+  logger,
+});
+
+const getFileRetentionDependencies = () => ({
+  getConvo: db.getConvoRetention ?? db.getConvo,
+  createExpirationDate: createFileExpirationDate,
   logger,
 });
 
@@ -22,6 +32,18 @@ async function getRetentionExpiry(req) {
 }
 
 /**
+ * Returns `{ expiredAt }` for file uploads when file retention is configured, otherwise
+ * falls back to conversation/message retention behavior.
+ * @param {ServerRequest} req
+ * @returns {Promise<{ expiredAt?: Date | null }>}
+ */
+async function getFileRetentionExpiry(req) {
+  return getRetentionExpiryWithDeps(req, getFileRetentionDependencies(), {
+    applyFileRetention: true,
+  });
+}
+
+/**
  * Returns `{ expiredAt }` for agent file uploads when retention applies, otherwise `{}`.
  * @param {object} params
  * @param {ServerRequest} params.req
@@ -33,11 +55,12 @@ async function getRetentionExpiry(req) {
 async function getAgentFileRetentionExpiry({ tool_resource, toolResource, ...params }) {
   return getAgentFileRetentionExpiryWithDeps(
     { ...params, toolResource: tool_resource ?? toolResource },
-    getRetentionDependencies(),
+    getFileRetentionDependencies(),
   );
 }
 
 module.exports = {
   getRetentionExpiry,
+  getFileRetentionExpiry,
   getAgentFileRetentionExpiry,
 };

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -167,6 +167,9 @@ interface:
 
   # Temporary chat retention period in hours (default: 720, min: 1, max: 8760)
   # temporaryChatRetention: 1
+  # Uploaded file retention period in hours (disabled by default, min: 1, max: 8760)
+  # Applies to uploaded images, documents, audio, and other files independently of conversation retention settings.
+  # fileRetention: 720
   # Retention mode: "all" applies expiry to all data types, "temporary" (default) only to temporary chats
   # Before switching from "all" back to "temporary", remove retention deadlines from non-temporary data
   # that should stop expiring:

--- a/packages/api/src/files/retention.spec.ts
+++ b/packages/api/src/files/retention.spec.ts
@@ -52,6 +52,44 @@ describe('retention helpers', () => {
     expect(dependencies.getConvo).not.toHaveBeenCalled();
   });
 
+  it('applies file retention when requested and configured', async () => {
+    const result = await getRetentionExpiry(
+      request({
+        config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY, fileRetention: 24 } },
+        body: { isTemporary: false },
+      }),
+      dependencies,
+      { applyFileRetention: true },
+    );
+
+    expect(result).toEqual({ expiredAt: expirationDate });
+    expect(dependencies.getConvo).not.toHaveBeenCalled();
+  });
+
+  it('does not apply file retention when requested but not configured', async () => {
+    const result = await getRetentionExpiry(
+      request({ body: { isTemporary: false } }),
+      dependencies,
+      { applyFileRetention: true },
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('uses a distinct cache entry for file retention mode', async () => {
+    const req = request({
+      config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY, fileRetention: 24 } },
+      body: { isTemporary: false },
+    });
+
+    const normalResult = await getRetentionExpiry(req, dependencies);
+    const fileResult = await getRetentionExpiry(req, dependencies, { applyFileRetention: true });
+
+    expect(normalResult).toEqual({});
+    expect(fileResult).toEqual({ expiredAt: expirationDate });
+    expect(dependencies.createExpirationDate).toHaveBeenCalledTimes(1);
+  });
+
   it('returns a fresh expiry when the conversation has an active expiration', async () => {
     dependencies.getConvo.mockResolvedValue({
       expiredAt: new Date(Date.now() + 60 * 60 * 1000),
@@ -234,6 +272,29 @@ describe('retention helpers', () => {
     expect(result).toEqual({});
     expect(dependencies.getConvo).not.toHaveBeenCalled();
     expect(dependencies.createExpirationDate).not.toHaveBeenCalled();
+  });
+
+  it('applies configured file retention to persistent agent files', async () => {
+    const result = await getAgentFileRetentionExpiry(
+      {
+        req: request({
+          config: {
+            interfaceConfig: {
+              retentionMode: RetentionMode.TEMPORARY,
+              retainAgentFiles: true,
+              fileRetention: 12,
+            },
+          },
+        }),
+        messageAttachment: false,
+        toolResource: 'context',
+      },
+      dependencies,
+    );
+
+    expect(result).toEqual({ expiredAt: expirationDate });
+    expect(dependencies.getConvo).not.toHaveBeenCalled();
+    expect(dependencies.createExpirationDate).toHaveBeenCalledTimes(1);
   });
 
   it('applies all-data retention to persistent agent files when retainAgentFiles is disabled', async () => {

--- a/packages/api/src/files/retention.ts
+++ b/packages/api/src/files/retention.ts
@@ -4,13 +4,7 @@ import type { AppConfig } from '@librechat/data-schemas';
 
 type InterfaceConfig = AppConfig['interfaceConfig'];
 
-const retentionExpiryCache = new WeakMap<
-  RetentionRequest,
-  {
-    key: string;
-    promise: Promise<RetentionExpiry>;
-  }
->();
+const retentionExpiryCache = new WeakMap<RetentionRequest, Map<string, Promise<RetentionExpiry>>>();
 
 export type RetentionConversation = {
   expiredAt?: Date | string | number | null;
@@ -32,6 +26,10 @@ export type RetentionRequest = {
 
 export type RetentionExpiry = {
   expiredAt?: Date | null;
+};
+
+export type RetentionOptions = {
+  applyFileRetention?: boolean;
 };
 
 export type AgentFileRetentionRequest = {
@@ -91,8 +89,13 @@ const createRetentionExpiry = (
   }
 };
 
-const getRetentionCacheKey = (req: RetentionRequest): string =>
+const hasFileRetentionConfigured = (req: RetentionRequest | null | undefined): boolean =>
+  req?.config?.interfaceConfig?.fileRetention != null;
+
+const getRetentionCacheKey = (req: RetentionRequest, options: RetentionOptions = {}): string =>
   [
+    String(options.applyFileRetention ?? false),
+    req.config?.interfaceConfig?.fileRetention ?? '',
     req.config?.interfaceConfig?.retentionMode ?? '',
     req.user?.id ?? '',
     req.body?.conversationId ?? '',
@@ -102,7 +105,12 @@ const getRetentionCacheKey = (req: RetentionRequest): string =>
 async function computeRetentionExpiry(
   req: RetentionRequest | null | undefined,
   dependencies: RetentionDependencies,
+  options: RetentionOptions,
 ): Promise<RetentionExpiry> {
+  if (options.applyFileRetention && hasFileRetentionConfigured(req)) {
+    return createRetentionExpiry(req, dependencies);
+  }
+
   if (req?.config?.interfaceConfig?.retentionMode === RetentionMode.ALL) {
     return createRetentionExpiry(req, dependencies);
   }
@@ -150,19 +158,27 @@ async function computeRetentionExpiry(
 export async function getRetentionExpiry(
   req: RetentionRequest | null | undefined,
   dependencies: RetentionDependencies,
+  options: RetentionOptions = {},
 ): Promise<RetentionExpiry> {
   if (!req) {
     return {};
   }
 
-  const key = getRetentionCacheKey(req);
-  const cached = retentionExpiryCache.get(req);
-  if (cached?.key === key) {
-    return cached.promise;
+  const key = getRetentionCacheKey(req, options);
+  const reqCache = retentionExpiryCache.get(req);
+  const cachedPromise = reqCache?.get(key);
+  if (cachedPromise) {
+    return cachedPromise;
   }
 
-  const promise = computeRetentionExpiry(req, dependencies);
-  retentionExpiryCache.set(req, { key, promise });
+  const promise = computeRetentionExpiry(req, dependencies, options);
+
+  if (reqCache) {
+    reqCache.set(key, promise);
+  } else {
+    retentionExpiryCache.set(req, new Map([[key, promise]]));
+  }
+
   return promise;
 }
 
@@ -188,6 +204,10 @@ export async function getAgentFileRetentionExpiry(
   params: AgentFileRetentionRequest,
   dependencies: RetentionDependencies,
 ): Promise<RetentionExpiry> {
+  if (hasFileRetentionConfigured(params.req)) {
+    return await getRetentionExpiry(params.req, dependencies, { applyFileRetention: true });
+  }
+
   if (shouldRetainPersistentAgentFile(params)) {
     return {};
   }

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -967,6 +967,7 @@ export const interfaceSchema = z
       .optional(),
     temporaryChat: z.boolean().optional(),
     temporaryChatRetention: z.number().min(1).max(8760).optional(),
+    fileRetention: z.number().min(1).max(8760).optional(),
     autoSubmitFromUrl: z.boolean().optional(),
     retentionMode: z.nativeEnum(RetentionMode).default(RetentionMode.TEMPORARY),
     retainAgentFiles: z.boolean().optional(),

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -66,6 +66,30 @@ describe('loadDefaultInterface', () => {
     expect(interfaceConfig).not.toHaveProperty('temporaryChatRetention');
   });
 
+  it('preserves the configured file retention period', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        fileRetention: 72,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.fileRetention).toBe(72);
+  });
+
+  it('omits file retention when it is not explicitly configured', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig).not.toHaveProperty('fileRetention');
+  });
+
   it('preserves the configured agent file retention exemption', async () => {
     const config: Partial<TCustomConfig> = {
       interface: {

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -48,6 +48,7 @@ export async function loadDefaultInterface({
     agents: interfaceConfig?.agents,
     temporaryChat: interfaceConfig?.temporaryChat,
     temporaryChatRetention: interfaceConfig?.temporaryChatRetention,
+    fileRetention: interfaceConfig?.fileRetention,
     retentionMode: interfaceConfig?.retentionMode,
     retainAgentFiles: interfaceConfig?.retainAgentFiles,
     runCode: interfaceConfig?.runCode,

--- a/packages/data-schemas/src/utils/tempChatRetention.spec.ts
+++ b/packages/data-schemas/src/utils/tempChatRetention.spec.ts
@@ -1,7 +1,9 @@
 import type { AppConfig } from '~/types';
 import {
   createTempChatExpirationDate,
+  createFileExpirationDate,
   getTempChatRetentionHours,
+  getFileRetentionHours,
   DEFAULT_RETENTION_HOURS,
   MIN_RETENTION_HOURS,
   MAX_RETENTION_HOURS,
@@ -90,6 +92,57 @@ describe('tempChatRetention', () => {
     });
   });
 
+  describe('getFileRetentionHours', () => {
+    it('should return null when file retention is not configured', () => {
+      const result = getFileRetentionHours();
+      expect(result).toBeNull();
+    });
+
+    it('should use configured file retention hours when set', () => {
+      const config: Partial<AppConfig> = {
+        interfaceConfig: {
+          fileRetention: 36,
+        },
+      };
+
+      const result = getFileRetentionHours(config?.interfaceConfig);
+      expect(result).toBe(36);
+    });
+
+    it('should enforce minimum file retention period', () => {
+      const config: Partial<AppConfig> = {
+        interfaceConfig: {
+          fileRetention: 0,
+        },
+      };
+
+      const result = getFileRetentionHours(config?.interfaceConfig);
+      expect(result).toBe(MIN_RETENTION_HOURS);
+    });
+
+    it('should enforce maximum file retention period', () => {
+      const config: Partial<AppConfig> = {
+        interfaceConfig: {
+          fileRetention: 10000,
+        },
+      };
+
+      const result = getFileRetentionHours(config?.interfaceConfig);
+      expect(result).toBe(MAX_RETENTION_HOURS);
+    });
+
+    it('should ignore invalid configured file retention values', () => {
+      const config: Partial<AppConfig> = {
+        interfaceConfig: {
+          fileRetention: 'invalid' as unknown as number,
+        },
+      };
+
+      const result = getFileRetentionHours(config?.interfaceConfig);
+      expect(result).toBeNull();
+    });
+  });
+
   describe('createTempChatExpirationDate', () => {
     it('should create expiration date with default retention period', () => {
       const beforeCall = Date.now();
@@ -99,7 +152,6 @@ describe('tempChatRetention', () => {
       const expectedMin = beforeCall + DEFAULT_RETENTION_HOURS * 60 * 60 * 1000;
       const expectedMax = afterCall + DEFAULT_RETENTION_HOURS * 60 * 60 * 1000;
 
-      // Result should be between expectedMin and expectedMax
       expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
       expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
     });
@@ -118,7 +170,6 @@ describe('tempChatRetention', () => {
       const expectedMin = beforeCall + 12 * 60 * 60 * 1000;
       const expectedMax = afterCall + 12 * 60 * 60 * 1000;
 
-      // Result should be between expectedMin and expectedMax
       expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
       expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
     });
@@ -132,6 +183,44 @@ describe('tempChatRetention', () => {
       const now = new Date();
       const result = createTempChatExpirationDate();
       expect(result.getTime()).toBeGreaterThan(now.getTime());
+    });
+  });
+
+  describe('createFileExpirationDate', () => {
+    it('should use file retention when configured', () => {
+      const config: Partial<AppConfig> = {
+        interfaceConfig: {
+          fileRetention: 8,
+        },
+      };
+
+      const beforeCall = Date.now();
+      const result = createFileExpirationDate(config?.interfaceConfig);
+      const afterCall = Date.now();
+
+      const expectedMin = beforeCall + 8 * 60 * 60 * 1000;
+      const expectedMax = afterCall + 8 * 60 * 60 * 1000;
+
+      expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
+      expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
+    });
+
+    it('should fall back to temporary chat retention when file retention is not configured', () => {
+      const config: Partial<AppConfig> = {
+        interfaceConfig: {
+          temporaryChatRetention: 6,
+        },
+      };
+
+      const beforeCall = Date.now();
+      const result = createFileExpirationDate(config?.interfaceConfig);
+      const afterCall = Date.now();
+
+      const expectedMin = beforeCall + 6 * 60 * 60 * 1000;
+      const expectedMax = afterCall + 6 * 60 * 60 * 1000;
+
+      expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
+      expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
     });
   });
 });

--- a/packages/data-schemas/src/utils/tempChatRetention.ts
+++ b/packages/data-schemas/src/utils/tempChatRetention.ts
@@ -26,7 +26,6 @@ export function getTempChatRetentionHours(
 ): number {
   let retentionHours = DEFAULT_RETENTION_HOURS;
 
-  // Check environment variable first
   if (process.env.TEMP_CHAT_RETENTION_HOURS) {
     const envValue = parseInt(process.env.TEMP_CHAT_RETENTION_HOURS, 10);
     if (!isNaN(envValue)) {
@@ -38,7 +37,6 @@ export function getTempChatRetentionHours(
     }
   }
 
-  // Check config file (takes precedence over environment variable)
   if (interfaceConfig?.temporaryChatRetention !== undefined) {
     const configValue = interfaceConfig.temporaryChatRetention;
     if (typeof configValue === 'number' && !isNaN(configValue)) {
@@ -50,7 +48,6 @@ export function getTempChatRetentionHours(
     }
   }
 
-  // Validate the retention period
   if (retentionHours < MIN_RETENTION_HOURS) {
     logger.warn(
       `Temporary chat retention period ${retentionHours} is below minimum ${MIN_RETENTION_HOURS} hours. Using minimum value.`,
@@ -64,6 +61,53 @@ export function getTempChatRetentionHours(
   }
 
   return retentionHours;
+}
+
+/**
+ * Gets the file retention period from config when configured.
+ * @param interfaceConfig - The custom configuration object
+ * @returns The file retention period in hours, or null when not configured
+ */
+export function getFileRetentionHours(interfaceConfig?: AppConfig['interfaceConfig'] | null): number | null {
+  const configValue = interfaceConfig?.fileRetention;
+
+  if (configValue == null) {
+    return null;
+  }
+
+  if (typeof configValue !== 'number' || isNaN(configValue)) {
+    logger.warn(`Invalid fileRetention in config: ${configValue}. Ignoring file retention override.`);
+    return null;
+  }
+
+  if (configValue < MIN_RETENTION_HOURS) {
+    logger.warn(
+      `File retention period ${configValue} is below minimum ${MIN_RETENTION_HOURS} hours. Using minimum value.`,
+    );
+    return MIN_RETENTION_HOURS;
+  }
+
+  if (configValue > MAX_RETENTION_HOURS) {
+    logger.warn(
+      `File retention period ${configValue} exceeds maximum ${MAX_RETENTION_HOURS} hours. Using maximum value.`,
+    );
+    return MAX_RETENTION_HOURS;
+  }
+
+  return configValue;
+}
+
+/**
+ * Creates an expiration date for uploaded files.
+ * @param interfaceConfig - The custom configuration object
+ * @returns The expiration date
+ */
+export function createFileExpirationDate(interfaceConfig?: AppConfig['interfaceConfig']): Date {
+  const fileRetentionHours = getFileRetentionHours(interfaceConfig);
+  const retentionHours =
+    fileRetentionHours == null ? getTempChatRetentionHours(interfaceConfig) : fileRetentionHours;
+
+  return new Date(Date.now() + retentionHours * 60 * 60 * 1000);
 }
 
 /**


### PR DESCRIPTION
## Summary

Implemented configurable uploaded-file retention so administrators can enforce automatic deletion of uploaded files (images, documents, audio, and other file uploads) after a configured number of hours.

This uses the existing retention/sweep pipeline so expiration removes both:
- file storage objects
- file metadata records

## Changes:
- Added `interface.fileRetention` validation to the shared config schema.
  - `packages/data-provider/src/config.ts`
- Propagated `fileRetention` into loaded interface config.
  - `packages/data-schemas/src/app/interface.ts`
- Added file-retention utilities:
  - `getFileRetentionHours(...)`
  - `createFileExpirationDate(...)`
  - `packages/data-schemas/src/utils/tempChatRetention.ts`
- Extended shared retention resolution with file-retention options:
  - Added `RetentionOptions` with `applyFileRetention`
  - Made retention cache key/options file-retention aware
  - Added file-retention-first resolution path when configured
  - `packages/api/src/files/retention.ts`
- Added backend service wrapper for file-specific retention:
  - `getFileRetentionExpiry(...)`
  - `api/server/services/Files/retention.js`
- Updated file persistence paths to use file-specific retention expiry.
  - `api/server/services/Files/process.js`
- Documented sample YAML configuration.
  - `librechat.example.yaml`
- Added/updated tests:
  - `packages/api/src/files/retention.spec.ts`
  - `packages/data-schemas/src/app/interface.spec.ts`
  - `packages/data-schemas/src/utils/tempChatRetention.spec.ts`
  - `api/server/services/Files/process.spec.js` (mock update)
  
## Configuration:
To automatically delete uploaded files after 30 days:

```yaml
interface:
  fileRetention: 720
```

- `fileRetention` is in **hours**.
- `720` = **30 days**.
- Allowed range is `1` to `8760`.
- If `fileRetention` is configured, uploaded files use file-specific expiration logic.
- If `fileRetention` is not configured, existing retention behavior is preserved.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Notes
- This setting is independent from `temporaryChatRetention` and `retentionMode` behavior for conversations/messages.
- If `fileRetention` is not configured, existing behavior is preserved. (this pr is a non-breaking change)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
