### PR TITLE
✂️ fix: Deduplicate Skill Bodies Across Fresh Primes and History

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -33,6 +33,7 @@ const {
   prependFileContext,
   hydrateMissingIndexTokenCounts,
   injectSkillPrimes,
+  collectFreshSkillPrimeNames,
   isSkillPrimeMessage,
   collectFileIds,
   buildAgentScopedContext,
@@ -912,7 +913,30 @@ class AgentClient extends BaseClient {
         hasDeepSeekAgent(this.options.agent) ||
         (this.agentConfigs != null &&
           Array.from(this.agentConfigs.values()).some(hasDeepSeekAgent));
-      const formatOptions = needsDeepSeekFormat ? { provider: Providers.DEEPSEEK } : undefined;
+      /**
+       * Skills primed fresh this turn — manual ($ popover) and always-apply
+       * (frontmatter). `injectSkillPrimes` (below) splices their SKILL.md
+       * bodies in, so `formatAgentMessages` must NOT also reconstruct the
+       * same names from a historical `skill` tool_call — otherwise the body
+       * lands twice and a prompt-cache marker can pin to the duplicated
+       * synthetic prefix. Names NOT primed this turn still reconstruct from
+       * history, preserving sticky manual re-priming across turns.
+       */
+      const manualSkillPrimes = this.options.agent?.manualSkillPrimes;
+      const alwaysApplySkillPrimes = this.options.agent?.alwaysApplySkillPrimes;
+      const freshSkillPrimeNames = collectFreshSkillPrimeNames({
+        manualSkillPrimes,
+        alwaysApplySkillPrimes,
+      });
+      const formatOptions =
+        needsDeepSeekFormat || freshSkillPrimeNames.size > 0
+          ? {
+              ...(needsDeepSeekFormat ? { provider: Providers.DEEPSEEK } : {}),
+              ...(freshSkillPrimeNames.size > 0
+                ? { skipSkillBodyNames: freshSkillPrimeNames }
+                : {}),
+            }
+          : undefined;
       let {
         messages: initialMessages,
         indexTokenCountMap,
@@ -943,9 +967,11 @@ class AgentClient extends BaseClient {
        * agent and multi-agent runs; how primes interact with handoff /
        * added-convo agents' per-agent state is an agents-SDK concern,
        * not this layer's to gate.
+       *
+       * `manualSkillPrimes` / `alwaysApplySkillPrimes` are resolved above
+       * (used to build `freshSkillPrimeNames` for dedupe against historical
+       * skill reconstruction).
        */
-      const manualSkillPrimes = this.options.agent?.manualSkillPrimes;
-      const alwaysApplySkillPrimes = this.options.agent?.alwaysApplySkillPrimes;
       if (
         (manualSkillPrimes && manualSkillPrimes.length > 0) ||
         (alwaysApplySkillPrimes && alwaysApplySkillPrimes.length > 0)

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -45,6 +45,7 @@ import {
   resolveAlwaysApplySkills,
   injectManualSkillPrimes,
   injectSkillPrimes,
+  collectFreshSkillPrimeNames,
   extractManualSkills,
   isSkillPrimeMessage,
   buildSkillPrimeContentParts,
@@ -2245,5 +2246,47 @@ describe('injectSkillPrimes', () => {
     expect(result.alwaysApplyDedupedFromManual).toBe(1);
     expect(result.alwaysApplyDropped).toBe(0);
     expect(result.inserted).toBe(2);
+  });
+});
+
+describe('collectFreshSkillPrimeNames', () => {
+  it('returns the union of manual + always-apply prime names', () => {
+    const names = collectFreshSkillPrimeNames({
+      manualSkillPrimes: [{ name: 'pdf-analyzer' }, { name: 'code-review' }],
+      alwaysApplySkillPrimes: [{ name: 'clickhouse-best-practices' }],
+    });
+    expect(names).toEqual(new Set(['pdf-analyzer', 'code-review', 'clickhouse-best-practices']));
+  });
+
+  it('dedupes a skill that is both manual and always-apply', () => {
+    const names = collectFreshSkillPrimeNames({
+      manualSkillPrimes: [{ name: 'clickhouse-best-practices' }],
+      alwaysApplySkillPrimes: [{ name: 'clickhouse-best-practices' }],
+    });
+    expect(names.size).toBe(1);
+    expect(names.has('clickhouse-best-practices')).toBe(true);
+  });
+
+  it('handles undefined / empty inputs', () => {
+    expect(collectFreshSkillPrimeNames({}).size).toBe(0);
+    expect(
+      collectFreshSkillPrimeNames({
+        manualSkillPrimes: [],
+        alwaysApplySkillPrimes: [],
+      }).size,
+    ).toBe(0);
+  });
+
+  it('collects names from only one side when the other is absent', () => {
+    expect(
+      collectFreshSkillPrimeNames({
+        alwaysApplySkillPrimes: [{ name: 'only-always' }],
+      }),
+    ).toEqual(new Set(['only-always']));
+    expect(
+      collectFreshSkillPrimeNames({
+        manualSkillPrimes: [{ name: 'only-manual' }],
+      }),
+    ).toEqual(new Set(['only-manual']));
   });
 });

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -1087,6 +1087,32 @@ export function injectManualSkillPrimes(
   return { initialMessages, indexTokenCountMap, inserted: numPrimes, insertIdx };
 }
 
+/**
+ * Collects the set of skill names primed fresh this turn — the union of manual
+ * ($-popover) and always-apply (frontmatter) primes. Passed to
+ * `formatAgentMessages` as `skipSkillBodyNames` so a skill that is BOTH primed
+ * this turn AND present in history (as a `skill` tool_call) has its SKILL.md
+ * body injected exactly once — by the fresh prime via `injectSkillPrimes` — and
+ * is NOT also reconstructed from history. Names absent from this set still
+ * reconstruct from history, preserving sticky manual re-priming across turns.
+ */
+export function collectFreshSkillPrimeNames({
+  manualSkillPrimes,
+  alwaysApplySkillPrimes,
+}: {
+  manualSkillPrimes?: Pick<ResolvedManualSkill, 'name'>[];
+  alwaysApplySkillPrimes?: Pick<ResolvedAlwaysApplySkill, 'name'>[];
+}): Set<string> {
+  const names = new Set<string>();
+  for (const prime of manualSkillPrimes ?? []) {
+    names.add(prime.name);
+  }
+  for (const prime of alwaysApplySkillPrimes ?? []) {
+    names.add(prime.name);
+  }
+  return names;
+}
+
 export interface InjectSkillPrimesParams {
   /** Formatted LangChain messages produced by `formatAgentMessages`. Mutated in place. */
   initialMessages: BaseMessage[];


### PR DESCRIPTION
## Problem

A skill that is primed fresh this turn (manual `$`-popover **or** always-apply frontmatter) **and** also present in history as a `skill` tool_call had its SKILL.md body injected **twice**:

1. `injectSkillPrimes` splices the fresh body in before the latest user message, and
2. `formatAgentMessages` reconstructs the historical body from the `skill` tool_call.

Repro: turn 1 invoke a skill manually/model-side, turn 2 have the same skill active as always-apply → two SKILL.md bodies, and prompt-cache markers could pin to the duplicated synthetic prefix.

## Changes
- **`packages/api`** — new `collectFreshSkillPrimeNames({ manualSkillPrimes, alwaysApplySkillPrimes })` helper returning the union of names primed this turn (TS, unit-tested).
- **`api/server/controllers/agents/client.js`** — build that set and pass it as `skipSkillBodyNames` to `formatAgentMessages` for **both** the `initialMessages` and `memoryMessages` paths. A skill primed this turn reconstructs once (the fresh prime); names not primed this turn still reconstruct from history, preserving sticky manual re-priming. `initialSessions` / skill-file availability untouched.

## Dependency
The `skipSkillBodyNames` option requires a build of `@librechat/agents` that supports it (companion PR on `danny-avila/agents`). The currently-published dist silently ignores the unknown option key until upgraded — safe to merge independently.

## Tests
- `packages/api/src/agents/__tests__/skills.test.ts`: `collectFreshSkillPrimeNames` union, manual+always-apply dedupe, empty/undefined inputs, one-sided inputs. 150 tests pass; lint + typecheck clean.
