### PR TITLE
feat(projects): add PageHeader and uniform 24px padding

### DIFF
--- a/client/src/components/Projects/ProjectWorkspace.tsx
+++ b/client/src/components/Projects/ProjectWorkspace.tsx
@@ -2,13 +2,14 @@ import { useCallback, useId, useMemo, useState } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { useRecoilValue } from 'recoil';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, ArrowUpDown, Check, Folder, Plus } from 'lucide-react';
+import { ArrowLeft, ArrowUpDown, Check, Plus } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { QueryKeys } from 'librechat-data-provider';
 import type { ConversationListResponse } from 'librechat-data-provider';
 import { Spinner, DropdownPopup } from '@librechat/client';
 import type { MenuItemProps, RenderProp } from '~/common';
 import { useConversationsInfiniteQuery, useProjectQuery } from '~/data-provider';
+import PageHeader from '~/components/ui/PageHeader';
 import { useLocalize, useNewConvo } from '~/hooks';
 import { cn, clearMessagesCache } from '~/utils';
 import ProjectChatList from './ProjectChatList';
@@ -127,31 +128,23 @@ export default function ProjectWorkspace() {
 
   return (
     <main className="flex h-full min-h-0 flex-col overflow-y-auto bg-surface-primary text-text-primary">
-      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 pb-10 pt-4 md:px-6 lg:pt-8">
+      <div className="px-6">
         <button
           type="button"
           onClick={() => navigate('/projects')}
-          className="-ml-1.5 inline-flex w-fit items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary"
+          className="-ml-1.5 mt-3 inline-flex w-fit items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary"
         >
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           {localize('com_ui_all_projects')}
         </button>
+      </div>
 
-        <header className="mt-5 flex items-start gap-3">
-          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-surface-secondary text-text-secondary">
-            <Folder className="h-6 w-6" aria-hidden="true" />
-          </span>
-          <div className="min-w-0 flex-1 pt-0.5">
-            <h1 className="truncate text-2xl font-semibold tracking-tight text-text-primary">
-              {project.name}
-            </h1>
-            {project.description ? (
-              <p className="mt-0.5 line-clamp-2 text-sm text-text-secondary">
-                {project.description}
-              </p>
-            ) : null}
-          </div>
-        </header>
+      <PageHeader title={project.name} />
+
+      <div className="flex w-full flex-1 flex-col px-6 pb-6">
+        {project.description ? (
+          <p className="mt-3 line-clamp-2 text-sm text-text-secondary">{project.description}</p>
+        ) : null}
 
         <button
           type="button"

--- a/client/src/components/Projects/ProjectsView.tsx
+++ b/client/src/components/Projects/ProjectsView.tsx
@@ -6,6 +6,7 @@ import type { TChatProject } from 'librechat-data-provider';
 import { Input, Button, Spinner, DropdownPopup } from '@librechat/client';
 import type { MenuItemProps, RenderProp } from '~/common';
 import { useProjectsInfiniteQuery } from '~/data-provider';
+import PageHeader from '~/components/ui/PageHeader';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 import ProjectCreateDialog from './ProjectCreateDialog';
@@ -101,12 +102,10 @@ export default function ProjectsView() {
 
   return (
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
-      <div className="container mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-4 py-8 md:px-6 lg:pt-12">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-text-primary md:text-3xl">
-            {localize('com_ui_projects')}
-          </h1>
-          <div className="flex items-center gap-2">
+      <PageHeader title={localize('com_ui_projects')} />
+
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <span className="hidden text-sm text-text-secondary sm:inline">
               {localize('com_ui_sort_by')}
             </span>
@@ -142,97 +141,96 @@ export default function ProjectsView() {
               {localize('com_ui_new_project')}
             </Button>
           </div>
-        </div>
 
-        <div className="flex flex-col gap-5">
-          <label className="relative min-w-0 flex-1">
-            <span className="sr-only">{localize('com_ui_search_projects')}</span>
-            <Search
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary"
-              aria-hidden="true"
-            />
-            <Input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder={localize('com_ui_search_projects')}
-              className="border-border-medium bg-surface-secondary pl-9 text-text-primary placeholder:text-text-secondary focus-visible:ring-2 focus-visible:ring-ring-primary"
-            />
-          </label>
-          <div className="flex items-center">
-            <span className="rounded-full bg-surface-active-alt px-4 py-2 text-sm font-medium text-text-primary">
-              {localize('com_ui_your_projects')}
-            </span>
+          <div className="flex flex-col gap-5">
+            <label className="relative min-w-0 flex-1">
+              <span className="sr-only">{localize('com_ui_search_projects')}</span>
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary"
+                aria-hidden="true"
+              />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder={localize('com_ui_search_projects')}
+                className="border-border-medium bg-surface-secondary pl-9 text-text-primary placeholder:text-text-secondary focus-visible:ring-2 focus-visible:ring-ring-primary"
+              />
+            </label>
+            <div className="flex items-center">
+              <span className="rounded-full bg-surface-active-alt px-4 py-2 text-sm font-medium text-text-primary">
+                {localize('com_ui_your_projects')}
+              </span>
+            </div>
           </div>
-        </div>
 
-        <ProjectCreateDialog
-          open={isCreating}
-          onOpenChange={handleCreateDialogChange}
-          onCreated={(project) => navigate(`/projects/${project._id}`)}
-        />
+          <ProjectCreateDialog
+            open={isCreating}
+            onOpenChange={handleCreateDialogChange}
+            onCreated={(project) => navigate(`/projects/${project._id}`)}
+          />
 
-        {isLoading ? (
-          <div className="flex flex-1 items-center justify-center">
-            <Spinner className="text-text-primary" />
-          </div>
-        ) : (
-          <div className="grid gap-3 md:grid-cols-2 md:gap-4">
-            {projects.map((project) => {
-              const activity = formatActivity(project);
-              return (
-                <button
-                  key={project._id}
-                  type="button"
-                  className={cn(
-                    'group/project flex min-h-[8.5rem] flex-col rounded-xl border border-border-medium bg-surface-secondary p-4 text-left transition-colors',
-                    'hover:border-border-heavy hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary',
-                  )}
-                  onClick={() => navigate(`/projects/${project._id}`)}
-                >
-                  <span className="flex min-w-0 items-center gap-2">
-                    <Folder className="h-4 w-4 shrink-0 text-text-secondary" aria-hidden="true" />
-                    <span className="truncate text-base font-semibold text-text-primary">
-                      {project.name}
+          {isLoading ? (
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner className="text-text-primary" />
+            </div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 md:gap-4">
+              {projects.map((project) => {
+                const activity = formatActivity(project);
+                return (
+                  <button
+                    key={project._id}
+                    type="button"
+                    className={cn(
+                      'group/project flex min-h-[8.5rem] flex-col rounded-xl border border-border-medium bg-surface-secondary p-4 text-left transition-colors',
+                      'hover:border-border-heavy hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary',
+                    )}
+                    onClick={() => navigate(`/projects/${project._id}`)}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Folder className="h-4 w-4 shrink-0 text-text-secondary" aria-hidden="true" />
+                      <span className="truncate text-base font-semibold text-text-primary">
+                        {project.name}
+                      </span>
                     </span>
-                  </span>
-                  {project.description ? (
-                    <span className="mt-2 line-clamp-2 text-sm leading-relaxed text-text-secondary">
-                      {project.description}
+                    {project.description ? (
+                      <span className="mt-2 line-clamp-2 text-sm leading-relaxed text-text-secondary">
+                        {project.description}
+                      </span>
+                    ) : null}
+                    <span className="mt-auto flex items-center justify-between gap-2 pt-4 text-xs text-text-secondary">
+                      <span>
+                        {project.conversationCount === 1
+                          ? localize('com_ui_project_chat_count_single')
+                          : localize('com_ui_project_chat_count', {
+                              count: project.conversationCount,
+                            })}
+                      </span>
+                      {activity ? <span className="shrink-0 truncate">{activity}</span> : null}
                     </span>
-                  ) : null}
-                  <span className="mt-auto flex items-center justify-between gap-2 pt-4 text-xs text-text-secondary">
-                    <span>
-                      {project.conversationCount === 1
-                        ? localize('com_ui_project_chat_count_single')
-                        : localize('com_ui_project_chat_count', {
-                            count: project.conversationCount,
-                          })}
-                    </span>
-                    {activity ? <span className="shrink-0 truncate">{activity}</span> : null}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
 
-        {!isLoading && projects.length === 0 && (
-          <div className="rounded-lg border border-border-medium bg-transparent py-16 text-center text-sm text-text-secondary">
-            {localize('com_ui_no_projects')}
-          </div>
-        )}
+          {!isLoading && projects.length === 0 && (
+            <div className="rounded-lg border border-border-medium bg-transparent py-16 text-center text-sm text-text-secondary">
+              {localize('com_ui_no_projects')}
+            </div>
+          )}
 
-        {hasNextPage && (
-          <Button
-            type="button"
-            variant="outline"
-            className="mx-auto"
-            onClick={() => fetchNextPage()}
-            disabled={isFetchingNextPage}
-          >
-            {isFetchingNextPage ? localize('com_ui_loading') : localize('com_ui_load_more')}
-          </Button>
-        )}
+          {hasNextPage && (
+            <Button
+              type="button"
+              variant="outline"
+              className="mx-auto"
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+            >
+              {isFetchingNextPage ? localize('com_ui_loading') : localize('com_ui_load_more')}
+            </Button>
+          )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

- Replace inline `h1` + `max-w-4xl` container in `ProjectsView` with the shared `PageHeader` component
- Replace custom project title header in `ProjectWorkspace` with `PageHeader`
- Both pages now use `px-6 pb-6` for consistent 24px edge padding on all viewports (removes `px-4 md:px-6` responsive variant)



Part of a 6-PR series — see #13753 for the full table and merge order.

**Requires #13753 (`feat/page-header-component`) to be merged first.**

## Test plan

- [ ] `/projects` — PageHeader with "Projects" title, 24px padding around content grid
- [ ] `/projects/:id` — PageHeader with project name, back button above header, 24px padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## PR Series

| # | PR | Depends on | Status |
|---|---|---|---|
| 1 | #13753 `PageHeader component` | — | ✅ merge anytime |
| 2 | #13755 `projects: PageHeader + 24px padding` | #13753 | after #13753 |
| 3 | #13756 `marketplace: PageHeader, remove hero` | #13753 | after #13753 |
| 4 | #13757 `prompts: PageHeader on /prompts/new` | #13753 | after #13753 |
| 5 | #13758 `chat: 24px header padding` | — | ✅ merge anytime |
| 6 | #13792 `sidebar: new chrome` | — | ✅ merge anytime |
| 7 | #13793 `sidebar: individual full-page routes` | #13753 + #13792 | after both |

PRs 2–4 and #13792 can merge in parallel once #13753 lands. #13758 is standalone. #13793 requires both #13753 and #13792.