### PR TITLE
🩹 fix: Bump GitNexus to 1.6.5 and Fail-Soft the PR Index Job

### DIFF
--- a/.do/gitnexus/Dockerfile
+++ b/.do/gitnexus/Dockerfile
@@ -7,7 +7,7 @@
 
 FROM node:24.16.0-slim
 
-ARG GITNEXUS_VERSION=1.5.3
+ARG GITNEXUS_VERSION=1.6.5
 
 # 1. Build native addons with Bookworm toolchain, then remove build tools.
 #    curl stays for the docker healthcheck; Caddy lives in its own container.

--- a/.do/gitnexus/Dockerfile
+++ b/.do/gitnexus/Dockerfile
@@ -8,12 +8,17 @@
 FROM node:24.16.0-slim
 
 ARG GITNEXUS_VERSION=1.6.5
+# Pin the native DB to match the index workflow; gitnexus's ^0.16.1 range
+# would otherwise let the served image drift from the CI-produced index.
+ARG LADYBUG_VERSION=0.16.1
 
 # 1. Build native addons with Bookworm toolchain, then remove build tools.
 #    curl stays for the docker healthcheck; Caddy lives in its own container.
+#    LadybugDB is pinned nested under gitnexus so step 3's require() resolves it.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ curl \
     && npm install -g gitnexus@${GITNEXUS_VERSION} \
+    && npm install --no-save --prefix /usr/local/lib/node_modules/gitnexus "@ladybugdb/core@${LADYBUG_VERSION}" \
     && apt-get purge -y --auto-remove python3 make g++ \
     && rm -rf /var/lib/apt/lists/* /root/.npm
 
@@ -26,16 +31,12 @@ RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.
     && rm -rf /var/lib/apt/lists/*
 
 # 3. Pre-install LadybugDB FTS + vector extensions so ~/.kuzu/extension/
-#    is baked into the image. Workaround for upstream GitNexus 1.5.3 bug.
+#    is baked into the image. gitnexus serve loads extensions with a
+#    load-only policy and never installs them at runtime, so the cache
+#    must already exist. (GitNexus 1.6.5 loads the vector extension itself
+#    via loadVectorExtension — no adapter patch needed.)
 COPY install-extensions.js /tmp/install-extensions.js
 RUN node /tmp/install-extensions.js && rm -rf /tmp/install-extensions.js /tmp/lbug-ext-install
-
-# 4. Patch lbug-adapter.js to also LOAD EXTENSION vector after FTS.
-RUN LBUG_ADAPTER=/usr/local/lib/node_modules/gitnexus/dist/mcp/core/lbug-adapter.js \
-    && grep -q "LOAD EXTENSION fts" "$LBUG_ADAPTER" \
-    && sed -i "s|await available\[0\]\.query('LOAD EXTENSION fts');|await available[0].query('LOAD EXTENSION fts'); try { await available[0].query('LOAD EXTENSION vector'); } catch (e) { /* vector extension may not be installed */ }|g" "$LBUG_ADAPTER" \
-    && grep -c "LOAD EXTENSION vector" "$LBUG_ADAPTER" \
-    && echo "lbug-adapter.js patched to load vector extension"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -84,7 +84,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GITNEXUS_VERSION: '1.5.3'
+  GITNEXUS_VERSION: '1.6.5'
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/librechat-gitnexus
 
 jobs:

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -43,7 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GITNEXUS_VERSION: '1.5.3'
+  GITNEXUS_VERSION: '1.6.5'
 
 jobs:
   index:
@@ -64,6 +64,9 @@ jobs:
       github.event.pull_request.user.login == 'danny-avila'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Best-effort index: a tool-internal crash must not block PRs. Fail soft on
+    # PR events; push/dispatch runs still fail loudly so regressions stay visible.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Validate dispatch inputs
         if: github.event_name == 'workflow_dispatch'
@@ -162,7 +165,7 @@ jobs:
             --no-save \
             --no-package-lock \
             "gitnexus@${{ env.GITNEXUS_VERSION }}" \
-            "@ladybugdb/core@0.15.2"
+            "@ladybugdb/core@0.16.1"
           test -x "$RUNNER_TEMP/gitnexus-cli/node_modules/.bin/gitnexus"
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

The **GitNexus Index** workflow started failing on most PRs (and on `dev`/`main` push runs) at the `Run GitNexus Analyze` step. This bumps the pinned GitNexus CLI to fix the crash and makes the PR index job fail-soft so a future tool-internal crash never blocks PRs again.

## Root cause

The failure is **inside the pinned `gitnexus@1.5.3` CLI**, not in any PR or in our workflow logic. Reproduced locally on this repo with Node v24.16.0 (CI's version): the swallowed stack trace points at `core/ingestion/pipeline.js`:

```js
deferredWorkerCalls.push(...chunkWorkerData.calls);   // chunk 0: calls = 125,384
```

`arr.push(...hugeArray)` passes every element as a separate function argument. Once a chunk's extracted-call count exceeds V8's argument-count limit, the spread-push throws `RangeError: Maximum call stack size exceeded` — a misleading message that has nothing to do with stack depth (bumping `--stack-size` + `ulimit -s` does **not** help; confirmed). It is **deterministic on repo size, not flaky**: LibreChat grew past the threshold, so it fails "more often" as more branches cross it.

Confirmation: patching those spread-pushes to loop-pushes locally made the same run succeed.

## The fix

`gitnexus@1.6.5` (latest stable) refactored that path — the `.calls` spread-pushes are gone — and indexes this repo cleanly (44,203 nodes, exit 0). The version is pinned in three places that must move in lockstep, since the deployed server reads the indexer's artifact and an index written by 1.6.5 may not load in a 1.5.3 server:

- `gitnexus-index.yml`: `GITNEXUS_VERSION` → `1.6.5`, co-pinned `@ladybugdb/core` → `0.16.1` (what 1.6.5 resolves to)
- `gitnexus-deploy.yml`: `GITNEXUS_VERSION` → `1.6.5` (image tag + build-arg)
- `.do/gitnexus/Dockerfile`: `ARG GITNEXUS_VERSION` default → `1.6.5`

## Prevent recurrence

Added `continue-on-error: ${{ github.event_name == 'pull_request' }}` to the index job. A best-effort code index must not block PRs on a tool-internal crash. `push`, `workflow_dispatch`, and `/gitnexus` command runs still **fail loudly**, so regressions stay visible and the deploy-gating / completion-comment logic (which only runs on dispatch) stays correct.

## Follow-ups (not in this PR)

- A separate, Linux-only native crash (`free(): invalid pointer`) was seen during the **embeddings** phase on the `dev` push. It's distinct from the spread-push overflow and couldn't be reproduced on macOS — the embedding-enabled `dev`/`main` push runs should be re-checked after this lands.
- The Dockerfile's `libstdc++` upgrade and the "GitNexus 1.5.3 bug" extension-cache workaround should be re-verified against 1.6.5 / `@ladybugdb/core` 0.16.1 when the deploy image is rebuilt.
- The real fix belongs upstream in GitNexus: replace `target.push(...src)` with a loop/batched append wherever `src` can be large (the same antipattern appears in ~30 spots across the ingestion layer).