### PR TITLE
🌵 fix: Align Mention Empty Result Behavior With Skills Command

### DIFF
--- a/client/src/components/Chat/Input/Mention.tsx
+++ b/client/src/components/Chat/Input/Mention.tsx
@@ -129,6 +129,10 @@ function MentionContent({
   }, [open, options]);
 
   useEffect(() => {
+    setActiveIndex((prev) => Math.min(prev, Math.max(matches.length - 1, 0)));
+  }, [matches.length]);
+
+  useEffect(() => {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -191,10 +195,25 @@ function MentionContent({
               textAreaRef.current?.focus();
             }
             if (e.key === 'ArrowDown') {
+              if (matches.length === 0) {
+                return;
+              }
               setActiveIndex((prevIndex) => (prevIndex + 1) % matches.length);
             } else if (e.key === 'ArrowUp') {
+              if (matches.length === 0) {
+                return;
+              }
               setActiveIndex((prevIndex) => (prevIndex - 1 + matches.length) % matches.length);
             } else if (e.key === 'Enter' || e.key === 'Tab') {
+              if (matches.length === 0) {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                }
+                setOpen(false);
+                setShowPopover(false);
+                textAreaRef.current?.focus();
+                return;
+              }
               const mentionOption = matches[activeIndex] as MentionOption | undefined;
               if (mentionOption?.type === 'endpoint') {
                 e.preventDefault();


### PR DESCRIPTION
## Summary

This fixes a small keyboard edge case in the Mention popover.

When using @ in the chat input, if the filtered mention list becomes empty, the arrow keys can leave the popover in a bad state. After deleting text so matches appear again, keyboard navigation no longer works as expected. Also, pressing Enter when there are no matches currently does nothing, which is inconsistent with the Skills command behavior.

This change makes the empty-state behavior more robust: arrow keys no longer try to navigate a non-existent item, and pressing Enter or Tab now closes the popover and returns focus to the chat input, matching the Skills command flow.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I validated the change against the existing client checks and made sure the Mention behavior stays aligned with the Skills command flow.

### **Test Configuration**:

- `npm run build:client-package`
- `npm run build:data-provider`
- `npm run build:client`
- `npm run test:client`
- `./node_modules/.bin/eslint client/src/components/Chat/Input/Mention.tsx`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
