### PR TITLE
feat(nav): add dedicated full-page routes for sidebar panels

### DIFF
--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -131,6 +131,7 @@ export type NavLink = {
   Component?: React.ComponentType;
   onClick?: (e?: React.MouseEvent) => void;
   variant?: 'default' | 'ghost';
+  href?: string;
   id: string;
 };
 

--- a/client/src/components/SidePanel/Bookmarks/BookmarkPanel.tsx
+++ b/client/src/components/SidePanel/Bookmarks/BookmarkPanel.tsx
@@ -2,11 +2,11 @@ import { useConversationTagsQuery } from '~/data-provider';
 import { BookmarkContext } from '~/Providers/BookmarkContext';
 import BookmarkTable from './BookmarkTable';
 
-const BookmarkPanel = () => {
+const BookmarkPanel = ({ noPadding = false }: { noPadding?: boolean }) => {
   const { data } = useConversationTagsQuery();
 
   return (
-    <div className="h-auto max-w-full overflow-x-visible pt-2">
+    <div className={noPadding ? 'h-auto max-w-full overflow-x-visible' : 'h-auto max-w-full overflow-x-visible px-3 pb-3 pt-2'}>
       <BookmarkContext.Provider value={{ bookmarks: data || [] }}>
         <BookmarkTable />
       </BookmarkContext.Provider>

--- a/client/src/components/SidePanel/Bookmarks/BookmarkTable.tsx
+++ b/client/src/components/SidePanel/Bookmarks/BookmarkTable.tsx
@@ -55,7 +55,7 @@ const BookmarkTable = () => {
 
   return (
     <BookmarkContext.Provider value={{ bookmarks }}>
-      <div role="region" aria-label={localize('com_ui_bookmarks')} className="space-y-2 px-3 pb-3">
+      <div role="region" aria-label={localize('com_ui_bookmarks')} className="space-y-2">
         {/* Header: Filter + Create Button */}
         <div className="flex items-center gap-2">
           <FilterInput

--- a/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
+++ b/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
@@ -1,0 +1,26 @@
+import { Navigate } from 'react-router-dom';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
+import BookmarkPanel from '../BookmarkPanel';
+
+export default function BookmarksView() {
+  const localize = useLocalize();
+  const hasAccess = useHasAccess({
+    permissionType: PermissionTypes.BOOKMARKS,
+    permission: Permissions.USE,
+  });
+
+  if (!hasAccess) {
+    return <Navigate to="/c/new" replace />;
+  }
+
+  return (
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_sidepanel_conversation_tags')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <BookmarkPanel noPadding />
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/SidePanel/Files/layouts/FilesView.tsx
+++ b/client/src/components/SidePanel/Files/layouts/FilesView.tsx
@@ -1,0 +1,29 @@
+import { FileSources, FileContext } from 'librechat-data-provider';
+import type { TFile } from 'librechat-data-provider';
+import { DataTable, columns } from '~/components/Chat/Input/Files/Table';
+import PageHeader from '~/components/ui/PageHeader';
+import { useGetFiles } from '~/data-provider';
+import { useLocalize } from '~/hooks';
+
+export default function FilesView() {
+  const localize = useLocalize();
+
+  const { data: files = [] } = useGetFiles<TFile[]>({
+    select: (data) =>
+      data.map((file) => {
+        file.context = file.context ?? FileContext.unknown;
+        file.filterSource =
+          file.source === FileSources.firebase ? FileSources.local : file.source;
+        return file;
+      }),
+  });
+
+  return (
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_nav_my_files')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <DataTable columns={columns} data={files} />
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
@@ -8,7 +8,7 @@ import MCPAdminSettings from './MCPAdminSettings';
 import MCPServerDialog from './MCPServerDialog';
 import MCPServerList from './MCPServerList';
 
-export default function MCPBuilderPanel() {
+export default function MCPBuilderPanel({ noPadding = false }: { noPadding?: boolean }) {
   const localize = useLocalize();
   const { availableMCPServers, isLoading, getServerStatusIconProps, getConfigDialogProps } =
     useMCPServerManager();
@@ -36,7 +36,7 @@ export default function MCPBuilderPanel() {
   }, [availableMCPServers, searchQuery]);
 
   return (
-    <div className="flex h-auto w-full flex-col px-3 pb-3 pt-2">
+    <div className={noPadding ? 'flex h-auto w-full flex-col' : 'flex h-auto w-full flex-col px-3 pb-3 pt-2'}>
       <div role="region" aria-label={localize('com_ui_mcp_servers')} className="space-y-2">
         {/* Toolbar: Search + Add Button */}
         <div className="flex items-center gap-2">

--- a/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
@@ -1,0 +1,30 @@
+import { Navigate } from 'react-router-dom';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
+import MCPBuilderPanel from '../MCPBuilderPanel';
+
+export default function MCPView() {
+  const localize = useLocalize();
+  const hasUseAccess = useHasAccess({
+    permissionType: PermissionTypes.MCP_SERVERS,
+    permission: Permissions.USE,
+  });
+  const hasCreateAccess = useHasAccess({
+    permissionType: PermissionTypes.MCP_SERVERS,
+    permission: Permissions.CREATE,
+  });
+
+  if (!hasUseAccess && !hasCreateAccess) {
+    return <Navigate to="/c/new" replace />;
+  }
+
+  return (
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_nav_setting_mcp')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <MCPBuilderPanel noPadding />
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/SidePanel/Memories/MemoryPanel.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryPanel.tsx
@@ -25,7 +25,7 @@ import MemoryList from './MemoryList';
 
 const pageSize = 10;
 
-export default function MemoryPanel() {
+export default function MemoryPanel({ noPadding = false }: { noPadding?: boolean }) {
   const localize = useLocalize();
   const { user } = useAuthContext();
   const { data: userData } = useGetUserQuery();
@@ -121,7 +121,7 @@ export default function MemoryPanel() {
   const totalPages = Math.ceil(filteredMemories.length / pageSize);
 
   return (
-    <div className="flex h-auto w-full flex-col px-3 pb-3 pt-2">
+    <div className={noPadding ? 'flex h-auto w-full flex-col' : 'flex h-auto w-full flex-col px-3 pb-3 pt-2'}>
       <div role="region" aria-label={localize('com_ui_memories')} className="space-y-2">
         {/* Header: Filter + Create Button */}
         <div className="flex items-center gap-2">

--- a/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
+++ b/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
@@ -1,0 +1,26 @@
+import { Navigate } from 'react-router-dom';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
+import MemoryPanel from '../MemoryPanel';
+
+export default function MemoriesView() {
+  const localize = useLocalize();
+  const hasAccess = useHasAccess({
+    permissionType: PermissionTypes.MEMORIES,
+    permission: Permissions.READ,
+  });
+
+  if (!hasAccess) {
+    return <Navigate to="/c/new" replace />;
+  }
+
+  return (
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_ui_memories')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <MemoryPanel noPadding />
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { SquarePen } from 'lucide-react';
@@ -95,6 +96,33 @@ const NavIconButton = memo(function NavIconButton({
     [link, isActive, setActive, expanded, onExpand, onCollapse],
   );
 
+  const buttonClass = cn(
+    'h-9 w-9 rounded-lg',
+    isActive ? 'bg-surface-active-alt text-text-primary' : 'text-text-secondary',
+  );
+
+  if (link.href) {
+    return (
+      <TooltipAnchor
+        description={localize(link.title)}
+        side="right"
+        render={
+          <Link
+            to={link.href}
+            aria-label={localize(link.title)}
+            aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              'inline-flex items-center justify-center rounded-lg transition-colors hover:bg-surface-hover',
+              buttonClass,
+            )}
+          >
+            <link.icon className="h-5 w-5" aria-hidden="true" />
+          </Link>
+        }
+      />
+    );
+  }
+
   return (
     <TooltipAnchor
       description={localize(link.title)}
@@ -105,10 +133,7 @@ const NavIconButton = memo(function NavIconButton({
           variant="ghost"
           aria-label={localize(link.title)}
           aria-pressed={isActive}
-          className={cn(
-            'h-9 w-9 rounded-lg',
-            isActive ? 'bg-surface-active-alt text-text-primary' : 'text-text-secondary',
-          )}
+          className={buttonClass}
           onClick={handleClick}
         >
           <link.icon className="h-5 w-5" aria-hidden="true" />
@@ -130,8 +155,12 @@ function ExpandedPanel({
   onExpand?: () => void;
 }) {
   const localize = useLocalize();
+  const { pathname } = useLocation();
   const { active, setActive } = useActivePanel();
-  const effectiveActive = resolveActivePanel(active, links);
+  const effectiveActive = (() => {
+    const matched = links.find((l) => l.href && pathname.startsWith(l.href));
+    return matched ? matched.id : resolveActivePanel(active, links);
+  })();
 
   const toggleLabel = expanded ? 'com_nav_close_sidebar' : 'com_nav_open_sidebar';
   const toggleClick = expanded ? onCollapse : onExpand;

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -107,6 +107,7 @@ export default function useSideNavLinks({
         label: '',
         icon: Bot,
         id: EModelEndpoint.agents,
+        href: '/agents',
         Component: AgentPanelSwitch,
       });
     }
@@ -136,6 +137,7 @@ export default function useSideNavLinks({
         label: '',
         icon: ScrollText,
         id: 'skills',
+        href: '/skills',
         Component: SkillsAccordion,
       });
     }
@@ -146,6 +148,7 @@ export default function useSideNavLinks({
         label: '',
         icon: NotebookPen,
         id: 'prompts',
+        href: '/prompts',
         Component: PromptsAccordion,
       });
     }
@@ -156,6 +159,7 @@ export default function useSideNavLinks({
         label: '',
         icon: Brain,
         id: 'memories',
+        href: '/memories',
         Component: MemoryPanel,
       });
     }
@@ -166,6 +170,7 @@ export default function useSideNavLinks({
         label: '',
         icon: Bookmark,
         id: 'bookmarks',
+        href: '/bookmarks',
         Component: BookmarkPanel,
       });
     }
@@ -175,6 +180,7 @@ export default function useSideNavLinks({
       label: '',
       icon: AttachmentIcon,
       id: 'files',
+      href: '/files',
       Component: FilesPanel,
     });
 
@@ -202,6 +208,7 @@ export default function useSideNavLinks({
         label: '',
         icon: MCPIcon,
         id: 'mcp-builder',
+        href: '/mcp',
         Component: MCPBuilderPanel,
       });
     }

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -51,6 +51,26 @@ const loadProjectWorkspace = () =>
     Component: m.ProjectWorkspace,
   }));
 
+const loadMemoriesView = () =>
+  import('~/components/SidePanel/Memories/layouts/MemoriesView').then((m) => ({
+    Component: m.default,
+  }));
+
+const loadBookmarksView = () =>
+  import('~/components/SidePanel/Bookmarks/layouts/BookmarksView').then((m) => ({
+    Component: m.default,
+  }));
+
+const loadFilesView = () =>
+  import('~/components/SidePanel/Files/layouts/FilesView').then((m) => ({
+    Component: m.default,
+  }));
+
+const loadMCPView = () =>
+  import('~/components/SidePanel/MCPBuilder/layouts/MCPView').then((m) => ({
+    Component: m.default,
+  }));
+
 const baseEl = document.querySelector('base');
 const baseHref = baseEl?.getAttribute('href') || '/';
 
@@ -185,6 +205,22 @@ export const router = createBrowserRouter(
                   <AgentMarketplace />
                 </MarketplaceProvider>
               ),
+            },
+            {
+              path: 'memories',
+              lazy: loadMemoriesView,
+            },
+            {
+              path: 'bookmarks',
+              lazy: loadBookmarksView,
+            },
+            {
+              path: 'files',
+              lazy: loadFilesView,
+            },
+            {
+              path: 'mcp',
+              lazy: loadMCPView,
             },
           ],
         },


### PR DESCRIPTION
## ⚠️ Status: Superseded

This PR has been superseded by a new combined implementation that includes a full sidebar chrome redesign alongside the individual-page routing. **Please do not merge this PR** — it will be closed once the replacement is up for review.

The new approach (in progress) differs in a few key ways:
- Sidebar chrome is fully replaced (60px collapsed strip with logo, 260px expanded panel — not patched onto the old sidebar)
- `href` is added to the `NavLink` type; `NavLabelRow` and `NavIconButton` each render a `<Link>` when `href` is set and derive active state from `pathname`
- The `noPadding` prop pattern was dropped — full-page views own their own padding via the layout wrapper
- 4 new lazy routes (`/memories`, `/bookmarks`, `/files`, `/mcp`) and access-gated layout views follow the same pattern used by `InlinePromptsView` and `SkillsView`

---

## Original summary (for context only)

Adds dedicated full-page URLs for four sidebar panels — Memories, Bookmarks, Files, and MCP — so each tool is a navigable page rather than an inline side panel expansion.

### What changed

- `NavLink` type gains `href?: string`
- `ExpandedPanel` renders a `<Link>` for nav icons when `href` is set
- `useSideNavLinks` adds `href` to memories, bookmarks, files, mcp-builder links
- 4 new lazy routes registered in `routes/index.tsx`: `/memories`, `/bookmarks`, `/files`, `/mcp`
- 4 layout view files with access guards that redirect to `/c/new` on deny
- `MemoryPanel`, `MCPBuilderPanel`, `BookmarkPanel` each gain a `noPadding` prop for full-page use

### Why individual pages

Inline side panels don't scale — they're narrow by design and compete with conversation content. A dedicated URL gives each tool full viewport width, a shareable address, and a natural back-navigation entry in browser history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)