### PR TITLE
feat: GitHub App auth for skillSync.github

### DIFF
--- a/packages/api/src/skills/sync/github-app-auth.spec.ts
+++ b/packages/api/src/skills/sync/github-app-auth.spec.ts
@@ -1,0 +1,219 @@
+import { generateKeyPairSync } from 'crypto';
+import {
+  GitHubAppAuthError,
+  appAuthErrorMessage,
+  createGitHubAppTokenProvider,
+  mintAppJwt,
+  normalizePrivateKey,
+} from './github-app-auth';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const TEST_PEM = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+}).privateKey;
+
+function response(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('normalizePrivateKey', () => {
+  it('passes through a raw multi-line PEM', () => {
+    expect(normalizePrivateKey(TEST_PEM)).toBe(TEST_PEM.trim());
+  });
+
+  it('un-escapes literal \\n sequences', () => {
+    const escaped = TEST_PEM.replace(/\n/g, '\\n');
+    const result = normalizePrivateKey(escaped);
+    expect(result).toContain('-----BEGIN');
+    expect(result).not.toContain('\\n');
+    expect(result.split('\n').length).toBe(TEST_PEM.split('\n').length);
+  });
+
+  it('decodes a base64-encoded PEM', () => {
+    const b64 = Buffer.from(TEST_PEM, 'utf8').toString('base64');
+    const result = normalizePrivateKey(b64);
+    expect(result).toContain('-----BEGIN');
+  });
+
+  it('throws GitHubAppAuthError for garbage input', () => {
+    expect(() => normalizePrivateKey('not a key')).toThrow(GitHubAppAuthError);
+  });
+});
+
+describe('mintAppJwt', () => {
+  it('produces a 3-segment base64url JWT signed with the private key', () => {
+    const jwt = mintAppJwt('12345', TEST_PEM);
+    const parts = jwt.split('.');
+    expect(parts).toHaveLength(3);
+    for (const part of parts) {
+      expect(part).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
+    const header = JSON.parse(Buffer.from(parts[0], 'base64url').toString('utf8'));
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    expect(header).toEqual({ alg: 'RS256', typ: 'JWT' });
+    expect(payload.iss).toBe('12345');
+    expect(payload.exp - payload.iat).toBeLessThanOrEqual(600);
+  });
+
+  it('throws GitHubAppAuthError for an unusable private key', () => {
+    expect(() => mintAppJwt('1', 'not-a-key')).toThrow(GitHubAppAuthError);
+  });
+});
+
+describe('createGitHubAppTokenProvider', () => {
+  function makeProvider(fetchFn: typeof fetch, overrides: { installationId?: string } = {}) {
+    return createGitHubAppTokenProvider({
+      appId: '12345',
+      privateKey: TEST_PEM,
+      owner: 'stordco',
+      repo: 'claude-ai-marketplace',
+      installationId: overrides.installationId,
+      fetchFn,
+    });
+  }
+
+  it('mints a token via installation discovery + access_tokens', async () => {
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/installation')) return response({ id: 99 });
+      if (u.endsWith('/access_tokens')) return response({ token: 'ghs_t1', expires_at: expiresAt });
+      return response({ message: 'not found' }, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch);
+    expect(await getToken()).toBe('ghs_t1');
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns cached token on subsequent calls until expiry', async () => {
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/installation')) return response({ id: 99 });
+      if (u.endsWith('/access_tokens')) return response({ token: 'ghs_t1', expires_at: expiresAt });
+      return response({}, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch);
+    await getToken();
+    await getToken();
+    await getToken();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips installation discovery when installationId is provided', async () => {
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/access_tokens'))
+        return response({ token: 'ghs_pinned', expires_at: expiresAt });
+      return response({}, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch, { installationId: '77' });
+    expect(await getToken()).toBe('ghs_pinned');
+    const calls = (fetchFn as jest.Mock).mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes('/app/installations/77/access_tokens'))).toBe(true);
+    // Installation-discovery endpoint (`/repos/.../installation`) should be skipped
+    // when an explicit installationId is provided.
+    expect(calls.some((u) => /\/repos\/[^/]+\/[^/]+\/installation$/.test(u))).toBe(false);
+  });
+
+  it('re-mints when the cached token is past its refresh window', async () => {
+    // First mint: token expiring within the 5-minute refresh skew → immediately stale.
+    const nearExpiry = new Date(Date.now() + 60_000).toISOString();
+    const farExpiry = new Date(Date.now() + 60 * 60_000).toISOString();
+    let calls = 0;
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/installation')) return response({ id: 99 });
+      if (u.endsWith('/access_tokens')) {
+        calls += 1;
+        return response({
+          token: calls === 1 ? 'ghs_stale' : 'ghs_fresh',
+          expires_at: calls === 1 ? nearExpiry : farExpiry,
+        });
+      }
+      return response({}, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch);
+    expect(await getToken()).toBe('ghs_stale');
+    expect(await getToken()).toBe('ghs_fresh');
+  });
+
+  it('throws GitHubAppAuthError with status on 401 from installation lookup', async () => {
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/installation')) return response({ message: 'Bad credentials' }, 401);
+      return response({}, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch);
+    await expect(getToken()).rejects.toMatchObject({
+      name: 'GitHubAppAuthError',
+      status: 401,
+    });
+  });
+
+  it('throws GitHubAppAuthError on missing expires_at (would otherwise poison the cache)', async () => {
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/installation')) return response({ id: 99 });
+      if (u.endsWith('/access_tokens'))
+        return response({ token: 'ghs_t1', expires_at: 'not-a-date' });
+      return response({}, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch);
+    await expect(getToken()).rejects.toThrow(GitHubAppAuthError);
+  });
+
+  it('does not cache failed mints (next call retries)', async () => {
+    let calls = 0;
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const fetchFn = jest.fn(async (url: RequestInfo | URL) => {
+      const u = url.toString();
+      if (u.endsWith('/installation')) return response({ id: 99 });
+      if (u.endsWith('/access_tokens')) {
+        calls += 1;
+        if (calls === 1) return response({ message: 'rate limited' }, 429);
+        return response({ token: 'ghs_recovered', expires_at: expiresAt });
+      }
+      return response({}, 404);
+    });
+    const getToken = makeProvider(fetchFn as unknown as typeof fetch);
+    await expect(getToken()).rejects.toThrow(GitHubAppAuthError);
+    expect(await getToken()).toBe('ghs_recovered');
+  });
+});
+
+describe('appAuthErrorMessage', () => {
+  it('names the App credential for 401/403', () => {
+    const err = new GitHubAppAuthError('boom', 401);
+    expect(appAuthErrorMessage(err, 'stordco', 'claude-ai-marketplace')).toMatch(
+      /App credential.*rejected/i,
+    );
+  });
+
+  it('names the installation gap for 404', () => {
+    const err = new GitHubAppAuthError('boom', 404);
+    expect(appAuthErrorMessage(err, 'stordco', 'claude-ai-marketplace')).toMatch(
+      /not be installed on stordco\/claude-ai-marketplace/i,
+    );
+  });
+
+  it('falls back to a generic config message for other statuses', () => {
+    const err = new GitHubAppAuthError('boom', 500);
+    expect(appAuthErrorMessage(err, 'a', 'b')).toMatch(/misconfigured/i);
+  });
+});

--- a/packages/api/src/skills/sync/github-app-auth.ts
+++ b/packages/api/src/skills/sync/github-app-auth.ts
@@ -1,0 +1,245 @@
+import jwt from 'jsonwebtoken';
+import { logger } from '@librechat/data-schemas';
+
+/**
+ * GitHub App authentication for `skillSync.github` sources.
+ *
+ * A GitHub App credential (app id + RSA private key) can't be used as a static
+ * PAT — the App credentials are long-lived but the *installation access token*
+ * you actually call the REST API with expires after ~1 hour. So when a source
+ * is configured with an App rather than a token, this module signs a short-lived
+ * App JWT and mints an installation access token at sync time, caching it
+ * in-process until shortly before expiry.
+ *
+ * Flow (per https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app):
+ *   1. Build a short-lived App JWT (RS256, signed with the app private key).
+ *   2. Resolve the installation id (configured, or discovered via
+ *      `GET /repos/{owner}/{repo}/installation`).
+ *   3. `POST /app/installations/{id}/access_tokens` → the installation token,
+ *      scoped to this repo + read-only Contents + Metadata permissions.
+ *
+ * Signing uses `jsonwebtoken` (already a dependency of this package), which
+ * reads the App's native PKCS#1 PEM (`-----BEGIN RSA PRIVATE KEY-----`)
+ * directly — no offline PKCS#8 conversion needed.
+ *
+ * Failures throw `GitHubAppAuthError` (distinct from the GitHub REST client's
+ * `SkillSyncError`) so callers can tell "the App credential is broken" apart
+ * from "the sync request itself failed" and surface an operator-actionable
+ * message instead of mislabeling it as a manifest/skill error.
+ */
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const TIMEOUT_MS = 15_000;
+/** Refresh the installation token when it's within this window of expiry. */
+const REFRESH_SKEW_MS = 5 * 60_000;
+
+/**
+ * Thrown for any failure in the App-auth path: signing, installation lookup,
+ * token exchange, a malformed private key, or a token with no usable expiry.
+ * Distinct type so the sync runner can branch on "credential/config problem"
+ * and surface a precise operator hint.
+ */
+export class GitHubAppAuthError extends Error {
+  /** Upstream HTTP status when the failure came from a GitHub call. */
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'GitHubAppAuthError';
+    this.status = status;
+  }
+}
+
+/**
+ * Operator-actionable message for a `GitHubAppAuthError`. Names the likely
+ * cause and never includes token material.
+ */
+export function appAuthErrorMessage(err: GitHubAppAuthError, owner: string, repo: string): string {
+  let hint = 'the App credential (appId / privateKey) is misconfigured';
+  if (err.status === 401 || err.status === 403) {
+    hint = 'the App credential (appId / privateKey) is rejected by GitHub';
+  } else if (err.status === 404) {
+    hint = `the GitHub App may not be installed on ${owner}/${repo}`;
+  }
+  return `GitHub App authentication failed — ${hint}. This is an operator config issue. Check server logs.`;
+}
+
+const ghHeaders = (bearer: string): Record<string, string> => ({
+  accept: 'application/vnd.github+json',
+  authorization: `Bearer ${bearer}`,
+  'x-github-api-version': '2022-11-28',
+  'user-agent': 'LibreChat-Skill-Sync',
+});
+
+/**
+ * Normalize a PEM private key read from an environment variable. Accepts:
+ *   - a raw multi-line PEM (`-----BEGIN RSA PRIVATE KEY-----\n...`)
+ *   - a PEM with literal `\n` escapes (common when entered via single-line env)
+ *   - a base64-encoded PEM
+ *
+ * Returns a PEM string that `crypto.createSign` can consume. Throws
+ * `GitHubAppAuthError` if the value is none of the above.
+ */
+export function normalizePrivateKey(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.includes('-----BEGIN')) {
+    return trimmed.includes('\\n') ? trimmed.replace(/\\n/g, '\n') : trimmed;
+  }
+  const decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+  if (!decoded.includes('-----BEGIN')) {
+    throw new GitHubAppAuthError(
+      'GitHub App privateKey is neither a PEM nor a base64-encoded PEM.',
+    );
+  }
+  return decoded;
+}
+
+/**
+ * Build a short-lived App JWT signed with the app private key (RS256).
+ * `iat` 60s in the past guards against clock skew; `exp` well under GitHub's
+ * 10-minute cap. `iss` accepts the numeric app id or the App's client id.
+ */
+export function mintAppJwt(appId: string, privateKeyPem: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  try {
+    return jwt.sign({ iat: now - 60, exp: now + 540, iss: appId }, privateKeyPem, {
+      algorithm: 'RS256',
+    });
+  } catch (err) {
+    throw new GitHubAppAuthError(
+      `Could not sign App JWT — privateKey is not a usable RSA private key: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+interface CachedToken {
+  token: string;
+  /** Epoch ms at which we should stop using this token. */
+  refreshAt: number;
+}
+
+export interface GitHubAppTokenProviderOpts {
+  appId: string;
+  /** Raw value of the privateKey env var (PEM, escaped-PEM, or base64). */
+  privateKey: string;
+  owner: string;
+  repo: string;
+  /** Optional. If omitted, discovered via `GET /repos/{owner}/{repo}/installation`. */
+  installationId?: string;
+  /** Injected for testability; defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Returns an async `() => Promise<string>` that yields a valid installation
+ * access token, minting + caching it as needed. The cache lives in this
+ * closure — construct ONCE per source and reuse for the lifetime of the
+ * process so the cache actually engages across syncs.
+ *
+ * The private key is NOT normalized eagerly — that's deferred to the first
+ * mint, so a malformed `privateKey` surfaces as a `GitHubAppAuthError` through
+ * the sync runner (an actionable per-source error) rather than throwing during
+ * provider construction.
+ */
+export function createGitHubAppTokenProvider(
+  opts: GitHubAppTokenProviderOpts,
+): () => Promise<string> {
+  const { appId, privateKey, owner, repo, installationId } = opts;
+  const fetchFn = opts.fetchFn ?? fetch;
+  let cached: CachedToken | null = null;
+
+  async function ghJson<T>(
+    method: 'GET' | 'POST',
+    pathname: string,
+    bearer: string,
+    body?: unknown,
+  ): Promise<T> {
+    let res: Response;
+    try {
+      res = await fetchFn(`${GITHUB_API_BASE}${pathname}`, {
+        method,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        headers: body
+          ? { ...ghHeaders(bearer), 'content-type': 'application/json' }
+          : ghHeaders(bearer),
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      // Network failure / timeout. Never include the bearer in the message.
+      logger.error('[SkillSync][GitHub App] auth request unreachable', {
+        method,
+        path: pathname,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      throw new GitHubAppAuthError(
+        `GitHub App auth request failed (unreachable): ${method} ${pathname}`,
+      );
+    }
+    if (!res.ok) {
+      // Never log the JWT/token; only the failing path + status.
+      logger.error('[SkillSync][GitHub App] auth request failed', {
+        method,
+        path: pathname,
+        status: res.status,
+      });
+      throw new GitHubAppAuthError(
+        `GitHub App auth failed: ${res.status} ${method} ${pathname}`,
+        res.status,
+      );
+    }
+    return (await res.json()) as T;
+  }
+
+  async function resolveInstallationId(appJwt: string): Promise<string> {
+    if (installationId) return installationId;
+    const result = await ghJson<{ id: number }>(
+      'GET',
+      `/repos/${owner}/${repo}/installation`,
+      appJwt,
+    );
+    return String(result.id);
+  }
+
+  async function mint(): Promise<CachedToken> {
+    const privateKeyPem = normalizePrivateKey(privateKey);
+    const appJwt = mintAppJwt(appId, privateKeyPem);
+    const id = await resolveInstallationId(appJwt);
+    const token = await ghJson<{ token: string; expires_at: string }>(
+      'POST',
+      `/app/installations/${id}/access_tokens`,
+      appJwt,
+      {
+        repositories: [repo],
+        // Read-only scope: sync mirrors files, never writes back. Apps with
+        // narrower permissions can also be installed in repos the App itself
+        // doesn't have write access to.
+        permissions: { contents: 'read', metadata: 'read' },
+      },
+    );
+    const expiresAtMs = Date.parse(token.expires_at);
+    if (Number.isNaN(expiresAtMs)) {
+      // A token with no parseable expiry would poison the cache: `refreshAt`
+      // would be NaN and `Date.now() < NaN` is always false, so we'd silently
+      // re-mint on every request. Fail loud — this is a contract violation by
+      // GitHub (or an unexpected response shape), not normal.
+      logger.error('[SkillSync][GitHub App] token has no valid expires_at', {
+        expires_at: token.expires_at,
+      });
+      throw new GitHubAppAuthError(
+        'GitHub returned an installation token with no valid expires_at.',
+      );
+    }
+    return { token: token.token, refreshAt: expiresAtMs - REFRESH_SKEW_MS };
+  }
+
+  return async function getToken(): Promise<string> {
+    if (cached && Date.now() < cached.refreshAt) {
+      return cached.token;
+    }
+    // On failure, leave `cached` untouched (null or the prior value) and let
+    // the GitHubAppAuthError propagate — never cache a bad result.
+    cached = await mint();
+    return cached.token;
+  };
+}

--- a/packages/api/src/skills/sync/github.spec.ts
+++ b/packages/api/src/skills/sync/github.spec.ts
@@ -243,6 +243,409 @@ function createDeps(
   return deps;
 }
 
+describe('createGitHubSkillSyncRunner with GitHub App auth', () => {
+  const TEST_PEM = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  }).privateKey;
+
+  beforeEach(() => {
+    process.env.GH_APP_AUTH_TEST_ID = '99999';
+    process.env.GH_APP_AUTH_TEST_PEM = TEST_PEM;
+  });
+
+  afterEach(() => {
+    delete process.env.GH_APP_AUTH_TEST_ID;
+    delete process.env.GH_APP_AUTH_TEST_PEM;
+  });
+
+  it('mints an installation token via the App and uses it for sync', async () => {
+    const authByUrl: Array<{ url: string; auth: string | undefined }> = [];
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const baseFetch = githubFetch();
+    const fetchFn = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const auth =
+        (init?.headers as Record<string, string> | undefined)?.authorization ??
+        (init?.headers as Record<string, string> | undefined)?.Authorization;
+      authByUrl.push({ url, auth });
+      if (url.endsWith('/repos/LibreChat/skills/installation')) {
+        return response({ id: 42 });
+      }
+      if (url.endsWith('/app/installations/42/access_tokens')) {
+        return response({ token: 'ghs_minted', expires_at: expiresAt });
+      }
+      return (baseFetch as unknown as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    const deps = createDeps({
+      fetchFn,
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-integration',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+
+    expect(result.status).toBe('completed');
+    expect(deps.createSkill).toHaveBeenCalledWith(expect.objectContaining({ name: 'research' }));
+    // Sync calls (commit/tree/blob) carry the minted installation token.
+    const syncAuth = authByUrl
+      .filter((e) => !e.url.endsWith('/installation') && !e.url.endsWith('/access_tokens'))
+      .map((e) => e.auth);
+    expect(syncAuth.length).toBeGreaterThan(0);
+    expect(syncAuth.every((a) => a === 'Bearer ghs_minted')).toBe(true);
+    // The two App-auth endpoints must be called with an App JWT (3-segment
+    // signed token) — never with the installation token, which would be a
+    // boundary-of-the-feature regression that the unit-level JWT test can't
+    // catch.
+    const jwtShape = /^Bearer [A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+    const installationCall = authByUrl.find((e) => e.url.endsWith('/installation'));
+    const tokenCall = authByUrl.find((e) => e.url.endsWith('/access_tokens'));
+    expect(installationCall?.auth).toMatch(jwtShape);
+    expect(tokenCall?.auth).toMatch(jwtShape);
+  });
+
+  it('reuses the cached App token provider across runOnce() calls (one mint, two syncs)', async () => {
+    let mintCount = 0;
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const baseFetch = githubFetch();
+    const fetchFn = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.endsWith('/repos/LibreChat/skills/installation')) {
+        return response({ id: 42 });
+      }
+      if (url.endsWith('/app/installations/42/access_tokens')) {
+        mintCount += 1;
+        return response({ token: 'ghs_cached', expires_at: expiresAt });
+      }
+      return (baseFetch as unknown as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    const config = {
+      github: {
+        enabled: true,
+        intervalMinutes: 60,
+        runOnStartup: false,
+        sources: [
+          {
+            id: 'app-auth-memoize',
+            owner: 'LibreChat',
+            repo: 'skills',
+            ref: 'main',
+            paths: ['skills'],
+            app: {
+              appId: '${GH_APP_AUTH_TEST_ID}',
+              privateKey: '${GH_APP_AUTH_TEST_PEM}',
+            },
+          },
+        ],
+      },
+    };
+    const deps = createDeps({ fetchFn, getConfig: () => config });
+    const runner = createGitHubSkillSyncRunner(deps);
+    await runner.runOnce();
+    await runner.runOnce();
+    // Two sync runs, one installation token mint — the module-scope cache
+    // engaged across runs.
+    expect(mintCount).toBe(1);
+  });
+
+  it('reads installationId from env and skips installation discovery', async () => {
+    process.env.GH_APP_AUTH_TEST_INSTALL = '77';
+    const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
+    const baseFetch = githubFetch();
+    const seenUrls: string[] = [];
+    const fetchFn = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      seenUrls.push(url);
+      if (url.endsWith('/app/installations/77/access_tokens')) {
+        return response({ token: 'ghs_pinned', expires_at: expiresAt });
+      }
+      return (baseFetch as unknown as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    const deps = createDeps({
+      fetchFn,
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-pinned-install',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+                installationId: '${GH_APP_AUTH_TEST_INSTALL}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+    expect(result.status).toBe('completed');
+    // Discovery endpoint MUST NOT be called when installationId is pinned.
+    expect(seenUrls.some((u) => /\/repos\/[^/]+\/[^/]+\/installation$/.test(u))).toBe(false);
+    expect(seenUrls.some((u) => u.endsWith('/app/installations/77/access_tokens'))).toBe(true);
+    delete process.env.GH_APP_AUTH_TEST_INSTALL;
+  });
+
+  it('getStatus() reports credentialPresent=true for a fully-resolved App source', async () => {
+    const deps = createDeps({
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-status',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const status = await runner.getStatus();
+    expect(status.sources[0]?.credentialPresent).toBe(true);
+  });
+
+  it('getStatus() reports credentialPresent=false when an App env var is unset', async () => {
+    delete process.env.GH_APP_AUTH_TEST_PEM;
+    const deps = createDeps({
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-status-missing',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const status = await runner.getStatus();
+    expect(status.sources[0]?.credentialPresent).toBe(false);
+  });
+
+  it('fails fast when the App appId env var is missing and names it in the status', async () => {
+    delete process.env.GH_APP_AUTH_TEST_ID;
+    const deps = createDeps({
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-missing-appid',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+    expect(result.status).toBe('failed');
+    const failed = deps.statuses.find((s) => s.status === 'failed');
+    expect(failed?.errorCode).toBe('GITHUB_APP_AUTH_FAILED');
+    expect(failed?.errorMessage).toMatch(/GH_APP_AUTH_TEST_ID/);
+  });
+
+  it('fails fast when the App privateKey env var is missing and names it in the status', async () => {
+    delete process.env.GH_APP_AUTH_TEST_PEM;
+    const deps = createDeps({
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-missing-pem',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+    expect(result.status).toBe('failed');
+    const failed = deps.statuses.find((s) => s.status === 'failed');
+    expect(failed?.errorCode).toBe('GITHUB_APP_AUTH_FAILED');
+    expect(failed?.errorMessage).toMatch(/GH_APP_AUTH_TEST_PEM/);
+  });
+
+  it('fails fast when a configured installationId env var is unset (no silent discovery fallback)', async () => {
+    // Do NOT set GH_APP_AUTH_TEST_INSTALL — config references it but it's unset.
+    const fetchFn = jest.fn(async () => response({}, 404)) as unknown as typeof fetch;
+    const deps = createDeps({
+      fetchFn,
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-missing-install',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+                installationId: '${GH_APP_AUTH_TEST_INSTALL}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+    expect(result.status).toBe('failed');
+    const failed = deps.statuses.find((s) => s.status === 'failed');
+    expect(failed?.errorCode).toBe('GITHUB_APP_AUTH_FAILED');
+    expect(failed?.errorMessage).toMatch(/GH_APP_AUTH_TEST_INSTALL/);
+    // Critical: nothing should have been fetched at all — fail-loud, not fall-through.
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a malformed-PEM as GITHUB_APP_AUTH_FAILED via the runner (deferred validation)', async () => {
+    process.env.GH_APP_AUTH_TEST_PEM = 'not-a-real-pem';
+    const fetchFn = jest.fn(async () => response({}, 404)) as unknown as typeof fetch;
+    const deps = createDeps({
+      fetchFn,
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-bad-pem',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+    expect(result.status).toBe('failed');
+    const failed = deps.statuses.find((s) => s.status === 'failed');
+    expect(failed?.errorCode).toBe('GITHUB_APP_AUTH_FAILED');
+    expect(failed?.errorMessage).toMatch(/privateKey|PEM/i);
+  });
+
+  it('surfaces a 404 from installation lookup as GITHUB_APP_AUTH_FAILED', async () => {
+    const fetchFn = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith('/installation')) return response({ message: 'Not Found' }, 404);
+      return response({}, 404);
+    }) as unknown as typeof fetch;
+    const deps = createDeps({
+      fetchFn,
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'app-auth-404',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              app: {
+                appId: '${GH_APP_AUTH_TEST_ID}',
+                privateKey: '${GH_APP_AUTH_TEST_PEM}',
+              },
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    const result = await runner.runOnce();
+    expect(result.status).toBe('failed');
+    const failed = deps.statuses.find((s) => s.status === 'failed');
+    expect(failed?.errorCode).toBe('GITHUB_APP_AUTH_FAILED');
+    expect(failed?.errorMessage).toMatch(/not be installed on LibreChat\/skills/);
+  });
+});
+
 describe('createGitHubSkillSyncRunner', () => {
   it('creates a GitHub skill and syncs bundled files from a configured path', async () => {
     const deps = createDeps();

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -24,6 +24,11 @@ import type {
 import type { SkillSyncConfig, SkillSyncGitHubSourceConfig } from 'librechat-data-provider';
 import { DEFAULT_SKILL_IMPORT_LIMITS } from '../limits';
 import { parseSkillMarkdown } from '../parse';
+import {
+  GitHubAppAuthError,
+  appAuthErrorMessage,
+  createGitHubAppTokenProvider,
+} from './github-app-auth';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const SYSTEM_AUTHOR_ID = new Types.ObjectId('000000000000000000000000');
@@ -1383,12 +1388,116 @@ function getTokenEnvVarName(tokenReference: string | undefined): string | null {
   return match?.[1] ?? null;
 }
 
+/**
+ * Memoize App token providers per source id so the in-process installation
+ * token cache (held inside the provider closure) survives across sync runs.
+ * Cache entries carry a fingerprint of the resolved App config so that any
+ * change to the underlying env vars or source attributes (App credential
+ * rotation, owner/repo/installation edits) replaces the closure on next sync
+ * instead of re-using a stale one for the process lifetime.
+ */
+type CachedAppProvider = {
+  fingerprint: string;
+  provider: () => Promise<string>;
+};
+const appTokenProviders = new Map<string, CachedAppProvider>();
+
+function appConfigFingerprint(parts: {
+  appId: string;
+  privateKey: string;
+  owner: string;
+  repo: string;
+  installationId: string | undefined;
+}): string {
+  // Hash the private key on its own first so it never enters the joined buffer
+  // verbatim; the joined buffer is itself hashed before being kept anywhere.
+  const keyDigest = crypto.createHash('sha256').update(parts.privateKey).digest('hex');
+  return crypto
+    .createHash('sha256')
+    .update(
+      [parts.appId, parts.owner, parts.repo, parts.installationId ?? '', keyDigest].join('\0'),
+    )
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function getEnvOrNull(reference: string | undefined): string | null {
+  const name = getTokenEnvVarName(reference);
+  if (!name) return null;
+  return process.env[name]?.trim() || null;
+}
+
+async function resolveAppToken(
+  source: SkillSyncGitHubSourceConfig,
+  fetchFn: FetchFn,
+): Promise<string> {
+  const app = source.app!;
+  const appId = getEnvOrNull(app.appId);
+  const privateKey = getEnvOrNull(app.privateKey);
+  const missing: string[] = [];
+  if (!appId) missing.push(getTokenEnvVarName(app.appId) ?? 'appId env var');
+  if (!privateKey) missing.push(getTokenEnvVarName(app.privateKey) ?? 'privateKey env var');
+  // `installationId` is optional in the schema, but a *configured* env var that
+  // doesn't resolve is operator misconfiguration — fall back to discovery only
+  // when the field is omitted entirely.
+  let installationId: string | undefined;
+  if (app.installationId) {
+    const resolved = getEnvOrNull(app.installationId);
+    if (!resolved) {
+      missing.push(getTokenEnvVarName(app.installationId) ?? 'installationId env var');
+    } else {
+      installationId = resolved;
+    }
+  }
+  if (missing.length > 0 || !appId || !privateKey) {
+    throw new GitHubAppAuthError(`Missing GitHub App env var(s): ${missing.join(', ')}`);
+  }
+  const fingerprint = appConfigFingerprint({
+    appId,
+    privateKey,
+    owner: source.owner,
+    repo: source.repo,
+    installationId,
+  });
+  const cached = appTokenProviders.get(source.id);
+  if (cached && cached.fingerprint === fingerprint) {
+    return cached.provider();
+  }
+  const provider = createGitHubAppTokenProvider({
+    appId,
+    privateKey,
+    owner: source.owner,
+    repo: source.repo,
+    installationId,
+    fetchFn,
+  });
+  appTokenProviders.set(source.id, { fingerprint, provider });
+  return provider();
+}
+
+/**
+ * Returns true when the resolved App config could authenticate now — every
+ * referenced env var resolves. Used by `getStatus()` to surface configured
+ * App credentials as present alongside PAT env vars and stored credentials.
+ */
+function isAppCredentialPresent(source: SkillSyncGitHubSourceConfig): boolean {
+  if (!source.app) return false;
+  if (!getEnvOrNull(source.app.appId)) return false;
+  if (!getEnvOrNull(source.app.privateKey)) return false;
+  if (source.app.installationId && !getEnvOrNull(source.app.installationId)) return false;
+  return true;
+}
+
 async function resolveGitHubToken(
   deps: GitHubSkillSyncDeps,
   source: SkillSyncGitHubSourceConfig,
+  fetchFn: FetchFn,
 ): Promise<string | null> {
   if (deps.allowServerCredentials === false) {
     return null;
+  }
+  if (source.app) {
+    return resolveAppToken(source, fetchFn);
   }
   const tokenEnvVar = getTokenEnvVarName(source.token);
   if (tokenEnvVar) {
@@ -1426,7 +1535,24 @@ async function syncSource(params: {
   try {
     assertNotCancelled();
     const allowServerCredentials = deps.allowServerCredentials !== false;
-    const token = await resolveGitHubToken(deps, source);
+    let token: string | null;
+    try {
+      token = await resolveGitHubToken(deps, source, fetchFn);
+    } catch (err) {
+      if (err instanceof GitHubAppAuthError) {
+        // `appAuthErrorMessage` is the right wrapper when the failure came
+        // from GitHub (status set). For local failures (missing env vars,
+        // unsignable PEM) the original `err.message` already names the exact
+        // env var or signing problem the operator needs to fix — preserve it
+        // rather than collapsing to the generic "misconfigured" template.
+        const message =
+          err.status === undefined
+            ? err.message
+            : appAuthErrorMessage(err, source.owner, source.repo);
+        throw new SkillSyncError('GITHUB_APP_AUTH_FAILED', message);
+      }
+      throw err;
+    }
     assertNotCancelled();
     if (!token) {
       throw new SkillSyncError(
@@ -1753,13 +1879,14 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
       const tokenEnvVar = getTokenEnvVarName(source.token);
       const envTokenPresent =
         allowServerCredentials && tokenEnvVar ? Boolean(process.env[tokenEnvVar]?.trim()) : false;
+      const appPresent = allowServerCredentials && isAppCredentialPresent(source);
       return {
         provider: PROVIDER,
         sourceId: source.id,
         tenantId: source.tenantId,
         status: stored?.status ?? 'idle',
         credentialKey: source.credentialKey,
-        credentialPresent: envTokenPresent || Boolean(credential),
+        credentialPresent: envTokenPresent || appPresent || Boolean(credential),
         owner: source.owner,
         repo: source.repo,
         ref: source.ref,

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -913,6 +913,120 @@ describe('configSchema skillSync', () => {
     expect(duplicateCredentialSources.success).toBe(false);
   });
 
+  it('accepts a GitHub skill sync source with a GitHub App credential', () => {
+    const result = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'stord-marketplace',
+              owner: 'stordco',
+              repo: 'claude-ai-marketplace',
+              paths: ['.'],
+              skillDiscoveryDepth: 3,
+              app: {
+                appId: '${GH_AI_APP_ID}',
+                privateKey: '${GH_AI_APP_PEM}',
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.skillSync?.github?.sources[0]?.app?.appId).toBe('${GH_AI_APP_ID}');
+    expect(result.data?.skillSync?.github?.sources[0]?.app?.privateKey).toBe('${GH_AI_APP_PEM}');
+  });
+
+  it('accepts a GitHub App credential with an optional installationId', () => {
+    const result = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'stord-marketplace',
+              owner: 'stordco',
+              repo: 'claude-ai-marketplace',
+              paths: ['.'],
+              app: {
+                appId: '${GH_AI_APP_ID}',
+                privateKey: '${GH_AI_APP_PEM}',
+                installationId: '${GH_AI_APP_INSTALLATION_ID}',
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects combining app with token or credentialKey', () => {
+    const appAndToken = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'stord-marketplace',
+              owner: 'stordco',
+              repo: 'claude-ai-marketplace',
+              paths: ['.'],
+              token: '${GITHUB_SKILLS_TOKEN}',
+              app: { appId: '${GH_AI_APP_ID}', privateKey: '${GH_AI_APP_PEM}' },
+            },
+          ],
+        },
+      },
+    });
+    const appAndCredentialKey = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'stord-marketplace',
+              owner: 'stordco',
+              repo: 'claude-ai-marketplace',
+              paths: ['.'],
+              credentialKey: 'github-skills-prod',
+              app: { appId: '${GH_AI_APP_ID}', privateKey: '${GH_AI_APP_PEM}' },
+            },
+          ],
+        },
+      },
+    });
+    expect(appAndToken.success).toBe(false);
+    expect(appAndCredentialKey.success).toBe(false);
+  });
+
+  it('rejects literal values in app.appId or app.privateKey (must be env refs)', () => {
+    const literalAppId = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'stord-marketplace',
+              owner: 'stordco',
+              repo: 'claude-ai-marketplace',
+              paths: ['.'],
+              app: { appId: '12345', privateKey: '${GH_AI_APP_PEM}' },
+            },
+          ],
+        },
+      },
+    });
+    expect(literalAppId.success).toBe(false);
+  });
+
   it('rejects GitHub skill sync discovery depths outside the allowed range', () => {
     const result = configSchema.safeParse({
       version: '1.3.11',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -362,6 +362,23 @@ const skillSyncTenantIdSchema = z
     message: 'must not be the reserved system tenant id',
   });
 
+/**
+ * GitHub App credential block. Used as an alternative to `token` /
+ * `credentialKey` when the organization can't issue PATs but has a GitHub
+ * App available. The sync runner mints short-lived installation access tokens
+ * from these at sync time; see `packages/api/src/skills/sync/github-app-auth.ts`.
+ *
+ * `appId` and `privateKey` are required and reference environment variables
+ * (the App's numeric id / client id and the App's RSA private key PEM).
+ * `installationId` is optional — when omitted the sync runner discovers it via
+ * `GET /repos/{owner}/{repo}/installation`.
+ */
+const skillSyncGitHubAppConfigSchema = z.object({
+  appId: skillSyncTokenReferenceSchema,
+  privateKey: skillSyncTokenReferenceSchema,
+  installationId: skillSyncTokenReferenceSchema.optional(),
+});
+
 export const skillSyncGitHubSourceSchema = z
   .object({
     id: skillSyncIdentifierSchema,
@@ -372,21 +389,24 @@ export const skillSyncGitHubSourceSchema = z
     skillDiscoveryDepth: z.number().int().min(0).max(SKILL_SYNC_MAX_DISCOVERY_DEPTH).optional(),
     credentialKey: skillSyncIdentifierSchema.optional(),
     token: skillSyncTokenReferenceSchema.optional(),
+    app: skillSyncGitHubAppConfigSchema.optional(),
     tenantId: skillSyncTenantIdSchema.optional(),
   })
   .superRefine((source, ctx) => {
-    if (!source.credentialKey && !source.token) {
+    const credentialCount =
+      (source.credentialKey ? 1 : 0) + (source.token ? 1 : 0) + (source.app ? 1 : 0);
+    if (credentialCount === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['credentialKey'],
-        message: 'Either credentialKey or token is required',
+        message: 'Either credentialKey, token, or app is required',
       });
     }
-    if (source.credentialKey && source.token) {
+    if (credentialCount > 1) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['token'],
-        message: 'Use either credentialKey or token, not both',
+        message: 'Use exactly one of credentialKey, token, or app — not multiple',
       });
     }
   });


### PR DESCRIPTION
## Summary

Adds `app: { appId, privateKey, installationId? }` as a third credential option alongside `token:` and `credentialKey:` on `skillSync.github` sources. The runner signs a short-lived App JWT, mints an installation access token (`contents:read` + `metadata:read`), and caches it in-process until ~5 min before expiry. For organisations that can't issue PATs but provision GitHub Apps.

- New `skillSyncGitHubAppConfigSchema` (`appId`, `privateKey`, optional `installationId`) in `packages/data-provider/src/config.ts`, with `superRefine` updated to require exactly one of `{token, credentialKey, app}`.
- New `packages/api/src/skills/sync/github-app-auth.ts`: JWT signing, PEM normalization (raw PEM, escaped-`\n` PEM, base64), token mint + in-process cache with refresh skew, typed `GitHubAppAuthError`, operator-actionable error messages that never include token material.
- `packages/api/src/skills/sync/github.ts`: `resolveGitHubToken` gains an `app:` branch that lazy-creates a per-source provider keyed by `(source.id, fingerprint of resolved config)` so credential/source-attribute rotation is picked up without a process restart. `getStatus()` recognises configured App env vars when computing `credentialPresent`. Local `GitHubAppAuthError`s (missing env var, unsignable PEM) preserve their actionable message through to the sync status; only GitHub-side failures go through the generic `appAuthErrorMessage` template.

Backward compatible — existing `token:` and `credentialKey:` configurations are unaffected.

Example:

```yaml
skillSync:
  github:
    enabled: true
    intervalMinutes: 60
    runOnStartup: true
    sources:
      - id: my-skills
        owner: my-org
        repo: skills-repo
        paths: ['skills']
        app:
          appId: '\${GH_APP_ID}'
          privateKey: '\${GH_APP_PEM}'
          # installationId: '\${GH_APP_INSTALLATION_ID}'  # optional; discovered if omitted
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- ` cd packages/data-provider && npx jest specs/config-schemas.spec.ts --runInBand --coverage=false` (92 pass, 4 new)
- `cd packages/api && npx jest src/skills/sync/github-app-auth.spec.ts --runInBand --coverage=false` (16 pass, new file: JWT, PEM, cache, 401/404, expiry-poison guard)
- `cd packages/api && npx jest src/skills/sync/github.spec.ts --runInBand --coverage=false` (44 pass, 10 new: happy path with JWT/installation-token boundary, missing-`appId` / missing-`privateKey` / unset-pinned-`installationId` each verifying the env-var name in the status message, malformed-PEM via the runner, pinned `installationId` skipping discovery, cross-`runOnce()` memoization, `getStatus()` for App sources)

End-to-end verified locally: a real source pointed at a private repo (the patched dist mounted into the LibreChat docker image) syncs `status: succeeded, syncedSkillCount: 26`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes