### PR TITLE
🪟 fix: Cross-Platform Absolute-Path Check in tsdown neverBundle Predicates

### DIFF
--- a/packages/api/tsdown.config.mjs
+++ b/packages/api/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -15,6 +16,6 @@ export default defineConfig({
   // only first-party code: relative imports and the `~/*` tsconfig alias (-> src).
   // `neverBundle` is the 0.22 replacement for the deprecated `external` option.
   deps: {
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !id.startsWith('/'),
+    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !path.isAbsolute(id),
   },
 });

--- a/packages/client/tsdown.config.mjs
+++ b/packages/client/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 // Mirror the prior Rollup `@rollup/plugin-replace` substitutions: only these three are
@@ -26,7 +27,7 @@ export default defineConfig({
   // Externalize every third-party import (consumers provide the peers + react/jsx-runtime);
   // bundle only relative, `~`-aliased, and absolute sources.
   deps: {
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !id.startsWith('/'),
+    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !path.isAbsolute(id),
     onlyBundle: false,
   },
 });

--- a/packages/data-provider/tsdown.config.mjs
+++ b/packages/data-provider/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { createRequire } from 'node:module';
 import replace from '@rollup/plugin-replace';
 import { defineConfig } from 'tsdown';
@@ -20,7 +21,7 @@ export default defineConfig({
     // Match the prior Rollup build: bundle nothing third-party. Externalize every
     // bare import (deps, peers, and node built-ins like `crypto`); bundle only the
     // package's own relative/aliased modules.
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('/') && !id.startsWith('src/'),
+    neverBundle: (id) => !id.startsWith('.') && !path.isAbsolute(id) && !id.startsWith('src/'),
     onlyBundle: false,
   },
   plugins: [

--- a/packages/data-schemas/tsdown.config.mjs
+++ b/packages/data-schemas/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -16,7 +17,7 @@ export default defineConfig({
       !id.startsWith('dotenv/') &&
       !id.startsWith('.') &&
       !id.startsWith('~') &&
-      !id.startsWith('/'),
+      !path.isAbsolute(id),
     // dotenv is bundled on purpose, so silence the "detected dependencies in bundle" hint.
     onlyBundle: false,
   },


### PR DESCRIPTION
## Summary

The `deps.neverBundle` predicates in the four package `tsdown.config.mjs` files detect first-party (resolved) module ids with `!id.startsWith('/')`. On Windows, resolved module ids are absolute paths like `C:\Users\...`, which never match this check — so **every project module is externalized**.

The builds still exit 0, but emit near-empty bundles. For `packages/client`:

| | broken (Windows) | correct |
|---|---|---|
| `dist/index.mjs` | ~2.7 kB | ~276 kB |
| `dist/style.css` | not emitted | 3.87 kB |

The missing `dist/style.css` then breaks the client dev server with:

```
[plugin:vite:import-analysis] Failed to resolve import "@librechat/client/style.css" from "src/main.jsx"
```

`packages/data-provider` is similarly affected — its dist re-exports raw unbundled `.ts` specifiers (e.g. `export * from "./react-query-service.ts"` inside `dist/react-query/index.mjs`).

## Fix

Replace the `startsWith('/')` check with `path.isAbsolute(id)` in all four configs (`packages/client`, `packages/api`, `packages/data-provider`, `packages/data-schemas`). `path.isAbsolute` is behavior-identical on POSIX (`/...` is absolute) and additionally matches Windows drive paths, so Linux/macOS builds are unaffected.

## Repro

On any Windows machine:

```
npm install
npm run build:packages
```

Before this fix: `packages/client/dist/index.mjs` is ~2.7 kB and `dist/style.css` is missing. After: ~276 kB and `style.css` present, matching POSIX output.

## Testing

- `npm run build:packages` on Windows 11 (Node v24): all four packages now produce correctly sized bundles and `packages/client/dist/style.css` is emitted; client dev server starts cleanly.
- The predicate change only affects ids that are absolute paths on Windows (previously mis-externalized); bare specifiers (deps/peers/builtins) are still externalized as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)