### PR TITLE
🖼️ fix: Upgrade Framer Motion for Vite 8 Compatibility

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -70,7 +70,7 @@
     "downloadjs": "^1.4.7",
     "export-from-json": "^1.7.2",
     "filenamify": "^6.0.0",
-    "framer-motion": "^11.5.4",
+    "framer-motion": "^12.40.0",
     "heic-to": "^1.1.14",
     "html-to-image": "^1.11.11",
     "i18next": "^24.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,7 +451,7 @@
         "downloadjs": "^1.4.7",
         "export-from-json": "^1.7.2",
         "filenamify": "^6.0.0",
-        "framer-motion": "^11.5.4",
+        "framer-motion": "^12.40.0",
         "heic-to": "^1.1.14",
         "html-to-image": "^1.11.11",
         "i18next": "^24.2.2",
@@ -847,33 +847,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.10.0"
-      }
-    },
-    "client/node_modules/framer-motion": {
-      "version": "11.18.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
-      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^11.18.1",
-        "motion-utils": "^11.18.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "client/node_modules/lucide-react": {
@@ -27146,14 +27119,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.9",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.9.tgz",
-      "integrity": "sha512-TqEHXj8LWfQSKqfdr5Y4mYltYLw96deu6/K9kGDd+ysqRJPNwF9nb5mZcrLmybHbU7gcJ+HQar41U3UTGanbbQ==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "motion-dom": "^12.23.9",
-        "motion-utils": "^12.23.6",
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -27172,23 +27144,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/framer-motion/node_modules/motion-dom": {
-      "version": "12.23.9",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.9.tgz",
-      "integrity": "sha512-6Sv++iWS8XMFCgU1qwKj9l4xuC47Hp4+2jvPfyTXkqDg2tTzSgX6nWKD4kNFXk0k7llO59LZTPuJigza4A2K1A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "motion-utils": "^12.23.6"
-      }
-    },
-    "node_modules/framer-motion/node_modules/motion-utils": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
-      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -34107,18 +34062,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
-      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^11.18.1"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
-      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/mpath": {
@@ -44172,7 +44127,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.0",
-        "framer-motion": "^12.23.6",
+        "framer-motion": "^12.40.0",
         "i18next": "^24.2.2 || ^25.3.2",
         "i18next-browser-languagedetector": "^8.2.0",
         "input-otp": "^1.4.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,7 +59,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.0",
-    "framer-motion": "^12.23.6",
+    "framer-motion": "^12.40.0",
     "i18next": "^24.2.2 || ^25.3.2",
     "i18next-browser-languagedetector": "^8.2.0",
     "input-otp": "^1.4.2",


### PR DESCRIPTION
## Summary

LibreChat recently updated Vite (see 7dba640c9).

The older version of framer-motion we're using is incompatible with this newer version of Vite; if you try to use it, you get the error "e is not a function."

(One easy way to reproduce: try to enable 2FA on your account.)

Updating to the latest framer-motion fixes this issue.

Resolves #13511

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Deploy the app (not dev/watch builds)
2. Go to account settings
3. Click on the "enable 2FA" buton

Before the fix, it would crash the client. Afterwards, it should work.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
