### PR TITLE
fix: stop agents from over-using the web_search tool (provider-agnostic prompt fix)

### DIFF
--- a/packages/api/src/tools/toolkits/web.spec.ts
+++ b/packages/api/src/tools/toolkits/web.spec.ts
@@ -14,6 +14,14 @@ describe('web search context', () => {
     expect(context).not.toContain('{{iso_datetime}}');
   });
 
+  it('defaults the model away from searching unless a trigger applies', () => {
+    const context = buildWebSearchContext();
+
+    expect(context).toContain('Default: answer from your own knowledge.');
+    expect(context).toContain('A search is justified ONLY if you can name a concrete reason');
+    expect(context).toContain('is NOT a reason to search');
+  });
+
   it('builds dynamic context from the supplied conversation anchor', () => {
     const context = buildWebSearchDynamicContext('2024-01-02T03:04:05.000Z');
     const secondContext = buildWebSearchDynamicContext('2024-01-02T03:04:05.000Z');

--- a/packages/api/src/tools/toolkits/web.ts
+++ b/packages/api/src/tools/toolkits/web.ts
@@ -3,7 +3,20 @@ import { Tools, replaceSpecialVars } from 'librechat-data-provider';
 /** Builds the web search tool context with citation format instructions. */
 export function buildWebSearchContext(): string {
   return `# \`${Tools.web_search}\`:
-**Execute immediately without preface.** After search, provide a brief summary addressing the query directly, then structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
+**Default: answer from your own knowledge.** Most messages do not need a search, so do not reach for this tool by reflex.
+
+A search is justified ONLY if you can name a concrete reason from this list. If none clearly applies, do not search:
+- The answer depends on information that changes over time and could be stale (today's news, prices, weather, schedules, standings, current office-holders, latest version numbers).
+- The user asks about a specific recent event or release, or anything dated after your knowledge cutoff.
+- The user explicitly asks you to search, or gives a link or source to read.
+- The answer hinges on niche, local, or hard-to-verify specifics you are genuinely unsure of (a specific business's hours, an obscure spec, a person who isn't widely documented).
+- You gave an answer and have real reason to believe it is outdated or wrong.
+
+Do NOT search for things you can already handle: definitions, concepts, explanations, reasoning, math, code, translation, writing, summarizing the user's own text, general how-tos, or opinions. The fact that a search might return relevant-looking results is NOT a reason to search — only the gaps above are.
+
+When you are unsure whether you know enough, answer from your knowledge and state what you're uncertain about, instead of defaulting to a search. An unnecessary search adds latency and noise and is worse than a direct answer.
+
+If — and only if — a trigger above applies: search once, immediately, without preface, then provide a brief summary addressing the query directly, and structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
 
 Use the conversation date/time from the dynamic runtime context when recency matters.
 


### PR DESCRIPTION
## Bug report (with a suggested fix)

### What's wrong
With web search enabled, the agent calls `web_search` on almost every turn, even for things it can answer directly (definitions, explanations, reasoning, coding, math, summarizing the user's own text). This happens across providers — I see it on Anthropic-API models and on OpenRouter models alike.

### Root cause
The instruction LibreChat injects into the agent system prompt for the web search tool is framed action-first and never tells the model when **not** to search. In `packages/api/src/tools/toolkits/web.ts`, `buildWebSearchContext()` opens with:

> **Execute immediately without preface.** After search, provide a brief summary...

It reads as "a search is already happening," with no gate on whether to search at all. Any model can rationalize that a search "might help," so without an explicit default-off, it searches by reflex.

This is **provider-agnostic**: `buildWebSearchContext()` is the single source of this text, consumed by both `api/server/services/ToolService.js` and `api/app/clients/tools/util/handleTools.js`, and neither branches on provider. So every agent endpoint with web search enabled (Anthropic, OpenRouter, etc.) gets the same over-eager instruction — and a single fix covers them all.

### Suggested fix (this PR)
Reframe the instruction so the default is to answer from the model's own knowledge, gate searching behind a concrete trigger list, and explicitly reject the "a search might return relevant results, so I should search" rationalization. The citation-format block is left unchanged. A unit assertion is added for the new gating language.

This is the instruction LibreChat controls. It can't fully override a model's own built-in bias toward searching, but it directly counters it and should meaningfully cut unnecessary searches.

### Note on testing
I have not been able to verify this against a live deployment. Production here runs the prebuilt image (`registry.librechat.ai/danny-avila/librechat-dev:latest`), and the prompt text is baked into the compiled bundle inside that image. Verifying live would require either building a custom image from patched source (resource-heavy) or hand-editing the compiled file inside the container. So please treat this as a clearly-identified bug with a proposed wording change rather than a battle-tested patch — happy to iterate on the wording.

### Suggested manual verification
With web search enabled, these should now be answered directly with **no** search:
- "What's the difference between TCP and UDP?"
- "Write a Python function to reverse a linked list."
- "Explain what a closure is in JavaScript."

And these should still trigger a search:
- "What's in the news today?"
- "What's the latest version of Node.js?"