### PR TITLE
🧾 fix: Bill Subagent Child-Run Model Usage in Parent Transactions

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.2.34",
+    "@librechat/agents": "^3.2.35",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -105,6 +105,7 @@ jest.mock('@librechat/api', () => ({
   createErrorResponse: jest.fn(),
   getTransactionsConfig: mockGetTransactionsConfig,
   recordCollectedUsage: mockRecordCollectedUsage,
+  createSubagentUsageSink: jest.fn().mockReturnValue(jest.fn()),
   extractManualSkills: jest.fn().mockReturnValue(undefined),
   injectSkillPrimes: jest.fn().mockReturnValue({
     initialMessages: [],

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -107,6 +107,7 @@ jest.mock('@librechat/api', () => ({
   getBalanceConfig: mockGetBalanceConfig,
   getTransactionsConfig: mockGetTransactionsConfig,
   recordCollectedUsage: mockRecordCollectedUsage,
+  createSubagentUsageSink: jest.fn().mockReturnValue(jest.fn()),
   extractManualSkills: jest.fn().mockReturnValue(undefined),
   injectSkillPrimes: jest.fn().mockReturnValue({
     initialMessages: [],

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -21,6 +21,7 @@ const {
   applyContextToAgent,
   isMemoryAgentEnabled,
   recordCollectedUsage,
+  createSubagentUsageSink,
   isDeepSeekReasoningProvider,
   GenerationJobManager,
   getTransactionsConfig,
@@ -1137,6 +1138,11 @@ class AgentClient extends BaseClient {
           summarizationConfig: appConfig?.summarization,
           appConfig,
           tokenCounter,
+          /** Bills subagent child-run model calls — child graphs execute
+           *  outside the streamEvents loop, so ModelEndHandler never sees
+           *  them. Entries land in collectedUsage tagged
+           *  `usage_type: 'subagent'` and are spent by recordCollectedUsage. */
+          subagentUsageSink: createSubagentUsageSink(this.collectedUsage),
         });
 
         if (!run) {

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -23,6 +23,7 @@ const {
   extractManualSkills,
   createErrorResponse,
   recordCollectedUsage,
+  createSubagentUsageSink,
   getTransactionsConfig,
   resolveRecursionLimit,
   findPiiMatchInMessages,
@@ -742,6 +743,9 @@ const OpenAIChatCompletionController = async (req, res) => {
         conversationId,
       },
       user: { id: userId },
+      /** Bills subagent child-run model calls (reported outside the
+       *  streamEvents loop) into the same collectedUsage array. */
+      subagentUsageSink: createSubagentUsageSink(collectedUsage),
     });
 
     if (!run) {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -19,6 +19,7 @@ const {
   injectSkillPrimes,
   extractManualSkills,
   recordCollectedUsage,
+  createSubagentUsageSink,
   getTransactionsConfig,
   findPiiMatchInMessages,
   discoverConnectedAgents,
@@ -749,6 +750,9 @@ const createResponse = async (req, res) => {
           conversationId,
         },
         user: { id: userId },
+        /** Bills subagent child-run model calls (reported outside the
+         *  streamEvents loop) into the same collectedUsage array. */
+        subagentUsageSink: createSubagentUsageSink(collectedUsage),
       });
 
       if (!run) {
@@ -923,6 +927,9 @@ const createResponse = async (req, res) => {
           conversationId,
         },
         user: { id: userId },
+        /** Bills subagent child-run model calls (reported outside the
+         *  streamEvents loop) into the same collectedUsage array. */
+        subagentUsageSink: createSubagentUsageSink(collectedUsage),
       });
 
       if (!run) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.2.34",
+        "@librechat/agents": "^3.2.35",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11685,9 +11685,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.2.34",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.2.34.tgz",
-      "integrity": "sha512-Njz5wxlDeTKSWpcUBO3ODLClrrcxfmEn1r3W2WTSeVFAYp8vMqvhFGgPPnG82v9fDdqajuMVKTScb0puhglEqg==",
+      "version": "3.2.35",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.2.35.tgz",
+      "integrity": "sha512-k/6e3WOkYSgqZVFtgw5XeNpuA+1+y0vX4u4pqGeX3MM3ERDk729OQLdO1qFbOCxkcP2hCZppMzZ5JExSyKdplw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -44251,7 +44251,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.2.34",
+        "@librechat/agents": "^3.2.35",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -112,7 +112,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.2.34",
+    "@librechat/agents": "^3.2.35",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -788,6 +788,7 @@ export async function createRun({
   initialSummary,
   calibrationRatio,
   appConfig,
+  subagentUsageSink,
   streaming = true,
   streamUsage = true,
 }: {
@@ -812,7 +813,7 @@ export async function createRun({
   appConfig?: AppConfig;
 } & Pick<
   RunConfig,
-  'tokenCounter' | 'customHandlers' | 'indexTokenCountMap' | 'initialSessions'
+  'tokenCounter' | 'customHandlers' | 'indexTokenCountMap' | 'initialSessions' | 'subagentUsageSink'
 >): Promise<Run<IState>> {
   /**
    * Only extract discovered tools if:
@@ -1039,6 +1040,7 @@ export async function createRun({
     initialSessions,
     calibrationRatio,
     indexTokenCountMap,
+    subagentUsageSink,
     eagerEventToolExecution: { enabled: true },
     // Derive the Langfuse trace id deterministically from runId so message
     // feedback can be scored against the trace without a lookup (see the

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -31,6 +31,7 @@ import type {
 } from 'librechat-data-provider';
 import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { AppConfig, IUser } from '@librechat/data-schemas';
+import type { SubagentUsageEvent } from '~/agents/usage';
 import type * as t from '~/types';
 import { getProviderConfig } from '~/endpoints/config/providers';
 import { resolveHeaders, createSafeUser } from '~/utils/env';
@@ -811,9 +812,18 @@ export async function createRun({
    * (e.g. "Ollama") in the summarization config to SDK-recognized providers.
    */
   appConfig?: AppConfig;
+  /**
+   * Receives per-model-call usage from subagent child runs so hosts can bill
+   * them (child graphs execute outside the run's `streamEvents` loop, so
+   * their usage never reaches `customHandlers`). Typed structurally — not as
+   * `Pick<RunConfig, 'subagentUsageSink'>` — because the field ships in
+   * `@librechat/agents` > 3.2.33; older SDK versions ignore it at runtime.
+   * Switch to the `RunConfig` pick once the dependency is bumped.
+   */
+  subagentUsageSink?: (event: SubagentUsageEvent) => void;
 } & Pick<
   RunConfig,
-  'tokenCounter' | 'customHandlers' | 'indexTokenCountMap' | 'initialSessions' | 'subagentUsageSink'
+  'tokenCounter' | 'customHandlers' | 'indexTokenCountMap' | 'initialSessions'
 >): Promise<Run<IState>> {
   /**
    * Only extract discovered tools if:
@@ -1032,7 +1042,14 @@ export async function createRun({
    */
   const enableToolOutputReferences = anyAgentHasCodeEnv(agents);
 
-  const run = await Run.create({
+  /**
+   * Built as a variable (not an inline literal) so the extra
+   * `subagentUsageSink` field passes assignability against SDK versions
+   * whose `RunConfig` predates it (<= 3.2.33, where it is ignored at
+   * runtime) — excess-property checks only apply to fresh literals. Inline
+   * the field at the call site once the dependency is bumped.
+   */
+  const runConfig = {
     runId,
     graphConfig,
     tokenCounter,
@@ -1050,7 +1067,8 @@ export async function createRun({
     ...(enableToolOutputReferences && {
       toolOutputReferences: { enabled: true },
     }),
-  });
+  };
+  const run = await Run.create(runConfig);
 
   applyTestRunHook(run, { messages, agents });
   return run;

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -1,6 +1,5 @@
-import type { SubagentUsageEvent } from '@librechat/agents';
+import type { RecordUsageDeps, RecordUsageParams, SubagentUsageEvent } from './usage';
 import type { UsageMetadata } from '../stream/interfaces/IJobStore';
-import type { RecordUsageDeps, RecordUsageParams } from './usage';
 import type { BulkWriteDeps, PricingFns } from './transactions';
 import { createSubagentUsageSink, recordCollectedUsage } from './usage';
 

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -1,7 +1,8 @@
+import type { SubagentUsageEvent } from '@librechat/agents';
 import type { UsageMetadata } from '../stream/interfaces/IJobStore';
 import type { RecordUsageDeps, RecordUsageParams } from './usage';
 import type { BulkWriteDeps, PricingFns } from './transactions';
-import { recordCollectedUsage } from './usage';
+import { createSubagentUsageSink, recordCollectedUsage } from './usage';
 
 describe('recordCollectedUsage', () => {
   let mockSpendTokens: jest.Mock;
@@ -144,6 +145,119 @@ describe('recordCollectedUsage', () => {
           model: 'gpt-4.1-mini',
         }),
         expect.any(Object),
+      );
+    });
+  });
+
+  describe('subagent usage segregation', () => {
+    it('bills subagent entries under separate context while excluding them from reported totals', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          usage_type: 'message',
+          input_tokens: 120,
+          output_tokens: 40,
+          model: 'gpt-4',
+        },
+        {
+          usage_type: 'subagent',
+          input_tokens: 900,
+          output_tokens: 700,
+          model: 'claude-haiku-4-5',
+          provider: 'anthropic',
+        },
+        {
+          usage_type: 'subagent',
+          input_tokens: 1100,
+          output_tokens: 300,
+          model: 'claude-haiku-4-5',
+          provider: 'anthropic',
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      /**
+       * `input_tokens` comes from the first MESSAGE usage; `output_tokens`
+       * excludes subagent completions — the result becomes the parent
+       * response message's tokenCount, and child output the parent never
+       * saw must not distort next-turn context accounting.
+       */
+      expect(result).toEqual({ input_tokens: 120, output_tokens: 40 });
+      /** ...but every subagent call is still billed against balance. */
+      expect(mockSpendTokens).toHaveBeenCalledTimes(3);
+      expect(mockSpendTokens).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          context: 'subagent',
+          model: 'claude-haiku-4-5',
+        }),
+        { promptTokens: 900, completionTokens: 700 },
+      );
+      expect(mockSpendTokens).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          context: 'subagent',
+          model: 'claude-haiku-4-5',
+        }),
+        { promptTokens: 1100, completionTokens: 300 },
+      );
+    });
+
+    it('does not let a leading subagent entry hijack reported input_tokens', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          usage_type: 'subagent',
+          input_tokens: 5000,
+          output_tokens: 900,
+          model: 'claude-haiku-4-5',
+        },
+        {
+          input_tokens: 120,
+          output_tokens: 40,
+          model: 'gpt-4',
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(result).toEqual({ input_tokens: 120, output_tokens: 40 });
+      expect(mockSpendTokens).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses structured spend for subagent entries with cache tokens', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        { input_tokens: 100, output_tokens: 50, model: 'gpt-4' },
+        {
+          usage_type: 'subagent',
+          input_tokens: 200,
+          output_tokens: 80,
+          model: 'claude-haiku-4-5',
+          provider: 'anthropic',
+          input_token_details: { cache_creation: 60, cache_read: 30 },
+        },
+      ];
+
+      await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendStructuredTokens).toHaveBeenCalledTimes(1);
+      expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: 'subagent',
+          model: 'claude-haiku-4-5',
+        }),
+        {
+          promptTokens: { input: 200, write: 60, read: 30 },
+          completionTokens: 80,
+        },
       );
     });
   });
@@ -1213,5 +1327,114 @@ describe('recordCollectedUsage', () => {
 
       expect(result).toEqual({ input_tokens: 100, output_tokens: 110 });
     });
+  });
+});
+
+describe('createSubagentUsageSink', () => {
+  const makeEvent = (overrides: Partial<SubagentUsageEvent> = {}): SubagentUsageEvent => ({
+    usage: { input_tokens: 900, output_tokens: 700, total_tokens: 1600 },
+    model: 'claude-haiku-4-5',
+    provider: 'anthropic',
+    subagentType: 'researcher',
+    subagentRunId: 'run-1_sub_abc',
+    subagentAgentId: 'researcher',
+    runId: 'run-1',
+    ...overrides,
+  });
+
+  it('pushes usage tagged with usage_type subagent and the child model/provider', () => {
+    const collectedUsage: UsageMetadata[] = [];
+    const sink = createSubagentUsageSink(collectedUsage);
+
+    sink(makeEvent());
+
+    expect(collectedUsage).toEqual([
+      {
+        usage_type: 'subagent',
+        input_tokens: 900,
+        output_tokens: 700,
+        total_tokens: 1600,
+        model: 'claude-haiku-4-5',
+        provider: 'anthropic',
+      },
+    ]);
+  });
+
+  it('preserves cache token details from the child call', () => {
+    const collectedUsage: UsageMetadata[] = [];
+    const sink = createSubagentUsageSink(collectedUsage);
+
+    sink(
+      makeEvent({
+        usage: {
+          input_tokens: 200,
+          output_tokens: 80,
+          total_tokens: 280,
+          input_token_details: { cache_creation: 60, cache_read: 30 },
+        } as SubagentUsageEvent['usage'],
+      }),
+    );
+
+    expect(collectedUsage[0].input_token_details).toEqual({
+      cache_creation: 60,
+      cache_read: 30,
+    });
+  });
+
+  it('omits model/provider tags when the event carries none', () => {
+    const collectedUsage: UsageMetadata[] = [];
+    const sink = createSubagentUsageSink(collectedUsage);
+
+    sink(makeEvent({ model: undefined, provider: undefined }));
+
+    expect(collectedUsage).toHaveLength(1);
+    expect(collectedUsage[0].usage_type).toBe('subagent');
+    expect(collectedUsage[0]).not.toHaveProperty('model');
+    expect(collectedUsage[0]).not.toHaveProperty('provider');
+  });
+
+  it('ignores events without usage', () => {
+    const collectedUsage: UsageMetadata[] = [];
+    const sink = createSubagentUsageSink(collectedUsage);
+
+    sink(makeEvent({ usage: undefined as unknown as SubagentUsageEvent['usage'] }));
+
+    expect(collectedUsage).toEqual([]);
+  });
+
+  it('round-trips into recordCollectedUsage as billed subagent transactions', async () => {
+    const collectedUsage: UsageMetadata[] = [];
+    const sink = createSubagentUsageSink(collectedUsage);
+
+    /** Parent's own call, collected by ModelEndHandler as usual. */
+    collectedUsage.push({ input_tokens: 120, output_tokens: 40, model: 'gpt-4' });
+    /** Child calls reported through the sink mid-run. */
+    sink(makeEvent());
+    sink(
+      makeEvent({
+        usage: { input_tokens: 1100, output_tokens: 300, total_tokens: 1400 },
+      }),
+    );
+
+    const spendTokens = jest.fn().mockResolvedValue(undefined);
+    const spendStructuredTokens = jest.fn().mockResolvedValue(undefined);
+    const result = await recordCollectedUsage(
+      { spendTokens, spendStructuredTokens },
+      {
+        user: 'user-123',
+        conversationId: 'convo-123',
+        model: 'gpt-4',
+        collectedUsage,
+      },
+    );
+
+    /** All three calls billed; child output excluded from reported totals. */
+    expect(spendTokens).toHaveBeenCalledTimes(3);
+    expect(spendTokens).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ context: 'subagent', model: 'claude-haiku-4-5' }),
+      { promptTokens: 900, completionTokens: 700 },
+    );
+    expect(result).toEqual({ input_tokens: 120, output_tokens: 40 });
   });
 });

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -1,5 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import { Providers } from 'librechat-data-provider';
+import type { SubagentUsageEvent } from '@librechat/agents';
 import type { TCustomConfig, TTransactionsConfig } from 'librechat-data-provider';
 import type {
   StructuredTokenUsage,
@@ -189,11 +190,18 @@ export async function recordCollectedUsage(
 
   const messageUsages: UsageMetadata[] = [];
   const summarizationUsages: UsageMetadata[] = [];
+  const subagentUsages: UsageMetadata[] = [];
   for (const usage of collectedUsage) {
     if (usage == null) {
       continue;
     }
-    (usage.usage_type === 'summarization' ? summarizationUsages : messageUsages).push(usage);
+    if (usage.usage_type === 'summarization') {
+      summarizationUsages.push(usage);
+    } else if (usage.usage_type === 'subagent') {
+      subagentUsages.push(usage);
+    } else {
+      messageUsages.push(usage);
+    }
   }
 
   const firstUsage = messageUsages[0];
@@ -208,6 +216,7 @@ export async function recordCollectedUsage(
     usages: UsageMetadata[],
     usageContext: string,
     docs: PreparedEntry[],
+    options?: { excludeFromOutputTotal?: boolean },
   ): void => {
     for (const usage of usages) {
       if (!usage) {
@@ -216,7 +225,9 @@ export async function recordCollectedUsage(
 
       const { inputOnly, cacheCreation, cacheRead, completion } = splitUsage(usage);
 
-      total_output_tokens += completion;
+      if (options?.excludeFromOutputTotal !== true) {
+        total_output_tokens += completion;
+      }
 
       const txMetadata: TxMetadata = {
         user,
@@ -292,6 +303,14 @@ export async function recordCollectedUsage(
   const allDocs: PreparedEntry[] = [];
   processUsageGroup(messageUsages, context, allDocs);
   processUsageGroup(summarizationUsages, 'summarization', allDocs);
+  /**
+   * Subagent child-run usage is billed in full (transactions + balance) but
+   * excluded from the reported output total: the result's `output_tokens`
+   * becomes the parent response message's `tokenCount` (see BaseClient's
+   * `getStreamUsage` consumer), and child output the parent never saw would
+   * distort next-turn context accounting by orders of magnitude.
+   */
+  processUsageGroup(subagentUsages, 'subagent', allDocs, { excludeFromOutputTotal: true });
   if (useBulk && allDocs.length > 0) {
     try {
       await bulkWriteTransactions({ user, docs: allDocs }, bulkWriteOps);
@@ -303,5 +322,33 @@ export async function recordCollectedUsage(
   return {
     input_tokens,
     output_tokens: total_output_tokens,
+  };
+}
+
+/**
+ * Builds the host-side `subagentUsageSink` for `Run.create`. Subagent child
+ * graphs execute outside the run's `streamEvents` loop, so their model calls
+ * never reach the `CHAT_MODEL_END` handler (`ModelEndHandler`) — the SDK
+ * reports them through this sink instead. Each event is tagged
+ * `usage_type: 'subagent'` with the child's model/provider and pushed onto
+ * the same `collectedUsage` array the handler fills, so
+ * {@link recordCollectedUsage} bills child calls (transactions + balance)
+ * alongside the parent's.
+ */
+export function createSubagentUsageSink(
+  collectedUsage: UsageMetadata[],
+): (event: SubagentUsageEvent) => void {
+  return (event) => {
+    if (event?.usage == null) {
+      return;
+    }
+    const usage: UsageMetadata = { ...event.usage, usage_type: 'subagent' };
+    if (event.model != null && event.model !== '') {
+      usage.model = event.model;
+    }
+    if (event.provider != null && event.provider !== '') {
+      usage.provider = event.provider;
+    }
+    collectedUsage.push(usage);
   };
 }

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -1,6 +1,5 @@
 import { logger } from '@librechat/data-schemas';
 import { Providers } from 'librechat-data-provider';
-import type { SubagentUsageEvent } from '@librechat/agents';
 import type { TCustomConfig, TTransactionsConfig } from 'librechat-data-provider';
 import type {
   StructuredTokenUsage,
@@ -323,6 +322,30 @@ export async function recordCollectedUsage(
     input_tokens,
     output_tokens: total_output_tokens,
   };
+}
+
+/**
+ * Structural mirror of the agents SDK's `SubagentUsageEvent` (added after
+ * `@librechat/agents` 3.2.33). Defined locally so type-checking does not
+ * depend on the unreleased SDK — replace with
+ * `import type { SubagentUsageEvent } from '@librechat/agents'` once the
+ * dependency is bumped.
+ */
+export interface SubagentUsageEvent {
+  /** Usage metadata reported by the child's model call. */
+  usage: UsageMetadata;
+  /** Model that produced this usage (per-call, falls back to the child config's model). */
+  model?: string;
+  /** Provider enum value of the subagent's configured agent. */
+  provider?: string;
+  /** Subagent `type` identifier from the SubagentConfig. */
+  subagentType: string;
+  /** Child run ID (unique per subagent execution). */
+  subagentRunId: string;
+  /** Child agent ID assigned to this subagent execution. */
+  subagentAgentId: string;
+  /** Parent run ID under which the subagent was spawned. */
+  runId: string;
 }
 
 /**

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -76,7 +76,7 @@ export interface SerializableJobData {
  */
 export interface UsageMetadata {
   /** Logical usage bucket for accounting/reporting. Defaults to model response usage. */
-  usage_type?: 'message' | 'summarization';
+  usage_type?: 'message' | 'summarization' | 'subagent';
   /** Total input tokens (prompt tokens) */
   input_tokens?: number;
   /** Total output tokens (completion tokens) */


### PR DESCRIPTION
## Summary

I fixed a billing leak where model calls made inside subagent child runs were never billed: the child graph executes outside the run's `streamEvents` loop, so its `chat_model_end` events never reach `ModelEndHandler` — child usage never landed in `collectedUsage`, `spendTokens` never recorded it, and balance enforcement was blind to it. The fix consumes the new `subagentUsageSink` from the agents SDK (danny-avila/agents#236) and routes child usage through the existing transaction pipeline.

- Added `createSubagentUsageSink(collectedUsage)` to `packages/api/src/agents/usage.ts`: receives the SDK's per-call `SubagentUsageEvent`s and pushes them onto the same `collectedUsage` array `ModelEndHandler` fills, tagged `usage_type: 'subagent'` with the child's model and provider (the provider drives the existing subset-vs-additive cache pricing semantics in `splitUsage`).
- Wired the sink at all three `createRun` call sites — `client.js` (chat), `openai.js` (OpenAI-compat completions), and `responses.js` (Responses API, both handlers) — so every surface that can spawn subagents bills them; nested subagents report through the same sink.
- Routed `usage_type: 'subagent'` entries into their own group in `recordCollectedUsage`, billed in full (transactions + balance) under transaction context `'subagent'` with the child's model. The abort path reuses `recordCollectedUsage`, so child usage on aborted runs is billed too.
- Excluded subagent completions from the reported `output_tokens` total: that result becomes the parent response message's `tokenCount` (via `getStreamUsage`), and child output the parent never saw would distort next-turn context accounting; `input_tokens` likewise stays pinned to the parent's first message usage.
- Forwarded `subagentUsageSink` through `createRun` into `Run.create`, and widened the `UsageMetadata.usage_type` union with `'subagent'`.
- Typed the sink **structurally** (local mirror of the SDK's `SubagentUsageEvent`, `Run.create` config built as a variable) so the build and CI pass against the published `@librechat/agents@3.2.33`. The PR is safe to merge before the SDK release: older SDK versions ignore the extra config field, and the sink activates once the dependency is bumped past 3.2.33 (danny-avila/agents#236). The structural types can then be swapped for `Pick<RunConfig, 'subagentUsageSink'>` and the SDK type import — call sites are commented accordingly.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added specs in `packages/api/src/agents/usage.spec.ts`: subagent entries billed under context `'subagent'` with the child model while excluded from reported totals; leading subagent entry cannot hijack `input_tokens`; cache-token entries route through structured spend; `createSubagentUsageSink` tagging, detail preservation, missing-model/provider omission, no-usage guard; and a sink → `collectedUsage` → `recordCollectedUsage` round-trip asserting child transactions alongside the parent's.
- Updated the full-replacement `@librechat/api` mocks in `openai.spec.js` / `responses.unit.spec.js` for the new export.
- Verified against the **published** `@librechat/agents@3.2.33`: `tsc` for `packages/api` clean, ESLint/Prettier/import-sort clean on all changed files, and all touched suites pass (107 packages/api usage/run tests, 284 `server/controllers/agents` tests, full packages/api unit suite green locally).
- Live-verified the SDK side end-to-end with real Anthropic and OpenAI credentials: the child's model call arrives through the sink with correct model/provider tagging and real token counts while parent calls stay on the `ModelEndHandler` path.

### **Test Configuration**:
- Node 24; published `@librechat/agents@3.2.33` for type/lint/test verification; locally built SDK from danny-avila/agents#236 for the live end-to-end run.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes