### PR TITLE
🏛️ refactor: Prioritize Deployment Skills over Persisted Duplicates

### DIFF
--- a/packages/api/src/skills/__tests__/deployment.test.ts
+++ b/packages/api/src/skills/__tests__/deployment.test.ts
@@ -393,7 +393,7 @@ describe('createDeploymentSkillMethods', () => {
 
     const methods = createDeploymentSkillMethods(base);
     const mergedIds = mergeDeploymentSkillIds([dbId, otherId]);
-    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
 
     const byName = await methods.getSkillByName?.(shadowedSkill.name, mergedIds, {
       preferUserInvocable: true,

--- a/packages/api/src/skills/__tests__/deployment.test.ts
+++ b/packages/api/src/skills/__tests__/deployment.test.ts
@@ -324,4 +324,101 @@ describe('createDeploymentSkillMethods', () => {
       (await methods.getSkillFileByPath?.(deploymentId, 'references/guide.txt'))?.codeEnvRef,
     ).toEqual(codeEnvRef);
   });
+
+  it('lets deployment skills shadow persisted skills with the same name', async () => {
+    const root = await makeTempRoot();
+    await writeDeploymentSkill(root, {
+      skillsDir: 'config/skills',
+      name: 'analysis-kit',
+      alwaysApply: true,
+    });
+    await initializeDeploymentSkills({
+      projectRoot: root,
+      env: { [DEPLOYMENT_SKILLS_DIR_ENV]: 'config/skills' },
+    });
+
+    const deploymentId = getDeploymentSkillIds()[0];
+    const dbId = new Types.ObjectId();
+    const otherId = new Types.ObjectId();
+    const dbAuthor = new Types.ObjectId();
+    const shadowedSkill = {
+      _id: dbId,
+      name: 'analysis-kit',
+      description: 'A persisted duplicate skill.',
+      body: 'persisted duplicate body',
+      author: dbAuthor,
+      version: 9,
+      fileCount: 0,
+      updatedAt: new Date(Date.now() + 60_000),
+    };
+    const otherSkill = {
+      _id: otherId,
+      name: 'db-skill',
+      description: 'A persisted non-duplicate skill.',
+      body: 'persisted body',
+      author: dbAuthor,
+      version: 1,
+      fileCount: 0,
+      updatedAt: new Date(0),
+    };
+    const base: DeploymentSkillBaseMethods = {
+      getSkillByName: jest.fn(async (name) => (name === shadowedSkill.name ? shadowedSkill : null)),
+      listSkillsByAccess: jest.fn(async () => ({
+        skills: [shadowedSkill, otherSkill],
+        has_more: false,
+        after: null,
+      })),
+      listAlwaysApplySkills: jest.fn(async () => ({
+        skills: [
+          {
+            _id: dbId,
+            name: shadowedSkill.name,
+            body: shadowedSkill.body,
+            author: dbAuthor,
+            updatedAt: shadowedSkill.updatedAt,
+          },
+          {
+            _id: otherId,
+            name: 'db-always',
+            body: 'db always',
+            author: dbAuthor,
+            updatedAt: otherSkill.updatedAt,
+          },
+        ],
+        has_more: false,
+        after: null,
+      })),
+    };
+
+    const methods = createDeploymentSkillMethods(base);
+    const mergedIds = mergeDeploymentSkillIds([dbId, otherId]);
+
+    const byName = await methods.getSkillByName?.(shadowedSkill.name, mergedIds, {
+      preferUserInvocable: true,
+    });
+    expect(byName).toMatchObject({
+      _id: deploymentId,
+      name: shadowedSkill.name,
+      source: 'deployment',
+    });
+    expect(base.getSkillByName).not.toHaveBeenCalled();
+
+    const listed = await methods.listSkillsByAccess?.({
+      accessibleIds: mergedIds,
+      limit: 10,
+    });
+    expect(listed?.skills.map((skill) => [skill.name, skill._id.toString()]).sort()).toEqual([
+      ['analysis-kit', deploymentId.toString()],
+      ['db-skill', otherId.toString()],
+    ]);
+
+    const alwaysApply = await methods.listAlwaysApplySkills?.({
+      accessibleIds: mergedIds,
+      limit: 10,
+    });
+    expect(alwaysApply?.skills.map((skill) => [skill.name, skill._id.toString()]).sort()).toEqual([
+      ['analysis-kit', deploymentId.toString()],
+      ['db-always', otherId.toString()],
+    ]);
+  });
 });

--- a/packages/api/src/skills/__tests__/deployment.test.ts
+++ b/packages/api/src/skills/__tests__/deployment.test.ts
@@ -444,4 +444,77 @@ describe('createDeploymentSkillMethods', () => {
     );
     warnSpy.mockRestore();
   });
+
+  it('preserves pagination when an always-apply DB page only contains shadowed skills', async () => {
+    const root = await makeTempRoot();
+    await writeDeploymentSkill(root, {
+      skillsDir: 'config/skills',
+      name: 'analysis-kit',
+      alwaysApply: false,
+    });
+    await initializeDeploymentSkills({
+      projectRoot: root,
+      env: { [DEPLOYMENT_SKILLS_DIR_ENV]: 'config/skills' },
+    });
+
+    const dbId = new Types.ObjectId();
+    const nextId = new Types.ObjectId();
+    const dbAuthor = new Types.ObjectId();
+    const shadowedSkill = {
+      _id: dbId,
+      name: 'analysis-kit',
+      body: 'persisted duplicate body',
+      author: dbAuthor,
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    };
+    const nextSkill = {
+      _id: nextId,
+      name: 'db-next',
+      body: 'next persisted body',
+      author: dbAuthor,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+    const base: DeploymentSkillBaseMethods = {
+      listAlwaysApplySkills: jest.fn(async (params) => {
+        if (params.cursor) {
+          return {
+            skills: [nextSkill],
+            has_more: false,
+            after: null,
+          };
+        }
+        return {
+          skills: [shadowedSkill],
+          has_more: true,
+          after: 'db-cursor',
+        };
+      }),
+    };
+
+    const methods = createDeploymentSkillMethods(base);
+    const mergedIds = mergeDeploymentSkillIds([dbId, nextId]);
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    const first = await methods.listAlwaysApplySkills?.({
+      accessibleIds: mergedIds,
+      limit: 1,
+    });
+    expect(first?.skills).toEqual([]);
+    expect(first?.has_more).toBe(true);
+    expect(first?.after).toEqual(expect.any(String));
+
+    const second = await methods.listAlwaysApplySkills?.({
+      accessibleIds: mergedIds,
+      limit: 1,
+      cursor: first?.after,
+    });
+    expect(second?.skills.map((skill) => skill.name)).toEqual(['db-next']);
+    expect(second?.has_more).toBe(false);
+    expect(base.listAlwaysApplySkills).toHaveBeenNthCalledWith(2, {
+      accessibleIds: [dbId, nextId],
+      limit: 1,
+      cursor: first?.after,
+    });
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/api/src/skills/__tests__/deployment.test.ts
+++ b/packages/api/src/skills/__tests__/deployment.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { Types } from 'mongoose';
 import type { CodeEnvRef } from 'librechat-data-provider';
+import type { DeploymentSkillBaseMethods } from '../deployment';
 import {
   DEPLOYMENT_SKILLS_DIR_ENV,
   createDeploymentSkillMethods,
@@ -12,7 +13,6 @@ import {
   mergeDeploymentSkillIds,
   resolveDeploymentSkillDirectory,
 } from '../deployment';
-import type { DeploymentSkillBaseMethods } from '../deployment';
 
 const DESCRIPTION = 'Use this skill when the deployment needs a shared testing fixture.';
 

--- a/packages/api/src/skills/__tests__/deployment.test.ts
+++ b/packages/api/src/skills/__tests__/deployment.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { Types } from 'mongoose';
+import { logger } from '@librechat/data-schemas';
 import type { CodeEnvRef } from 'librechat-data-provider';
 import type { DeploymentSkillBaseMethods } from '../deployment';
 import {
@@ -392,6 +393,7 @@ describe('createDeploymentSkillMethods', () => {
 
     const methods = createDeploymentSkillMethods(base);
     const mergedIds = mergeDeploymentSkillIds([dbId, otherId]);
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
 
     const byName = await methods.getSkillByName?.(shadowedSkill.name, mergedIds, {
       preferUserInvocable: true,
@@ -412,6 +414,16 @@ describe('createDeploymentSkillMethods', () => {
       ['db-skill', otherId.toString()],
     ]);
 
+    await methods.listSkillsByAccess?.({
+      accessibleIds: mergedIds,
+      limit: 10,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('persisted list skill row(s) shadowed'),
+    );
+
     const alwaysApply = await methods.listAlwaysApplySkills?.({
       accessibleIds: mergedIds,
       limit: 10,
@@ -420,5 +432,16 @@ describe('createDeploymentSkillMethods', () => {
       ['analysis-kit', deploymentId.toString()],
       ['db-always', otherId.toString()],
     ]);
+
+    await methods.listAlwaysApplySkills?.({
+      accessibleIds: mergedIds,
+      limit: 10,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('persisted always-apply skill row(s) shadowed'),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/packages/api/src/skills/__tests__/deployment.test.ts
+++ b/packages/api/src/skills/__tests__/deployment.test.ts
@@ -65,6 +65,15 @@ async function writeDeploymentSkill(
   return skillDir;
 }
 
+function encodeTestCursor(row: { _id: Types.ObjectId; updatedAt: Date }): string {
+  return Buffer.from(
+    JSON.stringify({
+      updatedAt: row.updatedAt.toISOString(),
+      _id: row._id.toString(),
+    }),
+  ).toString('base64');
+}
+
 afterEach(async () => {
   const emptyRoot = await makeTempRoot();
   await initializeDeploymentSkills({ projectRoot: emptyRoot, env: {} });
@@ -460,20 +469,20 @@ describe('createDeploymentSkillMethods', () => {
     const dbId = new Types.ObjectId();
     const nextId = new Types.ObjectId();
     const dbAuthor = new Types.ObjectId();
+    const shadowedUpdatedAt = new Date('2026-01-02T00:00:00.000Z');
     const shadowedSkill = {
       _id: dbId,
       name: 'analysis-kit',
       body: 'persisted duplicate body',
       author: dbAuthor,
-      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
     };
     const nextSkill = {
       _id: nextId,
       name: 'db-next',
       body: 'next persisted body',
       author: dbAuthor,
-      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
     };
+    const shadowedCursor = encodeTestCursor({ _id: dbId, updatedAt: shadowedUpdatedAt });
     const base: DeploymentSkillBaseMethods = {
       listAlwaysApplySkills: jest.fn(async (params) => {
         if (params.cursor) {
@@ -486,7 +495,7 @@ describe('createDeploymentSkillMethods', () => {
         return {
           skills: [shadowedSkill],
           has_more: true,
-          after: 'db-cursor',
+          after: shadowedCursor,
         };
       }),
     };
@@ -501,7 +510,7 @@ describe('createDeploymentSkillMethods', () => {
     });
     expect(first?.skills).toEqual([]);
     expect(first?.has_more).toBe(true);
-    expect(first?.after).toEqual(expect.any(String));
+    expect(first?.after).toBe(shadowedCursor);
 
     const second = await methods.listAlwaysApplySkills?.({
       accessibleIds: mergedIds,
@@ -515,6 +524,92 @@ describe('createDeploymentSkillMethods', () => {
       limit: 1,
       cursor: first?.after,
     });
+    warnSpy.mockRestore();
+  });
+
+  it('waits to return older deployment rows until the DB page boundary advances', async () => {
+    const root = await makeTempRoot();
+    await writeDeploymentSkill(root, {
+      skillsDir: 'config/skills',
+      name: 'analysis-kit',
+      alwaysApply: false,
+    });
+    await initializeDeploymentSkills({
+      projectRoot: root,
+      env: { [DEPLOYMENT_SKILLS_DIR_ENV]: 'config/skills' },
+    });
+
+    const hiddenId = new Types.ObjectId();
+    const visibleId = new Types.ObjectId();
+    const nextId = new Types.ObjectId();
+    const dbAuthor = new Types.ObjectId();
+    const hiddenSkill = {
+      _id: hiddenId,
+      name: 'analysis-kit',
+      description: 'A persisted duplicate skill.',
+      author: dbAuthor,
+      version: 1,
+      fileCount: 0,
+      updatedAt: new Date('2026-12-03T00:00:00.000Z'),
+    };
+    const visibleSkill = {
+      _id: visibleId,
+      name: 'db-visible',
+      description: 'A visible persisted skill.',
+      author: dbAuthor,
+      version: 1,
+      fileCount: 0,
+      updatedAt: new Date('2026-12-02T00:00:00.000Z'),
+    };
+    const nextSkill = {
+      _id: nextId,
+      name: 'db-next',
+      description: 'The next persisted skill.',
+      author: dbAuthor,
+      version: 1,
+      fileCount: 0,
+      updatedAt: new Date('2026-12-01T00:00:00.000Z'),
+    };
+    const visibleCursor = encodeTestCursor({
+      _id: visibleId,
+      updatedAt: visibleSkill.updatedAt,
+    });
+    const base: DeploymentSkillBaseMethods = {
+      listSkillsByAccess: jest.fn(async (params) => {
+        if (params.cursor) {
+          return {
+            skills: [nextSkill],
+            has_more: false,
+            after: null,
+          };
+        }
+        return {
+          skills: [hiddenSkill, visibleSkill],
+          has_more: true,
+          after: visibleCursor,
+        };
+      }),
+    };
+
+    const methods = createDeploymentSkillMethods(base);
+    const mergedIds = mergeDeploymentSkillIds([hiddenId, visibleId, nextId]);
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
+
+    const first = await methods.listSkillsByAccess?.({
+      accessibleIds: mergedIds,
+      limit: 2,
+    });
+    expect(first?.skills.map((skill) => skill.name)).toEqual(['db-visible']);
+    expect(first?.has_more).toBe(true);
+    expect(first?.after).toBe(visibleCursor);
+
+    const second = await methods.listSkillsByAccess?.({
+      accessibleIds: mergedIds,
+      limit: 2,
+      cursor: first?.after,
+    });
+    expect(second?.skills.map((skill) => skill.name)).toEqual(['db-next', 'analysis-kit']);
+    expect(second?.has_more).toBe(false);
     warnSpy.mockRestore();
   });
 });

--- a/packages/api/src/skills/deployment.ts
+++ b/packages/api/src/skills/deployment.ts
@@ -251,6 +251,17 @@ export class DeploymentSkillRegistry {
     return skill;
   }
 
+  namesByAccess(accessibleIds: Types.ObjectId[]): Set<string> {
+    const accessibleSet = new Set(accessibleIds.map((id) => id.toString()));
+    const names = new Set<string>();
+    for (const skill of this.list()) {
+      if (accessibleSet.has(skill._id.toString())) {
+        names.add(skill.name);
+      }
+    }
+    return names;
+  }
+
   listByAccess(params: ListSkillsByAccessParams): DeploymentSkill[] {
     const accessibleSet = new Set(params.accessibleIds.map((id) => id.toString()));
     const cursor = decodeCursor(params.cursor);
@@ -451,14 +462,14 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
       accessibleIds: Types.ObjectId[],
       options?: SkillLookupOptions,
     ): Promise<SkillDetailRow | null> => {
+      const deployment = registry.getByName(name, accessibleIds, options);
+      if (deployment) {
+        return toSkillDetailRow(deployment);
+      }
       const dbSkill = base.getSkillByName
         ? await base.getSkillByName(name, stripDeploymentIds(accessibleIds), options)
         : null;
-      const deployment = registry.getByName(name, accessibleIds, options);
-      return pickPreferredSkill(
-        [dbSkill, deployment ? toSkillDetailRow(deployment) : null],
-        options,
-      );
+      return dbSkill;
     },
     listSkillsByAccess: async (
       params: ListSkillsByAccessParams,
@@ -469,9 +480,14 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
             accessibleIds: stripDeploymentIds(params.accessibleIds),
           })
         : { skills: [], has_more: false, after: null };
+      const deploymentNames = registry.namesByAccess(params.accessibleIds);
+      const deploymentRows = registry.listByAccess(params).map(toSkillSummaryRow);
       return mergeSkillPage({
-        dbResult,
-        deploymentRows: registry.listByAccess(params).map(toSkillSummaryRow),
+        dbResult: {
+          ...dbResult,
+          skills: filterDeploymentNameCollisions(dbResult.skills, deploymentNames, 'list'),
+        },
+        deploymentRows,
         limit: params.limit,
       });
     },
@@ -484,8 +500,12 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
             accessibleIds: stripDeploymentIds(params.accessibleIds),
           })
         : { skills: [], has_more: false, after: null };
+      const deploymentNames = registry.namesByAccess(params.accessibleIds);
       return mergeAlwaysApplyPage({
-        dbResult,
+        dbResult: {
+          ...dbResult,
+          skills: filterDeploymentNameCollisions(dbResult.skills, deploymentNames, 'always-apply'),
+        },
         deploymentRows: registry.listAlwaysApply(params).map(toAlwaysApplyRow),
         limit: params.limit,
       });
@@ -832,31 +852,6 @@ function mergeAlwaysApplyPage({
   };
 }
 
-function pickPreferredSkill(
-  rows: Array<SkillDetailRow | null>,
-  options?: SkillLookupOptions,
-): SkillDetailRow | null {
-  const candidates = rows.filter((row): row is SkillDetailRow => row != null);
-  if (candidates.length === 0) {
-    return null;
-  }
-  const preferred = candidates.filter((row) => matchesLookupPreference(row, options));
-  return (preferred.length > 0 ? preferred : candidates).sort(compareBySkillCursor)[0];
-}
-
-function matchesLookupPreference(
-  row: Pick<SkillSummaryRow, 'disableModelInvocation' | 'userInvocable'>,
-  options?: SkillLookupOptions,
-): boolean {
-  if (options?.preferUserInvocable === true && row.userInvocable === false) {
-    return false;
-  }
-  if (options?.preferModelInvocable === true && row.disableModelInvocation === true) {
-    return false;
-  }
-  return true;
-}
-
 function toSkillSummaryRow(skill: DeploymentSkill): SkillSummaryRow {
   const { body: _body, frontmatter: _frontmatter, files: _files, ...row } = skill;
   return row;
@@ -900,6 +895,31 @@ function stripDeploymentIds(ids: Types.ObjectId[]): Types.ObjectId[] {
 function hasAccessibleId(ids: Types.ObjectId[], skillId: Types.ObjectId): boolean {
   const key = skillId.toString();
   return ids.some((id) => id.toString() === key);
+}
+
+function filterDeploymentNameCollisions<T extends { name: string }>(
+  rows: T[],
+  deploymentNames: Set<string>,
+  context: string,
+): T[] {
+  if (rows.length === 0 || deploymentNames.size === 0) {
+    return rows;
+  }
+  const hiddenNames = new Set<string>();
+  const filtered = rows.filter((row) => {
+    if (!deploymentNames.has(row.name)) {
+      return true;
+    }
+    hiddenNames.add(row.name);
+    return false;
+  });
+  if (hiddenNames.size > 0) {
+    const hiddenList = Array.from(hiddenNames).join(', ');
+    logger.warn(
+      `[deploymentSkills] Hid ${rows.length - filtered.length} persisted ${context} skill row(s) shadowed by deployment skill name(s): ${hiddenList}`,
+    );
+  }
+  return filtered;
 }
 
 function compareBySkillCursor(

--- a/packages/api/src/skills/deployment.ts
+++ b/packages/api/src/skills/deployment.ts
@@ -182,9 +182,8 @@ export type DeploymentSkillBaseMethods = {
 };
 
 type Cursor = { updatedAt: Date; _id: Types.ObjectId };
-type CollisionFilterResult<T extends Pick<SkillSummaryRow, '_id' | 'updatedAt'>> = {
+type CollisionFilterResult<T> = {
   rows: T[];
-  cursorFallback: T | null;
 };
 
 type LoadDeploymentSkillsOptions = {
@@ -487,13 +486,17 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
         : { skills: [], has_more: false, after: null };
       const deploymentNames = registry.namesByAccess(params.accessibleIds);
       const filteredDb = filterDeploymentNameCollisions(dbResult.skills, deploymentNames, 'list');
-      const deploymentRows = registry.listByAccess(params).map(toSkillSummaryRow);
+      const dbPageBoundary = getDbPageBoundary(dbResult);
+      const deploymentRows = limitRowsToDbPageBoundary(
+        registry.listByAccess(params).map(toSkillSummaryRow),
+        dbPageBoundary,
+      );
       return mergeSkillPage({
         dbResult: {
           ...dbResult,
           skills: filteredDb.rows,
         },
-        dbCursorFallback: filteredDb.cursorFallback,
+        dbPageBoundary,
         deploymentRows,
         limit: params.limit,
       });
@@ -513,13 +516,17 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
         deploymentNames,
         'always-apply',
       );
+      const dbPageBoundary = getDbPageBoundary(dbResult);
       return mergeAlwaysApplyPage({
         dbResult: {
           ...dbResult,
           skills: filteredDb.rows,
         },
-        dbCursorFallback: filteredDb.cursorFallback,
-        deploymentRows: registry.listAlwaysApply(params).map(toAlwaysApplyRow),
+        dbPageBoundary,
+        deploymentRows: limitRowsToDbPageBoundary(
+          registry.listAlwaysApply(params).map(toAlwaysApplyRow),
+          dbPageBoundary,
+        ),
         limit: params.limit,
       });
     },
@@ -827,12 +834,12 @@ function validateUniqueNames(skills: DeploymentSkill[]): void {
 
 function mergeSkillPage({
   dbResult,
-  dbCursorFallback,
+  dbPageBoundary,
   deploymentRows,
   limit,
 }: {
   dbResult: ListSkillsByAccessResult;
-  dbCursorFallback?: SkillSummaryRow | null;
+  dbPageBoundary?: Cursor | null;
   deploymentRows: SkillSummaryRow[];
   limit: number;
 }): ListSkillsByAccessResult {
@@ -840,7 +847,7 @@ function mergeSkillPage({
   const merged = [...deploymentRows, ...dbResult.skills].sort(compareBySkillCursor);
   const sliced = merged.slice(0, boundedLimit);
   const hasMore = merged.length > boundedLimit || dbResult.has_more === true;
-  const cursorRow = getMergedPageCursor(sliced, boundedLimit, dbCursorFallback);
+  const cursorRow = getMergedPageCursor(sliced, boundedLimit, dbPageBoundary);
   return {
     skills: sliced,
     has_more: hasMore,
@@ -850,12 +857,12 @@ function mergeSkillPage({
 
 function mergeAlwaysApplyPage({
   dbResult,
-  dbCursorFallback,
+  dbPageBoundary,
   deploymentRows,
   limit,
 }: {
   dbResult: ListAlwaysApplyResult;
-  dbCursorFallback?: AlwaysApplySkillRow | null;
+  dbPageBoundary?: Cursor | null;
   deploymentRows: AlwaysApplySkillRow[];
   limit: number;
 }): ListAlwaysApplyResult {
@@ -863,7 +870,7 @@ function mergeAlwaysApplyPage({
   const merged = [...deploymentRows, ...dbResult.skills].sort(compareBySkillCursor);
   const sliced = merged.slice(0, boundedLimit);
   const hasMore = merged.length > boundedLimit || dbResult.has_more === true;
-  const cursorRow = getMergedPageCursor(sliced, boundedLimit, dbCursorFallback);
+  const cursorRow = getMergedPageCursor(sliced, boundedLimit, dbPageBoundary);
   return {
     skills: sliced,
     has_more: hasMore,
@@ -874,16 +881,38 @@ function mergeAlwaysApplyPage({
 function getMergedPageCursor<T extends Pick<SkillSummaryRow, '_id' | 'updatedAt'>>(
   sliced: T[],
   boundedLimit: number,
-  dbCursorFallback?: T | null,
-): T | null {
+  dbPageBoundary?: Cursor | null,
+): Pick<SkillSummaryRow, '_id' | 'updatedAt'> | null {
   const lastReturned = sliced.length > 0 ? sliced[sliced.length - 1] : null;
-  if (sliced.length >= boundedLimit || !dbCursorFallback) {
-    return lastReturned;
+  if (sliced.length < boundedLimit && dbPageBoundary) {
+    return dbPageBoundary;
   }
-  if (!lastReturned) {
-    return dbCursorFallback;
+  return lastReturned;
+}
+
+function getDbPageBoundary<T extends Pick<SkillSummaryRow, '_id' | 'updatedAt'>>(dbResult: {
+  skills: T[];
+  has_more?: boolean;
+  after?: string | null;
+}): Cursor | null {
+  if (dbResult.has_more !== true) {
+    return null;
   }
-  return compareBySkillCursor(dbCursorFallback, lastReturned) > 0 ? dbCursorFallback : lastReturned;
+  const last = dbResult.skills.length > 0 ? dbResult.skills[dbResult.skills.length - 1] : null;
+  if (last?.updatedAt) {
+    return { _id: last._id, updatedAt: last.updatedAt };
+  }
+  return decodeCursor(dbResult.after);
+}
+
+function limitRowsToDbPageBoundary<T extends Pick<SkillSummaryRow, '_id' | 'updatedAt'>>(
+  rows: T[],
+  dbPageBoundary: Cursor | null,
+): T[] {
+  if (!dbPageBoundary) {
+    return rows;
+  }
+  return rows.filter((row) => compareBySkillCursor(row, dbPageBoundary) <= 0);
 }
 
 function toSkillSummaryRow(skill: DeploymentSkill): SkillSummaryRow {
@@ -935,7 +964,7 @@ function filterDeploymentNameCollisions<
   T extends { name: string } & Pick<SkillSummaryRow, '_id' | 'updatedAt'>,
 >(rows: T[], deploymentNames: Set<string>, context: string): CollisionFilterResult<T> {
   if (rows.length === 0 || deploymentNames.size === 0) {
-    return { rows, cursorFallback: null };
+    return { rows };
   }
   const hiddenNames = new Set<string>();
   const filtered = rows.filter((row) => {
@@ -960,10 +989,7 @@ function filterDeploymentNameCollisions<
       );
     }
   }
-  return {
-    rows: filtered,
-    cursorFallback: hiddenNames.size > 0 ? rows[rows.length - 1] : null,
-  };
+  return { rows: filtered };
 }
 
 function compareBySkillCursor(

--- a/packages/api/src/skills/deployment.ts
+++ b/packages/api/src/skills/deployment.ts
@@ -182,6 +182,10 @@ export type DeploymentSkillBaseMethods = {
 };
 
 type Cursor = { updatedAt: Date; _id: Types.ObjectId };
+type CollisionFilterResult<T extends Pick<SkillSummaryRow, '_id' | 'updatedAt'>> = {
+  rows: T[];
+  cursorFallback: T | null;
+};
 
 type LoadDeploymentSkillsOptions = {
   projectRoot?: string;
@@ -482,12 +486,14 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
           })
         : { skills: [], has_more: false, after: null };
       const deploymentNames = registry.namesByAccess(params.accessibleIds);
+      const filteredDb = filterDeploymentNameCollisions(dbResult.skills, deploymentNames, 'list');
       const deploymentRows = registry.listByAccess(params).map(toSkillSummaryRow);
       return mergeSkillPage({
         dbResult: {
           ...dbResult,
-          skills: filterDeploymentNameCollisions(dbResult.skills, deploymentNames, 'list'),
+          skills: filteredDb.rows,
         },
+        dbCursorFallback: filteredDb.cursorFallback,
         deploymentRows,
         limit: params.limit,
       });
@@ -502,11 +508,17 @@ export function createDeploymentSkillMethods<T extends DeploymentSkillBaseMethod
           })
         : { skills: [], has_more: false, after: null };
       const deploymentNames = registry.namesByAccess(params.accessibleIds);
+      const filteredDb = filterDeploymentNameCollisions(
+        dbResult.skills,
+        deploymentNames,
+        'always-apply',
+      );
       return mergeAlwaysApplyPage({
         dbResult: {
           ...dbResult,
-          skills: filterDeploymentNameCollisions(dbResult.skills, deploymentNames, 'always-apply'),
+          skills: filteredDb.rows,
         },
+        dbCursorFallback: filteredDb.cursorFallback,
         deploymentRows: registry.listAlwaysApply(params).map(toAlwaysApplyRow),
         limit: params.limit,
       });
@@ -815,10 +827,12 @@ function validateUniqueNames(skills: DeploymentSkill[]): void {
 
 function mergeSkillPage({
   dbResult,
+  dbCursorFallback,
   deploymentRows,
   limit,
 }: {
   dbResult: ListSkillsByAccessResult;
+  dbCursorFallback?: SkillSummaryRow | null;
   deploymentRows: SkillSummaryRow[];
   limit: number;
 }): ListSkillsByAccessResult {
@@ -826,19 +840,22 @@ function mergeSkillPage({
   const merged = [...deploymentRows, ...dbResult.skills].sort(compareBySkillCursor);
   const sliced = merged.slice(0, boundedLimit);
   const hasMore = merged.length > boundedLimit || dbResult.has_more === true;
+  const cursorRow = getMergedPageCursor(sliced, boundedLimit, dbCursorFallback);
   return {
     skills: sliced,
     has_more: hasMore,
-    after: hasMore && sliced.length > 0 ? encodeCursor(sliced[sliced.length - 1]) : null,
+    after: hasMore && cursorRow ? encodeCursor(cursorRow) : null,
   };
 }
 
 function mergeAlwaysApplyPage({
   dbResult,
+  dbCursorFallback,
   deploymentRows,
   limit,
 }: {
   dbResult: ListAlwaysApplyResult;
+  dbCursorFallback?: AlwaysApplySkillRow | null;
   deploymentRows: AlwaysApplySkillRow[];
   limit: number;
 }): ListAlwaysApplyResult {
@@ -846,11 +863,27 @@ function mergeAlwaysApplyPage({
   const merged = [...deploymentRows, ...dbResult.skills].sort(compareBySkillCursor);
   const sliced = merged.slice(0, boundedLimit);
   const hasMore = merged.length > boundedLimit || dbResult.has_more === true;
+  const cursorRow = getMergedPageCursor(sliced, boundedLimit, dbCursorFallback);
   return {
     skills: sliced,
     has_more: hasMore,
-    after: hasMore && sliced.length > 0 ? encodeCursor(sliced[sliced.length - 1]) : null,
+    after: hasMore && cursorRow ? encodeCursor(cursorRow) : null,
   };
+}
+
+function getMergedPageCursor<T extends Pick<SkillSummaryRow, '_id' | 'updatedAt'>>(
+  sliced: T[],
+  boundedLimit: number,
+  dbCursorFallback?: T | null,
+): T | null {
+  const lastReturned = sliced.length > 0 ? sliced[sliced.length - 1] : null;
+  if (sliced.length >= boundedLimit || !dbCursorFallback) {
+    return lastReturned;
+  }
+  if (!lastReturned) {
+    return dbCursorFallback;
+  }
+  return compareBySkillCursor(dbCursorFallback, lastReturned) > 0 ? dbCursorFallback : lastReturned;
 }
 
 function toSkillSummaryRow(skill: DeploymentSkill): SkillSummaryRow {
@@ -898,13 +931,11 @@ function hasAccessibleId(ids: Types.ObjectId[], skillId: Types.ObjectId): boolea
   return ids.some((id) => id.toString() === key);
 }
 
-function filterDeploymentNameCollisions<T extends { name: string }>(
-  rows: T[],
-  deploymentNames: Set<string>,
-  context: string,
-): T[] {
+function filterDeploymentNameCollisions<
+  T extends { name: string } & Pick<SkillSummaryRow, '_id' | 'updatedAt'>,
+>(rows: T[], deploymentNames: Set<string>, context: string): CollisionFilterResult<T> {
   if (rows.length === 0 || deploymentNames.size === 0) {
-    return rows;
+    return { rows, cursorFallback: null };
   }
   const hiddenNames = new Set<string>();
   const filtered = rows.filter((row) => {
@@ -929,7 +960,10 @@ function filterDeploymentNameCollisions<T extends { name: string }>(
       );
     }
   }
-  return filtered;
+  return {
+    rows: filtered,
+    cursorFallback: hiddenNames.size > 0 ? rows[rows.length - 1] : null,
+  };
 }
 
 function compareBySkillCursor(

--- a/packages/api/src/skills/deployment.ts
+++ b/packages/api/src/skills/deployment.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import crypto from 'crypto';
 import yaml from 'js-yaml';
+import crypto from 'crypto';
 import { Types } from 'mongoose';
 import {
   logger,

--- a/packages/api/src/skills/deployment.ts
+++ b/packages/api/src/skills/deployment.ts
@@ -327,6 +327,7 @@ export class DeploymentSkillRegistry {
 }
 
 let registry = new DeploymentSkillRegistry(null, []);
+const warnedDeploymentNameCollisions = new Set<string>();
 
 export function getDeploymentSkillRegistry(): DeploymentSkillRegistry {
   return registry;
@@ -914,10 +915,19 @@ function filterDeploymentNameCollisions<T extends { name: string }>(
     return false;
   });
   if (hiddenNames.size > 0) {
-    const hiddenList = Array.from(hiddenNames).join(', ');
-    logger.warn(
-      `[deploymentSkills] Hid ${rows.length - filtered.length} persisted ${context} skill row(s) shadowed by deployment skill name(s): ${hiddenList}`,
-    );
+    const unwarnedNames = Array.from(hiddenNames).filter((name) => {
+      const key = `${context}:${name}`;
+      if (warnedDeploymentNameCollisions.has(key)) {
+        return false;
+      }
+      warnedDeploymentNameCollisions.add(key);
+      return true;
+    });
+    if (unwarnedNames.length > 0) {
+      logger.warn(
+        `[deploymentSkills] Hid persisted ${context} skill row(s) shadowed by deployment skill name(s): ${unwarnedNames.join(', ')}`,
+      );
+    }
   }
   return filtered;
 }


### PR DESCRIPTION
## Summary

I fixed deployment-skill name collisions so deployment-provided skills behave as deterministic instance-level definitions instead of racing persisted skills by `updatedAt`.

- Added accessible deployment skill name tracking in the deployment skill registry.
- Changed `getSkillByName` to return an accessible deployment skill before querying persisted skills with the same name.
- Filtered persisted list and always-apply rows when a deployment skill with the same name is accessible, with warning logs for operator visibility.
- Added focused coverage for name lookup, catalog/list merging, and always-apply merging when persisted duplicates exist.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `eslint packages/api/src/skills/deployment.ts packages/api/src/skills/__tests__/deployment.test.ts`.
- Ran `jest src/skills/__tests__/deployment.test.ts --runInBand --coverage=false` from `packages/api`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js: v24.16.0
- Base branch: `origin/dev`
- Focused package: `packages/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes