### PR TITLE
feat: optionally delete conversation files on conversation delete

### DIFF
--- a/api/server/routes/__tests__/convos.spec.js
+++ b/api/server/routes/__tests__/convos.spec.js
@@ -17,6 +17,10 @@ jest.mock('~/server/routes/files/multer', () => require(MOCKS).multerSetup());
 jest.mock('multer', () => require(MOCKS).multerLib());
 jest.mock('~/server/services/Endpoints/azureAssistants', () => require(MOCKS).assistantEndpoint());
 jest.mock('~/server/services/Endpoints/assistants', () => require(MOCKS).assistantEndpoint());
+jest.mock('~/server/services/Files/process', () => ({
+  processDeleteRequest: jest.fn(),
+  getConvoFilesToDelete: jest.fn(),
+}));
 
 describe('Convos Routes', () => {
   let app;
@@ -430,6 +434,113 @@ describe('Convos Routes', () => {
     });
   });
 
+  describe('DELETE / with deleteFilesOnConversationDelete', () => {
+    const {
+      processDeleteRequest,
+      getConvoFilesToDelete,
+    } = require('~/server/services/Files/process');
+
+    /** Builds an app that injects the given fileConfig into req.config. */
+    const buildAppWithConfig = (fileConfig) => {
+      const localApp = express();
+      localApp.use(express.json());
+      localApp.use((req, res, next) => {
+        req.user = { id: 'test-user-123' };
+        req.config = { fileConfig };
+        next();
+      });
+      localApp.use('/api/convos', require('../convos'));
+      return localApp;
+    };
+
+    beforeEach(() => {
+      deleteConvos.mockResolvedValue({ deletedCount: 1 });
+      deleteToolCalls.mockResolvedValue({ deletedCount: 0 });
+      deleteConvoSharedLinksWithCleanup.mockResolvedValue({ deletedCount: 0 });
+    });
+
+    it('does not delete files when the flag is absent', async () => {
+      const response = await request(app)
+        .delete('/api/convos')
+        .send({ arg: { conversationId: 'conv-flag-off' } });
+
+      expect(response.status).toBe(201);
+      expect(getConvoFilesToDelete).not.toHaveBeenCalled();
+      expect(processDeleteRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not delete files when the flag is false', async () => {
+      const localApp = buildAppWithConfig({ deleteFilesOnConversationDelete: false });
+
+      const response = await request(localApp)
+        .delete('/api/convos')
+        .send({ arg: { conversationId: 'conv-flag-false' } });
+
+      expect(response.status).toBe(201);
+      expect(getConvoFilesToDelete).not.toHaveBeenCalled();
+      expect(processDeleteRequest).not.toHaveBeenCalled();
+    });
+
+    it('deletes the exclusively-owned files when the flag is true', async () => {
+      const files = [{ file_id: 'fileA', source: 'local' }];
+      getConvoFilesToDelete.mockResolvedValue(files);
+      const localApp = buildAppWithConfig({ deleteFilesOnConversationDelete: true });
+
+      const response = await request(localApp)
+        .delete('/api/convos')
+        .send({ arg: { conversationId: 'conv-flag-on' } });
+
+      expect(response.status).toBe(201);
+      expect(getConvoFilesToDelete).toHaveBeenCalledWith({
+        userId: 'test-user-123',
+        conversationId: 'conv-flag-on',
+      });
+      expect(processDeleteRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ files }),
+      );
+    });
+
+    it('collects the files before deleteConvos removes the messages', async () => {
+      getConvoFilesToDelete.mockResolvedValue([{ file_id: 'fileA', source: 'local' }]);
+      const localApp = buildAppWithConfig({ deleteFilesOnConversationDelete: true });
+
+      await request(localApp)
+        .delete('/api/convos')
+        .send({ arg: { conversationId: 'conv-order' } });
+
+      expect(getConvoFilesToDelete).toHaveBeenCalledBefore(deleteConvos);
+    });
+
+    it('is a no-op when the conversation has no files', async () => {
+      getConvoFilesToDelete.mockResolvedValue([]);
+      const localApp = buildAppWithConfig({ deleteFilesOnConversationDelete: true });
+
+      const response = await request(localApp)
+        .delete('/api/convos')
+        .send({ arg: { conversationId: 'conv-no-files' } });
+
+      expect(response.status).toBe(201);
+      expect(processDeleteRequest).not.toHaveBeenCalled();
+    });
+
+    it('still returns 201 when file deletion fails (error swallowed)', async () => {
+      getConvoFilesToDelete.mockResolvedValue([{ file_id: 'fileA', source: 'local' }]);
+      processDeleteRequest.mockRejectedValue(new Error('storage boom'));
+      const localApp = buildAppWithConfig({ deleteFilesOnConversationDelete: true });
+
+      const response = await request(localApp)
+        .delete('/api/convos')
+        .send({ arg: { conversationId: 'conv-file-error' } });
+
+      expect(response.status).toBe(201);
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).toHaveBeenCalledWith(
+        '[/convos] Failed to delete files associated with conversation',
+        expect.any(Error),
+      );
+    });
+  });
+
   describe('POST /archive', () => {
     it('should archive a conversation successfully', async () => {
       const mockConversationId = 'conv-123';
@@ -598,6 +709,30 @@ expect.extend({
         pass
           ? `Expected ${received.getMockName()} not to have been called after ${other.getMockName()}`
           : `Expected ${received.getMockName()} to have been called after ${other.getMockName()}`,
+    };
+  },
+  toHaveBeenCalledBefore(received, other) {
+    const receivedCalls = received.mock.invocationCallOrder;
+    const otherCalls = other.mock.invocationCallOrder;
+
+    if (receivedCalls.length === 0 || otherCalls.length === 0) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected ${received.getMockName()} to have been called before ${other.getMockName()}, but one of them was never called`,
+      };
+    }
+
+    const firstReceivedCall = receivedCalls[0];
+    const lastOtherCall = otherCalls[otherCalls.length - 1];
+    const pass = firstReceivedCall < lastOtherCall;
+
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `Expected ${received.getMockName()} not to have been called before ${other.getMockName()}`
+          : `Expected ${received.getMockName()} to have been called before ${other.getMockName()}`,
     };
   },
 });

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -19,6 +19,10 @@ const {
 const { forkConversation, duplicateConversation } = require('~/server/utils/import/fork');
 const { storage, importFileFilter } = require('~/server/routes/files/multer');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
+const {
+  processDeleteRequest,
+  getConvoFilesToDelete,
+} = require('~/server/services/Files/process');
 const { importConversations } = require('~/server/utils/import');
 const getLogStores = require('~/cache/getLogStores');
 const db = require('~/models');
@@ -111,7 +115,7 @@ router.get('/gen_title/:conversationId', async (req, res) => {
   }
 });
 
-router.delete('/', async (req, res) => {
+router.delete('/', configMiddleware, async (req, res) => {
   let filter = {};
   const { conversationId, source, thread_id, endpoint } = req.body?.arg ?? {};
 
@@ -142,11 +146,27 @@ router.delete('/', async (req, res) => {
     }
   }
 
+  // Collect files to delete before deleteConvos removes the conversation's messages.
+  let filesToDelete = [];
+  if (req.config?.fileConfig?.deleteFilesOnConversationDelete === true && filter.conversationId) {
+    filesToDelete = await getConvoFilesToDelete({
+      userId: req.user.id,
+      conversationId: filter.conversationId,
+    });
+  }
+
   try {
     const dbResponse = await db.deleteConvos(req.user.id, filter);
     if (filter.conversationId) {
       await db.deleteToolCalls(req.user.id, filter.conversationId);
       await deleteConvoSharedLinksWithCleanup(req.user.id, filter.conversationId);
+    }
+    if (filesToDelete.length > 0) {
+      try {
+        await processDeleteRequest({ req, files: filesToDelete });
+      } catch (error) {
+        logger.error('[/convos] Failed to delete files associated with conversation', error);
+      }
     }
     res.status(201).json(dbResponse);
   } catch (error) {

--- a/api/server/services/Files/getConvoFilesToDelete.spec.js
+++ b/api/server/services/Files/getConvoFilesToDelete.spec.js
@@ -1,0 +1,186 @@
+jest.mock('uuid', () => ({ v4: jest.fn(() => 'mock-uuid') }));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+  runAsSystem: jest.fn((fn) => fn()),
+}));
+
+jest.mock('@librechat/agents', () => ({
+  Providers: {},
+}));
+
+jest.mock('librechat-data-provider', () => {
+  const actual = jest.requireActual('librechat-data-provider');
+  return {
+    ...actual,
+    mergeFileConfig: jest.fn(),
+  };
+});
+
+jest.mock('@librechat/api', () => ({
+  sanitizeFilename: jest.fn((n) => n),
+  parseText: jest.fn(),
+  processAudioFile: jest.fn(),
+  getStorageMetadata: jest.fn(() => ({})),
+  sweepExpiredFiles: jest.fn(),
+  startExpiredFileSweep: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/images', () => ({
+  convertImage: jest.fn(),
+  resizeAndConvert: jest.fn(),
+  resizeImageBuffer: jest.fn(),
+}));
+
+jest.mock('~/server/controllers/assistants/v2', () => ({
+  addResourceFileId: jest.fn(),
+  deleteResourceFileId: jest.fn(),
+}));
+
+jest.mock('~/server/controllers/assistants/helpers', () => ({
+  getOpenAIClient: jest.fn(),
+}));
+
+jest.mock('~/server/services/Tools/credentials', () => ({
+  loadAuthValues: jest.fn(),
+}));
+
+jest.mock('~/server/utils/getFileStrategy', () => ({
+  getFileStrategy: jest.fn().mockReturnValue('local'),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  checkCapability: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('~/server/utils/queue', () => ({
+  LB_QueueAsyncCall: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/strategies', () => ({
+  getStrategyFunctions: jest.fn(),
+}));
+
+jest.mock('~/server/utils', () => ({
+  determineFileType: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/Audio/STTService', () => ({
+  STTService: { getInstance: jest.fn() },
+}));
+
+jest.mock('~/models', () => ({
+  getConvoFiles: jest.fn(),
+  getMessages: jest.fn(),
+  getFiles: jest.fn(),
+  findConvosWithFiles: jest.fn(),
+  findAgentFileIds: jest.fn(),
+}));
+
+const db = require('~/models');
+const { getConvoFilesToDelete } = require('./process');
+
+const userId = 'user-1';
+const conversationId = 'convo-1';
+
+const fileDoc = (file_id) => ({ file_id, user: userId, source: 'local', filepath: `/x/${file_id}` });
+
+describe('getConvoFilesToDelete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.getConvoFiles.mockResolvedValue([]);
+    db.getMessages.mockResolvedValue([]);
+    db.getFiles.mockResolvedValue([]);
+    db.findConvosWithFiles.mockResolvedValue([]);
+    db.findAgentFileIds.mockResolvedValue([]);
+  });
+
+  it('returns [] and skips lookups when there are no candidate files', async () => {
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(result).toEqual([]);
+    expect(db.getFiles).not.toHaveBeenCalled();
+    expect(db.findConvosWithFiles).not.toHaveBeenCalled();
+    expect(db.findAgentFileIds).not.toHaveBeenCalled();
+  });
+
+  it('returns exclusively-owned files from conversation.files and messages', async () => {
+    db.getConvoFiles.mockResolvedValue(['fileA']);
+    db.getMessages.mockResolvedValue([{ files: [{ file_id: 'fileB' }] }]);
+    db.getFiles.mockResolvedValue([fileDoc('fileA'), fileDoc('fileB')]);
+
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(result.map((f) => f.file_id).sort()).toEqual(['fileA', 'fileB']);
+    expect(db.getFiles).toHaveBeenCalledWith({
+      file_id: { $in: expect.arrayContaining(['fileA', 'fileB']) },
+      user: userId,
+    });
+  });
+
+  it('excludes files still referenced by another conversation', async () => {
+    db.getConvoFiles.mockResolvedValue(['fileA', 'fileB']);
+    db.getFiles.mockResolvedValue([fileDoc('fileA'), fileDoc('fileB')]);
+    db.findConvosWithFiles.mockResolvedValue(['fileB']);
+
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(result.map((f) => f.file_id)).toEqual(['fileA']);
+  });
+
+  it('excludes files attached to an agent tool_resource', async () => {
+    db.getConvoFiles.mockResolvedValue(['fileA', 'fileB']);
+    db.getFiles.mockResolvedValue([fileDoc('fileA'), fileDoc('fileB')]);
+    db.findAgentFileIds.mockResolvedValue(['fileA']);
+
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(result.map((f) => f.file_id)).toEqual(['fileB']);
+  });
+
+  it('returns [] when the conversation has no files', async () => {
+    db.getConvoFiles.mockResolvedValue([]);
+    db.getMessages.mockResolvedValue([]);
+
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates a file id present in both conversation.files and a message', async () => {
+    db.getConvoFiles.mockResolvedValue(['fileA']);
+    db.getMessages.mockResolvedValue([{ files: ['fileA'] }, { files: [{ file_id: 'fileA' }] }]);
+    db.getFiles.mockResolvedValue([fileDoc('fileA')]);
+
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(result.map((f) => f.file_id)).toEqual(['fileA']);
+    const calledWith = db.getFiles.mock.calls[0][0];
+    expect(calledWith.file_id.$in).toEqual(['fileA']);
+  });
+
+  it('passes the requesting user to the file lookup (user scoping)', async () => {
+    db.getConvoFiles.mockResolvedValue(['fileA']);
+    db.getFiles.mockResolvedValue([fileDoc('fileA')]);
+
+    await getConvoFilesToDelete({ userId, conversationId });
+
+    expect(db.getFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ user: userId }),
+    );
+    expect(db.findConvosWithFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ user: userId, excludeConversationId: conversationId }),
+    );
+  });
+
+  it('handles null returns from db methods gracefully', async () => {
+    db.getConvoFiles.mockResolvedValue(null);
+    db.getMessages.mockResolvedValue(null);
+    db.getFiles.mockResolvedValue(null);
+    db.findConvosWithFiles.mockResolvedValue(null);
+    db.findAgentFileIds.mockResolvedValue(null);
+
+    const result = await getConvoFilesToDelete({ userId, conversationId });
+    expect(result).toEqual([]);
+  });
+});

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -323,6 +323,66 @@ const processDeleteRequest = async ({ req, files }) => {
 };
 
 /**
+ * Collects the full file documents that are safe to delete when a single
+ * conversation is deleted.
+ *
+ * Candidates are the union of the conversation's `files` array and any
+ * `file_id`s found on the conversation's messages. A candidate is only
+ * returned when it is exclusively owned by this conversation; the safety
+ * guarantee is that this NEVER returns a file that is:
+ *   - still referenced by another of the user's conversations, or
+ *   - attached to any agent's `tool_resources`.
+ * File documents are also scoped to the requesting user, so files belonging to
+ * other users are never considered.
+ *
+ * @param {Object} params
+ * @param {string} params.userId - The id of the user who owns the conversation.
+ * @param {string} params.conversationId - The conversation being deleted.
+ * @returns {Promise<Array<MongoFile>>} Full file documents safe to delete (may be empty).
+ */
+const getConvoFilesToDelete = async ({ userId, conversationId }) => {
+  const candidateSet = new Set();
+
+  const convoFileIds = (await db.getConvoFiles(conversationId)) ?? [];
+  for (const fileId of convoFileIds) {
+    if (fileId) {
+      candidateSet.add(fileId);
+    }
+  }
+
+  const messages = (await db.getMessages({ conversationId, user: userId }, 'files')) ?? [];
+  for (const message of messages) {
+    for (const entry of message.files ?? []) {
+      const fileId = typeof entry === 'string' ? entry : entry?.file_id;
+      if (fileId) {
+        candidateSet.add(fileId);
+      }
+    }
+  }
+
+  const candidateIds = [...candidateSet];
+  if (candidateIds.length === 0) {
+    return [];
+  }
+
+  const fileDocs =
+    (await db.getFiles({ file_id: { $in: candidateIds }, user: userId })) ?? [];
+
+  const [convoReferenced, agentReferenced] = await Promise.all([
+    db.findConvosWithFiles({
+      user: userId,
+      excludeConversationId: conversationId,
+      fileIds: candidateIds,
+    }),
+    db.findAgentFileIds({ fileIds: candidateIds }),
+  ]);
+
+  const protectedIds = new Set([...(convoReferenced ?? []), ...(agentReferenced ?? [])]);
+
+  return fileDocs.filter((file) => !protectedIds.has(file.file_id));
+};
+
+/**
  * Deletes expired file storage before removing the corresponding File records.
  *
  * Mongo TTL indexes delete only the metadata document, so file retention uses
@@ -1332,6 +1392,7 @@ module.exports = {
   startExpiredFileSweep,
   processFileUpload,
   processDeleteRequest,
+  getConvoFilesToDelete,
   processAgentFileUpload,
   retrieveAndProcessFile,
 };

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -685,6 +685,7 @@ endpoints:
 #       fileSizeLimit: 5
 #   serverFileSizeLimit: 100  # Global server file size limit in MB
 #   avatarSizeLimit: 2  # Limit for user avatar image size in MB
+#   deleteFilesOnConversationDelete: false  # When true, deleting a conversation also deletes its files (DB + storage), except files shared with other conversations or agents
 #   imageGeneration: # Image Gen settings, either percentage or px
 #     percentage: 100
 #     px: 1024

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -473,6 +473,7 @@ export const fileConfigSchema = z.object({
   serverFileSizeLimit: z.number().min(0).optional(),
   avatarSizeLimit: z.number().min(0).optional(),
   fileTokenLimit: z.number().min(0).optional(),
+  deleteFilesOnConversationDelete: z.boolean().optional(),
   imageGeneration: z
     .object({
       percentage: z.number().min(0).max(100).optional(),

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -322,6 +322,7 @@ export function createAgentMethods(
   }: {
     file_ids: string[];
   }) => Promise<{ matchedCount: number; modifiedCount: number }>;
+  findAgentFileIds: ({ fileIds }: { fileIds: string[] }) => Promise<string[]>;
 } {
   const { removeAllPermissions, getActions, getSoleOwnedResourceIds } = deps;
 
@@ -650,6 +651,48 @@ export function createAgentMethods(
   }
 
   /**
+   * Returns the subset of the given file ids that are referenced by any agent's
+   * `tool_resources.*.file_ids`. Read-only; used to keep files attached to an
+   * agent from being deleted when their owning conversation is removed.
+   */
+  async function findAgentFileIds({ fileIds }: { fileIds: string[] }): Promise<string[]> {
+    if (!fileIds || fileIds.length === 0) {
+      return [];
+    }
+
+    const Agent = mongoose.models.Agent as Model<IAgent>;
+
+    const orQuery = TOOL_RESOURCE_KEYS.map((key) => ({
+      [`tool_resources.${key}.file_ids`]: { $in: fileIds },
+    }));
+
+    const projection = TOOL_RESOURCE_KEYS.reduce<Record<string, 1>>((acc, key) => {
+      acc[`tool_resources.${key}.file_ids`] = 1;
+      return acc;
+    }, {});
+
+    const agents = (await Agent.find({ $or: orQuery }, projection).lean()) as Array<{
+      tool_resources?: AgentToolResources;
+    }>;
+
+    const candidateSet = new Set(fileIds);
+    const referenced = new Set<string>();
+    for (const agent of agents) {
+      const toolResources = agent.tool_resources ?? {};
+      for (const key of TOOL_RESOURCE_KEYS) {
+        const resourceFileIds = (toolResources[key] as { file_ids?: string[] } | undefined)
+          ?.file_ids;
+        for (const fileId of resourceFileIds ?? []) {
+          if (candidateSet.has(fileId)) {
+            referenced.add(fileId);
+          }
+        }
+      }
+    }
+    return [...referenced];
+  }
+
+  /**
    * Deletes an agent based on the provided search parameter.
    */
   async function deleteAgent(searchParameter: FilterQuery<IAgent>): Promise<IAgent | null> {
@@ -963,6 +1006,7 @@ export function createAgentMethods(
     generateActionMetadataHash,
     removeAgentFromUserFavorites,
     removeAgentResourceFilesFromAllAgents,
+    findAgentFileIds,
   };
 }
 

--- a/packages/data-schemas/src/methods/agentFiles.spec.ts
+++ b/packages/data-schemas/src/methods/agentFiles.spec.ts
@@ -1,0 +1,127 @@
+import mongoose from 'mongoose';
+import { v4 as uuidv4 } from 'uuid';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { EToolResources } from 'librechat-data-provider';
+import type { IAgent } from '..';
+import { createAgentMethods, type AgentMethods } from './agent';
+
+jest.mock('~/config/winston', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+let mongoServer: InstanceType<typeof MongoMemoryServer>;
+let Agent: mongoose.Model<IAgent>;
+let modelsToCleanup: string[] = [];
+let methods: AgentMethods;
+
+const getActions = jest.fn().mockResolvedValue([]);
+
+const createAgentWithResources = (
+  toolResources: Record<string, { file_ids: string[] }>,
+): Promise<IAgent> =>
+  Agent.create({
+    id: `agent_${uuidv4()}`,
+    name: 'Test Agent',
+    provider: 'test',
+    model: 'test-model',
+    author: new mongoose.Types.ObjectId(),
+    tool_resources: toolResources,
+  }) as unknown as Promise<IAgent>;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+
+  const { createModels } = await import('~/models');
+  const models = createModels(mongoose);
+  modelsToCleanup = Object.keys(models);
+  Object.assign(mongoose.models, models);
+  Agent = mongoose.models.Agent as mongoose.Model<IAgent>;
+
+  methods = createAgentMethods(mongoose, {
+    removeAllPermissions: jest.fn().mockResolvedValue(undefined),
+    getActions,
+    getSoleOwnedResourceIds: jest.fn().mockResolvedValue([]),
+  });
+
+  await mongoose.connect(mongoUri);
+});
+
+afterAll(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    await collections[key].deleteMany({});
+  }
+  for (const modelName of modelsToCleanup) {
+    if (mongoose.models[modelName]) {
+      delete mongoose.models[modelName];
+    }
+  }
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await Agent.deleteMany({});
+  jest.clearAllMocks();
+});
+
+describe('findAgentFileIds', () => {
+  it('returns file ids attached to an agent tool_resource', async () => {
+    await createAgentWithResources({
+      [EToolResources.file_search]: { file_ids: ['fileA', 'fileB'] },
+    });
+
+    const result = await methods.findAgentFileIds({ fileIds: ['fileA', 'fileC'] });
+
+    expect(result).toEqual(['fileA']);
+  });
+
+  it('detects file ids across multiple tool_resource keys', async () => {
+    await createAgentWithResources({
+      [EToolResources.file_search]: { file_ids: ['fileA'] },
+      [EToolResources.context]: { file_ids: ['fileB'] },
+      [EToolResources.ocr]: { file_ids: ['fileC'] },
+    });
+
+    const result = await methods.findAgentFileIds({ fileIds: ['fileA', 'fileB', 'fileC'] });
+
+    expect(result.sort()).toEqual(['fileA', 'fileB', 'fileC']);
+  });
+
+  it('returns empty array when fileIds is empty', async () => {
+    await createAgentWithResources({
+      [EToolResources.file_search]: { file_ids: ['fileA'] },
+    });
+
+    const result = await methods.findAgentFileIds({ fileIds: [] });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no agent references the files', async () => {
+    await createAgentWithResources({
+      [EToolResources.file_search]: { file_ids: ['fileZ'] },
+    });
+
+    const result = await methods.findAgentFileIds({ fileIds: ['fileA', 'fileB'] });
+
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates a file id referenced by multiple agents', async () => {
+    await createAgentWithResources({
+      [EToolResources.file_search]: { file_ids: ['fileA'] },
+    });
+    await createAgentWithResources({
+      [EToolResources.context]: { file_ids: ['fileA'] },
+    });
+
+    const result = await methods.findAgentFileIds({ fileIds: ['fileA'] });
+
+    expect(result).toEqual(['fileA']);
+  });
+});

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -15,6 +15,11 @@ import type { DeleteResult } from 'mongoose';
 
 export interface ConversationMethods {
   getConvoFiles(conversationId: string): Promise<string[]>;
+  findConvosWithFiles(params: {
+    user: string;
+    excludeConversationId: string;
+    fileIds: string[];
+  }): Promise<string[]>;
   searchConversation(conversationId: string): Promise<IConversation | null>;
   deleteNullOrEmptyConversations(): Promise<{
     conversations: { deletedCount?: number };
@@ -172,6 +177,51 @@ export function createConversationMethods(
     } catch (error) {
       logger.error('[getConvoFiles] Error getting conversation files', error);
       throw new Error('Error getting conversation files');
+    }
+  }
+
+  /**
+   * Returns the subset of the given file ids that are still referenced by the
+   * user's other conversations (every conversation except `excludeConversationId`).
+   * Read-only; used to keep shared files from being deleted alongside a single
+   * conversation.
+   */
+  async function findConvosWithFiles({
+    user,
+    excludeConversationId,
+    fileIds,
+  }: {
+    user: string;
+    excludeConversationId: string;
+    fileIds: string[];
+  }): Promise<string[]> {
+    if (!fileIds || fileIds.length === 0) {
+      return [];
+    }
+    try {
+      const Conversation = mongoose.models.Conversation as Model<IConversation>;
+      const convos = await Conversation.find(
+        {
+          user,
+          conversationId: { $ne: excludeConversationId },
+          files: { $in: fileIds },
+        },
+        'files',
+      ).lean<Array<Pick<IConversation, 'files'>>>();
+
+      const candidateSet = new Set(fileIds);
+      const referenced = new Set<string>();
+      for (const convo of convos) {
+        for (const fileId of convo.files ?? []) {
+          if (candidateSet.has(fileId)) {
+            referenced.add(fileId);
+          }
+        }
+      }
+      return [...referenced];
+    } catch (error) {
+      logger.error('[findConvosWithFiles] Error finding conversations with files', error);
+      throw new Error('Error finding conversations with files');
     }
   }
 
@@ -783,6 +833,7 @@ export function createConversationMethods(
 
   return {
     getConvoFiles,
+    findConvosWithFiles,
     searchConversation,
     deleteNullOrEmptyConversations,
     saveConvo,

--- a/packages/data-schemas/src/methods/conversationFiles.spec.ts
+++ b/packages/data-schemas/src/methods/conversationFiles.spec.ts
@@ -1,0 +1,145 @@
+import mongoose from 'mongoose';
+import { v4 as uuidv4 } from 'uuid';
+import type { IConversation } from '../types';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { ConversationMethods, createConversationMethods } from './conversation';
+import { createModels } from '../models';
+
+jest.mock('~/config/winston', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+let mongoServer: InstanceType<typeof MongoMemoryServer>;
+let Conversation: mongoose.Model<IConversation>;
+let modelsToCleanup: string[] = [];
+
+const getMessages = jest.fn().mockResolvedValue([]);
+const deleteMessages = jest.fn().mockResolvedValue({ deletedCount: 0 });
+
+let methods: ConversationMethods;
+
+const createConvo = (
+  user: string,
+  files: string[],
+  conversationId: string = uuidv4(),
+): Promise<IConversation> =>
+  Conversation.create({
+    conversationId,
+    user,
+    endpoint: 'openAI',
+    files,
+  }) as unknown as Promise<IConversation>;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+
+  const models = createModels(mongoose);
+  modelsToCleanup = Object.keys(models);
+  Object.assign(mongoose.models, models);
+  Conversation = mongoose.models.Conversation as mongoose.Model<IConversation>;
+
+  methods = createConversationMethods(mongoose, { getMessages, deleteMessages });
+
+  await mongoose.connect(mongoUri);
+});
+
+afterAll(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    await collections[key].deleteMany({});
+  }
+  for (const modelName of modelsToCleanup) {
+    if (mongoose.models[modelName]) {
+      delete mongoose.models[modelName];
+    }
+  }
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await Conversation.deleteMany({});
+  jest.clearAllMocks();
+});
+
+describe('findConvosWithFiles', () => {
+  const user = 'user-1';
+  const target = 'convo-target';
+
+  it('returns file ids referenced by the user other conversations', async () => {
+    await createConvo(user, ['fileA', 'fileB'], 'convo-other');
+
+    const result = await methods.findConvosWithFiles({
+      user,
+      excludeConversationId: target,
+      fileIds: ['fileA', 'fileB', 'fileC'],
+    });
+
+    expect(result.sort()).toEqual(['fileA', 'fileB']);
+  });
+
+  it('excludes the conversation being deleted', async () => {
+    await createConvo(user, ['fileA'], target);
+
+    const result = await methods.findConvosWithFiles({
+      user,
+      excludeConversationId: target,
+      fileIds: ['fileA'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when fileIds is empty', async () => {
+    await createConvo(user, ['fileA'], 'convo-other');
+
+    const result = await methods.findConvosWithFiles({
+      user,
+      excludeConversationId: target,
+      fileIds: [],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no other conversation references the files', async () => {
+    await createConvo(user, ['fileX'], 'convo-other');
+
+    const result = await methods.findConvosWithFiles({
+      user,
+      excludeConversationId: target,
+      fileIds: ['fileA', 'fileB'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not consider other users conversations', async () => {
+    await createConvo('user-2', ['fileA'], 'convo-other-user');
+
+    const result = await methods.findConvosWithFiles({
+      user,
+      excludeConversationId: target,
+      fileIds: ['fileA'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('deduplicates a file id referenced by multiple conversations', async () => {
+    await createConvo(user, ['fileA'], 'convo-1');
+    await createConvo(user, ['fileA'], 'convo-2');
+
+    const result = await methods.findConvosWithFiles({
+      user,
+      excludeConversationId: target,
+      fileIds: ['fileA'],
+    });
+
+    expect(result).toEqual(['fileA']);
+  });
+});


### PR DESCRIPTION
Closes #13590

### Summary

Deleting a conversation currently removes the conversation and its messages but leaves the uploaded files behind — both the `files` documents and the storage blobs — with nothing referencing them anymore. This adds an opt-in way to have file cleanup follow the conversation.

### What changed

- New `fileConfig.deleteFilesOnConversationDelete` flag (boolean, optional). **Default off**, so existing behavior is unchanged.
- When the flag is on, deleting a single conversation (`DELETE /api/convos` with a `conversationId`) also deletes the files that belonged to it, reusing the existing `processDeleteRequest` pipeline so every storage strategy (local / S3 / Azure / Firebase) is handled.
- Candidate files are the union of the conversation's `files` array and the `file_id`s referenced by its messages.

### Safety

Files in use elsewhere are never deleted. Before deletion, a candidate is dropped if it is:

- still referenced by another of the user's conversations (covers fork / duplicate), or
- attached to any agent's `tool_resources`.

File lookups are scoped to the requesting user, and the files are collected *before* the conversation/messages are removed. File-deletion failures are logged but do not fail the request, so a storage hiccup can't block conversation deletion.

### Scope

This intentionally covers the single-conversation delete only. Bulk paths (`DELETE /api/convos/all`, delete-by-endpoint/source) are left untouched for now; happy to extend if you'd like.

### Tests

- `findConvosWithFiles` / `findAgentFileIds` data-schemas methods (mongodb-memory-server).
- Helper + route behavior: flag off → no deletion; flag on with exclusively-owned files → deleted; file shared with another conversation → preserved; file attached to an agent → preserved; no files → no-op; `processDeleteRequest` throwing → request still succeeds; de-dup across conversation/message files; user scoping.
