### PR TITLE
📌 fix: Preserve Project Scope Through Enforced Model Specs

### DIFF
--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -78,7 +78,7 @@ async function buildEndpointOption(req, res, next) {
     try {
       const result = applyModelSpecPreset({
         modelSpec: currentModelSpec,
-        parsedBody: currentModelSpec.preset,
+        parsedBody,
         endpoint,
         endpointType,
         defaultParamsEndpoint,

--- a/api/server/middleware/buildEndpointOption.spec.js
+++ b/api/server/middleware/buildEndpointOption.spec.js
@@ -189,6 +189,9 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
         endpointType: EModelEndpoint.custom,
         spec: 'claude-opus-4.5',
         model: 'anthropic/claude-opus-4.5',
+        temperature: 0.1,
+        topP: 0.2,
+        chatProjectId: 'project-1',
       },
       {
         modelSpecs: {
@@ -197,6 +200,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
         },
       },
     );
+    req.baseUrl = '/api/agents/chat';
 
     await buildEndpointOption(req, createRes(), jest.fn());
 
@@ -210,7 +214,10 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
     const enforcedResult = parseCompactConvo.mock.results[1].value;
     expect(enforcedResult.maxOutputTokens).toBe(8192);
     expect(enforcedResult.temperature).toBe(0.7);
+    expect(enforcedResult.topP).toBeUndefined();
     expect(enforcedResult.maxContextTokens).toBe(50000);
+    expect(enforcedResult.chatProjectId).toBe('project-1');
+    expect(req.body.endpointOption.chatProjectId).toBe('project-1');
   });
 
   it('should restore private model spec preset fields in non-enforced mode', async () => {

--- a/e2e/config/librechat.e2e.yaml
+++ b/e2e/config/librechat.e2e.yaml
@@ -27,6 +27,8 @@ endpoints:
       modelDisplayLabel: 'Mock Provider B'
 
 modelSpecs:
+  prioritize: true
+  enforce: true
   list:
     - name: 'e2e-mock-provider-a'
       label: 'Mock Provider A'

--- a/e2e/specs/mock/projects.spec.ts
+++ b/e2e/specs/mock/projects.spec.ts
@@ -33,7 +33,7 @@ test.describe('chat projects', () => {
     await expect(page.getByRole('button', { name }).first()).toBeVisible();
   });
 
-  test('starts a project-scoped chat and files it under the project', async ({ page }) => {
+  test('starts a project-scoped chat and persists it under the project', async ({ page }) => {
     test.setTimeout(120000);
     const name = uniqueName('E2E Project');
     const projectId = await createProject(page, name);
@@ -64,6 +64,18 @@ test.describe('chat projects', () => {
     const projectRow = page.getByRole('button', { name }).first();
     if ((await projectRow.getAttribute('aria-expanded')) !== 'true') {
       await projectRow.click();
+    }
+    await expect(
+      page.getByTestId(`project-chats-${projectId}`).getByTestId('convo-item').first(),
+    ).toBeVisible();
+
+    const conversationUrl = page.url();
+    await page.reload({ timeout: 10000 });
+    await expect(page).toHaveURL(conversationUrl);
+
+    const reloadedProjectRow = page.getByRole('button', { name }).first();
+    if ((await reloadedProjectRow.getAttribute('aria-expanded')) !== 'true') {
+      await reloadedProjectRow.click();
     }
     await expect(
       page.getByTestId(`project-chats-${projectId}`).getByTestId('convo-item').first(),

--- a/e2e/specs/mock/skill-file-authoring.spec.ts
+++ b/e2e/specs/mock/skill-file-authoring.spec.ts
@@ -92,7 +92,7 @@ test.describe('skill file authoring tools', () => {
     expect(response.ok()).toBeTruthy();
 
     await expect(page).toHaveURL(/\/c\/(?!new)/, { timeout: 15000 });
-    const conversationUrl = page.url();
+    const conversationPath = new URL(page.url()).pathname;
     await expect(
       page.getByTestId('messages-view').getByText(`${FINAL_TEXT}: ${skillName}`),
     ).toBeVisible({ timeout: 30000 });
@@ -113,7 +113,7 @@ test.describe('skill file authoring tools', () => {
     expect(editedSkill.body).toContain(EDITED_DESCRIPTION);
 
     await page.reload({ timeout: 10000 });
-    await expect(page).toHaveURL(conversationUrl);
+    await expect(page).toHaveURL((url) => url.pathname === conversationPath);
     await expect(
       page.getByTestId('messages-view').getByText(`${FINAL_TEXT}: ${skillName}`),
     ).toBeVisible({ timeout: 30000 });

--- a/packages/api/src/modelSpecs/index.ts
+++ b/packages/api/src/modelSpecs/index.ts
@@ -23,6 +23,10 @@ export type PrivateModelSpecPresetField = (typeof PRIVATE_MODEL_SPEC_PRESET_FIEL
 export type ModelSpecParsedBody = Partial<TConversation | TPreset | TModelSpecPreset> &
   Record<string, unknown>;
 
+export const ENFORCED_MODEL_SPEC_REQUEST_FIELDS = [
+  'chatProjectId',
+] as const satisfies readonly (keyof ModelSpecParsedBody)[];
+
 export type ApplyModelSpecPresetParams = {
   modelSpec: TModelSpec;
   parsedBody: ModelSpecParsedBody;
@@ -57,15 +61,30 @@ function hasModelSpecValue(field: PrivateModelSpecPresetField, value: unknown): 
   return value.length > 0;
 }
 
+function pickEnforcedModelSpecRequestFields(parsedBody: ModelSpecParsedBody): ModelSpecParsedBody {
+  const requestFields: ModelSpecParsedBody = {};
+
+  for (const field of ENFORCED_MODEL_SPEC_REQUEST_FIELDS) {
+    if (parsedBody[field] !== undefined) {
+      requestFields[field] = parsedBody[field];
+    }
+  }
+
+  return requestFields;
+}
+
 function mergeModelSpecPreset(
   modelSpec: TModelSpec,
   parsedBody: ModelSpecParsedBody,
   { includePresetDefaults = false }: Pick<ApplyModelSpecPresetParams, 'includePresetDefaults'> = {},
 ): ApplyModelSpecPresetResult {
   const preset = modelSpec.preset;
+  const requestFields = includePresetDefaults
+    ? pickEnforcedModelSpecRequestFields(parsedBody)
+    : parsedBody;
   const merged = {
+    ...requestFields,
     ...(includePresetDefaults ? preset : {}),
-    ...parsedBody,
     spec: modelSpec.name,
   } as ModelSpecParsedBody;
   const appliedPrivateFields = new Set<PrivateModelSpecPresetField>();

--- a/packages/api/src/modelSpecs/modelSpecs.test.ts
+++ b/packages/api/src/modelSpecs/modelSpecs.test.ts
@@ -92,14 +92,24 @@ describe('modelSpecs helpers', () => {
 
     const { parsedBody } = applyModelSpecPreset({
       modelSpec,
-      parsedBody: modelSpec.preset,
+      parsedBody: {
+        endpoint: EModelEndpoint.openAI,
+        spec: 'enforced-openai',
+        model: 'client-model',
+        temperature: 0.8,
+        topP: 0.9,
+        chatProjectId: 'project-1',
+      },
       endpoint: EModelEndpoint.openAI,
       includePresetDefaults: true,
     });
 
     expect(parsedBody.spec).toBe('enforced-openai');
+    expect(parsedBody.model).toBe('gpt-4o');
     expect(parsedBody.promptPrefix).toBe('private prompt prefix');
     expect(parsedBody.temperature).toBe(0.2);
+    expect(parsedBody.topP).toBeUndefined();
+    expect(parsedBody.chatProjectId).toBe('project-1');
   });
 
   it('should restore private examples when parser supplies an empty default', () => {


### PR DESCRIPTION
## Summary

I fixed project-scoped chats with enforced model specs so chats started from Projects persist their `chatProjectId` after refresh and remain listed under the Project. Fixes #13585.

- Preserve `chatProjectId` as an enforced model-spec request-scoped field while continuing to let model spec presets override model parameters.
- Pass the parsed request body through enforced model spec application instead of rebuilding solely from the preset.
- Enable enforced model specs in the mock e2e config and extend project e2e coverage to reload the conversation and verify it remains under the project.
- Relax the skill file authoring reload assertion to compare the conversation path because enforced model specs can drop transient `spec` query params after canonical navigation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest src/modelSpecs/modelSpecs.test.ts --runInBand`
- `npm run build:api`
- `cd api && npx jest server/middleware/buildEndpointOption.spec.js --runInBand`
- `npx playwright test --config=e2e/playwright.config.mock.ts`

### **Test Configuration**:

- Mock e2e config with `modelSpecs.prioritize: true` and `modelSpecs.enforce: true`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes