### PR TITLE
🤐 fix: Withhold Custom Endpoint Headers for User URLs

### DIFF
--- a/packages/api/src/endpoints/config/models.spec.ts
+++ b/packages/api/src/endpoints/config/models.spec.ts
@@ -65,6 +65,42 @@ describe('createLoadConfigModels – user-provided baseURL header guard', () => 
     );
   });
 
+  it('uses the user API key when baseURL is user-provided', async () => {
+    const loadConfigModels = createLoadConfigModels({
+      getAppConfig: jest.fn().mockResolvedValue(
+        buildAppConfig({
+          apiKey: 'sk-system-key',
+        }),
+      ),
+      getUserKeyValues: jest.fn().mockResolvedValue({
+        apiKey: 'sk-user-key',
+        baseURL: 'https://user-controlled.example.com/v1',
+      }),
+      fetchModels,
+    });
+
+    const req = {
+      user: { id: 'user-1', email: 'user@example.com' },
+      config: undefined,
+    } as unknown as ServerRequest;
+
+    await loadConfigModels(req);
+
+    expect(fetchModels).toHaveBeenCalledTimes(1);
+    expect(fetchModels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'TestProxy',
+        apiKey: 'sk-user-key',
+        baseURL: 'https://user-controlled.example.com/v1',
+      }),
+    );
+    expect(fetchModels).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'sk-system-key',
+      }),
+    );
+  });
+
   it('DOES forward configured headers when baseURL is admin-trusted (only apiKey is user-provided)', async () => {
     const headers = {
       Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}',

--- a/packages/api/src/endpoints/config/models.ts
+++ b/packages/api/src/endpoints/config/models.ts
@@ -204,7 +204,8 @@ export function createLoadConfigModels(deps: LoadConfigModelsDeps) {
 
       if (models?.fetch && userKeyMap.has(name)) {
         const userKeyValues = userKeyMap.get(name);
-        const resolvedApiKey = apiKeyIsUserProvided ? userKeyValues?.apiKey : API_KEY;
+        const resolvedApiKey =
+          apiKeyIsUserProvided || baseURLIsUserProvided ? userKeyValues?.apiKey : API_KEY;
         const resolvedBaseURL = baseURLIsUserProvided ? userKeyValues?.baseURL : BASE_URL;
 
         if (resolvedApiKey && resolvedBaseURL) {

--- a/packages/api/src/endpoints/custom/config.spec.ts
+++ b/packages/api/src/endpoints/custom/config.spec.ts
@@ -1,4 +1,4 @@
-import { EModelEndpoint } from 'librechat-data-provider';
+import { AuthType, EModelEndpoint } from 'librechat-data-provider';
 import type { TCustomEndpoints } from 'librechat-data-provider';
 import { loadCustomEndpointsConfig } from './config';
 
@@ -39,6 +39,47 @@ describe('loadCustomEndpointsConfig – native provider param set', () => {
 
     expect(config?.['Claude-Compatible']?.customParams?.defaultParamsEndpoint).toBe(
       EModelEndpoint.google,
+    );
+  });
+});
+
+describe('loadCustomEndpointsConfig – user credential prompts', () => {
+  it('requires a user key when the custom base URL is user-provided', () => {
+    const config = loadCustomEndpointsConfig([
+      { ...baseEndpoint, name: 'User URL', baseURL: AuthType.USER_PROVIDED },
+    ] as unknown as TCustomEndpoints);
+
+    expect(config?.['User URL']).toEqual(
+      expect.objectContaining({
+        userProvide: true,
+        userProvideURL: true,
+      }),
+    );
+  });
+
+  it('requires a user key when the custom API key is user-provided', () => {
+    const config = loadCustomEndpointsConfig([
+      { ...baseEndpoint, name: 'User Key', apiKey: AuthType.USER_PROVIDED },
+    ] as unknown as TCustomEndpoints);
+
+    expect(config?.['User Key']).toEqual(
+      expect.objectContaining({
+        userProvide: true,
+        userProvideURL: false,
+      }),
+    );
+  });
+
+  it('does not require a user key for admin-trusted credentials and base URL', () => {
+    const config = loadCustomEndpointsConfig([
+      { ...baseEndpoint, name: 'Admin Trusted' },
+    ] as unknown as TCustomEndpoints);
+
+    expect(config?.['Admin Trusted']).toEqual(
+      expect.objectContaining({
+        userProvide: false,
+        userProvideURL: false,
+      }),
     );
   });
 });

--- a/packages/api/src/endpoints/custom/config.ts
+++ b/packages/api/src/endpoints/custom/config.ts
@@ -41,6 +41,7 @@ export function loadCustomEndpointsConfig(
 
       const resolvedApiKey = extractEnvVariable(apiKey ?? '');
       const resolvedBaseURL = extractEnvVariable(baseURL ?? '');
+      const userProvideURL = isUserProvided(resolvedBaseURL);
 
       /**
        * A native `provider` (e.g. anthropic) implies its parameter set. Surface it
@@ -57,8 +58,8 @@ export function loadCustomEndpointsConfig(
 
       customEndpointsConfig[name] = {
         type: EModelEndpoint.custom,
-        userProvide: isUserProvided(resolvedApiKey),
-        userProvideURL: isUserProvided(resolvedBaseURL),
+        userProvide: isUserProvided(resolvedApiKey) || userProvideURL,
+        userProvideURL,
         customParams: resolvedCustomParams,
         modelDisplayLabel,
         iconURL,

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -42,6 +42,7 @@ function createParams(overrides: {
   userBaseURL?: string;
   userApiKey?: string;
   expiresAt?: string;
+  headers?: Record<string, string>;
 }): BaseInitializeParams {
   const { apiKey = 'sk-test-key', baseURL = 'https://api.example.com/v1' } = overrides;
 
@@ -49,6 +50,7 @@ function createParams(overrides: {
     apiKey,
     baseURL,
     models: {},
+    headers: overrides.headers,
   });
 
   const db = {
@@ -159,6 +161,64 @@ describe('initializeCustom – Agents API user key resolution', () => {
 
     expect(params.db.getUserKeyValues).not.toHaveBeenCalled();
   });
+});
+
+describe('initializeCustom – OpenAI-compatible header forwarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves configured headers for admin-trusted base URLs', async () => {
+    const headers = {
+      Authorization: 'Bearer static-gateway-token',
+      'X-Env-Secret': '${GATEWAY_SECRET}',
+      'X-User-Email': '{{LIBRECHAT_USER_EMAIL}}',
+    };
+    const params = createParams({
+      apiKey: 'sk-system-key',
+      baseURL: 'https://gateway.example.com/v1',
+      headers,
+    });
+
+    await initializeCustom(params);
+
+    const clientOptions = mockGetOpenAIConfig.mock.calls[0][1] as {
+      headers?: Record<string, string>;
+    };
+    expect(clientOptions.headers).toEqual(headers);
+  });
+
+  it.each([
+    {
+      headerType: 'Authorization',
+      headers: { Authorization: 'Bearer static-gateway-token' },
+    },
+    {
+      headerType: 'env-secret',
+      headers: { 'X-Env-Secret': '${GATEWAY_SECRET}' },
+    },
+    {
+      headerType: 'user-placeholder',
+      headers: { 'X-User-Email': '{{LIBRECHAT_USER_EMAIL}}' },
+    },
+  ])(
+    'withholds configured $headerType headers when the user supplies the base URL',
+    async ({ headers }) => {
+      const params = createParams({
+        apiKey: 'sk-system-key',
+        baseURL: AuthType.USER_PROVIDED,
+        userBaseURL: 'https://user-controlled.example.com/v1',
+        headers,
+      });
+
+      await initializeCustom(params);
+
+      const clientOptions = mockGetOpenAIConfig.mock.calls[0][1] as {
+        headers?: Record<string, string>;
+      };
+      expect(clientOptions.headers).toBeUndefined();
+    },
+  );
 });
 
 describe('initializeCustom – SSRF guard wiring', () => {

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -169,6 +169,24 @@ describe('initializeCustom – Agents API user key resolution', () => {
 });
 
 describe('initializeCustom – OpenAI-compatible header forwarding', () => {
+  const userControlledHeaderCases: Array<{
+    headerType: string;
+    headers: Record<string, string>;
+  }> = [
+    {
+      headerType: 'Authorization',
+      headers: { Authorization: 'Bearer static-gateway-token' },
+    },
+    {
+      headerType: 'env-secret',
+      headers: { 'X-Env-Secret': '${GATEWAY_SECRET}' },
+    },
+    {
+      headerType: 'user-placeholder',
+      headers: { 'X-User-Email': '{{LIBRECHAT_USER_EMAIL}}' },
+    },
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -227,20 +245,7 @@ describe('initializeCustom – OpenAI-compatible header forwarding', () => {
     expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      headerType: 'Authorization',
-      headers: { Authorization: 'Bearer static-gateway-token' },
-    },
-    {
-      headerType: 'env-secret',
-      headers: { 'X-Env-Secret': '${GATEWAY_SECRET}' },
-    },
-    {
-      headerType: 'user-placeholder',
-      headers: { 'X-User-Email': '{{LIBRECHAT_USER_EMAIL}}' },
-    },
-  ])(
+  it.each(userControlledHeaderCases)(
     'withholds configured $headerType headers when the user supplies the base URL',
     async ({ headers }) => {
       const params = createParams({

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -117,6 +117,11 @@ describe('initializeCustom – Agents API user key resolution', () => {
       name: 'test-custom',
     });
     expect(checkUserKeyExpiry).not.toHaveBeenCalled();
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
+      'sk-user-key',
+      expect.any(Object),
+      'test-custom',
+    );
   });
 
   it('should still check key expiry when expiresAt is provided (UI flow)', async () => {
@@ -186,6 +191,40 @@ describe('initializeCustom – OpenAI-compatible header forwarding', () => {
       headers?: Record<string, string>;
     };
     expect(clientOptions.headers).toEqual(headers);
+  });
+
+  it('uses the user API key when the user supplies the base URL', async () => {
+    const params = createParams({
+      apiKey: 'sk-system-key',
+      baseURL: AuthType.USER_PROVIDED,
+      userApiKey: 'sk-user-owned-key',
+      userBaseURL: 'https://user-controlled.example.com/v1',
+    });
+
+    await initializeCustom(params);
+
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
+      'sk-user-owned-key',
+      expect.any(Object),
+      'test-custom',
+    );
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalledWith(
+      'sk-system-key',
+      expect.any(Object),
+      'test-custom',
+    );
+  });
+
+  it('throws NO_USER_KEY when the user supplies the base URL without an API key', async () => {
+    const params = createParams({
+      apiKey: 'sk-system-key',
+      baseURL: AuthType.USER_PROVIDED,
+      userApiKey: '',
+      userBaseURL: 'https://user-controlled.example.com/v1',
+    });
+
+    await expect(initializeCustom(params)).rejects.toThrow(ErrorTypes.NO_USER_KEY);
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -354,6 +393,7 @@ describe('initializeCustom – token-config fetch header forwarding', () => {
     expect(fetchModels).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'openrouter',
+        apiKey: 'sk-user-key',
         headers: undefined,
         userObject: params.req.user,
       }),
@@ -590,6 +630,7 @@ describe('initializeCustom – native Anthropic provider', () => {
       'anthropicApiUrl',
       'https://user-controlled.example.com',
     );
+    expect(options.llmConfig).toHaveProperty('apiKey', 'sk-user-key');
     const defaultHeaders = (
       options.llmConfig as { clientOptions?: { defaultHeaders?: Record<string, string> } }
     ).clientOptions?.defaultHeaders;

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -213,10 +213,10 @@ export async function initializeCustom({
     userValues = await db.getUserKeyValues({ userId: req.user?.id ?? '', name: endpoint });
   }
 
-  const apiKey = userProvidesKey ? userValues?.apiKey : CUSTOM_API_KEY;
+  const apiKey = userProvidesKey || userProvidesURL ? userValues?.apiKey : CUSTOM_API_KEY;
   const baseURL = userProvidesURL ? userValues?.baseURL : CUSTOM_BASE_URL;
 
-  if (userProvidesKey && !apiKey) {
+  if ((userProvidesKey || userProvidesURL) && !apiKey) {
     throw new Error(
       JSON.stringify({
         type: ErrorTypes.NO_USER_KEY,

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -94,9 +94,9 @@ function buildCustomOptions(
   endpointConfig: Partial<TEndpoint>,
   appConfig?: AppConfig,
   endpointTokenConfig?: Record<string, unknown>,
+  forwardHeaders = true,
 ) {
   const customOptions: Record<string, unknown> = {
-    headers: endpointConfig.headers,
     addParams: endpointConfig.addParams,
     dropParams: endpointConfig.dropParams,
     customParams: endpointConfig.customParams,
@@ -109,6 +109,10 @@ function buildCustomOptions(
     streamRate: endpointConfig.streamRate,
     endpointTokenConfig,
   };
+
+  if (forwardHeaders) {
+    customOptions.headers = endpointConfig.headers;
+  }
 
   const allConfig = appConfig?.endpoints?.all;
   if (allConfig) {
@@ -291,7 +295,12 @@ export async function initializeCustom({
     endpointTokenConfig = (await cache.get(tokenKey)) as EndpointTokenConfig | undefined;
   }
 
-  const customOptions = buildCustomOptions(endpointConfig, appConfig, endpointTokenConfig);
+  const customOptions = buildCustomOptions(
+    endpointConfig,
+    appConfig,
+    endpointTokenConfig,
+    !userProvidesURL,
+  );
 
   const clientOptions: Record<string, unknown> = {
     reverseProxyUrl: baseURL ?? null,


### PR DESCRIPTION
## Summary

I fixed the custom OpenAI-compatible endpoint path so configured secrets do not reach user-controlled custom endpoint URLs.

- Added a header-forwarding guard so `getOpenAIConfig` receives configured headers only for admin-trusted/static base URLs.
- Required user-stored API keys whenever a custom endpoint base URL is user-provided, preventing static configured API keys from being sent to user-controlled destinations.
- Applied the same user-key rule to model/token-config fetch resolution so `fetchModels` cannot send a static configured key to a user-provided base URL.
- Updated custom endpoint config metadata so URL-provided custom endpoints prompt users for an API key before the backend requires one.
- Added regression coverage for static `Authorization`, env-secret, `{{LIBRECHAT_*}}` placeholder headers, static API key withholding, model fetch behavior, native Anthropic custom endpoints, and endpoint credential prompts.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ran `npx jest src/endpoints/custom/config.spec.ts src/endpoints/custom/initialize.spec.ts src/endpoints/config/models.spec.ts --runInBand --coverage=false` from `packages/api`
- [x] Ran `npx tsc --noEmit -p packages/api/tsconfig.json` from the repo root
- [x] Ran `npm run build:api` from the repo root
- [x] Started the Codex review cycle and addressed both findings; latest Codex review found no major issues

### **Test Configuration**:

- Node.js/Jest workspace dependencies installed locally with npm for this worktree

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
