### PR TITLE
✨ v0.8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# v0.8.7-rc1
+# v0.8.7
 
 # Base node image
 FROM node:24.16.0-alpine AS node

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,5 @@
 # Dockerfile.multi
-# v0.8.7-rc1
+# v0.8.7
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "v0.8.7-rc1",
+  "version": "v0.8.7",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.7-rc1",
+      "version": "0.8.7",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.14.3",
         "@aws-sdk/client-bedrock-runtime": "^3.980.0",
@@ -130,7 +130,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.7-rc1",
+      "version": "0.8.7",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@ariakit/react-core": "^0.4.17",
@@ -264,7 +264,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.33",
+      "version": "1.7.34",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
@@ -345,7 +345,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.62",
+      "version": "0.4.63",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
@@ -433,7 +433,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.508",
+      "version": "0.8.509",
       "dependencies": {
         "axios": "^1.13.5",
         "dayjs": "^1.11.13",
@@ -470,7 +470,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.55",
+      "version": "0.0.56",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,4 @@
-/** v0.8.7-rc1 */
+/** v0.8.7 */
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "v0.8.7-rc1",
+  "version": "v0.8.7",
   "description": "",
   "type": "module",
   "scripts": {

--- a/e2e/jestSetup.js
+++ b/e2e/jestSetup.js
@@ -1,3 +1,3 @@
-// v0.8.7-rc1
+// v0.8.7
 // See .env.test.example for an example of the '.env.test' file.
 require('dotenv').config({ path: './e2e/.env.test' });

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,7 +23,7 @@ version: 2.0.6
 # It is recommended to use it with quotes.
 
 # renovate: image=registry.librechat.ai/danny-avila/librechat
-appVersion: "v0.8.7-rc1"
+appVersion: "v0.8.7"
 
 home: https://www.librechat.ai
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.7-rc1",
+  "version": "v0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.7-rc1",
+      "version": "v0.8.7",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -46,7 +46,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.7-rc1",
+      "version": "v0.8.7",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -410,7 +410,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.7-rc1",
+      "version": "v0.8.7",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
@@ -42403,7 +42403,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.33",
+      "version": "1.7.34",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",
@@ -43107,7 +43107,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.62",
+      "version": "0.4.63",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44250,7 +44250,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.508",
+      "version": "0.8.509",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -44858,7 +44858,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.55",
+      "version": "0.0.56",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.7-rc1",
+  "version": "v0.8.7",
   "description": "",
   "packageManager": "npm@11.13.0",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.33",
+  "version": "1.7.34",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.62",
+  "version": "0.4.63",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.508",
+  "version": "0.8.509",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump LibreChat release markers from `v0.8.7-rc1` to `v0.8.7`.
- Bump Helm chart `version` to `2.0.7` and `appVersion` to `v0.8.7`.
- Bump package workspaces again: `@librechat/api` `1.7.34`, `@librechat/client` `0.4.63`, `@librechat/data-provider` `0.8.509`, and `@librechat/data-schemas` `0.0.56`.

## Validation
- `npm install --package-lock-only --ignore-scripts --no-audit --no-fund`
- Stale-version scan for `v0.8.7-rc1`, chart `2.0.6`, and previous package versions
- JSON/package version parser check
- `git diff --check`