### PR TITLE
fix: traverse shared non-circular references in object-traverse

### DIFF
--- a/packages/data-schemas/src/utils/object-traverse.spec.ts
+++ b/packages/data-schemas/src/utils/object-traverse.spec.ts
@@ -1,0 +1,76 @@
+import type { TraverseContext } from './object-traverse';
+import traverse from './object-traverse';
+
+/** Collects the dotted leaf paths visited during a traversal. */
+function collectLeafPaths(input: unknown): string[] {
+  const paths: string[] = [];
+  traverse(input).forEach(function (this: TraverseContext) {
+    if (this.isLeaf && !this.isRoot) {
+      paths.push(this.path.join('.'));
+    }
+  });
+  return paths;
+}
+
+describe('object-traverse', () => {
+  it('visits every leaf of a plain nested object', () => {
+    const paths = collectLeafPaths({ a: 1, b: { c: 2, d: 3 } });
+    expect(paths).toEqual(expect.arrayContaining(['a', 'b.c', 'b.d']));
+  });
+
+  it('traverses shared (non-circular) references that appear in multiple branches', () => {
+    const shared = { secret: 'value' };
+    const input = { a: shared, b: shared };
+
+    const paths = collectLeafPaths(input);
+
+    // Both branches reference the same object, but it is NOT circular, so each
+    // occurrence must be traversed independently.
+    expect(paths).toContain('a.secret');
+    expect(paths).toContain('b.secret');
+  });
+
+  it('traverses an array containing the same object multiple times', () => {
+    const shared = { value: 42 };
+    const paths = collectLeafPaths([shared, shared, shared]);
+
+    expect(paths).toEqual(['0.value', '1.value', '2.value']);
+  });
+
+  it('invokes the callback for shared references rather than skipping them', () => {
+    const shared = { name: 'duplicate' };
+    const input = { first: shared, second: shared };
+
+    const visitedNodes: unknown[] = [];
+    traverse(input).forEach(function (this: TraverseContext, value: unknown) {
+      visitedNodes.push(value);
+    });
+
+    // root, first(obj), first.name, second(obj), second.name
+    expect(visitedNodes.filter((node) => node === shared)).toHaveLength(2);
+  });
+
+  it('does not infinitely recurse on a self-referential (circular) object', () => {
+    const node: Record<string, unknown> = { id: 1 };
+    node.self = node;
+
+    const paths = collectLeafPaths(node);
+
+    // The circular `self` edge must not be followed, but the primitive leaf
+    // `id` is still visited.
+    expect(paths).toContain('id');
+    expect(paths).not.toContain('self.id');
+  });
+
+  it('does not treat a diamond-shaped (DAG) structure as circular', () => {
+    const leaf = { v: 1 };
+    const left = { leaf };
+    const right = { leaf };
+    const input = { left, right };
+
+    const paths = collectLeafPaths(input);
+
+    expect(paths).toContain('left.leaf.v');
+    expect(paths).toContain('right.leaf.v');
+  });
+});

--- a/packages/data-schemas/src/utils/object-traverse.ts
+++ b/packages/data-schemas/src/utils/object-traverse.ts
@@ -88,25 +88,24 @@ function deleteProperty(obj: TraversableObject, key: string | number): void {
 }
 
 function forEach(obj: unknown, callback: ForEachCallback): void {
-  const visited = new WeakSet<object>();
-
   function walk(node: unknown, path: (string | number)[] = [], parent?: TraverseContext): void {
-    // Check for circular references
+    // Detect circular references by walking the ancestor chain. A node is only
+    // circular when it appears among its own ancestors; a shared (non-circular)
+    // reference that merely appears in more than one branch must still be
+    // traversed independently for each occurrence.
     let circular: TraverseContext | null = null;
     if (isObject(node)) {
-      if (visited.has(node)) {
-        // Find the circular reference in the parent chain
-        let p = parent;
-        while (p) {
-          if (p.node === node) {
-            circular = p;
-            break;
-          }
-          p = p.parent;
+      let p = parent;
+      while (p) {
+        if (p.node === node) {
+          circular = p;
+          break;
         }
-        return; // Skip circular references
+        p = p.parent;
       }
-      visited.add(node);
+      if (circular) {
+        return; // Skip true circular references to avoid infinite recursion
+      }
     }
 
     const key = path.length > 0 ? path[path.length - 1] : undefined;


### PR DESCRIPTION
## Summary

`object-traverse`'s `forEach` used a single global `WeakSet` of every visited node to decide whether to skip a node as "circular". That set never distinguishes a true cycle from a **shared (non-circular) reference** — i.e. the same object appearing in two different branches of an otherwise acyclic graph (a DAG).

As a result, whenever the same object instance is reachable through more than one path, every occurrence after the first is silently dropped: its callback is never invoked and its subtree is never traversed.

```ts
const shared = { secret: 'value' };
traverse({ a: shared, b: shared }).forEach(function () {
  // before: only `a.secret` is visited — `b.secret` is skipped
});
```

Notably the existing code already computed `circular` by walking the **ancestor chain** (to populate `context.circular`), but then ignored that result and skipped based purely on the global visited set. A node is only genuinely circular when it appears among its own ancestors.

### Fix

Detect circular references using the ancestor chain alone and remove the global `visited` set. True cycles are still skipped (any infinite traversal path must revisit an ancestor, so this is sufficient to prevent infinite recursion), while shared references in sibling branches are now traversed independently. Behavior for plain nested objects and self-referential cycles is unchanged.

The change is confined to `packages/data-schemas/src/utils/object-traverse.ts` (the lone consumer, `config/parsers.ts`, is unaffected — its tests still pass).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `packages/data-schemas/src/utils/object-traverse.spec.ts` covering: plain nested traversal, shared references across object branches, repeated entries in arrays, callback invocation count for shared refs, self-referential (circular) safety, and diamond/DAG structures.

```
cd packages/data-schemas
npx jest src/utils/object-traverse.spec.ts src/config/parsers.spec.ts
# Test Suites: 2 passed, 2 total
# Tests:       27 passed, 27 total
```

Before the fix, 4 of the new tests fail (shared/DAG references dropped); the plain-nested and circular-safety tests pass both before and after, confirming existing behavior is preserved.

### **Test Configuration**:

Node 24, `jest` via the `@librechat/data-schemas` workspace config. No DB, network, or browser required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
