### PR TITLE
📌 feat: Seed Default Pinned Tools and MCP Dropdown via Interface Config

### DIFF
--- a/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
@@ -15,6 +15,14 @@ jest.mock('~/utils/timestamps', () => ({
 
 jest.mock('lodash/isEqual', () => jest.fn((a, b) => JSON.stringify(a) === JSON.stringify(b)));
 
+// Mutable startup config so tests can vary `interface.defaultPinnedTools`
+let mockStartupConfig: { interface?: { defaultPinnedTools?: string[] } } | undefined;
+
+jest.mock('~/data-provider', () => ({
+  ...jest.requireActual('~/data-provider'),
+  useGetStartupConfig: jest.fn(() => ({ data: mockStartupConfig })),
+}));
+
 // Helper to create MCPServerDefinition objects
 const createMCPServers = (serverNames: string[]): MCPServerDefinition[] => {
   return serverNames.map((serverName) => ({
@@ -44,6 +52,7 @@ describe('useMCPSelect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockStartupConfig = undefined;
   });
 
   describe('Basic Functionality', () => {
@@ -858,6 +867,59 @@ describe('useMCPSelect', () => {
 
       // Should handle remounting gracefully
       expect(newResult.current.mcpValues).toBeDefined();
+    });
+  });
+
+  describe('defaultPinnedTools (admin-configured default pin)', () => {
+    it('keeps the MCP dropdown pinned by default when "mcp" is listed', async () => {
+      mockStartupConfig = { interface: { defaultPinnedTools: ['artifacts', 'mcp'] } };
+      const { Wrapper, servers } = createWrapper();
+      const { result } = renderHook(() => useMCPSelect({ servers }), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isPinned).toBe(true);
+      });
+    });
+
+    it('unpins the MCP dropdown by default when configured without "mcp"', async () => {
+      mockStartupConfig = { interface: { defaultPinnedTools: ['artifacts'] } };
+      const { Wrapper, servers } = createWrapper(['serverA']);
+      const { result } = renderHook(() => useMCPSelect({ servers }), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isPinned).toBe(false);
+      });
+    });
+
+    it('pins the MCP dropdown when a configured server name is listed', async () => {
+      mockStartupConfig = { interface: { defaultPinnedTools: ['serverA'] } };
+      const { Wrapper, servers } = createWrapper(['serverA', 'serverB']);
+      const { result } = renderHook(() => useMCPSelect({ servers }), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isPinned).toBe(true);
+      });
+    });
+
+    it('keeps the legacy pinned default when defaultPinnedTools is not configured', async () => {
+      mockStartupConfig = { interface: {} };
+      const { Wrapper, servers } = createWrapper(['serverA']);
+      const { result } = renderHook(() => useMCPSelect({ servers }), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isPinned).toBe(true);
+      });
+    });
+
+    it('respects a stored user preference over the configured default', async () => {
+      localStorage.setItem(LocalStorageKeys.PIN_MCP_, JSON.stringify(false));
+      mockStartupConfig = { interface: { defaultPinnedTools: ['mcp'] } };
+      const { Wrapper, servers } = createWrapper();
+      const { result } = renderHook(() => useMCPSelect({ servers }), { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isPinned).toBe(false);
+      });
     });
   });
 });

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAtom } from 'jotai';
 import isEqual from 'lodash/isEqual';
 import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys } from 'librechat-data-provider';
 import { ephemeralAgentByConvoId, mcpValuesAtomFamily, mcpPinnedAtom } from '~/store';
-import { setTimestamp } from '~/utils/timestamps';
 import { MCPServerDefinition } from './useMCPServerManager';
+import { useGetStartupConfig } from '~/data-provider';
+import { setTimestamp } from '~/utils/timestamps';
+
+/** Sentinel in `interface.defaultPinnedTools` that pins the MCP dropdown to the prompt bar. */
+const MCP_PIN_KEYWORD = 'mcp';
 
 export function useMCPSelect({
   conversationId,
@@ -29,9 +33,43 @@ export function useMCPSelect({
   const isNewConvo = key === Constants.NEW_CONVO;
   const mcpAtomKey = isNewConvo && storageContextKey ? storageContextKey : key;
 
+  const { data: startupConfig } = useGetStartupConfig();
   const [isPinned, setIsPinned] = useAtom(mcpPinnedAtom);
   const [mcpValues, setMCPValuesRaw] = useAtom(mcpValuesAtomFamily(mcpAtomKey));
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
+  const hasAppliedDefaultPin = useRef(false);
+
+  /**
+   * Seed the MCP dropdown's pinned state from the admin-configured `defaultPinnedTools`:
+   * pin when the array includes the `'mcp'` keyword or any configured server name.
+   * Only applies on first load when the user has no stored preference; when the option
+   * is absent entirely, the legacy default (pinned) is kept.
+   */
+  useEffect(() => {
+    if (hasAppliedDefaultPin.current || !startupConfig) {
+      return;
+    }
+    const defaultPinnedTools = startupConfig.interface?.defaultPinnedTools;
+    if (!Array.isArray(defaultPinnedTools)) {
+      hasAppliedDefaultPin.current = true;
+      return;
+    }
+    if (localStorage.getItem(LocalStorageKeys.PIN_MCP_) != null) {
+      hasAppliedDefaultPin.current = true;
+      return;
+    }
+    const pinnedByKeyword = defaultPinnedTools.includes(MCP_PIN_KEYWORD);
+    /** Wait for servers before deciding so a configured server name isn't missed. */
+    if (!pinnedByKeyword && servers.length === 0) {
+      return;
+    }
+    hasAppliedDefaultPin.current = true;
+    const shouldPin =
+      pinnedByKeyword || servers.some((server) => defaultPinnedTools.includes(server.serverName));
+    if (shouldPin !== isPinned) {
+      setIsPinned(shouldPin);
+    }
+  }, [startupConfig, servers, isPinned, setIsPinned]);
 
   // Sync ephemeral agent MCP → Jotai atom (strip unconfigured servers)
   useEffect(() => {

--- a/client/src/hooks/Plugins/__tests__/useToolToggle.pinDefault.test.tsx
+++ b/client/src/hooks/Plugins/__tests__/useToolToggle.pinDefault.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { renderHook, waitFor } from '@testing-library/react';
+import { LocalStorageKeys, Tools } from 'librechat-data-provider';
+import { useToolToggle } from '../useToolToggle';
+
+/**
+ * Integration tests for the `defaultPinnedTools` pin-seeding logic in useToolToggle,
+ * exercising the REAL useLocalStorageAlt + jsdom localStorage (not mocked).
+ *
+ * Focus: the cold-load race where startupConfig resolves AFTER the hook mounts, and
+ * the guarantee that an existing stored pin preference is never overridden.
+ */
+
+let mockStartupConfig: { interface?: { defaultPinnedTools?: string[] } } | undefined;
+
+jest.mock('~/data-provider', () => ({
+  useVerifyAgentToolAuth: jest.fn(() => ({ data: { authenticated: true } })),
+  useGetStartupConfig: jest.fn(() => ({ data: mockStartupConfig })),
+}));
+
+jest.mock('~/utils/timestamps', () => ({
+  setTimestamp: jest.fn(),
+}));
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <RecoilRoot>{children}</RecoilRoot>
+);
+
+const pinKey = `${LocalStorageKeys.LAST_CODE_TOGGLE_}pinned`;
+
+const renderCodeToggle = () =>
+  renderHook(
+    () =>
+      useToolToggle({
+        toolKey: Tools.execute_code,
+        localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+        isAuthenticated: true,
+      }),
+    { wrapper: Wrapper },
+  );
+
+describe('useToolToggle — defaultPinnedTools seeding (real localStorage)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockStartupConfig = undefined;
+  });
+
+  it('applies the configured default once startupConfig resolves after mount (cold load)', async () => {
+    // Cold load: config not yet available when the hook mounts.
+    mockStartupConfig = undefined;
+    const { result, rerender } = renderCodeToggle();
+
+    // No stored preference + config unresolved → unpinned.
+    await waitFor(() => expect(result.current.isPinned).toBe(false));
+
+    // Startup config arrives listing this tool.
+    mockStartupConfig = { interface: { defaultPinnedTools: ['execute_code'] } };
+    rerender();
+
+    await waitFor(() => expect(result.current.isPinned).toBe(true));
+    expect(localStorage.getItem(pinKey)).toBe(JSON.stringify(true));
+  });
+
+  it('pins immediately when config is already cached at mount', async () => {
+    mockStartupConfig = { interface: { defaultPinnedTools: ['execute_code'] } };
+    const { result } = renderCodeToggle();
+
+    await waitFor(() => expect(result.current.isPinned).toBe(true));
+  });
+
+  it('does not override an existing stored unpin preference (conservative)', async () => {
+    localStorage.setItem(pinKey, JSON.stringify(false));
+    mockStartupConfig = { interface: { defaultPinnedTools: ['execute_code'] } };
+    const { result } = renderCodeToggle();
+
+    // Give the apply-default effect a chance to (incorrectly) fire.
+    await waitFor(() => expect(result.current.isPinned).toBe(false));
+    expect(localStorage.getItem(pinKey)).toBe(JSON.stringify(false));
+  });
+
+  it('leaves a tool unpinned by default when it is not listed', async () => {
+    mockStartupConfig = { interface: { defaultPinnedTools: ['artifacts'] } };
+    const { result } = renderCodeToggle();
+
+    await waitFor(() => expect(result.current.isPinned).toBe(false));
+  });
+});

--- a/client/src/hooks/Plugins/__tests__/useToolToggle.pinDefault.test.tsx
+++ b/client/src/hooks/Plugins/__tests__/useToolToggle.pinDefault.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { LocalStorageKeys, Tools } from 'librechat-data-provider';
 import { useToolToggle } from '../useToolToggle';
 
@@ -85,5 +85,24 @@ describe('useToolToggle — defaultPinnedTools seeding (real localStorage)', () 
     const { result } = renderCodeToggle();
 
     await waitFor(() => expect(result.current.isPinned).toBe(false));
+  });
+
+  it('preserves a pin toggled before startupConfig resolves', async () => {
+    // Cold load: user pins the tool before the config query resolves.
+    mockStartupConfig = undefined;
+    const { result, rerender } = renderCodeToggle();
+    await waitFor(() => expect(result.current.isPinned).toBe(false));
+
+    act(() => {
+      result.current.setIsPinned(true);
+    });
+    await waitFor(() => expect(result.current.isPinned).toBe(true));
+
+    // Config arrives WITHOUT this tool listed — the user's click must not be overwritten.
+    mockStartupConfig = { interface: { defaultPinnedTools: ['artifacts'] } };
+    rerender();
+
+    await waitFor(() => expect(result.current.isPinned).toBe(true));
+    expect(localStorage.getItem(pinKey)).toBe(JSON.stringify(true));
   });
 });

--- a/client/src/hooks/Plugins/__tests__/useToolToggle.test.tsx
+++ b/client/src/hooks/Plugins/__tests__/useToolToggle.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { LocalStorageKeys, Tools } from 'librechat-data-provider';
 import { RecoilRoot, useRecoilValue, useSetRecoilState } from 'recoil';
+import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import { ephemeralAgentByConvoId } from '~/store';
 import { useToolToggle } from '../useToolToggle';
 
@@ -17,11 +18,15 @@ import { useToolToggle } from '../useToolToggle';
  * - The hook reflects the current ephemeral agent state
  */
 
-// Mock data-provider auth query
+// Mutable startup config so tests can vary `interface.defaultPinnedTools`
+let mockStartupConfig: { interface?: { defaultPinnedTools?: string[] } } | undefined;
+
+// Mock data-provider auth query + startup config
 jest.mock('~/data-provider', () => ({
   useVerifyAgentToolAuth: jest.fn().mockReturnValue({
     data: { authenticated: true },
   }),
+  useGetStartupConfig: jest.fn(() => ({ data: mockStartupConfig })),
 }));
 
 // Mock timestamps (track calls without actual localStorage timestamp logic)
@@ -40,6 +45,7 @@ describe('useToolToggle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockStartupConfig = undefined;
   });
 
   // ─── Dual-Write Behavior ───────────────────────────────────────────
@@ -323,6 +329,48 @@ describe('useToolToggle', () => {
       await waitFor(() => {
         expect(result.current.toggle.isToolEnabled).toBe(false);
       });
+    });
+  });
+
+  // ─── Default pinned state from interface.defaultPinnedTools ─────────
+
+  describe('defaultPinnedTools (admin-configured default pin)', () => {
+    const renderToolToggle = () =>
+      renderHook(
+        () =>
+          useToolToggle({
+            toolKey: Tools.execute_code,
+            localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+            isAuthenticated: true,
+          }),
+        { wrapper: Wrapper },
+      );
+
+    it('seeds the pinned state to true when the tool key is listed', () => {
+      mockStartupConfig = { interface: { defaultPinnedTools: ['execute_code', 'mcp'] } };
+      renderToolToggle();
+      expect(useLocalStorage).toHaveBeenCalledWith(
+        `${LocalStorageKeys.LAST_CODE_TOGGLE_}pinned`,
+        true,
+      );
+    });
+
+    it('seeds the pinned state to false when the tool key is not listed', () => {
+      mockStartupConfig = { interface: { defaultPinnedTools: ['artifacts'] } };
+      renderToolToggle();
+      expect(useLocalStorage).toHaveBeenCalledWith(
+        `${LocalStorageKeys.LAST_CODE_TOGGLE_}pinned`,
+        false,
+      );
+    });
+
+    it('seeds the pinned state to false when defaultPinnedTools is not configured', () => {
+      mockStartupConfig = undefined;
+      renderToolToggle();
+      expect(useLocalStorage).toHaveBeenCalledWith(
+        `${LocalStorageKeys.LAST_CODE_TOGGLE_}pinned`,
+        false,
+      );
     });
   });
 });

--- a/client/src/hooks/Plugins/useToolToggle.ts
+++ b/client/src/hooks/Plugins/useToolToggle.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import debounce from 'lodash/debounce';
 import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys } from 'librechat-data-provider';
@@ -84,10 +84,31 @@ export function useToolToggle({
     return Array.isArray(defaultPinnedTools) && defaultPinnedTools.includes(toolKey);
   }, [startupConfig?.interface?.defaultPinnedTools, toolKey]);
 
+  /** Captured before mount (pre-seed): did the user already have a stored pin preference?
+   *  Distinguishes a real choice from `useLocalStorage`'s eager default-seed below. */
+  const [hadStoredPin] = useState(() => localStorage.getItem(`${localStorageKey}pinned`) != null);
+
   const [isPinned, setIsPinned] = useLocalStorage<boolean>(
     `${localStorageKey}pinned`,
     defaultPinned,
   );
+
+  /** Cold load: `startupConfig` can resolve after mount, so `defaultPinned` starts `false`
+   *  and gets eagerly persisted. Once config arrives, apply the real default for users with
+   *  no prior preference — runs once and never overrides an existing stored pin. */
+  const appliedDefaultPin = useRef(false);
+  useEffect(() => {
+    if (appliedDefaultPin.current || startupConfig == null) {
+      return;
+    }
+    appliedDefaultPin.current = true;
+    if (hadStoredPin) {
+      return;
+    }
+    if (defaultPinned !== isPinned) {
+      setIsPinned(defaultPinned);
+    }
+  }, [startupConfig, hadStoredPin, defaultPinned, isPinned, setIsPinned]);
 
   const handleChange = useCallback(
     ({ e, value }: { e?: React.ChangeEvent<HTMLInputElement>; value: ToolValue }) => {

--- a/client/src/hooks/Plugins/useToolToggle.ts
+++ b/client/src/hooks/Plugins/useToolToggle.ts
@@ -4,9 +4,9 @@ import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys } from 'librechat-data-provider';
 import type { VerifyToolAuthResponse } from 'librechat-data-provider';
 import type { UseQueryOptions } from '@tanstack/react-query';
-import { useVerifyAgentToolAuth } from '~/data-provider';
-import { setTimestamp } from '~/utils/timestamps';
+import { useVerifyAgentToolAuth, useGetStartupConfig } from '~/data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
+import { setTimestamp } from '~/utils/timestamps';
 import { ephemeralAgentByConvoId } from '~/store';
 
 type ToolValue = boolean | string;
@@ -36,6 +36,7 @@ export function useToolToggle({
 }: UseToolToggleOptions) {
   const key = conversationId ?? Constants.NEW_CONVO;
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
+  const { data: startupConfig } = useGetStartupConfig();
 
   const authQuery = useVerifyAgentToolAuth(
     { toolId: authConfig?.toolId || '' },
@@ -76,7 +77,17 @@ export function useToolToggle({
     }
   }, [ephemeralAgent, toolKey, storageKey]);
 
-  const [isPinned, setIsPinned] = useLocalStorage<boolean>(`${localStorageKey}pinned`, false);
+  /** Admin-configured default: pin this tool when its key is listed in `defaultPinnedTools`.
+   *  Only seeds the initial state — a user's stored pin preference always takes precedence. */
+  const defaultPinned = useMemo(() => {
+    const defaultPinnedTools = startupConfig?.interface?.defaultPinnedTools;
+    return Array.isArray(defaultPinnedTools) && defaultPinnedTools.includes(toolKey);
+  }, [startupConfig?.interface?.defaultPinnedTools, toolKey]);
+
+  const [isPinned, setIsPinned] = useLocalStorage<boolean>(
+    `${localStorageKey}pinned`,
+    defaultPinned,
+  );
 
   const handleChange = useCallback(
     ({ e, value }: { e?: React.ChangeEvent<HTMLInputElement>; value: ToolValue }) => {

--- a/client/src/hooks/Plugins/useToolToggle.ts
+++ b/client/src/hooks/Plugins/useToolToggle.ts
@@ -85,30 +85,42 @@ export function useToolToggle({
   }, [startupConfig?.interface?.defaultPinnedTools, toolKey]);
 
   /** Captured before mount (pre-seed): did the user already have a stored pin preference?
-   *  Distinguishes a real choice from `useLocalStorage`'s eager default-seed below. */
+   *  Distinguishes a real choice from `useLocalStorage`'s eager default-seed below. Legacy
+   *  auto-seeded values count as a preference, so existing users keep their state. */
   const [hadStoredPin] = useState(() => localStorage.getItem(`${localStorageKey}pinned`) != null);
 
-  const [isPinned, setIsPinned] = useLocalStorage<boolean>(
+  const [isPinned, setIsPinnedRaw] = useLocalStorage<boolean>(
     `${localStorageKey}pinned`,
     defaultPinned,
   );
 
+  /** Mark explicit pin toggles so a click made before `startupConfig` resolves is never
+   *  clobbered by the admin-default effect below. */
+  const userSetPin = useRef(false);
+  const setIsPinned = useCallback(
+    (value: boolean) => {
+      userSetPin.current = true;
+      setIsPinnedRaw(value);
+    },
+    [setIsPinnedRaw],
+  );
+
   /** Cold load: `startupConfig` can resolve after mount, so `defaultPinned` starts `false`
-   *  and gets eagerly persisted. Once config arrives, apply the real default for users with
-   *  no prior preference — runs once and never overrides an existing stored pin. */
+   *  and gets eagerly persisted. Once config arrives, apply the real default for users who
+   *  have neither a stored preference nor an in-session pin click — runs once. */
   const appliedDefaultPin = useRef(false);
   useEffect(() => {
     if (appliedDefaultPin.current || startupConfig == null) {
       return;
     }
     appliedDefaultPin.current = true;
-    if (hadStoredPin) {
+    if (hadStoredPin || userSetPin.current) {
       return;
     }
     if (defaultPinned !== isPinned) {
-      setIsPinned(defaultPinned);
+      setIsPinnedRaw(defaultPinned);
     }
-  }, [startupConfig, hadStoredPin, defaultPinned, isPinned, setIsPinned]);
+  }, [startupConfig, hadStoredPin, defaultPinned, isPinned, setIsPinnedRaw]);
 
   const handleChange = useCallback(
     ({ e, value }: { e?: React.ChangeEvent<HTMLInputElement>; value: ToolValue }) => {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -169,6 +169,15 @@ interface:
   marketplace:
     use: false
   fileCitations: true
+  # Tools pinned to the prompt bar by default for all users.
+  # Only seeds the initial state — once a user pins/unpins a tool, their choice is kept.
+  # Valid tool keys: artifacts, execute_code, web_search, file_search, skills.
+  # Use 'mcp' (or a specific MCP server name) to pin the MCP servers dropdown.
+  # When omitted, tools start unpinned and the MCP dropdown keeps its default (pinned).
+  # defaultPinnedTools:
+  #   - 'artifacts'
+  #   - 'execute_code'
+  #   - 'mcp'
   # Remote Agents configuration
   # Controls user permissions for remote agents with external API support
   # remoteAgents:

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -991,6 +991,20 @@ describe('interfaceSchema', () => {
     expect(result.retentionMode).toBe(RetentionMode.ALL);
     expect(result.retainAgentFiles).toBe(true);
   });
+
+  it('accepts defaultPinnedTools as a string array', () => {
+    const result = interfaceSchema.parse({
+      defaultPinnedTools: ['artifacts', 'execute_code', 'mcp'],
+    });
+
+    expect(result.defaultPinnedTools).toEqual(['artifacts', 'execute_code', 'mcp']);
+  });
+
+  it('leaves defaultPinnedTools undefined when not provided', () => {
+    const result = interfaceSchema.parse({ modelSelect: true });
+
+    expect(result.defaultPinnedTools).toBeUndefined();
+  });
 });
 
 describe('summarizationTriggerSchema', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1218,6 +1218,8 @@ export const interfaceSchema = z
       .optional(),
     fileSearch: z.boolean().optional(),
     fileCitations: z.boolean().optional(),
+    /** Tool keys (and `'mcp'` or an MCP server name) pinned to the prompt bar by default */
+    defaultPinnedTools: z.array(z.string()).optional(),
     buildInfo: z.boolean().optional(),
     remoteAgents: z
       .object({

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -184,4 +184,28 @@ describe('loadDefaultInterface', () => {
     expect(interfaceConfig?.retentionMode).toBe(RetentionMode.ALL);
     expect(interfaceConfig?.retainAgentFiles).toBe(true);
   });
+
+  it('passes through configured default pinned tools', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        defaultPinnedTools: ['artifacts', 'execute_code', 'mcp'],
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.defaultPinnedTools).toEqual(['artifacts', 'execute_code', 'mcp']);
+  });
+
+  it('omits default pinned tools when not explicitly configured', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig).not.toHaveProperty('defaultPinnedTools');
+  });
 });

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -58,6 +58,7 @@ export async function loadDefaultInterface({
     webSearch: interfaceConfig?.webSearch,
     fileSearch: interfaceConfig?.fileSearch,
     fileCitations: interfaceConfig?.fileCitations,
+    defaultPinnedTools: interfaceConfig?.defaultPinnedTools,
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,
     remoteAgents: interfaceConfig?.remoteAgents,


### PR DESCRIPTION
# ✨ feat: Add `defaultPinnedTools` interface config for default tool & MCP pinning

## 📋 Summary

Adds a single `interface.defaultPinnedTools` string array that lets admins control which tools — and the MCP servers dropdown — are **pinned to the prompt bar by default** for all users.

This unifies two prior community contributions into one config key:
- #11646 (`pinnedTools` array for tool pinning)
- #9251 (`defaultPinMcp` boolean for MCP dropdown pinning) — now folded in via the `'mcp'` sentinel, per the discussion on those PRs.

## 🎯 Problem

Users currently have to manually pin each tool (Artifacts, Code Interpreter, Web Search, etc.) one-by-one, every environment, and the MCP dropdown's default pinned state isn't configurable. Admins had no way to set sensible defaults org-wide.

## ✨ Solution

```yaml
interface:
  defaultPinnedTools:
    - 'artifacts'
    - 'execute_code'
    - 'mcp'
```

- **Tools** — listing a tool key (`artifacts`, `execute_code`, `web_search`, `file_search`, `skills`) pins that badge by default, wired through `useToolToggle`.
- **MCP** — listing the keyword `'mcp'` (or a specific configured MCP server name) pins the MCP servers dropdown, wired through `useMCPSelect`.
- **Default-only semantics** — this only *seeds* the initial pinned state. Once a user pins/unpins anything, their stored preference always takes precedence (mirrors how other `default*` options behave).
- **Backward compatible** — when the option is omitted entirely, behavior is unchanged: tools start unpinned and the MCP dropdown keeps its legacy default (pinned). Configuring the array *without* `'mcp'` is how an admin unpins MCP by default (the old `defaultPinMcp: false` use case).

### How it flows

`interface.defaultPinnedTools` → `interfaceSchema` (data-provider) → `loadDefaultInterface` (data-schemas) → `startupConfig.interface` → consumed by `useToolToggle` / `useMCPSelect` on the client.

## 🧪 Testing

- `packages/data-provider` `config-schemas.spec.ts` — schema accepts the array / leaves it undefined when unset.
- `packages/data-schemas` `interface.spec.ts` — passthrough when configured, omitted when not.
- `client` `useToolToggle.test.tsx` — seeds pinned state from the configured tool keys.
- `client` `useMCPSelect.test.tsx` — `'mcp'`/server-name pins, configured-without-mcp unpins, legacy default preserved, stored user preference wins.

All affected suites pass; `eslint` and client `tsc --noEmit` are clean.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] New tests added covering the feature
- [ ] A docs PR for `librechat.ai` will follow
