### PR TITLE
🔇 fix: Suppress Expected Speech Synthesis Cancellation Errors

### DIFF
--- a/client/src/hooks/Input/useTextToSpeechBrowser.ts
+++ b/client/src/hooks/Input/useTextToSpeechBrowser.ts
@@ -1,5 +1,5 @@
-import { useRecoilValue } from 'recoil';
 import { useState, useEffect, useCallback } from 'react';
+import { useRecoilValue } from 'recoil';
 import type { VoiceOption } from '~/common';
 import store from '~/store';
 
@@ -89,6 +89,11 @@ function useTextToSpeechBrowser({
         setIsSpeaking(false);
       };
       utterance.onerror = (event) => {
+        if (event.error === 'interrupted' || event.error === 'canceled') {
+          setIsSpeaking(false);
+          return;
+        }
+
         console.error('Speech synthesis error:', event);
         setIsSpeaking(false);
       };


### PR DESCRIPTION


## Summary

Suppress expected browser speech synthesis cancellation events from being logged as console errors. When a user starts TTS playback and then stops or interrupts it, browsers can fire `SpeechSynthesisErrorEvent` with `error` set to `interrupted` or `canceled`; these are expected control-flow outcomes rather than synthesis failures.

All other speech synthesis errors continue to be logged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced locally that stopping browser TTS playback emits `Speech synthesis error: SpeechSynthesisErrorEvent` before the change.
- Verified the source change only suppresses `interrupted` and `canceled`, leaving other speech synthesis errors logged.
- Ran `npx eslint client/src/hooks/Input/useTextToSpeechBrowser.ts`.

### **Test Configuration**:

- Local LibreChat harness using `scripts/local-librechat.sh start`
- Browser TTS via Web Speech API

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
