### PR TITLE
🫀 fix: Keep Agent SSE Streams Alive

### DIFF
--- a/api/server/routes/agents/__tests__/sseHeartbeat.spec.js
+++ b/api/server/routes/agents/__tests__/sseHeartbeat.spec.js
@@ -1,0 +1,65 @@
+const { EventEmitter } = require('node:events');
+const { SSE_HEARTBEAT_PAYLOAD, startSseHeartbeat, writeSseHeartbeat } = require('../sseHeartbeat');
+
+function createResponse() {
+  const res = new EventEmitter();
+  res.writableEnded = false;
+  res.destroyed = false;
+  res.write = jest.fn();
+  res.flush = jest.fn();
+  return res;
+}
+
+describe('sseHeartbeat', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('writes SSE comment heartbeats at the configured interval', () => {
+    const res = createResponse();
+
+    startSseHeartbeat(res, 1000);
+    jest.advanceTimersByTime(999);
+    expect(res.write).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(res.write).toHaveBeenCalledWith(SSE_HEARTBEAT_PAYLOAD);
+    expect(res.flush).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops writing when the response finishes', () => {
+    const res = createResponse();
+
+    startSseHeartbeat(res, 1000);
+    res.emit('finish');
+    jest.advanceTimersByTime(1000);
+
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  it('stops writing when the client connection closes', () => {
+    const res = createResponse();
+
+    startSseHeartbeat(res, 1000);
+    res.emit('close');
+    jest.advanceTimersByTime(1000);
+
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  it('does not write to ended or destroyed responses', () => {
+    const ended = createResponse();
+    ended.writableEnded = true;
+    const destroyed = createResponse();
+    destroyed.destroyed = true;
+
+    expect(writeSseHeartbeat(ended)).toBe(false);
+    expect(writeSseHeartbeat(destroyed)).toBe(false);
+    expect(ended.write).not.toHaveBeenCalled();
+    expect(destroyed.write).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/routes/agents/__tests__/streamTenant.spec.js
+++ b/api/server/routes/agents/__tests__/streamTenant.spec.js
@@ -122,6 +122,22 @@ describe('SSE stream tenant isolation', () => {
       expect(mockGenerationJobManager.subscribe).toHaveBeenCalledTimes(1);
     });
 
+    it('ends the SSE stream when subscription setup throws after headers are sent', async () => {
+      mockUserId = 'user-123';
+      mockTenantId = 'tenant-a';
+
+      mockGenerationJobManager.getJob.mockResolvedValue({
+        metadata: { userId: 'user-123', tenantId: 'tenant-a' },
+        status: 'running',
+      });
+      mockGenerationJobManager.subscribe.mockRejectedValue(new Error('subscribe failed'));
+
+      const res = await request(app).get('/agents/chat/stream/stream-123');
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('event: error');
+      expect(res.text).toContain('Failed to subscribe to stream');
+    });
+
     it('returns 403 when job has tenantId but user has no tenantId', async () => {
       mockUserId = 'user-123';
       mockTenantId = undefined;

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -15,6 +15,7 @@ const responses = require('./responses');
 const openai = require('./openai');
 const { v1 } = require('./v1');
 const chat = require('./chat');
+const { startSseHeartbeat } = require('./sseHeartbeat');
 
 const { LIMIT_MESSAGE_IP, LIMIT_MESSAGE_USER } = process.env ?? {};
 
@@ -86,6 +87,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
   res.setHeader('X-Accel-Buffering', 'no');
   res.flushHeaders();
   streamTelemetry.recordHeadersFlushed();
+  const stopHeartbeat = startSseHeartbeat(res);
 
   logger.debug(`[AgentStream] Client subscribed to ${streamId}, resume: ${isResume}`);
 
@@ -106,6 +108,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
 
   const onDone = (event) => {
     streamTelemetry.recordFinalEventEmitted();
+    stopHeartbeat();
     writeEvent(event, { final: true });
     res.end();
   };
@@ -113,6 +116,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
   const onError = (error) => {
     if (!res.writableEnded) {
       streamTelemetry.recordErrorEventEmitted();
+      stopHeartbeat();
       writeEvent({ error }, { eventName: 'error' });
       res.end();
     }
@@ -153,6 +157,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
   }
 
   req.on('close', () => {
+    stopHeartbeat();
     logger.debug(`[AgentStream] Client disconnected from ${streamId}`);
     result.unsubscribe();
   });

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -87,9 +87,11 @@ router.get('/chat/stream/:streamId', async (req, res) => {
   res.setHeader('X-Accel-Buffering', 'no');
   res.flushHeaders();
   streamTelemetry.recordHeadersFlushed();
-  const stopHeartbeat = startSseHeartbeat(res);
 
   logger.debug(`[AgentStream] Client subscribed to ${streamId}, resume: ${isResume}`);
+
+  let result;
+  let stopHeartbeat = () => {};
 
   const writeEvent = (event, options = {}) => {
     if (!res.writableEnded) {
@@ -122,32 +124,43 @@ router.get('/chat/stream/:streamId', async (req, res) => {
     }
   };
 
-  let result;
+  req.on('close', () => {
+    stopHeartbeat();
+    logger.debug(`[AgentStream] Client disconnected from ${streamId}`);
+    result?.unsubscribe();
+  });
 
-  if (isResume) {
-    const { subscription, resumeState, pendingEvents } =
-      await GenerationJobManager.subscribeWithResume(streamId, writeEvent, onDone, onError);
+  try {
+    if (isResume) {
+      const { subscription, resumeState, pendingEvents } =
+        await GenerationJobManager.subscribeWithResume(streamId, writeEvent, onDone, onError);
 
-    if (!res.writableEnded) {
-      if (resumeState) {
-        writeEvent({ sync: true, resumeState, pendingEvents });
-        GenerationJobManager.markSyncSent(streamId);
-        logger.debug(
-          `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps, ${pendingEvents.length} pending events`,
-        );
-      } else if (pendingEvents.length > 0) {
-        for (const event of pendingEvents) {
-          writeEvent(event);
+      if (!res.writableEnded) {
+        if (resumeState) {
+          writeEvent({ sync: true, resumeState, pendingEvents });
+          GenerationJobManager.markSyncSent(streamId);
+          logger.debug(
+            `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps, ${pendingEvents.length} pending events`,
+          );
+        } else if (pendingEvents.length > 0) {
+          for (const event of pendingEvents) {
+            writeEvent(event);
+          }
+          logger.warn(
+            `[AgentStream] Resume state null for ${streamId}, replayed ${pendingEvents.length} gap events directly`,
+          );
         }
-        logger.warn(
-          `[AgentStream] Resume state null for ${streamId}, replayed ${pendingEvents.length} gap events directly`,
-        );
       }
-    }
 
-    result = subscription;
-  } else {
-    result = await GenerationJobManager.subscribe(streamId, writeEvent, onDone, onError);
+      result = subscription;
+    } else {
+      result = await GenerationJobManager.subscribe(streamId, writeEvent, onDone, onError);
+    }
+  } catch (error) {
+    logger.error(`[AgentStream] Failed to subscribe to ${streamId}:`, error);
+    streamTelemetry.recordSubscribeFailed();
+    onError('Failed to subscribe to stream');
+    return;
   }
 
   if (!result) {
@@ -156,11 +169,9 @@ router.get('/chat/stream/:streamId', async (req, res) => {
     return;
   }
 
-  req.on('close', () => {
-    stopHeartbeat();
-    logger.debug(`[AgentStream] Client disconnected from ${streamId}`);
-    result.unsubscribe();
-  });
+  if (!res.writableEnded && !res.destroyed) {
+    stopHeartbeat = startSseHeartbeat(res);
+  }
 });
 
 /**

--- a/api/server/routes/agents/sseHeartbeat.js
+++ b/api/server/routes/agents/sseHeartbeat.js
@@ -1,0 +1,40 @@
+const SSE_HEARTBEAT_INTERVAL_MS = 15000;
+const SSE_HEARTBEAT_PAYLOAD = ': heartbeat\n\n';
+
+function writeSseHeartbeat(res) {
+  if (res.writableEnded || res.destroyed) {
+    return false;
+  }
+
+  res.write(SSE_HEARTBEAT_PAYLOAD);
+  if (typeof res.flush === 'function') {
+    res.flush();
+  }
+
+  return true;
+}
+
+function startSseHeartbeat(res, intervalMs = SSE_HEARTBEAT_INTERVAL_MS) {
+  const heartbeat = setInterval(() => {
+    if (!writeSseHeartbeat(res)) {
+      clearInterval(heartbeat);
+    }
+  }, intervalMs);
+
+  if (typeof heartbeat.unref === 'function') {
+    heartbeat.unref();
+  }
+
+  const stopHeartbeat = () => clearInterval(heartbeat);
+  res.once('finish', stopHeartbeat);
+  res.once('close', stopHeartbeat);
+
+  return stopHeartbeat;
+}
+
+module.exports = {
+  SSE_HEARTBEAT_INTERVAL_MS,
+  SSE_HEARTBEAT_PAYLOAD,
+  startSseHeartbeat,
+  writeSseHeartbeat,
+};

--- a/e2e/setup/fake-model.js
+++ b/e2e/setup/fake-model.js
@@ -1,3 +1,7 @@
+const { AIMessageChunk } = require('@langchain/core/messages');
+const { ChatGenerationChunk } = require('@langchain/core/outputs');
+const { FakeListChatModel } = require('@langchain/core/utils/testing');
+
 /**
  * In-process fake LLM for credential-free e2e tests. Loaded by `@librechat/api`'s
  * `createRun` via the `LIBRECHAT_TEST_RUN_HOOK` env var (set by the mock
@@ -11,16 +15,21 @@
  */
 const MOCK_REPLY = process.env.MOCK_LLM_REPLY || 'E2E mock reply: pong';
 const CHUNK_DELAY_MS = Number(process.env.MOCK_LLM_CHUNK_DELAY_MS) || 10;
+const TOOL_ARGS_DELAY_MS = Number(process.env.MOCK_LLM_TOOL_ARGS_DELAY_MS) || CHUNK_DELAY_MS;
 
 const CREATE_SKILL_MARKER = 'E2E_CREATE_SKILL:';
 const EDIT_SKILL_MARKER = 'E2E_EDIT_SKILL:';
+const BASH_TOOL_MARKER = 'E2E_BASH_TOOL:';
+const BASH_TOOL_STREAM_MARKER = 'E2E_BASH_TOOL_STREAM:';
 const CREATE_FILE_AUTHORING_FINAL_TEXT = 'E2E file authoring complete';
 const EDIT_FILE_AUTHORING_FINAL_TEXT = 'E2E file edit complete';
+const BASH_TOOL_FINAL_TEXT = 'E2E bash tool complete';
 const CREATE_FILE_TOOL_NAME = 'create_file';
 const EDIT_FILE_TOOL_NAME = 'edit_file';
 const BASH_TOOL_NAME = 'bash_tool';
 const CREATE_SKILL_TOOL_CALL_ID = 'call_e2e_create_skill';
 const EDIT_SKILL_TOOL_CALL_ID = 'call_e2e_edit_skill';
+const BASH_TOOL_CALL_ID = 'call_e2e_bash_tool';
 const SKILL_DESCRIPTION =
   'Use this skill to verify LibreChat skill file authoring in mock end-to-end tests.';
 const EDITED_SKILL_DESCRIPTION =
@@ -135,6 +144,123 @@ function buildEditSkillArgs(skillName) {
   };
 }
 
+function getRequestedCommand(text) {
+  const markerIndex = text.indexOf(BASH_TOOL_MARKER);
+  if (markerIndex === -1) {
+    return '';
+  }
+  const afterMarker = text.slice(markerIndex + BASH_TOOL_MARKER.length);
+  return afterMarker.split('\n')[0]?.trim() ?? '';
+}
+
+function getRequestedStreamedCommand(text) {
+  const markerIndex = text.indexOf(BASH_TOOL_STREAM_MARKER);
+  if (markerIndex === -1) {
+    return '';
+  }
+  const afterMarker = text.slice(markerIndex + BASH_TOOL_STREAM_MARKER.length);
+  return afterMarker.split('\n')[0]?.trim() ?? '';
+}
+
+class ChunkedToolArgsFakeModel extends FakeListChatModel {
+  constructor({ responses, sleep, toolDelay, toolCall }) {
+    super({ responses, sleep, emitCustomEvent: true });
+    this.toolDelay = toolDelay;
+    this.toolCall = toolCall;
+    this.addedToolCall = false;
+  }
+
+  splitText(text) {
+    return text.split(/(?<=\s+)|(?=\s+)/);
+  }
+
+  createResponseChunk(text, toolCallChunks, responseMetadata) {
+    return new ChatGenerationChunk({
+      text,
+      generationInfo: {},
+      message: new AIMessageChunk({
+        content: text,
+        tool_call_chunks: toolCallChunks,
+        response_metadata: responseMetadata,
+        additional_kwargs: toolCallChunks
+          ? {
+              tool_calls: toolCallChunks.map((toolCall) => ({
+                index: toolCall.index ?? 0,
+                id: toolCall.id ?? '',
+                type: 'function',
+                function: {
+                  name: toolCall.name ?? '',
+                  arguments: toolCall.args ?? '',
+                },
+              })),
+            }
+          : undefined,
+      }),
+    });
+  }
+
+  sleepForToolInput() {
+    if (!this.toolDelay) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => setTimeout(resolve, this.toolDelay));
+  }
+
+  async *_streamResponseChunks(_messages, options, runManager) {
+    const response = this._currentResponse();
+    this._incrementResponse();
+
+    if (this.emitCustomEvent) {
+      await runManager?.handleCustomEvent('some_test_event', {
+        someval: true,
+      });
+    }
+
+    for await (const chunk of this.splitText(response)) {
+      await this._sleepIfRequested();
+      if (options.thrownErrorString != null && options.thrownErrorString) {
+        throw new Error(options.thrownErrorString);
+      }
+      const responseChunk = super._createResponseChunk(chunk);
+      yield responseChunk;
+      void runManager?.handleLLMNewToken(chunk);
+    }
+
+    if (!this.toolCall || this.addedToolCall) {
+      return;
+    }
+
+    this.addedToolCall = true;
+    const args = JSON.stringify(this.toolCall.args);
+    const firstBreak = Math.max(1, Math.floor(args.length / 3));
+    const secondBreak = Math.max(firstBreak + 1, Math.floor((args.length * 2) / 3));
+    const pieces = [
+      args.slice(0, firstBreak),
+      args.slice(firstBreak, secondBreak),
+      args.slice(secondBreak),
+    ];
+    for (let index = 0; index < pieces.length; index++) {
+      await this.sleepForToolInput();
+      const isFinal = index === pieces.length - 1;
+      const responseChunk = this.createResponseChunk(
+        '',
+        [
+          {
+            name: this.toolCall.name,
+            args: pieces[index],
+            id: this.toolCall.id,
+            index: 0,
+            type: 'tool_call_chunk',
+          },
+        ],
+        isFinal ? { finish_reason: 'tool_calls' } : undefined,
+      );
+      yield responseChunk;
+      void runManager?.handleLLMNewToken('');
+    }
+  }
+}
+
 /**
  * Pick the fake-model script for a skill file-authoring turn. The graph runs two
  * model turns: turn 1 streams the (empty) preamble and emits the tool call, the
@@ -166,7 +292,47 @@ function fileAuthoringResponses(operation, toolNames) {
   };
 }
 
+function bashToolResponse(command, toolNames) {
+  if (!toolNames.has(BASH_TOOL_NAME)) {
+    return {
+      responses: [`E2E bash tool unavailable: ${BASH_TOOL_NAME} was not advertised.`],
+    };
+  }
+  return {
+    responses: ['', `${BASH_TOOL_FINAL_TEXT}: ${command}`],
+    toolCalls: [
+      {
+        id: BASH_TOOL_CALL_ID,
+        name: BASH_TOOL_NAME,
+        args: { command },
+        type: 'tool_call',
+      },
+    ],
+  };
+}
+
+function streamedBashToolResponse(command, toolNames) {
+  const response = bashToolResponse(command, toolNames);
+  if (!response.toolCalls?.[0]) {
+    return response;
+  }
+  return {
+    responses: ['E2E preparing bash input', response.responses[1]],
+    streamedToolCall: response.toolCalls[0],
+  };
+}
+
 function resolveResponses(text, toolNames) {
+  const streamedBashCommand = getRequestedStreamedCommand(text);
+  if (streamedBashCommand) {
+    return streamedBashToolResponse(streamedBashCommand, toolNames);
+  }
+
+  const bashCommand = getRequestedCommand(text);
+  if (bashCommand) {
+    return bashToolResponse(bashCommand, toolNames);
+  }
+
   const createSkillName = getRequestedSkillName(text, CREATE_SKILL_MARKER);
   if (createSkillName) {
     return fileAuthoringResponses(
@@ -208,6 +374,15 @@ module.exports = function fakeModelHook(run, context) {
 
   const text = getLatestUserText(context?.messages);
   const toolNames = collectToolNames(context?.agents);
-  const { responses, toolCalls } = resolveResponses(text, toolNames);
+  const { responses, toolCalls, streamedToolCall } = resolveResponses(text, toolNames);
+  if (streamedToolCall) {
+    graph.overrideModel = new ChunkedToolArgsFakeModel({
+      responses,
+      sleep: CHUNK_DELAY_MS,
+      toolDelay: TOOL_ARGS_DELAY_MS,
+      toolCall: streamedToolCall,
+    });
+    return;
+  }
   graph.overrideTestModel(responses, CHUNK_DELAY_MS, toolCalls);
 };

--- a/e2e/setup/fake-model.js
+++ b/e2e/setup/fake-model.js
@@ -171,7 +171,7 @@ class ChunkedToolArgsFakeModel extends FakeListChatModel {
   }
 
   splitText(text) {
-    return text.split(/(?<=\s+)|(?=\s+)/);
+    return text.split(/(\s+)/).filter(Boolean);
   }
 
   createResponseChunk(text, toolCallChunks, responseMetadata) {

--- a/e2e/setup/fake-model.js
+++ b/e2e/setup/fake-model.js
@@ -15,7 +15,7 @@ const { FakeListChatModel } = require('@langchain/core/utils/testing');
  */
 const MOCK_REPLY = process.env.MOCK_LLM_REPLY || 'E2E mock reply: pong';
 const CHUNK_DELAY_MS = Number(process.env.MOCK_LLM_CHUNK_DELAY_MS) || 10;
-const TOOL_ARGS_DELAY_MS = Number(process.env.MOCK_LLM_TOOL_ARGS_DELAY_MS) || CHUNK_DELAY_MS;
+const TOOL_ARGS_DELAY_MS = Number(process.env.MOCK_LLM_TOOL_ARGS_DELAY_MS) || 3000;
 
 const CREATE_SKILL_MARKER = 'E2E_CREATE_SKILL:';
 const EDIT_SKILL_MARKER = 'E2E_EDIT_SKILL:';

--- a/e2e/specs/mock/helpers.ts
+++ b/e2e/specs/mock/helpers.ts
@@ -37,6 +37,14 @@ export async function enableSkills(page: Page) {
   await expect(page.getByRole('button', { name: 'Skills' })).toBeVisible();
 }
 
+/** Enable the ephemeral Run Code capability from the composer tool menu. */
+export async function enableRunCode(page: Page) {
+  await page.getByRole('button', { name: 'Tools Options' }).click();
+  await page.getByText('Run Code').click();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('checkbox', { name: 'Run Code' })).toBeChecked();
+}
+
 /** The mock reply as rendered in the conversation, scoped to the messages view. */
 export function mockReply(page: Page) {
   return page.getByTestId('messages-view').getByText(new RegExp(MOCK_REPLY_TEXT, 'i'));

--- a/e2e/specs/mock/resumable-sse-bash.spec.ts
+++ b/e2e/specs/mock/resumable-sse-bash.spec.ts
@@ -1,0 +1,303 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import {
+  MOCK_ENDPOINTS,
+  NEW_CHAT_PATH,
+  enableRunCode,
+  selectMockEndpoint,
+  sendMessage,
+} from './helpers';
+
+const COMMAND = 'printf "resumable-bash-ok"';
+
+type FaultMode = 'before-args' | 'after-first-args';
+
+type StreamEventRecord = {
+  url: string;
+  isResume: boolean;
+  eventName: string;
+  kind: string;
+  payloadEvent?: string;
+  hasBashTool: boolean;
+  hasCommand: boolean;
+};
+
+test.setTimeout(120000);
+
+async function installStreamProbe(page: Page, faultMode: FaultMode) {
+  await page.addInitScript(
+    ({ commandText, mode }) => {
+      type ReproWindow = Window & {
+        __libreChatSseReproEvents?: StreamEventRecord[];
+        __libreChatSseReproFaulted?: boolean;
+        __libreChatSseReproFaultHadArgs?: boolean;
+        __libreChatSseReproFaultInjected?: boolean;
+      };
+
+      const reproWindow = window as ReproWindow;
+      reproWindow.__libreChatSseReproEvents = [];
+
+      const parseSseBlock = (block: string) => {
+        let eventName = 'message';
+        const dataLines: string[] = [];
+        for (const line of block.split(/\r\n|\n|\r/)) {
+          if (line.startsWith('event:')) {
+            eventName = line.slice('event:'.length).trim();
+          } else if (line.startsWith('data:')) {
+            dataLines.push(line.slice('data:'.length).trimStart());
+          }
+        }
+        const data = dataLines.join('\n');
+        if (!data) {
+          return null;
+        }
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = JSON.parse(data) as Record<string, unknown>;
+        } catch {
+          parsed = undefined;
+        }
+        const payloadEvent = typeof parsed?.event === 'string' ? parsed.event : undefined;
+        const payloadType = typeof parsed?.type === 'string' ? parsed.type : undefined;
+        const kind =
+          parsed?.sync === true
+            ? 'sync'
+            : parsed?.final != null
+              ? 'final'
+              : parsed?.created != null
+                ? 'created'
+                : (payloadEvent ?? payloadType ?? 'unknown');
+        return {
+          eventName,
+          kind,
+          payloadEvent,
+          hasBashTool: data.includes('bash_tool'),
+          hasCommand: data.includes(commandText),
+        };
+      };
+
+      const originalOpen = XMLHttpRequest.prototype.open;
+      const originalSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function patchedOpen(method, url) {
+        (this as XMLHttpRequest & { __libreChatSseReproUrl?: string }).__libreChatSseReproUrl =
+          String(url);
+        return originalOpen.apply(this, arguments as unknown as Parameters<typeof originalOpen>);
+      };
+      XMLHttpRequest.prototype.send = function patchedSend(body) {
+        const xhr = this as XMLHttpRequest & { __libreChatSseReproUrl?: string };
+        const url = xhr.__libreChatSseReproUrl ?? '';
+        if (!url.includes('/api/agents/chat/stream/')) {
+          return originalSend.call(this, body);
+        }
+
+        let parsedLength = 0;
+        let eventBuffer = '';
+        const recordProgress = () => {
+          const nextChunk = this.responseText.slice(parsedLength);
+          if (!nextChunk) {
+            return;
+          }
+          parsedLength = this.responseText.length;
+          eventBuffer += nextChunk;
+          const blocks = eventBuffer.split(/(?:\r\n\r\n|\n\n|\r\r)/);
+          eventBuffer = blocks.pop() ?? '';
+          for (const block of blocks) {
+            const parsed = parseSseBlock(block);
+            if (parsed) {
+              reproWindow.__libreChatSseReproEvents?.push({
+                url,
+                isResume: url.includes('resume=true'),
+                ...parsed,
+              });
+            }
+          }
+        };
+
+        this.addEventListener('progress', recordProgress);
+        this.addEventListener('load', recordProgress);
+
+        const shouldFault =
+          !url.includes('resume=true') &&
+          !reproWindow.__libreChatSseReproFaulted &&
+          url.includes('/api/agents/chat/stream/');
+        if (shouldFault && mode === 'before-args') {
+          let idleTimer: ReturnType<typeof window.setTimeout> | undefined;
+          const faultIfStillCreatingInput = () => {
+            recordProgress();
+            if (reproWindow.__libreChatSseReproFaulted || this.responseText.includes('bash_tool')) {
+              return;
+            }
+            reproWindow.__libreChatSseReproFaulted = true;
+            reproWindow.__libreChatSseReproFaultHadArgs = this.responseText.includes('bash_tool');
+            reproWindow.__libreChatSseReproFaultInjected = true;
+            this.dispatchEvent(new Event('error'));
+          };
+          const armIdleTimer = () => {
+            if (reproWindow.__libreChatSseReproFaulted || this.responseText.includes('bash_tool')) {
+              return;
+            }
+            if (idleTimer) {
+              window.clearTimeout(idleTimer);
+            }
+            idleTimer = window.setTimeout(faultIfStillCreatingInput, 800);
+          };
+          this.addEventListener('readystatechange', () => {
+            if (this.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
+              armIdleTimer();
+            }
+          });
+          this.addEventListener('progress', armIdleTimer);
+          this.addEventListener(
+            'loadend',
+            () => {
+              if (idleTimer) {
+                window.clearTimeout(idleTimer);
+              }
+            },
+            { once: true },
+          );
+        } else if (shouldFault && mode === 'after-first-args') {
+          this.addEventListener('progress', () => {
+            recordProgress();
+            if (
+              reproWindow.__libreChatSseReproFaulted ||
+              !this.responseText.includes('bash_tool')
+            ) {
+              return;
+            }
+            reproWindow.__libreChatSseReproFaulted = true;
+            reproWindow.__libreChatSseReproFaultHadArgs = true;
+            window.setTimeout(() => {
+              reproWindow.__libreChatSseReproFaultInjected = true;
+              this.dispatchEvent(new Event('error'));
+            }, 400);
+          });
+        }
+
+        return originalSend.call(this, body);
+      };
+    },
+    { commandText: COMMAND, mode: faultMode },
+  );
+}
+
+async function runBashResumeCase(page: Page, faultMode: FaultMode) {
+  const streamUrls: string[] = [];
+  page.on('response', (response) => {
+    const url = response.url();
+    if (url.includes('/api/agents/chat/stream/')) {
+      streamUrls.push(url);
+    }
+  });
+
+  await installStreamProbe(page, faultMode);
+  await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+  await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+  await enableRunCode(page);
+
+  const response = await sendMessage(
+    page,
+    [`E2E bash resume request`, `E2E_BASH_TOOL_STREAM:${COMMAND}`].join('\n'),
+  );
+  expect(response.ok()).toBeTruthy();
+
+  await expect.poll(() => streamUrls.length, { timeout: 15000 }).toBeGreaterThan(0);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          Boolean(
+            (window as Window & { __libreChatSseReproFaultInjected?: boolean })
+              .__libreChatSseReproFaultInjected,
+          ),
+        ),
+      { timeout: 10000 },
+    )
+    .toBeTruthy();
+
+  await expect
+    .poll(() => streamUrls.filter((url) => url.includes('resume=true')).length, {
+      timeout: 20000,
+    })
+    .toBeGreaterThan(0);
+
+  const commandCode = page.getByTestId('messages-view').locator('code').filter({
+    hasText: COMMAND,
+  });
+  await expect(commandCode).toBeVisible({ timeout: 30000 });
+  await expect(commandCode).toHaveCount(1);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          Boolean(
+            (
+              (window as Window & { __libreChatSseReproEvents?: StreamEventRecord[] })
+                .__libreChatSseReproEvents ?? []
+            ).some((event) => event.payloadEvent === 'on_run_step_completed'),
+          ),
+        ),
+      { timeout: 30000 },
+    )
+    .toBeTruthy();
+
+  return page.evaluate(
+    () =>
+      ({
+        faultHadArgs: Boolean(
+          (window as Window & { __libreChatSseReproFaultHadArgs?: boolean })
+            .__libreChatSseReproFaultHadArgs,
+        ),
+        events:
+          (window as Window & { __libreChatSseReproEvents?: StreamEventRecord[] })
+            .__libreChatSseReproEvents ?? [],
+      }) as { faultHadArgs: boolean; events: StreamEventRecord[] },
+  );
+}
+
+test.describe('resumable SSE bash tool calls', () => {
+  test('starts the bash tool call on the resumed stream when the first stream idles before args', async ({
+    page,
+  }) => {
+    const { faultHadArgs, events } = await runBashResumeCase(page, 'before-args');
+    expect(faultHadArgs).toBe(false);
+
+    const initialEvents = events.filter((event) => !event.isResume);
+    const resumeEvents = events.filter((event) => event.isResume);
+    expect(initialEvents.some((event) => event.hasBashTool)).toBe(false);
+    expect(resumeEvents.some((event) => event.kind === 'sync')).toBe(true);
+    expect(
+      resumeEvents.some((event) => event.payloadEvent === 'on_run_step' && event.hasBashTool),
+    ).toBe(true);
+    expect(
+      resumeEvents.some((event) => event.payloadEvent === 'on_run_step_delta' && event.hasBashTool),
+    ).toBe(true);
+    expect(resumeEvents.some((event) => event.payloadEvent === 'on_run_step_completed')).toBe(true);
+  });
+
+  test('syncs the existing bash tool call and continues args when reconnecting after args start', async ({
+    page,
+  }) => {
+    const { faultHadArgs, events } = await runBashResumeCase(page, 'after-first-args');
+    expect(faultHadArgs).toBe(true);
+
+    const initialEvents = events.filter((event) => !event.isResume);
+    const resumeEvents = events.filter((event) => event.isResume);
+    expect(
+      initialEvents.some((event) => event.payloadEvent === 'on_run_step' && event.hasBashTool),
+    ).toBe(true);
+    expect(
+      initialEvents.some(
+        (event) => event.payloadEvent === 'on_run_step_delta' && event.hasBashTool,
+      ),
+    ).toBe(true);
+    expect(resumeEvents.some((event) => event.kind === 'sync' && event.hasBashTool)).toBe(true);
+    expect(
+      resumeEvents.some((event) => event.payloadEvent === 'on_run_step' && event.hasBashTool),
+    ).toBe(false);
+    expect(
+      resumeEvents.some((event) => event.payloadEvent === 'on_run_step_delta' && event.hasBashTool),
+    ).toBe(true);
+    expect(resumeEvents.some((event) => event.payloadEvent === 'on_run_step_completed')).toBe(true);
+  });
+});

--- a/e2e/specs/mock/resumable-sse-bash.spec.ts
+++ b/e2e/specs/mock/resumable-sse-bash.spec.ts
@@ -131,6 +131,7 @@ async function installStreamProbe(page: Page, faultMode: FaultMode) {
             reproWindow.__libreChatSseReproFaultHadArgs = this.responseText.includes('bash_tool');
             reproWindow.__libreChatSseReproFaultInjected = true;
             this.dispatchEvent(new Event('error'));
+            this.abort();
           };
           const armIdleTimer = () => {
             if (reproWindow.__libreChatSseReproFaulted || this.responseText.includes('bash_tool')) {
@@ -170,6 +171,7 @@ async function installStreamProbe(page: Page, faultMode: FaultMode) {
             window.setTimeout(() => {
               reproWindow.__libreChatSseReproFaultInjected = true;
               this.dispatchEvent(new Event('error'));
+              this.abort();
             }, 400);
           });
         }


### PR DESCRIPTION
## Summary

I added SSE comment heartbeats to agent stream subscriptions so quiet phases during tool argument generation, tool execution, or final-output handoff are less likely to be mistaken for dropped connections. I also added mock e2e coverage that simulates delayed streamed `bash_tool` arguments and verifies resumable SSE behavior before and after tool args begin.

- Added a reusable `sseHeartbeat` helper that writes SSE comment frames and stops on finish, close, ended, or destroyed responses.
- Wired agent chat streams to send 15s heartbeat comments after headers are flushed and stop the timer on done, error, or client close.
- Added focused Jest coverage for heartbeat write, flush, and cleanup behavior.
- Extended the fake model e2e hook to stream `bash_tool` argument chunks with configurable delay.
- Added Playwright coverage for reconnecting before tool args and after tool args have started, including assertions that resumed streams sync or continue the expected tool-call state.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran focused API and Playwright coverage for the heartbeat and resumable SSE behavior.

### **Test Configuration**:

- Node/Jest backend test environment
- Playwright mock profile with in-memory MongoDB
- `MOCK_LLM_CHUNK_DELAY_MS=10`
- `MOCK_LLM_TOOL_ARGS_DELAY_MS=3000`

```sh
npm test -- --runInBand server/routes/agents/__tests__/sseHeartbeat.spec.js server/routes/agents/__tests__/streamTenant.spec.js
MOCK_LLM_CHUNK_DELAY_MS=10 MOCK_LLM_TOOL_ARGS_DELAY_MS=3000 npm exec playwright -- test --config=e2e/playwright.config.mock.ts resumable-sse-bash.spec.ts --reporter=line
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes