### PR TITLE
⏫ ci: Bump GitNexus to 1.6.7 to Fix Embeddings Index Timeout

### DIFF
--- a/.do/gitnexus/Dockerfile
+++ b/.do/gitnexus/Dockerfile
@@ -7,10 +7,10 @@
 
 FROM node:24.16.0-slim
 
-ARG GITNEXUS_VERSION=1.6.5
-# Pin the native DB to match the index workflow; gitnexus's ^0.16.1 range
+ARG GITNEXUS_VERSION=1.6.7
+# Pin the native DB to match the index workflow; gitnexus's ^0.17.0 range
 # would otherwise let the served image drift from the CI-produced index.
-ARG LADYBUG_VERSION=0.16.1
+ARG LADYBUG_VERSION=0.17.1
 
 # 1. Build native addons with Bookworm toolchain, then remove build tools.
 #    curl stays for the docker healthcheck; Caddy lives in its own container.
@@ -33,7 +33,7 @@ RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.
 # 3. Pre-install LadybugDB FTS + vector extensions so ~/.kuzu/extension/
 #    is baked into the image. gitnexus serve loads extensions with a
 #    load-only policy and never installs them at runtime, so the cache
-#    must already exist. (GitNexus 1.6.5 loads the vector extension itself
+#    must already exist. (GitNexus loads the vector extension itself
 #    via loadVectorExtension — no adapter patch needed.)
 COPY install-extensions.js /tmp/install-extensions.js
 RUN node /tmp/install-extensions.js && rm -rf /tmp/install-extensions.js /tmp/lbug-ext-install

--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -84,7 +84,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GITNEXUS_VERSION: '1.6.5'
+  GITNEXUS_VERSION: '1.6.7'
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/librechat-gitnexus
 
 jobs:

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -63,7 +63,9 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.user.login == 'danny-avila'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Embedding generation dominates the budget: ~45 min worst case on
+    # standard runners since the 1.6.x graph (~23k nodes) doubled vs 1.5.x.
+    timeout-minutes: 60
     # Best-effort index: a tool-internal crash must not block PRs. Fail soft on
     # PR events; push/dispatch runs still fail loudly so regressions stay visible.
     continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -43,7 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GITNEXUS_VERSION: '1.6.5'
+  GITNEXUS_VERSION: '1.6.7'
 
 jobs:
   index:
@@ -165,7 +165,7 @@ jobs:
             --no-save \
             --no-package-lock \
             "gitnexus@${{ env.GITNEXUS_VERSION }}" \
-            "@ladybugdb/core@0.16.1"
+            "@ladybugdb/core@0.17.1"
           test -x "$RUNNER_TEMP/gitnexus-cli/node_modules/.bin/gitnexus"
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Follow-up to #13653, which fixed the HuggingFace 429s/stalls but exposed deeper failures: no embeddings-enabled index run has genuinely succeeded since the GitNexus 1.6.5 bump on June 7 (#13569). Two compounding problems:

1. **gitnexus 1.6.5 has a single-threaded quadratic pass after parsing.** The latest timed-out run had `HF_TOKEN` active and gitnexus's 60-second download timeout never fired — the process was CPU-bound, not stuck downloading. Reproduced locally: 1.6.5 pegs exactly one core in silence after the parse phase (killed after 10+ minutes with no progress), while 1.6.7 completed the identical analysis in ~10 minutes on the same machine, producing 22,587 embeddings. The 1.6.6 release notes confirm the diagnosis: "O(n²)→indexed finalize", "scope-capture O(n²)→O(n)", and a parallel worker-pool parse.
2. **The 25-minute job timeout no longer fits embedding generation.** A verification dispatch of 1.6.7 from this branch cleared parsing, scope resolution, and FTS in ~2.5 minutes (where 1.6.5 hung), but embedding inference (hardcoded `batchSize: 16, threads: 2`) needs more wall-clock than the remaining budget — the 1.6.x graph (~23.4k nodes) roughly doubled vs 1.5.x (~13.3k), so there is about twice the embedding work the original 25-minute budget was calibrated for.

Changes:

- Bumped `GITNEXUS_VERSION` from 1.6.5 to 1.6.7 in the index workflow, the deploy workflow, and the DigitalOcean Dockerfile.
- Bumped the `@ladybugdb/core` pin from 0.16.1 to 0.17.1 in the index workflow and the Dockerfile — gitnexus 1.6.7 requires `^0.17.0`, and the served image must read the CI-produced index, so the index and serve sides cannot drift.
- Raised the index job timeout from 25 to 60 minutes. LibreChat is a public repo (standard-runner minutes are free) and the concurrency group already cancels superseded runs, so the generous ceiling costs nothing while restoring headroom.
- Updated Dockerfile comments referencing the old version range.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran gitnexus 1.6.5 and 1.6.7 side by side locally against a LibreChat clone with `--embeddings`: 1.6.5 sat at 100% of a single core producing no output after parsing (matching the silent CI timeouts) until killed; 1.6.7 completed in 597s with a valid index (23,402 nodes, 48,634 edges, 22,587 embeddings).
- First branch dispatch with `embeddings: true` ([run](https://github.com/danny-avila/LibreChat/actions/runs/27293721493)) proved 1.6.7 clears the 1.6.5 hang point in ~2.5 min but needs more than the old 25-minute budget for embedding inference, motivating the timeout raise.
- Second branch dispatch with `embeddings: true` after the timeout raise: [verification run](https://github.com/danny-avila/LibreChat/actions/runs/27295400064).
- Validated both workflow files parse cleanly.

### **Test Configuration**:

- gitnexus@1.6.7, @ladybugdb/core@0.17.1, ubuntu-latest runners

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
