### PR TITLE
fix: bundle local tsdown paths on Windows

### DIFF
--- a/api/server/routes/__tests__/keys.spec.js
+++ b/api/server/routes/__tests__/keys.spec.js
@@ -5,6 +5,7 @@ jest.mock('~/models', () => ({
   updateUserKey: jest.fn(),
   deleteUserKey: jest.fn(),
   getUserKeyExpiry: jest.fn(),
+  getUserKeyValues: jest.fn(),
 }));
 
 jest.mock('~/server/middleware/requireJwtAuth', () => (req, res, next) => next());
@@ -15,7 +16,7 @@ jest.mock('~/server/middleware', () => ({
 
 describe('Keys Routes', () => {
   let app;
-  const { updateUserKey, deleteUserKey, getUserKeyExpiry } = require('~/models');
+  const { updateUserKey, deleteUserKey, getUserKeyExpiry, getUserKeyValues } = require('~/models');
 
   beforeAll(() => {
     const keysRouter = require('../keys');
@@ -168,6 +169,27 @@ describe('Keys Routes', () => {
       expect(getUserKeyExpiry).toHaveBeenCalledWith({
         userId: 'test-user-123',
         name: 'openAI',
+      });
+    });
+
+    it('should return saved key values when explicitly requested', async () => {
+      const mockExpiry = { expiresAt: 'never' };
+      const values = {
+        apiKey: 'sk-test-key',
+        baseURL: 'https://api.deepseek.com/anthropic',
+      };
+      getUserKeyExpiry.mockResolvedValue(mockExpiry);
+      getUserKeyValues.mockResolvedValue(values);
+
+      const response = await request(app).get(
+        '/api/keys?name=OpenAI-compatible&includeValues=true',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ...mockExpiry, values });
+      expect(getUserKeyValues).toHaveBeenCalledWith({
+        userId: 'test-user-123',
+        name: 'OpenAI-compatible',
       });
     });
   });

--- a/api/server/routes/keys.js
+++ b/api/server/routes/keys.js
@@ -1,40 +1,23 @@
 const express = require('express');
-const { updateUserKey, deleteUserKey, getUserKeyExpiry } = require('~/models');
+const { createUserKeyHandlers } = require('@librechat/api');
+const { updateUserKey, deleteUserKey, getUserKeyExpiry, getUserKeyValues } = require('~/models');
 const { requireJwtAuth } = require('~/server/middleware');
 
 const router = express.Router();
 
-router.put('/', requireJwtAuth, async (req, res) => {
-  if (req.body == null || typeof req.body !== 'object') {
-    return res.status(400).send({ error: 'Invalid request body.' });
-  }
-  const { name, value, expiresAt } = req.body;
-  await updateUserKey({ userId: req.user.id, name, value, expiresAt });
-  res.status(201).send();
+const handlers = createUserKeyHandlers({
+  updateUserKey,
+  deleteUserKey,
+  getUserKeyExpiry,
+  getUserKeyValues,
 });
 
-router.delete('/:name', requireJwtAuth, async (req, res) => {
-  const { name } = req.params;
-  await deleteUserKey({ userId: req.user.id, name });
-  res.status(204).send();
-});
+router.put('/', requireJwtAuth, handlers.update);
 
-router.delete('/', requireJwtAuth, async (req, res) => {
-  const { all } = req.query;
+router.delete('/:name', requireJwtAuth, handlers.remove);
 
-  if (all !== 'true') {
-    return res.status(400).send({ error: 'Specify either all=true to delete.' });
-  }
+router.delete('/', requireJwtAuth, handlers.removeAll);
 
-  await deleteUserKey({ userId: req.user.id, all: true });
-
-  res.status(204).send();
-});
-
-router.get('/', requireJwtAuth, async (req, res) => {
-  const { name } = req.query;
-  const response = await getUserKeyExpiry({ userId: req.user.id, name });
-  res.status(200).send(response);
-});
+router.get('/', requireJwtAuth, handlers.get);
 
 module.exports = router;

--- a/api/server/services/Config/getEndpointsConfig.js
+++ b/api/server/services/Config/getEndpointsConfig.js
@@ -5,6 +5,7 @@ const { getAppConfig } = require('./app');
 const { getEndpointsConfig, checkCapability } = createEndpointsConfigService({
   getAppConfig,
   loadDefaultEndpointsConfig,
+  includeOpenAICompatibleEndpoint: true,
 });
 
 module.exports = { getEndpointsConfig, checkCapability };

--- a/api/server/services/Config/loadConfigModels.js
+++ b/api/server/services/Config/loadConfigModels.js
@@ -1,4 +1,4 @@
-const { createLoadConfigModels, fetchModels } = require('@librechat/api');
+const { createLoadConfigModels, fetchModels, validateEndpointURL } = require('@librechat/api');
 const { getAppConfig } = require('./app');
 const db = require('~/models');
 
@@ -6,6 +6,8 @@ const loadConfigModels = createLoadConfigModels({
   getAppConfig,
   getUserKeyValues: db.getUserKeyValues,
   fetchModels,
+  validateEndpointURL,
+  includeOpenAICompatibleEndpoint: true,
 });
 
 module.exports = loadConfigModels;

--- a/client/src/components/Chat/Menus/Endpoints/DialogManager.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/DialogManager.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { EModelEndpoint, getEndpointField } from 'librechat-data-provider';
+import { getEndpointField } from 'librechat-data-provider';
+import type { TEndpointsConfig } from 'librechat-data-provider';
 import { SetKeyDialog } from '~/components/Input/SetKeyDialog';
 
 interface DialogManagerProps {
   keyDialogOpen: boolean;
-  keyDialogEndpoint?: EModelEndpoint;
+  keyDialogEndpoint?: string | null;
   onOpenChange: (open: boolean) => void;
-  endpointsConfig: Record<string, any>;
+  endpointsConfig: TEndpointsConfig;
 }
 
 const DialogManager = ({

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -154,6 +154,7 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
   const [endpointSearchValues, setEndpointSearchValues] = useState<Record<string, string>>({});
 
   const keyProps = useKeyDialog();
+  const { openKeyDialog } = keyProps;
 
   /** Memoized search results */
   const searchResults = useMemo(() => {
@@ -199,6 +200,9 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
   const handleSelectEndpoint = useCallback(
     (endpoint: Endpoint) => {
       if (!endpoint.hasModels) {
+        if (endpoint.value && endpointRequiresUserKey(endpoint.value)) {
+          openKeyDialog(endpoint.value);
+        }
         if (endpoint.value) {
           onSelectEndpoint?.(endpoint.value);
         }
@@ -209,7 +213,7 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
         });
       }
     },
-    [onSelectEndpoint],
+    [endpointRequiresUserKey, onSelectEndpoint, openKeyDialog],
   );
 
   const handleSelectModel = useCallback(

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { VisuallyHidden } from '@ariakit/react';
 import { Spinner, TooltipAnchor } from '@librechat/client';
 import { CheckCircle2, MousePointerClick, SettingsIcon } from 'lucide-react';
-import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
 import { CustomMenu as Menu, CustomMenuItem as MenuItem, CustomMenuSeparator } from '../CustomMenu';
@@ -26,7 +26,7 @@ const SettingsButton = ({
 }: {
   endpoint: Endpoint;
   className?: string;
-  handleOpenKeyDialog: (endpoint: EModelEndpoint, e: React.MouseEvent) => void;
+  handleOpenKeyDialog: (endpoint: string, e: React.MouseEvent | React.KeyboardEvent) => void;
 }) => {
   const localize = useLocalize();
   const text = localize('com_endpoint_config_key');
@@ -36,7 +36,7 @@ const SettingsButton = ({
       return;
     }
     e.stopPropagation();
-    handleOpenKeyDialog(endpoint.value as EModelEndpoint, e);
+    handleOpenKeyDialog(endpoint.value, e);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -44,7 +44,7 @@ const SettingsButton = ({
       e.preventDefault();
       e.stopPropagation();
       if (endpoint.value) {
-        handleOpenKeyDialog(endpoint.value as EModelEndpoint, e as unknown as React.MouseEvent);
+        handleOpenKeyDialog(endpoint.value, e);
       }
     }
   };

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointItem.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointItem.test.tsx
@@ -6,6 +6,7 @@ import { EndpointItem } from '../EndpointItem';
 const mockHandleSelectEndpoint = jest.fn();
 const mockHandleOpenKeyDialog = jest.fn();
 const mockSetEndpointSearchValue = jest.fn();
+const mockEndpointRequiresUserKey = jest.fn(() => false);
 
 let mockSelectedValues: SelectedValues = { endpoint: '', model: '', modelSpec: '' };
 
@@ -23,7 +24,7 @@ jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
     handleOpenKeyDialog: mockHandleOpenKeyDialog,
     handleSelectEndpoint: mockHandleSelectEndpoint,
     setEndpointSearchValue: mockSetEndpointSearchValue,
-    endpointRequiresUserKey: () => false,
+    endpointRequiresUserKey: mockEndpointRequiresUserKey,
   }),
 }));
 
@@ -35,9 +36,9 @@ jest.mock('~/components/Chat/Menus/Endpoints/CustomMenu', () => {
       React.createElement('div', null, label, children),
     CustomMenuItem: React.forwardRef(function MockMenuItem(
       { children, ...rest }: { children?: React.ReactNode },
-      ref: React.Ref<HTMLButtonElement>,
+      ref: React.Ref<HTMLDivElement>,
     ) {
-      return React.createElement('button', { ref, type: 'button', ...rest }, children);
+      return React.createElement('div', { ref, role: 'button', tabIndex: 0, ...rest }, children);
     }),
     CustomMenuSeparator: () => React.createElement('hr'),
   };
@@ -60,6 +61,7 @@ const customEndpoint: Endpoint = {
 describe('EndpointItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEndpointRequiresUserKey.mockReturnValue(false);
     mockSelectedValues = { endpoint: '', model: '', modelSpec: '' };
   });
 
@@ -76,5 +78,19 @@ describe('EndpointItem', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
 
     expect(mockHandleSelectEndpoint).toHaveBeenCalledWith(customEndpoint);
+  });
+
+  it('renders key settings for user-provided endpoints without models', () => {
+    mockEndpointRequiresUserKey.mockReturnValue(true);
+
+    render(<EndpointItem endpoint={customEndpoint} endpointIndex={0} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'com_endpoint_config_key Custom' }));
+
+    expect(mockHandleOpenKeyDialog).toHaveBeenCalledWith(
+      customEndpoint.value,
+      expect.objectContaining({ type: 'click' }),
+    );
+    expect(mockHandleSelectEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/Input/SetKeyDialog/CustomEndpoint.tsx
+++ b/client/src/components/Input/SetKeyDialog/CustomEndpoint.tsx
@@ -1,4 +1,4 @@
-import { EModelEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, openAICompatibleEndpointName } from 'librechat-data-provider';
 import { useFormContext, Controller } from 'react-hook-form';
 import InputWithLabel from './InputWithLabel';
 
@@ -10,6 +10,8 @@ const CustomEndpoint = ({
   userProvideURL?: boolean | null;
 }) => {
   const { control } = useFormContext();
+  const endpointLabel =
+    endpoint === openAICompatibleEndpointName ? openAICompatibleEndpointName : endpoint;
   return (
     <form className="flex-wrap">
       <Controller
@@ -19,7 +21,7 @@ const CustomEndpoint = ({
           <InputWithLabel
             id="apiKey"
             {...field}
-            label={`${endpoint} API Key`}
+            label={`${endpointLabel} API Key`}
             labelClassName="mb-1"
             inputClassName="mb-2"
             secret
@@ -34,7 +36,7 @@ const CustomEndpoint = ({
             <InputWithLabel
               id="baseURL"
               {...field}
-              label={`${endpoint} API URL`}
+              label={`${endpointLabel} API Base URL (/v1)`}
               labelClassName="mb-1"
             />
           )}

--- a/client/src/components/Input/SetKeyDialog/SetKeyDialog.tsx
+++ b/client/src/components/Input/SetKeyDialog/SetKeyDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { EModelEndpoint, alternateName, isAssistantsEndpoint } from 'librechat-data-provider';
 import {
@@ -22,10 +22,10 @@ import type { TDialogProps } from '~/common';
 import { useUserKey, useLocalize } from '~/hooks';
 import { NotificationSeverity } from '~/common';
 import CustomConfig from './CustomEndpoint';
+import BedrockConfig from './BedrockConfig';
 import GoogleConfig from './GoogleConfig';
 import OpenAIConfig from './OpenAIConfig';
 import OtherConfig from './OtherConfig';
-import BedrockConfig from './BedrockConfig';
 import HelpText from './HelpText';
 import { logger } from '~/utils';
 
@@ -187,18 +187,29 @@ const SetKeyDialog = ({
 
   const [userKey, setUserKey] = useState('');
   const [expiresAtLabel, setExpiresAtLabel] = useState(EXPIRY.TWELVE_HOURS.label);
-  const { getExpiry, saveUserKey } = useUserKey(endpoint);
+  const { values: savedValues, getExpiry, saveUserKey } = useUserKey(endpoint, true);
   const { showToast } = useToastContext();
   const localize = useLocalize();
 
   const expirationOptions = Object.values(EXPIRY);
   const configuredEndpoint = endpointType ?? endpoint;
 
+  useEffect(() => {
+    if (!open || !savedValues) {
+      return;
+    }
+
+    methods.reset({
+      ...methods.getValues(),
+      ...savedValues,
+    });
+  }, [methods, open, savedValues]);
+
   const handleExpirationChange = (label: string) => {
     setExpiresAtLabel(label);
   };
 
-  const submit = () => {
+  const submit = async () => {
     const selectedOption = expirationOptions.find((option) => option.label === expiresAtLabel);
     let expiresAt: number | null;
 
@@ -208,9 +219,9 @@ const SetKeyDialog = ({
       expiresAt = Date.now() + (selectedOption ? selectedOption.value : 0);
     }
 
-    const saveKey = (key: string) => {
+    const saveKey = async (key: string) => {
       try {
-        saveUserKey(key, expiresAt);
+        await saveUserKey(key, expiresAt);
         showToast({
           message: localize('com_ui_save_key_success'),
           status: NotificationSeverity.SUCCESS,
@@ -227,7 +238,7 @@ const SetKeyDialog = ({
 
     if (formSet.has(endpoint) || formSet.has(endpointType ?? '')) {
       // TODO: handle other user provided options besides baseURL and apiKey
-      methods.handleSubmit((data) => {
+      await methods.handleSubmit(async (data) => {
         const isAzure = configuredEndpoint === EModelEndpoint.azureOpenAI;
         const isBedrock = configuredEndpoint === EModelEndpoint.bedrock;
         const isOpenAIBase =
@@ -343,8 +354,7 @@ const SetKeyDialog = ({
           }
         }
 
-        saveKey(JSON.stringify(userProvidedData));
-        methods.reset();
+        await saveKey(JSON.stringify(userProvidedData));
       })();
       return;
     }
@@ -357,7 +367,7 @@ const SetKeyDialog = ({
       return;
     }
 
-    saveKey(userKey);
+    await saveKey(userKey);
     setUserKey('');
   };
 

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -9,6 +9,7 @@ import {
   ResourceType,
   EModelEndpoint,
   PermissionBits,
+  isAgentProviderAllowed,
   isAssistantsEndpoint,
 } from 'librechat-data-provider';
 import type { FieldNamesMarkedBoolean } from 'react-hook-form';
@@ -315,7 +316,11 @@ export default function AgentPanel() {
         .filter(
           (key) =>
             !isAssistantsEndpoint(key) &&
-            (allowedProviders.size > 0 ? allowedProviders.has(key) : true) &&
+            isAgentProviderAllowed({
+              provider: key,
+              allowedProviders,
+              endpointsConfig,
+            }) &&
             key !== EModelEndpoint.agents,
         )
         .map((provider) => createProviderOption(provider)),

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import keyBy from 'lodash/keyBy';
 import { ControlCombobox } from '@librechat/client';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
-import { componentMapping } from '~/components/SidePanel/Parameters/components';
 import {
   alternateName,
   getSettingsKeys,
@@ -15,6 +14,8 @@ import {
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';
+import { componentMapping } from '~/components/SidePanel/Parameters/components';
+import { SetKeyDialog } from '~/components/Input/SetKeyDialog';
 import { useGetEndpointsQuery } from '~/data-provider';
 import { useLiveAnnouncer } from '~/Providers';
 import { useLocalize } from '~/hooks';
@@ -65,6 +66,7 @@ export default function ModelPanel({
   }, [provider, models, modelsData, setValue, model]);
 
   const { data: endpointsConfig = {} } = useGetEndpointsQuery();
+  const [keyDialogOpen, setKeyDialogOpen] = useState(false);
 
   const bedrockRegions = useMemo(() => {
     return endpointsConfig?.[provider]?.availableRegions ?? [];
@@ -73,6 +75,10 @@ export default function ModelPanel({
   const endpointType = useMemo(
     () => getEndpointField(endpointsConfig, provider, 'type'),
     [provider, endpointsConfig],
+  );
+  const providerRequiresUserKey = useMemo(
+    () => !!getEndpointField(endpointsConfig, provider, 'userProvide'),
+    [endpointsConfig, provider],
   );
 
   const parameters = useMemo((): SettingDefinition[] => {
@@ -173,6 +179,17 @@ export default function ModelPanel({
             }}
           />
         </div>
+        {provider && providerRequiresUserKey && (
+          <div className="mb-4">
+            <button
+              type="button"
+              onClick={() => setKeyDialogOpen(true)}
+              className="btn btn-neutral flex w-full items-center justify-center px-4 py-2 text-sm"
+            >
+              {localize('com_endpoint_config_key')}
+            </button>
+          </div>
+        )}
         {/* Model */}
         <div className="model-panel-section mb-4">
           <label
@@ -262,6 +279,35 @@ export default function ModelPanel({
         <RotateCcw className="h-4 w-4" aria-hidden="true" />
         {localize('com_ui_reset_var', { 0: localize('com_ui_model_parameters') })}
       </button>
+      {provider && providerRequiresUserKey && (
+        <SetKeyDialog
+          open={keyDialogOpen}
+          endpoint={provider}
+          endpointType={endpointType}
+          onOpenChange={setKeyDialogOpen}
+          userProvideURL={getEndpointField(endpointsConfig, provider, 'userProvideURL')}
+          userProvideAccessKeyId={getEndpointField(
+            endpointsConfig,
+            provider,
+            'userProvideAccessKeyId',
+          )}
+          userProvideSecretAccessKey={getEndpointField(
+            endpointsConfig,
+            provider,
+            'userProvideSecretAccessKey',
+          )}
+          userProvideSessionToken={getEndpointField(
+            endpointsConfig,
+            provider,
+            'userProvideSessionToken',
+          )}
+          userProvideBearerToken={getEndpointField(
+            endpointsConfig,
+            provider,
+            'userProvideBearerToken',
+          )}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/hooks/Endpoint/useKeyDialog.ts
+++ b/client/src/hooks/Endpoint/useKeyDialog.ts
@@ -1,18 +1,21 @@
 import { useState, useCallback, useMemo } from 'react';
-import { EModelEndpoint } from 'librechat-data-provider';
 
 export const useKeyDialog = () => {
   const [keyDialogOpen, setKeyDialogOpen] = useState(false);
-  const [keyDialogEndpoint, setKeyDialogEndpoint] = useState<EModelEndpoint | null>(null);
+  const [keyDialogEndpoint, setKeyDialogEndpoint] = useState<string | null>(null);
+
+  const openKeyDialog = useCallback((ep: string) => {
+    setKeyDialogEndpoint(ep);
+    setKeyDialogOpen(true);
+  }, []);
 
   const handleOpenKeyDialog = useCallback(
-    (ep: EModelEndpoint, e: React.MouseEvent | React.KeyboardEvent) => {
+    (ep: string, e: React.MouseEvent | React.KeyboardEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setKeyDialogEndpoint(ep);
-      setKeyDialogOpen(true);
+      openKeyDialog(ep);
     },
-    [],
+    [openKeyDialog],
   );
 
   const onOpenChange = useCallback(
@@ -35,9 +38,10 @@ export const useKeyDialog = () => {
       keyDialogOpen,
       keyDialogEndpoint,
       onOpenChange,
+      openKeyDialog,
       handleOpenKeyDialog,
     }),
-    [keyDialogOpen, keyDialogEndpoint, onOpenChange, handleOpenKeyDialog],
+    [keyDialogOpen, keyDialogEndpoint, onOpenChange, openKeyDialog, handleOpenKeyDialog],
   );
 };
 

--- a/client/src/hooks/Input/useUserKey.ts
+++ b/client/src/hooks/Input/useUserKey.ts
@@ -3,7 +3,7 @@ import { EModelEndpoint } from 'librechat-data-provider';
 import { useUserKeyQuery, useUpdateUserKeysMutation } from 'librechat-data-provider/react-query';
 import { useGetEndpointsQuery } from '~/data-provider';
 
-const useUserKey = (endpoint: string) => {
+const useUserKey = (endpoint: string, includeValues = false) => {
   const { data: endpointsConfig } = useGetEndpointsQuery();
   const config = endpointsConfig?.[endpoint ?? ''];
 
@@ -15,7 +15,7 @@ const useUserKey = (endpoint: string) => {
   }
 
   const updateKey = useUpdateUserKeysMutation();
-  const checkUserKey = useUserKeyQuery(keyName);
+  const checkUserKey = useUserKeyQuery(keyName, includeValues);
 
   const getExpiry = useCallback(() => {
     if (checkUserKey.data) {
@@ -39,7 +39,7 @@ const useUserKey = (endpoint: string) => {
   const saveUserKey = useCallback(
     (userKey: string, expiresAt: number | null) => {
       const dateStr = expiresAt ? new Date(expiresAt).toISOString() : '';
-      updateKey.mutate({
+      return updateKey.mutateAsync({
         name: keyName,
         value: userKey,
         expiresAt: dateStr,
@@ -49,8 +49,8 @@ const useUserKey = (endpoint: string) => {
   );
 
   return useMemo(
-    () => ({ getExpiry, checkExpiry, saveUserKey }),
-    [getExpiry, checkExpiry, saveUserKey],
+    () => ({ values: checkUserKey.data?.values, getExpiry, checkExpiry, saveUserKey }),
+    [checkUserKey.data?.values, getExpiry, checkExpiry, saveUserKey],
   );
 };
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -416,6 +416,12 @@ endpoints:
   #   # Useful for large organizations where many department-specific skills may be available.
   #   skills:
   #     maxCatalogSkills: 20
+  #   # (optional) Restrict providers shown in the Agent Builder.
+  #   # Add "custom" to allow every OpenAI-compatible custom endpoint. This includes the built-in
+  #   # self-service "OpenAI-compatible" option and configured endpoints under `endpoints.custom`
+  #   # (for example DeepSeek, Kimi, GLM, MiniMax). To allow only one custom endpoint, list its
+  #   # exact provider name instead.
+  #   allowedProviders: ["openAI", "anthropic", "custom"]
   #   # (optional) Agent Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
   #   capabilities: ["deferred_tools", "execute_code", "file_search", "actions", "tools"]
 
@@ -487,6 +493,21 @@ endpoints:
   #     #     deploymentName: claude-3-5-haiku@20241022  # Override for this model
 
   custom:
+    # A self-service "OpenAI-compatible" provider is also available in the UI.
+    # Users can enter their own /v1 base URL and API key from the provider selector.
+    #
+    # OpenAI-compatible providers such as DeepSeek, Kimi, GLM, and MiniMax can be added here.
+    # If `endpoints.agents.allowedProviders` includes "custom", these endpoint names are available
+    # in the Agent Builder provider selector.
+    #
+    # - name: 'DeepSeek'
+    #   apiKey: '${DEEPSEEK_API_KEY}'
+    #   baseURL: '<provider OpenAI-compatible /v1 base URL>'
+    #   models:
+    #     default: ['deepseek-chat']
+    #     fetch: true
+    #   modelDisplayLabel: 'DeepSeek'
+
     # Groq Example
     - name: 'groq'
       apiKey: '${GROQ_API_KEY}'

--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -316,6 +316,45 @@ describe('initializeAgent — custom provider token lookup', () => {
     // assertion above catches the actual provider-resolution regression.
     expect(result.maxContextTokens).toBe(Math.round((65536 - 4096) * 0.95));
   });
+
+  it('allows a configured custom provider when allowedProviders contains custom', async () => {
+    const { agent, req, res, loadTools, db } = createMocks({
+      provider: CUSTOM_PROVIDER,
+      overrideProvider: Providers.OPENAI,
+      model: 'kimi-k2',
+    });
+    req.config = {
+      endpoints: {
+        custom: [
+          {
+            name: CUSTOM_PROVIDER,
+            apiKey: '${CUSTOM_API_KEY}',
+            baseURL: 'https://api.example.test/v1',
+            models: { default: ['kimi-k2'] },
+          },
+        ],
+      },
+    } as ServerRequest['config'];
+
+    await expect(
+      initializeAgent(
+        {
+          req,
+          res,
+          agent,
+          loadTools,
+          endpointOption: { endpoint: EModelEndpoint.agents },
+          allowedProviders: new Set([EModelEndpoint.custom]),
+          isInitialAgent: true,
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({
+      endpoint: CUSTOM_PROVIDER,
+      provider: Providers.OPENAI,
+      model: 'kimi-k2',
+    });
+  });
 });
 
 describe('initializeAgent — provider web_search precedence', () => {

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -8,6 +8,7 @@ import {
   EToolResources,
   paramEndpoints,
   isAgentsEndpoint,
+  isAgentProviderAllowed,
   replaceSpecialVars,
   providerEndpointMap,
 } from 'librechat-data-provider';
@@ -558,8 +559,11 @@ export async function initializeAgent(
 
   if (
     isAgentsEndpoint(endpointOption?.endpoint) &&
-    allowedProviders.size > 0 &&
-    !allowedProviders.has(agent.provider)
+    !isAgentProviderAllowed({
+      provider: agent.provider,
+      allowedProviders,
+      customEndpoints: req.config?.endpoints?.[EModelEndpoint.custom],
+    })
   ) {
     throw new Error(
       `{ "type": "${ErrorTypes.INVALID_AGENT_PROVIDER}", "info": "${agent.provider}" }`,

--- a/packages/api/src/app/config.ts
+++ b/packages/api/src/app/config.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import {
   EModelEndpoint,
+  getCustomEndpoints,
   removeNullishValues,
   normalizeEndpointName,
 } from 'librechat-data-provider';
@@ -62,7 +63,7 @@ export const getCustomEndpointConfig = ({
     throw new Error(`Config not found for the ${endpoint} custom endpoint.`);
   }
 
-  const customEndpoints = appConfig.endpoints?.[EModelEndpoint.custom] ?? [];
+  const customEndpoints = getCustomEndpoints(appConfig.endpoints?.[EModelEndpoint.custom]);
   return customEndpoints.find(
     (endpointConfig) =>
       normalizeEndpointName(endpointConfig.name) === normalizeEndpointName(endpoint),

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -4,6 +4,7 @@ import {
   AgentCapabilities,
   EModelEndpoint,
   PrincipalType,
+  openAICompatibleEndpointName,
   defaultAgentCapabilities,
 } from 'librechat-data-provider';
 
@@ -77,6 +78,22 @@ describe('createEndpointsConfigService', () => {
 
       expect(result?.[EModelEndpoint.openAI]).toBeDefined();
       expect(result?.myCustom).toBeDefined();
+    });
+
+    it('can expose the self-service OpenAI-compatible endpoint', async () => {
+      const deps = createMockDeps({
+        includeOpenAICompatibleEndpoint: true,
+      });
+      const { getEndpointsConfig } = createEndpointsConfigService(deps);
+      const result = await getEndpointsConfig(fakeReq());
+
+      expect(result?.[openAICompatibleEndpointName]).toEqual(
+        expect.objectContaining({
+          type: EModelEndpoint.custom,
+          userProvide: true,
+          userProvideURL: true,
+        }),
+      );
     });
 
     it('adds azureOpenAI when configured', async () => {

--- a/packages/api/src/endpoints/config/endpoints.ts
+++ b/packages/api/src/endpoints/config/endpoints.ts
@@ -3,7 +3,9 @@ import {
   EModelEndpoint,
   isAgentsEndpoint,
   orderEndpointsConfig,
+  openAICompatibleEndpointName,
   defaultAgentCapabilities,
+  getOpenAICompatibleEndpointConfig,
 } from 'librechat-data-provider';
 import type { AgentCapabilities, TEndpointsConfig, TConfig } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
@@ -22,6 +24,7 @@ export interface EndpointsConfigDeps {
   }) => Promise<AppConfig>;
   loadDefaultEndpointsConfig: (appConfig: AppConfig) => Promise<DefaultEndpointsResult>;
   loadCustomEndpointsConfig?: (custom: unknown) => TCustomEndpointsConfig | undefined;
+  includeOpenAICompatibleEndpoint?: boolean;
 }
 
 export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
@@ -32,6 +35,7 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
     getAppConfig,
     loadDefaultEndpointsConfig,
     loadCustomEndpointsConfig = defaultLoadCustomEndpoints,
+    includeOpenAICompatibleEndpoint = false,
   } = deps;
 
   async function getEndpointsConfig(req: ServerRequest): Promise<TEndpointsConfig> {
@@ -49,6 +53,10 @@ export function createEndpointsConfigService(deps: EndpointsConfigDeps): {
       ...defaultEndpointsConfig,
       ...customEndpointsConfig,
     };
+
+    if (includeOpenAICompatibleEndpoint && !mergedConfig[openAICompatibleEndpointName]) {
+      mergedConfig[openAICompatibleEndpointName] = getOpenAICompatibleEndpointConfig();
+    }
 
     if (appConfig.endpoints?.[EModelEndpoint.azureOpenAI]) {
       mergedConfig[EModelEndpoint.azureOpenAI] = { userProvide: false };

--- a/packages/api/src/endpoints/config/models.spec.ts
+++ b/packages/api/src/endpoints/config/models.spec.ts
@@ -1,4 +1,4 @@
-import { AuthType, EModelEndpoint } from 'librechat-data-provider';
+import { AuthType, EModelEndpoint, openAICompatibleEndpointName } from 'librechat-data-provider';
 import type { ServerRequest } from '~/types';
 import { createLoadConfigModels } from './models';
 
@@ -105,6 +105,51 @@ describe('createLoadConfigModels – user-provided baseURL header guard', () => 
         headers,
       }),
     );
+  });
+});
+
+describe('createLoadConfigModels – OpenAI-compatible self-service endpoint', () => {
+  const fetchModels = jest.fn().mockResolvedValue(['custom-model']);
+  const validateEndpointURL = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    fetchModels.mockReset().mockResolvedValue(['custom-model']);
+    validateEndpointURL.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('fetches models from the stored user-provided URL and key when enabled', async () => {
+    const loadConfigModels = createLoadConfigModels({
+      getAppConfig: jest.fn().mockResolvedValue({ endpoints: {} }),
+      getUserKeyValues: jest.fn().mockResolvedValue({
+        apiKey: 'sk-user-key',
+        baseURL: 'https://gateway.example.com/v1',
+      }),
+      fetchModels,
+      validateEndpointURL,
+      includeOpenAICompatibleEndpoint: true,
+    });
+
+    const req = {
+      user: { id: 'user-1' },
+      config: undefined,
+    } as unknown as ServerRequest;
+
+    const result = await loadConfigModels(req);
+
+    expect(validateEndpointURL).toHaveBeenCalledWith(
+      'https://gateway.example.com/v1',
+      openAICompatibleEndpointName,
+      undefined,
+    );
+    expect(fetchModels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: openAICompatibleEndpointName,
+        apiKey: 'sk-user-key',
+        baseURL: 'https://gateway.example.com/v1',
+        skipCache: true,
+      }),
+    );
+    expect(result[openAICompatibleEndpointName]).toEqual(['custom-model']);
   });
 });
 

--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -3,6 +3,7 @@ import { logger } from '@librechat/data-schemas';
 import {
   ErrorTypes,
   EModelEndpoint,
+  getCustomEndpoints,
   extractEnvVariable,
   normalizeEndpointName,
 } from 'librechat-data-provider';
@@ -47,10 +48,22 @@ export interface LoadConfigModelsDeps {
   }) => Promise<AppConfig>;
   getUserKeyValues: GetUserKeyValuesFunction;
   fetchModels?: (params: FetchModelsParams) => Promise<string[]>;
+  includeOpenAICompatibleEndpoint?: boolean;
+  validateEndpointURL?: (
+    url: string,
+    endpoint: string,
+    allowedAddresses?: string[],
+  ) => Promise<void>;
 }
 
 export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
-  const { getAppConfig, getUserKeyValues, fetchModels = defaultFetchModels } = deps;
+  const {
+    getAppConfig,
+    getUserKeyValues,
+    fetchModels = defaultFetchModels,
+    includeOpenAICompatibleEndpoint = false,
+    validateEndpointURL,
+  } = deps;
 
   return async function loadConfigModels(req: ServerRequest): Promise<TModelsConfig> {
     const appConfig =
@@ -81,11 +94,16 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
       modelsConfig[EModelEndpoint.bedrock] = bedrockConfig.models;
     }
 
-    if (!Array.isArray(appConfig.endpoints?.[EModelEndpoint.custom])) {
+    const configuredCustomEndpoints = appConfig.endpoints?.[EModelEndpoint.custom];
+    if (!includeOpenAICompatibleEndpoint && !Array.isArray(configuredCustomEndpoints)) {
       return modelsConfig;
     }
 
-    const customEndpoints = (appConfig.endpoints[EModelEndpoint.custom] as TEndpoint[]).filter(
+    const allCustomEndpoints = includeOpenAICompatibleEndpoint
+      ? getCustomEndpoints(configuredCustomEndpoints)
+      : configuredCustomEndpoints;
+
+    const customEndpoints = (allCustomEndpoints as TEndpoint[]).filter(
       (endpoint) =>
         endpoint.baseURL &&
         endpoint.apiKey &&
@@ -197,6 +215,19 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
         const resolvedBaseURL = baseURLIsUserProvided ? userKeyValues?.baseURL : BASE_URL;
 
         if (resolvedApiKey && resolvedBaseURL) {
+          if (baseURLIsUserProvided && validateEndpointURL) {
+            try {
+              await validateEndpointURL(
+                resolvedBaseURL,
+                name,
+                appConfig.endpoints?.allowedAddresses,
+              );
+            } catch (error) {
+              const msg = error instanceof Error ? error.message : String(error);
+              logger.warn(`[loadConfigModels] Invalid user-provided baseURL for "${name}": ${msg}`);
+              continue;
+            }
+          }
           const userFetchKey = `user:${req.user?.id}:${name}`;
           fetchPromisesMap[userFetchKey] =
             fetchPromisesMap[userFetchKey] ||

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -1,4 +1,5 @@
-import { AuthType, ErrorTypes } from 'librechat-data-provider';
+import { Providers } from '@librechat/agents';
+import { AuthKeys, AuthType, ErrorTypes } from 'librechat-data-provider';
 import type { BaseInitializeParams } from '~/types';
 
 const mockValidateEndpointURL = jest.fn();
@@ -12,6 +13,13 @@ const mockGetOpenAIConfig = jest.fn().mockReturnValue({
 });
 jest.mock('~/endpoints/openai/config', () => ({
   getOpenAIConfig: (...args: unknown[]) => mockGetOpenAIConfig(...args),
+}));
+
+const mockGetAnthropicLLMConfig = jest.fn().mockReturnValue({
+  llmConfig: { model: 'deepseek-v4-flash' },
+});
+jest.mock('~/endpoints/anthropic/llm', () => ({
+  getLLMConfig: (...args: unknown[]) => mockGetAnthropicLLMConfig(...args),
 }));
 
 jest.mock('~/endpoints/models', () => ({
@@ -208,6 +216,38 @@ describe('initializeCustom – SSRF guard wiring', () => {
 
     await expect(initializeCustom(params)).rejects.toThrow('targets a restricted address');
     expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('initializeCustom – Anthropic-compatible base URL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the Anthropic provider for a user-provided DeepSeek /anthropic URL', async () => {
+    const params = createParams({
+      apiKey: AuthType.USER_PROVIDED,
+      baseURL: AuthType.USER_PROVIDED,
+      userApiKey: 'sk-user-key',
+      userBaseURL: 'https://api.deepseek.com/anthropic',
+    });
+    params.model_parameters = { model: 'deepseek-v4-flash', temperature: 0.2 };
+
+    const result = await initializeCustom(params);
+
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
+    expect(mockGetAnthropicLLMConfig).toHaveBeenCalledWith(
+      { [AuthKeys.ANTHROPIC_API_KEY]: 'sk-user-key' },
+      expect.objectContaining({
+        reverseProxyUrl: 'https://api.deepseek.com/anthropic',
+        modelOptions: expect.objectContaining({
+          model: 'deepseek-v4-flash',
+          temperature: 0.2,
+          user: 'user-1',
+        }),
+      }),
+    );
+    expect(result.provider).toBe(Providers.ANTHROPIC);
   });
 });
 

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -1,4 +1,6 @@
+import { Providers } from '@librechat/agents';
 import {
+  AuthKeys,
   ErrorTypes,
   envVarRegex,
   FetchTokenConfig,
@@ -8,7 +10,9 @@ import type { TEndpoint } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { BaseInitializeParams, InitializeResultBase, EndpointTokenConfig } from '~/types';
 import { isUserProvided, checkUserKeyExpiry } from '~/utils';
+import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
+import { extractDefaultParams } from '~/endpoints/openai/llm';
 import { getCustomEndpointConfig } from '~/app/config';
 import { fetchModels } from '~/endpoints/models';
 import { validateEndpointURL } from '~/auth';
@@ -45,6 +49,23 @@ function buildCustomOptions(
   }
 
   return customOptions;
+}
+
+function isAnthropicCompatibleBaseURL(baseURL: string): boolean {
+  try {
+    const parsed = new URL(baseURL.replace(/\/+$/, ''));
+    const path = parsed.pathname.replace(/\/+$/, '').toLowerCase();
+    return /(^|\/)anthropic(\/v\d+)?$/.test(path);
+  } catch {
+    return false;
+  }
+}
+
+function applyStreamRate(options: InitializeResultBase, streamRate?: number): InitializeResultBase {
+  if (streamRate) {
+    (options.llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
+  }
+  return options;
 }
 
 /**
@@ -198,16 +219,28 @@ export async function initializeCustom({
     ...clientOptions,
   };
 
+  if (isAnthropicCompatibleBaseURL(baseURL)) {
+    const options = getAnthropicLLMConfig(
+      { [AuthKeys.ANTHROPIC_API_KEY]: apiKey },
+      {
+        modelOptions,
+        proxy: PROXY ?? undefined,
+        reverseProxyUrl: baseURL,
+        addParams: endpointConfig.addParams,
+        dropParams: endpointConfig.dropParams,
+        defaultParams: extractDefaultParams(endpointConfig.customParams?.paramDefinitions),
+      },
+    ) as InitializeResultBase;
+    options.provider = Providers.ANTHROPIC;
+    options.endpointTokenConfig = endpointTokenConfig;
+    return applyStreamRate(options, clientOptions.streamRate as number | undefined);
+  }
+
   const options = getOpenAIConfig(apiKey, finalClientOptions, endpoint);
   if (options != null) {
     (options as InitializeResultBase).useLegacyContent = true;
     (options as InitializeResultBase).endpointTokenConfig = endpointTokenConfig;
   }
 
-  const streamRate = clientOptions.streamRate as number | undefined;
-  if (streamRate) {
-    (options.llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
-  }
-
-  return options;
+  return applyStreamRate(options, clientOptions.streamRate as number | undefined);
 }

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -85,6 +85,34 @@ describe('fetchModels', () => {
     );
   });
 
+  it('falls back to the API origin models endpoint for Anthropic-compatible base URLs', async () => {
+    mockedAxios.get
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ id: 'deepseek-chat' }, { id: 'deepseek-reasoner' }],
+        },
+      });
+
+    const models = await fetchModels({
+      apiKey: 'testApiKey',
+      baseURL: 'https://api.deepseek.com/anthropic',
+      name: 'OpenAI-compatible',
+    });
+
+    expect(models).toEqual(['deepseek-chat', 'deepseek-reasoner']);
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://api.deepseek.com/anthropic/models',
+      expect.any(Object),
+    );
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://api.deepseek.com/models',
+      expect.any(Object),
+    );
+  });
+
   it('should pass custom headers to the API request', async () => {
     const customHeaders = {
       'X-Custom-Header': 'custom-value',

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -95,6 +95,57 @@ export function splitAndTrim(input: string | null | undefined): string[] {
     .filter(Boolean);
 }
 
+function getModelListURLs(baseURL: string, azure: boolean): URL[] {
+  const trimmed = baseURL.replace(/\/+$/, '');
+  const primary = new URL(`${trimmed}${azure ? '' : '/models'}`);
+  if (azure) {
+    return [primary];
+  }
+
+  const parsedBase = new URL(trimmed);
+  const normalizedPath = parsedBase.pathname.replace(/\/+$/, '').toLowerCase();
+  const isAnthropicBase = /(^|\/)anthropic(\/v\d+)?$/.test(normalizedPath);
+  if (!isAnthropicBase) {
+    return [primary];
+  }
+
+  const fallback = new URL('/models', parsedBase.origin);
+  return fallback.toString() === primary.toString() ? [primary] : [primary, fallback];
+}
+
+async function fetchModelList({
+  baseURL,
+  azure,
+  options,
+  user,
+  userIdQuery,
+}: {
+  baseURL: string;
+  azure: boolean;
+  options: {
+    headers: Record<string, string>;
+    timeout: number;
+    httpsAgent?: HttpsProxyAgent<string>;
+  };
+  user?: string;
+  userIdQuery: boolean;
+}) {
+  let lastError: unknown;
+  const urls = getModelListURLs(baseURL, azure);
+  for (const url of urls) {
+    if (user && userIdQuery) {
+      url.searchParams.set('user', user);
+    }
+    try {
+      return await axios.get(url.toString(), options);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
 /**
  * Fetches models from the specified base API path or Azure, based on the provided configuration.
  *
@@ -210,11 +261,13 @@ export async function fetchModels({
       options.headers['OpenAI-Organization'] = process.env.OPENAI_ORGANIZATION;
     }
 
-    const url = new URL(`${(baseURL ?? '').replace(/\/+$/, '')}${azure ? '' : '/models'}`);
-    if (user && userIdQuery) {
-      url.searchParams.append('user', user);
-    }
-    const res = await axios.get(url.toString(), options);
+    const res = await fetchModelList({
+      baseURL: baseURL ?? '',
+      azure,
+      options,
+      user,
+      userIdQuery,
+    });
 
     const input = res.data;
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,6 +8,7 @@ export * from './cdn';
 export * from './auth';
 /* API Keys */
 export * from './apiKeys';
+export * from './keys';
 /* MCP */
 export * from './mcp/mcpConfig';
 export * from './mcp/registry/MCPServersRegistry';

--- a/packages/api/src/keys.ts
+++ b/packages/api/src/keys.ts
@@ -1,0 +1,103 @@
+import { ErrorTypes } from 'librechat-data-provider';
+import type { Request, Response } from 'express';
+
+interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+  };
+}
+
+export interface UserKeyHandlerDependencies {
+  updateUserKey: (params: {
+    userId: string;
+    name: string;
+    value: string;
+    expiresAt?: Date | string | null;
+  }) => Promise<unknown>;
+  deleteUserKey: (params: { userId: string; name?: string; all?: boolean }) => Promise<unknown>;
+  getUserKeyExpiry: (params: {
+    userId: string;
+    name: string;
+  }) => Promise<{ expiresAt: Date | string | 'never' | null }>;
+  getUserKeyValues: (params: { userId: string; name: string }) => Promise<Record<string, string>>;
+}
+
+function readStringQuery(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function isMissingUserKey(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes(ErrorTypes.NO_USER_KEY) || msg.includes(ErrorTypes.INVALID_USER_KEY);
+}
+
+export function createUserKeyHandlers(deps: UserKeyHandlerDependencies): {
+  update: (req: AuthenticatedRequest, res: Response) => Promise<Response | undefined>;
+  remove: (req: AuthenticatedRequest, res: Response) => Promise<Response | undefined>;
+  removeAll: (req: AuthenticatedRequest, res: Response) => Promise<Response | undefined>;
+  get: (req: AuthenticatedRequest, res: Response) => Promise<Response | undefined>;
+} {
+  async function update(
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<Response | undefined> {
+    if (req.body == null || typeof req.body !== 'object') {
+      return res.status(400).send({ error: 'Invalid request body.' });
+    }
+
+    const { name, value, expiresAt } = req.body as {
+      name: string;
+      value: string;
+      expiresAt?: string;
+    };
+    await deps.updateUserKey({ userId: req.user?.id ?? '', name, value, expiresAt });
+    res.status(201).send();
+  }
+
+  async function remove(
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<Response | undefined> {
+    await deps.deleteUserKey({ userId: req.user?.id ?? '', name: req.params.name });
+    res.status(204).send();
+  }
+
+  async function removeAll(
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<Response | undefined> {
+    if (req.query.all !== 'true') {
+      return res.status(400).send({ error: 'Specify either all=true to delete.' });
+    }
+
+    await deps.deleteUserKey({ userId: req.user?.id ?? '', all: true });
+    res.status(204).send();
+  }
+
+  async function get(req: AuthenticatedRequest, res: Response): Promise<Response | undefined> {
+    const name = readStringQuery(req.query.name);
+    const includeValues = req.query.includeValues === 'true';
+    const response = await deps.getUserKeyExpiry({ userId: req.user?.id ?? '', name });
+
+    if (!includeValues || !name) {
+      return res.status(200).send(response);
+    }
+
+    try {
+      const values = await deps.getUserKeyValues({ userId: req.user?.id ?? '', name });
+      return res.status(200).send({ ...response, values });
+    } catch (error) {
+      if (!isMissingUserKey(error)) {
+        throw error;
+      }
+      return res.status(200).send(response);
+    }
+  }
+
+  return {
+    update,
+    remove,
+    removeAll,
+    get,
+  };
+}

--- a/packages/api/tsdown.config.mjs
+++ b/packages/api/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -15,6 +16,6 @@ export default defineConfig({
   // only first-party code: relative imports and the `~/*` tsconfig alias (-> src).
   // `neverBundle` is the 0.22 replacement for the deprecated `external` option.
   deps: {
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !id.startsWith('/'),
+    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !path.isAbsolute(id),
   },
 });

--- a/packages/client/tsdown.config.mjs
+++ b/packages/client/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 // Mirror the prior Rollup `@rollup/plugin-replace` substitutions: only these three are
@@ -26,7 +27,7 @@ export default defineConfig({
   // Externalize every third-party import (consumers provide the peers + react/jsx-runtime);
   // bundle only relative, `~`-aliased, and absolute sources.
   deps: {
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !id.startsWith('/'),
+    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('~') && !path.isAbsolute(id),
     onlyBundle: false,
   },
 });

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -89,7 +89,8 @@ const keysEndpoint = `${BASE_URL}/api/keys`;
 
 export const keys = () => keysEndpoint;
 
-export const userKeyQuery = (name: string) => `${keysEndpoint}?name=${name}`;
+export const userKeyQuery = (name: string, includeValues = false) =>
+  `${keysEndpoint}${buildQuery({ name, includeValues: includeValues ? true : undefined })}`;
 
 export const revokeUserKey = (name: string) => `${keysEndpoint}/${name}`;
 

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -5,6 +5,10 @@ import {
   allowedAddressesSchema,
   configSchema,
   excludedKeys,
+  getCustomEndpoints,
+  openAICompatibleEndpointName,
+  isAgentProviderAllowed,
+  isCustomEndpointName,
   resolveEndpointType,
   webSearchSchema,
 } from './config';
@@ -154,6 +158,76 @@ describe('resolveEndpointType', () => {
     it('handles undefined endpointsConfig', () => {
       expect(resolveEndpointType(undefined, 'Moonshot')).toBe('Moonshot');
     });
+  });
+});
+
+describe('isAgentProviderAllowed', () => {
+  it('allows every provider when the allowlist is empty', () => {
+    expect(
+      isAgentProviderAllowed({
+        provider: 'MiniMax',
+        allowedProviders: [],
+        endpointsConfig,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows exact custom endpoint names', () => {
+    expect(
+      isAgentProviderAllowed({
+        provider: 'Moonshot',
+        allowedProviders: ['Moonshot'],
+        endpointsConfig,
+      }),
+    ).toBe(true);
+  });
+
+  it('treats "custom" as a wildcard for configured OpenAI-compatible endpoints', () => {
+    expect(
+      isAgentProviderAllowed({
+        provider: 'Some Endpoint',
+        allowedProviders: [EModelEndpoint.custom],
+        endpointsConfig,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not allow arbitrary providers when only custom is allowed', () => {
+    expect(
+      isAgentProviderAllowed({
+        provider: 'UnknownProvider',
+        allowedProviders: [EModelEndpoint.custom],
+        endpointsConfig,
+      }),
+    ).toBe(false);
+  });
+
+  it('can resolve custom endpoint names from raw custom endpoint config', () => {
+    const customEndpoints = [
+      { name: 'Kimi', baseURL: 'https://api.moonshot.cn/v1', apiKey: '${KIMI_API_KEY}' },
+    ];
+
+    expect(isCustomEndpointName('Kimi', customEndpoints)).toBe(true);
+    expect(
+      isAgentProviderAllowed({
+        provider: 'Kimi',
+        allowedProviders: [EModelEndpoint.custom],
+        customEndpoints,
+      }),
+    ).toBe(true);
+  });
+
+  it('includes the built-in OpenAI-compatible endpoint as a custom endpoint', () => {
+    expect(isCustomEndpointName(openAICompatibleEndpointName, [])).toBe(true);
+    expect(isCustomEndpointName(openAICompatibleEndpointName, undefined)).toBe(true);
+    expect(getCustomEndpoints([])).toHaveLength(1);
+    expect(
+      isAgentProviderAllowed({
+        provider: openAICompatibleEndpointName,
+        allowedProviders: [EModelEndpoint.custom],
+        customEndpoints: undefined,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { ZodError } from 'zod';
 import type { TEndpointsConfig, TModelsConfig, TConfig } from './types';
 import {
+  AuthType,
   EModelEndpoint,
   eModelEndpointSchema,
   isAgentsEndpoint,
@@ -12,6 +13,7 @@ import { ComponentTypes, SettingTypes, OptionTypes } from './generate';
 import { specsConfigSchema, TSpecsConfig } from './models';
 import { REFILL_INTERVAL_UNITS } from './balance';
 import { fileConfigSchema } from './file-config';
+import { normalizeEndpointName } from './utils';
 import { apiBaseUrl } from './api-endpoints';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
@@ -850,6 +852,30 @@ export const endpointSchema = baseEndpointSchema.merge(
 );
 
 export type TEndpoint = z.infer<typeof endpointSchema>;
+
+export const openAICompatibleEndpointName = 'OpenAI-compatible';
+
+export function getOpenAICompatibleEndpoint(): Partial<TEndpoint> {
+  return {
+    name: openAICompatibleEndpointName,
+    apiKey: AuthType.USER_PROVIDED,
+    baseURL: AuthType.USER_PROVIDED,
+    models: {
+      default: [],
+      fetch: true,
+    },
+    modelDisplayLabel: openAICompatibleEndpointName,
+  };
+}
+
+export function getOpenAICompatibleEndpointConfig(): Partial<TConfig> {
+  return {
+    type: EModelEndpoint.custom,
+    userProvide: true,
+    userProvideURL: true,
+    modelDisplayLabel: openAICompatibleEndpointName,
+  };
+}
 
 export const azureEndpointSchema = z
   .object({
@@ -1736,6 +1762,21 @@ export const getConfigDefaults = () => getSchemaDefaults(configSchema);
 export type TCustomConfig = DeepPartial<z.infer<typeof configSchema>>;
 export type TCustomEndpoints = z.infer<typeof customEndpointsSchema>;
 
+export function getCustomEndpoints(
+  customEndpoints: TCustomEndpoints | null | undefined,
+): NonNullable<TCustomEndpoints> {
+  const endpoints = Array.isArray(customEndpoints) ? customEndpoints : [];
+  const hasOpenAICompatible = endpoints.some(
+    (endpoint) => normalizeEndpointName(endpoint.name ?? '') === openAICompatibleEndpointName,
+  );
+
+  if (hasOpenAICompatible) {
+    return endpoints;
+  }
+
+  return [...endpoints, getOpenAICompatibleEndpoint()];
+}
+
 export type TProviderSchema =
   | z.infer<typeof ttsOpenaiSchema>
   | z.infer<typeof ttsElevenLabsSchema>
@@ -1797,6 +1838,7 @@ export const alternateName = {
   [KnownEndpoints.xai]: 'xAI',
   [KnownEndpoints.vercel]: 'Vercel',
   [KnownEndpoints.helicone]: 'Helicone',
+  [openAICompatibleEndpointName]: openAICompatibleEndpointName,
 };
 
 const sharedOpenAIModels = [
@@ -2648,6 +2690,56 @@ export function getEndpointField<
     return undefined;
   }
   return config[property];
+}
+
+export function isCustomEndpointName(
+  provider: string | null | undefined,
+  customEndpoints: TCustomEndpoints | null | undefined,
+): boolean {
+  if (!provider) {
+    return false;
+  }
+
+  const normalizedProvider = normalizeEndpointName(provider);
+  return getCustomEndpoints(customEndpoints).some(
+    (endpoint) => normalizeEndpointName(endpoint.name ?? '') === normalizedProvider,
+  );
+}
+
+export function isAgentProviderAllowed({
+  provider,
+  allowedProviders,
+  endpointsConfig,
+  customEndpoints,
+}: {
+  provider: string | null | undefined;
+  allowedProviders?: ReadonlySet<string | EModelEndpoint> | readonly (string | EModelEndpoint)[];
+  endpointsConfig?: TEndpointsConfig | null;
+  customEndpoints?: TCustomEndpoints | null;
+}): boolean {
+  const allowedSet =
+    allowedProviders instanceof Set ? allowedProviders : new Set(allowedProviders ?? []);
+
+  if (allowedSet.size === 0) {
+    return true;
+  }
+
+  if (!provider) {
+    return false;
+  }
+
+  if (allowedSet.has(provider)) {
+    return true;
+  }
+
+  if (!allowedSet.has(EModelEndpoint.custom)) {
+    return false;
+  }
+
+  return (
+    getEndpointField(endpointsConfig, provider, 'type') === EModelEndpoint.custom ||
+    isCustomEndpointName(provider, customEndpoints)
+  );
 }
 
 /**

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -160,8 +160,10 @@ export const register = (payload: t.TRegisterUser) => {
   return request.post(endpoints.register(), payload);
 };
 
-export const userKeyQuery = (name: string): Promise<t.TCheckUserKeyResponse> =>
-  request.get(endpoints.userKeyQuery(name));
+export const userKeyQuery = (
+  name: string,
+  includeValues = false,
+): Promise<t.TCheckUserKeyResponse> => request.get(endpoints.userKeyQuery(name, includeValues));
 
 export const getLoginGoogle = () => {
   return request.get(endpoints.loginGoogle());

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -4,17 +4,17 @@ import type {
   UseMutationResult,
   QueryObserverResult,
 } from '@tanstack/react-query';
+import { MCPServerConnectionStatusResponse } from '../types/queries';
 import { Constants, initialModelsConfig } from '../config';
 import { defaultOrderQuery } from '../types/assistants';
-import { MCPServerConnectionStatusResponse } from '../types/queries';
+import * as permissions from '../accessPermissions';
+import { ResourceType } from '../accessPermissions';
 import * as dataService from '../data-service';
 import * as m from '../types/mutations';
 import * as q from '../types/queries';
 import { QueryKeys } from '../keys';
 import * as s from '../schemas';
 import * as t from '../types';
-import * as permissions from '../accessPermissions';
-import { ResourceType } from '../accessPermissions';
 
 export { hasPermissions } from '../accessPermissions';
 
@@ -255,22 +255,25 @@ export const useRegisterUserMutation = (
 
 export const useUserKeyQuery = (
   name: string,
+  includeValuesOrConfig?: boolean | UseQueryOptions<t.TCheckUserKeyResponse>,
   config?: UseQueryOptions<t.TCheckUserKeyResponse>,
 ): QueryObserverResult<t.TCheckUserKeyResponse> => {
+  const includeValues = typeof includeValuesOrConfig === 'boolean' ? includeValuesOrConfig : false;
+  const queryConfig = typeof includeValuesOrConfig === 'boolean' ? config : includeValuesOrConfig;
   return useQuery<t.TCheckUserKeyResponse>(
-    [QueryKeys.name, name],
+    [QueryKeys.name, name, includeValues],
     () => {
       if (!name) {
         return Promise.resolve({ expiresAt: '' });
       }
-      return dataService.userKeyQuery(name);
+      return dataService.userKeyQuery(name, includeValues);
     },
     {
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       refetchOnMount: false,
       retry: false,
-      ...config,
+      ...queryConfig,
     },
   );
 };

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -565,6 +565,7 @@ export type TRefreshTokenResponse = {
 
 export type TCheckUserKeyResponse = {
   expiresAt: string;
+  values?: Record<string, string>;
 };
 
 export type TRequestPasswordResetResponse = {

--- a/packages/data-provider/tsdown.config.mjs
+++ b/packages/data-provider/tsdown.config.mjs
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import path from 'node:path';
 import replace from '@rollup/plugin-replace';
 import { defineConfig } from 'tsdown';
 
@@ -20,7 +21,8 @@ export default defineConfig({
     // Match the prior Rollup build: bundle nothing third-party. Externalize every
     // bare import (deps, peers, and node built-ins like `crypto`); bundle only the
     // package's own relative/aliased modules.
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('/') && !id.startsWith('src/'),
+    neverBundle: (id) =>
+      !id.startsWith('.') && !path.isAbsolute(id) && !id.startsWith('src/'),
     onlyBundle: false,
   },
   plugins: [

--- a/packages/data-schemas/tsdown.config.mjs
+++ b/packages/data-schemas/tsdown.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -16,7 +17,7 @@ export default defineConfig({
       !id.startsWith('dotenv/') &&
       !id.startsWith('.') &&
       !id.startsWith('~') &&
-      !id.startsWith('/'),
+      !path.isAbsolute(id),
     // dotenv is bundled on purpose, so silence the "detected dependencies in bundle" hint.
     onlyBundle: false,
   },

--- a/初版判定.md
+++ b/初版判定.md
@@ -1,0 +1,252 @@
+# LibreChat 初版判定
+
+## 结论摘要
+
+- LibreChat 是一个 Agent 应用平台，不只是普通聊天 UI。
+- 支持 K8s Pod 部署，也支持横向扩缩容，但默认部署不等于完全无状态生产部署。
+- 要实现可靠、稳定、流畅的多 Pod 生产部署，需要外置 MongoDB、Redis、对象存储、MeiliSearch、RAG/向量库、Code API 沙箱等状态组件。
+- Agent 能力支持 Skills、工具调用、MCP、文件检索、Web Search、代码执行；但 Bash/文件读写依赖外部 Code API 沙箱。
+- 飞书 SSO 可通过标准 OpenID Connect 或 SAML 低成本接入；如果是飞书专有 OAuth、免登、组织架构/角色同步，需要自定义扩展。
+- 5000 人同时在线在架构上可以支撑，但不能仅靠默认 Helm 配置承诺，需要容量规划、Redis、对象存储、外部沙箱池、LLM/API 配额和压测验证。
+
+## 1. 是否是 Agent
+
+判定：是 Agent 平台。
+
+LibreChat 当前代码中已经包含 Agents endpoint、Agent schema、tools、skills、subagents、MCP/actions 等能力。它不是单纯的 Chat UI，而是一个以 Agent 为核心的应用平台。
+
+关键依据：
+
+- Agent 能力枚举包含 `execute_code`、`file_search`、`web_search`、`subagents`、`actions`、`skills`、`tools`：`packages/data-provider/src/config.ts:562`
+- 默认 Agent capabilities 包含 `execute_code`、`file_search`、`web_search`、`subagents`、`skills`、`tools`：`packages/data-provider/src/config.ts:669`
+- Agent schema 持久化 `tools`、`skills`、`actions`、`tool_resources`、`subagents` 等字段：`packages/data-schemas/src/schema/agent.ts:43`
+- Runtime 初始化时会按 endpoint capabilities 判断 Skills、Code Env 等能力是否开启：`api/server/services/Endpoints/agents/initialize.js:144`
+
+能力边界：
+
+- `execute_code` 会注册/展开为 `bash_tool`、`read_file` 等运行时工具：`packages/api/src/agents/tools.ts:397`
+- `read_file` 面向代码执行沙箱中的文本文件，例如 `/mnt/data/...`：`packages/api/src/agents/tools.ts:136`
+- `create_file`、`edit_file` 支持在代码执行沙箱或 Skills 文件空间读写文件：`packages/api/src/agents/tools.ts:159`
+- Web 能力是 `web_search` 搜索/抓取能力，不等同于默认内置 Playwright/Chrome 级别的真实浏览器自动化。
+
+结论：
+
+- Agent：支持。
+- Bash：支持，但依赖外部 Code API 沙箱。
+- 读写文件：支持，主要在沙箱/技能文件体系内。
+- Web 查询：支持 Web Search；真实浏览器自动化需要通过 MCP/custom tool 扩展。
+
+## 2. Skills 集成与服务端一键安装
+
+判定：Skills 支持；HTTP 导入支持；通用服务端 HTTP/CLI 一键安装需要自定义扩展。
+
+已有能力：
+
+- Deployment Skills：服务启动时从 `skill/<name>/SKILL.md` 只读加载，对启用 Skills 的用户可见：`skill/README.md:14`
+- 环境变量可配置 deployment skills 目录：`.env.example:111`
+- 服务启动时初始化 deployment skills：`api/server/index.js:124`
+- 服务启动时初始化 GitHub skill sync：`api/server/index.js:125`
+- HTTP API 支持 Skills CRUD、导入、文件上传/下载/删除：`api/server/routes/skills.js:298`
+- 导入接口支持 `.md`、`.zip`、`.skill`：`packages/api/src/skills/import.ts:160`
+- Admin 侧有 GitHub 同步状态、手动 run、凭据管理接口：`api/server/routes/admin/skills.js:32`
+
+边界：
+
+- 当前没有看到类似“技能市场一键安装到服务端”的通用 CLI/HTTP 安装器。
+- 现有 HTTP 能力更接近“上传导入 `.md/.zip/.skill`”。
+- GitHub sync 可以同步 Skills，但不是通用 marketplace-style 一键安装。
+
+结论：
+
+- Skills 基础能力：支持。
+- HTTP 上传导入：支持。
+- 服务端通用一键安装、CLI installer、技能市场：需要自定义扩展，或基于现有导入/GitHub sync 封装。
+
+## 3. 飞书 SSO 登录
+
+判定：标准 OIDC/SAML 可接入；飞书专有能力需要自定义扩展。
+
+已有能力：
+
+- OpenID Connect 在环境变量完整时启用：`api/server/socialLogins.js:101`
+- SAML 在环境变量完整时启用：`api/server/socialLogins.js:110`
+- OpenID 路由包括 `/oauth/openid` 和 `/oauth/openid/callback`：`api/server/routes/oauth.js:116`
+- SAML 路由包括 `/oauth/saml` 和 `/oauth/saml/callback`：`api/server/routes/oauth.js:204`
+- OpenID 使用 issuer discovery、client id/secret 或 PKCE、scope、callback URL 建立 Passport strategy：`api/strategies/openidStrategy.js:924`
+- SAML 使用 `SAML_ENTRY_POINT`、`SAML_ISSUER`、`SAML_CERT`、callback URL 建立 Passport strategy：`api/strategies/samlStrategy.js:313`
+- `.env.example` 已提供 OpenID role sync、claim 映射、PKCE、SAML claim 映射等配置项：`.env.example:612`
+
+改造成本判断：
+
+- 如果飞书按标准 OIDC/SAML 作为 IdP 接入：低成本，主要是配置、回调地址、claims 映射和测试，约 0.5-2 人天。
+- 如果要自定义飞书 OAuth 登录：中等成本，需要新增 strategy、路由、环境变量、前端按钮、用户映射和测试，约 3-7 人天。
+- 如果要同步飞书组织架构、部门、角色、租户、权限：较高成本，属于 IAM 集成，约 1-3 周，取决于范围。
+
+结论：
+
+- 飞书标准 SSO：支持。
+- 飞书专有登录/组织架构/角色同步：需要自定义扩展。
+
+## 4. K8s Pod 无状态部署
+
+判定：架构支持无状态化，但默认配置不完全无状态。
+
+K8s 支持情况：
+
+- Helm chart 使用 Kubernetes Deployment：`helm/librechat/templates/deployment.yaml:2`
+- 副本数通过 `replicaCount` 控制：`helm/librechat/templates/deployment.yaml:15`
+- HPA 模板存在，但默认关闭：`helm/librechat/values.yaml:214`
+- 配置通过 ConfigMap/env/Secret 注入：`helm/librechat/templates/configmap-env.yaml:15`
+- `librechat.yaml` 可通过 ConfigMap 只读挂载：`helm/librechat/templates/deployment.yaml:85`
+
+状态存储位置：
+
+| 类型 | 存储位置 |
+| --- | --- |
+| 用户信息、账号、SSO 绑定 | MongoDB，`User` schema，含 email、openidId、samlId、tenantId 等 |
+| 登录 session / refresh token | MongoDB session/user refreshToken；OpenID/SAML 临时 session 可走 Redis |
+| 会话和消息 | MongoDB，`Conversation` / `Message` schema，带 tenantId |
+| Agent 配置 | MongoDB，`Agent` schema |
+| Skills | 普通 Skills 在 MongoDB + 文件存储；Deployment Skills 启动只读加载 |
+| MCP Server 配置 | MongoDB，`MCPServer` schema |
+| 应用配置覆盖 | MongoDB `Config` schema，按 principal/tenant 存储 |
+| 文件元数据 | MongoDB `File` schema |
+| 文件内容 | local/S3/Firebase/Azure/CloudFront，生产建议对象存储 |
+| 搜索索引 | MeiliSearch |
+| RAG / 向量 | RAG API + pgvector/vector DB |
+| 缓存、限流、OAuth flow、流式响应状态 | Redis，生产多 Pod 建议必须启用 |
+| 代码执行工作区 | 外部 Code API 沙箱 |
+
+无状态化关键点：
+
+- MongoDB 必须外置。
+- Redis 必须外置并启用，避免缓存、session、stream job 落到单 Pod 内存。
+- 文件存储应使用 S3/Azure/Firebase/CloudFront，或使用真正可多副本共享的 RWX 存储。
+- Code API 沙箱应独立部署和扩容，不应把 bash 执行放在 LibreChat API Pod 内。
+- MeiliSearch、RAG API、向量库等也应作为独立服务运行。
+
+默认配置风险：
+
+- Helm 默认 `imageVolume` 使用 PVC，并挂载到 `/app/client/public/images`：`helm/librechat/values.yaml:112`
+- 默认 access mode 是 `ReadWriteOnce`，多副本下不适合作为共享写入卷：`helm/librechat/values.yaml:115`
+- 文件策略如果不显式配置，默认可能走 local：`librechat.example.yaml:21`
+- Redis 默认关闭：`helm/librechat/values.yaml:324`
+- Redis 未启用时 session/cache/stream 可能回退到内存：`packages/api/src/cache/cacheFactory.ts:123`
+
+结论：
+
+- 支持 K8s Pod 无状态部署。
+- 默认部署不应直接视为生产级无状态。
+- 要支撑多副本和高并发，必须外置状态组件。
+
+## 5. 多用户隔离与沙箱安全
+
+判定：应用数据层支持用户/租户/ACL 隔离；代码执行沙箱依赖外部 Code API。
+
+应用数据隔离：
+
+- 鉴权后会把 tenant context 注入 AsyncLocalStorage：`api/server/middleware/requireJwtAuth.js:153`
+- tenant middleware strict 模式下没有 tenantId 会 403：`packages/api/src/middleware/tenant.ts:138`
+- Mongoose tenant isolation 会把 tenantId 注入查询：`packages/data-schemas/src/models/plugins/tenantIsolation.ts:80`
+- 会话、消息、文件、Skills schema 都有 tenantId 字段/索引：`packages/data-schemas/src/schema/convo.ts:48`、`packages/data-schemas/src/schema/message.ts:174`、`packages/data-schemas/src/schema/file.ts:146`、`packages/data-schemas/src/schema/skill.ts:218`
+- 文件访问会拒绝跨 tenant 文件：`api/server/middleware/accessResources/fileAccess.js:106`
+
+代码执行隔离：
+
+- Code API 文件/session 按 `kind: skill | agent | user`、`id`、`version` 等 resource identity 分桶：`api/server/services/Files/Code/crud.js:205`
+- 用户代码输出是 user-private：`api/server/services/Files/Code/process.js:380`
+- Skill 文件上传到 code env 时标记为只读：`packages/api/src/agents/skillFiles.ts:215`
+- Code API base URL 来自 `LIBRECHAT_CODE_BASEURL`，bash/读写沙箱文件依赖该服务：`api/server/services/Endpoints/agents/skillDeps.js:350`
+
+边界：
+
+- 不是每个用户一个 LibreChat API Pod。
+- 不是在 API Pod 本地目录做用户隔离。
+- Bash 执行隔离的安全性取决于外部 Code API 的容器隔离、网络隔离、资源限制、文件系统生命周期和对象存储权限。
+
+结论：
+
+- 用户/租户数据隔离：支持。
+- 文件访问隔离：支持。
+- Bash/代码执行沙箱隔离：依赖外部 Code API，需要单独审计和生产加固。
+
+## 6. 5000 人同时在线
+
+判定：架构上可做，但默认部署不能直接承诺。
+
+不同场景判断：
+
+- 5000 人在线但大部分空闲：通过多副本 API Pod、Redis、外部 MongoDB、对象存储、Ingress/LB，架构上可支撑。
+- 5000 人同时发消息并保持流式输出：压力显著增加，瓶颈包括 SSE/stream 连接、LLM API 配额、MongoDB 写入、Redis、网络带宽。
+- 5000 人同时跑 Agent + bash + 文件 + web_search：瓶颈主要转移到 Code API 沙箱池、LLM provider、搜索 provider、对象存储和队列/限流系统。
+
+已有并发控制：
+
+- 默认限制并发消息：`LIMIT_CONCURRENT_MESSAGES=true`：`.env.example:539`
+- 默认单用户并发消息上限是 `CONCURRENT_MESSAGE_MAX=2`：`.env.example:540`
+- Redis 可用于原子并发计数，避免多 Pod race：`packages/api/src/middleware/concurrency.ts:117`
+
+5000 在线所需条件：
+
+- API Pod 多副本 + HPA。
+- Redis 必须启用，承载 cache、session、OAuth flow、resumable stream job、并发控制。
+- MongoDB 使用高可用集群并按读写量调优。
+- 文件存储使用对象存储或共享存储，避免本地卷。
+- Code API 沙箱池独立扩容，并设置 CPU/内存/超时/网络策略。
+- LLM provider、Web Search provider、RAG/向量库都有足够配额。
+- 需要压测验证目标并发、平均响应时间、P95/P99、错误率、资源成本。
+
+结论：
+
+- 5000 在线：可以作为目标架构支撑。
+- 5000 并发 Agent 执行：需要专项容量设计和压测，不能默认承诺。
+- “无限横向扩容”：不成立，外部依赖和配额会成为上限。
+
+## 7. 架构设计概览
+
+整体链路：
+
+```text
+Browser / React SPA
+  -> LibreChat Express API Pod(s)
+  -> packages/api business services
+  -> MongoDB / Redis / MeiliSearch / RAG API / Object Storage / LLM Providers
+  -> MCP Servers / Actions / Code API Sandbox
+```
+
+核心模块：
+
+- `client`：React SPA。
+- `api`：Express server，处理认证、路由、流式响应、文件接口、Agent endpoint。
+- `packages/api`：新的后端 TypeScript 业务逻辑，包括 Skills、tenant、cache、stream、agents 工具辅助等。
+- `packages/data-schemas`：MongoDB schema/model。
+- `packages/data-provider`：前后端共享 API endpoint、类型、配置 schema。
+- `@librechat/agents`：Agent runtime、工具执行、代码执行工具定义等。
+
+生产部署建议架构：
+
+```text
+Ingress / Load Balancer
+  -> LibreChat API Pods, stateless
+      -> MongoDB Replica Set / Atlas
+      -> Redis / Redis Cluster
+      -> S3 or Azure Blob or Firebase or CloudFront
+      -> MeiliSearch
+      -> RAG API + Vector DB
+      -> Code API Sandbox Pool
+      -> LLM Providers
+      -> MCP Servers / Internal Tools
+```
+
+## 8. 最终判定
+
+围绕关注点的最终判断：
+
+1. 使用体验可靠、稳定、流畅
+   可以做到，但依赖生产化配置、外置状态服务、限流、监控、压测和容量规划。默认单 Pod/local 文件/无 Redis 不适合大规模生产。
+
+2. 本身是 Agent，可以执行 bash、查询浏览器、读写文件
+   是 Agent 平台。Bash/文件读写支持但依赖 Code API 沙箱；Web Search 支持；真实浏览器自动化需要通过 MCP/custom tool 扩展。
+
+3. 支持 K8s Pod 无状态部署，能支撑 5000 人同时在线
+   支持无状态化部署和横向扩容，但必须外置 MongoDB、Redis、对象存储、MeiliSearch、RAG/向量库、Code API 沙箱池等。5000 在线可作为目标架构支撑；5000 并发 Agent 执行需要专项压测，不能默认承诺。


### PR DESCRIPTION
## Summary
- use `path.isAbsolute` in tsdown dependency externalization checks
- keep Windows absolute source paths bundled for local workspace packages
- fix generated dist files retaining unresolved `./*.ts` imports on Windows

## Testing
- `npm run build:packages`
- `node -e "require('librechat-data-provider'); require('librechat-data-provider/react-query'); require('@librechat/data-schemas'); require('@librechat/api'); require('@librechat/client'); console.log('ok')"`
- `npm run frontend`
- `npm run backend` and checked `http://localhost:3080/`, `/login`, `/api/config`