### PR TITLE
🪢 fix: Prune Dangling Skill IDs from Agent Allowlists

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/FileAuthoringCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/FileAuthoringCall.tsx
@@ -123,6 +123,10 @@ export default function FileAuthoringCall({
 }) {
   const localize = useLocalize();
   const isCreate = toolName === 'create_file';
+  /** `create_file` can overwrite an existing file (sandbox `overwrite: true`,
+   *  or skill SKILL.md updates). The host-authored summary always opens with
+   *  `Created`/`Updated`, so key the finished label off it for truthfulness. */
+  const overwrote = isCreate && output.startsWith('Updated ');
   const filePath = useMemo(() => parseJsonField(args, 'file_path'), [args]);
   const authoredContent = useMemo(() => parseJsonField(args, 'content'), [args]);
   const editArgsPreview = useMemo(() => buildEditArgsPreview(args), [args]);
@@ -145,7 +149,12 @@ export default function FileAuthoringCall({
     useToolCallState(initialProgress, isSubmitting, output, !!filePath || !!preview, onExpand);
 
   const highlighted = useLazyHighlight(preview || undefined, previewLang);
-  const Icon = isCreate ? FilePlus2 : FilePenLine;
+  const Icon = isCreate && !overwrote ? FilePlus2 : FilePenLine;
+  let finishedKey: 'com_ui_created_file' | 'com_ui_updated_file' | 'com_ui_edited_file' =
+    'com_ui_edited_file';
+  if (isCreate) {
+    finishedKey = overwrote ? 'com_ui_updated_file' : 'com_ui_created_file';
+  }
 
   return (
     <>
@@ -157,9 +166,7 @@ export default function FileAuthoringCall({
             0: fileName,
           })}
           finishedText={
-            cancelled
-              ? localize('com_ui_cancelled')
-              : localize(isCreate ? 'com_ui_created_file' : 'com_ui_edited_file', { 0: fileName })
+            cancelled ? localize('com_ui_cancelled') : localize(finishedKey, { 0: fileName })
           }
           errorSuffix={hasError && !cancelled ? localize('com_ui_tool_failed') : undefined}
           icon={

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/FileAuthoringCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/FileAuthoringCall.test.tsx
@@ -9,6 +9,7 @@ jest.mock('~/hooks', () => ({
       const translations: Record<string, string> = {
         com_ui_created_file: 'Created {{0}}',
         com_ui_creating_file: 'Creating {{0}}',
+        com_ui_updated_file: 'Updated {{0}}',
         com_ui_edited_file: 'Edited {{0}}',
         com_ui_editing_file: 'Editing {{0}}',
         com_ui_cancelled: 'Cancelled',
@@ -102,6 +103,23 @@ describe('FileAuthoringCall', () => {
     expect(screen.getByTestId('code-window-header')).toHaveAttribute('data-language', 'SKILL.md');
     expect(screen.getByText(/Large generated body stays visible/)).toBeInTheDocument();
     expect(screen.getByText('Created skills/demo/SKILL.md (4096 chars).')).toBeInTheDocument();
+  });
+
+  it('labels a create_file overwrite as Updated when the output summary says so', () => {
+    render(
+      <FileAuthoringCall
+        toolName="create_file"
+        initialProgress={1}
+        isSubmitting={false}
+        args={{
+          file_path: 'skills/demo/SKILL.md',
+          content: '# Demo\n\nRevised body.',
+        }}
+        output="Updated skills/demo/SKILL.md (8302 chars)."
+      />,
+    );
+
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Updated SKILL.md');
   });
 
   it('prefers the output diff over the args preview after edit_file completes', () => {

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -40,6 +40,14 @@ import AgentTool from './AgentTool';
 import CodeForm from './Code/Form';
 import MCPTools from './MCPTools';
 
+/** A skill lookup only counts as a confirmed miss on 404/403 — deleted or no
+ *  longer shared. Transient/network/server errors must not present a valid
+ *  configured skill as removable. */
+const isConfirmedSkillMiss = (error: unknown): boolean => {
+  const status = (error as { response?: { status?: number } } | null)?.response?.status;
+  return status === 404 || status === 403;
+};
+
 const labelClass = 'mb-2 text-token-text-primary block text-sm font-medium';
 const inputClass = cn(
   defaultTextProps,
@@ -135,7 +143,7 @@ export default function AgentConfig() {
     const map = new Map<string, { name?: string; missing: boolean }>();
     unresolvedSkillIds.forEach((skillId, index) => {
       const query = unresolvedSkillQueries[index];
-      if (query?.isError === true) {
+      if (query?.isError === true && isConfirmedSkillMiss(query.error)) {
         map.set(skillId, { missing: true });
       } else if (query?.data?.name) {
         map.set(skillId, { name: query.data.name, missing: false });

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -18,14 +18,14 @@ import {
   cn,
 } from '~/utils';
 import { ToolSelectDialog, MCPToolSelectDialog } from '~/components/Tools';
-import { SkillSelectDialog } from '~/components/Skills/dialogs';
 import useAgentCapabilities from '~/hooks/Agents/useAgentCapabilities';
+import { useListSkillsQuery, useGetAgentFiles } from '~/data-provider';
 import { useFileMapContext, useAgentPanelContext } from '~/Providers';
+import { useLocalize, useVisibleTools, useHasAccess } from '~/hooks';
+import { SkillSelectDialog } from '~/components/Skills/dialogs';
 import AgentCategorySelector from './AgentCategorySelector';
 import Action from '~/components/SidePanel/Builder/Action';
-import { useLocalize, useVisibleTools, useHasAccess } from '~/hooks';
 import { Panel, isEphemeralAgent } from '~/common';
-import { useListSkillsQuery, useGetAgentFiles } from '~/data-provider';
 import { icons } from '~/hooks/Endpoint/Icons';
 import Instructions from './Instructions';
 import AgentAvatar from './AgentAvatar';
@@ -381,15 +381,29 @@ export default function AgentConfig() {
               <div className="mb-1">
                 {(skills ?? []).map((skillId) => {
                   const skillName = skillsMap.get(skillId);
-                  if (!skillName) {
+                  /** Hide chips only while the catalog query is in flight —
+                   *  once it resolves, an unresolvable id must stay visible
+                   *  (and removable), or the allowlist silently scopes the
+                   *  agent to zero skills with no way to fix it in the UI. */
+                  if (!skillName && skillsData === undefined) {
                     return null;
                   }
+                  const isUnavailable = !skillName;
                   return (
                     <div
                       key={skillId}
                       className="mb-1 flex items-center justify-between rounded-md border border-border-light px-3 py-2 text-sm"
                     >
-                      <span className="truncate text-text-primary">{skillName}</span>
+                      <span
+                        className={
+                          isUnavailable
+                            ? 'truncate italic text-text-secondary'
+                            : 'truncate text-text-primary'
+                        }
+                        title={isUnavailable ? skillId : undefined}
+                      >
+                        {skillName ?? localize('com_ui_skill_unavailable')}
+                      </span>
                       <button
                         type="button"
                         onClick={() => {
@@ -401,7 +415,9 @@ export default function AgentConfig() {
                           );
                         }}
                         className="ml-2 flex-shrink-0 text-text-secondary transition-colors hover:text-text-primary"
-                        aria-label={localize('com_ui_remove_skill_var', { 0: skillName })}
+                        aria-label={localize('com_ui_remove_skill_var', {
+                          0: skillName ?? skillId,
+                        })}
                         disabled={skillsActive !== true}
                       >
                         <X className="h-4 w-4" aria-hidden="true" />

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { X } from 'lucide-react';
+import { useQueries } from '@tanstack/react-query';
 import { Switch, useToastContext } from '@librechat/client';
 import { Controller, useWatch, useFormContext } from 'react-hook-form';
 import {
   EModelEndpoint,
   PermissionTypes,
   Permissions,
+  QueryKeys,
+  dataService,
   getEndpointField,
 } from 'librechat-data-provider';
 import type { AgentForm, IconComponentTypes } from '~/common';
@@ -110,6 +113,36 @@ export default function AgentConfig() {
     }
     return map;
   }, [skillsData?.skills]);
+
+  /** Allowlist ids missing from the first catalog page (`limit: 100`) are
+   *  resolved individually — a cache miss alone must never present a valid
+   *  configured skill as unavailable and invite its removal. */
+  const unresolvedSkillIds = useMemo(
+    () => (skillsData === undefined ? [] : (skills ?? []).filter((id) => !skillsMap.has(id))),
+    [skills, skillsMap, skillsData],
+  );
+  const unresolvedSkillQueries = useQueries({
+    queries: unresolvedSkillIds.map((skillId) => ({
+      queryKey: [QueryKeys.skill, skillId],
+      queryFn: () => dataService.getSkill(skillId),
+      retry: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    })),
+  });
+  const unresolvedSkills = useMemo(() => {
+    const map = new Map<string, { name?: string; missing: boolean }>();
+    unresolvedSkillIds.forEach((skillId, index) => {
+      const query = unresolvedSkillQueries[index];
+      if (query?.isError === true) {
+        map.set(skillId, { missing: true });
+      } else if (query?.data?.name) {
+        map.set(skillId, { name: query.data.name, missing: false });
+      }
+    });
+    return map;
+  }, [unresolvedSkillIds, unresolvedSkillQueries]);
 
   const { data: agentFiles = [] } = useGetAgentFiles(agent_id);
 
@@ -380,12 +413,13 @@ export default function AgentConfig() {
             >
               <div className="mb-1">
                 {(skills ?? []).map((skillId) => {
-                  const skillName = skillsMap.get(skillId);
-                  /** Hide chips only while the catalog query is in flight —
-                   *  once it resolves, an unresolvable id must stay visible
-                   *  (and removable), or the allowlist silently scopes the
-                   *  agent to zero skills with no way to fix it in the UI. */
-                  if (!skillName && skillsData === undefined) {
+                  const skillName = skillsMap.get(skillId) ?? unresolvedSkills.get(skillId)?.name;
+                  /** Hide chips while the catalog page or per-id lookup is in
+                   *  flight. Once the backend confirms a miss (deleted or no
+                   *  longer shared), the id must stay visible and removable —
+                   *  otherwise the allowlist silently scopes the agent to
+                   *  zero skills with no way to fix it in the UI. */
+                  if (!skillName && unresolvedSkills.get(skillId)?.missing !== true) {
                     return null;
                   }
                   const isUnavailable = !skillName;

--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -1,7 +1,10 @@
+import { createElement } from 'react';
 import { RecoilRoot, useRecoilCallback } from 'recoil';
 import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   Constants,
+  QueryKeys,
   StepTypes,
   StepEvents,
   ContentTypes,
@@ -17,12 +20,23 @@ import type {
   SubagentUpdateEvent,
   Agents,
 } from 'librechat-data-provider';
+import type { ReactNode } from 'react';
 import { subagentProgressByToolCallId } from '~/store/subagents';
 import useStepHandler from '~/hooks/SSE/useStepHandler';
 
 /** `Constants` is a heterogeneous enum (`string | number`); annotate as
  *  `string` so the member is usable where a `string` field is expected. */
 const USE_PRELIM_RESPONSE_MESSAGE_ID: string = Constants.USE_PRELIM_RESPONSE_MESSAGE_ID;
+
+const queryClient = new QueryClient();
+/** The hook reads the React Query client (skill-authoring invalidation) and
+ *  Recoil callbacks (subagent updates), so every render needs both providers. */
+const Wrapper = ({ children }: { children?: ReactNode }) =>
+  createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    createElement(RecoilRoot, null, children),
+  );
 
 const getToolCallName = (part?: TMessageContentParts): string | undefined => {
   if (part?.type !== ContentTypes.TOOL_CALL) {
@@ -158,7 +172,7 @@ describe('useStepHandler', () => {
 
   describe('initialization', () => {
     it('should return stepHandler, clearStepMaps, and syncStepMessage functions', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       expect(typeof result.current.stepHandler).toBe('function');
       expect(typeof result.current.clearStepMaps).toBe('function');
@@ -171,7 +185,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -190,7 +204,7 @@ describe('useStepHandler', () => {
     it('should warn and return early when no responseMessageId', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep({ runId: '' });
       const submission = createSubmission();
@@ -208,7 +222,7 @@ describe('useStepHandler', () => {
       const initialResponse = createResponseMessage({ messageId: 'initial-response-id' });
       mockGetMessages.mockReturnValue([initialResponse]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep({ runId: 'USE_PRELIM_RESPONSE_MESSAGE_ID' });
       const submission = createSubmission({
@@ -226,7 +240,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -254,7 +268,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission({ initialResponse: responseMessage });
 
       const firstRunStep = createToolCallRunStep({
@@ -317,7 +331,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission({ initialResponse: responseMessage });
 
       act(() => {
@@ -391,7 +405,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValueOnce([userMessage, responseMessage]).mockReturnValueOnce([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep({
         runId: responseMessage.messageId,
@@ -426,7 +440,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const submission = createSubmission();
       const stepId = 'step-buffered';
@@ -458,7 +472,7 @@ describe('useStepHandler', () => {
       const userMsg = createUserMessage();
       mockGetMessages.mockReturnValue([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission({ userMessage: userMsg });
@@ -513,7 +527,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-login',
@@ -586,7 +600,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission({
         userMessage: pendingUser,
         messages: [rootUser, existingResponse],
@@ -687,7 +701,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission({
         userMessage: pendingUser,
         messages: [rootUser, existingResponse],
@@ -758,7 +772,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-login',
@@ -821,7 +835,7 @@ describe('useStepHandler', () => {
 
       mockGetMessages.mockReturnValue([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-login',
@@ -910,7 +924,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep({
         id: 'step-message-create',
@@ -982,7 +996,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep({
         id: 'step-message-create',
@@ -1013,7 +1027,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep({
         agentId: 'agent-1',
@@ -1042,7 +1056,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1075,7 +1089,7 @@ describe('useStepHandler', () => {
     it('should warn when no responseMessageId for agent update', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const agentUpdate: Agents.AgentUpdate = {
         type: ContentTypes.AGENT_UPDATE,
@@ -1104,7 +1118,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1133,7 +1147,7 @@ describe('useStepHandler', () => {
     });
 
     it('should buffer delta when step does not exist', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const messageDelta = createMessageDelta('nonexistent-step', 'Buffered');
       const submission = createSubmission();
@@ -1152,7 +1166,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1186,7 +1200,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1218,7 +1232,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1247,7 +1261,7 @@ describe('useStepHandler', () => {
     });
 
     it('should buffer reasoning delta when step does not exist', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const reasoningDelta = createReasoningDelta('nonexistent-step', 'Buffered');
       const submission = createSubmission();
@@ -1266,7 +1280,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1302,7 +1316,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1332,7 +1346,7 @@ describe('useStepHandler', () => {
     });
 
     it('should buffer run step delta when step does not exist', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStepDelta: Agents.RunStepDeltaEvent = {
         id: 'nonexistent-step',
@@ -1357,7 +1371,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1400,7 +1414,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1445,10 +1459,101 @@ describe('useStepHandler', () => {
       expect(toolCallContent?.tool_call?.progress).toBe(1);
     });
 
+    it('invalidates skill queries when a completed create_file call targets a skill path', () => {
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+      const responseMessage = createResponseMessage();
+      mockGetMessages.mockReturnValue([responseMessage]);
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+
+      const runStep = createToolCallRunStep();
+      const submission = createSubmission();
+
+      act(() => {
+        result.current.stepHandler({ event: StepEvents.ON_RUN_STEP, data: runStep }, submission);
+      });
+
+      const completedEvent = {
+        result: {
+          id: 'step-tool-1',
+          index: 0,
+          tool_call: {
+            id: 'tool-call-1',
+            name: 'create_file',
+            args: JSON.stringify({ file_path: 'skills/demo/SKILL.md', content: '# Demo' }),
+            output: 'Updated skills/demo/SKILL.md (6 chars).',
+            type: ToolCallTypes.TOOL_CALL,
+          },
+        },
+      };
+
+      act(() => {
+        result.current.stepHandler(
+          {
+            event: StepEvents.ON_RUN_STEP_COMPLETED,
+            data: completedEvent as { result: Agents.ToolEndEvent },
+          },
+          submission,
+        );
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: [QueryKeys.skills],
+        refetchType: 'all',
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: [QueryKeys.skill],
+        refetchType: 'all',
+      });
+      invalidateSpy.mockRestore();
+    });
+
+    it('does not invalidate skill queries for non-skill file authoring calls', () => {
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+      const responseMessage = createResponseMessage();
+      mockGetMessages.mockReturnValue([responseMessage]);
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+
+      const runStep = createToolCallRunStep();
+      const submission = createSubmission();
+
+      act(() => {
+        result.current.stepHandler({ event: StepEvents.ON_RUN_STEP, data: runStep }, submission);
+      });
+
+      const completedEvent = {
+        result: {
+          id: 'step-tool-1',
+          index: 0,
+          tool_call: {
+            id: 'tool-call-1',
+            name: 'create_file',
+            args: JSON.stringify({ file_path: '/mnt/data/report.md', content: '# Report' }),
+            output: 'Created /mnt/data/report.md (8 chars).',
+            type: ToolCallTypes.TOOL_CALL,
+          },
+        },
+      };
+
+      act(() => {
+        result.current.stepHandler(
+          {
+            event: StepEvents.ON_RUN_STEP_COMPLETED,
+            data: completedEvent as { result: Agents.ToolEndEvent },
+          },
+          submission,
+        );
+      });
+
+      expect(invalidateSpy).not.toHaveBeenCalled();
+      invalidateSpy.mockRestore();
+    });
+
     it('should warn when step not found for completed event', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const completedEvent = {
         result: {
@@ -1484,7 +1589,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-eli',
@@ -1539,7 +1644,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1572,7 +1677,7 @@ describe('useStepHandler', () => {
       });
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       act(() => {
         result.current.syncStepMessage(responseMessage);
@@ -1600,7 +1705,7 @@ describe('useStepHandler', () => {
     });
 
     it('should handle null message gracefully', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       expect(() => {
         act(() => {
@@ -1610,7 +1715,7 @@ describe('useStepHandler', () => {
     });
 
     it('should handle message without messageId gracefully', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       expect(() => {
         act(() => {
@@ -1628,7 +1733,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1646,7 +1751,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1670,7 +1775,7 @@ describe('useStepHandler', () => {
       });
       mockGetMessages.mockReturnValue([initialResponse]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep({
         runId: 'initial-response-id',
@@ -1694,7 +1799,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const submission = createSubmission();
       const stepId = 'step-multi-buffer';
@@ -1734,7 +1839,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const submission = createSubmission();
       const stepId = 'step-mixed-buffer';
@@ -1774,7 +1879,7 @@ describe('useStepHandler', () => {
       });
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       act(() => {
         result.current.syncStepMessage(responseMessage);
@@ -1816,7 +1921,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       act(() => {
@@ -1846,7 +1951,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -1905,7 +2010,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       act(() => {
@@ -1937,7 +2042,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2019,7 +2124,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2097,7 +2202,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       act(() => {
@@ -2128,7 +2233,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2203,7 +2308,7 @@ describe('useStepHandler', () => {
     it('should handle empty messages array', () => {
       mockGetMessages.mockReturnValue([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2218,7 +2323,7 @@ describe('useStepHandler', () => {
     it('should handle undefined messages from getMessages', () => {
       mockGetMessages.mockReturnValue(undefined);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2234,7 +2339,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2267,7 +2372,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2320,7 +2425,7 @@ describe('useStepHandler', () => {
           );
           return { ...stepHandler, read };
         },
-        { wrapper: RecoilRoot },
+        { wrapper: Wrapper },
       );
 
       const getProgress = (toolCallId: string): unknown =>

--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -1,10 +1,7 @@
-import { createElement } from 'react';
 import { RecoilRoot, useRecoilCallback } from 'recoil';
 import { renderHook, act } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   Constants,
-  QueryKeys,
   StepTypes,
   StepEvents,
   ContentTypes,
@@ -20,23 +17,12 @@ import type {
   SubagentUpdateEvent,
   Agents,
 } from 'librechat-data-provider';
-import type { ReactNode } from 'react';
 import { subagentProgressByToolCallId } from '~/store/subagents';
 import useStepHandler from '~/hooks/SSE/useStepHandler';
 
 /** `Constants` is a heterogeneous enum (`string | number`); annotate as
  *  `string` so the member is usable where a `string` field is expected. */
 const USE_PRELIM_RESPONSE_MESSAGE_ID: string = Constants.USE_PRELIM_RESPONSE_MESSAGE_ID;
-
-const queryClient = new QueryClient();
-/** The hook reads the React Query client (skill-authoring invalidation) and
- *  Recoil callbacks (subagent updates), so every render needs both providers. */
-const Wrapper = ({ children }: { children?: ReactNode }) =>
-  createElement(
-    QueryClientProvider,
-    { client: queryClient },
-    createElement(RecoilRoot, null, children),
-  );
 
 const getToolCallName = (part?: TMessageContentParts): string | undefined => {
   if (part?.type !== ContentTypes.TOOL_CALL) {
@@ -63,6 +49,7 @@ describe('useStepHandler', () => {
   const mockSetMessages = jest.fn();
   const mockGetMessages = jest.fn();
   const mockAnnouncePolite = jest.fn();
+  const mockOnSkillAuthoringComplete = jest.fn();
   const mockLastAnnouncementTimeRef = { current: 0 };
 
   const createHookParams = () => ({
@@ -70,6 +57,7 @@ describe('useStepHandler', () => {
     getMessages: mockGetMessages,
     announcePolite: mockAnnouncePolite,
     lastAnnouncementTimeRef: mockLastAnnouncementTimeRef,
+    onSkillAuthoringComplete: mockOnSkillAuthoringComplete,
   });
 
   const createUserMessage = (overrides: Partial<TMessage> = {}): TMessage => ({
@@ -172,7 +160,7 @@ describe('useStepHandler', () => {
 
   describe('initialization', () => {
     it('should return stepHandler, clearStepMaps, and syncStepMessage functions', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       expect(typeof result.current.stepHandler).toBe('function');
       expect(typeof result.current.clearStepMaps).toBe('function');
@@ -185,7 +173,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -204,7 +192,7 @@ describe('useStepHandler', () => {
     it('should warn and return early when no responseMessageId', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep({ runId: '' });
       const submission = createSubmission();
@@ -222,7 +210,7 @@ describe('useStepHandler', () => {
       const initialResponse = createResponseMessage({ messageId: 'initial-response-id' });
       mockGetMessages.mockReturnValue([initialResponse]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep({ runId: 'USE_PRELIM_RESPONSE_MESSAGE_ID' });
       const submission = createSubmission({
@@ -240,7 +228,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -268,7 +256,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission({ initialResponse: responseMessage });
 
       const firstRunStep = createToolCallRunStep({
@@ -331,7 +319,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission({ initialResponse: responseMessage });
 
       act(() => {
@@ -405,7 +393,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValueOnce([userMessage, responseMessage]).mockReturnValueOnce([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep({
         runId: responseMessage.messageId,
@@ -440,7 +428,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const submission = createSubmission();
       const stepId = 'step-buffered';
@@ -472,7 +460,7 @@ describe('useStepHandler', () => {
       const userMsg = createUserMessage();
       mockGetMessages.mockReturnValue([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission({ userMessage: userMsg });
@@ -527,7 +515,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-login',
@@ -600,7 +588,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission({
         userMessage: pendingUser,
         messages: [rootUser, existingResponse],
@@ -701,7 +689,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission({
         userMessage: pendingUser,
         messages: [rootUser, existingResponse],
@@ -772,7 +760,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-login',
@@ -835,7 +823,7 @@ describe('useStepHandler', () => {
 
       mockGetMessages.mockReturnValue([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-login',
@@ -924,7 +912,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep({
         id: 'step-message-create',
@@ -996,7 +984,7 @@ describe('useStepHandler', () => {
         currentMessages = messages;
       });
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep({
         id: 'step-message-create',
@@ -1027,7 +1015,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep({
         agentId: 'agent-1',
@@ -1056,7 +1044,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1089,7 +1077,7 @@ describe('useStepHandler', () => {
     it('should warn when no responseMessageId for agent update', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const agentUpdate: Agents.AgentUpdate = {
         type: ContentTypes.AGENT_UPDATE,
@@ -1118,7 +1106,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1147,7 +1135,7 @@ describe('useStepHandler', () => {
     });
 
     it('should buffer delta when step does not exist', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const messageDelta = createMessageDelta('nonexistent-step', 'Buffered');
       const submission = createSubmission();
@@ -1166,7 +1154,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1200,7 +1188,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1232,7 +1220,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1261,7 +1249,7 @@ describe('useStepHandler', () => {
     });
 
     it('should buffer reasoning delta when step does not exist', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const reasoningDelta = createReasoningDelta('nonexistent-step', 'Buffered');
       const submission = createSubmission();
@@ -1280,7 +1268,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1316,7 +1304,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1346,7 +1334,7 @@ describe('useStepHandler', () => {
     });
 
     it('should buffer run step delta when step does not exist', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStepDelta: Agents.RunStepDeltaEvent = {
         id: 'nonexistent-step',
@@ -1371,7 +1359,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1414,7 +1402,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1459,12 +1447,11 @@ describe('useStepHandler', () => {
       expect(toolCallContent?.tool_call?.progress).toBe(1);
     });
 
-    it('invalidates skill queries when a completed create_file call targets a skill path', () => {
-      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    it('signals skill authoring when a completed create_file call targets a skill path', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1497,23 +1484,14 @@ describe('useStepHandler', () => {
         );
       });
 
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: [QueryKeys.skills],
-        refetchType: 'all',
-      });
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: [QueryKeys.skill],
-        refetchType: 'all',
-      });
-      invalidateSpy.mockRestore();
+      expect(mockOnSkillAuthoringComplete).toHaveBeenCalledTimes(1);
     });
 
-    it('does not invalidate skill queries for non-skill file authoring calls', () => {
-      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    it('does not signal skill authoring for non-skill file authoring calls', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep();
       const submission = createSubmission();
@@ -1546,14 +1524,13 @@ describe('useStepHandler', () => {
         );
       });
 
-      expect(invalidateSpy).not.toHaveBeenCalled();
-      invalidateSpy.mockRestore();
+      expect(mockOnSkillAuthoringComplete).not.toHaveBeenCalled();
     });
 
     it('should warn when step not found for completed event', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const completedEvent = {
         result: {
@@ -1589,7 +1566,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createToolCallRunStep({
         id: 'step-oauth-eli',
@@ -1644,7 +1621,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1677,7 +1654,7 @@ describe('useStepHandler', () => {
       });
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       act(() => {
         result.current.syncStepMessage(responseMessage);
@@ -1705,7 +1682,7 @@ describe('useStepHandler', () => {
     });
 
     it('should handle null message gracefully', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       expect(() => {
         act(() => {
@@ -1715,7 +1692,7 @@ describe('useStepHandler', () => {
     });
 
     it('should handle message without messageId gracefully', () => {
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       expect(() => {
         act(() => {
@@ -1733,7 +1710,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1751,7 +1728,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -1775,7 +1752,7 @@ describe('useStepHandler', () => {
       });
       mockGetMessages.mockReturnValue([initialResponse]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep({
         runId: 'initial-response-id',
@@ -1799,7 +1776,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const submission = createSubmission();
       const stepId = 'step-multi-buffer';
@@ -1839,7 +1816,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const submission = createSubmission();
       const stepId = 'step-mixed-buffer';
@@ -1879,7 +1856,7 @@ describe('useStepHandler', () => {
       });
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       act(() => {
         result.current.syncStepMessage(responseMessage);
@@ -1921,7 +1898,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       act(() => {
@@ -1951,7 +1928,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2010,7 +1987,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       act(() => {
@@ -2042,7 +2019,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2124,7 +2101,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2202,7 +2179,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       act(() => {
@@ -2233,7 +2210,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
       const submission = createSubmission();
 
       const runStep = createRunStep({
@@ -2308,7 +2285,7 @@ describe('useStepHandler', () => {
     it('should handle empty messages array', () => {
       mockGetMessages.mockReturnValue([]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2323,7 +2300,7 @@ describe('useStepHandler', () => {
     it('should handle undefined messages from getMessages', () => {
       mockGetMessages.mockReturnValue(undefined);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2339,7 +2316,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2372,7 +2349,7 @@ describe('useStepHandler', () => {
       const responseMessage = createResponseMessage();
       mockGetMessages.mockReturnValue([responseMessage]);
 
-      const { result } = renderHook(() => useStepHandler(createHookParams()), { wrapper: Wrapper });
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
 
       const runStep = createRunStep();
       const submission = createSubmission();
@@ -2425,7 +2402,7 @@ describe('useStepHandler', () => {
           );
           return { ...stepHandler, read };
         },
-        { wrapper: Wrapper },
+        { wrapper: RecoilRoot },
       );
 
       const getProgress = (toolCallId: string): unknown =>

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -68,6 +68,16 @@ type TTitleEvent = {
 const hasRealTitle = (title?: string | null): title is string =>
   title != null && title !== '' && title !== 'New Chat';
 
+/** Skill caches refreshed when a chat turn authors a skill via `create_file`/`edit_file`. */
+const SKILL_QUERY_KEYS = [
+  QueryKeys.skills,
+  QueryKeys.skill,
+  QueryKeys.skillFiles,
+  QueryKeys.skillFileContent,
+  QueryKeys.skillTree,
+  QueryKeys.skillNodeContent,
+] as const;
+
 export const buildCreatedInitialResponse = ({
   initialResponse,
   userMessage,
@@ -277,12 +287,21 @@ export default function useEventHandlers({
   const { token } = useAuthContext();
 
   const { contentHandler, resetContentHandler } = useContentHandler({ setMessages, getMessages });
+  /** `refetchType: 'all'` so cached-but-unmounted skill queries refresh too —
+   *  they opt out of `refetchOnMount`, so a plain invalidation would leave
+   *  the Skills panel stale until a manual refresh. */
+  const onSkillAuthoringComplete = useCallback(() => {
+    for (const key of SKILL_QUERY_KEYS) {
+      queryClient.invalidateQueries({ queryKey: [key], refetchType: 'all' });
+    }
+  }, [queryClient]);
   const { stepHandler, clearStepMaps, resetSubagentAtoms, syncStepMessage } = useStepHandler({
     setMessages,
     getMessages,
     announcePolite,
     setIsSubmitting,
     lastAnnouncementTimeRef,
+    onSkillAuthoringComplete,
   });
   const attachmentHandler = useAttachmentHandler(queryClient);
 

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -1,9 +1,7 @@
 import { useCallback, useRef } from 'react';
 import { useRecoilCallback } from 'recoil';
-import { useQueryClient } from '@tanstack/react-query';
 import {
   Constants,
-  QueryKeys,
   StepTypes,
   StepEvents,
   ContentTypes,
@@ -38,6 +36,12 @@ type TUseStepHandler = {
   /** @deprecated - isSubmitting should be derived from submission state */
   setIsSubmitting?: SetterOrUpdater<boolean>;
   lastAnnouncementTimeRef: React.MutableRefObject<number>;
+  /**
+   * Fired when a completed `create_file`/`edit_file` call targeted a
+   * `skills/...` path. The caller owns the side effect (skill query cache
+   * invalidation) so this hook stays free of query-client coupling.
+   */
+  onSkillAuthoringComplete?: () => void;
 };
 
 type TStepEvent =
@@ -110,8 +114,8 @@ export default function useStepHandler({
   getMessages,
   announcePolite,
   lastAnnouncementTimeRef,
+  onSkillAuthoringComplete,
 }: TUseStepHandler) {
-  const queryClient = useQueryClient();
   const toolCallIdMap = useRef(new Map<string, string | undefined>());
   const messageMap = useRef(new Map<string, TMessage>());
   const stepMap = useRef(new Map<string, Agents.RunStep>());
@@ -930,19 +934,7 @@ export default function useStepHandler({
         }
 
         if (isSkillAuthoringToolCall(result.tool_call)) {
-          /** `refetchType: 'all'` so cached-but-unmounted skill queries refresh
-           *  too — they opt out of `refetchOnMount`, so a plain invalidation
-           *  would leave the Skills panel stale until a manual refresh. */
-          for (const key of [
-            QueryKeys.skills,
-            QueryKeys.skill,
-            QueryKeys.skillFiles,
-            QueryKeys.skillFileContent,
-            QueryKeys.skillTree,
-            QueryKeys.skillNodeContent,
-          ]) {
-            queryClient.invalidateQueries({ queryKey: [key], refetchType: 'all' });
-          }
+          onSkillAuthoringComplete?.();
         }
 
         const response = messageMap.current.get(responseMessageId);
@@ -1076,7 +1068,7 @@ export default function useStepHandler({
       calculateContentIndex,
       getCurrentMessages,
       applySubagentUpdate,
-      queryClient,
+      onSkillAuthoringComplete,
     ],
   );
 

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -1,7 +1,9 @@
 import { useCallback, useRef } from 'react';
 import { useRecoilCallback } from 'recoil';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   Constants,
+  QueryKeys,
   StepTypes,
   StepEvents,
   ContentTypes,
@@ -63,6 +65,34 @@ type AllContentTypes =
   | ContentTypes.SUMMARY
   | ContentTypes.ERROR;
 
+/** Mirrors `SKILL_FILE_PREFIX` in `@librechat/api` file-authoring handlers. */
+const SKILL_FILE_PREFIX = 'skills/';
+const FILE_AUTHORING_TOOLS = new Set(['create_file', 'edit_file']);
+
+/**
+ * True when a completed tool call authored a skill file (`create_file` /
+ * `edit_file` targeting a `skills/...` path). Skills created or edited
+ * mid-chat must invalidate the cached skill queries, or the Skills panel
+ * and builder keep showing the pre-authoring catalog.
+ */
+function isSkillAuthoringToolCall(toolCall?: Agents.ToolCall): boolean {
+  if (!toolCall?.name || !FILE_AUTHORING_TOOLS.has(toolCall.name)) {
+    return false;
+  }
+  const { args } = toolCall;
+  let filePath: unknown;
+  if (typeof args === 'object' && args !== null) {
+    filePath = (args as { file_path?: unknown }).file_path;
+  } else if (typeof args === 'string') {
+    try {
+      filePath = (JSON.parse(args) as { file_path?: unknown }).file_path;
+    } catch {
+      return false;
+    }
+  }
+  return typeof filePath === 'string' && filePath.startsWith(SKILL_FILE_PREFIX);
+}
+
 const isOAuthToolCallName = (name?: string) =>
   typeof name === 'string' && name.startsWith(`oauth${Constants.mcp_delimiter}`);
 
@@ -81,6 +111,7 @@ export default function useStepHandler({
   announcePolite,
   lastAnnouncementTimeRef,
 }: TUseStepHandler) {
+  const queryClient = useQueryClient();
   const toolCallIdMap = useRef(new Map<string, string | undefined>());
   const messageMap = useRef(new Map<string, TMessage>());
   const stepMap = useRef(new Map<string, Agents.RunStep>());
@@ -898,6 +929,22 @@ export default function useStepHandler({
           return;
         }
 
+        if (isSkillAuthoringToolCall(result.tool_call)) {
+          /** `refetchType: 'all'` so cached-but-unmounted skill queries refresh
+           *  too — they opt out of `refetchOnMount`, so a plain invalidation
+           *  would leave the Skills panel stale until a manual refresh. */
+          for (const key of [
+            QueryKeys.skills,
+            QueryKeys.skill,
+            QueryKeys.skillFiles,
+            QueryKeys.skillFileContent,
+            QueryKeys.skillTree,
+            QueryKeys.skillNodeContent,
+          ]) {
+            queryClient.invalidateQueries({ queryKey: [key], refetchType: 'all' });
+          }
+        }
+
         const response = messageMap.current.get(responseMessageId);
         if (response) {
           let updatedResponse = { ...response };
@@ -1029,6 +1076,7 @@ export default function useStepHandler({
       calculateContentIndex,
       getCurrentMessages,
       applySubagentUpdate,
+      queryClient,
     ],
   );
 

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1575,6 +1575,7 @@
   "com_ui_skill_sr_public": "Public skill",
   "com_ui_skill_states_limit": "You've reached the limit of {{0}} active/inactive skill overrides. Remove some overrides to toggle new skills.",
   "com_ui_skill_toggle_active": "Toggle skill active state",
+  "com_ui_skill_unavailable": "Unavailable skill",
   "com_ui_skill_update_conflict": "Another edit was saved before yours. Reloading the latest version.",
   "com_ui_skill_update_error": "Failed to save skill",
   "com_ui_skill_updated": "Skill saved",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1704,6 +1704,7 @@
   "com_ui_untitled": "Untitled",
   "com_ui_update": "Update",
   "com_ui_update_mcp_server": "Update MCP server",
+  "com_ui_updated_file": "Updated {{0}}",
   "com_ui_updating": "Updating...",
   "com_ui_upload": "Upload",
   "com_ui_upload_agent_avatar": "Successfully updated agent avatar",

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -608,7 +608,7 @@ describe('Agent Methods', () => {
       expect(updatedAgent!.skills_enabled).toBe(true);
     });
 
-    test('should heal a fully dangling allowlist to an empty array on update', async () => {
+    test('should fail closed when pruning empties the allowlist on update', async () => {
       const { agentId, authorId } = createTestIds();
       const danglingId = new mongoose.Types.ObjectId().toString();
 
@@ -624,6 +624,23 @@ describe('Agent Methods', () => {
         { id: agentId },
         { skills: [danglingId], skills_enabled: true },
       );
+
+      expect(updatedAgent!.skills).toEqual([]);
+      expect(updatedAgent!.skills_enabled).toBe(false);
+    });
+
+    test('should keep full-catalog semantics for an explicit empty allowlist on update', async () => {
+      const { agentId, authorId } = createTestIds();
+
+      await createAgent({
+        id: agentId,
+        name: 'Explicit Empty Agent',
+        provider: 'test',
+        model: 'test-model',
+        author: authorId,
+      });
+
+      const updatedAgent = await updateAgent({ id: agentId }, { skills: [], skills_enabled: true });
 
       expect(updatedAgent!.skills).toEqual([]);
       expect(updatedAgent!.skills_enabled).toBe(true);
@@ -1841,7 +1858,7 @@ describe('Agent Methods', () => {
 
       expect(revertedAgent.name).toBe('Revert Skill Agent');
       expect(revertedAgent.skills).toEqual([]);
-      expect(revertedAgent.skills_enabled).toBe(true);
+      expect(revertedAgent.skills_enabled).toBe(false);
     });
 
     test('should detect action metadata changes and force version update', async () => {

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -558,6 +558,77 @@ describe('Agent Methods', () => {
       expect(updatedAgent!.mcpServerNames).toEqual(['authorizedServer']);
     });
 
+    test('should prune nonexistent skill ids from the allowlist on create', async () => {
+      const { agentId, authorId } = createTestIds();
+      const realSkill = await mongoose.models.Skill.create({
+        name: 'create-prune-skill',
+        description: 'Skill backing the create-time allowlist pruning test.',
+        author: authorId,
+        authorName: 'Test Author',
+      });
+      const danglingId = new mongoose.Types.ObjectId().toString();
+
+      const newAgent = await createAgent({
+        id: agentId,
+        name: 'Skill Prune Agent',
+        provider: 'test',
+        model: 'test-model',
+        author: authorId,
+        skills: [realSkill._id.toString(), danglingId],
+        skills_enabled: true,
+      });
+
+      expect(newAgent.skills).toEqual([realSkill._id.toString()]);
+    });
+
+    test('should prune nonexistent skill ids from the allowlist on update', async () => {
+      const { agentId, authorId } = createTestIds();
+      const realSkill = await mongoose.models.Skill.create({
+        name: 'update-prune-skill',
+        description: 'Skill backing the update-time allowlist pruning test.',
+        author: authorId,
+        authorName: 'Test Author',
+      });
+      const danglingId = new mongoose.Types.ObjectId().toString();
+
+      await createAgent({
+        id: agentId,
+        name: 'Skill Prune Agent',
+        provider: 'test',
+        model: 'test-model',
+        author: authorId,
+      });
+
+      const updatedAgent = await updateAgent(
+        { id: agentId },
+        { skills: [danglingId, realSkill._id.toString()], skills_enabled: true },
+      );
+
+      expect(updatedAgent!.skills).toEqual([realSkill._id.toString()]);
+      expect(updatedAgent!.skills_enabled).toBe(true);
+    });
+
+    test('should heal a fully dangling allowlist to an empty array on update', async () => {
+      const { agentId, authorId } = createTestIds();
+      const danglingId = new mongoose.Types.ObjectId().toString();
+
+      await createAgent({
+        id: agentId,
+        name: 'Skill Heal Agent',
+        provider: 'test',
+        model: 'test-model',
+        author: authorId,
+      });
+
+      const updatedAgent = await updateAgent(
+        { id: agentId },
+        { skills: [danglingId], skills_enabled: true },
+      );
+
+      expect(updatedAgent!.skills).toEqual([]);
+      expect(updatedAgent!.skills_enabled).toBe(true);
+    });
+
     test('should delete an agent', async () => {
       const agentId = `agent_${uuidv4()}`;
       const authorId = new mongoose.Types.ObjectId();
@@ -3373,10 +3444,21 @@ describe('Support Contact Field', () => {
     });
 
     test('should omit skill configuration from the default list projection', async () => {
-      const targetSkillIds = [
-        new mongoose.Types.ObjectId().toString(),
-        new mongoose.Types.ObjectId().toString(),
-      ];
+      const skillDocs = await mongoose.models.Skill.create([
+        {
+          name: 'projection-skill-a',
+          description: 'Skill backing projection test.',
+          author: userA,
+          authorName: 'Test Author',
+        },
+        {
+          name: 'projection-skill-b',
+          description: 'Skill backing projection test.',
+          author: userA,
+          authorName: 'Test Author',
+        },
+      ]);
+      const targetSkillIds = skillDocs.map((doc) => doc._id.toString());
       const scopedAgent = await createAgent({
         id: `agent_${uuidv4().slice(0, 12)}`,
         name: 'Scoped Agent',
@@ -3399,10 +3481,21 @@ describe('Support Contact Field', () => {
     });
 
     test('should include skill configuration only when explicitly requested', async () => {
-      const targetSkillIds = [
-        new mongoose.Types.ObjectId().toString(),
-        new mongoose.Types.ObjectId().toString(),
-      ];
+      const skillDocs = await mongoose.models.Skill.create([
+        {
+          name: 'scoped-skill-a',
+          description: 'Skill backing inclusion test.',
+          author: userA,
+          authorName: 'Test Author',
+        },
+        {
+          name: 'scoped-skill-b',
+          description: 'Skill backing inclusion test.',
+          author: userA,
+          authorName: 'Test Author',
+        },
+      ]);
+      const targetSkillIds = skillDocs.map((doc) => doc._id.toString());
       const scopedAgent = await createAgent({
         id: `agent_${uuidv4().slice(0, 12)}`,
         name: 'Scoped Agent',

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -1812,6 +1812,38 @@ describe('Agent Methods', () => {
       expect(revertedAgent.description).toBe('Original description');
     });
 
+    test('should prune deleted skill ids when reverting to an older version', async () => {
+      const agentId = `agent_${uuidv4()}`;
+      const authorId = new mongoose.Types.ObjectId();
+      const Skill = mongoose.models.Skill;
+      const skill = await Skill.create({
+        name: 'revert-prune-skill',
+        description: 'Skill backing the revert pruning test.',
+        author: authorId,
+        authorName: 'Test Author',
+      });
+      const skillId = skill._id.toString();
+
+      await createAgent({
+        id: agentId,
+        name: 'Revert Skill Agent',
+        provider: 'test',
+        model: 'test-model',
+        author: authorId,
+        skills: [skillId],
+        skills_enabled: true,
+      });
+
+      await updateAgent({ id: agentId }, { skills: [], name: 'No Skills Anymore' });
+      await Skill.deleteOne({ _id: skill._id });
+
+      const revertedAgent = await revertAgentVersion({ id: agentId }, 0);
+
+      expect(revertedAgent.name).toBe('Revert Skill Agent');
+      expect(revertedAgent.skills).toEqual([]);
+      expect(revertedAgent.skills_enabled).toBe(true);
+    });
+
     test('should detect action metadata changes and force version update', async () => {
       const agentId = `agent_${uuidv4()}`;
       const authorId = new mongoose.Types.ObjectId();

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -332,7 +332,13 @@ export function createAgentMethods(
   async function createAgent(agentData: Record<string, unknown>): Promise<IAgent> {
     const Agent = mongoose.models.Agent as Model<IAgent>;
     if (Array.isArray(agentData.skills) && agentData.skills.length > 0) {
-      agentData.skills = await filterExistingSkillIds(mongoose, agentData.skills as string[]);
+      const prunedSkills = await filterExistingSkillIds(mongoose, agentData.skills as string[]);
+      agentData.skills = prunedSkills;
+      /** Fail closed when pruning empties a non-empty allowlist — empty +
+       *  enabled means the full catalog, and hygiene must never widen scope. */
+      if (prunedSkills.length === 0) {
+        agentData.skills_enabled = false;
+      }
     }
     const { author: _author, ...versionData } = agentData;
     const timestamp = new Date();
@@ -445,7 +451,11 @@ export function createAgentMethods(
       /** Self-heal: drop allowlist ids whose skill doc no longer exists.
        *  A dangling id keeps the allowlist non-empty while scoping the
        *  runtime catalog to an empty intersection — silently disabling
-       *  skills for the agent. */
+       *  skills for the agent. When pruning empties a non-empty allowlist,
+       *  fail closed and disable skills: empty + enabled means the full
+       *  catalog, and hygiene must never widen scope. (An explicit user
+       *  `skills: []` submission skips this branch and keeps the
+       *  full-catalog semantics.) */
       if (Array.isArray(directUpdates.skills) && directUpdates.skills.length > 0) {
         const prunedSkills = await filterExistingSkillIds(
           mongoose,
@@ -453,6 +463,10 @@ export function createAgentMethods(
         );
         directUpdates.skills = prunedSkills;
         updateData.skills = prunedSkills;
+        if (prunedSkills.length === 0) {
+          directUpdates.skills_enabled = false;
+          updateData.skills_enabled = false;
+        }
       }
 
       // Sync mcpServerNames when tools are updated
@@ -929,12 +943,17 @@ export function createAgentMethods(
 
     /** Version snapshots can predate skill deletions; restoring one verbatim
      *  would resurrect dangling allowlist ids that scope the catalog to
-     *  nothing. Same self-heal as `createAgent`/`updateAgent`. */
+     *  nothing. Same self-heal (and fail-closed-on-empty rule) as
+     *  `createAgent`/`updateAgent`. */
     if (Array.isArray(revertToVersion.skills) && revertToVersion.skills.length > 0) {
-      revertToVersion.skills = await filterExistingSkillIds(
+      const prunedSkills = await filterExistingSkillIds(
         mongoose,
         revertToVersion.skills as string[],
       );
+      revertToVersion.skills = prunedSkills;
+      if (prunedSkills.length === 0) {
+        revertToVersion.skills_enabled = false;
+      }
     }
 
     const revertedAgent = await Agent.findOneAndUpdate(searchParameter, revertToVersion, {

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -927,6 +927,16 @@ export function createAgentMethods(
     delete revertToVersion.author;
     delete revertToVersion.updatedBy;
 
+    /** Version snapshots can predate skill deletions; restoring one verbatim
+     *  would resurrect dangling allowlist ids that scope the catalog to
+     *  nothing. Same self-heal as `createAgent`/`updateAgent`. */
+    if (Array.isArray(revertToVersion.skills) && revertToVersion.skills.length > 0) {
+      revertToVersion.skills = await filterExistingSkillIds(
+        mongoose,
+        revertToVersion.skills as string[],
+      );
+    }
+
     const revertedAgent = await Agent.findOneAndUpdate(searchParameter, revertToVersion, {
       new: true,
     }).lean<IAgent>();

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -9,6 +9,7 @@ import {
 import type { AgentToolResources } from 'librechat-data-provider';
 import type { FilterQuery, Model, Types } from 'mongoose';
 import type { IAgent, IAclEntry } from '~/types';
+import { filterExistingSkillIds } from './skill';
 import logger from '~/config/winston';
 
 const { mcp_delimiter } = Constants;
@@ -330,6 +331,9 @@ export function createAgentMethods(
    */
   async function createAgent(agentData: Record<string, unknown>): Promise<IAgent> {
     const Agent = mongoose.models.Agent as Model<IAgent>;
+    if (Array.isArray(agentData.skills) && agentData.skills.length > 0) {
+      agentData.skills = await filterExistingSkillIds(mongoose, agentData.skills as string[]);
+    }
     const { author: _author, ...versionData } = agentData;
     const timestamp = new Date();
     const initialAgentData = {
@@ -437,6 +441,19 @@ export function createAgentMethods(
         ...versionData
       } = currentAgent.toObject() as unknown as Record<string, unknown>;
       const { $push, $pull, $addToSet, ...directUpdates } = updateData;
+
+      /** Self-heal: drop allowlist ids whose skill doc no longer exists.
+       *  A dangling id keeps the allowlist non-empty while scoping the
+       *  runtime catalog to an empty intersection — silently disabling
+       *  skills for the agent. */
+      if (Array.isArray(directUpdates.skills) && directUpdates.skills.length > 0) {
+        const prunedSkills = await filterExistingSkillIds(
+          mongoose,
+          directUpdates.skills as string[],
+        );
+        directUpdates.skills = prunedSkills;
+        updateData.skills = prunedSkills;
+      }
 
       // Sync mcpServerNames when tools are updated
       if ((directUpdates as Record<string, unknown>).tools !== undefined) {

--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -15,6 +15,7 @@ import {
   validateAlwaysApply,
   validateRelativePath,
   inferSkillFileCategory,
+  filterExistingSkillIds,
   deriveStructuredFrontmatterFields,
 } from './skill';
 import { createAclEntryMethods } from './aclEntry';
@@ -545,6 +546,36 @@ describe('Skill CRUD methods', () => {
     expect(res.deleted).toBe(true);
     expect(await AclEntry.countDocuments({ resourceId: skill._id })).toBe(0);
     expect(await SkillFile.countDocuments({ skillId: skill._id })).toBe(0);
+  });
+
+  it('filterExistingSkillIds matches uppercase-hex candidates and returns canonical ids', async () => {
+    const { skill } = await methods.createSkill(makeSkillInput({ name: 'case-skill' }));
+    const canonical = skill._id.toString();
+
+    const filtered = await filterExistingSkillIds(mongoose, [canonical.toUpperCase()]);
+    expect(filtered).toEqual([canonical]);
+  });
+
+  it('deleteSkill prunes agent allowlists even when skill file cleanup fails', async () => {
+    const { skill } = await methods.createSkill(makeSkillInput({ name: 'flaky-files' }));
+    const Agent = mongoose.models.Agent;
+    const agent = await Agent.create(makeAgentDoc([skill._id.toString()]));
+
+    const deleteManySpy = jest
+      .spyOn(SkillFile, 'deleteMany')
+      .mockRejectedValueOnce(new Error('transient storage failure'));
+    try {
+      await expect(methods.deleteSkill(skill._id.toString())).rejects.toThrow(
+        'transient storage failure',
+      );
+    } finally {
+      deleteManySpy.mockRestore();
+    }
+
+    const agentAfter = (await Agent.findById(agent._id).lean()) as {
+      skills?: string[];
+    } | null;
+    expect(agentAfter?.skills).toEqual([]);
   });
 
   it('deleteSkill prunes the deleted id from agent skill allowlists', async () => {

--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -107,7 +107,21 @@ afterEach(async () => {
   await Skill.deleteMany({});
   await SkillFile.deleteMany({});
   await AclEntry.deleteMany({});
+  await mongoose.models.Agent.deleteMany({});
 });
+
+function makeAgentDoc(skillIds: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    id: `agent_${new mongoose.Types.ObjectId().toString()}`,
+    name: 'Allowlist Agent',
+    provider: 'openai',
+    model: 'gpt-4',
+    author: owner._id,
+    skills: skillIds,
+    skills_enabled: true,
+    ...overrides,
+  };
+}
 
 async function grantOwner(resourceId: mongoose.Types.ObjectId | string) {
   const role = (await AccessRole.findOne({ accessRoleId: AccessRoleIds.SKILL_OWNER }).lean()) as {
@@ -531,6 +545,31 @@ describe('Skill CRUD methods', () => {
     expect(res.deleted).toBe(true);
     expect(await AclEntry.countDocuments({ resourceId: skill._id })).toBe(0);
     expect(await SkillFile.countDocuments({ skillId: skill._id })).toBe(0);
+  });
+
+  it('deleteSkill prunes the deleted id from agent skill allowlists', async () => {
+    const { skill: doomed } = await methods.createSkill(makeSkillInput({ name: 'doomed-skill' }));
+    const { skill: kept } = await methods.createSkill(makeSkillInput({ name: 'kept-skill' }));
+    const Agent = mongoose.models.Agent;
+    const scoped = await Agent.create(makeAgentDoc([doomed._id.toString(), kept._id.toString()]));
+    const untouched = await Agent.create(
+      makeAgentDoc([kept._id.toString()], { name: 'Untouched Agent' }),
+    );
+
+    const res = await methods.deleteSkill(doomed._id.toString());
+    expect(res.deleted).toBe(true);
+
+    const scopedAfter = (await Agent.findById(scoped._id).lean()) as {
+      skills?: string[];
+      skills_enabled?: boolean;
+    } | null;
+    expect(scopedAfter?.skills).toEqual([kept._id.toString()]);
+    expect(scopedAfter?.skills_enabled).toBe(true);
+
+    const untouchedAfter = (await Agent.findById(untouched._id).lean()) as {
+      skills?: string[];
+    } | null;
+    expect(untouchedAfter?.skills).toEqual([kept._id.toString()]);
   });
 
   it('findSkillBySourceIdentity searches only the requested tenant bucket', async () => {
@@ -1791,5 +1830,22 @@ describe('deleteUserSkills', () => {
     expect(deleted).toBe(1);
     expect(await Skill.countDocuments()).toBe(1);
     expect(await Skill.countDocuments({ _id: sharedId })).toBe(1);
+  });
+
+  it('prunes deleted sole-owned skill ids from agent allowlists', async () => {
+    const { skill: mine } = await methods.createSkill(makeSkillInput({ name: 'mine' }));
+    await grantOwner(mine._id);
+    const Agent = mongoose.models.Agent;
+    const agent = await Agent.create(makeAgentDoc([mine._id.toString()]));
+
+    const deleted = await methods.deleteUserSkills(owner._id as mongoose.Types.ObjectId);
+    expect(deleted).toBe(1);
+
+    const agentAfter = (await Agent.findById(agent._id).lean()) as {
+      skills?: string[];
+      skills_enabled?: boolean;
+    } | null;
+    expect(agentAfter?.skills).toEqual([]);
+    expect(agentAfter?.skills_enabled).toBe(true);
   });
 });

--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -574,8 +574,26 @@ describe('Skill CRUD methods', () => {
 
     const agentAfter = (await Agent.findById(agent._id).lean()) as {
       skills?: string[];
+      skills_enabled?: boolean;
     } | null;
     expect(agentAfter?.skills).toEqual([]);
+    expect(agentAfter?.skills_enabled).toBe(false);
+  });
+
+  it('deleteSkill disables skills when the deleted id was the entire allowlist', async () => {
+    const { skill } = await methods.createSkill(makeSkillInput({ name: 'only-skill' }));
+    const Agent = mongoose.models.Agent;
+    const agent = await Agent.create(makeAgentDoc([skill._id.toString()]));
+
+    const res = await methods.deleteSkill(skill._id.toString().toUpperCase());
+    expect(res.deleted).toBe(true);
+
+    const agentAfter = (await Agent.findById(agent._id).lean()) as {
+      skills?: string[];
+      skills_enabled?: boolean;
+    } | null;
+    expect(agentAfter?.skills).toEqual([]);
+    expect(agentAfter?.skills_enabled).toBe(false);
   });
 
   it('deleteSkill prunes the deleted id from agent skill allowlists', async () => {
@@ -1877,6 +1895,6 @@ describe('deleteUserSkills', () => {
       skills_enabled?: boolean;
     } | null;
     expect(agentAfter?.skills).toEqual([]);
-    expect(agentAfter?.skills_enabled).toBe(true);
+    expect(agentAfter?.skills_enabled).toBe(false);
   });
 });

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -1505,16 +1505,32 @@ export function createSkillMethods(
    * runtime scopes the catalog to an empty intersection and the agent silently
    * loses all skills. Direct `updateMany` on purpose: hygiene, not an authored
    * edit — no version entry, timestamps untouched.
+   *
+   * Ids are lowercased first: allowlists store canonical `_id.toString()`
+   * values, and an uppercase-but-valid id would delete the Skill doc yet
+   * leave the dangling entry behind.
+   *
+   * Agents whose ENTIRE allowlist is being deleted fail closed instead:
+   * an emptied allowlist with `skills_enabled: true` means the full
+   * accessible catalog at runtime, so a plain `$pull` would silently widen
+   * a deliberately restricted agent. Disabling skills preserves the
+   * restriction until an author makes a new explicit choice.
    */
   async function removeSkillsFromAgentAllowlists(skillIds: string[]): Promise<void> {
     if (skillIds.length === 0) {
       return;
     }
+    const ids = skillIds.map((id) => id.toLowerCase());
     const Agent = mongoose.models.Agent as Model<IAgent>;
     try {
       await Agent.updateMany(
-        { skills: { $in: skillIds } },
-        { $pull: { skills: { $in: skillIds } } },
+        { skills: { $in: ids, $not: { $elemMatch: { $nin: ids } } } },
+        { $set: { skills: [], skills_enabled: false } },
+        { timestamps: false },
+      );
+      await Agent.updateMany(
+        { skills: { $in: ids } },
+        { $pull: { skills: { $in: ids } } },
         { timestamps: false },
       );
     } catch (error) {

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -839,13 +839,19 @@ function resolveAlwaysApplyFromInput(
  * Narrows candidate skill ids to those backed by an existing Skill doc.
  * Existence-only check (no ACL) so pruning an agent allowlist never drops
  * skills the saving user merely can't view. Preserves input order, dedupes,
- * and drops malformed ids — they can't reference anything.
+ * and drops malformed ids — they can't reference anything. Candidates are
+ * lowercased before comparison: `isValidObjectIdString` accepts uppercase
+ * hex, but `_id.toString()` is always lowercase, and a casing mismatch
+ * would silently drop a valid id (and an emptied allowlist means the full
+ * catalog — the opposite of the configured scope).
  */
 export async function filterExistingSkillIds(
   mongoose: typeof import('mongoose'),
   skillIds: string[],
 ): Promise<string[]> {
-  const candidates = [...new Set(skillIds.filter(isValidObjectIdString))];
+  const candidates = [
+    ...new Set(skillIds.filter(isValidObjectIdString).map((id) => id.toLowerCase())),
+  ];
   if (candidates.length === 0) {
     return [];
   }
@@ -1530,8 +1536,11 @@ export function createSkillMethods(
     if (!res.deletedCount) {
       return { deleted: false };
     }
-    await SkillFile.deleteMany({ skillId: objectId });
+    /** Prune allowlists immediately after the Skill row is gone: if the
+     *  SkillFile cleanup below throws, a retry exits early on
+     *  `deletedCount === 0` and would never reach a later prune. */
     await removeSkillsFromAgentAllowlists([id]);
+    await SkillFile.deleteMany({ skillId: objectId });
     try {
       await deps.removeAllPermissions({ resourceType: ResourceType.SKILL, resourceId: id });
     } catch (error) {

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -16,6 +16,7 @@ import type {
   ISkillFileDocument,
   ISkillSummary,
 } from '~/types/skill';
+import type { IAgent } from '~/types/agent';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { stripYamlTrailingComment } from '~/utils/yaml';
@@ -835,6 +836,29 @@ function resolveAlwaysApplyFromInput(
 }
 
 /**
+ * Narrows candidate skill ids to those backed by an existing Skill doc.
+ * Existence-only check (no ACL) so pruning an agent allowlist never drops
+ * skills the saving user merely can't view. Preserves input order, dedupes,
+ * and drops malformed ids — they can't reference anything.
+ */
+export async function filterExistingSkillIds(
+  mongoose: typeof import('mongoose'),
+  skillIds: string[],
+): Promise<string[]> {
+  const candidates = [...new Set(skillIds.filter(isValidObjectIdString))];
+  if (candidates.length === 0) {
+    return [];
+  }
+  const Skill = mongoose.models.Skill as Model<ISkillDocument>;
+  const docs = await Skill.find(
+    { _id: { $in: candidates.map((id) => new mongoose.Types.ObjectId(id)) } },
+    { _id: 1 },
+  ).lean<Array<{ _id: Types.ObjectId }>>();
+  const existing = new Set(docs.map((doc) => doc._id.toString()));
+  return candidates.filter((id) => existing.has(id));
+}
+
+/**
  * Validate the `always-apply` value that would be derived from the
  * SKILL.md body's inline frontmatter. Only reports an issue when the
  * key is present with an unparseable value — absent / valid / empty
@@ -1469,6 +1493,32 @@ export function createSkillMethods(
     };
   }
 
+  /**
+   * Removes deleted skill ids from every agent's `skills` allowlist. A dangling
+   * id is invisible in the builder yet keeps the allowlist non-empty, so the
+   * runtime scopes the catalog to an empty intersection and the agent silently
+   * loses all skills. Direct `updateMany` on purpose: hygiene, not an authored
+   * edit — no version entry, timestamps untouched.
+   */
+  async function removeSkillsFromAgentAllowlists(skillIds: string[]): Promise<void> {
+    if (skillIds.length === 0) {
+      return;
+    }
+    const Agent = mongoose.models.Agent as Model<IAgent>;
+    try {
+      await Agent.updateMany(
+        { skills: { $in: skillIds } },
+        { $pull: { skills: { $in: skillIds } } },
+        { timestamps: false },
+      );
+    } catch (error) {
+      logger.error(
+        '[removeSkillsFromAgentAllowlists] Error pruning agent skill allowlists:',
+        error,
+      );
+    }
+  }
+
   async function deleteSkill(id: string): Promise<{ deleted: boolean }> {
     if (!isValidObjectIdString(id)) {
       return { deleted: false };
@@ -1481,6 +1531,7 @@ export function createSkillMethods(
       return { deleted: false };
     }
     await SkillFile.deleteMany({ skillId: objectId });
+    await removeSkillsFromAgentAllowlists([id]);
     try {
       await deps.removeAllPermissions({ resourceType: ResourceType.SKILL, resourceId: id });
     } catch (error) {
@@ -1499,6 +1550,7 @@ export function createSkillMethods(
     const SkillFile = mongoose.models.SkillFile as Model<ISkillFileDocument>;
     await SkillFile.deleteMany({ skillId: { $in: soleOwned } });
     const res = await Skill.deleteMany({ _id: { $in: soleOwned } });
+    await removeSkillsFromAgentAllowlists(soleOwned.map((rid) => rid.toString()));
     await Promise.allSettled(
       soleOwned.map((rid) =>
         deps


### PR DESCRIPTION
## Summary

I fixed agents losing their entire skills catalog when their `skills` allowlist contains dangling ids — ids pointing at skills that were deleted (including GitHub skill-sync mirror delete/recreate cycles, which mint new `_id`s) or are otherwise unresolvable. The allowlist stayed non-empty in Mongo while the builder rendered nothing for those entries, so the panel looked like "no skills selected" yet the runtime intersected the allowlist with the user's accessible skills down to an empty set and injected no catalog at all. This is the case #13526 didn't cover: that fix restored the full catalog for a *genuinely empty* allowlist, but a poisoned allowlist looked identical in the UI while behaving like a maximally restrictive one. I also made the client truthful about skills authored mid-chat: the cached skill queries now refresh when `create_file`/`edit_file` touches a skill, and the tool card no longer claims "Created" for an overwrite.

- Pull deleted skill ids from every agent's `skills` allowlist in `deleteSkill` and `deleteUserSkills` via a direct `Agent.updateMany` `$pull` — no version entries, timestamps untouched, so hygiene never masquerades as an authored edit. This also covers skill-sync mirror deletions and account purges, which route through the same methods.
- Prune allowlist ids with no backing Skill doc in `createAgent` and `updateAgent` (`filterExistingSkillIds`), so already-poisoned agents self-heal on their next save and duplicated agents never inherit dead references. The check is existence-only, never ACL: an editor saving an agent can't drop skills they merely lack VIEW on, and allowlists beyond the builder's 100-item catalog page are unaffected.
- Render unresolvable allowlist entries in the agent builder as visible, removable "Unavailable skill" chips (italic, with the raw id as tooltip) once the skills catalog query resolves — instead of silently hiding them with no way to remove them. Chips stay hidden while the query is still in flight to avoid a mislabeled flash.
- Invalidate all skill query caches (`skills`, `skill`, `skillFiles`, `skillFileContent`, `skillTree`, `skillNodeContent`) when a completed `create_file`/`edit_file` tool call targets a `skills/` path, so skills created or edited mid-chat appear in the Skills panel and builder without a manual refresh. Uses `refetchType: 'all'` because the skill hooks opt out of `refetchOnMount`, so a plain invalidation would leave unmounted panels stale.
- Derive the file-authoring tool card's finished label from the host-authored output summary: a `create_file` that overwrote an existing file (sandbox `overwrite: true`, or a SKILL.md update routed through skill authoring) now reads "Updated <file>" with the edit icon instead of "Created <file>".
- Add `com_ui_skill_unavailable` and `com_ui_updated_file` to the English locale.
- Cover the new behavior with tests: allowlist pruning on skill delete and user-skill purge, allowlist pruning on agent create/update, full-dangling allowlists healing to an empty array (which #13526 semantics then treat as "full accessible catalog"), skill-query invalidation on skill-path authoring calls (plus a non-skill-path negative case), and the "Updated" overwrite label.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/data-schemas && npx jest` — full suite passes (45 suites, 1621 tests), including the new `skill.spec.ts` and `agent.spec.ts` cases exercising real `mongodb-memory-server` documents.
- `cd api && npx jest server/controllers/agents/v1.spec.js` — 67 tests pass, confirming viewer skill-scope sanitization and mass-assignment protections are unaffected.
- `cd client && npx jest useStepHandler FileAuthoringCall` — 72 tests pass, including the new invalidation and overwrite-label cases.
- `cd client && npm run typecheck` — passes.
- ESLint clean on all touched files.

Manual repro: configure an agent with a skill allowlist, delete one of the listed skills, and open the agent in the builder — the dangling entry now appears as a removable "Unavailable skill" chip, and saving the agent (or the deletion itself, going forward) restores the default catalog behavior in chat. For the authoring flow: ask an agent to update an existing skill via `create_file` — the tool card reads "Updated SKILL.md" and the Skills panel reflects the change without a refresh.

### **Test Configuration**:

- Node v24, MongoDB via `mongodb-memory-server`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes