### PR TITLE
🏷️ chore: Bump Individual Package Versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -264,7 +264,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.32",
+      "version": "1.7.33",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
@@ -345,7 +345,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.61",
+      "version": "0.4.62",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
@@ -433,7 +433,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.505",
+      "version": "0.8.508",
       "dependencies": {
         "axios": "^1.13.5",
         "dayjs": "^1.11.13",
@@ -470,7 +470,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.53",
+      "version": "0.0.55",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42403,7 +42403,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.32",
+      "version": "1.7.33",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",
@@ -43107,7 +43107,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.61",
+      "version": "0.4.62",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44250,7 +44250,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.507",
+      "version": "0.8.508",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -44858,7 +44858,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.54",
+      "version": "0.0.55",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.32",
+  "version": "1.7.33",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.61",
+  "version": "0.4.62",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.507",
+  "version": "0.8.508",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

I bumped the publishable package versions for v0.8.7 package release prep without advancing the LibreChat app version or Helm chart version.

- Bumped `@librechat/api` from `1.7.32` to `1.7.33`.
- Bumped `@librechat/client` from `0.4.61` to `0.4.62`.
- Bumped `librechat-data-provider` from `0.8.507` to `0.8.508`.
- Bumped `@librechat/data-schemas` from `0.0.54` to `0.0.55`.
- Updated `package-lock.json` and `bun.lock` workspace metadata to match the package manifests.

## Change Type

- [x] Package release prep (non-breaking version metadata update)

## Testing

I validated the package metadata updates and confirmed the app and chart versions were not advanced.

### **Test Configuration**:

- Repository: `danny-avila/LibreChat`
- Base branch: `dev`

Commands run:

```bash
npm install --package-lock-only --ignore-scripts --no-audit --no-fund
node -e "const fs=require('fs'); const files=['package.json','api/package.json','client/package.json','packages/api/package.json','packages/client/package.json','packages/data-provider/package.json','packages/data-schemas/package.json','package-lock.json']; for (const f of files) JSON.parse(fs.readFileSync(f,'utf8')); console.log('json ok');"
git diff --check
```

I also scanned for old package counters and confirmed the LibreChat app version remains `v0.8.7-rc1` while the Helm chart remains at `2.0.6`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local metadata checks pass with my changes
