### PR TITLE
✨ feat: Admin-configurable default MCP tool-call timeout (MCP_DEFAULT_TIMEOUT_MS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1007,6 +1007,11 @@ OPENWEATHER_API_KEY=
 # Cache connection status checks for this many milliseconds to avoid expensive verification
 # MCP_CONNECTION_CHECK_TTL=60000
 
+# Default per-request (tool call) timeout in ms for any MCP server that does not
+# declare an explicit `timeout` in librechat.yaml — including user-added (UI) servers.
+# Default: 60000 (60s)
+# MCP_DEFAULT_TIMEOUT_MS=60000
+
 # Max bytes allowed in a non-GET streamable HTTP MCP response before rejecting it.
 # Set to 0 to disable. Default: 16777216 (16 MiB)
 # MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES=16777216

--- a/packages/api/src/mcp/__tests__/MCPConnectionTimeout.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionTimeout.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Verifies how a connection's per-request (tool call) timeout is resolved:
+ * an explicit `serverConfig.timeout` wins, otherwise the connection falls back
+ * to the admin-configurable default (env `MCP_DEFAULT_TIMEOUT_MS`, else 60000).
+ *
+ * The default is read at module load, so the env-override case re-imports the
+ * module in isolation with the env set.
+ *
+ * Also guards that this per-request default never leaks into the SSE connect/handshake
+ * fallback (resolveSSEConnectTimeout), which must keep using SSE_CONNECT_TIMEOUT (120s).
+ */
+import { MCPConnection, resolveSSEConnectTimeout } from '~/mcp/connection';
+
+const baseServerConfig = {
+  type: 'streamable-http' as const,
+  url: 'http://127.0.0.1:1/mcp',
+};
+
+describe('MCPConnection timeout resolution', () => {
+  it('falls back to the 60s default when no timeout is configured', () => {
+    const conn = new MCPConnection({
+      serverName: 'no-timeout',
+      serverConfig: { ...baseServerConfig },
+      useSSRFProtection: false,
+    });
+
+    expect(conn.timeout).toBe(60000);
+  });
+
+  it('preserves an explicit per-server timeout', () => {
+    const conn = new MCPConnection({
+      serverName: 'explicit-timeout',
+      serverConfig: { ...baseServerConfig, timeout: 12345 },
+      useSSRFProtection: false,
+    });
+
+    expect(conn.timeout).toBe(12345);
+  });
+
+  it('applies MCP_DEFAULT_TIMEOUT_MS to servers without an explicit timeout', async () => {
+    process.env.MCP_DEFAULT_TIMEOUT_MS = '300000';
+    jest.resetModules();
+    try {
+      const { MCPConnection: FreshMCPConnection } = await import('~/mcp/connection');
+
+      const conn = new FreshMCPConnection({
+        serverName: 'env-default',
+        serverConfig: { ...baseServerConfig },
+        useSSRFProtection: false,
+      });
+
+      expect(conn.timeout).toBe(300000);
+    } finally {
+      delete process.env.MCP_DEFAULT_TIMEOUT_MS;
+      jest.resetModules();
+    }
+  });
+});
+
+describe('resolveSSEConnectTimeout', () => {
+  it('falls back to the 120s SSE/proxy handshake timeout when no explicit timeout is set', () => {
+    expect(resolveSSEConnectTimeout(undefined)).toBe(120000);
+  });
+
+  it('does not let the per-request default shorten the SSE handshake fallback', () => {
+    // Regression guard: an unset server timeout must still reach the 120s proxy
+    // handshake fallback, not the resolved per-request DEFAULT_TIMEOUT (60s).
+    expect(resolveSSEConnectTimeout(undefined)).not.toBe(60000);
+  });
+
+  it('honors an explicit per-server timeout', () => {
+    expect(resolveSSEConnectTimeout(45000)).toBe(45000);
+  });
+});

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -91,7 +91,13 @@ function isStreamableHTTPOptions(options: t.MCPOptions): options is t.Streamable
 }
 
 const FIVE_MINUTES = 5 * 60 * 1000;
-const DEFAULT_TIMEOUT = 60000;
+/**
+ * Default per-request (tool call) timeout in ms, admin-overridable via the
+ * `MCP_DEFAULT_TIMEOUT_MS` env var. Applies to every MCP server that does not
+ * declare an explicit `timeout` — including user-added (UI) servers, which share
+ * this connection constructor and have no way to set a timeout themselves.
+ */
+const DEFAULT_TIMEOUT = getNonNegativeIntegerEnv('MCP_DEFAULT_TIMEOUT_MS', 60000);
 /** SSE connections through proxies may need longer initial handshake time */
 const SSE_CONNECT_TIMEOUT = 120000;
 const DEFAULT_INIT_TIMEOUT = 30000;
@@ -113,6 +119,17 @@ function getNonNegativeIntegerEnv(name: string, defaultValue: number): number {
 
   const parsed = Number(trimmed);
   return Number.isSafeInteger(parsed) ? parsed : defaultValue;
+}
+
+/**
+ * Connect/handshake timeout for SSE transports. SSE connections through proxies need a
+ * longer initial handshake than a regular request, hence the SSE_CONNECT_TIMEOUT fallback.
+ * Resolved from the *explicitly configured* server `timeout` only — never the resolved
+ * DEFAULT_TIMEOUT — so the per-request MCP_DEFAULT_TIMEOUT_MS default cannot shorten the
+ * handshake fallback for servers that set no timeout of their own.
+ */
+export function resolveSSEConnectTimeout(explicitTimeoutMs: number | undefined): number {
+  return explicitTimeoutMs || SSE_CONNECT_TIMEOUT;
 }
 
 function bytesToMiB(bytes: number): string {
@@ -1237,7 +1254,7 @@ export class MCPConnection extends EventEmitter {
     this.ephemeralConnection = params.ephemeralConnection === true;
     this.proxyConfig = getMCPProxyConfig(params.serverConfig);
     this.iconPath = params.serverConfig.iconPath;
-    this.timeout = params.serverConfig.timeout;
+    this.timeout = params.serverConfig.timeout ?? DEFAULT_TIMEOUT;
     this.sseReadTimeout = params.serverConfig.sseReadTimeout;
     this.lastPingTime = Date.now();
     this.createdAt = Date.now(); // Record creation timestamp for staleness detection
@@ -1580,7 +1597,7 @@ export class MCPConnection extends EventEmitter {
            * SSE connections need longer timeouts for reliability.
            * The connect timeout is extended because proxies may delay initial response.
            */
-          const sseTimeout = this.timeout || SSE_CONNECT_TIMEOUT;
+          const sseTimeout = resolveSSEConnectTimeout(options.timeout);
           const sseAgents = new Map<string, ManagedDispatcher>();
           const getSSEDispatcher = (targetUrlString: string): ManagedDispatcher => {
             const proxyUrl = getProxyUrlForRequest(this.proxyConfig, targetUrlString);


### PR DESCRIPTION
## Summary

The per-request (tool call) timeout for MCP servers defaulted to a **hardcoded `60000` ms** (`DEFAULT_TIMEOUT` in `packages/api/src/mcp/connection.ts`). Servers without an explicit `timeout` had no admin-level override — most importantly **user-added (UI) servers**, which are stored in MongoDB and *cannot* set a `timeout` (the field is stripped from the user-input schema via `omitServerManagedFields`). They were stuck at the SDK's 60 s default with no way for an admin to raise it.

This introduces an admin-configurable default via the **`MCP_DEFAULT_TIMEOUT_MS`** env var (fallback `60000`), read once at module load and applied in the `MCPConnection` constructor:

```ts
const DEFAULT_TIMEOUT = getNonNegativeIntegerEnv('MCP_DEFAULT_TIMEOUT_MS', 60000);
...
this.timeout = params.serverConfig.timeout ?? DEFAULT_TIMEOUT;
```

Because **every** server — yaml-configured *and* DB-backed user/UI servers — flows through this single constructor, the default now covers all of them. An explicit per-server `timeout` still takes precedence. The change reuses the existing `getNonNegativeIntegerEnv` helper and matches the established pattern of other operational MCP knobs (`MCP_INIT_TIMEOUT_MS`, `MCP_USER_CONNECTION_IDLE_TIMEOUT`, `MCP_CONNECTION_CHECK_TTL`, …).

Usage:

```bash
# Default per-request timeout (ms) for any MCP server without an explicit `timeout`,
# including user-added (UI) servers.
MCP_DEFAULT_TIMEOUT_MS= 120000   # 2 min
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `cd packages/api && npx jest MCPConnectionTimeout` → **3/3 pass** (60 s fallback, explicit per-server timeout preserved, `MCP_DEFAULT_TIMEOUT_MS` override applied).
- `cd packages/api && npx jest MCPManager MCPConnection` → **90/90 pass** (no regression).
- `npx tsc --noEmit` clean; ESLint clean on changed files.

### **Test Configuration**:

- `npm ci` then `npm run build:data-provider` && `npm run build:data-schemas`.
- `MCP_DEFAULT_TIMEOUT_MS` set and unset to exercise both the default (`60000`) and override (`300000`) paths.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes (`.env.example`)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my feature works
- [x] Local unit tests pass with my changes
