### PR TITLE
fix(api): Prevent custom agent override in model specs enforcement

### DIFF
--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -57,7 +57,8 @@ async function buildEndpointOption(req, res, next) {
 
   const appConfig = req.config;
   let appliedModelSpecPrivateFields = new Set();
-  if (appConfig.modelSpecs?.list?.length && appConfig.modelSpecs?.enforce) {
+  const hasCustomAgent = isAgents && (req.body.agent_id || parsedBody.agent_id);
+  if (appConfig.modelSpecs?.list?.length && appConfig.modelSpecs?.enforce && !hasCustomAgent) {
     /** @type {{ list: TModelSpec[] }}*/
     const { list } = appConfig.modelSpecs;
     const { spec } = parsedBody;


### PR DESCRIPTION
## Summary

Custom agents from the Agent Builder fail with a loading spinner because buildEndpointOption rejects requests without a spec field — this fix bypasses that check when an agent_id is present.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Create an agent from agent Builder:

<img width="356" height="855" alt="image" src="https://github.com/user-attachments/assets/fa064a28-3865-476e-b047-5b5d97a45551" />

the loading spinner runs indefinitely
<img width="403" height="272" alt="image" src="https://github.com/user-attachments/assets/0097c8fa-ba8a-489b-ba1b-720de13bbe47" />