### PR TITLE
📎 fix: Preserve Provider Document Uploads

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1217,8 +1217,8 @@ class BaseClient {
     const provider = this.options.agent?.provider ?? this.options.endpoint;
     const isBedrock = provider === EModelEndpoint.bedrock;
 
-    if (!this._mergedFileConfig && this.options.req?.config?.fileConfig) {
-      this._mergedFileConfig = mergeFileConfig(this.options.req.config.fileConfig);
+    if (!this._mergedFileConfig) {
+      this._mergedFileConfig = mergeFileConfig(this.options.req?.config?.fileConfig);
       const endpoint = this.options.agent?.endpoint ?? this.options.endpoint;
       this._endpointFileConfig = getEndpointFileConfig({
         fileConfig: this._mergedFileConfig,

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -1497,6 +1497,19 @@ describe('AgentClient - titleConvo', () => {
       text,
     });
 
+    const makeUploadedFile = (file_id, filename, type) => ({
+      user: 'user-123',
+      file_id,
+      filename,
+      filepath: `/uploads/${filename}`,
+      object: 'file',
+      type,
+      bytes: 128,
+      embedded: false,
+      usage: 0,
+      source: 'local',
+    });
+
     beforeEach(() => {
       jest.clearAllMocks();
       mockFormatInstructions.mockResolvedValue('');
@@ -1544,6 +1557,48 @@ describe('AgentClient - titleConvo', () => {
       client.maxContextTokens = 4096;
       client.useMemory = jest.fn().mockResolvedValue(undefined);
     });
+
+    it.each([
+      ['CSV', 'csv-file', 'sample.csv', 'text/csv'],
+      [
+        'XLSX',
+        'xlsx-file',
+        'sample.xlsx',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      ],
+    ])(
+      'routes default-supported provider uploads like %s as request documents without custom file config',
+      async (_label, file_id, filename, type) => {
+        const currentFile = makeUploadedFile(file_id, filename, type);
+        const message = {
+          messageId: 'msg-1',
+          parentMessageId: null,
+          sender: 'User',
+          text: `Read this ${filename}.`,
+          isCreatedByUser: true,
+        };
+
+        client.addDocuments = jest.fn(async (targetMessage, attachments) => {
+          targetMessage.documents = attachments.map((file) => ({
+            type: 'input_file',
+            filename: file.filename,
+            file_data: `data:${file.type};base64,Y29sMQox`,
+          }));
+          return attachments;
+        });
+
+        const files = await client.processAttachments(message, [currentFile]);
+
+        expect(client.addDocuments).toHaveBeenCalledWith(message, [currentFile]);
+        expect(message.documents).toEqual([
+          expect.objectContaining({
+            type: 'input_file',
+            filename,
+          }),
+        ]);
+        expect(files).toEqual([currentFile]);
+      },
+    );
 
     it('places request context inline and applies each agent context doc only once', async () => {
       const requestFile = makeTextFile('request-file', 'request.txt', 'Shared request context');

--- a/e2e/setup/fake-model.js
+++ b/e2e/setup/fake-model.js
@@ -15,9 +15,11 @@ const CHUNK_DELAY_MS = Number(process.env.MOCK_LLM_CHUNK_DELAY_MS) || 10;
 const CREATE_SKILL_MARKER = 'E2E_CREATE_SKILL:';
 const EDIT_SKILL_MARKER = 'E2E_EDIT_SKILL:';
 const ASSERT_MODEL_SPEC_SKILLS_MARKER = 'E2E_ASSERT_MODEL_SPEC_SKILLS';
+const ASSERT_PROVIDER_FILE_MARKER = 'E2E_ASSERT_PROVIDER_FILE:';
 const CREATE_FILE_AUTHORING_FINAL_TEXT = 'E2E file authoring complete';
 const EDIT_FILE_AUTHORING_FINAL_TEXT = 'E2E file edit complete';
 const MODEL_SPEC_SKILL_ASSERTION_FINAL_TEXT = 'E2E model spec skill assertion passed';
+const PROVIDER_FILE_ASSERTION_FINAL_TEXT = 'E2E provider file assertion passed';
 const CREATE_FILE_TOOL_NAME = 'create_file';
 const EDIT_FILE_TOOL_NAME = 'edit_file';
 const BASH_TOOL_NAME = 'bash_tool';
@@ -64,8 +66,13 @@ function getContentText(content) {
 }
 
 function getLatestUserText(messages) {
+  const message = getLatestUserMessage(messages);
+  return message ? getContentText(message.content) : '';
+}
+
+function getLatestUserMessage(messages) {
   if (!Array.isArray(messages)) {
-    return '';
+    return null;
   }
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
@@ -74,10 +81,10 @@ function getLatestUserText(messages) {
     }
     const type = messageType(message);
     if (type === 'human' || type === 'user') {
-      return getContentText(message.content);
+      return message;
     }
   }
-  return '';
+  return null;
 }
 
 function getRequestedSkillName(text, marker) {
@@ -87,6 +94,14 @@ function getRequestedSkillName(text, marker) {
   }
   const afterMarker = text.slice(markerIndex + marker.length);
   return afterMarker.match(/[a-z0-9][a-z0-9-]*/)?.[0] ?? '';
+}
+
+function getMarkerValue(text, marker) {
+  const markerIndex = text.indexOf(marker);
+  if (markerIndex === -1) {
+    return '';
+  }
+  return text.slice(markerIndex + marker.length).trim().split(/\s+/, 1)[0] ?? '';
 }
 
 function collectToolNames(agents) {
@@ -132,6 +147,67 @@ function collectSkillPrimeMessages(messages) {
       trigger: message.additional_kwargs.trigger,
       content: getContentText(message.content),
     }));
+}
+
+function collectProviderFileNames(value, names = new Set()) {
+  if (value == null) {
+    return names;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectProviderFileNames(item, names);
+    }
+    return names;
+  }
+
+  if (typeof value !== 'object') {
+    return names;
+  }
+
+  if (value.type === 'input_file' && typeof value.filename === 'string') {
+    names.add(value.filename);
+  }
+
+  if (value.type === 'file' && typeof value.file?.filename === 'string') {
+    names.add(value.file.filename);
+  }
+
+  if (value.type === 'document' && typeof value.context === 'string') {
+    const match = value.context.match(/File:\s*"([^"]+)"/);
+    if (match?.[1]) {
+      names.add(match[1]);
+    }
+  }
+
+  for (const child of Object.values(value)) {
+    collectProviderFileNames(child, names);
+  }
+
+  return names;
+}
+
+function providerFileAssertionResponses({ messages, text }) {
+  const filename = getMarkerValue(text, ASSERT_PROVIDER_FILE_MARKER);
+  if (!filename) {
+    return null;
+  }
+
+  const latestUserMessage = getLatestUserMessage(messages);
+  const providerFileNames = collectProviderFileNames(latestUserMessage?.content);
+  if (providerFileNames.has(filename)) {
+    return {
+      responses: [`${PROVIDER_FILE_ASSERTION_FINAL_TEXT}: ${filename}`],
+    };
+  }
+
+  return {
+    responses: [
+      `E2E provider file assertion failed: expected ${filename}; saw ${
+        Array.from(providerFileNames).join(', ') || 'no provider files'
+      }`,
+    ],
+  };
 }
 
 function modelSpecSkillAssertionResponses({ agents, messages, toolNames }) {
@@ -235,6 +311,11 @@ function fileAuthoringResponses(operation, toolNames) {
 }
 
 function resolveResponses({ agents, messages, text, toolNames }) {
+  const providerFileAssertion = providerFileAssertionResponses({ messages, text });
+  if (providerFileAssertion) {
+    return providerFileAssertion;
+  }
+
   if (text.includes(ASSERT_MODEL_SPEC_SKILLS_MARKER)) {
     return modelSpecSkillAssertionResponses({ agents, messages, toolNames });
   }

--- a/e2e/specs/mock/chat.spec.ts
+++ b/e2e/specs/mock/chat.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+  isAgentsStream,
   MOCK_ENDPOINTS,
   NEW_CHAT_PATH,
   mockReply,
@@ -33,5 +34,62 @@ test.describe('core chat loop', () => {
     await expect(page.getByText(userMessage)).toBeVisible();
     await expect(mockReply(page)).toBeVisible();
     await expect(page.getByTestId('convo-item').first()).toBeVisible();
+  });
+
+  test('keeps upload-to-provider CSV attached to the sent message and model input', async ({
+    page,
+  }) => {
+    test.setTimeout(90000);
+
+    const filename = 'provider-upload.csv';
+    const assertionText = `E2E_ASSERT_PROVIDER_FILE:${filename}`;
+    const fileChip = page.getByTestId('messages-view').getByRole('button', { name: filename });
+
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+    await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+
+    await page.getByRole('button', { name: 'Attach File Options' }).click();
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByText('Upload to Provider').click();
+    const fileChooser = await fileChooserPromise;
+
+    const uploadResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/files') &&
+        response.request().method() === 'POST' &&
+        response.status() === 200,
+      { timeout: 30000 },
+    );
+    await fileChooser.setFiles({
+      name: filename,
+      mimeType: 'text/csv',
+      buffer: Buffer.from('name,value\nalpha,1\n'),
+    });
+    await uploadResponsePromise;
+
+    await expect(page.getByRole('button', { name: filename })).toBeVisible();
+
+    const input = page.getByRole('textbox', { name: 'Message input' });
+    await input.click();
+    await input.fill(assertionText);
+    await expect(page.getByTestId('send-button')).toBeEnabled();
+
+    const [response] = await Promise.all([
+      page.waitForResponse(isAgentsStream, { timeout: 30000 }),
+      page.getByTestId('send-button').click(),
+    ]);
+    expect(response.ok()).toBeTruthy();
+
+    await expect(
+      page
+        .getByTestId('messages-view')
+        .getByText(`E2E provider file assertion passed: ${filename}`),
+    ).toBeVisible();
+    await expect(fileChip).toBeVisible();
+
+    const conversationUrl = page.url();
+    await page.reload({ timeout: 10000 });
+    await expect(page).toHaveURL(conversationUrl);
+    await expect(fileChip).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

I fixed a regression where provider-uploaded CSV/XLSX attachments could disappear from the sent message and fail to reach the model when the server was using default file config.

- Initialized the merged file config in `processAttachments` even when no custom `req.config.fileConfig` is present, so default supported MIME types still route through document handling.
- Preserved endpoint-specific file routing by continuing to resolve the endpoint file config from the merged defaults.
- Added regression coverage for Agents provider uploads using CSV and XLSX MIME types without custom file config.

Fixes #13547

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd api && npx jest server/controllers/agents/client.test.js --runInBand`
- `cd packages/data-provider && npx jest src/config.spec.ts --runInBand`

### **Test Configuration**:

- Local focused Jest suites in the LibreChat worktree

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes