### PR TITLE
fix: allow IMAGE_GEN_OAI_MODEL to be set via agent credentials

### DIFF
--- a/api/app/clients/tools/manifest.json
+++ b/api/app/clients/tools/manifest.json
@@ -41,6 +41,11 @@
         "authField": "IMAGE_GEN_OAI_API_KEY",
         "label": "OpenAI Image Tools API Key",
         "description": "Your OpenAI API Key for Image Generation and Editing"
+      },
+      {
+        "authField": "IMAGE_GEN_OAI_MODEL",
+        "label": "OpenAI Image Model",
+        "description": "The image model to use (e.g. gpt-image-1, gpt-image-2). Defaults to gpt-image-1."
       }
     ]
   },

--- a/api/app/clients/tools/structured/OpenAIImageTools.js
+++ b/api/app/clients/tools/structured/OpenAIImageTools.js
@@ -54,6 +54,7 @@ function createAbortHandler() {
  * @param {ServerRequest} fields.req - Whether the tool is being used in an agent context
  * @param {boolean} fields.isAgent - Whether the tool is being used in an agent context
  * @param {string} fields.IMAGE_GEN_OAI_API_KEY - The OpenAI API key
+ * @param {string} [fields.IMAGE_GEN_OAI_MODEL] - The image model to use (e.g. 'gpt-image-1', 'gpt-image-2'). Falls back to IMAGE_GEN_OAI_MODEL env var, then 'gpt-image-1'.
  * @param {boolean} [fields.override] - Whether to override the API key check, necessary for app initialization
  * @param {MongoFile[]} [fields.imageFiles] - The images to be used for editing
  * @param {string} [fields.imageOutputType] - The image output type configuration
@@ -82,7 +83,7 @@ function createOpenAIImageTools(fields = {}) {
   let apiKey = fields.IMAGE_GEN_OAI_API_KEY ?? getApiKey();
   const closureConfig = { apiKey };
 
-  const imageModel = process.env.IMAGE_GEN_OAI_MODEL || 'gpt-image-1';
+  const imageModel = fields.IMAGE_GEN_OAI_MODEL || process.env.IMAGE_GEN_OAI_MODEL || 'gpt-image-1';
 
   let baseURL = 'https://api.openai.com/v1/';
   if (!override && process.env.IMAGE_GEN_OAI_BASEURL) {

--- a/api/test/app/clients/tools/structured/OpenAIImageTools.test.js
+++ b/api/test/app/clients/tools/structured/OpenAIImageTools.test.js
@@ -161,4 +161,30 @@ describe('OpenAIImageTools - IMAGE_GEN_OAI_MODEL environment variable', () => {
       expect.any(Object),
     );
   });
+
+  it('should prefer IMAGE_GEN_OAI_MODEL from fields over environment variable', async () => {
+    process.env.IMAGE_GEN_OAI_MODEL = 'env-model';
+
+    const mockGenerate = jest.fn().mockResolvedValue({
+      data: [{ b64_json: 'base64-encoded-image-data' }],
+    });
+
+    OpenAI.mockImplementation(() => ({
+      images: { generate: mockGenerate },
+    }));
+
+    const [imageGenTool] = createOpenAIImageTools({
+      isAgent: true,
+      override: false,
+      req: { user: { id: 'test-user' } },
+      IMAGE_GEN_OAI_MODEL: 'gpt-image-2',
+    });
+
+    await imageGenTool.func({ prompt: 'test prompt' });
+
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-image-2' }),
+      expect.any(Object),
+    );
+  });
 });


### PR DESCRIPTION
Fixes #13733

## What

Adds `IMAGE_GEN_OAI_MODEL` to the `image_gen_oai` plugin's `authConfig` in `manifest.json`, and updates `createOpenAIImageTools` to read the model from the credentials fields first (falling back to the env var, then `gpt-image-1`).

## Why

Previously `IMAGE_GEN_OAI_MODEL` was env-var-only, making it impossible for users to set a different image model per-agent through the plugin credentials UI (e.g. switching between `gpt-image-1` and `gpt-image-2`). Adding it to `authConfig` exposes it in the agent setup form and persists it per-agent.

## Testing

- Added a Jest test that verifies `fields.IMAGE_GEN_OAI_MODEL` takes precedence over the env var.
- All 4 tests in `api/test/app/clients/tools/structured/OpenAIImageTools.test.js` pass.