### PR TITLE
fix(assistants): enforce validateAuthor on action add/delete routes

### DIFF
--- a/api/server/routes/assistants/actions.js
+++ b/api/server/routes/assistants/actions.js
@@ -9,6 +9,7 @@ const {
   domainParser,
 } = require('~/server/services/ActionService');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
+const validateAuthor = require('~/server/middleware/assistants/validateAuthor');
 const db = require('~/models');
 
 const router = express.Router();
@@ -55,6 +56,7 @@ router.post('/:assistant_id', async (req, res) => {
     const initialPromises = [];
 
     const { openai } = await getOpenAIClient({ req, res });
+    await validateAuthor({ req, openai, overrideAssistantId: assistant_id });
 
     initialPromises.push(db.getAssistant({ assistant_id }));
     initialPromises.push(openai.beta.assistants.retrieve(assistant_id));
@@ -175,6 +177,7 @@ router.delete('/:assistant_id/:action_id/:model', async (req, res) => {
     req.body = req.body || {}; // Express 5: ensure req.body exists
     req.body.model = model;
     const { openai } = await getOpenAIClient({ req, res });
+    await validateAuthor({ req, openai, overrideAssistantId: assistant_id });
 
     const initialPromises = [];
     initialPromises.push(db.getAssistant({ assistant_id }));


### PR DESCRIPTION
## Summary

The assistant *action* routes in `api/server/routes/assistants/actions.js` do not call `validateAuthor`, unlike the v1/v2 assistant controllers:

- `POST /:assistant_id` (add/update actions)
- `DELETE /:assistant_id/:action_id/:model` (delete action)

With `privateAssistants` enabled, an authenticated user can add or delete actions on **another user's** assistant by id — grafting attacker-controlled OpenAPI actions that then execute under the victim's assistant.

Reported privately in GHSA-6v44-g6xm-qv59 and triaged as the legacy OpenAI Assistants path (being superseded by Agents). Opening this as the small defense-in-depth fix offered there, to cover deployments still using the Assistants endpoint until it is removed.

## Change

Add `await validateAuthor({ req, openai, overrideAssistantId: assistant_id })` immediately after the OpenAI client is initialized on both routes, mirroring the existing controller pattern (`v1.js`, `v2.js`, `chatV1.js`, `chatV2.js`).

`overrideAssistantId` is passed because these routes use the `:assistant_id` param (validateAuthor defaults to `req.params.id`). The endpoint resolves via the same `req.body.endpoint` / `req.query.endpoint` that `getOpenAIClient` already requires, so nothing changes for the assistant's owner; only cross-user access is rejected (consistent with v1/v2, which throw on non-author and are handled by the route's existing try/catch).

3-line change, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)