### PR TITLE
feat(prompts): add PageHeader on /prompts/new, uniform padding

### DIFF
--- a/client/src/components/Prompts/forms/CreatePromptForm.tsx
+++ b/client/src/components/Prompts/forms/CreatePromptForm.tsx
@@ -112,8 +112,7 @@ const CreatePromptForm = ({
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={handleSubmit(onSubmit)} className="w-full px-4 py-2">
-        <h1 className="sr-only">{localize('com_ui_create_prompt_page')}</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full px-6 pb-6">
         <div className="mb-2 flex items-center justify-between gap-2 sm:hidden">
           <OpenSidebar />
           <CategorySelector />

--- a/client/src/components/Prompts/layouts/InlinePromptsView.tsx
+++ b/client/src/components/Prompts/layouts/InlinePromptsView.tsx
@@ -3,10 +3,12 @@ import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import EmptyPromptPreview from '../display/EmptyPromptPreview';
 import CreatePromptForm from '../forms/CreatePromptForm';
-import { useHasAccess } from '~/hooks';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
 import PromptForm from '../forms/PromptForm';
 
 export default function InlinePromptsView() {
+  const localize = useLocalize();
   const { promptId } = useParams();
   const navigate = useNavigate();
   const isNew = promptId === undefined;
@@ -37,7 +39,8 @@ export default function InlinePromptsView() {
   }
 
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-surface-primary text-text-primary">
+      {isNew && <PageHeader title={localize('com_ui_prompts')} />}
       {isNew ? (
         <CreatePromptForm onSuccess={handleCreateSuccess} />
       ) : (


### PR DESCRIPTION
## Summary

- Show `PageHeader` ("Prompts") above the create form when visiting `/prompts/new`
- Set form padding to `px-6 pb-6` for consistent 24px edges (was `px-4 py-2`)
- Update view wrapper: `bg-presentation` → `bg-surface-primary text-text-primary`



Part of a 6-PR series — see #13753 for the full table and merge order.

**Requires #13753 (`feat/page-header-component`) to be merged first.**

## Test plan

- [ ] `/prompts/new` — PageHeader visible above the form, 24px padding on all sides
- [ ] Existing prompt edit page (`/prompts/:id`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## PR Series

| # | PR | Depends on | Status |
|---|---|---|---|
| 1 | #13753 `PageHeader component` | — | ✅ merge anytime |
| 2 | #13755 `projects: PageHeader + 24px padding` | #13753 | after #13753 |
| 3 | #13756 `marketplace: PageHeader, remove hero` | #13753 | after #13753 |
| 4 | #13757 `prompts: PageHeader on /prompts/new` | #13753 | after #13753 |
| 5 | #13758 `chat: 24px header padding` | — | ✅ merge anytime |
| 6 | #13792 `sidebar: new chrome` | — | ✅ merge anytime |
| 7 | #13793 `sidebar: individual full-page routes` | #13753 + #13792 | after both |

PRs 2–4 and #13792 can merge in parallel once #13753 lands. #13758 is standalone. #13793 requires both #13753 and #13792.