### PR TITLE
🧾 refactor: Disable Context Cost By Default

### DIFF
--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1274,7 +1274,7 @@ export const interfaceSchema = z
     runCode: true,
     webSearch: true,
     contextUsage: true,
-    contextCost: true,
+    contextCost: false,
     peoplePicker: {
       users: true,
       groups: true,

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -66,13 +66,13 @@ describe('loadDefaultInterface', () => {
     expect(interfaceConfig?.buildInfo).toBe(true);
   });
 
-  it('enables context cost by default', async () => {
+  it('disables context cost by default', async () => {
     const interfaceConfig = await loadDefaultInterface({
       config: {},
       configDefaults: getConfigDefaults(),
     });
 
-    expect(interfaceConfig?.contextCost).toBe(true);
+    expect(interfaceConfig?.contextCost).toBe(false);
   });
 
   it('preserves a disabled context cost flag', async () => {
@@ -88,6 +88,21 @@ describe('loadDefaultInterface', () => {
     });
 
     expect(interfaceConfig?.contextCost).toBe(false);
+  });
+
+  it('preserves enabled context cost config', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        contextCost: true,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.contextCost).toBe(true);
   });
 
   it('passes through a configured display currency', async () => {


### PR DESCRIPTION
## Summary

I disabled the default context cost display so deployments do not expose pricing metadata unless an operator explicitly opts in.

- Changed the `interface.contextCost` schema default from `true` to `false`.
- Updated the interface loader coverage to assert default-off behavior.
- Added coverage proving explicit `contextCost: true` still enables the opt-in path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci` to restore missing workspace dependencies.
- Ran `npm run build:data-provider` so `librechat-data-provider` resolved from its built workspace export.
- Ran `cd packages/data-schemas && npx jest src/app/interface.spec.ts --runInBand`.

### **Test Configuration**:

- Node/npm workspace install from this checkout
- Targeted Jest spec: `packages/data-schemas/src/app/interface.spec.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
