### PR TITLE
🧹 fix: Order Enabled Guard After Config Expansion in `useGetAgentByIdQuery`

### DIFF
--- a/client/src/data-provider/Agents/queries.ts
+++ b/client/src/data-provider/Agents/queries.ts
@@ -104,8 +104,8 @@ export const useGetAgentByIdQuery = (
       refetchOnReconnect: false,
       refetchOnMount: false,
       retry: false,
-      enabled: isValidAgentId && (config?.enabled ?? true),
       ...config,
+      enabled: isValidAgentId && (config?.enabled ?? true),
     },
   );
 };


### PR DESCRIPTION
## Summary

Otherwise, it's possible for a config to override the `isValidAgentId` check.

Without that check, it's possible to query `getAgentById()` with a blank `agent_id`, which can result in polluting the `QueryKeys.agent` cache with a full list of agents (instead of just a single agent result).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

This broke on our New Jersey fork for reasons that aren't related to core LibreChat. But basically, use `getAgentById()` w/ a null `agent_id` but a defined `{ enabled: true }`, and it'll pollute the query cache.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes