### PR TITLE
🚦 ci: Stop Auto-Indexing PR Branches in GitNexus Index

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -1,10 +1,11 @@
 name: GitNexus Index
 
 on:
+  # PR branches are NOT auto-indexed — an embeddings run is too slow to
+  # spend on every PR push. Only main/dev are indexed automatically;
+  # individual PRs are indexed on demand via the /gitnexus command or a
+  # manual workflow_dispatch.
   push:
-    branches: [main, dev]
-    paths-ignore: ['**.md', 'docs/**', 'LICENSE', '.github/**']
-  pull_request:
     branches: [main, dev]
     paths-ignore: ['**.md', 'docs/**', 'LICENSE', '.github/**']
   workflow_dispatch:
@@ -50,15 +51,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read # read changed files to decide whether embeddings are needed
-    # Push + dispatch run unconditionally. Native pull_request events
-    # are restricted to PRs authored by danny-avila only — this keeps
-    # automatic CI spend low on a repo with 200+ open PRs.
-    #
-    # Other contributors' PRs can still be indexed on demand:
+    # Push + dispatch run unconditionally. The pull_request trigger is
+    # disabled (see `on:` above), so this never runs automatically on a
+    # PR. PRs are indexed on demand instead:
     #   - /gitnexus index    (PR comment command, contributor-gated)
     #   - workflow_dispatch   (manual dispatch from Actions UI)
-    # Both bypass this filter because they arrive as workflow_dispatch,
-    # not pull_request.
+    # Both arrive as workflow_dispatch. The pull_request guard is kept as
+    # a safety net should the trigger ever be re-added.
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.user.login == 'danny-avila'


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from the GitNexus Index workflow so opening or pushing to a PR no longer kicks off an automatic index run. Auto-indexing is now limited to `main` and `dev`; individual PRs can still be indexed on demand.

The native PR trigger ran an embeddings build (`Snowflake/snowflake-arctic-embed-xs`, ~90MB model + full graph) on every danny-avila PR push. Even after [#13653](https://github.com/danny-avila/LibreChat/pull/13653) (HF model cache + auth) and [#13658](https://github.com/danny-avila/LibreChat/pull/13658) (bump to 1.6.7 + 60-min timeout), these runs are too slow and noisy to justify spending on every PR push, and PR-specific deploys are already paused ([gitnexus-deploy.yml](.github/workflows/gitnexus-deploy.yml) serves `main` and `dev` only). This aligns indexing with what actually gets served.

- Dropped the `pull_request:` trigger block; the workflow now runs on `push` (main/dev) and `workflow_dispatch` only.
- Updated the stale comment on the index job's `if:` guard — the `github.event.pull_request.*` guard is now unreachable and retained only as a safety net should the trigger ever be re-added.
- Left the on-demand paths fully intact: `/gitnexus index` (contributor-gated PR comment command) and manual `workflow_dispatch` both arrive as `workflow_dispatch` and continue to work.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Validated the workflow YAML parses cleanly and that the resulting triggers are exactly `push` and `workflow_dispatch`.
- Verified against [gitnexus-deploy.yml](.github/workflows/gitnexus-deploy.yml) that PR index deploys are already paused (serves `main`/`dev` only), so disabling PR indexing removes no served data.
- This workflow ignores `.github/**` on push, so merging this PR will not itself trigger an index run. After merge: opening/pushing a PR should no longer start a GitNexus Index run, while a push to `dev`/`main` and a manual dispatch should still run normally.

### **Test Configuration**:

- gitnexus@1.6.7, ubuntu-latest runners

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
