### PR TITLE
🧷 fix: Preserve Document Priority on Section-Scoped Config Writes

### DIFF
--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -647,6 +647,174 @@ describe('createAdminConfigHandlers', () => {
     });
   });
 
+  describe('patchConfigField: section-scoped priority preservation', () => {
+    it('ignores request-supplied priority when caller lacks broad manage:configs', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn(async (_user, section) => section === 'memory'),
+        findConfigByPrincipal: jest
+          .fn()
+          .mockResolvedValue({ _id: 'c1', priority: 7, overrides: {} }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: {
+          entries: [{ fieldPath: 'memory.context', value: 'updated' }],
+          priority: 999,
+        },
+      });
+      const res = mockRes();
+
+      await handlers.patchConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.patchConfigFields.mock.calls[0];
+      expect(priorityArg).toBe(7);
+    });
+
+    it('falls back to default priority when no existing doc and caller lacks broad manage', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn(async (_user, section) => section === 'memory'),
+        findConfigByPrincipal: jest.fn().mockResolvedValue(null),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: {
+          entries: [{ fieldPath: 'memory.context', value: 'updated' }],
+          priority: 999,
+        },
+      });
+      const res = mockRes();
+
+      await handlers.patchConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.patchConfigFields.mock.calls[0];
+      expect(priorityArg).toBe(10);
+    });
+
+    it('honors request-supplied priority when caller holds broad manage:configs', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: {
+          entries: [{ fieldPath: 'memory.context', value: 'updated' }],
+          priority: 999,
+        },
+      });
+      const res = mockRes();
+
+      await handlers.patchConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.patchConfigFields.mock.calls[0];
+      expect(priorityArg).toBe(999);
+      expect(deps.findConfigByPrincipal).not.toHaveBeenCalled();
+    });
+
+    it('preserves priority 0 when broad caller supplies it', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: {
+          entries: [{ fieldPath: 'memory.context', value: 'updated' }],
+          priority: 0,
+        },
+      });
+      const res = mockRes();
+
+      await handlers.patchConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.patchConfigFields.mock.calls[0];
+      expect(priorityArg).toBe(0);
+    });
+
+    it('preserves existing priority 0 for section-scoped callers', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn(async (_user, section) => section === 'memory'),
+        findConfigByPrincipal: jest
+          .fn()
+          .mockResolvedValue({ _id: 'c1', priority: 0, overrides: {} }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: {
+          entries: [{ fieldPath: 'memory.context', value: 'updated' }],
+          priority: 999,
+        },
+      });
+      const res = mockRes();
+
+      await handlers.patchConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.patchConfigFields.mock.calls[0];
+      expect(priorityArg).toBe(0);
+    });
+  });
+
+  describe('tombstoneConfigField: section-scoped priority preservation', () => {
+    it('ignores request-supplied priority when caller lacks broad manage:configs', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn(async (_user, section) => section === 'memory'),
+        findConfigByPrincipal: jest
+          .fn()
+          .mockResolvedValue({ _id: 'c1', priority: 7, overrides: {} }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { fieldPath: 'memory.context', priority: 999 },
+      });
+      const res = mockRes();
+
+      await handlers.tombstoneConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.tombstoneConfigField.mock.calls[0];
+      expect(priorityArg).toBe(7);
+    });
+
+    it('falls back to default priority when no existing doc and caller lacks broad manage', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn(async (_user, section) => section === 'memory'),
+        findConfigByPrincipal: jest.fn().mockResolvedValue(null),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { fieldPath: 'memory.context', priority: 999 },
+      });
+      const res = mockRes();
+
+      await handlers.tombstoneConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.tombstoneConfigField.mock.calls[0];
+      expect(priorityArg).toBe(10);
+    });
+
+    it('honors request-supplied priority when caller holds broad manage:configs', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { fieldPath: 'memory.context', priority: 999 },
+      });
+      const res = mockRes();
+
+      await handlers.tombstoneConfigField(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const [, , , , priorityArg] = deps.tombstoneConfigField.mock.calls[0];
+      expect(priorityArg).toBe(999);
+      expect(deps.findConfigByPrincipal).not.toHaveBeenCalled();
+    });
+  });
+
   describe('upsertConfigOverrides — Bug 2 regression', () => {
     it('returns 403 for empty overrides when user lacks MANAGE_CONFIGS', async () => {
       const { handlers } = createHandlers({

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -466,14 +466,16 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return true;
       });
 
+      const hasBroadManage = await hasConfigCapability(user, null, 'manage');
+
       if (validEntries.length === 0) {
-        if (!(await hasConfigCapability(user, null, 'manage'))) {
+        if (!hasBroadManage) {
           return res.status(403).json({ error: 'Insufficient permissions' });
         }
         return res.status(200).json({ message: 'No actionable field entries provided' });
       }
 
-      if (!(await hasConfigCapability(user, null, 'manage'))) {
+      if (!hasBroadManage) {
         const sections = [...new Set(validEntries.map((e) => getTopLevelSection(e.fieldPath)))];
         const allowed = await Promise.all(
           sections.map((s) => hasConfigCapability(user, s as ConfigSection, 'manage')),
@@ -496,8 +498,15 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         fields[entry.fieldPath] = entry.value;
       }
 
+      if (priority != null && !hasBroadManage) {
+        logger.warn(
+          `[adminConfig] Ignoring caller-supplied priority on section-scoped patch to ${principalType}/${principalId}: only broad manage:configs may modify document priority`,
+        );
+      }
+      const requestedPriority = hasBroadManage ? priority : undefined;
+
       const existing =
-        priority == null
+        requestedPriority == null
           ? await findConfigByPrincipal(principalType, principalId, { includeInactive: true })
           : null;
 
@@ -506,7 +515,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         principalId,
         principalModel(principalType),
         fields,
-        priority ?? existing?.priority ?? DEFAULT_PRIORITY,
+        requestedPriority ?? existing?.priority ?? DEFAULT_PRIORITY,
       );
 
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
@@ -557,7 +566,11 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
 
       const section = getTopLevelSection(fieldPath);
 
-      if (!(await hasConfigCapability(user, section as ConfigSection, 'manage'))) {
+      const hasBroadManage = await hasConfigCapability(user, null, 'manage');
+      if (
+        !hasBroadManage &&
+        !(await hasConfigCapability(user, section as ConfigSection, 'manage'))
+      ) {
         return res.status(403).json({
           error: `Insufficient permissions for config section: ${section}`,
         });
@@ -570,8 +583,15 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(200).json({ message: 'No actionable field path provided' });
       }
 
+      if (priority != null && !hasBroadManage) {
+        logger.warn(
+          `[adminConfig] Ignoring caller-supplied priority on section-scoped tombstone for ${principalType}/${principalId}: only broad manage:configs may modify document priority`,
+        );
+      }
+      const requestedPriority = hasBroadManage ? priority : undefined;
+
       const existing =
-        priority == null
+        requestedPriority == null
           ? await findConfigByPrincipal(principalType, principalId, { includeInactive: true })
           : null;
 
@@ -580,7 +600,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         principalId,
         principalModel(principalType),
         fieldPath,
-        priority ?? existing?.priority ?? DEFAULT_PRIORITY,
+        requestedPriority ?? existing?.priority ?? DEFAULT_PRIORITY,
       );
 
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>


### PR DESCRIPTION
## Summary

The admin-config field-patch and tombstone handlers accept a `priority` field on the request body, which controls the position of the entire Config document in the precedence cascade. Today, that priority is written unconditionally, even when the caller holds only a section-scoped grant (e.g. `manage:configs:memory`). On a document that contains overrides for other sections, this lets a section-scoped caller silently reorder overrides they have no permission to author.

This is a defense-in-depth fix that matters for deployments using section-scoped grants (`manage:configs:<section>`). In a vanilla setup where admins hold broad `manage:configs`, the path is unreachable because the broad-capability short-circuit lets every priority change through; the fix is a no-op for those callers. The change makes the contract safe-by-construction for any deployment that narrows the auth model.

### Concrete scenario

Tenant has two roles:
- `content-admin` holding `manage:configs:memory` only
- `platform-admin` holding broad `manage:configs`

`platform-admin` posts a config at `priority: 5` containing both `memory` and `endpoints` overrides. Later, `content-admin` patches a `memory.context` field and includes `priority: 999` in the body:

```
PATCH /api/admin/config/role/admin/fields
{ "entries": [{ "fieldPath": "memory.context", "value": "..." }], "priority": 999 }
```

Pre-PR: 200 OK, the entire document's `priority` jumps to 999, reordering the `endpoints` override in the cascade. Post-PR: 200 OK, document priority stays at 5; the section-scoped caller never touches priority. A `logger.warn` is emitted on strip so operators can see the request was partially honored.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest src/admin/config.handler.spec.ts` — 71/71 passing (8 new cases covering: section-scoped strip, default-fallback when no existing doc, broad-manage honors request, `priority: 0` preserved on broad write, existing `priority: 0` preserved for section-scoped, `findConfigByPrincipal` skipped when broad provides priority, both `patchConfigField` and `tombstoneConfigField`)
- ESLint + Prettier + tsc clean on changed files

## Checklist

- [x] My code follows the project style guide
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally