### PR TITLE
♊ chore: Upgrade `@google/genai` SDK to ^2.8.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@azure/identity": "^4.13.1",
     "@azure/search-documents": "^12.0.0",
     "@azure/storage-blob": "^12.30.0",
-    "@google/genai": "^2.0.1",
+    "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
     "@librechat/agents": "^3.2.31",
     "@librechat/api": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@azure/identity": "^4.13.1",
         "@azure/search-documents": "^12.0.0",
         "@azure/storage-blob": "^12.30.0",
-        "@google/genai": "^2.0.1",
+        "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
         "@librechat/agents": "^3.2.31",
         "@librechat/api": "*",
@@ -9363,9 +9363,9 @@
       "license": "MIT"
     },
     "node_modules/@google/genai": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.0.1.tgz",
-      "integrity": "sha512-trxxbVePM9J8Cuni5x7+xvApoqb2y6Zk27/wugjT2cuwHOT78nFGdf/Ni29MkDxzWwrj90OQpno1Ana6dm3D2A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.8.0.tgz",
+      "integrity": "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -44281,7 +44281,7 @@
         "@azure/identity": "^4.13.1",
         "@azure/search-documents": "^12.0.0",
         "@azure/storage-blob": "^12.30.0",
-        "@google/genai": "^2.0.1",
+        "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
         "@librechat/agents": "^3.2.31",
         "@librechat/data-schemas": "*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -110,7 +110,7 @@
     "@azure/identity": "^4.13.1",
     "@azure/search-documents": "^12.0.0",
     "@azure/storage-blob": "^12.30.0",
-    "@google/genai": "^2.0.1",
+    "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
     "@librechat/agents": "^3.2.31",
     "@librechat/data-schemas": "*",


### PR DESCRIPTION
## Summary

I upgraded the Google Gen AI SDK (`@google/genai`) from `^2.0.1` to `^2.8.0` to keep the Gemini integration aligned with the latest 2.x release and reduce the risk of falling behind newer Gemini model and multimodal support. Closes #13551.

- Bumped `@google/genai` to `^2.8.0` in `api/package.json` and `packages/api/package.json`.
- Regenerated `package-lock.json` (resolves `@google/genai` to `2.8.0`, deduped across both backend workspaces) with no transitive dependency churn — the SDK's own dependency subtree is unchanged.
- Made no application code changes: the sole consumer, `api/app/clients/tools/structured/GeminiImageGen.js`, uses the stable `GoogleGenAI` constructor (API-key and Vertex AI variants) and `models.generateContent`, and the upstream changelog records no breaking changes to those between 2.0 and 2.8 (the only 2.x breaking changes landed in 2.0.0 and affected the Interactions API, which this code does not use).

## What changed upstream (`@google/genai` 2.0.1 → 2.8.0)

Every release in this range is additive (new models, new APIs, new fields) or a bug fix. **No breaking changes** touch the surface this repo uses — the `GoogleGenAI` constructor, `models.generateContent`, or the `inlineData` image-response shape. (The only 2.x breaking changes were in 2.0.0, on the Interactions API, which predates our current 2.0.1 and is unused here.) Only minor releases exist in this span; there are no skipped patch versions.

Most relevant to LibreChat:
- New Gemini models become selectable: `gemini-3.1-flash-lite` (2.1.0) and `gemini-3.5-flash` (2.5.0 / 2.6.0).
- Function-calling robustness: added the missing `FunctionCallResultDelta` type and the `arguments` field on `ArgumentDelta` (2.2.0); fixed `output_text` for turns that don't end with text (2.4.0).

Per release:
- **2.1.0** — add `gemini-3.1-flash-lite`; parameters for video `response_format`; server-side tool deltas; blocking `FunctionCall` in the Live API (Vertex AgentPlatform); Vertex Lyria models. Fix: `Steps` is not optional.
- **2.2.0** — add missing `FunctionCallResultDelta` type and `arguments` field to `ArgumentDelta`.
- **2.3.0** — Interaction `output_{text,image,audio,video}` support.
- **2.4.0** — Agent & Environment APIs. Fix: `output_text` for turns that don't end with text.
- **2.5.0** — add `gemini-3.5-flash` to model options.
- **2.6.0** — add `gemini-3.5-flash`; `enable_prompt_injection_detection` (Computer Use, Gemini API); `budget_exceeded` status; new fields.
- **2.7.0** — Skill Registry (`ListSkills`/`DeleteSkill`); additional Vertex `computer_use` fields; allow `text/csv` doc mime for the Interaction API; BigQuery tool in Deep Research config; Reinforcement Tuning.
- **2.8.0** — Agent Platform MCP support in async `generateContent`; transcription language code; `TranslationConfig` for live translation; Reinforcement Tuning incl. `ValidateReward`.

Source: [googleapis/js-genai CHANGELOG](https://github.com/googleapis/js-genai/blob/main/CHANGELOG.md).

## Change Type

- [x] New feature (non-breaking change which adds functionality) — dependency maintenance; keeps the Gemini SDK current

## Testing

Verified the upgrade is mechanically and behaviorally safe:

- Confirmed `package-lock.json` resolves `@google/genai` to `2.8.0` in both `api` and `packages/api`, with a minimal diff (version + integrity only).
- Audited the single `@google/genai` consumer and confirmed its API surface (`new GoogleGenAI(...)`, `ai.models.generateContent(...)`, `candidates[].content.parts[].inlineData` response parsing) is unchanged in 2.8.0.
- Cross-checked the upstream `@google/genai` changelog for 2.1.0 → 2.8.0: no breaking changes to the constructor, `generateContent`, or core config fields.

### Test Configuration

Recommend a pre-merge smoke test of Gemini image generation (the one code path touching this SDK) with a real `GEMINI_API_KEY` (and the Vertex AI path with a service account), since live Gemini flows can't be exercised in CI. Unit suites were not run in the isolated worktree (no installed `node_modules`); CI will cover them.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
