### PR TITLE
feat: add Gateway API HTTPRoute support to the Helm chart

### DIFF
--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/librechat/templates/httproute.yaml
+++ b/helm/librechat/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "librechat.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "librechat.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- with .Values.httpRoute.matches }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+{{- end }}

--- a/helm/librechat/tests/httproute_render_test.sh
+++ b/helm/librechat/tests/httproute_render_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Behavior test for the librechat HTTPRoute (Gateway API) template.
+#
+# Renders templates/httproute.yaml under several value combinations and asserts
+# the opt-in contract: disabled by default, attaches to the configured
+# Gateway(s), defaults its rule match, and honors overrides. This is pure
+# `helm template` rendering, so no cluster and no Gateway API CRDs are required.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RELEASE="librechat"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "FAIL: helm not on PATH" >&2
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $1" >&2
+  shift || true
+  if [[ $# -gt 0 ]]; then
+    echo "----- rendered -----" >&2
+    printf '%s\n' "$@" >&2
+  fi
+  exit 1
+}
+
+# render_full renders the whole chart (used to assert the HTTPRoute is absent).
+render_full() {
+  helm template "${RELEASE}" "${CHART_DIR}" 2>/dev/null
+}
+
+# render_route renders only templates/httproute.yaml with the route enabled.
+render_route() {
+  helm template "${RELEASE}" "${CHART_DIR}" \
+    --show-only templates/httproute.yaml \
+    --set httpRoute.enabled=true \
+    "$@" 2>/dev/null
+}
+
+# 1. Disabled by default: no HTTPRoute is rendered.
+if render_full | grep -q "kind: HTTPRoute"; then
+  fail "HTTPRoute rendered even though httpRoute.enabled defaults to false"
+fi
+echo "PASS: HTTPRoute is not rendered by default"
+
+# 2. Enabled with a parentRef: the route attaches to the Gateway, matches the
+#    configured hostname, and points at the librechat Service.
+OUT="$(render_route \
+  --set 'httpRoute.parentRefs[0].name=example-gateway' \
+  --set 'httpRoute.hostnames[0]=chat.example.com')"
+
+for needle in \
+  "kind: HTTPRoute" \
+  "apiVersion: gateway.networking.k8s.io/v1" \
+  "name: ${RELEASE}-${RELEASE}" \
+  "name: example-gateway" \
+  "- chat.example.com"; do
+  printf '%s\n' "${OUT}" | grep -qF -- "${needle}" \
+    || fail "expected '${needle}' in rendered HTTPRoute" "${OUT}"
+done
+printf '%s\n' "${OUT}" | grep -qE "port: [0-9]+" \
+  || fail "expected a backendRef port in rendered HTTPRoute" "${OUT}"
+echo "PASS: HTTPRoute attaches to the Gateway and routes to the librechat Service"
+
+# 3. Default rule match is PathPrefix '/' when httpRoute.matches is empty.
+if ! printf '%s\n' "${OUT}" | grep -qE "type: PathPrefix" \
+  || ! printf '%s\n' "${OUT}" | grep -qE "value: /$"; then
+  fail "expected a default PathPrefix '/' match" "${OUT}"
+fi
+echo "PASS: default rule uses a PathPrefix '/' match"
+
+# 4. httpRoute.matches overrides the generated default match.
+OUT2="$(render_route \
+  --set 'httpRoute.parentRefs[0].name=example-gateway' \
+  --set 'httpRoute.matches[0].path.type=PathPrefix' \
+  --set 'httpRoute.matches[0].path.value=/api')"
+printf '%s\n' "${OUT2}" | grep -qE "value: /api$" \
+  || fail "expected the overridden match value '/api'" "${OUT2}"
+echo "PASS: httpRoute.matches overrides the default match"
+
+echo "PASS: librechat HTTPRoute template renders correctly across all cases"

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -198,6 +198,30 @@ ingress:
   #    hosts:
   #      - chat.example.com
 
+# Gateway API HTTPRoute settings (alternative to ingress)
+# This chart does not install the Gateway API CRDs or a Gateway controller;
+# both must already be present in the cluster.
+httpRoute:
+  # Enable the HTTPRoute (set ingress.enabled to false when exposing via Gateway API)
+  enabled: false
+  # Additional labels for the HTTPRoute
+  labels: {}
+  # Annotations for the HTTPRoute
+  annotations: {}
+  # Parent Gateways the route attaches to (required when enabled)
+  parentRefs: []
+    # - name: example-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+  # Hostnames the route matches
+  hostnames: []
+    # - chat.example.com
+  # Route match rules. When empty, a single PathPrefix "/" match is generated.
+  matches: []
+    # - path:
+    #     type: PathPrefix
+    #     value: /
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary

Resolves #12896. The `librechat` Helm chart can currently only be exposed via a standard `Ingress`. As the Kubernetes ecosystem migrates to the [Gateway API](https://gateway-api.sigs.k8s.io/), this adds an opt-in `httpRoute` block (mirroring `ingress`) that renders a `gateway.networking.k8s.io/v1` `HTTPRoute` pointing at the LibreChat service.

- New template `helm/librechat/templates/httproute.yaml`, gated on `httpRoute.enabled` (default `false`, so existing installs are unaffected).
- New `httpRoute` values: `enabled`, `labels`, `annotations`, `parentRefs`, `hostnames`, `matches`. When `matches` is empty a single `PathPrefix: /` rule is generated; `backendRefs` targets the chart service on `service.port`.
- Chart version bumped `2.0.5` → `2.1.0`.
- The chart does not install the Gateway API CRDs or a Gateway controller; both must already be present in the cluster (noted inline in `values.yaml`).

Example:

```yaml
ingress:
  enabled: false
httpRoute:
  enabled: true
  parentRefs:
    - name: example-gateway
      namespace: gateway-system
  hostnames:
    - chat.example.com
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `helm lint helm/librechat` passes.
- `helm template` rendered in three scenarios: disabled (default) → nothing rendered; enabled with `parentRefs`/`hostnames` → default `PathPrefix: /`; enabled with custom `matches`, `labels`, `annotations` and multiple `hostnames`.
- `kubeconform -strict` with the Gateway API CRD schema validates the full rendered chart: **21/21 resources valid**.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes (new values documented inline in `values.yaml`)
- [x] My changes do not introduce new warnings