### PR TITLE
fix(models): validate user-provided custom-endpoint baseURL before /models fetch (SSRF)

### DIFF
--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -12,6 +12,7 @@ import type { ServerRequest, GetUserKeyValuesFunction, UserKeyValues } from '~/t
 import type { FetchModelsParams } from '~/endpoints/models';
 import { fetchModels as defaultFetchModels } from '~/endpoints/models';
 import { getTokenConfigKey } from '~/endpoints/custom/initialize';
+import { validateEndpointURL } from '~/auth';
 import { tokenConfigCache } from '~/cache';
 import { isUserProvided } from '~/utils';
 
@@ -206,6 +207,20 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
         const userKeyValues = userKeyMap.get(name);
         const resolvedApiKey = apiKeyIsUserProvided ? userKeyValues?.apiKey : API_KEY;
         const resolvedBaseURL = baseURLIsUserProvided ? userKeyValues?.baseURL : BASE_URL;
+
+        // SSRF guard: a user-supplied baseURL must be validated before the
+        // server fetches /models from it (mirrors custom/openai initialize).
+        if (baseURLIsUserProvided && resolvedBaseURL) {
+          try {
+            await validateEndpointURL(resolvedBaseURL, name, appConfig?.endpoints?.allowedAddresses);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            logger.warn(
+              `[loadConfigModels] Skipping model fetch for "${name}": user-provided base URL rejected (${msg})`,
+            );
+            continue;
+          }
+        }
 
         if (resolvedApiKey && resolvedBaseURL) {
           const userFetchKey = `user:${req.user?.id}:${name}`;


### PR DESCRIPTION
## Summary

In `loadConfigModels` (`packages/api/src/endpoints/config/models.ts`), when a custom endpoint is configured to accept a **user-provided `baseURL`** (`baseURLIsUserProvided`), the user's stored `baseURL` is passed to `fetchModels` with no SSRF validation — letting an authenticated user make the server `GET /models` from internal/metadata hosts (e.g. `169.254.169.254`, `localhost`, internal services).

This is the defense-in-depth hardening acknowledged in GHSA-6v44-g6xm-qv59, and the same user-provided-baseURL SSRF class as the published GHSA-gc9r-88c3-7qhq — applied to the `/api/models` path, which currently does not go through `validateEndpointURL`.

## Change

Apply `validateEndpointURL(resolvedBaseURL, name, appConfig?.endpoints?.allowedAddresses)` before the fetch on the user-provided-`baseURL` branch, mirroring the existing guard in `endpoints/custom/initialize.ts` and `endpoints/openai/initialize.ts`.

On rejection, that endpoint's model fetch is skipped (`logger.warn` + `continue`) rather than failing the whole `/api/models` response — consistent with the loop's existing per-endpoint fault tolerance (`Promise.allSettled`, the user-key error handling above). Admin-trusted (`!baseURLIsUserProvided`) endpoints are unaffected, and `allowedAddresses` is honored so intentional private endpoints still work.

No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)