### PR TITLE
🎨 fix: Gate message hover-reveal controls on hover capability, not width

### DIFF
--- a/client/src/components/Chat/Messages/Feedback.tsx
+++ b/client/src/components/Chat/Messages/Feedback.tsx
@@ -2,14 +2,6 @@ import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { TFeedback, TFeedbackTag, getTagsForRating } from 'librechat-data-provider';
 import {
-  Button,
-  OGDialog,
-  OGDialogContent,
-  OGDialogTitle,
-  ThumbUpIcon,
-  ThumbDownIcon,
-} from '@librechat/client';
-import {
   AlertCircle,
   PenTool,
   ImageOff,
@@ -19,6 +11,14 @@ import {
   Lightbulb,
   Search,
 } from 'lucide-react';
+import {
+  Button,
+  OGDialog,
+  OGDialogContent,
+  OGDialogTitle,
+  ThumbUpIcon,
+  ThumbDownIcon,
+} from '@librechat/client';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -218,8 +218,9 @@ function buttonClasses(isActive: boolean, isLast: boolean) {
   return cn(
     'hover-button rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'md:group-hover:visible md:group-focus-within:visible md:group-[.final-completion]:visible',
-    !isLast && 'md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100',
+    'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
+    !isLast &&
+      'group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:hover)]:opacity-0',
     'focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white focus-visible:outline-none',
     isActive && 'active text-text-primary bg-surface-hover',
   );

--- a/client/src/components/Chat/Messages/Fork.tsx
+++ b/client/src/components/Chat/Messages/Fork.tsx
@@ -229,8 +229,9 @@ export default function Fork({
   const buttonStyle = cn(
     'hover-button rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'md:group-hover:visible md:group-focus-within:visible md:group-[.final-completion]:visible',
-    !isLast && 'md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100',
+    'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
+    !isLast &&
+      'group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:hover)]:opacity-0',
     'focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white focus-visible:outline-none',
     isActive && 'active text-text-primary bg-surface-hover',
   );

--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, memo } from 'react';
 import { useRecoilState } from 'recoil';
-import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
 import { EditIcon, Clipboard, CheckMark, ContinueIcon, RegenerateIcon } from '@librechat/client';
+import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
 import { Fork } from '~/components/Conversations';
 import MessageAudio from './MessageAudio';
@@ -84,8 +84,9 @@ const HoverButton = memo(
     const buttonStyle = cn(
       'hover-button rounded-lg p-1.5 text-text-secondary-alt',
       'hover:text-text-primary hover:bg-surface-hover',
-      'md:group-hover:visible md:group-focus-within:visible md:group-[.final-completion]:visible',
-      !isLast && 'md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100',
+      'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
+      !isLast &&
+        'group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:hover)]:opacity-0',
       !isVisible && 'opacity-0',
       'focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white focus-visible:outline-none',
       isActive && isVisible && 'active text-text-primary bg-surface-hover',
@@ -215,7 +216,9 @@ const HoverButtons = ({
         isLast={isLast}
         className={cn(
           'ml-0 flex items-center gap-1.5 text-xs',
-          isSubmitting && isCreatedByUser ? 'md:opacity-0 md:group-hover:opacity-100' : '',
+          isSubmitting && isCreatedByUser
+            ? 'group-hover:opacity-100 [@media(hover:hover)]:opacity-0'
+            : '',
         )}
       />
 

--- a/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
+++ b/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Clipboard, CheckMark } from '@librechat/client';
-import type { TMessage, TAttachment, SearchResultData } from 'librechat-data-provider';
+import type { TMessage, SearchResultData } from 'librechat-data-provider';
 import { useLocalize, useCopyToClipboard } from '~/hooks';
 
 type THoverButtons = {
@@ -20,7 +20,7 @@ export default function MinimalHoverButtons({ message, searchResults }: THoverBu
   return (
     <div className="visible mt-1 flex justify-center gap-1 self-end text-gray-400 lg:justify-start">
       <button
-        className="ml-0 flex items-center gap-1.5 rounded-lg p-1.5 text-xs text-text-secondary-alt transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white md:opacity-0 md:group-focus-within:opacity-100 md:group-hover:opacity-100"
+        className="ml-0 flex items-center gap-1.5 rounded-lg p-1.5 text-xs text-text-secondary-alt transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black group-focus-within:opacity-100 group-hover:opacity-100 dark:focus-visible:ring-white [@media(hover:hover)]:opacity-0"
         onClick={() => copyToClipboard(setIsCopied)}
         type="button"
         title={

--- a/client/src/components/Chat/Messages/SiblingSwitch.tsx
+++ b/client/src/components/Chat/Messages/SiblingSwitch.tsx
@@ -26,7 +26,7 @@ export default function SiblingSwitch({
   const buttonStyle = cn(
     'hover-button rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'md:group-hover:visible md:group-focus-within:visible md:group-[.final-completion]:visible',
+    'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
     'focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white focus-visible:outline-none',
   );
 


### PR DESCRIPTION
## Summary

Follow-up to the message timestamp fix in #13709, which switched the timestamp's hide-until-hover behavior from the `md:` width breakpoint to an actual `(hover: hover)` media query.

Every *other* hover-reveal control in the message UI still used `md:` as a stand-in for "has hover." On large touch devices (≥ the `md` width but with `hover: none`, e.g. tablets) those controls were hidden by default with **no way to reveal them**, since there's no pointer to hover. They also now behaved inconsistently with the already-fixed timestamp.

This applies the same transform to the remaining controls so they hide-until-hover only where a pointer can actually hover, and stay visible everywhere else:

- **Opacity variant** (the real hide mechanism): `md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100` becomes `group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:hover)]:opacity-0`
- **Visibility reveal trio** (`md:group-hover:visible md:group-focus-within:visible md:group-[.final-completion]:visible`): only the `md:` prefixes are dropped. These controls have no hidden `invisible` base anywhere, so introducing a `[@media(hover:hover)]:invisible` default would have changed desktop behavior and broken keyboard reveal (`visibility: hidden` elements can't receive focus, so `group-focus-within` could never fire). The hide-until-hover stays an opacity-only toggle.

Behavior on hover-capable desktops is unchanged (hidden until row hover/focus). All controls remain in the accessibility tree, toggling opacity/visibility only, never `display: none`.

Files touched (all under `client/src/components/Chat/Messages/`): `HoverButtons.tsx`, `Feedback.tsx`, `Fork.tsx`, `SiblingSwitch.tsx`, `MinimalHoverButtons.tsx`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified locally with the seeded conversation containing multiple assistant messages.

- **No-hover, wide viewport** (`matchMedia('(hover: none)')` matching at desktop width, the broken scenario): all message action controls render visible by default. With the old `md:` classes they were stuck hidden.
- **Hover-capable desktop** (`hover: hover`, `pointer: fine`): non-last message controls default to `opacity: 0` via a generated `@media (hover: hover) { ... opacity: 0 }` rule; the last message's controls stay visible; row hover reveals them; keyboard `Tab` into a control reveals it (`group-focus-within`, opacity 0 to 1 while the element stays focusable). Confirmed in both light and dark mode.
- **Accessibility**: hidden controls keep `visibility: visible` / `display: block` and remain tabbable, never removed from the a11y tree.
- `cd client && npx jest Messages`: 602 tests across 45 suites pass.

### **Test Configuration**:

- Branch off `dev` (independent of #13709; can ship separately)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
