### PR TITLE
🐛 fix: Don't enable Bedrock prompt caching for Nova models

### DIFF
--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -1066,13 +1066,22 @@ describe('bedrockInputParser', () => {
       expect(result.promptCache).toBe(true);
     });
 
-    test('should preserve promptCache for Nova models', () => {
+    test('should strip promptCache for Nova models (explicit caching unsupported)', () => {
+      // Nova rejects Bedrock cache checkpoints (danny-avila/LibreChat#13838), so
+      // it is treated like any other non-Claude model and never carries
+      // promptCache, even when explicitly set.
       const input = {
         model: 'amazon.nova-pro-v1:0',
         promptCache: true,
       };
       const result = bedrockInputParser.parse(input) as Record<string, unknown>;
-      expect(result.promptCache).toBe(true);
+      expect(result.promptCache).toBeUndefined();
+    });
+
+    test('should not default promptCache on for Nova models', () => {
+      const input = { model: 'amazon.nova-pro-v1:0' };
+      const result = bedrockInputParser.parse(input) as Record<string, unknown>;
+      expect(result.promptCache).toBeUndefined();
     });
 
     test('should strip stale thinking config from additionalModelRequestFields for non-Anthropic models', () => {

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -494,11 +494,16 @@ export const bedrockInputParser = s.tConversationSchema
       delete additionalFields.top_k;
     }
 
-    /** Default promptCache for claude and nova models, if not defined */
-    if (
-      typeof typedData.model === 'string' &&
-      (typedData.model.includes('claude') || typedData.model.includes('nova'))
-    ) {
+    /**
+     * Default promptCache for Claude models only, if not defined. Explicit
+     * Bedrock cache checkpoints (`cachePoint`) are supported solely on Claude;
+     * Amazon Nova and other families reject the key — Nova returns
+     * `extraneous key [cachePoint] is not permitted` for toolConfig.tools (see
+     * danny-avila/LibreChat#13838) — and rely on automatic caching instead. So
+     * Nova is treated like any other non-Claude model: never defaulted on, and a
+     * stray promptCache is cleared so the request never carries a checkpoint.
+     */
+    if (typeof typedData.model === 'string' && typedData.model.includes('claude')) {
       if (typedData.promptCache === undefined) {
         typedData.promptCache = true;
       }


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to the Nova prompt-caching bug ([#13838](https://github.com/danny-avila/LibreChat/issues/13838)).

Explicit Bedrock cache checkpoints (`cachePoint`) are supported **only on Claude models** — per the [AWS prompt-caching docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) the support table lists Claude exclusively. Amazon Nova rejects the key outright:

```
ValidationException: Malformed input request: #/toolConfig/tools/0: extraneous key [cachePoint] is not permitted
```

The bedrock parser grouped Nova with Claude and auto-defaulted Nova model strings to `promptCache: true`, which drove the SDK to inject the invalid checkpoint.

## Change

Drop Nova from the caching-default group so it's treated like every other non-Claude Bedrock model (Llama, Mistral, Titan): never defaulted on, and a stray `promptCache: true` is cleared so no checkpoint is sent.

```diff
-    /** Default promptCache for claude and nova models, if not defined */
     if (
       typeof typedData.model === 'string' &&
-      (typedData.model.includes('claude') || typedData.model.includes('nova'))
+      typedData.model.includes('claude')
     ) {
       if (typedData.promptCache === undefined) {
         typedData.promptCache = true;
       }
     } else if (typedData.promptCache === true) {
       typedData.promptCache = undefined;
     }
```

## Relationship to the SDK fix

The authoritative fix is in the agents SDK ([danny-avila/agents#253](https://github.com/danny-avila/agents/pull/253)), which gates every explicit Bedrock checkpoint to Claude server-side. This PR is **defense-in-depth**: it stops LibreChat from setting a `promptCache` flag that is a no-op for Nova, keeping the UI honest (Nova's "Use Prompt Caching" toggle no longer defaults on).

## Testing

- `should strip promptCache for Nova models (explicit caching unsupported)` → `promptCache` undefined
- `should not default promptCache on for Nova models` → undefined
- existing Claude default/preserve tests unchanged
- data-provider build + bedrock spec (154) green; lint clean