### PR TITLE
✂️ fix: Cap Audit Chain Verification and Honor Client Cancellation

### DIFF
--- a/packages/api/src/admin/auditLog.spec.ts
+++ b/packages/api/src/admin/auditLog.spec.ts
@@ -1,6 +1,6 @@
 import { Types } from 'mongoose';
 import { EventEmitter } from 'events';
-import { MAX_AUDIT_EXPORT_ROWS } from '@librechat/data-schemas';
+import { MAX_AUDIT_EXPORT_ROWS, MAX_AUDIT_VERIFY_ROWS } from '@librechat/data-schemas';
 import type {
   AdminAuditLogEntry,
   AuditChainVerification,
@@ -64,11 +64,20 @@ function createReqRes(
     user: 'user' in overrides ? overrides.user : { _id: new Types.ObjectId(), role: 'admin' },
   } as unknown as ServerRequest;
 
+  const emitter = new EventEmitter();
+  const reqEmitter = new EventEmitter();
   const json = jest.fn();
   const status = jest.fn().mockReturnValue({ json });
-  const res = { status, json } as unknown as Response;
+  const res = Object.assign(emitter, {
+    status,
+    json,
+    removeListener: emitter.removeListener.bind(emitter),
+  }) as unknown as Response;
+  const eventReq = Object.assign(reqEmitter, req, {
+    removeListener: reqEmitter.removeListener.bind(reqEmitter),
+  }) as unknown as ServerRequest;
 
-  return { req, res, status, json };
+  return { req: eventReq, res, status, json, emitter, reqEmitter };
 }
 
 interface CsvCaptureContext {
@@ -351,8 +360,27 @@ describe('createAdminAuditLogHandlers', () => {
       });
       await handlers.verifyAuditLog(req, res);
       expect((deps.verifyAuditChain as jest.Mock).mock.calls[0][0]).toBe('real-tenant');
+      expect((deps.verifyAuditChain as jest.Mock).mock.calls[0][1].maxRows).toBe(
+        MAX_AUDIT_VERIFY_ROWS,
+      );
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith(verification);
+    });
+
+    it('threads cancellation into verification and skips the response after client close', async () => {
+      const ctx = createReqRes();
+      const deps = createDeps({
+        verifyAuditChain: jest.fn(async (_tenantId, options) => {
+          ctx.emitter.emit('close');
+          options?.isCancelled?.();
+          return mockVerification({ ok: false, reason: 'verification cancelled' });
+        }),
+      });
+      const handlers = createAdminAuditLogHandlers(deps);
+      await handlers.verifyAuditLog(ctx.req, ctx.res);
+      const optionsArg = (deps.verifyAuditChain as jest.Mock).mock.calls[0][1];
+      expect(optionsArg.isCancelled()).toBe(true);
+      expect(ctx.status).not.toHaveBeenCalled();
     });
 
     it('returns 500 when verification throws', async () => {

--- a/packages/api/src/admin/auditLog.ts
+++ b/packages/api/src/admin/auditLog.ts
@@ -7,6 +7,7 @@ import {
   AUDIT_ACTOR_TYPES,
   MAX_AUDIT_EXPORT_ROWS,
   MAX_AUDIT_LOG_LIMIT,
+  MAX_AUDIT_VERIFY_ROWS,
 } from '@librechat/data-schemas';
 import type {
   AdminAuditLogEntry,
@@ -59,7 +60,10 @@ export interface AdminAuditLogDeps {
     onEntry: (entry: AdminAuditLogEntry) => void | Promise<void>,
     options?: { isCancelled?: () => boolean; maxRows?: number },
   ) => Promise<{ count: number; truncated: boolean }>;
-  verifyAuditChain: (tenantId: string | undefined) => Promise<AuditChainVerification>;
+  verifyAuditChain: (
+    tenantId: string | undefined,
+    options?: { isCancelled?: () => boolean; maxRows?: number },
+  ) => Promise<AuditChainVerification>;
 }
 
 interface CallerContext {
@@ -328,8 +332,25 @@ export function createAdminAuditLogHandlers(deps: AdminAuditLogDeps): {
       const caller = resolveCaller(req);
       if (!caller) return res.status(401).json({ error: 'Authentication required' });
 
-      const result = await verifyAuditChain(caller.tenantId);
-      return res.status(200).json(result);
+      let clientAborted = false;
+      const markAborted = () => {
+        clientAborted = true;
+      };
+      res.once('close', markAborted);
+      req.once('aborted', markAborted);
+
+      try {
+        const result = await verifyAuditChain(caller.tenantId, {
+          isCancelled: () => clientAborted,
+          maxRows: MAX_AUDIT_VERIFY_ROWS,
+        });
+
+        if (clientAborted) return res;
+        return res.status(200).json(result);
+      } finally {
+        res.removeListener('close', markAborted);
+        req.removeListener('aborted', markAborted);
+      }
     } catch (err) {
       logger.error('[adminAuditLog] verify error:', err);
       return res.status(500).json({ error: 'Failed to verify audit log integrity' });

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -27,6 +27,7 @@ export {
   AUDIT_SCHEMA_VERSION,
   MAX_AUDIT_EXPORT_ROWS,
   MAX_AUDIT_LOG_LIMIT,
+  MAX_AUDIT_VERIFY_ROWS,
 } from './methods';
 export type * from './types';
 export type * from './methods';

--- a/packages/data-schemas/src/methods/auditLog.spec.ts
+++ b/packages/data-schemas/src/methods/auditLog.spec.ts
@@ -351,6 +351,30 @@ describe('auditLog methods', () => {
       expect(result.checked).toBe(0);
     });
 
+    it('stops verification when the caller cancels', async () => {
+      await seed(3);
+      const result = await methods.verifyAuditChain('tenant-a', { isCancelled: () => true });
+      expect(result.ok).toBe(false);
+      expect(result.checked).toBe(0);
+      expect(result.reason).toBe('verification cancelled');
+    });
+
+    it('bounds verification when rows exceed the configured cap', async () => {
+      await seed(3);
+      const result = await methods.verifyAuditChain('tenant-a', { maxRows: 2 });
+      expect(result.ok).toBe(false);
+      expect(result.checked).toBe(2);
+      expect(result.brokenAt).toBe(3);
+      expect(result.reason).toMatch(/row limit exceeded/);
+    });
+
+    it('allows an exact-cap verification to complete', async () => {
+      await seed(2);
+      const result = await methods.verifyAuditChain('tenant-a', { maxRows: 2 });
+      expect(result.ok).toBe(true);
+      expect(result.checked).toBe(2);
+    });
+
     it('detects a tampered field (hash mismatch)', async () => {
       await seed(3);
       // mutate a field via the raw driver, bypassing the append-only hooks

--- a/packages/data-schemas/src/methods/auditLog.ts
+++ b/packages/data-schemas/src/methods/auditLog.ts
@@ -27,6 +27,11 @@ export const MAX_AUDIT_LOG_LIMIT = 500;
  * should be sliced by `from`/`to`.
  */
 export const MAX_AUDIT_EXPORT_ROWS = 100_000;
+/**
+ * Upper bound on rows verified in a single HTTP-triggered integrity check. Full
+ * offline jobs can pass a larger value explicitly when needed.
+ */
+export const MAX_AUDIT_VERIFY_ROWS = 100_000;
 /** Record-format version stamped on every new entry. */
 export const AUDIT_SCHEMA_VERSION = 1;
 const MAX_SEARCH_LENGTH = 200;
@@ -516,6 +521,8 @@ export function createAuditLogMethods(mongoose: typeof import('mongoose')): Audi
       .cursor({ batchSize: 500 });
 
     const trustedCheckpoint = options?.trustedCheckpoint;
+    const isCancelled = options?.isCancelled;
+    const maxRows = options?.maxRows;
     let prevHash = GENESIS_HASH;
     let expectedSeq: number | null = null;
     let firstSeq: number | null = null;
@@ -524,6 +531,28 @@ export function createAuditLogMethods(mongoose: typeof import('mongoose')): Audi
 
     try {
       for await (const doc of cursor) {
+        if (isCancelled?.()) {
+          await cursor.close();
+          return {
+            ok: false,
+            chainKey,
+            checked,
+            reason: 'verification cancelled',
+            range: firstSeq !== null ? { firstSeq, lastSeq } : undefined,
+          };
+        }
+        if (maxRows != null && checked >= maxRows) {
+          await cursor.close();
+          return {
+            ok: false,
+            chainKey,
+            checked,
+            brokenAt: doc.seq,
+            reason: `verification row limit exceeded (${maxRows})`,
+            range:
+              firstSeq !== null ? { firstSeq, lastSeq } : { firstSeq: doc.seq, lastSeq: doc.seq },
+          };
+        }
         if (firstSeq === null) {
           firstSeq = doc.seq;
           expectedSeq = doc.seq;

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -25,6 +25,7 @@ import {
   AUDIT_SCHEMA_VERSION,
   MAX_AUDIT_EXPORT_ROWS,
   MAX_AUDIT_LOG_LIMIT,
+  MAX_AUDIT_VERIFY_ROWS,
   type AuditLogMethods,
 } from './auditLog';
 import { createShareMethods, type ShareMethods } from './share';
@@ -108,7 +109,7 @@ export {
   deriveStructuredFrontmatterFields,
   inferSkillFileCategory,
 };
-export { AUDIT_SCHEMA_VERSION, MAX_AUDIT_EXPORT_ROWS, MAX_AUDIT_LOG_LIMIT };
+export { AUDIT_SCHEMA_VERSION, MAX_AUDIT_EXPORT_ROWS, MAX_AUDIT_LOG_LIMIT, MAX_AUDIT_VERIFY_ROWS };
 
 export type AllMethods = UserMethods &
   SessionMethods &

--- a/packages/data-schemas/src/types/auditLog.ts
+++ b/packages/data-schemas/src/types/auditLog.ts
@@ -166,6 +166,10 @@ export interface PurgeAuditLogResult {
 }
 
 export interface VerifyAuditChainOptions {
+  /** Stop verification early when the caller has gone away. */
+  isCancelled?: () => boolean;
+  /** Maximum rows to inspect before returning a bounded, non-OK result. */
+  maxRows?: number;
   /** When the chain no longer starts at `seq: 1` (a prefix was purged), the
    * verifier requires this boundary to distinguish an authorized retention purge
    * from an attacker deleting the oldest rows. Without it, a non-genesis start


### PR DESCRIPTION
### Motivation
- The audit verification path could walk and hash an unbounded per-tenant chain synchronously, allowing a delegated auditor to pin Node workers and MongoDB cursors (availability DoS). 
- The change limits server-side work for HTTP-triggered verification and makes verification abortable on client disconnect so a cancelled request no longer forces full cursor iteration.

### Description
- Add `MAX_AUDIT_VERIFY_ROWS` and extend `VerifyAuditChainOptions` with `isCancelled?: () => boolean` and `maxRows?: number` so the methods layer can stop early. 
- Update `verifyAuditChain` to observe `isCancelled` and `maxRows`, close the cursor and return a bounded non-OK result on cancellation or row-limit overflow. 
- Wire cancellation and the shared row cap into the admin handler: `verifyAuditLogHandler` now listens for `res.once('close')` / `req.once('aborted')`, passes `isCancelled` and `MAX_AUDIT_VERIFY_ROWS` to the methods layer, and skips writing a response if the client disconnected. 
- Add regression tests exercising cancellation and row-cap behavior in `packages/api/src/admin/auditLog.spec.ts` and `packages/data-schemas/src/methods/auditLog.spec.ts`, and export the new constant from `packages/data-schemas`.

### Testing
- Built the schemas package with `npm run build:data-schemas`, which completed successfully. 
- Built the API with `npm run build:api`, which completed successfully. 
- Ran the admin handler unit tests with `cd packages/api && npx jest src/admin/auditLog.spec.ts --runInBand`, which passed (34 tests). 
- Attempted to run the data-schemas methods tests with `cd packages/data-schemas && MONGOMS_VERSION=7.0.14 npx jest src/methods/auditLog.spec.ts --runInBand`, but the suite was blocked by `mongodb-memory-server` failing to download the MongoDB binary in this environment (HTTP 403), so the full methods-suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c42a0c0c832794b2d09f68389c82)