### PR TITLE
🚯 chore: Relax ESLint Rules for `packages/api` Test Files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -306,6 +306,19 @@ export default [
     },
   },
   {
+    /**
+     * Tests under `packages/api` routinely cast to `any` to spy on private
+     * internals and `require()` CommonJS test helpers (e.g. `supertest`).
+     * Relax these two rules for spec/test files so they don't accumulate
+     * per-line disable directives.
+     */
+    files: ['./packages/api/**/*.spec.ts', './packages/api/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
+  {
     files: ['./config/translations/**/*.ts'],
     languageOptions: {
       parser: tsParser,

--- a/packages/api/src/agents/context.spec.ts
+++ b/packages/api/src/agents/context.spec.ts
@@ -487,7 +487,6 @@ describe('Agent Context Utilities', () => {
       const agent: AgentWithTools = {
         id: 'test-agent',
         instructions: 'Base',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         tools: null as any, // Invalid tools - should not crash
       };
 

--- a/packages/api/src/app/config.test.ts
+++ b/packages/api/src/app/config.test.ts
@@ -166,7 +166,6 @@ describe('getTransactionsConfig', () => {
       it('should handle appConfig with null balance', () => {
         const appConfig = createTestAppConfig({
           transactions: { enabled: false },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           balance: null as any,
         });
         const result = getTransactionsConfig(appConfig);
@@ -187,7 +186,6 @@ describe('getTransactionsConfig', () => {
       it('should handle appConfig with balance enabled undefined', () => {
         const appConfig = createTestAppConfig({
           transactions: { enabled: false },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           balance: { enabled: undefined as any },
         });
         const result = getTransactionsConfig(appConfig);
@@ -272,7 +270,6 @@ describe('getBalanceConfig', () => {
     it('should handle appConfig with null balance', () => {
       process.env.CHECK_BALANCE = 'true';
       const appConfig = createTestAppConfig({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         balance: null as any,
       });
       const result = getBalanceConfig(appConfig);

--- a/packages/api/src/app/resolve.spec.ts
+++ b/packages/api/src/app/resolve.spec.ts
@@ -1,7 +1,6 @@
 import type { AsyncLocalStorage } from 'async_hooks';
 
 jest.mock('@librechat/data-schemas', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { AsyncLocalStorage: ALS } = require('async_hooks');
   return { tenantStorage: new ALS() };
 });

--- a/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
@@ -83,11 +83,7 @@ describe('MCP OAuth Race Condition Fixes', () => {
       };
 
       const registrySpy = jest
-        .spyOn(
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry,
-          'getInstance',
-        )
+        .spyOn(require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry, 'getInstance')
         .mockReturnValue({
           getServerConfig: jest.fn().mockResolvedValue(mockConfig),
           shouldEnableSSRFProtection: jest.fn().mockReturnValue(false),
@@ -155,11 +151,7 @@ describe('MCP OAuth Race Condition Fixes', () => {
       };
 
       const registrySpy = jest
-        .spyOn(
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry,
-          'getInstance',
-        )
+        .spyOn(require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry, 'getInstance')
         .mockReturnValue({
           getServerConfig: jest.fn().mockResolvedValue(mockConfig),
           shouldEnableSSRFProtection: jest.fn().mockReturnValue(false),
@@ -236,11 +228,7 @@ describe('MCP OAuth Race Condition Fixes', () => {
       };
 
       const registrySpy = jest
-        .spyOn(
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry,
-          'getInstance',
-        )
+        .spyOn(require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry, 'getInstance')
         .mockReturnValue({
           getServerConfig: jest.fn().mockResolvedValue(mockConfig),
           shouldEnableSSRFProtection: jest.fn().mockReturnValue(false),
@@ -336,11 +324,7 @@ describe('MCP OAuth Race Condition Fixes', () => {
       };
 
       const registrySpy = jest
-        .spyOn(
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry,
-          'getInstance',
-        )
+        .spyOn(require('~/mcp/registry/MCPServersRegistry').MCPServersRegistry, 'getInstance')
         .mockReturnValue({
           getServerConfig: jest.fn().mockResolvedValue(mockConfig),
           shouldEnableSSRFProtection: jest.fn().mockReturnValue(false),

--- a/packages/api/src/mcp/__tests__/reconnection-storm.test.ts
+++ b/packages/api/src/mcp/__tests__/reconnection-storm.test.ts
@@ -135,14 +135,12 @@ function createConnection(serverName: string, url: string, initTimeout = 5000): 
 }
 
 async function teardownConnection(conn: MCPConnection): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (conn as any).shouldStopReconnecting = true;
   conn.removeAllListeners();
   await conn.disconnect();
 }
 
 afterEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (MCPConnection as any).circuitBreakers.clear();
 });
 
@@ -162,7 +160,6 @@ describe('Fix #2: Circuit breaker stops rapid reconnect cycling', () => {
       try {
         await conn.connect();
         await teardownConnection(conn);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (conn as any).shouldStopReconnecting = false;
         completedCycles++;
       } catch (e) {
@@ -187,13 +184,11 @@ describe('Fix #3: SSE 400/405 handled in same branch as 404', () => {
     const conn = createConnection('sse-400', srv.url);
     await conn.connect();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (conn as any).shouldStopReconnecting = true;
 
     const changes: string[] = [];
     conn.on('connectionChange', (s: string) => changes.push(s));
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const transport = (conn as any).transport;
     transport.onerror({ message: 'Failed to open SSE stream', code: 400 });
 
@@ -208,13 +203,11 @@ describe('Fix #3: SSE 400/405 handled in same branch as 404', () => {
     const conn = createConnection('sse-405', srv.url);
     await conn.connect();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (conn as any).shouldStopReconnecting = true;
 
     const changes: string[] = [];
     conn.on('connectionChange', (s: string) => changes.push(s));
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const transport = (conn as any).transport;
     transport.onerror({ message: 'Method Not Allowed', code: 405 });
 
@@ -237,14 +230,12 @@ describe('Fix #4: Circuit breaker state persists across instance replacement', (
     await conn1.connect();
     await teardownConnection(conn1);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cbAfterConn1 = (MCPConnection as any).circuitBreakers.get('replace');
     expect(cbAfterConn1).toBeDefined();
     const cyclesAfterConn1 = cbAfterConn1.cycleCount;
     expect(cyclesAfterConn1).toBeGreaterThan(0);
 
     const conn2 = createConnection('replace', srv.url);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cbFromConn2 = (conn2 as any).getCircuitBreaker();
     expect(cbFromConn2.cycleCount).toBe(cyclesAfterConn1);
 
@@ -254,15 +245,12 @@ describe('Fix #4: Circuit breaker state persists across instance replacement', (
 
   it('clearCooldown resets static state so explicit retry proceeds', () => {
     const conn = createConnection('replace', 'http://127.0.0.1:1/mcp');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cb = (conn as any).getCircuitBreaker();
     cb.cooldownUntil = Date.now() + 999_999;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((conn as any).isCircuitOpen()).toBe(true);
 
     MCPConnection.clearCooldown('replace');
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((conn as any).isCircuitOpen()).toBe(false);
   });
 });
@@ -386,7 +374,6 @@ describe('Fix #5b: disconnect(false) preserves cycle tracking', () => {
     await conn.connect();
     expect(spy).toHaveBeenCalledWith(false);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cb = (MCPConnection as any).circuitBreakers.get('wipe');
     expect(cb).toBeDefined();
     expect(cb.cycleCount).toBeGreaterThan(0);
@@ -466,7 +453,6 @@ describe('Cascade: Circuit breaker caps rapid cycling', () => {
       try {
         await conn.connect();
         await teardownConnection(conn);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (conn as any).shouldStopReconnecting = false;
         completedCycles++;
       } catch (e) {
@@ -489,7 +475,6 @@ describe('Cascade: Circuit breaker caps rapid cycling', () => {
 
     await conn.connect();
     await teardownConnection(conn);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (conn as any).shouldStopReconnecting = false;
     await srv.close();
 
@@ -563,7 +548,6 @@ describe('OAuth: cycle budget recovery after successful OAuth', () => {
     // connect() sees not connected → throws "Connection not established"
     await expect(conn.connect()).rejects.toThrow('Connection not established');
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cb = (MCPConnection as any).circuitBreakers.get(serverName);
     const cyclesBeforeRetry = cb.cycleCount;
 
@@ -638,7 +622,6 @@ describe('OAuth: cycle budget recovery after successful OAuth', () => {
 
     await expect(conn.connect()).rejects.toThrow();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cb = (MCPConnection as any).circuitBreakers.get(serverName);
     const cyclesAfterFailure = cb.cycleCount;
 

--- a/packages/api/src/mcp/__tests__/zod.spec.ts
+++ b/packages/api/src/mcp/__tests__/zod.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // zod.spec.ts
 import { z } from 'zod';
 import type { JsonSchemaType } from '@librechat/data-schemas';

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.test.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.test.ts
@@ -36,7 +36,6 @@ describe('OAuthReconnectionManager', () => {
     jest.clearAllMocks();
 
     // Reset singleton instance
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (OAuthReconnectionManager as any).instance = null;
 
     // Setup mock flow manager

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
@@ -291,20 +291,17 @@ describe('MCPServersRegistry', () => {
     describe('Invalid storage location', () => {
       it('should throw error for unsupported storage location in addServer', async () => {
         await expect(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           registry.addServer('test_server', testParsedConfig, 'INVALID' as any),
         ).rejects.toThrow('The provided storage location "INVALID" is not supported');
       });
 
       it('should throw error for unsupported storage location in updateServer', async () => {
         await expect(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           registry.updateServer('test_server', testParsedConfig, 'REDIS' as any),
         ).rejects.toThrow('The provided storage location "REDIS" is not supported');
       });
 
       it('should throw error for unsupported storage location in removeServer', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await expect(registry.removeServer('test_server', 'S3' as any)).rejects.toThrow(
           'The provided storage location "S3" is not supported',
         );

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
@@ -254,7 +254,6 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       await cache.getAll();
 
       // Spy on the underlying Keyv cache to count Redis calls
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const cacheGetSpy = jest.spyOn((cache as any).cache, 'get');
 
       await cache.getAll();
@@ -325,10 +324,8 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       await cache.getAll(); // prime snapshot
 
       // Force-expire the snapshot without sleeping
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (cache as any).localSnapshotExpiry = Date.now() - 1;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const cacheGetSpy = jest.spyOn((cache as any).cache, 'get');
       const result = await cache.getAll();
       expect(cacheGetSpy.mock.calls).toHaveLength(1);


### PR DESCRIPTION
## Summary

I relaxed `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-require-imports` for spec/test files under `packages/api` and removed the per-line disable directives they made redundant. Tests in this package routinely cast to `any` to spy on private internals (e.g. `(cache as any).cache`, circuit-breaker state on `MCPConnection`) and `require()` CommonJS test helpers, so suppressing these rules per line had become pure noise — and any config drift turns those directives into `--max-warnings=0` CI failures as unused-disable-directive warnings.

- Added an ESLint config block scoped to `./packages/api/**/*.spec.ts` and `./packages/api/**/*.test.ts` that turns off `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-require-imports`, alongside the existing test-file rule relaxations.
- Removed all newly redundant `eslint-disable` directives for these two rules across 9 test files (`reconnection-storm.test.ts`, `MCPOAuthRaceCondition.test.ts`, `MCPServersRegistry.test.ts`, `ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts`, `OAuthReconnectionManager.test.ts`, `config.test.ts`, `context.spec.ts`, `resolve.spec.ts`, `zod.spec.ts`), so changed-file linting stays clean under the new config.
- Kept directives for rules that remain active (`ban-ts-comment`, `no-unused-vars`, `jest/*`) untouched.
- Production code under `packages/api/src` is unaffected — the relaxation applies exclusively to test files.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran ESLint with the CI invocation over every file touched by this PR and confirmed zero errors and zero warnings, including no unused-disable-directive reports:

```bash
npx eslint --config eslint.config.mjs --max-warnings=0 -- <changed files>
npx prettier --check -- <changed files>
```

Verified no remaining `eslint-disable` directives for the two relaxed rules exist anywhere under `packages/api`. Changes are comment removals and a Prettier reflow of `jest.spyOn` call sites only — no runtime behavior changes.

### **Test Configuration**:

- Node.js v24.16.0, ESLint via `eslint.config.mjs` flat config

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes