### PR TITLE
🚪 fix: Gate Artifacts Toggle on Agent Capability Flag

### DIFF
--- a/client/src/components/Chat/Input/Artifacts.tsx
+++ b/client/src/components/Chat/Input/Artifacts.tsx
@@ -1,10 +1,10 @@
 import React, { memo, useState, useCallback, useMemo, useEffect } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { CheckboxButton } from '@librechat/client';
-import { ArtifactModes, defaultAgentCapabilities } from 'librechat-data-provider';
 import { WandSparkles, ChevronDown } from 'lucide-react';
-import { useBadgeRowContext } from '~/Providers';
+import { ArtifactModes, defaultAgentCapabilities } from 'librechat-data-provider';
 import { useLocalize, useAgentCapabilities } from '~/hooks';
+import { useBadgeRowContext } from '~/Providers';
 import { cn } from '~/utils';
 
 interface ArtifactsToggleState {

--- a/client/src/components/Chat/Input/Artifacts.tsx
+++ b/client/src/components/Chat/Input/Artifacts.tsx
@@ -1,10 +1,10 @@
 import React, { memo, useState, useCallback, useMemo, useEffect } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { CheckboxButton } from '@librechat/client';
-import { ArtifactModes } from 'librechat-data-provider';
+import { ArtifactModes, defaultAgentCapabilities } from 'librechat-data-provider';
 import { WandSparkles, ChevronDown } from 'lucide-react';
 import { useBadgeRowContext } from '~/Providers';
-import { useLocalize } from '~/hooks';
+import { useLocalize, useAgentCapabilities } from '~/hooks';
 import { cn } from '~/utils';
 
 interface ArtifactsToggleState {
@@ -16,6 +16,10 @@ function Artifacts() {
   const localize = useLocalize();
   const context = useBadgeRowContext();
   const { toggleState, debouncedChange, isPinned } = context?.artifacts ?? {};
+
+  const { artifactsEnabled } = useAgentCapabilities(
+    context?.agentsConfig?.capabilities ?? defaultAgentCapabilities,
+  );
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isButtonExpanded, setIsButtonExpanded] = useState(false);
@@ -72,6 +76,10 @@ function Artifacts() {
       debouncedChange({ value: ArtifactModes.CUSTOM });
     }
   }, [isCustomEnabled, debouncedChange]);
+
+  if (!artifactsEnabled) {
+    return null;
+  }
 
   if (!isEnabled && !isPinned) {
     return null;

--- a/packages/data-provider/src/types/mutations.ts
+++ b/packages/data-provider/src/types/mutations.ts
@@ -1,18 +1,3 @@
-import * as types from '../types';
-import * as r from '../roles';
-import * as p from '../permissions';
-import {
-  Tools,
-  Assistant,
-  AssistantCreateParams,
-  AssistantUpdateParams,
-  FunctionTool,
-  AssistantDocument,
-  Agent,
-  AgentCreateParams,
-  AgentUpdateParams,
-} from './assistants';
-import { Action, ActionMetadata } from './agents';
 import type { InfiniteData, QueryKey } from '@tanstack/react-query';
 import type {
   TSkill,
@@ -26,6 +11,21 @@ import type {
   TDeleteSkillFileResponse,
   TSkillListResponse,
 } from './skills';
+import {
+  Tools,
+  Assistant,
+  AssistantCreateParams,
+  AssistantUpdateParams,
+  FunctionTool,
+  AssistantDocument,
+  Agent,
+  AgentCreateParams,
+  AgentUpdateParams,
+} from './assistants';
+import { Action, ActionMetadata } from './agents';
+import * as p from '../permissions';
+import * as types from '../types';
+import * as r from '../roles';
 
 export type MutationOptions<
   Response,


### PR DESCRIPTION
## Problem

Fixes #13659.

When the **artifacts** capability is enabled, pinned in the chat input, and then disabled again, the artifacts toggle stays pinned and visible. Unlike the other capability toggles, `Artifacts.tsx` never checks the agent capabilities config, so it keeps rendering regardless of whether the capability is on.

Steps to reproduce:
1. Enable the `artifacts` capability.
2. Pin **Artifacts** in the chat input.
3. Disable the `artifacts` capability.
4. The artifacts toggle remains pinned.

## Solution

Gate the component on `artifactsEnabled` from `useAgentCapabilities`, exactly how the sibling capability toggles already work:

- `Skills.tsx` → `skillsEnabled`
- `FileSearch.tsx` → `canUseFileSearch`
- `CodeInterpreter.tsx` → `canRunCode`

```tsx
const { artifactsEnabled } = useAgentCapabilities(
  context?.agentsConfig?.capabilities ?? defaultAgentCapabilities,
);

if (!artifactsEnabled) {
  return null;
}
```

The fallback to `defaultAgentCapabilities` (which includes `artifacts`) preserves current behavior when no config is present.

> Note: the issue suggested gating on `PermissionTypes.ARTIFACTS` / `useHasAccess`, but there is no `ARTIFACTS` permission in the permission system — artifacts is controlled as an agent **capability**, not a granular permission. Matching `Skills.tsx`'s capability check is the correct mechanism here.

## Testing

1. With `artifacts` in the agent capabilities, the toggle renders and can be pinned as before.
2. Remove `artifacts` from the capabilities (or disable it in the admin config) — the toggle no longer renders, even when previously pinned.
3. With no `agentsConfig`, the default capabilities still include `artifacts`, so the toggle behaves as it does today.