### PR TITLE
docs: complete Chinese translation (README.zh.md) parity and add maintainer info

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-<!-- Last synced with README.md: 2026-03-28 (cae3888) -->
+<!-- Last synced with README.md: 2026-06-14 (8154a31d2) -->
 
 <p align="center">
   <a href="https://librechat.ai">
@@ -76,6 +76,8 @@
     - 智能体市场：发现并部署社区构建的智能体。
     - 协作共享：与特定用户和群组共享智能体。
     - 灵活且可扩展：支持 MCP 服务器、工具、文件搜索、代码执行等。
+    - [技能 (Skills)](https://www.librechat.ai/docs/features/skills)：创建可复用的 `SKILL.md` 指令包，用于手动、自动或始终在线的智能体工作流。
+    - [子智能体 (Subagents)](https://www.librechat.ai/docs/features/subagents)：将特定工作委派给具有独立上下文窗口的隔离子智能体运行。
     - 兼容自定义端点、OpenAI, Azure, Anthropic, AWS Bedrock, Google, Vertex AI, Responses API 等。
     - [支持模型上下文协议 (MCP)](https://modelcontextprotocol.io/clients#librechat) 用于工具调用。
 
@@ -139,6 +141,7 @@
 
 - ⚙️ **配置与部署**：  
   - 支持代理、反向代理、Docker 及多种部署选项。  
+  - 使用 [S3 与 CloudFront](https://www.librechat.ai/docs/configuration/cdn/cloudfront) 实现稳定的媒体链接、边缘分发、签名 Cookie 和安全下载。
   - 可完全本地运行或部署在云端。
 
 - 📖 **开源与社区**：  
@@ -225,3 +228,5 @@ LibreChat 是一个自托管的 AI 对话平台，在一个注重隐私的统一
     <img src="https://github.com/user-attachments/assets/d6b70894-6064-475e-bb65-92a9e23e0077" alt="Locize Logo" height="50">
   </a>
 </p>
+
+> 中文翻译由 [JasonYeYuhe](https://github.com/JasonYeYuhe) 维护


### PR DESCRIPTION
This PR addresses the missing content issues that caused the previous PR (#13725) to be closed by the Codex Bot.

**Changes included in this PR:**
1. **Full Content Parity:** Added the missing translations for the **Skills** and **Subagents** bullet points under the Agents section.
2. **Missing Deployment Option:** Added the missing translation for the **S3 with CloudFront** bullet point under the Configuration & Deployment section.
3. **Updated Sync Hash:** The `Last synced` commit hash and date have been correctly updated to match the latest English `README.md`.
4. **Maintainer Credit:** Appended a note at the bottom of `README.zh.md` indicating that the Chinese translation is maintained by [@JasonYeYuhe](https://github.com/JasonYeYuhe).

**Translation Philosophy:**
Maintained standard technical terminology while ensuring the structural parity matches the English `README.md` exactly.

**Testing Conducted:**
- Visual inspection to ensure Markdown formatting is intact.
- Verified that all links are working and correctly formatted.
- Confirmed that no sections from the English README are missing in the Chinese version.