### PR TITLE
🎤 fix: Keep Microphone Icon Visible On Initial Chat Render

### DIFF
--- a/client/src/components/Chat/Input/AudioRecorder.tsx
+++ b/client/src/components/Chat/Input/AudioRecorder.tsx
@@ -82,10 +82,6 @@ export default memo(function AudioRecorder({
     onTranscriptionComplete,
   );
 
-  if (!textAreaRef.current) {
-    return null;
-  }
-
   const handleStartRecording = async () => {
     existingTextRef.current = getValues('text') || '';
     startRecording();
@@ -118,7 +114,7 @@ export default memo(function AudioRecorder({
           type="button"
           aria-label={localize('com_ui_use_micrphone')}
           onClick={isListening === true ? handleStopRecording : handleStartRecording}
-          disabled={disabled}
+          disabled={disabled || !textAreaRef.current}
           className={cn(
             'flex size-9 items-center justify-center rounded-full p-1 transition-colors hover:bg-surface-hover',
           )}

--- a/client/src/components/Chat/Input/AudioRecorder.tsx
+++ b/client/src/components/Chat/Input/AudioRecorder.tsx
@@ -11,13 +11,11 @@ export default memo(function AudioRecorder({
   disabled,
   ask,
   methods,
-  textAreaRef,
   isSubmitting,
 }: {
   disabled: boolean;
   ask: TAskFunction;
   methods: ReturnType<typeof useChatFormContext>;
-  textAreaRef: React.RefObject<HTMLTextAreaElement>;
   isSubmitting: boolean;
 }) {
   const { setValue, reset, getValues } = methods;
@@ -114,7 +112,7 @@ export default memo(function AudioRecorder({
           type="button"
           aria-label={localize('com_ui_use_micrphone')}
           onClick={isListening === true ? handleStopRecording : handleStartRecording}
-          disabled={disabled || !textAreaRef.current}
+          disabled={disabled}
           className={cn(
             'flex size-9 items-center justify-center rounded-full p-1 transition-colors hover:bg-surface-hover',
           )}

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -385,7 +385,6 @@ const ChatForm = memo(function ChatForm({
                 <AudioRecorder
                   methods={methods}
                   ask={submitMessage}
-                  textAreaRef={textAreaRef}
                   disabled={disableInputs || isNotAppendable}
                   isSubmitting={isSubmitting}
                 />


### PR DESCRIPTION
## Summary

`AudioRecorder` returned `null` whenever the parent `ChatForm`'s `textAreaRef` was still unset, which is always the case on the first paint of a new chat or a page refresh. Because populating a ref does not trigger a re-render and `AudioRecorder` is `memo`-wrapped, the microphone icon stayed missing until some unrelated prop change (`disabled`, `isSubmitting`, `ask`) forced a re-render.

This removes the early-return guard and instead renders the button in a disabled state while the ref is unset, so the icon is always visible.

## Changes

- `client/src/components/Chat/Input/AudioRecorder.tsx`
  - Removed the `if (!textAreaRef.current) { return null; }` guard.
  - Changed the button's `disabled` prop to `disabled={disabled || !textAreaRef.current}`.

## Why this is safe

`textAreaRef` was only ever read by that guard — the STT hook (`useSpeechToText`) and both `handleStartRecording`/`handleStopRecording` never touch `textAreaRef.current`, so there is no functional dependency on the ref being populated.

Closes #13786
