### PR TITLE
🪧 chore: Generalize Project Name Placeholder

### DIFF
--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1359,7 +1359,7 @@
   "com_ui_project_create_error": "Failed to create project",
   "com_ui_project_delete_error": "Failed to delete project",
   "com_ui_project_name": "Project name",
-  "com_ui_project_name_placeholder": "Copenhagen Trip",
+  "com_ui_project_name_placeholder": "New project",
   "com_ui_project_not_found": "Project not found",
   "com_ui_project_rename_error": "Failed to rename project",
   "com_ui_project_update_error": "Failed to update project assignment",


### PR DESCRIPTION
## Summary

I generalized the project name placeholder so the create project dialog no longer suggests a specific travel example.

- Changed the English `com_ui_project_name_placeholder` value from `Copenhagen Trip` to `New project`.
- Kept the update scoped to the English locale file, since translated locales are automated externally.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `node -e "JSON.parse(require('fs').readFileSync('client/src/locales/en/translation.json', 'utf8'))"` to verify the English translation JSON still parses.

### **Test Configuration**:

- Local shell in `/Users/danny/.codex/worktrees/dd75/LibreChat`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings