### PR TITLE
🔗 fix: refresh expired S3 presigned URLs in message and tool-call snapshots on read

### DIFF
--- a/api/server/controllers/__tests__/getToolCalls-attachment-refresh.spec.js
+++ b/api/server/controllers/__tests__/getToolCalls-attachment-refresh.spec.js
@@ -1,0 +1,100 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('@librechat/api', () => ({
+  checkAccess: jest.fn().mockResolvedValue(true),
+  loadWebSearchAuth: jest.fn(),
+  refreshS3Url: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('~/models', () => ({
+  getRoleByName: jest.fn(),
+  createToolCall: jest.fn(),
+  getToolCallsByConvo: jest.fn(),
+  getMessage: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/process', () => ({
+  processFileURL: jest.fn(),
+  uploadImageBuffer: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/retention', () => ({
+  getRetentionExpiry: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/Code/process', () => ({
+  processCodeOutput: jest.fn(),
+  runPreviewFinalize: jest.fn(),
+}));
+
+jest.mock('~/server/services/Tools/credentials', () => ({
+  loadAuthValues: jest.fn(),
+}));
+
+jest.mock('~/app/clients/tools/util', () => ({
+  loadTools: jest.fn(),
+}));
+
+const { getToolCallsByConvo } = require('~/models');
+const { refreshS3Url } = require('@librechat/api');
+const { FileSources } = require('librechat-data-provider');
+const { getToolCalls } = require('../tools');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.get('/api/agents/tools/calls', (req, res, next) => {
+    req.user = { id: 'u1' };
+    return getToolCalls(req, res, next);
+  });
+  return app;
+}
+
+describe('GET /api/agents/tools/calls — refresh expired S3 presigned URLs', () => {
+  const STALE = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=OLD&X-Amz-Expires=120';
+  const FRESH = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=NEW&X-Amz-Expires=120';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rewrites stale presigned URLs in toolcalls[].attachments[]', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    getToolCallsByConvo.mockResolvedValue([
+      {
+        conversationId: 'c1',
+        messageId: 'm1',
+        toolId: 'execute_code',
+        attachments: [{ file_id: 'tc1', source: FileSources.s3, filepath: STALE }],
+      },
+    ]);
+
+    const res = await request(buildApp()).get('/api/agents/tools/calls?conversationId=c1');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].attachments[0].filepath).toBe(FRESH);
+    expect(res.body[0].attachments[0].file_id).toBe('tc1');
+  });
+
+  test('toolcalls without attachments pass through cleanly', async () => {
+    getToolCallsByConvo.mockResolvedValue([
+      { conversationId: 'c1', messageId: 'm1', toolId: 'web_search', result: {} },
+    ]);
+
+    const res = await request(buildApp()).get('/api/agents/tools/calls?conversationId=c1');
+
+    expect(res.status).toBe(200);
+    expect(refreshS3Url).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/controllers/tools.js
+++ b/api/server/controllers/tools.js
@@ -10,6 +10,9 @@ const {
 } = require('librechat-data-provider');
 const { getRoleByName, createToolCall, getToolCallsByConvo, getMessage } = require('~/models');
 const { processFileURL, uploadImageBuffer } = require('~/server/services/Files/process');
+const {
+  refreshMessageAttachmentUrls,
+} = require('~/server/services/Files/refreshMessageAttachments');
 const { getRetentionExpiry } = require('~/server/services/Files/retention');
 const { processCodeOutput, runPreviewFinalize } = require('~/server/services/Files/Code/process');
 const { loadAuthValues } = require('~/server/services/Tools/credentials');
@@ -245,6 +248,7 @@ const getToolCalls = async (req, res) => {
   try {
     const { conversationId } = req.query;
     const toolCalls = await getToolCallsByConvo(conversationId, req.user.id);
+    await refreshMessageAttachmentUrls(toolCalls);
     res.status(200).json(toolCalls);
   } catch (error) {
     logger.error('Error getting tool calls', error);

--- a/api/server/routes/__tests__/messages-attachment-refresh.spec.js
+++ b/api/server/routes/__tests__/messages-attachment-refresh.spec.js
@@ -1,0 +1,142 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('@librechat/api', () => ({
+  unescapeLaTeX: jest.fn((x) => x),
+  countTokens: jest.fn().mockResolvedValue(10),
+  sendFeedbackScore: jest.fn(),
+  traceIdForMessage: jest.fn(),
+  refreshS3Url: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('~/models', () => ({
+  saveConvo: jest.fn(),
+  getMessage: jest.fn(),
+  saveMessage: jest.fn(),
+  getMessages: jest.fn(),
+  updateMessage: jest.fn(),
+  deleteMessages: jest.fn(),
+  getConvosQueried: jest.fn(),
+  searchMessages: jest.fn(),
+  getMessagesByCursor: jest.fn(),
+}));
+
+jest.mock('~/server/services/Artifacts/update', () => ({
+  findAllArtifacts: jest.fn(),
+  replaceArtifactContent: jest.fn(),
+}));
+
+jest.mock('~/server/middleware', () => ({
+  requireJwtAuth: (req, res, next) => {
+    req.user = { id: 'u1' };
+    next();
+  },
+  validateMessageReq: (req, res, next) => next(),
+}));
+
+const db = require('~/models');
+const { refreshS3Url } = require('@librechat/api');
+const { FileSources } = require('librechat-data-provider');
+
+const router = require('../messages');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/messages', router);
+  return app;
+}
+
+describe('GET /api/messages routes — refresh expired S3 presigned URLs', () => {
+  const STALE = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=OLD&X-Amz-Expires=120';
+  const FRESH = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=NEW&X-Amz-Expires=120';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('GET /:conversationId rewrites stale presigned URLs in attachments[]', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    db.getMessages.mockResolvedValue([
+      {
+        messageId: 'm1',
+        conversationId: 'c1',
+        attachments: [{ file_id: 'f1', source: FileSources.s3, filepath: STALE }],
+      },
+    ]);
+
+    const res = await request(buildApp()).get('/api/messages/c1');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].attachments[0].filepath).toBe(FRESH);
+    expect(res.body[0].attachments[0].file_id).toBe('f1');
+  });
+
+  test('GET /:conversationId also rewrites stale presigned URLs in files[]', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    db.getMessages.mockResolvedValue([
+      {
+        messageId: 'm1',
+        conversationId: 'c1',
+        files: [{ file_id: 'u1', source: FileSources.s3, filepath: STALE }],
+      },
+    ]);
+
+    const res = await request(buildApp()).get('/api/messages/c1');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].files[0].filepath).toBe(FRESH);
+  });
+
+  test('GET /:conversationId/:messageId rewrites stale presigned URLs', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    db.getMessages.mockResolvedValue([
+      {
+        messageId: 'm1',
+        conversationId: 'c1',
+        attachments: [{ source: FileSources.s3, filepath: STALE }],
+      },
+    ]);
+
+    const res = await request(buildApp()).get('/api/messages/c1/m1');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].attachments[0].filepath).toBe(FRESH);
+  });
+
+  test('non-S3 attachments are left untouched', async () => {
+    db.getMessages.mockResolvedValue([
+      {
+        messageId: 'm1',
+        conversationId: 'c1',
+        attachments: [{ source: 'local', filepath: '/uploads/u/local.png' }],
+      },
+    ]);
+
+    const res = await request(buildApp()).get('/api/messages/c1');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].attachments[0].filepath).toBe('/uploads/u/local.png');
+    expect(refreshS3Url).not.toHaveBeenCalled();
+  });
+
+  test('messages without attachments pass through cleanly', async () => {
+    db.getMessages.mockResolvedValue([{ messageId: 'm1', conversationId: 'c1', text: 'hello' }]);
+
+    const res = await request(buildApp()).get('/api/messages/c1');
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].text).toBe('hello');
+    expect(refreshS3Url).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/routes/__tests__/share-attachment-refresh.spec.js
+++ b/api/server/routes/__tests__/share-attachment-refresh.spec.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('@librechat/api', () => ({
+  isEnabled: (v) => v === undefined || v === true || v === 'true',
+  generateCheckAccess: () => (req, res, next) => next(),
+  grantCreationPermissions: jest.fn(),
+  ensureLinkPermissions: jest.fn(),
+  deleteSharedLinkWithCleanup: jest.fn(),
+  updateSharedLinkPermissionsExpiration: jest.fn(),
+  isActiveExpirationDate: jest.fn(),
+  getSharedLinkExpiration: jest.fn(),
+  refreshS3Url: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  createTempChatExpirationDate: jest.fn(),
+}));
+
+jest.mock('~/models', () => ({
+  getSharedMessages: jest.fn(),
+  createSharedLink: jest.fn(),
+  updateSharedLink: jest.fn(),
+  getSharedLinks: jest.fn(),
+  getSharedLink: jest.fn(),
+  getRoleByName: jest.fn(),
+}));
+
+jest.mock('~/server/middleware/canAccessSharedLink', () => (req, res, next) => next());
+jest.mock('~/server/middleware/optionalJwtAuth', () => (req, res, next) => next());
+jest.mock('~/server/middleware/requireJwtAuth', () => (req, res, next) => {
+  req.user = { id: 'u1' };
+  next();
+});
+
+const { getSharedMessages } = require('~/models');
+const { refreshS3Url } = require('@librechat/api');
+const { FileSources } = require('librechat-data-provider');
+
+const router = require('../share');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/share', router);
+  return app;
+}
+
+describe('GET /api/share/:shareId — refresh expired S3 presigned URLs', () => {
+  const STALE = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=OLD&X-Amz-Expires=120';
+  const FRESH = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=NEW&X-Amz-Expires=120';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rewrites stale presigned URLs in shared conversation attachments + files', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    getSharedMessages.mockResolvedValue({
+      shareId: 's1',
+      title: 't',
+      conversationId: 'anon-c1',
+      messages: [
+        {
+          messageId: 'm1',
+          attachments: [{ source: FileSources.s3, filepath: STALE }],
+          files: [{ source: FileSources.s3, filepath: STALE }],
+        },
+      ],
+    });
+
+    const res = await request(buildApp()).get('/api/share/s1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.messages[0].attachments[0].filepath).toBe(FRESH);
+    expect(res.body.messages[0].files[0].filepath).toBe(FRESH);
+    // same filepath in both fields — memoised to one call
+    expect(refreshS3Url).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 404 when getSharedMessages returns null', async () => {
+    getSharedMessages.mockResolvedValue(null);
+    const res = await request(buildApp()).get('/api/share/missing');
+    expect(res.status).toBe(404);
+    expect(refreshS3Url).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -9,6 +9,9 @@ const {
   traceIdForMessage,
 } = require('@librechat/api');
 const { findAllArtifacts, replaceArtifactContent } = require('~/server/services/Artifacts/update');
+const {
+  refreshMessageAttachmentUrls,
+} = require('~/server/services/Files/refreshMessageAttachments');
 const { requireJwtAuth, validateMessageReq } = require('~/server/middleware');
 const db = require('~/models');
 
@@ -90,6 +93,8 @@ router.get('/', async (req, res) => {
     } else {
       response = { messages: [], nextCursor: null };
     }
+
+    await refreshMessageAttachmentUrls(response.messages);
 
     res.status(200).json(response);
   } catch (error) {
@@ -275,6 +280,7 @@ router.get('/:conversationId', validateMessageReq, async (req, res) => {
   try {
     const { conversationId } = req.params;
     const messages = await db.getMessages({ conversationId, user: req.user.id }, '-_id -__v -user');
+    await refreshMessageAttachmentUrls(messages);
     res.status(200).json(messages);
   } catch (error) {
     logger.error('Error fetching messages:', error);
@@ -316,6 +322,7 @@ router.get('/:conversationId/:messageId', validateMessageReq, async (req, res) =
     if (!message) {
       return res.status(404).json({ error: 'Message not found' });
     }
+    await refreshMessageAttachmentUrls(message);
     res.status(200).json(message);
   } catch (error) {
     logger.error('Error fetching message:', error);

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -21,6 +21,9 @@ const {
   getRoleByName,
 } = require('~/models');
 const canAccessSharedLink = require('~/server/middleware/canAccessSharedLink');
+const {
+  refreshMessageAttachmentUrls,
+} = require('~/server/services/Files/refreshMessageAttachments');
 const optionalJwtAuth = require('~/server/middleware/optionalJwtAuth');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
 const router = express.Router();
@@ -58,6 +61,7 @@ if (allowSharedLinks) {
     try {
       const share = await getSharedMessages(req.params.shareId, req.shareResourceId);
       if (share) {
+        await refreshMessageAttachmentUrls(share.messages);
         res.set('Cache-Control', 'private, no-store');
         res.status(200).json(share);
       } else {

--- a/api/server/services/Files/refreshMessageAttachments.js
+++ b/api/server/services/Files/refreshMessageAttachments.js
@@ -1,0 +1,130 @@
+const { logger } = require('@librechat/data-schemas');
+const { refreshS3Url } = require('@librechat/api');
+const { FileSources } = require('librechat-data-provider');
+
+/**
+ * Refresh window passed to the underlying per-source refresh helper. With the
+ * default `S3_URL_EXPIRY_SECONDS=120`, any value larger than the TTL means
+ * "always re-sign on read" — which is what we want here because the snapshot
+ * in the message/toolcall document is never updated.
+ */
+const DEFAULT_BUFFER_SECONDS = 3600;
+
+/**
+ * @typedef {Object} AttachmentLike
+ * @property {string} [source]
+ * @property {string} [filepath]
+ * @property {string} [storageKey]
+ */
+
+/**
+ * Per-source refresh dispatch. Add a new entry here when another storage
+ * backend grows a refresh primitive (e.g. Azure SAS).
+ *
+ * @type {Record<string, (att: AttachmentLike, bufferSeconds: number) => Promise<string>>}
+ */
+const refresherBySource = {
+  [FileSources.s3]: (att, bufferSeconds) => refreshS3Url(att, bufferSeconds),
+};
+
+/**
+ * Refresh a single attachment's `filepath` in place if it is a near-expiry
+ * signed URL the backend owns. Non-eligible entries are left untouched. On
+ * error the original URL is retained — the client gets a diagnosable 403
+ * rather than a `null` href.
+ *
+ * @param {AttachmentLike | null | undefined} attachment
+ * @param {number} bufferSeconds
+ * @param {Map<string, Promise<string>>} cache - per-call memoization keyed on
+ *   the original `filepath`, so repeated references to the same blob within
+ *   one response only re-sign once.
+ * @returns {Promise<void>}
+ */
+async function refreshAttachment(attachment, bufferSeconds, cache) {
+  if (!attachment || typeof attachment !== 'object') {
+    return;
+  }
+  const filepath = attachment.filepath;
+  if (typeof filepath !== 'string' || filepath.length === 0) {
+    return;
+  }
+  const refresher = refresherBySource[attachment.source];
+  if (!refresher) {
+    return;
+  }
+  let pending = cache.get(filepath);
+  if (!pending) {
+    pending = (async () => {
+      try {
+        const newUrl = await refresher(attachment, bufferSeconds);
+        return newUrl || filepath;
+      } catch (error) {
+        logger.error(
+          `[refreshMessageAttachments] Error refreshing signed URL for "${filepath}":`,
+          error,
+        );
+        return filepath;
+      }
+    })();
+    cache.set(filepath, pending);
+  }
+  const resolved = await pending;
+  if (resolved && resolved !== filepath) {
+    attachment.filepath = resolved;
+  }
+}
+
+/**
+ * Walk one or more messages or tool-call rows and refresh signed URLs
+ * embedded in their `attachments[]` and `files[]` snapshots, in place.
+ * Designed to wrap the response payload of read endpoints; safe to call with
+ * `null`, `undefined`, `[]`, a single row, or an array. Returns the same
+ * shape it was given so callers can drop it in front of `res.json` without
+ * restructuring.
+ *
+ * The same function works against both message rows (which carry
+ * `attachments[]` and `files[]`) and toolcall rows (which carry only
+ * `attachments[]`) — the walker is duck-typed on the field names and skips
+ * any that aren't arrays.
+ *
+ * @template {Record<string, unknown>} TRow
+ * @param {TRow | TRow[] | null | undefined} rows
+ * @param {{ bufferSeconds?: number }} [options]
+ * @returns {Promise<TRow | TRow[] | null | undefined>}
+ */
+async function refreshMessageAttachmentUrls(rows, options = {}) {
+  if (rows == null) {
+    return rows;
+  }
+  const bufferSeconds = options.bufferSeconds ?? DEFAULT_BUFFER_SECONDS;
+  const list = Array.isArray(rows) ? rows : [rows];
+  if (list.length === 0) {
+    return rows;
+  }
+  const cache = new Map();
+  const tasks = [];
+  for (const row of list) {
+    if (!row || typeof row !== 'object') {
+      continue;
+    }
+    for (const field of ['attachments', 'files']) {
+      const entries = /** @type {unknown} */ (row[field]);
+      if (!Array.isArray(entries) || entries.length === 0) {
+        continue;
+      }
+      for (const entry of entries) {
+        tasks.push(refreshAttachment(entry, bufferSeconds, cache));
+      }
+    }
+  }
+  if (tasks.length > 0) {
+    await Promise.all(tasks);
+  }
+  return rows;
+}
+
+module.exports = {
+  refreshMessageAttachmentUrls,
+  refreshAttachment,
+  DEFAULT_BUFFER_SECONDS,
+};

--- a/api/server/services/Files/refreshMessageAttachments.js
+++ b/api/server/services/Files/refreshMessageAttachments.js
@@ -24,18 +24,23 @@ const DEFAULT_CONCURRENCY = 8;
  * Redact the query string from a signed URL before logging. Presigned URLs
  * are short-lived credentials (`X-Amz-Signature`, `X-Amz-Security-Token`,
  * etc. live in the query string); leaving them in log sinks defeats the
- * purpose of the TTL. Falls back to a fixed placeholder if the URL won't
- * parse so the log line still has shape.
+ * purpose of the TTL. For inputs that don't parse as URLs, fall back to
+ * stripping anything after `?` — keeps the path component intact for
+ * debugging without leaking credentials.
  *
  * @param {string} signedUrl
  * @returns {string}
  */
 function redactSignedUrlForLog(signedUrl) {
+  if (typeof signedUrl !== 'string') {
+    return '';
+  }
   try {
     const u = new URL(signedUrl);
     return `${u.origin}${u.pathname}`;
   } catch {
-    return '<unparseable url>';
+    const q = signedUrl.indexOf('?');
+    return q === -1 ? signedUrl : signedUrl.slice(0, q);
   }
 }
 
@@ -57,6 +62,26 @@ const refresherBySource = {
 };
 
 /**
+ * Cheap eligibility check used at enqueue time so the concurrency pool only
+ * runs tasks that can actually refresh something. Identical guards to those
+ * inside `refreshAttachment`, lifted here so we don't allocate closures or
+ * spin worker cursors over entries that will immediately no-op.
+ *
+ * @param {unknown} attachment
+ * @returns {attachment is AttachmentLike}
+ */
+function isRefreshable(attachment) {
+  if (!attachment || typeof attachment !== 'object') {
+    return false;
+  }
+  const att = /** @type {AttachmentLike} */ (attachment);
+  if (typeof att.filepath !== 'string' || att.filepath.length === 0) {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(refresherBySource, att.source);
+}
+
+/**
  * Refresh a single attachment's `filepath` in place if it is a near-expiry
  * signed URL the backend owns. Non-eligible entries are left untouched. On
  * error the original URL is retained — the client gets a diagnosable 403
@@ -70,17 +95,11 @@ const refresherBySource = {
  * @returns {Promise<void>}
  */
 async function refreshAttachment(attachment, bufferSeconds, cache) {
-  if (!attachment || typeof attachment !== 'object') {
+  if (!isRefreshable(attachment)) {
     return;
   }
   const filepath = attachment.filepath;
-  if (typeof filepath !== 'string' || filepath.length === 0) {
-    return;
-  }
   const refresher = refresherBySource[attachment.source];
-  if (!refresher) {
-    return;
-  }
   let pending = cache.get(filepath);
   if (!pending) {
     pending = (async () => {
@@ -170,6 +189,12 @@ async function refreshMessageAttachmentUrls(rows, options = {}) {
         continue;
       }
       for (const entry of entries) {
+        // Skip non-refreshable entries (non-S3 source, missing filepath,
+        // non-object) at enqueue time so the concurrency pool only runs
+        // tasks that can actually refresh.
+        if (!isRefreshable(entry)) {
+          continue;
+        }
         taskFactories.push(() => refreshAttachment(entry, bufferSeconds, cache));
       }
     }
@@ -181,6 +206,7 @@ async function refreshMessageAttachmentUrls(rows, options = {}) {
 module.exports = {
   refreshMessageAttachmentUrls,
   refreshAttachment,
+  isRefreshable,
   redactSignedUrlForLog,
   runWithConcurrency,
   DEFAULT_BUFFER_SECONDS,

--- a/api/server/services/Files/refreshMessageAttachments.js
+++ b/api/server/services/Files/refreshMessageAttachments.js
@@ -11,6 +11,35 @@ const { FileSources } = require('librechat-data-provider');
 const DEFAULT_BUFFER_SECONDS = 3600;
 
 /**
+ * Cap on concurrent refresh calls per response. A single conversation can
+ * carry dozens of attachments; the refresh primitives are CPU-cheap (local
+ * HMAC) but unbounded `Promise.all` over them can still spike event-loop
+ * latency and, where a backend does need a network round-trip (e.g.
+ * delegation key refresh), can hammer it. A small fixed limit keeps tail
+ * latency bounded without measurably hurting throughput.
+ */
+const DEFAULT_CONCURRENCY = 8;
+
+/**
+ * Redact the query string from a signed URL before logging. Presigned URLs
+ * are short-lived credentials (`X-Amz-Signature`, `X-Amz-Security-Token`,
+ * etc. live in the query string); leaving them in log sinks defeats the
+ * purpose of the TTL. Falls back to a fixed placeholder if the URL won't
+ * parse so the log line still has shape.
+ *
+ * @param {string} signedUrl
+ * @returns {string}
+ */
+function redactSignedUrlForLog(signedUrl) {
+  try {
+    const u = new URL(signedUrl);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return '<unparseable url>';
+  }
+}
+
+/**
  * @typedef {Object} AttachmentLike
  * @property {string} [source]
  * @property {string} [filepath]
@@ -60,7 +89,7 @@ async function refreshAttachment(attachment, bufferSeconds, cache) {
         return newUrl || filepath;
       } catch (error) {
         logger.error(
-          `[refreshMessageAttachments] Error refreshing signed URL for "${filepath}":`,
+          `[refreshMessageAttachments] Error refreshing signed URL for "${redactSignedUrlForLog(filepath)}":`,
           error,
         );
         return filepath;
@@ -72,6 +101,33 @@ async function refreshAttachment(attachment, bufferSeconds, cache) {
   if (resolved && resolved !== filepath) {
     attachment.filepath = resolved;
   }
+}
+
+/**
+ * Drain an array of async task factories with at most `concurrency` in
+ * flight. No new dependency — small inline worker-pool.
+ *
+ * @param {Array<() => Promise<unknown>>} taskFactories
+ * @param {number} concurrency
+ * @returns {Promise<void>}
+ */
+async function runWithConcurrency(taskFactories, concurrency) {
+  if (taskFactories.length === 0) {
+    return;
+  }
+  const limit = Math.max(1, concurrency);
+  if (taskFactories.length <= limit) {
+    await Promise.all(taskFactories.map((fn) => fn()));
+    return;
+  }
+  let cursor = 0;
+  const workers = new Array(Math.min(limit, taskFactories.length)).fill(null).map(async () => {
+    while (cursor < taskFactories.length) {
+      const i = cursor++;
+      await taskFactories[i]();
+    }
+  });
+  await Promise.all(workers);
 }
 
 /**
@@ -89,7 +145,7 @@ async function refreshAttachment(attachment, bufferSeconds, cache) {
  *
  * @template {Record<string, unknown>} TRow
  * @param {TRow | TRow[] | null | undefined} rows
- * @param {{ bufferSeconds?: number }} [options]
+ * @param {{ bufferSeconds?: number, concurrency?: number }} [options]
  * @returns {Promise<TRow | TRow[] | null | undefined>}
  */
 async function refreshMessageAttachmentUrls(rows, options = {}) {
@@ -97,12 +153,13 @@ async function refreshMessageAttachmentUrls(rows, options = {}) {
     return rows;
   }
   const bufferSeconds = options.bufferSeconds ?? DEFAULT_BUFFER_SECONDS;
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
   const list = Array.isArray(rows) ? rows : [rows];
   if (list.length === 0) {
     return rows;
   }
   const cache = new Map();
-  const tasks = [];
+  const taskFactories = [];
   for (const row of list) {
     if (!row || typeof row !== 'object') {
       continue;
@@ -113,18 +170,19 @@ async function refreshMessageAttachmentUrls(rows, options = {}) {
         continue;
       }
       for (const entry of entries) {
-        tasks.push(refreshAttachment(entry, bufferSeconds, cache));
+        taskFactories.push(() => refreshAttachment(entry, bufferSeconds, cache));
       }
     }
   }
-  if (tasks.length > 0) {
-    await Promise.all(tasks);
-  }
+  await runWithConcurrency(taskFactories, concurrency);
   return rows;
 }
 
 module.exports = {
   refreshMessageAttachmentUrls,
   refreshAttachment,
+  redactSignedUrlForLog,
+  runWithConcurrency,
   DEFAULT_BUFFER_SECONDS,
+  DEFAULT_CONCURRENCY,
 };

--- a/api/server/services/Files/refreshMessageAttachments.js
+++ b/api/server/services/Files/refreshMessageAttachments.js
@@ -52,14 +52,22 @@ function redactSignedUrlForLog(signedUrl) {
  */
 
 /**
- * Per-source refresh dispatch. Add a new entry here when another storage
- * backend grows a refresh primitive (e.g. Azure SAS).
+ * Per-source refresh dispatch. Resolved lazily so this module can be
+ * required by callers (including existing test suites) that mock
+ * `@librechat/api` or `librechat-data-provider` without including
+ * `refreshS3Url` / `FileSources` in the mock — missing dependencies just
+ * mean "no refresher available for that source", same as any other
+ * non-S3 entry.
  *
- * @type {Record<string, (att: AttachmentLike, bufferSeconds: number) => Promise<string>>}
+ * @returns {Record<string, (att: AttachmentLike, bufferSeconds: number) => Promise<string>>}
  */
-const refresherBySource = {
-  [FileSources.s3]: (att, bufferSeconds) => refreshS3Url(att, bufferSeconds),
-};
+function getRefresherBySource() {
+  const out = {};
+  if (FileSources && typeof FileSources.s3 === 'string' && typeof refreshS3Url === 'function') {
+    out[FileSources.s3] = (att, bufferSeconds) => refreshS3Url(att, bufferSeconds);
+  }
+  return out;
+}
 
 /**
  * Cheap eligibility check used at enqueue time so the concurrency pool only
@@ -78,7 +86,7 @@ function isRefreshable(attachment) {
   if (typeof att.filepath !== 'string' || att.filepath.length === 0) {
     return false;
   }
-  return Object.prototype.hasOwnProperty.call(refresherBySource, att.source);
+  return Object.prototype.hasOwnProperty.call(getRefresherBySource(), att.source);
 }
 
 /**
@@ -99,7 +107,7 @@ async function refreshAttachment(attachment, bufferSeconds, cache) {
     return;
   }
   const filepath = attachment.filepath;
-  const refresher = refresherBySource[attachment.source];
+  const refresher = getRefresherBySource()[attachment.source];
   let pending = cache.get(filepath);
   if (!pending) {
     pending = (async () => {

--- a/api/server/services/Files/refreshMessageAttachments.spec.js
+++ b/api/server/services/Files/refreshMessageAttachments.spec.js
@@ -154,3 +154,69 @@ describe('refreshMessageAttachmentUrls', () => {
     expect(rows[0].attachments[0].filepath).toBe(FRESH);
   });
 });
+
+describe('redactSignedUrlForLog', () => {
+  const { redactSignedUrlForLog } = require('./refreshMessageAttachments');
+
+  test('strips the query string (signature + token would otherwise leak)', () => {
+    const u =
+      'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=abc&X-Amz-Security-Token=xyz&X-Amz-Date=20260615';
+    expect(redactSignedUrlForLog(u)).toBe('https://bucket.s3.amazonaws.com/uploads/u/x');
+  });
+
+  test('returns a stable placeholder for unparseable inputs', () => {
+    expect(redactSignedUrlForLog('not a url')).toBe('<unparseable url>');
+  });
+
+  test('error path logs only the redacted URL, never the signature', async () => {
+    refreshS3Url.mockRejectedValue(new Error('boom'));
+    const { logger } = require('@librechat/data-schemas');
+    const rows = [
+      {
+        attachments: [
+          {
+            source: FileSources.s3,
+            filepath:
+              'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=SECRET&X-Amz-Date=20260615',
+          },
+        ],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(logger.error).toHaveBeenCalled();
+    const logged = logger.error.mock.calls[0][0];
+    expect(logged).not.toContain('SECRET');
+    expect(logged).not.toContain('X-Amz-Signature');
+    expect(logged).toContain('https://bucket.s3.amazonaws.com/uploads/u/x');
+  });
+});
+
+describe('runWithConcurrency', () => {
+  const { runWithConcurrency } = require('./refreshMessageAttachments');
+
+  test('caps in-flight tasks at the configured limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const total = 25;
+    const limit = 4;
+    const factories = Array.from({ length: total }, () => async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+    });
+    await runWithConcurrency(factories, limit);
+    expect(peak).toBeLessThanOrEqual(limit);
+    expect(peak).toBeGreaterThan(1);
+  });
+
+  test('returns immediately on empty input', async () => {
+    await expect(runWithConcurrency([], 8)).resolves.toBeUndefined();
+  });
+
+  test('fast-path when task count <= limit (no worker loop)', async () => {
+    const calls = [];
+    await runWithConcurrency([async () => calls.push('a'), async () => calls.push('b')], 8);
+    expect(calls.sort()).toEqual(['a', 'b']);
+  });
+});

--- a/api/server/services/Files/refreshMessageAttachments.spec.js
+++ b/api/server/services/Files/refreshMessageAttachments.spec.js
@@ -164,8 +164,22 @@ describe('redactSignedUrlForLog', () => {
     expect(redactSignedUrlForLog(u)).toBe('https://bucket.s3.amazonaws.com/uploads/u/x');
   });
 
-  test('returns a stable placeholder for unparseable inputs', () => {
-    expect(redactSignedUrlForLog('not a url')).toBe('<unparseable url>');
+  test('strips query string from unparseable inputs without losing the path', () => {
+    // Relative URL / local path: `new URL()` would throw on its own; we should
+    // still drop any `?signature=...` suffix and keep the rest for debug.
+    expect(redactSignedUrlForLog('/uploads/u/local-file.png?token=SECRET')).toBe(
+      '/uploads/u/local-file.png',
+    );
+    expect(redactSignedUrlForLog('not a url')).toBe('not a url');
+  });
+
+  test('returns empty string for non-string input', () => {
+    // @ts-expect-error — intentionally pass non-string to exercise guard
+    expect(redactSignedUrlForLog(undefined)).toBe('');
+    // @ts-expect-error — intentionally pass non-string to exercise guard
+    expect(redactSignedUrlForLog(null)).toBe('');
+    // @ts-expect-error — intentionally pass non-string to exercise guard
+    expect(redactSignedUrlForLog(123)).toBe('');
   });
 
   test('error path logs only the redacted URL, never the signature', async () => {
@@ -218,5 +232,49 @@ describe('runWithConcurrency', () => {
     const calls = [];
     await runWithConcurrency([async () => calls.push('a'), async () => calls.push('b')], 8);
     expect(calls.sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('isRefreshable', () => {
+  const { isRefreshable } = require('./refreshMessageAttachments');
+
+  test('true for S3-source with non-empty filepath', () => {
+    expect(isRefreshable({ source: FileSources.s3, filepath: 'https://x' })).toBe(true);
+  });
+
+  test('false for non-S3 sources, missing/empty filepath, non-objects', () => {
+    expect(isRefreshable(null)).toBe(false);
+    expect(isRefreshable(undefined)).toBe(false);
+    expect(isRefreshable('string')).toBe(false);
+    expect(isRefreshable({})).toBe(false);
+    expect(isRefreshable({ source: FileSources.s3 })).toBe(false);
+    expect(isRefreshable({ source: FileSources.s3, filepath: '' })).toBe(false);
+    expect(isRefreshable({ source: 'local', filepath: '/uploads/x' })).toBe(false);
+    expect(isRefreshable({ source: 'firebase', filepath: 'https://x' })).toBe(false);
+    expect(isRefreshable({ filepath: 'https://x' })).toBe(false);
+  });
+
+  test('refreshMessageAttachmentUrls does not enqueue non-refreshable entries', async () => {
+    // If a non-refreshable entry were enqueued, runWithConcurrency would
+    // schedule the no-op task and refreshS3Url would still not be called —
+    // so the observable signal is "no work scheduled at all". We assert via
+    // the refresher mock not being called *and* via the call-count of the
+    // memo cache observable as `refreshS3Url.mock.calls.length`.
+    refreshS3Url.mockResolvedValue(FRESH);
+    const rows = [
+      {
+        attachments: [
+          { source: 'local', filepath: '/uploads/u/x.png' },
+          { source: FileSources.s3 },
+          { source: FileSources.s3, filepath: '' },
+          null,
+          {},
+          { source: FileSources.s3, filepath: STALE },
+        ],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(refreshS3Url).toHaveBeenCalledTimes(1);
+    expect(rows[0].attachments[5].filepath).toBe(FRESH);
   });
 });

--- a/api/server/services/Files/refreshMessageAttachments.spec.js
+++ b/api/server/services/Files/refreshMessageAttachments.spec.js
@@ -1,0 +1,156 @@
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@librechat/api', () => ({
+  refreshS3Url: jest.fn(),
+}));
+
+const { FileSources } = require('librechat-data-provider');
+const { refreshS3Url } = require('@librechat/api');
+const { refreshMessageAttachmentUrls } = require('./refreshMessageAttachments');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const STALE = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=OLD&X-Amz-Expires=120';
+const FRESH = 'https://bucket.s3.amazonaws.com/uploads/u/x?X-Amz-Signature=NEW&X-Amz-Expires=120';
+
+describe('refreshMessageAttachmentUrls', () => {
+  test('returns input unchanged for null / undefined / []', async () => {
+    expect(await refreshMessageAttachmentUrls(null)).toBeNull();
+    expect(await refreshMessageAttachmentUrls(undefined)).toBeUndefined();
+    const arr = [];
+    expect(await refreshMessageAttachmentUrls(arr)).toBe(arr);
+    expect(refreshS3Url).not.toHaveBeenCalled();
+  });
+
+  test('skips rows without attachments or files', async () => {
+    const rows = [{ messageId: 'a' }, { messageId: 'b', attachments: undefined }];
+    await refreshMessageAttachmentUrls(rows);
+    expect(refreshS3Url).not.toHaveBeenCalled();
+  });
+
+  test('rewrites S3 filepath in place when refreshS3Url returns a new URL', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    const rows = [
+      {
+        messageId: 'm1',
+        attachments: [{ file_id: 'f1', source: FileSources.s3, filepath: STALE }],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(rows[0].attachments[0].filepath).toBe(FRESH);
+    expect(rows[0].attachments[0].file_id).toBe('f1');
+    expect(refreshS3Url).toHaveBeenCalledTimes(1);
+  });
+
+  test('also walks row.files[] (user-uploaded files)', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    const rows = [
+      {
+        messageId: 'm1',
+        files: [{ source: FileSources.s3, filepath: STALE }],
+        attachments: [{ source: FileSources.s3, filepath: STALE }],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(rows[0].files[0].filepath).toBe(FRESH);
+    expect(rows[0].attachments[0].filepath).toBe(FRESH);
+    // Same filepath in both fields — cache dedupes to one call.
+    expect(refreshS3Url).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps original URL on refreshS3Url rejection (no undefined leak)', async () => {
+    refreshS3Url.mockRejectedValue(new Error('boom'));
+    const rows = [{ messageId: 'm1', attachments: [{ source: FileSources.s3, filepath: STALE }] }];
+    await refreshMessageAttachmentUrls(rows);
+    expect(rows[0].attachments[0].filepath).toBe(STALE);
+  });
+
+  test('keeps original URL when refreshS3Url returns empty', async () => {
+    refreshS3Url.mockResolvedValue('');
+    const rows = [{ messageId: 'm1', attachments: [{ source: FileSources.s3, filepath: STALE }] }];
+    await refreshMessageAttachmentUrls(rows);
+    expect(rows[0].attachments[0].filepath).toBe(STALE);
+  });
+
+  test('skips attachments without a recognised source', async () => {
+    const rows = [
+      {
+        messageId: 'm1',
+        attachments: [
+          { source: 'local', filepath: '/uploads/u/local.png' },
+          { source: 'firebase', filepath: 'https://firebase/x' },
+          { filepath: 'https://google/avatar' },
+          null,
+          {},
+        ],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(refreshS3Url).not.toHaveBeenCalled();
+    expect(rows[0].attachments[0].filepath).toBe('/uploads/u/local.png');
+  });
+
+  test('tolerates attachments without filepath', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    const rows = [
+      {
+        messageId: 'm1',
+        attachments: [
+          { source: FileSources.s3 },
+          { source: FileSources.s3, filepath: '' },
+          { source: FileSources.s3, filepath: STALE },
+        ],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(rows[0].attachments[2].filepath).toBe(FRESH);
+    expect(refreshS3Url).toHaveBeenCalledTimes(1);
+  });
+
+  test('memoizes resigning across rows when the same filepath appears multiple times', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    const rows = [
+      { messageId: 'm1', attachments: [{ source: FileSources.s3, filepath: STALE }] },
+      { messageId: 'm2', attachments: [{ source: FileSources.s3, filepath: STALE }] },
+      { messageId: 'm3', attachments: [{ source: FileSources.s3, filepath: STALE }] },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(refreshS3Url).toHaveBeenCalledTimes(1);
+    for (const row of rows) {
+      expect(row.attachments[0].filepath).toBe(FRESH);
+    }
+  });
+
+  test('accepts a single row (not wrapped in an array)', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    const row = { messageId: 'm1', attachments: [{ source: FileSources.s3, filepath: STALE }] };
+    const result = await refreshMessageAttachmentUrls(row);
+    expect(result).toBe(row);
+    expect(row.attachments[0].filepath).toBe(FRESH);
+  });
+
+  test('forwards bufferSeconds to refreshS3Url', async () => {
+    refreshS3Url.mockResolvedValue(STALE);
+    const rows = [{ messageId: 'm1', attachments: [{ source: FileSources.s3, filepath: STALE }] }];
+    await refreshMessageAttachmentUrls(rows, { bufferSeconds: 42 });
+    expect(refreshS3Url).toHaveBeenCalledWith(rows[0].attachments[0], 42);
+  });
+
+  test('works against tool-call rows (only attachments[], no files[])', async () => {
+    refreshS3Url.mockResolvedValue(FRESH);
+    const rows = [
+      {
+        conversationId: 'c1',
+        messageId: 'm1',
+        toolId: 'execute_code',
+        attachments: [{ source: FileSources.s3, filepath: STALE }],
+      },
+    ];
+    await refreshMessageAttachmentUrls(rows);
+    expect(rows[0].attachments[0].filepath).toBe(FRESH);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #13751.
Also resolves the long-standing user reports #10269 and #10145 (both closed without a referenced fix; #10145 has 5 affected users discussing workarounds like maxing `S3_URL_EXPIRY_SECONDS` to 7 days).

S3 presigned URLs embedded in `messages.attachments[]`, `messages.files[]`, and `toolcalls.attachments[]` are denormalized snapshots that are never updated after write. Once a URL expires (default `S3_URL_EXPIRY_SECONDS=120` — `packages/api/src/storage/s3/s3Config.ts`), reopening a conversation serves expired URLs and the browser fetches return `403 SignatureDoesNotMatch`. Generated images, uploaded images, and code-interpreter artifacts all vanish from view.

The existing `refreshS3FileUrls` chain (`packages/api/src/storage/s3/crud.ts:936`) only runs for `GET /api/files` and the avatar dispatchers — never for the message or toolcall read paths.

## Change

Add `api/server/services/Files/refreshMessageAttachments.js` — a small refresh-on-read shim that walks `attachments[]` and `files[]` on the response payload, dispatches by `source` to the existing per-source refresh primitive (`refreshS3Url` today; extensible via the local `refresherBySource` map for future storage backends), and rewrites the `filepath` in place.

- **In-memory only** — no Mongo writes. The blob is durable; only the URL signature expires. Persisting refreshed URLs back would amplify writes for every list view.
- **Per-call memoization** keyed on `filepath` — a response carrying many copies of the same blob only re-signs once.
- **Error safety** — `refreshS3Url` rejection or empty return retains the original URL. The client gets a diagnosable 403 rather than a `null` href.
- **Source-agnostic walker** — duck-typed on `attachments[]` / `files[]`, so the same function works against both message rows (`attachments[]` + `files[]`) and toolcall rows (`attachments[]` only).

### Wired into

- `api/server/routes/messages.js` — root list (cursor + search branches), `GET /:conversationId`, `GET /:conversationId/:messageId`.
- `api/server/routes/share.js` — `GET /:shareId` (`getSharedMessages` response).
- `api/server/controllers/tools.js` — `GET /api/agents/tools/calls` (`getToolCalls`).

## Repro

1. `.env`: `fileStrategy=s3`, valid S3 creds, `S3_URL_EXPIRY_SECONDS=30`.
2. Configure an agent with `image_gen_oai` available (or any default chat with image gen enabled).
3. Send a message that triggers image generation. Image renders.
4. Wait 35s.
5. Reload the conversation → image tile is broken; DevTools shows `403 SignatureDoesNotMatch`.

With this patch: image renders. Same fix covers user-uploaded images in `messages.files[]` and code-interpreter outputs in `toolcalls.attachments[]`.

## Tests

- `api/server/services/Files/refreshMessageAttachments.spec.js` — 12 unit cases: null/empty inputs, missing fields, fresh / stale URL handling, error fallback, per-call memoization across `attachments[]` and `files[]`, single vs array inputs, `bufferSeconds` propagation, non-S3 source skipped, toolcall row shape.
- `api/server/routes/__tests__/messages-attachment-refresh.spec.js` — 5 supertest cases: `GET /:conversationId` (attachments + files), `GET /:conversationId/:messageId`, non-S3 passthrough, no-attachments passthrough.
- `api/server/routes/__tests__/share-attachment-refresh.spec.js` — 2 supertest cases: `GET /:shareId` rewrite + 404 path.
- `api/server/controllers/__tests__/getToolCalls-attachment-refresh.spec.js` — 2 supertest cases: rewrite + no-attachments passthrough.

All 21 new tests green. Lint clean. `npm run build` green.

## Why a separate shim instead of folding it into `refreshS3FileUrls`

The existing chain operates on `MongoFile[]` rows from the `files` collection and writes back to it via `batchUpdateFiles`. The three snapshot sites above are denormalized copies inside other collections (`messages`, `toolcalls`) — different schema, different write path, and persisting back to those collections on every read would multiply writes for no benefit (the blob is durable; we only need the signature on the way out).

## Related

- #13740 (open, Snapshot Files for Shared-Link Attachments) introduces `fileSnapshots[]` on `SharedLink` and applies a read-time URL rewrite in `getSharedMessages` for share-scoped serving. Different concern (auth boundaries for anonymous viewers) but same area of code; happy to rebase / coordinate if #13740 lands first.

