### PR TITLE
feat: configurable Langfuse trace userId via LANGFUSE_USER_ID_FIELD

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -46,6 +46,7 @@ const {
   buildAgentScopedContext,
   buildSkillPrimeContentParts,
   buildInitialToolSessions,
+  getLangfuseUserId,
 } = require('@librechat/api');
 const {
   Callback,
@@ -1069,7 +1070,7 @@ class AgentClient extends BaseClient {
         configurable: {
           thread_id: this.conversationId,
           last_agent_index: this.agentConfigs?.size ?? 0,
-          user_id: this.user ?? this.options.req.user?.id,
+          user_id: getLangfuseUserId(this.options.req?.user) ?? this.user ?? this.options.req?.user?.id,
           hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
           requestBody: {
             messageId: this.responseMessageId,
@@ -1672,7 +1673,7 @@ class AgentClient extends BaseClient {
           ],
           configurable: {
             thread_id: this.conversationId,
-            user_id: this.user ?? this.options.req.user?.id,
+            user_id: getLangfuseUserId(this.options.req?.user) ?? this.user ?? this.options.req?.user?.id,
           },
         },
       });

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -35,6 +35,7 @@ const {
   resolveAgentScopedSkillIds,
   createOpenAIContentAggregator,
   isChatCompletionValidationFailure,
+  getLangfuseUserId,
 } = require('@librechat/api');
 const {
   buildSummarizationHandlers,
@@ -756,7 +757,7 @@ const OpenAIChatCompletionController = async (req, res) => {
       runName: 'AgentRun',
       configurable: {
         thread_id: conversationId,
-        user_id: userId,
+        user_id: getLangfuseUserId(req.user) ?? userId,
         user: createSafeUser(req.user),
         requestBody: {
           messageId: responseId,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -43,6 +43,7 @@ const {
   sendResponsesErrorResponse,
   createResponsesEventHandlers,
   createAggregatorEventHandlers,
+  getLangfuseUserId,
 } = require('@librechat/api');
 const {
   createResponsesToolEndCallback,
@@ -764,7 +765,7 @@ const createResponse = async (req, res) => {
         runName: 'AgentRun',
         configurable: {
           thread_id: conversationId,
-          user_id: userId,
+          user_id: getLangfuseUserId(req.user) ?? userId,
           user: createSafeUser(req.user),
           requestBody: {
             messageId: responseId,
@@ -940,7 +941,7 @@ const createResponse = async (req, res) => {
         runName: 'AgentRun',
         configurable: {
           thread_id: conversationId,
-          user_id: userId,
+          user_id: getLangfuseUserId(req.user) ?? userId,
           user: createSafeUser(req.user),
           requestBody: {
             messageId: responseId,

--- a/packages/api/src/langfuse/index.ts
+++ b/packages/api/src/langfuse/index.ts
@@ -1,2 +1,3 @@
 export * from './feedback';
 export * from './trace';
+export * from './userId';

--- a/packages/api/src/langfuse/userId.spec.ts
+++ b/packages/api/src/langfuse/userId.spec.ts
@@ -1,0 +1,79 @@
+import { getLangfuseUserId } from './userId';
+import type { IUser } from '@librechat/data-schemas';
+
+const makeUser = (overrides: Partial<IUser> = {}): IUser =>
+  ({
+    id: 'mongo-id-123',
+    email: 'alice@example.com',
+    username: 'alice',
+    name: 'Alice Smith',
+    provider: 'local',
+    ...overrides,
+  }) as unknown as IUser;
+
+describe('getLangfuseUserId', () => {
+  const originalEnv = process.env.LANGFUSE_USER_ID_FIELD;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LANGFUSE_USER_ID_FIELD;
+    } else {
+      process.env.LANGFUSE_USER_ID_FIELD = originalEnv;
+    }
+  });
+
+  it('returns undefined when user is null', () => {
+    expect(getLangfuseUserId(null)).toBeUndefined();
+  });
+
+  it('returns undefined when user is undefined', () => {
+    expect(getLangfuseUserId(undefined)).toBeUndefined();
+  });
+
+  it('defaults to internal id when env var is not set', () => {
+    delete process.env.LANGFUSE_USER_ID_FIELD;
+    expect(getLangfuseUserId(makeUser())).toBe('mongo-id-123');
+  });
+
+  it('defaults to internal id when env var is set to "id"', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'id';
+    expect(getLangfuseUserId(makeUser())).toBe('mongo-id-123');
+  });
+
+  it('returns email when LANGFUSE_USER_ID_FIELD=email', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'email';
+    expect(getLangfuseUserId(makeUser())).toBe('alice@example.com');
+  });
+
+  it('returns username when LANGFUSE_USER_ID_FIELD=username', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'username';
+    expect(getLangfuseUserId(makeUser())).toBe('alice');
+  });
+
+  it('returns name when LANGFUSE_USER_ID_FIELD=name', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'name';
+    expect(getLangfuseUserId(makeUser())).toBe('Alice Smith');
+  });
+
+  it('falls back to id when requested field is empty', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'username';
+    expect(getLangfuseUserId(makeUser({ username: '' }))).toBe('mongo-id-123');
+  });
+
+  it('falls back to id when requested field is missing from user', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'username';
+    const user = makeUser();
+    delete (user as Partial<IUser>).username;
+    expect(getLangfuseUserId(user)).toBe('mongo-id-123');
+  });
+
+  it('falls back to id for unsupported field names', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = 'role';
+    expect(getLangfuseUserId(makeUser())).toBe('mongo-id-123');
+  });
+
+  it('trims whitespace from env var before comparing', () => {
+    process.env.LANGFUSE_USER_ID_FIELD = '  email  ';
+    expect(getLangfuseUserId(makeUser())).toBe('alice@example.com');
+  });
+});

--- a/packages/api/src/langfuse/userId.ts
+++ b/packages/api/src/langfuse/userId.ts
@@ -1,0 +1,34 @@
+import type { IUser } from '@librechat/data-schemas';
+
+/**
+ * Supported IUser fields that can be used as the Langfuse trace userId.
+ * These are non-sensitive, string-valued fields available on the user object.
+ */
+const SUPPORTED_FIELDS = ['id', 'email', 'username', 'name'] as const;
+type SupportedField = (typeof SUPPORTED_FIELDS)[number];
+
+function isSupportedField(value: string): value is SupportedField {
+  return (SUPPORTED_FIELDS as readonly string[]).includes(value);
+}
+
+/**
+ * Returns the Langfuse trace userId for the given user, controlled by the
+ * LANGFUSE_USER_ID_FIELD environment variable.
+ *
+ * Defaults to the internal MongoDB id ('id') when the env var is unset or
+ * set to an unsupported value, preserving the existing behaviour.
+ *
+ * Supported values: 'id' | 'email' | 'username' | 'name'
+ */
+export function getLangfuseUserId(user: IUser | null | undefined): string | undefined {
+  if (!user) {
+    return undefined;
+  }
+
+  const configured = process.env.LANGFUSE_USER_ID_FIELD?.trim();
+  const field: SupportedField =
+    configured && isSupportedField(configured) ? configured : 'id';
+
+  const value = user[field];
+  return typeof value === 'string' && value.length > 0 ? value : user.id;
+}


### PR DESCRIPTION
Fixes #13529

## What

Adds a `LANGFUSE_USER_ID_FIELD` env var that controls which user property becomes the Langfuse trace `userId`. Supported values: `id` (default), `email`, `username`, `name`. Implemented via a new `getLangfuseUserId` utility in `packages/api/src/langfuse/userId.ts`, applied across all three agent controllers (`client.js`, `openai.js`, `responses.js`).

## Why

Langfuse traces were always tagged with the internal MongoDB `_id`, making it hard to correlate traces to users in the Langfuse dashboard when the team identifies users by email or username.

## Testing

- 11 unit tests in `packages/api/src/langfuse/userId.spec.ts` covering all supported fields, fallback for empty values, unsupported field names, and whitespace trimming — all pass.