### PR TITLE
🧭 ci: Use System Chrome for Mock E2E

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -18,12 +18,15 @@ concurrency:
 
 env:
   NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 jobs:
   e2e:
-    name: Tier-1 smoke (headless Chromium)
+    name: Tier-1 smoke (headless Chrome)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      E2E_CHROMIUM_CHANNEL: chrome
     steps:
       - uses: actions/checkout@v4
 
@@ -105,19 +108,11 @@ jobs:
         if: steps.cache-client-app.outputs.cache-hit != 'true'
         run: npm run build:client
 
-      - name: Resolve Playwright version
-        id: pw
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: cache-playwright
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright runtime dependencies
+        timeout-minutes: 5
+        run: |
+          google-chrome --version
+          npx playwright install-deps chrome
 
       - name: Run mock-LLM Tier-1 e2e
         run: npx playwright test --config=e2e/playwright.config.mock.ts

--- a/e2e/playwright.config.mock.ts
+++ b/e2e/playwright.config.mock.ts
@@ -14,6 +14,7 @@ const baseURL = getE2EBaseURL();
 const mockLlmPort = getMockLlmPort();
 const defaultMockLlmBaseURL = 'http://127.0.0.1:8889/v1';
 const mockLlmBaseURL = `http://127.0.0.1:${mockLlmPort}/v1`;
+const chromiumChannel = process.env.E2E_CHROMIUM_CHANNEL || undefined;
 
 const vanillaOverrides = {
   TENANT_ISOLATION_STRICT: 'false',
@@ -119,8 +120,11 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: chromiumChannel ?? 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(chromiumChannel ? { channel: chromiumChannel } : {}),
+      },
     },
   ],
   webServer: [

--- a/e2e/setup/authenticate.ts
+++ b/e2e/setup/authenticate.ts
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const timeout = Number(process.env.E2E_AUTH_TIMEOUT ?? 15000);
+const chromiumChannel = process.env.E2E_CHROMIUM_CHANNEL || undefined;
 
 async function register(page: Page, user: User) {
   await page.getByRole('link', { name: 'Sign up' }).click();
@@ -50,6 +51,7 @@ async function authenticate(config: FullConfig, user: User) {
 
   const browser = await chromium.launch({
     headless: config.projects[0].use.headless ?? true,
+    ...(chromiumChannel ? { channel: chromiumChannel } : {}),
   });
   try {
     const page = await browser.newPage();


### PR DESCRIPTION
## Summary

I fixed the mock Playwright E2E workflow so cold-cache CI runs no longer hang while downloading Playwright-managed Chromium.

- Replaced the Playwright browser cache/download path with the GitHub runner's preinstalled system Chrome.
- Added `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` and `E2E_CHROMIUM_CHANNEL=chrome` so the mock suite and global auth setup launch the same browser channel.
- Kept a short, capped Playwright runtime dependency step for OS package safety without downloading the Chromium archive.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I validated the workflow and Playwright configuration locally:

- Ran `npm ci --ignore-scripts`
- Parsed `.github/workflows/playwright-mock.yml` as YAML
- Ran `git diff --check`
- Ran `E2E_CHROMIUM_CHANNEL=chrome npx playwright test --config=e2e/playwright.config.mock.ts --list`
- Ran targeted TypeScript validation for `e2e/playwright.config.mock.ts` and `e2e/setup/authenticate.ts`
- Ran `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npx playwright install-deps chrome --dry-run`

### **Test Configuration**:

- Node.js: 24.16.0
- Playwright: 1.56.1
- Browser channel: system Chrome via `E2E_CHROMIUM_CHANNEL=chrome`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings