### PR TITLE
🪙 chore: drop redundant voxtral-small token pricing key

### DIFF
--- a/packages/data-schemas/src/methods/tx.ts
+++ b/packages/data-schemas/src/methods/tx.ts
@@ -220,7 +220,6 @@ export const tokenValues: Record<string, { prompt: number; completion: number }>
     devstral: { prompt: 0.4, completion: 2.0 },
     'mistral-medium': { prompt: 1.5, completion: 7.5 },
     voxtral: { prompt: 0.1, completion: 0.4 },
-    'voxtral-small': { prompt: 0.1, completion: 0.4 },
     holo2: { prompt: 0.3, completion: 0.7 },
     'ministral-3b': { prompt: 0.04, completion: 0.04 },
     'ministral-8b': { prompt: 0.1, completion: 0.1 },


### PR DESCRIPTION
Follow-up to #13863 (per your review note).

`voxtral` already matches the versioned id `voxtral-small-24b-2507` via the longest-substring lookup in `findMatchingPattern`, and both keys carry the same rate — so the separate `voxtral-small` entry is redundant. Removing it.