### PR TITLE
🔒 fix: Scan All Message Roles in messageFilter.pii

### DIFF
--- a/packages/api/src/middleware/messageFilterPii.spec.ts
+++ b/packages/api/src/middleware/messageFilterPii.spec.ts
@@ -173,15 +173,28 @@ describe('findPiiMatchInMessages', () => {
     ).toBeNull();
   });
 
-  it('skips non-user messages', () => {
+  it('matches a system-role message (remote APIs accept caller-supplied system roles)', () => {
     const hit = findPiiMatchInMessages(
-      [
-        { role: 'system', content: 'sk-proj-FAKE1234567890ABCDEF' },
-        { role: 'assistant', content: 'sk-proj-FAKE1234567890ABCDEF' },
-      ],
+      [{ role: 'system', content: 'system primer with sk-proj-FAKE1234567890ABCDEF embedded' }],
       {},
     );
-    expect(hit).toBeNull();
+    expect(hit).toEqual({ id: 'sk_prefix', label: 'sk- prefix token' });
+  });
+
+  it('matches an assistant-role message (callers can include attacker-controlled history)', () => {
+    const hit = findPiiMatchInMessages(
+      [{ role: 'assistant', content: 'sk-proj-FAKE1234567890ABCDEF' }],
+      {},
+    );
+    expect(hit).toEqual({ id: 'sk_prefix', label: 'sk- prefix token' });
+  });
+
+  it('matches a tool-role message', () => {
+    const hit = findPiiMatchInMessages(
+      [{ role: 'tool', content: 'tool reply leaking sk-proj-FAKE1234567890ABCDEF' }],
+      {},
+    );
+    expect(hit).toEqual({ id: 'sk_prefix', label: 'sk- prefix token' });
   });
 
   it('matches a string-content user message', () => {

--- a/packages/api/src/middleware/messageFilterPii.ts
+++ b/packages/api/src/middleware/messageFilterPii.ts
@@ -87,7 +87,7 @@ export function findPiiMatchInMessages(
     return null;
   }
   for (const msg of messages) {
-    if (msg == null || msg.role !== 'user') {
+    if (msg == null) {
       continue;
     }
     if (typeof msg.content === 'string') {


### PR DESCRIPTION
## Summary

Closes a `messageFilter.pii` bypass on the remote agent APIs flagged by a Codex security finding against `5867f1a06`. `findPiiMatchInMessages` was gating on `msg.role === 'user'` and silently skipping every other role. The OpenAI-compatible validator at `packages/api/src/agents/openai/service.ts:299-310` accepts `system`, `assistant`, and `tool` from the caller, and the Responses input conversion at `packages/api/src/agents/responses/service.ts:141-196` accepts and converts `developer`/`system`. All of these flow into `formatAgentMessages` and then `createRun`, so an authenticated remote-agent caller could place a credential-shaped value in any non-user role and reach the model despite the configured filter.

The fix drops the role gate so every caller-supplied message content is scanned regardless of role. The helper still early-exits on the first match, and the loop count is unchanged (one outer over messages, one inner over content parts).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

### **Test Configuration**:

Enable `messageFilter.pii` in `librechat.yaml` (`messageFilter: { pii: {} }`). Run backend, call the remote agent APIs with an agent API key in `Authorization: Bearer <key>`.

Automated:

- [x] `cd packages/api && npx jest src/middleware/messageFilterPii.spec.ts` — 22 cases pass; the prior `skips non-user messages` test is replaced by three explicit cases (system, assistant, tool) that each assert a match against `sk-proj-FAKE1234567890ABCDEF` in their respective role.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted (LibreChat-AI/librechat.ai#599 updated)