### PR TITLE
🧭 fix: Restore Empty Skill Allowlist Catalog

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -77,10 +77,9 @@ const sanitizeViewerSkillScope = (agent, accessibleSkillSet) => {
 
   const configuredSkills = Array.isArray(agent.skills) ? agent.skills : [];
   if (configuredSkills.length === 0) {
+    // Empty allowlist means the viewer's full accessible catalog.
     delete agent.skills;
-    if (accessibleSkillSet.size > 0) {
-      agent.skills_enabled = true;
-    }
+    agent.skills_enabled = true;
     return agent;
   }
 

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -1548,6 +1548,33 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(response.data[0].skills_enabled).toBeUndefined();
     });
 
+    test('should preserve enabled skill scope for VIEW list callers with an empty allowlist', async () => {
+      await Agent.findByIdAndUpdate(agentA1._id, {
+        skills_enabled: true,
+        skills: [],
+      });
+
+      mockReq.user.id = userB.toString();
+      mockReq.query.requiredPermission = String(PermissionBits.VIEW);
+      findAccessibleResources.mockImplementation(({ resourceType }) => {
+        if (resourceType === ResourceType.AGENT) {
+          return Promise.resolve([agentA1._id]);
+        }
+        if (resourceType === ResourceType.SKILL) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      const response = mockRes.json.mock.calls[0][0];
+      expect(response.data).toHaveLength(1);
+      expect(response.data[0].skills).toBeUndefined();
+      expect(response.data[0].skills_enabled).toBe(true);
+    });
+
     test('should return raw skill configuration for EDIT list callers', async () => {
       const visibleSkillId = new mongoose.Types.ObjectId();
       const hiddenSkillId = new mongoose.Types.ObjectId();

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -320,7 +320,7 @@ describe('SkillsCommand', () => {
       isFetchingNextPage: false,
     });
     mockUseAgentsMapContext.mockReturnValue({
-      agent_1: { id: 'agent_1', skills_enabled: true },
+      agent_1: { id: 'agent_1', skills: [], skills_enabled: true },
     });
 
     const textAreaRef = makeTextarea('$');

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -252,9 +252,9 @@ describe('scopeSkillIds', () => {
     expect(scopeSkillIds(accessible, null)).toBe(accessible);
   });
 
-  it('returns [] when agentSkills is an empty array (explicit none)', () => {
+  it('returns the full set when agentSkills is an empty array (no allowlist)', () => {
     const accessible = [makeId(), makeId()];
-    expect(scopeSkillIds(accessible, [])).toEqual([]);
+    expect(scopeSkillIds(accessible, [])).toBe(accessible);
   });
 
   it('returns intersection when agentSkills overlaps accessibleSkillIds', () => {

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -98,9 +98,9 @@ export function isSkillPrimeMessage(msg: unknown): boolean {
  *
  * Semantics (pinned by unit tests):
  * - `undefined` / `null` → not configured, returns the full accessible catalog.
- * - `[]` (empty array) → explicitly none, returns `[]`. A user who narrows their
- *   agent to a subset and then removes all entries is explicitly opting out of
- *   the full catalog fallback.
+ * - `[]` (empty array) → no allowlist, returns the full accessible catalog.
+ *   Removing all selected skills in the builder restores the default full-catalog
+ *   behavior while `skills_enabled` remains true.
  * - non-empty array of skill `_id` hex strings → intersection of accessible IDs
  *   and agent-configured IDs.
  *
@@ -117,7 +117,7 @@ export function scopeSkillIds(
     return accessibleSkillIds;
   }
   if (agentSkills.length === 0) {
-    return [];
+    return accessibleSkillIds;
   }
   const agentSet = new Set(agentSkills);
   return accessibleSkillIds.filter((oid) => agentSet.has(oid.toString()));


### PR DESCRIPTION
## Summary

I fixed the agent skill allowlist behavior so removing all selected skills keeps skills enabled and restores the full accessible skill catalog.

- Preserved `skills_enabled: true` in the VIEW agent list response when an enabled agent has an empty skill allowlist.
- Updated the shared agent skill scoping helper so `skills: []` means no allowlist instead of no skills.
- Added regression coverage for the backend list hydration path and the chat `$` skill picker behavior.

Root cause: the saved empty allowlist could be flattened during agent list hydration, which made the client treat the persisted agent as skills-disabled even though the builder semantics expect an empty allowlist to mean full catalog.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Ran `node --check api/server/controllers/agents/v1.js`.
- Ran `node --check api/server/controllers/agents/v1.spec.js`.
- Attempted focused Jest coverage:
  - `cd packages/api && npx jest src/agents/__tests__/skills.test.ts --runInBand`
  - `cd api && npx jest server/controllers/agents/v1.spec.js --runInBand`
  - `cd client && npx jest src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx --runInBand`
- The focused Jest commands could not start in this worktree because local test dependencies are not installed (`jest-junit`, `@babel/preset-env`, `jest-environment-jsdom`).

### **Test Configuration**:

- Node.js: v24.16.0
- npm: 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes