### PR TITLE
🚰 ci: Close Leaked Redis Clients in Cache Integration Tests

### DIFF
--- a/packages/api/src/cache/__tests__/cacheFactory/limiterCache.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/limiterCache.cache_integration.spec.ts
@@ -1,4 +1,5 @@
 import type { RedisStore } from 'rate-limit-redis';
+import { closeRedisClients } from '../redisClients.helper';
 
 describe('limiterCache', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -20,6 +21,7 @@ describe('limiterCache', () => {
   });
 
   afterEach(async () => {
+    await closeRedisClients();
     process.env = originalEnv;
     jest.resetModules();
   });

--- a/packages/api/src/cache/__tests__/cacheFactory/sessionCache.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/sessionCache.cache_integration.spec.ts
@@ -1,5 +1,6 @@
 import type { MemoryStore, SessionData } from 'express-session';
 import type { RedisStore as ConnectRedis } from 'connect-redis';
+import { closeRedisClients } from '../redisClients.helper';
 
 interface TestSessionData {
   [key: string]: unknown;
@@ -49,6 +50,7 @@ describe('sessionCache', () => {
   });
 
   afterEach(async () => {
+    await closeRedisClients();
     process.env = originalEnv;
     jest.resetModules();
   });

--- a/packages/api/src/cache/__tests__/cacheFactory/standardCache.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/standardCache.cache_integration.spec.ts
@@ -1,4 +1,5 @@
 import type { Keyv } from 'keyv';
+import { closeRedisClients } from '../redisClients.helper';
 
 // Mock GLOBAL_PREFIX_SEPARATOR from cacheConfig
 jest.mock('../../cacheConfig', () => {
@@ -79,6 +80,7 @@ describe('standardCache', () => {
       testCache = null;
     }
 
+    await closeRedisClients();
     process.env = originalEnv;
     jest.resetModules();
   });

--- a/packages/api/src/cache/__tests__/cacheFactory/violationCache.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/violationCache.cache_integration.spec.ts
@@ -1,3 +1,5 @@
+import { closeRedisClients } from '../redisClients.helper';
+
 interface ViolationData {
   count?: number;
   timestamp?: number;
@@ -57,6 +59,7 @@ describe('violationCache', () => {
   });
 
   afterEach(async () => {
+    await closeRedisClients();
     process.env = originalEnv;
     jest.resetModules();
   });

--- a/packages/api/src/cache/__tests__/redisClients.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/redisClients.cache_integration.spec.ts
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "testRedisOperations"] }] */
 import type { Redis, Cluster } from 'ioredis';
 import type { RedisClientType, RedisClusterType } from '@redis/client';
 import { closeRedisClients } from './redisClients.helper';

--- a/packages/api/src/cache/__tests__/redisClients.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/redisClients.cache_integration.spec.ts
@@ -1,5 +1,6 @@
 import type { Redis, Cluster } from 'ioredis';
 import type { RedisClientType, RedisClusterType } from '@redis/client';
+import { closeRedisClients } from './redisClients.helper';
 
 type RedisClient = RedisClientType | RedisClusterType | Redis | Cluster;
 
@@ -64,27 +65,10 @@ describe('redisClients Integration Tests', () => {
       }
     }
 
-    // Cleanup Redis connections
-    if (ioredisClient) {
-      try {
-        if (ioredisClient.status === 'ready') {
-          ioredisClient.disconnect();
-        }
-      } catch (error) {
-        console.warn('Error disconnecting ioredis client:', (error as Error).message);
-      }
-      ioredisClient = null;
-    }
-
-    if (keyvRedisClient) {
-      try {
-        // Try to disconnect - keyv/redis client doesn't have an isReady property
-        await keyvRedisClient.disconnect();
-      } catch (error) {
-        console.warn('Error disconnecting keyv redis client:', (error as Error).message);
-      }
-      keyvRedisClient = null;
-    }
+    // Close BOTH clients created by the module import, not just the one the test exercised
+    await closeRedisClients();
+    ioredisClient = null;
+    keyvRedisClient = null;
 
     process.env = originalEnv;
     jest.resetModules();

--- a/packages/api/src/cache/__tests__/redisClients.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/redisClients.cache_integration.spec.ts
@@ -1,6 +1,6 @@
 /* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "testRedisOperations"] }] */
-import type { Redis, Cluster } from 'ioredis';
 import type { RedisClientType, RedisClusterType } from '@redis/client';
+import type { Redis, Cluster } from 'ioredis';
 import { closeRedisClients } from './redisClients.helper';
 
 type RedisClient = RedisClientType | RedisClusterType | Redis | Cluster;

--- a/packages/api/src/cache/__tests__/redisClients.helper.ts
+++ b/packages/api/src/cache/__tests__/redisClients.helper.ts
@@ -1,0 +1,25 @@
+export type RedisClientsModule = typeof import('~/cache/redisClients');
+
+/**
+ * Closes the Redis clients owned by a `redisClients` module instance so the jest process can
+ * exit once the suite finishes. Importing `redisClients` constructs and connects both
+ * `ioredisClient` and `keyvRedisClient` as module side effects, so every instance created
+ * through `jest.resetModules()` + re-import must be closed or its sockets and timers keep the
+ * (in-band) test process alive after all tests pass.
+ *
+ * Pass the captured module object when `jest.resetModules()` already dropped the instance from
+ * the registry (e.g. closing a `beforeAll` instance from `afterAll`); otherwise the current
+ * registry instance is used.
+ */
+export async function closeRedisClients(clients?: RedisClientsModule): Promise<void> {
+  const { ioredisClient, keyvRedisClient, keyvRedisClientReady } =
+    clients ?? (await import('~/cache/redisClients'));
+
+  if (keyvRedisClientReady) {
+    await keyvRedisClientReady.catch(() => undefined);
+  }
+  if (keyvRedisClient?.isOpen) {
+    await keyvRedisClient.disconnect().catch(() => undefined);
+  }
+  ioredisClient?.disconnect();
+}

--- a/packages/api/src/cache/__tests__/redisUtils.cache_integration.spec.ts
+++ b/packages/api/src/cache/__tests__/redisUtils.cache_integration.spec.ts
@@ -1,4 +1,5 @@
 import { batchDeleteKeys, scanKeys } from '../redisUtils';
+import { closeRedisClients } from './redisClients.helper';
 
 describe('redisUtils Integration Tests', () => {
   let keyvRedisClient: Awaited<typeof import('../redisClients')>['keyvRedisClient'];
@@ -44,8 +45,8 @@ describe('redisUtils Integration Tests', () => {
   });
 
   afterAll(async () => {
-    // Close Redis connection
-    if (keyvRedisClient?.isOpen) await keyvRedisClient.disconnect();
+    // Close both Redis clients created by the module import
+    await closeRedisClients();
   });
 
   describe('batchDeleteKeys', () => {

--- a/packages/api/src/cache/redisClients.ts
+++ b/packages/api/src/cache/redisClients.ts
@@ -1,9 +1,9 @@
 import IoRedis from 'ioredis';
-import type { Redis, Cluster } from 'ioredis';
 import { logger } from '@librechat/data-schemas';
 import { createClient, createCluster } from '@keyv/redis';
-import type { RedisClientType, RedisClusterType } from '@redis/client';
 import type { ScanCommandOptions } from '@redis/client/dist/lib/commands/SCAN';
+import type { RedisClientType, RedisClusterType } from '@redis/client';
+import type { Redis, Cluster } from 'ioredis';
 import { cacheConfig } from './cacheConfig';
 
 const urls = cacheConfig.REDIS_URI?.split(',').map((uri) => new URL(uri)) || [];

--- a/packages/api/src/cache/redisClients.ts
+++ b/packages/api/src/cache/redisClients.ts
@@ -217,7 +217,6 @@ if (cacheConfig.USE_REDIS) {
 
   keyvRedisClientReady.catch((err): void => {
     logger.error('@keyv/redis initial connection failed:', err);
-    throw err;
   });
 }
 

--- a/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts
@@ -1,7 +1,7 @@
-import type * as t from '~/mcp/types';
-import type { MCPConnection } from '~/mcp/connection';
 import type { MCPServersRegistry as MCPServersRegistryType } from '../MCPServersRegistry';
 import type { RedisClientsModule } from '~/cache/__tests__/redisClients.helper';
+import type { MCPConnection } from '~/mcp/connection';
+import type * as t from '~/mcp/types';
 import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 // Mock isLeader to always return true to avoid lock contention during parallel operations

--- a/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts
@@ -1,6 +1,8 @@
 import type * as t from '~/mcp/types';
 import type { MCPConnection } from '~/mcp/connection';
 import type { MCPServersRegistry as MCPServersRegistryType } from '../MCPServersRegistry';
+import type { RedisClientsModule } from '~/cache/__tests__/redisClients.helper';
+import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 // Mock isLeader to always return true to avoid lock contention during parallel operations
 jest.mock('~/cluster', () => ({
@@ -28,6 +30,7 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
   let MCPServerInspector: typeof import('../MCPServerInspector').MCPServerInspector;
   let MCPConnectionFactory: typeof import('~/mcp/MCPConnectionFactory').MCPConnectionFactory;
   let keyvRedisClient: Awaited<typeof import('~/cache/redisClients')>['keyvRedisClient'];
+  let redisClientsModule: RedisClientsModule;
   let LeaderElection: typeof import('~/cluster/LeaderElection').LeaderElection;
   let leaderInstance: InstanceType<typeof import('~/cluster/LeaderElection').LeaderElection>;
 
@@ -146,6 +149,7 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
     MCPServerInspector = inspectorModule.MCPServerInspector;
     MCPConnectionFactory = connectionFactoryModule.MCPConnectionFactory;
     keyvRedisClient = redisClients.keyvRedisClient;
+    redisClientsModule = redisClients;
     LeaderElection = leaderElectionModule.LeaderElection;
 
     // Reset singleton and create new instance with mongoose
@@ -232,8 +236,9 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
     // Resign as leader
     if (leaderInstance) await leaderInstance.resign();
 
-    // Close Redis connection
-    if (keyvRedisClient?.isOpen) await keyvRedisClient.disconnect();
+    // Close both Redis clients; pass the captured module since
+    // `jest.resetModules()` in beforeEach dropped it from the registry
+    await closeRedisClients(redisClientsModule);
   });
 
   describe('initialize()', () => {

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import type * as t from '~/mcp/types';
 import type { MCPServersRegistry as MCPServersRegistryType } from '../MCPServersRegistry';
+import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 // Mock ServerConfigsDB to avoid needing MongoDB for cache integration tests
 jest.mock('../db/ServerConfigsDB', () => ({
@@ -137,8 +138,8 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
     // Resign as leader
     if (leaderInstance) await leaderInstance.resign();
 
-    // Close Redis connection
-    if (keyvRedisClient?.isOpen) await keyvRedisClient.disconnect();
+    // Close both Redis clients created by the module import
+    await closeRedisClients();
   });
 
   // Tests for the old privateServersCache API have been removed

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import type * as t from '~/mcp/types';
 import type { MCPServersRegistry as MCPServersRegistryType } from '../MCPServersRegistry';
+import type * as t from '~/mcp/types';
 import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 // Mock ServerConfigsDB to avoid needing MongoDB for cache integration tests

--- a/packages/api/src/mcp/registry/cache/__tests__/RegistryStatusCache.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/RegistryStatusCache.cache_integration.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 describe('RegistryStatusCache Integration Tests', () => {
   let registryStatusCache: typeof import('../RegistryStatusCache').registryStatusCache;
@@ -56,8 +57,8 @@ describe('RegistryStatusCache Integration Tests', () => {
     // Resign as leader
     if (leaderInstance) await leaderInstance.resign();
 
-    // Close Redis connection
-    if (keyvRedisClient?.isOpen) await keyvRedisClient.disconnect();
+    // Close both Redis clients created by the module import
+    await closeRedisClients();
   });
 
   describe('Initialization status tracking', () => {

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
@@ -1,9 +1,12 @@
 import { expect } from '@playwright/test';
 import { ParsedServerConfig } from '~/mcp/types';
+import type { RedisClientsModule } from '~/cache/__tests__/redisClients.helper';
+import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 describe('ServerConfigsCacheRedis Integration Tests', () => {
   let ServerConfigsCacheRedis: typeof import('../ServerConfigsCacheRedis').ServerConfigsCacheRedis;
   let keyvRedisClient: Awaited<typeof import('~/cache/redisClients')>['keyvRedisClient'];
+  let redisClientsModule: RedisClientsModule;
 
   let cache: InstanceType<typeof import('../ServerConfigsCacheRedis').ServerConfigsCacheRedis>;
 
@@ -43,6 +46,7 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
 
     ServerConfigsCacheRedis = cacheModule.ServerConfigsCacheRedis;
     keyvRedisClient = redisClients.keyvRedisClient;
+    redisClientsModule = redisClients;
 
     // Ensure Redis is connected
     if (!keyvRedisClient) throw new Error('Redis client is not initialized');
@@ -75,8 +79,9 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
   });
 
   afterAll(async () => {
-    // Close Redis connection
-    if (keyvRedisClient?.isOpen) await keyvRedisClient.disconnect();
+    // Close both Redis clients; pass the captured module since
+    // `jest.resetModules()` in beforeEach dropped it from the registry
+    await closeRedisClients(redisClientsModule);
   });
 
   describe('add and get operations', () => {

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
-import { ParsedServerConfig } from '~/mcp/types';
 import type { RedisClientsModule } from '~/cache/__tests__/redisClients.helper';
 import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
+import { ParsedServerConfig } from '~/mcp/types';
 
 describe('ServerConfigsCacheRedis Integration Tests', () => {
   let ServerConfigsCacheRedis: typeof import('../ServerConfigsCacheRedis').ServerConfigsCacheRedis;

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import type { ParsedServerConfig } from '~/mcp/types';
+import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
 
 describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
   let ServerConfigsCacheRedisAggregateKey: typeof import('../ServerConfigsCacheRedisAggregateKey').ServerConfigsCacheRedisAggregateKey;
@@ -56,7 +57,7 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
   });
 
   afterAll(async () => {
-    if (keyvRedisClient?.isOpen) await keyvRedisClient.disconnect();
+    await closeRedisClients();
   });
 
   describe('add and get operations', () => {


### PR DESCRIPTION
## Summary

I fixed the cache integration test suites leaking connected Redis clients after every test, which keeps the jest process alive after all tests pass. Importing `redisClients` constructs and connects **both** `ioredisClient` and `keyvRedisClient` as module side effects, but most cache/mcp integration specs disconnected at most one of the two — and the specs that re-import the module per test via `jest.resetModules()` leaked a fresh pair of connected clients (sockets and ping timers) for every single test. On runners where jest resolves to a single worker (2-core machines with `maxWorkers: '50%'`), the suites run in-band and the leaked handles hang the main process until the CI job timeout; on larger runners jest recovers only by force-exiting the leaked worker — the "A worker process has failed to exit gracefully" warning currently visible in green CI runs of this workflow.

- Added a `closeRedisClients()` test helper that settles `keyvRedisClientReady` and closes both clients owned by a `redisClients` module instance, accepting a captured module object for specs whose `jest.resetModules()` already dropped the instance from the registry.
- Wired the helper into the teardown of all six `src/cache` integration specs and all five `src/mcp` registry integration specs, mirroring the both-clients cleanup `LeaderElection.cache_integration.spec.ts` already performs.
- Removed the rethrow inside the `keyvRedisClientReady.catch(...)` logging handler in `redisClients.ts`: rethrowing from `.catch` creates a new, never-observed rejected promise, turning any failed initial connect into a guaranteed unhandled rejection; code awaiting `keyvRedisClientReady` still observes the original rejection.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced the hang, then verified the fix locally against the same Redis topology the `Cache Integration Tests` workflow uses (single node on 6379 via `redis-server`, 3-node cluster on 7001-7003 via `redis-config/start-cluster.sh`):

1. **Baseline (before fix):** `npx jest --testPathPatterns="src/cache/.*\.cache_integration\.spec\.ts$" --coverage=false --maxWorkers=1` passes all 33 tests in ~19s, then the in-band process never exits (reproduces the CI hang).
2. **After fix:** the same command passes and exits cleanly in ~17s.
3. Ran all four `test:cache-integration` stages in-band (`--maxWorkers=1` / existing `--runInBand`) against **both** the single-node phase env and the cluster phase env — every stage passes and exits cleanly (236 tests per phase).
4. Ran the core stage with default workers — the "worker process has failed to exit gracefully" warning no longer appears.
5. `tsc --noEmit` and ESLint pass on all touched files.

### **Test Configuration**:

- Node.js 24.16.0, jest 30, macOS (darwin arm64)
- `USE_REDIS=true` with `REDIS_URI=redis://127.0.0.1:6379` (single) and `USE_REDIS_CLUSTER=true` with `REDIS_URI=redis://127.0.0.1:7001,redis://127.0.0.1:7002,redis://127.0.0.1:7003` (cluster)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

> [!NOTE]
> **Deliberate behavior change in `redisClients.ts`:** the `throw err` inside `keyvRedisClientReady.catch(...)` only ever rejected a floating derived promise nobody could observe — consumers awaiting `keyvRedisClientReady` get the original rejection with or without it. Its sole runtime effect was a guaranteed `unhandledRejection` (process crash) when the initial connect failed after retry exhaustion. Removing it means a boot-time Redis connection failure is now logged and the process continues — matching the ioredis client's identical give-up path in the same file and the existing post-boot reconnect-exhaustion behavior. If boot-time fail-fast is preferred for Redis-required deployments, that should be an explicit `process.exit(1)` / bootstrap await instead; flagging so it's a conscious review decision.
