### PR TITLE
🖼️ fix: Support Known Endpoint Group Icons

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/GroupIcon.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/GroupIcon.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useState } from 'react';
 import { AlertCircle } from 'lucide-react';
 import type { IconMapProps } from '~/common';
+import { getKnownEndpointAsset } from '~/hooks/Endpoint/UnknownIcon';
 import { icons } from '~/hooks/Endpoint/Icons';
 
 interface GroupIconProps {
@@ -42,13 +43,15 @@ const GroupIcon: React.FC<GroupIconProps> = ({ iconURL, groupName }) => {
     );
   }
 
+  const resolvedIconURL = getKnownEndpointAsset(iconURL) || iconURL;
+
   return (
     <div
       className="icon-md shrink-0 overflow-hidden rounded-full"
       style={{ width: 20, height: 20 }}
     >
       <img
-        src={iconURL}
+        src={resolvedIconURL}
         alt={groupName}
         className="h-full w-full object-cover"
         onError={handleImageError}

--- a/client/src/components/Chat/Menus/Endpoints/components/GroupIcon.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/GroupIcon.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useState } from 'react';
 import { AlertCircle } from 'lucide-react';
 import type { IconMapProps } from '~/common';
-import { getKnownEndpointAsset } from '~/hooks/Endpoint/UnknownIcon';
+import { getKnownEndpointAsset, hasKnownEndpointIcon } from '~/hooks/Endpoint/UnknownIcon';
 import { icons } from '~/hooks/Endpoint/Icons';
 
 interface GroupIconProps {
@@ -43,7 +43,19 @@ const GroupIcon: React.FC<GroupIconProps> = ({ iconURL, groupName }) => {
     );
   }
 
-  const resolvedIconURL = getKnownEndpointAsset(iconURL) || iconURL;
+  const resolvedIconURL = getKnownEndpointAsset(iconURL);
+
+  if (!resolvedIconURL && hasKnownEndpointIcon(iconURL)) {
+    const Icon: IconType = icons.unknown as IconType;
+    return (
+      <Icon
+        size={20}
+        endpoint={iconURL}
+        context="menu-item"
+        className="icon-md shrink-0 text-text-primary"
+      />
+    );
+  }
 
   return (
     <div
@@ -51,7 +63,7 @@ const GroupIcon: React.FC<GroupIconProps> = ({ iconURL, groupName }) => {
       style={{ width: 20, height: 20 }}
     >
       <img
-        src={resolvedIconURL}
+        src={resolvedIconURL || iconURL}
         alt={groupName}
         className="h-full w-full object-cover"
         onError={handleImageError}

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/GroupIcon.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/GroupIcon.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import GroupIcon from '../GroupIcon';
+
+jest.mock('~/hooks/Endpoint/Icons', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  const createIcon =
+    (iconKey: string) =>
+    ({ className }: { className?: string }) =>
+      React.createElement('span', {
+        className,
+        'data-testid': 'endpoint-icon',
+        'data-icon-key': iconKey,
+      });
+
+  return {
+    icons: {
+      openAI: createIcon('openAI'),
+      unknown: createIcon('unknown'),
+    },
+  };
+});
+
+describe('GroupIcon', () => {
+  it('renders built-in endpoint icon keys', () => {
+    render(<GroupIcon iconURL="openAI" groupName="OpenAI" />);
+
+    expect(screen.getByTestId('endpoint-icon')).toHaveAttribute('data-icon-key', 'openAI');
+  });
+
+  it('resolves known endpoint asset aliases case-insensitively', () => {
+    render(<GroupIcon iconURL="OpenRouter" groupName="OpenRouter" />);
+
+    expect(screen.getByRole('img', { name: 'OpenRouter' })).toHaveAttribute(
+      'src',
+      'assets/openrouter.png',
+    );
+  });
+
+  it('renders configured image URLs directly', () => {
+    render(<GroupIcon iconURL="/assets/openrouter.png" groupName="OpenRouter" />);
+
+    expect(screen.getByRole('img', { name: 'OpenRouter' })).toHaveAttribute(
+      'src',
+      '/assets/openrouter.png',
+    );
+  });
+});

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/GroupIcon.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/GroupIcon.test.tsx
@@ -5,11 +5,12 @@ jest.mock('~/hooks/Endpoint/Icons', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   const createIcon =
     (iconKey: string) =>
-    ({ className }: { className?: string }) =>
+    ({ className, endpoint }: { className?: string; endpoint?: string | null }) =>
       React.createElement('span', {
         className,
         'data-testid': 'endpoint-icon',
         'data-icon-key': iconKey,
+        'data-endpoint': endpoint ?? '',
       });
 
   return {
@@ -34,6 +35,22 @@ describe('GroupIcon', () => {
       'src',
       'assets/openrouter.png',
     );
+  });
+
+  it('resolves known endpoint asset aliases to shipped file paths', () => {
+    render(<GroupIcon iconURL="Helicone" groupName="Helicone" />);
+
+    expect(screen.getByRole('img', { name: 'Helicone' })).toHaveAttribute(
+      'src',
+      'assets/helicone.svg',
+    );
+  });
+
+  it('renders known endpoint aliases backed by components', () => {
+    render(<GroupIcon iconURL="Moonshot" groupName="Moonshot" />);
+
+    expect(screen.getByTestId('endpoint-icon')).toHaveAttribute('data-icon-key', 'unknown');
+    expect(screen.getByTestId('endpoint-icon')).toHaveAttribute('data-endpoint', 'Moonshot');
   });
 
   it('renders configured image URLs directly', () => {

--- a/client/src/hooks/Endpoint/UnknownIcon.tsx
+++ b/client/src/hooks/Endpoint/UnknownIcon.tsx
@@ -12,7 +12,7 @@ const knownEndpointAssets: Record<string, string> = {
   [KnownEndpoints.fireworks]: 'assets/fireworks.png',
   google: 'assets/google.svg',
   [KnownEndpoints.groq]: 'assets/groq.png',
-  [KnownEndpoints.helicone]: 'assets/helicone.png',
+  [KnownEndpoints.helicone]: 'assets/helicone.svg',
   [KnownEndpoints.huggingface]: 'assets/huggingface.svg',
   [KnownEndpoints.mistral]: 'assets/mistral.png',
   [KnownEndpoints.mlx]: 'assets/mlx.png',
@@ -26,12 +26,25 @@ const knownEndpointAssets: Record<string, string> = {
   [KnownEndpoints.unify]: 'assets/unify.webp',
 };
 
+const knownEndpointComponents = new Set<string>([KnownEndpoints.moonshot, KnownEndpoints.xai]);
+
 export function getKnownEndpointAsset(endpoint?: string | null): string {
   if (!endpoint) {
     return '';
   }
 
   return knownEndpointAssets[endpoint.toLowerCase()] ?? '';
+}
+
+export function hasKnownEndpointIcon(endpoint?: string | null): boolean {
+  if (!endpoint) {
+    return false;
+  }
+
+  const currentEndpoint = endpoint.toLowerCase();
+  return (
+    getKnownEndpointAsset(currentEndpoint) !== '' || knownEndpointComponents.has(currentEndpoint)
+  );
 }
 
 const knownEndpointClasses = {

--- a/client/src/hooks/Endpoint/UnknownIcon.tsx
+++ b/client/src/hooks/Endpoint/UnknownIcon.tsx
@@ -4,27 +4,35 @@ import { CustomMinimalIcon, XAIcon, MoonshotIcon } from '@librechat/client';
 import { IconContext } from '~/common';
 import { cn } from '~/utils';
 
-const knownEndpointAssets = {
+const knownEndpointAssets: Record<string, string> = {
   [KnownEndpoints.anyscale]: 'assets/anyscale.png',
   [KnownEndpoints.apipie]: 'assets/apipie.png',
   [KnownEndpoints.cohere]: 'assets/cohere.png',
   [KnownEndpoints.deepseek]: 'assets/deepseek.svg',
   [KnownEndpoints.fireworks]: 'assets/fireworks.png',
-  [KnownEndpoints.google]: 'assets/google.svg',
+  google: 'assets/google.svg',
   [KnownEndpoints.groq]: 'assets/groq.png',
   [KnownEndpoints.helicone]: 'assets/helicone.png',
   [KnownEndpoints.huggingface]: 'assets/huggingface.svg',
   [KnownEndpoints.mistral]: 'assets/mistral.png',
   [KnownEndpoints.mlx]: 'assets/mlx.png',
   [KnownEndpoints.ollama]: 'assets/ollama.png',
-  [KnownEndpoints.openai]: 'assets/openai.svg',
+  openai: 'assets/openai.svg',
   [KnownEndpoints.openrouter]: 'assets/openrouter.png',
   [KnownEndpoints.perplexity]: 'assets/perplexity.png',
-  [KnownEndpoints.qwen]: 'assets/qwen.svg',
+  qwen: 'assets/qwen.svg',
   [KnownEndpoints.shuttleai]: 'assets/shuttleai.png',
   [KnownEndpoints['together.ai']]: 'assets/together.png',
   [KnownEndpoints.unify]: 'assets/unify.webp',
 };
+
+export function getKnownEndpointAsset(endpoint?: string | null): string {
+  if (!endpoint) {
+    return '';
+  }
+
+  return knownEndpointAssets[endpoint.toLowerCase()] ?? '';
+}
 
 const knownEndpointClasses = {
   [KnownEndpoints.cohere]: {
@@ -81,7 +89,7 @@ function UnknownIcon({
     return <img className={className} src={iconURL} alt={`${endpoint} Icon`} />;
   }
 
-  const assetPath: string = knownEndpointAssets[currentEndpoint] ?? '';
+  const assetPath = getKnownEndpointAsset(currentEndpoint);
 
   if (!assetPath) {
     return <CustomMinimalIcon className={className} />;


### PR DESCRIPTION
## Summary

I fixed model spec group icons so known endpoint aliases like `OpenRouter`, `Helicone`, and component-backed providers resolve correctly, matching custom endpoint `iconURL` behavior. Fixes #13536.

- Exported shared known-endpoint icon helpers from `UnknownIcon` and kept existing unknown endpoint behavior intact.
- Updated `GroupIcon` to resolve known endpoint asset aliases before rendering image URLs.
- Pointed Helicone to the shipped `assets/helicone.svg` file.
- Routed component-backed known endpoint aliases like `Moonshot` and `xai` through the existing endpoint icon component path.
- Added focused regression coverage for built-in icon keys, OpenRouter alias resolution, Helicone asset resolution, component-backed aliases, and direct `/assets/...` group icon URLs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`.
- Ran `npm run build:client-package`.
- Ran `npx jest src/components/Chat/Menus/Endpoints/components/__tests__/GroupIcon.test.tsx --runInBand`.
- Ran `npx jest src/components/Chat/Menus/Endpoints/components/__tests__/SpecIcon.test.tsx --runInBand`.
- Ran `git diff --check`.
- Ran `npm run typecheck` from `client`; it still reports existing unrelated repo-wide errors, while a filtered check for `GroupIcon`/`UnknownIcon` returned no touched-file errors.

### **Test Configuration**:

- Repository: `danny-avila/LibreChat`
- Branch: `danny-avila/fix-group-icon-endpoint-assets`

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes