### PR TITLE
fix: Fix Anthropic 10MB limit when using Gemini Image Tools

### DIFF
--- a/api/app/clients/tools/structured/GeminiImageGen.js
+++ b/api/app/clients/tools/structured/GeminiImageGen.js
@@ -5,7 +5,7 @@ const { ProxyAgent } = require('undici');
 const { GoogleGenAI } = require('@google/genai');
 const { logger } = require('@librechat/data-schemas');
 const { tool } = require('@librechat/agents/langchain/tools');
-const { ContentTypes, EImageOutputType } = require('librechat-data-provider');
+const { ContentTypes, EImageOutputType, Providers } = require('librechat-data-provider');
 const {
   geminiToolkit,
   loadServiceKey,
@@ -316,7 +316,8 @@ function createGeminiImageTool(fields = {}) {
     throw new Error('This tool is only available for agents.');
   }
 
-  const { req, imageFiles = [], userId, fileStrategy, GEMINI_API_KEY, GOOGLE_KEY } = fields;
+  const { req, imageFiles = [], userId, fileStrategy, GEMINI_API_KEY, GOOGLE_KEY, provider } =
+    fields;
 
   const imageOutputType = fields.imageOutputType || EImageOutputType.PNG;
 
@@ -419,10 +420,38 @@ function createGeminiImageTool(fields = {}) {
       }
 
       const rawBuffer = Buffer.from(rawImageData, 'base64');
-      const { buffer: convertedBuffer, format: outputFormat } = await convertImageFormat(
+      logger.debug(`[GeminiImageGen] Raw image size: ${rawBuffer.length} bytes.`);
+      let { buffer: convertedBuffer, format: outputFormat } = await convertImageFormat(
         rawBuffer,
         imageOutputType,
       );
+
+      const maxBytes = 9.5 * 1024 * 1024;
+      const isAnthropic = provider === Providers.ANTHROPIC;
+      if (isAnthropic && convertedBuffer.length > maxBytes) {
+        logger.debug(`[GeminiImageGen] Image exceeds ${maxBytes} bytes, downscaling`);
+        let attempts = 0;
+        while (convertedBuffer.length > maxBytes && attempts < 5) {
+          const meta = await sharp(convertedBuffer).metadata();
+          const newWidth = Math.round(meta.width * 0.8);
+          const pipeline = sharp(convertedBuffer).resize({
+            width: newWidth,
+            withoutEnlargement: true,
+          });
+          if (outputFormat === 'jpeg') {
+            convertedBuffer = await pipeline.jpeg({ quality: 85 }).toBuffer();
+          } else if (outputFormat === 'webp') {
+            convertedBuffer = await pipeline.webp({ quality: 85 }).toBuffer();
+          } else {
+            convertedBuffer = await pipeline.png({ compressionLevel: 9 }).toBuffer();
+          }
+          attempts++;
+          logger.debug(
+            `[GeminiImageGen] Downscale attempt ${attempts}: ${newWidth}px wide, ${convertedBuffer.length} bytes`,
+          );
+        }
+      }
+
       const imageData = convertedBuffer.toString('base64');
       const mimeType = outputFormat === 'jpeg' ? 'image/jpeg' : `image/${outputFormat}`;
 

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -227,6 +227,8 @@ const loadTools = async ({
         imageFiles,
         userId: user,
         fileStrategy,
+        imageOutputType,
+        provider: agent?.provider ?? endpoint,
       });
     },
   };


### PR DESCRIPTION
 Background: The Anthropic Claude API enforces a [maximum image size of 10 MB](https://platform.claude.com/docs/en/build-with-claude/vision#general-limits) per base64-encoded image. Gemini's image generation can produce raw images exceeding this limit (~13 MB observed), causing a 400 error when the tool result is passed back to Claude as part of the agent loop. Other LLM providers don't have this constraint, so the downscaling is applied conditionally.
 
Changes:
- Pass the agent's provider to `createGeminiImageTool` and conditionally downscale oversized images only when the provider is Anthropic
- Wire the existing `imageOutputType` config through to `createGeminiImageTool`so the format setting in `librechat.yaml` is respected

Here's the error encountered: 
<img width="833" height="140" alt="Screenshot 2026-06-05 at 8 59 13 AM" src="https://github.com/user-attachments/assets/68046953-d978-4b08-8d2f-a377e8443884" />

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:
1. Anthropic agent with Gemini image gen
    - Create/use an agent with provider set to Anthropic (e.g., Claude Sonnet)
    - Enable gemini_image_gen tool on the agent
    - Send a prompt like: "Generate a highly detailed 4K landscape image of a mountain range"
    - Expected: Image generates successfully and displays in chat without a 400 error
    - Verify in logs: If the raw image exceeded 9.5 MB, you should see:
    [GeminiImageGen] Image exceeds 9977856 bytes, downscaling
  [GeminiImageGen] Downscale attempt 1: ...
  2. Non-Anthropic agent with Gemini image gen
    - Create/use an agent with a non-Anthropic provider (e.g., Google, OpenAI)
    - Enable gemini_image_gen tool on the agent
    - Send the same prompt
    - Expected: Image generates successfully; no downscale log messages appear regardless of image size
    
## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
