### PR TITLE
🤗 ci: Cache and Authenticate HF Model Downloads in GitNexus Index

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -180,12 +180,29 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # HuggingFace throttles anonymous model downloads from shared GHA
+      # runner IPs (429s or stalled transfers). Cache the embedding model
+      # across runs so warm runs never touch HF at all.
+      - name: Cache HuggingFace embedding model
+        if: steps.flags.outputs.enable_embeddings == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/hf-cache
+          key: hf-model-snowflake-arctic-embed-xs-v1
+
       - name: Run GitNexus Analyze
         working-directory: ${{ runner.temp }}
         env:
           ENABLE_EMBEDDINGS: ${{ steps.flags.outputs.enable_embeddings }}
           FORCE: ${{ inputs.force }}
           GITNEXUS_BIN: ${{ runner.temp }}/gitnexus-cli/node_modules/.bin/gitnexus
+          # Fail soft in ~2 min on stalled downloads instead of eating the
+          # 25-min job budget; HF_TOKEN lifts the anonymous rate limit on
+          # cold-cache runs (empty when the secret is unset — safe no-op).
+          HF_DOWNLOAD_TIMEOUT_MS: '60000'
+          HF_HOME: ${{ runner.temp }}/hf-cache
+          HF_MAX_ATTEMPTS: '2'
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           NPM_CONFIG_AUDIT: false
           NPM_CONFIG_CACHE: ${{ runner.temp }}/gitnexus-npm-cache
           NPM_CONFIG_FUND: false


### PR DESCRIPTION
## Summary

The GitNexus Index workflow has had zero genuine index successes for over a day: every embeddings-enabled run downloads the `Snowflake/snowflake-arctic-embed-xs` model (~90MB) anonymously from huggingface.co on a fresh runner, and HuggingFace now throttles GitHub Actions' shared IPs. This surfaces two ways — a fast HTTP 429 crash on `config.json` ([example run](https://github.com/danny-avila/LibreChat/actions/runs/27236367660)), or a stalled download that silently burns gitnexus's retry budget (3 attempts × 5-min per-attempt timeout) until the 25-minute job timeout kills it ([example run](https://github.com/danny-avila/LibreChat/actions/runs/27275803736)). The breakage went unnoticed because PR runs are `continue-on-error` (failures still show a green workflow) and rapid `dev` pushes cancel in-progress push runs via the concurrency group.

I fixed the workflow so the model is cached across runs and downloads are authenticated when they do happen:

- Added an `actions/cache@v4` step for the HuggingFace model directory, keyed on the model name and gated on `enable_embeddings` — warm runs never contact huggingface.co at all.
- Pointed `HF_HOME` at the cached directory; gitnexus bridges `HF_HOME` → transformers.js `env.cacheDir`.
- Passed `HF_TOKEN` from repo secrets to the analyze step; the bundled `@huggingface/transformers@4.1.0` natively sends it as a Bearer token for huggingface.co URLs, lifting the anonymous rate limit on cold-cache runs. An unset secret resolves to an empty string, which transformers.js treats as no auth — safe before the secret exists.
- Set `HF_DOWNLOAD_TIMEOUT_MS=60000` and `HF_MAX_ATTEMPTS=2` so a stalled download fails soft in ~2 minutes instead of consuming the entire 25-minute job budget.

**Action required after merge:** add an `HF_TOKEN` repo secret (a free HuggingFace read token) so the first cold-cache run can seed the cache reliably.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Validated the workflow YAML parses cleanly.
- Verified against gitnexus@1.6.5 source that `HF_HOME`, `HF_DOWNLOAD_TIMEOUT_MS`, and `HF_MAX_ATTEMPTS` are read by its embedder entry points, and against `@huggingface/transformers@4.1.0` that `HF_TOKEN` is sent as an `Authorization: Bearer` header for huggingface.co URLs.
- This workflow ignores `.github/**` paths, so the PR itself won't trigger an index run. To verify end-to-end: add the `HF_TOKEN` secret, then dispatch `gitnexus-index.yml` with `embeddings: true` — the first run seeds the cache, and a second dispatch should restore it and skip the HF download entirely.

### **Test Configuration**:

- gitnexus@1.6.5, @huggingface/transformers@4.1.0, ubuntu-latest runners

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
