### PR TITLE
🗝️ chore: Use Element Access over `any`-Casts in Registry Cache Spec

### DIFF
--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
@@ -254,8 +254,7 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       await cache.getAll();
 
       // Spy on the underlying Keyv cache to count Redis calls
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cacheGetSpy = jest.spyOn((cache as any).cache, 'get');
+      const cacheGetSpy = jest.spyOn(cache['cache'], 'get');
 
       await cache.getAll();
       await cache.getAll();
@@ -325,11 +324,9 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       await cache.getAll(); // prime snapshot
 
       // Force-expire the snapshot without sleeping
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (cache as any).localSnapshotExpiry = Date.now() - 1;
+      cache['localSnapshotExpiry'] = Date.now() - 1;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cacheGetSpy = jest.spyOn((cache as any).cache, 'get');
+      const cacheGetSpy = jest.spyOn(cache['cache'], 'get');
       const result = await cache.getAll();
       expect(cacheGetSpy.mock.calls).toHaveLength(1);
       expect(Object.keys(result).length).toBe(1);


### PR DESCRIPTION
## Summary

I replaced the three `(cache as any)` casts in `ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts` with TypeScript element access (`cache['cache']`, `cache['localSnapshotExpiry']`). The casts existed only to reach the protected `Keyv` cache and the private `localSnapshotExpiry` member from the test; element access is TypeScript's sanctioned escape hatch for exactly this and keeps the access fully typed, so the casts and their `eslint-disable-next-line @typescript-eslint/no-explicit-any` directives become unnecessary.

- Replaced `jest.spyOn((cache as any).cache, 'get')` with `jest.spyOn(cache['cache'], 'get')` at both spy sites — the spy is now typed against `Keyv` instead of `any`.
- Replaced `(cache as any).localSnapshotExpiry = Date.now() - 1` with `cache['localSnapshotExpiry'] = Date.now() - 1`.
- Removed the three disable directives the casts required. Besides dropping `any` from the spec, this keeps the file clean under lint setups that relax `no-explicit-any` for test files, where the directives report as unused under `--max-warnings=0`.

Compiled output is identical, so test behavior is unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx tsc --noEmit -p packages/api/tsconfig.json` — clean; the element access type-checks against the declared members.
- `npx eslint --max-warnings=0` and `npx prettier --check` on the spec — clean, with no unused-directive warnings.
- The spec itself runs in the Redis cache-integration workflow; the change is comment removal plus an equivalent member-access syntax, identical at runtime.

### **Test Configuration**:

- Node.js v24.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
