### PR TITLE
🛂 refactor: Accept Targeted `assign:configs` for Config Scope-Lifecycle Endpoints

### DIFF
--- a/api/server/routes/admin/config.js
+++ b/api/server/routes/admin/config.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { createAdminConfigHandlers } = require('@librechat/api');
 const { SystemCapabilities } = require('@librechat/data-schemas');
 const {
+  hasCapability,
   hasConfigCapability,
   requireCapability,
 } = require('~/server/middleware/roles/capabilities');
@@ -23,6 +24,7 @@ const handlers = createAdminConfigHandlers({
   deleteConfig: db.deleteConfig,
   toggleConfigActive: db.toggleConfigActive,
   hasConfigCapability,
+  hasCapability,
   getAppConfig,
   invalidateConfigCaches,
 });

--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -1120,6 +1120,69 @@ describe('createAdminConfigHandlers', () => {
       expect(deps.deleteConfig).toHaveBeenCalled();
     });
 
+    it('upsert empty payload is rejected when existing doc has tombstones (no overrides)', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: {},
+          tombstones: ['endpoints.openai.apiKey'],
+        }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+
+    it('delete is rejected when existing doc has tombstones (no overrides)', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: {},
+          tombstones: ['endpoints.openai.apiKey'],
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.deleteConfig).not.toHaveBeenCalled();
+    });
+
+    it('toggle is rejected when existing doc has tombstones (no overrides)', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: {},
+          tombstones: ['endpoints.openai.apiKey'],
+        }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.toggleConfigActive).not.toHaveBeenCalled();
+    });
+
     it('broad-manage caller bypasses the existing-overrides guard', async () => {
       const { handlers, deps } = createHandlers({
         hasConfigCapability: jest.fn().mockResolvedValue(true),

--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -1,4 +1,3 @@
-import { logger } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
 import { createAdminConfigHandlers } from './config';
@@ -688,7 +687,15 @@ describe('createAdminConfigHandlers', () => {
       expect(res.statusCode).toBe(201);
       expect(res.body).toHaveProperty('config');
       expect(res.body?.config).toHaveProperty('_id', 'c1');
-      expect(upsertConfig).toHaveBeenCalledWith('role', 'admin', expect.anything(), {}, 5);
+      expect(upsertConfig).toHaveBeenCalledWith(
+        'role',
+        'admin',
+        expect.anything(),
+        {},
+        5,
+        undefined,
+        expect.objectContaining({ expectEmpty: expect.any(Boolean) }),
+      );
     });
 
     it('returns no-op message when overrides is empty and no priority is provided', async () => {
@@ -1045,14 +1052,13 @@ describe('createAdminConfigHandlers', () => {
     });
   });
 
-  describe('scope-lifecycle: existing-overrides guard for assign-only callers', () => {
-    it('empty-overrides upsert is rejected when existing doc has non-empty overrides', async () => {
+  describe('scope-lifecycle: atomic empty-state guard for assign-only callers', () => {
+    it('empty-overrides upsert is rejected when atomic filter mismatches (existing doc not empty)', async () => {
       const { handlers, deps } = createHandlers({
         hasConfigCapability: jest.fn().mockResolvedValue(false),
         hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: { endpoints: { custom: true } },
+        upsertConfig: jest.fn(async (_pt, _pi, _pm, _o, _p, _session, opts) => {
+          return opts?.expectEmpty ? null : { _id: 'c1', configVersion: 1 };
         }),
       });
       const req = mockReq({
@@ -1064,212 +1070,129 @@ describe('createAdminConfigHandlers', () => {
       await handlers.upsertConfigOverrides(req, res);
 
       expect(res.statusCode).toBe(403);
-      expect(deps.upsertConfig).not.toHaveBeenCalled();
-    });
-
-    it('delete is rejected when existing doc has non-empty overrides', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: { endpoints: { custom: true } },
-        }),
-      });
-      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
-      const res = mockRes();
-
-      await handlers.deleteConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(403);
-      expect(deps.deleteConfig).not.toHaveBeenCalled();
-    });
-
-    it('toggle is rejected when existing doc has non-empty overrides', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: { endpoints: { custom: true } },
-        }),
-      });
-      const req = mockReq({
-        params: { principalType: 'role', principalId: 'admin' },
-        body: { isActive: false },
-      });
-      const res = mockRes();
-
-      await handlers.toggleConfig(req, res);
-
-      expect(res.statusCode).toBe(403);
-      expect(deps.toggleConfigActive).not.toHaveBeenCalled();
-    });
-
-    it('delete succeeds for assign-only caller when existing doc has empty overrides', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
-      });
-      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
-      const res = mockRes();
-
-      await handlers.deleteConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(200);
-      expect(deps.deleteConfig).toHaveBeenCalled();
-    });
-
-    it('upsert empty payload is rejected when existing doc has tombstones (no overrides)', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: {},
-          tombstones: ['endpoints.openai.apiKey'],
-        }),
-      });
-      const req = mockReq({
-        params: { principalType: 'role', principalId: 'admin' },
-        body: { overrides: {}, priority: 5 },
-      });
-      const res = mockRes();
-
-      await handlers.upsertConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(403);
-      expect(deps.upsertConfig).not.toHaveBeenCalled();
-    });
-
-    it('delete is rejected when existing doc has tombstones (no overrides)', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: {},
-          tombstones: ['endpoints.openai.apiKey'],
-        }),
-      });
-      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
-      const res = mockRes();
-
-      await handlers.deleteConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(403);
-      expect(deps.deleteConfig).not.toHaveBeenCalled();
-    });
-
-    it('toggle is rejected when existing doc has tombstones (no overrides)', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: {},
-          tombstones: ['endpoints.openai.apiKey'],
-        }),
-      });
-      const req = mockReq({
-        params: { principalType: 'role', principalId: 'admin' },
-        body: { isActive: false },
-      });
-      const res = mockRes();
-
-      await handlers.toggleConfig(req, res);
-
-      expect(res.statusCode).toBe(403);
-      expect(deps.toggleConfigActive).not.toHaveBeenCalled();
-    });
-
-    it('broad-manage caller bypasses the existing-overrides guard', async () => {
-      const { handlers, deps } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: { endpoints: { custom: true } },
-        }),
-      });
-      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
-      const res = mockRes();
-
-      await handlers.deleteConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(200);
-      expect(deps.deleteConfig).toHaveBeenCalled();
-    });
-  });
-
-  describe('scope-lifecycle: post-write race detection for assign-only callers', () => {
-    it('logger.warn fires when delete returns a doc with non-empty overrides (race detected)', async () => {
-      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => logger) as never);
-      const { handlers } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
-        deleteConfig: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: { endpoints: { custom: true } },
-        }),
-      });
-      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
-      const res = mockRes();
-
-      await handlers.deleteConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(200);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TOCTOU race on delete'));
-      warnSpy.mockRestore();
-    });
-
-    it('logger.warn fires when toggle returns a doc with non-empty tombstones (race detected)', async () => {
-      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => logger) as never);
-      const { handlers } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(false),
-        hasCapability: jest.fn().mockResolvedValue(true),
-        findConfigByPrincipal: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
-        toggleConfigActive: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: {},
-          tombstones: ['endpoints.openai.apiKey'],
-          isActive: false,
-        }),
-      });
-      const req = mockReq({
-        params: { principalType: 'role', principalId: 'admin' },
-        body: { isActive: false },
-      });
-      const res = mockRes();
-
-      await handlers.toggleConfig(req, res);
-
-      expect(res.statusCode).toBe(200);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TOCTOU race on toggle'));
-      warnSpy.mockRestore();
-    });
-
-    it('logger.warn does NOT fire when broad-manage caller deletes a non-empty doc', async () => {
-      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => logger) as never);
-      const { handlers } = createHandlers({
-        hasConfigCapability: jest.fn().mockResolvedValue(true),
-        deleteConfig: jest.fn().mockResolvedValue({
-          _id: 'c1',
-          overrides: { endpoints: { custom: true } },
-        }),
-      });
-      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
-      const res = mockRes();
-
-      await handlers.deleteConfigOverrides(req, res);
-
-      expect(res.statusCode).toBe(200);
-      const tomboCalls = warnSpy.mock.calls.filter((call) =>
-        String(call[0] ?? '').includes('TOCTOU'),
+      expect(deps.upsertConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        { expectEmpty: true },
       );
-      expect(tomboCalls.length).toBe(0);
-      warnSpy.mockRestore();
+    });
+
+    it('delete is rejected with 403 when atomic filter mismatches and doc still exists', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        deleteConfig: jest.fn(async (_pt, _pi, _session, opts) => {
+          return opts?.expectEmpty ? null : { _id: 'c1' };
+        }),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.deleteConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        { expectEmpty: true },
+      );
+    });
+
+    it('toggle is rejected with 403 when atomic filter mismatches and doc still exists', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        toggleConfigActive: jest.fn(async (_pt, _pi, _isActive, _session, opts) => {
+          return opts?.expectEmpty ? null : { _id: 'c1', isActive: false };
+        }),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          tombstones: ['endpoints.openai.apiKey'],
+        }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.toggleConfigActive).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        { expectEmpty: true },
+      );
+    });
+
+    it('delete returns 404 when atomic filter mismatches and doc does not exist', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        deleteConfig: jest.fn().mockResolvedValue(null),
+        findConfigByPrincipal: jest.fn().mockResolvedValue(null),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(404);
+      expect(deps.findConfigByPrincipal).toHaveBeenCalled();
+    });
+
+    it('delete succeeds for assign-only caller when atomic filter matches', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        deleteConfig: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(deps.deleteConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        { expectEmpty: true },
+      );
+    });
+
+    it('broad-manage caller calls destructive op without expectEmpty option', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+        deleteConfig: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(deps.deleteConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        { expectEmpty: false },
+      );
     });
   });
 

--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -1,3 +1,4 @@
+import { logger } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
 import { createAdminConfigHandlers } from './config';
@@ -1198,6 +1199,77 @@ describe('createAdminConfigHandlers', () => {
 
       expect(res.statusCode).toBe(200);
       expect(deps.deleteConfig).toHaveBeenCalled();
+    });
+  });
+
+  describe('scope-lifecycle: post-write race detection for assign-only callers', () => {
+    it('logger.warn fires when delete returns a doc with non-empty overrides (race detected)', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => logger) as never);
+      const { handlers } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
+        deleteConfig: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TOCTOU race on delete'));
+      warnSpy.mockRestore();
+    });
+
+    it('logger.warn fires when toggle returns a doc with non-empty tombstones (race detected)', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => logger) as never);
+      const { handlers } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
+        toggleConfigActive: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: {},
+          tombstones: ['endpoints.openai.apiKey'],
+          isActive: false,
+        }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TOCTOU race on toggle'));
+      warnSpy.mockRestore();
+    });
+
+    it('logger.warn does NOT fire when broad-manage caller deletes a non-empty doc', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((() => logger) as never);
+      const { handlers } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+        deleteConfig: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const tomboCalls = warnSpy.mock.calls.filter((call) =>
+        String(call[0] ?? '').includes('TOCTOU'),
+      );
+      expect(tomboCalls.length).toBe(0);
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -56,6 +56,7 @@ function createHandlers(overrides = {}) {
     deleteConfig: jest.fn().mockResolvedValue({ _id: 'c1' }),
     toggleConfigActive: jest.fn().mockResolvedValue({ _id: 'c1', isActive: false }),
     hasConfigCapability: jest.fn().mockResolvedValue(true),
+    hasCapability: jest.fn().mockResolvedValue(true),
 
     getAppConfig: jest.fn().mockResolvedValue({ interface: { modelSelect: true } }),
     ...overrides,
@@ -651,6 +652,7 @@ describe('createAdminConfigHandlers', () => {
     it('returns 403 for empty overrides when user lacks MANAGE_CONFIGS', async () => {
       const { handlers } = createHandlers({
         hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(false),
       });
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
@@ -724,6 +726,7 @@ describe('createAdminConfigHandlers', () => {
     it('returns 403 for empty overrides with priority when user lacks MANAGE_CONFIGS', async () => {
       const { handlers } = createHandlers({
         hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(false),
       });
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
@@ -800,6 +803,368 @@ describe('createAdminConfigHandlers', () => {
     },
   ];
 
+  describe('upsertConfigOverrides: scope-lifecycle auth (ASSIGN_CONFIGS)', () => {
+    it('allows empty-overrides scope creation when caller has ASSIGN_CONFIGS only', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(deps.upsertConfig).toHaveBeenCalled();
+    });
+
+    it('rejects non-empty overrides for ASSIGN_CONFIGS-only caller', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: { memory: { enabled: true } } },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty-overrides scope creation when caller has neither grant', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(false),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteConfigOverrides: accepts ASSIGN_CONFIGS', () => {
+    it('allows delete when caller has ASSIGN_CONFIGS only', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(deps.deleteConfig).toHaveBeenCalled();
+    });
+
+    it('rejects delete when caller has neither broad manage nor ASSIGN_CONFIGS', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(false),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.deleteConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleConfig: accepts ASSIGN_CONFIGS', () => {
+    it('allows toggle when caller has ASSIGN_CONFIGS only', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(deps.toggleConfigActive).toHaveBeenCalled();
+    });
+
+    it('rejects toggle when caller has neither broad manage nor ASSIGN_CONFIGS', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(false),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.toggleConfigActive).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scope-lifecycle: parameterized assign:configs check', () => {
+    it('allows upsert when caller holds assign:configs:<principalType>', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn(async (_user, cap) => cap === 'assign:configs:role'),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(deps.upsertConfig).toHaveBeenCalled();
+    });
+
+    it('rejects upsert when parameterized grant targets a different principalType', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn(async (_user, cap) => cap === 'assign:configs:user'),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+
+    it('queries hasCapability with the principalType-parameterized form', async () => {
+      const hasCap = jest.fn().mockResolvedValue(true);
+      const { handlers } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: hasCap,
+      });
+      const req = mockReq({
+        params: { principalType: 'group', principalId: 'engineers' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      const queriedCapabilities = hasCap.mock.calls.map((call) => call[1]);
+      expect(queriedCapabilities).toContain('assign:configs:group');
+    });
+  });
+
+  describe('scope-lifecycle: __base__ short-circuit', () => {
+    it('upsert against __base__ returns 403 for assign-only caller', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: '__base__' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+
+    it('delete against __base__ returns 403 for assign-only caller', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: '__base__' },
+      });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.deleteConfig).not.toHaveBeenCalled();
+    });
+
+    it('toggle against __base__ returns 403 for assign-only caller', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: '__base__' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.toggleConfigActive).not.toHaveBeenCalled();
+    });
+
+    it('upsert against __base__ succeeds for broad-manage caller', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: '__base__' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(deps.upsertConfig).toHaveBeenCalled();
+    });
+  });
+
+  describe('scope-lifecycle: existing-overrides guard for assign-only callers', () => {
+    it('empty-overrides upsert is rejected when existing doc has non-empty overrides', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+
+    it('delete is rejected when existing doc has non-empty overrides', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.deleteConfig).not.toHaveBeenCalled();
+    });
+
+    it('toggle is rejected when existing doc has non-empty overrides', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { isActive: false },
+      });
+      const res = mockRes();
+
+      await handlers.toggleConfig(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.toggleConfigActive).not.toHaveBeenCalled();
+    });
+
+    it('delete succeeds for assign-only caller when existing doc has empty overrides', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+        hasCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({ _id: 'c1', overrides: {} }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(deps.deleteConfig).toHaveBeenCalled();
+    });
+
+    it('broad-manage caller bypasses the existing-overrides guard', async () => {
+      const { handlers, deps } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(true),
+        findConfigByPrincipal: jest.fn().mockResolvedValue({
+          _id: 'c1',
+          overrides: { endpoints: { custom: true } },
+        }),
+      });
+      const req = mockReq({ params: { principalType: 'role', principalId: 'admin' } });
+      const res = mockRes();
+
+      await handlers.deleteConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(deps.deleteConfig).toHaveBeenCalled();
+    });
+  });
+
+  describe('AdminConfigDeps.hasCapability is optional', () => {
+    it('factory accepts deps without hasCapability and falls back to broad-manage-only auth', async () => {
+      const deps = {
+        listAllConfigs: jest.fn().mockResolvedValue([]),
+        findConfigByPrincipal: jest.fn().mockResolvedValue(null),
+        upsertConfig: jest.fn().mockResolvedValue({ _id: 'c1', configVersion: 1 }),
+        patchConfigFields: jest.fn(),
+        tombstoneConfigField: jest.fn(),
+        unsetConfigField: jest.fn(),
+        deleteConfig: jest.fn().mockResolvedValue({ _id: 'c1' }),
+        toggleConfigActive: jest.fn().mockResolvedValue({ _id: 'c1', isActive: false }),
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+      };
+      const handlers = createAdminConfigHandlers(deps);
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+      expect(deps.upsertConfig).not.toHaveBeenCalled();
+    });
+  });
+
   describe('invariant: all mutation handlers return 401 without auth', () => {
     for (const { name, reqOverrides } of MUTATION_HANDLERS) {
       it(`${name} returns 401 when user is missing`, async () => {
@@ -822,6 +1187,7 @@ describe('createAdminConfigHandlers', () => {
       it(`${name} returns 403 when user lacks capability`, async () => {
         const { handlers } = createHandlers({
           hasConfigCapability: jest.fn().mockResolvedValue(false),
+          hasCapability: jest.fn().mockResolvedValue(false),
         });
         const req = mockReq(reqOverrides);
         const res = mockRes();

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -721,6 +721,16 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(404).json({ error: 'Config not found' });
       }
 
+      if (!hasBroadManage) {
+        const postOverrideKeys = Object.keys(config.overrides ?? {});
+        const postTombstones = config.tombstones ?? [];
+        if (postOverrideKeys.length > 0 || postTombstones.length > 0) {
+          logger.warn(
+            `[adminConfig] TOCTOU race on delete of ${principalType}/${principalId}: assign-only caller ${user.id} deleted a doc whose state was non-empty at deletion time (overrides=${postOverrideKeys.length}, tombstones=${postTombstones.length}). A concurrent broad-manage write landed between the empty-state guard and the delete.`,
+          );
+        }
+      }
+
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
         logger.error('[adminConfig] Cache invalidation failed after config delete:', err),
       );
@@ -782,6 +792,16 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
       const config = await toggleConfigActive(principalType, principalId, isActive);
       if (!config) {
         return res.status(404).json({ error: 'Config not found' });
+      }
+
+      if (!hasBroadManage) {
+        const postOverrideKeys = Object.keys(config.overrides ?? {});
+        const postTombstones = config.tombstones ?? [];
+        if (postOverrideKeys.length > 0 || postTombstones.length > 0) {
+          logger.warn(
+            `[adminConfig] TOCTOU race on toggle of ${principalType}/${principalId}: assign-only caller ${user.id} toggled isActive on a doc whose state was non-empty at toggle time (overrides=${postOverrideKeys.length}, tombstones=${postTombstones.length}). A concurrent broad-manage write landed between the empty-state guard and the toggle.`,
+          );
+        }
       }
 
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -394,7 +394,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         const existing = await findConfigByPrincipal(principalType, principalId, {
           includeInactive: true,
         });
-        if (existing && Object.keys(existing.overrides ?? {}).length > 0) {
+        const overrideKeys = Object.keys(existing?.overrides ?? {});
+        const tombstoneList = existing?.tombstones ?? [];
+        if (existing && (overrideKeys.length > 0 || tombstoneList.length > 0)) {
           return res.status(403).json({ error: 'Insufficient permissions' });
         }
       }
@@ -707,7 +709,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         const existing = await findConfigByPrincipal(principalType, principalId, {
           includeInactive: true,
         });
-        if (existing && Object.keys(existing.overrides ?? {}).length > 0) {
+        const overrideKeys = Object.keys(existing?.overrides ?? {});
+        const tombstoneList = existing?.tombstones ?? [];
+        if (existing && (overrideKeys.length > 0 || tombstoneList.length > 0)) {
           return res.status(403).json({ error: 'Insufficient permissions' });
         }
       }
@@ -768,7 +772,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         const existing = await findConfigByPrincipal(principalType, principalId, {
           includeInactive: true,
         });
-        if (existing && Object.keys(existing.overrides ?? {}).length > 0) {
+        const overrideKeys = Object.keys(existing?.overrides ?? {});
+        const tombstoneList = existing?.tombstones ?? [];
+        if (existing && (overrideKeys.length > 0 || tombstoneList.length > 0)) {
           return res.status(403).json({ error: 'Insufficient permissions' });
         }
       }

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -79,6 +79,7 @@ export interface AdminConfigDeps {
     overrides: Partial<TCustomConfig>,
     priority: number,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ) => Promise<IConfig | null>;
   patchConfigFields: (
     principalType: PrincipalType,
@@ -106,12 +107,14 @@ export interface AdminConfigDeps {
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ) => Promise<IConfig | null>;
   toggleConfigActive: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
     isActive: boolean,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ) => Promise<IConfig | null>;
   hasConfigCapability: (
     user: CapabilityUser,
@@ -390,24 +393,18 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
-      if (!hasBroadManage) {
-        const existing = await findConfigByPrincipal(principalType, principalId, {
-          includeInactive: true,
-        });
-        const overrideKeys = Object.keys(existing?.overrides ?? {});
-        const tombstoneList = existing?.tombstones ?? [];
-        if (existing && (overrideKeys.length > 0 || tombstoneList.length > 0)) {
-          return res.status(403).json({ error: 'Insufficient permissions' });
-        }
-      }
-
       const config = await upsertConfig(
         principalType,
         principalId,
         principalModel(principalType),
         filteredOverrides,
         priority ?? DEFAULT_PRIORITY,
+        undefined,
+        { expectEmpty: !hasBroadManage },
       );
+      if (!config && !hasBroadManage) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
 
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
         logger.error('[adminConfig] Cache invalidation failed after upsert:', err),
@@ -705,30 +702,19 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
-      if (!hasBroadManage) {
-        const existing = await findConfigByPrincipal(principalType, principalId, {
-          includeInactive: true,
-        });
-        const overrideKeys = Object.keys(existing?.overrides ?? {});
-        const tombstoneList = existing?.tombstones ?? [];
-        if (existing && (overrideKeys.length > 0 || tombstoneList.length > 0)) {
-          return res.status(403).json({ error: 'Insufficient permissions' });
-        }
-      }
-
-      const config = await deleteConfig(principalType, principalId);
+      const config = await deleteConfig(principalType, principalId, undefined, {
+        expectEmpty: !hasBroadManage,
+      });
       if (!config) {
-        return res.status(404).json({ error: 'Config not found' });
-      }
-
-      if (!hasBroadManage) {
-        const postOverrideKeys = Object.keys(config.overrides ?? {});
-        const postTombstones = config.tombstones ?? [];
-        if (postOverrideKeys.length > 0 || postTombstones.length > 0) {
-          logger.warn(
-            `[adminConfig] TOCTOU race on delete of ${principalType}/${principalId}: assign-only caller ${user.id} deleted a doc whose state was non-empty at deletion time (overrides=${postOverrideKeys.length}, tombstones=${postTombstones.length}). A concurrent broad-manage write landed between the empty-state guard and the delete.`,
-          );
+        if (!hasBroadManage) {
+          const exists = await findConfigByPrincipal(principalType, principalId, {
+            includeInactive: true,
+          });
+          if (exists) {
+            return res.status(403).json({ error: 'Insufficient permissions' });
+          }
         }
+        return res.status(404).json({ error: 'Config not found' });
       }
 
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
@@ -778,30 +764,19 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
-      if (!hasBroadManage) {
-        const existing = await findConfigByPrincipal(principalType, principalId, {
-          includeInactive: true,
-        });
-        const overrideKeys = Object.keys(existing?.overrides ?? {});
-        const tombstoneList = existing?.tombstones ?? [];
-        if (existing && (overrideKeys.length > 0 || tombstoneList.length > 0)) {
-          return res.status(403).json({ error: 'Insufficient permissions' });
-        }
-      }
-
-      const config = await toggleConfigActive(principalType, principalId, isActive);
+      const config = await toggleConfigActive(principalType, principalId, isActive, undefined, {
+        expectEmpty: !hasBroadManage,
+      });
       if (!config) {
-        return res.status(404).json({ error: 'Config not found' });
-      }
-
-      if (!hasBroadManage) {
-        const postOverrideKeys = Object.keys(config.overrides ?? {});
-        const postTombstones = config.tombstones ?? [];
-        if (postOverrideKeys.length > 0 || postTombstones.length > 0) {
-          logger.warn(
-            `[adminConfig] TOCTOU race on toggle of ${principalType}/${principalId}: assign-only caller ${user.id} toggled isActive on a doc whose state was non-empty at toggle time (overrides=${postOverrideKeys.length}, tombstones=${postTombstones.length}). A concurrent broad-manage write landed between the empty-state guard and the toggle.`,
-          );
+        if (!hasBroadManage) {
+          const exists = await findConfigByPrincipal(principalType, principalId, {
+            includeInactive: true,
+          });
+          if (exists) {
+            return res.status(403).json({ error: 'Insufficient permissions' });
+          }
         }
+        return res.status(404).json({ error: 'Config not found' });
       }
 
       invalidateConfigCaches?.(user.tenantId)?.catch((err) =>

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -1,4 +1,4 @@
-import { logger } from '@librechat/data-schemas';
+import { logger, BASE_CONFIG_PRINCIPAL_ID } from '@librechat/data-schemas';
 import {
   BASE_ONLY_CONFIG_SECTIONS,
   PrincipalType,
@@ -6,7 +6,7 @@ import {
   INTERFACE_PERMISSION_FIELDS,
   PERMISSION_SUB_KEYS,
 } from 'librechat-data-provider';
-import type { AppConfig, ConfigSection, IConfig } from '@librechat/data-schemas';
+import type { AppConfig, ConfigSection, IConfig, SystemCapability } from '@librechat/data-schemas';
 import type { TCustomConfig } from 'librechat-data-provider';
 import type { Types, ClientSession } from 'mongoose';
 import type { Response } from 'express';
@@ -118,6 +118,7 @@ export interface AdminConfigDeps {
     section: ConfigSection | null,
     verb?: 'manage' | 'read',
   ) => Promise<boolean>;
+  hasCapability?: (user: CapabilityUser, capability: SystemCapability) => Promise<boolean>;
   getAppConfig?: (options?: {
     role?: string;
     userId?: string;
@@ -192,6 +193,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
     deleteConfig,
     toggleConfigActive,
     hasConfigCapability,
+    hasCapability = async () => false,
     getAppConfig,
     invalidateConfigCaches,
   } = deps;
@@ -318,7 +320,17 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      if (!(await hasConfigCapability(user, null, 'manage'))) {
+      const hasBroadManage = await hasConfigCapability(user, null, 'manage');
+
+      if (principalId === BASE_CONFIG_PRINCIPAL_ID && !hasBroadManage) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      const hasAssignConfigs =
+        hasBroadManage ||
+        (await hasCapability(user, `assign:configs:${principalType}` as SystemCapability));
+
+      if (!hasAssignConfigs) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
@@ -374,15 +386,16 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(200).json({ message: 'No actionable override sections provided' });
       }
 
-      if (overrideSections.length > 0) {
-        const allowed = await Promise.all(
-          overrideSections.map((s) => hasConfigCapability(user, s as ConfigSection, 'manage')),
-        );
-        const denied = overrideSections.find((_, i) => !allowed[i]);
-        if (denied) {
-          return res.status(403).json({
-            error: `Insufficient permissions for config section: ${denied}`,
-          });
+      if (overrideSections.length > 0 && !hasBroadManage) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      if (!hasBroadManage) {
+        const existing = await findConfigByPrincipal(principalType, principalId, {
+          includeInactive: true,
+        });
+        if (existing && Object.keys(existing.overrides ?? {}).length > 0) {
+          return res.status(403).json({ error: 'Insufficient permissions' });
         }
       }
 
@@ -677,8 +690,26 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      if (!(await hasConfigCapability(user, null, 'manage'))) {
+      const hasBroadManage = await hasConfigCapability(user, null, 'manage');
+
+      if (principalId === BASE_CONFIG_PRINCIPAL_ID && !hasBroadManage) {
         return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      const allowed =
+        hasBroadManage ||
+        (await hasCapability(user, `assign:configs:${principalType}` as SystemCapability));
+      if (!allowed) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      if (!hasBroadManage) {
+        const existing = await findConfigByPrincipal(principalType, principalId, {
+          includeInactive: true,
+        });
+        if (existing && Object.keys(existing.overrides ?? {}).length > 0) {
+          return res.status(403).json({ error: 'Insufficient permissions' });
+        }
       }
 
       const config = await deleteConfig(principalType, principalId);
@@ -720,8 +751,26 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      if (!(await hasConfigCapability(user, null, 'manage'))) {
+      const hasBroadManage = await hasConfigCapability(user, null, 'manage');
+
+      if (principalId === BASE_CONFIG_PRINCIPAL_ID && !hasBroadManage) {
         return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      const allowed =
+        hasBroadManage ||
+        (await hasCapability(user, `assign:configs:${principalType}` as SystemCapability));
+      if (!allowed) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      if (!hasBroadManage) {
+        const existing = await findConfigByPrincipal(principalType, principalId, {
+          includeInactive: true,
+        });
+        if (existing && Object.keys(existing.overrides ?? {}).length > 0) {
+          return res.status(403).json({ error: 'Insufficient permissions' });
+        }
       }
 
       const config = await toggleConfigActive(principalType, principalId, isActive);

--- a/packages/data-schemas/src/methods/config.spec.ts
+++ b/packages/data-schemas/src/methods/config.spec.ts
@@ -1,9 +1,9 @@
 import mongoose, { Types } from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { PrincipalType, PrincipalModel } from 'librechat-data-provider';
+import type { IConfig } from '~/types';
 import { createConfigMethods } from './config';
 import configSchema from '~/schema/config';
-import type { IConfig } from '~/types';
 
 let mongoServer: MongoMemoryServer;
 let methods: ReturnType<typeof createConfigMethods>;
@@ -474,5 +474,141 @@ describe('toggleConfigActive', () => {
 
     const result = await methods.toggleConfigActive(PrincipalType.ROLE, 'admin', true);
     expect(result!.isActive).toBe(true);
+  });
+});
+
+describe('expectEmpty atomic guard', () => {
+  it('deleteConfig with expectEmpty matches and deletes an empty doc', async () => {
+    await methods.upsertConfig(PrincipalType.ROLE, 'admin', PrincipalModel.ROLE, {}, 10);
+
+    const result = await methods.deleteConfig(PrincipalType.ROLE, 'admin', undefined, {
+      expectEmpty: true,
+    });
+    expect(result).toBeTruthy();
+
+    const remaining = await mongoose.models.Config.countDocuments({});
+    expect(remaining).toBe(0);
+  });
+
+  it('deleteConfig with expectEmpty returns null when overrides is non-empty (doc preserved)', async () => {
+    await methods.upsertConfig(
+      PrincipalType.ROLE,
+      'admin',
+      PrincipalModel.ROLE,
+      { interface: { modelSelect: false } },
+      10,
+    );
+
+    const result = await methods.deleteConfig(PrincipalType.ROLE, 'admin', undefined, {
+      expectEmpty: true,
+    });
+    expect(result).toBeNull();
+
+    const remaining = await mongoose.models.Config.countDocuments({});
+    expect(remaining).toBe(1);
+  });
+
+  it('deleteConfig with expectEmpty returns null when tombstones is non-empty (doc preserved)', async () => {
+    await mongoose.models.Config.create({
+      principalType: PrincipalType.ROLE,
+      principalId: 'admin',
+      principalModel: PrincipalModel.ROLE,
+      overrides: {},
+      tombstones: ['endpoints.openai.apiKey'],
+      priority: 10,
+      isActive: true,
+      configVersion: 1,
+    });
+
+    const result = await methods.deleteConfig(PrincipalType.ROLE, 'admin', undefined, {
+      expectEmpty: true,
+    });
+    expect(result).toBeNull();
+
+    const remaining = await mongoose.models.Config.countDocuments({});
+    expect(remaining).toBe(1);
+  });
+
+  it('toggleConfigActive with expectEmpty matches and toggles an empty doc', async () => {
+    await methods.upsertConfig(PrincipalType.ROLE, 'admin', PrincipalModel.ROLE, {}, 10);
+
+    const result = await methods.toggleConfigActive(PrincipalType.ROLE, 'admin', false, undefined, {
+      expectEmpty: true,
+    });
+    expect(result).toBeTruthy();
+    expect(result!.isActive).toBe(false);
+  });
+
+  it('toggleConfigActive with expectEmpty returns null on non-empty doc (isActive preserved)', async () => {
+    await methods.upsertConfig(
+      PrincipalType.ROLE,
+      'admin',
+      PrincipalModel.ROLE,
+      { interface: { modelSelect: false } },
+      10,
+    );
+
+    const result = await methods.toggleConfigActive(PrincipalType.ROLE, 'admin', false, undefined, {
+      expectEmpty: true,
+    });
+    expect(result).toBeNull();
+
+    const doc = await methods.findConfigByPrincipal(PrincipalType.ROLE, 'admin');
+    expect(doc!.isActive).toBe(true);
+  });
+
+  it('upsertConfig with expectEmpty inserts when no doc exists', async () => {
+    const result = await methods.upsertConfig(
+      PrincipalType.ROLE,
+      'admin',
+      PrincipalModel.ROLE,
+      {},
+      10,
+      undefined,
+      { expectEmpty: true },
+    );
+    expect(result).toBeTruthy();
+    expect(result!.principalId).toBe('admin');
+  });
+
+  it('upsertConfig with expectEmpty updates an empty existing doc', async () => {
+    await methods.upsertConfig(PrincipalType.ROLE, 'admin', PrincipalModel.ROLE, {}, 5);
+
+    const result = await methods.upsertConfig(
+      PrincipalType.ROLE,
+      'admin',
+      PrincipalModel.ROLE,
+      {},
+      99,
+      undefined,
+      { expectEmpty: true },
+    );
+    expect(result).toBeTruthy();
+    expect(result!.priority).toBe(99);
+  });
+
+  it('upsertConfig with expectEmpty returns null when existing doc has non-empty overrides', async () => {
+    await methods.upsertConfig(
+      PrincipalType.ROLE,
+      'admin',
+      PrincipalModel.ROLE,
+      { interface: { modelSelect: false } },
+      10,
+    );
+
+    const result = await methods.upsertConfig(
+      PrincipalType.ROLE,
+      'admin',
+      PrincipalModel.ROLE,
+      {},
+      99,
+      undefined,
+      { expectEmpty: true },
+    );
+    expect(result).toBeNull();
+
+    const doc = await methods.findConfigByPrincipal(PrincipalType.ROLE, 'admin');
+    expect(doc!.priority).toBe(10);
+    expect(Object.keys(doc!.overrides ?? {}).length).toBeGreaterThan(0);
   });
 });

--- a/packages/data-schemas/src/methods/config.ts
+++ b/packages/data-schemas/src/methods/config.ts
@@ -1,7 +1,7 @@
 import { Types } from 'mongoose';
 import { PrincipalType, PrincipalModel } from 'librechat-data-provider';
+import type { FilterQuery, Model, ClientSession } from 'mongoose';
 import type { TCustomConfig } from 'librechat-data-provider';
-import type { Model, ClientSession } from 'mongoose';
 import type { IConfig } from '~/types';
 import { BASE_CONFIG_PRINCIPAL_ID } from '~/admin/capabilities';
 import { escapeRegExp } from '~/utils/string';
@@ -37,6 +37,7 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
     overrides: Partial<TCustomConfig>,
     priority: number,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ) => Promise<IConfig | null>;
   patchConfigFields: (
     principalType: PrincipalType,
@@ -64,12 +65,14 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ) => Promise<IConfig | null>;
   toggleConfigActive: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
     isActive: boolean,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ) => Promise<IConfig | null>;
 } {
   async function findConfigByPrincipal(
@@ -146,13 +149,20 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
     overrides: Partial<TCustomConfig>,
     priority: number,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ): Promise<IConfig | null> {
     const Config = mongoose.models.Config as Model<IConfig>;
 
-    const query = {
+    const query: FilterQuery<IConfig> = {
       principalType,
       principalId: principalId.toString(),
     };
+    if (options?.expectEmpty) {
+      query.$and = [
+        { $or: [{ overrides: { $eq: {} } }, { overrides: { $exists: false } }] },
+        { $or: [{ tombstones: { $size: 0 } }, { tombstones: { $exists: false } }] },
+      ];
+    }
 
     const update = {
       $set: {
@@ -164,7 +174,7 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
       $inc: { configVersion: 1 },
     };
 
-    const options = {
+    const mongoOptions = {
       upsert: true,
       new: true,
       setDefaultsOnInsert: true,
@@ -172,11 +182,14 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
     };
 
     try {
-      return await Config.findOneAndUpdate(query, update, options);
+      return await Config.findOneAndUpdate(query, update, mongoOptions);
     } catch (err: unknown) {
       if ((err as { code?: number }).code === 11000) {
+        if (options?.expectEmpty) {
+          return null;
+        }
         return await Config.findOneAndUpdate(
-          query,
+          { principalType, principalId: principalId.toString() },
           { $set: update.$set, $inc: update.$inc },
           { new: true, ...(session ? { session } : {}) },
         );
@@ -289,13 +302,20 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ): Promise<IConfig | null> {
     const Config = mongoose.models.Config as Model<IConfig>;
-
-    return await Config.findOneAndDelete({
+    const filter: FilterQuery<IConfig> = {
       principalType,
       principalId: principalId.toString(),
-    }).session(session ?? null);
+    };
+    if (options?.expectEmpty) {
+      filter.$and = [
+        { $or: [{ overrides: { $eq: {} } }, { overrides: { $exists: false } }] },
+        { $or: [{ tombstones: { $size: 0 } }, { tombstones: { $exists: false } }] },
+      ];
+    }
+    return await Config.findOneAndDelete(filter).session(session ?? null);
   }
 
   async function toggleConfigActive(
@@ -303,10 +323,21 @@ export function createConfigMethods(mongoose: typeof import('mongoose')): {
     principalId: string | Types.ObjectId,
     isActive: boolean,
     session?: ClientSession,
+    options?: { expectEmpty?: boolean },
   ): Promise<IConfig | null> {
     const Config = mongoose.models.Config as Model<IConfig>;
+    const filter: FilterQuery<IConfig> = {
+      principalType,
+      principalId: principalId.toString(),
+    };
+    if (options?.expectEmpty) {
+      filter.$and = [
+        { $or: [{ overrides: { $eq: {} } }, { overrides: { $exists: false } }] },
+        { $or: [{ tombstones: { $size: 0 } }, { tombstones: { $exists: false } }] },
+      ];
+    }
     return await Config.findOneAndUpdate(
-      { principalType, principalId: principalId.toString() },
+      filter,
       { $set: { isActive } },
       { new: true, ...(session ? { session } : {}) },
     );


### PR DESCRIPTION
## Summary

Three admin-config endpoints currently require broad `manage:configs`: `PUT /:principalType/:principalId` (empty-overrides scope creation), `DELETE /:principalType/:principalId` (scope removal), and `PATCH /:principalType/:principalId/active` (scope toggle). The capability model already defines `assign:configs:user|group|role` for delegated administrators (validated via the `isValidCapability` regex in `packages/data-schemas/src/admin/capabilities.ts`), but no handler accepts it, so a delegate granted `assign:configs:role` via `/api/admin/grants` cannot manage scope lifecycle for the principal type they were explicitly delegated.

This PR aligns the server-side auth with the documented capability surface, while keeping every destructive path that could affect overrides or tombstones the caller is not authorized to author behind broad `manage:configs`.

### Concrete scenario

Tenant has a delegated admin holding `assign:configs:role` (granted through `/api/admin/grants` with the parameterized form). They want to create a fresh empty scope for a new role:

```
PUT /api/admin/config/role/new-role
{ "overrides": {}, "priority": 5 }
```

Pre-PR: 403 (the handler requires broad `manage:configs`, which this delegate does not hold). Post-PR: 201 Created. A delegate holding `assign:configs:user` posting the same request against `/api/admin/config/role/new-role` still gets 403, because the parameterized grant must match the URL's `principalType`.

Every destructive lateral path stays behind broad `manage:configs`:
- Operations against the base config principal (`__base__`)
- Non-empty `PUT` payloads (which `$set` the full overrides field)
- `DELETE` or toggle on a document whose `overrides` OR `tombstones` are non-empty (which would erase or neutralize state the caller could not author via the field/tombstone endpoints)

### Auth surface

| Endpoint                                          | Required capability                              |
|---------------------------------------------------|--------------------------------------------------|
| `PUT … empty + new or empty doc (no tombstones)`  | `manage:configs` OR `assign:configs:<type>`      |
| `PUT … non-empty overrides`                       | `manage:configs` only                            |
| `PUT … empty + existing has overrides/tombstones` | `manage:configs` only                            |
| `PUT … __base__`                                  | `manage:configs` only                            |
| `DELETE … empty doc (no overrides, no tombstones)`| `manage:configs` OR `assign:configs:<type>`      |
| `DELETE … doc with overrides or tombstones`       | `manage:configs` only                            |
| `DELETE … __base__`                               | `manage:configs` only                            |
| `PATCH /active … empty doc`                       | `manage:configs` OR `assign:configs:<type>`      |
| `PATCH /active … doc with overrides or tombstones`| `manage:configs` only                            |
| `PATCH /active … __base__`                        | `manage:configs` only                            |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes

- `AdminConfigDeps.hasCapability` is added as **optional** (`hasCapability?: ...`) with a default that returns `false`. External consumers constructing `createAdminConfigHandlers` without wiring the new dep continue to get pre-PR behavior (broad-manage only). The route in `api/server/routes/admin/config.js` is updated to pass the real resolver.
- The fix queries the parameterized form `assign:configs:<principalType>` rather than the bare `assign:configs`. The implication walk in `hasCapabilityForPrincipals` (`packages/data-schemas/src/methods/systemGrant.ts`) climbs parents, so bare-form holders still pass; the inverse is not true, so parameterized-form delegates are correctly scoped to their granted principal type.
- Extends `deleteConfig`, `toggleConfigActive`, and `upsertConfig` in `packages/data-schemas/src/methods/config.ts` with an optional `options.expectEmpty` parameter. When set, the Mongo filter requires both `overrides` and `tombstones` to be empty before the destructive write matches, eliminating the TOCTOU race window that would otherwise exist between a separate guard read and the destructive op. The parameter is optional and unused by existing callers; for `upsertConfig`, the E11000 retry path returns null instead of falling back to a filterless update when `expectEmpty` is set, preserving the atomic property.
- Section-grant parity at `upsertConfigOverrides` (allowing `manage:configs:<section>` holders to upsert their own section) is intentionally deferred. The fan-out at the old call site was unreachable under the pre-PR broad gate and is not load-bearing; reintroducing it would be a separate scope-expansion PR.

## Testing

- `cd packages/api && npx jest src/admin/config.handler.spec.ts` — 84/84 passing (assign-configs accept paths per handler, parameterized-form principalType matching/mismatch, `__base__` short-circuit per handler, atomic empty-state guard per handler, optional `hasCapability` dep)
- `cd packages/data-schemas && npx jest src/methods/config.spec.ts` — 37/37 passing (8 new cases against real `mongodb-memory-server` covering the `expectEmpty` atomic filter on `deleteConfig`, `toggleConfigActive`, and `upsertConfig` with empty/non-empty overrides and non-empty tombstones)
- ESLint + Prettier + tsc clean on changed files

## Checklist

- [x] My code follows the project style guide
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
