### PR TITLE
🧩 feat: Enable Model Spec Subagents

### DIFF
--- a/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
+++ b/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
@@ -118,6 +118,16 @@ describe('applyModelSpecEphemeralAgent', () => {
       const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
       expect(agent.artifacts).toBe('custom-renderer');
     });
+
+    it('should not copy model spec subagents into client ephemeral agent state', () => {
+      const subagents = { enabled: true, allowSelf: true, agent_ids: ['agent_private'] };
+      const modelSpec = createModelSpec({ subagents });
+
+      applyModelSpecEphemeralAgent({ convoId: null, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.subagents).toBeUndefined();
+    });
   });
 
   // ─── Existing Conversations: Per-Conversation Persistence ──────────

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -616,6 +616,12 @@ endpoints:
 #       # accessible skill catalog, false to force skills off, or a name list as
 #       # a strict allowlist for catalog, manual, and always-apply resolution.
 #       # skills: ["brand-guidelines", "code-review"]
+#       # Subagents can be enabled per model spec. `allowSelf: true` lets the
+#       # ephemeral agent spawn a fresh isolated copy of itself for focused work.
+#       # subagents:
+#       #   enabled: true
+#       #   allowSelf: true
+#       #   agent_ids: []
 #
 #     # Example 2: Nested under a custom endpoint (grouped with groq endpoint)
 #     - name: "llama3-70b-8192"

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 import { v4 as uuidv4 } from 'uuid';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { Constants, FileSources } from 'librechat-data-provider';
 import { agentSchema, createMethods } from '@librechat/data-schemas';
+import { Constants, FileSources, MAX_SUBAGENTS } from 'librechat-data-provider';
 import type {
   Agent as LibreChatAgent,
   AgentModelParameters,
@@ -265,7 +265,9 @@ describe('loadAgent', () => {
       {
         req: {
           user: { id: 'user123' },
-          body: {},
+          body: {
+            ephemeralAgent: { subagents: { enabled: false, agent_ids: ['agent_tampered'] } },
+          },
           config: {
             config: {},
             fileStrategy: FileSources.local,
@@ -328,6 +330,124 @@ describe('loadAgent', () => {
 
     expect(result?.skills_enabled).toBe(true);
     expect(result?.skills).toEqual([]);
+  });
+
+  test('should apply subagent config for ephemeral model specs', async () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+    const subagents = { enabled: true, allowSelf: true, agent_ids: [] };
+
+    const result = await loadAgent(
+      {
+        req: {
+          user: { id: 'user123' },
+          body: {},
+          config: {
+            config: {},
+            fileStrategy: FileSources.local,
+            imageOutputType: 'png',
+            modelSpecs: {
+              list: [
+                {
+                  name: 'self-spawn',
+                  label: 'Self Spawn',
+                  preset: { endpoint: 'openai', model: 'gpt-4' },
+                  subagents,
+                },
+              ],
+            },
+          },
+        },
+        spec: 'self-spawn',
+        agent_id: EPHEMERAL_AGENT_ID as string,
+        endpoint: 'openai',
+        model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+      },
+      deps,
+    );
+
+    expect(result?.subagents).toEqual(subagents);
+  });
+
+  test('should discard oversized request subagent ids for ephemeral agents', async () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+    const oversized = Array.from({ length: MAX_SUBAGENTS + 1 }, (_, index) => `agent_${index}`);
+
+    const result = await loadAgent(
+      {
+        req: {
+          user: { id: 'user123' },
+          body: {
+            ephemeralAgent: {
+              subagents: { enabled: true, allowSelf: false, agent_ids: oversized },
+            },
+          },
+        },
+        agent_id: EPHEMERAL_AGENT_ID as string,
+        endpoint: 'openai',
+        model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+      },
+      deps,
+    );
+
+    expect(result?.subagents).toEqual({ enabled: true, allowSelf: false });
+  });
+
+  test('should preserve request subagents when added agent mirrors ephemeral primary tools', async () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+    const subagents = { enabled: true, allowSelf: true, agent_ids: [] };
+
+    const result = await loadAddedAgent(
+      {
+        req: {
+          user: { id: 'user123' },
+          config: {
+            config: {},
+            fileStrategy: FileSources.local,
+            imageOutputType: 'png',
+          },
+        },
+        conversation: {
+          endpoint: 'openai',
+          model: 'gpt-4',
+          ephemeralAgent: { subagents },
+        } as unknown as TConversation,
+        primaryAgent: { id: EPHEMERAL_AGENT_ID as string, tools: ['web_search'] } as LibreChatAgent,
+      },
+      deps,
+    );
+
+    expect(result?.tools).toEqual(['web_search']);
+    expect(result?.subagents).toEqual(subagents);
+  });
+
+  test('should discard oversized request subagent ids for mirrored added agents', async () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+    const oversized = Array.from({ length: MAX_SUBAGENTS + 1 }, (_, index) => `agent_${index}`);
+
+    const result = await loadAddedAgent(
+      {
+        req: {
+          user: { id: 'user123' },
+          config: {
+            config: {},
+            fileStrategy: FileSources.local,
+            imageOutputType: 'png',
+          },
+        },
+        conversation: {
+          endpoint: 'openai',
+          model: 'gpt-4',
+          ephemeralAgent: {
+            subagents: { enabled: true, allowSelf: false, agent_ids: oversized },
+          },
+        } as unknown as TConversation,
+        primaryAgent: { id: EPHEMERAL_AGENT_ID as string, tools: ['web_search'] } as LibreChatAgent,
+      },
+      deps,
+    );
+
+    expect(result?.tools).toEqual(['web_search']);
+    expect(result?.subagents).toEqual({ enabled: true, allowSelf: false });
   });
 
   test('should enable full skill scope for added ephemeral model spec with skills true', async () => {
@@ -398,8 +518,44 @@ describe('loadAgent', () => {
     expect(result?.skills).toEqual([]);
   });
 
+  test('should apply subagent config for added ephemeral model specs', async () => {
+    const subagents = { enabled: true, allowSelf: true, agent_ids: [] };
+
+    const result = await loadAddedAgent(
+      {
+        req: {
+          user: { id: 'user123' },
+          config: {
+            config: {},
+            fileStrategy: FileSources.local,
+            imageOutputType: 'png',
+            modelSpecs: {
+              list: [
+                {
+                  name: 'added-self-spawn',
+                  label: 'Added Self Spawn',
+                  preset: { endpoint: 'openai', model: 'gpt-4' },
+                  subagents,
+                },
+              ],
+            },
+          },
+        },
+        conversation: {
+          endpoint: 'openai',
+          model: 'gpt-4',
+          spec: 'added-self-spawn',
+        } as unknown as TConversation,
+      },
+      deps,
+    );
+
+    expect(result?.subagents).toEqual(subagents);
+  });
+
   test('should apply model spec skills when added agent mirrors ephemeral primary tools', async () => {
     const { EPHEMERAL_AGENT_ID } = Constants;
+    const subagents = { enabled: true, allowSelf: true, agent_ids: [] };
 
     const result = await loadAddedAgent(
       {
@@ -416,6 +572,7 @@ describe('loadAgent', () => {
                   label: 'Mirrored Scoped Skills',
                   preset: { endpoint: 'openai', model: 'gpt-4' },
                   skills: ['brand-writer'],
+                  subagents,
                 },
               ],
             },
@@ -434,6 +591,7 @@ describe('loadAgent', () => {
     expect(result?.tools).toEqual(['web_search']);
     expect(result?.skills_enabled).toBe(true);
     expect(result?.skills).toEqual([]);
+    expect(result?.subagents).toEqual(subagents);
   });
 
   test('should handle ephemeral agent with undefined ephemeralAgent in body', async () => {

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -1,5 +1,4 @@
 import { logger } from '@librechat/data-schemas';
-import type { AppConfig } from '@librechat/data-schemas';
 import {
   Tools,
   Constants,
@@ -8,8 +7,15 @@ import {
   appendAgentIdSuffix,
   encodeEphemeralAgentId,
 } from 'librechat-data-provider';
-import type { Agent, TConversation, TModelSpec } from 'librechat-data-provider';
+import type {
+  Agent,
+  TConversation,
+  TModelSpec,
+  AgentSubagentsConfig,
+} from 'librechat-data-provider';
+import type { AppConfig } from '@librechat/data-schemas';
 import { getCustomEndpointConfig } from '~/app/config';
+import { sanitizeRequestSubagents } from './subagents';
 
 const { mcp_all, mcp_delimiter } = Constants;
 
@@ -31,6 +37,17 @@ function applyModelSpecSkills(
   } else if (Array.isArray(modelSpec.skills)) {
     result.skills_enabled = true;
     result.skills = [];
+  }
+}
+
+function applyModelSpecSubagents(
+  result: Record<string, unknown>,
+  modelSpec: Pick<TModelSpec, 'subagents'> | null | undefined,
+  ephemeralAgent?: { subagents?: AgentSubagentsConfig },
+): void {
+  const subagents = modelSpec?.subagents ?? sanitizeRequestSubagents(ephemeralAgent?.subagents);
+  if (subagents) {
+    result.subagents = subagents;
   }
 }
 
@@ -88,6 +105,7 @@ export async function loadAddedAgent(
       file_search?: boolean;
       web_search?: boolean;
       artifacts?: unknown;
+      subagents?: AgentSubagentsConfig;
     };
     [key: string]: unknown;
   };
@@ -98,6 +116,16 @@ export async function loadAddedAgent(
   }
 
   const appConfig = req.config as AppConfig | undefined;
+  const ephemeralAgent = rest.ephemeralAgent as
+    | {
+        mcp?: string[];
+        execute_code?: boolean;
+        file_search?: boolean;
+        web_search?: boolean;
+        artifacts?: unknown;
+        subagents?: AgentSubagentsConfig;
+      }
+    | undefined;
 
   const primaryIsEphemeral = primaryAgent && isEphemeralAgentId(primaryAgent.id);
   if (primaryIsEphemeral && Array.isArray(primaryAgent.tools)) {
@@ -132,18 +160,10 @@ export async function loadAddedAgent(
       tools: [...primaryAgent.tools],
     };
     applyModelSpecSkills(result, modelSpec);
+    applyModelSpecSubagents(result, modelSpec, ephemeralAgent);
     return result as unknown as Agent;
   }
 
-  const ephemeralAgent = rest.ephemeralAgent as
-    | {
-        mcp?: string[];
-        execute_code?: boolean;
-        file_search?: boolean;
-        web_search?: boolean;
-        artifacts?: unknown;
-      }
-    | undefined;
   const mcpServers = new Set<string>(ephemeralAgent?.mcp);
   const userId = req.user?.id ?? '';
 
@@ -234,6 +254,7 @@ export async function loadAddedAgent(
   if (ephemeralAgent?.artifacts != null && ephemeralAgent.artifacts) {
     result.artifacts = ephemeralAgent.artifacts;
   }
+  applyModelSpecSubagents(result, modelSpec, ephemeralAgent);
   applyModelSpecSkills(result, modelSpec);
 
   return result as unknown as Agent;

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -1,5 +1,4 @@
 import { logger } from '@librechat/data-schemas';
-import type { AppConfig } from '@librechat/data-schemas';
 import {
   Tools,
   Constants,
@@ -13,7 +12,9 @@ import type {
   TModelSpec,
   Agent,
 } from 'librechat-data-provider';
+import type { AppConfig } from '@librechat/data-schemas';
 import { getCustomEndpointConfig } from '~/app/config';
+import { sanitizeRequestSubagents } from './subagents';
 
 const { mcp_all, mcp_delimiter } = Constants;
 type ModelParametersWithPromptPrefix = AgentModelParameters & { promptPrefix?: string | null };
@@ -134,6 +135,14 @@ export async function loadEphemeralAgent(
 
   if (ephemeralAgent?.artifacts) {
     result.artifacts = ephemeralAgent.artifacts;
+  }
+  if (modelSpec?.subagents) {
+    result.subagents = modelSpec.subagents;
+  } else {
+    const requestSubagents = sanitizeRequestSubagents(ephemeralAgent?.subagents);
+    if (requestSubagents) {
+      result.subagents = requestSubagents;
+    }
   }
   if (modelSpec && Object.prototype.hasOwnProperty.call(modelSpec, 'skills')) {
     if (modelSpec.skills === true) {

--- a/packages/api/src/agents/subagents.ts
+++ b/packages/api/src/agents/subagents.ts
@@ -1,0 +1,27 @@
+import { MAX_SUBAGENTS } from 'librechat-data-provider';
+import type { AgentSubagentsConfig } from 'librechat-data-provider';
+
+export function sanitizeRequestSubagents(
+  subagents?: AgentSubagentsConfig | null,
+): AgentSubagentsConfig | undefined {
+  if (!subagents || typeof subagents !== 'object') {
+    return undefined;
+  }
+
+  const sanitized: AgentSubagentsConfig = {};
+  if (typeof subagents.enabled === 'boolean') {
+    sanitized.enabled = subagents.enabled;
+  }
+  if (typeof subagents.allowSelf === 'boolean') {
+    sanitized.allowSelf = subagents.allowSelf;
+  }
+  if (
+    Array.isArray(subagents.agent_ids) &&
+    subagents.agent_ids.length <= MAX_SUBAGENTS &&
+    subagents.agent_ids.every((agentId) => typeof agentId === 'string')
+  ) {
+    sanitized.agent_ids = subagents.agent_ids;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}

--- a/packages/api/src/modelSpecs/index.ts
+++ b/packages/api/src/modelSpecs/index.ts
@@ -203,6 +203,21 @@ export function sanitizeModelSpecs<T extends Partial<TSpecsConfig> | null | unde
       const preset = modelSpec?.preset;
       const sanitizedModelSpec = { ...modelSpec };
       delete (sanitizedModelSpec as { skills?: unknown }).skills;
+      const subagents = sanitizedModelSpec.subagents;
+      if (subagents && typeof subagents === 'object') {
+        const sanitizedSubagents: TModelSpec['subagents'] = {};
+        if (subagents.enabled !== undefined) {
+          sanitizedSubagents.enabled = subagents.enabled;
+        }
+        if (subagents.allowSelf !== undefined) {
+          sanitizedSubagents.allowSelf = subagents.allowSelf;
+        }
+        if (Object.keys(sanitizedSubagents).length > 0) {
+          sanitizedModelSpec.subagents = sanitizedSubagents;
+        } else {
+          delete sanitizedModelSpec.subagents;
+        }
+      }
       if (!preset || typeof preset !== 'object') {
         return sanitizedModelSpec;
       }

--- a/packages/api/src/modelSpecs/modelSpecs.test.ts
+++ b/packages/api/src/modelSpecs/modelSpecs.test.ts
@@ -18,6 +18,7 @@ describe('modelSpecs helpers', () => {
           name: 'guarded-spec',
           label: 'Guarded Spec',
           skills: ['private-skill'],
+          subagents: { enabled: true, allowSelf: true, agent_ids: ['agent_private'] },
           preset: {
             endpoint: EModelEndpoint.openAI,
             model: 'gpt-4o',
@@ -34,6 +35,10 @@ describe('modelSpecs helpers', () => {
     };
 
     const sanitizedModelSpecs = sanitizeModelSpecs(modelSpecs);
+    expect(sanitizedModelSpecs.list[0].subagents).toEqual({
+      enabled: true,
+      allowSelf: true,
+    });
     expect(sanitizedModelSpecs.list[0].preset).toEqual({
       endpoint: EModelEndpoint.openAI,
       model: 'gpt-4o',

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -10,6 +10,7 @@ import {
   fileStrategiesSchema,
   summarizationTriggerSchema,
   summarizationConfigSchema,
+  MAX_SUBAGENTS,
 } from '../src/config';
 import {
   tModelSpecPresetSchema,
@@ -838,6 +839,7 @@ describe('specsConfigSchema', () => {
           hideBadgeRow: true,
           softDefault: true,
           preset: { endpoint: EModelEndpoint.openAI },
+          subagents: { enabled: true, allowSelf: true, agent_ids: ['agent_researcher'] },
         },
       ],
     });
@@ -845,11 +847,31 @@ describe('specsConfigSchema', () => {
     if (result.success) {
       expect(result.data.list[0].hideBadgeRow).toBe(true);
       expect(result.data.list[0].softDefault).toBe(true);
+      expect(result.data.list[0].subagents).toEqual({
+        enabled: true,
+        allowSelf: true,
+        agent_ids: ['agent_researcher'],
+      });
     }
   });
 
   it('still rejects null list', () => {
     const result = specsConfigSchema.safeParse({ list: null });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects model spec subagent ids above the shared cap', () => {
+    const oversized = Array.from({ length: MAX_SUBAGENTS + 1 }, (_, i) => `agent_${i}`);
+    const result = specsConfigSchema.safeParse({
+      list: [
+        {
+          name: 'spec-1',
+          label: 'Spec 1',
+          preset: { endpoint: EModelEndpoint.openAI },
+          subagents: { enabled: true, agent_ids: oversized },
+        },
+      ],
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -10,11 +10,12 @@ import {
 } from './schemas';
 import { ComponentTypes, SettingTypes, OptionTypes } from './generate';
 import { specsConfigSchema, TSpecsConfig } from './models';
+import { REFILL_INTERVAL_UNITS } from './balance';
 import { fileConfigSchema } from './file-config';
 import { apiBaseUrl } from './api-endpoints';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
-import { REFILL_INTERVAL_UNITS } from './balance';
+export { MAX_SUBAGENTS } from './limits';
 
 export const defaultSocialLogins = ['google', 'facebook', 'openid', 'github', 'discord', 'saml'];
 
@@ -2287,9 +2288,6 @@ export enum Constants {
   /** Subagent spawn tool name (must match `@librechat/agents` `Constants.SUBAGENT`). */
   SUBAGENT = 'subagent',
 }
-
-/** Maximum number of explicit subagents per parent agent. UI + Zod schema share this. */
-export const MAX_SUBAGENTS = 10;
 
 /** Maximum explicit subagent hops allowed from any root agent at runtime. */
 export const MAX_SUBAGENT_DEPTH = 5;

--- a/packages/data-provider/src/limits.ts
+++ b/packages/data-provider/src/limits.ts
@@ -1,0 +1,2 @@
+/** Maximum number of explicit subagents per parent agent. UI + Zod schema share this. */
+export const MAX_SUBAGENTS = 10;

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { AgentSubagentsConfig } from './types/assistants';
 import type { TModelSpecPreset } from './schemas';
 import {
   EModelEndpoint,
@@ -7,6 +8,7 @@ import {
   AuthType,
   authTypeSchema,
 } from './schemas';
+import { MAX_SUBAGENTS } from './limits';
 
 export type TModelSpec = {
   name: string;
@@ -41,7 +43,14 @@ export type TModelSpec = {
   artifacts?: string | boolean;
   mcpServers?: string[];
   skills?: boolean | string[];
+  subagents?: AgentSubagentsConfig;
 };
+
+export const modelSpecSubagentsSchema = z.object({
+  enabled: z.boolean().optional(),
+  allowSelf: z.boolean().optional(),
+  agent_ids: z.array(z.string()).max(MAX_SUBAGENTS).optional(),
+});
 
 export const tModelSpecSchema = z.object({
   name: z.string(),
@@ -64,6 +73,7 @@ export const tModelSpecSchema = z.object({
   artifacts: z.union([z.string(), z.boolean()]).optional(),
   mcpServers: z.array(z.string()).optional(),
   skills: z.union([z.boolean(), z.array(z.string())]).optional(),
+  subagents: modelSpecSubagentsSchema.optional(),
 });
 
 export const specsConfigSchema = z.object({

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -10,11 +10,11 @@ import type {
   ReasoningResponseKey,
   ReasoningParameterFormat,
 } from './schemas';
+import type { Agent, AgentSubagentsConfig } from './types/assistants';
 import type { RefillIntervalUnit } from './balance';
 import type { SettingDefinition } from './generate';
 import type { TMinimalFeedback } from './feedback';
 import type { ContentTypes } from './types/runs';
-import type { Agent } from './types/assistants';
 
 export * from './schemas';
 
@@ -107,6 +107,7 @@ export type TEphemeralAgent = {
   execute_code?: boolean;
   artifacts?: string;
   skills?: boolean;
+  subagents?: AgentSubagentsConfig;
 };
 
 export type TPayload = Partial<TMessage> &


### PR DESCRIPTION
## Summary

I enabled model spec configuration for ephemeral-agent subagent behavior, with server-side enforcement for model-spec settings and private agent IDs.

- Added `subagents` to the shared model spec type and schema so LibreChat config can validate model-spec subagent settings.
- Capped model-spec `subagents.agent_ids` with the shared `MAX_SUBAGENTS` limit so oversized configs fail during config parsing.
- Applied model-spec and request-level `subagents` while building primary and added-conversation ephemeral agents on the backend, keeping selected model specs authoritative over request payloads.
- Sanitized startup model specs so clients only receive public `enabled` and `allowSelf` subagent flags, while private `agent_ids` stay server-side.
- Documented the model spec YAML shape for enabling self-spawn subagents.
- Added regression coverage for config parsing, startup sanitization, frontend ephemeral hydration, backend ephemeral agent loading, and mirrored added-conversation subagent behavior.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- [x] `npm run build:data-provider`
- [x] `npm run build:data-schemas`
- [x] `npm run build:api`
- [x] `npm run build:client-package`
- [x] `cd client && npm run typecheck`
- [x] `npx prettier --check --no-error-on-unmatched-pattern -- <changed files>`
- [x] `node scripts/sort-imports.mts --check <changed files>`
- [x] `npx eslint --no-error-on-unmatched-pattern --config eslint.config.mjs --max-warnings=0 -- <changed files>`
- [x] `cd packages/data-provider && npx jest specs/config-schemas.spec.ts --runInBand --coverage=false`
- [x] `cd packages/api && npx jest src/modelSpecs/modelSpecs.test.ts src/agents/__tests__/load.spec.ts --runInBand --coverage=false`
- [x] `cd client && npx jest src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts --runInBand --coverage=false`

### **Test Configuration**:

- Node.js: v24.16.0
- npm: 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
