### PR TITLE
🪹 feat: Collapse Empty Projects Section in the Sidebar by Default

### DIFF
--- a/client/src/components/Conversations/ProjectsSection.tsx
+++ b/client/src/components/Conversations/ProjectsSection.tsx
@@ -382,7 +382,11 @@ interface ProjectsSectionProps {
 const ProjectsSection = ({ toggleNav, isAuthenticated }: ProjectsSectionProps) => {
   const localize = useLocalize();
   const navigate = useNavigate();
-  const [isExpanded, setIsExpanded] = useLocalStorage('projectsSectionExpanded', true);
+  const [storedExpanded, setStoredExpanded] = useLocalStorage('projectsSectionExpanded', true);
+  const [hasToggledSection, setHasToggledSection] = useLocalStorage(
+    'projectsSectionToggled',
+    false,
+  );
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const conversation = useRecoilValue(store.conversationByIndex(0));
   const activeProjectId = conversation?.chatProjectId ?? null;
@@ -394,6 +398,14 @@ const ProjectsSection = ({ toggleNav, isAuthenticated }: ProjectsSectionProps) =
 
   const projects = useMemo(() => data?.pages.flatMap((page) => page.projects) ?? [], [data?.pages]);
   const hasMore = (data?.pages[data.pages.length - 1]?.nextCursor ?? null) != null;
+
+  /**
+   * Collapse the section by default for users with no projects who have never
+   * toggled it, to keep the sidebar compact. An explicit toggle — or a collapse
+   * set before this default existed (stored === false) — is always respected.
+   */
+  const respectStoredExpanded = hasToggledSection || storedExpanded === false;
+  const isExpanded = respectStoredExpanded ? storedExpanded : isLoading || projects.length > 0;
 
   const openProjects = useCallback(() => {
     navigate('/projects');
@@ -455,7 +467,10 @@ const ProjectsSection = ({ toggleNav, isAuthenticated }: ProjectsSectionProps) =
     <div className="flex flex-col px-3 text-sm">
       <div className="flex h-8 w-full items-center gap-0.5 pr-2">
         <button
-          onClick={() => setIsExpanded(!isExpanded)}
+          onClick={() => {
+            setStoredExpanded(!isExpanded);
+            setHasToggledSection(true);
+          }}
           className="group flex min-w-0 flex-1 items-center gap-1 rounded-lg px-1 py-2 text-xs font-bold text-text-secondary outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
           type="button"
           aria-expanded={isExpanded}


### PR DESCRIPTION
## Summary

Minor sidebar UX: the **Projects** section now defaults to **collapsed** for users who have no projects and have never toggled it, so it doesn't take up vertical space on an empty account. Once they have a project (it auto-expands) or explicitly expand/collapse the section, that choice is respected.

## Behavior

| State | Result |
|---|---|
| No projects, never toggled | **Collapsed** (new) |
| Has projects (or still loading), never toggled | Expanded (unchanged) |
| User explicitly expands/collapses | Persisted + respected |
| Pre-existing explicit collapse (`projectsSectionExpanded === false`) | Still respected |

Creating the first project flips `projects.length > 0`, so the section auto-expands to reveal it.

## Implementation

`ProjectsSection` now derives the effective `isExpanded` rather than reading it straight from localStorage:

```ts
const respectStoredExpanded = hasToggledSection || storedExpanded === false;
const isExpanded = respectStoredExpanded ? storedExpanded : isLoading || projects.length > 0;
```

Adds a `projectsSectionToggled` localStorage flag (set on user toggle) to distinguish "never interacted" from the auto-persisted default, without overriding anyone's prior explicit collapse.

UI-only change; lint + typecheck clean.
