### PR TITLE
🧪 ci: Resolve DataTable test infinite re-render

### DIFF
--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -122,6 +122,44 @@ jobs:
         run: npm run typecheck
         working-directory: client
 
+  test-packages-client:
+    name: 'Tests: @librechat/client'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24.16.0
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.16.0'
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            client/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+          key: node-modules-frontend-${{ runner.os }}-24.16.0-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Download data-provider build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Run unit tests
+        run: npm run test:ci
+        working-directory: packages/client
+
   test-ubuntu:
     name: 'Tests: Ubuntu (shard ${{ matrix.shard }}/4)'
     needs: build

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,9 @@
     "build:dev": "npm run clean && NODE_ENV=development tsdown",
     "b:build": "bun run b:clean && bun run tsdown",
     "build:watch": "tsdown --watch",
-    "dev": "tsdown --watch"
+    "dev": "tsdown --watch",
+    "test": "jest",
+    "test:ci": "jest --ci"
   },
   "peerDependencies": {
     "@ariakit/react": "^0.4.29",

--- a/packages/client/src/components/DataTable/DataTable.spec.tsx
+++ b/packages/client/src/components/DataTable/DataTable.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Provider as JotaiProvider } from 'jotai';
-import DataTable from './DataTable';
-import type { TableColumn } from './DataTable.types';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { SortingState } from '@tanstack/react-table';
+import type { TableColumn } from './DataTable.types';
+import DataTable from './DataTable';
 
 // Mock utilities
 jest.mock('~/utils', () => ({
@@ -28,6 +28,35 @@ jest.mock('~/hooks', () => ({
     return key;
   },
   useMediaQuery: jest.fn(() => false),
+}));
+
+// jsdom can't measure layout, so @tanstack/react-virtual's measurement-driven re-render loop
+// never converges (infinite "Too many re-renders"). Stub it to render every row deterministically.
+jest.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({
+    count,
+    estimateSize,
+  }: {
+    count: number;
+    estimateSize?: (index: number) => number;
+  }) => {
+    const size = estimateSize ? estimateSize(0) : 56;
+    return {
+      getVirtualItems: () =>
+        Array.from({ length: count }, (_, index) => ({
+          index,
+          key: index,
+          start: index * size,
+          end: (index + 1) * size,
+          size,
+          lane: 0,
+        })),
+      getTotalSize: () => count * size,
+      calculateRange: () => {},
+      measureElement: () => {},
+      scrollToIndex: () => {},
+    };
+  },
 }));
 
 // Mock svgs

--- a/packages/client/src/components/DataTable/DataTable.tsx
+++ b/packages/client/src/components/DataTable/DataTable.tsx
@@ -271,8 +271,10 @@ function DataTable<TData extends Record<string, unknown>, TValue>({
     overscan: dynamicOverscan,
   });
 
-  const virtualRows = rowVirtualizer.getVirtualItems();
-  const totalSize = rowVirtualizer.getTotalSize();
+  // Only read the virtualizer when active; the non-virtualized branch renders rows directly,
+  // so engaging it for small tables is wasted render-phase work.
+  const virtualRows = virtualizationActive ? rowVirtualizer.getVirtualItems() : [];
+  const totalSize = virtualizationActive ? rowVirtualizer.getTotalSize() : 0;
   const paddingTop = virtualRows[0]?.start ?? 0;
   const paddingBottom =
     virtualRows.length > 0 ? totalSize - (virtualRows[virtualRows.length - 1]?.end ?? 0) : 0;


### PR DESCRIPTION
## Summary

`packages/client/src/components/DataTable/DataTable.spec.tsx` was failing with `Too many re-renders. React limits the number of renders to prevent an infinite loop.` — **35 of its tests**. This is pre-existing on `dev`.

**Root cause:** `@tanstack/react-virtual` is measurement-driven, and jsdom has no real layout (element sizes are 0, the mocked `ResizeObserver` never fires). Its measurement → re-render loop therefore never converges in the test environment. This is a jsdom limitation, not a production bug — the component renders fine in a real browser.

**Why it went unnoticed:** `packages/client` had **no jest CI job**. Only the `client` workspace runs jest in `frontend-review.yml`, so these specs never ran in CI.

## Changes

- **`DataTable.tsx`** — only read the virtualizer (`getVirtualItems()` / `getTotalSize()`) when virtualization is active. The non-virtualized branch renders rows directly, so engaging the virtualizer for small tables was wasted render-phase work. This alone fixes 33/35 tests.
- **`DataTable.spec.tsx`** — mock `@tanstack/react-virtual`, since jsdom can't exercise real virtualization layout (covers the 2 active-virtualization tests). The stub renders every row deterministically.
- **`@librechat/client`** — add `test` / `test:ci` scripts and a `Tests: @librechat/client` CI job in `frontend-review.yml`, so `packages/client` specs run on every frontend PR and this can't silently regress again.

## Verification

- `DataTable.spec.tsx`: **35/35 pass**.
- Full `packages/client` suite: **10 suites / 143 tests pass** (no other pre-existing failures).
- `tsc --noEmit` on `packages/client`: clean.

## Notes

- No production behavior change: when virtualization is inactive the gated values were already unused (the non-virtualized branch renders `rows` directly); when active, the virtualizer is read exactly as before.
- The new CI job mirrors the existing `typecheck` job (restores the node_modules cache, downloads the `build-data-provider` artifact, runs `npm run test:ci` in `packages/client`).