### PR TITLE
fix: resize oversized generated images for agent tool results

### DIFF
--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -7,8 +7,16 @@ const {
   applyAxiosProxyConfig,
   createMinimalRetentionRequest,
   getHttpsProxyAgent,
+  resizeImageToFit,
 } = require('@librechat/api');
-const { FileContext, ContentTypes } = require('librechat-data-provider');
+const { FileContext, ContentTypes, mbToBytes } = require('librechat-data-provider');
+
+/**
+ * Agent-returned images are re-sent to the model as tool results on the next
+ * turn. Cap them at Anthropic's 5 MB per-image limit — the smallest among
+ * supported providers — so large generations don't break the conversation.
+ */
+const MAX_AGENT_IMAGE_BYTES = mbToBytes(5);
 
 const fluxApiJsonSchema = {
   type: 'object',
@@ -313,7 +321,8 @@ class FluxAPI extends Tool {
         }
         const imageResponse = await fetch(imageUrl, fetchOptions);
         const arrayBuffer = await imageResponse.arrayBuffer();
-        const base64 = Buffer.from(arrayBuffer).toString('base64');
+        const imageBuffer = await resizeImageToFit(Buffer.from(arrayBuffer), MAX_AGENT_IMAGE_BYTES);
+        const base64 = imageBuffer.toString('base64');
         const content = [
           {
             type: ContentTypes.IMAGE_URL,
@@ -546,7 +555,8 @@ class FluxAPI extends Tool {
         }
         const imageResponse = await fetch(imageUrl, fetchOptions);
         const arrayBuffer = await imageResponse.arrayBuffer();
-        const base64 = Buffer.from(arrayBuffer).toString('base64');
+        const imageBuffer = await resizeImageToFit(Buffer.from(arrayBuffer), MAX_AGENT_IMAGE_BYTES);
+        const base64 = imageBuffer.toString('base64');
         const content = [
           {
             type: ContentTypes.IMAGE_URL,

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -9,6 +9,7 @@ export * from './mistral/crud';
 export * from './ocr';
 export * from './parse';
 export * from './rag';
+export * from './resize';
 export * from './retention';
 export * from './sweep';
 export * from './validation';

--- a/packages/api/src/files/resize.spec.ts
+++ b/packages/api/src/files/resize.spec.ts
@@ -1,0 +1,90 @@
+import sharp from 'sharp';
+import { resizeImageToFit } from './resize';
+
+/** Fills a raw RGB buffer with incompressible noise so the encoded PNG stays large. */
+function randomRawBuffer(width: number, height: number, channels: 3 | 4 = 3): Buffer {
+  const raw = Buffer.allocUnsafe(width * height * channels);
+  for (let i = 0; i < raw.length; i++) {
+    raw[i] = Math.floor(Math.random() * 256);
+  }
+  return raw;
+}
+
+/** Encodes a noisy PNG large enough to exceed `minBytes`. */
+async function createLargePng(minBytes: number): Promise<Buffer> {
+  let size = 512;
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const channels = 3;
+    const png = await sharp(randomRawBuffer(size, size, channels), {
+      raw: { width: size, height: size, channels },
+    })
+      .png()
+      .toBuffer();
+    if (png.length >= minBytes) {
+      return png;
+    }
+    size *= 2;
+  }
+  throw new Error('Unable to build a sufficiently large PNG fixture');
+}
+
+async function createSmallPng(): Promise<Buffer> {
+  return sharp({
+    create: { width: 8, height: 8, channels: 3, background: { r: 10, g: 20, b: 30 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe('resizeImageToFit', () => {
+  it('returns the original buffer untouched when it already fits', async () => {
+    const small = await createSmallPng();
+    const result = await resizeImageToFit(small, 5 * 1024 * 1024);
+    expect(result).toBe(small);
+  });
+
+  it('returns the original buffer when the limit is not positive', async () => {
+    const small = await createSmallPng();
+    expect(await resizeImageToFit(small, 0)).toBe(small);
+  });
+
+  it('downscales an oversized image to fit within the byte limit', async () => {
+    const maxBytes = 200 * 1024;
+    const large = await createLargePng(maxBytes * 4);
+    expect(large.length).toBeGreaterThan(maxBytes);
+
+    const result = await resizeImageToFit(large, maxBytes);
+
+    expect(result.length).toBeLessThanOrEqual(maxBytes);
+    const metadata = await sharp(result).metadata();
+    expect(metadata.format).toBe('png');
+    expect(metadata.width).toBeGreaterThan(0);
+    expect(metadata.height).toBeGreaterThan(0);
+  });
+
+  it('preserves the original aspect ratio while downscaling', async () => {
+    const maxBytes = 150 * 1024;
+    const width = 1600;
+    const height = 800;
+    const large = await sharp(randomRawBuffer(width, height), {
+      raw: { width, height, channels: 3 },
+    })
+      .png()
+      .toBuffer();
+    expect(large.length).toBeGreaterThan(maxBytes);
+
+    const result = await resizeImageToFit(large, maxBytes);
+    const metadata = await sharp(result).metadata();
+
+    expect(result.length).toBeLessThanOrEqual(maxBytes);
+    const originalRatio = width / height;
+    const resizedRatio = (metadata.width ?? 0) / (metadata.height ?? 1);
+    expect(Math.abs(resizedRatio - originalRatio)).toBeLessThan(0.1);
+  });
+
+  it('returns the input unchanged when it cannot be decoded as an image', async () => {
+    const notAnImage = Buffer.from('this is definitely not an image payload', 'utf-8');
+    const result = await resizeImageToFit(notAnImage, 4);
+    expect(result).toBe(notAnImage);
+  });
+});

--- a/packages/api/src/files/resize.ts
+++ b/packages/api/src/files/resize.ts
@@ -1,0 +1,53 @@
+import sharp from 'sharp';
+
+/**
+ * Downscales an image buffer until its encoded size fits within `maxBytes`,
+ * preserving the original aspect ratio and image format.
+ *
+ * Encoded size scales roughly with pixel area, so each pass targets the square
+ * root of the size ratio (with a safety margin) and re-encodes from the source
+ * buffer to avoid cumulative quality loss. The input is returned unchanged when
+ * it already fits, when `maxBytes` is not positive, or when the buffer cannot be
+ * decoded as a raster image.
+ *
+ * @param inputBuffer - The source image buffer.
+ * @param maxBytes - The maximum allowed encoded size, in bytes.
+ * @returns A buffer that fits within `maxBytes` when achievable, otherwise the
+ *   smallest buffer produced.
+ */
+export async function resizeImageToFit(inputBuffer: Buffer, maxBytes: number): Promise<Buffer> {
+  if (maxBytes <= 0 || inputBuffer.length <= maxBytes) {
+    return inputBuffer;
+  }
+
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    ({ width, height } = await sharp(inputBuffer).metadata());
+  } catch {
+    return inputBuffer;
+  }
+
+  if (!width || !height) {
+    return inputBuffer;
+  }
+
+  let scale = 1;
+  let output = inputBuffer;
+
+  for (let attempt = 0; attempt < 6 && output.length > maxBytes; attempt++) {
+    scale *= Math.sqrt(maxBytes / output.length) * 0.9;
+    const targetWidth = Math.max(1, Math.round(width * scale));
+    const targetHeight = Math.max(1, Math.round(height * scale));
+
+    output = await sharp(inputBuffer)
+      .resize({ width: targetWidth, height: targetHeight, fit: 'inside', withoutEnlargement: true })
+      .toBuffer();
+
+    if (targetWidth <= 1 && targetHeight <= 1) {
+      break;
+    }
+  }
+
+  return output;
+}


### PR DESCRIPTION
## Summary

Image generation tools running in an agent context (e.g. the Flux tool) return the generated image inline as base64. When a generation is large, it is sent back to the model on the next turn as a tool result and can exceed a provider's per-image size limit. Anthropic rejects images larger than its 5 MB maximum with a `400 ... image exceeds 5 MB maximum` error, which interrupts the conversation even though the image was generated successfully.

This adds a small, reusable `resizeImageToFit(buffer, maxBytes)` helper in `@librechat/api` that downscales an image to fit within a byte budget while preserving aspect ratio and format, and applies it in the Flux tool's agent paths before the image is base64-encoded. Images already within the limit are returned untouched, so behavior is unchanged for normal-sized generations.

Closes #6954

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added unit tests for the helper (`packages/api/src/files/resize.spec.ts`) using real `sharp` (no mocks):

- returns the original buffer untouched when it already fits or the limit is non-positive
- downscales an oversized PNG to within the byte limit and keeps it a valid, decodable image
- preserves the original aspect ratio while downscaling
- returns the input unchanged when it cannot be decoded as an image

Run:

```bash
cd packages/api && npx jest src/files/resize.spec.ts
```

### **Test Configuration**:

- `@librechat/api` workspace unit tests (Jest)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
