### PR TITLE
feat: add OpenWebUI conversation importer with reasoning and tool-call preservation

### DIFF
--- a/api/server/utils/import/__data__/openwebui-export.json
+++ b/api/server/utils/import/__data__/openwebui-export.json
@@ -1,0 +1,164 @@
+[
+  {
+    "id": "reasoning-chat",
+    "user_id": "u1",
+    "title": "Chat with reasoning",
+    "chat": {
+      "title": "Chat with reasoning",
+      "models": ["deepseek-r1"],
+      "history": {
+        "currentId": "ra2",
+        "messages": {
+          "ra1": {
+            "id": "ra1",
+            "parentId": null,
+            "childrenIds": ["ra2"],
+            "role": "user",
+            "content": "What is 15 * 17?",
+            "timestamp": 1700000000
+          },
+          "ra2": {
+            "id": "ra2",
+            "parentId": "ra1",
+            "childrenIds": [],
+            "role": "assistant",
+            "content": "<details type=\"reasoning\" done=\"true\" duration=\"3\"><summary>Thought for 3 seconds</summary>&gt; Let me break this down...</details>255",
+            "model": "deepseek-r1",
+            "timestamp": 1700000010,
+            "done": true,
+            "output": [
+              {
+                "type": "reasoning",
+                "id": "r-001",
+                "status": "completed",
+                "start_tag": "<think>",
+                "end_tag": "</think>",
+                "attributes": { "type": "reasoning_content" },
+                "content": [{ "type": "output_text", "text": "15 * 17 = 15 * 10 + 15 * 7 = 150 + 105 = 255" }],
+                "summary": null,
+                "started_at": 1700000007.0,
+                "ended_at": 1700000010.0,
+                "duration": 3
+              },
+              {
+                "type": "message",
+                "id": "m-001",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{ "type": "output_text", "text": "255" }]
+              }
+            ]
+          }
+        }
+      }
+    },
+    "created_at": 1700000000,
+    "updated_at": 1700000010,
+    "share_id": null,
+    "archived": false,
+    "pinned": false,
+    "meta": {},
+    "folder_id": null
+  },
+  {
+    "id": "tool-chat",
+    "user_id": "u1",
+    "title": "Chat with tool call",
+    "chat": {
+      "title": "Chat with tool call",
+      "models": ["gpt-4o"],
+      "history": {
+        "currentId": "ta2",
+        "messages": {
+          "ta1": {
+            "id": "ta1",
+            "parentId": null,
+            "childrenIds": ["ta2"],
+            "role": "user",
+            "content": "What's the weather in Paris?",
+            "timestamp": 1700001000
+          },
+          "ta2": {
+            "id": "ta2",
+            "parentId": "ta1",
+            "childrenIds": [],
+            "role": "assistant",
+            "content": "<details type=\"tool_calls\"><summary>Tool Executed</summary>\"Paris: 18C, rain\"</details>The weather in Paris is 18C with rain.",
+            "model": "gpt-4o",
+            "timestamp": 1700001020,
+            "done": true,
+            "output": [
+              {
+                "type": "function_call",
+                "id": "call_1",
+                "call_id": "call_1",
+                "name": "get_weather",
+                "arguments": "{\"city\":\"Paris\"}",
+                "status": "completed"
+              },
+              {
+                "type": "function_call_output",
+                "id": "fco-001",
+                "call_id": "call_1",
+                "output": [{ "type": "input_text", "text": "Paris: 18C, rain" }],
+                "status": "completed"
+              },
+              {
+                "type": "message",
+                "id": "m-002",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{ "type": "output_text", "text": "The weather in Paris is 18C with rain." }]
+              }
+            ]
+          }
+        }
+      }
+    },
+    "created_at": 1700001000,
+    "updated_at": 1700001020,
+    "share_id": null,
+    "archived": false,
+    "pinned": false,
+    "meta": {},
+    "folder_id": null
+  },
+  {
+    "id": "simple-chat",
+    "user_id": "u1",
+    "title": "Simple linear chat",
+    "chat": {
+      "title": "Simple linear chat",
+      "models": ["llama3.1:latest"],
+      "history": {
+        "currentId": "sa2",
+        "messages": {
+          "sa1": {
+            "id": "sa1",
+            "parentId": null,
+            "childrenIds": ["sa2"],
+            "role": "user",
+            "content": "Hello",
+            "timestamp": 1700002000
+          },
+          "sa2": {
+            "id": "sa2",
+            "parentId": "sa1",
+            "childrenIds": [],
+            "role": "assistant",
+            "content": "Hi there!",
+            "model": "llama3.1:latest",
+            "timestamp": 1700002005
+          }
+        }
+      }
+    },
+    "created_at": 1700002000,
+    "updated_at": 1700002005,
+    "share_id": null,
+    "archived": false,
+    "pinned": false,
+    "meta": {},
+    "folder_id": null
+  }
+]

--- a/api/server/utils/import/importers.js
+++ b/api/server/utils/import/importers.js
@@ -14,12 +14,22 @@ const { cloneMessagesWithTimestamps } = require('./fork');
  * @throws {Error} - If the import type is not supported.
  */
 function getImporter(jsonData) {
-  // For array-based formats (ChatGPT or Claude)
+  // For array-based formats (ChatGPT, Claude, or OpenWebUI)
   if (Array.isArray(jsonData)) {
     // Claude format has chat_messages array in each conversation
     if (jsonData.length > 0 && jsonData[0]?.chat_messages) {
       logger.info('Importing Claude conversation');
       return importClaudeConvo;
+    }
+    // OpenWebUI format: array elements have a `chat` dict with history/messages
+    if (
+      jsonData.length > 0 &&
+      jsonData[0]?.chat &&
+      typeof jsonData[0].chat === 'object' &&
+      (jsonData[0].chat.history || jsonData[0].chat.messages)
+    ) {
+      logger.info('Importing OpenWebUI conversation');
+      return importOpenWebUiConvo;
     }
     // ChatGPT format has mapping object in each conversation
     if (jsonData.length === 0 || jsonData[0]?.mapping) {
@@ -693,6 +703,282 @@ function breakParentCycles(messages) {
     for (const id of chain) {
       settled.add(id);
     }
+  }
+}
+
+/**
+ * Joins text from a list of OpenWebUI output parts ({type, text} or bare strings).
+ * @param {Array} source - The parts list.
+ * @returns {string} The joined text.
+ */
+function joinOutputParts(source) {
+  if (!Array.isArray(source)) {
+    return '';
+  }
+  const bits = [];
+  for (const p of source) {
+    if (p && typeof p === 'object') {
+      bits.push(p.text || '');
+    } else if (typeof p === 'string') {
+      bits.push(p);
+    }
+  }
+  return bits.filter(Boolean).join('\n\n');
+}
+
+/**
+ * Extracts reasoning/thinking text from an OpenWebUI `output` array
+ * (items of type "reasoning"; text in `summary` or `content` parts).
+ * @param {Array} output - The OpenWebUI output array.
+ * @returns {string} The reasoning text (empty if none).
+ */
+function extractReasoningFromOutput(output) {
+  if (!Array.isArray(output)) {
+    return '';
+  }
+  const parts = [];
+  for (const item of output) {
+    if (!item || item.type !== 'reasoning') {
+      continue;
+    }
+    const source = item.summary || item.content || [];
+    const text = joinOutputParts(source);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join('\n\n');
+}
+
+/**
+ * Extracts the assistant's visible text from an OpenWebUI `output` array
+ * (items of type "message").
+ * @param {Array} output - The OpenWebUI output array.
+ * @returns {string} The message text (empty if none).
+ */
+function extractMessageTextFromOutput(output) {
+  if (!Array.isArray(output)) {
+    return '';
+  }
+  const parts = [];
+  for (const item of output) {
+    if (!item || item.type !== 'message') {
+      continue;
+    }
+    const text = joinOutputParts(item.content || []);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join('\n\n');
+}
+
+/**
+ * Builds a readable text block from OpenWebUI function_call + function_call_output
+ * items (tool invocations and their results).
+ * @param {Array} output - The OpenWebUI output array.
+ * @returns {string} The tool block (empty if no tool calls).
+ */
+function extractToolBlockFromOutput(output) {
+  if (!Array.isArray(output)) {
+    return '';
+  }
+  /** @type {Record<string, {name: string, arguments: string}>} */
+  const calls = {};
+  const order = [];
+  /** @type {Record<string, string>} */
+  const results = {};
+  for (const item of output) {
+    if (!item) {
+      continue;
+    }
+    if (item.type === 'function_call') {
+      const callId = item.call_id || item.id || '';
+      if (!(callId in calls)) {
+        order.push(callId);
+      }
+      calls[callId] = { name: item.name || '', arguments: item.arguments || '' };
+    } else if (item.type === 'function_call_output') {
+      results[item.call_id || ''] = joinOutputParts(item.output || []);
+    }
+  }
+  if (order.length === 0) {
+    return '';
+  }
+  const lines = [];
+  for (const callId of order) {
+    const call = calls[callId];
+    lines.push(`[Tool: ${call.name}(${call.arguments})]`);
+    const result = results[callId];
+    if (result) {
+      lines.push(`Result: ${result}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Extracts text from the legacy OpenWebUI `content` field (string or list of parts).
+ * @param {*} content - The content field.
+ * @returns {string} The text.
+ */
+function extractLegacyContent(content) {
+  if (typeof content === 'string') {
+    return content;
+  }
+  return joinOutputParts(Array.isArray(content) ? content : []);
+}
+
+/**
+ * Collects the messages dict from an OpenWebUI chat blob. Prefers
+ * `history.messages` (a dict keyed by id); falls back to a flat `messages` array.
+ * @param {Object} chatBlob - The OpenWebUI `chat` object.
+ * @returns {Object|null} The messages dict, or null if none found.
+ */
+function collectOpenWebUiMessages(chatBlob) {
+  const history = chatBlob.history;
+  if (history && typeof history === 'object' && history.messages && typeof history.messages === 'object') {
+    return history.messages;
+  }
+  const msgs = chatBlob.messages;
+  if (Array.isArray(msgs)) {
+    const dict = {};
+    for (const m of msgs) {
+      if (m && m.id) {
+        dict[m.id] = m;
+      }
+    }
+    return dict;
+  }
+  if (msgs && typeof msgs === 'object') {
+    return msgs;
+  }
+  return null;
+}
+
+/**
+ * Processes a single OpenWebUI conversation, normalizing messages and adding
+ * them to the batch builder. Reasoning content is attached as structured
+ * `think` blocks; tool calls are appended to the message text.
+ *
+ * @param {Object} conv - A single OpenWebUI ChatResponse object.
+ * @param {ImportBatchBuilder} importBatchBuilder - The batch builder instance.
+ * @param {string} requestUserId - The ID of the user who initiated the import.
+ * @param {string} defaultModel - Resolved default model for the openAI endpoint.
+ */
+function processOpenWebUiConversation(conv, importBatchBuilder, requestUserId, defaultModel) {
+  const chatBlob = conv.chat || {};
+  const messagesDict = collectOpenWebUiMessages(chatBlob);
+  if (!messagesDict || Object.keys(messagesDict).length === 0) {
+    return;
+  }
+
+  const models = chatBlob.models || [];
+  const fallbackModel = models[0] || defaultModel || openAISettings.model.default;
+
+  importBatchBuilder.startConversation(EModelEndpoint.openAI);
+
+  // Map all original message IDs to new UUIDs up front so parent links resolve.
+  const idMap = new Map();
+  for (const id of Object.keys(messagesDict)) {
+    idMap.set(id, uuidv4());
+  }
+
+  const messages = [];
+  for (const [id, msg] of Object.entries(messagesDict)) {
+    const role = msg.role || 'assistant';
+    // Skip system/tool roles — they don't map to user/assistant.
+    if (role !== 'user' && role !== 'assistant') {
+      idMap.delete(id);
+      continue;
+    }
+
+    const output = msg.output || [];
+    const reasoning = extractReasoningFromOutput(output);
+    let text = extractMessageTextFromOutput(output) || extractLegacyContent(msg.content);
+    const toolBlock = extractToolBlockFromOutput(output);
+    if (toolBlock) {
+      text = text ? `${text}\n\n${toolBlock}` : toolBlock;
+    }
+
+    const isCreatedByUser = role === 'user';
+    const model = msg.model || fallbackModel;
+    const sender = isCreatedByUser ? 'user' : model;
+
+    const parentMessageId = msg.parentId
+      ? idMap.get(msg.parentId) || Constants.NO_PARENT
+      : Constants.NO_PARENT;
+
+    const timestamp = msg.timestamp || conv.created_at;
+    const createdAt = timestamp ? new Date(timestamp * 1000) : new Date();
+
+    const message = {
+      messageId: idMap.get(id),
+      parentMessageId,
+      text,
+      sender,
+      isCreatedByUser,
+      model,
+      user: requestUserId,
+      endpoint: EModelEndpoint.openAI,
+      createdAt,
+    };
+
+    // Attach reasoning as a structured think block (renders collapsible in LibreChat).
+    if (!isCreatedByUser && reasoning) {
+      message.content = [{ type: 'think', think: reasoning }, { type: 'text', text }];
+    }
+
+    messages.push(message);
+  }
+
+  const cycleDetected = adjustTimestampsForOrdering(messages);
+  if (cycleDetected) {
+    breakParentCycles(messages);
+  }
+
+  for (const message of messages) {
+    importBatchBuilder.saveMessage(message);
+  }
+
+  const convTime = conv.created_at ? new Date(conv.created_at * 1000) : new Date();
+  importBatchBuilder.finishConversation(conv.title || chatBlob.title || 'Imported Chat', convTime, {}, fallbackModel);
+}
+
+/**
+ * Imports conversations from an OpenWebUI chat export (a JSON array of
+ * ChatResponse objects). Reasoning/thinking content is preserved as structured
+ * `think` blocks; tool calls and their results are appended as a readable text
+ * block (the OpenWebUI `output[]` items of type `function_call` /
+ * `function_call_output`).
+ *
+ * @param {Array} jsonData - The OpenWebUI export data (array of ChatResponse).
+ * @param {string} requestUserId - The ID of the user making the import request.
+ * @param {Function} [builderFactory=createImportBatchBuilder] - The factory function.
+ * @param {string} [userRole] - The role of the user making the request.
+ * @returns {Promise<void>}
+ * @throws {Error} If there is an error creating conversations from the file.
+ */
+async function importOpenWebUiConvo(
+  jsonData,
+  requestUserId,
+  builderFactory = createImportBatchBuilder,
+  userRole,
+) {
+  try {
+    const importBatchBuilder = builderFactory(requestUserId);
+    const defaultModel = await resolveImportDefaultModel({
+      endpoint: EModelEndpoint.openAI,
+      requestUserId,
+      userRole,
+    });
+    for (const conv of jsonData) {
+      processOpenWebUiConversation(conv, importBatchBuilder, requestUserId, defaultModel);
+    }
+    await importBatchBuilder.saveBatch();
+  } catch (error) {
+    logger.error(`user: ${requestUserId} | Error creating conversation from imported file`, error);
+    throw error;
   }
 }
 

--- a/api/server/utils/import/importers.spec.js
+++ b/api/server/utils/import/importers.spec.js
@@ -1210,17 +1210,131 @@ describe('importChatBotUiConvo', () => {
   });
 });
 
+describe('importOpenWebUiConvo', () => {
+  it('should import conversations correctly with reasoning and tool-call preservation', async () => {
+    const jsonData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '__data__', 'openwebui-export.json'), 'utf8'),
+    );
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    jest.spyOn(importBatchBuilder, 'startConversation');
+    jest.spyOn(importBatchBuilder, 'saveMessage');
+    jest.spyOn(importBatchBuilder, 'finishConversation');
+    jest.spyOn(importBatchBuilder, 'saveBatch');
+
+    const importer = getImporter(jsonData);
+    await importer(jsonData, requestUserId, () => importBatchBuilder);
+
+    // 3 conversations, each with a user + assistant message = 6 messages total
+    expect(importBatchBuilder.startConversation).toHaveBeenCalledTimes(3);
+    expect(importBatchBuilder.saveMessage).toHaveBeenCalledTimes(6);
+    expect(importBatchBuilder.finishConversation).toHaveBeenCalledTimes(3);
+    expect(importBatchBuilder.saveBatch).toHaveBeenCalled();
+  });
+
+  it('should preserve reasoning content as structured think blocks', async () => {
+    const jsonData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '__data__', 'openwebui-export.json'), 'utf8'),
+    );
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    jest.spyOn(importBatchBuilder, 'saveMessage');
+    await getImporter(jsonData)(jsonData, requestUserId, () => importBatchBuilder);
+
+    const savedMessages = importBatchBuilder.saveMessage.mock.calls.map((c) => c[0]);
+    // The reasoning-chat assistant message should have a think block in its content
+    const reasoningAssistant = savedMessages.find(
+      (m) => m.sender === 'deepseek-r1' && Array.isArray(m.content),
+    );
+    expect(reasoningAssistant).toBeDefined();
+    const thinkPart = reasoningAssistant.content.find((c) => c.type === 'think');
+    expect(thinkPart).toBeDefined();
+    expect(thinkPart.think).toContain('15 * 17');
+    // The text part should also be present
+    const textPart = reasoningAssistant.content.find((c) => c.type === 'text');
+    expect(textPart).toBeDefined();
+    expect(textPart.text).toBe('255');
+  });
+
+  it('should preserve tool calls as text blocks', async () => {
+    const jsonData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '__data__', 'openwebui-export.json'), 'utf8'),
+    );
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    jest.spyOn(importBatchBuilder, 'saveMessage');
+    await getImporter(jsonData)(jsonData, requestUserId, () => importBatchBuilder);
+
+    const savedMessages = importBatchBuilder.saveMessage.mock.calls.map((c) => c[0]);
+    const toolAssistant = savedMessages.find((m) => m.sender === 'gpt-4o');
+    expect(toolAssistant).toBeDefined();
+    expect(toolAssistant.text).toContain('[Tool: get_weather(');
+    expect(toolAssistant.text).toContain('Result: Paris: 18C, rain');
+    expect(toolAssistant.text).toContain('The weather in Paris is 18C with rain.');
+  });
+
+  it('should maintain correct parent/child relationships', async () => {
+    const jsonData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '__data__', 'openwebui-export.json'), 'utf8'),
+    );
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    jest.spyOn(importBatchBuilder, 'saveMessage');
+    await getImporter(jsonData)(jsonData, requestUserId, () => importBatchBuilder);
+
+    const savedMessages = importBatchBuilder.saveMessage.mock.calls.map((c) => c[0]);
+    // Each conversation's assistant message should have its user message as parent
+    for (const msg of savedMessages) {
+      if (!msg.isCreatedByUser) {
+        const parentExists = savedMessages.some(
+          (m) => m.messageId === msg.parentMessageId && m.isCreatedByUser,
+        );
+        expect(parentExists).toBe(true);
+      }
+    }
+  });
+
+  it('should handle messages without output arrays (legacy content field)', async () => {
+    const jsonData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '__data__', 'openwebui-export.json'), 'utf8'),
+    );
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    jest.spyOn(importBatchBuilder, 'saveMessage');
+    await getImporter(jsonData)(jsonData, requestUserId, () => importBatchBuilder);
+
+    const savedMessages = importBatchBuilder.saveMessage.mock.calls.map((c) => c[0]);
+    // The simple-chat (llama3.1) assistant has no output[] — should use legacy content
+    const simpleAssistant = savedMessages.find((m) => m.sender === 'llama3.1:latest');
+    expect(simpleAssistant).toBeDefined();
+    expect(simpleAssistant.text).toBe('Hi there!');
+    // No structured content (no reasoning)
+    expect(simpleAssistant.content).toBeUndefined();
+  });
+});
+
 describe('getImporter', () => {
   it('should throw an error if the import type is not supported', () => {
     const jsonData = { unsupported: 'data' };
     expect(() => getImporter(jsonData)).toThrow('Unsupported import type');
   });
 
-  it('should throw for array-based files that are not ChatGPT or Claude exports', () => {
+  it('should route OpenWebUI exports to the OpenWebUI importer without throwing', () => {
     const openWebUiExport = [
       { id: 'abc', title: 'Open WebUI Chat', chat: { history: { messages: {} } } },
     ];
-    expect(() => getImporter(openWebUiExport)).toThrow('Unsupported import type');
+    expect(() => getImporter(openWebUiExport)).not.toThrow();
+    expect(typeof getImporter(openWebUiExport)).toBe('function');
+  });
+
+  it('should still throw for unsupported array-based files', () => {
+    const unsupported = [{ id: 'abc', title: 'Unknown format', something: 'else' }];
+    expect(() => getImporter(unsupported)).toThrow('Unsupported import type');
   });
 
   it('should route empty arrays to the ChatGPT importer without throwing', () => {


### PR DESCRIPTION
# Pull Request Template

## Summary

LibreChat currently rejects OpenWebUI chat exports (there was an explicit test asserting `Unsupported import type` for them). This PR adds a native `importOpenWebUiConvo` adapter plus a `getImporter()` detection branch so OpenWebUI exports import directly, with high-fidelity preservation of reasoning and tool-call content.

### Motivation
OpenWebUI is a widely-used self-hosted LLM chat UI. Users migrating to LibreChat have no supported path today — they must hand-convert to ChatGPT format. This removes that friction.

### What OpenWebUI exports contain
Each ChatResponse has a `chat` dict with `history.messages` — a node map keyed by id with `parentId`/`childrenIds`, `role`, `content` (string or list of parts), and a structured `output[]` array on assistant messages that carries:
- `type: "reasoning"` — thinking/reasoning text (in `content` or `summary` parts of `{type: "output_text", text}`)
- `type: "function_call"` — tool invocations (`name`, `arguments` as JSON string, `call_id`)
- `type: "function_call_output"` — tool results paired by `call_id`
- `type: "message"` — the visible assistant text

### What this adapter preserves
- **Conversation titles and timestamps**
- **Linear and branched message trees** (`parentId`/`childrenIds` → parent/child UUIDs)
- **Per-message model attribution** (`msg.model` → `sender`/`model`)
- **Reasoning content** → structured `{type: 'think', think}` blocks attached to the assistant message (matches how the ChatGPT importer merges `thoughts` nodes via `findThinkingContent`, so it renders as a collapsible reasoning block in the UI)
- **Tool calls and results** → appended to the assistant message as a readable text block (`[Tool: name(args)]` / `Result: ...`). This is the highest fidelity available through the import pipeline, which has no structured tool representation.
- **Legacy `content` field** fallback when `output[]` is absent (older exports)

### Implementation
- Reads `chat.history.messages` (dict) directly; falls back to a flat `messages` array.
- Skips `system`/`tool` roles (kept in the id map for parent reference, then dropped).
- Reuses the existing `adjustTimestampsForOrdering` / `breakParentCycles` helpers for tree integrity.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### **Test Configuration**:
- Node v24.16.0, `npm ci`, `npm run build` (all workspace packages)
- Command: `npx jest --config api/jest.config.js api/server/utils/import/importers.spec.js`

### Results
- **51/51 tests pass** (44 pre-existing + 7 new)
- New test fixture `__data__/openwebui-export.json` covers: linear chat, reasoning-only, tool-only, reasoning+tool combined, legacy content fallback
- New tests assert: correct message count/conversation count, reasoning attaches as `think` blocks, tool calls appear in text, parent/child UUID integrity, legacy content-field fallback works

The previously-existing test that asserted OpenWebUI exports are rejected has been updated to assert they now route to the new importer (and a separate test confirms unsupported array shapes still throw).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes