### PR TITLE
🐛 fix: Include Sandpack bundler URLs in shared conversation config

### DIFF
--- a/api/server/routes/__tests__/config.spec.js
+++ b/api/server/routes/__tests__/config.spec.js
@@ -185,10 +185,12 @@ describe('GET /api/config', () => {
       expect(response.body).not.toHaveProperty('customFooter');
     });
 
-    it('should include public share footer fields when share context is requested', async () => {
+    it('should include public share fields when share context is requested', async () => {
       process.env.ANALYTICS_GTM_ID = 'GTM-XYZ';
       process.env.CUSTOM_FOOTER = 'public footer text';
       process.env.HELP_AND_FAQ_URL = 'https://internal.example.com/faq';
+      process.env.SANDPACK_BUNDLER_URL = 'https://bundler.test';
+      process.env.SANDPACK_STATIC_BUNDLER_URL = 'https://static-bundler.test';
       mockGetAppConfig.mockResolvedValue(baseAppConfig);
       const app = createApp(null);
 
@@ -197,8 +199,23 @@ describe('GET /api/config', () => {
       expect(response.statusCode).toBe(200);
       expect(response.body.analyticsGtmId).toBe('GTM-XYZ');
       expect(response.body.customFooter).toBe('public footer text');
+      expect(response.body.bundlerURL).toBe('https://bundler.test');
+      expect(response.body.staticBundlerURL).toBe('https://static-bundler.test');
       expect(response.body).not.toHaveProperty('helpAndFaqURL');
       expect(response.body).not.toHaveProperty('allowAccountDeletion');
+    });
+
+    it('should not include bundler URLs without share context', async () => {
+      process.env.SANDPACK_BUNDLER_URL = 'https://bundler.test';
+      process.env.SANDPACK_STATIC_BUNDLER_URL = 'https://static-bundler.test';
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      const app = createApp(null);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).not.toHaveProperty('bundlerURL');
+      expect(response.body).not.toHaveProperty('staticBundlerURL');
     });
 
     it('should include socialLogins and turnstile from base config', async () => {

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -115,6 +115,8 @@ function buildPublicSharePayload() {
   /** @type {Partial<TStartupConfig>} */
   const payload = {
     analyticsGtmId: process.env.ANALYTICS_GTM_ID,
+    bundlerURL: process.env.SANDPACK_BUNDLER_URL,
+    staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,
   };
 
   if (typeof process.env.CUSTOM_FOOTER === 'string') {
@@ -268,8 +270,6 @@ router.get('/', async function (req, res) {
       turnstile: appConfig?.turnstileConfig,
       modelSpecs: sanitizeModelSpecs(appConfig?.modelSpecs),
       balance: balanceConfig,
-      bundlerURL: process.env.SANDPACK_BUNDLER_URL,
-      staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,
       sharePointFilePickerEnabled,
       sharePointBaseUrl: process.env.SHAREPOINT_BASE_URL,
       sharePointPickerGraphScope: process.env.SHAREPOINT_PICKER_GRAPH_SCOPE,


### PR DESCRIPTION
## Summary

Fixes #13881.

Artifacts render in normal (authenticated) chats but not in **shared conversations** (`/share/:shareId`) on instances that configure a custom Sandpack bundler via `SANDPACK_BUNDLER_URL` / `SANDPACK_STATIC_BUNDLER_URL`.

`ShareView` requests startup config with `useGetStartupConfig(undefined, { context: 'share' })`, which the server answers from `buildPublicSharePayload()`. That payload (introduced in #13102) carries the share-needed fields `analyticsGtmId` and `customFooter`, but not `bundlerURL` / `staticBundlerURL`. So `ShareArtifacts` → `Artifacts` → `buildSandpackOptions()` receives no bundler URL and Sandpack falls back to the codesandbox.io defaults — invisible on default deployments, but broken on self-hosted / network-restricted bundlers (the `static` template times out with `ENV: static / ERROR: TIME_OUT`).

This moves `bundlerURL` / `staticBundlerURL` into `buildPublicSharePayload()` and drops the now-duplicate entries from the authenticated payload (which already spreads `...publicSharePayload`).

These two values are non-sensitive instance hostnames — already present in the authenticated payload and visible in every rendered artifact's network traffic — so unlike `modelSpecs`/system prompts they carry no secret, and this does not reintroduce the exposure addressed by #12490 / #13102. They remain off the default anonymous (login-screen) config; they are returned only when the client requests `?context=share` or is authenticated.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```
cd api && npx jest server/routes/__tests__/config.spec.js
```

Updated `api/server/routes/__tests__/config.spec.js`:
- the `?context=share` test now also asserts `bundlerURL` / `staticBundlerURL` are returned;
- a new test asserts the default anonymous config (no `context=share`) still does **not** expose the bundler URLs, even with the env vars set;
- the existing authenticated-config test still asserts both URLs are present, verifying the dedup through `...publicSharePayload`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
