### PR TITLE
🎚️ feat: Add Focus Management and Drag-to-Scrub to MessageNav

### DIFF
--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -73,6 +73,7 @@ function getMessageEntries(root: ParentNode, messagesById: Map<string, TMessage>
 const JUMP_EPS = 4;
 const SCROLL_DURATION = 400;
 const BOTTOM_SNAP_RETRIES = 2;
+const DRAG_THRESHOLD = 4;
 
 function easeOutCubic(t: number): number {
   return 1 - Math.pow(1 - t, 3);
@@ -84,6 +85,18 @@ function readScrollMargin(el: HTMLElement | null): number {
   }
   const value = parseFloat(getComputedStyle(el).scrollMarginTop);
   return Number.isFinite(value) ? value : 0;
+}
+
+function computeTargetScroll(
+  container: HTMLElement,
+  el: HTMLElement,
+  scrollMargin: number,
+): number {
+  const cRect = container.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+  const target = container.scrollTop + (elRect.top - cRect.top) - scrollMargin;
+  const max = container.scrollHeight - container.clientHeight;
+  return Math.max(0, Math.min(target, max));
 }
 
 const indicatorButtonClasses = cn(
@@ -180,6 +193,12 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
   const messagesByIdRef = useRef(messagesById);
   const scrollTokenRef = useRef(0);
   const scrollMarginRef = useRef(0);
+  const navRef = useRef<HTMLElement>(null);
+  const draggingRef = useRef(false);
+  const dragStateRef = useRef<{ pointerId: number; startY: number; dragging: boolean } | null>(
+    null,
+  );
+  const suppressClickRef = useRef(false);
 
   const getCurrentVisibleId = useCallback((): string | null => {
     let nextId: string | null = null;
@@ -246,11 +265,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       if (!current) {
         return;
       }
-      const cRect = container.getBoundingClientRect();
-      const elRect = current.getBoundingClientRect();
-      const targetScroll = container.scrollTop + (elRect.top - cRect.top) - scrollMargin;
-      const max = container.scrollHeight - container.clientHeight;
-      const clamped = Math.max(0, Math.min(targetScroll, max));
+      const clamped = computeTargetScroll(container, current, scrollMargin);
       container.scrollTop = startScroll + (clamped - startScroll) * easeOutCubic(progress);
       if (progress < 1) {
         requestAnimationFrame(step);
@@ -258,6 +273,136 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
     };
 
     requestAnimationFrame(step);
+  }, []);
+
+  const scrollToImmediate = useCallback((id: string) => {
+    const el = document.getElementById(id);
+    if (!el) {
+      return;
+    }
+    const container = el.closest<HTMLElement>('.scrollbar-gutter-stable');
+    if (!container) {
+      return;
+    }
+    scrollTokenRef.current++;
+    const scrollMargin = scrollMarginRef.current || readScrollMargin(el);
+    container.scrollTop = computeTargetScroll(container, el, scrollMargin);
+  }, []);
+
+  const focusMessage = useCallback((id: string) => {
+    const el = document.getElementById(id);
+    if (!el) {
+      return;
+    }
+    if (!el.hasAttribute('tabindex')) {
+      el.setAttribute('tabindex', '-1');
+    }
+    el.focus({ preventScroll: true });
+  }, []);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      if (suppressClickRef.current) {
+        suppressClickRef.current = false;
+        return;
+      }
+      scrollToStart(id);
+      focusMessage(id);
+    },
+    [scrollToStart, focusMessage],
+  );
+
+  const focusNav = useCallback(() => {
+    const nav = navRef.current;
+    if (!nav) {
+      return;
+    }
+    const target =
+      nav.querySelector<HTMLElement>('[aria-current="true"]') ??
+      nav.querySelector<HTMLElement>('[data-msg-id]');
+    target?.focus();
+  }, []);
+
+  const scrubTo = useCallback(
+    (clientY: number) => {
+      const col = columnRef.current;
+      if (!col) {
+        return;
+      }
+      const ribs = col.querySelectorAll<HTMLElement>('[data-msg-id]');
+      const count = ribs.length;
+      if (count === 0) {
+        return;
+      }
+      let target = ribs[count - 1];
+      for (let i = 0; i < count; i++) {
+        if (clientY < ribs[i].getBoundingClientRect().bottom) {
+          target = ribs[i];
+          break;
+        }
+      }
+      const id = target.getAttribute('data-msg-id');
+      if (id) {
+        scrollToImmediate(id);
+      }
+    },
+    [scrollToImmediate],
+  );
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) {
+      return;
+    }
+    suppressClickRef.current = false;
+    dragStateRef.current = { pointerId: e.pointerId, startY: e.clientY, dragging: false };
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== e.pointerId) {
+        return;
+      }
+      if (!state.dragging) {
+        if (Math.abs(e.clientY - state.startY) < DRAG_THRESHOLD) {
+          return;
+        }
+        state.dragging = true;
+        draggingRef.current = true;
+        columnRef.current?.setPointerCapture?.(e.pointerId);
+      }
+      scrubTo(e.clientY);
+    },
+    [scrubTo],
+  );
+
+  const endDrag = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== e.pointerId) {
+        return;
+      }
+      dragStateRef.current = null;
+      if (!state.dragging) {
+        return;
+      }
+      draggingRef.current = false;
+      suppressClickRef.current = true;
+      const col = columnRef.current;
+      if (col?.hasPointerCapture?.(e.pointerId)) {
+        col.releasePointerCapture(e.pointerId);
+      }
+      scrollableRef.current?.dispatchEvent(new Event('scroll'));
+    },
+    [scrollableRef],
+  );
+
+  const handleLostPointerCapture = useCallback(() => {
+    if (!dragStateRef.current) {
+      return;
+    }
+    dragStateRef.current = null;
+    draggingRef.current = false;
   }, []);
 
   useEffect(() => {
@@ -400,6 +545,10 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       }
       setCanGoUp((prev) => (prev === nextCanUp ? prev : nextCanUp));
       setCanGoDown((prev) => (prev === nextCanDown ? prev : nextCanDown));
+
+      if (draggingRef.current) {
+        return;
+      }
 
       const col = columnRef.current;
       if (!col) {
@@ -628,13 +777,26 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
     }
   }, [entries, scrollableRef, scrollToStart]);
 
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.altKey && e.shiftKey && e.code === 'KeyM') {
+        e.preventDefault();
+        focusNav();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [focusNav]);
+
   if (entries.length < 3) {
     return null;
   }
 
   return (
     <nav
+      ref={navRef}
       aria-label={localize('com_ui_message_nav')}
+      aria-keyshortcuts="Shift+Alt+M"
       className={cn(
         'group/nav absolute right-2 top-1/2 z-40 hidden max-h-[min(24rem,calc(100%-2rem))]',
         '-translate-y-1/2 flex-col items-center gap-1.5 rounded-full px-1 py-2 md:flex',
@@ -655,7 +817,12 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
 
       <div
         ref={columnRef}
-        className="flex min-h-0 flex-col items-center gap-1.5 overflow-y-auto [&::-webkit-scrollbar]:hidden"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onLostPointerCapture={handleLostPointerCapture}
+        className="flex min-h-0 cursor-ns-resize touch-none select-none flex-col items-center gap-1.5 overflow-y-auto [&::-webkit-scrollbar]:hidden"
         style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
       >
         {entries.map((entry) => (
@@ -664,7 +831,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
             entry={entry}
             isActive={visibleIds.has(entry.id)}
             isCurrent={currentId === entry.id}
-            onSelect={scrollToStart}
+            onSelect={handleSelect}
             label={localize(
               entry.isUser ? 'com_ui_message_nav_go_to_user' : 'com_ui_message_nav_go_to_assistant',
               { 0: entry.preview.slice(0, 30) },

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -194,7 +194,6 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
   const scrollTokenRef = useRef(0);
   const scrollMarginRef = useRef(0);
   const navRef = useRef<HTMLElement>(null);
-  const draggingRef = useRef(false);
   const dragCleanupRef = useRef<(() => void) | null>(null);
   const suppressClickRef = useRef(false);
 
@@ -322,7 +321,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       return false;
     }
     target.focus();
-    return true;
+    return document.activeElement === target;
   }, []);
 
   const scrubTo = useCallback(
@@ -336,14 +335,10 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       if (count === 0) {
         return;
       }
-      let target = ribs[count - 1];
-      for (let i = 0; i < count; i++) {
-        if (clientY < ribs[i].getBoundingClientRect().bottom) {
-          target = ribs[i];
-          break;
-        }
-      }
-      const id = target.getAttribute('data-msg-id');
+      const rect = col.getBoundingClientRect();
+      const fraction = rect.height > 0 ? (clientY - rect.top) / rect.height : 0;
+      const index = Math.max(0, Math.min(count - 1, Math.round(fraction * (count - 1))));
+      const id = ribs[index].getAttribute('data-msg-id');
       if (id) {
         scrollToImmediate(id);
       }
@@ -364,14 +359,13 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         document.removeEventListener('pointermove', onMove);
         document.removeEventListener('pointerup', onUp);
         document.removeEventListener('pointercancel', onUp);
+        window.removeEventListener('blur', onBlur);
         dragCleanupRef.current = null;
         if (wasDragging) {
-          draggingRef.current = false;
           suppressClickRef.current = true;
           window.setTimeout(() => {
             suppressClickRef.current = false;
           }, 0);
-          scrollableRef.current?.dispatchEvent(new Event('scroll'));
         }
       };
 
@@ -379,16 +373,15 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         if (ev.pointerId !== state.pointerId) {
           return;
         }
+        if ((ev.buttons & 1) === 0) {
+          finish(state.dragging);
+          return;
+        }
         if (!state.dragging) {
-          if ((ev.buttons & 1) === 0) {
-            finish(false);
-            return;
-          }
           if (Math.abs(ev.clientY - state.startY) < DRAG_THRESHOLD) {
             return;
           }
           state.dragging = true;
-          draggingRef.current = true;
         }
         scrubTo(ev.clientY);
       }
@@ -400,12 +393,17 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         finish(state.dragging);
       }
 
+      function onBlur() {
+        finish(state.dragging);
+      }
+
       dragCleanupRef.current = () => finish(state.dragging);
       document.addEventListener('pointermove', onMove);
       document.addEventListener('pointerup', onUp);
       document.addEventListener('pointercancel', onUp);
+      window.addEventListener('blur', onBlur);
     },
-    [scrubTo, scrollableRef],
+    [scrubTo],
   );
 
   useEffect(() => () => dragCleanupRef.current?.(), []);
@@ -550,10 +548,6 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       }
       setCanGoUp((prev) => (prev === nextCanUp ? prev : nextCanUp));
       setCanGoDown((prev) => (prev === nextCanDown ? prev : nextCanDown));
-
-      if (draggingRef.current) {
-        return;
-      }
 
       const col = columnRef.current;
       if (!col) {

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -364,6 +364,10 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         return;
       }
       if (!state.dragging) {
+        if ((e.buttons & 1) === 0) {
+          dragStateRef.current = null;
+          return;
+        }
         if (Math.abs(e.clientY - state.startY) < DRAG_THRESHOLD) {
           return;
         }
@@ -388,6 +392,9 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       }
       draggingRef.current = false;
       suppressClickRef.current = true;
+      window.setTimeout(() => {
+        suppressClickRef.current = false;
+      }, 0);
       const col = columnRef.current;
       if (col?.hasPointerCapture?.(e.pointerId)) {
         col.releasePointerCapture(e.pointerId);
@@ -779,7 +786,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.altKey && e.shiftKey && e.code === 'KeyM') {
+      if (e.altKey && e.shiftKey && (e.code === 'KeyM' || e.key.toLowerCase() === 'm')) {
         e.preventDefault();
         focusNav();
       }

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -310,15 +310,19 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
     [scrollToStart, focusMessage],
   );
 
-  const focusNav = useCallback(() => {
+  const focusNav = useCallback((): boolean => {
     const nav = navRef.current;
     if (!nav) {
-      return;
+      return false;
     }
     const target =
       nav.querySelector<HTMLElement>('[aria-current="true"]') ??
       nav.querySelector<HTMLElement>('[data-msg-id]');
-    target?.focus();
+    if (!target) {
+      return false;
+    }
+    target.focus();
+    return true;
   }, []);
 
   const scrubTo = useCallback(
@@ -396,7 +400,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         finish(state.dragging);
       }
 
-      dragCleanupRef.current = () => finish(false);
+      dragCleanupRef.current = () => finish(state.dragging);
       document.addEventListener('pointermove', onMove);
       document.addEventListener('pointerup', onUp);
       document.addEventListener('pointercancel', onUp);
@@ -781,8 +785,9 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.altKey && e.shiftKey && (e.code === 'KeyM' || e.key.toLowerCase() === 'm')) {
-        e.preventDefault();
-        focusNav();
+        if (focusNav()) {
+          e.preventDefault();
+        }
       }
     };
     document.addEventListener('keydown', onKeyDown);

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -195,9 +195,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
   const scrollMarginRef = useRef(0);
   const navRef = useRef<HTMLElement>(null);
   const draggingRef = useRef(false);
-  const dragStateRef = useRef<{ pointerId: number; startY: number; dragging: boolean } | null>(
-    null,
-  );
+  const dragCleanupRef = useRef<(() => void) | null>(null);
   const suppressClickRef = useRef(false);
 
   const getCurrentVisibleId = useCallback((): string | null => {
@@ -349,68 +347,64 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
     [scrollToImmediate],
   );
 
-  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (e.button !== 0) {
-      return;
-    }
-    suppressClickRef.current = false;
-    dragStateRef.current = { pointerId: e.pointerId, startY: e.clientY, dragging: false };
-  }, []);
-
-  const handlePointerMove = useCallback(
+  const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      const state = dragStateRef.current;
-      if (!state || state.pointerId !== e.pointerId) {
+      if (e.button !== 0) {
         return;
       }
-      if (!state.dragging) {
-        if ((e.buttons & 1) === 0) {
-          dragStateRef.current = null;
+      dragCleanupRef.current?.();
+      suppressClickRef.current = false;
+      const state = { pointerId: e.pointerId, startY: e.clientY, dragging: false };
+
+      const finish = (wasDragging: boolean) => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        document.removeEventListener('pointercancel', onUp);
+        dragCleanupRef.current = null;
+        if (wasDragging) {
+          draggingRef.current = false;
+          suppressClickRef.current = true;
+          window.setTimeout(() => {
+            suppressClickRef.current = false;
+          }, 0);
+          scrollableRef.current?.dispatchEvent(new Event('scroll'));
+        }
+      };
+
+      function onMove(ev: PointerEvent) {
+        if (ev.pointerId !== state.pointerId) {
           return;
         }
-        if (Math.abs(e.clientY - state.startY) < DRAG_THRESHOLD) {
+        if (!state.dragging) {
+          if ((ev.buttons & 1) === 0) {
+            finish(false);
+            return;
+          }
+          if (Math.abs(ev.clientY - state.startY) < DRAG_THRESHOLD) {
+            return;
+          }
+          state.dragging = true;
+          draggingRef.current = true;
+        }
+        scrubTo(ev.clientY);
+      }
+
+      function onUp(ev: PointerEvent) {
+        if (ev.pointerId !== state.pointerId) {
           return;
         }
-        state.dragging = true;
-        draggingRef.current = true;
-        columnRef.current?.setPointerCapture?.(e.pointerId);
+        finish(state.dragging);
       }
-      scrubTo(e.clientY);
+
+      dragCleanupRef.current = () => finish(false);
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+      document.addEventListener('pointercancel', onUp);
     },
-    [scrubTo],
+    [scrubTo, scrollableRef],
   );
 
-  const endDrag = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      const state = dragStateRef.current;
-      if (!state || state.pointerId !== e.pointerId) {
-        return;
-      }
-      dragStateRef.current = null;
-      if (!state.dragging) {
-        return;
-      }
-      draggingRef.current = false;
-      suppressClickRef.current = true;
-      window.setTimeout(() => {
-        suppressClickRef.current = false;
-      }, 0);
-      const col = columnRef.current;
-      if (col?.hasPointerCapture?.(e.pointerId)) {
-        col.releasePointerCapture(e.pointerId);
-      }
-      scrollableRef.current?.dispatchEvent(new Event('scroll'));
-    },
-    [scrollableRef],
-  );
-
-  const handleLostPointerCapture = useCallback(() => {
-    if (!dragStateRef.current) {
-      return;
-    }
-    dragStateRef.current = null;
-    draggingRef.current = false;
-  }, []);
+  useEffect(() => () => dragCleanupRef.current?.(), []);
 
   useEffect(() => {
     refreshEntries();
@@ -825,10 +819,6 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       <div
         ref={columnRef}
         onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={endDrag}
-        onPointerCancel={endDrag}
-        onLostPointerCapture={handleLostPointerCapture}
         className="flex min-h-0 cursor-grab touch-none select-none flex-col items-center gap-1.5 overflow-y-auto active:cursor-grabbing [&::-webkit-scrollbar]:hidden"
         style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
       >

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -822,7 +822,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
         onLostPointerCapture={handleLostPointerCapture}
-        className="flex min-h-0 cursor-ns-resize touch-none select-none flex-col items-center gap-1.5 overflow-y-auto [&::-webkit-scrollbar]:hidden"
+        className="flex min-h-0 cursor-grab touch-none select-none flex-col items-center gap-1.5 overflow-y-auto active:cursor-grabbing [&::-webkit-scrollbar]:hidden"
         style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
       >
         {entries.map((entry) => (

--- a/client/src/components/Chat/Messages/MessageParts.tsx
+++ b/client/src/components/Chat/Messages/MessageParts.tsx
@@ -107,7 +107,12 @@ export default function Message(props: TMessageProps) {
           <div
             id={messageId ?? ''}
             aria-label={getMessageAriaLabel(message, localize)}
-            className={cn(baseClasses.common, baseClasses.chat, 'message-render')}
+            className={cn(
+              baseClasses.common,
+              baseClasses.chat,
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy',
+              'message-render',
+            )}
           >
             {!hasParallelContent && (
               <div className="relative flex flex-shrink-0 flex-col items-center">

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -684,6 +684,41 @@ describe('MessageNav', () => {
       expect(document.activeElement).toBe(container.querySelector('[data-msg-id="b"]'));
     });
 
+    it('consumes Shift+Alt+M only when the nav is rendered', () => {
+      const messages = [
+        buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      renderNav(messages);
+
+      let notPrevented = true;
+      act(() => {
+        notPrevented = fireEvent.keyDown(document, {
+          code: 'KeyM',
+          altKey: true,
+          shiftKey: true,
+        });
+      });
+
+      expect(notPrevented).toBe(false);
+    });
+
+    it('does not consume Shift+Alt+M when the nav is not rendered', () => {
+      renderNav([buildMessage({ messageId: 'solo', text: 'only one', isCreatedByUser: true })]);
+
+      let notPrevented = true;
+      act(() => {
+        notPrevented = fireEvent.keyDown(document, {
+          code: 'KeyM',
+          altKey: true,
+          shiftKey: true,
+        });
+      });
+
+      expect(notPrevented).toBe(true);
+    });
+
     it('ignores the keyboard shortcut without the alt and shift modifiers', () => {
       const messages = [
         buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
@@ -824,6 +859,26 @@ describe('MessageNav', () => {
       });
 
       expect(document.activeElement).toBe(document.getElementById('m-0'));
+    });
+
+    it('ends the active drag when a second pointer replaces it', () => {
+      const { column, scrollable } = setupDraggableNav();
+      const dispatchSpy = jest.spyOn(scrollable, 'dispatchEvent');
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+      });
+
+      dispatchSpy.mockClear();
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 2, button: 0, buttons: 1, clientY: 0 });
+      });
+
+      const finishedActiveDrag = dispatchSpy.mock.calls.some(
+        ([ev]) => (ev as Event).type === 'scroll',
+      );
+      expect(finishedActiveDrag).toBe(true);
     });
   });
 

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -663,6 +663,27 @@ describe('MessageNav', () => {
       expect(document.activeElement).toBe(container.querySelector('[data-msg-id="b"]'));
     });
 
+    it('focuses the current indicator via the produced key on non-QWERTY layouts', () => {
+      const messages = [
+        buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      const { container } = renderNav(messages);
+
+      const io = MockIntersectionObserver.last();
+      act(() => {
+        io!.trigger([{ target: document.getElementById('b')!, isIntersecting: true }]);
+        jest.advanceTimersByTime(32);
+      });
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'm', code: 'Semicolon', altKey: true, shiftKey: true });
+      });
+
+      expect(document.activeElement).toBe(container.querySelector('[data-msg-id="b"]'));
+    });
+
     it('ignores the keyboard shortcut without the alt and shift modifiers', () => {
       const messages = [
         buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
@@ -716,8 +737,8 @@ describe('MessageNav', () => {
       });
 
       act(() => {
-        fireEvent.pointerDown(column, { pointerId: 1, button: 0, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, clientY: 25 });
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 25 });
       });
 
       expect(column.setPointerCapture).toHaveBeenCalledWith(1);
@@ -728,8 +749,23 @@ describe('MessageNav', () => {
       const { column } = setupDraggableNav();
 
       act(() => {
-        fireEvent.pointerDown(column, { pointerId: 1, button: 0, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, clientY: 2 });
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 2 });
+      });
+
+      expect(column.setPointerCapture).not.toHaveBeenCalled();
+    });
+
+    it('does not start a drag from a later hover move when the button was released outside', () => {
+      const { column } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 2 });
+      });
+
+      act(() => {
+        fireEvent.pointerMove(column, { pointerId: 1, buttons: 0, clientY: 40 });
       });
 
       expect(column.setPointerCapture).not.toHaveBeenCalled();
@@ -739,8 +775,8 @@ describe('MessageNav', () => {
       const { column, ribs } = setupDraggableNav();
 
       act(() => {
-        fireEvent.pointerDown(column, { pointerId: 1, button: 0, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, clientY: 25 });
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 25 });
         fireEvent.pointerUp(column, { pointerId: 1, clientY: 25 });
       });
 
@@ -749,6 +785,23 @@ describe('MessageNav', () => {
       });
 
       expect(document.activeElement).not.toBe(document.getElementById('m-0'));
+    });
+
+    it('clears click suppression after the drag so a later activation is honored', () => {
+      const { column, ribs } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 25 });
+        fireEvent.pointerUp(column, { pointerId: 1, clientY: 25 });
+        jest.advanceTimersByTime(1);
+      });
+
+      act(() => {
+        fireEvent.click(ribs[0]);
+      });
+
+      expect(document.activeElement).toBe(document.getElementById('m-0'));
     });
   });
 

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -747,38 +747,35 @@ describe('MessageNav', () => {
       );
       const result = renderNav(messages);
       const column = result.container.querySelector('nav > div') as HTMLDivElement;
+      column.getBoundingClientRect = () => ({ top: 0, bottom: 50, height: 50 }) as DOMRect;
 
       const ribs = Array.from(column.querySelectorAll('[data-msg-id]')) as HTMLElement[];
-      ribs.forEach((rib, i) => {
-        rib.getBoundingClientRect = () =>
-          ({ top: i * 10, bottom: (i + 1) * 10, height: 10 }) as DOMRect;
-      });
 
-      let wrote = -1;
+      const writes: number[] = [];
       Object.defineProperty(result.scrollable, 'scrollTop', {
         get: () => 0,
         set: (v: number) => {
-          wrote = v;
+          writes.push(v);
         },
         configurable: true,
       });
 
-      return { ...result, column, ribs, wrote: () => wrote };
+      return { ...result, column, ribs, writes };
     }
 
     it('scrubs the conversation while dragging past the threshold', () => {
-      const { column, wrote } = setupDraggableNav();
+      const { column, writes } = setupDraggableNav();
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
         fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
       });
 
-      expect(wrote()).toBeGreaterThanOrEqual(0);
+      expect(writes.length).toBeGreaterThan(0);
     });
 
     it('keeps tracking the drag after the pointer leaves the narrow column', () => {
-      const { column, wrote } = setupDraggableNav();
+      const { column, writes } = setupDraggableNav();
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
@@ -786,22 +783,41 @@ describe('MessageNav', () => {
         fireEvent.pointerMove(document.body, { pointerId: 1, buttons: 1, clientY: 25 });
       });
 
-      expect(wrote()).toBeGreaterThanOrEqual(0);
+      expect(writes.length).toBeGreaterThan(0);
+    });
+
+    it('maps the pointer proportionally across the full set of messages', () => {
+      const { column } = setupDraggableNav();
+      const getById = jest.spyOn(document, 'getElementById');
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+      });
+      expect(getById.mock.calls.map((c) => c[0])).toContain('m-2');
+
+      getById.mockClear();
+      act(() => {
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 50 });
+      });
+      expect(getById.mock.calls.map((c) => c[0])).toContain('m-4');
+
+      getById.mockRestore();
     });
 
     it('does not scrub for movement under the threshold', () => {
-      const { column, wrote } = setupDraggableNav();
+      const { column, writes } = setupDraggableNav();
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
         fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 2 });
       });
 
-      expect(wrote()).toBe(-1);
+      expect(writes.length).toBe(0);
     });
 
     it('ignores pointer moves after the interaction ends', () => {
-      const { column, wrote } = setupDraggableNav();
+      const { column, writes } = setupDraggableNav();
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
@@ -811,7 +827,57 @@ describe('MessageNav', () => {
         fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 40 });
       });
 
-      expect(wrote()).toBe(-1);
+      expect(writes.length).toBe(0);
+    });
+
+    it('ends the drag when the primary button is released during a move', () => {
+      const { column, writes } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 0, clientY: 30 });
+      });
+      const before = writes.length;
+      act(() => {
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 45 });
+      });
+
+      expect(writes.length).toBe(before);
+    });
+
+    it('ends the drag when the window loses focus', () => {
+      const { column, writes } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+        window.dispatchEvent(new Event('blur'));
+      });
+      const before = writes.length;
+      act(() => {
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 45 });
+      });
+
+      expect(writes.length).toBe(before);
+    });
+
+    it('tears down a previous drag when a new pointer starts', () => {
+      const { column, writes } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+      });
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 2, button: 0, buttons: 1, clientY: 0 });
+      });
+      const before = writes.length;
+      act(() => {
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 45 });
+      });
+
+      expect(writes.length).toBe(before);
     });
 
     it('selects via the native click when a press does not become a drag', () => {
@@ -859,26 +925,6 @@ describe('MessageNav', () => {
       });
 
       expect(document.activeElement).toBe(document.getElementById('m-0'));
-    });
-
-    it('ends the active drag when a second pointer replaces it', () => {
-      const { column, scrollable } = setupDraggableNav();
-      const dispatchSpy = jest.spyOn(scrollable, 'dispatchEvent');
-
-      act(() => {
-        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
-        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
-      });
-
-      dispatchSpy.mockClear();
-      act(() => {
-        fireEvent.pointerDown(column, { pointerId: 2, button: 0, buttons: 1, clientY: 0 });
-      });
-
-      const finishedActiveDrag = dispatchSpy.mock.calls.some(
-        ([ev]) => (ev as Event).type === 'scroll',
-      );
-      expect(finishedActiveDrag).toBe(true);
     });
   });
 

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -712,23 +712,15 @@ describe('MessageNav', () => {
       );
       const result = renderNav(messages);
       const column = result.container.querySelector('nav > div') as HTMLDivElement;
-      column.setPointerCapture = jest.fn();
-      column.hasPointerCapture = jest.fn(() => true);
-      column.releasePointerCapture = jest.fn();
 
       const ribs = Array.from(column.querySelectorAll('[data-msg-id]')) as HTMLElement[];
       ribs.forEach((rib, i) => {
         rib.getBoundingClientRect = () =>
           ({ top: i * 10, bottom: (i + 1) * 10, height: 10 }) as DOMRect;
       });
-      return { ...result, column, ribs };
-    }
-
-    it('scrubs the conversation while dragging past the threshold', () => {
-      const { column, scrollable } = setupDraggableNav();
 
       let wrote = -1;
-      Object.defineProperty(scrollable, 'scrollTop', {
+      Object.defineProperty(result.scrollable, 'scrollTop', {
         get: () => 0,
         set: (v: number) => {
           wrote = v;
@@ -736,39 +728,69 @@ describe('MessageNav', () => {
         configurable: true,
       });
 
+      return { ...result, column, ribs, wrote: () => wrote };
+    }
+
+    it('scrubs the conversation while dragging past the threshold', () => {
+      const { column, wrote } = setupDraggableNav();
+
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 25 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
       });
 
-      expect(column.setPointerCapture).toHaveBeenCalledWith(1);
-      expect(wrote).toBeGreaterThanOrEqual(0);
+      expect(wrote()).toBeGreaterThanOrEqual(0);
     });
 
-    it('does not start a drag for movement under the threshold', () => {
-      const { column } = setupDraggableNav();
+    it('keeps tracking the drag after the pointer leaves the narrow column', () => {
+      const { column, wrote } = setupDraggableNav();
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 2 });
+        // pointer has moved off the column; the move bubbles to the document listener
+        fireEvent.pointerMove(document.body, { pointerId: 1, buttons: 1, clientY: 25 });
       });
 
-      expect(column.setPointerCapture).not.toHaveBeenCalled();
+      expect(wrote()).toBeGreaterThanOrEqual(0);
     });
 
-    it('does not start a drag from a later hover move when the button was released outside', () => {
-      const { column } = setupDraggableNav();
+    it('does not scrub for movement under the threshold', () => {
+      const { column, wrote } = setupDraggableNav();
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 2 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 2 });
       });
+
+      expect(wrote()).toBe(-1);
+    });
+
+    it('ignores pointer moves after the interaction ends', () => {
+      const { column, wrote } = setupDraggableNav();
 
       act(() => {
-        fireEvent.pointerMove(column, { pointerId: 1, buttons: 0, clientY: 40 });
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerUp(document, { pointerId: 1, clientY: 0 });
+      });
+      act(() => {
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 40 });
       });
 
-      expect(column.setPointerCapture).not.toHaveBeenCalled();
+      expect(wrote()).toBe(-1);
+    });
+
+    it('selects via the native click when a press does not become a drag', () => {
+      const { column, ribs } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
+        fireEvent.pointerUp(document, { pointerId: 1, clientY: 0 });
+      });
+      act(() => {
+        fireEvent.click(ribs[0]);
+      });
+
+      expect(document.activeElement).toBe(document.getElementById('m-0'));
     });
 
     it('suppresses the click that immediately follows a drag', () => {
@@ -776,8 +798,8 @@ describe('MessageNav', () => {
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 25 });
-        fireEvent.pointerUp(column, { pointerId: 1, clientY: 25 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+        fireEvent.pointerUp(document, { pointerId: 1, clientY: 25 });
       });
 
       act(() => {
@@ -792,8 +814,8 @@ describe('MessageNav', () => {
 
       act(() => {
         fireEvent.pointerDown(column, { pointerId: 1, button: 0, buttons: 1, clientY: 0 });
-        fireEvent.pointerMove(column, { pointerId: 1, buttons: 1, clientY: 25 });
-        fireEvent.pointerUp(column, { pointerId: 1, clientY: 25 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 25 });
+        fireEvent.pointerUp(document, { pointerId: 1, clientY: 25 });
         jest.advanceTimersByTime(1);
       });
 

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -88,6 +88,21 @@ class MockIntersectionObserver {
 
 const originalIO = global.IntersectionObserver;
 
+class PointerEventPolyfill extends MouseEvent {
+  pointerId: number;
+  constructor(type: string, params: MouseEventInit & { pointerId?: number } = {}) {
+    super(type, params);
+    this.pointerId = params.pointerId ?? 0;
+  }
+}
+
+if (typeof (global as { PointerEvent?: unknown }).PointerEvent === 'undefined') {
+  (global as unknown as { PointerEvent: typeof PointerEventPolyfill }).PointerEvent =
+    PointerEventPolyfill;
+  (window as unknown as { PointerEvent: typeof PointerEventPolyfill }).PointerEvent =
+    PointerEventPolyfill;
+}
+
 import MessageNav from '../MessageNav';
 
 function buildMessage(overrides: Partial<TestMessage> = {}): TestMessage {
@@ -605,6 +620,135 @@ describe('MessageNav', () => {
       expect(aScrollTouched).toBe(true);
 
       rafSpy.mockRestore();
+    });
+  });
+
+  describe('focus management', () => {
+    it('moves focus to the target message when an indicator is clicked', () => {
+      const messages = [
+        buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      const { container } = renderNav(messages);
+
+      const indicator = container.querySelectorAll('[data-msg-id]')[1] as HTMLButtonElement;
+      act(() => {
+        fireEvent.click(indicator);
+      });
+
+      const message = document.getElementById('b');
+      expect(message).toHaveAttribute('tabindex', '-1');
+      expect(document.activeElement).toBe(message);
+    });
+
+    it('focuses the current indicator when Shift+Alt+M is pressed', () => {
+      const messages = [
+        buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      const { container } = renderNav(messages);
+
+      const io = MockIntersectionObserver.last();
+      act(() => {
+        io!.trigger([{ target: document.getElementById('b')!, isIntersecting: true }]);
+        jest.advanceTimersByTime(32);
+      });
+
+      act(() => {
+        fireEvent.keyDown(document, { code: 'KeyM', altKey: true, shiftKey: true });
+      });
+
+      expect(document.activeElement).toBe(container.querySelector('[data-msg-id="b"]'));
+    });
+
+    it('ignores the keyboard shortcut without the alt and shift modifiers', () => {
+      const messages = [
+        buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      const { container } = renderNav(messages);
+
+      act(() => {
+        fireEvent.keyDown(document, { code: 'KeyM' });
+      });
+
+      const navButtons = container.querySelectorAll('[data-msg-id]');
+      expect(Array.from(navButtons)).not.toContain(document.activeElement);
+    });
+  });
+
+  describe('drag to scroll', () => {
+    function setupDraggableNav() {
+      const messages = Array.from({ length: 5 }, (_, i) =>
+        buildMessage({
+          messageId: `m-${i}`,
+          text: `message ${i}`,
+          isCreatedByUser: i % 2 === 0,
+        }),
+      );
+      const result = renderNav(messages);
+      const column = result.container.querySelector('nav > div') as HTMLDivElement;
+      column.setPointerCapture = jest.fn();
+      column.hasPointerCapture = jest.fn(() => true);
+      column.releasePointerCapture = jest.fn();
+
+      const ribs = Array.from(column.querySelectorAll('[data-msg-id]')) as HTMLElement[];
+      ribs.forEach((rib, i) => {
+        rib.getBoundingClientRect = () =>
+          ({ top: i * 10, bottom: (i + 1) * 10, height: 10 }) as DOMRect;
+      });
+      return { ...result, column, ribs };
+    }
+
+    it('scrubs the conversation while dragging past the threshold', () => {
+      const { column, scrollable } = setupDraggableNav();
+
+      let wrote = -1;
+      Object.defineProperty(scrollable, 'scrollTop', {
+        get: () => 0,
+        set: (v: number) => {
+          wrote = v;
+        },
+        configurable: true,
+      });
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, clientY: 25 });
+      });
+
+      expect(column.setPointerCapture).toHaveBeenCalledWith(1);
+      expect(wrote).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not start a drag for movement under the threshold', () => {
+      const { column } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, clientY: 2 });
+      });
+
+      expect(column.setPointerCapture).not.toHaveBeenCalled();
+    });
+
+    it('suppresses the click that immediately follows a drag', () => {
+      const { column, ribs } = setupDraggableNav();
+
+      act(() => {
+        fireEvent.pointerDown(column, { pointerId: 1, button: 0, clientY: 0 });
+        fireEvent.pointerMove(column, { pointerId: 1, clientY: 25 });
+        fireEvent.pointerUp(column, { pointerId: 1, clientY: 25 });
+      });
+
+      act(() => {
+        fireEvent.click(ribs[0]);
+      });
+
+      expect(document.activeElement).not.toBe(document.getElementById('m-0'));
     });
   });
 

--- a/client/src/components/Chat/Messages/ui/MessageRender.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRender.tsx
@@ -179,7 +179,7 @@ const MessageRender = memo(function MessageRender({
   };
 
   const conditionalClasses = {
-    focus: 'focus:outline-none focus:ring-2 focus:ring-border-xheavy',
+    focus: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy',
   };
 
   return (

--- a/client/src/components/Messages/ContentRender.tsx
+++ b/client/src/components/Messages/ContentRender.tsx
@@ -172,7 +172,7 @@ const ContentRender = memo(function ContentRender({
   };
 
   const conditionalClasses = {
-    focus: 'focus:outline-none focus:ring-2 focus:ring-border-xheavy',
+    focus: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy',
   };
 
   return (


### PR DESCRIPTION
## Summary

This resolves #13491 by giving the `MessageNav` indicator proper keyboard focus management, and additionally makes the rib column draggable so it behaves like an intuitive scrubber instead of a click-only control.

- Move keyboard focus to the target message when an indicator (rib) is selected, so screen-reader and keyboard users land on the conversation instead of staying stuck on `MessageNav`. The message is made programmatically focusable on demand (`tabIndex=-1`) and focused with `preventScroll` so it doesn't fight the smooth-scroll animation.
- Add a `Shift+Alt+M` shortcut to jump focus back to the nav's current indicator (or the first rib as a fallback), following the existing `Shift+Alt+L` shortcut convention. Declared via `aria-keyshortcuts` so assistive tech announces it.
- Switch the message focus ring from `focus:` to `focus-visible:` (in `MessageRender`, `ContentRender`, and now `MessageParts` for consistency) so the ring appears for keyboard navigation but not for mouse clicks.
- Add drag-to-scrub on the rib column: pressing and dragging vertically scrolls the conversation to the message under the pointer, like dragging a scrollbar thumb (`cursor-ns-resize`).
- Use a 4px movement threshold and pointer capture to distinguish a drag from a click, preserving plain rib clicks and tracking the drag even when the pointer leaves the column.
- Scroll immediately (no easing) during a drag and freeze the rib column's auto-centering so ribs stay put under the cursor, then re-center on release.
- Suppress the synthetic click that follows a drag so it doesn't double-jump or steal focus.
- Extract a shared `computeTargetScroll` helper used by both the eased click-scroll and the immediate drag-scroll.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Extended the `MessageNav` test suite with 6 new cases covering focus-on-select, the `Shift+Alt+M` shortcut (and its modifier guard), drag scrubbing past the threshold, the sub-threshold no-drag case, and post-drag click suppression. Added a minimal `PointerEvent` polyfill (extending jsdom's `MouseEvent`) since jsdom does not implement `PointerEvent`.

To reproduce manually:
1. Open a conversation long enough to show `MessageNav` (3+ messages).
2. Tab to a rib and press Enter — focus should move into the conversation onto that message (visible focus ring).
3. From a focused message, press `Shift+Alt+M` — focus should return to the nav's current indicator.
4. With a mouse, press and drag up/down over the ribs — the conversation should scrub to the message under the pointer.

### **Test Configuration**:

- `cd client && npx jest src/components/Chat/Messages/__tests__/MessageNav.spec.tsx` — 29/29 pass.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
