### PR TITLE
🖱️ fix: Summon Quote Popup on Double-Click Word Selection

### DIFF
--- a/client/src/components/Chat/Input/QuoteButton.tsx
+++ b/client/src/components/Chat/Input/QuoteButton.tsx
@@ -92,12 +92,16 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
     const clearSelection = () => setSelection(null);
 
     document.addEventListener('mouseup', updateSelection);
+    /** Chromium commits a double-click word selection on `dblclick`, after
+     *  `mouseup` has already read a still-collapsed range, so listen here too. */
+    document.addEventListener('dblclick', updateSelection);
     document.addEventListener('keyup', updateSelection);
     document.addEventListener('scroll', clearSelection, true);
     window.addEventListener('resize', clearSelection);
 
     return () => {
       document.removeEventListener('mouseup', updateSelection);
+      document.removeEventListener('dblclick', updateSelection);
       document.removeEventListener('keyup', updateSelection);
       document.removeEventListener('scroll', clearSelection, true);
       window.removeEventListener('resize', clearSelection);

--- a/e2e/specs/mock/quotes.spec.ts
+++ b/e2e/specs/mock/quotes.spec.ts
@@ -48,12 +48,13 @@ async function selectMessageText(page: Page, needle: string) {
 }
 
 /**
- * Double-click the first real word inside the most recent message containing
- * `needle`, using native mouse events at the word's measured coordinates.
+ * Double-click the first word of `needle` inside the most recent message
+ * containing it, using native mouse events at that word's measured coordinates.
  * Unlike `selectMessageText` (a programmatic Range), this exercises the
  * browser's own double-click word selection — the path the `dblclick` listener
- * guards. Targeting measured coordinates avoids landing on the empty right side
- * of a full-width message row (which selects only inter-block whitespace).
+ * guards. Measuring the `needle` text node itself (not the first text node in
+ * `.message-render`, which may be a `select-none` screen-reader/model-label
+ * header) keeps the click on the actual reply word, not metadata or whitespace.
  */
 async function doubleClickWord(page: Page, needle: string) {
   const point = await page.evaluate((text) => {
@@ -64,17 +65,16 @@ async function doubleClickWord(page: Page, needle: string) {
     }
     const walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT);
     let node = walker.nextNode();
-    while (node && (node.nodeValue ?? '').trim().length === 0) {
+    while (node && !(node.nodeValue ?? '').includes(text)) {
       node = walker.nextNode();
     }
     if (!node) {
-      throw new Error(`No non-empty text node in: ${text}`);
+      throw new Error(`No text node contains: ${text}`);
     }
-    const value = node.nodeValue ?? '';
-    const start = value.search(/\S/);
+    const index = (node.nodeValue ?? '').indexOf(text);
     const range = document.createRange();
-    range.setStart(node, start);
-    range.setEnd(node, start + 1);
+    range.setStart(node, index);
+    range.setEnd(node, index + 1);
     const r = range.getBoundingClientRect();
     return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
   }, needle);

--- a/e2e/specs/mock/quotes.spec.ts
+++ b/e2e/specs/mock/quotes.spec.ts
@@ -47,6 +47,40 @@ async function selectMessageText(page: Page, needle: string) {
   }, needle);
 }
 
+/**
+ * Double-click the first real word inside the most recent message containing
+ * `needle`, using native mouse events at the word's measured coordinates.
+ * Unlike `selectMessageText` (a programmatic Range), this exercises the
+ * browser's own double-click word selection — the path the `dblclick` listener
+ * guards. Targeting measured coordinates avoids landing on the empty right side
+ * of a full-width message row (which selects only inter-block whitespace).
+ */
+async function doubleClickWord(page: Page, needle: string) {
+  const point = await page.evaluate((text) => {
+    const renders = Array.from(document.querySelectorAll('.message-render'));
+    const host = [...renders].reverse().find((el) => (el.textContent ?? '').includes(text));
+    if (!host) {
+      throw new Error(`No message contains: ${text}`);
+    }
+    const walker = document.createTreeWalker(host, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node && (node.nodeValue ?? '').trim().length === 0) {
+      node = walker.nextNode();
+    }
+    if (!node) {
+      throw new Error(`No non-empty text node in: ${text}`);
+    }
+    const value = node.nodeValue ?? '';
+    const start = value.search(/\S/);
+    const range = document.createRange();
+    range.setStart(node, start);
+    range.setEnd(node, start + 1);
+    const r = range.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  }, needle);
+  await page.mouse.dblclick(point.x, point.y);
+}
+
 const addToChat = (page: Page) => page.getByTestId('add-to-chat-button');
 const pendingChips = (page: Page) => page.getByTestId('pending-quote-chips');
 const messageQuotes = (page: Page) => messagesView(page).getByTestId('message-quotes');
@@ -106,6 +140,32 @@ test.describe('quote references', () => {
     await page.reload({ timeout: 10000 });
     await expect(page).toHaveURL(conversationUrl);
     await expect(messageQuotes(page)).toContainText(MOCK_REPLY_TEXT);
+  });
+
+  test('summons the popup from a native double-click word selection', async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+    await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+
+    const response = await sendMessage(page, 'seed for dblclick');
+    expect(response.ok()).toBeTruthy();
+    await expect(mockReply(page)).toBeVisible({ timeout: 20000 });
+
+    // A real double-click selects the word under the cursor. Chromium commits
+    // that selection on `dblclick`, AFTER `mouseup` fires, so only a `dblclick`
+    // listener catches it — a programmatic Range (the other tests) would bypass
+    // this path entirely. Retried as a unit: auto-scroll can clear a fresh
+    // selection, which races the scripted double-click.
+    await expect(async () => {
+      await doubleClickWord(page, MOCK_REPLY_TEXT);
+      const button = addToChat(page);
+      await expect(button).toBeVisible({ timeout: 3000 });
+      await button.click();
+      await expect(pendingChips(page)).toHaveAttribute('data-quote-count', '1');
+    }).toPass({ timeout: 30000 });
+
+    // The quoted excerpt is a word from the reply, not empty.
+    await expect(pendingChips(page)).toContainText(/E2E|mock|reply/i);
   });
 
   test('collapses multiple selections into one chip with a hover popup, and removes one', async ({


### PR DESCRIPTION
## Summary

A follow-up fix to the quote-references feature ([#13868](https://github.com/danny-avila/LibreChat/pull/13868)): double-clicking a word in a message did not summon the "Add to chat" popup. Chromium commits a double-click word selection on the `dblclick` event, after `mouseup` has already fired and read a still-collapsed range, so the selection listener missed it.

- Added a `dblclick` listener (alongside the existing `mouseup`/`keyup`) in `QuoteButton` so a double-click word selection is read once the browser has committed it.
- Added a Playwright e2e that selects a word via a real, measured-coordinate double-click (`page.mouse.dblclick` at the word's bounding box), exercising the native browser path the programmatic-Range helper bypasses.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced the bug with the new e2e against the pre-fix build (the popup never appeared); confirmed it passes with the fix. Diagnosed via instrumentation that double-clicking the empty right side of a full-width message row selects only inter-block whitespace, so the test now targets the first real word's measured coordinates.

### **Test Configuration**:

- `npx playwright test --config=e2e/playwright.config.mock.ts e2e/specs/mock/quotes.spec.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
