### PR TITLE
test: pin locale in formatCost tests for cross-environment determinism

### DIFF
--- a/client/src/utils/tokens.spec.ts
+++ b/client/src/utils/tokens.spec.ts
@@ -345,6 +345,34 @@ describe('normalizeUsageUnits', () => {
 });
 
 describe('formatCost', () => {
+  /**
+   * `formatCost` calls `Intl.NumberFormat(undefined, …)`, which resolves to the
+   * runtime's default locale. The exact-string assertions below (e.g. `$0.00`)
+   * only hold under an en-US default; on a CI runner or developer machine with a
+   * non-en default locale they format differently (e.g. `US$ 0,00` under pt-BR)
+   * and the suite fails for environmental reasons unrelated to the code. Pin the
+   * `undefined`-locale path to en-US for the duration of this block so the test
+   * is deterministic everywhere. Explicit locales are still honored.
+   */
+  const RealNumberFormat = Intl.NumberFormat;
+
+  beforeAll(() => {
+    const Pinned = function (
+      this: unknown,
+      locales?: Intl.LocalesArgument,
+      options?: Intl.NumberFormatOptions,
+    ) {
+      return new RealNumberFormat(locales ?? 'en-US', options);
+    } as unknown as typeof Intl.NumberFormat;
+    Pinned.prototype = RealNumberFormat.prototype;
+    Pinned.supportedLocalesOf = RealNumberFormat.supportedLocalesOf;
+    Intl.NumberFormat = Pinned;
+  });
+
+  afterAll(() => {
+    Intl.NumberFormat = RealNumberFormat;
+  });
+
   it('formats across magnitude bands (USD default, unchanged)', () => {
     expect(formatCost(0)).toBe('$0.00');
     expect(formatCost(0.004)).toBe('<$0.01');


### PR DESCRIPTION
## Summary

Fixes #13776.

`formatCost` (`client/src/utils/tokens.ts`) formats currency with `new Intl.NumberFormat(undefined, …)`, so the output depends on the **runtime default locale**. The `formatCost` tests in `client/src/utils/tokens.spec.ts` assert exact USD literals (`$0.00`, `$1.23`, `$5.00`, …), which only hold under an `en-US` default. On any machine/CI runner with a different default locale the formatter produces a different string (e.g. `US$ 0,00` under `pt-BR`) and the suite fails for environmental reasons.

This PR makes the suite deterministic by pinning the `undefined`-locale path to `en-US` for the duration of the `formatCost` describe block (via `beforeAll`/`afterAll`), restoring `Intl.NumberFormat` afterward. Explicit locales are still honored, and **no production code changes** — only the test gains a locale guard.

The override is scoped to this describe block; `formatCost` is the only API exercised there, and the module's internal formatter cache is only populated within that block, so the pin can't leak across suites.

### Note for maintainers (not done here)

The deeper question is whether `formatCost` should keep using the ambient locale at all. An alternative would be to pass an explicit/configurable locale to `Intl.NumberFormat` in production rather than `undefined`. That changes user-visible formatting behavior and is more opinionated, so I kept this PR to test determinism only. Happy to follow up with a production change if you'd prefer that direction.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`formatCost` calls `Intl.NumberFormat` internally, which can't be parameterized from the test without touching production code, so I validated the fix by reproducing the exact `formatCost` logic in a standalone Node harness (same source as `tokens.ts`) and running the full set of spec assertions under non-en locales:

- Unpatched, `LANG/LC_ALL=pt_BR.UTF-8`: 13 assertions fail (e.g. `Expected "$0.00" Received "US$ 0,00"`).
- With the locale pin applied, `pt_BR.UTF-8`: all assertions pass.
- With the locale pin applied, `de_DE.UTF-8`: all assertions pass.

EUR/JPY/KWD assertions (which check for symbols and decimal behavior rather than exact `$` strings) continue to pass under the pin.

I did **not** run the full Jest client suite locally (the monorepo Turborepo install/build was heavier than this sandbox allowed); the change is confined to a single spec file and adds only a scoped `beforeAll`/`afterAll` guard.

### **Test Configuration**:

- Node default locale varied via `LANG` / `LC_ALL`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
