### PR TITLE
fix: replace leftover placeholder text in preset name input

### DIFF
--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -319,7 +319,7 @@
   "com_endpoint_plug_resend_files": "Resend Files",
   "com_endpoint_presence_penalty": "Presence Penalty",
   "com_endpoint_preset": "preset",
-  "com_endpoint_preset_custom_name_placeholder": "something needs to go here. was empty",
+  "com_endpoint_preset_custom_name_placeholder": "Set a custom name for the preset",
   "com_endpoint_preset_default": "is now the default preset.",
   "com_endpoint_preset_default_item": "Default:",
   "com_endpoint_preset_default_none": "No default preset active.",


### PR DESCRIPTION
## Summary

The English value for `com_endpoint_preset_custom_name_placeholder` is a leftover developer placeholder:

```json
"com_endpoint_preset_custom_name_placeholder": "something needs to go here. was empty"
```

It is used as the input placeholder in the **Save As Preset** dialog (`client/src/components/Endpoints/SaveAsPresetDialog.tsx`), so users see `something needs to go here. was empty` where a real hint should be. I confirmed the string still ships in the current build (`v0.8.7-rc1`).

This replaces it with wording consistent with the sibling custom-name placeholders in the same file:

- `com_endpoint_openai_custom_name_placeholder` → "Set a custom name for the AI"
- `com_endpoint_google_custom_name_placeholder` → "Set a custom name for Google"
- `com_endpoint_preset_custom_name_placeholder` → **"Set a custom name for the preset"**

Same class of issue as #6632, which fixed other keys carrying this exact placeholder value. Only the English source key is changed; other locales re-sync from Locize per `CONTRIBUTING.md`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Test Configuration:

- LibreChat `v0.8.7-rc1`, English locale.

Steps to reproduce / verify:

1. Open a conversation with a preset-capable endpoint.
2. Open the endpoint's advanced settings → **Save As Preset**.
3. Observe the preset-name input placeholder.

- **Before:** `something needs to go here. was empty`
- **After:** `Set a custom name for the preset`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
