### PR TITLE
🏪 feat: Surface Agent Marketplace in Model Selector

### DIFF
--- a/client/src/common/selector.ts
+++ b/client/src/common/selector.ts
@@ -10,6 +10,8 @@ export interface Endpoint {
   agentNames?: Record<string, string>;
   assistantNames?: Record<string, string>;
   modelIcons?: Record<string, string | undefined>;
+  showMarketplace?: boolean;
+  searchAliases?: string[];
 }
 
 export interface SelectedValues {

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -1,5 +1,5 @@
-import debounce from 'lodash/debounce';
 import React, { createContext, useContext, useState, useMemo, useCallback } from 'react';
+import debounce from 'lodash/debounce';
 import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { Endpoint, SelectedValues } from '~/common';
@@ -161,8 +161,8 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
       return null;
     }
     const allItems = [...modelSpecs, ...mappedEndpoints];
-    return filterItems(allItems, searchValue, agentsMap, assistantsMap || {});
-  }, [searchValue, modelSpecs, mappedEndpoints, agentsMap, assistantsMap]);
+    return filterItems(allItems, searchValue, agentsMap, assistantsMap || {}, localize);
+  }, [searchValue, modelSpecs, mappedEndpoints, agentsMap, assistantsMap, localize]);
 
   const setDebouncedSearchValue = useMemo(
     () =>

--- a/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
+++ b/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
@@ -1,0 +1,18 @@
+import type { Endpoint } from '~/common';
+import { filterItems } from '../utils';
+
+const agentsEndpoint: Endpoint = {
+  value: 'agents',
+  label: 'My Agents',
+  hasModels: true,
+  icon: null,
+  showMarketplace: true,
+  searchAliases: ['agent marketplace', 'marketplace'],
+};
+
+describe('model selector utilities', () => {
+  it('matches endpoint search aliases', () => {
+    const results = filterItems([agentsEndpoint], 'marketplace', undefined, undefined);
+    expect(results).toEqual([agentsEndpoint]);
+  });
+});

--- a/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
+++ b/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+import type { useLocalize } from '~/hooks';
 import type { Endpoint } from '~/common';
 import { filterItems } from '../utils';
 
@@ -13,6 +14,21 @@ const agentsEndpoint: Endpoint = {
 describe('model selector utilities', () => {
   it('matches endpoint search aliases', () => {
     const results = filterItems([agentsEndpoint], 'marketplace', undefined, undefined);
+    expect(results).toEqual([agentsEndpoint]);
+  });
+
+  it('matches localized Marketplace labels', () => {
+    const localize = ((key: string) => {
+      if (key === 'com_agents_marketplace') {
+        return 'Tienda de Agentes';
+      }
+      if (key === 'com_ui_marketplace') {
+        return 'Tienda';
+      }
+      return key;
+    }) as ReturnType<typeof useLocalize>;
+
+    const results = filterItems([agentsEndpoint], 'tienda', undefined, undefined, localize);
     expect(results).toEqual([agentsEndpoint]);
   });
 });

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -6,10 +6,10 @@ import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librecha
 import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
 import { CustomMenu as Menu, CustomMenuItem as MenuItem, CustomMenuSeparator } from '../CustomMenu';
+import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { renderEndpointModels } from './EndpointModelItem';
 import { ModelSpecItem } from './ModelSpecItem';
-import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import { filterModels } from '../utils';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -5,10 +5,11 @@ import { CheckCircle2, MousePointerClick, SettingsIcon } from 'lucide-react';
 import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
-import { CustomMenu as Menu, CustomMenuItem as MenuItem } from '../CustomMenu';
+import { CustomMenu as Menu, CustomMenuItem as MenuItem, CustomMenuSeparator } from '../CustomMenu';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { renderEndpointModels } from './EndpointModelItem';
 import { ModelSpecItem } from './ModelSpecItem';
+import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import { filterModels } from '../utils';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
@@ -127,9 +128,15 @@ function EndpointMenuContent({
         assistantsMap,
       )
     : null;
+  const renderedModels = filteredModels ?? endpoint.models?.map((model) => model.name) ?? [];
+  const showMarketplace =
+    endpoint.showMarketplace === true && marketplaceSearchMatches(searchValue, localize);
+  const hasSelectableRows = endpointSpecs.length > 0 || renderedModels.length > 0;
 
   return (
     <>
+      {showMarketplace && <MarketplaceItem label={localize('com_agents_marketplace')} />}
+      {showMarketplace && hasSelectableRows && <CustomMenuSeparator />}
       {endpointSpecs.map((spec: TModelSpec) => (
         <ModelSpecItem key={spec.name} spec={spec} isSelected={selectedSpec === spec.name} />
       ))}

--- a/client/src/components/Chat/Menus/Endpoints/components/Marketplace.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/Marketplace.tsx
@@ -1,8 +1,8 @@
 import { LayoutGrid } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { LocalizeFunction } from '~/common';
-import { cn } from '~/utils';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
+import { cn } from '~/utils';
 
 const marketplaceSearchAliases = ['agent marketplace', 'marketplace'];
 

--- a/client/src/components/Chat/Menus/Endpoints/components/Marketplace.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/Marketplace.tsx
@@ -1,0 +1,49 @@
+import { LayoutGrid } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { LocalizeFunction } from '~/common';
+import { cn } from '~/utils';
+import { CustomMenuItem as MenuItem } from '../CustomMenu';
+
+const marketplaceSearchAliases = ['agent marketplace', 'marketplace'];
+
+export function marketplaceSearchMatches(searchValue: string, localize: LocalizeFunction): boolean {
+  const searchTerm = searchValue.trim().toLowerCase();
+  if (!searchTerm) {
+    return true;
+  }
+
+  return [
+    localize('com_agents_marketplace'),
+    localize('com_ui_marketplace'),
+    ...marketplaceSearchAliases,
+  ].some((label) => label.toLowerCase().includes(searchTerm));
+}
+
+export default function MarketplaceItem({
+  className,
+  label,
+}: {
+  className?: string;
+  label: string;
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <MenuItem
+      onClick={() => navigate('/agents')}
+      aria-label={label}
+      data-testid="model-selector-marketplace-item"
+      className={cn(
+        'flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm',
+        className,
+      )}
+    >
+      <div className="flex w-full min-w-0 items-center gap-2 px-1 py-1">
+        <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+          <LayoutGrid className="h-5 w-5 text-text-primary" aria-hidden="true" />
+        </div>
+        <span className="truncate text-left">{label}</span>
+      </div>
+    </MenuItem>
+  );
+}

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -4,9 +4,9 @@ import { CheckCircle2, EarthIcon } from 'lucide-react';
 import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
+import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
-import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
 

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -6,6 +6,7 @@ import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
+import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
 
@@ -102,11 +103,16 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
         } else {
           // For an endpoint item
           const endpoint = item as Endpoint;
-          if (endpoint.hasModels && endpoint.models && endpoint.models.length > 0) {
+          if (endpoint.hasModels) {
             const lowerQuery = searchValue.toLowerCase();
-            const filteredModels = endpoint.label.toLowerCase().includes(lowerQuery)
-              ? endpoint.models
-              : endpoint.models.filter((model) => {
+            const endpointMatches = endpoint.label.toLowerCase().includes(lowerQuery);
+            const showMarketplace =
+              endpoint.showMarketplace === true &&
+              (endpointMatches || marketplaceSearchMatches(searchValue, localize));
+            const models = endpoint.models ?? [];
+            const filteredModels = endpointMatches
+              ? models
+              : models.filter((model) => {
                   let modelName = model.name;
                   if (
                     isAgentsEndpoint(endpoint.value) &&
@@ -124,7 +130,7 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                   return modelName.toLowerCase().includes(lowerQuery);
                 });
 
-            if (!filteredModels.length) {
+            if (!filteredModels.length && !showMarketplace) {
               return null; // skip if no models match
             }
 
@@ -138,6 +144,12 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                   )}
                   {endpoint.label}
                 </div>
+                {showMarketplace && (
+                  <MarketplaceItem
+                    className="px-3 py-2 pl-6"
+                    label={localize('com_agents_marketplace')}
+                  />
+                )}
                 {filteredModels.map((model) => {
                   const modelId = model.name;
 

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { Endpoint, SelectedValues } from '~/common';
 import { SearchResults } from '../SearchResults';
 
 const mockHandleSelectSpec = jest.fn();
 const mockHandleSelectModel = jest.fn();
 const mockHandleSelectEndpoint = jest.fn();
+const mockNavigate = jest.fn();
 let mockSelectedValues: SelectedValues;
 
 jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
@@ -29,6 +30,10 @@ jest.mock('~/components/Chat/Menus/Endpoints/CustomMenu', () => {
   };
 });
 
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
 jest.mock('../SpecIcon', () => {
   const React = jest.requireActual<typeof import('react')>('react');
   return {
@@ -51,6 +56,17 @@ const noModelsEndpoint: Endpoint = {
   value: 'custom',
   label: 'Custom',
   hasModels: false,
+  icon: null,
+};
+
+const agentsMarketplaceEndpoint: Endpoint = {
+  value: 'agents',
+  label: 'My Agents',
+  hasModels: true,
+  models: [{ name: 'agent-1' }],
+  agentNames: { 'agent-1': 'Support Agent' },
+  showMarketplace: true,
+  searchAliases: ['agent marketplace', 'marketplace'],
   icon: null,
 };
 
@@ -105,5 +121,23 @@ describe('SearchResults', () => {
 
     const item = screen.getByRole('menuitem');
     expect(item).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('renders Marketplace from agent endpoint search results and navigates to agents', () => {
+    mockSelectedValues = { endpoint: '', model: '', modelSpec: '' };
+    render(
+      <SearchResults
+        results={[agentsMarketplaceEndpoint]}
+        localize={localize}
+        searchValue="marketplace"
+      />,
+    );
+
+    const item = screen.getByRole('menuitem', { name: 'com_agents_marketplace' });
+    expect(item).toBeInTheDocument();
+
+    fireEvent.click(item);
+    expect(mockNavigate).toHaveBeenCalledWith('/agents');
+    expect(mockHandleSelectModel).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/Chat/Menus/Endpoints/components/index.ts
+++ b/client/src/components/Chat/Menus/Endpoints/components/index.ts
@@ -3,3 +3,4 @@ export * from './EndpointModelItem';
 export * from './EndpointItem';
 export * from './SearchResults';
 export * from './CustomGroup';
+export * from './Marketplace';

--- a/client/src/components/Chat/Menus/Endpoints/utils.ts
+++ b/client/src/components/Chat/Menus/Endpoints/utils.ts
@@ -18,12 +18,14 @@ export function filterItems<
     value?: string;
     models?: Array<{ name: string; isGlobal?: boolean }>;
     searchAliases?: string[];
+    showMarketplace?: boolean;
   },
 >(
   items: T[],
   searchValue: string,
   agentsMap: TAgentsMap | undefined,
   assistantsMap: TAssistantsMap | undefined,
+  localize?: ReturnType<typeof useLocalize>,
 ): T[] | null {
   const searchTermLower = searchValue.trim().toLowerCase();
   if (!searchTermLower) {
@@ -35,7 +37,12 @@ export function filterItems<
       item.label.toLowerCase().includes(searchTermLower) ||
       (item.name && item.name.toLowerCase().includes(searchTermLower)) ||
       (item.value && item.value.toLowerCase().includes(searchTermLower)) ||
-      item.searchAliases?.some((alias) => alias.toLowerCase().includes(searchTermLower));
+      item.searchAliases?.some((alias) => alias.toLowerCase().includes(searchTermLower)) ||
+      (item.showMarketplace === true &&
+        localize != null &&
+        [localize('com_agents_marketplace'), localize('com_ui_marketplace')].some((label) =>
+          label.toLowerCase().includes(searchTermLower),
+        ));
 
     if (itemMatches) {
       return true;

--- a/client/src/components/Chat/Menus/Endpoints/utils.ts
+++ b/client/src/components/Chat/Menus/Endpoints/utils.ts
@@ -17,6 +17,7 @@ export function filterItems<
     name?: string;
     value?: string;
     models?: Array<{ name: string; isGlobal?: boolean }>;
+    searchAliases?: string[];
   },
 >(
   items: T[],
@@ -33,7 +34,8 @@ export function filterItems<
     const itemMatches =
       item.label.toLowerCase().includes(searchTermLower) ||
       (item.name && item.name.toLowerCase().includes(searchTermLower)) ||
-      (item.value && item.value.toLowerCase().includes(searchTermLower));
+      (item.value && item.value.toLowerCase().includes(searchTermLower)) ||
+      item.searchAliases?.some((alias) => alias.toLowerCase().includes(searchTermLower));
 
     if (itemMatches) {
       return true;

--- a/client/src/hooks/Endpoint/useEndpoints.ts
+++ b/client/src/hooks/Endpoint/useEndpoints.ts
@@ -18,7 +18,7 @@ import type {
 import type { Endpoint } from '~/common';
 import { useGetEndpointsQuery } from '~/data-provider';
 import { mapEndpoints, getIconKey } from '~/utils';
-import { useHasAccess } from '~/hooks';
+import { useHasAccess, useShowMarketplace } from '~/hooks';
 import { icons } from './Icons';
 
 const defaultInterface = getConfigDefaults().interface;
@@ -46,6 +46,7 @@ export const useEndpoints = ({
     permissionType: PermissionTypes.AGENTS,
     permission: Permissions.USE,
   });
+  const showAgentMarketplace = useShowMarketplace();
 
   const assistants: Assistant[] = useMemo(
     () => Object.values(assistantsMap?.[EModelEndpoint.assistants] ?? {}),
@@ -89,7 +90,7 @@ export const useEndpoints = ({
       const Icon = icons[iconKey];
       const endpointIconURL = getEndpointField(endpointsConfig, ep, 'iconURL');
       const hasModels =
-        (ep === EModelEndpoint.agents && (agents?.length ?? 0) > 0) ||
+        (ep === EModelEndpoint.agents && ((agents?.length ?? 0) > 0 || showAgentMarketplace)) ||
         (ep === EModelEndpoint.assistants && assistants?.length > 0) ||
         (ep !== EModelEndpoint.assistants &&
           ep !== EModelEndpoint.agents &&
@@ -109,6 +110,11 @@ export const useEndpoints = ({
             })
           : null,
       };
+
+      if (ep === EModelEndpoint.agents && showAgentMarketplace) {
+        result.showMarketplace = true;
+        result.searchAliases = ['agent marketplace', 'marketplace'];
+      }
 
       // Handle agents case
       if (ep === EModelEndpoint.agents && (agents?.length ?? 0) > 0) {
@@ -181,7 +187,15 @@ export const useEndpoints = ({
 
       return result;
     });
-  }, [filteredEndpoints, endpointsConfig, modelsQuery.data, agents, assistants, azureAssistants]);
+  }, [
+    agents,
+    assistants,
+    azureAssistants,
+    endpointsConfig,
+    filteredEndpoints,
+    modelsQuery.data,
+    showAgentMarketplace,
+  ]);
 
   return {
     mappedEndpoints,

--- a/client/src/hooks/Endpoint/useEndpoints.ts
+++ b/client/src/hooks/Endpoint/useEndpoints.ts
@@ -16,9 +16,9 @@ import type {
   Agent,
 } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
+import { useHasAccess, useShowMarketplace } from '~/hooks';
 import { useGetEndpointsQuery } from '~/data-provider';
 import { mapEndpoints, getIconKey } from '~/utils';
-import { useHasAccess, useShowMarketplace } from '~/hooks';
 import { icons } from './Icons';
 
 const defaultInterface = getConfigDefaults().interface;


### PR DESCRIPTION
I improved Agent Marketplace discoverability from the primary chat experience by surfacing Marketplace inside the Model Selector under My Agents.

- Added a Marketplace action at the top of the My Agents submenu, gated by the existing Marketplace and Agents permissions.
- Kept direct `/agents` navigation, shared agent links, and pinned-agent flows intact by routing the new entry to the existing Marketplace page.
- Enabled My Agents to open when Marketplace is available even if the user has no owned agents yet, so shared org agents remain discoverable from chat.
- Added Marketplace search aliases so searching `marketplace` in the model selector surfaces the entry.
- Covered the selector search and Marketplace navigation behavior with focused tests.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Ran `npm run smart-reinstall`
- [x] Ran `npm run build` from `client/`
- [x] Ran `npx jest src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts --runInBand` from `client/`

### **Test Configuration**:

- Node.js v24.16.0
- Frontend workspace: `client/`

Note: `npm run typecheck` currently fails on unrelated existing frontend diagnostics outside these selector changes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes