### PR TITLE
📬 feat: Report Tool Results Per Call via `onResult` Channel

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.2.33",
+    "@librechat/agents": "^3.2.34",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.2.33",
+        "@librechat/agents": "^3.2.34",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11684,9 +11684,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.2.33.tgz",
-      "integrity": "sha512-f1+aV4HgG7H8QPdNZdVAF/qQcscuNhZvXYOpM/FPzAVpkN+Ah+BF4dlksb6MCx2HxrqCdV5AxjwobtlIBI7GLg==",
+      "version": "3.2.34",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.2.34.tgz",
+      "integrity": "sha512-Njz5wxlDeTKSWpcUBO3ODLClrrcxfmEn1r3W2WTSeVFAYp8vMqvhFGgPPnG82v9fDdqajuMVKTScb0puhglEqg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -44250,7 +44250,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.2.33",
+        "@librechat/agents": "^3.2.34",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -112,7 +112,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.2.33",
+    "@librechat/agents": "^3.2.34",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -2990,9 +2990,7 @@ describe('per-call onResult reporting', () => {
     const results = await batchPromise;
 
     expect(reported.map((r) => r.toolCallId)).toEqual(['call_fast', 'call_slow']);
-    expect(timeline.indexOf('reported:call_fast')).toBeLessThan(
-      timeline.indexOf('slow:done'),
-    );
+    expect(timeline.indexOf('reported:call_fast')).toBeLessThan(timeline.indexOf('slow:done'));
     expect(results.map((r) => r.toolCallId).sort()).toEqual(['call_fast', 'call_slow']);
     expect(results.find((r) => r.toolCallId === 'call_fast')?.content).toBe('fast result');
   });

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -2928,3 +2928,110 @@ describe('createToolExecuteHandler', () => {
     });
   });
 });
+
+describe('per-call onResult reporting', () => {
+  function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolveFn!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolveFn = res;
+    });
+    return { promise, resolve: resolveFn };
+  }
+
+  it('reports each result as it settles, before the batch resolves', async () => {
+    const slowGate = deferred<void>();
+    const timeline: string[] = [];
+
+    const fastTool = {
+      name: 'fast_tool',
+      invoke: jest.fn(async () => {
+        timeline.push('fast:done');
+        return { content: 'fast result' };
+      }),
+    };
+    const slowTool = {
+      name: 'slow_tool',
+      invoke: jest.fn(async () => {
+        await slowGate.promise;
+        timeline.push('slow:done');
+        return { content: 'slow result' };
+      }),
+    };
+
+    const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
+      loadedTools: [fastTool, slowTool] as never[],
+    }));
+    const handler = createToolExecuteHandler({ loadTools });
+
+    const reported: ToolExecuteResult[] = [];
+    const batchPromise = new Promise<ToolExecuteResult[]>((resolve, reject) => {
+      const request = {
+        toolCalls: [
+          { id: 'call_fast', name: 'fast_tool', args: {} },
+          { id: 'call_slow', name: 'slow_tool', args: {} },
+        ],
+        resolve,
+        reject,
+        onResult: (result: ToolExecuteResult) => {
+          reported.push(result);
+          timeline.push(`reported:${result.toolCallId}`);
+        },
+      } as ToolExecuteBatchRequest & {
+        onResult: (result: ToolExecuteResult) => void;
+      };
+      handler.handle('on_tool_execute', request);
+    });
+
+    // Let the fast tool settle and report while the slow tool is gated.
+    await new Promise((res) => setTimeout(res, 0));
+    expect(reported.map((r) => r.toolCallId)).toEqual(['call_fast']);
+
+    slowGate.resolve();
+    const results = await batchPromise;
+
+    expect(reported.map((r) => r.toolCallId)).toEqual(['call_fast', 'call_slow']);
+    expect(timeline.indexOf('reported:call_fast')).toBeLessThan(
+      timeline.indexOf('slow:done'),
+    );
+    expect(results.map((r) => r.toolCallId).sort()).toEqual(['call_fast', 'call_slow']);
+    expect(results.find((r) => r.toolCallId === 'call_fast')?.content).toBe('fast result');
+  });
+
+  it('keeps the batch resolving when onResult throws', async () => {
+    const tool = {
+      name: 'sturdy_tool',
+      invoke: jest.fn(async () => ({ content: 'ok' })),
+    };
+    const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
+      loadedTools: [tool] as never[],
+    }));
+    const handler = createToolExecuteHandler({ loadTools });
+
+    const results = await new Promise<ToolExecuteResult[]>((resolve, reject) => {
+      const request = {
+        toolCalls: [{ id: 'call_1', name: 'sturdy_tool', args: {} }],
+        resolve,
+        reject,
+        onResult: () => {
+          throw new Error('listener exploded');
+        },
+      } as ToolExecuteBatchRequest & { onResult: () => void };
+      handler.handle('on_tool_execute', request);
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ toolCallId: 'call_1', content: 'ok' });
+  });
+
+  it('behaves identically when no onResult is provided', async () => {
+    const capturedConfigs: Record<string, unknown>[] = [];
+    const handler = createHandler(capturedConfigs);
+
+    const results = await invokeHandler(handler, [
+      { id: 'call_1', name: Constants.EXECUTE_CODE, args: { lang: 'py', code: '1' } },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('success');
+  });
+});

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -3151,6 +3151,24 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
   return {
     handle: async (_event: string, data: ToolExecuteBatchRequest) => {
       const { toolCalls, agentId, configurable, metadata, resolve, reject } = data;
+      /** Optional per-call channel (agents SDK > 3.2.33); cast keeps older
+       * installed SDK typings compiling until the release lands. */
+      const onResult = (
+        data as ToolExecuteBatchRequest & {
+          onResult?: (result: ToolExecuteResult) => void;
+        }
+      ).onResult;
+      /** Reports a settled result so the agent graph can emit that call's
+       * completion immediately instead of waiting for the whole batch;
+       * `resolve` below remains the authoritative batch outcome. */
+      const reportResult = (result: ToolExecuteResult): ToolExecuteResult => {
+        try {
+          onResult?.(result);
+        } catch (callbackError) {
+          logger.warn('[ON_TOOL_EXECUTE] onResult callback error:', callbackError);
+        }
+        return result;
+      };
 
       try {
         await runOutsideTracing(async () => {
@@ -3455,7 +3473,7 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
 
                 const queueKey = getFileAuthoringQueueKey(tc, mergedConfigurable);
                 if (!queueKey) {
-                  return await execute();
+                  return reportResult(await execute());
                 }
                 let sandboxContext: SandboxSessionContext | undefined;
                 if (queueKey.startsWith('sandbox:')) {
@@ -3476,7 +3494,7 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                     () => undefined,
                   ),
                 );
-                return await resultPromise;
+                return reportResult(await resultPromise);
               }),
             );
 

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -15,17 +15,17 @@ import type { StructuredToolInterface } from '@librechat/agents/langchain/tools'
 import type { CodeEnvRef } from 'librechat-data-provider';
 import type { SkillFileRecord } from './skillFiles';
 import type { ServerRequest } from '~/types';
-import { logAxiosError, runOutsideTracing } from '~/utils';
-import { buildSkillPrimeMessage } from './skills';
-import { cleanCodeToolOutput } from './cleanup';
-import { primeSkillFiles } from './skillFiles';
 import {
   CREATE_FILE_TOOL_NAME,
   EDIT_FILE_TOOL_NAME,
   HOST_FILE_AUTHORING_ARTIFACT_KEY,
   isCodeSessionToolName,
 } from './tools';
+import { logAxiosError, runOutsideTracing } from '~/utils';
 import { parseFrontmatter } from '../skills/import';
+import { buildSkillPrimeMessage } from './skills';
+import { cleanCodeToolOutput } from './cleanup';
+import { primeSkillFiles } from './skillFiles';
 
 export interface ToolEndCallbackData {
   output: {


### PR DESCRIPTION
## Summary

I wired the tool-execution handler to report each result to the agent graph as it settles, instead of only delivering the full batch at the end. The handler already runs tool batches in parallel (`Promise.all` over the calls), but the `ON_TOOL_EXECUTE` contract previously exposed only the single `resolve(results[])` channel — so a 1-second tool's completion event waited for the slowest call in the same batch. The agents SDK now accepts an optional per-call `onResult` callback ([agents#239](https://github.com/danny-avila/agents/pull/239)) and emits that call's completed run step immediately when invoked; this PR is the host half.

- Pulled the optional `onResult` callback off the batch request with a forward-compatible cast, so this compiles against the currently installed SDK typings and activates automatically once the release containing agents#239 lands; until then `onResult` is `undefined` and the optional chain makes this a no-op.
- Wrapped both mapper exit points (direct execution and the file-authoring queue path) in a `reportResult` helper, so every result shape — success, error, host-tool, queued — is reported exactly once as it settles; `resolve(results)` remains the authoritative batch outcome and is unchanged.
- Guarded the callback invocation so a throwing listener can never break batch resolution.

The SDK side gates the fast-path on no-hooks/no-HITL configurations and dedupes against batch-time emission, so no changes are needed here for those cases — when the SDK withholds `onResult`, this code path is simply inert.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Added three specs to `packages/api/src/agents/handlers.spec.ts`: a gated slow tool proves the fast call is reported before the batch resolves (and before the slow tool finishes); a throwing `onResult` listener doesn't prevent `resolve`; behavior without `onResult` is unchanged. Full `handlers.spec.ts` passes (78 tests).
- `tsc` reports no errors in the touched files.

### **Test Configuration**:

- Node 24, jest via `packages/api`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes