### PR TITLE
⬆️ chore: Migrate off deprecated @ariakit/react-core to @ariakit/react-components

### DIFF
--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -36,13 +36,14 @@ module.exports = {
   restoreMocks: true,
   testResultsProcessor: 'jest-junit',
   coverageReporters: ['text', 'cobertura', 'lcov'],
+  resolver: '<rootDir>/jest.resolver.cjs',
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       'jest-file-loader',
   },
   transformIgnorePatterns: [
-    '/node_modules/(?!(@zattoo/use-double-click|@dicebear|@react-dnd|react-dnd.*|dnd-core|filenamify|filename-reserved-regex|heic-to|lowlight|highlight\\.js|fault|react-markdown|unified|bail|trough|devlop|is-.*|parse-entities|stringify-entities|character-.*|trim-lines|style-to-object|inline-style-parser|html-url-attributes|escape-string-regexp|longest-streak|zwitch|ccount|markdown-table|comma-separated-tokens|space-separated-tokens|web-namespaces|property-information|remark-.*|rehype-.*|recma-.*|hast.*|mdast-.*|unist-.*|vfile.*|micromark.*|estree-util-.*|decode-named-character-reference)/)/',
+    '/node_modules/(?!(@ariakit/react-components|@ariakit/react-utils|@ariakit/react-store|@ariakit/components|@ariakit/store|@ariakit/utils|@zattoo/use-double-click|@dicebear|@react-dnd|react-dnd.*|dnd-core|filenamify|filename-reserved-regex|heic-to|lowlight|highlight\\.js|fault|react-markdown|unified|bail|trough|devlop|is-.*|parse-entities|stringify-entities|character-.*|trim-lines|style-to-object|inline-style-parser|html-url-attributes|escape-string-regexp|longest-streak|zwitch|ccount|markdown-table|comma-separated-tokens|space-separated-tokens|web-namespaces|property-information|remark-.*|rehype-.*|recma-.*|hast.*|mdast-.*|unist-.*|vfile.*|micromark.*|estree-util-.*|decode-named-character-reference)/)/',
   ],
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect', '<rootDir>/test/setupTests.js'],
   clearMocks: true,

--- a/client/jest.resolver.cjs
+++ b/client/jest.resolver.cjs
@@ -1,0 +1,17 @@
+/**
+ * The modern @ariakit/* split packages (react-components and its peers) are ESM-only and
+ * declare only an `import` export condition, which jest's CJS resolver can't match. Resolve
+ * those with the `import` condition; babel (see transformIgnorePatterns) transpiles them to CJS.
+ */
+const ESM_ONLY_ARIAKIT =
+  /^@ariakit\/(react-components|react-utils|react-store|components|store|utils)(\/|$)/;
+
+module.exports = (request, options) => {
+  if (ESM_ONLY_ARIAKIT.test(request)) {
+    return options.defaultResolver(request, {
+      ...options,
+      conditions: [...(options.conditions ?? []), 'import'],
+    });
+  }
+  return options.defaultResolver(request, options);
+};

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://librechat.ai",
   "dependencies": {
     "@ariakit/react": "^0.4.29",
-    "@ariakit/react-core": "^0.4.26",
+    "@ariakit/react-components": "^0.1.2",
     "@codesandbox/sandpack-react": "^2.19.10",
     "@dicebear/collection": "^9.4.1",
     "@dicebear/core": "^9.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -414,7 +414,7 @@
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
-        "@ariakit/react-core": "^0.4.26",
+        "@ariakit/react-components": "^0.1.2",
         "@codesandbox/sandpack-react": "^2.19.10",
         "@dicebear/collection": "^9.4.1",
         "@dicebear/core": "^9.4.1",
@@ -772,13 +772,6 @@
         "@ariakit/utils": "0.1.2"
       }
     },
-    "node_modules/@ariakit/core": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-      "deprecated": "This package has been split into smaller packages. Use @ariakit/components, @ariakit/store, or @ariakit/utils depending on the APIs you need.",
-      "license": "MIT"
-    },
     "node_modules/@ariakit/react": {
       "version": "0.4.29",
       "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
@@ -808,22 +801,6 @@
         "@ariakit/store": "0.1.2",
         "@ariakit/utils": "0.1.2",
         "@floating-ui/dom": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@ariakit/react-core": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
-      "deprecated": "This package has been split into smaller packages. Use @ariakit/react-components or @ariakit/react-utils depending on the APIs you need.",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/core": "0.4.20",
-        "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -43150,7 +43127,7 @@
       },
       "peerDependencies": {
         "@ariakit/react": "^0.4.29",
-        "@ariakit/react-core": "^0.4.26",
+        "@ariakit/react-components": "^0.1.2",
         "@dicebear/collection": "^9.4.1",
         "@dicebear/core": "^9.4.1",
         "@headlessui/react": "^2.1.2",

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -22,9 +22,12 @@ export default {
   // React component testing requires jsdom environment
   testEnvironment: 'jsdom',
   testEnvironmentOptions: { url: 'http://localhost:3080' },
+  resolver: '<rootDir>/jest.resolver.cjs',
   transform: {
     '^.+\\.(ts|tsx|js|jsx)$': 'babel-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!(@tanstack|lucide-react|@dicebear)/)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(@tanstack|lucide-react|@dicebear|@ariakit/react-components|@ariakit/react-utils|@ariakit/react-store|@ariakit/components|@ariakit/store|@ariakit/utils)/)',
+  ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/packages/client/jest.resolver.cjs
+++ b/packages/client/jest.resolver.cjs
@@ -1,0 +1,17 @@
+/**
+ * The modern @ariakit/* split packages (react-components and its peers) are ESM-only and
+ * declare only an `import` export condition, which jest's CJS resolver can't match. Resolve
+ * those with the `import` condition; babel (see transformIgnorePatterns) transpiles them to CJS.
+ */
+const ESM_ONLY_ARIAKIT =
+  /^@ariakit\/(react-components|react-utils|react-store|components|store|utils)(\/|$)/;
+
+module.exports = (request, options) => {
+  if (ESM_ONLY_ARIAKIT.test(request)) {
+    return options.defaultResolver(request, {
+      ...options,
+      conditions: [...(options.conditions ?? []), 'import'],
+    });
+  }
+  return options.defaultResolver(request, options);
+};

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@ariakit/react": "^0.4.29",
-    "@ariakit/react-core": "^0.4.26",
+    "@ariakit/react-components": "^0.1.2",
     "@dicebear/collection": "^9.4.1",
     "@dicebear/core": "^9.4.1",
     "@headlessui/react": "^2.1.2",

--- a/packages/client/src/components/ControlCombobox.tsx
+++ b/packages/client/src/components/ControlCombobox.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useRef, memo, useEffect, MemoExoticComponent } from 
 import * as Ariakit from '@ariakit/react';
 import { matchSorter } from 'match-sorter';
 import { Search, ChevronDown } from 'lucide-react';
-import { SelectRenderer } from '@ariakit/react-core/select/select-renderer';
+import { SelectRenderer } from '@ariakit/react-components/select/select-renderer';
 import type { OptionWithIcon } from '~/common';
 import './AnimatePopover.css';
 import { JSX } from 'react/jsx-runtime';


### PR DESCRIPTION
## Summary

`npm install` emits two deprecation warnings:

```
npm warn deprecated @ariakit/core@0.4.20: This package has been split into smaller packages...
npm warn deprecated @ariakit/react-core@0.4.26: This package has been split into smaller packages...
```

Both trace to a single cause: the explicit `@ariakit/react-core` dependency in `client` and `packages/client`. `@ariakit/core` only entered the tree as `react-core`'s own dependency.

`@ariakit/react@0.4.29` already migrated to the non-deprecated successor `@ariakit/react-components` (a transitive dep). The only direct use of `@ariakit/react-core` was the `SelectRenderer` deep import in `ControlCombobox.tsx` (`SelectRenderer` is not exposed through `@ariakit/react`'s public entry). The successor exposes the identical symbol at the identical subpath.

## Changes

- Swap the direct dependency `@ariakit/react-core` for `@ariakit/react-components` in `client/package.json` (dependencies) and `packages/client/package.json` (peerDependencies)
- Repoint the one import in `ControlCombobox.tsx` to `@ariakit/react-components/select/select-renderer`
- Regenerate `package-lock.json` (lockfile-only): both deprecated packages dropped, no other drift

## Result

- Lockfile has zero references to `@ariakit/react-core` and `@ariakit/core`
- `@ariakit/react-components` dedupes to the single `0.1.2` that `@ariakit/react@0.4.29` pins, so there is no duplicate React-context instance
- `packages/client` type-checks clean (`tsc --noEmit`, exit 0)

## Note

`@ariakit/react-components` must stay in lockstep with whatever `@ariakit/react` pins. A future bump of `@ariakit/react` to a version that pins `react-components@0.2.x` should update this `^0.1.2` to match, otherwise two copies install and `SelectRenderer`'s context would mismatch.

`bun.lock` was left untouched; it is already stale (pins `@ariakit/react@0.4.17` vs `0.4.29` in `package-lock.json`) and is not the active source of truth.