### PR TITLE
🪪 fix: re-derive Azure model list for group-scoped config overrides

### DIFF
--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -588,3 +588,96 @@ describe('INTERFACE_PERMISSION_FIELDS', () => {
     }
   });
 });
+
+describe('mergeConfigOverrides — Azure groups re-derivation', () => {
+  const azureBase = {
+    endpoints: {
+      azureOpenAI: {
+        isValid: true,
+        errors: [],
+        modelNames: ['gpt-4o'],
+        modelGroupMap: { 'gpt-4o': { group: 'my-group' } },
+        groupMap: {
+          'my-group': {
+            apiKey: 'test-key',
+            instanceName: 'test-instance',
+            version: '2024-08-01-preview',
+            models: { 'gpt-4o': { deploymentName: 'gpt-4o' } },
+          },
+        },
+      },
+    },
+  } as unknown as AppConfig;
+
+  function azureGroupsOverride(models: Record<string, unknown>, priority = 20): IConfig[] {
+    return [
+      fakeConfig(
+        {
+          endpoints: {
+            azureOpenAI: {
+              groups: [
+                {
+                  group: 'my-group',
+                  apiKey: 'test-key',
+                  instanceName: 'test-instance',
+                  version: '2024-08-01-preview',
+                  models,
+                },
+              ],
+            },
+          },
+        },
+        priority,
+      ),
+    ];
+  }
+
+  it('re-derives modelNames and routing maps when a scoped override adds a model', () => {
+    const configs = azureGroupsOverride({
+      'gpt-4o': { deploymentName: 'gpt-4o' },
+      'gpt-4o-mini': { deploymentName: 'gpt-4o-mini' },
+    });
+    const result = mergeConfigOverrides(azureBase, configs) as unknown as Record<string, unknown>;
+    const azure = (result.endpoints as Record<string, unknown>).azureOpenAI as Record<
+      string,
+      unknown
+    >;
+
+    expect(azure.modelNames).toEqual(['gpt-4o', 'gpt-4o-mini']);
+    expect((azure.modelGroupMap as Record<string, unknown>)['gpt-4o-mini']).toEqual({
+      group: 'my-group',
+    });
+    // raw groups are consumed by re-derivation, not left on the resolved config
+    expect(azure.groups).toBeUndefined();
+  });
+
+  it('keeps the base-derived config when the override groups are invalid', () => {
+    const configs = azureGroupsOverride({ 'gpt-4o-mini': { deploymentName: 'gpt-4o-mini' } });
+    // strip the mandatory instanceName to force a validation failure
+    (
+      (configs[0].overrides as Record<string, unknown>).endpoints as Record<string, unknown>
+    ).azureOpenAI = {
+      groups: [{ group: 'broken', apiKey: 'k', version: 'v', models: { 'gpt-4o-mini': true } }],
+    };
+
+    const result = mergeConfigOverrides(azureBase, configs) as unknown as Record<string, unknown>;
+    const azure = (result.endpoints as Record<string, unknown>).azureOpenAI as Record<
+      string,
+      unknown
+    >;
+
+    expect(azure.modelNames).toEqual(['gpt-4o']);
+  });
+
+  it('leaves the resolved Azure config untouched when no override supplies groups', () => {
+    const configs = [fakeConfig({ registration: { enabled: false } }, 10)];
+    const result = mergeConfigOverrides(azureBase, configs) as unknown as Record<string, unknown>;
+    const azure = (result.endpoints as Record<string, unknown>).azureOpenAI as Record<
+      string,
+      unknown
+    >;
+
+    expect(azure.modelNames).toEqual(['gpt-4o']);
+    expect(azure.groups).toBeUndefined();
+  });
+});

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -1,9 +1,12 @@
+import logger from '~/config/winston';
 import {
+  EModelEndpoint,
+  validateAzureGroups,
   BASE_ONLY_CONFIG_SECTIONS,
   INTERFACE_PERMISSION_FIELDS,
   PERMISSION_SUB_KEYS,
 } from 'librechat-data-provider';
-import type { TCustomConfig } from 'librechat-data-provider';
+import type { TCustomConfig, TAzureConfig, TAzureGroups } from 'librechat-data-provider';
 import type { AppConfig, IConfig } from '~/types';
 
 type AnyObject = { [key: string]: unknown };
@@ -179,6 +182,35 @@ function deepMerge<T extends AnyObject>(target: T, source: AnyObject, depth = 0,
 }
 
 /**
+ * A group/role/user override can re-introduce raw Azure `groups` into the merged
+ * config, but the deep-merge leaves the base config's derived `modelNames`,
+ * `modelGroupMap`, and `groupMap` untouched — so the override's models never reach
+ * the model list (picker + enforcement) or request-time routing. Re-validate the
+ * merged `groups` with the same `validateAzureGroups` the base path uses so scoped
+ * Azure overrides take effect; on invalid groups the base-derived config is kept.
+ *
+ * Assistant model derivation (an AppService base-load concern) is intentionally
+ * not recomputed here.
+ */
+function rederiveAzureGroups(merged: AppConfig): void {
+  const azure = merged.endpoints?.[EModelEndpoint.azureOpenAI] as
+    | (TAzureConfig & { groups?: TAzureGroups })
+    | undefined;
+  if (!azure || !Array.isArray(azure.groups)) {
+    return;
+  }
+
+  const { groups, ...rest } = azure;
+  const { isValid, modelNames, modelGroupMap, groupMap, errors } = validateAzureGroups(groups);
+  if (!isValid) {
+    logger.warn('[mergeConfigOverrides] Invalid Azure `groups` in override; keeping base:', errors);
+    return;
+  }
+
+  merged.endpoints![EModelEndpoint.azureOpenAI] = { ...rest, modelNames, modelGroupMap, groupMap };
+}
+
+/**
  * Merge DB config overrides into a base AppConfig.
  *
  * Configs are sorted by priority ascending (lowest first, highest wins).
@@ -247,6 +279,8 @@ export function mergeConfigOverrides(baseConfig: AppConfig, configs: IConfig[]):
       merged = deepMerge(merged, remapped);
     }
   }
+
+  rederiveAzureGroups(merged);
 
   return merged;
 }


### PR DESCRIPTION
## Summary

Per-principal (group / role / user) config overrides that grant **additional Azure (`azureOpenAI`) models** via `endpoints.azureOpenAI.groups` are silently ignored. The override is stored and merged, but the extra models never appear in the model picker, are rejected by `validateModel`, and don't route.

This is a follow-up to #13176 (which made group-scoped overrides *participate* in config resolution) and completes the Azure case from the original report in #13172 (a "Research" group with access to additional models/endpoints).

## Root cause

Azure is the only endpoint whose config is **compiled at load**: `azureConfigSetup` runs `validateAzureGroups(groups)` to produce `modelNames` / `modelGroupMap` / `groupMap`, then **discards the raw `groups`**. At request time, `loadConfigModels` reads the derived `modelNames`, and `mapModelToAzureConfig` reads `modelGroupMap` / `groupMap`.

`mergeConfigOverrides` deep-merges a principal override's raw `endpoints.azureOpenAI.groups` back onto the already-resolved base config, but nothing re-runs `validateAzureGroups` afterward — so the derived fields keep their **base** values. The override's `groups` sit unused and the extra models never surface.

Other endpoints (`bedrock`, `custom`) read their raw `models` arrays directly from the resolved config, so per-group overrides already work for them. Azure is the sole exception because of the compile-and-discard step.

## Fix

After the override merge, if `endpoints.azureOpenAI` carries a `groups` array, re-run `validateAzureGroups` (the same validation `AppService` uses at load) and overwrite `modelNames` / `modelGroupMap` / `groupMap`. Invalid groups log a warning and keep the base-derived config (no throw mid-request). No-op when no override supplies `groups`, so non-Azure and override-less paths are untouched.

## Steps to reproduce (before this PR)

1. Configure `endpoints.azureOpenAI` with one model in `librechat.yaml` (base).
2. Create a GROUP-scoped config override that adds a second Azure model via `endpoints.azureOpenAI.groups`.
3. Sign in as a member of that group → the second model does **not** appear in the picker and is rejected by `validateModel`. (A ROLE-scoped override behaves the same.)

With this PR, the group resolves to the union of base + override models.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added 3 cases to `packages/data-schemas/src/app/resolution.spec.ts`:
  - re-derives `modelNames` + routing maps when a scoped override adds a model
  - keeps the base-derived config when the override groups are invalid
  - no-op when no override supplies `groups`
- `cd packages/data-schemas && npx jest src/app/resolution.spec.ts` → green.

## Checklist

- [x] My code adheres to the project's style guidelines (mirrors `app/azure.ts`)
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my fix works
- [x] My changes generate no new warnings
