### PR TITLE
feat: optional vision flag in OpenAI LLM config

### DIFF
--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -97,6 +97,7 @@ export function getOpenAIConfig(
 ): t.OpenAIConfigResult {
   const {
     proxy,
+    vision,
     addParams,
     dropParams,
     defaultQuery,
@@ -202,6 +203,7 @@ export function getOpenAIConfig(
       defaultParams,
       modelOptions,
       useOpenRouter,
+      vision,
       reasoningFormat: getReasoningFormat({
         customFormat: options.customParams?.reasoningFormat,
         isVercel: Boolean(isVercel),

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -27,6 +27,38 @@ describe('getOpenAILLMConfig', () => {
       expect(result.tools).toEqual([]);
     });
 
+    it('should forward vision=false to llmConfig', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        vision: false,
+        modelOptions: { model: 'gpt-4' },
+      });
+
+      expect(result.llmConfig).toHaveProperty('vision', false);
+    });
+
+    it('should forward vision=true to llmConfig', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        vision: true,
+        modelOptions: { model: 'gpt-4' },
+      });
+
+      expect(result.llmConfig).toHaveProperty('vision', true);
+    });
+
+    it('should omit vision from llmConfig when not provided', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        modelOptions: { model: 'gpt-4' },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('vision');
+    });
+
     it('should handle model options including temperature and penalties', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -508,6 +508,7 @@ export function getOpenAILLMConfig({
   dropParams,
   defaultParams,
   useOpenRouter,
+  vision,
   reasoningFormat = ReasoningParameterFormat.reasoningEffort,
   modelOptions: _modelOptions,
 }: {
@@ -520,6 +521,7 @@ export function getOpenAILLMConfig({
   dropParams?: string[];
   defaultParams?: Record<string, unknown>;
   useOpenRouter?: boolean;
+  vision?: boolean;
   reasoningFormat?: ReasoningParameterFormat;
   azure?: false | t.AzureOptions;
 }): Pick<t.LLMConfigResult, 'llmConfig' | 'tools'> & {
@@ -554,6 +556,10 @@ export function getOpenAILLMConfig({
     },
     modelOptions,
   ) as OpenAILLMConfig;
+
+  if (vision != null) {
+    llmConfig.vision = vision;
+  }
 
   if (frequency_penalty != null) {
     llmConfig.frequencyPenalty = frequency_penalty;

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -14,6 +14,8 @@ export type OpenAIModelOptions = Partial<OpenAIParameters>;
  */
 export interface OpenAIConfigOptions {
   modelOptions?: OpenAIModelOptions;
+  /** When false, the client strips image content for models without vision support. */
+  vision?: boolean;
   directEndpoint?: boolean;
   reverseProxyUrl?: string | null;
   baseURLIsUserProvided?: boolean;
@@ -34,6 +36,8 @@ export type OAIClientOptions = Omit<OpenAIClientOptions, 'verbosity'> & {
   include_reasoning?: boolean;
   /** Replays `reasoning_content` on tool-bearing turns (DeepSeek thinking-mode, #13366). */
   includeReasoningContent?: boolean;
+  /** When false, the client strips image content for models without vision support. */
+  vision?: boolean;
   promptCache?: boolean;
   promptCacheTtl?: '5m' | '1h';
   _lc_stream_delay?: number;


### PR DESCRIPTION
## Depends on

danny-avila/agents#257 (the agents-side change that consumes this flag). **Draft until that lands** - this option is a no-op without it.

## Problem

When an agent routes image content to a model with no vision support, OpenAI-compatible providers reject the whole request:

- `model is not a multimodal model`
- `No endpoints found that support image input`

This happens in practice when a tool returns image content (e.g. an image-generation tool whose base64 artifact is fed back as context) and the active model is text-only. Today there is no way to tell the OpenAI client "this model can't take images, drop them."

## Change

Add an optional `vision` flag to `getOpenAIConfig` / `getOpenAILLMConfig`, forwarded onto the OpenAI `llmConfig` (`OAIClientOptions.vision`). When a caller sets `vision: false`, the chat client strips image content before sending.

- `OpenAIConfigOptions.vision?: boolean` (public input) and `OAIClientOptions.vision?: boolean` (the client options).
- `getOpenAILLMConfig` sets `llmConfig.vision` when the flag is provided; otherwise it is omitted.
- Scoped to the OpenAI branch only (the ChatOpenAI / Azure / DeepSeek / xAI family that agents#257 covers). Anthropic/Google are untouched.

Defaults to `undefined`, so existing behavior is unchanged unless a caller opts in.

## Consumption

The image stripping itself lives in `@librechat/agents` (danny-avila/agents#257): `ChatOpenAI`/`AzureChatOpenAI`/`ChatDeepSeek`/`ChatXAI` read `vision` from their constructor fields and strip `image_url` parts before streaming. The `llmConfig` produced here becomes those constructor fields, so this flag drives that behavior.

The capability source (a model spec / agent `vision` boolean → `options.vision`) is intentionally left to the caller; this PR is the config-layer plumbing.

## Tests

`getOpenAILLMConfig` unit tests cover `vision` true / false / absent.

## Testing status

Built and unit-tested at the `@librechat/api` package level (typecheck clean, 85/85 in `llm.spec.ts`). Not yet end-to-end integration tested against agents#257, since that change is unpublished - hence draft.
