### PR TITLE
🔍 fix: Render Web Search Favicons on Raw SERP Results During Streaming

### DIFF
--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -141,26 +141,21 @@ export default function WebSearch({
     return [];
   }, [searchResults, attachments, ownTurn]);
 
-  const processedSources = useMemo(() => {
+  // Show favicons from the raw SERP results immediately rather than waiting for
+  // each source to flip to `processed`; the agents scrape barrier would otherwise
+  // freeze the stack on "Searching the web" for the slowest scrape's duration.
+  const streamingSources = useMemo(() => {
     if (complete && !finalizing) {
       return [];
     }
-    if (!searchResults) {
-      return [];
-    }
-    const result = searchResults[ownTurn];
+    const result = searchResults?.[ownTurn];
     if (!result) {
       return [];
     }
-    if (finalizing) {
-      return [...(result.organic || []), ...(result.topStories || [])];
-    }
-    return [...(result.organic || []), ...(result.topStories || [])].filter(
-      (source) => source.processed === true,
-    );
+    return [...(result.organic || []), ...(result.topStories || [])];
   }, [searchResults, complete, finalizing, ownTurn]);
 
-  const showSources = processedSources.length > 0;
+  const showSources = streamingSources.length > 0;
   const progressText = useMemo(() => {
     let text: ProgressKeys =
       ownTurn !== '0' ? 'com_ui_web_searching_again' : 'com_ui_web_searching';
@@ -278,7 +273,7 @@ export default function WebSearch({
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {progressText}
       </span>
-      {showSources && <StackedFavicons sources={processedSources} start={-5} />}
+      {showSources && <StackedFavicons sources={streamingSources} start={-5} />}
       <Globe className="size-4 shrink-0 text-text-secondary" aria-hidden="true" />
       <span className="tool-status-text shimmer font-medium text-text-secondary">
         {progressText}

--- a/client/src/components/Chat/Messages/Content/__tests__/WebSearch.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/WebSearch.test.tsx
@@ -205,13 +205,13 @@ describe('WebSearch', () => {
     });
   });
 
-  describe('processedSources scoping', () => {
-    it('shows processed sources only from ownTurn during streaming', () => {
+  describe('streaming favicons', () => {
+    it('renders favicons for all ownTurn sources during streaming, before they are processed', () => {
       const searchResults = makeSearchResults({
         0: {
           organic: [
             { link: 'https://a.com', title: 'A', processed: true } as ValidSource,
-            { link: 'https://b.com', title: 'B', processed: false } as ValidSource,
+            { link: 'https://b.com', title: 'B' } as ValidSource,
           ],
         },
         1: {
@@ -229,11 +229,27 @@ describe('WebSearch', () => {
         initialProgress: 0.5,
       });
 
-      const favicons = screen.queryAllByTestId('stacked-favicons');
-      if (favicons.length > 0) {
-        const count = Number(favicons[0].getAttribute('data-count'));
-        expect(count).toBeLessThanOrEqual(2);
-      }
+      const favicons = screen.getByTestId('stacked-favicons');
+      // Both turn-0 sources show immediately — including the unprocessed one —
+      // while the turn-1 source stays scoped out.
+      expect(Number(favicons.getAttribute('data-count'))).toBe(2);
+      expect(screen.getAllByText('Processing results').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('stays on "Searching the web" until any source for the turn arrives', () => {
+      const searchResults = makeSearchResults({ 0: { organic: [] } });
+      const attachments = [makeAttachment(0, searchResults['0'])];
+
+      renderWebSearch({
+        searchResults,
+        attachments,
+        isSubmitting: true,
+        isLast: true,
+        initialProgress: 0.5,
+      });
+
+      expect(screen.queryByTestId('stacked-favicons')).not.toBeInTheDocument();
+      expect(screen.getAllByText('Searching the web').length).toBeGreaterThanOrEqual(1);
     });
   });
 


### PR DESCRIPTION
## Summary

The web search tool call UI froze on **"Searching the web"** with no favicons for several seconds, making search feel slow and unresponsive.

Tracing the full pipeline (frontend → LibreChat backend → `@librechat/agents`):

1. The agents tool fires `onSearchResults` the instant the SERP returns, so the backend ([`api/server/services/Tools/search.js`](https://github.com/danny-avila/LibreChat/blob/dev/api/server/services/Tools/search.js)) emits the **first** `web_search` attachment with all the raw organic results — but with **no `processed` flag** yet.
2. The agents library then scrapes every source behind a `Promise.all` **barrier**. Nothing is emitted during this window, and it lasts as long as the *slowest* page fetch.
3. Only after the barrier does each source flip to `processed: true`, emitted in a quick burst.

The streaming favicon stack in `WebSearch.tsx` was gated on `source.processed === true`. So during the entire scrape barrier — the slowest part of the operation — the stack stayed empty even though every favicon was already available from the raw results delivered in step 1.

## Fix

During streaming, render favicons from **all of the current turn's sources** as soon as they arrive, instead of waiting for `processed`:

```ts
const streamingSources = useMemo(() => {
  if (complete && !finalizing) return [];
  const result = searchResults?.[ownTurn];
  if (!result) return [];
  return [...(result.organic || []), ...(result.topStories || [])];
}, [searchResults, complete, finalizing, ownTurn]);
```

Favicons now appear the moment the SERP results land, and the label moves to "Processing results" — filling the dead window that was previously blank. Completed-state rendering, turn scoping, and the "Reading sources" finalizing behavior are all unchanged.

## Tests

Updated `WebSearch.test.tsx`: replaced the stale `processedSources scoping` test with two that lock in the new behavior — favicons render for all of the turn's sources during streaming (including unprocessed ones, while staying turn-scoped), and the UI still holds on "Searching the web" until any source arrives. All 11 tests pass.

## Notes / out of scope

The SSE attachment handler appends each `web_search` attachment update as a duplicate rather than upserting (web_search has no `file_id`), so a search accumulates N duplicate attachments in memory during streaming. It's functionally correct — `useSearchResultsByTurn` dedupes by `turn` (last wins) — so it doesn't affect this fix, but it's a reasonable cleanup for a separate pass.