### PR TITLE
🎒 fix: Apply OCR Context to Responses API Agents and Handoffs

### DIFF
--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -54,6 +54,9 @@ const mockCanAuthorSkillFiles = jest.fn(
     scopedEditableSkillIds.length > 0 || skillCreateAllowed === true,
 );
 const mockGetSkillToolDeps = jest.fn(() => ({}));
+const mockBuildAgentScopedContext = jest.fn().mockResolvedValue(new Map());
+const mockBuildAgentContextAttachmentsByAgentId = jest.fn().mockReturnValue(new Map());
+const mockApplyContextToAgent = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('nanoid', () => ({
   nanoid: jest.fn(() => 'mock-nanoid-123'),
@@ -84,7 +87,11 @@ jest.mock('@librechat/api', () => ({
   createRun: jest.fn().mockResolvedValue({
     processStream: jest.fn().mockResolvedValue(undefined),
   }),
+  applyContextToAgent: (...args) => mockApplyContextToAgent(...args),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  buildAgentScopedContext: (...args) => mockBuildAgentScopedContext(...args),
+  buildAgentContextAttachmentsByAgentId: (...args) =>
+    mockBuildAgentContextAttachmentsByAgentId(...args),
   scopeSkillIds: jest.fn().mockImplementation((ids) => ids),
   resolveAgentScopedSkillIds: jest
     .fn()
@@ -97,12 +104,21 @@ jest.mock('@librechat/api', () => ({
     model_parameters: {},
     toolRegistry: {},
     edges: [],
+    agentContextAttachments: [],
   }),
-  discoverConnectedAgents: jest.fn().mockResolvedValue({
-    agentConfigs: new Map(),
-    edges: [],
-    skippedAgentIds: new Set(),
-    userMCPAuthMap: undefined,
+  discoverConnectedAgents: jest.fn().mockImplementation(async (computedParams, deps) => {
+    // Call onAgentInitialized for each agent config if provided by the mock setup
+    if (deps?.onAgentInitialized && mockGlobalDiscoveredAgentConfigs) {
+      for (const [agentId, config] of mockGlobalDiscoveredAgentConfigs) {
+        deps.onAgentInitialized(agentId, config, config);
+      }
+    }
+    return {
+      agentConfigs: mockGlobalDiscoveredAgentConfigs ?? new Map(),
+      edges: [],
+      skippedAgentIds: new Set(),
+      userMCPAuthMap: undefined,
+    };
   }),
   getBalanceConfig: mockGetBalanceConfig,
   getTransactionsConfig: mockGetTransactionsConfig,
@@ -195,6 +211,14 @@ jest.mock('~/server/controllers/ModelController', () => ({
   getModelsConfig: jest.fn().mockResolvedValue({}),
 }));
 
+jest.mock('~/server/services/MCP', () => ({
+  resolveConfigServers: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('~/config', () => ({
+  getMCPManager: jest.fn().mockReturnValue({}),
+}));
+
 jest.mock('~/server/services/Files/permissions', () => ({
   filterFilesByAgentAccess: jest.fn(),
 }));
@@ -252,12 +276,15 @@ jest.mock('~/models', () => ({
   getConvo: jest.fn().mockResolvedValue(null),
 }));
 
+let mockGlobalDiscoveredAgentConfigs = null;
+
 describe('createResponse controller', () => {
   let createResponse;
   let req, res;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGlobalDiscoveredAgentConfigs = null;
 
     const controller = require('../responses');
     createResponse = controller.createResponse;
@@ -443,6 +470,89 @@ describe('createResponse controller', () => {
         expect.any(Object),
         expect.objectContaining({
           model: 'claude-3',
+        }),
+      );
+    });
+  });
+
+  describe('agent context parity with UI path', () => {
+    it('applies agent-scoped attachment context before createRun', async () => {
+      const api = require('@librechat/api');
+      api.initializeAgent.mockResolvedValueOnce({
+        id: 'agent-123',
+        model: 'claude-3',
+        model_parameters: {},
+        toolRegistry: {},
+        edges: [],
+        agentContextAttachments: [{ file_id: 'file-1', filename: 'ocr_file.pdf' }],
+      });
+      mockBuildAgentContextAttachmentsByAgentId.mockReturnValueOnce(
+        new Map([['agent-123', [{ file_id: 'file-1', filename: 'ocr_file.pdf' }]]]),
+      );
+      mockBuildAgentScopedContext.mockResolvedValueOnce(
+        new Map([['agent-123', 'PDF context: ocr_file.pdf']]),
+      );
+
+      await createResponse(req, res);
+
+      expect(mockBuildAgentContextAttachmentsByAgentId).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'agent-123' }),
+      ]);
+      expect(mockBuildAgentScopedContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentIds: ['agent-123'],
+          attachmentsByAgentId: expect.any(Map),
+          req,
+        }),
+      );
+      expect(mockApplyContextToAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: expect.objectContaining({ id: 'agent-123' }),
+          agentId: 'agent-123',
+          sharedRunContext: 'PDF context: ocr_file.pdf',
+        }),
+      );
+    });
+
+    it('applies context to primary and discovered handoff agents', async () => {
+      const api = require('@librechat/api');
+      const handoffConfig = {
+        id: 'agent-handoff',
+        model: 'claude-3',
+        model_parameters: {},
+        toolRegistry: {},
+        edges: [],
+        agentContextAttachments: [{ file_id: 'file-2', filename: 'handoff_context.pdf' }],
+      };
+
+      // Set primary agent to have edges pointing to handoff agent
+      api.initializeAgent.mockResolvedValueOnce({
+        id: 'agent-123',
+        model: 'claude-3',
+        model_parameters: {},
+        toolRegistry: {},
+        edges: [{ source: 'agent-123', target: 'agent-handoff' }],
+        agentContextAttachments: [{ file_id: 'file-1', filename: 'primary_context.pdf' }],
+      });
+
+      // Set global config so discoverConnectedAgents mock can invoke onAgentInitialized
+      mockGlobalDiscoveredAgentConfigs = new Map([['agent-handoff', handoffConfig]]);
+
+      mockBuildAgentScopedContext.mockResolvedValueOnce(
+        new Map([
+          ['agent-123', 'Primary context'],
+          ['agent-handoff', 'Handoff context'],
+        ]),
+      );
+
+      await createResponse(req, res);
+
+      const appliedAgentIds = mockApplyContextToAgent.mock.calls.map((call) => call[0].agentId);
+      expect(appliedAgentIds).toEqual(expect.arrayContaining(['agent-123', 'agent-handoff']));
+      expect(mockApplyContextToAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'agent-handoff',
+          sharedRunContext: 'Handoff context',
         }),
       );
     });

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -11,7 +11,10 @@ const {
 } = require('librechat-data-provider');
 const {
   createRun,
+  applyContextToAgent,
   buildToolSet,
+  buildAgentScopedContext,
+  buildAgentContextAttachmentsByAgentId,
   createSafeUser,
   initializeAgent,
   loadSkillStates,
@@ -64,6 +67,8 @@ const {
   enrichLoadedToolsWithAgentContext,
 } = require('~/server/services/Endpoints/agents/skillDeps');
 const { getModelsConfig } = require('~/server/controllers/ModelController');
+const { resolveConfigServers } = require('~/server/services/MCP');
+const { getMCPManager } = require('~/config');
 const { logViolation } = require('~/cache');
 const db = require('~/models');
 
@@ -560,6 +565,29 @@ const createResponse = async (req, res) => {
     primaryConfig.edges = discoveredEdges;
     const runAgents = [primaryConfig, ...handoffAgentConfigs.values()];
     const mergedMCPAuthMap = discoveredMCPAuthMap ?? primaryConfig.userMCPAuthMap;
+
+    const agentContextAttachmentsByAgentId = buildAgentContextAttachmentsByAgentId(runAgents);
+    const agentScopedContext = await buildAgentScopedContext({
+      agentIds: runAgents.map(({ id }) => id),
+      attachmentsByAgentId: agentContextAttachmentsByAgentId,
+      req,
+    });
+
+    const mcpManager = getMCPManager();
+    const configServers = await resolveConfigServers(req);
+
+    await Promise.all(
+      runAgents.map((runAgent) =>
+        applyContextToAgent({
+          agent: runAgent,
+          agentId: runAgent.id,
+          logger,
+          mcpManager,
+          configServers,
+          sharedRunContext: agentScopedContext.get(runAgent.id) ?? '',
+        }),
+      ),
+    );
 
     // Determine if streaming is enabled (check both request and agent config)
     const streamingDisabled = !!primaryConfig.model_parameters?.disableStreaming;


### PR DESCRIPTION
## Summary

Hello, hello!

This PR adds a small fix to add the context files of OCR for the API calls to the agent

Mainly I just did mostly the same thing when adding the context on the Agent itself on `client.js` when `applyContextToAgent` method is called

Hope you like it!

Fixes #13706

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

LibreChat configuration
<img width="1550" height="1024" alt="context1" src="https://github.com/user-attachments/assets/78d5f368-a6a7-42ef-9139-4fd181eed5d3" />

Before the fix
<img width="1491" height="843" alt="context2" src="https://github.com/user-attachments/assets/619a8b75-0aae-4508-8040-e326520a211f" />

After the fix
<img width="1483" height="835" alt="context3" src="https://github.com/user-attachments/assets/dafaf7d7-2c1c-42cf-b839-655bc5569a3b" />

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes