### PR TITLE
📦 chore: Bump librechat-data-provider 0.8.505, @librechat/data-schemas 0.0.53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46037,7 +46037,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.504",
+      "version": "0.8.505",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -46645,7 +46645,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.504",
+  "version": "0.8.505",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Bumps **`librechat-data-provider` `0.8.504` → `0.8.505`** and
**`@librechat/data-schemas` `0.0.52` → `0.0.53`**. Workspace lockfile mirrors
both versions.

## Change Type

- [x] Build / release (no functional code change)

## Testing

CI will validate this mechanical version bump.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings