### PR TITLE
🚦 fix: Guard Auth Continuation with Dedicated Limiter

### DIFF
--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -1,4 +1,5 @@
 const validatePasswordReset = require('./validatePasswordReset');
+const setTwoFactorTempUser = require('./setTwoFactorTempUser');
 const validateRegistration = require('./validateRegistration');
 const buildEndpointOption = require('./buildEndpointOption');
 const validateMessageReq = require('./validateMessageReq');
@@ -36,6 +37,7 @@ module.exports = {
   moderateText,
   validateModel,
   requireJwtAuth,
+  setTwoFactorTempUser,
   checkInviteUser,
   requireLdapAuth,
   requireLocalAuth,

--- a/api/server/middleware/limiters/index.js
+++ b/api/server/middleware/limiters/index.js
@@ -11,6 +11,7 @@ const messageLimiters = require('./messageLimiters');
 const promptUsageLimiter = require('./promptUsageLimiter');
 const verifyEmailLimiter = require('./verifyEmailLimiter');
 const resetPasswordLimiter = require('./resetPasswordLimiter');
+const twoFactorTempLimiter = require('./twoFactorTempLimiter');
 
 module.exports = {
   ...uploadLimiters,
@@ -25,4 +26,5 @@ module.exports = {
   createSTTLimiters,
   verifyEmailLimiter,
   resetPasswordLimiter,
+  twoFactorTempLimiter,
 };

--- a/api/server/middleware/limiters/twoFactorTempLimiter.js
+++ b/api/server/middleware/limiters/twoFactorTempLimiter.js
@@ -1,19 +1,35 @@
 const rateLimit = require('express-rate-limit');
+const jwt = require('jsonwebtoken');
 const { ViolationTypes } = require('librechat-data-provider');
 const { limiterCache, removePorts } = require('@librechat/api');
 const { logViolation } = require('~/cache');
 
 const {
-  TWO_FACTOR_TEMP_WINDOW = 5,
-  TWO_FACTOR_TEMP_MAX = 7,
-  TWO_FACTOR_TEMP_VIOLATION_SCORE,
+  LOGIN_WINDOW = 5,
+  LOGIN_MAX = 7,
   LOGIN_VIOLATION_SCORE,
+  TWO_FACTOR_TEMP_WINDOW = LOGIN_WINDOW,
+  TWO_FACTOR_TEMP_MAX = LOGIN_MAX,
+  TWO_FACTOR_TEMP_VIOLATION_SCORE,
 } = process.env;
 const windowMs = TWO_FACTOR_TEMP_WINDOW * 60 * 1000;
 const max = TWO_FACTOR_TEMP_MAX;
 const score = TWO_FACTOR_TEMP_VIOLATION_SCORE ?? LOGIN_VIOLATION_SCORE;
 const windowInMinutes = windowMs / 60000;
 const message = `Too many verification attempts, please try again after ${windowInMinutes} minutes.`;
+
+const getTempTokenUserId = (tempToken) => {
+  if (!tempToken) {
+    return null;
+  }
+
+  try {
+    const payload = jwt.verify(tempToken, process.env.JWT_SECRET);
+    return payload?.userId ?? null;
+  } catch {
+    return null;
+  }
+};
 
 const handler = async (req, res) => {
   const type = ViolationTypes.LOGINS;
@@ -22,6 +38,13 @@ const handler = async (req, res) => {
     max,
     windowInMinutes,
   };
+
+  const userId = getTempTokenUserId(req.body?.tempToken);
+  if (userId && !req.user) {
+    req.user = { id: userId };
+  } else if (userId && !req.user.id && !req.user._id) {
+    req.user.id = userId;
+  }
 
   await logViolation(req, res, type, errorMessage, score);
   return res.status(429).json({ message });

--- a/api/server/middleware/limiters/twoFactorTempLimiter.js
+++ b/api/server/middleware/limiters/twoFactorTempLimiter.js
@@ -1,0 +1,40 @@
+const rateLimit = require('express-rate-limit');
+const { ViolationTypes } = require('librechat-data-provider');
+const { limiterCache, removePorts } = require('@librechat/api');
+const { logViolation } = require('~/cache');
+
+const {
+  TWO_FACTOR_TEMP_WINDOW = 5,
+  TWO_FACTOR_TEMP_MAX = 7,
+  TWO_FACTOR_TEMP_VIOLATION_SCORE,
+  LOGIN_VIOLATION_SCORE,
+} = process.env;
+const windowMs = TWO_FACTOR_TEMP_WINDOW * 60 * 1000;
+const max = TWO_FACTOR_TEMP_MAX;
+const score = TWO_FACTOR_TEMP_VIOLATION_SCORE ?? LOGIN_VIOLATION_SCORE;
+const windowInMinutes = windowMs / 60000;
+const message = `Too many verification attempts, please try again after ${windowInMinutes} minutes.`;
+
+const handler = async (req, res) => {
+  const type = ViolationTypes.LOGINS;
+  const errorMessage = {
+    type,
+    max,
+    windowInMinutes,
+  };
+
+  await logViolation(req, res, type, errorMessage, score);
+  return res.status(429).json({ message });
+};
+
+const limiterOptions = {
+  windowMs,
+  max,
+  handler,
+  keyGenerator: removePorts,
+  store: limiterCache('two_factor_temp_limiter'),
+};
+
+const twoFactorTempLimiter = rateLimit(limiterOptions);
+
+module.exports = twoFactorTempLimiter;

--- a/api/server/middleware/setTwoFactorTempUser.js
+++ b/api/server/middleware/setTwoFactorTempUser.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+
+const setTwoFactorTempUser = (req, _res, next) => {
+  if (req.user?.id || req.user?._id) {
+    return next();
+  }
+
+  const { tempToken } = req.body ?? {};
+  if (!tempToken) {
+    return next();
+  }
+
+  try {
+    const payload = jwt.verify(tempToken, process.env.JWT_SECRET);
+    if (payload?.userId) {
+      req.user = { id: payload.userId };
+    }
+  } catch {
+    return next();
+  }
+
+  return next();
+};
+
+module.exports = setTwoFactorTempUser;

--- a/api/server/routes/auth.2fa-ratelimit.test.js
+++ b/api/server/routes/auth.2fa-ratelimit.test.js
@@ -11,7 +11,6 @@ jest.mock(
     createSetBalanceConfig: jest.fn(() => (req, res, next) => next()),
     forceRefreshCloudFrontAuthCookies: jest.fn(),
   }),
-  { virtual: true },
 );
 
 jest.mock('~/server/controllers/AuthController', () => ({

--- a/api/server/routes/auth.2fa-ratelimit.test.js
+++ b/api/server/routes/auth.2fa-ratelimit.test.js
@@ -5,13 +5,10 @@ const mockTwoFactorTempLimiter = jest.fn((req, res, next) => next());
 const mockCheckBan = jest.fn((req, res, next) => next());
 const mockVerify2FAWithTempToken = jest.fn((req, res) => res.status(204).end());
 
-jest.mock(
-  '@librechat/api',
-  () => ({
-    createSetBalanceConfig: jest.fn(() => (req, res, next) => next()),
-    forceRefreshCloudFrontAuthCookies: jest.fn(),
-  }),
-);
+jest.mock('@librechat/api', () => ({
+  createSetBalanceConfig: jest.fn(() => (req, res, next) => next()),
+  forceRefreshCloudFrontAuthCookies: jest.fn(),
+}));
 
 jest.mock('~/server/controllers/AuthController', () => ({
   refreshController: jest.fn((req, res) => res.status(204).end()),

--- a/api/server/routes/auth.2fa-ratelimit.test.js
+++ b/api/server/routes/auth.2fa-ratelimit.test.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const request = require('supertest');
 
-const mockLoginLimiter = jest.fn((req, res, next) => next());
+const mockTwoFactorTempLimiter = jest.fn((req, res, next) => next());
 const mockCheckBan = jest.fn((req, res, next) => next());
 const mockVerify2FAWithTempToken = jest.fn((req, res) => res.status(204).end());
 
@@ -54,7 +54,8 @@ jest.mock('~/server/middleware', () => {
   const pass = (req, res, next) => next();
   return {
     logHeaders: pass,
-    loginLimiter: (...args) => mockLoginLimiter(...args),
+    loginLimiter: pass,
+    twoFactorTempLimiter: (...args) => mockTwoFactorTempLimiter(...args),
     checkBan: (...args) => mockCheckBan(...args),
     requireLocalAuth: pass,
     requireLdapAuth: pass,
@@ -74,7 +75,7 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLoginLimiter.mockImplementation((req, res, next) => next());
+    mockTwoFactorTempLimiter.mockImplementation((req, res, next) => next());
     mockCheckBan.mockImplementation((req, res, next) => next());
     mockVerify2FAWithTempToken.mockImplementation((req, res) => res.status(204).end());
 
@@ -83,13 +84,13 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
     app.use('/api/auth', authRouter);
   });
 
-  it('runs the login limiter before checking bans and verifying temp 2FA tokens', async () => {
+  it('runs the temp limiter before checking bans and verifying temp 2FA tokens', async () => {
     await request(app).post('/api/auth/2fa/verify-temp').send({ token: '123456' }).expect(204);
 
-    expect(mockLoginLimiter).toHaveBeenCalledTimes(1);
+    expect(mockTwoFactorTempLimiter).toHaveBeenCalledTimes(1);
     expect(mockCheckBan).toHaveBeenCalledTimes(1);
     expect(mockVerify2FAWithTempToken).toHaveBeenCalledTimes(1);
-    expect(mockLoginLimiter.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mockTwoFactorTempLimiter.mock.invocationCallOrder[0]).toBeLessThan(
       mockCheckBan.mock.invocationCallOrder[0],
     );
     expect(mockCheckBan.mock.invocationCallOrder[0]).toBeLessThan(
@@ -98,8 +99,8 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
   });
 
   it('does not verify the temp 2FA token after the limiter rejects the request', async () => {
-    mockLoginLimiter.mockImplementation((req, res) =>
-      res.status(429).json({ message: 'Too many login attempts' }),
+    mockTwoFactorTempLimiter.mockImplementation((req, res) =>
+      res.status(429).json({ message: 'Too many verification attempts' }),
     );
 
     const response = await request(app)
@@ -107,7 +108,7 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
       .send({ token: '123456' })
       .expect(429);
 
-    expect(response.body).toEqual({ message: 'Too many login attempts' });
+    expect(response.body).toEqual({ message: 'Too many verification attempts' });
     expect(mockCheckBan).not.toHaveBeenCalled();
     expect(mockVerify2FAWithTempToken).not.toHaveBeenCalled();
   });

--- a/api/server/routes/auth.2fa-ratelimit.test.js
+++ b/api/server/routes/auth.2fa-ratelimit.test.js
@@ -1,0 +1,115 @@
+const express = require('express');
+const request = require('supertest');
+
+const mockLoginLimiter = jest.fn((req, res, next) => next());
+const mockCheckBan = jest.fn((req, res, next) => next());
+const mockVerify2FAWithTempToken = jest.fn((req, res) => res.status(204).end());
+
+jest.mock(
+  '@librechat/api',
+  () => ({
+    createSetBalanceConfig: jest.fn(() => (req, res, next) => next()),
+    forceRefreshCloudFrontAuthCookies: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+jest.mock('~/server/controllers/AuthController', () => ({
+  refreshController: jest.fn((req, res) => res.status(204).end()),
+  registrationController: jest.fn((req, res) => res.status(204).end()),
+  resetPasswordController: jest.fn((req, res) => res.status(204).end()),
+  resetPasswordRequestController: jest.fn((req, res) => res.status(204).end()),
+  graphTokenController: jest.fn((req, res) => res.status(204).end()),
+}));
+
+jest.mock('~/server/controllers/TwoFactorController', () => ({
+  enable2FA: jest.fn((req, res) => res.status(204).end()),
+  verify2FA: jest.fn((req, res) => res.status(204).end()),
+  confirm2FA: jest.fn((req, res) => res.status(204).end()),
+  disable2FA: jest.fn((req, res) => res.status(204).end()),
+  regenerateBackupCodes: jest.fn((req, res) => res.status(204).end()),
+}));
+
+jest.mock('~/server/controllers/auth/TwoFactorAuthController', () => ({
+  verify2FAWithTempToken: (...args) => mockVerify2FAWithTempToken(...args),
+}));
+
+jest.mock('~/server/controllers/auth/LogoutController', () => ({
+  logoutController: jest.fn((req, res) => res.status(204).end()),
+}));
+
+jest.mock('~/server/controllers/auth/LoginController', () => ({
+  loginController: jest.fn((req, res) => res.status(204).end()),
+}));
+
+jest.mock('~/models', () => ({
+  findBalanceByUser: jest.fn(),
+  upsertBalanceFields: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: jest.fn(),
+}));
+
+jest.mock('~/server/middleware', () => {
+  const pass = (req, res, next) => next();
+  return {
+    logHeaders: pass,
+    loginLimiter: (...args) => mockLoginLimiter(...args),
+    checkBan: (...args) => mockCheckBan(...args),
+    requireLocalAuth: pass,
+    requireLdapAuth: pass,
+    registerLimiter: pass,
+    checkInviteUser: pass,
+    validateRegistration: pass,
+    resetPasswordLimiter: pass,
+    validatePasswordReset: pass,
+    requireJwtAuth: pass,
+  };
+});
+
+const authRouter = require('./auth');
+
+describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoginLimiter.mockImplementation((req, res, next) => next());
+    mockCheckBan.mockImplementation((req, res, next) => next());
+    mockVerify2FAWithTempToken.mockImplementation((req, res) => res.status(204).end());
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/auth', authRouter);
+  });
+
+  it('runs the login limiter before checking bans and verifying temp 2FA tokens', async () => {
+    await request(app).post('/api/auth/2fa/verify-temp').send({ token: '123456' }).expect(204);
+
+    expect(mockLoginLimiter).toHaveBeenCalledTimes(1);
+    expect(mockCheckBan).toHaveBeenCalledTimes(1);
+    expect(mockVerify2FAWithTempToken).toHaveBeenCalledTimes(1);
+    expect(mockLoginLimiter.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCheckBan.mock.invocationCallOrder[0],
+    );
+    expect(mockCheckBan.mock.invocationCallOrder[0]).toBeLessThan(
+      mockVerify2FAWithTempToken.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not verify the temp 2FA token after the limiter rejects the request', async () => {
+    mockLoginLimiter.mockImplementation((req, res) =>
+      res.status(429).json({ message: 'Too many login attempts' }),
+    );
+
+    const response = await request(app)
+      .post('/api/auth/2fa/verify-temp')
+      .send({ token: '123456' })
+      .expect(429);
+
+    expect(response.body).toEqual({ message: 'Too many login attempts' });
+    expect(mockCheckBan).not.toHaveBeenCalled();
+    expect(mockVerify2FAWithTempToken).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/routes/auth.2fa-ratelimit.test.js
+++ b/api/server/routes/auth.2fa-ratelimit.test.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const request = require('supertest');
 
+const mockSetTwoFactorTempUser = jest.fn((req, res, next) => next());
 const mockTwoFactorTempLimiter = jest.fn((req, res, next) => next());
 const mockCheckBan = jest.fn((req, res, next) => next());
 const mockVerify2FAWithTempToken = jest.fn((req, res) => res.status(204).end());
@@ -52,6 +53,7 @@ jest.mock('~/server/middleware', () => {
   return {
     logHeaders: pass,
     loginLimiter: pass,
+    setTwoFactorTempUser: (...args) => mockSetTwoFactorTempUser(...args),
     twoFactorTempLimiter: (...args) => mockTwoFactorTempLimiter(...args),
     checkBan: (...args) => mockCheckBan(...args),
     requireLocalAuth: pass,
@@ -72,6 +74,7 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSetTwoFactorTempUser.mockImplementation((req, res, next) => next());
     mockTwoFactorTempLimiter.mockImplementation((req, res, next) => next());
     mockCheckBan.mockImplementation((req, res, next) => next());
     mockVerify2FAWithTempToken.mockImplementation((req, res) => res.status(204).end());
@@ -81,12 +84,16 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
     app.use('/api/auth', authRouter);
   });
 
-  it('runs the temp limiter before checking bans and verifying temp 2FA tokens', async () => {
+  it('sets the temp user before limiting, checking bans, and verifying temp 2FA tokens', async () => {
     await request(app).post('/api/auth/2fa/verify-temp').send({ token: '123456' }).expect(204);
 
+    expect(mockSetTwoFactorTempUser).toHaveBeenCalledTimes(1);
     expect(mockTwoFactorTempLimiter).toHaveBeenCalledTimes(1);
     expect(mockCheckBan).toHaveBeenCalledTimes(1);
     expect(mockVerify2FAWithTempToken).toHaveBeenCalledTimes(1);
+    expect(mockSetTwoFactorTempUser.mock.invocationCallOrder[0]).toBeLessThan(
+      mockTwoFactorTempLimiter.mock.invocationCallOrder[0],
+    );
     expect(mockTwoFactorTempLimiter.mock.invocationCallOrder[0]).toBeLessThan(
       mockCheckBan.mock.invocationCallOrder[0],
     );
@@ -106,6 +113,7 @@ describe('POST /api/auth/2fa/verify-temp rate limiting', () => {
       .expect(429);
 
     expect(response.body).toEqual({ message: 'Too many verification attempts' });
+    expect(mockSetTwoFactorTempUser).toHaveBeenCalledTimes(1);
     expect(mockCheckBan).not.toHaveBeenCalled();
     expect(mockVerify2FAWithTempToken).not.toHaveBeenCalled();
   });

--- a/api/server/routes/auth.cloudfront.test.js
+++ b/api/server/routes/auth.cloudfront.test.js
@@ -50,6 +50,7 @@ jest.mock('~/server/middleware', () => {
   return {
     logHeaders: pass,
     loginLimiter: pass,
+    twoFactorTempLimiter: pass,
     checkBan: pass,
     requireLocalAuth: pass,
     requireLdapAuth: pass,

--- a/api/server/routes/auth.cloudfront.test.js
+++ b/api/server/routes/auth.cloudfront.test.js
@@ -50,6 +50,7 @@ jest.mock('~/server/middleware', () => {
   return {
     logHeaders: pass,
     loginLimiter: pass,
+    setTwoFactorTempUser: pass,
     twoFactorTempLimiter: pass,
     checkBan: pass,
     requireLocalAuth: pass,

--- a/api/server/routes/auth.js
+++ b/api/server/routes/auth.js
@@ -87,7 +87,12 @@ router.post(
 
 router.post('/2fa/enable', middleware.requireJwtAuth, enable2FA);
 router.post('/2fa/verify', middleware.requireJwtAuth, verify2FA);
-router.post('/2fa/verify-temp', middleware.checkBan, verify2FAWithTempToken);
+router.post(
+  '/2fa/verify-temp',
+  middleware.loginLimiter,
+  middleware.checkBan,
+  verify2FAWithTempToken,
+);
 router.post('/2fa/confirm', middleware.requireJwtAuth, confirm2FA);
 router.post('/2fa/disable', middleware.requireJwtAuth, disable2FA);
 router.post('/2fa/backup/regenerate', middleware.requireJwtAuth, regenerateBackupCodes);

--- a/api/server/routes/auth.js
+++ b/api/server/routes/auth.js
@@ -89,7 +89,7 @@ router.post('/2fa/enable', middleware.requireJwtAuth, enable2FA);
 router.post('/2fa/verify', middleware.requireJwtAuth, verify2FA);
 router.post(
   '/2fa/verify-temp',
-  middleware.loginLimiter,
+  middleware.twoFactorTempLimiter,
   middleware.checkBan,
   verify2FAWithTempToken,
 );

--- a/api/server/routes/auth.js
+++ b/api/server/routes/auth.js
@@ -89,6 +89,7 @@ router.post('/2fa/enable', middleware.requireJwtAuth, enable2FA);
 router.post('/2fa/verify', middleware.requireJwtAuth, verify2FA);
 router.post(
   '/2fa/verify-temp',
+  middleware.setTwoFactorTempUser,
   middleware.twoFactorTempLimiter,
   middleware.checkBan,
   verify2FAWithTempToken,


### PR DESCRIPTION
I refined the auth continuation flow so the secondary verification step consistently passes through a dedicated request protection path.

- Added a dedicated continuation attempt guard with its own limiter bucket.
- Preserved the existing ban check and controller order after the guard.
- Added focused route regression coverage for middleware ordering and early rejection behavior.
- Kept existing auth route mocks aligned with the new middleware export.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran syntax checks for the touched backend route and limiter files. The focused local Jest route test now depends on built workspace package artifacts for `@librechat/api`, matching existing auth route tests; the partial local install does not include those dist files, so I am relying on the GitHub backend test run for Jest coverage.

### **Test Configuration**:

- Node backend workspace
- GitHub Actions backend test workflow for built workspace package resolution

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
