### PR TITLE
🛑 refactor: Demote User Abort Logs

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1450,11 +1450,12 @@ class AgentClient extends BaseClient {
         });
       }
     } catch (err) {
-      logger.error(
-        '[api/server/controllers/agents/client.js #sendCompletion] Operation aborted',
-        err,
-      );
-      if (!abortController.signal.aborted) {
+      if (abortController.signal.aborted) {
+        logger.debug(
+          '[api/server/controllers/agents/client.js #sendCompletion] Operation aborted by user',
+          { conversationId: this.conversationId, name: err?.name, code: err?.code },
+        );
+      } else {
         logger.error(
           '[api/server/controllers/agents/client.js #sendCompletion] Unhandled error type',
           err,

--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -20,16 +20,29 @@ const db = require('~/models');
  * @returns {boolean}
  */
 const isAbortError = (error) => {
-  const errorName = error?.name ?? error?.cause?.name;
-  const errorCode = error?.code ?? error?.cause?.code;
-  const errorMessage = error?.message ?? error?.cause?.message ?? '';
+  const visited = new Set();
+  let current = error;
 
-  return (
-    errorName === 'AbortError' ||
-    errorCode === 'ABORT_ERR' ||
-    errorMessage.includes('AbortError') ||
-    /(?:operation|request|stream) was aborted/i.test(errorMessage)
-  );
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+
+    const errorName = current.name;
+    const errorCode = current.code;
+    const errorMessage = typeof current.message === 'string' ? current.message : '';
+
+    if (
+      errorName === 'AbortError' ||
+      errorCode === 'ABORT_ERR' ||
+      errorMessage.includes('AbortError') ||
+      /(?:operation|request|stream) was aborted/i.test(errorMessage)
+    ) {
+      return true;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
 };
 
 /**

--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -16,6 +16,23 @@ const { abortRun } = require('./abortRun');
 const db = require('~/models');
 
 /**
+ * @param {Error | unknown} error
+ * @returns {boolean}
+ */
+const isAbortError = (error) => {
+  const errorName = error?.name ?? error?.cause?.name;
+  const errorCode = error?.code ?? error?.cause?.code;
+  const errorMessage = error?.message ?? error?.cause?.message ?? '';
+
+  return (
+    errorName === 'AbortError' ||
+    errorCode === 'ABORT_ERR' ||
+    errorMessage.includes('AbortError') ||
+    /(?:operation|request|stream) was aborted/i.test(errorMessage)
+  );
+};
+
+/**
  * Spend tokens for all models from collected usage.
  * This handles both sequential and parallel agent execution.
  *
@@ -200,18 +217,26 @@ const handleAbort = function () {
  * @returns {Promise<void>}
  */
 const handleAbortError = async (res, req, error, data) => {
+  const { sender, conversationId, messageId, parentMessageId, userMessageId, partialText } = data;
+
   if (error?.message?.includes('base64')) {
     logger.error('[handleAbortError] Error in base64 encoding', {
       ...error,
       stack: smartTruncateText(error?.stack, 1000),
       message: truncateText(error.message, 350),
     });
+  } else if (isAbortError(error)) {
+    logger.debug('[handleAbortError] AI response aborted by user', {
+      conversationId,
+      code: error?.code,
+      name: error?.name,
+      message: truncateText(error?.message ?? 'AbortError', 350),
+    });
   } else {
     logger.error('[handleAbortError] AI response error; aborting request:', error);
   }
-  const { sender, conversationId, messageId, parentMessageId, userMessageId, partialText } = data;
 
-  if (error.stack && error.stack.includes('google')) {
+  if (error?.stack && error.stack.includes('google')) {
     logger.warn(
       `AI Response error for conversation ${conversationId} likely caused by Google censor/filter`,
     );

--- a/api/server/middleware/abortMiddleware.spec.js
+++ b/api/server/middleware/abortMiddleware.spec.js
@@ -255,15 +255,24 @@ describe('abortMiddleware - handleAbortError', () => {
   });
 
   it.each([
-    [new DOMException('The operation was aborted', 'AbortError'), 'AbortError'],
-    [new Error('SSE stream disconnected: AbortError: The operation was aborted'), 'Error'],
     [
+      'native DOMException AbortError',
+      new DOMException('The operation was aborted', 'AbortError'),
+      'AbortError',
+    ],
+    [
+      'wrapped AbortError message',
+      new Error('SSE stream disconnected: AbortError: The operation was aborted'),
+      'Error',
+    ],
+    [
+      'cause-nested AbortError',
       new Error('Request failed', {
         cause: new DOMException('The operation was aborted', 'AbortError'),
       }),
       'Error',
     ],
-  ])('logs user aborts as debug events instead of errors', async (error, name) => {
+  ])('logs a %s as a debug event instead of an error', async (_label, error, name) => {
     await handleAbortError({}, buildAbortRequest(), error, {
       sender: 'AI',
       conversationId: 'convo-123',

--- a/api/server/middleware/abortMiddleware.spec.js
+++ b/api/server/middleware/abortMiddleware.spec.js
@@ -257,6 +257,12 @@ describe('abortMiddleware - handleAbortError', () => {
   it.each([
     [new DOMException('The operation was aborted', 'AbortError'), 'AbortError'],
     [new Error('SSE stream disconnected: AbortError: The operation was aborted'), 'Error'],
+    [
+      new Error('Request failed', {
+        cause: new DOMException('The operation was aborted', 'AbortError'),
+      }),
+      'Error',
+    ],
   ])('logs user aborts as debug events instead of errors', async (error, name) => {
     await handleAbortError({}, buildAbortRequest(), error, {
       sender: 'AI',

--- a/api/server/middleware/abortMiddleware.spec.js
+++ b/api/server/middleware/abortMiddleware.spec.js
@@ -73,7 +73,18 @@ jest.mock('./abortRun', () => ({
   abortRun: jest.fn(),
 }));
 
-const { spendCollectedUsage } = require('./abortMiddleware');
+const { logger } = require('@librechat/data-schemas');
+const { sendError } = require('~/server/middleware/error');
+const { handleAbortError, spendCollectedUsage } = require('./abortMiddleware');
+
+const buildAbortRequest = () => ({
+  body: {
+    model: 'gpt-4',
+  },
+  user: {
+    id: 'user-123',
+  },
+});
 
 describe('abortMiddleware - spendCollectedUsage', () => {
   beforeEach(() => {
@@ -235,5 +246,52 @@ describe('abortMiddleware - spendCollectedUsage', () => {
       expect(resolved).toBe(true);
       expect(collectedUsage.length).toBe(0);
     });
+  });
+});
+
+describe('abortMiddleware - handleAbortError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [new DOMException('The operation was aborted', 'AbortError'), 'AbortError'],
+    [new Error('SSE stream disconnected: AbortError: The operation was aborted'), 'Error'],
+  ])('logs user aborts as debug events instead of errors', async (error, name) => {
+    await handleAbortError({}, buildAbortRequest(), error, {
+      sender: 'AI',
+      conversationId: 'convo-123',
+      messageId: 'message-123',
+      parentMessageId: 'parent-123',
+      userMessageId: 'user-message-123',
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith('[handleAbortError] AI response aborted by user', {
+      conversationId: 'convo-123',
+      code: error.code,
+      name,
+      message: error.message,
+    });
+    expect(sendError).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps unexpected generation errors classified as errors', async () => {
+    const error = new Error('Provider failed');
+
+    await handleAbortError({}, buildAbortRequest(), error, {
+      sender: 'AI',
+      conversationId: 'convo-123',
+      messageId: 'message-123',
+      parentMessageId: 'parent-123',
+      userMessageId: 'user-message-123',
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '[handleAbortError] AI response error; aborting request:',
+      error,
+    );
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(sendError).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

User-initiated generation cancellations were still surfacing as `error`-level logs. The original abort log seen in production,

```
[api/server/controllers/agents/client.js #sendCompletion] Operation aborted This operation was aborted
```

came from `AgentClient`'s completion catch, not from the abort middleware. That catch logged **every** caught error at `error` level first, and only afterward checked the abort signal to decide whether to surface an error content part. So a normal user Stop always emitted a spurious error log even though it was handled correctly.

This PR demotes expected user-initiated cancellations to `debug` in both abort sinks while keeping real generation failures error-classified.

- `AgentClient` completion catch (resumable flow, the path in the report above): branch on `abortController.signal.aborted` (the same controller `GenerationJobManager.abortJob` aborts) so user aborts log at `debug` and only genuine failures log at `error` and push an error content part.
- `handleAbortError` (non-resumable `AgentController` / assistants flow): added an abort-error classifier for native `AbortError`, `ABORT_ERR`, and wrapped/cause-nested provider messages, and demoted those to `debug`.
- Preserved `logger.error` for base64 failures, unexpected generation failures, and failures while trying to abort a partial message.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd api && npx jest server/middleware/abortMiddleware.spec.js --runInBand` (11 passing; covers DOMException aborts, wrapped `AbortError` messages, cause-nested aborts, and ordinary provider errors).
- `npx eslint api/server/middleware/abortMiddleware.js api/server/middleware/abortMiddleware.spec.js api/server/controllers/agents/client.js`
- `git diff --check`

### **Test Configuration**:

- Node.js: v24.16.0
- npm: 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
