### PR TITLE
🐛 fix: Preserve agent builder form state across panel switches

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
@@ -170,32 +170,37 @@ let mockFormSubmitHandler: (() => void) | null = null;
 
 jest.mock('react-hook-form', () => {
   const actual = jest.requireActual('react-hook-form') as any;
+  /** AgentPanel consumes the form via useFormContext (provided by
+   * AgentPanelSwitch); the tests render AgentPanel directly, so both
+   * hooks resolve to the same mocked form. */
+  const useMockedForm = () => {
+    const methods = actual.useForm({
+      defaultValues: {
+        id: 'agent-123',
+        name: 'Test Agent',
+        description: 'Test description',
+        model: 'gpt-4',
+        provider: 'openai',
+        tools: [],
+        execute_code: false,
+        file_search: false,
+        web_search: false,
+      },
+    });
+
+    return {
+      ...methods,
+      handleSubmit: (onSubmit: any) => (e?: any) => {
+        e?.preventDefault?.();
+        mockFormSubmitHandler = () => onSubmit(methods.getValues());
+        return mockFormSubmitHandler;
+      },
+    };
+  };
   return {
     ...actual,
-    useForm: () => {
-      const methods = actual.useForm({
-        defaultValues: {
-          id: 'agent-123',
-          name: 'Test Agent',
-          description: 'Test description',
-          model: 'gpt-4',
-          provider: 'openai',
-          tools: [],
-          execute_code: false,
-          file_search: false,
-          web_search: false,
-        },
-      });
-
-      return {
-        ...methods,
-        handleSubmit: (onSubmit: any) => (e?: any) => {
-          e?.preventDefault?.();
-          mockFormSubmitHandler = () => onSubmit(methods.getValues());
-          return mockFormSubmitHandler;
-        },
-      };
-    },
+    useForm: useMockedForm,
+    useFormContext: useMockedForm,
     FormProvider: ({ children }: any) => children,
     useWatch: () => 'agent-123',
   };

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Button, useToastContext } from '@librechat/client';
-import { useWatch, useForm, FormProvider } from 'react-hook-form';
+import { useWatch, useFormContext } from 'react-hook-form';
 import { useGetModelsQuery } from 'librechat-data-provider/react-query';
 import {
   Tools,
@@ -244,10 +244,8 @@ export default function AgentPanel() {
   const agentQuery = canEdit && expandedAgentQuery.data ? expandedAgentQuery : basicAgentQuery;
 
   const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
-  const methods = useForm<AgentForm>({
-    defaultValues: getDefaultAgentFormValues(),
-    mode: 'onChange',
-  });
+  /** Provided by AgentPanelSwitch so form state survives panel switches */
+  const methods = useFormContext<AgentForm>();
 
   const {
     control,
@@ -483,84 +481,82 @@ export default function AgentPanel() {
   }, [agentQuery.data?.id, user?.role, canEdit]);
 
   return (
-    <FormProvider {...methods}>
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="scrollbar-gutter-stable flex flex-1 flex-col px-3 pb-3 pt-2"
-        aria-label="Agent configuration form"
-      >
-        <div className="flex-1">
-          <div className="flex w-full flex-wrap gap-2">
-            <div className="w-full">
-              <AgentSelect
-                createMutation={create}
-                agentQuery={agentQuery}
-                setCurrentAgentId={setCurrentAgentId}
-                selectedAgentId={agentQuery.isInitialLoading ? null : (current_agent_id ?? null)}
-              />
-            </div>
-            {agent_id && (
-              <div className="flex w-full gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="w-full justify-center"
-                  onClick={() => {
-                    reset(getDefaultAgentFormValues());
-                    setCurrentAgentId(undefined);
-                  }}
-                  disabled={agentQuery.isInitialLoading}
-                  aria-label={localize('com_ui_create_new_agent')}
-                >
-                  <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
-                  {localize('com_ui_create_new_agent')}
-                </Button>
-                <Button
-                  variant="submit"
-                  disabled={isEphemeralAgent(agent_id) || agentQuery.isInitialLoading}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleSelectAgent();
-                  }}
-                  aria-label={localize('com_ui_select_agent')}
-                >
-                  {localize('com_ui_select')}
-                </Button>
-              </div>
-            )}
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="scrollbar-gutter-stable flex flex-1 flex-col px-3 pb-3 pt-2"
+      aria-label="Agent configuration form"
+    >
+      <div className="flex-1">
+        <div className="flex w-full flex-wrap gap-2">
+          <div className="w-full">
+            <AgentSelect
+              createMutation={create}
+              agentQuery={agentQuery}
+              setCurrentAgentId={setCurrentAgentId}
+              selectedAgentId={agentQuery.isInitialLoading ? null : (current_agent_id ?? null)}
+            />
           </div>
-          {agentQuery.isInitialLoading && <AgentPanelSkeleton />}
-          {!canEditAgent && !agentQuery.isInitialLoading && (
-            <div className="flex h-[30vh] w-full items-center justify-center">
-              <div className="text-center">
-                <h2 className="text-token-text-primary m-2 text-xl font-semibold">
-                  {localize('com_agents_not_available')}
-                </h2>
-                <p className="text-token-text-secondary">{localize('com_agents_no_access')}</p>
-              </div>
+          {agent_id && (
+            <div className="flex w-full gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full justify-center"
+                onClick={() => {
+                  reset(getDefaultAgentFormValues());
+                  setCurrentAgentId(undefined);
+                }}
+                disabled={agentQuery.isInitialLoading}
+                aria-label={localize('com_ui_create_new_agent')}
+              >
+                <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
+                {localize('com_ui_create_new_agent')}
+              </Button>
+              <Button
+                variant="submit"
+                disabled={isEphemeralAgent(agent_id) || agentQuery.isInitialLoading}
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleSelectAgent();
+                }}
+                aria-label={localize('com_ui_select_agent')}
+              >
+                {localize('com_ui_select')}
+              </Button>
             </div>
-          )}
-          {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.model && (
-            <ModelPanel models={models} providers={providers} setActivePanel={setActivePanel} />
-          )}
-          {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.builder && (
-            <AgentConfig />
-          )}
-          {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.advanced && (
-            <AdvancedPanel />
           )}
         </div>
-        {canEditAgent && !agentQuery.isInitialLoading && (
-          <AgentFooter
-            createMutation={create}
-            updateMutation={update}
-            isAvatarUploading={isAvatarUploadInFlight || uploadAvatarMutation.isLoading}
-            activePanel={activePanel}
-            setActivePanel={setActivePanel}
-            setCurrentAgentId={setCurrentAgentId}
-          />
+        {agentQuery.isInitialLoading && <AgentPanelSkeleton />}
+        {!canEditAgent && !agentQuery.isInitialLoading && (
+          <div className="flex h-[30vh] w-full items-center justify-center">
+            <div className="text-center">
+              <h2 className="text-token-text-primary m-2 text-xl font-semibold">
+                {localize('com_agents_not_available')}
+              </h2>
+              <p className="text-token-text-secondary">{localize('com_agents_no_access')}</p>
+            </div>
+          </div>
         )}
-      </form>
-    </FormProvider>
+        {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.model && (
+          <ModelPanel models={models} providers={providers} setActivePanel={setActivePanel} />
+        )}
+        {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.builder && (
+          <AgentConfig />
+        )}
+        {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.advanced && (
+          <AdvancedPanel />
+        )}
+      </div>
+      {canEditAgent && !agentQuery.isInitialLoading && (
+        <AgentFooter
+          createMutation={create}
+          updateMutation={update}
+          isAvatarUploading={isAvatarUploadInFlight || uploadAvatarMutation.isLoading}
+          activePanel={activePanel}
+          setActivePanel={setActivePanel}
+          setCurrentAgentId={setCurrentAgentId}
+        />
+      )}
+    </form>
   );
 }

--- a/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
+import { useForm, FormProvider } from 'react-hook-form';
+import type { AgentForm } from '~/common';
 import { AgentPanelProvider, useAgentPanelContext } from '~/Providers/AgentPanelContext';
 import { Panel, isEphemeralAgent } from '~/common';
 import VersionPanel from './Version/VersionPanel';
+import { getDefaultAgentFormValues } from '~/utils';
 import ActionsPanel from './ActionsPanel';
 import AgentPanel from './AgentPanel';
 import store from '~/store';
@@ -19,6 +22,17 @@ function AgentPanelSwitchWithContext() {
   const { activePanel, setCurrentAgentId } = useAgentPanelContext();
   const agentId = useRecoilValue(store.conversationAgentIdByIndex(0));
 
+  /**
+   * The agent form lives above the panel switch so unsaved form state
+   * survives navigating to the Actions/Version panels and back. When it
+   * lived inside AgentPanel, switching panels unmounted the form and
+   * silently discarded everything the user had typed.
+   */
+  const methods = useForm<AgentForm>({
+    defaultValues: getDefaultAgentFormValues(),
+    mode: 'onChange',
+  });
+
   useEffect(() => {
     const agent_id = agentId ?? '';
     if (!isEphemeralAgent(agent_id)) {
@@ -27,10 +41,22 @@ function AgentPanelSwitchWithContext() {
   }, [setCurrentAgentId, agentId]);
 
   if (activePanel === Panel.actions) {
-    return <ActionsPanel />;
+    return (
+      <FormProvider {...methods}>
+        <ActionsPanel />
+      </FormProvider>
+    );
   }
   if (activePanel === Panel.version) {
-    return <VersionPanel />;
+    return (
+      <FormProvider {...methods}>
+        <VersionPanel />
+      </FormProvider>
+    );
   }
-  return <AgentPanel />;
+  return (
+    <FormProvider {...methods}>
+      <AgentPanel />
+    </FormProvider>
+  );
 }


### PR DESCRIPTION
## Summary

Fixes #13156.

The agent builder form (`useForm` + `FormProvider`) lived inside `AgentPanel`, but `AgentPanelSwitch` replaces `AgentPanel` entirely when the user navigates to the Actions or Version panels. That unmounted the form and silently discarded every unsaved field — name, description, instructions, model selection, capability toggles — so returning to the builder showed a blank form (create flow) or the last persisted values (edit flow).

This PR lifts the form up to `AgentPanelSwitchWithContext` and provides it via `FormProvider` around every panel branch; `AgentPanel` now consumes it with `useFormContext`. As a result, unsaved form state survives any panel round-trip.

Notes on scope:

- Sub-panels that already rendered inside the form (`model`, `advanced`) are unaffected.
- `ActionsPanel`'s own `ActionAuthForm` provider still shadows the agent form for its subtree exactly as before (nested `FormProvider` wins for its children).
- `AgentPanelSwitch` is the sole mount point of `AgentPanel`, so no other consumer needs a provider.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `AgentPanel.test.tsx` updated: the `react-hook-form` mock now serves the same mocked form from both `useForm` and `useFormContext` (the tests render `AgentPanel` directly). All 5 tests pass.
- `npm run typecheck` (client) — clean.
- `npx eslint` on all changed files — clean.
- Manual repro from the issue: Create Agent → fill name/description/instructions/model → open a sub-panel and come back → all values retained.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
