### PR TITLE
🫥 fix: Hide Quote Popup When Selection Collapses Silently

### DIFF
--- a/client/src/components/Chat/Input/QuoteButton.tsx
+++ b/client/src/components/Chat/Input/QuoteButton.tsx
@@ -90,12 +90,24 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
       setPos(null);
     };
     const clearSelection = () => setSelection(null);
+    /** Hide the popup the instant the selection collapses or empties, including
+     *  paths that fire no mouse/key event — e.g. a streaming markdown re-render
+     *  replacing the selected text node, which would otherwise leave the button
+     *  stranded over a now-collapsed caret. Only hides here; showing stays gated
+     *  on mouseup/dblclick/keyup so an in-progress drag never flickers it. */
+    const handleSelectionChange = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+        setSelection(null);
+      }
+    };
 
     document.addEventListener('mouseup', updateSelection);
     /** Chromium commits a double-click word selection on `dblclick`, after
      *  `mouseup` has already read a still-collapsed range, so listen here too. */
     document.addEventListener('dblclick', updateSelection);
     document.addEventListener('keyup', updateSelection);
+    document.addEventListener('selectionchange', handleSelectionChange);
     document.addEventListener('scroll', clearSelection, true);
     window.addEventListener('resize', clearSelection);
 
@@ -103,6 +115,7 @@ function QuoteButton({ conversationId }: { conversationId: string }) {
       document.removeEventListener('mouseup', updateSelection);
       document.removeEventListener('dblclick', updateSelection);
       document.removeEventListener('keyup', updateSelection);
+      document.removeEventListener('selectionchange', handleSelectionChange);
       document.removeEventListener('scroll', clearSelection, true);
       window.removeEventListener('resize', clearSelection);
     };

--- a/e2e/specs/mock/quotes.spec.ts
+++ b/e2e/specs/mock/quotes.spec.ts
@@ -168,6 +168,27 @@ test.describe('quote references', () => {
     await expect(pendingChips(page)).toContainText(/E2E|mock|reply/i);
   });
 
+  test('hides the popup when the selection collapses without a mouse event', async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+    await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+
+    const response = await sendMessage(page, 'seed for collapse');
+    expect(response.ok()).toBeTruthy();
+    await expect(mockReply(page)).toBeVisible({ timeout: 20000 });
+
+    await expect(async () => {
+      await doubleClickWord(page, MOCK_REPLY_TEXT);
+      await expect(addToChat(page)).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 30000 });
+
+    // Collapse the selection the way a streaming markdown re-render does —
+    // dropping the selected text node fires only `selectionchange`, not a
+    // mouse/key event. The popup must not linger over the now-empty caret.
+    await page.evaluate(() => window.getSelection()?.collapseToEnd());
+    await expect(addToChat(page)).toBeHidden({ timeout: 5000 });
+  });
+
   test('collapses multiple selections into one chip with a hover popup, and removes one', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

A follow-up fix to the quote-references feature: the "Add to chat" popup showed up even when nothing was selected. The selection state only updated on `mouseup`/`dblclick`/`keyup`/`scroll`/`resize`, so when a selection collapsed through a path that fires none of those — most often a streaming markdown re-render replacing the selected text node — the button stayed stranded over a now-empty caret.

- Added a `selectionchange` listener in `QuoteButton` that hides the popup the instant the selection collapses or empties. It only hides, never shows, so an in-progress drag-select still does not flicker the popup.
- Added a Playwright e2e that collapses the selection without a mouse event (`window.getSelection().collapseToEnd()`, the deterministic proxy for a re-render dropping the anchor node) and asserts the popup disappears.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced via instrumentation: after a real double-click selected a word and showed the popup, a programmatic collapse (and an `innerHTML` re-render) left the button visible with `window.getSelection().isCollapsed === true` and empty text. With the `selectionchange` listener the popup hides. Full mock quotes suite passes (6/6), including the new regression test.

### **Test Configuration**:

- `npx playwright test --config=e2e/playwright.config.mock.ts e2e/specs/mock/quotes.spec.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
