### PR TITLE
🛡️ feat: Configurable Message PII Filter

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2,7 +2,9 @@ require('events').EventEmitter.defaultMaxListeners = 100;
 const { logger } = require('@librechat/data-schemas');
 const { getBufferString, HumanMessage } = require('@librechat/agents/langchain/messages');
 const {
+  sendEvent,
   createRun,
+  createMessagePiiFilterHooks,
   isEnabled,
   checkAccess,
   buildToolSet,
@@ -1055,6 +1057,8 @@ class AgentClient extends BaseClient {
           );
         }
 
+        const piiFilterResult = createMessagePiiFilterHooks(appConfig?.messagePiiFilter);
+
         run = await createRun({
           agents,
           messages,
@@ -1070,6 +1074,7 @@ class AgentClient extends BaseClient {
           summarizationConfig: appConfig?.summarization,
           appConfig,
           tokenCounter,
+          hooks: piiFilterResult?.registry,
         });
 
         if (!run) {
@@ -1100,6 +1105,35 @@ class AgentClient extends BaseClient {
         });
 
         config.signal = null;
+
+        if (
+          piiFilterResult != null &&
+          this.options.res != null &&
+          !this.options.res.writableEnded
+        ) {
+          const piiHaltReason = run.getHaltReason?.();
+          if (piiHaltReason === 'message_pii_filter_block') {
+            // Surface a friendly error on block mode so the frontend
+            // doesn't render an empty assistant bubble. The existing
+            // error event vocabulary is whatever the host expects; use
+            // a typed payload so a downstream toast/banner can render
+            // a real message rather than the silent halt LibreChat
+            // would otherwise show.
+            sendEvent(this.options.res, {
+              type: 'pii_blocked',
+              reason: piiHaltReason,
+              matches: piiFilterResult.collector.matches,
+            });
+          } else if (
+            appConfig?.messagePiiFilter?.onMatch === 'warn' &&
+            piiFilterResult.collector.matches.length > 0
+          ) {
+            sendEvent(this.options.res, {
+              type: 'pii_matches',
+              matches: piiFilterResult.collector.matches,
+            });
+          }
+        }
       };
 
       const hideSequentialOutputs = config.configurable.hide_sequential_outputs;

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2,7 +2,6 @@ require('events').EventEmitter.defaultMaxListeners = 100;
 const { logger } = require('@librechat/data-schemas');
 const { getBufferString, HumanMessage } = require('@librechat/agents/langchain/messages');
 const {
-  sendEvent,
   createRun,
   createMessagePiiFilterHooks,
   isEnabled,
@@ -1057,7 +1056,20 @@ class AgentClient extends BaseClient {
           );
         }
 
-        const piiFilterResult = createMessagePiiFilterHooks(appConfig?.messagePiiFilter);
+        const piiFilterResult = createMessagePiiFilterHooks(appConfig?.messagePiiFilter, {
+          onMatches: (matches) => {
+            // Agents use the resumable-stream architecture: the POST
+            // response (this.options.res) ends immediately after the
+            // controller returns a streamId, and the long-lived SSE
+            // bytes flow through a separate GET endpoint fed by
+            // GenerationJobManager. Writing to this.options.res here
+            // is silently swallowed because it's already ended.
+            const streamId = this.options.req?._resumableStreamId;
+            if (streamId != null) {
+              GenerationJobManager.emitChunk(streamId, { type: 'pii_matches', matches });
+            }
+          },
+        });
 
         run = await createRun({
           agents,
@@ -1119,17 +1131,6 @@ class AgentClient extends BaseClient {
             throw new Error(
               `Message blocked by PII filter${labels.length > 0 ? `: ${labels}` : ''}. Edit and retry.`,
             );
-          }
-          if (
-            appConfig?.messagePiiFilter?.onMatch === 'warn' &&
-            piiFilterResult.collector.matches.length > 0 &&
-            this.options.res != null &&
-            !this.options.res.writableEnded
-          ) {
-            sendEvent(this.options.res, {
-              type: 'pii_matches',
-              matches: piiFilterResult.collector.matches,
-            });
           }
         }
       };

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1064,9 +1064,19 @@ class AgentClient extends BaseClient {
             // bytes flow through a separate GET endpoint fed by
             // GenerationJobManager. Writing to this.options.res here
             // is silently swallowed because it's already ended.
+            // Persisting on the job in parallel with the live emit
+            // lets the cross-replica subscribe fallback replay the
+            // toast for a subscriber that lands on a different
+            // replica than this one.
             const streamId = this.options.req?._resumableStreamId;
             if (streamId != null) {
               GenerationJobManager.emitChunk(streamId, { type: 'pii_matches', matches });
+              GenerationJobManager.updateMetadata(streamId, { piiMatches: matches }).catch((err) =>
+                logger.warn(
+                  `[messagePiiFilter] Failed to persist piiMatches on job ${streamId}:`,
+                  err,
+                ),
+              );
             }
           },
         });

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1106,27 +1106,25 @@ class AgentClient extends BaseClient {
 
         config.signal = null;
 
-        if (
-          piiFilterResult != null &&
-          this.options.res != null &&
-          !this.options.res.writableEnded
-        ) {
+        if (piiFilterResult != null) {
           const piiHaltReason = run.getHaltReason?.();
           if (piiHaltReason === 'message_pii_filter_block') {
-            // Surface a friendly error on block mode so the frontend
-            // doesn't render an empty assistant bubble. The existing
-            // error event vocabulary is whatever the host expects; use
-            // a typed payload so a downstream toast/banner can render
-            // a real message rather than the silent halt LibreChat
-            // would otherwise show.
-            sendEvent(this.options.res, {
-              type: 'pii_blocked',
-              reason: piiHaltReason,
-              matches: piiFilterResult.collector.matches,
-            });
-          } else if (
+            // Throwing here routes through the existing error UX in the
+            // sendCompletion catch block, which pushes a ContentTypes.ERROR
+            // part into the assistant turn. The user sees a real error
+            // message in chat instead of an empty bubble + stalled
+            // spinner. Labels are joined so the message names what was
+            // matched (e.g. "Anthropic API key, GitHub token").
+            const labels = piiFilterResult.collector.matches.map((m) => m.patternLabel).join(', ');
+            throw new Error(
+              `Message blocked by PII filter${labels.length > 0 ? `: ${labels}` : ''}. Edit and retry.`,
+            );
+          }
+          if (
             appConfig?.messagePiiFilter?.onMatch === 'warn' &&
-            piiFilterResult.collector.matches.length > 0
+            piiFilterResult.collector.matches.length > 0 &&
+            this.options.res != null &&
+            !this.options.res.writableEnded
           ) {
             sendEvent(this.options.res, {
               type: 'pii_matches',

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -33,6 +33,7 @@ const {
   resolveAgentScopedSkillIds,
   createOpenAIContentAggregator,
   isChatCompletionValidationFailure,
+  applyMessagePiiRedactionToMessages,
 } = require('@librechat/api');
 const {
   buildSummarizationHandlers,
@@ -175,6 +176,30 @@ const OpenAIChatCompletionController = async (req, res) => {
       'invalid_request_error',
       'model_not_found',
     );
+  }
+
+  // Apply messagePiiFilter to user messages before any downstream
+  // work (formatting, run creation, LLM dispatch, Langfuse trace). The
+  // chat endpoint pre-redacts in api/server/controllers/agents/request.js;
+  // this is the same guarantee for OpenAI-compatible API clients.
+  const piiConfig = appConfig?.messagePiiFilter;
+  if (piiConfig != null && typeof piiConfig.onMatch === 'string') {
+    const { matches } = applyMessagePiiRedactionToMessages(request.messages, piiConfig);
+    if (matches.length > 0) {
+      const labels = matches.map((m) => m.patternLabel).join(', ');
+      if (piiConfig.onMatch === 'block') {
+        return sendErrorResponse(
+          res,
+          400,
+          `Message blocked by PII filter: ${labels}. Edit and retry.`,
+          'invalid_request_error',
+          'message_pii_filter_block',
+        );
+      }
+      logger.info(
+        `[messagePiiFilter] redacted ${matches.length} match(es) on OpenAI API (mode=${piiConfig.onMatch}, patterns=${matches.map((m) => m.patternId).join(',')})`,
+      );
+    }
   }
 
   const responseId = `chatcmpl-${nanoid()}`;

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -10,7 +10,6 @@ const {
   decrementPendingRequest,
   sanitizeMessageForTransmit,
   checkAndIncrementPendingRequest,
-  applyMessagePiiRedaction,
 } = require('@librechat/api');
 const { disposeClient, clientRegistry, requestDataMap } = require('~/server/cleanup');
 const { handleAbortError } = require('~/server/middleware');
@@ -121,28 +120,15 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
 
   const userId = req.user.id;
 
-  // Pre-redact PII before user message is constructed/saved so the
-  // persisted message, the `created` SSE event, and the prompt sent
-  // to the LLM all carry the redacted text. The agents-side hook
-  // remains the redaction site for block mode (which denies rather
-  // than rewrites).
-  let piiPreRedactMatches = null;
-  let piiBlockReason = null;
-  const piiConfig = req.config?.messagePiiFilter;
-  if (piiConfig != null && typeof piiConfig.onMatch === 'string') {
-    const result = applyMessagePiiRedaction(text, piiConfig);
-    if (result.matches.length > 0) {
-      // All modes redact the persisted/displayed user message so the
-      // raw credential never reaches MongoDB or the `created` SSE event.
-      // Mode differs only in what happens after redaction.
-      text = result.text;
-      req.body.text = result.text;
-      if (piiConfig.onMatch === 'warn') {
-        piiPreRedactMatches = result.matches;
-      } else if (piiConfig.onMatch === 'block') {
-        piiBlockReason = result.matches.map((m) => m.patternLabel).join(', ');
-      }
-    }
+  // Pre-redaction + block-mode rejection run in the
+  // `messagePiiFilter` middleware before `moderateText` so any
+  // credential-shaped text is scrubbed (or refused) before it can
+  // leave the server toward the moderation endpoint. The middleware
+  // mutates `req.body.text` in place and attaches the matches array
+  // here for the post-job SSE emit.
+  const piiPreRedactMatches = req._piiPreRedactMatches ?? null;
+  if (piiPreRedactMatches != null) {
+    text = req.body.text;
   }
 
   /** When to generate the conversation title. `immediate` (default) fires title
@@ -323,16 +309,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         userMessage = data.userMessage;
       }
       // conversationId is pre-generated, no need to update from callback
-
-      // Block-mode abort. BaseClient calls getReqData twice: the first time
-      // before saveMessageToDatabase fires (data.userMessage is set), the
-      // second time after (data.userMessagePromise is set). Throw on the
-      // SECOND call so the already-redacted user message has been queued for
-      // persistence; then the throw propagates up through sendMessage's
-      // catch and routes through the existing emitError path.
-      if (piiBlockReason != null && data.userMessagePromise != null) {
-        throw new Error(`Message blocked by PII filter: ${piiBlockReason}. Edit and retry.`);
-      }
     };
 
     // Start background generation - readyPromise resolves immediately now

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -10,6 +10,7 @@ const {
   decrementPendingRequest,
   sanitizeMessageForTransmit,
   checkAndIncrementPendingRequest,
+  applyMessagePiiRedaction,
 } = require('@librechat/api');
 const { disposeClient, clientRegistry, requestDataMap } = require('~/server/cleanup');
 const { handleAbortError } = require('~/server/middleware');
@@ -107,7 +108,6 @@ function getPreliminaryUserMessage({ messageId, parentMessageId, text }, convers
  */
 const ResumableAgentController = async (req, res, next, initializeClient, addTitle) => {
   const {
-    text,
     isRegenerate,
     endpointOption,
     conversationId: reqConversationId,
@@ -117,8 +117,33 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     overrideParentMessageId = null,
     responseMessageId: editedResponseMessageId = null,
   } = req.body;
+  let text = req.body.text;
 
   const userId = req.user.id;
+
+  // Pre-redact PII before user message is constructed/saved so the
+  // persisted message, the `created` SSE event, and the prompt sent
+  // to the LLM all carry the redacted text. The agents-side hook
+  // remains the redaction site for block mode (which denies rather
+  // than rewrites).
+  let piiPreRedactMatches = null;
+  let piiBlockReason = null;
+  const piiConfig = req.config?.messagePiiFilter;
+  if (piiConfig != null && typeof piiConfig.onMatch === 'string') {
+    const result = applyMessagePiiRedaction(text, piiConfig);
+    if (result.matches.length > 0) {
+      // All modes redact the persisted/displayed user message so the
+      // raw credential never reaches MongoDB or the `created` SSE event.
+      // Mode differs only in what happens after redaction.
+      text = result.text;
+      req.body.text = result.text;
+      if (piiConfig.onMatch === 'warn') {
+        piiPreRedactMatches = result.matches;
+      } else if (piiConfig.onMatch === 'block') {
+        piiBlockReason = result.matches.map((m) => m.patternLabel).join(', ');
+      }
+    }
+  }
 
   /** When to generate the conversation title. `immediate` (default) fires title
    *  generation in parallel with the response, from the user's first message;
@@ -153,6 +178,13 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     const job = await GenerationJobManager.createJob(streamId, userId, conversationId);
     const jobCreatedAt = job.createdAt; // Capture creation time to detect job replacement
     req._resumableStreamId = streamId;
+
+    if (piiPreRedactMatches != null) {
+      GenerationJobManager.emitChunk(streamId, {
+        type: 'pii_matches',
+        matches: piiPreRedactMatches,
+      });
+    }
 
     // Send JSON response IMMEDIATELY so client can connect to SSE stream
     // This is critical: tool loading (MCP OAuth) may emit events that the client needs to receive
@@ -285,6 +317,16 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         userMessage = data.userMessage;
       }
       // conversationId is pre-generated, no need to update from callback
+
+      // Block-mode abort. BaseClient calls getReqData twice: the first time
+      // before saveMessageToDatabase fires (data.userMessage is set), the
+      // second time after (data.userMessagePromise is set). Throw on the
+      // SECOND call so the already-redacted user message has been queued for
+      // persistence; then the throw propagates up through sendMessage's
+      // catch and routes through the existing emitError path.
+      if (piiBlockReason != null && data.userMessagePromise != null) {
+        throw new Error(`Message blocked by PII filter: ${piiBlockReason}. Edit and retry.`);
+      }
     };
 
     // Start background generation - readyPromise resolves immediately now

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -184,6 +184,12 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         type: 'pii_matches',
         matches: piiPreRedactMatches,
       });
+      // Persist on the job so a subscriber landing on a different
+      // replica than this one gets the toast via the cross-replica
+      // reconstruction in GenerationJobManager.subscribe.
+      await GenerationJobManager.updateMetadata(streamId, {
+        piiMatches: piiPreRedactMatches,
+      });
     }
 
     // Send JSON response IMMEDIATELY so client can connect to SSE stream

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -41,6 +41,7 @@ const {
   sendResponsesErrorResponse,
   createResponsesEventHandlers,
   createAggregatorEventHandlers,
+  applyMessagePiiRedactionToMessages,
 } = require('@librechat/api');
 const {
   createResponsesToolEndCallback,
@@ -574,6 +575,30 @@ const createResponse = async (req, res) => {
     const inputMessages = convertToInternalMessages(
       typeof request.input === 'string' ? request.input : request.input,
     );
+
+    // Apply messagePiiFilter to user input before saving, formatting,
+    // or dispatching to the model. The chat endpoint pre-redacts in
+    // api/server/controllers/agents/request.js; this is the same
+    // guarantee for Responses API clients.
+    const piiConfig = appConfig?.messagePiiFilter;
+    if (piiConfig != null && typeof piiConfig.onMatch === 'string') {
+      const { matches } = applyMessagePiiRedactionToMessages(inputMessages, piiConfig);
+      if (matches.length > 0) {
+        const labels = matches.map((m) => m.patternLabel).join(', ');
+        if (piiConfig.onMatch === 'block') {
+          return sendResponsesErrorResponse(
+            res,
+            400,
+            `Message blocked by PII filter: ${labels}. Edit and retry.`,
+            'invalid_request',
+            'message_pii_filter_block',
+          );
+        }
+        logger.info(
+          `[messagePiiFilter] redacted ${matches.length} match(es) on Responses API (mode=${piiConfig.onMatch}, patterns=${matches.map((m) => m.patternId).join(',')})`,
+        );
+      }
+    }
 
     // Merge previous messages with new input
     const allMessages = [...previousMessages, ...inputMessages];

--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -14,6 +14,7 @@ const requireJwtAuth = require('./requireJwtAuth');
 const configMiddleware = require('./config/app');
 const validateModel = require('./validateModel');
 const moderateText = require('./moderateText');
+const messagePiiFilter = require('./messagePiiFilter');
 const logHeaders = require('./logHeaders');
 const setHeaders = require('./setHeaders');
 const validate = require('./validate');
@@ -35,6 +36,7 @@ module.exports = {
   setHeaders,
   logHeaders,
   moderateText,
+  messagePiiFilter,
   validateModel,
   requireJwtAuth,
   setTwoFactorTempUser,

--- a/api/server/middleware/messagePiiFilter.js
+++ b/api/server/middleware/messagePiiFilter.js
@@ -31,6 +31,13 @@ async function messagePiiFilter(req, res, next) {
     if (result.matches.length === 0) {
       return next();
     }
+    // Mutate req.body.text FIRST so every code path below (block's
+    // denyRequest, warn/silent's downstream middleware + controller)
+    // sees the redacted text. denyRequest emits a `created` SSE event
+    // built from req.body.text and conditionally persists that user
+    // message; running it on the original would leak the credential
+    // even though the assistant turn is refused.
+    req.body.text = result.text;
     if (config.onMatch === 'block') {
       const labels = result.matches.map((m) => m.patternLabel).join(', ');
       logger.info(
@@ -42,7 +49,6 @@ async function messagePiiFilter(req, res, next) {
         message: `Message blocked by PII filter: ${labels}. Edit and retry.`,
       });
     }
-    req.body.text = result.text;
     if (config.onMatch === 'warn') {
       req._piiPreRedactMatches = result.matches;
     }

--- a/api/server/middleware/messagePiiFilter.js
+++ b/api/server/middleware/messagePiiFilter.js
@@ -1,0 +1,61 @@
+const { logger } = require('@librechat/data-schemas');
+const { applyMessagePiiRedaction } = require('@librechat/api');
+const denyRequest = require('./denyRequest');
+
+/**
+ * Pre-redact `req.body.text` before downstream middleware sees it. Mounted
+ * before `moderateText` on the agent chat route so credentials that match
+ * a configured `messagePiiFilter` pattern never leave the server toward
+ * the OpenAI moderation endpoint, the agent run, or MongoDB.
+ *
+ * `block` mode returns a 400 here via `denyRequest`, mirroring how
+ * `moderateText` rejects flagged content. `warn` mutates the text and
+ * attaches the matches on `req._piiPreRedactMatches` so the controller
+ * can emit the `pii_matches` SSE event for the warn toast after the
+ * job (and its streamId) exist. `silent` mutates without attaching.
+ *
+ * Runs in addition to the browser-side prefilter in `useClientPiiFilter`
+ * to cover API callers and any UI bypass.
+ */
+async function messagePiiFilter(req, res, next) {
+  const config = req.config?.messagePiiFilter;
+  if (config == null || typeof config.onMatch !== 'string') {
+    return next();
+  }
+  const text = req.body?.text;
+  if (typeof text !== 'string' || text.length === 0) {
+    return next();
+  }
+  try {
+    const result = applyMessagePiiRedaction(text, config);
+    if (result.matches.length === 0) {
+      return next();
+    }
+    if (config.onMatch === 'block') {
+      const labels = result.matches.map((m) => m.patternLabel).join(', ');
+      logger.info(
+        `[messagePiiFilter] blocked send (patterns=${result.matches
+          .map((m) => m.patternId)
+          .join(',')})`,
+      );
+      return await denyRequest(req, res, {
+        message: `Message blocked by PII filter: ${labels}. Edit and retry.`,
+      });
+    }
+    req.body.text = result.text;
+    if (config.onMatch === 'warn') {
+      req._piiPreRedactMatches = result.matches;
+    }
+    logger.info(
+      `[messagePiiFilter] redacted ${result.matches.length} match(es) (mode=${config.onMatch}, patterns=${result.matches
+        .map((m) => m.patternId)
+        .join(',')})`,
+    );
+    return next();
+  } catch (err) {
+    logger.error('[messagePiiFilter] middleware error:', err);
+    return next();
+  }
+}
+
+module.exports = messagePiiFilter;

--- a/api/server/routes/agents/chat.js
+++ b/api/server/routes/agents/chat.js
@@ -3,6 +3,7 @@ const { generateCheckAccess, skipAgentCheck } = require('@librechat/api');
 const { PermissionTypes, Permissions, PermissionBits } = require('librechat-data-provider');
 const {
   moderateText,
+  messagePiiFilter,
   // validateModel,
   validateConvoAccess,
   buildEndpointOption,
@@ -25,6 +26,7 @@ const checkAgentResourceAccess = canAccessAgentFromBody({
   requiredPermission: PermissionBits.VIEW,
 });
 
+router.use(messagePiiFilter);
 router.use(moderateText);
 router.use(checkAgentAccess);
 router.use(checkAgentResourceAccess);

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -6,6 +6,7 @@ const {
   resolveBuildInfo,
   resolveTitleTiming,
   sanitizeModelSpecs,
+  serializeMessagePiiFilterForClient,
 } = require('@librechat/api');
 const { EModelEndpoint, defaultSocialLogins } = require('librechat-data-provider');
 const { logger, getTenantId, SystemCapabilities } = require('@librechat/data-schemas');
@@ -287,6 +288,11 @@ router.get('/', async function (req, res) {
     const buildInfo = buildBuildInfoPayload(appConfig?.interfaceConfig);
     if (buildInfo) {
       payload.buildInfo = buildInfo;
+    }
+
+    const messagePiiFilter = serializeMessagePiiFilterForClient(appConfig?.messagePiiFilter);
+    if (messagePiiFilter) {
+      payload.messagePiiFilter = messagePiiFilter;
     }
 
     if (!payload.allowAccountDeletion) {

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -33,6 +33,7 @@ import {
   getRouteChatProjectId,
 } from '~/utils';
 import useSetFilesToDelete from '~/hooks/Files/useSetFilesToDelete';
+import useClientPiiFilter from '~/hooks/SSE/useClientPiiFilter';
 import useGetSender from '~/hooks/Conversations/useGetSender';
 import store, { useGetEphemeralAgent } from '~/store';
 import { startupConfigKey } from '~/data-provider';
@@ -184,6 +185,7 @@ export default function useChatFunctions({
   const { getExpiry } = useUserKey(immutableConversation?.endpoint ?? '');
   const setIsSubmitting = useSetRecoilState(store.isSubmittingFamily(index));
   const setShowStopButton = useSetRecoilState(store.showStopButtonByIndex(index));
+  const { apply: applyClientPiiFilter } = useClientPiiFilter();
 
   /**
    * Atomically read + reset the per-conversation queue of manually-invoked
@@ -237,6 +239,12 @@ export default function useChatFunctions({
     if (!!isSubmitting || text === '') {
       return;
     }
+
+    const piiResult = applyClientPiiFilter(text);
+    if (piiResult.blocked) {
+      return;
+    }
+    text = piiResult.text;
 
     const conversation = cloneDeep(immutableConversation);
 

--- a/client/src/hooks/SSE/__tests__/usePiiHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/usePiiHandler.spec.ts
@@ -1,0 +1,38 @@
+import type { PiiPatternMatch } from '~/hooks/SSE/piiLabels';
+import { formatPiiLabels } from '~/hooks/SSE/piiLabels';
+
+describe('formatPiiLabels', () => {
+  it('returns empty string when matches is undefined', () => {
+    expect(formatPiiLabels(undefined)).toBe('');
+  });
+
+  it('returns empty string when matches is empty', () => {
+    expect(formatPiiLabels([])).toBe('');
+  });
+
+  it('joins multiple distinct pattern labels with a comma', () => {
+    const matches: PiiPatternMatch[] = [
+      { patternId: 'a', patternLabel: 'Anthropic API key', count: 1 },
+      { patternId: 'b', patternLabel: 'GitHub token', count: 2 },
+    ];
+    expect(formatPiiLabels(matches)).toBe('Anthropic API key, GitHub token');
+  });
+
+  it('dedupes pattern labels by display name', () => {
+    const matches: PiiPatternMatch[] = [
+      { patternId: 'a', patternLabel: 'Anthropic API key', count: 1 },
+      { patternId: 'b', patternLabel: 'Anthropic API key', count: 1 },
+      { patternId: 'c', patternLabel: 'GitHub token', count: 1 },
+    ];
+    expect(formatPiiLabels(matches)).toBe('Anthropic API key, GitHub token');
+  });
+
+  it('skips entries without a usable label', () => {
+    const matches = [
+      { patternId: 'a', patternLabel: '', count: 1 },
+      { patternId: 'b', patternLabel: '   ', count: 1 },
+      { patternId: 'c', patternLabel: 'GitHub token', count: 1 },
+    ] as PiiPatternMatch[];
+    expect(formatPiiLabels(matches)).toBe('GitHub token');
+  });
+});

--- a/client/src/hooks/SSE/piiLabels.ts
+++ b/client/src/hooks/SSE/piiLabels.ts
@@ -1,0 +1,31 @@
+export type PiiPatternMatch = {
+  patternId: string;
+  patternLabel: string;
+  count: number;
+};
+
+export type PiiEvent = {
+  type: 'pii_matches';
+  matches?: PiiPatternMatch[];
+};
+
+const dedupeLabels = (matches: PiiPatternMatch[]): string[] => {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const match of matches) {
+    const label = match?.patternLabel?.trim();
+    if (!label || seen.has(label)) {
+      continue;
+    }
+    seen.add(label);
+    labels.push(label);
+  }
+  return labels;
+};
+
+export const formatPiiLabels = (matches?: PiiPatternMatch[]): string => {
+  if (!matches || matches.length === 0) {
+    return '';
+  }
+  return dedupeLabels(matches).join(', ');
+};

--- a/client/src/hooks/SSE/useClientPiiFilter.ts
+++ b/client/src/hooks/SSE/useClientPiiFilter.ts
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+import { useToastContext } from '@librechat/client';
+import { redactSensitiveText } from '~/utils/piiRedact';
+import { formatPiiLabels } from '~/hooks/SSE/piiLabels';
+import { useGetStartupConfig } from '~/data-provider';
+import useLocalize from '~/hooks/useLocalize';
+
+export type ClientPiiApplyResult = {
+  /** Text to send downstream. Equal to the input when no patterns matched. */
+  text: string;
+  /** When true, the caller should NOT proceed with submission (block mode). */
+  blocked: boolean;
+};
+
+/**
+ * Client-side prefilter that runs in the chat submit handler before
+ * `text` ever leaves the browser. Defense in depth: the server still
+ * pre-redacts on receipt for callers that bypass the UI (curl, custom
+ * clients). When both fire on the same prompt the server side will
+ * find no matches in the already-redacted text and stay silent, so no
+ * duplicate toast.
+ */
+export default function useClientPiiFilter() {
+  const localize = useLocalize();
+  const { showToast } = useToastContext();
+  const { data: startupConfig } = useGetStartupConfig();
+
+  const apply = useCallback(
+    (text: string): ClientPiiApplyResult => {
+      const config = startupConfig?.messagePiiFilter;
+      if (!config || !text) {
+        return { text, blocked: false };
+      }
+
+      const { text: redacted, matches } = redactSensitiveText(text, config);
+      if (matches.length === 0) {
+        return { text, blocked: false };
+      }
+
+      const labels = formatPiiLabels(matches);
+
+      if (config.onMatch === 'block') {
+        if (labels) {
+          showToast({
+            message: localize('com_ui_pii_blocked', { 0: labels }),
+            status: 'error',
+          });
+        }
+        return { text, blocked: true };
+      }
+
+      if (config.onMatch === 'warn' && labels) {
+        showToast({
+          message: localize('com_ui_pii_redacted', { 0: labels }),
+          status: 'warning',
+        });
+      }
+
+      return { text: redacted, blocked: false };
+    },
+    [localize, showToast, startupConfig],
+  );
+
+  return { apply };
+}

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -43,6 +43,7 @@ import useAttachmentHandler from '~/hooks/SSE/useAttachmentHandler';
 import useContentHandler from '~/hooks/SSE/useContentHandler';
 import useStepHandler from '~/hooks/SSE/useStepHandler';
 import { useApplyAgentTemplate } from '~/hooks/Agents';
+import usePiiHandler from '~/hooks/SSE/usePiiHandler';
 import { useAuthContext } from '~/hooks/AuthContext';
 import { MESSAGE_UPDATE_INTERVAL } from '~/common';
 import { useLiveAnnouncer } from '~/Providers';
@@ -285,6 +286,7 @@ export default function useEventHandlers({
     lastAnnouncementTimeRef,
   });
   const attachmentHandler = useAttachmentHandler(queryClient);
+  const { piiMatchesHandler } = usePiiHandler();
 
   /** Wipe the per-subagent Recoil atoms on conversation navigation.
    *  Historical subagent dialogs rehydrate from the persisted
@@ -1079,5 +1081,6 @@ export default function useEventHandlers({
     attachmentHandler,
     abortConversation,
     resetContentHandler,
+    piiMatchesHandler,
   };
 }

--- a/client/src/hooks/SSE/usePiiHandler.ts
+++ b/client/src/hooks/SSE/usePiiHandler.ts
@@ -18,7 +18,7 @@ export default function usePiiHandler() {
       }
       showToast({
         message: localize('com_ui_pii_redacted', { 0: labels }),
-        status: 'info',
+        status: 'warning',
       });
     },
     [localize, showToast],

--- a/client/src/hooks/SSE/usePiiHandler.ts
+++ b/client/src/hooks/SSE/usePiiHandler.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { useToastContext } from '@librechat/client';
+import type { PiiEvent } from '~/hooks/SSE/piiLabels';
+import { formatPiiLabels } from '~/hooks/SSE/piiLabels';
+import useLocalize from '~/hooks/useLocalize';
+
+export type { PiiEvent, PiiPatternMatch } from '~/hooks/SSE/piiLabels';
+
+export default function usePiiHandler() {
+  const localize = useLocalize();
+  const { showToast } = useToastContext();
+
+  const piiMatchesHandler = useCallback(
+    (data: PiiEvent) => {
+      const labels = formatPiiLabels(data.matches);
+      if (!labels) {
+        return;
+      }
+      showToast({
+        message: localize('com_ui_pii_redacted', { 0: labels }),
+        status: 'info',
+      });
+    },
+    [localize, showToast],
+  );
+
+  return { piiMatchesHandler };
+}

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -702,6 +702,8 @@ export default function useResumableSSE(
                   titleHandler(pendingEvent);
                 } else if (pendingEvent.event != null) {
                   stepHandler(pendingEvent, resumeSubmission);
+                } else if (pendingEvent.type === 'pii_matches') {
+                  piiMatchesHandler(pendingEvent);
                 } else if (pendingEvent.type != null) {
                   contentHandler({ data: pendingEvent, submission: resumeSubmission });
                 }

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -453,6 +453,7 @@ export default function useResumableSSE(
     syncStepMessage,
     attachmentHandler,
     resetContentHandler,
+    piiMatchesHandler,
   } = useEventHandlers({
     setMessages,
     getMessages,
@@ -709,6 +710,11 @@ export default function useResumableSSE(
 
             setIsSubmitting(true);
             setShowStopButton(true);
+            return;
+          }
+
+          if (data.type === 'pii_matches') {
+            piiMatchesHandler(data);
             return;
           }
 
@@ -975,6 +981,7 @@ export default function useResumableSSE(
       clearStepMaps,
       messageHandler,
       errorHandler,
+      piiMatchesHandler,
       setIsSubmitting,
       getMessages,
       setMessages,

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -45,6 +45,7 @@ export default function useSSE(
     titleHandler,
     attachmentHandler,
     abortConversation,
+    piiMatchesHandler,
   } = useEventHandlers({
     setMessages,
     getMessages,
@@ -123,6 +124,8 @@ export default function useSSE(
         setActiveRunId(runId);
         /* synchronize messages to Assistants API as well as with real DB ID's */
         syncHandler(data, { ...submission, userMessage } as EventSubmission);
+      } else if (data.type === 'pii_matches') {
+        piiMatchesHandler(data);
       } else if (data.type != null) {
         const { text, index } = data;
         if (text != null && index !== textIndex) {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1344,6 +1344,7 @@
   "com_ui_permissions_failed_load": "Failed to load permissions. Please try again.",
   "com_ui_permissions_failed_update": "Failed to update permissions. Please try again.",
   "com_ui_permissions_updated_success": "Permissions updated successfully",
+  "com_ui_pii_blocked": "Message blocked. Remove this from your message and try again: {{0}}",
   "com_ui_pii_redacted": "Redacted from your message: {{0}}",
   "com_ui_pin": "Pin",
   "com_ui_plus_n_more": "+{{0}} more",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1344,6 +1344,7 @@
   "com_ui_permissions_failed_load": "Failed to load permissions. Please try again.",
   "com_ui_permissions_failed_update": "Failed to update permissions. Please try again.",
   "com_ui_permissions_updated_success": "Permissions updated successfully",
+  "com_ui_pii_redacted": "Redacted from your message: {{0}}",
   "com_ui_pin": "Pin",
   "com_ui_plus_n_more": "+{{0}} more",
   "com_ui_preferences_updated": "Preferences updated successfully",

--- a/client/src/utils/piiRedact.ts
+++ b/client/src/utils/piiRedact.ts
@@ -1,0 +1,43 @@
+import type { MessagePiiFilterClientConfig } from 'librechat-data-provider';
+import type { PiiPatternMatch } from '~/hooks/SSE/piiLabels';
+
+export type ClientRedactResult = {
+  text: string;
+  matches: PiiPatternMatch[];
+};
+
+/**
+ * Browser-side mirror of the agents-side `redactSensitiveText`. Replaces
+ * regex matches with the first capture group (visible prefix like
+ * `sk-`/`Bearer `) followed by the configured redaction text, so chat
+ * readers can still tell which family of secret was scrubbed.
+ *
+ * Reconstructs RegExp objects from the wire-format `{source, flags}`
+ * shape each call. Inexpensive given the small starter+custom pattern
+ * counts; not memoized to keep the call site free of cache invalidation
+ * concerns when the operator changes patterns.
+ */
+export function redactSensitiveText(
+  text: string,
+  config: MessagePiiFilterClientConfig,
+): ClientRedactResult {
+  if (!text || config.patterns.length === 0) {
+    return { text, matches: [] };
+  }
+  const aggregate = new Map<string, PiiPatternMatch>();
+  let next = text;
+  for (const p of config.patterns) {
+    const regex = new RegExp(p.source, p.flags);
+    let count = 0;
+    next = next.replace(regex, (...args: unknown[]) => {
+      count++;
+      const groups = args.slice(1, -2);
+      const prefix = typeof groups[0] === 'string' ? groups[0] : '';
+      return `${prefix}${config.redactionText}`;
+    });
+    if (count > 0) {
+      aggregate.set(p.id, { patternId: p.id, patternLabel: p.label, count });
+    }
+  }
+  return { text: next, matches: Array.from(aggregate.values()) };
+}

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -786,10 +786,12 @@ endpoints:
 #   onMatch: warn
 #
 #   # Starter patterns ported from danny-avila/LibreChat#13561's winston log
-#   # redaction. Omit the field to enable all 5; pass an empty list to enable
-#   # none and rely entirely on customPatterns.
-#   # Available ids: sk_prefix, bearer_header, api_key_header, api_key_query, key_query
-#   starterPatterns: [sk_prefix, bearer_header, api_key_header, api_key_query, key_query]
+#   # redaction. Omit the field to enable the low-false-positive default set
+#   # (sk_prefix, bearer_header, api_key_header). Pass an explicit list to
+#   # subset the default set or to opt in to the higher-false-positive query
+#   # patterns (api_key_query, key_query); pass an empty list to disable
+#   # starters entirely and rely on customPatterns alone.
+#   starterPatterns: [sk_prefix, bearer_header, api_key_header]
 #
 #   # Operator-defined regex additions. Each entry needs a stable id (used in
 #   # logs and the SSE payload), a human-readable label (shown to users in the

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -770,3 +770,52 @@ endpoints:
 #     # instructions: "You are a memory management assistant. Store and manage user information accurately."
 #     # model_parameters:
 #     #   temperature: 0.1
+
+# Message PII filter
+# Registers a UserPromptSubmit hook in @librechat/agents that scrubs
+# credential-shaped substrings from user prompts before the agent reaches
+# the LLM. Per-user/group/role/tenant overrides flow through the existing
+# AppConfig override system, same as every other librechat.yaml section.
+#
+# onMatch modes:
+#   silent - server-side redact, no UI feedback
+#   warn   - server-side redact + sendEvent(piiMatches) for client toast
+#   block  - server always denies on match
+#
+# messagePiiFilter:
+#   onMatch: warn
+#
+#   # Starter patterns ported from danny-avila/LibreChat#13561's winston log
+#   # redaction. Omit the field to enable all 5; pass an empty list to enable
+#   # none and rely entirely on customPatterns.
+#   # Available ids: sk_prefix, bearer_header, api_key_header, api_key_query, key_query
+#   starterPatterns: [sk_prefix, bearer_header, api_key_header, api_key_query, key_query]
+#
+#   # Operator-defined regex additions. Each entry needs a stable id (used in
+#   # logs and the SSE payload), a human-readable label (shown to users in the
+#   # warn toast), and a JavaScript-flavor regex.
+#   customPatterns:
+#     - id: anthropic_api_key
+#       label: Anthropic API key
+#       regex: "sk-ant-[A-Za-z0-9_-]{20,}"
+#     - id: aws_access_key
+#       label: AWS access key
+#       regex: "(AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{12,16}"
+#     - id: github_token
+#       label: GitHub token
+#       regex: "gh[poshru]_[A-Za-z0-9]{36,255}"
+#     - id: slack_token
+#       label: Slack token
+#       regex: "xox[bpasr]-[A-Za-z0-9-]{10,200}"
+#     - id: google_api_key
+#       label: Google API key
+#       regex: "AIza[A-Za-z0-9_-]{35}"
+#     - id: stripe_key
+#       label: Stripe key
+#       regex: "(sk|pk|rk)_(live|test|prod)_[A-Za-z0-9]{10,99}"
+#     - id: jwt
+#       label: JWT
+#       regex: "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"
+#
+#   # Replacement string inserted after the matched prefix. Defaults to [REDACTED].
+#   redactionText: "[REDACTED]"

--- a/packages/api/src/agents/__tests__/messagePiiFilter.spec.ts
+++ b/packages/api/src/agents/__tests__/messagePiiFilter.spec.ts
@@ -1,0 +1,139 @@
+import { executeHooks } from '@librechat/agents';
+import type { MessagePiiFilterConfig } from 'librechat-data-provider';
+import type { UserPromptSubmitHookInput } from '@librechat/agents';
+import { createMessagePiiFilterHooks } from '../messagePiiFilter';
+
+function promptInput(prompt: string): UserPromptSubmitHookInput {
+  return {
+    hook_event_name: 'UserPromptSubmit',
+    runId: 'run-1',
+    threadId: 'thread-1',
+    agentId: 'agent-1',
+    prompt,
+  };
+}
+
+function silent(overrides: Partial<MessagePiiFilterConfig> = {}): MessagePiiFilterConfig {
+  return {
+    onMatch: 'silent',
+    redactionText: '[REDACTED]',
+    ...overrides,
+  };
+}
+
+describe('createMessagePiiFilterHooks', () => {
+  it('returns undefined when config is undefined', () => {
+    expect(createMessagePiiFilterHooks(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when no patterns would be selected', () => {
+    const result = createMessagePiiFilterHooks(silent({ starterPatterns: ['nonexistent'] }));
+    expect(result).toBeUndefined();
+  });
+
+  it('exposes a per-request collector for matches', () => {
+    const result = createMessagePiiFilterHooks(silent());
+    expect(result?.collector).toEqual({ matches: [] });
+  });
+
+  describe('silent mode', () => {
+    it('redacts and surfaces updatedPrompt without blocking', async () => {
+      const built = createMessagePiiFilterHooks(silent());
+      expect(built).toBeDefined();
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('key sk-ant-FAKE1234567890 please'),
+      });
+
+      expect(result.updatedPrompt).toBe('key sk-[REDACTED] please');
+      expect(result.decision).toBeUndefined();
+      expect(built!.collector.matches).toHaveLength(1);
+    });
+
+    it('is a no-op when nothing matches', async () => {
+      const built = createMessagePiiFilterHooks(silent());
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('a perfectly normal question'),
+      });
+
+      expect(result.updatedPrompt).toBeUndefined();
+      expect(built!.collector.matches).toEqual([]);
+    });
+  });
+
+  describe('warn mode', () => {
+    it('redacts and reports matches identically to silent (controller surfaces them)', async () => {
+      const built = createMessagePiiFilterHooks(silent({ onMatch: 'warn' }));
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('key sk-ant-FAKE1234567890 please'),
+      });
+
+      expect(result.updatedPrompt).toBe('key sk-[REDACTED] please');
+      expect(built!.collector.matches.map((m) => m.patternId)).toEqual(['sk_prefix']);
+    });
+  });
+
+  describe('block mode', () => {
+    it('always denies on match', async () => {
+      const built = createMessagePiiFilterHooks(silent({ onMatch: 'block' }));
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('key sk-ant-FAKE1234567890 please'),
+      });
+
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toBe('message_pii_filter_block');
+      expect(result.updatedPrompt).toBeUndefined();
+    });
+
+    it('passes through when nothing matches', async () => {
+      const built = createMessagePiiFilterHooks(silent({ onMatch: 'block' }));
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('plain words'),
+      });
+
+      expect(result.decision).toBeUndefined();
+    });
+  });
+
+  describe('pattern selection', () => {
+    it('honors a starterPatterns subset', async () => {
+      const built = createMessagePiiFilterHooks(silent({ starterPatterns: ['bearer_header'] }));
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('auth Bearer abc.def-ghi and key sk-ant-1234567890ABC'),
+      });
+
+      expect(result.updatedPrompt).toBe('auth Bearer [REDACTED] and key sk-ant-1234567890ABC');
+    });
+
+    it('layers customPatterns on top of starters', async () => {
+      const built = createMessagePiiFilterHooks(
+        silent({
+          starterPatterns: [],
+          customPatterns: [{ id: 'acme', label: 'Acme token', regex: '\\bACME-[A-Z0-9]{6,}' }],
+        }),
+      );
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('token ACME-DEADBEEF12 ok'),
+      });
+
+      expect(result.updatedPrompt).toBe('token [REDACTED] ok');
+      expect(built!.collector.matches.map((m) => m.patternId)).toEqual(['acme']);
+    });
+
+    it('honors a custom redactionText', async () => {
+      const built = createMessagePiiFilterHooks(silent({ redactionText: '[scrubbed]' }));
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('key sk-ant-FAKE1234567890 found'),
+      });
+
+      expect(result.updatedPrompt).toBe('key sk-[scrubbed] found');
+    });
+  });
+});

--- a/packages/api/src/agents/__tests__/messagePiiFilter.spec.ts
+++ b/packages/api/src/agents/__tests__/messagePiiFilter.spec.ts
@@ -47,7 +47,8 @@ describe('createMessagePiiFilterHooks', () => {
 
       expect(result.updatedPrompt).toBe('key sk-[REDACTED] please');
       expect(result.decision).toBeUndefined();
-      expect(built!.collector.matches).toHaveLength(1);
+      // Silent mode skips collector population (no consumer reads it)
+      expect(built!.collector.matches).toEqual([]);
     });
 
     it('is a no-op when nothing matches', async () => {
@@ -110,7 +111,7 @@ describe('createMessagePiiFilterHooks', () => {
       expect(result.updatedPrompt).toBe('auth Bearer [REDACTED] and key sk-ant-1234567890ABC');
     });
 
-    it('layers customPatterns on top of starters', async () => {
+    it('uses customPatterns only when starterPatterns is empty', async () => {
       const built = createMessagePiiFilterHooks(
         silent({
           starterPatterns: [],
@@ -123,7 +124,25 @@ describe('createMessagePiiFilterHooks', () => {
       });
 
       expect(result.updatedPrompt).toBe('token [REDACTED] ok');
-      expect(built!.collector.matches.map((m) => m.patternId)).toEqual(['acme']);
+    });
+
+    it('layers customPatterns on top of starters (both fire in one prompt)', async () => {
+      const built = createMessagePiiFilterHooks(
+        silent({
+          onMatch: 'warn',
+          customPatterns: [{ id: 'acme', label: 'Acme token', regex: '\\bACME-[A-Z0-9]{6,}' }],
+        }),
+      );
+      const result = await executeHooks({
+        registry: built!.registry,
+        input: promptInput('starter sk-anything-here and custom ACME-DEADBEEF12'),
+      });
+
+      const ids = built!.collector.matches.map((m) => m.patternId).sort();
+      expect(ids).toContain('sk_prefix');
+      expect(ids).toContain('acme');
+      expect(result.updatedPrompt).toContain('sk-[REDACTED]');
+      expect(result.updatedPrompt).toContain('[REDACTED]');
     });
 
     it('honors a custom redactionText', async () => {

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -27,3 +27,4 @@ export * from './tools';
 export * from './validation';
 export * from './added';
 export * from './load';
+export * from './messagePiiFilter';

--- a/packages/api/src/agents/messagePiiFilter.ts
+++ b/packages/api/src/agents/messagePiiFilter.ts
@@ -187,3 +187,56 @@ export function serializeMessagePiiFilterForClient(
     })),
   };
 }
+
+/**
+ * Walk an OpenAI-style messages array and apply PII redaction to user
+ * message content in place. Used by the OpenAI-compatible and
+ * Responses agent controllers, which receive a messages array instead
+ * of the chat endpoint's single `req.body.text`.
+ *
+ * Handles both content shapes: plain strings and arrays of content
+ * parts (text, image_url, etc.). Only `text`-bearing parts are
+ * scrubbed. Mutates the array in place and returns the aggregated
+ * match set so the caller can choose the mode reaction (HTTP 400 for
+ * block, log for warn/silent).
+ */
+export function applyMessagePiiRedactionToMessages(
+  messages: Array<{
+    role?: string;
+    content?: string | Array<{ type?: string; text?: string; [key: string]: unknown }>;
+  }>,
+  config: MessagePiiFilterConfig | undefined,
+): { matches: PatternMatch[] } {
+  if (config == null || !Array.isArray(messages) || messages.length === 0) {
+    return { matches: [] };
+  }
+  const aggregate = new Map<string, PatternMatch>();
+  const accumulate = (text: string): string => {
+    const result = applyMessagePiiRedaction(text, config);
+    for (const m of result.matches) {
+      const prior = aggregate.get(m.patternId);
+      if (prior == null) {
+        aggregate.set(m.patternId, { ...m });
+      } else {
+        prior.count += m.count;
+      }
+    }
+    return result.text;
+  };
+
+  for (const msg of messages) {
+    if (msg == null || msg.role !== 'user') {
+      continue;
+    }
+    if (typeof msg.content === 'string') {
+      msg.content = accumulate(msg.content);
+    } else if (Array.isArray(msg.content)) {
+      for (const part of msg.content) {
+        if (part != null && typeof part.text === 'string') {
+          part.text = accumulate(part.text);
+        }
+      }
+    }
+  }
+  return { matches: Array.from(aggregate.values()) };
+}

--- a/packages/api/src/agents/messagePiiFilter.ts
+++ b/packages/api/src/agents/messagePiiFilter.ts
@@ -1,11 +1,15 @@
 import { logger } from '@librechat/data-schemas';
-import { selectStarterPatterns, type MessagePiiFilterConfig } from 'librechat-data-provider';
 import {
   HookRegistry,
   redactSensitiveText,
   type SensitivePattern,
   type PatternMatch,
 } from '@librechat/agents';
+import {
+  selectStarterPatterns,
+  type MessagePiiFilterConfig,
+  type MessagePiiFilterClientConfig,
+} from 'librechat-data-provider';
 import type { UserPromptSubmitHookOutput } from '@librechat/agents';
 
 /**
@@ -155,4 +159,31 @@ export function applyMessagePiiRedaction(
     return { text, matches: [] };
   }
   return redactSensitiveText(text, { patterns, redactionText: config.redactionText });
+}
+
+/**
+ * Build the browser-safe wire format of the configured filter for the
+ * startup config endpoint. Returns undefined when no patterns would be
+ * selected so the client-side hook can no-op cleanly.
+ */
+export function serializeMessagePiiFilterForClient(
+  config: MessagePiiFilterConfig | undefined,
+): MessagePiiFilterClientConfig | undefined {
+  if (config == null) {
+    return undefined;
+  }
+  const patterns = buildPatternList(config);
+  if (patterns.length === 0) {
+    return undefined;
+  }
+  return {
+    onMatch: config.onMatch,
+    redactionText: config.redactionText ?? '[REDACTED]',
+    patterns: patterns.map((p) => ({
+      id: p.id,
+      label: p.label,
+      source: p.pattern.source,
+      flags: p.pattern.flags,
+    })),
+  };
 }

--- a/packages/api/src/agents/messagePiiFilter.ts
+++ b/packages/api/src/agents/messagePiiFilter.ts
@@ -13,6 +13,16 @@ import {
 import type { UserPromptSubmitHookOutput } from '@librechat/agents';
 
 /**
+ * Mirrors the `.default('[REDACTED]')` on `messagePiiFilterSchema`
+ * (packages/data-provider/src/config.ts). Coalesced at every helper
+ * entry point because the LibreChat config loader keeps the raw YAML
+ * object instead of applying Zod parsed defaults back to it, so an
+ * operator who omits `redactionText` ends up with `undefined` here at
+ * runtime even though the schema documents a default.
+ */
+const DEFAULT_PII_REDACTION_TEXT = '[REDACTED]';
+
+/**
  * Per-request match collector. The factory creates one for each
  * request; the controller reads it after `processStream` resolves to
  * surface matches to the client (e.g. via SSE for `warn` mode) or to
@@ -86,7 +96,7 @@ export function createMessagePiiFilterHooks(
     return undefined;
   }
 
-  const { redactionText } = config;
+  const redactionText = config.redactionText ?? DEFAULT_PII_REDACTION_TEXT;
   const mode = config.onMatch;
   const collector: PiiMatchCollector = options.collector ?? { matches: [] };
   const { onMatches } = options;
@@ -158,7 +168,10 @@ export function applyMessagePiiRedaction(
   if (patterns.length === 0) {
     return { text, matches: [] };
   }
-  return redactSensitiveText(text, { patterns, redactionText: config.redactionText });
+  return redactSensitiveText(text, {
+    patterns,
+    redactionText: config.redactionText ?? DEFAULT_PII_REDACTION_TEXT,
+  });
 }
 
 /**
@@ -178,7 +191,7 @@ export function serializeMessagePiiFilterForClient(
   }
   return {
     onMatch: config.onMatch,
-    redactionText: config.redactionText ?? '[REDACTED]',
+    redactionText: config.redactionText ?? DEFAULT_PII_REDACTION_TEXT,
     patterns: patterns.map((p) => ({
       id: p.id,
       label: p.label,

--- a/packages/api/src/agents/messagePiiFilter.ts
+++ b/packages/api/src/agents/messagePiiFilter.ts
@@ -1,0 +1,125 @@
+import { logger } from '@librechat/data-schemas';
+import { selectStarterPatterns, type MessagePiiFilterConfig } from 'librechat-data-provider';
+import {
+  HookRegistry,
+  redactSensitiveText,
+  type SensitivePattern,
+  type PatternMatch,
+} from '@librechat/agents';
+import type { UserPromptSubmitHookOutput } from '@librechat/agents';
+
+/**
+ * Per-request match collector. The factory creates one for each
+ * request; the controller reads it after `processStream` resolves to
+ * surface matches to the client (e.g. via SSE for `warn` mode) or to
+ * log them.
+ */
+export type PiiMatchCollector = {
+  matches: PatternMatch[];
+};
+
+export type CreatePiiFilterOptions = {
+  /**
+   * Optional pre-allocated collector. The factory pushes matches into
+   * this object's `matches` array as the hook fires. Default: a fresh
+   * collector returned alongside the registry.
+   */
+  collector?: PiiMatchCollector;
+};
+
+export type CreatePiiFilterResult = {
+  registry: HookRegistry;
+  collector: PiiMatchCollector;
+};
+
+function buildPatternList(config: MessagePiiFilterConfig): SensitivePattern[] {
+  const starter = selectStarterPatterns(config.starterPatterns).map(
+    (p): SensitivePattern => ({
+      id: p.id,
+      label: p.label,
+      pattern: p.pattern,
+    }),
+  );
+  const custom = (config.customPatterns ?? []).map(
+    (p): SensitivePattern => ({
+      id: p.id,
+      label: p.label,
+      // Force global flag; redactSensitiveText uses .replace with /g.
+      pattern: new RegExp(p.regex, 'g'),
+    }),
+  );
+  return [...starter, ...custom];
+}
+
+/**
+ * Builds a HookRegistry that registers a single `UserPromptSubmit`
+ * hook configured per `messagePiiFilter.onMatch`. Returns `undefined`
+ * when the filter is disabled (no config) or selects zero patterns.
+ *
+ * Mode semantics:
+ * - silent: redact + return rewritten prompt
+ * - warn:   redact + return rewritten prompt + matches in collector
+ *           (controller is expected to surface them to the client)
+ * - block:  always block with `decision: 'deny'` on match
+ */
+export function createMessagePiiFilterHooks(
+  config: MessagePiiFilterConfig | undefined,
+  options: CreatePiiFilterOptions = {},
+): CreatePiiFilterResult | undefined {
+  if (config == null) {
+    return undefined;
+  }
+
+  const patterns = buildPatternList(config);
+  if (patterns.length === 0) {
+    return undefined;
+  }
+
+  const { redactionText } = config;
+  const mode = config.onMatch;
+  const collector: PiiMatchCollector = options.collector ?? { matches: [] };
+  const registry = new HookRegistry();
+
+  registry.register('UserPromptSubmit', {
+    hooks: [
+      async (input): Promise<UserPromptSubmitHookOutput> => {
+        const { text, matches } = redactSensitiveText(input.prompt, {
+          patterns,
+          redactionText,
+        });
+        if (matches.length === 0) {
+          return {};
+        }
+
+        collector.matches.push(...matches);
+
+        if (mode === 'block') {
+          logger.info(
+            `[messagePiiFilter] blocked send (mode=block, patterns=${matches
+              .map((m) => m.patternId)
+              .join(',')})`,
+          );
+          return {
+            decision: 'deny',
+            reason: 'message_pii_filter_block',
+          };
+        }
+
+        // silent + warn both redact server-side. The difference is
+        // that warn surfaces the matches to the UI via the controller
+        // (which reads collector.matches after processStream resolves).
+        if (mode === 'warn') {
+          logger.info(
+            `[messagePiiFilter] redacted ${matches.length} match(es) (mode=warn, patterns=${matches
+              .map((m) => m.patternId)
+              .join(',')})`,
+          );
+        }
+
+        return { updatedPrompt: text };
+      },
+    ],
+  });
+
+  return { registry, collector };
+}

--- a/packages/api/src/agents/messagePiiFilter.ts
+++ b/packages/api/src/agents/messagePiiFilter.ts
@@ -91,7 +91,9 @@ export function createMessagePiiFilterHooks(
           return {};
         }
 
-        collector.matches.push(...matches);
+        if (mode !== 'silent') {
+          collector.matches.push(...matches);
+        }
 
         if (mode === 'block') {
           logger.info(
@@ -108,13 +110,11 @@ export function createMessagePiiFilterHooks(
         // silent + warn both redact server-side. The difference is
         // that warn surfaces the matches to the UI via the controller
         // (which reads collector.matches after processStream resolves).
-        if (mode === 'warn') {
-          logger.info(
-            `[messagePiiFilter] redacted ${matches.length} match(es) (mode=warn, patterns=${matches
-              .map((m) => m.patternId)
-              .join(',')})`,
-          );
-        }
+        logger.info(
+          `[messagePiiFilter] redacted ${matches.length} match(es) (mode=${mode}, patterns=${matches
+            .map((m) => m.patternId)
+            .join(',')})`,
+        );
 
         return { updatedPrompt: text };
       },

--- a/packages/api/src/agents/messagePiiFilter.ts
+++ b/packages/api/src/agents/messagePiiFilter.ts
@@ -25,6 +25,13 @@ export type CreatePiiFilterOptions = {
    * collector returned alongside the registry.
    */
   collector?: PiiMatchCollector;
+  /**
+   * Invoked from inside the hook (while the response is still open)
+   * with the matches detected for this prompt. Used by the controller
+   * to emit a `pii_matches` SSE event for warn mode before
+   * processStream closes the response.
+   */
+  onMatches?: (matches: PatternMatch[]) => void;
 };
 
 export type CreatePiiFilterResult = {
@@ -32,7 +39,7 @@ export type CreatePiiFilterResult = {
   collector: PiiMatchCollector;
 };
 
-function buildPatternList(config: MessagePiiFilterConfig): SensitivePattern[] {
+export function buildPatternList(config: MessagePiiFilterConfig): SensitivePattern[] {
   const starter = selectStarterPatterns(config.starterPatterns).map(
     (p): SensitivePattern => ({
       id: p.id,
@@ -78,6 +85,7 @@ export function createMessagePiiFilterHooks(
   const { redactionText } = config;
   const mode = config.onMatch;
   const collector: PiiMatchCollector = options.collector ?? { matches: [] };
+  const { onMatches } = options;
   const registry = new HookRegistry();
 
   registry.register('UserPromptSubmit', {
@@ -93,6 +101,9 @@ export function createMessagePiiFilterHooks(
 
         if (mode !== 'silent') {
           collector.matches.push(...matches);
+          if (mode === 'warn' && onMatches != null) {
+            onMatches(matches);
+          }
         }
 
         if (mode === 'block') {
@@ -122,4 +133,26 @@ export function createMessagePiiFilterHooks(
   });
 
   return { registry, collector };
+}
+
+/**
+ * Apply the configured PII filter directly to a text blob, bypassing
+ * the agents hook plumbing. Used by the agents request controller to
+ * pre-redact `req.body.text` before the user message is created/saved,
+ * so the chat-history display and persisted message both have the
+ * redacted text. Mode semantics are interpreted by the caller. This
+ * helper just runs the scrubber and returns the result.
+ */
+export function applyMessagePiiRedaction(
+  text: string,
+  config: MessagePiiFilterConfig | undefined,
+): { text: string; matches: PatternMatch[] } {
+  if (config == null || typeof text !== 'string' || text.length === 0) {
+    return { text: text ?? '', matches: [] };
+  }
+  const patterns = buildPatternList(config);
+  if (patterns.length === 0) {
+    return { text, matches: [] };
+  }
+  return redactSensitiveText(text, { patterns, redactionText: config.redactionText });
 }

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,5 +1,5 @@
 import { logger } from '@librechat/data-schemas';
-import { Run, Providers, Constants } from '@librechat/agents';
+import { Run, HookRegistry, Providers, Constants } from '@librechat/agents';
 import {
   KnownEndpoints,
   MAX_SUBAGENT_DEPTH,
@@ -777,6 +777,7 @@ export async function createRun({
   runId,
   signal,
   agents,
+  hooks,
   messages,
   requestBody,
   user,
@@ -810,6 +811,8 @@ export async function createRun({
    * (e.g. "Ollama") in the summarization config to SDK-recognized providers.
    */
   appConfig?: AppConfig;
+  /** Optional hook registry, passed through to `Run.create`. */
+  hooks?: HookRegistry;
 } & Pick<
   RunConfig,
   'tokenCounter' | 'customHandlers' | 'indexTokenCountMap' | 'initialSessions'
@@ -1045,6 +1048,7 @@ export async function createRun({
     // feedback route in api/server/routes/messages.js). No-op unless Langfuse
     // tracing is enabled. Requires @librechat/agents >= 3.2.21.
     langfuse: { deterministicTraceId: true },
+    ...(hooks != null && { hooks }),
     ...(enableToolOutputReferences && {
       toolOutputReferences: { enabled: true },
     }),

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -948,6 +948,20 @@ class GenerationJobManagerClass {
           streamId,
         };
         onChunk(createdEvent);
+
+        /**
+         * Replay pii_matches from persisted metadata so the warn-mode
+         * toast still fires for subscribers that connect on a
+         * different replica than the one that emitted the live event.
+         * The same-replica path is already covered by earlyEventBuffer
+         * replay above; this branch only runs when no buffer exists.
+         */
+        if (jobData.piiMatches && jobData.piiMatches.length > 0) {
+          logger.debug(
+            `[GenerationJobManager] Cross-replica subscribe: emitting pii_matches from metadata for ${streamId}`,
+          );
+          onChunk({ type: 'pii_matches', matches: jobData.piiMatches });
+        }
       }
 
       try {
@@ -1268,6 +1282,9 @@ class GenerationJobManagerClass {
     }
     if (metadata.promptTokens !== undefined) {
       updates.promptTokens = metadata.promptTokens;
+    }
+    if (metadata.piiMatches) {
+      updates.piiMatches = metadata.piiMatches;
     }
     await this.jobStore.updateJob(streamId, updates);
   }

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -927,36 +927,37 @@ class GenerationJobManagerClass {
           }
         }
         runtime.earlyEventBuffer = [];
-      } else if (this._isRedis && !options?.skipBufferReplay && jobData?.userMessage) {
+      } else if (this._isRedis && !options?.skipBufferReplay) {
         /**
-         * Cross-replica fallback: the created event was buffered on the generating
-         * instance and published via Redis pub/sub before this subscriber was active.
-         * Reconstruct from persisted metadata. Only fields stored by trackUserMessage()
-         * are available (messageId, parentMessageId, conversationId, text);
-         * sender/isCreatedByUser are invariant for user messages and added back here.
+         * Cross-replica fallback. Events emitted on the generating
+         * instance were buffered there and published via Redis pub/sub
+         * before this subscriber was active, so reconstruct from
+         * persisted metadata. The two reconstructions are independent
+         * because they are persisted at different points in the
+         * request lifecycle: `pii_matches` is written by the
+         * pre-redaction step in the request controller (before the
+         * agent run starts), while `userMessage` is written by the
+         * agent's `onStart` callback after the user message is
+         * created. A subscriber that connects between those two
+         * moments must still receive the pii_matches reconstruction
+         * even though `jobData.userMessage` is not yet set.
          */
-        logger.debug(
-          `[GenerationJobManager] Cross-replica subscribe: emitting created event from metadata for ${streamId}`,
-        );
-        const createdEvent: t.CreatedEvent = {
-          created: true,
-          message: {
-            ...jobData.userMessage,
-            sender: 'User',
-            isCreatedByUser: true,
-          },
-          streamId,
-        };
-        onChunk(createdEvent);
-
-        /**
-         * Replay pii_matches from persisted metadata so the warn-mode
-         * toast still fires for subscribers that connect on a
-         * different replica than the one that emitted the live event.
-         * The same-replica path is already covered by earlyEventBuffer
-         * replay above; this branch only runs when no buffer exists.
-         */
-        if (jobData.piiMatches && jobData.piiMatches.length > 0) {
+        if (jobData?.userMessage) {
+          logger.debug(
+            `[GenerationJobManager] Cross-replica subscribe: emitting created event from metadata for ${streamId}`,
+          );
+          const createdEvent: t.CreatedEvent = {
+            created: true,
+            message: {
+              ...jobData.userMessage,
+              sender: 'User',
+              isCreatedByUser: true,
+            },
+            streamId,
+          };
+          onChunk(createdEvent);
+        }
+        if (jobData?.piiMatches && jobData.piiMatches.length > 0) {
           logger.debug(
             `[GenerationJobManager] Cross-replica subscribe: emitting pii_matches from metadata for ${streamId}`,
           );

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -912,6 +912,7 @@ export class RedisJobStore implements IJobStore {
       conversationId: data.conversationId || undefined,
       error: data.error || undefined,
       userMessage: data.userMessage ? JSON.parse(data.userMessage) : undefined,
+      piiMatches: data.piiMatches ? JSON.parse(data.piiMatches) : undefined,
       responseMessageId: data.responseMessageId || undefined,
       createdEventEmitted: data.createdEventEmitted === '1',
       sender: data.sender || undefined,

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -33,6 +33,19 @@ export interface SerializableJobData {
   /** Whether the user-message created event has been emitted */
   createdEventEmitted?: boolean;
 
+  /**
+   * PII matches detected by the messagePiiFilter pre-redaction step.
+   * Persisted so a subscriber that connects on a different replica
+   * than the one that emitted the live `pii_matches` SSE event can
+   * still receive the warn-mode toast via the cross-replica
+   * reconstruction path in `GenerationJobManager.subscribe`.
+   */
+  piiMatches?: Array<{
+    patternId: string;
+    patternLabel: string;
+    count: number;
+  }>;
+
   /** Sender name for UI display */
   sender?: string;
 

--- a/packages/api/src/types/events.ts
+++ b/packages/api/src/types/events.ts
@@ -46,4 +46,18 @@ export type FinalEvent = {
   error?: { message: string };
 };
 
-export type ServerSentEvent = StreamEvent | CreatedEvent | FinalEvent;
+/**
+ * Surfaces PII / credential pattern matches detected by the
+ * messagePiiFilter (server-side pre-redaction or agents-side hook).
+ * Frontend renders the configured `warn`-mode toast off this event.
+ */
+export type PiiMatchesEvent = {
+  type: 'pii_matches';
+  matches: Array<{
+    patternId: string;
+    patternLabel: string;
+    count: number;
+  }>;
+};
+
+export type ServerSentEvent = StreamEvent | CreatedEvent | FinalEvent | PiiMatchesEvent;

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -1,5 +1,5 @@
-import type { EventEmitter } from 'events';
 import type { Agents } from 'librechat-data-provider';
+import type { EventEmitter } from 'events';
 import type { ServerSentEvent } from '~/types';
 
 export interface GenerationJobMetadata {
@@ -20,6 +20,18 @@ export interface GenerationJobMetadata {
   model?: string;
   /** Prompt token count for abort token spending */
   promptTokens?: number;
+  /**
+   * PII matches detected by messagePiiFilter pre-redaction. When set
+   * via `updateMetadata`, the cross-replica subscribe fallback emits
+   * a `pii_matches` SSE event from this payload (parallel to the
+   * `created` event reconstruction) so the warn-mode toast survives
+   * a subscriber landing on a different replica than the emitter.
+   */
+  piiMatches?: Array<{
+    patternId: string;
+    patternLabel: string;
+    count: number;
+  }>;
 }
 
 export type GenerationJobStatus = 'running' | 'complete' | 'error' | 'aborted';

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -10,11 +10,11 @@ import {
 } from './schemas';
 import { ComponentTypes, SettingTypes, OptionTypes } from './generate';
 import { specsConfigSchema, TSpecsConfig } from './models';
+import { REFILL_INTERVAL_UNITS } from './balance';
 import { fileConfigSchema } from './file-config';
 import { apiBaseUrl } from './api-endpoints';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
-import { REFILL_INTERVAL_UNITS } from './balance';
 
 export const defaultSocialLogins = ['google', 'facebook', 'openid', 'github', 'discord', 'saml'];
 
@@ -1417,6 +1417,44 @@ export const summarizationConfigSchema = z.object({
 
 export type SummarizationConfig = z.infer<typeof summarizationConfigSchema>;
 
+export const messagePiiOnMatchSchema = z.enum(['silent', 'warn', 'block']);
+
+export type MessagePiiOnMatch = z.infer<typeof messagePiiOnMatchSchema>;
+
+export const messagePiiCustomPatternSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    regex: z
+      .string()
+      .min(1)
+      .refine(
+        (value) => {
+          try {
+            new RegExp(value, 'g');
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { message: 'regex must compile via `new RegExp(value, "g")`' },
+      ),
+  })
+  .strict();
+
+export type MessagePiiCustomPattern = z.infer<typeof messagePiiCustomPatternSchema>;
+
+export const messagePiiFilterSchema = z
+  .object({
+    onMatch: messagePiiOnMatchSchema,
+    starterPatterns: z.array(z.string()).optional(),
+    customPatterns: z.array(messagePiiCustomPatternSchema).optional(),
+    redactionText: z.string().default('[REDACTED]'),
+  })
+  .strict();
+
+export type MessagePiiFilterConfig = z.infer<typeof messagePiiFilterSchema>;
+
 const customEndpointsSchema = z.array(endpointSchema.partial()).optional();
 
 export const configSchema = z.object({
@@ -1426,6 +1464,7 @@ export const configSchema = z.object({
   webSearch: webSearchSchema.optional(),
   memory: memorySchema.optional(),
   summarization: summarizationConfigSchema.optional(),
+  messagePiiFilter: messagePiiFilterSchema.optional(),
   secureImageLinks: z.boolean().optional(),
   imageOutputType: z.nativeEnum(EImageOutputType).default(EImageOutputType.PNG),
   includedTools: z.array(z.string()).optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1211,6 +1211,7 @@ export type TStartupConfig = {
     branch?: string | null;
     buildDate?: string | null;
   };
+  messagePiiFilter?: MessagePiiFilterClientConfig;
 };
 
 export enum OCRStrategy {
@@ -1454,6 +1455,24 @@ export const messagePiiFilterSchema = z
   .strict();
 
 export type MessagePiiFilterConfig = z.infer<typeof messagePiiFilterSchema>;
+
+/**
+ * Wire format of MessagePiiFilterConfig as exposed to the browser via the
+ * startup config endpoint. Patterns are serialized as { source, flags }
+ * because RegExp doesn't survive JSON; the client reconstructs them with
+ * `new RegExp(source, flags)`. Only present when the operator has
+ * configured `messagePiiFilter` in librechat.yaml.
+ */
+export type MessagePiiFilterClientConfig = {
+  onMatch: 'warn' | 'silent' | 'block';
+  redactionText: string;
+  patterns: Array<{
+    id: string;
+    label: string;
+    source: string;
+    flags: string;
+  }>;
+};
 
 const customEndpointsSchema = z.array(endpointSchema.partial()).optional();
 

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -51,3 +51,4 @@ export * from './feedback';
 export * from './parameterSettings';
 /* code-execution sandbox */
 export * from './codeEnvRef';
+export * from './messagePiiPatterns';

--- a/packages/data-provider/src/messagePiiPatterns.ts
+++ b/packages/data-provider/src/messagePiiPatterns.ts
@@ -1,0 +1,87 @@
+/**
+ * Starter PII regex catalog. Patterns ported from LibreChat#13561's
+ * winston log redaction (`packages/data-schemas/src/config/parsers.ts`),
+ * which already had production CI coverage there. These are the
+ * defaults the `messagePiiFilter` ships with; operators can subset
+ * them via `starterPatterns: [ids...]` or add their own under
+ * `customPatterns` in `librechat.yaml`.
+ *
+ * Each pattern's first capture group is the visible prefix that
+ * survives redaction (so trace/log readers can still tell which
+ * family of secret matched). All patterns use the `g` flag, required
+ * by the agents-side scrubber to scan past the first match.
+ */
+
+export type PiiPattern = {
+  id: string;
+  label: string;
+  pattern: RegExp;
+};
+
+/**
+ * Lower-false-positive starter set. Enabled by default when the
+ * messagePiiFilter section is present and `starterPatterns` is omitted.
+ */
+export const STARTER_PII_PATTERNS: PiiPattern[] = [
+  {
+    id: 'sk_prefix',
+    label: 'sk- prefix token (OpenAI/Anthropic/Langfuse/etc.)',
+    pattern: /\b(sk-)[a-zA-Z0-9_-]+/g,
+  },
+  {
+    id: 'bearer_header',
+    label: 'Bearer token',
+    pattern: /\b(Bearer )[^\s"']+/gi,
+  },
+  {
+    id: 'api_key_header',
+    label: 'api-key header',
+    pattern: /\b(api-key:?\s+)[^\s"']+/gi,
+  },
+];
+
+/**
+ * Patterns that are useful but high-false-positive in prompt contexts:
+ * `?key=value` and `?api_key=…` match normal sentences in code-help
+ * conversations. Available by id but NOT in the default starter set.
+ * operators opt in explicitly via `starterPatterns: [api_key_query, ...]`.
+ */
+export const OPT_IN_PII_PATTERNS: PiiPattern[] = [
+  {
+    id: 'api_key_query',
+    label: 'api_key URL param',
+    pattern: /\b(api_key=)[^\s"'&]+/gi,
+  },
+  {
+    id: 'key_query',
+    label: 'key URL param',
+    pattern: /\b(key=)[^\s"'&]+/g,
+  },
+];
+
+const ALL_PII_PATTERNS: PiiPattern[] = [...STARTER_PII_PATTERNS, ...OPT_IN_PII_PATTERNS];
+
+export const STARTER_PATTERN_IDS = STARTER_PII_PATTERNS.map((p) => p.id);
+
+const PATTERN_BY_ID = new Map<string, PiiPattern>(ALL_PII_PATTERNS.map((p) => [p.id, p]));
+
+/**
+ * Picks patterns from the starter + opt-in catalog by id. Returns a
+ * fresh array so callers can mutate without affecting module state.
+ * Pass `undefined` for the default starter set; pass explicit ids to
+ * select from both starter and opt-in patterns. Unknown ids are
+ * silently dropped.
+ */
+export function selectStarterPatterns(ids?: string[]): PiiPattern[] {
+  if (ids == null) {
+    return [...STARTER_PII_PATTERNS];
+  }
+  const selected: PiiPattern[] = [];
+  for (const id of ids) {
+    const entry = PATTERN_BY_ID.get(id);
+    if (entry != null) {
+      selected.push(entry);
+    }
+  }
+  return selected;
+}

--- a/packages/data-schemas/src/app/service.ts
+++ b/packages/data-schemas/src/app/service.ts
@@ -110,6 +110,7 @@ export const AppService = async (params?: {
   const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
   const turnstileConfig = loadTurnstileConfig(config, configDefaults);
   const speech = config.speech;
+  const messagePiiFilter = config.messagePiiFilter;
 
   const defaultConfig = {
     ocr,
@@ -117,6 +118,7 @@ export const AppService = async (params?: {
     config,
     memory,
     speech,
+    messagePiiFilter,
     balance,
     actions,
     webSearch,

--- a/packages/data-schemas/src/types/app.ts
+++ b/packages/data-schemas/src/types/app.ts
@@ -62,6 +62,8 @@ export interface AppConfig {
   summarization?: SummarizationConfig;
   /** Web search configuration */
   webSearch?: TCustomConfig['webSearch'];
+  /** Message PII filter configuration */
+  messagePiiFilter?: TCustomConfig['messagePiiFilter'];
   /** File storage strategy ('local', 's3', 'firebase', 'azure_blob', 'cloudfront') */
   fileStrategy: FileStorage;
   /** File strategies configuration */


### PR DESCRIPTION
## Summary

Adds a configurable PII / credential filter for user messages. Credentials matching the configured patterns are caught both client-side (instant UX) and server-side (enforcement boundary) before they reach the model, the chat history, or external observability (Langfuse and similar).

Three modes via `messagePiiFilter.onMatch` in `librechat.yaml`:

* `warn`: redact inline + show a warning toast
* `silent`: redact inline, no UI
* `block`: refuse the submission, show an error toast

Patterns come from a starter catalog (`sk-` prefix tokens, Bearer headers, `api-key:` headers) that operators can subset via `starterPatterns: [...]` and extend with regex via `customPatterns`.

### Architecture

Defense in depth across three layers:

1. **Client-side prefilter** runs in the submit handler at the single `useChatFunctions.ask` chokepoint that covers all seven submit paths (form submit, regenerate, continue, edit-and-resubmit, edit content part, voice auto-send, programmatic ask). Patterns ship to the browser via the existing startup config endpoint, serialized as `{ source, flags }` so RegExp survives JSON.
2. **Server-side pre-redaction** mutates `req.body.text` before the user message is constructed, so the persisted MongoDB row and the `created` SSE event both carry redacted text from the start. For block mode it also throws from inside `getReqData`'s second invocation (after the user message save is in-flight) to route through the existing `emitError` path for the assistant turn.
3. **Agents-side hook** as a no-op safety net for the layers above when text has already been pre-redacted.

The client-side layer is for UX. The server-side layer is the enforcement boundary for callers that bypass the UI (curl, custom clients). When both fire on the same prompt, the server finds nothing to scrub in the already-redacted text and stays silent, so no duplicate toast.

### Dependencies

Depends on **danny-avila/agents#230** for the `updatedPrompt` hook output + `redactSensitiveText` primitive used by the agents-side hook in `packages/api/src/agents/messagePiiFilter.ts`. Backend unit tests will fail in CI until danny-avila/agents#230 is merged and a new `@librechat/agents` release is published, because the currently published agents version returns `undefined` for `updatedPrompt`. Once danny-avila/agents#230 ships and this PR's `@librechat/agents` dependency is bumped to that release, CI will go green. All other checks (lint, prettier, import sort, typecheck) pass locally.

### Example config

```yaml
messagePiiFilter:
  onMatch: warn
  redactionText: "[REDACTED]"
  starterPatterns:
    - sk_prefix
    - bearer_header
    - api_key_header
  customPatterns:
    - id: my_org_token
      label: My Org token
      regex: "\\bORG-[A-Z0-9]{10,}"
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

### **Test Configuration**:

`librechat.yaml` with the example config above. Run backend + frontend dev servers, send a chat message containing one of the configured pattern matches.

- [ ] `cd packages/api && npx jest src/agents/__tests__/messagePiiFilter.spec.ts` passes (12 cases) once agents PR **danny-avila/agents#230** is merged + a new `@librechat/agents` release is published
- [ ] Manual `warn`: send `my key is sk-proj-FAKE1234567890 please debug` → warning toast, redacted text in chat bubble, redacted in Langfuse trace
- [ ] Manual `block`: same prompt → error toast, no POST fires (Network tab), nothing persists
- [ ] Manual `silent`: redacted in chat history, no toast
- [ ] Manual curl bypass: send raw credential without browser → server still pre-redacts (verify MongoDB row)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes (with companion **danny-avila/agents#230** vendored locally)
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.