### PR TITLE
fix: show user-friendly message when agent hits tool call limit

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1402,9 +1402,12 @@ class AgentClient extends BaseClient {
           '[api/server/controllers/agents/client.js #sendCompletion] Unhandled error type',
           err,
         );
+        const isRecursionLimit = err?.name === 'GraphRecursionError';
         this.contentParts.push({
           type: ContentTypes.ERROR,
-          [ContentTypes.ERROR]: `An error occurred while processing the request${err?.message ? `: ${err.message}` : ''}`,
+          [ContentTypes.ERROR]: isRecursionLimit
+            ? 'The agent reached its tool call limit for this turn. Send a new message to continue the conversation.'
+            : `An error occurred while processing the request${err?.message ? `: ${err.message}` : ''}`,
         });
       }
     } finally {

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -851,7 +851,12 @@ const OpenAIChatCompletionController = async (req, res) => {
       );
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'An error occurred';
+    const isRecursionLimit = error?.name === 'GraphRecursionError';
+    const errorMessage = isRecursionLimit
+      ? 'The agent reached its tool call limit. Send a new request to continue.'
+      : error instanceof Error
+        ? error.message
+        : 'An error occurred';
     logger.error('[OpenAI API] Error:', error);
 
     // Check if we already started streaming (headers sent)

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -1020,7 +1020,12 @@ const createResponse = async (req, res) => {
       );
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'An error occurred';
+    const isRecursionLimit = error?.name === 'GraphRecursionError';
+    const errorMessage = isRecursionLimit
+      ? 'The agent reached its tool call limit. Send a new request to continue.'
+      : error instanceof Error
+        ? error.message
+        : 'An error occurred';
     logger.error('[Responses API] Error:', error);
 
     // Check if we already started streaming (headers sent)


### PR DESCRIPTION
Fixes #13432

## What

When LangGraph throws a `GraphRecursionError` (agent exceeded `recursionLimit`), all three agent controllers (`client.js`, `openai.js`, `responses.js`) now detect it by `err.name === 'GraphRecursionError'` and surface a clear, actionable message instead of the raw exception:

> "The agent reached its tool call limit for this turn. Send a new message to continue the conversation."

## Why

The previous error was the raw LangGraph exception message, which is confusing to end users who have no context about graph recursion limits.

## Testing

Manual: trigger a long tool-calling chain that exceeds the recursion limit — the new message appears in the chat instead of the raw error.