### PR TITLE
🧭 fix: Mobile Sidebar Navigation on Projects View

### DIFF
--- a/client/src/components/Projects/ProjectsView.tsx
+++ b/client/src/components/Projects/ProjectsView.tsx
@@ -1,14 +1,15 @@
 import { useDeferredValue, useEffect, useId, useMemo, useState } from 'react';
 import * as Ariakit from '@ariakit/react';
-import { ArrowUpDown, Check, Folder, Plus, Search } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import type { TChatProject } from 'librechat-data-provider';
+import { ArrowUpDown, Check, Folder, Plus, Search } from 'lucide-react';
 import { Input, Button, Spinner, DropdownPopup } from '@librechat/client';
+import type { TChatProject } from 'librechat-data-provider';
 import type { MenuItemProps, RenderProp } from '~/common';
+import OpenSidebar from '~/components/Chat/Menus/OpenSidebar';
 import { useProjectsInfiniteQuery } from '~/data-provider';
+import ProjectCreateDialog from './ProjectCreateDialog';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
-import ProjectCreateDialog from './ProjectCreateDialog';
 
 type ProjectSort = 'name' | 'createdAt' | 'lastConversationAt';
 
@@ -103,9 +104,12 @@ export default function ProjectsView() {
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
       <div className="container mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-4 py-8 md:px-6 lg:pt-12">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-text-primary md:text-3xl">
-            {localize('com_ui_projects')}
-          </h1>
+          <div className="flex min-w-0 items-center gap-2.5">
+            <OpenSidebar className="md:hidden" />
+            <h1 className="text-2xl font-bold tracking-tight text-text-primary md:text-3xl">
+              {localize('com_ui_projects')}
+            </h1>
+          </div>
           <div className="flex items-center gap-2">
             <span className="hidden text-sm text-text-secondary sm:inline">
               {localize('com_ui_sort_by')}

--- a/client/src/components/Projects/ProjectsView.tsx
+++ b/client/src/components/Projects/ProjectsView.tsx
@@ -2,7 +2,7 @@ import { useDeferredValue, useEffect, useId, useMemo, useState } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowUpDown, Check, Folder, Plus, Search } from 'lucide-react';
-import { Input, Button, Spinner, DropdownPopup } from '@librechat/client';
+import { Input, Button, Spinner, DropdownPopup, useMediaQuery } from '@librechat/client';
 import type { TChatProject } from 'librechat-data-provider';
 import type { MenuItemProps, RenderProp } from '~/common';
 import OpenSidebar from '~/components/Chat/Menus/OpenSidebar';
@@ -50,6 +50,7 @@ export default function ProjectsView() {
   const sortMenuId = useId();
   const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
   const deferredSearch = useDeferredValue(search);
+  const isSmallScreen = useMediaQuery('(max-width: 768px)');
 
   const { data, fetchNextPage, isFetchingNextPage, isLoading } = useProjectsInfiniteQuery({
     search: deferredSearch || undefined,
@@ -105,7 +106,7 @@ export default function ProjectsView() {
       <div className="container mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-4 py-8 md:px-6 lg:pt-12">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2.5">
-            <OpenSidebar className="md:hidden" />
+            {isSmallScreen ? <OpenSidebar /> : null}
             <h1 className="text-2xl font-bold tracking-tight text-text-primary md:text-3xl">
               {localize('com_ui_projects')}
             </h1>


### PR DESCRIPTION
## Summary

I fixed a navigation dead end on the Projects list view on mobile: opening Projects from the sidebar closes the sidebar on small screens, and the page rendered no control to reopen it, leaving users stranded with no way back. The project detail view already has an "All projects" back button, so the list page was the only stranded view.

- Added the existing `OpenSidebar` toggle to the Projects view header, rendered only below the `md` breakpoint, matching the Agents Marketplace pattern for full-page views.
- Grouped the toggle and the page title in a flex container so the header layout is unchanged on desktop, where the collapsed sidebar rail already provides navigation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified ESLint, Prettier, and the import-sort check pass on the changed file. To reproduce manually: in a mobile viewport (≤768px), navigate to Projects from the sidebar and confirm the sidebar toggle appears next to the "Projects" title and reopens the sidebar; confirm the toggle does not render at desktop widths.

### **Test Configuration**:

- Mobile viewport ≤768px (matches `useMediaQuery('(max-width: 768px)')` used by the sidebar)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
