### PR TITLE
💼 fix: Harden Shared-Link Message Sanitization with an Allowlist

### DIFF
--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -45,6 +45,9 @@ describe('Share Methods', () => {
         clientId: String,
         plugin: mongoose.Schema.Types.Mixed,
         metadata: mongoose.Schema.Types.Mixed,
+        feedback: mongoose.Schema.Types.Mixed,
+        manualSkills: [String],
+        alwaysAppliedSkills: [String],
         parentMessageId: String,
         attachments: [mongoose.Schema.Types.Mixed],
         files: [mongoose.Schema.Types.Mixed],
@@ -424,6 +427,9 @@ describe('Share Methods', () => {
         clientId: 'client-id',
         plugin: { latest: 'internal' },
         metadata: { codeEnvRef: 'internal-ref' },
+        feedback: { rating: 'thumbsDown', tag: { key: 'inaccurate' }, text: 'private note' },
+        manualSkills: ['research'],
+        alwaysAppliedSkills: ['brand-voice'],
         files: [
           {
             file_id: 'file123',
@@ -431,9 +437,9 @@ describe('Share Methods', () => {
             type: 'image/png',
             width: 100,
             height: 100,
+            filepath: '/images/upload.png',
             user: userId,
             tenantId: 'tenant-a',
-            filepath: '/private/upload.png',
             storageKey: 'private/upload.png',
             source: 's3',
           },
@@ -444,7 +450,7 @@ describe('Share Methods', () => {
             type: 'web_search',
             web_search: { results: [{ title: 'Cited source', link: 'https://example.com' }] },
             filename: 'result.json',
-            filepath: '/private/result.json',
+            filepath: '/images/result.json',
             storageKey: 'private/result.json',
             metadata: { codeEnvRef: 'internal-ref' },
           },
@@ -469,25 +475,30 @@ describe('Share Methods', () => {
       expect(shared).not.toHaveProperty('clientId');
       expect(shared).not.toHaveProperty('plugin');
       expect(shared).not.toHaveProperty('metadata');
+      // Private owner feedback is not render data and must not leak publicly.
+      expect(shared).not.toHaveProperty('feedback');
+      // Skill badges are non-sensitive UI metadata and should still render.
+      expect(shared?.manualSkills).toEqual(['research']);
+      expect(shared?.alwaysAppliedSkills).toEqual(['brand-voice']);
 
-      // User-uploaded files are preserved (render data) but storage internals are stripped.
+      // User-uploaded files keep their render URL (filepath/preview) but drop storage internals.
       const file = shared?.files?.[0];
       expect(file).toMatchObject({ filename: 'upload.png', type: 'image/png' });
-      expect(file).not.toHaveProperty('filepath');
+      expect(file?.filepath).toBe('/images/upload.png');
       expect(file).not.toHaveProperty('storageKey');
       expect(file).not.toHaveProperty('user');
       expect(file).not.toHaveProperty('tenantId');
       expect(file).not.toHaveProperty('source');
 
-      // Tool-call attachments keep their correlation id and payload so citations
-      // still render, while storage-only fields are removed.
+      // Tool-call attachments keep their correlation id, payload, and render URL so
+      // citations still render, while storage-only fields are removed.
       const attachment = shared?.attachments?.[0];
       expect(attachment).toMatchObject({
         toolCallId: 'call_abc',
         type: 'web_search',
         web_search: { results: [{ title: 'Cited source', link: 'https://example.com' }] },
+        filepath: '/images/result.json',
       });
-      expect(attachment).not.toHaveProperty('filepath');
       expect(attachment).not.toHaveProperty('storageKey');
       expect(attachment).not.toHaveProperty('metadata');
     });

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -40,6 +40,7 @@ describe('Share Methods', () => {
         text: String,
         isCreatedByUser: Boolean,
         model: String,
+        iconURL: String,
         endpoint: String,
         conversationSignature: String,
         clientId: String,
@@ -422,6 +423,7 @@ describe('Share Methods', () => {
         text: 'safe text',
         isCreatedByUser: false,
         model: 'gpt-4',
+        iconURL: 'https://cdn.example.com/icon.png',
         endpoint: 'openAI',
         conversationSignature: 'signature',
         clientId: 'client-id',
@@ -438,6 +440,7 @@ describe('Share Methods', () => {
             width: 100,
             height: 100,
             filepath: '/images/upload.png',
+            conversationId,
             user: userId,
             tenantId: 'tenant-a',
             storageKey: 'private/upload.png',
@@ -468,6 +471,8 @@ describe('Share Methods', () => {
       const shared = result?.messages[0];
 
       expect(shared?.text).toBe('safe text');
+      // Custom message icon is render metadata and should be preserved.
+      expect(shared?.iconURL).toBe('https://cdn.example.com/icon.png');
       // Non-assistant model and internal message fields must not be disclosed.
       expect(shared?.model).toBeUndefined();
       expect(shared).not.toHaveProperty('endpoint');
@@ -489,6 +494,9 @@ describe('Share Methods', () => {
       expect(file).not.toHaveProperty('user');
       expect(file).not.toHaveProperty('tenantId');
       expect(file).not.toHaveProperty('source');
+      // The file's conversation id is rewritten to the anonymized id, not the original.
+      expect(file?.conversationId).toBe(shared?.conversationId);
+      expect(file?.conversationId).not.toBe(conversationId);
 
       // Tool-call attachments keep their correlation id, payload, and render URL so
       // citations still render, while storage-only fields are removed.

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -40,6 +40,11 @@ describe('Share Methods', () => {
         text: String,
         isCreatedByUser: Boolean,
         model: String,
+        endpoint: String,
+        conversationSignature: String,
+        clientId: String,
+        plugin: mongoose.Schema.Types.Mixed,
+        metadata: mongoose.Schema.Types.Mixed,
         parentMessageId: String,
         attachments: [mongoose.Schema.Types.Mixed],
         content: [mongoose.Schema.Types.Mixed],
@@ -399,6 +404,70 @@ describe('Share Methods', () => {
       expect(
         (result?.messages[0].attachments?.[0] as unknown as t.IMessage | undefined)?.conversationId,
       ).toBe(result?.conversationId);
+    });
+
+    test('should strip internal message and attachment fields from shared output', async () => {
+      const userId = new mongoose.Types.ObjectId().toString();
+      const conversationId = `conv_${nanoid()}`;
+      const shareId = `share_${nanoid()}`;
+
+      const message = await Message.create({
+        messageId: `msg_${nanoid()}`,
+        conversationId,
+        user: userId,
+        text: 'safe text',
+        isCreatedByUser: false,
+        model: 'gpt-4',
+        endpoint: 'openAI',
+        conversationSignature: 'signature',
+        clientId: 'client-id',
+        plugin: { latest: 'internal' },
+        metadata: { codeEnvRef: 'internal-ref' },
+        attachments: [
+          {
+            file_id: 'file123',
+            filename: 'safe.pdf',
+            type: 'application/pdf',
+            width: 640,
+            height: 480,
+            filepath: '/private/safe.pdf',
+            storageKey: 'private/safe.pdf',
+            metadata: { codeEnvRef: 'internal-ref' },
+          },
+        ],
+      });
+
+      await SharedLink.create({
+        shareId,
+        conversationId,
+        user: userId,
+        messages: [message._id],
+      });
+
+      const result = await shareMethods.getSharedMessages(shareId);
+      const shared = result?.messages[0] as (t.IMessage & Record<string, unknown>) | undefined;
+
+      expect(shared?.text).toBe('safe text');
+      // Non-assistant model and internal message fields must not be disclosed.
+      expect(shared?.model).toBeUndefined();
+      expect(shared).not.toHaveProperty('endpoint');
+      expect(shared).not.toHaveProperty('conversationSignature');
+      expect(shared).not.toHaveProperty('clientId');
+      expect(shared).not.toHaveProperty('plugin');
+      expect(shared).not.toHaveProperty('metadata');
+
+      // Attachments keep render-relevant fields but drop internal storage fields.
+      const attachment = shared?.attachments?.[0] as Record<string, unknown> | undefined;
+      expect(attachment).toMatchObject({
+        filename: 'safe.pdf',
+        type: 'application/pdf',
+        width: 640,
+        height: 480,
+      });
+      expect(attachment).not.toHaveProperty('file_id');
+      expect(attachment).not.toHaveProperty('filepath');
+      expect(attachment).not.toHaveProperty('storageKey');
+      expect(attachment).not.toHaveProperty('metadata');
     });
   });
 

--- a/packages/data-schemas/src/methods/share.test.ts
+++ b/packages/data-schemas/src/methods/share.test.ts
@@ -47,6 +47,7 @@ describe('Share Methods', () => {
         metadata: mongoose.Schema.Types.Mixed,
         parentMessageId: String,
         attachments: [mongoose.Schema.Types.Mixed],
+        files: [mongoose.Schema.Types.Mixed],
         content: [mongoose.Schema.Types.Mixed],
       },
       { timestamps: true },
@@ -345,7 +346,7 @@ describe('Share Methods', () => {
         expect(msg.messageId).toMatch(/^msg_/); // Should be anonymized with msg_ prefix
         expect(msg.messageId).not.toBe(messages[0].messageId); // Should be different from original
         expect(msg.conversationId).toBe(result.conversationId);
-        expect(msg.user).toBeUndefined(); // User should be removed
+        expect((msg as Record<string, unknown>).user).toBeUndefined(); // User should be removed
       });
     });
 
@@ -406,7 +407,7 @@ describe('Share Methods', () => {
       ).toBe(result?.conversationId);
     });
 
-    test('should strip internal message and attachment fields from shared output', async () => {
+    test('strips storage-internal fields while preserving shared render data', async () => {
       const userId = new mongoose.Types.ObjectId().toString();
       const conversationId = `conv_${nanoid()}`;
       const shareId = `share_${nanoid()}`;
@@ -423,15 +424,28 @@ describe('Share Methods', () => {
         clientId: 'client-id',
         plugin: { latest: 'internal' },
         metadata: { codeEnvRef: 'internal-ref' },
-        attachments: [
+        files: [
           {
             file_id: 'file123',
-            filename: 'safe.pdf',
-            type: 'application/pdf',
-            width: 640,
-            height: 480,
-            filepath: '/private/safe.pdf',
-            storageKey: 'private/safe.pdf',
+            filename: 'upload.png',
+            type: 'image/png',
+            width: 100,
+            height: 100,
+            user: userId,
+            tenantId: 'tenant-a',
+            filepath: '/private/upload.png',
+            storageKey: 'private/upload.png',
+            source: 's3',
+          },
+        ],
+        attachments: [
+          {
+            toolCallId: 'call_abc',
+            type: 'web_search',
+            web_search: { results: [{ title: 'Cited source', link: 'https://example.com' }] },
+            filename: 'result.json',
+            filepath: '/private/result.json',
+            storageKey: 'private/result.json',
             metadata: { codeEnvRef: 'internal-ref' },
           },
         ],
@@ -445,7 +459,7 @@ describe('Share Methods', () => {
       });
 
       const result = await shareMethods.getSharedMessages(shareId);
-      const shared = result?.messages[0] as (t.IMessage & Record<string, unknown>) | undefined;
+      const shared = result?.messages[0];
 
       expect(shared?.text).toBe('safe text');
       // Non-assistant model and internal message fields must not be disclosed.
@@ -456,15 +470,23 @@ describe('Share Methods', () => {
       expect(shared).not.toHaveProperty('plugin');
       expect(shared).not.toHaveProperty('metadata');
 
-      // Attachments keep render-relevant fields but drop internal storage fields.
-      const attachment = shared?.attachments?.[0] as Record<string, unknown> | undefined;
+      // User-uploaded files are preserved (render data) but storage internals are stripped.
+      const file = shared?.files?.[0];
+      expect(file).toMatchObject({ filename: 'upload.png', type: 'image/png' });
+      expect(file).not.toHaveProperty('filepath');
+      expect(file).not.toHaveProperty('storageKey');
+      expect(file).not.toHaveProperty('user');
+      expect(file).not.toHaveProperty('tenantId');
+      expect(file).not.toHaveProperty('source');
+
+      // Tool-call attachments keep their correlation id and payload so citations
+      // still render, while storage-only fields are removed.
+      const attachment = shared?.attachments?.[0];
       expect(attachment).toMatchObject({
-        filename: 'safe.pdf',
-        type: 'application/pdf',
-        width: 640,
-        height: 480,
+        toolCallId: 'call_abc',
+        type: 'web_search',
+        web_search: { results: [{ title: 'Cited source', link: 'https://example.com' }] },
       });
-      expect(attachment).not.toHaveProperty('file_id');
       expect(attachment).not.toHaveProperty('filepath');
       expect(attachment).not.toHaveProperty('storageKey');
       expect(attachment).not.toHaveProperty('metadata');

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -42,61 +42,57 @@ function anonymizeConvo(conversation: Partial<t.IConversation> & Partial<t.IShar
   return newConvo;
 }
 
-type SharedAttachment = {
-  filename?: string;
-  type?: string;
-  width?: number;
-  height?: number;
-};
-
-type MessageAttachment = SharedAttachment & {
-  messageId?: string;
-  conversationId?: string;
-};
-
-function getString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
-}
-
-function getNumber(value: unknown): number | undefined {
-  return typeof value === 'number' ? value : undefined;
-}
+/**
+ * Storage- and identity-internal fields that must never be exposed through a
+ * public shared link. Everything else on a file/attachment (filename, type,
+ * dimensions, previews, and tool-call payloads such as `toolCallId` and search
+ * results) is render data the shared view needs, so it is preserved.
+ */
+const SENSITIVE_SHARED_FILE_FIELDS = new Set([
+  '_id',
+  '__v',
+  'user',
+  'tenantId',
+  'storageRegion',
+  'storageKey',
+  'filepath',
+  'temp_file_id',
+  'message',
+  'source',
+  'filterSource',
+  'context',
+  'embedded',
+  'usage',
+  'metadata',
+]);
 
 /**
- * Allowlist the safe, render-relevant fields of an attachment, dropping internal
- * fields (e.g. `filepath`, `storageKey`, `metadata`) that must not be exposed
- * through a public shared link.
+ * Strip storage/identity-internal fields from a file or attachment while keeping
+ * render-relevant data (including tool-call payloads keyed by tool name).
  */
-function sanitizeAttachment(value: unknown): SharedAttachment | null {
+function sanitizeSharedFile(value: unknown): t.SharedFile | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return null;
   }
 
-  const source = value as Record<string, unknown>;
-  const filename = getString(source.filename);
-  const type = getString(source.type);
-  const width = getNumber(source.width);
-  const height = getNumber(source.height);
-  const attachment: SharedAttachment = {
-    ...(filename && { filename }),
-    ...(type && { type }),
-    ...(width !== undefined && { width }),
-    ...(height !== undefined && { height }),
-  };
+  const result: t.SharedFile = {};
+  for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
+    if (!SENSITIVE_SHARED_FILE_FIELDS.has(key)) {
+      result[key] = fieldValue;
+    }
+  }
 
-  return Object.keys(attachment).length > 0 ? attachment : null;
+  return Object.keys(result).length > 0 ? result : null;
 }
 
-function sanitizeAttachments(
-  attachments: t.IMessage['attachments'],
-): SharedAttachment[] | undefined {
-  if (!Array.isArray(attachments)) {
+function sanitizeSharedFiles(files: unknown): t.SharedFile[] | undefined {
+  if (!Array.isArray(files)) {
     return undefined;
   }
 
-  const sanitized = attachments
-    .map(sanitizeAttachment)
-    .filter((attachment): attachment is SharedAttachment => attachment != null);
+  const sanitized = files
+    .map(sanitizeSharedFile)
+    .filter((file): file is t.SharedFile => file != null);
 
   return sanitized.length > 0 ? sanitized : undefined;
 }
@@ -113,11 +109,14 @@ function anonymizeSharedModel(model?: string): string | undefined {
 }
 
 /**
- * Build the public, anonymized view of shared messages. Uses an allowlist so that
- * internal message fields (endpoint, conversationSignature, clientId, plugin(s),
- * metadata, etc.) and internal attachment fields are never exposed in a shared link.
+ * Build the public, anonymized view of shared messages. An allowlist of
+ * render-relevant fields keeps internal message fields (endpoint,
+ * conversationSignature, clientId, plugin(s), metadata, etc.) out of the
+ * payload, while user files and tool-call attachments are sanitized field by
+ * field so render data (uploaded files, `toolCallId`, search results, generated
+ * outputs) is preserved without leaking storage internals.
  */
-function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.IMessage[] {
+function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.SharedMessage[] {
   if (!Array.isArray(messages)) {
     return [];
   }
@@ -127,13 +126,12 @@ function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.IMessa
     const newMessageId = anonymizeMessageId(message.messageId);
     idMap.set(message.messageId, newMessageId);
 
-    const anonymizedAttachments = sanitizeAttachments(message.attachments)?.map(
-      (attachment): MessageAttachment => ({
-        ...attachment,
-        messageId: newMessageId,
-        conversationId: newConvoId,
-      }),
-    );
+    const attachments = sanitizeSharedFiles(message.attachments)?.map((attachment) => ({
+      ...attachment,
+      messageId: newMessageId,
+      conversationId: newConvoId,
+    }));
+    const files = sanitizeSharedFiles(message.files);
     const model = anonymizeSharedModel(message.model);
 
     return {
@@ -154,8 +152,9 @@ function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.IMessa
       error: message.error,
       finish_reason: message.finish_reason,
       feedback: message.feedback,
-      ...(anonymizedAttachments && { attachments: anonymizedAttachments }),
-    } as t.IMessage;
+      ...(files && { files }),
+      ...(attachments && { attachments }),
+    };
   });
 }
 

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -42,6 +42,81 @@ function anonymizeConvo(conversation: Partial<t.IConversation> & Partial<t.IShar
   return newConvo;
 }
 
+type SharedAttachment = {
+  filename?: string;
+  type?: string;
+  width?: number;
+  height?: number;
+};
+
+type MessageAttachment = SharedAttachment & {
+  messageId?: string;
+  conversationId?: string;
+};
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+/**
+ * Allowlist the safe, render-relevant fields of an attachment, dropping internal
+ * fields (e.g. `filepath`, `storageKey`, `metadata`) that must not be exposed
+ * through a public shared link.
+ */
+function sanitizeAttachment(value: unknown): SharedAttachment | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const source = value as Record<string, unknown>;
+  const filename = getString(source.filename);
+  const type = getString(source.type);
+  const width = getNumber(source.width);
+  const height = getNumber(source.height);
+  const attachment: SharedAttachment = {
+    ...(filename && { filename }),
+    ...(type && { type }),
+    ...(width !== undefined && { width }),
+    ...(height !== undefined && { height }),
+  };
+
+  return Object.keys(attachment).length > 0 ? attachment : null;
+}
+
+function sanitizeAttachments(
+  attachments: t.IMessage['attachments'],
+): SharedAttachment[] | undefined {
+  if (!Array.isArray(attachments)) {
+    return undefined;
+  }
+
+  const sanitized = attachments
+    .map(sanitizeAttachment)
+    .filter((attachment): attachment is SharedAttachment => attachment != null);
+
+  return sanitized.length > 0 ? sanitized : undefined;
+}
+
+/**
+ * Only surface a model name when it is an (already-anonymized) assistant id;
+ * otherwise omit it so the underlying provider/model is not disclosed.
+ */
+function anonymizeSharedModel(model?: string): string | undefined {
+  if (!model?.startsWith('asst_')) {
+    return undefined;
+  }
+  return anonymizeAssistantId(model);
+}
+
+/**
+ * Build the public, anonymized view of shared messages. Uses an allowlist so that
+ * internal message fields (endpoint, conversationSignature, clientId, plugin(s),
+ * metadata, etc.) and internal attachment fields are never exposed in a shared link.
+ */
 function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.IMessage[] {
   if (!Array.isArray(messages)) {
     return [];
@@ -52,33 +127,34 @@ function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.IMessa
     const newMessageId = anonymizeMessageId(message.messageId);
     idMap.set(message.messageId, newMessageId);
 
-    type MessageAttachment = {
-      messageId?: string;
-      conversationId?: string;
-      [key: string]: unknown;
-    };
-
-    const anonymizedAttachments = (message.attachments as MessageAttachment[])?.map(
-      (attachment) => {
-        return {
-          ...attachment,
-          messageId: newMessageId,
-          conversationId: newConvoId,
-        };
-      },
+    const anonymizedAttachments = sanitizeAttachments(message.attachments)?.map(
+      (attachment): MessageAttachment => ({
+        ...attachment,
+        messageId: newMessageId,
+        conversationId: newConvoId,
+      }),
     );
+    const model = anonymizeSharedModel(message.model);
 
     return {
-      ...message,
       messageId: newMessageId,
       parentMessageId:
         idMap.get(message.parentMessageId || '') ||
         anonymizeMessageId(message.parentMessageId || ''),
       conversationId: newConvoId,
-      model: message.model?.startsWith('asst_')
-        ? anonymizeAssistantId(message.model)
-        : message.model,
-      attachments: anonymizedAttachments,
+      sender: message.sender,
+      text: message.text,
+      content: message.content,
+      ...(model && { model }),
+      isCreatedByUser: message.isCreatedByUser,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+      tokenCount: message.tokenCount,
+      unfinished: message.unfinished,
+      error: message.error,
+      finish_reason: message.finish_reason,
+      feedback: message.feedback,
+      ...(anonymizedAttachments && { attachments: anonymizedAttachments }),
     } as t.IMessage;
   });
 }

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -132,7 +132,13 @@ function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.Shared
       messageId: newMessageId,
       conversationId: newConvoId,
     }));
-    const files = sanitizeSharedFiles(message.files);
+    // Persisted file records can carry the original conversation/message ids;
+    // rewrite them to the anonymized ids so shared files don't expose them.
+    const files = sanitizeSharedFiles(message.files)?.map((file) => ({
+      ...file,
+      ...(file.conversationId !== undefined && { conversationId: newConvoId }),
+      ...(file.messageId !== undefined && { messageId: newMessageId }),
+    }));
     const model = anonymizeSharedModel(message.model);
 
     return {
@@ -144,6 +150,7 @@ function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.Shared
       sender: message.sender,
       text: message.text,
       content: message.content,
+      ...(message.iconURL && { iconURL: message.iconURL }),
       ...(model && { model }),
       isCreatedByUser: message.isCreatedByUser,
       createdAt: message.createdAt,

--- a/packages/data-schemas/src/methods/share.ts
+++ b/packages/data-schemas/src/methods/share.ts
@@ -44,9 +44,11 @@ function anonymizeConvo(conversation: Partial<t.IConversation> & Partial<t.IShar
 
 /**
  * Storage- and identity-internal fields that must never be exposed through a
- * public shared link. Everything else on a file/attachment (filename, type,
- * dimensions, previews, and tool-call payloads such as `toolCallId` and search
- * results) is render data the shared view needs, so it is preserved.
+ * public shared link. Everything else on a file/attachment — including the
+ * `filepath`/`preview` render URLs, dimensions, and tool-call payloads such as
+ * `toolCallId` and search results — is render data the shared view needs, so it
+ * is preserved. (`storageKey` is the raw object key and is dropped; `filepath`
+ * is the URL the share renderer actually loads, so it is kept.)
  */
 const SENSITIVE_SHARED_FILE_FIELDS = new Set([
   '_id',
@@ -55,7 +57,6 @@ const SENSITIVE_SHARED_FILE_FIELDS = new Set([
   'tenantId',
   'storageRegion',
   'storageKey',
-  'filepath',
   'temp_file_id',
   'message',
   'source',
@@ -151,7 +152,8 @@ function anonymizeMessages(messages: t.IMessage[], newConvoId: string): t.Shared
       unfinished: message.unfinished,
       error: message.error,
       finish_reason: message.finish_reason,
-      feedback: message.feedback,
+      ...(message.manualSkills && { manualSkills: message.manualSkills }),
+      ...(message.alwaysAppliedSkills && { alwaysAppliedSkills: message.alwaysAppliedSkills }),
       ...(files && { files }),
       ...(attachments && { attachments }),
     };

--- a/packages/data-schemas/src/types/share.ts
+++ b/packages/data-schemas/src/types/share.ts
@@ -47,7 +47,8 @@ export type SharedMessage = Pick<
   | 'unfinished'
   | 'error'
   | 'finish_reason'
-  | 'feedback'
+  | 'manualSkills'
+  | 'alwaysAppliedSkills'
 > & {
   model?: string;
   files?: SharedFile[];

--- a/packages/data-schemas/src/types/share.ts
+++ b/packages/data-schemas/src/types/share.ts
@@ -12,6 +12,8 @@ export interface ISharedLink {
   expiredAt?: Date;
   createdAt?: Date;
   updatedAt?: Date;
+  /** Owning tenant for multi-tenant deployments (read by the shared-link access middleware). */
+  tenantId?: string;
 }
 
 export interface ShareServiceError extends Error {

--- a/packages/data-schemas/src/types/share.ts
+++ b/packages/data-schemas/src/types/share.ts
@@ -20,6 +20,40 @@ export interface ShareServiceError extends Error {
   code: string;
 }
 
+/**
+ * A file or attachment as exposed through a public shared link: storage- and
+ * identity-internal fields are stripped, but render-relevant data (including
+ * dynamic tool-call payloads keyed by tool name) is preserved.
+ */
+export type SharedFile = Record<string, unknown>;
+
+/**
+ * Public, anonymized projection of a message returned by a shared link. Only
+ * render-relevant fields are surfaced; internal fields (user, endpoint,
+ * conversationSignature, clientId, plugin(s), metadata, etc.) are omitted.
+ */
+export type SharedMessage = Pick<
+  IMessage,
+  | 'messageId'
+  | 'parentMessageId'
+  | 'conversationId'
+  | 'sender'
+  | 'text'
+  | 'content'
+  | 'isCreatedByUser'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'tokenCount'
+  | 'unfinished'
+  | 'error'
+  | 'finish_reason'
+  | 'feedback'
+> & {
+  model?: string;
+  files?: SharedFile[];
+  attachments?: SharedFile[];
+};
+
 export interface SharedLinksResult {
   links: Array<{
     shareId: string;
@@ -33,7 +67,7 @@ export interface SharedLinksResult {
 
 export interface SharedMessagesResult {
   conversationId: string;
-  messages: Array<IMessage>;
+  messages: Array<SharedMessage>;
   shareId: string;
   title?: string;
   createdAt?: Date;

--- a/packages/data-schemas/src/types/share.ts
+++ b/packages/data-schemas/src/types/share.ts
@@ -40,6 +40,7 @@ export type SharedMessage = Pick<
   | 'sender'
   | 'text'
   | 'content'
+  | 'iconURL'
   | 'isCreatedByUser'
   | 'createdAt'
   | 'updatedAt'


### PR DESCRIPTION
## Summary

`getSharedMessages` builds the public payload for a shared link via `anonymizeMessages`, which spread the full Mongo document and each attachment (`{ ...message }` / `{ ...attachment }`). Because the document is only `.select('-_id -__v -user')`-filtered, this leaked internal fields into a **publicly accessible** shared conversation:

- **message**: `endpoint`, `conversationSignature`, `clientId`, `plugin` / `plugins`, `metadata`
- **files/attachments**: `filepath`, `storageKey`, `storageRegion`, `user`, `tenantId`, `source`, …

## Change

- **Messages** use an allowlist of render-relevant fields, so internal message fields are never surfaced.
- **Files and attachments** are sanitized via a **denylist** of storage/identity-internal fields. This strips the sensitive keys while preserving everything the shared view needs to render — crucially `toolCallId` and tool-call payloads (`web_search` / `file_search` / `memory` / `ui_resources`), dimensions, previews, and user-uploaded `message.files`.
- Assistant model ids stay anonymized (`asst_…` → `a_…`); other model names are omitted rather than disclosed.
- Adds `tenantId?: string` to `ISharedLink` — already read by the shared-link access middleware (`RawSharedLink.tenantId`) for multi-tenant deployments.
- Introduces dedicated `SharedMessage` / `SharedFile` types (used for `SharedMessagesResult.messages`) instead of casting the projected object to `IMessage`, so omitted fields are caught at compile time.

## Tests

- All existing `share.test.ts` cases pass unchanged (51 total).
- Adds a regression test asserting `toolCallId`, the `web_search` payload, and `files` survive shared output while `filepath` / `storageKey` / `user` / `tenantId` / `metadata` are stripped.

The shared view only ever rendered the preserved fields, so there is no API-shape change for legitimate consumers — tool-call attachments and uploaded files keep rendering, internal storage details no longer leak.