### PR TITLE
🐛 fix: resolve dayjs plugin ESM imports in data-provider (0.8.507)

### DIFF
--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.506",
+  "version": "0.8.507",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezonePlugin from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc.js';
+import timezonePlugin from 'dayjs/plugin/timezone.js';
 import type { ZodIssue } from 'zod';
 import type * as a from './types/assistants';
 import type * as s from './schemas';


### PR DESCRIPTION
## Summary

`librechat-data-provider@0.8.506` is a **broken ESM publish**. `parsers.ts` imports the dayjs timezone plugins without a file extension:

```ts
import utc from 'dayjs/plugin/utc';
import timezonePlugin from 'dayjs/plugin/timezone';
```

The tsdown build externalizes every bare import, so it emits those specifiers verbatim into `dist/index.mjs`. `dayjs@1.11` ships **no `exports` map**, so under strict Node ESM the extensionless subpaths fail:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/dayjs/plugin/utc'
  imported from .../librechat-data-provider/dist/index.mjs
Did you mean to import "dayjs/plugin/utc.js"?
```

This breaks **any strict-ESM consumer** that transitively imports `data-provider` — and `@librechat/data-schemas`, which re-exports it. It surfaced as 9 failing vitest suites in the admin-panel, which had to pin `data-provider` to exactly `0.8.505` to work around it.

## Fix

Add the `.js` extension so the externalized imports resolve under strict Node ESM. With `moduleResolution: bundler` the types still resolve from the plugin `.d.ts`, and the CJS build (`require('dayjs/plugin/utc.js')`) is unaffected. Version bumped to **0.8.507** to supersede the broken `0.8.506`.

`0.8.505` was fine only because it predates the timezone feature that introduced these plugin imports.

## Verification

- `npm run build:data-provider` — clean
- `node --input-type=module -e "import('./dist/index.mjs')"` — resolves, 428 exports (was `ERR_MODULE_NOT_FOUND`)
- `parsers` specs — 50/50 pass
- eslint + sort-imports:check — clean