### PR TITLE
🛂 fix: Normalize Verification Flow Error Responses

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -404,7 +404,7 @@ const resendVerificationController = async (req, res) => {
     if (result instanceof Error) {
       return res.status(400).json({ message: result.message });
     } else {
-      return res.status(200).json(result);
+      return res.status(result.status ?? 200).json({ message: result.message });
     }
   } catch (e) {
     logger.error('[verifyEmailController]', e);

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -388,7 +388,7 @@ const verifyEmailController = async (req, res) => {
   try {
     const verifyEmailService = await verifyEmail(req);
     if (verifyEmailService instanceof Error) {
-      return res.status(400).json(verifyEmailService);
+      return res.status(400).json({ message: verifyEmailService.message });
     } else {
       return res.status(200).json(verifyEmailService);
     }
@@ -402,7 +402,7 @@ const resendVerificationController = async (req, res) => {
   try {
     const result = await resendVerificationEmail(req);
     if (result instanceof Error) {
-      return res.status(400).json(result);
+      return res.status(400).json({ message: result.message });
     } else {
       return res.status(200).json(result);
     }

--- a/api/server/controllers/UserController.spec.js
+++ b/api/server/controllers/UserController.spec.js
@@ -111,11 +111,12 @@ afterEach(async () => {
 const {
   deleteUserController,
   getUserController,
+  resendVerificationController,
   verifyEmailController,
 } = require('./UserController');
 const { Group } = require('~/db/models');
 const { deleteConvos } = require('~/models');
-const { verifyEmail } = require('~/server/services/AuthService');
+const { verifyEmail, resendVerificationEmail } = require('~/server/services/AuthService');
 
 describe('verifyEmailController', () => {
   const mockRes = {
@@ -139,6 +140,15 @@ describe('verifyEmailController', () => {
     expect(mockRes.json).toHaveBeenCalledWith({
       message: 'Invalid or expired email verification token',
     });
+  });
+
+  it('uses the service status for resend verification responses', async () => {
+    resendVerificationEmail.mockResolvedValue({ status: 500, message: 'Something went wrong.' });
+
+    await resendVerificationController({ body: { email: 'user@example.com' } }, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(500);
+    expect(mockRes.json).toHaveBeenCalledWith({ message: 'Something went wrong.' });
   });
 });
 

--- a/api/server/controllers/UserController.spec.js
+++ b/api/server/controllers/UserController.spec.js
@@ -108,9 +108,39 @@ afterEach(async () => {
   }
 });
 
-const { deleteUserController, getUserController } = require('./UserController');
+const {
+  deleteUserController,
+  getUserController,
+  verifyEmailController,
+} = require('./UserController');
 const { Group } = require('~/db/models');
 const { deleteConvos } = require('~/models');
+const { verifyEmail } = require('~/server/services/AuthService');
+
+describe('verifyEmailController', () => {
+  const mockRes = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the generic verification error message from service failures', async () => {
+    verifyEmail.mockResolvedValue(new Error('Invalid or expired email verification token'));
+
+    await verifyEmailController(
+      { body: { email: 'user%40example.com', token: 'not-the-token' } },
+      mockRes,
+    );
+
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: 'Invalid or expired email verification token',
+    });
+  });
+});
 
 describe('getUserController', () => {
   const mockRes = {

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -212,7 +212,7 @@ const verifyEmail = async (req) => {
 
   if (!updatedUser) {
     logger.warn(`[verifyEmail] [User update failed] [Email: ${decodedEmail}]`);
-    return new Error('Failed to update user verification status');
+    return new Error(invalidEmailVerificationMessage);
   }
 
   await deleteTokens({ token: emailVerificationData.token });

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -46,6 +46,7 @@ const domains = {
 };
 
 const genericVerificationMessage = 'Please check your email to verify your email address.';
+const invalidEmailVerificationMessage = 'Invalid or expired email verification token';
 const OPENID_SESSION_ID_TOKEN_EXPIRY_BUFFER_SECONDS = 30;
 
 const getUnexpiredOpenIDSessionIdToken = (idToken) => {
@@ -147,25 +148,49 @@ const sendVerificationEmail = async (user) => {
  */
 const verifyEmail = async (req) => {
   const { email, token } = req.body;
-  const decodedEmail = decodeURIComponent(email);
+
+  if (typeof email !== 'string' || typeof token !== 'string' || !email || !token) {
+    logger.warn('[verifyEmail] [Invalid email verification request]');
+    return new Error(invalidEmailVerificationMessage);
+  }
+
+  let decodedEmail;
+  try {
+    decodedEmail = decodeURIComponent(email);
+  } catch {
+    logger.warn(`[verifyEmail] [Invalid email encoding] [Email: ${email}]`);
+    return new Error(invalidEmailVerificationMessage);
+  }
 
   const user = await findUser({ email: decodedEmail }, 'email _id emailVerified');
 
   if (!user) {
     logger.warn(`[verifyEmail] [User not found] [Email: ${decodedEmail}]`);
-    return new Error('User not found');
+    return new Error(invalidEmailVerificationMessage);
   }
 
-  if (user.emailVerified) {
-    logger.info(`[verifyEmail] Email already verified [Email: ${decodedEmail}]`);
-    return { message: 'Email already verified', status: 'success' };
-  }
-
-  let emailVerificationData = await findToken({ email: decodedEmail }, { sort: { createdAt: -1 } });
+  const emailVerificationData = await findToken(
+    { email: decodedEmail },
+    { sort: { createdAt: -1 } },
+  );
 
   if (!emailVerificationData) {
     logger.warn(`[verifyEmail] [No email verification data found] [Email: ${decodedEmail}]`);
-    return new Error('Invalid or expired password reset token');
+    return new Error(invalidEmailVerificationMessage);
+  }
+
+  if (!emailVerificationData.token) {
+    logger.warn(
+      `[verifyEmail] [Email verification token data is invalid] [Email: ${decodedEmail}]`,
+    );
+    return new Error(invalidEmailVerificationMessage);
+  }
+
+  const tokenUserId = emailVerificationData.userId?.toString();
+  const userId = user._id?.toString();
+  if (!tokenUserId || tokenUserId !== userId) {
+    logger.warn(`[verifyEmail] [Email verification token user mismatch] [Email: ${decodedEmail}]`);
+    return new Error(invalidEmailVerificationMessage);
   }
 
   const isValid = bcrypt.compareSync(token, emailVerificationData.token);
@@ -174,7 +199,13 @@ const verifyEmail = async (req) => {
     logger.warn(
       `[verifyEmail] [Invalid or expired email verification token] [Email: ${decodedEmail}]`,
     );
-    return new Error('Invalid or expired email verification token');
+    return new Error(invalidEmailVerificationMessage);
+  }
+
+  if (user.emailVerified) {
+    await deleteTokens({ token: emailVerificationData.token });
+    logger.info(`[verifyEmail] Email already verified [Email: ${decodedEmail}]`);
+    return { message: 'Email verification was successful', status: 'success' };
   }
 
   const updatedUser = await updateUser(emailVerificationData.userId, { emailVerified: true });

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -70,9 +70,11 @@ const {
   parseCloudFrontCookieScope,
 } = require('@librechat/api');
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 const { logger, getTenantId } = require('@librechat/data-schemas');
 const {
   findUser,
+  findToken,
   createUser,
   updateUser,
   countUsers,
@@ -80,6 +82,7 @@ const {
   generateToken,
   generateRefreshToken,
   createSession,
+  deleteTokens,
 } = require('~/models');
 const { getAppConfig } = require('~/server/services/Config');
 const {
@@ -87,6 +90,7 @@ const {
   requestPasswordReset,
   registerUser,
   setAuthTokens,
+  verifyEmail,
   setCloudFrontAuthCookies,
 } = require('./AuthService');
 
@@ -450,6 +454,83 @@ describe('registerUser', () => {
         provider: 'google',
       }),
     );
+  });
+});
+
+describe('verifyEmail', () => {
+  const email = 'user@example.com';
+  const encodedEmail = encodeURIComponent(email);
+  const invalidEmailVerificationMessage = 'Invalid or expired email verification token';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not reveal that an account is already verified without a valid token', async () => {
+    findUser.mockResolvedValue({ _id: 'user-id', email, emailVerified: true });
+    findToken.mockResolvedValue(null);
+
+    const result = await verifyEmail({ body: { email: encodedEmail, token: 'not-the-token' } });
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe(invalidEmailVerificationMessage);
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
+  it('returns the same generic error for missing users and invalid tokens', async () => {
+    findUser.mockResolvedValueOnce(null);
+
+    const missingUserResult = await verifyEmail({
+      body: { email: encodedEmail, token: 'not-the-token' },
+    });
+
+    findUser.mockResolvedValueOnce({ _id: 'user-id', email, emailVerified: false });
+    findToken.mockResolvedValueOnce({
+      userId: 'user-id',
+      email,
+      token: bcrypt.hashSync('real-token', 10),
+    });
+
+    const invalidTokenResult = await verifyEmail({
+      body: { email: encodedEmail, token: 'not-the-token' },
+    });
+
+    expect(missingUserResult).toBeInstanceOf(Error);
+    expect(invalidTokenResult).toBeInstanceOf(Error);
+    expect(missingUserResult.message).toBe(invalidEmailVerificationMessage);
+    expect(invalidTokenResult.message).toBe(invalidEmailVerificationMessage);
+  });
+
+  it('verifies an unverified account when the token is valid', async () => {
+    const hashedToken = bcrypt.hashSync('real-token', 10);
+    findUser.mockResolvedValue({ _id: 'user-id', email, emailVerified: false });
+    findToken.mockResolvedValue({ userId: 'user-id', email, token: hashedToken });
+    updateUser.mockResolvedValue({ _id: 'user-id', emailVerified: true });
+
+    const result = await verifyEmail({ body: { email: encodedEmail, token: 'real-token' } });
+
+    expect(result).toEqual({
+      message: 'Email verification was successful',
+      status: 'success',
+    });
+    expect(updateUser).toHaveBeenCalledWith('user-id', { emailVerified: true });
+    expect(deleteTokens).toHaveBeenCalledWith({ token: hashedToken });
+  });
+
+  it('allows idempotent success only when an already verified account presents a valid token', async () => {
+    const hashedToken = bcrypt.hashSync('real-token', 10);
+    findUser.mockResolvedValue({ _id: 'user-id', email, emailVerified: true });
+    findToken.mockResolvedValue({ userId: 'user-id', email, token: hashedToken });
+
+    const result = await verifyEmail({ body: { email: encodedEmail, token: 'real-token' } });
+
+    expect(result).toEqual({
+      message: 'Email verification was successful',
+      status: 'success',
+    });
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(deleteTokens).toHaveBeenCalledWith({ token: hashedToken });
   });
 });
 

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -518,6 +518,19 @@ describe('verifyEmail', () => {
     expect(deleteTokens).toHaveBeenCalledWith({ token: hashedToken });
   });
 
+  it('returns the generic error when a valid verification update fails', async () => {
+    const hashedToken = bcrypt.hashSync('real-token', 10);
+    findUser.mockResolvedValue({ _id: 'user-id', email, emailVerified: false });
+    findToken.mockResolvedValue({ userId: 'user-id', email, token: hashedToken });
+    updateUser.mockResolvedValue(null);
+
+    const result = await verifyEmail({ body: { email: encodedEmail, token: 'real-token' } });
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe(invalidEmailVerificationMessage);
+    expect(deleteTokens).not.toHaveBeenCalled();
+  });
+
   it('allows idempotent success only when an already verified account presents a valid token', async () => {
     const hashedToken = bcrypt.hashSync('real-token', 10);
     findUser.mockResolvedValue({ _id: 'user-id', email, emailVerified: true });


### PR DESCRIPTION
I normalized verification-flow error handling so public responses stay consistent while preserving successful completion behavior.

- Consolidated invalid verification attempts behind one client-facing failure message.
- Required a valid stored token tied to the account before returning success, including already-completed flows.
- Serialized controller errors as explicit `{ message }` responses for predictable clients.
- Added backend regression coverage for invalid states, valid verification, and idempotent valid-token completion.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci` to install the workspace dependencies.
- Ran `npm run build:data-provider`.
- Ran `npm run build:data-schemas`.
- Ran `npm run build:api`.
- Ran `cd api && npm test -- server/services/AuthService.spec.js server/controllers/UserController.spec.js --runInBand`.
- Ran `npx eslint api/server/services/AuthService.js api/server/services/AuthService.spec.js api/server/controllers/UserController.js api/server/controllers/UserController.spec.js`.
- Ran `npx prettier --check api/server/services/AuthService.js api/server/services/AuthService.spec.js api/server/controllers/UserController.js api/server/controllers/UserController.spec.js`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js workspace dependencies installed with `npm ci`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes