### PR TITLE
🛰️ feat: Add Auth Fallback Observability

### DIFF
--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -43,6 +43,7 @@ jest.mock('@librechat/data-schemas', () => {
     getTenantId: () => tenantStorage.getStore()?.tenantId,
     getUserId: () => tenantStorage.getStore()?.userId,
     getRequestId: () => tenantStorage.getStore()?.requestId,
+    logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     tenantStorage,
   };
 });
@@ -84,7 +85,7 @@ jest.mock('@librechat/api', () => {
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 const requireJwtAuth = require('../requireJwtAuth');
-const { getTenantId, getUserId } = require('@librechat/data-schemas');
+const { getTenantId, getUserId, logger } = require('@librechat/data-schemas');
 const { isEnabled, maybeRefreshCloudFrontAuthCookiesMiddleware } = require('@librechat/api');
 const passport = require('passport');
 
@@ -127,6 +128,10 @@ describe('requireJwtAuth tenant context chaining', () => {
     mockRegisteredStrategies = new Set(['jwt']);
     isEnabled.mockReturnValue(false);
     maybeRefreshCloudFrontAuthCookiesMiddleware.mockClear();
+    logger.debug.mockClear();
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    logger.error.mockClear();
     passport.authenticate.mockClear();
     passport._strategy.mockClear();
     if (originalJwtSecret === undefined) {
@@ -206,6 +211,130 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(getTenantId()).toBeUndefined();
   });
 
+  it('logs OpenID JWT expiry when JWT fallback succeeds', () => {
+    isEnabled.mockReturnValue(true);
+    mockRegisteredStrategies.add('openidJwt');
+    const req = mockReq(undefined, {
+      requestId: 'req-expired-success',
+      method: 'GET',
+      path: '/api/messages',
+      headers: {
+        cookie: `token_provider=openid; openid_user_id=${signedOpenIdUserCookie('user-jwt')}`,
+      },
+      _mockStrategies: {
+        openidJwt: {
+          user: false,
+          info: { message: 'jwt expired', name: 'TokenExpiredError' },
+          status: 401,
+        },
+        jwt: { user: { id: 'user-jwt', tenantId: 'tenant-jwt', role: 'user' } },
+      },
+    });
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireJwtAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.authStrategy).toBe('jwt');
+    expect(res.status).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.objectContaining({
+        request_id: 'req-expired-success',
+        method: 'GET',
+        path: '/api/messages',
+        token_provider: 'openid',
+        openid_reuse_enabled: true,
+        openid_jwt_available: true,
+        has_openid_reuse_user_id: true,
+        primary_strategy: 'openidJwt',
+        fallback_strategy: 'jwt',
+        fallback_attempted: true,
+        reason: 'jwt expired',
+        error_name: 'TokenExpiredError',
+        status: 401,
+      }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      expect.objectContaining({
+        request_id: 'req-expired-success',
+        auth_strategy: 'jwt',
+        primary_strategy: 'openidJwt',
+        fallback_strategy: 'jwt',
+        fallback_attempted: true,
+        fallback_succeeded: true,
+        primary_failure_reason: 'jwt expired',
+        reason: 'jwt expired',
+        error_name: 'TokenExpiredError',
+      }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs OpenID JWT expiry when JWT fallback fails', () => {
+    isEnabled.mockReturnValue(true);
+    mockRegisteredStrategies.add('openidJwt');
+    const req = mockReq(undefined, {
+      id: 'req-expired-fail',
+      method: 'POST',
+      originalUrl: '/api/ask?access_token=hidden',
+      headers: {
+        cookie: `token_provider=openid; openid_user_id=${signedOpenIdUserCookie('user-jwt')}`,
+      },
+      _mockStrategies: {
+        openidJwt: {
+          user: false,
+          info: { message: 'jwt expired', name: 'TokenExpiredError' },
+          status: 401,
+        },
+        jwt: {
+          user: false,
+          info: { message: 'invalid signature', name: 'JsonWebTokenError' },
+          status: 401,
+        },
+      },
+    });
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireJwtAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.objectContaining({
+        request_id: 'req-expired-fail',
+        method: 'POST',
+        path: '/api/ask',
+        fallback_attempted: true,
+        reason: 'jwt expired',
+        error_name: 'TokenExpiredError',
+        status: 401,
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[requireJwtAuth] Authentication failed after all strategies',
+      expect.objectContaining({
+        request_id: 'req-expired-fail',
+        method: 'POST',
+        path: '/api/ask',
+        token_provider: 'openid',
+        attempted_strategies: ['openidJwt', 'jwt'],
+        final_strategy: 'jwt',
+        primary_strategy: 'openidJwt',
+        fallback_strategy: 'jwt',
+        fallback_attempted: true,
+        fallback_succeeded: false,
+        reason: 'invalid signature',
+        error_name: 'JsonWebTokenError',
+        status: 401,
+      }),
+    );
+  });
+
   it('does not fall back to OpenID JWT for bearer-only reuse requests', () => {
     isEnabled.mockReturnValue(true);
     mockRegisteredStrategies.add('openidJwt');
@@ -260,6 +389,98 @@ describe('requireJwtAuth tenant context chaining', () => {
       req,
       res,
       expect.any(Function),
+    );
+  });
+
+  it('logs OpenID user-id mismatch when JWT fallback succeeds', () => {
+    isEnabled.mockReturnValue(true);
+    mockRegisteredStrategies.add('openidJwt');
+    const req = mockReq(undefined, {
+      requestId: 'req-mismatch-success',
+      method: 'GET',
+      path: '/api/auth/me',
+      headers: {
+        cookie: `token_provider=openid; openid_user_id=${signedOpenIdUserCookie('user-a')}`,
+      },
+      _mockStrategies: {
+        openidJwt: { user: { id: 'user-b', tenantId: 'tenant-openid', role: 'user' } },
+        jwt: { user: { id: 'user-a', tenantId: 'tenant-jwt', role: 'user' } },
+      },
+    });
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireJwtAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.authStrategy).toBe('jwt');
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.objectContaining({
+        request_id: 'req-mismatch-success',
+        primary_strategy: 'openidJwt',
+        fallback_strategy: 'jwt',
+        fallback_attempted: true,
+        reason: 'openid user-id mismatch',
+        status: 401,
+      }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      expect.objectContaining({
+        request_id: 'req-mismatch-success',
+        auth_strategy: 'jwt',
+        fallback_attempted: true,
+        fallback_succeeded: true,
+        primary_failure_reason: 'openid user-id mismatch',
+        reason: 'openid user-id mismatch',
+      }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs OpenID user-id mismatch when JWT fallback fails', () => {
+    isEnabled.mockReturnValue(true);
+    mockRegisteredStrategies.add('openidJwt');
+    const req = mockReq(undefined, {
+      requestId: 'req-mismatch-fail',
+      method: 'GET',
+      path: '/api/auth/me',
+      headers: {
+        cookie: `token_provider=openid; openid_user_id=${signedOpenIdUserCookie('user-a')}`,
+      },
+      _mockStrategies: {
+        openidJwt: { user: { id: 'user-b', tenantId: 'tenant-openid', role: 'user' } },
+        jwt: { user: false, info: { message: 'Unauthorized' }, status: 401 },
+      },
+    });
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireJwtAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.objectContaining({
+        request_id: 'req-mismatch-fail',
+        fallback_attempted: true,
+        reason: 'openid user-id mismatch',
+        status: 401,
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[requireJwtAuth] Authentication failed after all strategies',
+      expect.objectContaining({
+        request_id: 'req-mismatch-fail',
+        attempted_strategies: ['openidJwt', 'jwt'],
+        final_strategy: 'jwt',
+        fallback_attempted: true,
+        fallback_succeeded: false,
+        reason: 'Unauthorized',
+        status: 401,
+      }),
     );
   });
 

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -76,6 +76,27 @@ jest.mock('@librechat/api', () => {
     }
     return undefined;
   };
+  const normalizeAuthLogContextValue = (value) => {
+    if (value == null) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      const values = value
+        .map((entry) => normalizeAuthLogValue(entry))
+        .filter((entry) => entry !== undefined);
+      return values.length > 0 ? values : undefined;
+    }
+    if (typeof value === 'string') {
+      return normalizeAuthLogValue(value);
+    }
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : undefined;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    return undefined;
+  };
   const getAuthFailureField = (source, field) => {
     if (!source) {
       return undefined;
@@ -84,7 +105,11 @@ jest.mock('@librechat/api', () => {
       return field === 'message' ? source : undefined;
     }
     if (typeof source === 'object') {
-      return source[field];
+      try {
+        return source[field];
+      } catch {
+        return undefined;
+      }
     }
     return undefined;
   };
@@ -95,23 +120,27 @@ jest.mock('@librechat/api', () => {
   const getAuthFailureErrorName = (err, info) =>
     normalizeAuthLogValue(getAuthFailureField(info, 'name')) ??
     normalizeAuthLogValue(getAuthFailureField(err, 'name'));
-  const buildSafeAuthLogContext = (req, authState, extra = {}) =>
+  const compactAuthLogContext = (log) =>
     Object.fromEntries(
-      Object.entries({
-        request_id:
-          normalizeAuthLogValue(req.requestId) ??
-          normalizeAuthLogValue(req.id) ??
-          normalizeAuthLogValue(req.headers?.['x-request-id']) ??
-          normalizeAuthLogValue(req.headers?.['x-correlation-id']),
-        method: normalizeAuthLogValue(req.method),
-        path: normalizeAuthLogValue(req.path ?? req.originalUrl ?? req.url)?.split('?')[0],
-        token_provider: normalizeAuthLogValue(authState.tokenProvider),
-        openid_reuse_enabled: authState.openidReuseEnabled,
-        openid_jwt_available: authState.openidJwtAvailable,
-        has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
-        ...extra,
-      }).filter(([, value]) => value !== undefined),
+      Object.entries(log)
+        .map(([key, value]) => [key, normalizeAuthLogContextValue(value)])
+        .filter(([, value]) => value !== undefined),
     );
+  const buildSafeAuthLogContext = (req, authState, extra = {}) =>
+    compactAuthLogContext({
+      ...extra,
+      request_id:
+        normalizeAuthLogValue(req.requestId) ??
+        normalizeAuthLogValue(req.id) ??
+        normalizeAuthLogValue(req.headers?.['x-request-id']) ??
+        normalizeAuthLogValue(req.headers?.['x-correlation-id']),
+      method: normalizeAuthLogValue(req.method),
+      path: normalizeAuthLogValue(req.path ?? req.originalUrl ?? req.url)?.split('?')[0],
+      token_provider: normalizeAuthLogValue(authState.tokenProvider),
+      openid_reuse_enabled: authState.openidReuseEnabled,
+      openid_jwt_available: authState.openidJwtAvailable,
+      has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
+    });
   const normalizeContextValue = (value) => {
     const trimmed = value?.trim?.();
     return trimmed || undefined;
@@ -332,6 +361,65 @@ describe('requireJwtAuth tenant context chaining', () => {
       }),
     );
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not let malformed Passport info break JWT fallback logging', () => {
+    isEnabled.mockReturnValue(true);
+    mockRegisteredStrategies.add('openidJwt');
+    const info = {};
+    Object.defineProperties(info, {
+      message: {
+        get() {
+          throw new TypeError('message getter failed');
+        },
+      },
+      name: {
+        get() {
+          throw new TypeError('name getter failed');
+        },
+      },
+    });
+    const req = mockReq(undefined, {
+      requestId: 'req-malformed-info',
+      method: 'GET',
+      path: '/api/messages',
+      headers: {
+        cookie: `token_provider=openid; openid_user_id=${signedOpenIdUserCookie('user-jwt')}`,
+      },
+      _mockStrategies: {
+        openidJwt: {
+          user: false,
+          info,
+          status: 401,
+        },
+        jwt: { user: { id: 'user-jwt', tenantId: 'tenant-jwt', role: 'user' } },
+      },
+    });
+    const res = mockRes();
+    const next = jest.fn();
+
+    expect(() => requireJwtAuth(req, res, next)).not.toThrow();
+
+    expect(next).toHaveBeenCalled();
+    expect(req.authStrategy).toBe('jwt');
+    expect(res.status).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.objectContaining({
+        request_id: 'req-malformed-info',
+        fallback_attempted: true,
+        reason: 'Unauthorized',
+        status: 401,
+      }),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      expect.objectContaining({
+        request_id: 'req-malformed-info',
+        fallback_succeeded: true,
+        primary_failure_reason: 'Unauthorized',
+      }),
+    );
   });
 
   it('logs OpenID JWT expiry when JWT fallback fails', () => {

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -120,6 +120,64 @@ jest.mock('@librechat/api', () => {
   const getAuthFailureErrorName = (err, info) =>
     normalizeAuthLogValue(getAuthFailureField(info, 'name')) ??
     normalizeAuthLogValue(getAuthFailureField(err, 'name'));
+  const getSafeTokenProvider = (tokenProvider) => {
+    const normalized = normalizeAuthLogValue(tokenProvider);
+    if (!normalized) {
+      return undefined;
+    }
+    return normalized === 'openid' || normalized === 'librechat' ? normalized : 'other';
+  };
+  const normalizeRoutePath = (path) => {
+    if (typeof path === 'string') {
+      return normalizeAuthLogValue(path);
+    }
+    if (Array.isArray(path)) {
+      for (const entry of path) {
+        const normalized = normalizeRoutePath(entry);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+    return undefined;
+  };
+  const joinRoutePath = (baseUrl, routePath) => {
+    const normalizedRoute = routePath === '/' ? '' : routePath;
+    if (!baseUrl) {
+      return normalizedRoute || '/';
+    }
+    if (!normalizedRoute) {
+      return baseUrl;
+    }
+    return `${baseUrl.replace(/\/$/, '')}/${normalizedRoute.replace(/^\//, '')}`;
+  };
+  const bucketConcretePath = (path) => {
+    const queryless = path?.split('?')[0];
+    if (!queryless) {
+      return undefined;
+    }
+    const segments = queryless.split('/').filter(Boolean);
+    if (segments.length === 0) {
+      return '/';
+    }
+    if (segments[0] === 'api' && segments[1]) {
+      return `/${segments.slice(0, 2).join('/')}`;
+    }
+    return `/${segments[0]}`;
+  };
+  const getRequestPath = (req) => {
+    const baseUrl = normalizeAuthLogValue(req.baseUrl);
+    const routePath = normalizeRoutePath(req.route?.path);
+    if (routePath) {
+      return joinRoutePath(baseUrl, routePath);
+    }
+    if (baseUrl) {
+      return baseUrl;
+    }
+    const path =
+      normalizeAuthLogValue(req.path) ?? normalizeAuthLogValue(req.originalUrl ?? req.url);
+    return bucketConcretePath(path);
+  };
   const compactAuthLogContext = (log) =>
     Object.fromEntries(
       Object.entries(log)
@@ -135,8 +193,8 @@ jest.mock('@librechat/api', () => {
         normalizeAuthLogValue(req.headers?.['x-request-id']) ??
         normalizeAuthLogValue(req.headers?.['x-correlation-id']),
       method: normalizeAuthLogValue(req.method),
-      path: normalizeAuthLogValue(req.path ?? req.originalUrl ?? req.url)?.split('?')[0],
-      token_provider: normalizeAuthLogValue(authState.tokenProvider),
+      path: getRequestPath(req),
+      token_provider: getSafeTokenProvider(authState.tokenProvider),
       openid_reuse_enabled: authState.openidReuseEnabled,
       openid_jwt_available: authState.openidJwtAvailable,
       has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
@@ -465,7 +523,7 @@ describe('requireJwtAuth tenant context chaining', () => {
       }),
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      '[requireJwtAuth] Authentication failed after all strategies',
+      expect.stringContaining('[requireJwtAuth] Authentication failed after all strategies'),
       expect.objectContaining({
         request_id: 'req-expired-fail',
         method: 'POST',
@@ -482,6 +540,8 @@ describe('requireJwtAuth tenant context chaining', () => {
         status: 401,
       }),
     );
+    expect(logger.warn.mock.calls[0][0]).toContain('"reason":"invalid signature"');
+    expect(logger.warn.mock.calls[0][0]).toContain('"path":"/api/ask"');
   });
 
   it('does not fall back to OpenID JWT for bearer-only reuse requests', () => {
@@ -620,7 +680,7 @@ describe('requireJwtAuth tenant context chaining', () => {
       }),
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      '[requireJwtAuth] Authentication failed after all strategies',
+      expect.stringContaining('[requireJwtAuth] Authentication failed after all strategies'),
       expect.objectContaining({
         request_id: 'req-mismatch-fail',
         attempted_strategies: ['openidJwt', 'jwt'],

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -359,6 +359,19 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
     expect(getTenantId()).toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('[requireJwtAuth] Authentication failed after all strategies'),
+      expect.objectContaining({
+        primary_strategy: 'jwt',
+        fallback_attempted: false,
+        fallback_succeeded: false,
+        attempted_strategies: ['jwt'],
+        final_strategy: 'jwt',
+        reason: 'Unauthorized',
+        status: 401,
+      }),
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('logs OpenID JWT expiry when JWT fallback succeeds', () => {

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -199,6 +199,7 @@ jest.mock('@librechat/api', () => {
       openid_jwt_available: authState.openidJwtAvailable,
       has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
     });
+  const formatAuthLogMessage = (message, context) => `${message} ${JSON.stringify(context)}`;
   const normalizeContextValue = (value) => {
     const trimmed = value?.trim?.();
     return trimmed || undefined;
@@ -215,6 +216,7 @@ jest.mock('@librechat/api', () => {
     getAuthFailureReason,
     getAuthFailureErrorName,
     buildSafeAuthLogContext,
+    formatAuthLogMessage,
     maybeRefreshCloudFrontAuthCookiesMiddleware: jest.fn((req, res, next) => next()),
     tenantContextMiddleware: (req, res, next) => {
       const context = {
@@ -387,7 +389,7 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(req.authStrategy).toBe('jwt');
     expect(res.status).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
         request_id: 'req-expired-success',
         method: 'GET',
@@ -405,7 +407,7 @@ describe('requireJwtAuth tenant context chaining', () => {
       }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      expect.stringContaining('[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure'),
       expect.objectContaining({
         request_id: 'req-expired-success',
         auth_strategy: 'jwt',
@@ -418,6 +420,9 @@ describe('requireJwtAuth tenant context chaining', () => {
         error_name: 'TokenExpiredError',
       }),
     );
+    expect(logger.debug.mock.calls[0][0]).toContain('"reason":"jwt expired"');
+    expect(logger.debug.mock.calls[0][0]).toContain('"fallback_attempted":true');
+    expect(logger.debug.mock.calls[1][0]).toContain('"fallback_succeeded":true');
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
@@ -462,7 +467,7 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(req.authStrategy).toBe('jwt');
     expect(res.status).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
         request_id: 'req-malformed-info',
         fallback_attempted: true,
@@ -471,7 +476,7 @@ describe('requireJwtAuth tenant context chaining', () => {
       }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      expect.stringContaining('[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure'),
       expect.objectContaining({
         request_id: 'req-malformed-info',
         fallback_succeeded: true,
@@ -511,7 +516,7 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
         request_id: 'req-expired-fail',
         method: 'POST',
@@ -624,7 +629,7 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).toHaveBeenCalled();
     expect(req.authStrategy).toBe('jwt');
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
         request_id: 'req-mismatch-success',
         primary_strategy: 'openidJwt',
@@ -635,7 +640,7 @@ describe('requireJwtAuth tenant context chaining', () => {
       }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      expect.stringContaining('[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure'),
       expect.objectContaining({
         request_id: 'req-mismatch-success',
         auth_strategy: 'jwt',
@@ -671,7 +676,7 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
     expect(logger.debug).toHaveBeenCalledWith(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
         request_id: 'req-mismatch-fail',
         fallback_attempted: true,

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -54,6 +54,64 @@ jest.mock('@librechat/data-schemas', () => {
 // primitives. The real implementation is covered by packages/api tenant.spec.ts.
 jest.mock('@librechat/api', () => {
   const { tenantStorage } = require('@librechat/data-schemas');
+  const normalizeAuthLogValue = (value) => {
+    if (value == null) {
+      return undefined;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        const normalized = normalizeAuthLogValue(entry);
+        if (normalized) {
+          return normalized;
+        }
+      }
+      return undefined;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed || undefined;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+    return undefined;
+  };
+  const getAuthFailureField = (source, field) => {
+    if (!source) {
+      return undefined;
+    }
+    if (typeof source === 'string') {
+      return field === 'message' ? source : undefined;
+    }
+    if (typeof source === 'object') {
+      return source[field];
+    }
+    return undefined;
+  };
+  const getAuthFailureReason = (err, info, fallback = 'Unauthorized') =>
+    normalizeAuthLogValue(getAuthFailureField(info, 'message')) ??
+    normalizeAuthLogValue(getAuthFailureField(err, 'message')) ??
+    fallback;
+  const getAuthFailureErrorName = (err, info) =>
+    normalizeAuthLogValue(getAuthFailureField(info, 'name')) ??
+    normalizeAuthLogValue(getAuthFailureField(err, 'name'));
+  const buildSafeAuthLogContext = (req, authState, extra = {}) =>
+    Object.fromEntries(
+      Object.entries({
+        request_id:
+          normalizeAuthLogValue(req.requestId) ??
+          normalizeAuthLogValue(req.id) ??
+          normalizeAuthLogValue(req.headers?.['x-request-id']) ??
+          normalizeAuthLogValue(req.headers?.['x-correlation-id']),
+        method: normalizeAuthLogValue(req.method),
+        path: normalizeAuthLogValue(req.path ?? req.originalUrl ?? req.url)?.split('?')[0],
+        token_provider: normalizeAuthLogValue(authState.tokenProvider),
+        openid_reuse_enabled: authState.openidReuseEnabled,
+        openid_jwt_available: authState.openidJwtAvailable,
+        has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
+        ...extra,
+      }).filter(([, value]) => value !== undefined),
+    );
   const normalizeContextValue = (value) => {
     const trimmed = value?.trim?.();
     return trimmed || undefined;
@@ -67,6 +125,9 @@ jest.mock('@librechat/api', () => {
     normalizeContextValue(req.headers?.['x-correlation-id']);
   return {
     isEnabled: jest.fn(() => false),
+    getAuthFailureReason,
+    getAuthFailureErrorName,
+    buildSafeAuthLogContext,
     maybeRefreshCloudFrontAuthCookiesMiddleware: jest.fn((req, res, next) => next()),
     tenantContextMiddleware: (req, res, next) => {
       const context = {

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -5,6 +5,9 @@ const { logger } = require('@librechat/data-schemas');
 const {
   isEnabled,
   tenantContextMiddleware,
+  getAuthFailureReason,
+  getAuthFailureErrorName,
+  buildSafeAuthLogContext,
   maybeRefreshCloudFrontAuthCookiesMiddleware,
 } = require('@librechat/api');
 
@@ -31,43 +34,6 @@ const getAuthenticatedUserId = (user) => user?.id?.toString?.() ?? user?._id?.to
 const refreshCloudFrontCookies =
   maybeRefreshCloudFrontAuthCookiesMiddleware ?? ((_req, _res, next) => next());
 
-const normalizeContextValue = (value) => {
-  const stringValue = Array.isArray(value) ? value[0] : value;
-  const trimmed = stringValue?.toString?.().trim();
-  return trimmed || undefined;
-};
-
-const getRequestId = (req) =>
-  normalizeContextValue(req.requestId) ??
-  normalizeContextValue(req.id) ??
-  normalizeContextValue(req.headers?.['x-request-id']) ??
-  normalizeContextValue(req.headers?.['x-correlation-id']);
-
-const getRequestPath = (req) => {
-  const path = normalizeContextValue(req.path) ?? normalizeContextValue(req.originalUrl ?? req.url);
-  return path?.split('?')[0];
-};
-
-const getAuthFailureReason = (err, info, fallback = 'Unauthorized') =>
-  normalizeContextValue(info?.message) ?? normalizeContextValue(err?.message) ?? fallback;
-
-const getAuthFailureErrorName = (err, info) =>
-  normalizeContextValue(info?.name) ?? normalizeContextValue(err?.name);
-
-const buildSafeAuthLogContext = (req, authState, extra = {}) =>
-  Object.fromEntries(
-    Object.entries({
-      request_id: getRequestId(req),
-      method: normalizeContextValue(req.method),
-      path: getRequestPath(req),
-      token_provider: normalizeContextValue(authState.tokenProvider),
-      openid_reuse_enabled: authState.openidReuseEnabled,
-      openid_jwt_available: authState.openidJwtAvailable,
-      has_openid_reuse_user_id: authState.openIdReuseUserId != null,
-      ...extra,
-    }).filter(([, value]) => value !== undefined),
-  );
-
 /**
  * Custom Middleware to handle JWT authentication, with support for OpenID token reuse.
  * Switches between JWT and OpenID authentication based on cookies and environment settings.
@@ -90,7 +56,7 @@ const requireJwtAuth = (req, res, next) => {
     tokenProvider,
     openidReuseEnabled,
     openidJwtAvailable,
-    openIdReuseUserId,
+    hasOpenIdReuseUserId: openIdReuseUserId != null,
   };
   let primaryFailureReason;
   let primaryFailureErrorName;

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -92,7 +92,8 @@ const requireJwtAuth = (req, res, next) => {
       error_name: getAuthFailureErrorName(err, info),
       status: status || 401,
     });
-    logger.warn(formatAuthLogMessage(message, context), context);
+    const log = fallbackAttempted ? logger.warn : logger.debug;
+    log.call(logger, formatAuthLogMessage(message, context), context);
   };
 
   const logFallbackSuccess = (strategy) => {

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -80,19 +80,20 @@ const requireJwtAuth = (req, res, next) => {
   };
 
   const logAuthenticationFailure = ({ strategy, info, status, err }) => {
+    const context = buildSafeAuthLogContext(req, authLogState, {
+      primary_strategy: strategies[0],
+      fallback_strategy: strategies[1],
+      fallback_attempted: fallbackAttempted,
+      fallback_succeeded: false,
+      attempted_strategies: strategies,
+      final_strategy: strategy,
+      reason: getAuthFailureReason(err, info),
+      error_name: getAuthFailureErrorName(err, info),
+      status: status || 401,
+    });
     logger.warn(
-      '[requireJwtAuth] Authentication failed after all strategies',
-      buildSafeAuthLogContext(req, authLogState, {
-        primary_strategy: strategies[0],
-        fallback_strategy: strategies[1],
-        fallback_attempted: fallbackAttempted,
-        fallback_succeeded: false,
-        attempted_strategies: strategies,
-        final_strategy: strategy,
-        reason: getAuthFailureReason(err, info),
-        error_name: getAuthFailureErrorName(err, info),
-        status: status || 401,
-      }),
+      `[requireJwtAuth] Authentication failed after all strategies ${JSON.stringify(context)}`,
+      context,
     );
   };
 

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -8,6 +8,7 @@ const {
   getAuthFailureReason,
   getAuthFailureErrorName,
   buildSafeAuthLogContext,
+  formatAuthLogMessage,
   maybeRefreshCloudFrontAuthCookiesMiddleware,
 } = require('@librechat/api');
 
@@ -66,20 +67,20 @@ const requireJwtAuth = (req, res, next) => {
     primaryFailureReason = reason;
     primaryFailureErrorName = errorName;
     fallbackAttempted = true;
-    logger.debug(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
-      buildSafeAuthLogContext(req, authLogState, {
-        primary_strategy: 'openidJwt',
-        fallback_strategy: fallbackStrategy,
-        fallback_attempted: true,
-        reason,
-        error_name: errorName,
-        status,
-      }),
-    );
+    const message = '[requireJwtAuth] OpenID JWT auth failed; trying fallback';
+    const context = buildSafeAuthLogContext(req, authLogState, {
+      primary_strategy: 'openidJwt',
+      fallback_strategy: fallbackStrategy,
+      fallback_attempted: true,
+      reason,
+      error_name: errorName,
+      status,
+    });
+    logger.debug(formatAuthLogMessage(message, context), context);
   };
 
   const logAuthenticationFailure = ({ strategy, info, status, err }) => {
+    const message = '[requireJwtAuth] Authentication failed after all strategies';
     const context = buildSafeAuthLogContext(req, authLogState, {
       primary_strategy: strategies[0],
       fallback_strategy: strategies[1],
@@ -91,29 +92,25 @@ const requireJwtAuth = (req, res, next) => {
       error_name: getAuthFailureErrorName(err, info),
       status: status || 401,
     });
-    logger.warn(
-      `[requireJwtAuth] Authentication failed after all strategies ${JSON.stringify(context)}`,
-      context,
-    );
+    logger.warn(formatAuthLogMessage(message, context), context);
   };
 
   const logFallbackSuccess = (strategy) => {
     if (!fallbackAttempted || strategy !== 'jwt') {
       return;
     }
-    logger.debug(
-      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
-      buildSafeAuthLogContext(req, authLogState, {
-        auth_strategy: 'jwt',
-        primary_strategy: 'openidJwt',
-        fallback_strategy: 'jwt',
-        fallback_attempted: true,
-        fallback_succeeded: true,
-        primary_failure_reason: primaryFailureReason,
-        reason: primaryFailureReason,
-        error_name: primaryFailureErrorName,
-      }),
-    );
+    const message = '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure';
+    const context = buildSafeAuthLogContext(req, authLogState, {
+      auth_strategy: 'jwt',
+      primary_strategy: 'openidJwt',
+      fallback_strategy: 'jwt',
+      fallback_attempted: true,
+      fallback_succeeded: true,
+      primary_failure_reason: primaryFailureReason,
+      reason: primaryFailureReason,
+      error_name: primaryFailureErrorName,
+    });
+    logger.debug(formatAuthLogMessage(message, context), context);
   };
 
   const authenticateWithStrategy = (index) => {

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -1,6 +1,7 @@
 const cookies = require('cookie');
 const jwt = require('jsonwebtoken');
 const passport = require('passport');
+const { logger } = require('@librechat/data-schemas');
 const {
   isEnabled,
   tenantContextMiddleware,
@@ -30,6 +31,43 @@ const getAuthenticatedUserId = (user) => user?.id?.toString?.() ?? user?._id?.to
 const refreshCloudFrontCookies =
   maybeRefreshCloudFrontAuthCookiesMiddleware ?? ((_req, _res, next) => next());
 
+const normalizeContextValue = (value) => {
+  const stringValue = Array.isArray(value) ? value[0] : value;
+  const trimmed = stringValue?.toString?.().trim();
+  return trimmed || undefined;
+};
+
+const getRequestId = (req) =>
+  normalizeContextValue(req.requestId) ??
+  normalizeContextValue(req.id) ??
+  normalizeContextValue(req.headers?.['x-request-id']) ??
+  normalizeContextValue(req.headers?.['x-correlation-id']);
+
+const getRequestPath = (req) => {
+  const path = normalizeContextValue(req.path) ?? normalizeContextValue(req.originalUrl ?? req.url);
+  return path?.split('?')[0];
+};
+
+const getAuthFailureReason = (err, info, fallback = 'Unauthorized') =>
+  normalizeContextValue(info?.message) ?? normalizeContextValue(err?.message) ?? fallback;
+
+const getAuthFailureErrorName = (err, info) =>
+  normalizeContextValue(info?.name) ?? normalizeContextValue(err?.name);
+
+const buildSafeAuthLogContext = (req, authState, extra = {}) =>
+  Object.fromEntries(
+    Object.entries({
+      request_id: getRequestId(req),
+      method: normalizeContextValue(req.method),
+      path: getRequestPath(req),
+      token_provider: normalizeContextValue(authState.tokenProvider),
+      openid_reuse_enabled: authState.openidReuseEnabled,
+      openid_jwt_available: authState.openidJwtAvailable,
+      has_openid_reuse_user_id: authState.openIdReuseUserId != null,
+      ...extra,
+    }).filter(([, value]) => value !== undefined),
+  );
+
 /**
  * Custom Middleware to handle JWT authentication, with support for OpenID token reuse.
  * Switches between JWT and OpenID authentication based on cookies and environment settings.
@@ -48,6 +86,68 @@ const requireJwtAuth = (req, res, next) => {
   const useOpenIdJwt =
     tokenProvider === 'openid' && openidJwtAvailable && openIdReuseUserId != null;
   const strategies = useOpenIdJwt ? ['openidJwt', 'jwt'] : ['jwt'];
+  const authLogState = {
+    tokenProvider,
+    openidReuseEnabled,
+    openidJwtAvailable,
+    openIdReuseUserId,
+  };
+  let primaryFailureReason;
+  let primaryFailureErrorName;
+  let fallbackAttempted = false;
+
+  const logOpenIdFallbackAttempt = ({ fallbackStrategy, reason, errorName, status }) => {
+    primaryFailureReason = reason;
+    primaryFailureErrorName = errorName;
+    fallbackAttempted = true;
+    logger.debug(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+      buildSafeAuthLogContext(req, authLogState, {
+        primary_strategy: 'openidJwt',
+        fallback_strategy: fallbackStrategy,
+        fallback_attempted: true,
+        reason,
+        error_name: errorName,
+        status,
+      }),
+    );
+  };
+
+  const logAuthenticationFailure = ({ strategy, info, status, err }) => {
+    logger.warn(
+      '[requireJwtAuth] Authentication failed after all strategies',
+      buildSafeAuthLogContext(req, authLogState, {
+        primary_strategy: strategies[0],
+        fallback_strategy: strategies[1],
+        fallback_attempted: fallbackAttempted,
+        fallback_succeeded: false,
+        attempted_strategies: strategies,
+        final_strategy: strategy,
+        reason: getAuthFailureReason(err, info),
+        error_name: getAuthFailureErrorName(err, info),
+        status: status || 401,
+      }),
+    );
+  };
+
+  const logFallbackSuccess = (strategy) => {
+    if (!fallbackAttempted || strategy !== 'jwt') {
+      return;
+    }
+    logger.debug(
+      '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+      buildSafeAuthLogContext(req, authLogState, {
+        auth_strategy: 'jwt',
+        primary_strategy: 'openidJwt',
+        fallback_strategy: 'jwt',
+        fallback_attempted: true,
+        fallback_succeeded: true,
+        primary_failure_reason: primaryFailureReason,
+        reason: primaryFailureReason,
+        error_name: primaryFailureErrorName,
+      }),
+    );
+  };
 
   const authenticateWithStrategy = (index) => {
     const strategy = strategies[index];
@@ -57,20 +157,34 @@ const requireJwtAuth = (req, res, next) => {
       }
       if (!user) {
         if (index + 1 < strategies.length) {
+          logOpenIdFallbackAttempt({
+            fallbackStrategy: strategies[index + 1],
+            reason: getAuthFailureReason(err, info),
+            errorName: getAuthFailureErrorName(err, info),
+            status: status || 401,
+          });
           return authenticateWithStrategy(index + 1);
         }
+        logAuthenticationFailure({ strategy, info, status, err });
         return res.status(status || 401).json({
           message: info?.message || 'Unauthorized',
         });
       }
       if (strategy === 'openidJwt' && getAuthenticatedUserId(user) !== openIdReuseUserId) {
         if (index + 1 < strategies.length) {
+          logOpenIdFallbackAttempt({
+            fallbackStrategy: strategies[index + 1],
+            reason: 'openid user-id mismatch',
+            status: 401,
+          });
           return authenticateWithStrategy(index + 1);
         }
+        logAuthenticationFailure({ strategy, info, status: 401, err });
         return res.status(401).json({ message: 'Unauthorized' });
       }
       req.user = user;
       req.authStrategy = strategy;
+      logFallbackSuccess(strategy);
       tenantContextMiddleware(req, res, (tenantErr) => {
         if (tenantErr) {
           return next(tenantErr);

--- a/packages/api/src/middleware/auth.spec.ts
+++ b/packages/api/src/middleware/auth.spec.ts
@@ -1,4 +1,9 @@
-import { buildSafeAuthLogContext, getAuthFailureErrorName, getAuthFailureReason } from './auth';
+import {
+  buildSafeAuthLogContext,
+  formatAuthLogMessage,
+  getAuthFailureErrorName,
+  getAuthFailureReason,
+} from './auth';
 import type { AuthLogRequest, AuthLogState } from './auth';
 
 function createRequest(overrides: Partial<AuthLogRequest> = {}): AuthLogRequest {
@@ -147,6 +152,21 @@ describe('auth middleware logging helpers', () => {
       reason: 'jwt expired',
     });
     expect(JSON.stringify(log)).not.toContain('secret-token');
+  });
+
+  it('formats auth log messages with serialized safe context for stdout collectors', () => {
+    const log = buildSafeAuthLogContext(createRequest({ id: 'request-id' }), createAuthState(), {
+      fallback_attempted: true,
+      reason: 'jwt expired',
+      error_name: 'TokenExpiredError',
+      status: 401,
+    });
+
+    expect(
+      formatAuthLogMessage('[requireJwtAuth] OpenID JWT auth failed; trying fallback', log),
+    ).toBe(
+      '[requireJwtAuth] OpenID JWT auth failed; trying fallback {"fallback_attempted":true,"reason":"jwt expired","error_name":"TokenExpiredError","status":401,"request_id":"request-id","method":"GET","path":"/api/messages","token_provider":"openid","openid_reuse_enabled":true,"openid_jwt_available":true,"has_openid_reuse_user_id":true}',
+    );
   });
 
   it('prefers Passport info fields for auth failure reason and error name', () => {

--- a/packages/api/src/middleware/auth.spec.ts
+++ b/packages/api/src/middleware/auth.spec.ts
@@ -83,6 +83,46 @@ describe('auth middleware logging helpers', () => {
     });
   });
 
+  it('buckets unknown token providers to keep auth logs low-cardinality', () => {
+    const log = buildSafeAuthLogContext(
+      createRequest(),
+      createAuthState({
+        tokenProvider: 'attacker-controlled-provider',
+      }),
+    );
+
+    expect(log.token_provider).toBe('other');
+  });
+
+  it('prefers route buckets over concrete dynamic request paths', () => {
+    const log = buildSafeAuthLogContext(
+      createRequest({
+        baseUrl: '/api/messages',
+        path: '/conversation-123/message-456',
+        originalUrl: '/api/messages/conversation-123/message-456?access_token=secret-token',
+      }),
+      createAuthState(),
+    );
+
+    expect(log.path).toBe('/api/messages');
+    expect(JSON.stringify(log)).not.toContain('conversation-123');
+    expect(JSON.stringify(log)).not.toContain('message-456');
+    expect(JSON.stringify(log)).not.toContain('secret-token');
+  });
+
+  it('logs route templates when Express exposes them', () => {
+    const log = buildSafeAuthLogContext(
+      createRequest({
+        baseUrl: '/api/share',
+        path: '/link/conversation-123',
+        route: { path: '/link/:conversationId' },
+      }),
+      createAuthState(),
+    );
+
+    expect(log.path).toBe('/api/share/link/:conversationId');
+  });
+
   it('drops unsupported extra values and keeps safe arrays primitive', () => {
     const log = buildSafeAuthLogContext(createRequest({ id: 'request-id' }), createAuthState(), {
       attempted_strategies: ['openidJwt', '', { strategy: 'jwt' }, 'jwt'],

--- a/packages/api/src/middleware/auth.spec.ts
+++ b/packages/api/src/middleware/auth.spec.ts
@@ -83,6 +83,32 @@ describe('auth middleware logging helpers', () => {
     });
   });
 
+  it('drops unsupported extra values and keeps safe arrays primitive', () => {
+    const log = buildSafeAuthLogContext(createRequest({ id: 'request-id' }), createAuthState(), {
+      attempted_strategies: ['openidJwt', '', { strategy: 'jwt' }, 'jwt'],
+      fallback_attempted: true,
+      path: { unsafe: true },
+      request_id: { unsafe: true },
+      status: Number.NaN,
+      unsafe_object: { token: 'secret-token' },
+      reason: '  jwt expired  ',
+    });
+
+    expect(log).toEqual({
+      request_id: 'request-id',
+      method: 'GET',
+      path: '/api/messages',
+      token_provider: 'openid',
+      openid_reuse_enabled: true,
+      openid_jwt_available: true,
+      has_openid_reuse_user_id: true,
+      attempted_strategies: ['openidJwt', 'jwt'],
+      fallback_attempted: true,
+      reason: 'jwt expired',
+    });
+    expect(JSON.stringify(log)).not.toContain('secret-token');
+  });
+
   it('prefers Passport info fields for auth failure reason and error name', () => {
     const err = Object.assign(new Error('outer failure'), { name: 'OuterError' });
     const info = { message: 'jwt expired', name: 'TokenExpiredError' };
@@ -96,5 +122,25 @@ describe('auth middleware logging helpers', () => {
 
     expect(getAuthFailureReason(err, undefined)).toBe('invalid signature');
     expect(getAuthFailureErrorName(err, undefined)).toBe('JsonWebTokenError');
+  });
+
+  it('does not throw when Passport failure objects expose throwing getters', () => {
+    const err = Object.assign(new Error('invalid signature'), { name: 'JsonWebTokenError' });
+    const info = {};
+    Object.defineProperties(info, {
+      message: {
+        get() {
+          throw new TypeError('message getter failed');
+        },
+      },
+      name: {
+        get() {
+          throw new TypeError('name getter failed');
+        },
+      },
+    });
+
+    expect(getAuthFailureReason(err, info)).toBe('invalid signature');
+    expect(getAuthFailureErrorName(err, info)).toBe('JsonWebTokenError');
   });
 });

--- a/packages/api/src/middleware/auth.spec.ts
+++ b/packages/api/src/middleware/auth.spec.ts
@@ -1,0 +1,100 @@
+import { buildSafeAuthLogContext, getAuthFailureErrorName, getAuthFailureReason } from './auth';
+import type { AuthLogRequest, AuthLogState } from './auth';
+
+function createRequest(overrides: Partial<AuthLogRequest> = {}): AuthLogRequest {
+  return {
+    headers: {},
+    method: 'GET',
+    path: '/api/messages',
+    originalUrl: '/api/messages',
+    ...overrides,
+  };
+}
+
+function createAuthState(overrides: Partial<AuthLogState> = {}): AuthLogState {
+  return {
+    tokenProvider: 'openid',
+    openidReuseEnabled: true,
+    openidJwtAvailable: true,
+    hasOpenIdReuseUserId: true,
+    ...overrides,
+  };
+}
+
+describe('auth middleware logging helpers', () => {
+  it('builds safe auth log context without raw query strings or user identifiers', () => {
+    const log = buildSafeAuthLogContext(
+      createRequest({
+        id: 'request-id',
+        path: undefined,
+        originalUrl: '/api/ask?access_token=secret-token',
+      }),
+      createAuthState(),
+      {
+        attempted_strategies: ['openidJwt', 'jwt'],
+        fallback_attempted: true,
+        fallback_succeeded: false,
+        reason: 'jwt expired',
+        error_name: 'TokenExpiredError',
+        status: 401,
+      },
+    );
+
+    expect(log).toEqual({
+      request_id: 'request-id',
+      method: 'GET',
+      path: '/api/ask',
+      token_provider: 'openid',
+      openid_reuse_enabled: true,
+      openid_jwt_available: true,
+      has_openid_reuse_user_id: true,
+      attempted_strategies: ['openidJwt', 'jwt'],
+      fallback_attempted: true,
+      fallback_succeeded: false,
+      reason: 'jwt expired',
+      error_name: 'TokenExpiredError',
+      status: 401,
+    });
+    expect(JSON.stringify(log)).not.toContain('secret-token');
+  });
+
+  it('uses request headers when request ids are not directly set', () => {
+    const log = buildSafeAuthLogContext(
+      createRequest({
+        headers: {
+          'x-request-id': ['header-request-id'],
+        },
+      }),
+      createAuthState({
+        tokenProvider: null,
+        openidReuseEnabled: false,
+        openidJwtAvailable: false,
+        hasOpenIdReuseUserId: false,
+      }),
+    );
+
+    expect(log).toEqual({
+      request_id: 'header-request-id',
+      method: 'GET',
+      path: '/api/messages',
+      openid_reuse_enabled: false,
+      openid_jwt_available: false,
+      has_openid_reuse_user_id: false,
+    });
+  });
+
+  it('prefers Passport info fields for auth failure reason and error name', () => {
+    const err = Object.assign(new Error('outer failure'), { name: 'OuterError' });
+    const info = { message: 'jwt expired', name: 'TokenExpiredError' };
+
+    expect(getAuthFailureReason(err, info)).toBe('jwt expired');
+    expect(getAuthFailureErrorName(err, info)).toBe('TokenExpiredError');
+  });
+
+  it('falls back to Error fields when Passport info is absent', () => {
+    const err = Object.assign(new Error('invalid signature'), { name: 'JsonWebTokenError' });
+
+    expect(getAuthFailureReason(err, undefined)).toBe('invalid signature');
+    expect(getAuthFailureErrorName(err, undefined)).toBe('JsonWebTokenError');
+  });
+});

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -52,6 +52,33 @@ function normalizeAuthLogValue(value: unknown): string | undefined {
   return undefined;
 }
 
+function normalizeAuthLogContextValue(value: unknown): AuthLogValue | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const values = value
+      .map((entry) => normalizeAuthLogValue(entry))
+      .filter((entry): entry is string => entry !== undefined);
+    return values.length > 0 ? values : undefined;
+  }
+
+  if (typeof value === 'string') {
+    return normalizeAuthLogValue(value);
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return undefined;
+}
+
 function getRequestId(req: AuthLogRequest): string | undefined {
   return (
     normalizeAuthLogValue(req.requestId) ??
@@ -74,9 +101,24 @@ function getAuthFailureField(source: unknown, field: keyof AuthFailureLike): unk
     return field === 'message' ? source : undefined;
   }
   if (typeof source === 'object') {
-    return (source as AuthFailureLike)[field];
+    try {
+      return (source as AuthFailureLike)[field];
+    } catch {
+      return undefined;
+    }
   }
   return undefined;
+}
+
+function compactAuthLogContext(log: Record<string, unknown>): AuthLogContext {
+  const compacted: Partial<AuthLogContext> = {};
+  for (const key of Object.keys(log)) {
+    const value = normalizeAuthLogContextValue(log[key]);
+    if (value !== undefined) {
+      Object.assign(compacted, { [key]: value });
+    }
+  }
+  return compacted as AuthLogContext;
 }
 
 export function getAuthFailureReason(
@@ -101,9 +143,10 @@ export function getAuthFailureErrorName(err: unknown, info: unknown): string | u
 export function buildSafeAuthLogContext(
   req: AuthLogRequest,
   authState: AuthLogState,
-  extra: Partial<AuthLogContext> = {},
+  extra: Record<string, unknown> = {},
 ): AuthLogContext {
-  const log: Partial<AuthLogContext> = {
+  return compactAuthLogContext({
+    ...extra,
     request_id: getRequestId(req),
     method: normalizeAuthLogValue(req.method),
     path: getRequestPath(req),
@@ -111,14 +154,5 @@ export function buildSafeAuthLogContext(
     openid_reuse_enabled: authState.openidReuseEnabled,
     openid_jwt_available: authState.openidJwtAvailable,
     has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
-    ...extra,
-  };
-  const compacted: Partial<AuthLogContext> = {};
-  for (const key of Object.keys(log)) {
-    const value = log[key];
-    if (value !== undefined) {
-      Object.assign(compacted, { [key]: value });
-    }
-  }
-  return compacted as AuthLogContext;
+  });
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -222,3 +222,7 @@ export function buildSafeAuthLogContext(
     has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
   });
 }
+
+export function formatAuthLogMessage(message: string, context: AuthLogContext): string {
+  return `${message} ${JSON.stringify(context)}`;
+}

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -5,6 +5,7 @@ type AuthFailureLike = {
 
 type AuthLogValue = string | number | boolean | readonly string[];
 type AuthLogHeaderValue = string | string[] | undefined;
+type AuthRoutePath = string | RegExp | readonly (string | RegExp)[];
 
 export type AuthLogRequest = {
   headers?: Record<string, AuthLogHeaderValue>;
@@ -12,6 +13,10 @@ export type AuthLogRequest = {
   path?: string;
   originalUrl?: string;
   url?: string;
+  baseUrl?: string;
+  route?: {
+    path?: AuthRoutePath;
+  };
   id?: string;
   requestId?: string;
 };
@@ -88,9 +93,62 @@ function getRequestId(req: AuthLogRequest): string | undefined {
   );
 }
 
+function normalizeRoutePath(path: AuthRoutePath | undefined): string | undefined {
+  if (typeof path === 'string') {
+    return normalizeAuthLogValue(path);
+  }
+
+  if (Array.isArray(path)) {
+    for (const entry of path) {
+      const normalized = normalizeRoutePath(entry);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function joinRoutePath(baseUrl: string | undefined, routePath: string): string {
+  const normalizedRoute = routePath === '/' ? '' : routePath;
+  if (!baseUrl) {
+    return normalizedRoute || '/';
+  }
+  if (!normalizedRoute) {
+    return baseUrl;
+  }
+  return `${baseUrl.replace(/\/$/, '')}/${normalizedRoute.replace(/^\//, '')}`;
+}
+
+function bucketConcretePath(path: string | undefined): string | undefined {
+  const queryless = path?.split('?')[0];
+  if (!queryless) {
+    return undefined;
+  }
+
+  const segments = queryless.split('/').filter(Boolean);
+  if (segments.length === 0) {
+    return '/';
+  }
+  if (segments[0] === 'api' && segments[1]) {
+    return `/${segments.slice(0, 2).join('/')}`;
+  }
+  return `/${segments[0]}`;
+}
+
 function getRequestPath(req: AuthLogRequest): string | undefined {
+  const baseUrl = normalizeAuthLogValue(req.baseUrl);
+  const routePath = normalizeRoutePath(req.route?.path);
+  if (routePath) {
+    return joinRoutePath(baseUrl, routePath);
+  }
+  if (baseUrl) {
+    return baseUrl;
+  }
+
   const path = normalizeAuthLogValue(req.path) ?? normalizeAuthLogValue(req.originalUrl ?? req.url);
-  return path?.split('?')[0];
+  return bucketConcretePath(path);
 }
 
 function getAuthFailureField(source: unknown, field: keyof AuthFailureLike): unknown {
@@ -140,6 +198,14 @@ export function getAuthFailureErrorName(err: unknown, info: unknown): string | u
   );
 }
 
+function getSafeTokenProvider(tokenProvider: unknown): string | undefined {
+  const normalized = normalizeAuthLogValue(tokenProvider);
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized === 'openid' || normalized === 'librechat' ? normalized : 'other';
+}
+
 export function buildSafeAuthLogContext(
   req: AuthLogRequest,
   authState: AuthLogState,
@@ -150,7 +216,7 @@ export function buildSafeAuthLogContext(
     request_id: getRequestId(req),
     method: normalizeAuthLogValue(req.method),
     path: getRequestPath(req),
-    token_provider: normalizeAuthLogValue(authState.tokenProvider),
+    token_provider: getSafeTokenProvider(authState.tokenProvider),
     openid_reuse_enabled: authState.openidReuseEnabled,
     openid_jwt_available: authState.openidJwtAvailable,
     has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,0 +1,124 @@
+type AuthFailureLike = {
+  message?: unknown;
+  name?: unknown;
+};
+
+type AuthLogValue = string | number | boolean | readonly string[];
+type AuthLogHeaderValue = string | string[] | undefined;
+
+export type AuthLogRequest = {
+  headers?: Record<string, AuthLogHeaderValue>;
+  method?: string;
+  path?: string;
+  originalUrl?: string;
+  url?: string;
+  id?: string;
+  requestId?: string;
+};
+
+export type AuthLogState = {
+  tokenProvider?: string | null;
+  openidReuseEnabled: boolean;
+  openidJwtAvailable: boolean;
+  hasOpenIdReuseUserId: boolean;
+};
+
+export type AuthLogContext = Record<string, AuthLogValue>;
+
+function normalizeAuthLogValue(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const normalized = normalizeAuthLogValue(entry);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function getRequestId(req: AuthLogRequest): string | undefined {
+  return (
+    normalizeAuthLogValue(req.requestId) ??
+    normalizeAuthLogValue(req.id) ??
+    normalizeAuthLogValue(req.headers?.['x-request-id']) ??
+    normalizeAuthLogValue(req.headers?.['x-correlation-id'])
+  );
+}
+
+function getRequestPath(req: AuthLogRequest): string | undefined {
+  const path = normalizeAuthLogValue(req.path) ?? normalizeAuthLogValue(req.originalUrl ?? req.url);
+  return path?.split('?')[0];
+}
+
+function getAuthFailureField(source: unknown, field: keyof AuthFailureLike): unknown {
+  if (!source) {
+    return undefined;
+  }
+  if (typeof source === 'string') {
+    return field === 'message' ? source : undefined;
+  }
+  if (typeof source === 'object') {
+    return (source as AuthFailureLike)[field];
+  }
+  return undefined;
+}
+
+export function getAuthFailureReason(
+  err: unknown,
+  info: unknown,
+  fallback = 'Unauthorized',
+): string {
+  return (
+    normalizeAuthLogValue(getAuthFailureField(info, 'message')) ??
+    normalizeAuthLogValue(getAuthFailureField(err, 'message')) ??
+    fallback
+  );
+}
+
+export function getAuthFailureErrorName(err: unknown, info: unknown): string | undefined {
+  return (
+    normalizeAuthLogValue(getAuthFailureField(info, 'name')) ??
+    normalizeAuthLogValue(getAuthFailureField(err, 'name'))
+  );
+}
+
+export function buildSafeAuthLogContext(
+  req: AuthLogRequest,
+  authState: AuthLogState,
+  extra: Partial<AuthLogContext> = {},
+): AuthLogContext {
+  const log: Partial<AuthLogContext> = {
+    request_id: getRequestId(req),
+    method: normalizeAuthLogValue(req.method),
+    path: getRequestPath(req),
+    token_provider: normalizeAuthLogValue(authState.tokenProvider),
+    openid_reuse_enabled: authState.openidReuseEnabled,
+    openid_jwt_available: authState.openidJwtAvailable,
+    has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
+    ...extra,
+  };
+  const compacted: Partial<AuthLogContext> = {};
+  for (const key of Object.keys(log)) {
+    const value = log[key];
+    if (value !== undefined) {
+      Object.assign(compacted, { [key]: value });
+    }
+  }
+  return compacted as AuthLogContext;
+}

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -5,6 +5,7 @@ export * from './notFound';
 export * from './balance';
 export * from './json';
 export * from './capabilities';
+export * from './auth';
 export {
   tenantContextMiddleware,
   restoreTenantContextFromReq,


### PR DESCRIPTION
## Summary

I added generic LibreChat auth outcome observability for OpenID JWT reuse and JWT fallback behavior, with the shared log-context helper implemented in `packages/api` for TypeScript support.

- Added TS helpers in `packages/api/src/middleware/auth.ts` for safe auth log context, failure reason extraction, error-name extraction, and auth log message formatting.
- Exported the helpers from the `@librechat/api` middleware barrel and kept `requireJwtAuth` as a thin JS strategy-chain caller.
- Added structured logging in `requireJwtAuth` for OpenID JWT primary failures, successful JWT fallback, and final authentication failure after all strategies are exhausted.
- Included low-cardinality request and auth context such as `request_id`, `method`, normalized `path`, allowlisted `token_provider`, OpenID reuse availability, attempted strategies, fallback outcome, failure reason, error name, and status.
- Kept OpenID-primary plus JWT-fallback failures at `warn`, while plain single-strategy JWT failures log at `debug` to avoid warning noise from normal logout fan-out requests.
- Hardened the log context builder so malformed extra fields, unsupported value types, throwing Passport failure-object getters, forged token providers, and dynamic request IDs in paths cannot make auth logging throw or pollute log cardinality.
- Rendered auth context into both debug and warn message text while preserving structured metadata, so stdout collectors and LogHouse `Body` searches include the essential auth outcome fields even when object metadata is not surfaced by plain console formatting.
- Preserved credential safety by avoiding raw tokens, cookies, authorization headers, raw query strings, OpenID subjects, and email fields in the middleware logs.
- Covered OpenID JWT expiry, OpenID user-id mismatch, malformed Passport info, token-provider bucketing, route/path normalization, safe helper sanitization paths, serialized stdout log messages, and plain JWT 401 severity.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `cd packages/api && NODE_PATH=/Users/danny/Projects/LibreChat/api/node_modules:/Users/danny/Projects/LibreChat/packages/api/node_modules:/Users/danny/Projects/LibreChat/node_modules /Users/danny/Projects/LibreChat/node_modules/.bin/jest src/middleware/auth.spec.ts --runInBand`
- Ran `cd api && NODE_PATH=/Users/danny/Projects/LibreChat/api/node_modules:/Users/danny/Projects/LibreChat/packages/api/node_modules:/Users/danny/Projects/LibreChat/node_modules /Users/danny/Projects/LibreChat/node_modules/.bin/jest server/middleware/__tests__/requireJwtAuth.spec.js --runInBand`
- Ran `cd /Users/danny/Projects/LibreChat && NODE_PATH=/Users/danny/Projects/LibreChat/node_modules ./node_modules/.bin/prettier --check <touched files>`
- Ran `cd packages/api && PATH=/Users/danny/Projects/LibreChat/node_modules/.bin:$PATH NODE_PATH=/Users/danny/Projects/LibreChat/packages/api/node_modules:/Users/danny/Projects/LibreChat/node_modules npm run build`
- Ran `git diff --check`

### **Test Configuration**:

- Node.js v24.16.0
- Jest focused middleware specs
- Existing dependency install borrowed from `/Users/danny/Projects/LibreChat` for local verification

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
