### PR TITLE
🪙 refactor: Reconcile Context Gauge to Actual Provider Tokens

### DIFF
--- a/api/server/controllers/agents/__tests__/usageEvents.integration.spec.js
+++ b/api/server/controllers/agents/__tests__/usageEvents.integration.spec.js
@@ -375,6 +375,12 @@ describe('usage events through the real agents pipeline', () => {
       expect(resumeState.contextUsage.breakdown.maxContextTokens).toBe(MAX_CONTEXT_TOKENS);
       /** Latest-wins: the persisted snapshot is the second call's */
       expect(resumeState.contextUsage.prePruneContextTokens).toBeGreaterThan(0);
+      /** Reconciled to the final primary call's actual prompt: openAI folds cache
+       *  into input_tokens (150), so the resume snapshot's used = 150 — the real
+       *  context, not the calibrated estimate. */
+      const used =
+        resumeState.contextUsage.contextBudget - resumeState.contextUsage.remainingContextTokens;
+      expect(used).toBe(SECOND_CALL_USAGE.input_tokens);
     }
   });
 

--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -46,7 +46,12 @@ export default function Breakdown({ view, showCost, currency }: BreakdownProps) 
     snapshot?.effectiveInstructionTokens ?? breakdown?.instructionTokens ?? 0;
   const systemTokens =
     (breakdown?.systemMessageTokens ?? 0) + (breakdown?.dynamicInstructionTokens ?? 0);
-  const messageTokens = Math.max(0, usedTokens - instructionTokens);
+  /** Summary has its own row, so exclude it (it's part of `usedTokens`) to avoid
+   *  double-counting it inside the Messages row on a summarized turn. */
+  const messageTokens = Math.max(
+    0,
+    usedTokens - instructionTokens - (breakdown?.summaryTokens ?? 0),
+  );
   const freeTokens = maxTokens != null ? Math.max(0, maxTokens - usedTokens) : null;
 
   const groups =

--- a/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
@@ -91,26 +91,4 @@ describe('useUsageHandler — live snapshot reconciliation', () => {
 
     expect(store.get(contextSnapshotFamily(convo))?.breakdown.messageTokens).toBe(187471);
   });
-
-  it('reconciles the restored snapshot from backfilled usage on resume', () => {
-    /** Resume restores usage via backfill (no live on_token_usage in Redis mode);
-     *  reconcileBackfill must still correct the snapshot from the final primary. */
-    const convo = 'convo-recon-4';
-    const submission = {
-      userMessage: { messageId: 'u4', conversationId: convo },
-      conversation: { conversationId: convo },
-    };
-    const { result } = renderHook(() => useUsageHandler());
-    const store = getDefaultStore();
-
-    result.current.contextHandler(inflatedSnapshot(), submission);
-    result.current.reconcileBackfill(
-      [{ ...primaryUsage(), usage_type: 'summarization', output_tokens: 1905 }, primaryUsage()],
-      submission,
-    );
-
-    const snap = store.get(contextSnapshotFamily(convo));
-    expect(237500 - (snap?.remainingContextTokens ?? 0)).toBe(55773);
-    expect(snap?.breakdown.messageTokens).toBe(55773 - 4205 - 1938);
-  });
 });

--- a/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
@@ -1,0 +1,94 @@
+import { getDefaultStore } from 'jotai';
+import { renderHook } from '@testing-library/react';
+import type { TContextUsageEvent, TTokenUsageEvent } from 'librechat-data-provider';
+import useUsageHandler from '~/hooks/SSE/useUsageHandler';
+import { contextSnapshotFamily } from '~/store/usage';
+
+/** Mirrors a real web-search + summarization turn: calibration pinned at 5
+ *  inflated messageTokens to 187471 (used 213375), while the call's true prompt
+ *  was 53702 + 2071 cache = 55773. */
+const inflatedSnapshot = (over?: Partial<TContextUsageEvent>): TContextUsageEvent => ({
+  runId: 'run-1',
+  breakdown: {
+    maxContextTokens: 250000,
+    instructionTokens: 4205,
+    systemMessageTokens: 384,
+    dynamicInstructionTokens: 1525,
+    toolSchemaTokens: 2296,
+    summaryTokens: 1938,
+    toolCount: 1,
+    messageCount: 2,
+    messageTokens: 187471,
+    availableForMessages: 233295,
+  },
+  contextBudget: 237500,
+  remainingContextTokens: 24125,
+  calibrationRatio: 5,
+  ...over,
+});
+
+const primaryUsage = (over?: Partial<TTokenUsageEvent>): TTokenUsageEvent => ({
+  input_tokens: 53702,
+  output_tokens: 3780,
+  total_tokens: 57482,
+  input_token_details: { cache_read: 2071, cache_creation: 0 },
+  provider: 'anthropic',
+  runId: 'run-1',
+  seq: 1,
+  ...over,
+});
+
+describe('useUsageHandler — live snapshot reconciliation', () => {
+  it('reconciles the live snapshot to the primary call’s actual prompt tokens', () => {
+    const convo = 'convo-recon-1';
+    const submission = {
+      userMessage: { messageId: 'u1', conversationId: convo },
+      conversation: { conversationId: convo },
+    };
+    const { result } = renderHook(() => useUsageHandler());
+    const store = getDefaultStore();
+
+    result.current.contextHandler(inflatedSnapshot(), submission);
+    expect(store.get(contextSnapshotFamily(convo))?.breakdown.messageTokens).toBe(187471);
+
+    result.current.usageHandler(primaryUsage(), submission);
+
+    const snap = store.get(contextSnapshotFamily(convo));
+    /** used = budget − remaining = real prompt (55773), down from 213375 */
+    expect(237500 - (snap?.remainingContextTokens ?? 0)).toBe(55773);
+    expect(snap?.breakdown.messageTokens).toBe(55773 - 4205 - 1938);
+    /** instructions/summary stay raw; the anchor is preserved */
+    expect(snap?.breakdown.instructionTokens).toBe(4205);
+    expect(snap?.anchorMessageId).toBe('u1');
+  });
+
+  it('does not reconcile when the usage belongs to a different run', () => {
+    const convo = 'convo-recon-2';
+    const submission = {
+      userMessage: { messageId: 'u2', conversationId: convo },
+      conversation: { conversationId: convo },
+    };
+    const { result } = renderHook(() => useUsageHandler());
+    const store = getDefaultStore();
+
+    result.current.contextHandler(inflatedSnapshot({ runId: 'run-A' }), submission);
+    result.current.usageHandler(primaryUsage({ runId: 'run-Z', seq: 9 }), submission);
+
+    expect(store.get(contextSnapshotFamily(convo))?.breakdown.messageTokens).toBe(187471);
+  });
+
+  it('does not let a tagged (summarization) usage touch the gauge', () => {
+    const convo = 'convo-recon-3';
+    const submission = {
+      userMessage: { messageId: 'u3', conversationId: convo },
+      conversation: { conversationId: convo },
+    };
+    const { result } = renderHook(() => useUsageHandler());
+    const store = getDefaultStore();
+
+    result.current.contextHandler(inflatedSnapshot(), submission);
+    result.current.usageHandler(primaryUsage({ usage_type: 'summarization', seq: 2 }), submission);
+
+    expect(store.get(contextSnapshotFamily(convo))?.breakdown.messageTokens).toBe(187471);
+  });
+});

--- a/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
@@ -91,4 +91,26 @@ describe('useUsageHandler — live snapshot reconciliation', () => {
 
     expect(store.get(contextSnapshotFamily(convo))?.breakdown.messageTokens).toBe(187471);
   });
+
+  it('reconciles the restored snapshot from backfilled usage on resume', () => {
+    /** Resume restores usage via backfill (no live on_token_usage in Redis mode);
+     *  reconcileBackfill must still correct the snapshot from the final primary. */
+    const convo = 'convo-recon-4';
+    const submission = {
+      userMessage: { messageId: 'u4', conversationId: convo },
+      conversation: { conversationId: convo },
+    };
+    const { result } = renderHook(() => useUsageHandler());
+    const store = getDefaultStore();
+
+    result.current.contextHandler(inflatedSnapshot(), submission);
+    result.current.reconcileBackfill(
+      [{ ...primaryUsage(), usage_type: 'summarization', output_tokens: 1905 }, primaryUsage()],
+      submission,
+    );
+
+    const snap = store.get(contextSnapshotFamily(convo));
+    expect(237500 - (snap?.remainingContextTokens ?? 0)).toBe(55773);
+    expect(snap?.breakdown.messageTokens).toBe(55773 - 4205 - 1938);
+  });
 });

--- a/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useUsageHandler.spec.tsx
@@ -62,6 +62,28 @@ describe('useUsageHandler — live snapshot reconciliation', () => {
     expect(snap?.anchorMessageId).toBe('u1');
   });
 
+  it('does not reconcile a replayed (already-folded) primary usage', () => {
+    /** On resume, backfill marks the run's collected usages folded; a replayed
+     *  `on_token_usage` then arrives folded=false. Since tool-loop calls share the
+     *  run id, reconciling with such a duplicate could overwrite the latest
+     *  snapshot with an earlier call's prompt — so it must be skipped. */
+    const convo = 'convo-recon-replay';
+    const submission = {
+      userMessage: { messageId: 'ur', conversationId: convo },
+      conversation: { conversationId: convo },
+    };
+    const { result } = renderHook(() => useUsageHandler());
+    const store = getDefaultStore();
+
+    result.current.contextHandler(inflatedSnapshot(), submission);
+    /** Mark the usage folded (as resume backfill would), then replay it live. */
+    result.current.backfillUsage([primaryUsage()], submission);
+    result.current.usageHandler(primaryUsage(), submission);
+
+    /** Duplicate (folded=false) → no reconcile → snapshot stays the raw estimate. */
+    expect(store.get(contextSnapshotFamily(convo))?.breakdown.messageTokens).toBe(187471);
+  });
+
   it('does not reconcile when the usage belongs to a different run', () => {
     const convo = 'convo-recon-2';
     const submission = {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -483,7 +483,6 @@ export default function useResumableSSE(
     tapContent,
     finalizeUsage,
     backfillUsage,
-    reconcileBackfill,
     resetLive,
     seedLive,
   } = useUsageHandler();
@@ -661,11 +660,10 @@ export default function useResumableSSE(
              *  this conversation keep their usage and gap events still count */
             backfillUsage(data.resumeState?.collectedUsage ?? [], resumeSubmission);
             if (data.resumeState?.contextUsage) {
+              /** Already reconciled to the call's real prompt tokens server-side
+               *  (GenerationJobManager.persistTokenUsage) when the snapshot's call
+               *  completed, so install it as-is — no client backfill reconcile. */
               contextHandler(data.resumeState.contextUsage, resumeSubmission);
-              /** The restored snapshot is the raw pre-invoke estimate; reconcile it
-               *  to the backfilled primary call's real prompt tokens (the usage came
-               *  via backfill, not a live event that would have reconciled it). */
-              reconcileBackfill(data.resumeState?.collectedUsage ?? [], resumeSubmission);
             }
             /** Output streamed before this resume is not re-delivered as deltas
              *  — estimate it from the trailing aggregated content. This is
@@ -1098,7 +1096,6 @@ export default function useResumableSSE(
       tapContent,
       finalizeUsage,
       backfillUsage,
-      reconcileBackfill,
       resetLive,
       seedLive,
     ],

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -483,6 +483,7 @@ export default function useResumableSSE(
     tapContent,
     finalizeUsage,
     backfillUsage,
+    reconcileBackfill,
     resetLive,
     seedLive,
   } = useUsageHandler();
@@ -661,6 +662,10 @@ export default function useResumableSSE(
             backfillUsage(data.resumeState?.collectedUsage ?? [], resumeSubmission);
             if (data.resumeState?.contextUsage) {
               contextHandler(data.resumeState.contextUsage, resumeSubmission);
+              /** The restored snapshot is the raw pre-invoke estimate; reconcile it
+               *  to the backfilled primary call's real prompt tokens (the usage came
+               *  via backfill, not a live event that would have reconciled it). */
+              reconcileBackfill(data.resumeState?.collectedUsage ?? [], resumeSubmission);
             }
             /** Output streamed before this resume is not re-delivered as deltas
              *  — estimate it from the trailing aggregated content. This is
@@ -1093,6 +1098,7 @@ export default function useResumableSSE(
       tapContent,
       finalizeUsage,
       backfillUsage,
+      reconcileBackfill,
       resetLive,
       seedLive,
     ],

--- a/client/src/hooks/SSE/useUsageHandler.ts
+++ b/client/src/hooks/SSE/useUsageHandler.ts
@@ -60,9 +60,6 @@ export interface UsageHandlers {
   attributePending: (responseId: string | null, submission: UsageSubmissionLike) => void;
   /** Idempotently folds the resumed run's collected usage into the totals */
   backfillUsage: (entries: TTokenUsageEvent[], submission: UsageSubmissionLike) => void;
-  /** Reconciles the restored snapshot to the final primary call's real prompt
-   *  tokens on resume, where the usage arrives via backfill not a live event */
-  reconcileBackfill: (entries: TTokenUsageEvent[], submission: UsageSubmissionLike) => void;
   /** Seeds the live estimate from already-streamed output chars on resume */
   seedLive: (chars: number, submission: UsageSubmissionLike) => void;
 }
@@ -194,54 +191,25 @@ export default function useUsageHandler(): UsageHandlers {
       return true;
     };
 
-    /** Reconcile the active snapshot's calibrated estimate to a primary call's
+    /** Reconcile the live snapshot's calibrated estimate to a primary call's
      *  ACTUAL prompt tokens. The snapshot is pre-invoke for that call; this usage
      *  is its post-invoke truth, so the gauge stops showing the SDK multiplier's
      *  inflation (severe when a provider injects server-side content like web
-     *  search). Idempotent for the same prompt size, so safe on replay. */
-    const applyReconcile = (convoKey: string, event: TTokenUsageEvent) => {
+     *  search). Resume is handled server-side (the job-store snapshot is reconciled
+     *  when the call's usage is persisted), so no backfill reconcile is needed. */
+    const reconcileLiveSnapshot = (data: TTokenUsageEvent, submission: UsageSubmissionLike) => {
+      const convoKey = getConvoKey(submission);
       const snapshotAtom = contextSnapshotFamily(convoKey);
       const snapshot = jotai.get(snapshotAtom);
       if (snapshot == null) {
         return;
       }
       /** The snapshot precedes this call, so it must belong to the same run */
-      if (snapshot.runId != null && event.runId != null && snapshot.runId !== event.runId) {
+      if (snapshot.runId != null && data.runId != null && snapshot.runId !== data.runId) {
         return;
       }
-      const reconciled = reconcileContextUsage(snapshot, promptTokensFromUsage(event));
+      const reconciled = reconcileContextUsage(snapshot, promptTokensFromUsage(data));
       jotai.set(snapshotAtom, { ...reconciled, anchorMessageId: snapshot.anchorMessageId });
-    };
-
-    const reconcileLiveSnapshot = (data: TTokenUsageEvent, submission: UsageSubmissionLike) => {
-      applyReconcile(getConvoKey(submission), data);
-    };
-
-    /** Resume sync restores a primary call's usage through `backfillUsage` (Redis
-     *  mode doesn't replay it as a live `on_token_usage`), so the live
-     *  `usageHandler` reconcile never runs. Reconcile the restored snapshot to the
-     *  final primary call's real prompt tokens here so a reconnected session isn't
-     *  stuck on the inflated estimate until reload. */
-    const reconcileBackfill: UsageHandlers['reconcileBackfill'] = (entries, submission) => {
-      if (!Array.isArray(entries)) {
-        return;
-      }
-      const convoKey = getConvoKey(submission);
-      const snapshot = jotai.get(contextSnapshotFamily(convoKey));
-      if (snapshot == null) {
-        return;
-      }
-      for (let i = entries.length - 1; i >= 0; i--) {
-        const event = entries[i];
-        if (event?.usage_type != null) {
-          continue;
-        }
-        if (snapshot.runId != null && event.runId != null && event.runId !== snapshot.runId) {
-          continue;
-        }
-        applyReconcile(convoKey, event);
-        return;
-      }
     };
 
     const usageHandler: UsageHandlers['usageHandler'] = (data, submission) => {
@@ -428,7 +396,6 @@ export default function useUsageHandler(): UsageHandlers {
       resetLive,
       attributePending,
       backfillUsage,
-      reconcileBackfill,
       seedLive,
     };
   }, []);

--- a/client/src/hooks/SSE/useUsageHandler.ts
+++ b/client/src/hooks/SSE/useUsageHandler.ts
@@ -60,6 +60,9 @@ export interface UsageHandlers {
   attributePending: (responseId: string | null, submission: UsageSubmissionLike) => void;
   /** Idempotently folds the resumed run's collected usage into the totals */
   backfillUsage: (entries: TTokenUsageEvent[], submission: UsageSubmissionLike) => void;
+  /** Reconciles the restored snapshot to the final primary call's real prompt
+   *  tokens on resume, where the usage arrives via backfill not a live event */
+  reconcileBackfill: (entries: TTokenUsageEvent[], submission: UsageSubmissionLike) => void;
   /** Seeds the live estimate from already-streamed output chars on resume */
   seedLive: (chars: number, submission: UsageSubmissionLike) => void;
 }
@@ -191,25 +194,54 @@ export default function useUsageHandler(): UsageHandlers {
       return true;
     };
 
-    /** Reconcile the live snapshot's calibrated estimate to a primary call's
+    /** Reconcile the active snapshot's calibrated estimate to a primary call's
      *  ACTUAL prompt tokens. The snapshot is pre-invoke for that call; this usage
      *  is its post-invoke truth, so the gauge stops showing the SDK multiplier's
      *  inflation (severe when a provider injects server-side content like web
-     *  search). Runs even on a resume replay — `reconcileContextUsage` is
-     *  idempotent for the same prompt size. */
-    const reconcileLiveSnapshot = (data: TTokenUsageEvent, submission: UsageSubmissionLike) => {
-      const convoKey = getConvoKey(submission);
+     *  search). Idempotent for the same prompt size, so safe on replay. */
+    const applyReconcile = (convoKey: string, event: TTokenUsageEvent) => {
       const snapshotAtom = contextSnapshotFamily(convoKey);
       const snapshot = jotai.get(snapshotAtom);
       if (snapshot == null) {
         return;
       }
       /** The snapshot precedes this call, so it must belong to the same run */
-      if (snapshot.runId != null && data.runId != null && snapshot.runId !== data.runId) {
+      if (snapshot.runId != null && event.runId != null && snapshot.runId !== event.runId) {
         return;
       }
-      const reconciled = reconcileContextUsage(snapshot, promptTokensFromUsage(data));
+      const reconciled = reconcileContextUsage(snapshot, promptTokensFromUsage(event));
       jotai.set(snapshotAtom, { ...reconciled, anchorMessageId: snapshot.anchorMessageId });
+    };
+
+    const reconcileLiveSnapshot = (data: TTokenUsageEvent, submission: UsageSubmissionLike) => {
+      applyReconcile(getConvoKey(submission), data);
+    };
+
+    /** Resume sync restores a primary call's usage through `backfillUsage` (Redis
+     *  mode doesn't replay it as a live `on_token_usage`), so the live
+     *  `usageHandler` reconcile never runs. Reconcile the restored snapshot to the
+     *  final primary call's real prompt tokens here so a reconnected session isn't
+     *  stuck on the inflated estimate until reload. */
+    const reconcileBackfill: UsageHandlers['reconcileBackfill'] = (entries, submission) => {
+      if (!Array.isArray(entries)) {
+        return;
+      }
+      const convoKey = getConvoKey(submission);
+      const snapshot = jotai.get(contextSnapshotFamily(convoKey));
+      if (snapshot == null) {
+        return;
+      }
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const event = entries[i];
+        if (event?.usage_type != null) {
+          continue;
+        }
+        if (snapshot.runId != null && event.runId != null && event.runId !== snapshot.runId) {
+          continue;
+        }
+        applyReconcile(convoKey, event);
+        return;
+      }
     };
 
     const usageHandler: UsageHandlers['usageHandler'] = (data, submission) => {
@@ -396,6 +428,7 @@ export default function useUsageHandler(): UsageHandlers {
       resetLive,
       attributePending,
       backfillUsage,
+      reconcileBackfill,
       seedLive,
     };
   }, []);

--- a/client/src/hooks/SSE/useUsageHandler.ts
+++ b/client/src/hooks/SSE/useUsageHandler.ts
@@ -1,6 +1,6 @@
 import { useRef, useMemo } from 'react';
 import { getDefaultStore } from 'jotai';
-import { Constants } from 'librechat-data-provider';
+import { Constants, reconcileContextUsage, promptTokensFromUsage } from 'librechat-data-provider';
 import type {
   TMessage,
   TConversation,
@@ -191,8 +191,36 @@ export default function useUsageHandler(): UsageHandlers {
       return true;
     };
 
+    /** Reconcile the live snapshot's calibrated estimate to a primary call's
+     *  ACTUAL prompt tokens. The snapshot is pre-invoke for that call; this usage
+     *  is its post-invoke truth, so the gauge stops showing the SDK multiplier's
+     *  inflation (severe when a provider injects server-side content like web
+     *  search). Runs even on a resume replay — `reconcileContextUsage` is
+     *  idempotent for the same prompt size. */
+    const reconcileLiveSnapshot = (data: TTokenUsageEvent, submission: UsageSubmissionLike) => {
+      const convoKey = getConvoKey(submission);
+      const snapshotAtom = contextSnapshotFamily(convoKey);
+      const snapshot = jotai.get(snapshotAtom);
+      if (snapshot == null) {
+        return;
+      }
+      /** The snapshot precedes this call, so it must belong to the same run */
+      if (snapshot.runId != null && data.runId != null && snapshot.runId !== data.runId) {
+        return;
+      }
+      const reconciled = reconcileContextUsage(snapshot, promptTokensFromUsage(data));
+      jotai.set(snapshotAtom, { ...reconciled, anchorMessageId: snapshot.anchorMessageId });
+    };
+
     const usageHandler: UsageHandlers['usageHandler'] = (data, submission) => {
       const folded = foldUsage(data, submission);
+
+      /** Primary-call usage carries the provider's real prompt size — correct the
+       *  live gauge to it before the bump below (tagged buckets never touch the
+       *  context gauge). */
+      if (data.usage_type == null) {
+        reconcileLiveSnapshot(data, submission);
+      }
 
       /** Only primary-call usage drives the live context estimate; tagged
        *  buckets (summarization, subagent) fold into totals/cost only. Skip

--- a/client/src/hooks/SSE/useUsageHandler.ts
+++ b/client/src/hooks/SSE/useUsageHandler.ts
@@ -215,19 +215,17 @@ export default function useUsageHandler(): UsageHandlers {
     const usageHandler: UsageHandlers['usageHandler'] = (data, submission) => {
       const folded = foldUsage(data, submission);
 
-      /** Primary-call usage carries the provider's real prompt size — correct the
-       *  live gauge to it before the bump below (tagged buckets never touch the
-       *  context gauge). */
-      if (data.usage_type == null) {
-        reconcileLiveSnapshot(data, submission);
-      }
-
-      /** Only primary-call usage drives the live context estimate; tagged
-       *  buckets (summarization, subagent) fold into totals/cost only. Skip
-       *  the bump for an already-counted event replayed on resume. */
+      /** Only a NEWLY folded primary call drives the live gauge. A replayed
+       *  duplicate (folded=false on resume) can be an EARLIER tool-loop call that
+       *  shares this run's id — reconciling with it would overwrite the latest
+       *  snapshot with an earlier, smaller prompt. Tagged buckets (summarization,
+       *  subagent) never touch the context gauge. */
       if (!folded || data.usage_type != null) {
         return;
       }
+      /** This primary's provider-reported prompt is the post-invoke truth for the
+       *  call the latest snapshot precedes — reconcile the gauge to it. */
+      reconcileLiveSnapshot(data, submission);
       /** Use the repaired completion count (not raw output_tokens) so the
        *  snapshot gauge keeps the full response for under-reporting providers */
       confirmedRef.current += normalizeUsageUnits(data).output;

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -1755,6 +1755,44 @@ describe('buildPersistedContextUsage', () => {
     expect(buildPersistedContextUsage(baseSnapshot, []).completedOutputTokens).toBeUndefined();
   });
 
+  it('reconciles the inflated estimate to the final call’s real prompt tokens', () => {
+    /** Real web-search + summarization turn: calibration pinned at 5 inflated
+     *  messageTokens to 187471 (used 213375), but the answer call's true prompt was
+     *  53702 + 2071 cache = 55773. The persisted blob must show the real context so
+     *  a reload isn't stuck several× too high. */
+    const inflated: TContextUsageEvent = {
+      runId: 'run-1',
+      breakdown: {
+        maxContextTokens: 250000,
+        instructionTokens: 4205,
+        systemMessageTokens: 384,
+        dynamicInstructionTokens: 1525,
+        toolSchemaTokens: 2296,
+        summaryTokens: 1938,
+        toolCount: 1,
+        messageCount: 2,
+        messageTokens: 187471,
+        availableForMessages: 233295,
+      },
+      contextBudget: 237500,
+      remainingContextTokens: 24125,
+      calibrationRatio: 5,
+    };
+    const events: TTokenUsageEvent[] = [
+      {
+        input_tokens: 53702,
+        output_tokens: 3780,
+        input_token_details: { cache_read: 2071, cache_creation: 0 },
+        provider: 'anthropic',
+        runId: 'run-1',
+      },
+    ];
+    const result = buildPersistedContextUsage(inflated, events);
+    expect(237500 - (result.remainingContextTokens ?? 0)).toBe(55773);
+    expect(result.breakdown.messageTokens).toBe(55773 - 4205 - 1938);
+    expect(result.completedOutputTokens).toBe(3780);
+  });
+
   it('attributes completedOutputTokens to the snapshot run, not a parallel run', () => {
     /** Parallel/direct runs interleave: this snapshot is run-1, but run-2 emits a
      *  later primary usage. The persisted delta must be run-1's own output (40),

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -1,5 +1,9 @@
 import { logger } from '@librechat/data-schemas';
-import { inputTokensIncludesCache } from 'librechat-data-provider';
+import {
+  inputTokensIncludesCache,
+  reconcileContextUsage,
+  promptTokensFromUsage,
+} from 'librechat-data-provider';
 import type {
   TCustomConfig,
   TResponseUsage,
@@ -247,14 +251,14 @@ function normalizeEventUnits(event: TTokenUsageEvent): {
   };
 }
 
-/** Output tokens of the final primary model call belonging to the snapshot's
- *  run — the call the latest pre-invoke snapshot precedes. Persisted as the
- *  snapshot's `completedOutputTokens` so a reloaded multi-call turn adds only
- *  this delta (matching the live finalizer) instead of the full response
- *  `tokenCount`, which the snapshot already counts for earlier steps. Filtering
- *  by `runId` prevents a parallel run's later usage from being attributed to this
- *  snapshot; untagged events (older lib / resume) match any run for back-compat. */
-function finalCallOutputTokens(events: ReadonlyArray<TTokenUsageEvent>, runId?: string): number {
+/** The final primary (non-tagged) model call belonging to the snapshot's run —
+ *  the call the latest pre-invoke snapshot precedes. Filtering by `runId` prevents
+ *  a parallel run's later usage from being attributed to this snapshot; untagged
+ *  events (older lib / resume) match any run for back-compat. */
+function finalPrimaryCall(
+  events: ReadonlyArray<TTokenUsageEvent>,
+  runId?: string,
+): TTokenUsageEvent | undefined {
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
     if (event.usage_type != null) {
@@ -263,24 +267,32 @@ function finalCallOutputTokens(events: ReadonlyArray<TTokenUsageEvent>, runId?: 
     if (runId != null && event.runId != null && event.runId !== runId) {
       continue;
     }
-    return normalizeEventUnits(event).output;
+    return event;
   }
-  return 0;
+  return undefined;
 }
 
 /**
  * Projects the latest live context snapshot into the blob persisted on
- * `responseMessage.metadata.contextUsage`. Trims zero-valued per-tool counts
- * (privacy/size) and records the final call's output as `completedOutputTokens`
- * so rehydration adds the same post-snapshot delta the live gauge did. The
- * client re-anchors the blob to the response message id on load.
+ * `responseMessage.metadata.contextUsage`. Reconciles the calibrated estimate to
+ * the final call's ACTUAL prompt tokens (the SDK multiplier over-inflates
+ * `messageTokens`, badly so when a provider injects server-side content like web
+ * search), so a reloaded turn shows the real context — not a several×-too-high
+ * number. Trims zero-valued per-tool counts (privacy/size) and records the final
+ * call's output as `completedOutputTokens` so rehydration adds the same
+ * post-snapshot delta the live gauge did. The client re-anchors the blob to the
+ * response message id on load.
  */
 export function buildPersistedContextUsage(
   snapshot: TContextUsageEvent,
   usageEvents: ReadonlyArray<TTokenUsageEvent> = [],
 ): TContextUsageEvent {
-  const { breakdown } = snapshot;
-  const completedOutputTokens = finalCallOutputTokens(usageEvents, snapshot.runId);
+  const finalCall = finalPrimaryCall(usageEvents, snapshot.runId);
+  const completedOutputTokens = finalCall ? normalizeEventUnits(finalCall).output : 0;
+  const reconciled = finalCall
+    ? reconcileContextUsage(snapshot, promptTokensFromUsage(finalCall))
+    : snapshot;
+  const { breakdown } = reconciled;
   let toolTokenCounts = breakdown.toolTokenCounts;
   if (toolTokenCounts != null) {
     const trimmed: Record<string, number> = {};
@@ -292,7 +304,7 @@ export function buildPersistedContextUsage(
     toolTokenCounts = Object.keys(trimmed).length > 0 ? trimmed : undefined;
   }
   return {
-    ...snapshot,
+    ...reconciled,
     breakdown: { ...breakdown, toolTokenCounts },
     ...(completedOutputTokens > 0 && { completedOutputTokens }),
   };

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -7,10 +7,10 @@ import {
   promptTokensFromUsage,
 } from 'librechat-data-provider';
 import type {
-  Agents,
   TMessageContentParts,
-  TTokenUsageEvent,
   TContextUsageEvent,
+  TTokenUsageEvent,
+  Agents,
 } from 'librechat-data-provider';
 import type { StandardGraph } from '@librechat/agents';
 import type {
@@ -23,10 +23,10 @@ import type {
 import type { GenerationJobStore } from '~/app/metrics';
 import type * as t from '~/types';
 import {
-  recordGenerationJob,
   recordGenerationStreamResumePendingEvents,
   recordGenerationStreamSubscription,
   setGenerationJobsInFlight,
+  recordGenerationJob,
 } from '~/app/metrics';
 import { InMemoryEventTransport } from './implementations/InMemoryEventTransport';
 import { InMemoryJobStore } from './implementations/InMemoryJobStore';

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -1,6 +1,17 @@
 import { logger, getTenantId, SYSTEM_TENANT_ID } from '@librechat/data-schemas';
-import { Constants, UsageEvents, parseTextParts } from 'librechat-data-provider';
-import type { Agents, TMessageContentParts } from 'librechat-data-provider';
+import {
+  Constants,
+  UsageEvents,
+  parseTextParts,
+  reconcileContextUsage,
+  promptTokensFromUsage,
+} from 'librechat-data-provider';
+import type {
+  Agents,
+  TMessageContentParts,
+  TTokenUsageEvent,
+  TContextUsageEvent,
+} from 'librechat-data-provider';
 import type { StandardGraph } from '@librechat/agents';
 import type {
   SerializableJobData,
@@ -1244,9 +1255,32 @@ class GenerationJobManagerClass {
     }
     tokenUsage.push(event.data);
 
-    await this.jobStore.updateJob(streamId, {
-      tokenUsage: JSON.stringify(tokenUsage),
-    });
+    const update: Partial<SerializableJobData> = { tokenUsage: JSON.stringify(tokenUsage) };
+
+    /** Reconcile the resume snapshot to this call's ACTUAL prompt tokens. A primary
+     *  usage is the post-invoke truth for the call the latest stored snapshot
+     *  precedes (no snapshot is captured between a call's pre-invoke dispatch and
+     *  its usage), so a resuming client restores the real context instead of the
+     *  calibration-inflated estimate — and a mid-call resume (no usage yet) simply
+     *  keeps the raw snapshot rather than mis-applying an earlier call's tokens. */
+    const usage = event.data as TTokenUsageEvent;
+    if (usage.usage_type == null && jobData.contextUsage) {
+      try {
+        const snapshot = JSON.parse(jobData.contextUsage) as TContextUsageEvent | null;
+        if (
+          snapshot != null &&
+          (snapshot.runId == null || usage.runId == null || snapshot.runId === usage.runId)
+        ) {
+          update.contextUsage = JSON.stringify(
+            reconcileContextUsage(snapshot, promptTokensFromUsage(usage)),
+          );
+        }
+      } catch {
+        /* leave the stored snapshot as-is on parse failure */
+      }
+    }
+
+    await this.jobStore.updateJob(streamId, update);
   }
 
   private async persistReplayEvent(streamId: string, event: t.ServerSentEvent): Promise<void> {

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -1178,9 +1178,17 @@ class GenerationJobManagerClass {
       return;
     }
 
-    await this.jobStore.updateJob(streamId, {
-      contextUsage: JSON.stringify((event as { data?: unknown }).data ?? null),
-    });
+    /** Share the token-usage queue so snapshot + usage writes are serialized per
+     *  stream: `persistTokenUsage` reconciles the stored snapshot (read-modify-
+     *  write), and a snapshot landing between its read and write — or a stale
+     *  reconciled write landing after a newer snapshot — would clobber the newer
+     *  run's gauge when visible calls interleave. FIFO ordering keeps each call's
+     *  pre-invoke snapshot ahead of its own usage and behind the next snapshot. */
+    await this.queueJobWrite(this.tokenUsageWriteQueues, streamId, () =>
+      this.jobStore.updateJob(streamId, {
+        contextUsage: JSON.stringify((event as { data?: unknown }).data ?? null),
+      }),
+    );
   }
 
   /**

--- a/packages/data-provider/src/types/runs.spec.ts
+++ b/packages/data-provider/src/types/runs.spec.ts
@@ -23,6 +23,24 @@ describe('promptTokensFromUsage', () => {
   it('handles missing fields', () => {
     expect(promptTokensFromUsage({ provider: 'anthropic' })).toBe(0);
   });
+
+  it('uses the magnitude heuristic when the provider is absent (cache ≤ input ⇒ included)', () => {
+    /** OpenAI-compatible/custom payload with no provider: cache already folded
+     *  into input_tokens, so it must NOT be re-added. */
+    const event: TTokenUsageEvent = {
+      input_tokens: 1000,
+      input_token_details: { cache_read: 400, cache_creation: 0 },
+    };
+    expect(promptTokensFromUsage(event)).toBe(1000);
+  });
+
+  it('adds cache when provider is absent and cache exceeds input (additive shape)', () => {
+    const event: TTokenUsageEvent = {
+      input_tokens: 100,
+      input_token_details: { cache_read: 900, cache_creation: 0 },
+    };
+    expect(promptTokensFromUsage(event)).toBe(1000);
+  });
 });
 
 describe('reconcileContextUsage', () => {

--- a/packages/data-provider/src/types/runs.spec.ts
+++ b/packages/data-provider/src/types/runs.spec.ts
@@ -1,0 +1,94 @@
+import type { TContextUsageEvent, TTokenUsageEvent } from './runs';
+import { promptTokensFromUsage, reconcileContextUsage } from './runs';
+
+describe('promptTokensFromUsage', () => {
+  it('adds cache reads/writes for additive providers (Anthropic)', () => {
+    const event: TTokenUsageEvent = {
+      input_tokens: 53702,
+      input_token_details: { cache_read: 2071, cache_creation: 0 },
+      provider: 'anthropic',
+    };
+    expect(promptTokensFromUsage(event)).toBe(55773);
+  });
+
+  it('treats input_tokens as the full prompt for subset providers (OpenAI)', () => {
+    const event: TTokenUsageEvent = {
+      input_tokens: 1000,
+      input_token_details: { cache_read: 200, cache_creation: 100 },
+      provider: 'openAI',
+    };
+    expect(promptTokensFromUsage(event)).toBe(1000);
+  });
+
+  it('handles missing fields', () => {
+    expect(promptTokensFromUsage({ provider: 'anthropic' })).toBe(0);
+  });
+});
+
+describe('reconcileContextUsage', () => {
+  /** The exact over-reporting case from a real web-search + summarization turn:
+   *  calibrationRatio pinned at 5 inflated messageTokens to 187471 → used 213375,
+   *  while the provider's real prompt for that call was 55773. */
+  const inflatedSnapshot: TContextUsageEvent = {
+    runId: 'run-1',
+    breakdown: {
+      maxContextTokens: 250000,
+      instructionTokens: 4205,
+      systemMessageTokens: 384,
+      dynamicInstructionTokens: 1525,
+      toolSchemaTokens: 2296,
+      summaryTokens: 1938,
+      toolCount: 1,
+      messageCount: 2,
+      messageTokens: 187471,
+      availableForMessages: 233295,
+    },
+    contextBudget: 237500,
+    remainingContextTokens: 24125,
+    calibrationRatio: 5,
+  };
+
+  it('reconciles the inflated estimate to the real prompt tokens', () => {
+    const result = reconcileContextUsage(inflatedSnapshot, 55773);
+    /** used = budget − remaining = real prompt, down from the inflated 213375 */
+    expect(237500 - (result.remainingContextTokens ?? 0)).toBe(55773);
+    /** only messageTokens is corrected; instructions/summary stay raw */
+    expect(result.breakdown.messageTokens).toBe(55773 - 4205 - 1938);
+    expect(result.breakdown.instructionTokens).toBe(4205);
+    expect(result.breakdown.summaryTokens).toBe(1938);
+    /** rows still sum to the real total */
+    expect(
+      result.breakdown.messageTokens +
+        result.breakdown.instructionTokens +
+        result.breakdown.summaryTokens,
+    ).toBe(55773);
+  });
+
+  it('clamps messageTokens to zero when the prompt is smaller than the overhead', () => {
+    const result = reconcileContextUsage(inflatedSnapshot, 3000);
+    expect(result.breakdown.messageTokens).toBe(0);
+    expect(result.remainingContextTokens).toBe(237500 - 3000);
+  });
+
+  it('is a no-op for an unusable prompt count', () => {
+    expect(reconcileContextUsage(inflatedSnapshot, 0)).toBe(inflatedSnapshot);
+    expect(reconcileContextUsage(inflatedSnapshot, -5)).toBe(inflatedSnapshot);
+    expect(reconcileContextUsage(inflatedSnapshot, NaN)).toBe(inflatedSnapshot);
+  });
+
+  it('end-to-end: promptTokensFromUsage feeds reconcileContextUsage (followup turn)', () => {
+    const followupSnapshot: TContextUsageEvent = {
+      ...inflatedSnapshot,
+      breakdown: { ...inflatedSnapshot.breakdown, messageTokens: 30480 },
+      remainingContextTokens: 202815,
+    };
+    const usage: TTokenUsageEvent = {
+      input_tokens: 7804,
+      input_token_details: { cache_read: 2071, cache_creation: 0 },
+      provider: 'anthropic',
+    };
+    const result = reconcileContextUsage(followupSnapshot, promptTokensFromUsage(usage));
+    expect(237500 - (result.remainingContextTokens ?? 0)).toBe(9875);
+    expect(result.breakdown.messageTokens).toBe(9875 - 4205 - 1938);
+  });
+});

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -132,16 +132,22 @@ export type TTokenUsageEvent = {
  * Full prompt token count for one completed model call — the EXACT context the
  * model saw, provider-aware: additive providers (Anthropic/Bedrock) report
  * `input_tokens` excluding cache, so cache reads/writes are added back; subset
- * providers (OpenAI/…) already fold cache into `input_tokens`. This is the ground
- * truth the gauge reconciles its calibrated estimate to.
+ * providers (OpenAI/…) already fold cache into `input_tokens`. When the provider
+ * is absent (custom/OpenAI-compatible payloads), fall back to the same magnitude
+ * heuristic `normalizeUsageUnits` uses — cache ≤ input means it's already
+ * included — so cached events aren't re-inflated. The ground truth the gauge
+ * reconciles its calibrated estimate to.
  */
 export const promptTokensFromUsage = (event: TTokenUsageEvent): number => {
   const input = event.input_tokens ?? 0;
-  if (inputTokensIncludesCache(event.provider)) {
-    return input;
-  }
   const details = event.input_token_details ?? {};
-  return input + (details.cache_read ?? 0) + (details.cache_creation ?? 0);
+  const cacheRead = details.cache_read ?? 0;
+  const cacheCreation = details.cache_creation ?? 0;
+  const includesCache =
+    event.provider != null
+      ? inputTokensIncludesCache(event.provider)
+      : cacheRead + cacheCreation <= input;
+  return includesCache ? input : input + cacheRead + cacheCreation;
 };
 
 /**

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -1,3 +1,5 @@
+import { inputTokensIncludesCache } from '../schemas';
+
 export enum ContentTypes {
   TEXT = 'text',
   THINK = 'think',
@@ -124,6 +126,51 @@ export type TTokenUsageEvent = {
    *  rates); present only when `interface.contextCost` is enabled. Clients sum
    *  this rather than re-deriving cost from base rates. */
   cost?: number;
+};
+
+/**
+ * Full prompt token count for one completed model call — the EXACT context the
+ * model saw, provider-aware: additive providers (Anthropic/Bedrock) report
+ * `input_tokens` excluding cache, so cache reads/writes are added back; subset
+ * providers (OpenAI/…) already fold cache into `input_tokens`. This is the ground
+ * truth the gauge reconciles its calibrated estimate to.
+ */
+export const promptTokensFromUsage = (event: TTokenUsageEvent): number => {
+  const input = event.input_tokens ?? 0;
+  if (inputTokensIncludesCache(event.provider)) {
+    return input;
+  }
+  const details = event.input_token_details ?? {};
+  return input + (details.cache_read ?? 0) + (details.cache_creation ?? 0);
+};
+
+/**
+ * Reconciles a pre-invoke context snapshot's CALIBRATED estimate to a call's
+ * ACTUAL prompt tokens. The SDK's calibration multiplier scales only
+ * `messageTokens` (instructions/summary are raw tiktoken counts), and it can
+ * over-shoot badly when a provider injects server-side content the SDK never
+ * counted (e.g. Anthropic web search) — pinning the gauge several× too high and
+ * persisting it. Trust the provider's own prompt count: keep the raw
+ * instruction/summary rows, set `messageTokens` to the remainder, and recompute
+ * the free space. No-op when `promptTokens` is unusable.
+ */
+export const reconcileContextUsage = (
+  snapshot: TContextUsageEvent,
+  promptTokens: number,
+): TContextUsageEvent => {
+  if (!Number.isFinite(promptTokens) || promptTokens <= 0) {
+    return snapshot;
+  }
+  const { breakdown } = snapshot;
+  const budget = snapshot.contextBudget ?? breakdown.maxContextTokens;
+  const nonMessageTokens = (breakdown.instructionTokens ?? 0) + (breakdown.summaryTokens ?? 0);
+  const messageTokens = Math.max(0, promptTokens - nonMessageTokens);
+  return {
+    ...snapshot,
+    breakdown: { ...breakdown, messageTokens },
+    remainingContextTokens:
+      budget != null ? Math.max(0, budget - promptTokens) : snapshot.remainingContextTokens,
+  };
 };
 
 /** Lifecycle phase carried on subagent-progress envelopes (mirrors SDK SubagentUpdatePhase). */


### PR DESCRIPTION
## Summary

The context-window gauge could read **several× too high** and stay there across reloads — most visibly right after a summarization triggered by web-search-heavy turns (e.g. shows `213K / 250K` when the real prompt was `~56K`, only dropping to the truth on the next message).

### Root cause
The gauge renders the SDK's *calibrated estimate*, never the provider's *actual* token count. The SDK's `calibrationRatio` is `cumulativeProviderReported / cumulativeRawSent`. When a provider runs **server-side web search**, it injects the fetched content into the prompt (one captured call: `input 83031 + cache_creation 82635 ≈ 166K`) that LibreChat never sent or counted (it estimated `~16K`). That ~10× gap pins the ratio at its cap (**5**), and the sticky 5× then multiplies every later message estimate — including the post-summary answer (real prompt `56K` → shown & persisted as `213K`). Reload reads the persisted inflated blob, so it stays wrong until the next turn emits a fresh snapshot.

### Fix
Reconcile the snapshot to the call's **actual prompt tokens** (`input + cache_read + cache_creation`), which already arrive in `on_token_usage`. Only `messageTokens` is calibration-scaled (instructions/summary are raw tiktoken counts), so we keep those and set `messageTokens` to the remainder, recomputing free space.

- **`packages/data-provider`** — shared `promptTokensFromUsage` (provider-aware: additive vs cache-subset) + `reconcileContextUsage`.
- **Server** (`buildPersistedContextUsage`) — reconcile to the snapshot run's final primary call before persisting → **reload-stable**.
- **Client** (`useUsageHandler`) — reconcile the live snapshot on each primary `on_token_usage` → corrects **at turn-end, no follow-up message needed**.
- **`Breakdown`** — exclude the summary from the Messages row (it has its own row) to drop a pre-existing double-count on summarized turns.

### Deferred (separate `@librechat/agents` PR)
The same over-calibration also fires **summarization prematurely** (estimated pre-prune `399K` vs real `~166K`). Fixing it at the source means decoupling real-content estimation from server-side-injection headroom *without* weakening pruning-overflow safety — a focused SDK change with its own pruning tests, tracked separately.

## Testing
- `packages/data-provider` `runs.spec` — 7 (helpers, incl. the real `213K → 56K` case)
- `packages/api` `usage.spec` — 118 (incl. `buildPersistedContextUsage` reconciliation)
- `client` `useUsageHandler.spec` (new, 3) + `tokens.spec` (45)
- `tsc` (client) + eslint + sort-imports clean.

Verified against a real captured SSE stream + conversation export (Anthropic web search + summarization, `maxContextTokens 250K`).