### PR TITLE
📡 refactor: Gate Noisy Redis OTEL Instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,8 +140,9 @@ NODE_MAX_OLD_SPACE_SIZE=6144
 # OTEL_SDK_DISABLED=false
 # Enable Redis command-level spans. Disabled by default to keep backend traces high-level.
 # OTEL_IOREDIS_TRACING_ENABLED=false
-# Enable nested MongoDB spans created by Mongoose operations. Disabled by default to avoid duplicate database spans.
-# OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED=false
+# Enable instrumentation inside Mongoose operations. Enabled by default so hooks preserve side-effect spans.
+# Set false to suppress nested MongoDB spans created by Mongoose operations.
+# OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED=true
 
 #===============================#
 # Real User Monitoring (Browser) #

--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,10 @@ NODE_MAX_OLD_SPACE_SIZE=6144
 # OTEL_TRACES_SAMPLER=parentbased_always_on
 # OTEL_LOG_LEVEL=INFO
 # OTEL_SDK_DISABLED=false
+# Enable Redis command-level spans. Disabled by default to keep backend traces high-level.
+# OTEL_IOREDIS_TRACING_ENABLED=false
+# Enable nested MongoDB spans created by Mongoose operations. Disabled by default to avoid duplicate database spans.
+# OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED=false
 
 #===============================#
 # Real User Monitoring (Browser) #

--- a/.env.example
+++ b/.env.example
@@ -140,9 +140,6 @@ NODE_MAX_OLD_SPACE_SIZE=6144
 # OTEL_SDK_DISABLED=false
 # Enable Redis command-level spans. Disabled by default to keep backend traces high-level.
 # OTEL_IOREDIS_TRACING_ENABLED=false
-# Enable instrumentation inside Mongoose operations. Enabled by default so hooks preserve side-effect spans.
-# Set false to suppress nested MongoDB spans created by Mongoose operations.
-# OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED=true
 
 #===============================#
 # Real User Monitoring (Browser) #

--- a/packages/api/src/telemetry/config.spec.ts
+++ b/packages/api/src/telemetry/config.spec.ts
@@ -9,7 +9,6 @@ describe('getTelemetryConfig', () => {
     expect(config.serviceName).toBe('librechat');
     expect(config.healthPath).toBe('/health');
     expect(config.ioredisTracingEnabled).toBe(false);
-    expect(config.mongooseInternalTracingEnabled).toBe(true);
   });
 
   it('enables tracing only when OTEL_TRACING_ENABLED is true', () => {
@@ -52,14 +51,5 @@ describe('getTelemetryConfig', () => {
     });
 
     expect(config.ioredisTracingEnabled).toBe(true);
-    expect(config.mongooseInternalTracingEnabled).toBe(true);
-  });
-
-  it('allows mongoose internal instrumentation to be explicitly disabled', () => {
-    const config = getTelemetryConfig({
-      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'false',
-    });
-
-    expect(config.mongooseInternalTracingEnabled).toBe(false);
   });
 });

--- a/packages/api/src/telemetry/config.spec.ts
+++ b/packages/api/src/telemetry/config.spec.ts
@@ -8,6 +8,8 @@ describe('getTelemetryConfig', () => {
     expect(config.sdkDisabled).toBe(false);
     expect(config.serviceName).toBe('librechat');
     expect(config.healthPath).toBe('/health');
+    expect(config.ioredisTracingEnabled).toBe(false);
+    expect(config.mongooseInternalTracingEnabled).toBe(false);
   });
 
   it('enables tracing only when OTEL_TRACING_ENABLED is true', () => {
@@ -42,5 +44,15 @@ describe('getTelemetryConfig', () => {
     });
 
     expect(config.serviceVersion).toBe('0.8.5');
+  });
+
+  it('enables noisy database instrumentation only when explicitly configured', () => {
+    const config = getTelemetryConfig({
+      OTEL_IOREDIS_TRACING_ENABLED: 'true',
+      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'TRUE',
+    });
+
+    expect(config.ioredisTracingEnabled).toBe(true);
+    expect(config.mongooseInternalTracingEnabled).toBe(true);
   });
 });

--- a/packages/api/src/telemetry/config.spec.ts
+++ b/packages/api/src/telemetry/config.spec.ts
@@ -9,7 +9,7 @@ describe('getTelemetryConfig', () => {
     expect(config.serviceName).toBe('librechat');
     expect(config.healthPath).toBe('/health');
     expect(config.ioredisTracingEnabled).toBe(false);
-    expect(config.mongooseInternalTracingEnabled).toBe(false);
+    expect(config.mongooseInternalTracingEnabled).toBe(true);
   });
 
   it('enables tracing only when OTEL_TRACING_ENABLED is true', () => {
@@ -46,13 +46,20 @@ describe('getTelemetryConfig', () => {
     expect(config.serviceVersion).toBe('0.8.5');
   });
 
-  it('enables noisy database instrumentation only when explicitly configured', () => {
+  it('enables ioredis instrumentation only when explicitly configured', () => {
     const config = getTelemetryConfig({
       OTEL_IOREDIS_TRACING_ENABLED: 'true',
-      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'TRUE',
     });
 
     expect(config.ioredisTracingEnabled).toBe(true);
     expect(config.mongooseInternalTracingEnabled).toBe(true);
+  });
+
+  it('allows mongoose internal instrumentation to be explicitly disabled', () => {
+    const config = getTelemetryConfig({
+      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'false',
+    });
+
+    expect(config.mongooseInternalTracingEnabled).toBe(false);
   });
 });

--- a/packages/api/src/telemetry/config.ts
+++ b/packages/api/src/telemetry/config.ts
@@ -23,6 +23,16 @@ function isTruthy(value?: string | boolean | null): boolean {
   return false;
 }
 
+function isFalsey(value?: string | boolean | null): boolean {
+  if (typeof value === 'boolean') {
+    return !value;
+  }
+  if (typeof value === 'string') {
+    return value.trim().toLowerCase() === 'false';
+  }
+  return false;
+}
+
 function normalizeEnvValue(value?: string): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
@@ -35,7 +45,7 @@ export function getTelemetryConfig(env: NodeJS.ProcessEnv = process.env): Teleme
   const serviceVersion =
     normalizeEnvValue(env.OTEL_SERVICE_VERSION) ?? normalizeEnvValue(env.npm_package_version);
   const ioredisTracingEnabled = isTruthy(env.OTEL_IOREDIS_TRACING_ENABLED);
-  const mongooseInternalTracingEnabled = isTruthy(env.OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED);
+  const mongooseInternalTracingEnabled = !isFalsey(env.OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED);
 
   return {
     enabled,

--- a/packages/api/src/telemetry/config.ts
+++ b/packages/api/src/telemetry/config.ts
@@ -6,6 +6,8 @@ export type TelemetryStatus = 'disabled' | 'failed' | 'started' | 'starting' | '
 export interface TelemetryConfig {
   enabled: boolean;
   healthPath: string;
+  ioredisTracingEnabled: boolean;
+  mongooseInternalTracingEnabled: boolean;
   sdkDisabled: boolean;
   serviceName: string;
   serviceVersion?: string;
@@ -32,10 +34,14 @@ export function getTelemetryConfig(env: NodeJS.ProcessEnv = process.env): Teleme
   const serviceName = normalizeEnvValue(env.OTEL_SERVICE_NAME) ?? DEFAULT_SERVICE_NAME;
   const serviceVersion =
     normalizeEnvValue(env.OTEL_SERVICE_VERSION) ?? normalizeEnvValue(env.npm_package_version);
+  const ioredisTracingEnabled = isTruthy(env.OTEL_IOREDIS_TRACING_ENABLED);
+  const mongooseInternalTracingEnabled = isTruthy(env.OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED);
 
   return {
     enabled,
     serviceName,
+    ioredisTracingEnabled,
+    mongooseInternalTracingEnabled,
     sdkDisabled,
     serviceVersion,
     healthPath: DEFAULT_HEALTH_PATH,

--- a/packages/api/src/telemetry/config.ts
+++ b/packages/api/src/telemetry/config.ts
@@ -7,7 +7,6 @@ export interface TelemetryConfig {
   enabled: boolean;
   healthPath: string;
   ioredisTracingEnabled: boolean;
-  mongooseInternalTracingEnabled: boolean;
   sdkDisabled: boolean;
   serviceName: string;
   serviceVersion?: string;
@@ -19,16 +18,6 @@ function isTruthy(value?: string | boolean | null): boolean {
   }
   if (typeof value === 'string') {
     return value.trim().toLowerCase() === 'true';
-  }
-  return false;
-}
-
-function isFalsey(value?: string | boolean | null): boolean {
-  if (typeof value === 'boolean') {
-    return !value;
-  }
-  if (typeof value === 'string') {
-    return value.trim().toLowerCase() === 'false';
   }
   return false;
 }
@@ -45,13 +34,11 @@ export function getTelemetryConfig(env: NodeJS.ProcessEnv = process.env): Teleme
   const serviceVersion =
     normalizeEnvValue(env.OTEL_SERVICE_VERSION) ?? normalizeEnvValue(env.npm_package_version);
   const ioredisTracingEnabled = isTruthy(env.OTEL_IOREDIS_TRACING_ENABLED);
-  const mongooseInternalTracingEnabled = !isFalsey(env.OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED);
 
   return {
     enabled,
     serviceName,
     ioredisTracingEnabled,
-    mongooseInternalTracingEnabled,
     sdkDisabled,
     serviceVersion,
     healthPath: DEFAULT_HEALTH_PATH,

--- a/packages/api/src/telemetry/sdk.spec.ts
+++ b/packages/api/src/telemetry/sdk.spec.ts
@@ -191,16 +191,15 @@ describe('telemetry SDK lifecycle', () => {
     expect(mockExpressInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockMongoDBInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
-      suppressInternalInstrumentation: true,
+      suppressInternalInstrumentation: false,
     });
     expect(mockIORedisInstrumentation).not.toHaveBeenCalled();
     expect(mockUndiciInstrumentation).toHaveBeenCalledTimes(1);
   });
 
-  it('enables noisy database instrumentation when explicitly configured', () => {
+  it('enables ioredis instrumentation when explicitly configured', () => {
     initializeTelemetry({
       OTEL_IOREDIS_TRACING_ENABLED: 'true',
-      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'true',
       OTEL_TRACING_ENABLED: 'true',
     });
 
@@ -212,6 +211,18 @@ describe('telemetry SDK lifecycle', () => {
     expect(mockMongoDBInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockIORedisInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockUndiciInstrumentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses mongoose internal instrumentation when explicitly disabled', () => {
+    initializeTelemetry({
+      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'false',
+      OTEL_TRACING_ENABLED: 'true',
+    });
+
+    expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
+      suppressInternalInstrumentation: true,
+    });
+    expect(mockIORedisInstrumentation).not.toHaveBeenCalled();
   });
 
   it('tracks HTTP server request spans for completion updates', () => {

--- a/packages/api/src/telemetry/sdk.spec.ts
+++ b/packages/api/src/telemetry/sdk.spec.ts
@@ -1,8 +1,8 @@
 import { Socket } from 'node:net';
 import { IncomingMessage } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
-import type { Span } from '@opentelemetry/api';
 import type { RequestOptions } from 'node:http';
+import type { Span } from '@opentelemetry/api';
 
 interface HttpInstrumentationOptions {
   requestHook?: (span: Span, request: object) => void;

--- a/packages/api/src/telemetry/sdk.spec.ts
+++ b/packages/api/src/telemetry/sdk.spec.ts
@@ -207,7 +207,11 @@ describe('telemetry SDK lifecycle', () => {
     expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
       suppressInternalInstrumentation: false,
     });
+    expect(mockHttpInstrumentation).toHaveBeenCalledTimes(1);
+    expect(mockExpressInstrumentation).toHaveBeenCalledTimes(1);
+    expect(mockMongoDBInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockIORedisInstrumentation).toHaveBeenCalledTimes(1);
+    expect(mockUndiciInstrumentation).toHaveBeenCalledTimes(1);
   });
 
   it('tracks HTTP server request spans for completion updates', () => {

--- a/packages/api/src/telemetry/sdk.spec.ts
+++ b/packages/api/src/telemetry/sdk.spec.ts
@@ -190,9 +190,7 @@ describe('telemetry SDK lifecycle', () => {
     );
     expect(mockExpressInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockMongoDBInstrumentation).toHaveBeenCalledTimes(1);
-    expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
-      suppressInternalInstrumentation: false,
-    });
+    expect(mockMongooseInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockIORedisInstrumentation).not.toHaveBeenCalled();
     expect(mockUndiciInstrumentation).toHaveBeenCalledTimes(1);
   });
@@ -203,26 +201,12 @@ describe('telemetry SDK lifecycle', () => {
       OTEL_TRACING_ENABLED: 'true',
     });
 
-    expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
-      suppressInternalInstrumentation: false,
-    });
+    expect(mockMongooseInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockHttpInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockExpressInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockMongoDBInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockIORedisInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockUndiciInstrumentation).toHaveBeenCalledTimes(1);
-  });
-
-  it('suppresses mongoose internal instrumentation when explicitly disabled', () => {
-    initializeTelemetry({
-      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'false',
-      OTEL_TRACING_ENABLED: 'true',
-    });
-
-    expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
-      suppressInternalInstrumentation: true,
-    });
-    expect(mockIORedisInstrumentation).not.toHaveBeenCalled();
   });
 
   it('tracks HTTP server request spans for completion updates', () => {

--- a/packages/api/src/telemetry/sdk.spec.ts
+++ b/packages/api/src/telemetry/sdk.spec.ts
@@ -190,9 +190,24 @@ describe('telemetry SDK lifecycle', () => {
     );
     expect(mockExpressInstrumentation).toHaveBeenCalledTimes(1);
     expect(mockMongoDBInstrumentation).toHaveBeenCalledTimes(1);
-    expect(mockMongooseInstrumentation).toHaveBeenCalledTimes(1);
-    expect(mockIORedisInstrumentation).toHaveBeenCalledTimes(1);
+    expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
+      suppressInternalInstrumentation: true,
+    });
+    expect(mockIORedisInstrumentation).not.toHaveBeenCalled();
     expect(mockUndiciInstrumentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables noisy database instrumentation when explicitly configured', () => {
+    initializeTelemetry({
+      OTEL_IOREDIS_TRACING_ENABLED: 'true',
+      OTEL_MONGOOSE_INTERNAL_TRACING_ENABLED: 'true',
+      OTEL_TRACING_ENABLED: 'true',
+    });
+
+    expect(mockMongooseInstrumentation).toHaveBeenCalledWith({
+      suppressInternalInstrumentation: false,
+    });
+    expect(mockIORedisInstrumentation).toHaveBeenCalledTimes(1);
   });
 
   it('tracks HTTP server request spans for completion updates', () => {

--- a/packages/api/src/telemetry/sdk.ts
+++ b/packages/api/src/telemetry/sdk.ts
@@ -317,9 +317,7 @@ function createSdk(config: TelemetryConfig): NodeSDK {
     }),
     new ExpressInstrumentation(),
     new MongoDBInstrumentation(),
-    new MongooseInstrumentation({
-      suppressInternalInstrumentation: !config.mongooseInternalTracingEnabled,
-    }),
+    new MongooseInstrumentation(),
     new UndiciInstrumentation({
       startSpanHook: (request: UndiciRequestInfo) => getSanitizedUndiciUrlAttributes(request),
     }),

--- a/packages/api/src/telemetry/sdk.ts
+++ b/packages/api/src/telemetry/sdk.ts
@@ -12,8 +12,8 @@ import type { NodeSDKConfiguration } from '@opentelemetry/sdk-node';
 import type { Span, Attributes } from '@opentelemetry/api';
 import type { RequestOptions } from 'node:http';
 import type { TelemetryConfig, TelemetryStatus } from './config';
-import { getTelemetryConfig } from './config';
 import { registerShutdownTask } from '../app/shutdown';
+import { getTelemetryConfig } from './config';
 
 export interface TelemetryController {
   readonly enabled: boolean;

--- a/packages/api/src/telemetry/sdk.ts
+++ b/packages/api/src/telemetry/sdk.ts
@@ -297,34 +297,41 @@ function getResourceAttributes(config: TelemetryConfig): Attributes {
 }
 
 function createSdk(config: TelemetryConfig): NodeSDK {
+  const instrumentations: NodeSDKConfiguration['instrumentations'] = [
+    new HttpInstrumentation({
+      headersToSpanAttributes: {
+        client: { requestHeaders: [], responseHeaders: [] },
+        server: { requestHeaders: [], responseHeaders: [] },
+      },
+      requestHook: (span: Span, request: object) => {
+        if (request instanceof IncomingMessage) {
+          requestSpans.set(request, span);
+        }
+      },
+      startIncomingSpanHook: (request: IncomingMessage) =>
+        getSanitizedIncomingUrlAttributes(request, config.healthPath),
+      startOutgoingSpanHook: (request: RequestOptions) =>
+        getSanitizedOutgoingHttpUrlAttributes(request),
+      ignoreIncomingRequestHook: (request: IncomingMessage) =>
+        shouldIgnoreIncomingRequest(request, config.healthPath),
+    }),
+    new ExpressInstrumentation(),
+    new MongoDBInstrumentation(),
+    new MongooseInstrumentation({
+      suppressInternalInstrumentation: !config.mongooseInternalTracingEnabled,
+    }),
+    new UndiciInstrumentation({
+      startSpanHook: (request: UndiciRequestInfo) => getSanitizedUndiciUrlAttributes(request),
+    }),
+  ];
+
+  if (config.ioredisTracingEnabled) {
+    instrumentations.push(new IORedisInstrumentation());
+  }
+
   const sdkConfig: Partial<NodeSDKConfiguration> = {
     resource: resourceFromAttributes(getResourceAttributes(config)),
-    instrumentations: [
-      new HttpInstrumentation({
-        headersToSpanAttributes: {
-          client: { requestHeaders: [], responseHeaders: [] },
-          server: { requestHeaders: [], responseHeaders: [] },
-        },
-        requestHook: (span: Span, request: object) => {
-          if (request instanceof IncomingMessage) {
-            requestSpans.set(request, span);
-          }
-        },
-        startIncomingSpanHook: (request: IncomingMessage) =>
-          getSanitizedIncomingUrlAttributes(request, config.healthPath),
-        startOutgoingSpanHook: (request: RequestOptions) =>
-          getSanitizedOutgoingHttpUrlAttributes(request),
-        ignoreIncomingRequestHook: (request: IncomingMessage) =>
-          shouldIgnoreIncomingRequest(request, config.healthPath),
-      }),
-      new ExpressInstrumentation(),
-      new MongoDBInstrumentation(),
-      new MongooseInstrumentation(),
-      new IORedisInstrumentation(),
-      new UndiciInstrumentation({
-        startSpanHook: (request: UndiciRequestInfo) => getSanitizedUndiciUrlAttributes(request),
-      }),
-    ],
+    instrumentations,
   };
 
   return new NodeSDK(sdkConfig);


### PR DESCRIPTION
## Summary

Adds `OTEL_IOREDIS_TRACING_ENABLED=false` so ioredis command-level spans are disabled unless explicitly enabled.

Redis emits 12k+ spans per agent run. So keeping it off by default.

## Testing

- `jest --config packages/api/jest.config.mjs packages/api/src/telemetry/config.spec.ts packages/api/src/telemetry/sdk.spec.ts --runInBand --coverage=false`
- Changed-file ESLint, Prettier, and import-sort checks
