### PR TITLE
🪤 fix: Reload Messages When Reopening a Chat from a Non-Chat Route

### DIFF
--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -119,6 +119,14 @@ const useNavigateToConvo = (index = 0) => {
     clearAllConversations(true);
     clearMessagesCache(queryClient, currentConvoId);
     if (convo.conversationId !== Constants.NEW_CONVO && convo.conversationId) {
+      /**
+       * Remove (not just invalidate) the target's messages so a freshly-mounted
+       * ChatView refetches them. A prior `clearMessagesCache` can leave this
+       * conversation cached as `[]`, which the messages query's `refetchOnMount: false`
+       * would treat as valid — leaving the chat stuck on an empty cache with no
+       * request when navigating in from a non-chat route (e.g. /projects).
+       */
+      queryClient.removeQueries([QueryKeys.messages, convo.conversationId]);
       queryClient.invalidateQueries([QueryKeys.conversation, convo.conversationId]);
       fetchFreshData(convo);
     } else {


### PR DESCRIPTION
## Summary

Fixes a bug where clicking a previously-visited project chat from the sidebar **while on the `/projects` page** leaves the chat stuck on a loading spinner — the messages query never fires.

## Reproduction

1. Load `/c/new`.
2. Expand a project in the sidebar and open two of its chats (both load fine).
3. Click **All projects** to go to `/projects`.
4. From the **sidebar**, click one of the already-visited chats.
5. The chat never loads — no `/api/messages/:id` request goes out.

## Root cause

When you navigate away from conversation `X`, `clearMessagesCache(X)` sets `[QueryKeys.messages, X]` to `[]` — a *defined-but-empty* value, not `undefined`.

The messages query (`useGetMessagesByConvoId`) defaults to **`refetchOnMount: false`**. When you later return to `X` via `navigateToConvo` from a route where `ChatRoute` was unmounted (e.g. `/projects`), `ChatView` mounts **fresh**, finds the cached `[]`, and — per `refetchOnMount: false` — never refetches. Result: no network request, `messagesTree` stays empty, and `ChatView` shows `LoadingSpinner` forever.

It only worked when navigating from another `/c/:id` because the messages observer stayed continuously mounted there, so the query-key change refetched the stale `[]`. From a non-chat route the observer mounts fresh and that recovery never happens — an observer-lifecycle accident that shouldn't be load-bearing.

## Fix

`navigateToConvo` — the single entry point for in-app conversation navigation — now **removes** the target's messages cache before fetching:

```ts
queryClient.removeQueries([QueryKeys.messages, convo.conversationId]);
```

With the cache `undefined`, a freshly-mounted `ChatView` performs an initial fetch regardless of `refetchOnMount`. This is route-agnostic (works from `/projects`, search, settings, agent detail — anywhere `ChatRoute` was unmounted) and doesn't touch `clearMessagesCache` (removing there would force a wasteful refetch of the *outgoing* conversation right before it unmounts). It also matches existing behavior — the working case already refetches messages on navigation.

## Notes

- One-line behavioral change; no API or schema changes.
- A Playwright regression test (mock harness) for the project-sidebar → `/projects` → reopen flow is a good follow-up.
