### PR TITLE
🧠 feat: Configurable Reasoning Replay for Custom Endpoints

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.2.44",
+    "@librechat/agents": "^3.2.46",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1161,10 +1161,9 @@ class AgentClient extends BaseClient {
       });
 
       /**
-       * Spoof `Providers.DEEPSEEK` so `formatAgentMessages` reconstructs
-       * `reasoning_content` on prior tool-call turns (#13366). Also applies to
-       * custom endpoints opting in via `customParams.includeReasoningContent`
-       * (e.g. Xiaomi MiMo, Kimi) for cross-turn reasoning replay parity.
+       * Reconstruct `reasoning_content` on prior tool-call turns: DeepSeek
+       * thinking-mode (#13366) or custom endpoints opting in via
+       * `customParams.includeReasoningHistory` (e.g. Xiaomi MiMo, Kimi).
        */
       const needsReasoningContentFormat =
         shouldReplayReasoningContent(this.options.agent) ||
@@ -1188,7 +1187,7 @@ class AgentClient extends BaseClient {
       const formatOptions =
         needsReasoningContentFormat || freshSkillPrimeNames.size > 0
           ? {
-              ...(needsReasoningContentFormat ? { provider: Providers.DEEPSEEK } : {}),
+              ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
               ...(freshSkillPrimeNames.size > 0
                 ? { skipSkillBodyNames: freshSkillPrimeNames }
                 : {}),

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -29,7 +29,7 @@ const {
   computeSummaryUsedTokens,
   priorRunOutputTokens,
   createSubagentUsageSink,
-  shouldReplayReasoningContent,
+  anyAgentReplaysReasoningContent,
   GenerationJobManager,
   getTransactionsConfig,
   resolveRecursionLimit,
@@ -1164,11 +1164,13 @@ class AgentClient extends BaseClient {
        * Reconstruct `reasoning_content` on prior tool-call turns: DeepSeek
        * thinking-mode (#13366) or custom endpoints opting in via
        * `customParams.includeReasoningHistory` (e.g. Xiaomi MiMo, Kimi).
+       * Walks subagents too — the opted-in endpoint may appear only as a
+       * nested subagent, not the primary or a top-level handoff agent.
        */
-      const needsReasoningContentFormat =
-        shouldReplayReasoningContent(this.options.agent) ||
-        (this.agentConfigs != null &&
-          Array.from(this.agentConfigs.values()).some(shouldReplayReasoningContent));
+      const needsReasoningContentFormat = anyAgentReplaysReasoningContent([
+        this.options.agent,
+        ...(this.agentConfigs ? Array.from(this.agentConfigs.values()) : []),
+      ]);
       /**
        * Skills primed fresh this turn — manual ($ popover) and always-apply
        * (frontmatter). `injectSkillPrimes` (below) splices their SKILL.md

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -29,7 +29,7 @@ const {
   computeSummaryUsedTokens,
   priorRunOutputTokens,
   createSubagentUsageSink,
-  isDeepSeekReasoningProvider,
+  shouldReplayReasoningContent,
   GenerationJobManager,
   getTransactionsConfig,
   resolveRecursionLimit,
@@ -1160,14 +1160,16 @@ class AgentClient extends BaseClient {
         agents: [this.options.agent, ...(this.agentConfigs ? this.agentConfigs.values() : [])],
       });
 
-      /** Spoof `Providers.DEEPSEEK` so the SDK preserves `reasoning_content` on tool turns (#13366). */
-      const hasDeepSeekAgent = (agent) =>
-        agent != null &&
-        isDeepSeekReasoningProvider(agent.provider, agent.model_parameters?.model ?? agent.model);
-      const needsDeepSeekFormat =
-        hasDeepSeekAgent(this.options.agent) ||
+      /**
+       * Spoof `Providers.DEEPSEEK` so `formatAgentMessages` reconstructs
+       * `reasoning_content` on prior tool-call turns (#13366). Also applies to
+       * custom endpoints opting in via `customParams.includeReasoningContent`
+       * (e.g. Xiaomi MiMo, Kimi) for cross-turn reasoning replay parity.
+       */
+      const needsReasoningContentFormat =
+        shouldReplayReasoningContent(this.options.agent) ||
         (this.agentConfigs != null &&
-          Array.from(this.agentConfigs.values()).some(hasDeepSeekAgent));
+          Array.from(this.agentConfigs.values()).some(shouldReplayReasoningContent));
       /**
        * Skills primed fresh this turn — manual ($ popover) and always-apply
        * (frontmatter). `injectSkillPrimes` (below) splices their SKILL.md
@@ -1184,9 +1186,9 @@ class AgentClient extends BaseClient {
         alwaysApplySkillPrimes,
       });
       const formatOptions =
-        needsDeepSeekFormat || freshSkillPrimeNames.size > 0
+        needsReasoningContentFormat || freshSkillPrimeNames.size > 0
           ? {
-              ...(needsDeepSeekFormat ? { provider: Providers.DEEPSEEK } : {}),
+              ...(needsReasoningContentFormat ? { provider: Providers.DEEPSEEK } : {}),
               ...(freshSkillPrimeNames.size > 0
                 ? { skipSkillBodyNames: freshSkillPrimeNames }
                 : {}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.2.44",
+        "@librechat/agents": "^3.2.46",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -9907,9 +9907,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.2.44",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.2.44.tgz",
-      "integrity": "sha512-kBfF22rUye1D32FR55BaVqukphsYHfNpNxqvst2i/7iyFig81SVfCQaJQb715sEAkLTI8tYMOuoc1ui/l21ucA==",
+      "version": "3.2.46",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.2.46.tgz",
+      "integrity": "sha512-ppylwuFF3BOlhrnzDdD6J7h9mkUgAi9aF7LBt5pPpk6/Hab/h5BecxA6a7PyRo5x4xNfgPvAlnTn6MSDeAqJBg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -42463,7 +42463,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.2.44",
+        "@librechat/agents": "^3.2.46",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.2.44",
+    "@librechat/agents": "^3.2.46",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -261,8 +261,8 @@ export type InitializedAgent = Agent & {
   maxToolResultChars?: number;
   /** Response field to read model reasoning from for custom OpenAI-compatible endpoints. */
   reasoningKey?: ReasoningResponseKey;
-  /** Whether to replay `reasoning_content` on tool-call turns (custom endpoint opt-in). */
-  includeReasoningContent?: boolean;
+  /** Whether to reconstruct `reasoning_content` from persisted history across turns (custom endpoint opt-in). */
+  includeReasoningHistory?: boolean;
   /**
    * Whether the code-execution environment is available *for this agent*.
    * Narrower than the incoming `params.codeEnvAvailable` admin flag — this
@@ -1225,7 +1225,7 @@ export async function initializeAgent(
     baseContextTokens,
     codeEnvAvailable: effectiveCodeEnvAvailable,
     reasoningKey: customEndpointConfig?.customParams?.reasoningKey,
-    includeReasoningContent: customEndpointConfig?.customParams?.includeReasoningContent,
+    includeReasoningHistory: customEndpointConfig?.customParams?.includeReasoningHistory,
     skillAuthoringAvailable,
     fileAuthoringToolNames: fileAuthoringToolNames.size > 0 ? fileAuthoringToolNames : undefined,
     skillCount,

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -261,6 +261,8 @@ export type InitializedAgent = Agent & {
   maxToolResultChars?: number;
   /** Response field to read model reasoning from for custom OpenAI-compatible endpoints. */
   reasoningKey?: ReasoningResponseKey;
+  /** Whether to replay `reasoning_content` on tool-call turns (custom endpoint opt-in). */
+  includeReasoningContent?: boolean;
   /**
    * Whether the code-execution environment is available *for this agent*.
    * Narrower than the incoming `params.codeEnvAvailable` admin flag — this
@@ -1223,6 +1225,7 @@ export async function initializeAgent(
     baseContextTokens,
     codeEnvAvailable: effectiveCodeEnvAvailable,
     reasoningKey: customEndpointConfig?.customParams?.reasoningKey,
+    includeReasoningContent: customEndpointConfig?.customParams?.includeReasoningContent,
     skillAuthoringAvailable,
     fileAuthoringToolNames: fileAuthoringToolNames.size > 0 ? fileAuthoringToolNames : undefined,
     skillCount,

--- a/packages/api/src/agents/run.spec.ts
+++ b/packages/api/src/agents/run.spec.ts
@@ -276,12 +276,12 @@ describe('isDeepSeekReasoningProvider', () => {
 });
 
 describe('shouldReplayReasoningContent', () => {
-  it('returns true when a custom endpoint opts in via includeReasoningContent', () => {
+  it('returns true when a custom endpoint opts in via includeReasoningHistory', () => {
     expect(
       shouldReplayReasoningContent({
         provider: Providers.OPENAI,
         model_parameters: { model: 'MiMo-V2.5' },
-        includeReasoningContent: true,
+        includeReasoningHistory: true,
       }),
     ).toBe(true);
   });
@@ -312,7 +312,7 @@ describe('shouldReplayReasoningContent', () => {
       shouldReplayReasoningContent({
         provider: Providers.OPENAI,
         model_parameters: { model: 'MiMo-V2.5' },
-        includeReasoningContent: false,
+        includeReasoningHistory: false,
       }),
     ).toBe(false);
   });

--- a/packages/api/src/agents/run.spec.ts
+++ b/packages/api/src/agents/run.spec.ts
@@ -6,6 +6,7 @@ import {
   getReasoningKey,
   isDeepSeekReasoningProvider,
   shouldReplayReasoningContent,
+  anyAgentReplaysReasoningContent,
 } from './run';
 
 describe('extractDiscoveredToolsFromHistory', () => {
@@ -320,5 +321,50 @@ describe('shouldReplayReasoningContent', () => {
   it('returns false for nullish agents', () => {
     expect(shouldReplayReasoningContent(null)).toBe(false);
     expect(shouldReplayReasoningContent(undefined)).toBe(false);
+  });
+});
+
+describe('anyAgentReplaysReasoningContent', () => {
+  const plainAgent = (id: string, extra = {}) =>
+    ({
+      id,
+      provider: Providers.OPENAI,
+      model_parameters: { model: 'MiMo-V2.5' },
+      ...extra,
+    }) as unknown as Parameters<typeof anyAgentReplaysReasoningContent>[0][number];
+
+  it('returns true when the primary agent opts in', () => {
+    expect(
+      anyAgentReplaysReasoningContent([plainAgent('a', { includeReasoningHistory: true })]),
+    ).toBe(true);
+  });
+
+  it('returns true when only a nested subagent opts in', () => {
+    const subagent = plainAgent('child', { includeReasoningHistory: true });
+    const primary = plainAgent('root', {
+      subagentAgentConfigs: [plainAgent('mid', { subagentAgentConfigs: [subagent] })],
+    });
+    expect(anyAgentReplaysReasoningContent([primary])).toBe(true);
+  });
+
+  it('returns false when no reachable agent opts in', () => {
+    const primary = plainAgent('root', {
+      subagentAgentConfigs: [plainAgent('child')],
+    });
+    expect(anyAgentReplaysReasoningContent([primary, null, undefined])).toBe(false);
+  });
+
+  it('is cycle-safe across subagent references', () => {
+    const a = plainAgent('a');
+    const b = plainAgent('b', { includeReasoningHistory: true });
+    (a as { subagentAgentConfigs?: unknown[] }).subagentAgentConfigs = [b];
+    (b as { subagentAgentConfigs?: unknown[] }).subagentAgentConfigs = [a];
+    expect(anyAgentReplaysReasoningContent([a])).toBe(true);
+
+    const x = plainAgent('x');
+    const y = plainAgent('y');
+    (x as { subagentAgentConfigs?: unknown[] }).subagentAgentConfigs = [y];
+    (y as { subagentAgentConfigs?: unknown[] }).subagentAgentConfigs = [x];
+    expect(anyAgentReplaysReasoningContent([x])).toBe(false);
   });
 });

--- a/packages/api/src/agents/run.spec.ts
+++ b/packages/api/src/agents/run.spec.ts
@@ -1,11 +1,11 @@
 import { Providers } from '@librechat/agents';
-import { ToolMessage, AIMessage, HumanMessage } from '@librechat/agents/langchain/messages';
 import { ReasoningResponseKey } from 'librechat-data-provider';
-
+import { ToolMessage, AIMessage, HumanMessage } from '@librechat/agents/langchain/messages';
 import {
   extractDiscoveredToolsFromHistory,
   getReasoningKey,
   isDeepSeekReasoningProvider,
+  shouldReplayReasoningContent,
 } from './run';
 
 describe('extractDiscoveredToolsFromHistory', () => {
@@ -272,5 +272,53 @@ describe('isDeepSeekReasoningProvider', () => {
       isDeepSeekReasoningProvider(Providers.OPENROUTER, 'mistral/deepseek-distilled-foo'),
     ).toBe(false);
     expect(isDeepSeekReasoningProvider(undefined, 'community/deepseek-r1')).toBe(false);
+  });
+});
+
+describe('shouldReplayReasoningContent', () => {
+  it('returns true when a custom endpoint opts in via includeReasoningContent', () => {
+    expect(
+      shouldReplayReasoningContent({
+        provider: Providers.OPENAI,
+        model_parameters: { model: 'MiMo-V2.5' },
+        includeReasoningContent: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for DeepSeek reasoning agents without the flag', () => {
+    expect(
+      shouldReplayReasoningContent({
+        provider: Providers.DEEPSEEK,
+        model_parameters: { model: 'deepseek-chat' },
+      }),
+    ).toBe(true);
+    expect(
+      shouldReplayReasoningContent({
+        provider: Providers.OPENROUTER,
+        model_parameters: { model: 'deepseek/deepseek-v4-pro' },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for a non-DeepSeek agent that has not opted in', () => {
+    expect(
+      shouldReplayReasoningContent({
+        provider: Providers.OPENAI,
+        model_parameters: { model: 'MiMo-V2.5' },
+      }),
+    ).toBe(false);
+    expect(
+      shouldReplayReasoningContent({
+        provider: Providers.OPENAI,
+        model_parameters: { model: 'MiMo-V2.5' },
+        includeReasoningContent: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for nullish agents', () => {
+    expect(shouldReplayReasoningContent(null)).toBe(false);
+    expect(shouldReplayReasoningContent(undefined)).toBe(false);
   });
 });

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -288,20 +288,20 @@ export function isDeepSeekReasoningProvider(
  * Whether prior assistant tool-call messages should have `reasoning_content`
  * reconstructed when reformatting persisted history (cross-turn replay): either
  * DeepSeek thinking-mode (#13366) or a custom OpenAI-compatible endpoint that
- * opted in via `customParams.includeReasoningContent` (e.g. Xiaomi MiMo, Kimi).
+ * opted in via `customParams.includeReasoningHistory` (e.g. Xiaomi MiMo, Kimi).
  */
 export function shouldReplayReasoningContent(
   agent?: {
     provider?: string | Providers | null;
     model?: string | null;
     model_parameters?: { model?: string | null } | null;
-    includeReasoningContent?: boolean | null;
+    includeReasoningHistory?: boolean | null;
   } | null,
 ): boolean {
   if (agent == null) {
     return false;
   }
-  if (agent.includeReasoningContent === true) {
+  if (agent.includeReasoningHistory === true) {
     return true;
   }
   return isDeepSeekReasoningProvider(agent.provider, agent.model_parameters?.model ?? agent.model);

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -332,6 +332,8 @@ type RunAgent = Omit<Agent, 'tools'> & {
   summarization?: SummarizationConfig;
   /** Response field to read model reasoning from for custom OpenAI-compatible endpoints. */
   reasoningKey?: ReasoningResponseKey;
+  /** Whether to reconstruct `reasoning_content` from persisted history across turns. */
+  includeReasoningHistory?: boolean;
   /**
    * Maximum characters allowed in a single tool result before truncation.
    * Overrides the default computed from maxContextTokens.
@@ -711,6 +713,36 @@ function anyAgentHasCodeEnv(agents: RunAgent[]): boolean {
     }
     visited.add(agent.id);
     if (agent.codeEnvAvailable === true) {
+      return true;
+    }
+    for (const child of agent.subagentAgentConfigs ?? []) {
+      if (!visited.has(child.id)) {
+        pending.push(child);
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether any agent reachable in the run — primary, handoff/parallel, or a
+ * nested subagent — opts into cross-turn `reasoning_content` reconstruction.
+ * Walks `subagentAgentConfigs` like {@link anyAgentHasCodeEnv}, since an
+ * opted-in custom endpoint may appear only as a (possibly pruned) subagent.
+ */
+export function anyAgentReplaysReasoningContent(
+  agents: Array<RunAgent | null | undefined>,
+): boolean {
+  const visited = new Set<string>();
+  const pending = [...agents];
+
+  for (let index = 0; index < pending.length; index++) {
+    const agent = pending[index];
+    if (agent == null || visited.has(agent.id)) {
+      continue;
+    }
+    visited.add(agent.id);
+    if (shouldReplayReasoningContent(agent)) {
       return true;
     }
     for (const child of agent.subagentAgentConfigs ?? []) {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -284,6 +284,29 @@ export function isDeepSeekReasoningProvider(
   return matchesDeepSeekModel(model);
 }
 
+/**
+ * Whether prior assistant tool-call messages should have `reasoning_content`
+ * reconstructed when reformatting persisted history (cross-turn replay): either
+ * DeepSeek thinking-mode (#13366) or a custom OpenAI-compatible endpoint that
+ * opted in via `customParams.includeReasoningContent` (e.g. Xiaomi MiMo, Kimi).
+ */
+export function shouldReplayReasoningContent(
+  agent?: {
+    provider?: string | Providers | null;
+    model?: string | null;
+    model_parameters?: { model?: string | null } | null;
+    includeReasoningContent?: boolean | null;
+  } | null,
+): boolean {
+  if (agent == null) {
+    return false;
+  }
+  if (agent.includeReasoningContent === true) {
+    return true;
+  }
+  return isDeepSeekReasoningProvider(agent.provider, agent.model_parameters?.model ?? agent.model);
+}
+
 type RunAgent = Omit<Agent, 'tools'> & {
   tools?: GenericTool[];
   maxContextTokens?: number;

--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -253,6 +253,34 @@ describe('getOpenAIConfig', () => {
     expect(result.llmConfig).toHaveProperty('includeReasoningContent', true);
   });
 
+  it('should enable within-run replay for non-OpenAI param-format gateways (anthropic/google)', () => {
+    const anthropic = getOpenAIConfig(
+      mockApiKey,
+      {
+        customParams: {
+          defaultParamsEndpoint: EModelEndpoint.anthropic,
+          includeReasoningContent: true,
+        },
+        modelOptions: { model: 'claude-3-7-sonnet' },
+      },
+      'custom-endpoint',
+    );
+    expect(anthropic.llmConfig).toHaveProperty('includeReasoningContent', true);
+
+    const google = getOpenAIConfig(
+      mockApiKey,
+      {
+        customParams: {
+          defaultParamsEndpoint: EModelEndpoint.google,
+          includeReasoningHistory: true,
+        },
+        modelOptions: { model: 'gemini-2.5-pro' },
+      },
+      'custom-endpoint',
+    );
+    expect(google.llmConfig).toHaveProperty('includeReasoningContent', true);
+  });
+
   it('should not replay reasoning content for custom endpoints by default', () => {
     const result = getOpenAIConfig(
       mockApiKey,

--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -235,6 +235,24 @@ describe('getOpenAIConfig', () => {
     expect(result.llmConfig).toHaveProperty('includeReasoningContent', true);
   });
 
+  it('should enable within-run replay when custom endpoint enables includeReasoningHistory', () => {
+    const result = getOpenAIConfig(
+      mockApiKey,
+      {
+        customParams: {
+          reasoningKey: ReasoningResponseKey.reasoningContent,
+          includeReasoningHistory: true,
+        },
+        modelOptions: {
+          model: 'MiMo-VL-7B-RL',
+        },
+      },
+      'custom-endpoint',
+    );
+
+    expect(result.llmConfig).toHaveProperty('includeReasoningContent', true);
+  });
+
   it('should not replay reasoning content for custom endpoints by default', () => {
     const result = getOpenAIConfig(
       mockApiKey,

--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -3,6 +3,7 @@ import {
   EModelEndpoint,
   ReasoningEffort,
   ReasoningSummary,
+  ReasoningResponseKey,
   ReasoningParameterFormat,
 } from 'librechat-data-provider';
 import type { RequestInit } from 'undici';
@@ -214,6 +215,38 @@ describe('getOpenAIConfig', () => {
     });
     expect(result.llmConfig.reasoning).toBeUndefined();
     expect((result.llmConfig as Record<string, unknown>).reasoning_effort).toBeUndefined();
+  });
+
+  it('should replay reasoning content when custom endpoint enables includeReasoningContent', () => {
+    const result = getOpenAIConfig(
+      mockApiKey,
+      {
+        customParams: {
+          reasoningKey: ReasoningResponseKey.reasoningContent,
+          includeReasoningContent: true,
+        },
+        modelOptions: {
+          model: 'MiMo-VL-7B-RL',
+        },
+      },
+      'custom-endpoint',
+    );
+
+    expect(result.llmConfig).toHaveProperty('includeReasoningContent', true);
+  });
+
+  it('should not replay reasoning content for custom endpoints by default', () => {
+    const result = getOpenAIConfig(
+      mockApiKey,
+      {
+        modelOptions: {
+          model: 'MiMo-VL-7B-RL',
+        },
+      },
+      'custom-endpoint',
+    );
+
+    expect(result.llmConfig).not.toHaveProperty('includeReasoningContent');
   });
 
   it('should default Vercel custom endpoints to reasoning object format', () => {

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -160,6 +160,7 @@ export function getOpenAIConfig(
         customFormat: options.customParams?.reasoningFormat,
         isVercel: Boolean(isVercel),
       }),
+      includeReasoningContent: options.customParams?.includeReasoningContent,
     });
     llmConfig = openaiResult.llmConfig;
     azure = openaiResult.azure;

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -160,7 +160,10 @@ export function getOpenAIConfig(
         customFormat: options.customParams?.reasoningFormat,
         isVercel: Boolean(isVercel),
       }),
-      includeReasoningContent: options.customParams?.includeReasoningContent,
+      /** History reconstruction requires the within-run replay flag to be set too. */
+      includeReasoningContent:
+        options.customParams?.includeReasoningContent === true ||
+        options.customParams?.includeReasoningHistory === true,
     });
     llmConfig = openaiResult.llmConfig;
     azure = openaiResult.azure;

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -160,14 +160,23 @@ export function getOpenAIConfig(
         customFormat: options.customParams?.reasoningFormat,
         isVercel: Boolean(isVercel),
       }),
-      /** History reconstruction requires the within-run replay flag to be set too. */
-      includeReasoningContent:
-        options.customParams?.includeReasoningContent === true ||
-        options.customParams?.includeReasoningHistory === true,
     });
     llmConfig = openaiResult.llmConfig;
     azure = openaiResult.azure;
     tools = openaiResult.tools;
+  }
+
+  /**
+   * Within-run `reasoning_content` replay applies across every param-format
+   * branch above (OpenAI / Anthropic / Google gateway modes all resolve to the
+   * OpenAI client). `includeReasoningHistory` implies it, since reconstructed
+   * history reasoning is only sent when the within-run flag is set.
+   */
+  if (
+    options.customParams?.includeReasoningContent === true ||
+    options.customParams?.includeReasoningHistory === true
+  ) {
+    llmConfig.includeReasoningContent = true;
   }
 
   const configOptions: t.OpenAIConfiguration = {};

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -1224,6 +1224,32 @@ describe('getOpenAILLMConfig', () => {
 
       expect(result.llmConfig).not.toHaveProperty('includeReasoningContent');
     });
+
+    it('should set includeReasoningContent for non-DeepSeek models when explicitly enabled', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        includeReasoningContent: true,
+        modelOptions: {
+          model: 'MiMo-VL-7B-RL',
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('includeReasoningContent', true);
+    });
+
+    it('should not set includeReasoningContent when the flag is false', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        includeReasoningContent: false,
+        modelOptions: {
+          model: 'MiMo-VL-7B-RL',
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('includeReasoningContent');
+    });
   });
 
   describe('Verbosity Handling', () => {

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -1224,32 +1224,6 @@ describe('getOpenAILLMConfig', () => {
 
       expect(result.llmConfig).not.toHaveProperty('includeReasoningContent');
     });
-
-    it('should set includeReasoningContent for non-DeepSeek models when explicitly enabled', () => {
-      const result = getOpenAILLMConfig({
-        apiKey: 'test-api-key',
-        streaming: true,
-        includeReasoningContent: true,
-        modelOptions: {
-          model: 'MiMo-VL-7B-RL',
-        },
-      });
-
-      expect(result.llmConfig).toHaveProperty('includeReasoningContent', true);
-    });
-
-    it('should not set includeReasoningContent when the flag is false', () => {
-      const result = getOpenAILLMConfig({
-        apiKey: 'test-api-key',
-        streaming: true,
-        includeReasoningContent: false,
-        modelOptions: {
-          model: 'MiMo-VL-7B-RL',
-        },
-      });
-
-      expect(result.llmConfig).not.toHaveProperty('includeReasoningContent');
-    });
   });
 
   describe('Verbosity Handling', () => {

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -426,7 +426,6 @@ export function getOpenAILLMConfig({
   defaultParams,
   useOpenRouter,
   reasoningFormat = ReasoningParameterFormat.reasoningEffort,
-  includeReasoningContent,
   modelOptions: _modelOptions,
 }: {
   apiKey: string;
@@ -439,7 +438,6 @@ export function getOpenAILLMConfig({
   defaultParams?: Record<string, unknown>;
   useOpenRouter?: boolean;
   reasoningFormat?: ReasoningParameterFormat;
-  includeReasoningContent?: boolean;
   azure?: false | t.AzureOptions;
 }): Pick<t.LLMConfigResult, 'llmConfig' | 'tools'> & {
   azure?: t.AzureOptions;
@@ -668,15 +666,11 @@ export function getOpenAILLMConfig({
       }) || hasModelKwargs;
   }
 
-  /**
-   * Replay `reasoning_content` on tool-call turns: auto-on for DeepSeek thinking-mode
-   * (#13366), or opt-in per custom endpoint via `customParams.includeReasoningContent`
-   * (e.g. Xiaomi MiMo, Kimi), removing the need to impersonate the moonshot provider.
-   */
+  /** DeepSeek thinking-mode requires `reasoning_content` replay on tool turns (#13366). */
   const isDeepSeekModel =
     typeof modelOptions.model === 'string' &&
     /^deepseek(?:[-/]|$)/i.test(modelOptions.model.replace(/^~/, ''));
-  if (includeReasoningContent === true || isDeepSeekModel) {
+  if (isDeepSeekModel) {
     llmConfig.includeReasoningContent = true;
   }
 

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -426,6 +426,7 @@ export function getOpenAILLMConfig({
   defaultParams,
   useOpenRouter,
   reasoningFormat = ReasoningParameterFormat.reasoningEffort,
+  includeReasoningContent,
   modelOptions: _modelOptions,
 }: {
   apiKey: string;
@@ -438,6 +439,7 @@ export function getOpenAILLMConfig({
   defaultParams?: Record<string, unknown>;
   useOpenRouter?: boolean;
   reasoningFormat?: ReasoningParameterFormat;
+  includeReasoningContent?: boolean;
   azure?: false | t.AzureOptions;
 }): Pick<t.LLMConfigResult, 'llmConfig' | 'tools'> & {
   azure?: t.AzureOptions;
@@ -666,11 +668,15 @@ export function getOpenAILLMConfig({
       }) || hasModelKwargs;
   }
 
-  /** DeepSeek thinking-mode requires `reasoning_content` replay on tool turns (#13366). */
-  if (
+  /**
+   * Replay `reasoning_content` on tool-call turns: auto-on for DeepSeek thinking-mode
+   * (#13366), or opt-in per custom endpoint via `customParams.includeReasoningContent`
+   * (e.g. Xiaomi MiMo, Kimi), removing the need to impersonate the moonshot provider.
+   */
+  const isDeepSeekModel =
     typeof modelOptions.model === 'string' &&
-    /^deepseek(?:[-/]|$)/i.test(modelOptions.model.replace(/^~/, ''))
-  ) {
+    /^deepseek(?:[-/]|$)/i.test(modelOptions.model.replace(/^~/, ''));
+  if (includeReasoningContent === true || isDeepSeekModel) {
     llmConfig.includeReasoningContent = true;
   }
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -857,6 +857,8 @@ export const endpointSchema = baseEndpointSchema.merge(
         defaultParamsEndpoint: z.string().default('custom'),
         reasoningFormat: eReasoningParameterFormatSchema.optional(),
         reasoningKey: eReasoningResponseKeySchema.optional(),
+        /** Replays `reasoning_content` on tool-call turns (e.g. Xiaomi MiMo, Kimi). */
+        includeReasoningContent: z.boolean().optional(),
         paramDefinitions: z.array(paramDefinitionSchema).optional(),
       })
       .strict()

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -857,8 +857,10 @@ export const endpointSchema = baseEndpointSchema.merge(
         defaultParamsEndpoint: z.string().default('custom'),
         reasoningFormat: eReasoningParameterFormatSchema.optional(),
         reasoningKey: eReasoningResponseKeySchema.optional(),
-        /** Replays `reasoning_content` on tool-call turns (e.g. Xiaomi MiMo, Kimi). */
+        /** Replays `reasoning_content` within a run's tool-call turns (e.g. Xiaomi MiMo, Kimi). */
         includeReasoningContent: z.boolean().optional(),
+        /** Also reconstructs `reasoning_content` from persisted history across turns (implies `includeReasoningContent`). */
+        includeReasoningHistory: z.boolean().optional(),
         paramDefinitions: z.array(paramDefinitionSchema).optional(),
       })
       .strict()

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -457,6 +457,7 @@ export type TConfig = {
     reasoningFormat?: ReasoningParameterFormat;
     reasoningKey?: ReasoningResponseKey;
     includeReasoningContent?: boolean;
+    includeReasoningHistory?: boolean;
     paramDefinitions?: Partial<SettingDefinition>[];
   };
 };

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -456,6 +456,7 @@ export type TConfig = {
     defaultParamsEndpoint?: string;
     reasoningFormat?: ReasoningParameterFormat;
     reasoningKey?: ReasoningResponseKey;
+    includeReasoningContent?: boolean;
     paramDefinitions?: Partial<SettingDefinition>[];
   };
 };


### PR DESCRIPTION
## Summary

I added per-custom-endpoint reasoning replay controls so OpenAI-compatible endpoints can preserve `reasoning_content` on tool-call turns natively, removing the need to impersonate the `moonshot` provider.

Reasoning models like Xiaomi MiMo and Kimi recommend echoing the prior turn's `reasoning_content` back on subsequent tool-call turns. Until now the only way to get this in LibreChat was to point a custom endpoint at the `moonshot` provider name, because the agents SDK's `ChatMoonshot` class is simply `ChatOpenAI` with `includeReasoningContent: true` baked in. That flag is the entire mechanism for within-run tool-turn replay, and LibreChat already forwards `llmConfig.includeReasoningContent` to the SDK, auto-enabling it for DeepSeek-named models (#13366). The missing piece was a config knob to opt in explicitly.

Two distinct behaviors, two distinct flags under `customParams`:

- **`includeReasoningContent`** (boolean) — replays `reasoning_content` within a run's tool-call turns. This is exact parity with the `moonshot` workaround (which only preserves reasoning across tool calls, not across user turns).
- **`includeReasoningHistory`** (boolean) — additionally reconstructs `reasoning_content` from persisted history across user turns (full DeepSeek thinking-mode parity). Implies `includeReasoningContent`, since reconstructed reasoning is only sent when the within-run flag is on.

Implementation:

- Added both fields to the custom endpoint schema (`packages/data-provider/src/config.ts`) and mirrored them on the hand-written `TConfig['customParams']` type (`packages/data-provider/src/types.ts`).
- `includeReasoningContent` threads through `getOpenAIConfig` → `getOpenAILLMConfig` to set `llmConfig.includeReasoningContent`; `includeReasoningHistory` also enables it (within-run is required for history replay).
- `includeReasoningHistory` is surfaced onto the initialized agent and drives `shouldReplayReasoningContent`, generalizing the previously DeepSeek-only format gate in `api/server/controllers/agents/client.js` so `formatAgentMessages` reconstructs reasoning on prior persisted tool-call turns.
- No `@librechat/agents` change required: the SDK already supports both paths end-to-end.

Example `librechat.yaml`:

```yaml
endpoints:
  custom:
    - name: "Xiaomi MiMo"
      apiKey: "${MIMO_API_KEY}"
      baseURL: "https://api.xiaomimimo.com/v1"
      models:
        default: ["MiMo-V2.5"]
      customParams:
        includeReasoningContent: true   # within-run (moonshot parity)
        includeReasoningHistory: true   # optional: also replay across turns (DeepSeek-style)
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I added unit coverage and ran the affected suites locally.

- `getOpenAILLMConfig` sets `includeReasoningContent` for a non-DeepSeek model when the flag is `true`, and leaves it unset when `false`/absent (`packages/api/src/endpoints/openai/llm.spec.ts`).
- `getOpenAIConfig` enables the within-run flag from either `includeReasoningContent` or `includeReasoningHistory`, and omits it by default (`packages/api/src/endpoints/openai/config.spec.ts`).
- `shouldReplayReasoningContent` returns true for `includeReasoningHistory` or DeepSeek agents, false otherwise (`packages/api/src/agents/run.spec.ts`).
- `packages/api`: endpoint + agent suites pass (284 across the touched specs); full `tsc --noEmit` clean; eslint clean. `packages/data-provider`: 343 config-schema tests pass. `/api` controller tests load the new export and pass.

### **Test Configuration**:

Node v24.16.0; Jest per-workspace. To verify end-to-end, configure a custom endpoint with `customParams.includeReasoningContent: true` (and optionally `includeReasoningHistory: true`) against a reasoning model that returns `reasoning_content` (e.g. MiMo/Kimi) and confirm reasoning persists across tool calls within a run (and across turns with the history flag).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
