### PR TITLE
test: seed tool-expansion atoms instead of relying on product defaults

### DIFF
--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { ContentTypes } from 'librechat-data-provider';
-import type { TAttachment, TMessageContentParts } from 'librechat-data-provider';
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { TAttachment, TMessageContentParts } from 'librechat-data-provider';
+import type { MutableSnapshot } from 'recoil';
 import ContentParts from '../ContentParts';
+import store from '~/store';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string, values?: Record<string | number, string>) => {
@@ -151,9 +153,14 @@ const imageAttachment = (toolCallId: string, name = 'tiny.png'): TAttachment =>
     conversationId: 'c1',
   }) as unknown as TAttachment;
 
+/** Seed the tool-expansion atom so these tests assert against a known initial
+ *  collapsed state instead of inheriting the product default, which a fork may
+ *  change (or upstream may flip later) and silently break these assertions. */
+const seedCollapsed = ({ set }: MutableSnapshot) => set(store.autoExpandTools, false);
+
 const renderContentParts = (props: React.ComponentProps<typeof ContentParts>) =>
   render(
-    <RecoilRoot>
+    <RecoilRoot initializeState={seedCollapsed}>
       <ContentParts {...props} />
     </RecoilRoot>,
   );
@@ -242,7 +249,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     const nextContent = [makeTextPart('streamed preface'), ...content];
 
     const { rerender } = render(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} content={content} />
       </RecoilRoot>,
     );
@@ -254,7 +261,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
     rerender(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} content={nextContent} />
       </RecoilRoot>,
     );
@@ -270,7 +277,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     const completedContent = [makeMcpToolCall('t1'), makeMcpToolCall('t2')];
 
     const { rerender } = render(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} isSubmitting isLatestMessage content={runningContent} />
       </RecoilRoot>,
     );
@@ -281,7 +288,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     fireEvent.click(screen.getAllByTestId('progress-text')[0]);
 
     rerender(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts
           {...baseProps}
           isSubmitting={false}
@@ -301,7 +308,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     const content = [makeMcpToolCallWithoutId('first'), makeMcpToolCallWithoutId('second')];
 
     const { rerender } = render(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} messageId="msg1" content={content} />
       </RecoilRoot>,
     );
@@ -313,7 +320,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
     rerender(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} messageId="msg2" content={content} />
       </RecoilRoot>,
     );
@@ -328,7 +335,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     const content = [makeMcpToolCall('t1'), makeMcpToolCall('t2')];
 
     const { rerender } = render(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} messageId="placeholder-msg" content={content} />
       </RecoilRoot>,
     );
@@ -340,7 +347,7 @@ describe('ContentParts integration: MCP image hoist and grouping', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
     rerender(
-      <RecoilRoot>
+      <RecoilRoot initializeState={seedCollapsed}>
         <ContentParts {...baseProps} messageId="server-msg" content={content} />
       </RecoilRoot>,
     );

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { Tools, Constants, ContentTypes } from 'librechat-data-provider';
-import type { TAttachment, TMessageContentParts } from 'librechat-data-provider';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import ToolCallGroup from '../ToolCallGroup';
+import type { TAttachment, TMessageContentParts } from 'librechat-data-provider';
+import type { MutableSnapshot } from 'recoil';
 import { scheduleMessageContentLayoutReconcile } from '~/hooks';
+import ToolCallGroup from '../ToolCallGroup';
+import store from '~/store';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string, values?: Record<string | number, string>) => {
@@ -90,9 +92,14 @@ const fileAttachment: TAttachment = {
   conversationId: 'c1',
 } as unknown as TAttachment;
 
+/** Seed the tool-expansion atom so these tests assert against a known initial
+ *  collapsed state instead of inheriting the product default, which a fork may
+ *  change (or upstream may flip later) and silently break these assertions. */
+const seedCollapsed = ({ set }: MutableSnapshot) => set(store.autoExpandTools, false);
+
 const renderGroup = (props: React.ComponentProps<typeof ToolCallGroup>) =>
   render(
-    <RecoilRoot>
+    <RecoilRoot initializeState={seedCollapsed}>
       <ToolCallGroup {...props} />
     </RecoilRoot>,
   );

--- a/client/src/hooks/Messages/__tests__/useMessageScrolling.spec.tsx
+++ b/client/src/hooks/Messages/__tests__/useMessageScrolling.spec.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { TConversation, TMessage } from 'librechat-data-provider';
+import type { MutableSnapshot } from 'recoil';
 import {
   MessagesViewContext,
   type MessagesViewContextValue,
 } from '~/Providers/MessagesViewContext';
+import store from '~/store';
 
 type MockScrollToBottom = jest.Mock & {
   cancel: jest.Mock;
@@ -149,6 +151,12 @@ function ScrollingHarness({ messagesTree }: { messagesTree?: TMessage[] | null }
   );
 }
 
+/** Seed the auto-scroll atom so these tests assert against a known disabled
+ *  state instead of inheriting the product default, which a fork may change (or
+ *  upstream may flip later); a `true` default would fire scrollToBottom on mount
+ *  and silently break the `not.toHaveBeenCalled()` assertions below. */
+const seedAutoScrollOff = ({ set }: MutableSnapshot) => set(store.autoScroll, false);
+
 function renderScrolling({
   contextOverrides,
   messagesTree,
@@ -157,7 +165,7 @@ function renderScrolling({
   messagesTree?: TMessage[] | null;
 } = {}) {
   return render(
-    <RecoilRoot>
+    <RecoilRoot initializeState={seedAutoScrollOff}>
       <MessagesViewContext.Provider value={createContextValue(contextOverrides)}>
         <ScrollingHarness messagesTree={messagesTree} />
       </MessagesViewContext.Provider>


### PR DESCRIPTION
## Summary

Fixes #13777.

The tool-expansion test suites render under a bare `<RecoilRoot>`, so the `autoExpandTools` and `autoScroll` atoms (`client/src/store/settings.ts`) inherit their configured product defaults. Several assertions silently depend on those defaults staying `false`:

- `ToolCallGroup.test.tsx` / `ContentParts.integration.test.tsx` expect tool groups to render **initially collapsed** (`aria-expanded="false"`, bodies not mounted). With `autoExpandTools = true` they render expanded and the assertions fail.
- `useMessageScrolling.spec.tsx` expects `scrollToBottom` **not** to be called on mount. With `autoScroll = true`, the mount effect calls `scrollToBottom()` for a non-new conversation and breaks those assertions.

This PR seeds the relevant atoms explicitly via `RecoilRoot`'s `initializeState`, so each suite asserts against a known initial state and stays decoupled from whatever the configured default happens to be. The seeded values match the current upstream defaults, so behavior is unchanged today — this only removes the hidden coupling so a default change (in a fork or upstream) can't silently break these tests. **No production code changes.**

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Code review of each affected suite to confirm which atom each assertion depends on:
  - `useMessageScrolling` reads `store.autoScroll`; the `not.toHaveBeenCalled()` assertions rely on it being `false` (the mount effect at the `autoScroll && conversationId !== NEW_CONVO` guard would otherwise fire on the harness's `conversation-1`).
  - `ToolCallGroup` reads `store.autoExpandTools`; `ContentParts` renders `ToolCallGroup`, so its `aria-expanded="false"` assertions depend on the same atom.
- Verified the seed value equals the current default, so the suites pass identically today; the change only adds robustness against a flipped default.

I did **not** run the full Jest client suite locally (the monorepo Turborepo install/build was heavier than this sandbox allowed). The change is limited to three test files and adds only `initializeState` seeding via the existing Recoil `MutableSnapshot` API; no production code is touched.

### **Test Configuration**:

- N/A (test-only change).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
