### PR TITLE
fix(helm): add release namespace to LibreChat resources

### DIFF
--- a/helm/librechat/templates/configmap-env.yaml
+++ b/helm/librechat/templates/configmap-env.yaml
@@ -2,6 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "librechat.fullname" $ }}-configenv
+  namespace: {{ .Release.Namespace }}
 data:
   {{- $configEnv := default dict .Values.librechat.configEnv }}
   {{- $adminPanelUrl := .Values.librechat.adminPanelUrl }}

--- a/helm/librechat/templates/configmap.yaml
+++ b/helm/librechat/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "librechat.fullname" $ }}-config
+  namespace: {{ .Release.Namespace }}
 data:
   librechat.yaml: |
 {{ .Values.librechat.configYamlContent | indent 4 }}

--- a/helm/librechat/templates/configmaps-additional.yaml
+++ b/helm/librechat/templates/configmaps-additional.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "librechat.fullname" $ }}-{{ default "custom" $key }}
+  namespace: {{ $.Release.Namespace }}
   {{- with .labels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "librechat.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
     {{- with .Values.deploymentLabels }}

--- a/helm/librechat/templates/hpa.yaml
+++ b/helm/librechat/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "librechat.hpa.apiVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "librechat.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
 spec:

--- a/helm/librechat/templates/ingress.yaml
+++ b/helm/librechat/templates/ingress.yaml
@@ -15,6 +15,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "librechat.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/helm/librechat/templates/persistentvolumeclaim.yaml
+++ b/helm/librechat/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "librechat.fullname" $ }}-images
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - {{ .Values.librechat.imageVolume.accessModes }}

--- a/helm/librechat/templates/service.yaml
+++ b/helm/librechat/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "librechat.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
   annotations:

--- a/helm/librechat/templates/serviceaccount.yaml
+++ b/helm/librechat/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "librechat.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/librechat/templates/tests/test-connection.yaml
+++ b/helm/librechat/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "librechat.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "librechat.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
## Summary

- add `metadata.namespace: {{ .Release.Namespace }}` to LibreChat-owned namespaced Helm resources
- use root scope for additional ConfigMaps rendered inside a range
- keep dependency subcharts unchanged

## Motivation

Explicit namespaces make `helm template` output safe and predictable when it is committed, reviewed, or passed through Kustomize/GitOps before applying. Without these fields, rendered parent-chart resources can fall back to the active/default namespace when applied outside Helm.

## Validation

- `helm lint helm/librechat`
- rendered with namespace `namespace-pr-test`
- enabled optional parent-chart resources: config YAML, image PVC, HPA, ingress, additional ConfigMap, and Helm test pod
- verified every LibreChat-owned namespaced rendered resource contains `namespace: namespace-pr-test`