### PR TITLE
🕳️ fix: Guard Sparse Content Parts in Message Nav Preview

### DIFF
--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -3,8 +3,8 @@ import { ChevronUp, ChevronDown } from 'lucide-react';
 import { ContentTypes } from 'librechat-data-provider';
 import { HoverCard, HoverCardTrigger, HoverCardPortal, HoverCardContent } from '@librechat/client';
 import type { TMessage, TMessageContentParts } from 'librechat-data-provider';
-import { useGetMessagesByConvoId } from '~/data-provider';
 import { useMessagesConversation, useMessagesSubmission } from '~/Providers';
+import { useGetMessagesByConvoId } from '~/data-provider';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -19,7 +19,7 @@ function extractPreviewFromContent(content?: TMessageContentParts[]): string {
     return '';
   }
   for (const part of content) {
-    if (part.type !== ContentTypes.TEXT) {
+    if (part?.type !== ContentTypes.TEXT) {
       continue;
     }
     const textField = part.text;

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -9,6 +9,13 @@ type TestMessage = {
   conversationId?: string;
   text?: string;
   isCreatedByUser?: boolean;
+  content?: Array<
+    | {
+        type?: string;
+        text?: string | { value?: string };
+      }
+    | undefined
+  >;
 };
 
 const mockUseGetMessagesByConvoId = jest.fn();
@@ -293,6 +300,22 @@ describe('MessageNav', () => {
       const text = preview?.textContent ?? '';
       expect(text.endsWith('...')).toBe(true);
       expect(text.length).toBe(83);
+    });
+
+    it('skips sparse content entries when deriving preview text', () => {
+      const messages = [
+        buildMessage({
+          messageId: 'a',
+          text: '',
+          isCreatedByUser: true,
+          content: [undefined, { type: 'text', text: 'content-preview' }],
+        }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      const { container } = renderNav(messages);
+      const preview = container.querySelectorAll('[data-testid="hover-card-content"] p')[0];
+      expect(preview).toHaveTextContent('content-preview');
     });
   });
 


### PR DESCRIPTION
## Summary

Prevents MessageNav preview extraction from crashing when streamed message content contains a sparse/undefined entry. The preview loop now skips missing parts and continues to the next valid text part.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- npx jest client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx --runInBand