### PR TITLE
🐳 feat: Bundle Admin Panel in Docker Compose Stacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,16 @@ DOMAIN_SERVER=http://localhost:3080
 # Example: https://admin.example.com/admin
 ADMIN_PANEL_URL=
 
+# Session encryption key for the bundled admin panel (min 32 characters).
+# The admin panel ships enabled in docker-compose/deploy-compose; the value
+# below is a development default. Generate a unique one for production:
+#   openssl rand -hex 32
+ADMIN_PANEL_SESSION_SECRET=0f7114d0b0b192b59fde7e3b730949b27d49a8717fa32ad3167d94c7684fede3
+
+# Host port for the bundled admin panel (default docker-compose only).
+# In deploy-compose the panel is served at http://admin.localhost via nginx.
+# ADMIN_PANEL_PORT=3000
+
 NO_INDEX=true
 # Use the address that is at most n number of hops away from the Express application.
 # req.socket.remoteAddress is the first hop, and the rest are looked for in the X-Forwarded-For header from right to left.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
   - Secure, Sandboxed Execution in Python, Node.js (JS/TS), Go, C/C++, Java, PHP, Rust, and Fortran
   - Seamless File Handling: Upload, process, and download files directly
   - No Privacy Concerns: Fully isolated and secure execution
+  - Open-Source & Self-Hostable: powered by [ClickHouse/code-interpreter](https://github.com/ClickHouse/code-interpreter)
 
 - 🔦 **Agents & Tools Integration**:  
   - **[LibreChat Agents](https://www.librechat.ai/docs/features/agents)**:

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@
   - Multi-User, Secure Authentication with OAuth2, LDAP, & Email Login Support
   - Built-in Moderation, and Token spend tools
 
+- 🎛️ **[Admin Panel](https://www.librechat.ai/docs/features/admin_panel)**:
+  - Browser-based UI to manage users, groups, roles, and configuration overrides
+  - Edit settings and per-role/group permissions live, without redeploying
+  - Bundled with the Docker Compose stacks for one-command setup
+
 - ⚙️ **Configuration & Deployment**:  
   - Configure Proxy, Reverse Proxy, Docker, & many Deployment options  
   - Use [S3 with CloudFront](https://www.librechat.ai/docs/configuration/cdn/cloudfront) for stable media links, edge delivery, signed cookies, and secured downloads

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -2,6 +2,12 @@
 # generated 2024-01-21, Mozilla Guideline v5.7, nginx 1.24.0, OpenSSL 3.1.4, intermediate configuration
 # https://ssl-config.mozilla.org/#server=nginx&version=1.24.0&config=intermediate&openssl=3.1.4&guideline=5.7
 
+# Map the Upgrade header so the admin-panel proxy can pass WebSocket/SSE connections.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
@@ -36,6 +42,31 @@ server {
 #    location / {
 #        return 301 https://$host$request_uri;
 #    }
+}
+
+# Admin panel (ClickHouse) served on the admin.localhost subdomain.
+# Uses Docker's embedded DNS (127.0.0.11) with a variable upstream so nginx
+# still starts when the admin-panel service is not running.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name admin.localhost;
+
+    client_max_body_size 25M;
+
+    resolver 127.0.0.11 valid=30s;
+    set $admin_panel_upstream http://admin-panel:3000;
+
+    location / {
+        proxy_pass $admin_panel_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
 }
 
 #server {
@@ -96,5 +127,33 @@ server {
 #        proxy_set_header X-Forwarded-Proto $scheme;
 #        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 #        proxy_set_header Host $host;
+#    }
+#}
+
+# SSL variant for the admin panel subdomain (mirror of the admin.localhost block above).
+# Over HTTPS you can also set ADMIN_PANEL_SESSION_COOKIE_SECURE=true on the admin-panel service.
+#server {
+#    listen 443 ssl http2;
+#    listen [::]:443 ssl http2;
+
+#    ssl_certificate /etc/nginx/ssl/nginx.crt;
+#    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+#    server_name admin.localhost;
+
+#    client_max_body_size 25M;
+
+#    resolver 127.0.0.11 valid=30s;
+#    set $admin_panel_upstream http://admin-panel:3000;
+
+#    location / {
+#        proxy_pass $admin_panel_upstream;
+#        proxy_set_header Host $host;
+#        proxy_set_header X-Real-IP $remote_addr;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        proxy_set_header X-Forwarded-Proto $scheme;
+#        proxy_http_version 1.1;
+#        proxy_set_header Upgrade $http_upgrade;
+#        proxy_set_header Connection $connection_upgrade;
 #    }
 #}

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -30,6 +30,7 @@ services:
       - http_proxy=${http_proxy:-}
       - https_proxy=${https_proxy:-}
       - no_proxy=${no_proxy:-localhost,127.0.0.1,::1},${NO_PROXY:-},mongodb,chat-mongodb,meilisearch,chat-meilisearch,rag_api,vectordb,host.docker.internal
+      - ADMIN_PANEL_URL=${ADMIN_PANEL_URL:-http://admin.localhost}
     volumes:
       - type: bind
         source: ./librechat.yaml
@@ -39,6 +40,19 @@ services:
       - ./logs:/app/api/logs
       - ./skill:/app/skill
 
+  admin-panel:
+    image: ghcr.io/clickhouse/librechat-admin-panel:latest
+    container_name: LibreChat-Admin
+    depends_on:
+      - api
+    restart: always
+    environment:
+      - PORT=3000
+      - SESSION_SECRET=${ADMIN_PANEL_SESSION_SECRET}
+      - API_SERVER_URL=http://api:3080
+      - VITE_API_BASE_URL=${DOMAIN_CLIENT:-http://localhost}
+      - SESSION_COOKIE_SECURE=${ADMIN_PANEL_SESSION_COOKIE_SECURE:-false}
+
   client:
     image: nginx:1.27.0-alpine
     container_name: LibreChat-NGINX
@@ -47,6 +61,7 @@ services:
       - 443:443
     depends_on:
       - api
+      - admin-panel
     restart: always
     volumes:
       - ./client/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -48,7 +48,7 @@ services:
     restart: always
     environment:
       - PORT=3000
-      - SESSION_SECRET=${ADMIN_PANEL_SESSION_SECRET}
+      - SESSION_SECRET=${ADMIN_PANEL_SESSION_SECRET:-${CREDS_KEY}}
       - API_SERVER_URL=http://api:3080
       - VITE_API_BASE_URL=${DOMAIN_CLIENT:-http://localhost}
       - SESSION_COOKIE_SECURE=${ADMIN_PANEL_SESSION_COOKIE_SECURE:-false}

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -41,7 +41,7 @@ services:
       - ./skill:/app/skill
 
   admin-panel:
-    image: ghcr.io/clickhouse/librechat-admin-panel:latest
+    image: registry.librechat.ai/clickhouse/librechat-admin-panel:latest
     container_name: LibreChat-Admin
     depends_on:
       - api

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -42,7 +42,7 @@ services:
 
   admin-panel:
     image: registry.librechat.ai/clickhouse/librechat-admin-panel:latest
-    container_name: LibreChat-Admin
+    container_name: admin-panel
     depends_on:
       - api
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,20 @@ services:
       - ./uploads:/app/uploads
       - ./logs:/app/logs
       - ./skill:/app/skill
+  admin-panel:
+    container_name: LibreChat-Admin
+    image: ghcr.io/clickhouse/librechat-admin-panel:latest
+    ports:
+      - "${ADMIN_PANEL_PORT:-3000}:3000"
+    depends_on:
+      - api
+    restart: always
+    environment:
+      - PORT=3000
+      - SESSION_SECRET=${ADMIN_PANEL_SESSION_SECRET}
+      - API_SERVER_URL=http://api:${PORT:-3080}
+      - VITE_API_BASE_URL=${DOMAIN_CLIENT:-http://localhost:3080}
+      - SESSION_COOKIE_SECURE=${ADMIN_PANEL_SESSION_COOKIE_SECURE:-false}
   mongodb:
     container_name: chat-mongodb
     image: mongo:8.0.20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./logs:/app/logs
       - ./skill:/app/skill
   admin-panel:
-    container_name: LibreChat-Admin
+    container_name: admin-panel
     image: registry.librechat.ai/clickhouse/librechat-admin-panel:latest
     ports:
       - "${ADMIN_PANEL_PORT:-3000}:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - ./skill:/app/skill
   admin-panel:
     container_name: LibreChat-Admin
-    image: ghcr.io/clickhouse/librechat-admin-panel:latest
+    image: registry.librechat.ai/clickhouse/librechat-admin-panel:latest
     ports:
       - "${ADMIN_PANEL_PORT:-3000}:3000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     restart: always
     environment:
       - PORT=3000
-      - SESSION_SECRET=${ADMIN_PANEL_SESSION_SECRET}
+      - SESSION_SECRET=${ADMIN_PANEL_SESSION_SECRET:-${CREDS_KEY}}
       - API_SERVER_URL=http://api:${PORT:-3080}
       - VITE_API_BASE_URL=${DOMAIN_CLIENT:-http://localhost:3080}
       - SESSION_COOKIE_SECURE=${ADMIN_PANEL_SESSION_COOKIE_SECURE:-false}


### PR DESCRIPTION
## Summary

I bundled the [LibreChat Admin Panel](https://github.com/ClickHouse/librechat-admin-panel) into both Docker Compose stacks so a default deployment ships with the admin panel running alongside LibreChat, with no extra setup. The panel is an API client (it reaches LibreChat over the REST API, not the database directly), so it only needs to talk to the `api` service.

- Added an `admin-panel` service to `docker-compose.yml`, published on a host port (`http://localhost:3000` by default, overridable via `ADMIN_PANEL_PORT`). It points `API_SERVER_URL` at `http://api:${PORT}` for server-side calls and `VITE_API_BASE_URL` at `DOMAIN_CLIENT` for browser-facing OAuth redirects.
- Added an `admin-panel` service to `deploy-compose.yml` with no published port, fronted by the existing nginx reverse proxy and served at the `http://admin.localhost` subdomain.
- Set `ADMIN_PANEL_URL=http://admin.localhost` on the deploy-compose `api` service so LibreChat builds admin OAuth/SSO callbacks against the subdomain, and added `admin-panel` to the nginx `client` service's `depends_on`.
- Added an `admin.localhost` server block to `client/nginx.conf` that proxies to `admin-panel:3000`. It resolves the upstream through Docker's embedded DNS (`127.0.0.11`) with a variable, so nginx still starts when the `admin-panel` service is absent (this config is also shared by `utils/docker/test-compose.yml`). Added a `$connection_upgrade` map for WebSocket/SSE passthrough and a commented SSL variant mirroring the existing one.
- Added `ADMIN_PANEL_SESSION_SECRET` to `.env.example` with a development default (the panel requires a 32+ char secret and the image has no built-in default, so "always on" must work out of the box), matching the existing convention for `CREDS_KEY`/`JWT_SECRET`/`MEILI_MASTER_KEY`. Documented `ADMIN_PANEL_PORT`.

### Access

- Default stack (`docker-compose.yml`): `http://localhost:3000`
- Deploy stack (`deploy-compose.yml`): `http://admin.localhost` (browsers resolve `*.localhost` to `127.0.0.1` automatically; non-browser tools may need a hosts entry)

### Notes

- The panel runs by default in both stacks. To opt out, remove the `admin-panel` service or gate it behind a compose `profiles:` entry.
- `SESSION_COOKIE_SECURE` defaults to `false` for plain-HTTP local use; set it to `true` (via `ADMIN_PANEL_SESSION_COOKIE_SECURE`) when serving the panel over HTTPS.
- Production hardening: rotate `ADMIN_PANEL_SESSION_SECRET`, point `DOMAIN_CLIENT` and `ADMIN_PANEL_URL` at real domains, and terminate TLS.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I validated the configuration statically without booting the full stack:

- `docker compose -f docker-compose.yml config` and `docker compose -f deploy-compose.yml config` both render cleanly; the `admin-panel` service resolves its env, the deploy `api` service receives `ADMIN_PANEL_URL=http://admin.localhost`, and the nginx `client` service depends on `admin-panel`.
- `nginx -t` passes against the updated `client/nginx.conf`.
- Confirmed the `ghcr.io/clickhouse/librechat-admin-panel:latest` image manifest exists and is multi-arch (amd64 + arm64).

Recommended follow-up smoke test: `cp .env.example .env`, then `docker compose up` and confirm the panel loads at `http://localhost:3000`; and `docker compose -f deploy-compose.yml up`, then confirm `http://admin.localhost` loads and email/password login against LibreChat succeeds.

### **Test Configuration**:

- Docker 29.x, nginx 1.27.0-alpine

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
