### PR TITLE
📊 fix: Contain Markdown Table Overflow

### DIFF
--- a/client/src/components/Chat/Messages/Content/Markdown.tsx
+++ b/client/src/components/Chat/Messages/Content/Markdown.tsx
@@ -19,7 +19,7 @@ import { ArtifactProvider, CodeBlockProvider } from '~/Providers';
 import MarkdownErrorBoundary from './MarkdownErrorBoundary';
 import { langSubset, preprocessLaTeX } from '~/utils';
 import { unicodeCitation } from '~/components/Web';
-import { code, a, p, img } from './MarkdownComponents';
+import { code, a, p, img, table } from './MarkdownComponents';
 import store from '~/store';
 
 type TContentProps = {
@@ -88,6 +88,7 @@ const Markdown = memo(function Markdown({ content = '', isLatestMessage }: TCont
                 a,
                 p,
                 img,
+                table,
                 artifact: Artifact,
                 citation: Citation,
                 'highlighted-text': HighlightedText,

--- a/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
@@ -191,7 +191,7 @@ type TTableProps = {
 
 export const table: React.ElementType = memo(function MarkdownTable({ children }: TTableProps) {
   return (
-    <div className="w-full max-w-full overflow-x-auto">
+    <div className="markdown-table-wrapper w-full max-w-full">
       <table>{children}</table>
     </div>
   );

--- a/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
@@ -185,6 +185,19 @@ export const p: React.ElementType = memo(function MarkdownParagraph({ children }
 });
 p.displayName = 'MarkdownParagraph';
 
+type TTableProps = {
+  children: React.ReactNode;
+};
+
+export const table: React.ElementType = memo(function MarkdownTable({ children }: TTableProps) {
+  return (
+    <div className="w-full max-w-full overflow-x-auto">
+      <table>{children}</table>
+    </div>
+  );
+});
+table.displayName = 'MarkdownTable';
+
 type TImageProps = {
   src?: string;
   alt?: string;

--- a/client/src/components/Chat/Messages/Content/MarkdownErrorBoundary.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownErrorBoundary.tsx
@@ -4,7 +4,7 @@ import supersub from 'remark-supersub';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import type { PluggableList } from 'unified';
-import { code, codeNoExecution, a, p } from './MarkdownComponents';
+import { code, codeNoExecution, a, p, table } from './MarkdownComponents';
 import { CodeBlockProvider } from '~/Providers';
 import { langSubset } from '~/utils';
 
@@ -72,6 +72,7 @@ class MarkdownErrorBoundary extends React.Component<
                 code: codeExecution ? code : codeNoExecution,
                 a,
                 p,
+                table,
               } as {
                 [nodeType: string]: React.ElementType;
               }

--- a/client/src/components/Chat/Messages/Content/MarkdownLite.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownLite.tsx
@@ -6,7 +6,7 @@ import supersub from 'remark-supersub';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import type { PluggableList } from 'unified';
-import { code, codeNoExecution, a, p, img } from './MarkdownComponents';
+import { code, codeNoExecution, a, p, img, table } from './MarkdownComponents';
 import { CodeBlockProvider, ArtifactProvider } from '~/Providers';
 import MarkdownErrorBoundary from './MarkdownErrorBoundary';
 import { langSubset } from '~/utils';
@@ -44,6 +44,7 @@ const MarkdownLite = memo(
                   a,
                   p,
                   img,
+                  table,
                 } as {
                   [nodeType: string]: React.ElementType;
                 }

--- a/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Markdown from '../Markdown';
+import MarkdownLite from '../MarkdownLite';
 import { RecoilRoot } from 'recoil';
 import { UI_RESOURCE_MARKER } from '~/components/MCPUIResource/plugin';
 import {
@@ -106,5 +107,37 @@ describe('Markdown with MCP UI markers (resource IDs)', () => {
     expect(renderers).toHaveLength(2);
     expect(renderers[0]).toHaveAttribute('data-resource-uri', 'ui://weather/paris');
     expect(renderers[1]).toHaveAttribute('data-resource-uri', 'ui://weather/nyc');
+  });
+});
+
+describe('Markdown table rendering', () => {
+  const tableMarkdown = [
+    '| Alpha | Bravo | Charlie | Delta | Echo | Foxtrot | Golf | Hotel |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
+    '| one | two | three | four | five | six | seven | eight |',
+  ].join('\n');
+
+  it('wraps GFM tables in a horizontally scrollable container', () => {
+    render(
+      <RecoilRoot>
+        <Markdown content={tableMarkdown} isLatestMessage={false} />
+      </RecoilRoot>,
+    );
+
+    expect(screen.getByRole('table').parentElement).toHaveClass(
+      'w-full',
+      'max-w-full',
+      'overflow-x-auto',
+    );
+  });
+
+  it('wraps lightweight Markdown tables in a horizontally scrollable container', () => {
+    render(<MarkdownLite content={tableMarkdown} />);
+
+    expect(screen.getByRole('table').parentElement).toHaveClass(
+      'w-full',
+      'max-w-full',
+      'overflow-x-auto',
+    );
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
@@ -125,9 +125,9 @@ describe('Markdown table rendering', () => {
     );
 
     expect(screen.getByRole('table').parentElement).toHaveClass(
+      'markdown-table-wrapper',
       'w-full',
       'max-w-full',
-      'overflow-x-auto',
     );
   });
 
@@ -135,9 +135,9 @@ describe('Markdown table rendering', () => {
     render(<MarkdownLite content={tableMarkdown} />);
 
     expect(screen.getByRole('table').parentElement).toHaveClass(
+      'markdown-table-wrapper',
       'w-full',
       'max-w-full',
-      'overflow-x-auto',
     );
   });
 });

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1496,6 +1496,27 @@ button {
   background-color: transparent;
 }
 
+.markdown-table-wrapper {
+  -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding-bottom: 0.25rem;
+  scrollbar-color: var(--border-medium) transparent;
+  scrollbar-width: thin;
+}
+
+.markdown-table-wrapper::-webkit-scrollbar {
+  height: 0.5rem;
+}
+
+.markdown-table-wrapper::-webkit-scrollbar-thumb {
+  background-color: var(--border-medium);
+}
+
+.markdown-table-wrapper::-webkit-scrollbar-thumb:hover {
+  background-color: var(--border-heavy);
+}
+
 /* Show scrollbar only on hover */
 .scrollbar-hover {
   scrollbar-width: thin;


### PR DESCRIPTION
## Summary

I contained wide Markdown tables within chat messages and added regression coverage for the full and lightweight Markdown renderers. Closes #13535.

- Added a shared Markdown table component that wraps rendered tables in a horizontally scrollable container.
- Registered the table component in `Markdown`, `MarkdownLite`, and the Markdown error-boundary fallback.
- Covered full chat Markdown and lightweight Markdown table rendering with focused Jest assertions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci --ignore-scripts --no-audit --no-fund` to install dependencies for local validation.
- Ran `npm run build:client-package` so Jest could resolve `@librechat/client`.
- Ran `npm run build:data-provider` so Jest could resolve `librechat-data-provider`.
- Ran `npm --prefix client run test:ci -- --runTestsByPath src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx --coverage=false`.
- Ran `git diff --check`.
- Ran `npm --prefix client run typecheck`; it still fails on existing unrelated TypeScript errors outside the touched Markdown files.

### **Test Configuration**:

- Node.js v24.16.0
- npm 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works