### PR TITLE
Fix reasoning Bedrock validation error

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -584,6 +584,7 @@ class BaseClient {
       );
     }
 
+    this.sanitizeBedrockPayload(payload);
     const { completion, metadata } = await this.sendCompletion(payload, opts);
     if (this.abortController) {
       this.abortController.requestCompleted = true;
@@ -1143,11 +1144,42 @@ class BaseClient {
     return mergedContent.concat(newCompletion.slice(1));
   }
 
+  sanitizeBedrockPayload(payload) {
+    const provider = this.options.agent?.provider ?? this.options.endpoint;
+
+    if (provider !== EModelEndpoint.bedrock || !Array.isArray(payload?.messages)) {
+      return;
+    }
+
+    payload.messages = payload.messages
+      .map((message) => {
+        if (!Array.isArray(message.content)) {
+          return message;
+        }
+
+        const content = message.content.filter((block) => {
+          const text = block?.reasoningContent?.reasoningText?.text;
+          return text !== null && text !== undefined && text !== '';
+        });
+
+        if (content.length === 0) {
+          return null;
+        }
+
+        return {
+          ...message,
+          content,
+        };
+      })
+      .filter(Boolean);
+  }
+
+
   async sendPayload(payload, opts = {}) {
     if (opts && typeof opts === 'object') {
       this.setOptions(opts);
     }
-
+    this.sanitizeBedrockPayload(payload);
     return await this.sendCompletion(payload, opts);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a Bedrock validation error that can happen when an existing conversation contains a malformed reasoning content block with `reasoningContent.reasoningText.text` set to `null`, `undefined`, or an empty string.

Bedrock rejects such requests with an error like:

`Value at 'messages.X.member.content.Y.member.reasoningContent.reasoningText.text' failed to satisfy constraint: Member must not be null`

This bug constantly appears with Claude 4.8.

This can happen with already-saved conversation history, so config options such as `thinkingDisplay: "omitted"` do not necessarily fix affected conversations.

The change sanitizes Bedrock payloads before calling `sendCompletion`, removing invalid reasoning content blocks and dropping messages whose content becomes empty after sanitization.

## Change Type

* [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested locally with a LibreChat deployment using the Bedrock endpoint and an existing conversation that previously failed with the Bedrock validation error:

`reasoningContent.reasoningText.text failed to satisfy constraint: Member must not be null`

After applying the patch and restarting the API container, the same conversation continued successfully without the Bedrock validation error.

### **Test Configuration**:

* LibreChat with Bedrock endpoint enabled
* Bedrock Claude model
* Existing multi-turn conversation containing malformed reasoning content in history
* API container restarted after applying the patch

## Checklist

* [x] My code adheres to this project's style guidelines
* [x] I have performed a self-review of my own code
* [x] My changes do not introduce new warnings
* [ ] I have written tests demonstrating that my changes are effective or that my feature works
* [ ] Local unit tests pass with my changes
