### PR TITLE
📛 feat: Tag Langfuse Traces With Tenant ID

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1327,6 +1327,7 @@ class AgentClient extends BaseClient {
           customHandlers: this.options.eventHandlers,
           requestBody: config.configurable.requestBody,
           user: createSafeUser(this.options.req?.user),
+          tenantId: this.options.req?.user?.tenantId,
           summarizationConfig: appConfig?.summarization,
           appConfig,
           tokenCounter,

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -743,6 +743,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         conversationId,
       },
       user: { id: userId },
+      tenantId: req.user?.tenantId,
       /** Bills subagent child-run model calls (reported outside the
        *  streamEvents loop) into the same collectedUsage array. */
       subagentUsageSink: createSubagentUsageSink(collectedUsage),

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -750,6 +750,7 @@ const createResponse = async (req, res) => {
           conversationId,
         },
         user: { id: userId },
+        tenantId: req.user?.tenantId,
         /** Bills subagent child-run model calls (reported outside the
          *  streamEvents loop) into the same collectedUsage array. */
         subagentUsageSink: createSubagentUsageSink(collectedUsage),
@@ -927,6 +928,7 @@ const createResponse = async (req, res) => {
           conversationId,
         },
         user: { id: userId },
+        tenantId: req.user?.tenantId,
         /** Bills subagent child-run model calls (reported outside the
          *  streamEvents loop) into the same collectedUsage array. */
         subagentUsageSink: createSubagentUsageSink(collectedUsage),

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1103,41 +1103,50 @@ describe('subagentConfigs', () => {
   });
 });
 
+/**
+ * Captures the top-level `Run.create` config (not just agentInputs) so tests
+ * can assert presence/absence of run-level options.
+ */
+async function callAndCaptureRunConfig({
+  overrides,
+  user,
+  tenantId,
+}: {
+  overrides?: Record<string, unknown>;
+  user?: Record<string, unknown>;
+  tenantId?: string;
+} = {}): Promise<Record<string, unknown>> {
+  const agents = [makeAgent(overrides)];
+  const signal = new AbortController().signal;
+
+  await createRun({
+    agents: agents as never,
+    signal,
+    streaming: true,
+    streamUsage: true,
+    user: user as never,
+    tenantId,
+  });
+
+  const createMock = Run.create as jest.Mock;
+  expect(createMock).toHaveBeenCalledTimes(1);
+  return createMock.mock.calls[0][0] as Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
-// Suite: toolOutputReferences gating
+// Suite: Langfuse run config
 // ---------------------------------------------------------------------------
-describe('toolOutputReferences gating', () => {
-  /**
-   * Captures the top-level `Run.create` config (not just agentInputs) so the
-   * test can assert presence/absence of the `toolOutputReferences` key.
-   */
-  async function callAndCaptureRunConfig(
-    overrides?: Record<string, unknown>,
-    user?: Record<string, unknown>,
-  ): Promise<Record<string, unknown>> {
-    const agents = [makeAgent(overrides)];
-    const signal = new AbortController().signal;
-
-    await createRun({
-      agents: agents as never,
-      signal,
-      streaming: true,
-      streamUsage: true,
-      user: user as never,
-    });
-
-    const createMock = Run.create as jest.Mock;
-    expect(createMock).toHaveBeenCalledTimes(1);
-    return createMock.mock.calls[0][0] as Record<string, unknown>;
-  }
-
+describe('Langfuse run config', () => {
   it('passes deterministic Langfuse trace config without tenant metadata by default', async () => {
     const callArgs = await callAndCaptureRunConfig();
     expect(callArgs.langfuse).toEqual({ deterministicTraceId: true });
   });
 
-  it('adds the authenticated tenant id to Langfuse trace metadata and tags', async () => {
-    const callArgs = await callAndCaptureRunConfig(undefined, {
+  it('adds the explicit request tenant id to Langfuse trace metadata and tags', async () => {
+    const callArgs = await callAndCaptureRunConfig({
+      user: {
+        id: 'user-1',
+      },
       tenantId: 'tenant-1',
     });
     expect(callArgs.langfuse).toEqual({
@@ -1147,13 +1156,35 @@ describe('toolOutputReferences gating', () => {
     });
   });
 
+  it('falls back to a full user tenant id for direct createRun callers', async () => {
+    const callArgs = await callAndCaptureRunConfig({
+      user: {
+        tenantId: 'tenant-2',
+      },
+    });
+    expect(callArgs.langfuse).toEqual({
+      deterministicTraceId: true,
+      metadata: { 'librechat.tenant.id': 'tenant-2' },
+      tags: ['tenant:tenant-2'],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: toolOutputReferences gating
+// ---------------------------------------------------------------------------
+describe('toolOutputReferences gating', () => {
   it('passes toolOutputReferences when agent has codeEnvAvailable=true', async () => {
-    const callArgs = await callAndCaptureRunConfig({ codeEnvAvailable: true });
+    const callArgs = await callAndCaptureRunConfig({
+      overrides: { codeEnvAvailable: true },
+    });
     expect(callArgs.toolOutputReferences).toEqual({ enabled: true });
   });
 
   it('omits toolOutputReferences when codeEnvAvailable is false', async () => {
-    const callArgs = await callAndCaptureRunConfig({ codeEnvAvailable: false });
+    const callArgs = await callAndCaptureRunConfig({
+      overrides: { codeEnvAvailable: false },
+    });
     expect(callArgs).not.toHaveProperty('toolOutputReferences');
   });
 

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,12 +1,12 @@
 import { logger } from '@librechat/data-schemas';
-import type { AppConfig } from '@librechat/data-schemas';
-import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
 import {
   EModelEndpoint,
   FileSources,
   MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_RUN_CONFIGS,
 } from 'librechat-data-provider';
+import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
+import type { AppConfig } from '@librechat/data-schemas';
 import { createRun } from '~/agents/run';
 
 // Mock winston logger — `format` must be callable so @librechat/data-schemas
@@ -1113,6 +1113,7 @@ describe('toolOutputReferences gating', () => {
    */
   async function callAndCaptureRunConfig(
     overrides?: Record<string, unknown>,
+    user?: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     const agents = [makeAgent(overrides)];
     const signal = new AbortController().signal;
@@ -1122,12 +1123,29 @@ describe('toolOutputReferences gating', () => {
       signal,
       streaming: true,
       streamUsage: true,
+      user: user as never,
     });
 
     const createMock = Run.create as jest.Mock;
     expect(createMock).toHaveBeenCalledTimes(1);
     return createMock.mock.calls[0][0] as Record<string, unknown>;
   }
+
+  it('passes deterministic Langfuse trace config without tenant metadata by default', async () => {
+    const callArgs = await callAndCaptureRunConfig();
+    expect(callArgs.langfuse).toEqual({ deterministicTraceId: true });
+  });
+
+  it('adds the authenticated tenant id to Langfuse trace metadata and tags', async () => {
+    const callArgs = await callAndCaptureRunConfig(undefined, {
+      tenantId: 'tenant-1',
+    });
+    expect(callArgs.langfuse).toEqual({
+      deterministicTraceId: true,
+      metadata: { 'librechat.tenant.id': 'tenant-1' },
+      tags: ['tenant:tenant-1'],
+    });
+  });
 
   it('passes toolOutputReferences when agent has codeEnvAvailable=true', async () => {
     const callArgs = await callAndCaptureRunConfig({ codeEnvAvailable: true });

--- a/packages/api/src/agents/openai/service.ts
+++ b/packages/api/src/agents/openai/service.ts
@@ -31,6 +31,7 @@ import type {
   ToolCall,
 } from './types';
 import type { OpenAIStreamHandlerConfig, EventHandler } from './handlers';
+import type { ToolExecuteOptions } from '../handlers';
 import {
   createOpenAIContentAggregator,
   createOpenAIStreamTracker,
@@ -40,7 +41,6 @@ import {
   writeSSE,
 } from './handlers';
 import { createSafeUser } from '~/utils';
-import type { ToolExecuteOptions } from '../handlers';
 
 /**
  * Dependencies for the chat completion service
@@ -175,6 +175,7 @@ type CreateRunFn = (params: {
   customHandlers: Record<string, EventHandler>;
   requestBody: Record<string, unknown>;
   user: Record<string, unknown>;
+  tenantId?: string;
   tokenCounter?: (message: unknown) => number;
 }) => Promise<{
   Graph?: unknown;
@@ -524,6 +525,7 @@ export async function createAgentChatCompletion(
           conversationId,
         },
         user: safeUser,
+        tenantId: typeof reqUser?.tenantId === 'string' ? reqUser.tenantId : undefined,
       });
 
       if (run) {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -794,8 +794,8 @@ function buildSubagentConfigs(
   return configs;
 }
 
-function buildLangfuseConfig(user?: IUser) {
-  const tenantId = typeof user?.tenantId === 'string' ? user.tenantId.trim() : '';
+function buildLangfuseConfig(tenantIdInput?: unknown) {
+  const tenantId = typeof tenantIdInput === 'string' ? tenantIdInput.trim() : '';
   return {
     deterministicTraceId: true,
     ...(tenantId !== '' && {
@@ -827,6 +827,7 @@ export async function createRun({
   messages,
   requestBody,
   user,
+  tenantId,
   tokenCounter,
   customHandlers,
   indexTokenCountMap,
@@ -846,6 +847,7 @@ export async function createRun({
   streamUsage?: boolean;
   requestBody?: t.RequestBody;
   user?: IUser;
+  tenantId?: string;
   /** Message history for extracting previously discovered tools */
   messages?: BaseMessage[];
   summarizationConfig?: SummarizationConfig;
@@ -1108,7 +1110,7 @@ export async function createRun({
     // feedback can be scored against the trace without a lookup (see the
     // feedback route in api/server/routes/messages.js). No-op unless Langfuse
     // tracing is enabled. Requires @librechat/agents >= 3.2.21.
-    langfuse: buildLangfuseConfig(user),
+    langfuse: buildLangfuseConfig(tenantId ?? user?.tenantId),
     ...(enableToolOutputReferences && {
       toolOutputReferences: { enabled: true },
     }),

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -794,6 +794,17 @@ function buildSubagentConfigs(
   return configs;
 }
 
+function buildLangfuseConfig(user?: IUser) {
+  const tenantId = typeof user?.tenantId === 'string' ? user.tenantId.trim() : '';
+  return {
+    deterministicTraceId: true,
+    ...(tenantId !== '' && {
+      metadata: { 'librechat.tenant.id': tenantId },
+      tags: [`tenant:${tenantId}`],
+    }),
+  };
+}
+
 /**
  * Creates a new Run instance with custom handlers and configuration.
  *
@@ -1097,7 +1108,7 @@ export async function createRun({
     // feedback can be scored against the trace without a lookup (see the
     // feedback route in api/server/routes/messages.js). No-op unless Langfuse
     // tracing is enabled. Requires @librechat/agents >= 3.2.21.
-    langfuse: { deterministicTraceId: true },
+    langfuse: buildLangfuseConfig(user),
     ...(enableToolOutputReferences && {
       toolOutputReferences: { enabled: true },
     }),


### PR DESCRIPTION
## Summary

Adds the authenticated user's tenant id to agent-run Langfuse config so traces can carry:

- `metadata['librechat.tenant.id']`
- `tags: ['tenant:<tenantId>']`

The tag form is intended for Langfuse Metrics API filtering, while metadata keeps the trace readable.

## Notes

This is paired with an `@librechat/agents` SDK change that adds support for merging run-level Langfuse metadata/tags into callback handlers and propagated attributes. Until that SDK change is released and consumed, the app-side config is present but older SDK versions will ignore the extra fields.

## Validation

- `jest src/agents/__tests__/run-summarization.test.ts --runInBand --testNamePattern='Langfuse|toolOutputReferences'` from `packages/api`