### PR TITLE
🗜️ ci: Cache Dependencies and Builds in Cache Integration Tests

### DIFF
--- a/.github/workflows/cache-integration-tests.yml
+++ b/.github/workflows/cache-integration-tests.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.16.0'
-          cache: 'npm'
 
       - name: Install Redis tools
         run: |
@@ -57,14 +56,54 @@ jobs:
           redis-cli -p 7002 cluster info || exit 1
           redis-cli -p 7003 cluster info || exit 1
 
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            api/node_modules
+            packages/api/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
+          key: node-modules-backend-${{ runner.os }}-24.16.0-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Build packages
-        run: |
-          npm run build:data-provider
-          npm run build:data-schemas
-          npm run build:api
+      - name: Restore data-provider build cache
+        id: cache-data-provider
+        uses: actions/cache@v4
+        with:
+          path: packages/data-provider/dist
+          key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
+
+      - name: Build data-provider
+        if: steps.cache-data-provider.outputs.cache-hit != 'true'
+        run: npm run build:data-provider
+
+      - name: Restore data-schemas build cache
+        id: cache-data-schemas
+        uses: actions/cache@v4
+        with:
+          path: packages/data-schemas/dist
+          key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
+
+      - name: Build data-schemas
+        if: steps.cache-data-schemas.outputs.cache-hit != 'true'
+        run: npm run build:data-schemas
+
+      - name: Restore api build cache
+        id: cache-api
+        uses: actions/cache@v4
+        with:
+          path: packages/api/dist
+          key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/tsdown.config.mjs', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json') }}
+
+      - name: Build api
+        if: steps.cache-api.outputs.cache-hit != 'true'
+        run: npm run build:api
 
       - name: Run all cache integration tests (Single Redis Node)
         working-directory: packages/api


### PR DESCRIPTION
## Summary

I ported the dependency and build caching the backend test workflow already uses to the Cache Integration Tests workflow, which ran a full `npm ci` (~72s on a recent run) and rebuilt `data-provider`, `data-schemas`, and `api` from scratch on every run.

- Added the `node_modules` restore step from `backend-review.yml` with a conditional `npm ci` on cache miss, using the identical `node-modules-backend-*` key and paths so both workflows share cache entries.
- Replaced the monolithic "Build packages" step with the three restore-or-build blocks from `backend-review.yml` (`build-data-provider-*`, `build-data-schemas-*`, `build-api-*` keys), so unchanged packages restore their `dist` instead of rebuilding.
- Removed `cache: 'npm'` from `setup-node` — the npm tarball cache is superseded by the `node_modules` restore, matching `backend-review.yml`.

Same scoping caveat as the existing backend/frontend caching: the first run on a PR misses and populates; subsequent pushes to that PR (and any branch sharing a populated base scope) hit. This workflow lists itself in its `paths` trigger, so this PR's own run exercises the miss path end-to-end.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Validated the workflow YAML parses and the step sequence is intact (redis setup → restores/installs/builds → both test phases → teardown). The caching steps are byte-for-byte the proven blocks from `backend-review.yml`; this PR's own Cache Integration Tests run verifies the miss path, and a follow-up push exercises the hit path.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings