### PR TITLE
🔧 fix: Honor NO_PROXY for OpenID requests when PROXY is set

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -13,6 +13,7 @@ const {
   findOpenIDUser,
   getOpenIdEmail,
   getOpenIdIssuer,
+  getOpenIdProxyDispatcher,
   getBalanceConfig,
   isEmailDomainAllowed,
   getAvatarFileStrategy,
@@ -33,40 +34,6 @@ const getLogStores = require('~/cache/getLogStores');
  * @typedef {import('openid-client').ClientMetadata} ClientMetadata
  * @typedef {import('openid-client').Configuration} Configuration
  **/
-
-/** @type {undici.EnvHttpProxyAgent | undefined} */
-let proxyDispatcher;
-/** @type {string | undefined} */
-let proxyDispatcherKey;
-
-/**
- * Returns a shared dispatcher routing requests through the `PROXY` env var
- * while honoring the standard `NO_PROXY`/`no_proxy` exclusion list.
- *
- * Unlike `undici.ProxyAgent`, `undici.EnvHttpProxyAgent` applies `NO_PROXY`
- * per request host, so OIDC providers on an internal network the proxy
- * cannot reach (issuer discovery, JWKS, token endpoint) are requested
- * directly when excluded. The agent is memoized so repeated requests reuse
- * its connection pool instead of constructing a new agent per request.
- *
- * @returns {undici.EnvHttpProxyAgent | undefined} The dispatcher, or
- * `undefined` when no `PROXY` is configured.
- */
-function getProxyDispatcher() {
-  const proxy = process.env.PROXY;
-  if (!proxy) {
-    return undefined;
-  }
-  /** EnvHttpProxyAgent falls back to `no_proxy` / `NO_PROXY` env vars on
-   * its own; the cache key tracks them so env changes rebuild the agent. */
-  const noProxy = process.env.no_proxy ?? process.env.NO_PROXY ?? '';
-  const key = `${proxy}|${noProxy}`;
-  if (!proxyDispatcher || proxyDispatcherKey !== key) {
-    proxyDispatcher = new undici.EnvHttpProxyAgent({ httpProxy: proxy, httpsProxy: proxy });
-    proxyDispatcherKey = key;
-  }
-  return proxyDispatcher;
-}
 
 /**
  * @param {string} url
@@ -95,7 +62,7 @@ async function customFetch(url, options) {
   try {
     /** @type {undici.RequestInit} */
     let fetchOptions = options;
-    const dispatcher = getProxyDispatcher();
+    const dispatcher = getOpenIdProxyDispatcher();
     if (dispatcher) {
       logger.info(`[openidStrategy] proxy agent configured: ${process.env.PROXY}`);
       fetchOptions = {
@@ -454,7 +421,7 @@ async function resolveGroupsFromOverage(accessToken, sub) {
       body: JSON.stringify({ securityEnabledOnly: false }),
     };
 
-    const dispatcher = getProxyDispatcher();
+    const dispatcher = getOpenIdProxyDispatcher();
     if (dispatcher) {
       fetchOptions.dispatcher = dispatcher;
     }
@@ -1017,5 +984,4 @@ module.exports = {
   getOpenIdConfig,
   getOpenIdEmail,
   getRoleSource,
-  getProxyDispatcher,
 };

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -34,6 +34,40 @@ const getLogStores = require('~/cache/getLogStores');
  * @typedef {import('openid-client').Configuration} Configuration
  **/
 
+/** @type {undici.EnvHttpProxyAgent | undefined} */
+let proxyDispatcher;
+/** @type {string | undefined} */
+let proxyDispatcherKey;
+
+/**
+ * Returns a shared dispatcher routing requests through the `PROXY` env var
+ * while honoring the standard `NO_PROXY`/`no_proxy` exclusion list.
+ *
+ * Unlike `undici.ProxyAgent`, `undici.EnvHttpProxyAgent` applies `NO_PROXY`
+ * per request host, so OIDC providers on an internal network the proxy
+ * cannot reach (issuer discovery, JWKS, token endpoint) are requested
+ * directly when excluded. The agent is memoized so repeated requests reuse
+ * its connection pool instead of constructing a new agent per request.
+ *
+ * @returns {undici.EnvHttpProxyAgent | undefined} The dispatcher, or
+ * `undefined` when no `PROXY` is configured.
+ */
+function getProxyDispatcher() {
+  const proxy = process.env.PROXY;
+  if (!proxy) {
+    return undefined;
+  }
+  /** EnvHttpProxyAgent falls back to `no_proxy` / `NO_PROXY` env vars on
+   * its own; the cache key tracks them so env changes rebuild the agent. */
+  const noProxy = process.env.no_proxy ?? process.env.NO_PROXY ?? '';
+  const key = `${proxy}|${noProxy}`;
+  if (!proxyDispatcher || proxyDispatcherKey !== key) {
+    proxyDispatcher = new undici.EnvHttpProxyAgent({ httpProxy: proxy, httpsProxy: proxy });
+    proxyDispatcherKey = key;
+  }
+  return proxyDispatcher;
+}
+
 /**
  * @param {string} url
  * @param {client.CustomFetchOptions} options
@@ -61,11 +95,12 @@ async function customFetch(url, options) {
   try {
     /** @type {undici.RequestInit} */
     let fetchOptions = options;
-    if (process.env.PROXY) {
+    const dispatcher = getProxyDispatcher();
+    if (dispatcher) {
       logger.info(`[openidStrategy] proxy agent configured: ${process.env.PROXY}`);
       fetchOptions = {
         ...options,
-        dispatcher: new undici.ProxyAgent(process.env.PROXY),
+        dispatcher,
       };
     }
 
@@ -419,9 +454,9 @@ async function resolveGroupsFromOverage(accessToken, sub) {
       body: JSON.stringify({ securityEnabledOnly: false }),
     };
 
-    if (process.env.PROXY) {
-      const { ProxyAgent } = undici;
-      fetchOptions.dispatcher = new ProxyAgent(process.env.PROXY);
+    const dispatcher = getProxyDispatcher();
+    if (dispatcher) {
+      fetchOptions.dispatcher = dispatcher;
     }
 
     const response = await undici.fetch(url, fetchOptions);
@@ -982,4 +1017,5 @@ module.exports = {
   getOpenIdConfig,
   getOpenIdEmail,
   getRoleSource,
+  getProxyDispatcher,
 };

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -13,16 +13,16 @@ const {
   findOpenIDUser,
   getOpenIdEmail,
   getOpenIdIssuer,
-  getOpenIdProxyDispatcher,
   getBalanceConfig,
+  selectOpenIdRole,
+  getAvatarSaveParams,
   isEmailDomainAllowed,
   getAvatarFileStrategy,
-  getAvatarSaveParams,
-  selectOpenIdRole,
+  resolveAppConfigForUser,
+  getOpenIdProxyDispatcher,
   getOpenIdRoleSyncOptions,
   getOpenIdRolesForOpenIdSync,
   getLibreChatRolesForOpenIdSync,
-  resolveAppConfigForUser,
 } = require('@librechat/api');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -4,9 +4,9 @@ const jwtDecode = require('jsonwebtoken/decode');
 const { ErrorTypes, FileSources } = require('librechat-data-provider');
 const { findUser, createUser, updateUser, findRolesByNames } = require('~/models');
 const {
-  getOpenIdIssuer,
   getOpenIdProxyDispatcher,
   resolveAppConfigForUser,
+  getOpenIdIssuer,
   isEnabled,
 } = require('@librechat/api');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -3,10 +3,15 @@ const fetch = require('node-fetch');
 const jwtDecode = require('jsonwebtoken/decode');
 const { ErrorTypes, FileSources } = require('librechat-data-provider');
 const { findUser, createUser, updateUser, findRolesByNames } = require('~/models');
-const { getOpenIdIssuer, resolveAppConfigForUser, isEnabled } = require('@librechat/api');
+const {
+  getOpenIdIssuer,
+  getOpenIdProxyDispatcher,
+  resolveAppConfigForUser,
+  isEnabled,
+} = require('@librechat/api');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');
 const { getAppConfig } = require('~/server/services/Config');
-const { setupOpenId, getProxyDispatcher } = require('./openidStrategy');
+const { setupOpenId } = require('./openidStrategy');
 
 const mockCloudfrontFileSource = FileSources.cloudfront ?? 'cloudfront';
 
@@ -15,7 +20,6 @@ jest.mock('node-fetch');
 jest.mock('jsonwebtoken/decode');
 jest.mock('undici', () => ({
   fetch: jest.fn(),
-  EnvHttpProxyAgent: jest.fn(),
 }));
 jest.mock('~/server/services/Files/strategies', () => ({
   getStrategyFunctions: jest.fn(() => ({
@@ -74,6 +78,7 @@ jest.mock('@librechat/api', () => {
       enabled: false,
     })),
     getOpenIdIssuer: jest.fn(() => 'https://fake-issuer.com'),
+    getOpenIdProxyDispatcher: jest.fn(() => undefined),
     getAvatarFileStrategy: jest.fn((config, fallbackStrategy) => {
       const { FileSources } = jest.requireActual('librechat-data-provider');
       if (config?.fileStrategies) {
@@ -216,6 +221,7 @@ describe('setupOpenId', () => {
       get: jest.fn(),
       set: jest.fn(),
     }));
+    getOpenIdProxyDispatcher.mockReturnValue(undefined);
     require('openid-client').genericGrantRequest.mockReset();
     require('openid-client').genericGrantRequest.mockResolvedValue({
       access_token: 'exchanged_graph_token',
@@ -341,6 +347,32 @@ describe('setupOpenId', () => {
       const [, , metadata] = openidClient.discovery.mock.calls.at(-1);
       expect(metadata.client_secret).toBe('my-secret');
       expect(metadata.token_endpoint_auth_method).toBeUndefined();
+    });
+
+    it('uses the shared OpenID proxy dispatcher for custom fetch requests', async () => {
+      const dispatcher = { dispatch: jest.fn() };
+      const response = { status: 204, statusText: 'No Content', headers: new Headers() };
+      getOpenIdProxyDispatcher.mockReturnValue(dispatcher);
+      undici.fetch.mockResolvedValue(response);
+
+      await setupOpenId();
+
+      const [, , , , options] = openidClient.discovery.mock.calls.at(-1);
+      const openIdFetch = options[openidClient.customFetch];
+      await expect(
+        openIdFetch('https://issuer.example.com/.well-known/openid-configuration', {
+          method: 'GET',
+        }),
+      ).resolves.toBe(response);
+
+      expect(getOpenIdProxyDispatcher).toHaveBeenCalled();
+      expect(undici.fetch).toHaveBeenCalledWith(
+        'https://issuer.example.com/.well-known/openid-configuration',
+        {
+          method: 'GET',
+          dispatcher,
+        },
+      );
     });
   });
 
@@ -2557,69 +2589,5 @@ describe('getRoleSource', () => {
     expect(() => getRoleSource('access', 'required role', {}, userinfo)).toThrow(
       'Invalid token specified',
     );
-  });
-});
-
-describe('getProxyDispatcher', () => {
-  beforeEach(() => {
-    undici.EnvHttpProxyAgent.mockClear();
-    delete process.env.PROXY;
-    delete process.env.NO_PROXY;
-    delete process.env.no_proxy;
-  });
-
-  afterAll(() => {
-    delete process.env.PROXY;
-    delete process.env.NO_PROXY;
-    delete process.env.no_proxy;
-  });
-
-  it('returns undefined when PROXY is not set', () => {
-    expect(getProxyDispatcher()).toBeUndefined();
-    expect(undici.EnvHttpProxyAgent).not.toHaveBeenCalled();
-  });
-
-  it('creates a NO_PROXY-aware agent for both protocols when PROXY is set', () => {
-    process.env.PROXY = 'http://corporate-proxy:8080';
-
-    const dispatcher = getProxyDispatcher();
-
-    expect(dispatcher).toBeInstanceOf(undici.EnvHttpProxyAgent);
-    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledWith({
-      httpProxy: 'http://corporate-proxy:8080',
-      httpsProxy: 'http://corporate-proxy:8080',
-    });
-  });
-
-  it('reuses the same agent across calls', () => {
-    process.env.PROXY = 'http://corporate-proxy:8080';
-    process.env.NO_PROXY = 'localhost,.internal-domain.com';
-
-    const first = getProxyDispatcher();
-    const second = getProxyDispatcher();
-
-    expect(second).toBe(first);
-    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledTimes(1);
-  });
-
-  it('rebuilds the agent when NO_PROXY changes', () => {
-    process.env.PROXY = 'http://corporate-proxy:8080';
-    process.env.NO_PROXY = 'localhost';
-    getProxyDispatcher();
-
-    process.env.NO_PROXY = 'localhost,.internal-domain.com';
-    getProxyDispatcher();
-
-    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledTimes(2);
-  });
-
-  it('rebuilds the agent when PROXY changes', () => {
-    process.env.PROXY = 'http://corporate-proxy:8080';
-    getProxyDispatcher();
-
-    process.env.PROXY = 'http://other-proxy:3128';
-    getProxyDispatcher();
-
-    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledTimes(2);
   });
 });

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -6,7 +6,7 @@ const { findUser, createUser, updateUser, findRolesByNames } = require('~/models
 const { getOpenIdIssuer, resolveAppConfigForUser, isEnabled } = require('@librechat/api');
 const { resizeAvatar } = require('~/server/services/Files/images/avatar');
 const { getAppConfig } = require('~/server/services/Config');
-const { setupOpenId } = require('./openidStrategy');
+const { setupOpenId, getProxyDispatcher } = require('./openidStrategy');
 
 const mockCloudfrontFileSource = FileSources.cloudfront ?? 'cloudfront';
 
@@ -15,7 +15,7 @@ jest.mock('node-fetch');
 jest.mock('jsonwebtoken/decode');
 jest.mock('undici', () => ({
   fetch: jest.fn(),
-  ProxyAgent: jest.fn(),
+  EnvHttpProxyAgent: jest.fn(),
 }));
 jest.mock('~/server/services/Files/strategies', () => ({
   getStrategyFunctions: jest.fn(() => ({
@@ -2557,5 +2557,69 @@ describe('getRoleSource', () => {
     expect(() => getRoleSource('access', 'required role', {}, userinfo)).toThrow(
       'Invalid token specified',
     );
+  });
+});
+
+describe('getProxyDispatcher', () => {
+  beforeEach(() => {
+    undici.EnvHttpProxyAgent.mockClear();
+    delete process.env.PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  afterAll(() => {
+    delete process.env.PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  it('returns undefined when PROXY is not set', () => {
+    expect(getProxyDispatcher()).toBeUndefined();
+    expect(undici.EnvHttpProxyAgent).not.toHaveBeenCalled();
+  });
+
+  it('creates a NO_PROXY-aware agent for both protocols when PROXY is set', () => {
+    process.env.PROXY = 'http://corporate-proxy:8080';
+
+    const dispatcher = getProxyDispatcher();
+
+    expect(dispatcher).toBeInstanceOf(undici.EnvHttpProxyAgent);
+    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: 'http://corporate-proxy:8080',
+      httpsProxy: 'http://corporate-proxy:8080',
+    });
+  });
+
+  it('reuses the same agent across calls', () => {
+    process.env.PROXY = 'http://corporate-proxy:8080';
+    process.env.NO_PROXY = 'localhost,.internal-domain.com';
+
+    const first = getProxyDispatcher();
+    const second = getProxyDispatcher();
+
+    expect(second).toBe(first);
+    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds the agent when NO_PROXY changes', () => {
+    process.env.PROXY = 'http://corporate-proxy:8080';
+    process.env.NO_PROXY = 'localhost';
+    getProxyDispatcher();
+
+    process.env.NO_PROXY = 'localhost,.internal-domain.com';
+    getProxyDispatcher();
+
+    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebuilds the agent when PROXY changes', () => {
+    process.env.PROXY = 'http://corporate-proxy:8080';
+    getProxyDispatcher();
+
+    process.env.PROXY = 'http://other-proxy:3128';
+    getProxyDispatcher();
+
+    expect(undici.EnvHttpProxyAgent).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,5 +1,6 @@
 export * from './domain';
 export * from './openid';
+export * from './proxy';
 export * from './exchange';
 export * from './refresh';
 export * from './agent';

--- a/packages/api/src/auth/proxy.spec.ts
+++ b/packages/api/src/auth/proxy.spec.ts
@@ -1,0 +1,83 @@
+import { EnvHttpProxyAgent } from 'undici';
+import { getOpenIdProxyDispatcher } from './proxy';
+
+jest.mock('undici', () => ({
+  EnvHttpProxyAgent: jest.fn(),
+}));
+
+const MockEnvHttpProxyAgent = EnvHttpProxyAgent as jest.MockedClass<typeof EnvHttpProxyAgent>;
+
+describe('getOpenIdProxyDispatcher', () => {
+  beforeEach(() => {
+    MockEnvHttpProxyAgent.mockClear();
+    delete process.env.PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  afterAll(() => {
+    delete process.env.PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  it('returns undefined when PROXY is not set', () => {
+    expect(getOpenIdProxyDispatcher()).toBeUndefined();
+    expect(MockEnvHttpProxyAgent).not.toHaveBeenCalled();
+  });
+
+  it('creates a NO_PROXY-aware agent for both protocols when PROXY is set', () => {
+    process.env.PROXY = 'http://corporate-proxy-create:8080';
+
+    const dispatcher = getOpenIdProxyDispatcher();
+
+    expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+    expect(MockEnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: 'http://corporate-proxy-create:8080',
+      httpsProxy: 'http://corporate-proxy-create:8080',
+    });
+  });
+
+  it('reuses the same agent across calls', () => {
+    process.env.PROXY = 'http://corporate-proxy-reuse:8080';
+    process.env.NO_PROXY = 'localhost,.internal-domain.com';
+
+    const first = getOpenIdProxyDispatcher();
+    const second = getOpenIdProxyDispatcher();
+
+    expect(second).toBe(first);
+    expect(MockEnvHttpProxyAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds the agent when NO_PROXY changes', () => {
+    process.env.PROXY = 'http://corporate-proxy-no-proxy:8080';
+    process.env.NO_PROXY = 'localhost';
+    getOpenIdProxyDispatcher();
+
+    process.env.NO_PROXY = 'localhost,.internal-domain.com';
+    getOpenIdProxyDispatcher();
+
+    expect(MockEnvHttpProxyAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebuilds the agent when lowercase no_proxy changes', () => {
+    process.env.PROXY = 'http://corporate-proxy-lowercase:8080';
+    process.env.no_proxy = 'localhost';
+    getOpenIdProxyDispatcher();
+
+    process.env.no_proxy = 'localhost,.internal-domain.com';
+    getOpenIdProxyDispatcher();
+
+    expect(MockEnvHttpProxyAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebuilds the agent when PROXY changes', () => {
+    process.env.PROXY = 'http://corporate-proxy-change:8080';
+    getOpenIdProxyDispatcher();
+
+    process.env.PROXY = 'http://other-proxy:3128';
+    getOpenIdProxyDispatcher();
+
+    expect(MockEnvHttpProxyAgent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api/src/auth/proxy.ts
+++ b/packages/api/src/auth/proxy.ts
@@ -1,0 +1,19 @@
+import { EnvHttpProxyAgent } from 'undici';
+import type { Dispatcher } from 'undici';
+
+let proxyDispatcher: EnvHttpProxyAgent | undefined;
+let proxyDispatcherKey: string | undefined;
+
+export function getOpenIdProxyDispatcher(): Dispatcher | undefined {
+  const proxy = process.env.PROXY;
+  if (!proxy) return undefined;
+
+  const noProxy = process.env.no_proxy ?? process.env.NO_PROXY ?? '';
+  const key = `${proxy}|${noProxy}`;
+  if (!proxyDispatcher || proxyDispatcherKey !== key) {
+    proxyDispatcher = new EnvHttpProxyAgent({ httpProxy: proxy, httpsProxy: proxy });
+    proxyDispatcherKey = key;
+  }
+
+  return proxyDispatcher;
+}


### PR DESCRIPTION
## Summary

Fixes #13705.

`api/strategies/openidStrategy.js` routed every OIDC request (issuer discovery, JWKS, token endpoint, Microsoft Graph overage resolution) through `undici.ProxyAgent` whenever `PROXY` was set. `undici.ProxyAgent` does not consult `NO_PROXY`, so OIDC providers on internal networks that the corporate proxy cannot reach failed at startup with `ECONNREFUSED` or discovery timeouts — even when the issuer host was explicitly listed in `NO_PROXY`.

The fix replaces `ProxyAgent` with `undici.EnvHttpProxyAgent` configured to use `PROXY` for both protocols. `EnvHttpProxyAgent` applies the standard `NO_PROXY`/`no_proxy` exclusion list per request host (suffix matching, leading-dot domains, `host:port` entries, and `*`), so excluded hosts are requested directly. It also reads `NO_PROXY` from the environment on its own — no hand-rolled matcher needed.

The agent is additionally memoized (keyed on `PROXY` + `NO_PROXY`) instead of constructing a new `ProxyAgent` per request, so repeated OIDC calls reuse one connection pool.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New `getProxyDispatcher` test block in `api/strategies/openidStrategy.spec.js`: returns `undefined` without `PROXY`; constructs an `EnvHttpProxyAgent` with `PROXY` for both protocols; reuses the agent across calls; rebuilds when `NO_PROXY` or `PROXY` changes.
- `npx jest openidStrategy.spec` — 130/130 pass (125 existing + 5 new).
- `npx eslint` on changed files — clean.

### **Test Configuration**:

Repro from the issue: `PROXY=http://corporate-proxy:8080`, `NO_PROXY=localhost,127.0.0.1,.internal-domain.com`, `OPENID_ISSUER=https://sso.internal-domain.com/...` — discovery now bypasses the proxy for the excluded issuer host.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes