### PR TITLE
fix: don't reset agent builder after file upload

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -44,7 +44,7 @@ function AgentSelect({
   );
 
   const resetAgentForm = useCallback(
-    (fullAgent: Agent) => {
+    (fullAgent: Agent, options?: Record<string, boolean>) => {
       const isGlobal = fullAgent.isPublic ?? false;
       const update = {
         ...fullAgent,
@@ -150,7 +150,7 @@ function AgentSelect({
         }
       });
 
-      reset(formValues);
+      reset(formValues, options);
     },
     [reset],
   );
@@ -181,7 +181,7 @@ function AgentSelect({
 
   useEffect(() => {
     if (agentQuery.data && agentQuery.isSuccess) {
-      resetAgentForm(agentQuery.data);
+      resetAgentForm(agentQuery.data, { keepDirtyValues: true });
     }
   }, [agentQuery.data, agentQuery.isSuccess, resetAgentForm]);
 


### PR DESCRIPTION
## Summary

If you edited one of the form fields in the agent builder (such as instructions), then uploaded a file, the form field would get reset due to `resetAgentForm()` being called every time the `agentQuery` updates.

Now, we pass the `keepDirtyValues` option when that happens, which keeps the other form fields as they were before the file was uploaded.

Note that this preserves the behavior wherein changing the agent resets the whole form (as it should).**

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Create a new agent.
2. Add anything to the instructions ("here are instructions")
3. Upload a file to the file context.

Before, this would cause the instructions field to reset to blank.

After, it should preserve the instructions you typed in.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
