### PR TITLE
📋 refactor: Attach Message Context to Langfuse Feedback Scores

### DIFF
--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -401,6 +401,17 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
       sendFeedbackScore({
         traceId: traceIdForMessage(messageId),
         feedback: updatedMessage.feedback,
+        metadata: {
+          messageId: updatedMessage.messageId ?? messageId,
+          parentMessageId: updatedMessage.parentMessageId,
+          conversationId: updatedMessage.conversationId ?? conversationId,
+          sessionId: updatedMessage.conversationId ?? conversationId,
+          userId: req?.user?.id,
+          endpoint: updatedMessage.endpoint,
+          sender: updatedMessage.sender,
+          isCreatedByUser: updatedMessage.isCreatedByUser,
+          tokenCount: updatedMessage.tokenCount,
+        },
       }).catch((err) => logger.error('[langfuse] feedback score failed:', err));
     }
 

--- a/packages/api/src/langfuse/feedback.spec.ts
+++ b/packages/api/src/langfuse/feedback.spec.ts
@@ -59,6 +59,16 @@ describe('Langfuse feedback scores', () => {
     await sendFeedbackScore({
       traceId: 'trace-id',
       feedback: { rating: 'thumbsUp', tag: 'helpful', text: 'nice' },
+      metadata: {
+        messageId: 'message-id',
+        conversationId: 'conversation-id',
+        sessionId: 'conversation-id',
+        userId: 'user-id',
+        endpoint: 'agents',
+        empty: '',
+        missing: undefined,
+      },
+      observationId: 'observation-id',
     });
 
     expect(getFetchMock()).toHaveBeenCalledWith(
@@ -80,8 +90,19 @@ describe('Langfuse feedback scores', () => {
       value: 1,
       dataType: 'BOOLEAN',
       comment: 'helpful — nice',
-      metadata: { rating: 'thumbsUp', tag: 'helpful' },
+      observationId: 'observation-id',
+      metadata: {
+        rating: 'thumbsUp',
+        tag: 'helpful',
+        messageId: 'message-id',
+        conversationId: 'conversation-id',
+        sessionId: 'conversation-id',
+        userId: 'user-id',
+        endpoint: 'agents',
+      },
     });
+    expect(JSON.parse(init?.body as string).metadata).not.toHaveProperty('empty');
+    expect(JSON.parse(init?.body as string).metadata).not.toHaveProperty('missing');
   });
 
   it('posts feedback scores to the configured Langfuse host', async () => {

--- a/packages/api/src/langfuse/feedback.ts
+++ b/packages/api/src/langfuse/feedback.ts
@@ -6,9 +6,13 @@ export type LangfuseFeedback = {
   text?: string;
 };
 
+export type LangfuseFeedbackMetadata = Record<string, string | number | boolean | null | undefined>;
+
 export type SendFeedbackScoreParams = {
   traceId: string;
   feedback?: LangfuseFeedback | null;
+  metadata?: LangfuseFeedbackMetadata;
+  observationId?: string;
 };
 
 const DEFAULT_BASE_URL = 'https://cloud.langfuse.com';
@@ -42,9 +46,26 @@ const AUTHORIZATION = ENABLED
   : undefined;
 const ENVIRONMENT = process.env.LANGFUSE_TRACING_ENVIRONMENT;
 
+function cleanMetadata(
+  metadata: LangfuseFeedbackMetadata,
+): Record<string, string | number | boolean> {
+  return Object.entries(metadata).reduce<Record<string, string | number | boolean>>(
+    (result, [key, value]) => {
+      if (value == null || (typeof value === 'string' && value.trim() === '')) {
+        return result;
+      }
+      result[key] = value;
+      return result;
+    },
+    {},
+  );
+}
+
 export async function sendFeedbackScore({
   traceId,
   feedback,
+  metadata = {},
+  observationId,
 }: SendFeedbackScoreParams): Promise<void> {
   if (!ENABLED || !AUTHORIZATION || !traceId) {
     return;
@@ -70,7 +91,8 @@ export async function sendFeedbackScore({
     value: feedback.rating === 'thumbsUp' ? 1 : 0,
     dataType: 'BOOLEAN',
     comment: [feedback.tag, feedback.text].filter(Boolean).join(' — ') || undefined,
-    metadata: { rating: feedback.rating, tag: feedback.tag },
+    metadata: cleanMetadata({ ...metadata, rating: feedback.rating, tag: feedback.tag }),
+    ...(observationId ? { observationId } : {}),
     ...(ENVIRONMENT ? { environment: ENVIRONMENT } : {}),
   };
 


### PR DESCRIPTION
## Summary

Enriches Langfuse user feedback scores with LibreChat-derived metadata so score rows are easier to filter and correlate without querying Langfuse during feedback submission.

The feedback route now passes message, conversation/session, user, endpoint, sender, and token-count context to `sendFeedbackScore`. The Langfuse score sender sanitizes empty metadata values and preserves the existing trace-level score behavior. It also accepts an optional `observationId` for a future path where LibreChat stores a concrete Langfuse observation id.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

- `git diff --check`
- `npx jest src/langfuse/feedback.spec.ts --coverage=false --runInBand --testPathIgnorePatterns="\\.*integration\\.|\\.*helper\\.|__tests__/helpers/|\\.*manual\\.spec\."`

### **Test Configuration**:

- Local checkout: `/Users/danny/Projects/LibreChat`
- Base branch: `main`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.