### PR TITLE
feat(sidebar): individual full-page routes for tool panels (memories, bookmarks, files, mcp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ monospace.json
 *.iml
 *.pem
 config.local.ts
+client/src/dev.local.jsx
 **/storageState.json
 junit.xml
 **/.venv/

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -132,6 +132,7 @@ export type NavLink = {
   onClick?: (e?: React.MouseEvent) => void;
   variant?: 'default' | 'ghost';
   id: string;
+  href?: string;
 };
 
 export interface DataColumnMeta {

--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -42,17 +42,12 @@ function Header() {
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
 
   return (
-    <div className="via-presentation/70 md:from-presentation/80 md:via-presentation/50 2xl:from-presentation/0 absolute top-0 z-10 flex h-[52px] w-full items-center justify-between bg-gradient-to-b from-presentation to-transparent p-2 font-semibold text-text-primary 2xl:via-transparent">
+    <div className="via-presentation/70 md:from-presentation/80 md:via-presentation/50 2xl:from-presentation/0 absolute top-0 z-10 flex w-full items-center justify-between bg-gradient-to-b from-presentation to-transparent p-4 font-semibold text-text-primary 2xl:via-transparent">
       <div className="hide-scrollbar flex w-full items-center justify-between gap-2 overflow-x-auto">
-        <div className="mx-1 flex items-center">
+        <div className="flex items-center gap-2">
           <OpenSidebar className="md:hidden" />
           {!(navVisible && isSmallScreen) && (
-            <div
-              className={cn(
-                'flex items-center gap-2 pl-2',
-                !isSmallScreen ? 'transition-all duration-200 ease-in-out' : '',
-              )}
-            >
+            <>
               <ModelSelector startupConfig={startupConfig} />
               {interfaceConfig.presets === true && interfaceConfig.modelSelect && <PresetsMenu />}
               {hasAccessToBookmarks === true && <BookmarkMenu />}
@@ -65,7 +60,7 @@ function Header() {
                   {hasAccessToTemporaryChat === true && <TemporaryChat />}
                 </>
               )}
-            </div>
+            </>
           )}
         </div>
 

--- a/client/src/components/Chat/Input/Files/Table/DataTable.tsx
+++ b/client/src/components/Chat/Input/Files/Table/DataTable.tsx
@@ -93,7 +93,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <div className="flex flex-wrap items-center gap-2 py-2 sm:gap-4 sm:py-4">
+      <div className="flex flex-wrap items-center gap-2 sm:gap-4">
         <Button
           variant="outline"
           onClick={() => {

--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -57,7 +57,7 @@ const MeasuredRow: FC<MeasuredRowProps> = memo(
   ({ cache, rowKey, parent, index, style, children }) => (
     <CellMeasurer cache={cache} columnIndex={0} key={rowKey} parent={parent} rowIndex={index}>
       {({ registerChild }) => (
-        <div ref={registerChild as React.LegacyRef<HTMLDivElement>} style={style} className="px-3">
+        <div ref={registerChild as React.LegacyRef<HTMLDivElement>} style={style} className="px-2">
           {children}
         </div>
       )}
@@ -102,17 +102,23 @@ const ChatsHeader: FC<ChatsHeaderProps> = memo(({ isExpanded, onToggle }) => {
   }, [conversation?.conversationId, newConversation, queryClient]);
 
   return (
-    <div className="flex h-8 w-full items-center gap-0.5 pr-2">
+    <div className="flex h-7 w-full items-center justify-between gap-0.5 pr-1">
       <button
         onClick={onToggle}
-        className="group flex min-w-0 flex-1 items-center gap-1 rounded-lg px-1 py-2 text-xs font-bold text-text-secondary outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
+        className="flex min-w-0 flex-1 items-center gap-1 rounded px-1 py-1 outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
         type="button"
         aria-expanded={isExpanded}
+        aria-label={localize('com_ui_chats')}
       >
-        <span className="select-none truncate">{localize('com_ui_chats')}</span>
+        <span
+          className="select-none truncate tracking-wide text-text-secondary"
+          style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}
+        >
+          {localize('com_ui_chats')}
+        </span>
         <ChevronDown
           className={cn(
-            'h-3 w-3 shrink-0 transition-transform duration-200',
+            'h-3 w-3 shrink-0 text-text-secondary transition-transform duration-200',
             isExpanded ? '' : '-rotate-90',
           )}
           aria-hidden="true"
@@ -127,7 +133,7 @@ const ChatsHeader: FC<ChatsHeaderProps> = memo(({ isExpanded, onToggle }) => {
             className={headerIconButtonClassName}
             onClick={handleNewChat}
           >
-            <NewChatIcon className="h-4 w-4" />
+            <NewChatIcon className="h-3.5 w-3.5" />
           </button>
         }
       />
@@ -144,8 +150,11 @@ const DateLabel: FC<{ groupName: string; isFirst?: boolean }> = memo(({ groupNam
       aria-label={localize('com_a11y_chats_date_section', {
         date: localize(groupName as TranslationKeys) || groupName,
       })}
-      className={cn('pl-1 pt-1 text-text-secondary', isFirst === true ? 'mt-0' : 'mt-2')}
-      style={{ fontSize: '0.7rem' }}
+      className={cn(
+        'select-none pl-1 tracking-wide text-text-secondary',
+        isFirst === true ? 'pt-1' : 'mt-3 pt-1',
+      )}
+      style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}
     >
       {localize(groupName as TranslationKeys) || groupName}
     </h2>
@@ -176,7 +185,7 @@ const Conversations: FC<ConversationsProps> = ({
   const search = useRecoilValue(store.search);
   const { favorites, isLoading: isFavoritesLoading } = useFavorites();
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
-  const convoHeight = isSmallScreen ? 44 : 34;
+  const convoHeight = isSmallScreen ? 40 : 32;
   const showAgentMarketplace = useShowMarketplace();
 
   const favoritesContentKeyRef = useRef('');
@@ -356,7 +365,7 @@ const Conversations: FC<ConversationsProps> = ({
 
   return (
     <div className="relative flex h-full min-h-0 flex-col pb-2 text-sm text-text-primary">
-      <div className="px-3">
+      <div className="px-2">
         <ChatsHeader
           isExpanded={isChatsExpanded}
           onToggle={() => setIsChatsExpanded(!isChatsExpanded)}

--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -11,7 +11,6 @@ import {
   useLocalize,
   TranslationKeys,
   useFavorites,
-  useShowMarketplace,
   useNewConvo,
 } from '~/hooks';
 import { groupConversationsByDate, clearMessagesCache, cn } from '~/utils';
@@ -41,6 +40,7 @@ interface ConversationsProps {
   isChatsExpanded: boolean;
   setIsChatsExpanded: (expanded: boolean) => void;
   showFavorites?: boolean;
+  hideHeader?: boolean;
 }
 
 interface MeasuredRowProps {
@@ -180,13 +180,13 @@ const Conversations: FC<ConversationsProps> = ({
   isChatsExpanded,
   setIsChatsExpanded,
   showFavorites = true,
+  hideHeader = false,
 }) => {
   const localize = useLocalize();
   const search = useRecoilValue(store.search);
   const { favorites, isLoading: isFavoritesLoading } = useFavorites();
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
   const convoHeight = isSmallScreen ? 40 : 32;
-  const showAgentMarketplace = useShowMarketplace();
 
   const favoritesContentKeyRef = useRef('');
 
@@ -199,11 +199,9 @@ const Conversations: FC<ConversationsProps> = ({
 
   // Determine if FavoritesList will render content
   const shouldShowFavorites =
-    showFavorites &&
-    !search.query &&
-    (isFavoritesLoading || favorites.length > 0 || showAgentMarketplace);
+    showFavorites && !search.query && (isFavoritesLoading || favorites.length > 0);
 
-  favoritesContentKeyRef.current = `${favorites.length}-${showAgentMarketplace ? 1 : 0}-${isFavoritesLoading ? 1 : 0}`;
+  favoritesContentKeyRef.current = `${favorites.length}-${isFavoritesLoading ? 1 : 0}`;
 
   const filteredConversations = useMemo(
     () => rawConversations.filter(Boolean) as TConversation[],
@@ -282,7 +280,7 @@ const Conversations: FC<ConversationsProps> = ({
       clearFavoritesCache();
     });
     return () => cancelAnimationFrame(frameId);
-  }, [favorites.length, isFavoritesLoading, showAgentMarketplace, clearFavoritesCache]);
+  }, [favorites.length, isFavoritesLoading, clearFavoritesCache]);
 
   useEffect(() => {
     const frameId = requestAnimationFrame(() => {
@@ -365,12 +363,14 @@ const Conversations: FC<ConversationsProps> = ({
 
   return (
     <div className="relative flex h-full min-h-0 flex-col pb-2 text-sm text-text-primary">
-      <div className="px-2">
-        <ChatsHeader
-          isExpanded={isChatsExpanded}
-          onToggle={() => setIsChatsExpanded(!isChatsExpanded)}
-        />
-      </div>
+      {!hideHeader && (
+        <div className="px-2">
+          <ChatsHeader
+            isExpanded={isChatsExpanded}
+            onToggle={() => setIsChatsExpanded(!isChatsExpanded)}
+          />
+        </div>
+      )}
       {isSearchLoading ? (
         <div className="flex flex-1 items-center justify-center">
           <Spinner className="text-text-primary" />
@@ -405,5 +405,5 @@ const Conversations: FC<ConversationsProps> = ({
   );
 };
 
-export { DateLabel };
+export { DateLabel, ChatsHeader };
 export default memo(Conversations);

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -216,10 +216,10 @@ function Conversation({
     <div
       ref={containerRef}
       className={cn(
-        'group relative flex h-12 w-full items-center rounded-lg outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white md:h-9',
+        'group relative flex h-10 w-full items-center rounded-md outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white md:h-8',
         isActiveConvo || isPopoverActive
-          ? 'bg-surface-active-alt before:absolute before:bottom-1 before:left-0 before:top-1 before:w-0.5 before:rounded-full before:bg-black dark:before:bg-white'
-          : 'hover:bg-surface-active-alt',
+          ? 'bg-surface-active-alt before:absolute before:bottom-1 before:left-0 before:top-1 before:w-0.5 before:rounded-full before:bg-text-primary'
+          : 'hover:bg-surface-hover',
       )}
       role="button"
       tabIndex={renaming ? -1 : 0}

--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -23,7 +23,7 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
   return (
     <div
       className={cn(
-        'flex min-w-0 grow items-center gap-2 overflow-hidden rounded-lg px-2',
+        'flex min-w-0 grow items-center gap-1.5 overflow-hidden rounded-md px-2',
         isActiveConvo || isPopoverActive ? 'bg-surface-active-alt' : '',
       )}
       title={title ?? undefined}
@@ -32,7 +32,7 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
     >
       {children}
       <div
-        className="relative flex-1 grow overflow-hidden whitespace-nowrap"
+        className="relative flex-1 grow overflow-hidden whitespace-nowrap text-sm"
         style={{ textOverflow: 'clip' }}
         onDoubleClick={(e) => {
           if (isSmallScreen) {
@@ -48,10 +48,10 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
       </div>
       <div
         className={cn(
-          'pointer-events-none absolute bottom-0.5 right-0.5 top-0.5 w-20 rounded-r-md bg-gradient-to-l',
+          'pointer-events-none absolute bottom-0.5 right-0.5 top-0.5 w-16 rounded-r-md bg-gradient-to-l',
           isActiveConvo || isPopoverActive
             ? 'from-surface-active-alt'
-            : 'from-surface-primary-alt from-0% to-transparent group-hover:from-surface-active-alt group-hover:from-40%',
+            : 'from-surface-primary-alt from-0% to-transparent group-hover:from-surface-hover group-hover:from-40%',
         )}
         aria-hidden="true"
       />

--- a/client/src/components/Conversations/ProjectsSection.tsx
+++ b/client/src/components/Conversations/ProjectsSection.tsx
@@ -326,13 +326,13 @@ const ProjectItem = memo(
 
     return (
       <li className="list-none">
-        <div className="group/project-row relative flex h-9 items-center rounded-lg text-sm text-text-primary transition-colors hover:bg-surface-active-alt">
+        <div className="group/project-row relative flex h-8 items-center rounded-md text-sm text-text-primary transition-colors hover:bg-surface-hover">
           <button
             type="button"
             onClick={() => setExpanded((prev) => !prev)}
             aria-expanded={expanded}
             aria-label={project.name}
-            className="flex min-w-0 flex-1 items-center gap-1.5 rounded-lg py-1.5 pl-1.5 pr-14 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
+            className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md py-1 pl-1.5 pr-14 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
           >
             <ChevronRight
               className={cn(
@@ -494,21 +494,26 @@ const ProjectsSection = ({ toggleNav, isAuthenticated }: ProjectsSectionProps) =
   }
 
   return (
-    <div className="flex flex-col px-3 text-sm">
-      <div className="flex h-8 w-full items-center gap-0.5 pr-2">
+    <div className="flex flex-col px-2 text-sm">
+      <div className="flex h-7 w-full items-center gap-0.5 pr-1">
         <button
           onClick={() => {
             setStoredExpanded(!isExpanded);
             setHasToggledSection(true);
           }}
-          className="group flex min-w-0 flex-1 items-center gap-1 rounded-lg px-1 py-2 text-xs font-bold text-text-secondary outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
+          className="flex min-w-0 flex-1 items-center gap-1 rounded px-1 py-1 outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
           type="button"
           aria-expanded={isExpanded}
         >
-          <span className="select-none truncate">{localize('com_ui_projects')}</span>
+          <span
+            className="select-none truncate tracking-wide text-text-secondary"
+            style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}
+          >
+            {localize('com_ui_projects')}
+          </span>
           <ChevronDown
             className={cn(
-              'h-3 w-3 shrink-0 transition-transform duration-200',
+              'h-3 w-3 shrink-0 text-text-secondary transition-transform duration-200',
               isExpanded ? '' : '-rotate-90',
             )}
             aria-hidden="true"

--- a/client/src/components/Conversations/index.ts
+++ b/client/src/components/Conversations/index.ts
@@ -1,4 +1,4 @@
 export { default as Fork } from '../Chat/Messages/Fork';
 export { default as Pages } from './Pages';
-export { default as Conversations } from './Conversations';
+export { default as Conversations, ChatsHeader } from './Conversations';
 export * from './ConvoOptions';

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -1,9 +1,7 @@
 import React, { useRef, useCallback, useMemo, useEffect } from 'react';
-import { LayoutGrid } from 'lucide-react';
 import { useRecoilValue } from 'recoil';
 import { useDrag, useDrop } from 'react-dnd';
 import { Skeleton } from '@librechat/client';
-import { useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
 import { QueryKeys, dataService } from 'librechat-data-provider';
 import type { Agent, TEndpointsConfig, TModelSpec } from 'librechat-data-provider';
@@ -12,7 +10,6 @@ import {
   useGetConversation,
   useFavorites,
   useLocalize,
-  useShowMarketplace,
   useNewConvo,
 } from '~/hooks';
 import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
@@ -123,13 +120,10 @@ export default function FavoritesList({
   isSmallScreen?: boolean;
   toggleNav?: () => void;
 }) {
-  const navigate = useNavigate();
   const localize = useLocalize();
   const search = useRecoilValue(store.search);
   const getConversation = useGetConversation(0);
   const { favorites, reorderFavorites, isLoading: isFavoritesLoading } = useFavorites();
-  const showAgentMarketplace = useShowMarketplace();
-
   const { newConversation } = useNewConvo();
   const assistantsMap = useAssistantsMapContext();
   const agentsMap = useAgentsMapContext();
@@ -178,21 +172,9 @@ export default function FavoritesList({
     [_onSelectSpec, isSmallScreen, toggleNav],
   );
 
-  const marketplaceRef = useRef<HTMLDivElement>(null);
   const listContainerRef = useRef<HTMLDivElement>(null);
 
-  const handleAgentMarketplace = useCallback(() => {
-    navigate('/agents');
-    if (isSmallScreen && toggleNav) {
-      toggleNav();
-    }
-  }, [navigate, isSmallScreen, toggleNav]);
-
   const handleRemoveFocus = useCallback(() => {
-    if (marketplaceRef.current) {
-      marketplaceRef.current.focus();
-      return;
-    }
     const nextFavorite = listContainerRef.current?.querySelector<HTMLElement>(
       '[data-testid="favorite-item"]',
     );
@@ -341,7 +323,7 @@ export default function FavoritesList({
     return null;
   }
 
-  if (!isFavoritesLoading && safeFavorites.length === 0 && !showAgentMarketplace) {
+  if (!isFavoritesLoading && safeFavorites.length === 0) {
     return null;
   }
 
@@ -349,7 +331,6 @@ export default function FavoritesList({
     return (
       <div className="mb-2 flex flex-col pb-2">
         <div className="mt-1 flex flex-col gap-1">
-          {showAgentMarketplace && <MarketplaceSkeleton />}
           <FavoriteItemSkeleton />
         </div>
       </div>
@@ -359,43 +340,14 @@ export default function FavoritesList({
   return (
     <div className="mb-2 flex flex-col">
       <div ref={listContainerRef} className="mt-1 flex flex-col gap-1">
-        {/* Show skeletons for ALL items while agents are still loading */}
         {isAgentsLoading ? (
           <>
-            {/* Marketplace skeleton */}
-            {showAgentMarketplace && <MarketplaceSkeleton />}
-            {/* Favorite items skeletons */}
             {safeFavorites.map((_, index) => (
               <FavoriteItemSkeleton key={`skeleton-${index}`} />
             ))}
           </>
         ) : (
           <>
-            {/* Agent Marketplace button */}
-            {showAgentMarketplace && (
-              <div
-                ref={marketplaceRef}
-                role="button"
-                tabIndex={0}
-                aria-label={localize('com_agents_marketplace')}
-                className="group relative flex w-full cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-sm text-text-primary outline-none hover:bg-surface-active-alt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-black dark:focus-visible:ring-white"
-                onClick={handleAgentMarketplace}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    handleAgentMarketplace();
-                  }
-                }}
-                data-testid="nav-agents-marketplace-button"
-              >
-                <div className="flex flex-1 items-center truncate pr-6">
-                  <div className="mr-2 h-5 w-5">
-                    <LayoutGrid className="h-5 w-5 text-text-primary" />
-                  </div>
-                  <span className="truncate">{localize('com_agents_marketplace')}</span>
-                </div>
-              </div>
-            )}
             {safeFavorites.map((fav, index) => {
               if (fav.agentId) {
                 const agent = combinedAgentsMap?.[fav.agentId];

--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -109,16 +109,16 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
   return (
     <div
       ref={ref}
-      className="group relative flex h-9 min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-lg border-2 border-transparent px-3 py-1.5 text-text-primary focus-within:border-ring-primary focus-within:bg-surface-active-alt hover:bg-surface-active-alt"
+      className="group relative flex h-7 min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-md border border-border-light bg-surface-secondary px-2 py-1 text-text-primary focus-within:border-ring-primary focus-within:bg-surface-active-alt hover:bg-surface-active-alt"
     >
       <Search
         aria-hidden="true"
-        className="absolute left-3 h-4 w-4 text-text-secondary group-focus-within:text-text-primary group-hover:text-text-primary"
+        className="absolute left-2 h-3.5 w-3.5 text-text-secondary group-focus-within:text-text-primary group-hover:text-text-primary"
       />
       <input
         type="text"
         ref={inputRef}
-        className="m-0 mr-0 w-full border-none bg-transparent p-0 pl-7 text-sm leading-tight placeholder-text-secondary placeholder-opacity-100 focus-visible:outline-none group-focus-within:placeholder-text-primary group-hover:placeholder-text-primary"
+        className="m-0 mr-0 w-full border-none bg-transparent p-0 pl-5 text-xs leading-tight placeholder-text-secondary placeholder-opacity-100 focus-visible:outline-none group-focus-within:placeholder-text-primary group-hover:placeholder-text-primary"
         value={text}
         onChange={onChange}
         onKeyDown={(e) => {
@@ -136,15 +136,15 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
         type="button"
         aria-label={localize('com_ui_clear_search')}
         className={cn(
-          'absolute right-[7px] flex h-5 w-5 items-center justify-center rounded-full border-none bg-transparent p-0 transition-opacity duration-200',
+          'absolute right-1.5 flex h-4 w-4 items-center justify-center rounded-full border-none bg-transparent p-0 transition-opacity duration-200',
           showClearIcon ? 'opacity-100' : 'opacity-0',
-          isSmallScreen === true ? 'right-[16px]' : '',
+          isSmallScreen === true ? 'right-3' : '',
         )}
         onClick={() => clearText(location.pathname)}
         tabIndex={showClearIcon ? 0 : -1}
         disabled={!showClearIcon}
       >
-        <X className="h-5 w-5 cursor-pointer" aria-hidden="true" />
+        <X className="h-3.5 w-3.5 cursor-pointer" aria-hidden="true" />
       </button>
     </div>
   );

--- a/client/src/components/Prompts/forms/CreatePromptForm.tsx
+++ b/client/src/components/Prompts/forms/CreatePromptForm.tsx
@@ -112,7 +112,7 @@ const CreatePromptForm = ({
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={handleSubmit(onSubmit)} className="w-full px-4 py-2">
+      <form onSubmit={handleSubmit(onSubmit)} className="w-full">
         <h1 className="sr-only">{localize('com_ui_create_prompt_page')}</h1>
         <div className="mb-2 flex items-center justify-between gap-2 sm:hidden">
           <OpenSidebar />

--- a/client/src/components/Prompts/layouts/InlinePromptsView.tsx
+++ b/client/src/components/Prompts/layouts/InlinePromptsView.tsx
@@ -1,12 +1,14 @@
 import { useCallback } from 'react';
 import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import PageHeader from '~/components/ui/PageHeader';
 import EmptyPromptPreview from '../display/EmptyPromptPreview';
 import CreatePromptForm from '../forms/CreatePromptForm';
-import { useHasAccess } from '~/hooks';
+import { useHasAccess, useLocalize } from '~/hooks';
 import PromptForm from '../forms/PromptForm';
 
 export default function InlinePromptsView() {
+  const localize = useLocalize();
   const { promptId } = useParams();
   const navigate = useNavigate();
   const isNew = promptId === undefined;
@@ -37,12 +39,15 @@ export default function InlinePromptsView() {
   }
 
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
-      {isNew ? (
-        <CreatePromptForm onSuccess={handleCreateSuccess} />
-      ) : (
-        <PromptForm promptId={promptId} />
-      )}
-    </div>
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_ui_prompts')} />
+      <div className="flex w-full flex-1 flex-col p-6">
+        {isNew ? (
+          <CreatePromptForm onSuccess={handleCreateSuccess} />
+        ) : (
+          <PromptForm promptId={promptId} />
+        )}
+      </div>
+    </main>
   );
 }

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -22,7 +22,7 @@ import {
   useGetExpandedAgentByIdQuery,
   useUploadAgentAvatarMutation,
 } from '~/data-provider';
-import { createProviderOption, getDefaultAgentFormValues } from '~/utils';
+import { createProviderOption, getDefaultAgentFormValues, cn } from '~/utils';
 import { useResourcePermissions } from '~/hooks/useResourcePermissions';
 import { useSelectAgent, useLocalize, useAuthContext } from '~/hooks';
 import { useAgentPanelContext } from '~/Providers/AgentPanelContext';
@@ -212,7 +212,7 @@ export const isAvatarUploadOnlyDirty = (
   return result.sawDirty && result.onlyAvatarDirty;
 };
 
-export default function AgentPanel() {
+export default function AgentPanel({ noPadding = false }: { noPadding?: boolean }) {
   const localize = useLocalize();
   const { user } = useAuthContext();
   const { showToast } = useToastContext();
@@ -486,7 +486,7 @@ export default function AgentPanel() {
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="scrollbar-gutter-stable flex flex-1 flex-col px-3 pb-3 pt-2"
+        className={cn('scrollbar-gutter-stable flex flex-1 flex-col', !noPadding && 'px-3 pb-3 pt-2')}
         aria-label="Agent configuration form"
       >
         <div className="flex-1">

--- a/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSwitch.tsx
@@ -7,15 +7,15 @@ import ActionsPanel from './ActionsPanel';
 import AgentPanel from './AgentPanel';
 import store from '~/store';
 
-export default function AgentPanelSwitch() {
+export default function AgentPanelSwitch({ noPadding = false }: { noPadding?: boolean }) {
   return (
     <AgentPanelProvider>
-      <AgentPanelSwitchWithContext />
+      <AgentPanelSwitchWithContext noPadding={noPadding} />
     </AgentPanelProvider>
   );
 }
 
-function AgentPanelSwitchWithContext() {
+function AgentPanelSwitchWithContext({ noPadding }: { noPadding?: boolean }) {
   const { activePanel, setCurrentAgentId } = useAgentPanelContext();
   const agentId = useRecoilValue(store.conversationAgentIdByIndex(0));
 
@@ -32,5 +32,5 @@ function AgentPanelSwitchWithContext() {
   if (activePanel === Panel.version) {
     return <VersionPanel />;
   }
-  return <AgentPanel />;
+  return <AgentPanel noPadding={noPadding} />;
 }

--- a/client/src/components/SidePanel/Agents/layouts/AgentsView.tsx
+++ b/client/src/components/SidePanel/Agents/layouts/AgentsView.tsx
@@ -1,0 +1,15 @@
+import PageHeader from '~/components/ui/PageHeader';
+import { useLocalize } from '~/hooks';
+import AgentPanelSwitch from '../AgentPanelSwitch';
+
+export default function AgentsView() {
+  const localize = useLocalize();
+  return (
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_sidepanel_agent_builder')} />
+      <div className="flex w-full flex-1 flex-col gap-6 p-6">
+        <AgentPanelSwitch noPadding />
+      </div>
+    </main>
+  );
+}

--- a/client/src/components/SidePanel/Bookmarks/BookmarkPanel.tsx
+++ b/client/src/components/SidePanel/Bookmarks/BookmarkPanel.tsx
@@ -2,11 +2,11 @@ import { useConversationTagsQuery } from '~/data-provider';
 import { BookmarkContext } from '~/Providers/BookmarkContext';
 import BookmarkTable from './BookmarkTable';
 
-const BookmarkPanel = () => {
+const BookmarkPanel = ({ noPadding = false }: { noPadding?: boolean }) => {
   const { data } = useConversationTagsQuery();
 
   return (
-    <div className="h-auto max-w-full overflow-x-visible pt-2">
+    <div className={noPadding ? 'h-auto max-w-full overflow-x-visible' : 'h-auto max-w-full overflow-x-visible px-3 pb-3 pt-2'}>
       <BookmarkContext.Provider value={{ bookmarks: data || [] }}>
         <BookmarkTable />
       </BookmarkContext.Provider>

--- a/client/src/components/SidePanel/Bookmarks/BookmarkTable.tsx
+++ b/client/src/components/SidePanel/Bookmarks/BookmarkTable.tsx
@@ -55,7 +55,7 @@ const BookmarkTable = () => {
 
   return (
     <BookmarkContext.Provider value={{ bookmarks }}>
-      <div role="region" aria-label={localize('com_ui_bookmarks')} className="space-y-2 px-3 pb-3">
+      <div role="region" aria-label={localize('com_ui_bookmarks')} className="space-y-2 pb-3">
         {/* Header: Filter + Create Button */}
         <div className="flex items-center gap-2">
           <FilterInput

--- a/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
+++ b/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
@@ -1,14 +1,19 @@
 import { Navigate } from 'react-router-dom';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
-import { useHasAccess } from '~/hooks';
-import BookmarkPanel from '~/components/SidePanel/Bookmarks/BookmarkPanel';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
+import BookmarkPanel from '../BookmarkPanel';
 
 export default function BookmarksView() {
+  const localize = useLocalize();
   const hasAccess = useHasAccess({ permissionType: PermissionTypes.BOOKMARKS, permission: Permissions.USE });
   if (!hasAccess) return <Navigate to="/c/new" replace />;
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
-      <BookmarkPanel />
-    </div>
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_sidepanel_conversation_tags')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <BookmarkPanel noPadding />
+      </div>
+    </main>
   );
 }

--- a/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
+++ b/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
@@ -1,0 +1,14 @@
+import { Navigate } from 'react-router-dom';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import { useHasAccess } from '~/hooks';
+import BookmarkPanel from '~/components/SidePanel/Bookmarks/BookmarkPanel';
+
+export default function BookmarksView() {
+  const hasAccess = useHasAccess({ permissionType: PermissionTypes.BOOKMARKS, permission: Permissions.USE });
+  if (!hasAccess) return <Navigate to="/c/new" replace />;
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
+      <BookmarkPanel />
+    </div>
+  );
+}

--- a/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
+++ b/client/src/components/SidePanel/Bookmarks/layouts/BookmarksView.tsx
@@ -11,7 +11,7 @@ export default function BookmarksView() {
   return (
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
       <PageHeader title={localize('com_sidepanel_conversation_tags')} />
-      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+      <div className="flex w-full flex-1 flex-col gap-6 p-6">
         <BookmarkPanel noPadding />
       </div>
     </main>

--- a/client/src/components/SidePanel/Files/layouts/FilesView.tsx
+++ b/client/src/components/SidePanel/Files/layouts/FilesView.tsx
@@ -1,0 +1,9 @@
+import FilesPanel from '~/components/SidePanel/Files/Panel';
+
+export default function FilesView() {
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
+      <FilesPanel />
+    </div>
+  );
+}

--- a/client/src/components/SidePanel/Files/layouts/FilesView.tsx
+++ b/client/src/components/SidePanel/Files/layouts/FilesView.tsx
@@ -20,8 +20,8 @@ export default function FilesView() {
 
   return (
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
-      <PageHeader title={localize('com_nav_my_files')} />
-      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+      <PageHeader title={localize('com_sidepanel_attach_files')} />
+      <div className="flex w-full flex-1 flex-col gap-6 p-6">
         <DataTable columns={columns} data={files} />
       </div>
     </main>

--- a/client/src/components/SidePanel/Files/layouts/FilesView.tsx
+++ b/client/src/components/SidePanel/Files/layouts/FilesView.tsx
@@ -1,9 +1,29 @@
-import FilesPanel from '~/components/SidePanel/Files/Panel';
+import { FileSources, FileContext } from 'librechat-data-provider';
+import type { TFile } from 'librechat-data-provider';
+import { DataTable, columns } from '~/components/Chat/Input/Files/Table';
+import PageHeader from '~/components/ui/PageHeader';
+import { useGetFiles } from '~/data-provider';
+import { useLocalize } from '~/hooks';
 
 export default function FilesView() {
+  const localize = useLocalize();
+
+  const { data: files = [] } = useGetFiles<TFile[]>({
+    select: (data) =>
+      data.map((file) => {
+        file.context = file.context ?? FileContext.unknown;
+        file.filterSource =
+          file.source === FileSources.firebase ? FileSources.local : file.source;
+        return file;
+      }),
+  });
+
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
-      <FilesPanel />
-    </div>
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_nav_my_files')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <DataTable columns={columns} data={files} />
+      </div>
+    </main>
   );
 }

--- a/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
@@ -8,7 +8,7 @@ import MCPAdminSettings from './MCPAdminSettings';
 import MCPServerDialog from './MCPServerDialog';
 import MCPServerList from './MCPServerList';
 
-export default function MCPBuilderPanel() {
+export default function MCPBuilderPanel({ noPadding = false }: { noPadding?: boolean }) {
   const localize = useLocalize();
   const { availableMCPServers, isLoading, getServerStatusIconProps, getConfigDialogProps } =
     useMCPServerManager();
@@ -36,7 +36,7 @@ export default function MCPBuilderPanel() {
   }, [availableMCPServers, searchQuery]);
 
   return (
-    <div className="flex h-auto w-full flex-col px-3 pb-3 pt-2">
+    <div className={noPadding ? 'flex h-auto w-full flex-col' : 'flex h-auto w-full flex-col px-3 pb-3 pt-2'}>
       <div role="region" aria-label={localize('com_ui_mcp_servers')} className="space-y-2">
         {/* Toolbar: Search + Add Button */}
         <div className="flex items-center gap-2">

--- a/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
@@ -1,15 +1,20 @@
 import { Navigate } from 'react-router-dom';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
-import { useHasAccess } from '~/hooks';
-import MCPBuilderPanel from '~/components/SidePanel/MCPBuilder/MCPBuilderPanel';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
+import MCPBuilderPanel from '../MCPBuilderPanel';
 
 export default function MCPView() {
+  const localize = useLocalize();
   const hasUse = useHasAccess({ permissionType: PermissionTypes.MCP_SERVERS, permission: Permissions.USE });
   const hasCreate = useHasAccess({ permissionType: PermissionTypes.MCP_SERVERS, permission: Permissions.CREATE });
   if (!hasUse && !hasCreate) return <Navigate to="/c/new" replace />;
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
-      <MCPBuilderPanel />
-    </div>
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_nav_setting_mcp')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <MCPBuilderPanel noPadding />
+      </div>
+    </main>
   );
 }

--- a/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
@@ -12,7 +12,7 @@ export default function MCPView() {
   return (
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
       <PageHeader title={localize('com_nav_setting_mcp')} />
-      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+      <div className="flex w-full flex-1 flex-col gap-6 p-6">
         <MCPBuilderPanel noPadding />
       </div>
     </main>

--- a/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/layouts/MCPView.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import { useHasAccess } from '~/hooks';
+import MCPBuilderPanel from '~/components/SidePanel/MCPBuilder/MCPBuilderPanel';
+
+export default function MCPView() {
+  const hasUse = useHasAccess({ permissionType: PermissionTypes.MCP_SERVERS, permission: Permissions.USE });
+  const hasCreate = useHasAccess({ permissionType: PermissionTypes.MCP_SERVERS, permission: Permissions.CREATE });
+  if (!hasUse && !hasCreate) return <Navigate to="/c/new" replace />;
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
+      <MCPBuilderPanel />
+    </div>
+  );
+}

--- a/client/src/components/SidePanel/Memories/MemoryPanel.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryPanel.tsx
@@ -25,7 +25,7 @@ import MemoryList from './MemoryList';
 
 const pageSize = 10;
 
-export default function MemoryPanel() {
+export default function MemoryPanel({ noPadding = false }: { noPadding?: boolean }) {
   const localize = useLocalize();
   const { user } = useAuthContext();
   const { data: userData } = useGetUserQuery();
@@ -121,7 +121,7 @@ export default function MemoryPanel() {
   const totalPages = Math.ceil(filteredMemories.length / pageSize);
 
   return (
-    <div className="flex h-auto w-full flex-col px-3 pb-3 pt-2">
+    <div className={noPadding ? 'flex h-auto w-full flex-col' : 'flex h-auto w-full flex-col px-3 pb-3 pt-2'}>
       <div role="region" aria-label={localize('com_ui_memories')} className="space-y-2">
         {/* Header: Filter + Create Button */}
         <div className="flex items-center gap-2">

--- a/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
+++ b/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { PermissionTypes, Permissions } from 'librechat-data-provider';
+import { useHasAccess } from '~/hooks';
+import { MemoryPanel } from '~/components/SidePanel/Memories';
+
+export default function MemoriesView() {
+  const hasUse = useHasAccess({ permissionType: PermissionTypes.MEMORIES, permission: Permissions.USE });
+  const hasRead = useHasAccess({ permissionType: PermissionTypes.MEMORIES, permission: Permissions.READ });
+  if (!hasUse || !hasRead) return <Navigate to="/c/new" replace />;
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
+      <MemoryPanel />
+    </div>
+  );
+}

--- a/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
+++ b/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
@@ -1,15 +1,20 @@
 import { Navigate } from 'react-router-dom';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
-import { useHasAccess } from '~/hooks';
-import { MemoryPanel } from '~/components/SidePanel/Memories';
+import PageHeader from '~/components/ui/PageHeader';
+import { useHasAccess, useLocalize } from '~/hooks';
+import MemoryPanel from '../MemoryPanel';
 
 export default function MemoriesView() {
+  const localize = useLocalize();
   const hasUse = useHasAccess({ permissionType: PermissionTypes.MEMORIES, permission: Permissions.USE });
   const hasRead = useHasAccess({ permissionType: PermissionTypes.MEMORIES, permission: Permissions.READ });
   if (!hasUse || !hasRead) return <Navigate to="/c/new" replace />;
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-presentation">
-      <MemoryPanel />
-    </div>
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
+      <PageHeader title={localize('com_ui_memories')} />
+      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+        <MemoryPanel noPadding />
+      </div>
+    </main>
   );
 }

--- a/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
+++ b/client/src/components/SidePanel/Memories/layouts/MemoriesView.tsx
@@ -12,7 +12,7 @@ export default function MemoriesView() {
   return (
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-surface-primary text-text-primary">
       <PageHeader title={localize('com_ui_memories')} />
-      <div className="flex w-full flex-1 flex-col gap-6 px-6 pb-6">
+      <div className="flex w-full flex-1 flex-col gap-6 p-6">
         <MemoryPanel noPadding />
       </div>
     </main>

--- a/client/src/components/SidePanel/Nav.tsx
+++ b/client/src/components/SidePanel/Nav.tsx
@@ -7,7 +7,9 @@ export default function Nav({ links }: { links: NavLink[] }) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-y-auto overflow-x-hidden text-text-primary">
       {links.map((link) =>
-        link.id === effectiveActive && link.Component ? <link.Component key={link.id} /> : null,
+        link.id === effectiveActive && link.Component && !link.href ? (
+          <link.Component key={link.id} />
+        ) : null,
       )}
     </div>
   );

--- a/client/src/components/Skills/display/SkillDetail.tsx
+++ b/client/src/components/Skills/display/SkillDetail.tsx
@@ -86,7 +86,7 @@ export default function SkillDetail({ skill, onEdit, onDelete }: SkillDetailProp
 
   return (
     <article
-      className="flex h-full min-w-0 flex-col gap-2 overflow-y-auto px-5 pb-5"
+      className="flex h-full min-w-0 flex-col gap-2 overflow-y-auto p-6"
       aria-label={skill.name}
     >
       {/* Header row */}

--- a/client/src/components/Skills/forms/CreateSkillForm.tsx
+++ b/client/src/components/Skills/forms/CreateSkillForm.tsx
@@ -142,7 +142,7 @@ export default function CreateSkillForm({
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="w-full px-4 py-2"
+        className="w-full p-6"
         aria-label={localize('com_ui_skill_create_title')}
       >
         <h1 className="sr-only">{localize('com_ui_skill_create_title')}</h1>

--- a/client/src/components/Skills/forms/SkillForm.tsx
+++ b/client/src/components/Skills/forms/SkillForm.tsx
@@ -160,7 +160,7 @@ export default function SkillForm({ skillId }: SkillFormProps) {
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="w-full px-4 py-2"
+        className="w-full p-6"
         aria-label={localize('com_ui_skill_edit_title')}
       >
         <h1 className="sr-only">{localize('com_ui_skill_edit_title')}</h1>

--- a/client/src/components/Skills/layouts/SkillsLayout.tsx
+++ b/client/src/components/Skills/layouts/SkillsLayout.tsx
@@ -1,0 +1,43 @@
+import { Outlet } from 'react-router-dom';
+import { SystemRoles, PermissionTypes, Permissions } from 'librechat-data-provider';
+import { AdminSettings, CreateSkillMenu } from '~/components/Skills/buttons';
+import SkillsSidePanel from '~/components/Skills/sidebar/SkillsSidePanel';
+import PageHeader from '~/components/ui/PageHeader';
+import { useAuthContext, useHasAccess, useLocalize } from '~/hooks';
+
+export default function SkillsLayout() {
+  const localize = useLocalize();
+  const { user } = useAuthContext();
+
+  const hasCreateAccess = useHasAccess({
+    permissionType: PermissionTypes.SKILLS,
+    permission: Permissions.CREATE,
+  });
+
+  const headerActions = hasCreateAccess ? <CreateSkillMenu /> : undefined;
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden">
+      {/* Full-width page header */}
+      <PageHeader title={localize('com_ui_skills')} actions={headerActions} />
+
+      {/* Two-column section below header */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {/* Left column — skills list */}
+        <div className="flex w-[280px] flex-shrink-0 flex-col overflow-hidden border-r border-border-light">
+          <SkillsSidePanel className="flex-1 border-r-0" hideHeader />
+          {user?.role === SystemRoles.ADMIN && (
+            <div className="flex w-full items-center justify-end px-4 pb-2">
+              <AdminSettings />
+            </div>
+          )}
+        </div>
+
+        {/* Right column — detail / edit / create */}
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Skills/sidebar/SkillsSidePanel.tsx
+++ b/client/src/components/Skills/sidebar/SkillsSidePanel.tsx
@@ -10,6 +10,7 @@ import { cn } from '~/utils';
 
 interface SkillsSidePanelProps {
   className?: string;
+  hideHeader?: boolean;
 }
 
 /**
@@ -17,11 +18,15 @@ interface SkillsSidePanelProps {
  * Header: "Skills" title + search icon + create menu (+ dropdown).
  * Body: "My Skills" collapsible section with skill list.
  */
-export default function SkillsSidePanel({ className }: SkillsSidePanelProps) {
+export default function SkillsSidePanel({ className, hideHeader = false }: SkillsSidePanelProps) {
   const localize = useLocalize();
   const { skillId: activeSkillId } = useParams();
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+
+  const handleOpenSearch = () => setSearchOpen(true);
+  const handleCloseSearchInternal = () => { setSearchOpen(false); setSearchTerm(''); };
+
   const debouncedSearch = useDebounce(searchTerm, 250);
 
   const hasCreateAccess = useHasAccess({
@@ -32,11 +37,6 @@ export default function SkillsSidePanel({ className }: SkillsSidePanelProps) {
   const listQuery = useListSkillsQuery({ search: debouncedSearch || undefined, limit: 50 });
   const skills = useMemo(() => listQuery.data?.skills ?? [], [listQuery.data]);
 
-  const handleCloseSearch = () => {
-    setSearchOpen(false);
-    setSearchTerm('');
-  };
-
   return (
     <div
       className={cn(
@@ -44,54 +44,73 @@ export default function SkillsSidePanel({ className }: SkillsSidePanelProps) {
         className,
       )}
     >
-      {/* Header — title+icons or inline search input */}
-      <div className="flex items-center justify-between px-4 py-2">
-        {searchOpen ? (
-          <>
-            <div className="relative flex-1">
-              <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-text-secondary" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder={localize('com_ui_search')}
-                aria-label={localize('com_ui_search_skills')}
-                className="h-8 w-full rounded-md border border-border-light bg-transparent pl-8 pr-3 text-sm text-text-primary placeholder:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring-primary"
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus
-              />
-            </div>
-            <button
-              type="button"
-              onClick={handleCloseSearch}
-              className="ml-2 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
-              aria-label={localize('com_ui_close')}
-            >
-              <X className="size-4" />
-            </button>
-          </>
-        ) : (
-          <>
-            <h2 className="truncate text-lg font-bold text-text-primary">
-              {localize('com_ui_skills')}
-            </h2>
-            <div className="flex items-center gap-1">
+      {/* Header — title+icons or inline search input (hidden when controlled externally) */}
+      {!hideHeader && (
+        <div className="flex items-center justify-between px-4 py-2">
+          {searchOpen ? (
+            <>
+              <div className="relative flex-1">
+                <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-text-secondary" />
+                <input
+                  type="text"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  placeholder={localize('com_ui_search')}
+                  aria-label={localize('com_ui_search_skills')}
+                  className="h-8 w-full rounded-md border border-border-light bg-transparent pl-8 pr-3 text-sm text-text-primary placeholder:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring-primary"
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                />
+              </div>
               <button
                 type="button"
-                onClick={() => setSearchOpen(true)}
-                className="inline-flex size-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
-                aria-label={localize('com_ui_search')}
+                onClick={handleCloseSearchInternal}
+                className="ml-2 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+                aria-label={localize('com_ui_close')}
               >
-                <Search className="size-4" />
+                <X className="size-4" />
               </button>
-              {hasCreateAccess && <CreateSkillMenu />}
-            </div>
-          </>
-        )}
-      </div>
+            </>
+          ) : (
+            <>
+              <h2 className="truncate text-lg font-bold text-text-primary">
+                {localize('com_ui_skills')}
+              </h2>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={handleOpenSearch}
+                  className="inline-flex size-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+                  aria-label={localize('com_ui_search')}
+                >
+                  <Search className="size-4" />
+                </button>
+                {hasCreateAccess && <CreateSkillMenu />}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Always-visible search input when used in full-page layout */}
+      {hideHeader && (
+        <div className="flex-shrink-0 px-6 pb-6 pt-6">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-text-secondary" />
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder={localize('com_ui_search')}
+              aria-label={localize('com_ui_search_skills')}
+              className="h-8 w-full rounded-md border border-border-light bg-transparent pl-8 pr-3 text-sm text-text-primary placeholder:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring-primary"
+            />
+          </div>
+        </div>
+      )}
 
       {/* Skill list */}
-      <div className="flex-1 overflow-y-auto px-4">
+      <div className={cn('flex-1 overflow-y-auto', hideHeader ? 'px-6 pb-6' : 'px-4')}>
         <SkillListPanel
           skills={skills as unknown as import('librechat-data-provider').TSkill[]}
           isLoading={listQuery.isLoading}

--- a/client/src/components/UnifiedSidebar/ConversationsSection.tsx
+++ b/client/src/components/UnifiedSidebar/ConversationsSection.tsx
@@ -106,11 +106,11 @@ const ConversationsSection = memo(() => {
 
   return (
     <div
-      className="flex h-full min-h-0 flex-col overflow-hidden pb-3 pt-2"
+      className="flex h-full min-h-0 flex-col overflow-hidden pb-2 pt-2"
       role="region"
       aria-label={localize('com_ui_chat_history')}
     >
-      <div className="flex items-center gap-0.5 px-3">
+      <div className="flex items-center gap-0.5 px-2">
         {hasAccessToBookmarks && (
           <Suspense fallback={null}>
             <BookmarkNav tags={tags} setTags={setTags} />
@@ -119,7 +119,7 @@ const ConversationsSection = memo(() => {
         {search.enabled && <SearchBar isSmallScreen={isSmallScreen} />}
       </div>
       {!search.query && (
-        <div className="px-3">
+        <div className="px-2">
           <FavoritesList isSmallScreen={isSmallScreen} toggleNav={toggleNav} />
         </div>
       )}

--- a/client/src/components/UnifiedSidebar/ConversationsSection.tsx
+++ b/client/src/components/UnifiedSidebar/ConversationsSection.tsx
@@ -1,25 +1,15 @@
-import { useCallback, useEffect, useState, useMemo, memo, lazy, Suspense, useRef } from 'react';
+import { useCallback, useEffect, useState, useMemo, memo, useRef } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { useMediaQuery } from '@librechat/client';
-import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { InfiniteQueryObserverResult } from '@tanstack/react-query';
 import type { ConversationListResponse } from 'librechat-data-provider';
 import type { List } from 'react-virtualized';
-import {
-  useLocalize,
-  useHasAccess,
-  useAuthContext,
-  useLocalStorage,
-  useNavScrolling,
-} from '~/hooks';
+import { useLocalize, useAuthContext, useLocalStorage, useNavScrolling } from '~/hooks';
 import { useConversationsInfiniteQuery, useTitleGeneration } from '~/data-provider';
 import { Conversations } from '~/components/Conversations';
-import ProjectsSection from '~/components/Conversations/ProjectsSection';
 import FavoritesList from '~/components/Nav/Favorites/FavoritesList';
 import SearchBar from '~/components/Nav/SearchBar';
 import store from '~/store';
-
-const BookmarkNav = lazy(() => import('~/components/Nav/Bookmarks/BookmarkNav'));
 
 const ConversationsSection = memo(() => {
   const localize = useLocalize();
@@ -28,21 +18,14 @@ const ConversationsSection = memo(() => {
   const { isAuthenticated } = useAuthContext();
   useTitleGeneration(isAuthenticated);
 
-  const [isChatsExpanded, setIsChatsExpanded] = useLocalStorage('chatsExpanded', true);
+  const [isChatsExpanded] = useLocalStorage('chatsExpanded', true);
   const [showLoading, setShowLoading] = useState(false);
-  const [tags, setTags] = useState<string[]>([]);
-
-  const hasAccessToBookmarks = useHasAccess({
-    permissionType: PermissionTypes.BOOKMARKS,
-    permission: Permissions.USE,
-  });
 
   const search = useRecoilValue(store.search);
 
   const { data, fetchNextPage, isFetchingNextPage, isLoading, isFetching } =
     useConversationsInfiniteQuery(
       {
-        tags: tags.length === 0 ? undefined : tags,
         search: search.debouncedQuery || undefined,
       },
       {
@@ -110,20 +93,16 @@ const ConversationsSection = memo(() => {
       role="region"
       aria-label={localize('com_ui_chat_history')}
     >
-      <div className="flex items-center gap-0.5 px-2">
-        {hasAccessToBookmarks && (
-          <Suspense fallback={null}>
-            <BookmarkNav tags={tags} setTags={setTags} />
-          </Suspense>
-        )}
-        {search.enabled && <SearchBar isSmallScreen={isSmallScreen} />}
-      </div>
+      {search.enabled && (
+        <div className="px-2">
+          <SearchBar isSmallScreen={isSmallScreen} />
+        </div>
+      )}
       {!search.query && (
         <div className="px-2">
           <FavoritesList isSmallScreen={isSmallScreen} toggleNav={toggleNav} />
         </div>
       )}
-      {!search.query && <ProjectsSection toggleNav={toggleNav} isAuthenticated={isAuthenticated} />}
       <div className="flex min-h-0 flex-grow flex-col overflow-hidden">
         <Conversations
           conversations={conversations}
@@ -134,8 +113,9 @@ const ConversationsSection = memo(() => {
           isLoading={isFetchingNextPage || showLoading || isLoading}
           isSearchLoading={isSearchLoading}
           isChatsExpanded={isChatsExpanded}
-          setIsChatsExpanded={setIsChatsExpanded}
+          setIsChatsExpanded={() => undefined}
           showFavorites={false}
+          hideHeader={true}
         />
       </div>
     </div>

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { SquarePen, SidebarClose, SidebarOpen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
@@ -102,6 +102,8 @@ const NavIconButton = memo(function NavIconButton({
   onCollapse?: () => void;
 }) {
   const localize = useLocalize();
+  const { pathname } = useLocation();
+  const effectiveIsActive = link.href ? pathname.startsWith(link.href) : isActive;
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -123,25 +125,37 @@ const NavIconButton = memo(function NavIconButton({
     [link, isActive, setActive, expanded, onExpand, onCollapse],
   );
 
+  const iconClass = cn(
+    'h-[48px] w-full rounded-none flex items-center justify-center',
+    effectiveIsActive
+      ? 'bg-surface-active-alt text-text-primary'
+      : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+  );
+
   return (
     <TooltipAnchor
       description={localize(link.title)}
       side="right"
       render={
-        <Button
-          variant="ghost"
-          aria-label={localize(link.title)}
-          aria-pressed={isActive}
-          className={cn(
-            'h-[48px] w-full rounded-none flex items-center justify-center',
-            isActive
-              ? 'bg-surface-active-alt text-text-primary'
-              : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
-          )}
-          onClick={handleClick}
-        >
-          <link.icon className="h-5 w-5" aria-hidden="true" />
-        </Button>
+        link.href ? (
+          <Link
+            to={link.href}
+            aria-label={localize(link.title)}
+            className={iconClass}
+          >
+            <link.icon className="h-5 w-5" aria-hidden="true" />
+          </Link>
+        ) : (
+          <Button
+            variant="ghost"
+            aria-label={localize(link.title)}
+            aria-pressed={effectiveIsActive}
+            className={iconClass}
+            onClick={handleClick}
+          >
+            <link.icon className="h-5 w-5" aria-hidden="true" />
+          </Button>
+        )
       }
     />
   );

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -3,7 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { SquarePen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
-import { Skeleton, Sidebar, Button, TooltipAnchor } from '@librechat/client';
+import { SidebarOpen, SidebarClose } from 'lucide-react';
+import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
 import { useActivePanel, resolveActivePanel, DEFAULT_PANEL } from '~/Providers';
@@ -154,7 +155,11 @@ function ExpandedPanel({
             className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
-            <Sidebar aria-hidden="true" className="h-4 w-4" />
+            {expanded ? (
+              <SidebarClose aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <SidebarOpen aria-hidden="true" className="h-4 w-4" />
+            )}
           </Button>
         }
       />

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { SquarePen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
+import { SidebarOpen, SidebarClose } from 'lucide-react';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -12,52 +13,6 @@ import { clearMessagesCache, cn } from '~/utils';
 import store from '~/store';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
-
-function SlideInIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-      className={className}
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-        d="M5.297 11.985h11.867M12.424 7.491l4.78 4.51-4.78 4.508"
-      />
-      <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M19 17V7" />
-    </svg>
-  );
-}
-
-function SlideOutIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-      className={className}
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-        d="M18.703 12.015H6.836M11.576 16.509l-4.78-4.51 4.78-4.508"
-      />
-      <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M5 7v10" />
-    </svg>
-  );
-}
 
 const NewChatButton = memo(function NewChatButton({
   setActive,
@@ -200,7 +155,11 @@ function ExpandedPanel({
             className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
-            {expanded ? <SlideOutIcon /> : <SlideInIcon />}
+            {expanded ? (
+              <SidebarClose aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <SidebarOpen aria-hidden="true" className="h-4 w-4" />
+            )}
           </Button>
         }
       />

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { SquarePen, SidebarClose, SidebarOpen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
@@ -57,6 +58,9 @@ const NewChatButton = memo(function NewChatButton({
     [queryClient, conversation?.conversationId, newConversation, switchToHistory, setActive],
   );
 
+  const { pathname } = useLocation();
+  const isActive = pathname === '/c/new';
+
   return (
     <TooltipAnchor
       side="right"
@@ -66,10 +70,16 @@ const NewChatButton = memo(function NewChatButton({
           href="/c/new"
           data-testid="new-chat-button"
           aria-label={localize('com_ui_new_chat')}
-          className="flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-surface-hover"
+          aria-current={isActive ? 'page' : undefined}
+          className={cn(
+            'flex h-[48px] w-full items-center justify-center rounded-none transition-colors',
+            isActive
+              ? 'bg-surface-active-alt text-text-primary'
+              : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+          )}
           onClick={handleClick}
         >
-          <SquarePen className="h-4 w-4 text-text-secondary" />
+          <SquarePen className="h-5 w-5" aria-hidden="true" />
         </a>
       }
     />
@@ -156,7 +166,7 @@ function ExpandedPanel({
   const toggleClick = expanded ? onCollapse : onExpand;
 
   return (
-    <div className="flex h-full w-[60px] flex-shrink-0 flex-col items-center gap-1 border-r border-border-light bg-white py-2">
+    <div className="flex h-full w-[60px] flex-shrink-0 flex-col items-center gap-1 border-r border-border-light bg-white pb-3 pt-6">
       <TooltipAnchor
         side="right"
         description={localize(toggleLabel)}
@@ -168,37 +178,44 @@ function ExpandedPanel({
             variant="ghost"
             aria-label={localize(toggleLabel)}
             aria-expanded={expanded}
-            className="group h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
+            className="group h-8 w-8 rounded-md pb-1 text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
             {expanded ? (
               <SidebarClose aria-hidden="true" className="h-4 w-4" />
             ) : (
               <>
-                {/* Default: expand arrow; Hover: ClickHouse logo */}
-                <SidebarOpen aria-hidden="true" className="h-4 w-4 group-hover:hidden" />
-                <ClickHouseLogo className="hidden h-4 w-4 group-hover:block" />
+                {/* Default: ClickHouse logo; Hover: expand arrow */}
+                <ClickHouseLogo className="h-5 w-5 text-black group-hover:hidden" />
+                <SidebarOpen aria-hidden="true" className="hidden h-4 w-4 group-hover:block" />
               </>
             )}
           </Button>
         }
       />
-      <NewChatButton setActive={setActive} />
+      {/* New Chat — mirrors top of expanded nav */}
+      <div className="mt-6 w-full">
+        <NewChatButton setActive={setActive} />
+      </div>
 
-      <div className="my-1 w-6 border-b border-border-light" />
+      {/* Divider — mirrors the one after CHATS/PROJECTS in expanded nav */}
+      <div className="my-1 w-8 border-b border-border-light" />
 
+      {/* All other nav icons (skip conversations) */}
       <div className="flex w-full flex-col overflow-y-auto">
-        {links.map((link) => (
-          <NavIconButton
-            key={link.id}
-            link={link}
-            isActive={link.id === effectiveActive}
-            expanded={expanded ?? true}
-            setActive={setActive}
-            onExpand={onExpand}
-            onCollapse={onCollapse}
-          />
-        ))}
+        {links
+          .filter((link) => link.id !== 'conversations')
+          .map((link) => (
+            <NavIconButton
+              key={link.id}
+              link={link}
+              isActive={link.id === effectiveActive}
+              expanded={expanded ?? true}
+              setActive={setActive}
+              onExpand={onExpand}
+              onCollapse={onCollapse}
+            />
+          ))}
       </div>
 
       <div className="mt-auto">

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { SquarePen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
-import { SidebarOpen, SidebarClose } from 'lucide-react';
+import { Icon } from '@clickhouse/click-ui';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -155,11 +155,7 @@ function ExpandedPanel({
             className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
-            {expanded ? (
-              <SidebarClose aria-hidden="true" className="h-4 w-4" />
-            ) : (
-              <SidebarOpen aria-hidden="true" className="h-4 w-4" />
-            )}
+            <Icon name={expanded ? 'slide-out' : 'slide-in'} size="sm" />
           </Button>
         }
       />

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -3,7 +3,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { SquarePen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
-import { Icon } from '@clickhouse/click-ui';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -13,6 +12,52 @@ import { clearMessagesCache, cn } from '~/utils';
 import store from '~/store';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
+
+function SlideInIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M5.297 11.985h11.867M12.424 7.491l4.78 4.51-4.78 4.508"
+      />
+      <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M19 17V7" />
+    </svg>
+  );
+}
+
+function SlideOutIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M18.703 12.015H6.836M11.576 16.509l-4.78-4.51 4.78-4.508"
+      />
+      <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M5 7v10" />
+    </svg>
+  );
+}
 
 const NewChatButton = memo(function NewChatButton({
   setActive,
@@ -155,7 +200,7 @@ function ExpandedPanel({
             className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
-            <Icon name={expanded ? 'slide-out' : 'slide-in'} size="sm" />
+            {expanded ? <SlideOutIcon /> : <SlideInIcon />}
           </Button>
         }
       />

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -1,9 +1,8 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
-import { SquarePen } from 'lucide-react';
+import { SquarePen, SidebarClose, SidebarOpen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
-import { SidebarOpen, SidebarClose } from 'lucide-react';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -13,6 +12,24 @@ import { clearMessagesCache, cn } from '~/utils';
 import store from '~/store';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
+
+/** ClickHouse logo — 5 bars with currentColor fill, shown on hover of the open button. */
+function ClickHouseLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 54 54"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <rect width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+      <rect x="12" width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+      <rect x="24.001" width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+      <rect x="35.998" width="5.9998" height="53.9982" rx="1.45943" fill="currentColor" />
+      <rect x="48.001" y="21.0005" width="5.9998" height="11.9996" rx="1.45943" fill="currentColor" />
+    </svg>
+  );
+}
 
 const NewChatButton = memo(function NewChatButton({
   setActive,
@@ -102,19 +119,18 @@ const NavIconButton = memo(function NavIconButton({
       side="right"
       render={
         <Button
-          size="icon"
           variant="ghost"
           aria-label={localize(link.title)}
           aria-pressed={isActive}
           className={cn(
-            'h-8 w-8 rounded-md',
+            'h-[48px] w-full rounded-none flex items-center justify-center',
             isActive
               ? 'bg-surface-active-alt text-text-primary'
-              : 'text-text-secondary hover:text-text-primary',
+              : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
           )}
           onClick={handleClick}
         >
-          <link.icon className="h-4 w-4" aria-hidden="true" />
+          <link.icon className="h-5 w-5" aria-hidden="true" />
         </Button>
       }
     />
@@ -140,7 +156,7 @@ function ExpandedPanel({
   const toggleClick = expanded ? onCollapse : onExpand;
 
   return (
-    <div className="flex h-full w-[52px] flex-shrink-0 flex-col items-center gap-1 border-r border-border-light bg-surface-primary-alt py-2">
+    <div className="flex h-full w-[60px] flex-shrink-0 flex-col items-center gap-1 border-r border-border-light bg-white py-2">
       <TooltipAnchor
         side="right"
         description={localize(toggleLabel)}
@@ -152,13 +168,17 @@ function ExpandedPanel({
             variant="ghost"
             aria-label={localize(toggleLabel)}
             aria-expanded={expanded}
-            className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
+            className="group h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
             {expanded ? (
               <SidebarClose aria-hidden="true" className="h-4 w-4" />
             ) : (
-              <SidebarOpen aria-hidden="true" className="h-4 w-4" />
+              <>
+                {/* Default: expand arrow; Hover: ClickHouse logo */}
+                <SidebarOpen aria-hidden="true" className="h-4 w-4 group-hover:hidden" />
+                <ClickHouseLogo className="hidden h-4 w-4 group-hover:block" />
+              </>
             )}
           </Button>
         }
@@ -167,7 +187,7 @@ function ExpandedPanel({
 
       <div className="my-1 w-6 border-b border-border-light" />
 
-      <div className="flex flex-col gap-0.5 overflow-y-auto">
+      <div className="flex w-full flex-col overflow-y-auto">
         {links.map((link) => (
           <NavIconButton
             key={link.id}

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -48,10 +48,10 @@ const NewChatButton = memo(function NewChatButton({
           href="/c/new"
           data-testid="new-chat-button"
           aria-label={localize('com_ui_new_chat')}
-          className="flex h-9 w-9 items-center justify-center rounded-lg transition-colors hover:bg-surface-hover"
+          className="flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-surface-hover"
           onClick={handleClick}
         >
-          <SquarePen className="h-5 w-5 text-text-primary" />
+          <SquarePen className="h-4 w-4 text-text-secondary" />
         </a>
       }
     />
@@ -106,12 +106,14 @@ const NavIconButton = memo(function NavIconButton({
           aria-label={localize(link.title)}
           aria-pressed={isActive}
           className={cn(
-            'h-9 w-9 rounded-lg',
-            isActive ? 'bg-surface-active-alt text-text-primary' : 'text-text-secondary',
+            'h-8 w-8 rounded-md',
+            isActive
+              ? 'bg-surface-active-alt text-text-primary'
+              : 'text-text-secondary hover:text-text-primary',
           )}
           onClick={handleClick}
         >
-          <link.icon className="h-5 w-5" aria-hidden="true" />
+          <link.icon className="h-4 w-4" aria-hidden="true" />
         </Button>
       }
     />
@@ -137,7 +139,7 @@ function ExpandedPanel({
   const toggleClick = expanded ? onCollapse : onExpand;
 
   return (
-    <div className="flex h-full flex-shrink-0 flex-col gap-2 border-r border-border-light bg-surface-primary-alt px-2 py-2">
+    <div className="flex h-full w-[52px] flex-shrink-0 flex-col items-center gap-1 border-r border-border-light bg-surface-primary-alt py-2">
       <TooltipAnchor
         side="right"
         description={localize(toggleLabel)}
@@ -149,16 +151,18 @@ function ExpandedPanel({
             variant="ghost"
             aria-label={localize(toggleLabel)}
             aria-expanded={expanded}
-            className="h-9 w-9 rounded-lg"
+            className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
             onClick={toggleClick}
           >
-            <Sidebar aria-hidden="true" className="h-5 w-5 text-text-primary" />
+            <Sidebar aria-hidden="true" className="h-4 w-4" />
           </Button>
         }
       />
       <NewChatButton setActive={setActive} />
-      <div className="mx-2 border-b border-border-light" />
-      <div className="flex flex-col gap-1 overflow-y-auto">
+
+      <div className="my-1 w-6 border-b border-border-light" />
+
+      <div className="flex flex-col gap-0.5 overflow-y-auto">
         {links.map((link) => (
           <NavIconButton
             key={link.id}
@@ -173,7 +177,7 @@ function ExpandedPanel({
       </div>
 
       <div className="mt-auto">
-        <Suspense fallback={<Skeleton className="h-9 w-9 rounded-lg" />}>
+        <Suspense fallback={<Skeleton className="h-8 w-8 rounded-md" />}>
           <AccountSettings collapsed />
         </Suspense>
       </div>

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -1,14 +1,17 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRecoilValue } from 'recoil';
+import { useLocation } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { SquarePen, SidebarClose } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
-import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
+import { Skeleton, Button, TooltipAnchor, useMediaQuery } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
 import { useActivePanel, resolveActivePanel, DEFAULT_PANEL } from '~/Providers';
+import { ChatsHeader } from '~/components/Conversations';
+import ProjectsSection from '~/components/Conversations/ProjectsSection';
 import SidePanelNav from '~/components/SidePanel/Nav';
-import { useLocalize, useNewConvo } from '~/hooks';
+import { useLocalize, useNewConvo, useAuthContext, useLocalStorage } from '~/hooks';
 import { clearMessagesCache, cn } from '~/utils';
 import ExpandedPanel from './ExpandedPanel';
 import store from '~/store';
@@ -33,18 +36,19 @@ function LibreChatLogo({ className }: { className?: string }) {
   );
 }
 
-const NewChatButton = memo(function NewChatButton({
+/** Nav-row style New Chat button — sits at the top of the nav list. */
+const NewChatNavRow = memo(function NewChatNavRow({
   setActive,
-  collapsed = false,
 }: {
   setActive: (id: string) => void;
-  collapsed?: boolean;
 }) {
   const localize = useLocalize();
+  const { pathname } = useLocation();
   const queryClient = useQueryClient();
   const { newConversation } = useNewConvo();
   const conversation = useRecoilValue(store.conversationByIndex(0));
   const switchToHistory = useRecoilValue(store.newChatSwitchToHistory);
+  const isActive = pathname === '/c/new';
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -61,36 +65,23 @@ const NewChatButton = memo(function NewChatButton({
     [queryClient, conversation?.conversationId, newConversation, switchToHistory, setActive],
   );
 
-  if (!collapsed) {
-    return (
-      <a
-        href="/c/new"
-        data-testid="new-chat-button"
-        aria-label={localize('com_ui_new_chat')}
-        className="flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-surface-hover"
-        onClick={handleClick}
-      >
-        <SquarePen className="h-4 w-4 text-text-secondary" />
-      </a>
-    );
-  }
-
   return (
-    <TooltipAnchor
-      side="right"
-      description={localize('com_ui_new_chat')}
-      render={
-        <a
-          href="/c/new"
-          data-testid="new-chat-button"
-          aria-label={localize('com_ui_new_chat')}
-          className="flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-surface-hover"
-          onClick={handleClick}
-        >
-          <SquarePen className="h-4 w-4 text-text-secondary" />
-        </a>
-      }
-    />
+    <a
+      href="/c/new"
+      data-testid="new-chat-button"
+      aria-label={localize('com_ui_new_chat')}
+      aria-current={isActive ? 'page' : undefined}
+      className={cn(
+        'flex h-8 w-full items-center gap-2 rounded-md px-4 text-left text-sm transition-colors',
+        isActive
+          ? 'bg-surface-active-alt text-text-primary'
+          : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+      )}
+      onClick={handleClick}
+    >
+      <SquarePen className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+      <span className="truncate">{localize('com_ui_new_chat')}</span>
+    </a>
   );
 });
 
@@ -136,56 +127,79 @@ function FullSidebar({
   const localize = useLocalize();
   const { active, setActive } = useActivePanel();
   const effectiveActive = resolveActivePanel(active, links);
+  const { isAuthenticated } = useAuthContext();
+  const isSmallScreen = useMediaQuery('(max-width: 768px)');
+  const setSidebarExpanded = useSetRecoilState(store.sidebarExpanded);
+  const [isChatsExpanded, setIsChatsExpanded] = useLocalStorage('chatsExpanded', true);
+
+  const toggleNav = useCallback(() => {
+    if (isSmallScreen) {
+      setSidebarExpanded(false);
+    }
+  }, [isSmallScreen, setSidebarExpanded]);
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden border-r border-border-light bg-white">
-      {/* Header: logo + name + new-chat + collapse */}
+      {/* Header: logo + name + collapse */}
       <div className="flex flex-shrink-0 items-center justify-between p-4">
         <div className="flex items-center gap-2">
           <LibreChatLogo className="h-5 w-5 text-text-primary" />
-          <span className="text-base font-normal text-text-primary">LibreChat</span>
+          <span className="text-xl font-normal text-text-primary">LibreChat</span>
         </div>
-        <div className="flex items-center gap-1">
-          <NewChatButton setActive={setActive} collapsed={false} />
-          <TooltipAnchor
-            side="right"
-            description={localize('com_nav_close_sidebar')}
-            render={
-              <Button
-                id={CLOSE_SIDEBAR_ID}
-                data-testid="close-sidebar-button"
-                size="icon"
-                variant="ghost"
-                aria-label={localize('com_nav_close_sidebar')}
-                aria-expanded={true}
-                className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
-                onClick={onCollapse}
-              >
-                <SidebarClose className="h-4 w-4" />
-              </Button>
-            }
-          />
-        </div>
+        <TooltipAnchor
+          side="right"
+          description={localize('com_nav_close_sidebar')}
+          render={
+            <Button
+              id={CLOSE_SIDEBAR_ID}
+              data-testid="close-sidebar-button"
+              size="icon"
+              variant="ghost"
+              aria-label={localize('com_nav_close_sidebar')}
+              aria-expanded={true}
+              className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
+              onClick={onCollapse}
+            >
+              <SidebarClose className="h-4 w-4" />
+            </Button>
+          }
+        />
       </div>
 
       <div className="mx-4 flex-shrink-0 border-b border-border-light" />
 
-      {/* Nav items with icon + label */}
+      {/* Nav items */}
       <div className="flex flex-shrink-0 flex-col gap-0.5 px-4 py-2">
-        {links.map((link) => (
-          <NavLabelRow
-            key={link.id}
-            link={link}
-            isActive={link.id === effectiveActive}
-            onClick={() => {
-              if (link.onClick) {
-                link.onClick();
-                return;
-              }
-              setActive(link.id);
-            }}
+        {/* New Chat — top of nav */}
+        <NewChatNavRow setActive={setActive} />
+
+        {/* Chats + Projects — always visible */}
+        <div className="px-2">
+          <ChatsHeader
+            isExpanded={isChatsExpanded}
+            onToggle={() => setIsChatsExpanded(!isChatsExpanded)}
           />
-        ))}
+        </div>
+        <ProjectsSection toggleNav={toggleNav} isAuthenticated={isAuthenticated} />
+
+        <div className="my-1 border-b border-border-light" />
+
+        {links
+          .filter((link) => link.id !== 'conversations')
+          .map((link) => (
+            <NavLabelRow
+              key={link.id}
+              link={link}
+              isActive={link.id === effectiveActive}
+              onClick={() => {
+                if (link.onClick) {
+                  link.onClick();
+                  return;
+                }
+                setActive(link.id);
+              }}
+            />
+          ))}
       </div>
 
       <div className="mx-3 flex-shrink-0 border-b border-border-light" />

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -1,8 +1,9 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
-import { SquarePen, SidebarClose } from 'lucide-react';
+import { SquarePen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
+import { Icon } from '@clickhouse/click-ui';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -161,7 +162,7 @@ function FullSidebar({
                 className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
                 onClick={onCollapse}
               >
-                <SidebarClose className="h-4 w-4" />
+                <Icon name="slide-out" size="sm" />
               </Button>
             }
           />

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -3,7 +3,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { SquarePen } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
-import { Icon } from '@clickhouse/click-ui';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -15,6 +14,30 @@ import ExpandedPanel from './ExpandedPanel';
 import store from '~/store';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
+
+/** Click UI "slide-out" icon (arrow left + vertical bar) — paths from @clickhouse/click-ui */
+function SlideOutIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M18.703 12.015H6.836M11.576 16.509l-4.78-4.51 4.78-4.508"
+      />
+      <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M5 7v10" />
+    </svg>
+  );
+}
 
 /** LibreChat logomark — 5 vertical bars matching the design file. */
 function LibreChatLogo({ className }: { className?: string }) {
@@ -162,7 +185,7 @@ function FullSidebar({
                 className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
                 onClick={onCollapse}
               >
-                <Icon name="slide-out" size="sm" />
+                <SlideOutIcon />
               </Button>
             }
           />

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -232,9 +232,9 @@ function Sidebar({
 
       {/* Full sidebar — slides in/out over the icon strip */}
       <div
-        className="absolute inset-0"
+        className="absolute inset-y-0 left-0 w-[260px]"
         style={{
-          transform: expanded ? 'translateX(0)' : 'translateX(-100%)',
+          transform: expanded ? 'translateX(0)' : 'translateX(-260px)',
           transition: 'transform 300ms cubic-bezier(0.2, 0, 0, 1)',
         }}
         inert={!expanded ? ('' as unknown as boolean) : undefined}

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -153,7 +153,7 @@ function FullSidebar({
   return (
     <div className="flex h-full w-full flex-col overflow-hidden border-r border-border-light bg-white">
       {/* Header: logo + name + collapse */}
-      <div className="flex flex-shrink-0 items-center justify-between p-4">
+      <div className="flex flex-shrink-0 items-center justify-between px-4 pb-[11px] pt-[12px]">
         <div className="flex items-center gap-2">
           <LibreChatLogo className="h-5 w-5 text-text-primary" />
           <span className="text-xl font-normal text-text-primary">LibreChat</span>
@@ -178,7 +178,7 @@ function FullSidebar({
         />
       </div>
 
-      <div className="mx-4 flex-shrink-0 border-b border-border-light" />
+      <div className="flex-shrink-0 border-b border-border-light" />
 
       {/* Nav items */}
       <div className="flex flex-shrink-0 flex-col gap-0.5 px-4 py-2">

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
-import { SquarePen } from 'lucide-react';
+import { SquarePen, SidebarClose } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
@@ -19,8 +19,6 @@ const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
 function LibreChatLogo({ className }: { className?: string }) {
   return (
     <svg
-      width="18"
-      height="16"
       viewBox="0 0 18 16"
       fill="currentColor"
       aria-hidden="true"
@@ -115,7 +113,7 @@ const NavLabelRow = memo(function NavLabelRow({
       aria-label={localize(link.title)}
       onClick={onClick}
       className={cn(
-        'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left transition-colors',
+        'flex h-8 w-full items-center gap-2 rounded-md px-4 text-left transition-colors',
         isActive
           ? 'bg-surface-active-alt text-text-primary'
           : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
@@ -140,12 +138,12 @@ function FullSidebar({
   const effectiveActive = resolveActivePanel(active, links);
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden border-r border-border-light bg-surface-primary-alt">
+    <div className="flex h-full w-full flex-col overflow-hidden border-r border-border-light bg-white">
       {/* Header: logo + name + new-chat + collapse */}
-      <div className="flex flex-shrink-0 items-center justify-between px-3 py-2">
+      <div className="flex flex-shrink-0 items-center justify-between p-4">
         <div className="flex items-center gap-2">
-          <LibreChatLogo className="text-text-primary" />
-          <span className="text-sm font-semibold text-text-primary">LibreChat</span>
+          <LibreChatLogo className="h-5 w-5 text-text-primary" />
+          <span className="text-base font-normal text-text-primary">LibreChat</span>
         </div>
         <div className="flex items-center gap-1">
           <NewChatButton setActive={setActive} collapsed={false} />
@@ -163,17 +161,17 @@ function FullSidebar({
                 className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
                 onClick={onCollapse}
               >
-                <LibreChatLogo className="h-4 w-4" />
+                <SidebarClose className="h-4 w-4" />
               </Button>
             }
           />
         </div>
       </div>
 
-      <div className="mx-3 flex-shrink-0 border-b border-border-light" />
+      <div className="mx-4 flex-shrink-0 border-b border-border-light" />
 
       {/* Nav items with icon + label */}
-      <div className="flex flex-shrink-0 flex-col gap-0.5 px-2 py-2">
+      <div className="flex flex-shrink-0 flex-col gap-0.5 px-4 py-2">
         {links.map((link) => (
           <NavLabelRow
             key={link.id}

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -218,17 +218,30 @@ function Sidebar({
   onCollapse: () => void;
   onExpand: () => void;
 }) {
-  if (expanded) {
-    return <FullSidebar links={links} onCollapse={onCollapse} />;
-  }
-
   return (
-    <ExpandedPanel
-      links={links}
-      expanded={false}
-      onExpand={onExpand}
-      onCollapse={onCollapse}
-    />
+    <div className="relative h-full w-full overflow-hidden">
+      {/* Icon strip — always rendered as the base layer */}
+      <div className="absolute inset-y-0 left-0 w-[52px]">
+        <ExpandedPanel
+          links={links}
+          expanded={false}
+          onExpand={onExpand}
+          onCollapse={onCollapse}
+        />
+      </div>
+
+      {/* Full sidebar — slides in/out over the icon strip */}
+      <div
+        className="absolute inset-0"
+        style={{
+          transform: expanded ? 'translateX(0)' : 'translateX(-100%)',
+          transition: 'transform 300ms cubic-bezier(0.2, 0, 0, 1)',
+        }}
+        inert={!expanded ? ('' as unknown as boolean) : undefined}
+      >
+        <FullSidebar links={links} onCollapse={onCollapse} />
+      </div>
+    </div>
   );
 }
 

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -219,7 +219,7 @@ function Sidebar({
   onExpand: () => void;
 }) {
   return (
-    <div className="relative h-full w-full overflow-hidden">
+    <div className="relative h-full w-full">
       {/* Icon strip — always rendered as the base layer */}
       <div className="absolute inset-y-0 left-0 w-[52px]">
         <ExpandedPanel

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -9,56 +9,31 @@ function Sidebar({
   expanded,
   onCollapse,
   onExpand,
-  onResizeStart,
-  onResizeKeyboard,
 }: {
   links: NavLink[];
   expanded: boolean;
   onCollapse: () => void;
   onExpand: () => void;
-  onResizeStart: (e: React.MouseEvent) => void;
-  onResizeKeyboard: (direction: 'shrink' | 'grow') => void;
 }) {
   return (
-    <>
-      <div className="flex h-full w-full overflow-hidden">
-        <ExpandedPanel
-          links={links}
-          expanded={expanded}
-          onCollapse={onCollapse}
-          onExpand={onExpand}
-        />
-        <nav
-          className={cn(
-            'min-h-0 flex-1 overflow-hidden bg-surface-primary-alt',
-            expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
-          )}
-          style={{ transition: expanded ? 'opacity 200ms ease 80ms' : 'opacity 150ms ease' }}
-          aria-hidden={!expanded}
-        >
-          <SidePanelNav links={links} />
-        </nav>
-      </div>
-      <div
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize sidebar"
-        tabIndex={expanded ? 0 : -1}
+    <div className="flex h-full w-full overflow-hidden">
+      <ExpandedPanel
+        links={links}
+        expanded={expanded}
+        onCollapse={onCollapse}
+        onExpand={onExpand}
+      />
+      <nav
         className={cn(
-          'absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-border-medium active:bg-border-heavy',
+          'min-h-0 flex-1 overflow-hidden bg-surface-primary-alt',
           expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
         )}
         style={{ transition: expanded ? 'opacity 200ms ease 80ms' : 'opacity 150ms ease' }}
-        onMouseDown={onResizeStart}
-        onKeyDown={(e) => {
-          if (e.key === 'ArrowLeft') {
-            onResizeKeyboard('shrink');
-          } else if (e.key === 'ArrowRight') {
-            onResizeKeyboard('grow');
-          }
-        }}
-      />
-    </>
+        aria-hidden={!expanded}
+      >
+        <SidePanelNav links={links} />
+      </nav>
+    </div>
   );
 }
 

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -1,8 +1,211 @@
-import { memo } from 'react';
+import { memo, useCallback, lazy, Suspense } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+import { SquarePen } from 'lucide-react';
+import { QueryKeys } from 'librechat-data-provider';
+import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
+import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
+import { useActivePanel, resolveActivePanel, DEFAULT_PANEL } from '~/Providers';
 import SidePanelNav from '~/components/SidePanel/Nav';
+import { useLocalize, useNewConvo } from '~/hooks';
+import { clearMessagesCache, cn } from '~/utils';
 import ExpandedPanel from './ExpandedPanel';
-import { cn } from '~/utils';
+import store from '~/store';
+
+const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
+
+/** LibreChat logomark — 5 vertical bars matching the design file. */
+function LibreChatLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      width="18"
+      height="16"
+      viewBox="0 0 18 16"
+      fill="currentColor"
+      aria-hidden="true"
+      className={className}
+    >
+      <rect x="0" y="0" width="2" height="16" rx="0.25" />
+      <rect x="4" y="0" width="2" height="16" rx="0.25" />
+      <rect x="8" y="0" width="2" height="16" rx="0.25" />
+      <rect x="12" y="0" width="2" height="16" rx="0.25" />
+      <rect x="16" y="6" width="2" height="4" rx="0.25" />
+    </svg>
+  );
+}
+
+const NewChatButton = memo(function NewChatButton({
+  setActive,
+  collapsed = false,
+}: {
+  setActive: (id: string) => void;
+  collapsed?: boolean;
+}) {
+  const localize = useLocalize();
+  const queryClient = useQueryClient();
+  const { newConversation } = useNewConvo();
+  const conversation = useRecoilValue(store.conversationByIndex(0));
+  const switchToHistory = useRecoilValue(store.newChatSwitchToHistory);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (e.button === 0 && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        clearMessagesCache(queryClient, conversation?.conversationId);
+        queryClient.invalidateQueries([QueryKeys.messages]);
+        newConversation();
+        if (switchToHistory) {
+          setActive(DEFAULT_PANEL);
+        }
+      }
+    },
+    [queryClient, conversation?.conversationId, newConversation, switchToHistory, setActive],
+  );
+
+  if (!collapsed) {
+    return (
+      <a
+        href="/c/new"
+        data-testid="new-chat-button"
+        aria-label={localize('com_ui_new_chat')}
+        className="flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-surface-hover"
+        onClick={handleClick}
+      >
+        <SquarePen className="h-4 w-4 text-text-secondary" />
+      </a>
+    );
+  }
+
+  return (
+    <TooltipAnchor
+      side="right"
+      description={localize('com_ui_new_chat')}
+      render={
+        <a
+          href="/c/new"
+          data-testid="new-chat-button"
+          aria-label={localize('com_ui_new_chat')}
+          className="flex h-8 w-8 items-center justify-center rounded-md transition-colors hover:bg-surface-hover"
+          onClick={handleClick}
+        >
+          <SquarePen className="h-4 w-4 text-text-secondary" />
+        </a>
+      }
+    />
+  );
+});
+
+/** A single nav row in the expanded sidebar: icon on left, localized label on right. */
+const NavLabelRow = memo(function NavLabelRow({
+  link,
+  isActive,
+  onClick,
+}: {
+  link: NavLink;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  const localize = useLocalize();
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isActive}
+      aria-label={localize(link.title)}
+      onClick={onClick}
+      className={cn(
+        'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left transition-colors',
+        isActive
+          ? 'bg-surface-active-alt text-text-primary'
+          : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+      )}
+    >
+      <link.icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+      <span className="truncate text-sm">{localize(link.title)}</span>
+    </button>
+  );
+});
+
+/** Full expanded sidebar: logo header + labeled nav rows + active panel content + account */
+function FullSidebar({
+  links,
+  onCollapse,
+}: {
+  links: NavLink[];
+  onCollapse: () => void;
+}) {
+  const localize = useLocalize();
+  const { active, setActive } = useActivePanel();
+  const effectiveActive = resolveActivePanel(active, links);
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden border-r border-border-light bg-surface-primary-alt">
+      {/* Header: logo + name + new-chat + collapse */}
+      <div className="flex flex-shrink-0 items-center justify-between px-3 py-2">
+        <div className="flex items-center gap-2">
+          <LibreChatLogo className="text-text-primary" />
+          <span className="text-sm font-semibold text-text-primary">LibreChat</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <NewChatButton setActive={setActive} collapsed={false} />
+          <TooltipAnchor
+            side="right"
+            description={localize('com_nav_close_sidebar')}
+            render={
+              <Button
+                id={CLOSE_SIDEBAR_ID}
+                data-testid="close-sidebar-button"
+                size="icon"
+                variant="ghost"
+                aria-label={localize('com_nav_close_sidebar')}
+                aria-expanded={true}
+                className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
+                onClick={onCollapse}
+              >
+                <LibreChatLogo className="h-4 w-4" />
+              </Button>
+            }
+          />
+        </div>
+      </div>
+
+      <div className="mx-3 flex-shrink-0 border-b border-border-light" />
+
+      {/* Nav items with icon + label */}
+      <div className="flex flex-shrink-0 flex-col gap-0.5 px-2 py-2">
+        {links.map((link) => (
+          <NavLabelRow
+            key={link.id}
+            link={link}
+            isActive={link.id === effectiveActive}
+            onClick={() => {
+              if (link.onClick) {
+                link.onClick();
+                return;
+              }
+              setActive(link.id);
+            }}
+          />
+        ))}
+      </div>
+
+      <div className="mx-3 flex-shrink-0 border-b border-border-light" />
+
+      {/* Active panel content */}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <SidePanelNav links={links} />
+      </div>
+
+      {/* Account settings */}
+      <div className="flex-shrink-0 px-2 py-2">
+        <Suspense fallback={<Skeleton className="h-9 w-full rounded-lg" />}>
+          <AccountSettings collapsed={false} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}
 
 function Sidebar({
   links,
@@ -15,25 +218,17 @@ function Sidebar({
   onCollapse: () => void;
   onExpand: () => void;
 }) {
+  if (expanded) {
+    return <FullSidebar links={links} onCollapse={onCollapse} />;
+  }
+
   return (
-    <div className="flex h-full w-full overflow-hidden">
-      <ExpandedPanel
-        links={links}
-        expanded={expanded}
-        onCollapse={onCollapse}
-        onExpand={onExpand}
-      />
-      <nav
-        className={cn(
-          'min-h-0 flex-1 overflow-hidden bg-surface-primary-alt',
-          expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
-        )}
-        style={{ transition: expanded ? 'opacity 200ms ease 80ms' : 'opacity 150ms ease' }}
-        aria-hidden={!expanded}
-      >
-        <SidePanelNav links={links} />
-      </nav>
-    </div>
+    <ExpandedPanel
+      links={links}
+      expanded={false}
+      onExpand={onExpand}
+      onCollapse={onCollapse}
+    />
   );
 }
 

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -219,7 +219,7 @@ function Sidebar({
   return (
     <div className="relative h-full w-full">
       {/* Icon strip — always rendered as the base layer */}
-      <div className="absolute inset-y-0 left-0 w-[52px]">
+      <div className="absolute inset-y-0 left-0 w-[60px]">
         <ExpandedPanel
           links={links}
           expanded={false}

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
-import { SquarePen } from 'lucide-react';
+import { SquarePen, SidebarClose } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
 import { Skeleton, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
@@ -14,30 +14,6 @@ import ExpandedPanel from './ExpandedPanel';
 import store from '~/store';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
-
-/** Click UI "slide-out" icon (arrow left + vertical bar) — paths from @clickhouse/click-ui */
-function SlideOutIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-      className={className}
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-        d="M18.703 12.015H6.836M11.576 16.509l-4.78-4.51 4.78-4.508"
-      />
-      <path stroke="currentColor" strokeLinecap="round" strokeWidth={1.5} d="M5 7v10" />
-    </svg>
-  );
-}
 
 /** LibreChat logomark — 5 vertical bars matching the design file. */
 function LibreChatLogo({ className }: { className?: string }) {
@@ -185,7 +161,7 @@ function FullSidebar({
                 className="h-8 w-8 rounded-md text-text-secondary hover:text-text-primary"
                 onClick={onCollapse}
               >
-                <SlideOutIcon />
+                <SidebarClose className="h-4 w-4" />
               </Button>
             }
           />

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { SquarePen, SidebarClose } from 'lucide-react';
 import { QueryKeys } from 'librechat-data-provider';
@@ -97,18 +97,29 @@ const NavLabelRow = memo(function NavLabelRow({
 }) {
   const localize = useLocalize();
 
+  const rowClass = cn(
+    'flex h-8 w-full items-center gap-2 rounded-md px-4 text-left transition-colors',
+    isActive
+      ? 'bg-surface-active-alt text-text-primary'
+      : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
+  );
+
+  if (link.href) {
+    return (
+      <Link to={link.href} aria-label={localize(link.title)} className={rowClass}>
+        <link.icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+        <span className="truncate text-sm">{localize(link.title)}</span>
+      </Link>
+    );
+  }
+
   return (
     <button
       type="button"
       aria-pressed={isActive}
       aria-label={localize(link.title)}
       onClick={onClick}
-      className={cn(
-        'flex h-8 w-full items-center gap-2 rounded-md px-4 text-left transition-colors',
-        isActive
-          ? 'bg-surface-active-alt text-text-primary'
-          : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary',
-      )}
+      className={rowClass}
     >
       <link.icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
       <span className="truncate text-sm">{localize(link.title)}</span>
@@ -125,6 +136,7 @@ function FullSidebar({
   onCollapse: () => void;
 }) {
   const localize = useLocalize();
+  const { pathname } = useLocation();
   const { active, setActive } = useActivePanel();
   const effectiveActive = resolveActivePanel(active, links);
   const { isAuthenticated } = useAuthContext();
@@ -190,7 +202,7 @@ function FullSidebar({
             <NavLabelRow
               key={link.id}
               link={link}
-              isActive={link.id === effectiveActive}
+              isActive={link.href ? pathname.startsWith(link.href) : link.id === effectiveActive}
               onClick={() => {
                 if (link.onClick) {
                   link.onClick();

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useRef, memo, startTransition } from 'react';
+import { useCallback, useState, useEffect, memo, startTransition } from 'react';
 import type { ReactNode } from 'react';
 import { useRecoilState } from 'recoil';
 import { useForm } from 'react-hook-form';
@@ -14,19 +14,14 @@ import { cn } from '~/utils';
 import store from '~/store';
 
 const COLLAPSED_WIDTH = 52;
-const EXPANDED_MIN = 360;
+const SIDEBAR_WIDTH = 260;
 const TRANSITION_MS = 300;
 const EASING = 'cubic-bezier(0.2, 0, 0, 1)';
-
-function getInitialWidth(): number {
-  const saved = localStorage.getItem('side:width');
-  return saved ? Math.max(Number(saved), EXPANDED_MIN) : EXPANDED_MIN;
-}
 
 /**
  * Isolates useChatHelpers Recoil subscriptions from the sidebar layout.
  * Atom changes (e.g. during streaming) only re-render this component
- * and the active panel — not the sidebar shell, resize logic, or icon strip.
+ * and the active panel — not the sidebar shell or icon strip.
  * This works because Recoil subscriptions don't propagate to parent components.
  */
 function SidebarChatProvider({ children }: { children: ReactNode }) {
@@ -43,9 +38,6 @@ function UnifiedSidebar() {
   const localize = useLocalize();
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
   const [expanded, setExpanded] = useRecoilState(store.sidebarExpanded);
-  const [sidebarWidth, setSidebarWidth] = useState(getInitialWidth);
-  const [isResizing, setIsResizing] = useState(false);
-  const resizeHandlers = useRef<{ move: (e: MouseEvent) => void; up: () => void } | null>(null);
 
   const links = useUnifiedSidebarLinks();
 
@@ -60,64 +52,6 @@ function UnifiedSidebar() {
       setExpanded(true);
     });
   }, [setExpanded]);
-
-  const handleResizeStart = useCallback(() => {
-    setIsResizing(true);
-    document.body.style.userSelect = 'none';
-    const maxWidth = window.innerWidth * 0.4;
-    let rafId: number | null = null;
-
-    const move = (e: MouseEvent) => {
-      if (rafId != null) {
-        return;
-      }
-      rafId = requestAnimationFrame(() => {
-        rafId = null;
-        const next = Math.max(EXPANDED_MIN, Math.min(e.clientX, maxWidth));
-        setSidebarWidth(next);
-      });
-    };
-
-    const up = () => {
-      if (rafId != null) {
-        cancelAnimationFrame(rafId);
-        rafId = null;
-      }
-      document.body.style.userSelect = '';
-      setIsResizing(false);
-      resizeHandlers.current = null;
-      setSidebarWidth((w) => {
-        localStorage.setItem('side:width', String(Math.round(w)));
-        return w;
-      });
-      document.removeEventListener('mousemove', move);
-      document.removeEventListener('mouseup', up);
-    };
-
-    resizeHandlers.current = { move, up };
-    document.addEventListener('mousemove', move);
-    document.addEventListener('mouseup', up);
-  }, []);
-
-  const handleResizeKeyboard = useCallback((direction: 'shrink' | 'grow') => {
-    setSidebarWidth((w) => {
-      const next =
-        direction === 'shrink'
-          ? Math.max(w - 20, EXPANDED_MIN)
-          : Math.min(w + 20, window.innerWidth * 0.4);
-      localStorage.setItem('side:width', String(Math.round(next)));
-      return next;
-    });
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (resizeHandlers.current) {
-        document.removeEventListener('mousemove', resizeHandlers.current.move);
-        document.removeEventListener('mouseup', resizeHandlers.current.up);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     if (!isSmallScreen || !expanded) {
@@ -180,12 +114,10 @@ function UnifiedSidebar() {
         <aside
           className="relative flex h-full flex-shrink-0 overflow-hidden"
           style={{
-            width: expanded ? sidebarWidth : COLLAPSED_WIDTH,
-            minWidth: expanded ? EXPANDED_MIN : COLLAPSED_WIDTH,
-            maxWidth: expanded ? '40%' : COLLAPSED_WIDTH,
-            transition: isResizing
-              ? 'none'
-              : `width ${TRANSITION_MS}ms ${EASING}, min-width ${TRANSITION_MS}ms ${EASING}, max-width ${TRANSITION_MS}ms ${EASING}`,
+            width: expanded ? SIDEBAR_WIDTH : COLLAPSED_WIDTH,
+            minWidth: expanded ? SIDEBAR_WIDTH : COLLAPSED_WIDTH,
+            maxWidth: expanded ? SIDEBAR_WIDTH : COLLAPSED_WIDTH,
+            transition: `width ${TRANSITION_MS}ms ${EASING}, min-width ${TRANSITION_MS}ms ${EASING}, max-width ${TRANSITION_MS}ms ${EASING}`,
           }}
           aria-label={localize('com_nav_control_panel')}
         >
@@ -194,8 +126,6 @@ function UnifiedSidebar() {
             expanded={expanded}
             onCollapse={handleCollapse}
             onExpand={handleExpand}
-            onResizeStart={handleResizeStart}
-            onResizeKeyboard={handleResizeKeyboard}
           />
         </aside>
       </ActivePanelProvider>

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -16,6 +16,7 @@ import store from '~/store';
 const COLLAPSED_WIDTH = 52;
 const SIDEBAR_WIDTH = 260;
 const TRANSITION_MS = 300;
+const SNAP_MS = 150;
 const EASING = 'cubic-bezier(0.2, 0, 0, 1)';
 
 /**
@@ -117,7 +118,11 @@ function UnifiedSidebar() {
             width: expanded ? SIDEBAR_WIDTH : COLLAPSED_WIDTH,
             minWidth: expanded ? SIDEBAR_WIDTH : COLLAPSED_WIDTH,
             maxWidth: expanded ? SIDEBAR_WIDTH : COLLAPSED_WIDTH,
-            transition: `width ${TRANSITION_MS}ms ${EASING}, min-width ${TRANSITION_MS}ms ${EASING}, max-width ${TRANSITION_MS}ms ${EASING}`,
+            // Collapsing: let FullSidebar slide out first (TRANSITION_MS), then snap the width.
+            // Expanding: grow the aside immediately so FullSidebar has room to slide into.
+            transition: expanded
+              ? `width ${TRANSITION_MS}ms ${EASING}, min-width ${TRANSITION_MS}ms ${EASING}, max-width ${TRANSITION_MS}ms ${EASING}`
+              : `width ${SNAP_MS}ms ${EASING} ${TRANSITION_MS}ms, min-width ${SNAP_MS}ms ${EASING} ${TRANSITION_MS}ms, max-width ${SNAP_MS}ms ${EASING} ${TRANSITION_MS}ms`,
           }}
           aria-label={localize('com_nav_control_panel')}
         >

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -13,7 +13,7 @@ import Sidebar from './Sidebar';
 import { cn } from '~/utils';
 import store from '~/store';
 
-const COLLAPSED_WIDTH = 52;
+const COLLAPSED_WIDTH = 60;
 const SIDEBAR_WIDTH = 260;
 const TRANSITION_MS = 300;
 const SNAP_MS = 150;

--- a/client/src/components/ui/PageHeader.tsx
+++ b/client/src/components/ui/PageHeader.tsx
@@ -1,38 +1,18 @@
-const FONT_FAMILY =
-  'Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
-
 interface PageHeaderProps {
   title: string;
+  actions?: React.ReactNode;
 }
 
-export default function PageHeader({ title }: PageHeaderProps) {
+export default function PageHeader({ title, actions }: PageHeaderProps) {
   return (
-    <div className="w-full">
-      <div className="px-6" style={{ paddingTop: '18px' }}>
-        <h1
-          style={{
-            fontFamily: FONT_FAMILY,
-            fontSize: '0.875rem',
-            fontWeight: 500,
-            lineHeight: 1.5,
-            color: '#161517',
-            margin: 0,
-            padding: 0,
-          }}
-        >
-          {title}
-        </h1>
+    <div className="relative w-full flex-shrink-0">
+      <div className="px-6 pt-[18px]">
+        <div className="text-sm font-medium leading-normal text-text-primary">{title}</div>
       </div>
-      <hr
-        style={{
-          border: 'none',
-          borderTop: '1px solid rgba(22,21,23,0.1)',
-          marginTop: '16px',
-          marginBottom: '24px',
-          padding: 0,
-          width: '100%',
-        }}
-      />
+      {actions != null && (
+        <div className="absolute inset-y-0 right-6 flex items-center gap-1">{actions}</div>
+      )}
+      <div className="mt-4 border-b border-border-light" />
     </div>
   );
 }

--- a/client/src/components/ui/PageHeader.tsx
+++ b/client/src/components/ui/PageHeader.tsx
@@ -1,0 +1,38 @@
+const FONT_FAMILY =
+  'Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+interface PageHeaderProps {
+  title: string;
+}
+
+export default function PageHeader({ title }: PageHeaderProps) {
+  return (
+    <div className="w-full">
+      <div className="px-6" style={{ paddingTop: '18px' }}>
+        <h1
+          style={{
+            fontFamily: FONT_FAMILY,
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            lineHeight: 1.5,
+            color: '#161517',
+            margin: 0,
+            padding: 0,
+          }}
+        >
+          {title}
+        </h1>
+      </div>
+      <hr
+        style={{
+          border: 'none',
+          borderTop: '1px solid rgba(22,21,23,0.1)',
+          marginTop: '16px',
+          marginBottom: '24px',
+          padding: 0,
+          width: '100%',
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -107,6 +107,7 @@ export default function useSideNavLinks({
         label: '',
         icon: Bot,
         id: EModelEndpoint.agents,
+        href: '/agents',
         Component: AgentPanelSwitch,
       });
     }

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -136,6 +136,7 @@ export default function useSideNavLinks({
         label: '',
         icon: ScrollText,
         id: 'skills',
+        href: '/skills',
         Component: SkillsAccordion,
       });
     }
@@ -146,6 +147,7 @@ export default function useSideNavLinks({
         label: '',
         icon: NotebookPen,
         id: 'prompts',
+        href: '/prompts/new',
         Component: PromptsAccordion,
       });
     }
@@ -156,6 +158,7 @@ export default function useSideNavLinks({
         label: '',
         icon: Brain,
         id: 'memories',
+        href: '/memories',
         Component: MemoryPanel,
       });
     }
@@ -166,6 +169,7 @@ export default function useSideNavLinks({
         label: '',
         icon: Bookmark,
         id: 'bookmarks',
+        href: '/bookmarks',
         Component: BookmarkPanel,
       });
     }
@@ -175,6 +179,7 @@ export default function useSideNavLinks({
       label: '',
       icon: AttachmentIcon,
       id: 'files',
+      href: '/files',
       Component: FilesPanel,
     });
 
@@ -202,6 +207,7 @@ export default function useSideNavLinks({
         label: '',
         icon: MCPIcon,
         id: 'mcp-builder',
+        href: '/mcp',
         Component: MCPBuilderPanel,
       });
     }

--- a/client/src/hooks/Nav/useUnifiedSidebarLinks.ts
+++ b/client/src/hooks/Nav/useUnifiedSidebarLinks.ts
@@ -72,7 +72,7 @@ export default function useUnifiedSidebarLinks() {
         label: '',
         icon: LayoutGrid,
         id: 'marketplace',
-        onClick: () => navigate('/agents'),
+        onClick: () => navigate('/agents/explore'),
       });
     }
 

--- a/client/src/hooks/Nav/useUnifiedSidebarLinks.ts
+++ b/client/src/hooks/Nav/useUnifiedSidebarLinks.ts
@@ -1,18 +1,22 @@
 import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import { MessagesSquare } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { MessagesSquare, LayoutGrid } from 'lucide-react';
 import { useUserKeyQuery } from 'librechat-data-provider/react-query';
-import { getConfigDefaults, getEndpointField } from 'librechat-data-provider';
+import { getConfigDefaults, getEndpointField, EModelEndpoint } from 'librechat-data-provider';
 import type { TEndpointsConfig } from 'librechat-data-provider';
 import type { NavLink } from '~/common';
 import ConversationsSection from '~/components/UnifiedSidebar/ConversationsSection';
 import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
 import useSideNavLinks from '~/hooks/Nav/useSideNavLinks';
+import { useShowMarketplace } from '~/hooks';
 import store from '~/store';
 
 const defaultInterface = getConfigDefaults().interface;
 
 export default function useUnifiedSidebarLinks() {
+  const navigate = useNavigate();
+  const showMarketplace = useShowMarketplace();
   const conversation = useRecoilValue(store.conversationByIndex(0));
   const endpoint = conversation?.endpoint;
   const { data: startupConfig } = useGetStartupConfig();
@@ -58,8 +62,22 @@ export default function useUnifiedSidebarLinks() {
       Component: ConversationsSection,
     };
 
-    return [conversationLink, ...sideNavLinks];
-  }, [sideNavLinks]);
+    const result = [conversationLink, ...sideNavLinks];
+
+    if (showMarketplace) {
+      const agentsIndex = result.findIndex((l) => l.id === EModelEndpoint.agents);
+      const insertAt = agentsIndex >= 0 ? agentsIndex + 1 : result.length;
+      result.splice(insertAt, 0, {
+        title: 'com_agents_marketplace',
+        label: '',
+        icon: LayoutGrid,
+        id: 'marketplace',
+        onClick: () => navigate('/agents'),
+      });
+    }
+
+    return result;
+  }, [sideNavLinks, showMarketplace, navigate]);
 
   return links;
 }

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -36,6 +36,11 @@ const loadInlinePromptsView = () =>
     Component: m.default,
   }));
 
+const loadSkillsLayout = () =>
+  import('~/components/Skills/layouts/SkillsLayout').then((m) => ({
+    Component: m.default,
+  }));
+
 const loadSkillsView = () =>
   import('~/components/Skills/layouts/SkillsView').then((m) => ({
     Component: m.default,
@@ -49,6 +54,11 @@ const loadProjectsView = () =>
 const loadProjectWorkspace = () =>
   import('~/components/Projects').then((m) => ({
     Component: m.ProjectWorkspace,
+  }));
+
+const loadAgentsView = () =>
+  import('~/components/SidePanel/Agents/layouts/AgentsView').then((m) => ({
+    Component: m.default,
   }));
 
 const loadMemoriesView = () =>
@@ -168,19 +178,13 @@ export const router = createBrowserRouter(
             },
             {
               path: 'skills',
-              lazy: loadSkillsView,
-            },
-            {
-              path: 'skills/new',
-              lazy: loadSkillsView,
-            },
-            {
-              path: 'skills/:skillId',
-              lazy: loadSkillsView,
-            },
-            {
-              path: 'skills/:skillId/edit',
-              lazy: loadSkillsView,
+              lazy: loadSkillsLayout,
+              children: [
+                { index: true, lazy: loadSkillsView },
+                { path: 'new', lazy: loadSkillsView },
+                { path: ':skillId', lazy: loadSkillsView },
+                { path: ':skillId/edit', lazy: loadSkillsView },
+              ],
             },
             {
               path: 'projects',
@@ -190,14 +194,7 @@ export const router = createBrowserRouter(
               path: 'projects/:projectId',
               lazy: loadProjectWorkspace,
             },
-            {
-              path: 'agents',
-              element: (
-                <MarketplaceProvider>
-                  <AgentMarketplace />
-                </MarketplaceProvider>
-              ),
-            },
+            { path: 'agents', lazy: loadAgentsView },
             {
               path: 'agents/:category',
               element: (

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -51,6 +51,26 @@ const loadProjectWorkspace = () =>
     Component: m.ProjectWorkspace,
   }));
 
+const loadMemoriesView = () =>
+  import('~/components/SidePanel/Memories/layouts/MemoriesView').then((m) => ({
+    Component: m.default,
+  }));
+
+const loadBookmarksView = () =>
+  import('~/components/SidePanel/Bookmarks/layouts/BookmarksView').then((m) => ({
+    Component: m.default,
+  }));
+
+const loadFilesView = () =>
+  import('~/components/SidePanel/Files/layouts/FilesView').then((m) => ({
+    Component: m.default,
+  }));
+
+const loadMCPView = () =>
+  import('~/components/SidePanel/MCPBuilder/layouts/MCPView').then((m) => ({
+    Component: m.default,
+  }));
+
 const baseEl = document.querySelector('base');
 const baseHref = baseEl?.getAttribute('href') || '/';
 
@@ -186,6 +206,10 @@ export const router = createBrowserRouter(
                 </MarketplaceProvider>
               ),
             },
+            { path: 'memories', lazy: loadMemoriesView },
+            { path: 'bookmarks', lazy: loadBookmarksView },
+            { path: 'files', lazy: loadFilesView },
+            { path: 'mcp', lazy: loadMCPView },
           ],
         },
       ],

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import fs from 'fs';
 import { defineConfig } from 'vite';
 import { createRequire } from 'module';
 import { VitePWA } from 'vite-plugin-pwa';
@@ -59,6 +60,17 @@ export default defineConfig(({ command }) => ({
   envPrefix: ['VITE_', 'SCRIPT_', 'DOMAIN_', 'ALLOW_'],
   plugins: [
     react(),
+    // Injects ./src/dev.local.jsx into the app entry in dev mode when present.
+    // This file is gitignored — use it for local dev tools (e.g. agentation).
+    {
+      name: 'dev-local-inject',
+      apply: 'serve',
+      transform(code: string, id: string) {
+        if (id.endsWith('main.jsx') && fs.existsSync(path.join(__dirname, 'src/dev.local.jsx'))) {
+          return code + "\nimport './dev.local.jsx';";
+        }
+      },
+    },
     {
       name: 'node-polyfills-shims-resolver',
       resolveId(id) {

--- a/packages/client/src/components/Avatar.tsx
+++ b/packages/client/src/components/Avatar.tsx
@@ -51,7 +51,7 @@ const Avatar: React.FC<AvatarProps> = ({
     () => (
       <div
         style={{
-          backgroundColor: 'rgb(121, 137, 255)',
+          backgroundColor: 'rgb(156, 163, 175)',
           width: `${size}px`,
           height: `${size}px`,
           boxShadow: 'rgba(240, 246, 252, 0.1) 0px 0px 0px 1px',


### PR DESCRIPTION
## Summary

Every tool nav item in the sidebar now navigates to its own dedicated full-page URL instead of expanding an inline panel. Tool pages are bookmarkable, deep-linkable, and each has a consistent `PageHeader` + 24px content padding matching the rest of the app.

## Depends on

**Both of these must merge first:**

| PR | Branch |
|---|---|
| #13792 `feat(sidebar): new chrome` | `feat/sidebar-chrome` |
| #13753 `feat(ui): PageHeader component` | `feat/page-header-component` |

> To review only the individual-pages delta on top of the chrome:
> ```
> git diff feat/sidebar-chrome...feat/sidebar-sql-console
> ```

## Route map

| Nav link | URL | Layout |
|---|---|---|
| Agent Builder | `/agents` | `AgentsView` |
| Memories | `/memories` | `MemoriesView` (access-gated) |
| Bookmarks | `/bookmarks` | `BookmarksView` (access-gated) |
| Files | `/files` | `FilesView` |
| MCP | `/mcp` | `MCPView` (access-gated) |
| Prompts | `/prompts/new` | `InlinePromptsView` (pre-existing route, now with `PageHeader`) |
| Skills | `/skills` | `SkillsLayout` two-column (pre-existing route, now with `PageHeader`) |
| Assistants | — | inline panel (unchanged) |
| Parameters | — | inline panel (unchanged) |
| Marketplace | `/agents/explore` | `navigate()` (unchanged) |

## What changed

### Routing (`routes/index.tsx`)
- New lazy routes: `/agents`, `/memories`, `/bookmarks`, `/files`, `/mcp`
- Skills restructured as layout route: `/skills`, `/skills/new`, `/skills/:id`, `/skills/:id/edit`
- Agent marketplace moved to `/agents/explore`; `/agents` now renders `AgentsView`

### `NavLink` type + `useSideNavLinks.ts`
- `href?: string` added to `NavLink`; 7 links now have `href`
- Links without `href` (Assistants, Parameters) continue to expand inline panels
- `Nav.tsx`: skips inline panel render for `href`-bearing links

### `Sidebar.tsx` + `ExpandedPanel.tsx`
- `NavLabelRow` renders `<Link>` when `href` set, `<button>` otherwise
- Active state: `pathname.startsWith(link.href)` for routed links

### `PageHeader` component
- Used on all individual pages — 55px total height aligns with sidebar header divider
- `actions` prop (absolutely positioned) used on Skills page for `CreateSkillMenu` button

### New page views
| File | Route | Access guard |
|---|---|---|
| `AgentsView.tsx` | `/agents` | none |
| `MemoriesView.tsx` | `/memories` | `MEMORIES:USE + READ` |
| `BookmarksView.tsx` | `/bookmarks` | `BOOKMARKS:USE` |
| `FilesView.tsx` | `/files` | none |
| `MCPView.tsx` | `/mcp` | `MCP_SERVERS:USE or CREATE` |
| `SkillsLayout.tsx` | `/skills` (layout) | — |

### Two-column Skills layout
- `PageHeader` full-width with `CreateSkillMenu` on the right
- 280px left column: `SkillsSidePanel` with `hideHeader=true` (always-visible search, 24px padding)
- Right column: `<Outlet />` → `SkillsView` (detail / edit / create)

### Double-padding removed (`noPadding` props)
All panels strip internal padding when rendered full-page so the outer `p-6` wrapper is the sole padding source:
- `AgentPanel` — `noPadding` threaded through `AgentPanelSwitch`
- `MemoryPanel`, `BookmarkPanel`, `MCPBuilderPanel` — existing `noPadding` props passed
- `CreatePromptForm`, `BookmarkTable`, `SkillDetail`, `CreateSkillForm`, `SkillForm` — internal `px-*` removed

## Test plan

- [ ] Click each sidebar nav item → correct URL, active state in both strip and expanded nav
- [ ] Revisit URL directly → page loads, sidebar active state correct
- [ ] `/agents` — Agent Builder renders, 24px content padding, no double-indent
- [ ] `/memories` — Memory panel; redirects to `/c/new` without permission
- [ ] `/bookmarks` — Bookmark table; redirects without permission
- [ ] `/files` — Files DataTable with filter/sort/pagination
- [ ] `/mcp` — MCP builder; redirects without permission
- [ ] `/prompts/new` and `/prompts/:id` — correct page with `PageHeader`
- [ ] `/skills` — two-column: skill list left, empty state right
- [ ] `/skills/new` — Create Skill form on the right with 24px padding
- [ ] `/skills/:id` — Skill detail with 24px padding
- [ ] Agent Builder inline panel still works from chat context
- [ ] Marketplace → `/agents/explore` still works
- [ ] `PageHeader` divider aligns with sidebar header divider on all pages
- [ ] All pages: 24px left + top padding on content

🤖 Generated with [Claude Code](https://claude.com/claude-code)