### PR TITLE
feat(chat): increase header padding to 24px top and sides

### DIFF
--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -42,14 +42,14 @@ function Header() {
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
 
   return (
-    <div className="via-presentation/70 md:from-presentation/80 md:via-presentation/50 2xl:from-presentation/0 absolute top-0 z-10 flex h-[52px] w-full items-center justify-between bg-gradient-to-b from-presentation to-transparent p-2 font-semibold text-text-primary 2xl:via-transparent">
+    <div className="via-presentation/70 md:from-presentation/80 md:via-presentation/50 2xl:from-presentation/0 absolute top-0 z-10 flex w-full items-center justify-between bg-gradient-to-b from-presentation to-transparent px-6 pb-2 pt-6 font-semibold text-text-primary 2xl:via-transparent">
       <div className="hide-scrollbar flex w-full items-center justify-between gap-2 overflow-x-auto">
-        <div className="mx-1 flex items-center">
+        <div className="flex items-center gap-2">
           <OpenSidebar className="md:hidden" />
           {!(navVisible && isSmallScreen) && (
             <div
               className={cn(
-                'flex items-center gap-2 pl-2',
+                'flex items-center gap-2',
                 !isSmallScreen ? 'transition-all duration-200 ease-in-out' : '',
               )}
             >


### PR DESCRIPTION
## Summary

- Change `p-2` → `px-6 pt-6 pb-2` on the chat header so the model selector and action buttons sit 24px from the top and side edges
- Remove fixed `h-[52px]` height — the header now sizes to its content
- Remove redundant `mx-1` / `pl-2` inner offsets; add `gap-2` to the left button group for proper spacing between the sidebar toggle and model selector on mobile

## PR Series

Part of a 6-PR series — see #13753 for the full table and merge order.

**No dependencies — this PR can merge independently at any time.**

## Test plan

- [ ] `/c/new` — model selector (top-left) and share/temp-chat buttons (top-right) sit 24px from page edges
- [ ] Chat conversation view — header gradient still fades correctly over messages
- [ ] Mobile — sidebar toggle and model selector have proper spacing between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)