### PR TITLE
🥽 fix: Restrict MCP Server URL Disclosure to Admins, Owners, and Editors

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -30,9 +30,9 @@ const {
   resolveAllMcpConfigs,
 } = require('~/server/services/MCP');
 const { cacheMCPServerTools, getMCPServerTools } = require('~/server/services/Config');
-const { getMCPManager, getMCPServersRegistry } = require('~/config');
-const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const { getResourcePermissionsMap } = require('~/server/services/PermissionService');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
+const { getMCPManager, getMCPServersRegistry } = require('~/config');
 const db = require('~/models');
 
 /**

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -5,9 +5,10 @@
  * @import { MCPServerRegistry } from '@librechat/api'
  * @import { MCPServerDocument } from 'librechat-data-provider'
  */
-const { logger } = require('@librechat/data-schemas');
+const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
   checkAccess,
+  isUserSourced,
   MCPErrorCodes,
   redactServerSecrets,
   redactAllServerSecrets,
@@ -18,6 +19,8 @@ const {
   Constants,
   Permissions,
   PermissionTypes,
+  PermissionBits,
+  ResourceType,
   MCPServerUserInputSchema,
   MCP_USER_INPUT_FIELDS,
 } = require('librechat-data-provider');
@@ -28,6 +31,8 @@ const {
 } = require('~/server/services/MCP');
 const { cacheMCPServerTools, getMCPServerTools } = require('~/server/services/Config');
 const { getMCPManager, getMCPServersRegistry } = require('~/config');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
+const { getResourcePermissionsMap } = require('~/server/controllers/PermissionsController');
 const db = require('~/models');
 
 /**
@@ -197,6 +202,73 @@ const getMCPTools = async (req, res) => {
   }
 };
 /**
+ * For each server, compute whether the caller has edit authority over it.
+ * Used to gate URL/oauth-URL disclosure on non-user-sourced configs to callers
+ * who could already edit the resource via PATCH, mirroring the ACL check that
+ * canAccessMCPServerResource enforces on the update route.
+ *
+ * - User-sourced configs always resolve to true (caller's own URL, no
+ *   operator-sensitive data to hide).
+ * - Broad MANAGE_MCP_SERVERS capability acts as a bypass for all configs,
+ *   matching the capability bypass in canAccessResource.
+ * - Non-user-sourced configs with a persisted dbId get a per-resource ACL
+ *   check via getResourcePermissionsMap (PermissionBits.EDIT).
+ * - Non-user-sourced configs without a dbId default to false (they are
+ *   YAML-defined and not part of the per-resource ACL space).
+ */
+async function computeCanEditByServer(req, serverConfigs) {
+  const canEditByServer = new Map();
+  let bypass = false;
+  try {
+    bypass = await hasCapability(req.user, SystemCapabilities.MANAGE_MCP_SERVERS);
+  } catch (err) {
+    logger.warn(`[computeCanEditByServer] Capability bypass check failed: ${err.message}`);
+  }
+  if (bypass) {
+    for (const name of Object.keys(serverConfigs)) {
+      canEditByServer.set(name, true);
+    }
+    return canEditByServer;
+  }
+  const dbIdsToCheck = [];
+  const dbIdToServerName = new Map();
+  for (const [name, config] of Object.entries(serverConfigs)) {
+    if (isUserSourced(config)) {
+      canEditByServer.set(name, true);
+      continue;
+    }
+    if (config.dbId) {
+      dbIdsToCheck.push(config.dbId);
+      dbIdToServerName.set(String(config.dbId), name);
+      continue;
+    }
+    canEditByServer.set(name, false);
+  }
+  if (dbIdsToCheck.length > 0) {
+    try {
+      const permsMap = await getResourcePermissionsMap({
+        userId: req.user.id,
+        role: req.user.role,
+        resourceType: ResourceType.MCPSERVER,
+        resourceIds: dbIdsToCheck,
+      });
+      for (const [dbIdStr, name] of dbIdToServerName) {
+        const bits = permsMap.get(dbIdStr) ?? 0;
+        canEditByServer.set(name, (bits & PermissionBits.EDIT) !== 0);
+      }
+    } catch (err) {
+      logger.warn(
+        `[computeCanEditByServer] ACL lookup failed, defaulting to no edit: ${err.message}`,
+      );
+      for (const name of dbIdToServerName.values()) {
+        canEditByServer.set(name, false);
+      }
+    }
+  }
+  return canEditByServer;
+}
+
+/**
  * Get all MCP servers with permissions
  * @route GET /api/mcp/servers
  */
@@ -208,7 +280,8 @@ const getMCPServersList = async (req, res) => {
     }
 
     const serverConfigs = await resolveAllMcpConfigs(userId, req.user);
-    return res.json(redactAllServerSecrets(serverConfigs));
+    const canEditByServer = await computeCanEditByServer(req, serverConfigs);
+    return res.json(redactAllServerSecrets(serverConfigs, { canEditByServer }));
   } catch (error) {
     logger.error('[getMCPServersList]', error);
     res.status(500).json({ error: error.message });
@@ -339,7 +412,9 @@ const getMCPServerById = async (req, res) => {
       return res.status(404).json({ message: 'MCP server not found' });
     }
 
-    res.status(200).json(redactServerSecrets(parsedConfig));
+    const canEditMap = await computeCanEditByServer(req, { [serverName]: parsedConfig });
+    const canEdit = canEditMap.get(serverName) ?? false;
+    res.status(200).json(redactServerSecrets(parsedConfig, { canEdit }));
   } catch (error) {
     logger.error('[getMCPServerById]', error);
     res.status(500).json({ message: error.message });

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -18,11 +18,11 @@ const {
 const {
   Constants,
   Permissions,
-  PermissionTypes,
-  PermissionBits,
   ResourceType,
-  MCPServerUserInputSchema,
+  PermissionBits,
+  PermissionTypes,
   MCP_USER_INPUT_FIELDS,
+  MCPServerUserInputSchema,
 } = require('librechat-data-provider');
 const {
   resolveConfigServers,
@@ -32,7 +32,7 @@ const {
 const { cacheMCPServerTools, getMCPServerTools } = require('~/server/services/Config');
 const { getMCPManager, getMCPServersRegistry } = require('~/config');
 const { hasCapability } = require('~/server/middleware/roles/capabilities');
-const { getResourcePermissionsMap } = require('~/server/controllers/PermissionsController');
+const { getResourcePermissionsMap } = require('~/server/services/PermissionService');
 const db = require('~/models');
 
 /**
@@ -201,21 +201,7 @@ const getMCPTools = async (req, res) => {
     res.status(500).json({ message: error.message });
   }
 };
-/**
- * For each server, compute whether the caller has edit authority over it.
- * Used to gate URL/oauth-URL disclosure on non-user-sourced configs to callers
- * who could already edit the resource via PATCH, mirroring the ACL check that
- * canAccessMCPServerResource enforces on the update route.
- *
- * - User-sourced configs always resolve to true (caller's own URL, no
- *   operator-sensitive data to hide).
- * - Broad MANAGE_MCP_SERVERS capability acts as a bypass for all configs,
- *   matching the capability bypass in canAccessResource.
- * - Non-user-sourced configs with a persisted dbId get a per-resource ACL
- *   check via getResourcePermissionsMap (PermissionBits.EDIT).
- * - Non-user-sourced configs without a dbId default to false (they are
- *   YAML-defined and not part of the per-resource ACL space).
- */
+/** Mirrors canAccessResource's capability bypass plus per-resource ACL EDIT check. */
 async function computeCanEditByServer(req, serverConfigs) {
   const canEditByServer = new Map();
   let bypass = false;

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -219,16 +219,12 @@ async function computeCanEditByServer(req, serverConfigs) {
   const dbIdsToCheck = [];
   const dbIdToServerName = new Map();
   for (const [name, config] of Object.entries(serverConfigs)) {
-    if (isUserSourced(config)) {
-      canEditByServer.set(name, true);
-      continue;
-    }
     if (config.dbId) {
       dbIdsToCheck.push(config.dbId);
       dbIdToServerName.set(String(config.dbId), name);
       continue;
     }
-    canEditByServer.set(name, false);
+    canEditByServer.set(name, isUserSourced(config));
   }
   if (dbIdsToCheck.length > 0) {
     try {
@@ -365,7 +361,7 @@ const createMCPServerController = async (req, res) => {
     );
     res.status(201).json({
       serverName: result.serverName,
-      ...redactServerSecrets(result.config),
+      ...redactServerSecrets(result.config, { canEdit: true }),
     });
   } catch (error) {
     logger.error('[createMCPServer]', error);
@@ -461,7 +457,7 @@ const updateMCPServerController = async (req, res) => {
       userId,
     );
 
-    res.status(200).json(redactServerSecrets(parsedConfig));
+    res.status(200).json(redactServerSecrets(parsedConfig, { canEdit: true }));
   } catch (error) {
     logger.error('[updateMCPServer]', error);
     const mcpErrorResponse = handleMCPError(error, res);

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -2600,11 +2600,13 @@ describe('MCP Routes', () => {
           type: 'sse',
           url: 'http://server1.com/sse',
           title: 'Server 1',
+          source: 'user',
         },
         'server-2': {
           type: 'sse',
           url: 'http://server2.com/sse',
           title: 'Server 2',
+          source: 'user',
         },
       };
 
@@ -2676,7 +2678,7 @@ describe('MCP Routes', () => {
 
       mockRegistryInstance.addServer.mockResolvedValue({
         serverName: 'test-sse-server',
-        config: validConfig,
+        config: { ...validConfig, source: 'user' },
       });
 
       const response = await request(app).post('/api/mcp/servers').send({ config: validConfig });
@@ -3096,6 +3098,7 @@ describe('MCP Routes', () => {
         type: 'sse',
         url: 'https://mcp-server.example.com/sse',
         title: 'Test Server',
+        source: 'user',
       };
 
       mockRegistryInstance.getServerConfig.mockResolvedValue(mockConfig);
@@ -3164,7 +3167,7 @@ describe('MCP Routes', () => {
         description: 'Updated description',
       };
 
-      mockRegistryInstance.updateServer.mockResolvedValue(updatedConfig);
+      mockRegistryInstance.updateServer.mockResolvedValue({ ...updatedConfig, source: 'user' });
 
       const response = await request(app)
         .patch('/api/mcp/servers/test-server')

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -265,6 +265,7 @@ describe('redactServerSecrets', () => {
         client_id: 'cid',
         authorization_url: 'https://infra.internal/oauth/authorize',
         token_url: 'https://infra.internal/oauth/token',
+        revocation_endpoint: 'https://infra.internal/oauth/revoke',
         scope: 'read',
       },
     };
@@ -272,6 +273,7 @@ describe('redactServerSecrets', () => {
     expect(redacted.url).toBeUndefined();
     expect(redacted.oauth?.authorization_url).toBeUndefined();
     expect(redacted.oauth?.token_url).toBeUndefined();
+    expect(redacted.oauth?.revocation_endpoint).toBeUndefined();
     expect(redacted.oauth?.client_id).toBe('cid');
     expect(redacted.oauth?.scope).toBe('read');
   });

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -236,16 +236,6 @@ describe('redactServerSecrets', () => {
     expect(redacted.customUserVars).toEqual(config.customUserVars);
   });
 
-  it('should pass URLs through unchanged for user-sourced configs', () => {
-    const config: ParsedServerConfig = {
-      type: 'sse',
-      url: 'https://mcp.example.com/sse?param=value',
-      source: 'user',
-    };
-    const redacted = redactServerSecrets(config);
-    expect(redacted.url).toBe('https://mcp.example.com/sse?param=value');
-  });
-
   it('should pass URLs through unchanged when caller has edit authority', () => {
     const config: ParsedServerConfig = {
       type: 'sse',
@@ -276,6 +266,25 @@ describe('redactServerSecrets', () => {
     expect(redacted.oauth?.revocation_endpoint).toBeUndefined();
     expect(redacted.oauth?.client_id).toBe('cid');
     expect(redacted.oauth?.scope).toBe('read');
+  });
+
+  it('should strip url for a VIEW-shared user-sourced config when caller lacks edit', () => {
+    const config: ParsedServerConfig = {
+      type: 'sse',
+      url: 'https://owner-private.example.com/mcp',
+      source: 'user',
+      dbId: 'abc123',
+      oauth: {
+        client_id: 'cid',
+        authorization_url: 'https://owner-private.example.com/oauth/authorize',
+        token_url: 'https://owner-private.example.com/oauth/token',
+      },
+    };
+    const redacted = redactServerSecrets(config);
+    expect(redacted.url).toBeUndefined();
+    expect(redacted.oauth?.authorization_url).toBeUndefined();
+    expect(redacted.oauth?.token_url).toBeUndefined();
+    expect(redacted.oauth?.client_id).toBe('cid');
   });
 
   it('should retain non-sensitive oauth fields when stripping oauth flow URLs', () => {
@@ -378,20 +387,29 @@ describe('redactAllServerSecrets', () => {
           authorization_url: 'https://infra.internal/oauth/authorize',
         },
       },
-      'user-server': {
+      'user-server-owner': {
         type: 'sse',
-        url: 'https://user.example.com/mcp',
+        url: 'https://owner.example.com/mcp',
         source: 'user',
+        dbId: 'owner-id',
+      },
+      'user-server-shared': {
+        type: 'sse',
+        url: 'https://shared.example.com/mcp',
+        source: 'user',
+        dbId: 'shared-id',
       },
     };
     const canEditByServer = new Map<string, boolean>([
       ['config-server', false],
-      ['user-server', false],
+      ['user-server-owner', true],
+      ['user-server-shared', false],
     ]);
     const redacted = redactAllServerSecrets(configs, { canEditByServer });
     expect(redacted['config-server'].url).toBeUndefined();
     expect(redacted['config-server'].oauth?.authorization_url).toBeUndefined();
-    expect(redacted['user-server'].url).toBe('https://user.example.com/mcp');
+    expect(redacted['user-server-owner'].url).toBe('https://owner.example.com/mcp');
+    expect(redacted['user-server-shared'].url).toBeUndefined();
   });
 
   it('should expose URL for non-user-sourced configs when canEditByServer is true', () => {

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -236,13 +236,82 @@ describe('redactServerSecrets', () => {
     expect(redacted.customUserVars).toEqual(config.customUserVars);
   });
 
-  it('should pass URLs through unchanged', () => {
+  it('should pass URLs through unchanged for user-sourced configs', () => {
     const config: ParsedServerConfig = {
       type: 'sse',
       url: 'https://mcp.example.com/sse?param=value',
+      source: 'user',
     };
     const redacted = redactServerSecrets(config);
     expect(redacted.url).toBe('https://mcp.example.com/sse?param=value');
+  });
+
+  it('should pass URLs through unchanged when caller has edit authority', () => {
+    const config: ParsedServerConfig = {
+      type: 'sse',
+      url: 'https://infra.internal/mcp',
+      source: 'config',
+    };
+    const redacted = redactServerSecrets(config, { canEdit: true });
+    expect(redacted.url).toBe('https://infra.internal/mcp');
+  });
+
+  it('should strip url and oauth flow URLs for non-user-sourced configs without edit authority', () => {
+    const config: ParsedServerConfig = {
+      type: 'sse',
+      url: 'https://infra.internal/mcp',
+      source: 'config',
+      oauth: {
+        client_id: 'cid',
+        authorization_url: 'https://infra.internal/oauth/authorize',
+        token_url: 'https://infra.internal/oauth/token',
+        scope: 'read',
+      },
+    };
+    const redacted = redactServerSecrets(config);
+    expect(redacted.url).toBeUndefined();
+    expect(redacted.oauth?.authorization_url).toBeUndefined();
+    expect(redacted.oauth?.token_url).toBeUndefined();
+    expect(redacted.oauth?.client_id).toBe('cid');
+    expect(redacted.oauth?.scope).toBe('read');
+  });
+
+  it('should retain non-sensitive oauth fields when stripping oauth flow URLs', () => {
+    const config: ParsedServerConfig = {
+      type: 'sse',
+      url: 'https://infra.internal/mcp',
+      source: 'config',
+      oauth: {
+        client_id: 'cid',
+        client_secret: 'csecret',
+        authorization_url: 'https://infra.internal/oauth/authorize',
+        token_url: 'https://infra.internal/oauth/token',
+        scope: 'read',
+        redirect_uri: 'https://app.example.com/callback',
+      },
+    };
+    const redacted = redactServerSecrets(config);
+    expect(redacted.oauth?.client_secret).toBeUndefined();
+    expect(redacted.oauth?.authorization_url).toBeUndefined();
+    expect(redacted.oauth?.token_url).toBeUndefined();
+    expect(redacted.oauth?.client_id).toBe('cid');
+    expect(redacted.oauth?.scope).toBe('read');
+    expect(redacted.oauth?.redirect_uri).toBe('https://app.example.com/callback');
+  });
+
+  it('should preserve customUserVars metadata for non-user-sourced configs without edit authority', () => {
+    const config: ParsedServerConfig = {
+      type: 'sse',
+      url: 'https://infra.internal/mcp',
+      source: 'config',
+      customUserVars: {
+        API_KEY: { title: 'API Key', description: 'Your key', sensitive: true },
+      },
+    };
+    const redacted = redactServerSecrets(config);
+    expect(redacted.customUserVars).toEqual({
+      API_KEY: { title: 'API Key', description: 'Your key', sensitive: true },
+    });
   });
 
   it('should only include explicitly allowlisted fields', () => {
@@ -294,6 +363,46 @@ describe('redactAllServerSecrets', () => {
     expect(redacted['server-b'].oauth?.client_secret).toBeUndefined();
     expect(redacted['server-b'].oauth?.client_id).toBe('cid-b');
     expect((redacted['server-c'] as Record<string, unknown>).command).toBeUndefined();
+  });
+
+  it('should pass canEdit through per-server via canEditByServer map', () => {
+    const configs: Record<string, ParsedServerConfig> = {
+      'config-server': {
+        type: 'sse',
+        url: 'https://infra.internal/mcp',
+        source: 'config',
+        oauth: {
+          client_id: 'cid',
+          authorization_url: 'https://infra.internal/oauth/authorize',
+        },
+      },
+      'user-server': {
+        type: 'sse',
+        url: 'https://user.example.com/mcp',
+        source: 'user',
+      },
+    };
+    const canEditByServer = new Map<string, boolean>([
+      ['config-server', false],
+      ['user-server', false],
+    ]);
+    const redacted = redactAllServerSecrets(configs, { canEditByServer });
+    expect(redacted['config-server'].url).toBeUndefined();
+    expect(redacted['config-server'].oauth?.authorization_url).toBeUndefined();
+    expect(redacted['user-server'].url).toBe('https://user.example.com/mcp');
+  });
+
+  it('should expose URL for non-user-sourced configs when canEditByServer is true', () => {
+    const configs: Record<string, ParsedServerConfig> = {
+      'config-server': {
+        type: 'sse',
+        url: 'https://infra.internal/mcp',
+        source: 'config',
+      },
+    };
+    const canEditByServer = new Map<string, boolean>([['config-server', true]]);
+    const redacted = redactAllServerSecrets(configs, { canEditByServer });
+    expect(redacted['config-server'].url).toBe('https://infra.internal/mcp');
   });
 });
 

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -296,7 +296,7 @@ export function redactServerSecrets(
     safe.obo = config.obo;
   }
 
-  if (!isUserSourced(config) && !options?.canEdit) {
+  if (!options?.canEdit) {
     delete safe.url;
     if (safe.oauth) {
       const {

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -299,7 +299,12 @@ export function redactServerSecrets(
   if (!isUserSourced(config) && !options?.canEdit) {
     delete safe.url;
     if (safe.oauth) {
-      const { authorization_url: _au, token_url: _tu, ...restOAuth } = safe.oauth;
+      const {
+        authorization_url: _au,
+        token_url: _tu,
+        revocation_endpoint: _re,
+        ...restOAuth
+      } = safe.oauth;
       safe.oauth = restOAuth;
     }
   }

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -247,14 +247,11 @@ export function isUserSourced(config: Pick<ParsedServerConfig, 'source' | 'dbId'
  * Allowlist-based sanitization for API responses. Only explicitly listed fields are included;
  * new fields added to ParsedServerConfig are excluded by default until allowlisted here.
  *
- * URLs are returned as-is for user-sourced configs (the caller's own URL) and for callers
- * with edit authority on a non-user-sourced config (same disclosure they'd get via PATCH).
- * Non-user-sourced configs (operator-defined YAML/config tiers) have `url`,
- * `oauth.authorization_url`, and `oauth.token_url` stripped when the caller lacks edit
- * authority, since those values are operator-sensitive and the caller cannot edit them.
- * DB-stored configs reject ${VAR} patterns at validation time (MCPServerUserInputSchema),
- * and YAML configs are admin-managed. Env variable resolution is handled at the
- * schema/input boundary, not the output boundary.
+ * `url` and oauth flow URLs are operator-sensitive on non-user-sourced configs (YAML or
+ * config-tier); they are stripped unless the caller can edit the resource (same disclosure
+ * threshold the PATCH route enforces). User-sourced configs always disclose their URL.
+ * DB-stored configs reject ${VAR} patterns at validation time (MCPServerUserInputSchema);
+ * env variable resolution is handled at the schema/input boundary.
  */
 export function redactServerSecrets(
   config: ParsedServerConfig,
@@ -312,11 +309,7 @@ export function redactServerSecrets(
   ) as Partial<ParsedServerConfig>;
 }
 
-/**
- * Applies allowlist-based sanitization to a map of server configs.
- * Pass `canEditByServer` to allow URL/oauth-URL disclosure on non-user-sourced configs
- * for callers with edit authority on the corresponding resource.
- */
+/** Applies allowlist-based sanitization to a map of server configs. */
 export function redactAllServerSecrets(
   configs: Record<string, ParsedServerConfig>,
   options?: { canEditByServer?: ReadonlyMap<string, boolean> },

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -247,9 +247,12 @@ export function isUserSourced(config: Pick<ParsedServerConfig, 'source' | 'dbId'
  * Allowlist-based sanitization for API responses. Only explicitly listed fields are included;
  * new fields added to ParsedServerConfig are excluded by default until allowlisted here.
  *
- * `url` and oauth flow URLs are operator-sensitive on non-user-sourced configs (YAML or
- * config-tier); they are stripped unless the caller can edit the resource (same disclosure
- * threshold the PATCH route enforces). User-sourced configs always disclose their URL.
+ * `url` and the oauth flow URLs (`authorization_url`, `token_url`, `revocation_endpoint`) can
+ * encode internal infrastructure, so they are stripped unless `canEdit` is set: the same
+ * disclosure threshold the PATCH route enforces. Callers derive `canEdit` per server (operator
+ * YAML/config-tier servers from the MANAGE_MCP_SERVERS capability, user-sourced servers from
+ * per-resource ACL EDIT), so a user-sourced config shared view-only does not disclose its URL
+ * to the viewer.
  * DB-stored configs reject ${VAR} patterns at validation time (MCPServerUserInputSchema);
  * env variable resolution is handled at the schema/input boundary.
  */

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -247,11 +247,19 @@ export function isUserSourced(config: Pick<ParsedServerConfig, 'source' | 'dbId'
  * Allowlist-based sanitization for API responses. Only explicitly listed fields are included;
  * new fields added to ParsedServerConfig are excluded by default until allowlisted here.
  *
- * URLs are returned as-is: DB-stored configs reject ${VAR} patterns at validation time
- * (MCPServerUserInputSchema), and YAML configs are admin-managed. Env variable resolution
- * is handled at the schema/input boundary, not the output boundary.
+ * URLs are returned as-is for user-sourced configs (the caller's own URL) and for callers
+ * with edit authority on a non-user-sourced config (same disclosure they'd get via PATCH).
+ * Non-user-sourced configs (operator-defined YAML/config tiers) have `url`,
+ * `oauth.authorization_url`, and `oauth.token_url` stripped when the caller lacks edit
+ * authority, since those values are operator-sensitive and the caller cannot edit them.
+ * DB-stored configs reject ${VAR} patterns at validation time (MCPServerUserInputSchema),
+ * and YAML configs are admin-managed. Env variable resolution is handled at the
+ * schema/input boundary, not the output boundary.
  */
-export function redactServerSecrets(config: ParsedServerConfig): Partial<ParsedServerConfig> {
+export function redactServerSecrets(
+  config: ParsedServerConfig,
+  options?: { canEdit?: boolean },
+): Partial<ParsedServerConfig> {
   const safe: Partial<ParsedServerConfig> = {
     type: config.type,
     url: config.url,
@@ -291,18 +299,32 @@ export function redactServerSecrets(config: ParsedServerConfig): Partial<ParsedS
     safe.obo = config.obo;
   }
 
+  if (!isUserSourced(config) && !options?.canEdit) {
+    delete safe.url;
+    if (safe.oauth) {
+      const { authorization_url: _au, token_url: _tu, ...restOAuth } = safe.oauth;
+      safe.oauth = restOAuth;
+    }
+  }
+
   return Object.fromEntries(
     Object.entries(safe).filter(([, v]) => v !== undefined),
   ) as Partial<ParsedServerConfig>;
 }
 
-/** Applies allowlist-based sanitization to a map of server configs. */
+/**
+ * Applies allowlist-based sanitization to a map of server configs.
+ * Pass `canEditByServer` to allow URL/oauth-URL disclosure on non-user-sourced configs
+ * for callers with edit authority on the corresponding resource.
+ */
 export function redactAllServerSecrets(
   configs: Record<string, ParsedServerConfig>,
+  options?: { canEditByServer?: ReadonlyMap<string, boolean> },
 ): Record<string, Partial<ParsedServerConfig>> {
   const result: Record<string, Partial<ParsedServerConfig>> = {};
   for (const [key, config] of Object.entries(configs)) {
-    result[key] = redactServerSecrets(config);
+    const canEdit = options?.canEditByServer?.get(key) ?? false;
+    result[key] = redactServerSecrets(config, { canEdit });
   }
   return result;
 }


### PR DESCRIPTION
## Summary

`GET /api/mcp/servers` and `GET /api/mcp/servers/:serverName` return MCP server configs to any caller with MCP-use permission. For user-sourced configs (DB-stored, UI-submitted), the URL is the caller's own and is intentionally disclosed. For non-user-sourced configs (YAML or config-tier, operator-defined), the URL and OAuth flow endpoints (`authorization_url`, `token_url`) are operator-sensitive: they can encode internal infrastructure hostnames and are not editable through the API.

This PR redacts those fields on non-user-sourced configs unless the caller has edit authority on the resource, using the same ACL check (`PermissionBits.EDIT`) that the `PATCH` and `DELETE` routes already enforce via `canAccessMCPServerResource`. Callers with broad `MANAGE_MCP_SERVERS` capability bypass the per-resource check, matching the existing capability bypass in `canAccessResource`. `customUserVars` is intentionally not stripped: its values are UI hint metadata (`{ title, description, sensitive? }`), not user-supplied secrets; blanking it would give non-editor callers a Configure form with no field labels.

### Concrete scenario

Operator defines an MCP server in `librechat.yaml`:

```yaml
mcpServers:
  internal-tools:
    type: sse
    url: https://internal-tools.corp.example.com/mcp
    oauth:
      client_id: client-abc
      authorization_url: https://auth.corp.example.com/oauth/authorize
      token_url: https://auth.corp.example.com/oauth/token
```

Pre-PR: any user with MCP-use permission calling `GET /api/mcp/servers` sees the full config including the internal hostnames. Post-PR: a regular user receives the config with `url`, `oauth.authorization_url`, and `oauth.token_url` omitted; the rest (`client_id`, `scope`, `redirect_uri`, `customUserVars`, etc.) is preserved. A user with `EDIT` on that resource (or broad `MANAGE_MCP_SERVERS`) sees the full URLs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:

Local dev backend on `http://localhost:3080` with `librechat.yaml` containing multiple non-user-sourced MCP servers (yaml-tier and config-tier). Two accounts: one with `role: ADMIN` (broad `MANAGE_MCP_SERVERS`), one with `role: USER` (no MCP management capability, no per-server EDIT ACL).

Steps run:

1. `cd packages/api && npx jest src/mcp/__tests__/utils.test.ts`. 76 of 76 passing (6 new cases covering: URL pass-through for user-sourced configs, URL pass-through with `canEdit: true` on non-user-sourced, URL + oauth-URL stripping on non-user-sourced without `canEdit`, oauth non-sensitive fields preserved through stripping, `customUserVars` metadata preserved, `canEditByServer` map propagation).
2. `curl -H "Authorization: Bearer <admin-jwt>" http://localhost:3080/api/mcp/servers`. ADMIN sees every yaml/config-tier server with `url`, `oauth.authorization_url`, `oauth.token_url` populated. Bypass via `MANAGE_MCP_SERVERS` capability fires as expected.
3. Same curl with a USER-role JWT. 13 yaml/config-tier servers returned with `url` and `oauth.authorization_url`/`oauth.token_url` absent. `customUserVars` metadata fully preserved on the servers that declared it (e.g. `langfuse-1`, `github`, `bedrock-agentcore`): titles, descriptions, and sensitive flags all intact, so the Configure form retains its labels.
4. ESLint, Prettier, sort-imports, em-dash check, and tsc all clean on the three touched files (`packages/api/src/mcp/utils.ts`, `packages/api/src/mcp/__tests__/utils.test.ts`, `api/server/controllers/mcp.js`).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
