### PR TITLE
👷 fix: Preserve disabled build info flag in loadDefaultInterface

### DIFF
--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -27,6 +27,45 @@ describe('loadDefaultInterface', () => {
     expect(interfaceConfig?.autoSubmitFromUrl).toBe(false);
   });
 
+  it('preserves a disabled build info flag', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        buildInfo: false,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.buildInfo).toBe(false);
+  });
+
+  it('uses the schema default for build info when not configured', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.buildInfo).toBe(true);
+  });
+
+  it('preserves enabled build info config', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        buildInfo: true,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.buildInfo).toBe(true);
+  });
+
   it('preserves enabled URL auto-submit config', async () => {
     const config: Partial<TCustomConfig> = {
       interface: {

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -39,6 +39,7 @@ export async function loadDefaultInterface({
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
     autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
+    buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo,
 
     // Permissions and related settings - only include if explicitly configured
     bookmarks: interfaceConfig?.bookmarks,


### PR DESCRIPTION
## Summary

Fix the backend interface config merge so `buildInfo` follows the same schema-default behavior as the other UI fields and still preserves explicit `false`.

This change updates `packages/data-schemas/src/app/interface.ts` to include `buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo` in the object passed to `removeNullishValues(...)`.

A regression test was added in `packages/data-schemas/src/app/interface.spec.ts` to verify that:
- `loadDefaultInterface({})` uses the schema default for `buildInfo`
- `loadDefaultInterface({ interface: { buildInfo: true } })` preserves `true`
- `loadDefaultInterface({ interface: { buildInfo: false } })` preserves `false`

No client gating logic was changed. `client/src/components/Nav/Settings.tsx` already hides the About tab when `startupConfig?.interface?.buildInfo === false`.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Rebuilt the affected backend packages and ran the targeted regression spec.

- `npm run build:data-provider`
- `npm run build:data-schemas`
- `cd packages/data-schemas && npm run test:ci -- src/app/interface.spec.ts --runInBand`

Verification target:
- Authenticated `/api/config` should return `interface.buildInfo: false` when configured
- Authenticated `/api/config` should return `interface.buildInfo: true` by default
- The About tab should disappear through the existing client gate

### **Test Configuration**:

- Local workspace
- Backend package builds refreshed before running the regression test
- Jest target: `packages/data-schemas/src/app/interface.spec.ts`

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
