### PR TITLE
✨ v0.8.7-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# v0.8.6
+# v0.8.7-rc1
 
 # Base node image
 FROM node:24.16.0-alpine AS node

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,5 @@
 # Dockerfile.multi
-# v0.8.6
+# v0.8.7-rc1
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-<!-- Last synced with README.md: 2026-03-28 (cae3888) -->
+<!-- Last synced with README.md: 2026-05-12 (947bfa4c40) -->
 
 <p align="center">
   <a href="https://librechat.ai">
@@ -76,6 +76,8 @@
     - 智能体市场：发现并部署社区构建的智能体。
     - 协作共享：与特定用户和群组共享智能体。
     - 灵活且可扩展：支持 MCP 服务器、工具、文件搜索、代码执行等。
+    - [Skills](https://www.librechat.ai/docs/features/skills)：创建可复用的 `SKILL.md` 指令包，用于手动、自动或始终启用的智能体工作流。
+    - [Subagents](https://www.librechat.ai/docs/features/subagents)：将专门任务委派给拥有独立上下文窗口的隔离子智能体运行。
     - 兼容自定义端点、OpenAI, Azure, Anthropic, AWS Bedrock, Google, Vertex AI, Responses API 等。
     - [支持模型上下文协议 (MCP)](https://modelcontextprotocol.io/clients#librechat) 用于工具调用。
 
@@ -139,6 +141,7 @@
 
 - ⚙️ **配置与部署**：  
   - 支持代理、反向代理、Docker 及多种部署选项。  
+  - 使用 [S3 与 CloudFront](https://www.librechat.ai/docs/configuration/cdn/cloudfront) 获得稳定的媒体链接、边缘分发、签名 Cookie 和安全下载。
   - 可完全本地运行或部署在云端。
 
 - 📖 **开源与社区**：  

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "v0.8.6",
+  "version": "v0.8.7-rc1",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.6",
+      "version": "0.8.7-rc1",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.14.3",
         "@aws-sdk/client-bedrock-runtime": "^3.980.0",
@@ -130,7 +130,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.6",
+      "version": "0.8.7-rc1",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@ariakit/react-core": "^0.4.17",
@@ -264,7 +264,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.31",
+      "version": "1.7.32",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
@@ -345,7 +345,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.60",
+      "version": "0.4.61",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
@@ -433,7 +433,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.503",
+      "version": "0.8.505",
       "dependencies": {
         "axios": "^1.13.5",
         "dayjs": "^1.11.13",
@@ -470,7 +470,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,4 @@
-/** v0.8.6 */
+/** v0.8.7-rc1 */
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "v0.8.6",
+  "version": "v0.8.7-rc1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/e2e/jestSetup.js
+++ b/e2e/jestSetup.js
@@ -1,3 +1,3 @@
-// v0.8.6
+// v0.8.7-rc1
 // See .env.test.example for an example of the '.env.test' file.
 require('dotenv').config({ path: './e2e/.env.test' });

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -23,7 +23,7 @@ version: 2.0.5
 # It is recommended to use it with quotes.
 
 # renovate: image=registry.librechat.ai/danny-avila/librechat
-appVersion: "v0.8.6"
+appVersion: "v0.8.7-rc1"
 
 home: https://www.librechat.ai
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -2,7 +2,7 @@
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.12
+version: 1.3.13
 
 # Cache settings: Set to true to enable caching
 cache: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.6",
+  "version": "v0.8.7-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.6",
+      "version": "v0.8.7-rc1",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -46,7 +46,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.6",
+      "version": "v0.8.7-rc1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -411,7 +411,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.6",
+      "version": "v0.8.7-rc1",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
@@ -44230,7 +44230,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.31",
+      "version": "1.7.32",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",
@@ -44934,7 +44934,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.60",
+      "version": "0.4.61",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -46077,7 +46077,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.504",
+      "version": "0.8.505",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -46685,7 +46685,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.6",
+  "version": "v0.8.7-rc1",
   "description": "",
   "packageManager": "npm@11.13.0",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.31",
+  "version": "1.7.32",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.60",
+  "version": "0.4.61",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.504",
+  "version": "0.8.505",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2488,7 +2488,7 @@ export enum Constants {
    */
   VERSION = '__LIBRECHAT_VERSION__',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.3.12',
+  CONFIG_VERSION = '1.3.13',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value to use whatever the submission prelim. `responseMessageId` is */

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

I rebased the LibreChat release branch onto the latest `dev` fetched in this pass (`fbc990f684`, #13765), kept the release branch scoped to `v0.8.7-rc1` metadata plus the requested Chinese README sync, and pushed a backup branch before rebasing: `danny-avila/backup-release-v0.8.7-rc1-pre-dev-rebase-20260615-125057`. The documentation update is covered in LibreChat-AI/librechat.ai#598.

- Updated root, backend, frontend, Docker, Jest, E2E, and Helm release markers from `v0.8.6` to `v0.8.7-rc1`.
- Bumped published workspace packages by the smallest increment: `@librechat/api`, `@librechat/client`, `librechat-data-provider`, and `@librechat/data-schemas`.
- Updated the custom config version from `1.3.12` to `1.3.13` in the example config and data-provider constant.
- Refreshed lockfile metadata so package and workspace versions stay aligned after the latest `dev` rebase.
- Synced `README.zh.md` with the English README additions for Skills, Subagents, and S3/CloudFront deployment docs.
- Confirmed the release branch remains limited to version/config release metadata plus the requested Chinese README sync after rebasing through RUM proxy auth isolation and gated Redis OTEL instrumentation.

## Change Type

- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- Ran `npm install --package-lock-only --ignore-scripts`.
- Ran `node scripts/sort-imports.mts --check packages/data-provider/src/config.ts`.
- Ran `npx eslint --no-error-on-unmatched-pattern --config eslint.config.mjs --max-warnings=0 -- packages/data-provider/src/config.ts`.
- Ran `npx prettier --check --no-error-on-unmatched-pattern -- packages/data-provider/src/config.ts`.
- Ran `git diff --check origin/dev..HEAD`.
- Re-audited `v0.8.6..origin/dev` against the docs PR changelog coverage; no missing PR numbers remained (`165` app PR refs, `165` changelog refs).
- Checked `.env.example`, `packages/data-provider/src/config.ts`, and `librechat.example.yaml` changes since `v0.8.6` against the docs PR coverage.

### **Test Configuration**:

- macOS local checkout
- Node/npm metadata and README docs only; no runtime behavior changes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.
