### PR TITLE
🍪 fix: Validate Shared-File Cookie Auth Against the Live Refresh Session

### DIFF
--- a/api/server/middleware/optionalShareFileAuth.js
+++ b/api/server/middleware/optionalShareFileAuth.js
@@ -3,9 +3,9 @@ const jwt = require('jsonwebtoken');
 const { isEnabled } = require('@librechat/api');
 const { logger, runAsSystem } = require('@librechat/data-schemas');
 const { SystemRoles } = require('librechat-data-provider');
-const { getUserById } = require('~/models');
+const { getUserById, findSession } = require('~/models');
 
-const verifyRefreshToken = (token) => {
+const verifySignedUserId = (token) => {
   try {
     const payload = jwt.verify(token, process.env.JWT_REFRESH_SECRET);
     return typeof payload?.id === 'string' ? payload.id : null;
@@ -14,13 +14,36 @@ const verifyRefreshToken = (token) => {
   }
 };
 
+const getRefreshTokenUserId = async (token) => {
+  const userId = verifySignedUserId(token);
+  if (!userId) {
+    return null;
+  }
+
+  const session = await findSession({ userId, refreshToken: token });
+  return session ? userId : null;
+};
+
+const getOpenIdUserId = (parsed, req) => {
+  if (parsed.token_provider !== 'openid' || !isEnabled(process.env.OPENID_REUSE_TOKENS)) {
+    return null;
+  }
+
+  const sessionRefreshToken = req.session?.openidTokens?.refreshToken;
+  if (!parsed.refreshToken || parsed.refreshToken !== sessionRefreshToken) {
+    return null;
+  }
+
+  return verifySignedUserId(parsed.openid_user_id);
+};
+
 /**
  * Fallback auth for share file routes that are hit by `<img>`/anchor requests,
  * which can't carry the bearer access token. Resolves the viewer from the
- * `refreshToken` cookie (or the signed `openid_user_id` cookie) — the same
- * mechanism secure image links use — so non-public shared links can authorize
- * the viewer's ACL. Never blocks: on any failure it leaves `req.user` unset and
- * lets `canAccessSharedLink` decide (public access, 401, or 403).
+ * `refreshToken` cookie (or an active OpenID session plus signed `openid_user_id`
+ * cookie) so non-public shared links can authorize the viewer's ACL. Never
+ * blocks: on any failure it leaves `req.user` unset and lets
+ * `canAccessSharedLink` decide (public access, 401, or 403).
  */
 const optionalShareFileAuth = async (req, res, next) => {
   if (req.user) {
@@ -34,22 +57,17 @@ const optionalShareFileAuth = async (req, res, next) => {
     }
 
     const parsed = cookie.parse(cookieHeader);
-    const useOpenId =
-      parsed.token_provider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS);
-    const token = useOpenId ? parsed.openid_user_id : parsed.refreshToken;
-    if (!token) {
-      return next();
-    }
-
-    const userId = verifyRefreshToken(token);
+    const userId =
+      getOpenIdUserId(parsed, req) ||
+      (parsed.refreshToken ? await getRefreshTokenUserId(parsed.refreshToken) : null);
     if (!userId) {
       return next();
     }
 
     // Resolve in system context: this runs before canAccessSharedLink establishes
     // the share tenant, so under strict tenant isolation a tenant-scoped User
-    // query would otherwise throw. The viewer's id comes from their own verified
-    // refresh token; the share's tenant-scoped ACL check still gates access.
+    // query would otherwise throw. The viewer's id comes from verified, active
+    // cookie auth; the share's tenant-scoped ACL check still gates access.
     const user = await runAsSystem(() =>
       getUserById(userId, '-password -__v -totpSecret -backupCodes'),
     );

--- a/api/server/middleware/optionalShareFileAuth.js
+++ b/api/server/middleware/optionalShareFileAuth.js
@@ -20,7 +20,7 @@ const getRefreshTokenUserId = async (token) => {
     return null;
   }
 
-  const session = await findSession({ userId, refreshToken: token });
+  const session = await runAsSystem(() => findSession({ userId, refreshToken: token }));
   return session ? userId : null;
 };
 

--- a/api/server/middleware/optionalShareFileAuth.spec.js
+++ b/api/server/middleware/optionalShareFileAuth.spec.js
@@ -1,6 +1,7 @@
 const mockVerify = jest.fn();
 const mockGetUserById = jest.fn();
 const mockFindSession = jest.fn();
+const mockRunAsSystem = jest.fn((fn) => fn());
 
 jest.mock('jsonwebtoken', () => ({ verify: (...args) => mockVerify(...args) }));
 jest.mock('@librechat/api', () => ({ isEnabled: (v) => v === 'true' || v === true }), {
@@ -10,7 +11,7 @@ jest.mock(
   '@librechat/data-schemas',
   () => ({
     logger: { warn: jest.fn(), error: jest.fn() },
-    runAsSystem: (fn) => fn(),
+    runAsSystem: (...args) => mockRunAsSystem(...args),
   }),
   { virtual: true },
 );
@@ -54,6 +55,7 @@ describe('optionalShareFileAuth', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(mockVerify).toHaveBeenCalledWith('good.jwt', 'test-secret');
     expect(mockFindSession).toHaveBeenCalledWith({ userId: 'viewer-1', refreshToken: 'good.jwt' });
+    expect(mockRunAsSystem).toHaveBeenCalledTimes(2);
     expect(req.user).toMatchObject({ id: 'viewer-1', role: 'USER' });
   });
 
@@ -85,6 +87,7 @@ describe('optionalShareFileAuth', () => {
       userId: 'viewer-3',
       refreshToken: 'revoked.jwt',
     });
+    expect(mockRunAsSystem).toHaveBeenCalledTimes(1);
     expect(mockGetUserById).not.toHaveBeenCalled();
   });
 

--- a/api/server/middleware/optionalShareFileAuth.spec.js
+++ b/api/server/middleware/optionalShareFileAuth.spec.js
@@ -1,14 +1,26 @@
 const mockVerify = jest.fn();
 const mockGetUserById = jest.fn();
+const mockFindSession = jest.fn();
 
 jest.mock('jsonwebtoken', () => ({ verify: (...args) => mockVerify(...args) }));
-jest.mock('@librechat/api', () => ({ isEnabled: (v) => v === 'true' || v === true }));
-jest.mock('@librechat/data-schemas', () => ({
-  logger: { warn: jest.fn(), error: jest.fn() },
-  runAsSystem: (fn) => fn(),
+jest.mock('@librechat/api', () => ({ isEnabled: (v) => v === 'true' || v === true }), {
+  virtual: true,
+});
+jest.mock(
+  '@librechat/data-schemas',
+  () => ({
+    logger: { warn: jest.fn(), error: jest.fn() },
+    runAsSystem: (fn) => fn(),
+  }),
+  { virtual: true },
+);
+jest.mock('librechat-data-provider', () => ({ SystemRoles: { USER: 'USER' } }), {
+  virtual: true,
+});
+jest.mock('~/models', () => ({
+  getUserById: (...args) => mockGetUserById(...args),
+  findSession: (...args) => mockFindSession(...args),
 }));
-jest.mock('librechat-data-provider', () => ({ SystemRoles: { USER: 'USER' } }));
-jest.mock('~/models', () => ({ getUserById: (...args) => mockGetUserById(...args) }));
 
 const optionalShareFileAuth = require('./optionalShareFileAuth');
 
@@ -30,20 +42,24 @@ describe('optionalShareFileAuth', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(mockVerify).not.toHaveBeenCalled();
     expect(mockGetUserById).not.toHaveBeenCalled();
+    expect(mockFindSession).not.toHaveBeenCalled();
   });
 
-  it('resolves the viewer from a valid refreshToken cookie', async () => {
+  it('resolves the viewer from a valid refreshToken cookie with a live session', async () => {
     mockVerify.mockReturnValue({ id: 'viewer-1' });
+    mockFindSession.mockResolvedValue({ _id: 'session-1' });
     mockGetUserById.mockResolvedValue({ _id: 'viewer-1', role: 'USER' });
     const req = { headers: { cookie: 'refreshToken=good.jwt' } };
     const next = await run(req);
     expect(next).toHaveBeenCalledTimes(1);
     expect(mockVerify).toHaveBeenCalledWith('good.jwt', 'test-secret');
+    expect(mockFindSession).toHaveBeenCalledWith({ userId: 'viewer-1', refreshToken: 'good.jwt' });
     expect(req.user).toMatchObject({ id: 'viewer-1', role: 'USER' });
   });
 
   it('defaults the role to USER when the record has none', async () => {
     mockVerify.mockReturnValue({ id: 'viewer-2' });
+    mockFindSession.mockResolvedValue({ _id: 'session-2' });
     mockGetUserById.mockResolvedValue({ _id: 'viewer-2' });
     const req = { headers: { cookie: 'refreshToken=good.jwt' } };
     await run(req);
@@ -58,6 +74,20 @@ describe('optionalShareFileAuth', () => {
     expect(mockGetUserById).not.toHaveBeenCalled();
   });
 
+  it('leaves req.user unset when the refresh token has no live session', async () => {
+    mockVerify.mockReturnValue({ id: 'viewer-3' });
+    mockFindSession.mockResolvedValue(null);
+    const req = { headers: { cookie: 'refreshToken=revoked.jwt' } };
+    const next = await run(req);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.user).toBeUndefined();
+    expect(mockFindSession).toHaveBeenCalledWith({
+      userId: 'viewer-3',
+      refreshToken: 'revoked.jwt',
+    });
+    expect(mockGetUserById).not.toHaveBeenCalled();
+  });
+
   it('leaves req.user unset when the token is invalid', async () => {
     mockVerify.mockImplementation(() => {
       throw new Error('bad token');
@@ -69,16 +99,35 @@ describe('optionalShareFileAuth', () => {
     expect(mockGetUserById).not.toHaveBeenCalled();
   });
 
-  it('uses the signed openid_user_id cookie for OpenID-reuse sessions', async () => {
+  it('uses the signed openid_user_id cookie only for active OpenID-reuse sessions', async () => {
     process.env.OPENID_REUSE_TOKENS = 'true';
     mockVerify.mockReturnValue({ id: 'oidc-1' });
     mockGetUserById.mockResolvedValue({ _id: 'oidc-1', role: 'USER' });
     const req = {
-      headers: { cookie: 'token_provider=openid; openid_user_id=signed.jwt' },
+      headers: {
+        cookie: 'token_provider=openid; refreshToken=stored-refresh; openid_user_id=signed.jwt',
+      },
+      session: { openidTokens: { refreshToken: 'stored-refresh' } },
     };
     await run(req);
     expect(mockVerify).toHaveBeenCalledWith('signed.jwt', 'test-secret');
+    expect(mockFindSession).not.toHaveBeenCalled();
     expect(req.user).toMatchObject({ id: 'oidc-1' });
+    delete process.env.OPENID_REUSE_TOKENS;
+  });
+
+  it('leaves req.user unset for OpenID-reuse cookies without an active matching session', async () => {
+    process.env.OPENID_REUSE_TOKENS = 'true';
+    mockVerify.mockReturnValue({ id: 'oidc-2' });
+    const req = {
+      headers: {
+        cookie: 'token_provider=openid; refreshToken=stale-refresh; openid_user_id=signed.jwt',
+      },
+      session: { openidTokens: { refreshToken: 'current-refresh' } },
+    };
+    await run(req);
+    expect(req.user).toBeUndefined();
+    expect(mockGetUserById).not.toHaveBeenCalled();
     delete process.env.OPENID_REUSE_TOKENS;
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent revoked or rotated refresh tokens (and stale OpenID helper cookies) from authenticating requests to shared-link file routes, which could let a previously-logged-out user still access non-public snapshot attachments.
- Harden the cookie-based fallback used by image/anchor loads so it mirrors the normal refresh flow's revocation checks while preserving the non-blocking behavior for anonymous/public shares.

### Description
- Update `api/server/middleware/optionalShareFileAuth.js` to verify that a `refreshToken` cookie resolves to a live session via `findSession` before setting `req.user`, and rename/clarify helpers (`verifySignedUserId`, `getRefreshTokenUserId`, `getOpenIdUserId`).
- Restrict the OpenID `openid_user_id` fallback so it only applies when an active server-side OpenID session refresh token matches the request, preventing the signed cookie alone from granting access.
- Preserve the middleware's non-blocking semantics (fall through to `canAccessSharedLink` on failure) and load the resolved user with `getUserById` under `runAsSystem` to respect tenant isolation.
- Add and update unit tests in `api/server/middleware/optionalShareFileAuth.spec.js` to cover live-session acceptance, revoked-session rejection, active OpenID fallback acceptance, and stale OpenID rejection.

### Testing
- Ran the middleware unit tests with `npm --prefix api test -- optionalShareFileAuth.spec.js --runInBand`, and all tests passed (`8 passed`).
- Ran repository checks with `git diff --check` (no issues reported) to validate formatting/whitespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39cabe265083278e2815fde8d06a23)