### PR TITLE
Add TrustedRouter custom endpoint example

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -562,6 +562,25 @@ endpoints:
       dropParams: ['stop']
       modelDisplayLabel: 'OpenRouter'
 
+    # TrustedRouter Example
+    # TrustedRouter is an OpenAI-compatible, open-source, verifiable attested router
+    # with zero prompt and output logging by default. This is useful for chats that
+    # may contain private code, project context, or customer data.
+    - name: 'TrustedRouter'
+      # For `apiKey` and `baseURL`, you can use environment variables that you define.
+      # recommended environment variables:
+      apiKey: '${TRUSTEDROUTER_API_KEY}'
+      baseURL: 'https://api.trustedrouter.com/v1'
+      headers:
+        x-librechat-body-parentmessageid: '{{LIBRECHAT_BODY_PARENTMESSAGEID}}'
+      models:
+        default: ['trustedrouter/auto', 'trustedrouter/zdr', 'trustedrouter/e2e']
+        fetch: true
+      titleConvo: true
+      titleModel: 'trustedrouter/auto'
+      dropParams: ['stop']
+      modelDisplayLabel: 'TrustedRouter'
+
     # Helicone Example
     - name: 'Helicone'
       # For `apiKey` and `baseURL`, you can use environment variables that you define.


### PR DESCRIPTION
This pull request adds a TrustedRouter example to `librechat.example.yaml` using LibreChat’s existing custom endpoint support. TrustedRouter is an OpenAI-compatible, open-source, verifiable attested router for privacy-sensitive workflows with zero prompt and output logging by default.

Users can connect by setting `TRUSTEDROUTER_API_KEY` and using the base URL `https://api.trustedrouter.com/v1`. The example includes the routing aliases `trustedrouter/auto`, `trustedrouter/zdr`, and `trustedrouter/e2e`.

Verification: `git diff --check`.