### PR TITLE
🫷 fix: Withhold Anthropic Custom Headers From User URLs

### DIFF
--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -407,14 +407,17 @@ describe('initializeCustom – native Anthropic provider', () => {
     mockGetCustomEndpointConfig.mockReturnValue(config);
     return {
       req: {
-        user: { id: 'user-1' },
+        user: { id: 'user-1', email: 'user@example.com' },
         body: { conversationId: 'convo-1' },
         config: {},
       } as unknown as BaseInitializeParams['req'],
       endpoint: 'Claude-Compatible',
       model_parameters,
       db: {
-        getUserKeyValues: jest.fn(),
+        getUserKeyValues: jest.fn().mockResolvedValue({
+          apiKey: 'sk-user-key',
+          baseURL: 'https://user-controlled.example.com',
+        }),
         getUserKey: jest.fn(),
       } as unknown as BaseInitializeParams['db'],
     };
@@ -444,6 +447,36 @@ describe('initializeCustom – native Anthropic provider', () => {
     expect(defaultHeaders?.['anthropic-version']).toBe('2023-06-01');
     /** Native Anthropic path must NOT use OpenAI legacy content formatting */
     expect(options.useLegacyContent).toBeUndefined();
+  });
+
+  it('withholds configured headers when the user supplies the base URL', async () => {
+    const params = createAnthropicParams({
+      provider: 'anthropic',
+      apiKey: 'sk-ant-custom',
+      baseURL: AuthType.USER_PROVIDED,
+      headers: {
+        Authorization: 'Bearer ${GATEWAY_SECRET}',
+        'X-User-Email': '{{LIBRECHAT_USER_EMAIL}}',
+      },
+      models: { default: ['claude-sonnet-4-5'] },
+    });
+
+    const options = await initializeCustom(params);
+
+    expect(mockValidateEndpointURL).toHaveBeenCalledWith(
+      'https://user-controlled.example.com',
+      'Claude-Compatible',
+      undefined,
+    );
+    expect(options.llmConfig).toHaveProperty(
+      'anthropicApiUrl',
+      'https://user-controlled.example.com',
+    );
+    const defaultHeaders = (
+      options.llmConfig as { clientOptions?: { defaultHeaders?: Record<string, string> } }
+    ).clientOptions?.defaultHeaders;
+    expect(defaultHeaders?.Authorization).toBeUndefined();
+    expect(defaultHeaders?.['X-User-Email']).toBeUndefined();
   });
 
   it('applies customParams.paramDefinitions defaults on the native path', async () => {

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -111,17 +111,19 @@ function buildAnthropicCustomConfig({
   baseURL,
   modelOptions,
   endpointConfig,
+  userProvidesURL,
 }: {
   apiKey: string;
   baseURL: string;
   modelOptions: AnthropicModelOptions;
   endpointConfig: Partial<TEndpoint>;
+  userProvidesURL: boolean;
 }): InitializeResultBase {
   const result = getAnthropicLLMConfig(apiKey, {
     modelOptions,
     proxy: PROXY ?? undefined,
     reverseProxyUrl: baseURL,
-    headers: endpointConfig.headers,
+    headers: userProvidesURL ? undefined : endpointConfig.headers,
     addParams: endpointConfig.addParams,
     dropParams: endpointConfig.dropParams,
     /** Apply admin `customParams.paramDefinitions` defaults (e.g. promptCache,
@@ -289,6 +291,7 @@ export async function initializeCustom({
       baseURL,
       modelOptions: modelOptions as AnthropicModelOptions,
       endpointConfig,
+      userProvidesURL,
     });
     options.endpointTokenConfig = endpointTokenConfig;
   } else {


### PR DESCRIPTION
## Summary

I fixed the native Anthropic custom endpoint path so admin-configured headers are withheld when users supply the destination base URL.

- Passed the existing `userProvidesURL` signal into the native Anthropic custom endpoint config builder.
- Withheld configured headers from the native Anthropic client when `baseURL` is `user_provided`, matching the existing OpenAI-compatible and model-fetch guards.
- Added regression coverage for the reported secret/user-placeholder header leak shape.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`.
- Ran `npm run build:data-schemas`.
- Ran `cd packages/api && npx jest src/endpoints/custom/initialize.spec.ts --runInBand --testResultsProcessor=`.
- Ran `npm run build:api`.

### **Test Configuration**:

- Node.js local workspace dependencies installed via `npm install --no-audit --no-fund`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes