### PR TITLE
🚦 fix: Gate Chat Starts During Readiness

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -56,6 +56,30 @@ const trusted_proxy = Number(TRUST_PROXY) || 1; /* trust first proxy by default 
 const app = express();
 let serverReady = false;
 
+const SERVER_NOT_READY_CODE = 'SERVER_NOT_READY';
+const CHAT_START_RETRY_AFTER_SECONDS = '1';
+
+const rejectChatStartsUntilReady = (req, res, next) => {
+  if (serverReady || req.method !== 'POST' || req.path === '/abort') {
+    return next();
+  }
+
+  res.set('Retry-After', CHAT_START_RETRY_AFTER_SECONDS);
+  return res.status(503).json({
+    code: SERVER_NOT_READY_CODE,
+    error: 'Server is still starting. Please retry shortly.',
+  });
+};
+
+const configureGenerationStreams = () => {
+  const streamServices = createStreamServices();
+  GenerationJobManager.configure({
+    ...streamServices,
+    cleanupOnComplete: !isEnabled(process.env.STREAM_KEEP_COMPLETED_JOBS),
+  });
+  GenerationJobManager.initialize();
+};
+
 const startServer = async () => {
   const { metricsMiddleware, metricsRouter } = createMetrics();
   if (!process.env.METRICS_SECRET) {
@@ -214,6 +238,7 @@ const startServer = async () => {
   app.use('/images/', createValidateImageRequest(appConfig.secureImageLinks), routes.staticRoute);
   app.use('/api/share', preAuthTenantMiddleware, routes.share);
   app.use('/api/roles', routes.roles);
+  app.use('/api/agents/chat', rejectChatStartsUntilReady);
   app.use('/api/agents', routes.agents);
   app.use('/api/banner', routes.banner);
   app.use('/api/memories', routes.memories);
@@ -251,6 +276,8 @@ const startServer = async () => {
   /** Error handler (must be last - Express identifies error middleware by its 4-arg signature) */
   app.use(ErrorController);
 
+  configureGenerationStreams();
+
   const server = app.listen(port, host, async (err) => {
     if (err) {
       logger.error('Failed to start server:', err);
@@ -279,14 +306,6 @@ const startServer = async () => {
         await initializeOAuthReconnectManager();
       });
       await checkMigrations();
-
-      // Configure stream services (auto-detects Redis from USE_REDIS env var)
-      const streamServices = createStreamServices();
-      GenerationJobManager.configure({
-        ...streamServices,
-        cleanupOnComplete: !isEnabled(process.env.STREAM_KEEP_COMPLETED_JOBS),
-      });
-      GenerationJobManager.initialize();
 
       const inspectFlags = process.execArgv.some((arg) => arg.startsWith('--inspect'));
       if (inspectFlags || isEnabled(process.env.MEM_DIAG)) {

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -83,6 +83,33 @@ describe('Telemetry wiring', () => {
   });
 });
 
+describe('Startup readiness wiring', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+
+  it('configures generation streams before the server accepts requests', () => {
+    const streamConfigIndex = source.indexOf('configureGenerationStreams();');
+    const listenIndex = source.indexOf('const server = app.listen');
+    const postListenMcpIndex = source.indexOf('await initializeMCPs();');
+
+    expect(streamConfigIndex).toBeGreaterThan(-1);
+    expect(listenIndex).toBeGreaterThan(-1);
+    expect(postListenMcpIndex).toBeGreaterThan(-1);
+    expect(streamConfigIndex).toBeLessThan(listenIndex);
+    expect(streamConfigIndex).toBeLessThan(postListenMcpIndex);
+  });
+
+  it('mounts the chat-start readiness gate before agent routes', () => {
+    const readinessGateIndex = source.indexOf(
+      "app.use('/api/agents/chat', rejectChatStartsUntilReady);",
+    );
+    const agentsRouteIndex = source.indexOf("app.use('/api/agents', routes.agents);");
+
+    expect(readinessGateIndex).toBeGreaterThan(-1);
+    expect(agentsRouteIndex).toBeGreaterThan(-1);
+    expect(readinessGateIndex).toBeLessThan(agentsRouteIndex);
+  });
+});
+
 describe('Server Configuration', () => {
   // Increase the default timeout to allow for Mongo cleanup
   jest.setTimeout(30_000);

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { Constants, LocalStorageKeys, QueryKeys } from 'librechat-data-provider';
+import { Constants, LocalStorageKeys, QueryKeys, request } from 'librechat-data-provider';
 import type { TSubmission } from 'librechat-data-provider';
 
 type SSEEventListener = (e: Partial<MessageEvent> & { responseCode?: number }) => void;
@@ -189,6 +189,8 @@ describe('useResumableSSE - 404 error path', () => {
     mockInvalidateQueries.mockClear();
     mockRemoveQueries.mockClear();
     mockFindAll.mockClear();
+    (request.post as jest.Mock).mockReset();
+    (request.post as jest.Mock).mockResolvedValue({ streamId: 'stream-123' });
   });
 
   const seedDraft = (conversationId: string) => {
@@ -459,6 +461,41 @@ describe('useResumableSSE - 404 error path', () => {
 
     expect(mockTitleHandler).toHaveBeenCalledWith(titleEvent);
     expect(mockStepHandler).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('retries chat start while the server reports startup readiness pending', async () => {
+    (request.post as jest.Mock)
+      .mockRejectedValueOnce({
+        response: {
+          status: 503,
+          data: { code: 'SERVER_NOT_READY' },
+          headers: { 'retry-after': '0' },
+        },
+      })
+      .mockResolvedValueOnce({ streamId: 'stream-ready' });
+
+    const submission = buildSubmission();
+    const chatHelpers = buildChatHelpers();
+
+    const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(request.post).toHaveBeenCalledTimes(2);
+    expect(mockSSEInstances).toHaveLength(1);
+    expect(mockSSEInstances[0].stream).toHaveBeenCalledTimes(1);
+    expect(mockErrorHandler).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -174,6 +174,28 @@ const getLastSSE = (): MockSSEInstance => {
   return sse;
 };
 
+const serverNotReadyError = (retryAfter = '0') => ({
+  response: {
+    status: 503,
+    data: { code: 'SERVER_NOT_READY' },
+    headers: { 'retry-after': retryAfter },
+  },
+});
+
+const flushMicrotasks = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const advanceRetryTimer = async (ms: number) => {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+    await Promise.resolve();
+  });
+  await flushMicrotasks();
+};
+
 describe('useResumableSSE - 404 error path', () => {
   beforeEach(() => {
     mockSSEInstances.length = 0;
@@ -191,6 +213,10 @@ describe('useResumableSSE - 404 error path', () => {
     mockFindAll.mockClear();
     (request.post as jest.Mock).mockReset();
     (request.post as jest.Mock).mockResolvedValue({ streamId: 'stream-123' });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   const seedDraft = (conversationId: string) => {
@@ -464,39 +490,51 @@ describe('useResumableSSE - 404 error path', () => {
     unmount();
   });
 
-  it('retries chat start while the server reports startup readiness pending', async () => {
-    (request.post as jest.Mock)
-      .mockRejectedValueOnce({
-        response: {
-          status: 503,
-          data: { code: 'SERVER_NOT_READY' },
-          headers: { 'retry-after': '0' },
-        },
-      })
-      .mockResolvedValueOnce({ streamId: 'stream-ready' });
+  it('continues retrying chat start while the server reports startup readiness pending', async () => {
+    jest.useFakeTimers();
+    for (let i = 0; i < 9; i++) {
+      (request.post as jest.Mock).mockRejectedValueOnce(serverNotReadyError('1'));
+    }
+    (request.post as jest.Mock).mockResolvedValueOnce({ streamId: 'stream-ready' });
 
     const submission = buildSubmission();
     const chatHelpers = buildChatHelpers();
 
     const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushMicrotasks();
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    for (let i = 0; i < 9; i++) {
+      await advanceRetryTimer(1000);
+    }
 
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    expect(request.post).toHaveBeenCalledTimes(2);
+    expect(request.post).toHaveBeenCalledTimes(10);
     expect(mockSSEInstances).toHaveLength(1);
     expect(mockSSEInstances[0].stream).toHaveBeenCalledTimes(1);
     expect(mockErrorHandler).not.toHaveBeenCalled();
     unmount();
+    jest.useRealTimers();
+  });
+
+  it('cancels startup readiness retries on cleanup before opening a stream', async () => {
+    jest.useFakeTimers();
+    (request.post as jest.Mock)
+      .mockRejectedValueOnce(serverNotReadyError('1'))
+      .mockResolvedValueOnce({ streamId: 'stale-stream' });
+
+    const submission = buildSubmission();
+    const chatHelpers = buildChatHelpers();
+
+    const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+
+    await flushMicrotasks();
+    unmount();
+    await advanceRetryTimer(1000);
+
+    expect(request.post).toHaveBeenCalledTimes(1);
+    expect(mockSSEInstances).toHaveLength(0);
+    expect(mockErrorHandler).not.toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   it('replays title events from resume state sync', async () => {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -40,8 +40,8 @@ type ChatHelpers = Pick<
 >;
 
 const MAX_RETRIES = 5;
-const START_GENERATION_MAX_RETRIES = 8;
 const START_GENERATION_NETWORK_RETRIES = 3;
+const START_GENERATION_READINESS_TIMEOUT_MS = 120000;
 const SERVER_NOT_READY_CODE = 'SERVER_NOT_READY';
 
 type StartGenerationError = {
@@ -86,6 +86,30 @@ const getRetryAfterDelay = (error: unknown, fallbackDelay: number) => {
 
   return Math.min(seconds * 1000, 30000);
 };
+
+const waitForRetryDelay = (delay: number, signal?: AbortSignal): Promise<boolean> =>
+  new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve(false);
+      return;
+    }
+
+    let timeout: ReturnType<typeof setTimeout>;
+    function cleanup() {
+      signal?.removeEventListener('abort', onAbort);
+    }
+    function onAbort() {
+      clearTimeout(timeout);
+      cleanup();
+      resolve(false);
+    }
+    timeout = setTimeout(() => {
+      cleanup();
+      resolve(true);
+    }, delay);
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 
 const hasConcreteConversationId = (conversationId?: string | null) =>
   !!conversationId &&
@@ -750,10 +774,10 @@ export default function useResumableSSE(
    * Start generation (POST request that returns streamId)
    * Uses request.post which has axios interceptors for automatic token refresh.
    * Retries transient network failures and startup readiness responses.
-   * Readiness retries honor Retry-After when the server provides it.
+   * Readiness retries honor Retry-After until cleanup or the readiness window expires.
    */
   const startGeneration = useCallback(
-    async (currentSubmission: TSubmission): Promise<string | null> => {
+    async (currentSubmission: TSubmission, signal?: AbortSignal): Promise<string | null> => {
       const payloadData = createPayload(currentSubmission);
       let { payload } = payloadData;
       payload = removeNullishValues(payload) as TPayload;
@@ -763,40 +787,63 @@ export default function useResumableSSE(
       const url = payloadData.server;
 
       let lastError: unknown = null;
+      let requestAttempts = 0;
+      let networkAttempts = 0;
+      let readinessAttempts = 0;
+      const readinessDeadline = Date.now() + START_GENERATION_READINESS_TIMEOUT_MS;
 
-      for (let attempt = 1; attempt <= START_GENERATION_MAX_RETRIES; attempt++) {
+      while (!signal?.aborted) {
+        requestAttempts += 1;
         try {
           // Use request.post which handles auth token refresh via axios interceptors
           const data = (await request.post(url, payload)) as { streamId: string };
+          if (signal?.aborted) {
+            return null;
+          }
           console.log('[ResumableSSE] Generation started:', { streamId: data.streamId });
           return data.streamId;
         } catch (error) {
+          if (signal?.aborted) {
+            return null;
+          }
+
           lastError = error;
           const isNetworkError = isRetryableNetworkError(error);
           const isServerNotReady = isServerNotReadyError(error);
-          const shouldRetryNetwork = isNetworkError && attempt < START_GENERATION_NETWORK_RETRIES;
-          const shouldRetryServerNotReady =
-            isServerNotReady && attempt < START_GENERATION_MAX_RETRIES;
+          const remainingReadinessMs = readinessDeadline - Date.now();
+          const shouldRetryNetwork =
+            isNetworkError && networkAttempts < START_GENERATION_NETWORK_RETRIES - 1;
+          const shouldRetryServerNotReady = isServerNotReady && remainingReadinessMs > 0;
 
           if (shouldRetryNetwork || shouldRetryServerNotReady) {
-            const fallbackDelay = Math.min(1000 * Math.pow(2, attempt - 1), 8000);
-            const delay = isServerNotReady
-              ? getRetryAfterDelay(error, fallbackDelay)
+            networkAttempts += isNetworkError ? 1 : 0;
+            readinessAttempts += isServerNotReady ? 1 : 0;
+            const fallbackDelay = Math.min(1000 * Math.pow(2, requestAttempts - 1), 8000);
+            const retryDelay = isServerNotReady
+              ? Math.min(getRetryAfterDelay(error, fallbackDelay), remainingReadinessMs)
               : fallbackDelay;
             const reason = isServerNotReady ? 'Server not ready' : 'Network error';
-            const maxAttempts = isServerNotReady
-              ? START_GENERATION_MAX_RETRIES
-              : START_GENERATION_NETWORK_RETRIES;
+            const attempt = isServerNotReady ? readinessAttempts : networkAttempts;
+            const limit = isServerNotReady
+              ? `${Math.ceil(START_GENERATION_READINESS_TIMEOUT_MS / 1000)}s readiness window`
+              : `${START_GENERATION_NETWORK_RETRIES}`;
             console.log(
-              `[ResumableSSE] ${reason} starting generation, retrying in ${delay}ms (attempt ${attempt}/${maxAttempts})`,
+              `[ResumableSSE] ${reason} starting generation, retrying in ${retryDelay}ms (attempt ${attempt}/${limit})`,
             );
-            await new Promise((resolve) => setTimeout(resolve, delay));
+            const shouldContinue = await waitForRetryDelay(retryDelay, signal);
+            if (!shouldContinue) {
+              return null;
+            }
             continue;
           }
 
           // Don't retry: either not a network error or max retries reached
           break;
         }
+      }
+
+      if (signal?.aborted) {
+        return null;
       }
 
       console.error('[ResumableSSE] Error starting generation:', lastError);
@@ -847,12 +894,21 @@ export default function useResumableSSE(
     });
 
     submissionRef.current = submission;
+    const startController = new AbortController();
+    const { signal } = startController;
 
     const initStream = async () => {
+      if (signal.aborted) {
+        return;
+      }
+
       setIsSubmitting(true);
       setShowStopButton(true);
 
       if (resumeStreamId) {
+        if (signal.aborted) {
+          return;
+        }
         // Resume: just subscribe to existing stream, don't start new generation
         console.log('[ResumableSSE] Resuming existing stream:', resumeStreamId);
         setStreamId(resumeStreamId);
@@ -862,7 +918,10 @@ export default function useResumableSSE(
       } else {
         // New generation: start and then subscribe
         console.log('[ResumableSSE] Starting NEW generation');
-        const newStreamId = await startGeneration(submission);
+        const newStreamId = await startGeneration(submission, signal);
+        if (signal.aborted) {
+          return;
+        }
         if (newStreamId) {
           setStreamId(newStreamId);
           // Optimistically add to active jobs
@@ -890,6 +949,7 @@ export default function useResumableSSE(
 
     return () => {
       console.log('[ResumableSSE] Cleanup - closing SSE, resetting UI state');
+      startController.abort();
       // Cleanup on unmount/navigation - close connection but DO NOT abort backend
       // Reset UI state so it doesn't leak to other conversations
       // If user returns to this conversation, useResumeOnLoad will restore the state

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -94,7 +94,6 @@ const waitForRetryDelay = (delay: number, signal?: AbortSignal): Promise<boolean
       return;
     }
 
-    let timeout: ReturnType<typeof setTimeout>;
     function cleanup() {
       signal?.removeEventListener('abort', onAbort);
     }
@@ -103,7 +102,7 @@ const waitForRetryDelay = (delay: number, signal?: AbortSignal): Promise<boolean
       cleanup();
       resolve(false);
     }
-    timeout = setTimeout(() => {
+    const timeout = setTimeout(() => {
       cleanup();
       resolve(true);
     }, delay);

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -773,8 +773,7 @@ export default function useResumableSSE(
           lastError = error;
           const isNetworkError = isRetryableNetworkError(error);
           const isServerNotReady = isServerNotReadyError(error);
-          const shouldRetryNetwork =
-            isNetworkError && attempt < START_GENERATION_NETWORK_RETRIES;
+          const shouldRetryNetwork = isNetworkError && attempt < START_GENERATION_NETWORK_RETRIES;
           const shouldRetryServerNotReady =
             isServerNotReady && attempt < START_GENERATION_MAX_RETRIES;
 

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -749,7 +749,8 @@ export default function useResumableSSE(
   /**
    * Start generation (POST request that returns streamId)
    * Uses request.post which has axios interceptors for automatic token refresh.
-   * Retries up to 3 times on network errors with exponential backoff.
+   * Retries transient network failures and startup readiness responses.
+   * Readiness retries honor Retry-After when the server provides it.
    */
   const startGeneration = useCallback(
     async (currentSubmission: TSubmission): Promise<string | null> => {
@@ -783,8 +784,11 @@ export default function useResumableSSE(
               ? getRetryAfterDelay(error, fallbackDelay)
               : fallbackDelay;
             const reason = isServerNotReady ? 'Server not ready' : 'Network error';
+            const maxAttempts = isServerNotReady
+              ? START_GENERATION_MAX_RETRIES
+              : START_GENERATION_NETWORK_RETRIES;
             console.log(
-              `[ResumableSSE] ${reason} starting generation, retrying in ${delay}ms (attempt ${attempt}/${START_GENERATION_MAX_RETRIES})`,
+              `[ResumableSSE] ${reason} starting generation, retrying in ${delay}ms (attempt ${attempt}/${maxAttempts})`,
             );
             await new Promise((resolve) => setTimeout(resolve, delay));
             continue;

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -40,6 +40,52 @@ type ChatHelpers = Pick<
 >;
 
 const MAX_RETRIES = 5;
+const START_GENERATION_MAX_RETRIES = 8;
+const START_GENERATION_NETWORK_RETRIES = 3;
+const SERVER_NOT_READY_CODE = 'SERVER_NOT_READY';
+
+type StartGenerationError = {
+  code?: string;
+  response?: {
+    status?: number;
+    data?: {
+      code?: string;
+    };
+    headers?: Record<string, string | number | string[] | undefined>;
+  };
+};
+
+const toStartGenerationError = (error: unknown): StartGenerationError | undefined =>
+  error != null && typeof error === 'object' ? (error as StartGenerationError) : undefined;
+
+const isRetryableNetworkError = (error: unknown) => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const { code } = toStartGenerationError(error) ?? {};
+  return code === 'ERR_NETWORK' || code === 'ERR_INTERNET_DISCONNECTED';
+};
+
+const isServerNotReadyError = (error: unknown) => {
+  const candidate = toStartGenerationError(error);
+  return (
+    candidate?.response?.status === 503 && candidate.response?.data?.code === SERVER_NOT_READY_CODE
+  );
+};
+
+const getRetryAfterDelay = (error: unknown, fallbackDelay: number) => {
+  const headers = toStartGenerationError(error)?.response?.headers;
+  const rawValue = headers?.['retry-after'] ?? headers?.['Retry-After'];
+  const retryAfter = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+  const seconds = typeof retryAfter === 'number' ? retryAfter : Number(retryAfter);
+
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return fallbackDelay;
+  }
+
+  return Math.min(seconds * 1000, 30000);
+};
 
 const hasConcreteConversationId = (conversationId?: string | null) =>
   !!conversationId &&
@@ -715,10 +761,9 @@ export default function useResumableSSE(
 
       const url = payloadData.server;
 
-      const maxRetries = 3;
       let lastError: unknown = null;
 
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      for (let attempt = 1; attempt <= START_GENERATION_MAX_RETRIES; attempt++) {
         try {
           // Use request.post which handles auth token refresh via axios interceptors
           const data = (await request.post(url, payload)) as { streamId: string };
@@ -726,16 +771,21 @@ export default function useResumableSSE(
           return data.streamId;
         } catch (error) {
           lastError = error;
-          // Check if it's a network error (retry) vs server error (don't retry)
-          const isNetworkError =
-            error instanceof Error &&
-            'code' in error &&
-            (error.code === 'ERR_NETWORK' || error.code === 'ERR_INTERNET_DISCONNECTED');
+          const isNetworkError = isRetryableNetworkError(error);
+          const isServerNotReady = isServerNotReadyError(error);
+          const shouldRetryNetwork =
+            isNetworkError && attempt < START_GENERATION_NETWORK_RETRIES;
+          const shouldRetryServerNotReady =
+            isServerNotReady && attempt < START_GENERATION_MAX_RETRIES;
 
-          if (isNetworkError && attempt < maxRetries) {
-            const delay = Math.min(1000 * Math.pow(2, attempt - 1), 8000);
+          if (shouldRetryNetwork || shouldRetryServerNotReady) {
+            const fallbackDelay = Math.min(1000 * Math.pow(2, attempt - 1), 8000);
+            const delay = isServerNotReady
+              ? getRetryAfterDelay(error, fallbackDelay)
+              : fallbackDelay;
+            const reason = isServerNotReady ? 'Server not ready' : 'Network error';
             console.log(
-              `[ResumableSSE] Network error starting generation, retrying in ${delay}ms (attempt ${attempt}/${maxRetries})`,
+              `[ResumableSSE] ${reason} starting generation, retrying in ${delay}ms (attempt ${attempt}/${START_GENERATION_MAX_RETRIES})`,
             );
             await new Promise((resolve) => setTimeout(resolve, delay));
             continue;


### PR DESCRIPTION
I fixed a startup race where chat requests could create resumable stream jobs before server readiness completed, leaving clients attached to a stream transport that later got replaced.

- Moved generation stream service configuration before `app.listen` accepts requests so the stream manager is stable before any chat job can be created.
- Added a retryable `503 SERVER_NOT_READY` guard for chat-start POST requests while post-listen readiness work is still pending.
- Preserved non-start chat routes such as stream subscription/status and abort handling during readiness gating.
- Added client retry handling for the explicit startup readiness response using `Retry-After` when present.
- Added regression coverage for startup wiring order and client retry behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Not run locally at user request. PR CI should validate the focused backend and frontend coverage.

### **Test Configuration**:

- Local tests: not run
- Validation source: PR CI

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works