### PR TITLE
🌍 fix: Prefer Imagen-Specific Location over Default Google Region

### DIFF
--- a/api/app/clients/tools/structured/GeminiImageGen.js
+++ b/api/app/clients/tools/structured/GeminiImageGen.js
@@ -119,7 +119,7 @@ async function initializeGeminiClient(options = {}) {
   return new GoogleGenAI({
     vertexai: true,
     project: serviceKey.project_id,
-    location: process.env.GOOGLE_LOC || process.env.GOOGLE_CLOUD_LOCATION || 'global',
+    location: process.env.GOOGLE_CLOUD_LOCATION || process.env.GOOGLE_LOC || 'global',
     googleAuthOptions: { credentials: serviceKey },
   });
 }


### PR DESCRIPTION
## Summary

As per docs we see we have a specific env var to be used on Google Imagen, but the code is always "preferring" the standard API calls and thus defeating the purpose of that specific env var.
We should prefer the usage of GOOGLE_CLOUD_LOCATION if available, so that users can :
- use GOOGLE_CLOUD_LOCATION go point to a specific location
- use GOOGLE_LOC to point to another location

As you might be aware, new imagen models are now GA but only global, so if we point to "multi-region" us/eu we cannot use the new imagen models due to this issue.

<img width="814" height="233" alt="image" src="https://github.com/user-attachments/assets/3b674ce7-30e3-4f27-adb3-3efc7fd054e4" />


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
