### PR TITLE
🐛 fix: de-duplicate grouped modelSpecs from raw endpoint models in the picker

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
+++ b/client/src/components/Chat/Menus/Endpoints/__tests__/utils.test.ts
@@ -1,6 +1,15 @@
+import type { TModelSpec } from 'librechat-data-provider';
 import type { useLocalize } from '~/hooks';
 import type { Endpoint } from '~/common';
-import { filterItems } from '../utils';
+import { filterItems, getSpecModelIds } from '../utils';
+
+const makeSpec = (overrides: Partial<TModelSpec>): TModelSpec =>
+  ({
+    name: 'spec',
+    label: 'Spec',
+    preset: { endpoint: 'openAI', model: 'gpt-4o' },
+    ...overrides,
+  }) as TModelSpec;
 
 const agentsEndpoint: Endpoint = {
   value: 'agents',
@@ -42,5 +51,24 @@ describe('model selector utilities', () => {
   it('does not match agents when there are no selectable agent options', () => {
     const results = filterItems([disabledAgentsEndpoint], 'my agents', undefined, undefined);
     expect(results).toEqual([]);
+  });
+});
+
+describe('getSpecModelIds', () => {
+  it('returns the underlying model ids referenced by the specs', () => {
+    const specs = [
+      makeSpec({ name: 'a', preset: { endpoint: 'openAI', model: 'gpt-4o' } }),
+      makeSpec({ name: 'b', preset: { endpoint: 'openAI', model: 'gpt-4o-mini' } }),
+    ];
+    expect(getSpecModelIds(specs)).toEqual(new Set(['gpt-4o', 'gpt-4o-mini']));
+  });
+
+  it('ignores specs whose preset has no model', () => {
+    const specs = [makeSpec({ name: 'agent', preset: { endpoint: 'agents', agent_id: 'a_1' } })];
+    expect(getSpecModelIds(specs).size).toBe(0);
+  });
+
+  it('returns an empty set for no specs', () => {
+    expect(getSpecModelIds([]).size).toBe(0);
   });
 });

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -7,7 +7,7 @@ import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
 import { CustomMenu as Menu, CustomMenuItem as MenuItem, CustomMenuSeparator } from '../CustomMenu';
 import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
-import { filterModels, shouldRenderEndpointOption } from '../utils';
+import { filterModels, getSpecModelIds, shouldRenderEndpointOption } from '../utils';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { renderEndpointModels } from './EndpointModelItem';
 import { ModelSpecItem } from './ModelSpecItem';
@@ -107,6 +107,14 @@ function EndpointMenuContent({
     return modelSpecs.filter((spec: TModelSpec) => spec.group === endpoint.value);
   }, [modelSpecs, endpoint.value]);
 
+  const visibleModels = useMemo(() => {
+    const specModelIds = getSpecModelIds(endpointSpecs);
+    if (!specModelIds.size) {
+      return endpoint.models;
+    }
+    return (endpoint.models || []).filter((model) => !specModelIds.has(model.name));
+  }, [endpoint.models, endpointSpecs]);
+
   if (isAssistantsEndpoint(endpoint.value) && endpoint.models === undefined) {
     return (
       <div
@@ -122,13 +130,13 @@ function EndpointMenuContent({
   const filteredModels = searchValue
     ? filterModels(
         endpoint,
-        (endpoint.models || []).map((model) => model.name),
+        (visibleModels || []).map((model) => model.name),
         searchValue,
         agentsMap,
         assistantsMap,
       )
     : null;
-  const renderedModels = filteredModels ?? endpoint.models?.map((model) => model.name) ?? [];
+  const renderedModels = filteredModels ?? visibleModels?.map((model) => model.name) ?? [];
   const showMarketplace =
     endpoint.showMarketplace === true && marketplaceSearchMatches(searchValue, localize);
   const hasSelectableRows = endpointSpecs.length > 0 || renderedModels.length > 0;
@@ -141,9 +149,9 @@ function EndpointMenuContent({
         <ModelSpecItem key={spec.name} spec={spec} isSelected={selectedSpec === spec.name} />
       ))}
       {filteredModels
-        ? renderEndpointModels(endpoint, endpoint.models || [], filteredModels, endpointIndex)
-        : endpoint.models &&
-          renderEndpointModels(endpoint, endpoint.models, undefined, endpointIndex)}
+        ? renderEndpointModels(endpoint, visibleModels || [], filteredModels, endpointIndex)
+        : visibleModels &&
+          renderEndpointModels(endpoint, visibleModels, undefined, endpointIndex)}
     </>
   );
 }

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -7,7 +7,7 @@ import type { Endpoint } from '~/common';
 import MarketplaceItem, { marketplaceSearchMatches } from './Marketplace';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
-import { shouldRenderEndpointOption } from '../utils';
+import { getSpecModelIds, shouldRenderEndpointOption } from '../utils';
 import SpecDescription from './SpecDescription';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
@@ -25,6 +25,7 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
     handleSelectModel,
     handleSelectEndpoint,
     endpointsConfig,
+    modelSpecs,
   } = useModelSelectorContext();
 
   const {
@@ -113,7 +114,12 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
             const showMarketplace =
               endpoint.showMarketplace === true &&
               (endpointMatches || marketplaceSearchMatches(searchValue, localize));
-            const models = endpoint.models ?? [];
+            const specModelIds = getSpecModelIds(
+              (modelSpecs ?? []).filter((spec) => spec.group === endpoint.value),
+            );
+            const models = specModelIds.size
+              ? (endpoint.models ?? []).filter((model) => !specModelIds.has(model.name))
+              : endpoint.models ?? [];
             const filteredModels = endpointMatches
               ? models
               : models.filter((model) => {

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint, SelectedValues } from '~/common';
 import { SearchResults } from '../SearchResults';
 
@@ -7,6 +8,7 @@ const mockHandleSelectModel = jest.fn();
 const mockHandleSelectEndpoint = jest.fn();
 const mockNavigate = jest.fn();
 let mockSelectedValues: SelectedValues;
+let mockModelSpecs: TModelSpec[];
 
 jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
   useModelSelectorContext: () => ({
@@ -15,6 +17,7 @@ jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
     handleSelectModel: mockHandleSelectModel,
     handleSelectEndpoint: mockHandleSelectEndpoint,
     endpointsConfig: {},
+    modelSpecs: mockModelSpecs,
   }),
 }));
 
@@ -80,6 +83,7 @@ const disabledAgentsEndpoint: Endpoint = {
 describe('SearchResults', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockModelSpecs = [];
   });
 
   it('marks model as selected when endpoint and model match with no active spec', () => {
@@ -160,5 +164,41 @@ describe('SearchResults', () => {
 
     expect(screen.queryByRole('menuitem', { name: 'My Agents' })).not.toBeInTheDocument();
     expect(mockHandleSelectEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('hides a raw endpoint model that a grouped spec already represents', () => {
+    mockSelectedValues = { endpoint: 'anthropic', model: '', modelSpec: '' };
+    mockModelSpecs = [
+      {
+        name: 'claude-opus-spec',
+        label: 'Claude Opus',
+        group: 'anthropic',
+        preset: { endpoint: 'anthropic', model: 'claude-opus-4-6' },
+      } as TModelSpec,
+    ];
+    render(
+      <SearchResults results={[anthropicEndpoint]} localize={localize} searchValue="claude" />,
+    );
+
+    expect(screen.queryByText('claude-opus-4-6')).not.toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-4-5')).toBeInTheDocument();
+  });
+
+  it('keeps raw models when no grouped spec covers them', () => {
+    mockSelectedValues = { endpoint: 'anthropic', model: '', modelSpec: '' };
+    mockModelSpecs = [
+      {
+        name: 'other-spec',
+        label: 'Other',
+        group: 'openAI',
+        preset: { endpoint: 'openAI', model: 'gpt-4o' },
+      } as TModelSpec,
+    ];
+    render(
+      <SearchResults results={[anthropicEndpoint]} localize={localize} searchValue="claude" />,
+    );
+
+    expect(screen.getByText('claude-opus-4-6')).toBeInTheDocument();
+    expect(screen.getByText('claude-sonnet-4-5')).toBeInTheDocument();
   });
 });

--- a/client/src/components/Chat/Menus/Endpoints/utils.ts
+++ b/client/src/components/Chat/Menus/Endpoints/utils.ts
@@ -119,6 +119,21 @@ export function filterModels(
   });
 }
 
+/**
+ * Collects the underlying model ids referenced by a set of grouped model specs,
+ * so the raw endpoint models they represent can be hidden from the picker — a
+ * model surfaced as a friendly spec card should not also appear as a raw row.
+ */
+export function getSpecModelIds(specs: TModelSpec[]): Set<string> {
+  const modelIds = new Set<string>();
+  for (const spec of specs) {
+    if (spec.preset.model) {
+      modelIds.add(spec.preset.model);
+    }
+  }
+  return modelIds;
+}
+
 export function getSelectedIcon({
   mappedEndpoints,
   selectedValues,


### PR DESCRIPTION
## Summary

A `modelSpecs` entry that uses the **`group`** field (added in #9996) to nest under an endpoint is shown **twice** in the model picker:

1. once as the curated spec card (the friendly label), and
2. again as the **raw model id** under that same endpoint's dropdown.

`client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx` renders the grouped specs (`modelSpecs.filter(s => s.group === endpoint.value)`) **and** the full `endpoint.models` with no de-duplication. `SearchResults.tsx` has the same gap.

The only existing way to suppress the raw models is `modelSpecs.enforce: true`, but that's not usable when **agents** are in play: an agent request carries no `spec`, and `buildEndpointOption` rejects requests without one ("No model spec selected"). So today there is no *additive* way to get friendly grouped names without also showing the duplicate raw row.

## Change

Hide a raw endpoint model when a grouped spec already represents it:

- A small shared helper `getSpecModelIds(specs)` (in `Endpoints/utils.ts`) collects the `preset.model` ids of an endpoint's grouped specs into a `Set`.
- `EndpointItem` computes `visibleModels` = `endpoint.models` minus those ids, and uses it on both the search and non-search render paths.
- `SearchResults` applies the same per-endpoint exclusion.

It's intentionally minimal and additive — a raw row is removed **only** when a shown spec card already covers it (matching `preset.model`). Endpoints with no matching grouped spec are completely untouched, so `enforce` is not required and agent flows keep working. This closes the duplication gap in the existing `group` feature rather than adding new config.

## Before / after

With a grouped spec like:

```yaml
modelSpecs:
  enforce: false
  list:
    - name: gpt-4o-spec
      label: "GPT-4o"
      group: openAI
      preset:
        endpoint: openAI
        model: gpt-4o
```

- **Before:** the openAI dropdown shows a **"GPT-4o"** card *and* a raw **`gpt-4o`** row.
- **After:** just the **"GPT-4o"** card; the raw `gpt-4o` row is hidden (other openAI models without a spec are unaffected).

## Tests

- `Endpoints/utils.test.ts` — `getSpecModelIds` returns referenced model ids, ignores presets with no model, handles the empty case.
- `SearchResults.test.tsx` — a raw model covered by a grouped spec is hidden; raw models with no covering spec remain.

(Neutral example ids — `gpt-4o`, `claude-*` — used throughout.)

## Related

Addresses the duplication side of the friendly-name/grouping requests: #8098, #8109, #8444, #6051 — and completes the `group` feature from #9996.