### PR TITLE
🧪 test: Add E2E Regression For 2FA framer-motion Crash

### DIFF
--- a/e2e/specs/mock/two-factor.spec.ts
+++ b/e2e/specs/mock/two-factor.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import { NEW_CHAT_PATH } from './helpers';
+
+/**
+ * Regression test for the framer-motion / Vite incompatibility that crashed the
+ * client with "e is not a function" when opening the Enable 2FA dialog
+ * (issue #13511). The dialog body is a framer-motion `<motion.div>`; on the
+ * broken build it throws while rendering, so the dialog never appears.
+ *
+ * This only reproduces in a production build (the mock harness builds the client
+ * via `e2e:prepare`), matching the original report.
+ */
+test.describe('account settings · two-factor dialog', () => {
+  test('opening the Enable 2FA dialog renders without a framer-motion crash', async ({ page }) => {
+    test.setTimeout(60000);
+
+    const framerErrors: string[] = [];
+    page.on('pageerror', (error) => {
+      if (/is not a function/i.test(error.message)) {
+        framerErrors.push(error.message);
+      }
+    });
+
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+
+    await page.getByTestId('nav-user').click();
+    await page.getByRole('menuitem', { name: 'Settings' }).click();
+    await page.getByRole('tab', { name: 'Account' }).click();
+
+    // Opening the dialog mounts the framer-motion-animated body — the crash site.
+    await page.getByRole('button', { name: 'Enable 2FA' }).click();
+
+    // With the broken framer-motion build this content never renders.
+    await expect(page.locator('#two-factor-authentication-dialog')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('button', { name: 'Generate QR Code' })).toBeVisible();
+
+    expect(
+      framerErrors,
+      `framer-motion threw while rendering the 2FA dialog: ${framerErrors.join(' | ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Independent Playwright e2e regression test for the framer-motion / Vite crash reported in #13511 — opening **Account Settings → Enable 2FA** throws `"e is not a function"` and crashes the client on the current build.

The spec drives the real flow in the mock harness (`nav-user` → Settings → Account tab → Enable 2FA) and asserts the framer-motion `<motion.div>` dialog (`#two-factor-authentication-dialog`) actually renders. It needs no real LLM key — the mock harness builds a production client bundle, which is the only place this crash reproduces.

> ⚠️ **This test is expected to FAIL on `dev` right now — that failure _is_ the reproduction.** It turns green once the framer-motion bump in #13512 is merged and this branch is rebased on top.

I verified both directions locally against a production client build:

- framer-motion `11.18.2` (current `dev`): ❌ fails — the global error boundary renders `"e is not a function"` and the dialog never appears.
- framer-motion `12.40.0` (the #13512 fix): ✅ passes in ~1s — the dialog and its "Generate QR Code" button render.

## Change Type

- [x] New feature (non-breaking change which adds functionality) — adds e2e regression coverage only.

## Testing

```bash
E2E_BASE_URL=http://localhost:3334 npm run e2e:mock -- e2e/specs/mock/two-factor.spec.ts
```

Run against current `dev` it fails at the `#two-factor-authentication-dialog` visibility assertion (screenshot shows the `"e is not a function"` error boundary). After merging #13512 and rebasing, it passes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
