### PR TITLE
✨ feat: Add adminListAllAgents configuration option for agent access …

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -1,7 +1,7 @@
 const { z } = require('zod');
 const fs = require('fs').promises;
 const { nanoid } = require('nanoid');
-const { logger } = require('@librechat/data-schemas');
+const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
   refreshS3Url,
   agentCreateSchema,
@@ -50,6 +50,7 @@ const {
 } = require('~/server/services/MCP');
 const { getMCPServersRegistry } = require('~/config');
 const { getLogStores } = require('~/cache');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const db = require('~/models');
 
 const systemTools = {
@@ -970,13 +971,31 @@ const getListAgentsHandler = async (req, res) => {
       filter.$or = [{ name: regex }, { description: regex }];
     }
 
-    // Get agent IDs the user has VIEW access to via ACL
-    const accessibleIds = await findAccessibleResources({
-      userId,
-      role: req.user.role,
-      resourceType: ResourceType.AGENT,
-      requiredPermissions: requiredPermission,
-    });
+    // When enabled in librechat.yaml, admins with read:agents list all agents (not just ACL shares).
+    const adminListAllAgents =
+      req.config?.endpoints?.[EModelEndpoint.agents]?.adminListAllAgents === true;
+
+    let bypassAccessFilter = false;
+    if (adminListAllAgents) {
+      try {
+        bypassAccessFilter = await hasCapability(req.user, SystemCapabilities.READ_AGENTS);
+      } catch (err) {
+        logger.warn(`[/Agents] capability check failed, denying list bypass: ${err.message}`);
+      }
+    }
+
+    if (bypassAccessFilter) {
+      logger.debug(`[/Agents] READ_AGENTS bypass for user ${userId}`);
+    }
+
+    const accessibleIds = bypassAccessFilter
+      ? []
+      : await findAccessibleResources({
+          userId,
+          role: req.user.role,
+          resourceType: ResourceType.AGENT,
+          requiredPermissions: requiredPermission,
+        });
 
     const publiclyAccessibleIds = await findPubliclyAccessibleResources({
       resourceType: ResourceType.AGENT,
@@ -999,6 +1018,7 @@ const getListAgentsHandler = async (req, res) => {
           otherParams: {},
           limit: MAX_AVATAR_REFRESH_AGENTS,
           after: null,
+          bypassAccessFilter,
         });
         const { urlCache } = await refreshListAvatars({
           agents: fullList?.data ?? [],
@@ -1022,6 +1042,7 @@ const getListAgentsHandler = async (req, res) => {
       limit,
       after: cursor,
       includeSkillConfig: true,
+      bypassAccessFilter,
     });
 
     const agents = data?.data ?? [];

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const { nanoid } = require('nanoid');
 const { v4: uuidv4 } = require('uuid');
 const { agentSchema, fileSchema } = require('@librechat/data-schemas');
-const { FileSources, PermissionBits, ResourceType } = require('librechat-data-provider');
+const { FileSources, PermissionBits, ResourceType, EModelEndpoint } = require('librechat-data-provider');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 
 // Only mock the dependencies that are not database-related
@@ -47,6 +47,10 @@ jest.mock('~/server/services/PermissionService', () => ({
   hasPublicPermission: jest.fn().mockResolvedValue(false),
 }));
 
+jest.mock('~/server/middleware/roles/capabilities', () => ({
+  hasCapability: jest.fn().mockResolvedValue(false),
+}));
+
 jest.mock('~/models', () => {
   const mongoose = require('mongoose');
   const { createMethods } = require('@librechat/data-schemas');
@@ -84,6 +88,8 @@ const {
   findPubliclyAccessibleResources,
   getResourcePermissionsMap,
 } = require('~/server/services/PermissionService');
+
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
 
 const { refreshS3Url } = require('@librechat/api');
 
@@ -1160,6 +1166,8 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
     beforeEach(async () => {
       await Agent.deleteMany({});
       jest.clearAllMocks();
+      hasCapability.mockResolvedValue(false);
+      mockReq.config = undefined;
 
       // Create two test users
       userA = new mongoose.Types.ObjectId();
@@ -1666,6 +1674,66 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(response.data[0].id).toBe(productivityPromoted.id);
       expect(response.data[0].category).toBe('productivity');
       expect(response.data[0].is_promoted).toBe(true);
+    });
+
+    describe('adminListAllAgents yaml toggle', () => {
+      const setAdminListConfig = (enabled) => {
+        mockReq.config = {
+          endpoints: {
+            [EModelEndpoint.agents]: {
+              adminListAllAgents: enabled,
+            },
+          },
+        };
+      };
+
+      test('does not bypass ACL when adminListAllAgents is false even with read:agents', async () => {
+        setAdminListConfig(false);
+        hasCapability.mockResolvedValue(true);
+        mockReq.user.id = userB.toString();
+        findAccessibleResources.mockResolvedValue([]);
+        findPubliclyAccessibleResources.mockResolvedValue([]);
+
+        await getListAgentsHandler(mockReq, mockRes);
+
+        expect(hasCapability).not.toHaveBeenCalled();
+        expect(findAccessibleResources).toHaveBeenCalled();
+        expect(mockRes.json.mock.calls[0][0].data).toHaveLength(0);
+      });
+
+      test('lists all agents when adminListAllAgents is true and user has read:agents', async () => {
+        setAdminListConfig(true);
+        hasCapability.mockResolvedValue(true);
+        mockReq.user.id = userB.toString();
+        findPubliclyAccessibleResources.mockResolvedValue([]);
+
+        await getListAgentsHandler(mockReq, mockRes);
+
+        expect(hasCapability).toHaveBeenCalled();
+        expect(findAccessibleResources).not.toHaveBeenCalledWith(
+          expect.objectContaining({ resourceType: ResourceType.AGENT }),
+        );
+
+        const agentIds = mockRes.json.mock.calls[0][0].data.map((agent) => agent.id);
+        expect(agentIds).toEqual(
+          expect.arrayContaining([agentA1.id, agentA2.id, agentA3.id, agentB1.id]),
+        );
+        expect(agentIds).toHaveLength(4);
+      });
+
+      test('does not bypass ACL when adminListAllAgents is true but user lacks read:agents', async () => {
+        setAdminListConfig(true);
+        hasCapability.mockResolvedValue(false);
+        mockReq.user.id = userB.toString();
+        findAccessibleResources.mockResolvedValue([]);
+        findPubliclyAccessibleResources.mockResolvedValue([]);
+
+        await getListAgentsHandler(mockReq, mockRes);
+
+        expect(hasCapability).toHaveBeenCalled();
+        expect(findAccessibleResources).toHaveBeenCalled();
+        expect(mockRes.json.mock.calls[0][0].data).toHaveLength(0);
+      });
     });
   });
 

--- a/api/server/routes/agents/v1.js
+++ b/api/server/routes/agents/v1.js
@@ -22,18 +22,19 @@ const checkAgentCreate = generateCheckAccess({
 });
 
 router.use(requireJwtAuth);
+router.use(configMiddleware);
 
 /**
  * Agent actions route.
  * @route GET|POST /agents/actions
  */
-router.use('/actions', configMiddleware, actions);
+router.use('/actions', actions);
 
 /**
  * Get a list of available tools for agents.
  * @route GET /agents/tools
  */
-router.use('/tools', configMiddleware, tools);
+router.use('/tools', tools);
 
 /**
  * Get all agent categories with counts

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -359,6 +359,8 @@ endpoints:
   #   maxRecursionLimit: 100
   #   # (optional) Disable the builder interface for agents
   #   disableBuilder: false
+  #   # (optional) When true, users with read:agents list all agents (ACL bypass for listing only)
+  #   adminListAllAgents: false
   #   # (optional) Maximum total citations to include in agent responses, defaults to 30
   #   maxCitations: 30
   #   # (optional) Maximum citations per file to include in agent responses, defaults to 7

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -354,6 +354,25 @@ describe('agentsEndpointSchema', () => {
     }
   });
 
+  it('defaults adminListAllAgents to false when omitted', () => {
+    const result = agentsEndpointSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.adminListAllAgents).toBe(false);
+    }
+  });
+
+  it('accepts adminListAllAgents true and false', () => {
+    const enabled = agentsEndpointSchema.safeParse({ adminListAllAgents: true });
+    const disabled = agentsEndpointSchema.safeParse({ adminListAllAgents: false });
+    expect(enabled.success).toBe(true);
+    expect(disabled.success).toBe(true);
+    if (enabled.success && disabled.success) {
+      expect(enabled.data.adminListAllAgents).toBe(true);
+      expect(disabled.data.adminListAllAgents).toBe(false);
+    }
+  });
+
   it('allows explicitly disabled remote OIDC auth without issuer', () => {
     const result = agentsEndpointSchema.safeParse({
       remoteApi: {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -549,6 +549,7 @@ export const agentsEndpointSchema = baseEndpointSchema
       /* agents specific */
       recursionLimit: z.number().optional(),
       disableBuilder: z.boolean().optional().default(false),
+      adminListAllAgents: z.boolean().optional().default(false),
       maxRecursionLimit: z.number().optional(),
       maxCitations: z.number().min(1).max(50).optional().default(30),
       maxCitationsPerFile: z.number().min(1).max(10).optional().default(7),
@@ -563,6 +564,7 @@ export const agentsEndpointSchema = baseEndpointSchema
   )
   .default({
     disableBuilder: false,
+    adminListAllAgents: false,
     capabilities: defaultAgentCapabilities,
     maxCitations: 30,
     maxCitationsPerFile: 7,

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -700,12 +700,15 @@ export function createAgentMethods(mongoose: typeof import('mongoose'), deps: Ag
     limit = 100,
     after = null,
     includeSkillConfig = false,
+    bypassAccessFilter = false,
   }: {
     accessibleIds?: Types.ObjectId[];
     otherParams?: Record<string, unknown>;
     limit?: number | null;
     after?: string | null;
     includeSkillConfig?: boolean;
+    /** When true, skip ACL id filter so admins with read:agents see every agent. */
+    bypassAccessFilter?: boolean;
   }): Promise<{
     object: string;
     data: Array<Record<string, unknown>>;
@@ -720,10 +723,11 @@ export function createAgentMethods(mongoose: typeof import('mongoose'), deps: Ag
       ? Math.min(Math.max(1, parseInt(String(limit)) || 20), 1000)
       : null;
 
-    const baseQuery: Record<string, unknown> = {
-      ...otherParams,
-      _id: { $in: accessibleIds },
-    };
+    const baseQuery: Record<string, unknown> = { ...otherParams };
+    // Default: restrict to ACL-accessible agents; admins bypass via bypassAccessFilter.
+    if (!bypassAccessFilter) {
+      baseQuery._id = { $in: accessibleIds };
+    }
 
     if (after) {
       try {


### PR DESCRIPTION
* Introduced `adminListAllAgents` option in `librechat.example.yaml` to allow admins with `read:agents` capability to list all agents, bypassing ACL restrictions.
* Updated agent listing logic in `v1.js` to check for this configuration and adjust access filters accordingly.
* Enhanced tests to cover scenarios for the new configuration, ensuring proper behavior based on the `adminListAllAgents` setting.
* Updated schema to default `adminListAllAgents` to false
<img width="420" height="258" alt="Screenshot 2026-06-19 at 11 46 18" src="https://github.com/user-attachments/assets/11a19ec2-3a6f-4c17-9cc6-c190741c9bc1" />
 when omitted.
