### PR TITLE
🗜️ fix: Support Windows ZIP MIME Uploads

### DIFF
--- a/api/server/routes/files/multer.js
+++ b/api/server/routes/files/multer.js
@@ -5,6 +5,7 @@ const multer = require('multer');
 const { sanitizeFilename } = require('@librechat/api');
 const {
   mergeFileConfig,
+  inferMimeType,
   getEndpointFileConfig,
   fileConfig: defaultFileConfig,
 } = require('librechat-data-provider');
@@ -37,6 +38,14 @@ const importFileFilter = (req, file, cb) => {
   }
 };
 
+const normalizeUploadMimeType = (file) => {
+  const mimeType = inferMimeType(file.originalname || '', file.mimetype || '');
+  if (mimeType && file.mimetype !== mimeType) {
+    file.mimetype = mimeType;
+  }
+  return mimeType;
+};
+
 /**
  *
  * @param {import('librechat-data-provider').FileConfig | undefined} customFileConfig
@@ -52,7 +61,9 @@ const createFileFilter = (customFileConfig) => {
       return cb(new Error('No file provided'), false);
     }
 
-    if (req.originalUrl.endsWith('/speech/stt') && file.mimetype.startsWith('audio/')) {
+    const mimeType = normalizeUploadMimeType(file);
+
+    if (req.originalUrl.endsWith('/speech/stt') && mimeType.startsWith('audio/')) {
       return cb(null, true);
     }
 
@@ -64,8 +75,8 @@ const createFileFilter = (customFileConfig) => {
       endpointType,
     });
 
-    if (!defaultFileConfig.checkType(file.mimetype, endpointFileConfig.supportedMimeTypes)) {
-      return cb(new Error('Unsupported file type: ' + file.mimetype), false);
+    if (!defaultFileConfig.checkType(mimeType, endpointFileConfig.supportedMimeTypes)) {
+      return cb(new Error('Unsupported file type: ' + (file.mimetype || mimeType)), false);
     }
 
     cb(null, true);
@@ -85,4 +96,4 @@ const createMulterInstance = async () => {
   });
 };
 
-module.exports = { createMulterInstance, storage, importFileFilter };
+module.exports = { createMulterInstance, storage, importFileFilter, createFileFilter };

--- a/api/server/routes/files/multer.spec.js
+++ b/api/server/routes/files/multer.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
-const { createMulterInstance, storage, importFileFilter } = require('./multer');
+const { createMulterInstance, storage, importFileFilter, createFileFilter } = require('./multer');
 
 // Mock only the config service that requires external dependencies
 jest.mock('~/server/services/Config', () => ({
@@ -279,6 +279,25 @@ describe('Multer Configuration', () => {
         // Restore original function
         require('librechat-data-provider').fileConfig.checkType = originalCheckType;
       }
+    });
+
+    it('should infer ZIP MIME type when multipart upload omits it', (done) => {
+      const { mergeFileConfig } = require('librechat-data-provider');
+      const fileFilter = createFileFilter(mergeFileConfig());
+      const zipFile = {
+        ...mockFile,
+        originalname: 'archive.zip',
+        mimetype: '',
+      };
+
+      const cb = jest.fn((err, result) => {
+        expect(err).toBeNull();
+        expect(result).toBe(true);
+        expect(zipFile.mimetype).toBe('application/zip');
+        done();
+      });
+
+      fileFilter(mockReq, zipFile, cb);
     });
 
     it('should use real mergeFileConfig function', async () => {

--- a/client/src/utils/__tests__/validateFiles.spec.ts
+++ b/client/src/utils/__tests__/validateFiles.spec.ts
@@ -98,6 +98,22 @@ describe('validateFiles', () => {
     expect(setError).toHaveBeenCalledWith('Unsupported file type: application/x-unknown');
   });
 
+  it('normalizes Windows ZIP MIME type before validation', () => {
+    const fileList = [makeFile('archive.zip', 'application/x-zip-compressed', 1024)];
+    const result = validateFiles({ files, fileList, setError, endpointFileConfig, fileConfig });
+    expect(result).toBe(true);
+    expect(fileList[0].type).toBe('application/zip');
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('infers ZIP MIME type when the browser does not provide one', () => {
+    const fileList = [makeFile('archive.zip', '', 1024)];
+    const result = validateFiles({ files, fileList, setError, endpointFileConfig, fileConfig });
+    expect(result).toBe(true);
+    expect(fileList[0].type).toBe('application/zip');
+    expect(setError).not.toHaveBeenCalled();
+  });
+
   it('rejects when file size equals fileSizeLimit (>= comparison)', () => {
     const limit = 5 * megabyte;
     endpointFileConfig = makeEndpointConfig({ fileSizeLimit: limit });

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -23,6 +23,10 @@ describe('inferMimeType', () => {
     expect(inferMimeType('test.md', 'text/x-markdown')).toBe('text/markdown');
   });
 
+  it('should normalize application/x-zip-compressed to application/zip', () => {
+    expect(inferMimeType('archive.zip', 'application/x-zip-compressed')).toBe('application/zip');
+  });
+
   it('should return a type that matches textMimeTypes after normalization', () => {
     const normalized = inferMimeType('test.py', 'text/x-python-script');
     expect(textMimeTypes.test(normalized)).toBe(true);
@@ -36,6 +40,7 @@ describe('inferMimeType', () => {
   it('should infer from extension when browser type is empty', () => {
     expect(inferMimeType('test.py', '')).toBe('text/x-python');
     expect(inferMimeType('code.js', '')).toBe('text/javascript');
+    expect(inferMimeType('archive.zip', '')).toBe('application/zip');
     expect(inferMimeType('photo.heic', '')).toBe('image/heic');
     expect(inferMimeType('Main.java', '')).toBe('text/x-java');
   });
@@ -82,6 +87,7 @@ describe('applicationMimeTypes', () => {
     'application/msword',
     'application/xml',
     'application/zip',
+    'application/x-zip-compressed',
     'application/epub+zip',
     'application/x-tar',
     'application/x-sh',

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -61,6 +61,7 @@ export const fullMimeTypesList = [
   'application/vnd.coffeescript',
   'application/xml',
   'application/zip',
+  'application/x-zip-compressed',
   'application/x-parquet',
   'application/vnd.oasis.opendocument.text',
   'application/vnd.oasis.opendocument.spreadsheet',
@@ -121,6 +122,7 @@ export const codeInterpreterMimeTypesList = [
   'application/typescript',
   'application/xml',
   'application/zip',
+  'application/x-zip-compressed',
   'application/x-parquet',
   ...excelFileTypes,
 ];
@@ -185,7 +187,7 @@ export const textMimeTypes =
   /^(text\/(x-c|x-csharp|tab-separated-values|x-c\+\+|x-h|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|vtt|javascript|csv|xml|calendar))$/;
 
 export const applicationMimeTypes =
-  /^(application\/(epub\+zip|csv|json|msword|pdf|x-tar|x-sh|typescript|sql|yaml|x-parquet|vnd\.apache\.parquet|vnd\.coffeescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet)|vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)|xml|zip))$/;
+  /^(application\/(epub\+zip|csv|json|msword|pdf|x-tar|x-sh|x-zip-compressed|typescript|sql|yaml|x-parquet|vnd\.apache\.parquet|vnd\.coffeescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet)|vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)|xml|zip))$/;
 
 export const imageMimeTypes = /^image\/(jpeg|gif|png|webp|heic|heif)$/;
 
@@ -367,6 +369,7 @@ export const imageTypeMapping: { [key: string]: string } = {
 
 /** Normalizes non-standard MIME types that browsers may report to their canonical forms */
 export const mimeTypeAliases: Readonly<Record<string, string>> = {
+  'application/x-zip-compressed': 'application/zip',
   'text/x-python-script': 'text/x-python',
   'text/x-markdown': 'text/markdown',
 };


### PR DESCRIPTION
## Summary

I fixed ZIP uploads for Code Interpreter across Windows browser MIME aliases and empty multipart MIME metadata.

- Added `application/x-zip-compressed` to the shared full and Code Interpreter MIME allowlists.
- Normalized `application/x-zip-compressed` to `application/zip` before client-side upload validation.
- Reused shared filename-based MIME inference in the backend Multer upload filter so direct multipart uploads with an empty ZIP MIME are canonicalized before validation and downstream processing.
- Covered shared MIME inference, client validation, and backend upload filtering with focused regression tests.

Fixes #13785

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ran `git diff --check`
- [ ] `npx jest src/file-config.spec.ts specs/filetypes.spec.ts --runInBand` from `packages/data-provider` could not run locally because this worktree has no installed dependencies; Jest reported missing `jest-junit`.
- [ ] `npx jest src/utils/__tests__/validateFiles.spec.ts --runInBand` from `client` could not run locally because this worktree has no installed dependencies; Jest reported missing `jest-environment-jsdom`.

### **Test Configuration**:

- Local worktree: `/Users/danny/.codex/worktrees/0464/LibreChat`
- Node modules were not installed in this worktree.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works