### PR TITLE
🧭 refactor: `web_search` Description on When To Search vs Answer Directly

### DIFF
--- a/packages/api/src/tools/toolkits/web.spec.ts
+++ b/packages/api/src/tools/toolkits/web.spec.ts
@@ -14,12 +14,11 @@ describe('web search context', () => {
     expect(context).not.toContain('{{iso_datetime}}');
   });
 
-  it('defaults the model away from searching unless a trigger applies', () => {
+  it('guides the model to answer directly when a search is not warranted', () => {
     const context = buildWebSearchContext();
 
-    expect(context).toContain('Default: answer from your own knowledge.');
-    expect(context).toContain('A search is justified ONLY if you can name a concrete reason');
-    expect(context).toContain('is NOT a reason to search');
+    expect(context).toContain('respond directly without searching');
+    expect(context).toContain('current, real-time, or otherwise beyond your own knowledge');
   });
 
   it('builds dynamic context from the supplied conversation anchor', () => {

--- a/packages/api/src/tools/toolkits/web.spec.ts
+++ b/packages/api/src/tools/toolkits/web.spec.ts
@@ -14,6 +14,14 @@ describe('web search context', () => {
     expect(context).not.toContain('{{iso_datetime}}');
   });
 
+  it('defaults the model away from searching unless a trigger applies', () => {
+    const context = buildWebSearchContext();
+
+    expect(context).toContain('Default: answer from your own knowledge.');
+    expect(context).toContain('A search is justified ONLY if you can name a concrete reason');
+    expect(context).toContain('is NOT a reason to search');
+  });
+
   it('builds dynamic context from the supplied conversation anchor', () => {
     const context = buildWebSearchDynamicContext('2024-01-02T03:04:05.000Z');
     const secondContext = buildWebSearchDynamicContext('2024-01-02T03:04:05.000Z');

--- a/packages/api/src/tools/toolkits/web.ts
+++ b/packages/api/src/tools/toolkits/web.ts
@@ -3,7 +3,20 @@ import { Tools, replaceSpecialVars } from 'librechat-data-provider';
 /** Builds the web search tool context with citation format instructions. */
 export function buildWebSearchContext(): string {
   return `# \`${Tools.web_search}\`:
-**Execute immediately without preface.** After search, provide a brief summary addressing the query directly, then structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
+**Default: answer from your own knowledge.** Most messages do not need a search, so do not reach for this tool by reflex.
+
+A search is justified ONLY if you can name a concrete reason from this list. If none clearly applies, do not search:
+- The answer depends on information that changes over time and could be stale (today's news, prices, weather, schedules, standings, current office-holders, latest version numbers).
+- The user asks about a specific recent event or release, or anything dated after your knowledge cutoff.
+- The user explicitly asks you to search, or gives a link or source to read.
+- The answer hinges on niche, local, or hard-to-verify specifics you are genuinely unsure of (a specific business's hours, an obscure spec, a person who isn't widely documented).
+- You gave an answer and have real reason to believe it is outdated or wrong.
+
+Do NOT search for things you can already handle: definitions, concepts, explanations, reasoning, math, code, translation, writing, summarizing the user's own text, general how-tos, or opinions. The fact that a search might return relevant-looking results is NOT a reason to search — only the gaps above are.
+
+When you are unsure whether you know enough, answer from your knowledge and state what you're uncertain about, instead of defaulting to a search. An unnecessary search adds latency and noise and is worse than a direct answer.
+
+If — and only if — a trigger above applies: search once, immediately, without preface, then provide a brief summary addressing the query directly, and structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
 
 Use the conversation date/time from the dynamic runtime context when recency matters.
 

--- a/packages/api/src/tools/toolkits/web.ts
+++ b/packages/api/src/tools/toolkits/web.ts
@@ -3,20 +3,7 @@ import { Tools, replaceSpecialVars } from 'librechat-data-provider';
 /** Builds the web search tool context with citation format instructions. */
 export function buildWebSearchContext(): string {
   return `# \`${Tools.web_search}\`:
-**Default: answer from your own knowledge.** Most messages do not need a search, so do not reach for this tool by reflex.
-
-A search is justified ONLY if you can name a concrete reason from this list. If none clearly applies, do not search:
-- The answer depends on information that changes over time and could be stale (today's news, prices, weather, schedules, standings, current office-holders, latest version numbers).
-- The user asks about a specific recent event or release, or anything dated after your knowledge cutoff.
-- The user explicitly asks you to search, or gives a link or source to read.
-- The answer hinges on niche, local, or hard-to-verify specifics you are genuinely unsure of (a specific business's hours, an obscure spec, a person who isn't widely documented).
-- You gave an answer and have real reason to believe it is outdated or wrong.
-
-Do NOT search for things you can already handle: definitions, concepts, explanations, reasoning, math, code, translation, writing, summarizing the user's own text, general how-tos, or opinions. The fact that a search might return relevant-looking results is NOT a reason to search — only the gaps above are.
-
-When you are unsure whether you know enough, answer from your knowledge and state what you're uncertain about, instead of defaulting to a search. An unnecessary search adds latency and noise and is worse than a direct answer.
-
-If — and only if — a trigger above applies: search once, immediately, without preface, then provide a brief summary addressing the query directly, and structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
+Use this tool when the user's request calls for it, whether directly, indirectly, or implicitly, or when answering requires information that is current, real-time, or otherwise beyond your own knowledge; for questions you can answer reliably on your own, respond directly without searching. When searching, execute immediately without preface, then provide a brief summary addressing the query directly, then structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
 
 Use the conversation date/time from the dynamic runtime context when recency matters.
 


### PR DESCRIPTION
Follow-up to #13837, revised per @danny-avila's feedback there to keep the change minimal, concise, and neutral rather than the longer rewrite in the original PR.

## The problem
With web search enabled, the agent calls `web_search` on nearly every turn, including for things it could answer directly. It is noticeably more trigger-happy than ChatGPT or Claude, which search only when the query actually calls for it. I see this across providers (Anthropic API and OpenRouter alike), which makes sense because the instruction is provider-agnostic.

## Likely cause
The instruction injected into the agent system prompt for web search currently opens with:

> **Execute immediately without preface.**

In practice models appear to read that as "run a search on essentially every turn," so it fires even when no search is warranted. There is no statement of when to answer directly instead.

## This change
One added sentence, plus relocating the existing "execute immediately without preface" so it applies once a search is warranted rather than as the default. Nothing else in the wording changes, and the citation-format block is untouched.

Before:
> **Execute immediately without preface.** After search, provide a brief summary addressing the query directly, then structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.

After:
> Use this tool when the user's request calls for it, whether directly, indirectly, or implicitly, or when answering requires information that is current, real-time, or otherwise beyond your own knowledge; for questions you can answer reliably on your own, respond directly without searching. When searching, execute immediately without preface, then provide a brief summary addressing the query directly, then structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.

The intent is just to restore "search when it adds value, otherwise answer directly" as the default behavior, matching what users expect from other assistants, without forcing opinionated text on deployments.

## Question for maintainer
@danny-avila does this concise version look better than the original? Happy to trim it further. If you would rather this be configurable than a built-in default change, I can move it behind a `webSearch` config option with this wording as the default instead.

## Note on testing
I have not verified this against a live deployment. Production here runs the prebuilt image with the prompt baked into the compiled bundle, so verifying live would require building a custom image or editing the compiled file inside the container. Treating this as a clearly identified issue with a small proposed wording fix.