### PR TITLE
🛟 fix: Auto-Recover from Stale Service Worker Assets After Deploys

### DIFF
--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -40,6 +40,7 @@ const {
 const { checkMigrations } = require('./services/start/migration');
 const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
+const createSpaFallback = require('./utils/fallback');
 const { getAppConfig } = require('./services/Config');
 const staticCache = require('./utils/staticCache');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
@@ -432,7 +433,7 @@ if (cluster.isMaster) {
     app.use('/api', apiNotFound);
 
     /** SPA fallback - serve index.html for all unmatched routes */
-    app.use(sendIndexHtml);
+    app.use(createSpaFallback(sendIndexHtml));
 
     /** Error handler (must be last - Express identifies error middleware by its 4-arg signature) */
     app.use(ErrorController);

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -45,6 +45,7 @@ const { checkMigrations } = require('./services/start/migration');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
 const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
+const createSpaFallback = require('./utils/fallback');
 const { getAppConfig } = require('./services/Config');
 const staticCache = require('./utils/staticCache');
 const noIndex = require('./middleware/noIndex');
@@ -62,10 +63,6 @@ let serverReady = false;
 
 const SERVER_NOT_READY_CODE = 'SERVER_NOT_READY';
 const CHAT_START_RETRY_AFTER_SECONDS = '1';
-/** Static asset extensions that must 404 when missing — serving the SPA's
- * index.html for them breaks strict MIME checks and poisons SW/browser caches. */
-const STATIC_ASSET_EXT =
-  /\.(?:js|mjs|css|map|json|wasm|webmanifest|png|jpe?g|gif|svg|ico|webp|avif|woff2?|ttf|otf|eot)$/i;
 
 const rejectChatStartsUntilReady = (req, res, next) => {
   if (serverReady || req.method !== 'POST' || req.path === '/abort') {
@@ -283,12 +280,7 @@ const startServer = async () => {
   app.use('/api', apiNotFound);
 
   /** SPA fallback - serve index.html for all unmatched routes */
-  app.use((req, res) => {
-    if (STATIC_ASSET_EXT.test(req.path)) {
-      return res.status(404).end();
-    }
-    return sendIndexHtml(req, res);
-  });
+  app.use(createSpaFallback(sendIndexHtml));
 
   /** Record trace errors before the final error controller. */
   if (telemetry.enabled) {

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -62,6 +62,10 @@ let serverReady = false;
 
 const SERVER_NOT_READY_CODE = 'SERVER_NOT_READY';
 const CHAT_START_RETRY_AFTER_SECONDS = '1';
+/** Static asset extensions that must 404 when missing — serving the SPA's
+ * index.html for them breaks strict MIME checks and poisons SW/browser caches. */
+const STATIC_ASSET_EXT =
+  /\.(?:js|mjs|css|map|json|wasm|webmanifest|png|jpe?g|gif|svg|ico|webp|avif|woff2?|ttf|otf|eot)$/i;
 
 const rejectChatStartsUntilReady = (req, res, next) => {
   if (serverReady || req.method !== 'POST' || req.path === '/abort') {
@@ -279,7 +283,12 @@ const startServer = async () => {
   app.use('/api', apiNotFound);
 
   /** SPA fallback - serve index.html for all unmatched routes */
-  app.use(sendIndexHtml);
+  app.use((req, res) => {
+    if (STATIC_ASSET_EXT.test(req.path)) {
+      return res.status(404).end();
+    }
+    return sendIndexHtml(req, res);
+  });
 
   /** Record trace errors before the final error controller. */
   if (telemetry.enabled) {

--- a/api/server/utils/fallback.js
+++ b/api/server/utils/fallback.js
@@ -1,0 +1,20 @@
+/** Static asset extensions that must 404 when missing — serving the SPA's
+ * index.html for them breaks strict MIME checks and poisons SW/browser caches. */
+const STATIC_ASSET_EXT =
+  /\.(?:js|mjs|css|map|json|wasm|webmanifest|png|jpe?g|gif|svg|ico|webp|avif|woff2?|ttf|otf|eot)$/i;
+
+/**
+ * Creates the SPA fallback middleware: serves index.html for unmatched
+ * routes while returning 404 for missing static assets.
+ * @param {(req: import('express').Request, res: import('express').Response) => void} sendIndexHtml
+ */
+function createSpaFallback(sendIndexHtml) {
+  return (req, res) => {
+    if (STATIC_ASSET_EXT.test(req.path)) {
+      return res.status(404).end();
+    }
+    return sendIndexHtml(req, res);
+  };
+}
+
+module.exports = createSpaFallback;

--- a/api/server/utils/staticCache.js
+++ b/api/server/utils/staticCache.js
@@ -38,7 +38,8 @@ function staticCache(staticPath, options = {}) {
       fileName === 'index.html' ||
       fileName.endsWith('.webmanifest') ||
       fileName === 'manifest.json' ||
-      fileName === 'sw.js'
+      fileName === 'sw.js' ||
+      fileName === 'sw-heal.js'
     ) {
       res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
     } else {

--- a/client/index.html
+++ b/client/index.html
@@ -48,6 +48,73 @@
       `;
       document.head.appendChild(loadingContainerStyle);
     </script>
+    <script>
+      (function () {
+        var KEY = 'lc-asset-recovery-at';
+        function shouldRecover() {
+          try {
+            var last = Number(sessionStorage.getItem(KEY)) || 0;
+            if (Date.now() - last < 60000) {
+              return false;
+            }
+            sessionStorage.setItem(KEY, String(Date.now()));
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+        /** Recovers from stale builds (e.g. an outdated service worker serving old
+         * hashed chunks after a deploy) by unregistering workers and reloading once. */
+        window.__lcRecoverStaleAssets = function () {
+          if (!shouldRecover()) {
+            return;
+          }
+          var reload = function () {
+            window.location.reload();
+          };
+          if (navigator.serviceWorker) {
+            navigator.serviceWorker
+              .getRegistrations()
+              .then(function (registrations) {
+                return Promise.all(
+                  registrations.map(function (registration) {
+                    return registration.unregister();
+                  }),
+                );
+              })
+              .then(reload, reload);
+          } else {
+            reload();
+          }
+        };
+        window.addEventListener(
+          'error',
+          function (event) {
+            var el = event.target;
+            if (!el || !el.tagName) {
+              return;
+            }
+            var failedScript = el.tagName === 'SCRIPT' && el.src;
+            var failedPreload =
+              el.tagName === 'LINK' && /preload/.test(el.rel || '') && /\.js$/.test(el.href || '');
+            if (failedScript || failedPreload) {
+              window.__lcRecoverStaleAssets();
+            }
+          },
+          true,
+        );
+        window.addEventListener('unhandledrejection', function (event) {
+          var message = event.reason && event.reason.message;
+          if (
+            typeof message === 'string' &&
+            (message.indexOf('dynamically imported module') !== -1 ||
+              message.indexOf('Importing a module script failed') !== -1)
+          ) {
+            window.__lcRecoverStaleAssets();
+          }
+        });
+      })();
+    </script>
     <script defer type="module" src="/src/main.jsx"></script>
   </head>
   <body>

--- a/client/index.html
+++ b/client/index.html
@@ -64,29 +64,47 @@
           }
         }
         /** Recovers from stale builds (e.g. an outdated service worker serving old
-         * hashed chunks after a deploy) by unregistering workers and reloading once. */
+         * hashed chunks after a deploy) by unregistering workers and reloading once.
+         * Returns true when a recovery reload was initiated. */
         window.__lcRecoverStaleAssets = function () {
           if (!shouldRecover()) {
-            return;
+            return false;
           }
           var reload = function () {
             window.location.reload();
           };
           if (navigator.serviceWorker) {
+            var scopeBase = new URL('./', document.baseURI || window.location.href).href;
             navigator.serviceWorker
               .getRegistrations()
               .then(function (registrations) {
                 return Promise.all(
-                  registrations.map(function (registration) {
-                    return registration.unregister();
-                  }),
+                  registrations
+                    .filter(function (registration) {
+                      return registration.scope.indexOf(scopeBase) === 0;
+                    })
+                    .map(function (registration) {
+                      return registration.unregister();
+                    }),
                 );
               })
               .then(reload, reload);
           } else {
             reload();
           }
+          return true;
         };
+        if (navigator.serviceWorker) {
+          navigator.serviceWorker.addEventListener('message', function (event) {
+            if (!event.data || event.data.type !== 'LC_SW_PING') {
+              return;
+            }
+            var source = event.source || navigator.serviceWorker.controller;
+            if (source) {
+              source.postMessage({ type: 'LC_SW_PONG' });
+            }
+          });
+        }
         window.addEventListener(
           'error',
           function (event) {

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -9,8 +9,10 @@ import { ApiErrorBoundaryProvider } from './hooks/ApiErrorBoundaryContext';
 import 'katex/dist/katex.min.css';
 import 'katex/dist/contrib/copy-tex.js';
 
-window.addEventListener('vite:preloadError', () => {
-  window.__lcRecoverStaleAssets?.();
+window.addEventListener('vite:preloadError', (event) => {
+  if (window.__lcRecoverStaleAssets?.()) {
+    event.preventDefault();
+  }
 });
 
 const container = document.getElementById('root');

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -9,6 +9,10 @@ import { ApiErrorBoundaryProvider } from './hooks/ApiErrorBoundaryContext';
 import 'katex/dist/katex.min.css';
 import 'katex/dist/contrib/copy-tex.js';
 
+window.addEventListener('vite:preloadError', () => {
+  window.__lcRecoverStaleAssets?.();
+});
+
 const container = document.getElementById('root');
 const root = createRoot(container);
 

--- a/client/sw/heal.js
+++ b/client/sw/heal.js
@@ -1,0 +1,60 @@
+/* Runs inside the generated service worker via workbox `importScripts`.
+ * When a new build's worker activates, pages served from a previous build
+ * can no longer load their hashed chunks (the old precache is purged) and
+ * carry no recovery code of their own — the worker is the only code path
+ * stale clients fetch fresh. Ping every window client; reload the ones
+ * that cannot answer. */
+const PING_TYPE = 'LC_SW_PING';
+const PONG_TYPE = 'LC_SW_PONG';
+const PONG_TIMEOUT_MS = 1500;
+
+const pendingPongs = new Map();
+
+self.addEventListener('message', (event) => {
+  if (!event.data || event.data.type !== PONG_TYPE || !event.source) {
+    return;
+  }
+  const resolvePong = pendingPongs.get(event.source.id);
+  if (resolvePong) {
+    pendingPongs.delete(event.source.id);
+    resolvePong(true);
+  }
+});
+
+function pingClient(client) {
+  return new Promise((resolve) => {
+    pendingPongs.set(client.id, resolve);
+    setTimeout(() => {
+      if (pendingPongs.delete(client.id)) {
+        resolve(false);
+      }
+    }, PONG_TIMEOUT_MS);
+    client.postMessage({ type: PING_TYPE });
+  });
+}
+
+async function reloadUnresponsiveClients() {
+  await self.clients.claim();
+  const windowClients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  });
+  const topLevelClients = windowClients.filter((client) => client.frameType !== 'nested');
+  await Promise.all(
+    topLevelClients.map(async (client) => {
+      const responsive = await pingClient(client);
+      if (responsive) {
+        return;
+      }
+      try {
+        await client.navigate(client.url);
+      } catch {
+        /* client closed or no longer controllable */
+      }
+    }),
+  );
+}
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(reloadUnresponsiveClients());
+});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import fs from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 import { createRequire } from 'module';
@@ -73,6 +74,17 @@ export default defineConfig(({ command }) => ({
       },
     },
     nodePolyfills(),
+    {
+      name: 'emit-sw-heal',
+      apply: 'build',
+      generateBundle() {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'sw-heal.js',
+          source: fs.readFileSync(path.resolve(__dirname, 'sw/heal.js'), 'utf8'),
+        });
+      },
+    },
     VitePWA({
       injectRegister: 'auto', // 'auto' | 'manual' | 'disabled'
       registerType: 'autoUpdate', // 'prompt' | 'autoUpdate'
@@ -94,6 +106,7 @@ export default defineConfig(({ command }) => ({
           'images/**/*',
           '**/*.map',
           'index.html',
+          'sw-heal.js',
           'assets/rum.*.js',
           'assets/locale-*.js',
           'assets/query-devtools*.js',
@@ -101,6 +114,10 @@ export default defineConfig(({ command }) => ({
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         /** LibreChat mutates index.html per request for subpath and language support. */
         navigateFallback: null,
+        /** Reloads window clients that cannot answer a ping after activation —
+         * pages stuck on a previous build's purged precache (stale index.html)
+         * have no working code of their own to recover with. */
+        importScripts: ['sw-heal.js'],
         runtimeCaching: [
           {
             urlPattern: ({ url }) => /\/assets\/locale-[^/]+\.js$/.test(url.pathname),


### PR DESCRIPTION
## Summary

Fixes the blank screen that requires a hard refresh (CMD+Shift+R) after deploying an update, caused by stale service workers serving an outdated `index.html` whose hashed chunks no longer exist on the server:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html". Strict MIME type checking is enforced for module scripts per HTML spec.
```

Builds prior to #13450 precached `index.html` and served it app-shell style for all navigations (vite-plugin-pwa's default `navigateFallback`). Browsers still carrying one of those service workers load stale HTML on every visit; after a deploy, the chunks it references are gone, and the Express SPA fallback answered those `/assets/*.js` requests with `index.html` (HTTP 200, `text/html`), killing the module graph and leaving a dead page.

- Returned 404 from the SPA fallback for paths with static asset extensions instead of serving `index.html`. This removes the misleading MIME error, prevents the service worker's `StaleWhileRevalidate` locale cache from storing HTML under `.js` URLs, and lets browsers drop registrations whose `sw.js` no longer exists (a 404 on the update check unregisters per spec).
- Added an inline classic script to `client/index.html` that detects failed module scripts, JS modulepreloads, and dynamic import rejections, then unregisters all service workers and reloads — throttled to once per 60 seconds via `sessionStorage` so it cannot loop. It must be inline because no module script can load in this failure mode.
- Routed Vite's `vite:preloadError` event into the same recovery path in `main.jsx`, covering tabs left open across a deploy that lazy-load a chunk deleted by the new build (e.g. `ProjectCreateDialog`).

After this change, affected browsers hit the stale service worker once more, auto-recover (unregister + reload) instead of blank-screening, and stay healthy across subsequent deploys.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran ESLint on the changed files and parse-checked both inline scripts; pre-commit hooks (prettier, eslint, sort-imports) pass.
- Recommended manual verification:
  1. Build the client and serve via the backend; request a non-existent asset (e.g. `/assets/does-not-exist.js`) and confirm a 404 instead of HTML.
  2. Load the app from an older build so its service worker installs, deploy a new build, and revisit — the page should auto-reload into the fresh build instead of blank-screening.
  3. Leave a tab open across a rebuild and open a lazy-loaded view — the tab should reload once and continue working.

### Test Configuration:

- Node v24.16.0, local build, MongoDB

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
