### PR TITLE
🔄 feat: Continue Shared Conversations as Personal Copies

### DIFF
--- a/api/server/routes/__tests__/share.spec.js
+++ b/api/server/routes/__tests__/share.spec.js
@@ -7,7 +7,10 @@ const mockGrantCreationPermissions = jest.fn();
 const mockUpdateSharedLinkPermissionsExpiration = jest.fn();
 const mockSharedLinksAccess = jest.fn((_req, _res, next) => next());
 const mockBuildSharedLinkStartupPayload = jest.fn();
-const mockCanAccessSharedLink = jest.fn((_req, _res, next) => next());
+const mockCanAccessSharedLink = jest.fn((req, _res, next) => {
+  req.shareResourceId = 'resource-123';
+  next();
+});
 const mockGetAppConfig = jest.fn();
 const mockGetTenantId = jest.fn(() => undefined);
 
@@ -105,6 +108,17 @@ jest.mock('~/server/services/Config/app', () => ({
   getAppConfig: (...args) => mockGetAppConfig(...args),
 }));
 
+jest.mock('~/server/middleware/limiters', () => ({
+  createForkLimiters: () => ({
+    forkIpLimiter: (_req, _res, next) => next(),
+    forkUserLimiter: (_req, _res, next) => next(),
+  }),
+}));
+
+jest.mock('~/server/utils/import/fork', () => ({
+  forkSharedConversation: jest.fn(),
+}));
+
 const { Readable } = require('stream');
 const { RetentionMode } = require('librechat-data-provider');
 const { createTempChatExpirationDate, logger } = require('@librechat/data-schemas');
@@ -123,6 +137,7 @@ const {
   backfillSharedLinkFiles,
   getRoleByName,
 } = require('~/models');
+const { forkSharedConversation } = require('~/server/utils/import/fork');
 const shareRouter = require('../share');
 
 const activeExpiration = new Date('2030-01-01T00:00:00.000Z');
@@ -132,11 +147,11 @@ const lean = (value) => ({
   lean: jest.fn().mockResolvedValue(value),
 });
 
-const buildApp = ({ retentionMode = RetentionMode.TEMPORARY } = {}) => {
+const buildApp = ({ retentionMode = RetentionMode.TEMPORARY, user = { id: 'user-123' } } = {}) => {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    req.user = { id: 'user-123' };
+    req.user = user;
     req.config = { interfaceConfig: { retentionMode } };
     next();
   });
@@ -503,6 +518,68 @@ describe('share routes', () => {
     expect(response.status).toBe(200);
     expect(mockSharedLinksAccess).not.toHaveBeenCalled();
     expect(deleteSharedLinkWithCleanup).toHaveBeenCalledWith('user-123', 'share-123');
+  });
+});
+
+describe('share fork route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forks a shared conversation for the requesting user', async () => {
+    const forkResult = {
+      conversation: { conversationId: 'convo-456', title: 'Shared Title' },
+      messages: [{ messageId: 'msg-456' }],
+    };
+    forkSharedConversation.mockResolvedValue(forkResult);
+
+    const response = await request(
+      buildApp({ user: { id: 'user-123', role: 'USER', tenantId: 'tenant-viewer' } }),
+    )
+      .post('/api/share/share-123/fork')
+      .send({ targetMessageIndex: 3 });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual(forkResult);
+    expect(forkSharedConversation).toHaveBeenCalledWith({
+      shareId: 'share-123',
+      shareResourceId: 'resource-123',
+      requestUserId: 'user-123',
+      userRole: 'USER',
+      userTenantId: 'tenant-viewer',
+      targetMessageIndex: 3,
+      snapshotFiles: true,
+    });
+  });
+
+  it('forces snapshotFiles=false into the fork when the file snapshot kill switch is active', async () => {
+    isFileSnapshotKillSwitchActive.mockReturnValueOnce(true);
+    forkSharedConversation.mockResolvedValue({
+      conversation: { conversationId: 'convo-456' },
+      messages: [],
+    });
+
+    await request(buildApp()).post('/api/share/share-123/fork');
+
+    expect(forkSharedConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ snapshotFiles: false }),
+    );
+  });
+
+  it('returns 404 when the shared conversation is missing or empty', async () => {
+    forkSharedConversation.mockResolvedValue(null);
+
+    const response = await request(buildApp()).post('/api/share/share-123/fork');
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 500 when forking fails', async () => {
+    forkSharedConversation.mockRejectedValue(new Error('db down'));
+
+    const response = await request(buildApp()).post('/api/share/share-123/fork');
+
+    expect(response.status).toBe(500);
   });
 });
 

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -37,6 +37,8 @@ const {
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { cleanFileName, getContentDisposition } = require('~/server/utils/files');
 const canAccessSharedLink = require('~/server/middleware/canAccessSharedLink');
+const { forkSharedConversation } = require('~/server/utils/import/fork');
+const { createForkLimiters } = require('~/server/middleware/limiters');
 const optionalShareFileAuth = require('~/server/middleware/optionalShareFileAuth');
 const optionalJwtAuth = require('~/server/middleware/optionalJwtAuth');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
@@ -224,6 +226,8 @@ const streamSharedFile = async (req, res, file, requestedDisposition) => {
 };
 
 if (allowSharedLinks) {
+  const { forkIpLimiter, forkUserLimiter } = createForkLimiters();
+
   router.get('/:shareId/config', optionalJwtAuth, canAccessSharedLink, async (_req, res) => {
     try {
       const payload = await getShareStartupPayload();
@@ -256,6 +260,36 @@ if (allowSharedLinks) {
       } catch (error) {
         logger.error('Error getting shared messages:', error);
         res.status(500).json({ message: 'Error getting shared messages' });
+      }
+    },
+  );
+
+  router.post(
+    '/:shareId/fork',
+    requireJwtAuth,
+    forkIpLimiter,
+    forkUserLimiter,
+    canAccessSharedLink,
+    async (req, res) => {
+      try {
+        const result = await forkSharedConversation({
+          shareId: req.params.shareId,
+          shareResourceId: req.shareResourceId,
+          requestUserId: req.user.id,
+          userRole: req.user.role,
+          userTenantId: req.user.tenantId,
+          targetMessageIndex: req.body?.targetMessageIndex,
+          // Viewer-independent: honor the global shared-file kill switch, matching
+          // the GET share route so disabled file snapshots aren't copied into forks.
+          snapshotFiles: !isFileSnapshotKillSwitchActive(),
+        });
+        if (!result) {
+          return res.status(404).json({ message: 'Shared conversation not found' });
+        }
+        res.status(201).json(result);
+      } catch (error) {
+        logger.error('Error forking shared conversation:', error);
+        res.status(500).json({ message: 'Error forking shared conversation' });
       }
     },
   );

--- a/api/server/utils/import/defaults.js
+++ b/api/server/utils/import/defaults.js
@@ -60,8 +60,83 @@ async function resolveImportDefaultModel({ endpoint, requestUserId, userRole }) 
   return FALLBACK_MODEL_BY_ENDPOINT[endpoint] ?? openAISettings.model.default;
 }
 
+/**
+ * Preferred endpoint order for conversations cloned without a known source
+ * endpoint. OpenAI is first so deployments that expose it keep prior behavior;
+ * any other configured endpoint is still selected when these are unavailable.
+ */
+const DEFAULT_ENDPOINT_PREFERENCE = [
+  EModelEndpoint.openAI,
+  EModelEndpoint.anthropic,
+  EModelEndpoint.google,
+  EModelEndpoint.azureOpenAI,
+  EModelEndpoint.bedrock,
+];
+
+/**
+ * Endpoints excluded as fork targets because they are stateful: each
+ * conversation needs an assistant_id and thread_id that a cloned conversation
+ * never creates, so the assistants chat controller rejects the first follow-up
+ * ("Missing thread_id for existing conversation"). A fork must land on a
+ * stateless chat endpoint. These can still surface in the runtime models config
+ * (e.g. a deployment exposing only assistant models), so filter them out.
+ */
+const EXCLUDED_FORK_ENDPOINTS = new Set([
+  EModelEndpoint.assistants,
+  EModelEndpoint.azureAssistants,
+]);
+
+/**
+ * Resolves an endpoint and model the requesting user can actually use, for
+ * conversations cloned without a known source endpoint (shared forks, whose
+ * original endpoint is stripped from the sanitized payload). Picks the first
+ * preferred endpoint exposing models, then any other configured endpoint
+ * (excluding stateful assistant endpoints, which a fork cannot resume), so a
+ * deployment that doesn't expose OpenAI doesn't produce a conversation whose
+ * first message is rejected by model validation. Falls back to OpenAI defaults
+ * only when the runtime models config is empty or unavailable.
+ *
+ * @param {object} args
+ * @param {string} args.requestUserId - The id of the requesting user.
+ * @param {string} [args.userRole] - The role of the requesting user.
+ * @returns {Promise<{ endpoint: string, model: string }>} A usable endpoint and model.
+ */
+async function resolveImportDefaultEndpoint({ requestUserId, userRole }) {
+  try {
+    const modelsConfig = await getModelsConfig({
+      user: { id: requestUserId, role: userRole, tenantId: getTenantId() },
+    });
+    if (modelsConfig) {
+      const orderedEndpoints = [
+        ...DEFAULT_ENDPOINT_PREFERENCE,
+        ...Object.keys(modelsConfig).filter(
+          (endpoint) => !DEFAULT_ENDPOINT_PREFERENCE.includes(endpoint),
+        ),
+      ];
+      for (const endpoint of orderedEndpoints) {
+        if (EXCLUDED_FORK_ENDPOINTS.has(endpoint)) {
+          continue;
+        }
+        const model = pickFirstConfiguredModel(endpoint, modelsConfig);
+        if (model) {
+          return { endpoint, model };
+        }
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      `[import] Failed to resolve a default endpoint from modelsConfig: ${error.message}`,
+    );
+  }
+  return {
+    endpoint: EModelEndpoint.openAI,
+    model: FALLBACK_MODEL_BY_ENDPOINT[EModelEndpoint.openAI] ?? openAISettings.model.default,
+  };
+}
+
 module.exports = {
   FALLBACK_MODEL_BY_ENDPOINT,
   pickFirstConfiguredModel,
   resolveImportDefaultModel,
+  resolveImportDefaultEndpoint,
 };

--- a/api/server/utils/import/defaults.spec.js
+++ b/api/server/utils/import/defaults.spec.js
@@ -18,6 +18,7 @@ jest.mock('@librechat/data-schemas', () => {
 const {
   pickFirstConfiguredModel,
   resolveImportDefaultModel,
+  resolveImportDefaultEndpoint,
   FALLBACK_MODEL_BY_ENDPOINT,
 } = require('./defaults');
 
@@ -118,5 +119,87 @@ describe('resolveImportDefaultModel', () => {
     expect(FALLBACK_MODEL_BY_ENDPOINT[EModelEndpoint.anthropic]).toBe(
       anthropicSettings.model.default,
     );
+  });
+});
+
+describe('resolveImportDefaultEndpoint', () => {
+  it('prefers OpenAI when it exposes models', async () => {
+    mockGetModelsConfig.mockResolvedValueOnce({
+      [EModelEndpoint.openAI]: ['gpt-4o'],
+      [EModelEndpoint.anthropic]: ['claude-opus-4-7'],
+    });
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({ endpoint: EModelEndpoint.openAI, model: 'gpt-4o' });
+  });
+
+  it('falls back to another configured endpoint when OpenAI is unavailable', async () => {
+    mockGetModelsConfig.mockResolvedValueOnce({
+      [EModelEndpoint.openAI]: [],
+      [EModelEndpoint.anthropic]: ['claude-opus-4-7'],
+    });
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({ endpoint: EModelEndpoint.anthropic, model: 'claude-opus-4-7' });
+  });
+
+  it('selects a custom endpoint when no preferred endpoint has models', async () => {
+    mockGetModelsConfig.mockResolvedValueOnce({
+      'my-custom': ['custom-model-1'],
+    });
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({ endpoint: 'my-custom', model: 'custom-model-1' });
+  });
+
+  it('skips stateful assistant endpoints and selects a stateless one', async () => {
+    mockGetModelsConfig.mockResolvedValueOnce({
+      [EModelEndpoint.assistants]: ['gpt-4o'],
+      [EModelEndpoint.azureAssistants]: ['gpt-4o'],
+      'my-custom': ['custom-model-1'],
+    });
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({ endpoint: 'my-custom', model: 'custom-model-1' });
+  });
+
+  it('falls back to OpenAI defaults when only assistant endpoints expose models', async () => {
+    mockGetModelsConfig.mockResolvedValueOnce({
+      [EModelEndpoint.assistants]: ['gpt-4o'],
+      [EModelEndpoint.azureAssistants]: ['gpt-4o'],
+    });
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({
+      endpoint: EModelEndpoint.openAI,
+      model: openAISettings.model.default,
+    });
+  });
+
+  it('falls back to OpenAI defaults when the models config is empty', async () => {
+    mockGetModelsConfig.mockResolvedValueOnce({});
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({
+      endpoint: EModelEndpoint.openAI,
+      model: openAISettings.model.default,
+    });
+  });
+
+  it('falls back to OpenAI defaults when getModelsConfig rejects', async () => {
+    mockGetModelsConfig.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await resolveImportDefaultEndpoint({ requestUserId: 'user-1' });
+
+    expect(result).toEqual({
+      endpoint: EModelEndpoint.openAI,
+      model: openAISettings.model.default,
+    });
   });
 });

--- a/api/server/utils/import/fork.js
+++ b/api/server/utils/import/fork.js
@@ -1,9 +1,11 @@
 const { v4: uuidv4 } = require('uuid');
-const { logger } = require('@librechat/data-schemas');
+const { logger, tenantStorage } = require('@librechat/data-schemas');
 const { EModelEndpoint, Constants, ForkOptions } = require('librechat-data-provider');
+const { getConvo, getMessages, getSharedMessages } = require('~/models');
 const { createImportBatchBuilder } = require('./importBatchBuilder');
+const { getAppConfig } = require('~/server/services/Config');
+const { resolveImportDefaultEndpoint } = require('./defaults');
 const BaseClient = require('~/app/clients/BaseClient');
-const { getConvo, getMessages } = require('~/models');
 
 /**
  * Helper function to clone messages with proper parent-child relationships and timestamps
@@ -353,6 +355,146 @@ function splitAtTargetLevel(messages, targetMessageId) {
 }
 
 /**
+ * Strips file identifiers from a shared message's `files` and `attachments`.
+ * A shared fork is owned by the requesting user, but the underlying file records
+ * still belong to the original sharer. Persisting their `file_id`s would let the
+ * agents file-resend path collect them on the next turn and call `getUserCodeFiles`,
+ * which looks them up by `file_id` with no ownership filter, rehydrating the
+ * sharer's files into the viewer's run. Dropping the ids keeps a fork's file
+ * access no broader than viewing the read-only share, while leaving render-only
+ * metadata (e.g. `filepath`, `toolCallId`) intact.
+ * @param {TMessage} message - The shared message to sanitize.
+ * @returns {TMessage} The message with file identifiers removed.
+ */
+function stripSharedFileIds(message) {
+  const sanitized = { ...message };
+  if (Array.isArray(sanitized.files)) {
+    sanitized.files = sanitized.files.map(({ file_id: _fileId, ...file }) => file);
+  }
+  if (Array.isArray(sanitized.attachments)) {
+    sanitized.attachments = sanitized.attachments.map(
+      ({ file_id: _fileId, ...attachment }) => attachment,
+    );
+  }
+  return sanitized;
+}
+
+/**
+ * Forks a shared (sanitized) conversation into a fresh conversation owned by the requesting user.
+ * Only the anonymized, allowlisted message fields returned by `getSharedMessages` are cloned,
+ * so no private data from the original owner can leak into the new conversation.
+ * @param {object} params - The parameters for forking the shared conversation.
+ * @param {string} params.shareId - The ID of the shared link to fork from.
+ * @param {string} [params.shareResourceId] - The SharedLink resource ID set by `canAccessSharedLink`.
+ * @param {string} params.requestUserId - The ID of the user making the request.
+ * @param {string} [params.userRole] - The role of the requesting user, used to resolve the default model.
+ * @param {string} [params.userTenantId] - Tenant of the requesting user. `canAccessSharedLink` runs this handler under the share owner's tenant so the share resolves, so the copy must be persisted (and its config/retention resolved) under the requesting user's tenant or it would be invisible (404) when they open it normally.
+ * @param {number} [params.targetMessageIndex] - Index, within the shared payload, of the message at the tip of the branch the viewer has active. When set, only the direct path to that message is cloned so the fork continues the branch that was actually shown rather than the newest sibling. An index is used (not id or `createdAt`) because shared ids are re-anonymized per request while `getSharedMessages` returns a deterministic, stable order, so the same index resolves to the same message on the server.
+ * @param {boolean} [params.snapshotFiles] - When `false`, file/attachment metadata is omitted from the cloned messages, mirroring the GET share route so the global shared-file kill switch is honored.
+ * @param {(userId: string, interfaceConfig?: object) => ImportBatchBuilder} [params.builderFactory] - Optional factory function for creating an ImportBatchBuilder instance.
+ * @param {(options: object) => Promise<object>} [params.loadAppConfig] - Resolves the app config; injectable for tests. Called inside the requesting user's tenant context so retention policy is read from the viewer's tenant, not the share owner's.
+ * @returns {Promise<TForkConvoResponse | null>} The new conversation and messages, or null when the share is missing or empty.
+ */
+async function forkSharedConversation({
+  shareId,
+  shareResourceId,
+  requestUserId,
+  userRole,
+  userTenantId,
+  targetMessageIndex,
+  snapshotFiles,
+  builderFactory = createImportBatchBuilder,
+  loadAppConfig = getAppConfig,
+}) {
+  // Mirror the GET share route: when the shared-file snapshot is globally
+  // disabled, omit file/attachment metadata so a fork can't persist filenames
+  // or share file URLs into the new conversation while file serving is off.
+  const share = await getSharedMessages(shareId, shareResourceId, { snapshotFiles });
+  if (!share?.messages?.length) {
+    return null;
+  }
+
+  /**
+   * The shared payload includes sibling branches. Reduce to the direct path of
+   * the viewer's active message so the fork continues exactly the branch that
+   * was shown; without this the default branch selection lands on the newest
+   * sibling. The active tip is located by its index in the shared payload, which
+   * `getSharedMessages` returns in a deterministic order (stored ref-array order)
+   * — unlike ids (re-anonymized per request) or `createdAt` (can collide). Falls
+   * back to the full set when the index is absent or out of range.
+   */
+  let sourceMessages = share.messages;
+  if (
+    Number.isInteger(targetMessageIndex) &&
+    targetMessageIndex >= 0 &&
+    targetMessageIndex < share.messages.length
+  ) {
+    const targetMessage = share.messages[targetMessageIndex];
+    const directPath = BaseClient.getMessagesForConversation({
+      messages: share.messages,
+      parentMessageId: targetMessage.messageId,
+    });
+    if (directPath.length > 0) {
+      sourceMessages = directPath;
+    }
+  }
+
+  const messageIds = new Set(sourceMessages.map((message) => message.messageId));
+  const messagesToClone = sourceMessages.map(({ model: _model, ...message }) =>
+    stripSharedFileIds({
+      ...message,
+      parentMessageId:
+        message.parentMessageId != null && messageIds.has(message.parentMessageId)
+          ? message.parentMessageId
+          : Constants.NO_PARENT,
+    }),
+  );
+
+  /**
+   * Persist and read back under the requesting user's tenant rather than the
+   * share owner's. The read above runs in the share owner's tenant (set by
+   * `canAccessSharedLink`); writing the copy there would leave it invisible to
+   * the user under their normal tenant context (the new conversation would 404
+   * when they navigate to it). Switching to the user's tenant only affects this
+   * deployment when tenant isolation is enabled; otherwise it is a no-op.
+   */
+  return tenantStorage.run({ tenantId: userTenantId, userId: requestUserId }, async () => {
+    // Resolve config inside the viewer's tenant so retention (e.g. all-data
+    // expiry) reflects the requesting user's tenant, not the share owner's.
+    const appConfig = await loadAppConfig({
+      role: userRole,
+      userId: requestUserId,
+      tenantId: userTenantId,
+    });
+    // The shared payload strips the original endpoint, so resolve one the viewer
+    // can actually use; hard-coding OpenAI breaks the first follow-up message on
+    // deployments that don't expose it.
+    const { endpoint, model } = await resolveImportDefaultEndpoint({ requestUserId, userRole });
+    const importBatchBuilder = builderFactory(requestUserId, appConfig?.interfaceConfig);
+    importBatchBuilder.startConversation(endpoint);
+
+    cloneMessagesWithTimestamps(messagesToClone, importBatchBuilder);
+
+    const result = importBatchBuilder.finishConversation(share.title, new Date(), {}, model);
+    await importBatchBuilder.saveBatch();
+    logger.debug(
+      `user: ${requestUserId} | New conversation "${result.conversation.title}" forked from share ID ${shareId}`,
+    );
+
+    const conversation = await getConvo(requestUserId, result.conversation.conversationId);
+    const messages = await getMessages({
+      user: requestUserId,
+      conversationId: conversation.conversationId,
+    });
+
+    return {
+      conversation,
+      messages,
+    };
+  });
+}
+
+/**
  * Duplicates a conversation and all its messages.
  * @param {object} params - The parameters for duplicating the conversation.
  * @param {string} params.userId - The ID of the user duplicating the conversation.
@@ -404,6 +546,7 @@ module.exports = {
   forkConversation,
   splitAtTargetLevel,
   duplicateConversation,
+  forkSharedConversation,
   getAllMessagesUpToParent,
   getMessagesUpToTargetLevel,
   cloneMessagesWithTimestamps,

--- a/api/server/utils/import/fork.spec.js
+++ b/api/server/utils/import/fork.spec.js
@@ -6,6 +6,15 @@ jest.mock('~/models', () => ({
   getMessages: jest.fn(),
   bulkSaveMessages: jest.fn(),
   bulkIncrementTagCounts: jest.fn(),
+  getSharedMessages: jest.fn(),
+}));
+
+jest.mock('~/server/controllers/ModelController', () => ({
+  getModelsConfig: jest.fn().mockResolvedValue({ openAI: ['gpt-test'] }),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: jest.fn().mockResolvedValue({ interfaceConfig: {} }),
 }));
 
 let mockIdCounter = 0;
@@ -21,6 +30,7 @@ jest.mock('uuid', () => {
 const {
   forkConversation,
   duplicateConversation,
+  forkSharedConversation,
   splitAtTargetLevel,
   getAllMessagesUpToParent,
   getMessagesUpToTargetLevel,
@@ -32,7 +42,9 @@ const {
   bulkSaveConvos,
   getMessages,
   bulkSaveMessages,
+  getSharedMessages,
 } = require('~/models');
+const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { createImportBatchBuilder } = require('./importBatchBuilder');
 const BaseClient = require('~/app/clients/BaseClient');
 
@@ -298,6 +310,359 @@ describe('duplicateConversation', () => {
 
     // bulkIncrementTagCounts will be called with empty array
     expect(bulkIncrementTagCounts).toHaveBeenCalledWith('user1', []);
+  });
+});
+
+describe('forkSharedConversation', () => {
+  const mockSharedMessages = [
+    {
+      messageId: 'msg_a',
+      parentMessageId: Constants.NO_PARENT,
+      text: 'Shared root',
+      isCreatedByUser: true,
+      createdAt: '2021-01-01',
+    },
+    {
+      messageId: 'msg_b',
+      parentMessageId: 'msg_a',
+      text: 'Shared reply',
+      isCreatedByUser: false,
+      createdAt: '2021-01-02',
+    },
+  ];
+
+  const mockShare = {
+    shareId: 'share123',
+    conversationId: 'convo_anon',
+    title: 'Shared Title',
+    messages: mockSharedMessages,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIdCounter = 0;
+    getSharedMessages.mockResolvedValue(mockShare);
+    getConvo.mockResolvedValue(mockConversation);
+    getMessages.mockResolvedValue(mockSharedMessages);
+    bulkSaveConvos.mockResolvedValue(null);
+    bulkSaveMessages.mockResolvedValue(null);
+    bulkIncrementTagCounts.mockResolvedValue(null);
+  });
+
+  test('should clone shared messages into a conversation owned by the requesting user', async () => {
+    const result = await forkSharedConversation({
+      shareId: 'share123',
+      shareResourceId: 'resource123',
+      requestUserId: 'user1',
+    });
+
+    expect(getSharedMessages).toHaveBeenCalledWith('share123', 'resource123', {
+      snapshotFiles: undefined,
+    });
+
+    const savedMessages = bulkSaveMessages.mock.calls[0][0];
+    expect(savedMessages).toHaveLength(2);
+    const [root, reply] = savedMessages;
+    expect(root).toMatchObject({
+      text: 'Shared root',
+      user: 'user1',
+      endpoint: 'openAI',
+      parentMessageId: Constants.NO_PARENT,
+    });
+    expect(reply).toMatchObject({
+      text: 'Shared reply',
+      user: 'user1',
+      parentMessageId: root.messageId,
+    });
+    expect(root.messageId).not.toBe('msg_a');
+    expect(reply.messageId).not.toBe('msg_b');
+
+    const savedConvos = bulkSaveConvos.mock.calls[0][0];
+    expect(savedConvos[0]).toMatchObject({
+      user: 'user1',
+      title: 'Shared Title',
+      endpoint: 'openAI',
+      model: 'gpt-test',
+    });
+
+    expect(getConvo).toHaveBeenCalledWith('user1', savedConvos[0].conversationId);
+    expect(result).toMatchObject({ conversation: mockConversation, messages: mockSharedMessages });
+  });
+
+  test('should use an available endpoint when the deployment does not expose OpenAI', async () => {
+    getModelsConfig.mockResolvedValueOnce({ anthropic: ['claude-test'] });
+
+    await forkSharedConversation({
+      shareId: 'share123',
+      shareResourceId: 'resource123',
+      requestUserId: 'user1',
+    });
+
+    const savedConvos = bulkSaveConvos.mock.calls[0][0];
+    expect(savedConvos[0]).toMatchObject({ endpoint: 'anthropic', model: 'claude-test' });
+
+    const savedMessages = bulkSaveMessages.mock.calls[0][0];
+    expect(savedMessages.every((message) => message.endpoint === 'anthropic')).toBe(true);
+  });
+
+  test('should return null when the share is not found', async () => {
+    getSharedMessages.mockResolvedValue(null);
+
+    const result = await forkSharedConversation({
+      shareId: 'missing',
+      requestUserId: 'user1',
+    });
+
+    expect(result).toBeNull();
+    expect(bulkSaveMessages).not.toHaveBeenCalled();
+  });
+
+  test('should return null when the share has no messages', async () => {
+    getSharedMessages.mockResolvedValue({ ...mockShare, messages: [] });
+
+    const result = await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+    });
+
+    expect(result).toBeNull();
+    expect(bulkSaveMessages).not.toHaveBeenCalled();
+  });
+
+  test('should normalize orphaned parentMessageId references to NO_PARENT', async () => {
+    getSharedMessages.mockResolvedValue({
+      ...mockShare,
+      messages: [
+        {
+          messageId: 'msg_orphan',
+          parentMessageId: 'msg_deleted',
+          text: 'Orphaned message',
+          createdAt: '2021-01-01',
+        },
+      ],
+    });
+
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+    });
+
+    const savedMessages = bulkSaveMessages.mock.calls[0][0];
+    expect(savedMessages[0].parentMessageId).toBe(Constants.NO_PARENT);
+  });
+
+  test('should forward snapshotFiles to getSharedMessages so the kill switch is honored', async () => {
+    await forkSharedConversation({
+      shareId: 'share123',
+      shareResourceId: 'resource123',
+      requestUserId: 'user1',
+      snapshotFiles: false,
+    });
+
+    expect(getSharedMessages).toHaveBeenCalledWith('share123', 'resource123', {
+      snapshotFiles: false,
+    });
+  });
+
+  test('should strip anonymized model identifiers from cloned messages', async () => {
+    getSharedMessages.mockResolvedValue({
+      ...mockShare,
+      messages: [
+        {
+          messageId: 'msg_a',
+          parentMessageId: Constants.NO_PARENT,
+          text: 'Assistant message',
+          model: 'a_anon123',
+          createdAt: '2021-01-01',
+        },
+      ],
+    });
+
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+    });
+
+    const savedMessages = bulkSaveMessages.mock.calls[0][0];
+    expect(savedMessages[0].model).not.toBe('a_anon123');
+  });
+
+  test('should strip file_id from cloned files and attachments', async () => {
+    getSharedMessages.mockResolvedValue({
+      ...mockShare,
+      messages: [
+        {
+          messageId: 'msg_a',
+          parentMessageId: Constants.NO_PARENT,
+          text: 'Message with files',
+          isCreatedByUser: true,
+          createdAt: '2021-01-01',
+          files: [{ file_id: 'owner-file-1', filepath: '/images/owner/a.png' }],
+          attachments: [
+            { file_id: 'owner-file-2', toolCallId: 'tool_1', filepath: '/images/owner/b.png' },
+          ],
+        },
+      ],
+    });
+
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+    });
+
+    const savedMessages = bulkSaveMessages.mock.calls[0][0];
+    const [message] = savedMessages;
+    expect(message.files[0]).not.toHaveProperty('file_id');
+    expect(message.attachments[0]).not.toHaveProperty('file_id');
+    // Render-only metadata is preserved
+    expect(message.files[0].filepath).toBe('/images/owner/a.png');
+    expect(message.attachments[0].toolCallId).toBe('tool_1');
+  });
+
+  test('should resolve interfaceConfig from the app config and pass it to the builder', async () => {
+    const interfaceConfig = { retentionMode: 'all', retention: { days: 30 } };
+    const loadAppConfig = jest.fn().mockResolvedValue({ interfaceConfig });
+    const builderFactory = jest.fn((userId, config) => createImportBatchBuilder(userId, config));
+
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+      userRole: 'USER',
+      userTenantId: 'tenant-viewer',
+      loadAppConfig,
+      builderFactory,
+    });
+
+    expect(loadAppConfig).toHaveBeenCalledWith({
+      role: 'USER',
+      userId: 'user1',
+      tenantId: 'tenant-viewer',
+    });
+    expect(builderFactory).toHaveBeenCalledWith('user1', interfaceConfig);
+  });
+
+  test('should resolve the app config under the requesting user tenant', async () => {
+    const { tenantStorage, getTenantId } = require('@librechat/data-schemas');
+    let tenantDuringConfigLoad;
+    const loadAppConfig = jest.fn(async () => {
+      tenantDuringConfigLoad = getTenantId();
+      return { interfaceConfig: {} };
+    });
+
+    await tenantStorage.run({ tenantId: 'tenant-share-owner' }, () =>
+      forkSharedConversation({
+        shareId: 'share123',
+        requestUserId: 'user1',
+        userTenantId: 'tenant-viewer',
+        loadAppConfig,
+      }),
+    );
+
+    expect(tenantDuringConfigLoad).toBe('tenant-viewer');
+  });
+
+  test('should clone only the active branch path when targetMessageIndex is provided', async () => {
+    getSharedMessages.mockResolvedValue({
+      ...mockShare,
+      messages: [
+        {
+          messageId: 'msg_root',
+          parentMessageId: Constants.NO_PARENT,
+          text: 'Root',
+          createdAt: '2021-01-01T00:00:00.000Z',
+        },
+        {
+          messageId: 'msg_branch_a',
+          parentMessageId: 'msg_root',
+          text: 'Branch A (shared)',
+          createdAt: '2021-01-02T00:00:00.000Z',
+        },
+        {
+          messageId: 'msg_branch_b',
+          parentMessageId: 'msg_root',
+          text: 'Branch B (newer sibling)',
+          createdAt: '2021-01-03T00:00:00.000Z',
+        },
+      ],
+    });
+
+    // Index 1 = the "Branch A" tip the viewer had active.
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+      targetMessageIndex: 1,
+    });
+
+    const savedTexts = bulkSaveMessages.mock.calls[0][0].map((message) => message.text);
+    expect(savedTexts).toEqual(['Root', 'Branch A (shared)']);
+    expect(savedTexts).not.toContain('Branch B (newer sibling)');
+  });
+
+  test('should select the correct branch even when siblings share a createdAt', async () => {
+    getSharedMessages.mockResolvedValue({
+      ...mockShare,
+      messages: [
+        {
+          messageId: 'msg_root',
+          parentMessageId: Constants.NO_PARENT,
+          text: 'Root',
+          createdAt: '2021-01-01T00:00:00.000Z',
+        },
+        {
+          messageId: 'msg_sib_a',
+          parentMessageId: 'msg_root',
+          text: 'Sibling A',
+          createdAt: '2021-01-02T00:00:00.000Z',
+        },
+        {
+          messageId: 'msg_sib_b',
+          parentMessageId: 'msg_root',
+          text: 'Sibling B (same timestamp)',
+          createdAt: '2021-01-02T00:00:00.000Z',
+        },
+      ],
+    });
+
+    // Index 2 unambiguously targets Sibling B despite the shared createdAt.
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+      targetMessageIndex: 2,
+    });
+
+    const savedTexts = bulkSaveMessages.mock.calls[0][0].map((message) => message.text);
+    expect(savedTexts).toEqual(['Root', 'Sibling B (same timestamp)']);
+    expect(savedTexts).not.toContain('Sibling A');
+  });
+
+  test('should fall back to the full set when targetMessageIndex is out of range', async () => {
+    await forkSharedConversation({
+      shareId: 'share123',
+      requestUserId: 'user1',
+      targetMessageIndex: 999,
+    });
+
+    expect(bulkSaveMessages.mock.calls[0][0]).toHaveLength(mockSharedMessages.length);
+  });
+
+  test('should persist under the requesting user tenant, not the share tenant', async () => {
+    const { tenantStorage, getTenantId } = require('@librechat/data-schemas');
+    let tenantDuringSave;
+    bulkSaveConvos.mockImplementation(async () => {
+      tenantDuringSave = getTenantId();
+    });
+
+    // Simulate the handler running inside the share owner's tenant context
+    // (as `canAccessSharedLink` does) and ensure the write switches to the viewer's.
+    await tenantStorage.run({ tenantId: 'tenant-share-owner' }, () =>
+      forkSharedConversation({
+        shareId: 'share123',
+        requestUserId: 'user1',
+        userTenantId: 'tenant-viewer',
+      }),
+    );
+
+    expect(tenantDuringSave).toBe('tenant-viewer');
   });
 });
 

--- a/client/src/components/Chat/TemporaryChat.tsx
+++ b/client/src/components/Chat/TemporaryChat.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { TooltipAnchor } from '@librechat/client';
 import { MessageCircleDashed } from 'lucide-react';
+import { Constants } from 'librechat-data-provider';
 import { useRecoilState, useRecoilCallback } from 'recoil';
 import { useShortcutAriaKey, useShortcutHint } from '~/hooks/useKeyboardShortcuts';
 import { useLocalize } from '~/hooks';
@@ -23,7 +24,11 @@ export function TemporaryChat() {
     [isTemporary],
   );
 
+  const conversationId = conversation?.conversationId;
+  const hasStarted = conversationId != null && conversationId !== Constants.NEW_CONVO;
+
   if (
+    hasStarted ||
     (Array.isArray(conversation?.messages) && conversation.messages.length >= 1) ||
     isSubmitting
   ) {

--- a/client/src/components/Nav/SettingsTabs/General/Selectors.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/Selectors.tsx
@@ -1,16 +1,19 @@
 import { useRecoilValue } from 'recoil';
 import { Dropdown, Spinner } from '@librechat/client';
 import { useLocalize } from '~/hooks';
+import { cn } from '~/utils';
 import store from '~/store';
 
 export const ThemeSelector = ({
   theme,
   onChange,
   portal = true,
+  popoverClassName,
 }: {
   theme: string;
   onChange: (value: string) => void;
   portal?: boolean;
+  popoverClassName?: string;
 }) => {
   const localize = useLocalize();
 
@@ -30,9 +33,8 @@ export const ThemeSelector = ({
         value={theme}
         onChange={onChange}
         options={themeOptions}
-        sizeClasses="w-[180px]"
+        sizeClasses={cn('z-50 w-[180px]', popoverClassName)}
         testId="theme-selector"
-        className="z-50"
         aria-labelledby={labelId}
         portal={portal}
       />
@@ -44,10 +46,12 @@ export const LangSelector = ({
   langcode,
   onChange,
   portal = true,
+  popoverClassName,
 }: {
   langcode: string;
   onChange: (value: string) => void;
   portal?: boolean;
+  popoverClassName?: string;
 }) => {
   const localize = useLocalize();
   const isLanguageLoading = useRecoilValue(store.languageLoading);
@@ -116,9 +120,11 @@ export const LangSelector = ({
         <Dropdown
           value={langcode}
           onChange={onChange}
-          sizeClasses="[--anchor-max-height:256px] max-h-[60vh] w-[220px]"
+          sizeClasses={cn(
+            'z-50 [--anchor-max-height:256px] max-h-[60vh] w-[220px]',
+            popoverClassName,
+          )}
           options={languageOptions}
-          className="z-50"
           aria-labelledby={labelId}
           portal={portal}
           searchable

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -1,9 +1,9 @@
 import { memo, useState, useCallback, useContext } from 'react';
 import Cookies from 'js-cookie';
-import { useRecoilState } from 'recoil';
-import { useParams } from 'react-router-dom';
 import { buildTree } from 'librechat-data-provider';
-import { CalendarDays, Settings } from 'lucide-react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useRecoilState, useRecoilCallback } from 'recoil';
+import { CalendarDays, Settings, MessageSquarePlus } from 'lucide-react';
 import { useGetSharedMessages } from 'librechat-data-provider/react-query';
 import {
   Spinner,
@@ -15,20 +15,27 @@ import {
   OGDialogHeader,
   OGDialogContent,
   OGDialogTrigger,
+  useToastContext,
 } from '@librechat/client';
 import { ThemeSelector, LangSelector } from '~/components/Nav/SettingsTabs/General/Selectors';
+import { cn, getResponseStatus, selectActiveBranchTail } from '~/utils';
 import { ShareMessagesProvider } from './ShareMessagesProvider';
+import { useForkSharedConvoMutation } from '~/data-provider';
 import { useGetSharedStartupConfig } from '~/data-provider';
 import { ShareArtifactsContainer } from './ShareArtifacts';
 import { useLocalize, useDocumentTitle } from '~/hooks';
 import { ShareContext } from '~/Providers';
 import MessagesView from './MessagesView';
 import Footer from '../Chat/Footer';
-import { cn } from '~/utils';
 import store from '~/store';
+
+/** Root sibling-index key used by the shared MessagesView/MultiMessage tree. */
+const SHARED_CONVO_KEY = 'shared-conversation';
 
 function SharedView() {
   const localize = useLocalize();
+  const navigate = useNavigate();
+  const { showToast } = useToastContext();
   const { theme, setTheme } = useContext(ThemeContext);
   const { shareId } = useParams();
   const { data: config } = useGetSharedStartupConfig(shareId);
@@ -37,6 +44,64 @@ function SharedView() {
   const messagesTree = dataTree?.length === 0 ? null : (dataTree ?? null);
 
   const [langcode, setLangcode] = useRecoilState(store.lang);
+
+  const forkShare = useForkSharedConvoMutation({
+    onSuccess: (forkData) => {
+      navigate(`/c/${forkData.conversation.conversationId}`);
+    },
+    onError: (error) => {
+      const status = getResponseStatus(error);
+      /** A 401 means the viewer isn't authenticated; the request interceptor
+       *  routes them through login (with a redirect back to this share), so a
+       *  generic error toast would be misleading noise before the redirect. */
+      if (status === 401) {
+        return;
+      }
+      showToast({
+        message:
+          status === 429
+            ? localize('com_ui_fork_error_rate_limit')
+            : localize('com_ui_continue_chat_error'),
+        status: 'error',
+      });
+    },
+  });
+
+  /** Resolve the index, within the shared payload, of the message at the tip of
+   *  the branch the viewer currently has active (default or manually navigated),
+   *  so the fork continues that exact branch instead of the newest sibling.
+   *  Mirrors the share tree's sibling selection, which is keyed by parent id with
+   *  the root on SHARED_CONVO_KEY. An index is sent (not id or createdAt) because
+   *  shared ids are re-anonymized per request and createdAt can collide, while
+   *  the payload order is stable across requests. */
+  const getActiveTargetIndex = useRecoilCallback(
+    ({ snapshot }) =>
+      () => {
+        const messages = data?.messages;
+        if (messages == null || messages.length === 0) {
+          return undefined;
+        }
+        const getSiblingIndex = (parentMessageId: string | null | undefined) =>
+          snapshot
+            .getLoadable(store.messagesSiblingIdxFamily(parentMessageId ?? SHARED_CONVO_KEY))
+            .getValue() ?? 0;
+        const tail = selectActiveBranchTail(messages, SHARED_CONVO_KEY, getSiblingIndex);
+        if (tail == null) {
+          return undefined;
+        }
+        const index = messages.findIndex((message) => message.messageId === tail.messageId);
+        return index >= 0 ? index : undefined;
+      },
+    [data?.messages],
+  );
+
+  const { mutate: forkSharedConvo } = forkShare;
+  const handleContinue = useCallback(() => {
+    if (shareId == null || shareId === '') {
+      return;
+    }
+    forkSharedConvo({ shareId, targetMessageIndex: getActiveTargetIndex() });
+  }, [shareId, forkSharedConvo, getActiveTargetIndex]);
 
   // configure document title
   let docTitle = '';
@@ -104,9 +169,12 @@ function SharedView() {
           onThemeChange={handleThemeChange}
           onLangChange={handleLangChange}
           settingsLabel={localize('com_nav_settings')}
+          continueLabel={localize('com_ui_continue_chat')}
+          onContinue={handleContinue}
+          isContinuing={forkShare.isLoading}
         />
         <ShareMessagesProvider messages={data.messages}>
-          <MessagesView messagesTree={messagesTree} conversationId="shared-conversation" />
+          <MessagesView messagesTree={messagesTree} conversationId={SHARED_CONVO_KEY} />
         </ShareMessagesProvider>
       </>
     );
@@ -164,6 +232,9 @@ interface ShareHeaderProps {
   theme: string;
   langcode: string;
   settingsLabel: string;
+  continueLabel: string;
+  isContinuing: boolean;
+  onContinue: () => void;
   onThemeChange: (value: string) => void;
   onLangChange: (value: string) => void;
 }
@@ -174,6 +245,9 @@ function ShareHeader({
   theme,
   langcode,
   settingsLabel,
+  continueLabel,
+  isContinuing,
+  onContinue,
   onThemeChange,
   onLangChange,
 }: ShareHeaderProps) {
@@ -182,7 +256,7 @@ function ShareHeader({
 
   const handleDialogOutside = useCallback((event: Event) => {
     const target = event.target as HTMLElement | null;
-    if (target?.closest('[data-dialog-ignore="true"]')) {
+    if (target?.closest('[data-dialog-ignore="true"], .popover-ui')) {
       event.preventDefault();
     }
   }, []);
@@ -203,44 +277,64 @@ function ShareHeader({
             )}
           </div>
 
-          <OGDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <OGDialogTrigger asChild>
-              <Button
-                size={isMobile ? 'icon' : 'default'}
-                type="button"
-                variant="outline"
-                aria-label={settingsLabel}
-                className={cn(
-                  'rounded-full border-border-medium text-sm text-text-primary transition-colors',
-                  isMobile
-                    ? 'absolute bottom-4 right-4 justify-center p-0 shadow-lg'
-                    : 'gap-2 self-start px-4 py-2',
-                )}
-              >
-                <Settings className="size-4" aria-hidden="true" />
-                <span className="hidden md:inline">{settingsLabel}</span>
-              </Button>
-            </OGDialogTrigger>
-            <OGDialogContent
-              className="w-11/12 max-w-lg"
-              showCloseButton={true}
-              onPointerDownOutside={handleDialogOutside}
-              onInteractOutside={handleDialogOutside}
+          <div className="flex items-center gap-2 md:self-start">
+            <Button
+              type="button"
+              variant="submit"
+              onClick={onContinue}
+              disabled={isContinuing}
+              className="gap-2 rounded-full px-4 py-2 text-sm"
             >
-              <OGDialogHeader className="text-left">
-                <OGDialogTitle>{settingsLabel}</OGDialogTitle>
-              </OGDialogHeader>
-              <div className="flex flex-col gap-4 pt-2 text-sm">
-                <div className="relative focus-within:z-[100]">
-                  <ThemeSelector theme={theme} onChange={onThemeChange} portal={false} />
+              {isContinuing ? (
+                <Spinner className="size-4" />
+              ) : (
+                <MessageSquarePlus className="size-4" aria-hidden="true" />
+              )}
+              {continueLabel}
+            </Button>
+            <OGDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+              <OGDialogTrigger asChild>
+                <Button
+                  size={isMobile ? 'icon' : 'default'}
+                  type="button"
+                  variant="outline"
+                  aria-label={settingsLabel}
+                  className={cn(
+                    'rounded-full border-border-medium text-sm text-text-primary transition-colors',
+                    isMobile
+                      ? 'absolute bottom-4 right-4 justify-center p-0 shadow-lg'
+                      : 'gap-2 self-start px-4 py-2',
+                  )}
+                >
+                  <Settings className="size-4" aria-hidden="true" />
+                  <span className="hidden md:inline">{settingsLabel}</span>
+                </Button>
+              </OGDialogTrigger>
+              <OGDialogContent
+                className="w-11/12 max-w-lg"
+                showCloseButton={true}
+                onPointerDownOutside={handleDialogOutside}
+                onInteractOutside={handleDialogOutside}
+              >
+                <OGDialogHeader className="text-left">
+                  <OGDialogTitle>{settingsLabel}</OGDialogTitle>
+                </OGDialogHeader>
+                <div className="flex flex-col gap-4 pt-2 text-sm">
+                  <ThemeSelector
+                    theme={theme}
+                    onChange={onThemeChange}
+                    popoverClassName="z-[150]"
+                  />
+                  <div className="bg-border-medium/60 h-px w-full" />
+                  <LangSelector
+                    langcode={langcode}
+                    onChange={onLangChange}
+                    popoverClassName="z-[150]"
+                  />
                 </div>
-                <div className="bg-border-medium/60 h-px w-full" />
-                <div className="relative focus-within:z-[100]">
-                  <LangSelector langcode={langcode} onChange={onLangChange} portal={false} />
-                </div>
-              </div>
-            </OGDialogContent>
-          </OGDialog>
+              </OGDialogContent>
+            </OGDialog>
+          </div>
         </div>
       </div>
     </section>

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -695,6 +695,41 @@ export const useForkConvoMutation = (
   });
 };
 
+export const useForkSharedConvoMutation = (
+  options?: t.ForkSharedConvoOptions,
+): UseMutationResult<t.TForkConvoResponse, unknown, t.TForkSharedConvoRequest, unknown> => {
+  const queryClient = useQueryClient();
+  const { onSuccess, ..._options } = options ?? {};
+
+  return useMutation(
+    (payload: t.TForkSharedConvoRequest) =>
+      dataService.forkSharedConversation(payload.shareId, payload.targetMessageIndex),
+    {
+      onSuccess: (data, vars, context) => {
+        const forkedConversation = data.conversation;
+        const forkedConversationId = forkedConversation?.conversationId;
+        if (!forkedConversationId) {
+          return;
+        }
+
+        queryClient.setQueryData(
+          [QueryKeys.conversation, forkedConversationId],
+          forkedConversation,
+        );
+        addConvoToAllQueries(queryClient, forkedConversation);
+        queryClient.setQueryData([QueryKeys.messages, forkedConversationId], data.messages);
+        queryClient.invalidateQueries({
+          queryKey: [QueryKeys.allConversations],
+          refetchPage: (_, index) => index === 0,
+        });
+
+        onSuccess?.(data, vars, context);
+      },
+      ..._options,
+    },
+  );
+};
+
 export const useUploadConversationsMutation = (
   _options?: t.MutationOptions<t.TImportResponse, FormData>,
 ) => {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -964,6 +964,8 @@
   "com_ui_context_usage_snapshot_unknown": "Context {{0}}",
   "com_ui_context_window": "Context window",
   "com_ui_continue": "Continue",
+  "com_ui_continue_chat": "Continue this chat",
+  "com_ui_continue_chat_error": "There was an error copying this conversation",
   "com_ui_continue_oauth": "Continue with OAuth",
   "com_ui_control_bar": "Control bar",
   "com_ui_conversation": "conversation",

--- a/packages/api/src/shared-links/access.test.ts
+++ b/packages/api/src/shared-links/access.test.ts
@@ -5,7 +5,7 @@ jest.mock('@librechat/data-schemas', () => ({
 
 import mongoose, { Types, Model } from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { createModels, createMethods } from '@librechat/data-schemas';
+import { createModels, createMethods, tenantStorage } from '@librechat/data-schemas';
 import { ResourceType, PrincipalType, AccessRoleIds } from 'librechat-data-provider';
 import type { Request, Response, NextFunction } from 'express';
 import type { IAclEntry, ISharedLink } from '@librechat/data-schemas';
@@ -237,6 +237,36 @@ describe('canAccessSharedLink', () => {
 
       expect(next).toHaveBeenCalled();
       expect((req as unknown as Record<string, unknown>).shareResourceId).toBe(link._id.toString());
+    });
+  });
+
+  describe('cross-tenant lookup', () => {
+    test('resolves a share owned by another tenant via system fallback, then enforces the ACL', async () => {
+      // Share created under tenant-a; an authenticated viewer from tenant-b would
+      // miss the tenant-scoped lookup and previously get a 404 before access could
+      // be evaluated. The system fallback now resolves the share, and the ACL check
+      // (run under the share's own tenant) denies the viewer who has no grant. A 403
+      // rather than a 404 confirms the share was found cross-tenant but not authorized
+      // — the fallback broadens the lookup, never the authorization.
+      const link = await tenantStorage.run({ tenantId: 'tenant-a' }, () => createTestLink());
+      const viewer = new Types.ObjectId();
+      mockGetUserPrincipals.mockResolvedValue([
+        { principalType: PrincipalType.USER, principalId: viewer },
+      ]);
+
+      const req = createReq({
+        params: { shareId: link.shareId },
+        user: { id: viewer.toString(), _id: viewer, role: 'USER' },
+      });
+      const res = createRes();
+      const next = jest.fn();
+      await tenantStorage.run({ tenantId: 'tenant-b' }, () =>
+        canAccessSharedLink(req, res, next as unknown as NextFunction),
+      );
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res._status).toBe(403);
+      expect(res._status).not.toBe(404);
     });
   });
 

--- a/packages/api/src/shared-links/access.ts
+++ b/packages/api/src/shared-links/access.ts
@@ -62,7 +62,16 @@ export function createSharedLinkAccessMiddleware(deps: SharedLinkAccessDeps) {
         shareId,
         ...activeExpirationFilter<RawSharedLink>(),
       }).lean()) as RawSharedLink | null;
-    const rawShare = getTenantId() ? await findShare() : await runAsSystem(findShare);
+    // Resolve by the (globally unique, secret) shareId under the viewer's tenant
+    // first, then fall back to a system-wide lookup so a share owned by another
+    // tenant — e.g. a public link opened by an authenticated user from a
+    // different tenant — still resolves. Access remains gated by the ACL check
+    // below, which runs under the share's own tenant, so this only broadens the
+    // lookup, never the authorization.
+    let rawShare = getTenantId() ? await findShare() : await runAsSystem(findShare);
+    if (!rawShare && getTenantId()) {
+      rawShare = await runAsSystem(findShare);
+    }
 
     if (!rawShare) {
       res.status(404).json({ message: 'Shared link not found' });

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -187,6 +187,46 @@ describe('axios 401 interceptor — Authorization header guard', () => {
     expect(refreshCall[0].url).toContain('api/auth/refresh');
   });
 
+  it('attempts refresh for the share fork POST even without Authorization header', async () => {
+    expect.assertions(2);
+    setTokenHeader(undefined);
+
+    setWindowLocation({
+      href: 'http://localhost/share/abc123',
+      pathname: '/share/abc123',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/share/abc123/fork', method: 'post', headers: {} },
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: 'new-token' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { conversation: {}, messages: [] },
+      status: 201,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.post('/api/share/abc123/fork');
+    } catch {
+      // may reject depending on exact flow
+    }
+
+    expect(mockAdapter.mock.calls.length).toBe(3);
+    expect(mockAdapter.mock.calls[1][0].url).toContain('api/auth/refresh');
+  });
+
   it('does not refresh or redirect for unrelated 401s on public shared link pages', async () => {
     expect.assertions(2);
     setTokenHeader(undefined);
@@ -313,6 +353,36 @@ describe('axios 401 interceptor — Authorization header guard', () => {
 
     try {
       await axios.get('/api/share/abc123');
+    } catch {
+      // expected rejection
+    }
+
+    expect(window.location.href).toBe('/login?redirect_to=%2Fshare%2Fabc123');
+  });
+
+  it('redirects to login when the share fork refresh itself fails (stale session)', async () => {
+    expect.assertions(1);
+    setTokenHeader(undefined);
+
+    setWindowLocation({
+      href: 'http://localhost/share/abc123',
+      pathname: '/share/abc123',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/share/abc123/fork', method: 'post', headers: {} },
+    });
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 403 },
+      config: { url: '/api/auth/refresh', method: 'post', headers: {} },
+    });
+
+    try {
+      await axios.post('/api/share/abc123/fork');
     } catch {
       // expected rejection
     }

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -71,6 +71,7 @@ export const messagesBranch = () => `${messagesRoot}/branch`;
 
 const shareRoot = `${BASE_URL}/api/share`;
 export const shareMessages = (shareId: string) => `${shareRoot}/${shareId}`;
+export const forkSharedMessages = (shareId: string) => `${shareRoot}/${shareId}/fork`;
 export const sharedStartupConfig = (shareId: string) => `${shareMessages(shareId)}/config`;
 export const getSharedLink = (conversationId: string) => `${shareRoot}/link/${conversationId}`;
 export const getSharedLinks = (

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -799,6 +799,13 @@ export function forkConversation(payload: t.TForkConvoRequest): Promise<t.TForkC
   return request.post(endpoints.forkConversation(), payload);
 }
 
+export function forkSharedConversation(
+  shareId: string,
+  targetMessageIndex?: number,
+): Promise<t.TForkConvoResponse> {
+  return request.post(endpoints.forkSharedMessages(shareId), { targetMessageIndex });
+}
+
 export function deleteConversation(payload: t.TDeleteConversationRequest) {
   return request.deleteWithOptions(endpoints.deleteConversation(), { data: { arg: payload } });
 }

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -83,6 +83,7 @@ const refreshToken = (retry?: boolean): Promise<t.TRefreshTokenResponse | undefi
 
 const SHARE_PAGE_PATH_REGEX = /^\/share\/[^/]+\/?$/;
 const SHARED_MESSAGES_PATH_REGEX = /^\/api\/share\/[^/]+$/;
+const SHARE_FORK_PATH_REGEX = /^\/api\/share\/[^/]+\/fork$/;
 
 const normalizePathname = (pathname: string) =>
   pathname.startsWith('/') ? pathname : `/${pathname}`;
@@ -120,6 +121,14 @@ const getRequestPathname = (url?: string) => {
 const isSharedMessagesRequest = (url?: string, method?: string) =>
   method?.toLowerCase() === 'get' &&
   SHARED_MESSAGES_PATH_REGEX.test(stripBasePath(getRequestPathname(url)));
+
+/** The "continue this chat" fork is a deliberate authenticated action initiated
+ *  from a share page, so it must reach auth recovery/redirect like the shared
+ *  data request — otherwise a logged-out (or cold-loaded) viewer's 401 is
+ *  rejected silently instead of routing them through login. */
+const isShareForkRequest = (url?: string, method?: string) =>
+  method?.toLowerCase() === 'post' &&
+  SHARE_FORK_PATH_REGEX.test(stripBasePath(getRequestPathname(url)));
 
 const dispatchTokenUpdatedEvent = (token: string) => {
   setTokenHeader(token);
@@ -318,7 +327,11 @@ if (typeof window !== 'undefined') {
        *  recover auth/redirect without unrelated share-page queries forcing login. */
       if (
         !axios.defaults.headers.common['Authorization'] &&
-        !(isSharePage() && isSharedMessagesRequest(originalRequest.url, originalRequest.method))
+        !(
+          isSharePage() &&
+          (isSharedMessagesRequest(originalRequest.url, originalRequest.method) ||
+            isShareForkRequest(originalRequest.url, originalRequest.method))
+        )
       ) {
         return Promise.reject(error);
       }
@@ -347,8 +360,12 @@ if (typeof window !== 'undefined') {
 
           redirectToLoginOnce();
           return Promise.reject(error);
-        } catch (err) {
-          return Promise.reject(err);
+        } catch {
+          /** A rejected refresh (stale/invalid session → 401/403) must route to
+           *  login just like an empty-token refresh, otherwise the original 401
+           *  surfaces to the caller (e.g. the share fork button) with no redirect. */
+          redirectToLoginOnce();
+          return Promise.reject(error);
         }
       }
 

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -422,6 +422,14 @@ export type TForkConvoResponse = {
   messages: TMessage[];
 };
 
+export type TForkSharedConvoRequest = {
+  shareId: string;
+  /** Index of the viewer's active message within the shared payload; reduces the
+   *  fork to that branch. An index is used because shared ids are re-anonymized
+   *  per request and `createdAt` can collide, while the payload order is stable. */
+  targetMessageIndex?: number;
+};
+
 export type TSearchResults = {
   conversations: TConversation[];
   messages: TMessage[];

--- a/packages/data-provider/src/types/mutations.ts
+++ b/packages/data-provider/src/types/mutations.ts
@@ -207,6 +207,11 @@ export type DuplicateConvoOptions = MutationOptions<
 
 export type ForkConvoOptions = MutationOptions<types.TForkConvoResponse, types.TForkConvoRequest>;
 
+export type ForkSharedConvoOptions = MutationOptions<
+  types.TForkConvoResponse,
+  types.TForkSharedConvoRequest
+>;
+
 export type CreateSharedLinkOptions = MutationOptions<
   types.TSharedLink,
   Partial<types.TSharedLink>


### PR DESCRIPTION
## Summary

Resolves #13001.

Right now a shared conversation at `/share/:shareId` is read-only. If you're logged in and want to pick up where the conversation left off (continue an agent's workflow trace, branch off an answer, etc.) there's no way to do it short of copy-pasting messages by hand.

This adds a **"Continue this chat"** button to the share view header. Clicking it forks the shared conversation into a brand new conversation owned by you and drops you straight into it, ready to keep typing.

A few notes on how it works:

- New endpoint `POST /api/share/:shareId/fork`, behind `requireJwtAuth`, the existing fork rate limiters, and the same `canAccessSharedLink` ACL the GET uses, so you can only fork a share you're already allowed to view.
- The fork reads from `getSharedMessages`, i.e. the same anonymized, allow-listed payload the share page already renders. Nothing that isn't visible on the public share page can leak into the copy. The cloning itself reuses the existing `cloneMessagesWithTimestamps` + `ImportBatchBuilder` path that import/duplicate already rely on, so message tree, branches and timestamps come over intact. I strip the placeholder assistant model id and reparent any orphaned messages to root so the tree stays valid.
- Logged-out visitors aren't treated specially: the button is always shown, the request 401s, and the existing `/share/` auth-recovery flow bounces them to login with `redirect_to` pointing back at the share page. After login they land back on the share and click again.

While I was in the share settings dialog I also fixed the Theme/Language dropdowns, which were rendering inline (`portal={false}`) and getting clipped/flipped inside the dialog. They're now portaled and stacked above the dialog, so the full option lists are usable.

Last commit is a small unrelated fix I tripped over while testing: the "Temporary Chat" toggle in the chat header was showing on conversations created via the bulk-save path (import / fork / duplicate / share-fork) before they'd been continued, because it only checked the conversation's `messages` array, which that path leaves empty. It now also hides once the conversation has a real id, since the toggle only means anything on a brand new chat. The bug is easy to miss because the first message you send heals it, but it's exactly the state a share-fork lands you in.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Translation update

## Testing

Backend unit tests cover `forkSharedConversation` (happy path with anonymized message shapes, missing/empty share → null, orphaned parent → root, placeholder model stripped) and the new route (201 with the fork result, 404 on missing share, 500 on failure). The existing `share.spec.js` was updated for the new middleware/imports.

Manually verified end to end against a local instance:

- Logged-out: button → redirected to `/login?redirect_to=/share/:shareId` → after login, back on the share page; clicking again forks and opens `/c/:newId`.
- Logged-in: button → lands on the forked conversation with all messages, branches intact, composer ready.
- A branched share forks only the shared branch and keeps the sibling switcher.
- Theme/Language dropdowns in the share settings dialog show their full lists and selecting an option no longer closes the dialog; checked the main app settings dialog for regressions.
- Temporary Chat toggle: hidden on a forked/duplicated conversation, still shown on `/c/new`.

### **Test Configuration**:

LibreChat dev (backend + Vite), MongoDB, `ALLOW_SHARED_LINKS=true`, light and dark mode.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
