### PR TITLE
👻 fix: Clear Project-Scoped Landing When the Selected Project Is Deleted

### DIFF
--- a/client/src/data-provider/Projects/mutations.ts
+++ b/client/src/data-provider/Projects/mutations.ts
@@ -65,7 +65,11 @@ export const useDeleteProjectMutation = (): UseMutationResult<
   return useMutation((projectId: string) => dataService.deleteProject(projectId), {
     onSuccess: (_result, projectId) => {
       clearActiveConversationProject(projectId);
-      queryClient.removeQueries([QueryKeys.project, projectId]);
+      // Invalidate (not remove) so an active project-detail observer refetches and
+      // settles into an error/not-found state. Removing the query leaves observers
+      // with `refetchOnMount: false` stuck in a perpetual loading state, which would
+      // prevent consumers (e.g. ChatRoute) from reacting to the deletion.
+      queryClient.invalidateQueries([QueryKeys.project, projectId]);
       queryClient.invalidateQueries([QueryKeys.projects]);
       queryClient.invalidateQueries([QueryKeys.allConversations]);
     },

--- a/client/src/data-provider/Projects/mutations.ts
+++ b/client/src/data-provider/Projects/mutations.ts
@@ -65,11 +65,13 @@ export const useDeleteProjectMutation = (): UseMutationResult<
   return useMutation((projectId: string) => dataService.deleteProject(projectId), {
     onSuccess: (_result, projectId) => {
       clearActiveConversationProject(projectId);
-      // Invalidate (not remove) so an active project-detail observer refetches and
-      // settles into an error/not-found state. Removing the query leaves observers
-      // with `refetchOnMount: false` stuck in a perpetual loading state, which would
-      // prevent consumers (e.g. ChatRoute) from reacting to the deletion.
+      // Invalidate so an *active* project-detail observer refetches and settles into a
+      // not-found state — consumers (e.g. ChatRoute) can then react to the deletion.
+      // (Removing it instead leaves observers stuck loading under `refetchOnMount: false`.)
       queryClient.invalidateQueries([QueryKeys.project, projectId]);
+      // Drop any *inactive* cached detail so a later visit to the deleted project
+      // refetches (→ not-found) rather than rendering stale cache within `cacheTime`.
+      queryClient.removeQueries([QueryKeys.project, projectId], { type: 'inactive' });
       queryClient.invalidateQueries([QueryKeys.projects]);
       queryClient.invalidateQueries([QueryKeys.allConversations]);
     },

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -55,7 +55,7 @@ export default function ChatRoute() {
   useAppStartup({ startupConfig, user });
 
   const index = 0;
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { conversationId = '' } = useParams();
   const projectIdParam = searchParams.get('projectId');
   const chatProjectId = isValidChatProjectId(projectIdParam) ? projectIdParam : null;
@@ -70,11 +70,45 @@ export default function ChatRoute() {
     staleTime: 30000,
     cacheTime: 300000,
   });
-  const verifiedChatProjectId = projectQuery.data?._id === chatProjectId ? chatProjectId : null;
+  /**
+   * Only trust the project scope when the query actually succeeded. If the scoped
+   * project was deleted (or isn't owned), the query errors — and React Query may
+   * retain the last successful data — so a plain `data?._id` check would keep the
+   * landing chip alive for a project that no longer exists.
+   */
+  const verifiedChatProjectId =
+    projectQuery.isSuccess && projectQuery.data?._id === chatProjectId ? chatProjectId : null;
   const projectTemplate = useMemo(
     () => (verifiedChatProjectId ? { chatProjectId: verifiedChatProjectId } : {}),
     [verifiedChatProjectId],
   );
+
+  /**
+   * The scoped project no longer resolves (deleted, or not owned) even though the
+   * URL still carries `?projectId`. Drop the param so the new-chat landing reverts
+   * to an unscoped chat — otherwise the stale chip lingers and sends target a dead
+   * project. Wait for the query to settle so we don't strip a still-loading scope.
+   */
+  const projectScopeMissing =
+    Boolean(chatProjectId) &&
+    conversationId === Constants.NEW_CONVO &&
+    !projectQuery.isLoading &&
+    !projectQuery.isFetching &&
+    verifiedChatProjectId == null;
+
+  useEffect(() => {
+    if (!projectScopeMissing) {
+      return;
+    }
+    setSearchParams(
+      (params) => {
+        const next = new URLSearchParams(params);
+        next.delete('projectId');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [projectScopeMissing, setSearchParams]);
 
   const modelsQuery = useGetModelsQuery({
     enabled: isAuthenticated,

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -71,30 +71,34 @@ export default function ChatRoute() {
     cacheTime: 300000,
   });
   /**
-   * Only trust the project scope when the query actually succeeded. If the scoped
-   * project was deleted (or isn't owned), the query errors — and React Query may
-   * retain the last successful data — so a plain `data?._id` check would keep the
-   * landing chip alive for a project that no longer exists.
+   * The scoped project is *confirmed gone* — a not-found/not-owned (404) response,
+   * or a success that resolved to a different/empty project. Transient failures
+   * (500, network, auth refresh race) are deliberately excluded: this query runs with
+   * `retry: false`, so treating any error as "gone" would unscope a valid project on
+   * a single blip.
+   */
+  const projectNotFound = projectQuery.isError && isNotFoundError(projectQuery.error);
+  /**
+   * Trust the scope when the project resolves to itself, and keep showing it through
+   * transient errors via React Query's retained data — but never for a project that
+   * is confirmed gone (otherwise the deleted project's chip lingers).
    */
   const verifiedChatProjectId =
-    projectQuery.isSuccess && projectQuery.data?._id === chatProjectId ? chatProjectId : null;
+    !projectNotFound && projectQuery.data?._id === chatProjectId ? chatProjectId : null;
   const projectTemplate = useMemo(
     () => (verifiedChatProjectId ? { chatProjectId: verifiedChatProjectId } : {}),
     [verifiedChatProjectId],
   );
 
   /**
-   * The scoped project no longer resolves (deleted, or not owned) even though the
-   * URL still carries `?projectId`. Drop the param so the new-chat landing reverts
-   * to an unscoped chat — otherwise the stale chip lingers and sends target a dead
-   * project. Wait for the query to settle so we don't strip a still-loading scope.
+   * The scoped project is gone even though the URL still carries `?projectId`. Drop
+   * the param so the new-chat landing reverts to an unscoped chat — otherwise the
+   * stale chip lingers and sends target a dead project.
    */
   const projectScopeMissing =
     Boolean(chatProjectId) &&
     conversationId === Constants.NEW_CONVO &&
-    !projectQuery.isLoading &&
-    !projectQuery.isFetching &&
-    verifiedChatProjectId == null;
+    (projectNotFound || (projectQuery.isSuccess && projectQuery.data?._id !== chatProjectId));
 
   useEffect(() => {
     if (!projectScopeMissing) {

--- a/e2e/specs/mock/projects.spec.ts
+++ b/e2e/specs/mock/projects.spec.ts
@@ -85,6 +85,33 @@ test.describe('chat projects', () => {
     await expect(page).toHaveURL((url) => !url.searchParams.has('projectId'));
   });
 
+  test('drops the project scope when the scoped project is deleted', async ({ page }) => {
+    test.setTimeout(90000);
+    const name = uniqueName('E2E Project');
+    const projectId = await createProject(page, name);
+
+    await page.goto(`/c/new?projectId=${projectId}`, { timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Remove from project' })).toBeVisible();
+
+    // Delete the scoped project from the sidebar while it is selected on the landing.
+    const row = page.getByRole('button', { name, exact: true }).first();
+    await expect(row).toBeVisible();
+    const item = row.locator('..');
+    await item.hover();
+    await item.getByRole('button', { name: 'More options' }).click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click();
+
+    // The stale chip is gone, the URL drops the now-dead project scope, and the
+    // composer reverts to an unscoped chat (placeholder no longer names the project).
+    await expect(page.getByRole('button', { name: 'Remove from project' })).toBeHidden();
+    await expect(page).toHaveURL((url) => !url.searchParams.has('projectId'));
+    await expect(page.getByRole('textbox', { name: 'Message input' })).not.toHaveAttribute(
+      'placeholder',
+      new RegExp(name),
+    );
+  });
+
   test('switches the project via the chip combobox', async ({ page }) => {
     test.setTimeout(90000);
     const nameA = uniqueName('E2E Project A');


### PR DESCRIPTION
## Summary

Fixes a stale-state bug in the project-scoped new-chat landing: if you open **New chat in &lt;project&gt;** (`/c/new?projectId=…`) and then **delete that project while it's still selected**, the landing chip kept showing the now-deleted project, and sending produced a visual glitch with the message ending up unscoped — confusingly, as if the send half-worked.

## Root cause

`ChatRoute` derived the scoped project as:

```ts
const verifiedChatProjectId = projectQuery.data?._id === chatProjectId ? chatProjectId : null;
```

When the project is deleted, `useProjectQuery` errors (404), but React Query keeps the last successful `data`, so `data?._id` still matched and the chip stayed alive. The URL also still carried `?projectId=…`, so the composer stayed scoped and a send still targeted the dead project (the server drops the invalid id on save, leaving the chat unscoped — hence the "did it even work?" feeling).

## Fix

In `client/src/routes/ChatRoute.tsx`:

1. **Only trust a project that actually resolved** — gate on `projectQuery.isSuccess`, so retained-on-error data can't keep a deleted project's chip alive:
   ```ts
   const verifiedChatProjectId =
     projectQuery.isSuccess && projectQuery.data?._id === chatProjectId ? chatProjectId : null;
   ```
2. **Drop the dead scope from the URL** once the query has settled and the project no longer resolves, so the landing reverts to a normal unscoped chat and sends aren't tied to a deleted project:
   ```ts
   // strip ?projectId when the scoped project is gone (deleted / not owned)
   ```

This is route-agnostic and handles deletion from anywhere, stale links, and another tab — not just the sidebar delete. It also covers the case where the backend returns `null` instead of a 404.

## Test

Adds a Playwright mock-harness regression test (`e2e/specs/mock/projects.spec.ts`): create a project, open its scoped landing, delete the project from the sidebar while selected, and assert the chip disappears, `?projectId` is stripped, and the composer reverts to an unscoped chat.
