### PR TITLE
🦥 feat: Server-Level deferLoading Default for MCP Servers

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -266,6 +266,7 @@ const getMCPTools = async (req, res) => {
           authenticated: true,
           authConfig: [],
           tools: [],
+          deferLoading: serverConfig?.deferLoading === true,
         };
 
         // Set authentication config once for the server

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -254,6 +254,7 @@ const getMCPTools = async (req, res) => {
           authenticated: true,
           authConfig: [],
           tools: [],
+          deferLoading: serverConfig?.deferLoading === true,
         };
 
         // Set authentication config once for the server

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -1172,6 +1172,7 @@ function createToolInstance({
   toolInstance.mcpRequiresEphemeralConnection = capturedServerConfig
     ? requiresEphemeralUserConnection(capturedServerConfig)
     : true;
+  toolInstance.mcpServerDeferLoading = capturedServerConfig?.deferLoading === true;
   // On Google/Vertex, propagate the union-flattened schema so definitions extracted
   // from this instance don't reach the Gemini converter with unsupported unions.
   toolInstance.mcpJsonSchema = isGoogle ? schema : parameters;

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -1400,6 +1400,7 @@ function createToolInstance({
   toolInstance.mcpRequiresEphemeralConnection = capturedServerConfig
     ? requiresEphemeralUserConnection(capturedServerConfig)
     : true;
+  toolInstance.mcpServerDeferLoading = capturedServerConfig?.deferLoading === true;
   // On Google/Vertex, propagate the union-flattened schema so definitions extracted
   // from this instance don't reach the Gemini converter with unsupported unions.
   toolInstance.mcpJsonSchema = isGoogle ? schema : parameters;

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -948,6 +948,22 @@ async function loadToolDefinitionsWrapper({
     return result?.availableTools || null;
   };
 
+  const getServerDeferLoading = async (userId, serverName) => {
+    try {
+      const serverConfig =
+        configServers?.[serverName] ??
+        (await getMCPServersRegistry().getServerConfig(serverName, userId, configServers));
+      return serverConfig?.deferLoading === true;
+    } catch (err) {
+      logger.warn(
+        `[Tool Definitions] MCP registry unavailable while resolving deferLoading for '${serverName}': ${
+          err?.message ?? err
+        }. Treating as not deferred.`,
+      );
+      return false;
+    }
+  };
+
   const getActionToolDefinitions = async (agentId, actionToolNames) => {
     const actionSets = (await loadActionSets({ agent_id: agentId })) ?? [];
     if (actionSets.length === 0) {
@@ -1026,6 +1042,7 @@ async function loadToolDefinitionsWrapper({
         isBuiltInTool,
         getOrFetchMCPServerTools,
         refreshMCPServerTools,
+        getServerDeferLoading,
         getActionToolDefinitions,
       },
     );
@@ -1114,6 +1131,7 @@ async function loadToolDefinitionsWrapper({
           isBuiltInTool,
           getOrFetchMCPServerTools,
           refreshMCPServerTools,
+          getServerDeferLoading,
           getActionToolDefinitions,
         },
       );

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1205,6 +1205,22 @@ async function loadToolDefinitionsWrapper({
     return result?.availableTools || null;
   };
 
+  const getServerDeferLoading = async (userId, serverName) => {
+    try {
+      const serverConfig =
+        configServers?.[serverName] ??
+        (await getMCPServersRegistry().getServerConfig(serverName, userId, configServers));
+      return serverConfig?.deferLoading === true;
+    } catch (err) {
+      logger.warn(
+        `[Tool Definitions] MCP registry unavailable while resolving deferLoading for '${serverName}': ${
+          err?.message ?? err
+        }. Treating as not deferred.`,
+      );
+      return false;
+    }
+  };
+
   const getActionToolDefinitions = async (agentId, actionToolNames) => {
     if (agentId !== agent.id || preparedActionSnapshot == null) {
       return [];
@@ -1297,6 +1313,7 @@ async function loadToolDefinitionsWrapper({
       isBuiltInTool,
       getOrFetchMCPServerTools,
       refreshMCPServerTools,
+      getServerDeferLoading,
       getActionToolDefinitions,
     },
   );
@@ -1387,6 +1404,7 @@ async function loadToolDefinitionsWrapper({
           isBuiltInTool,
           getOrFetchMCPServerTools,
           refreshMCPServerTools,
+          getServerDeferLoading,
           getActionToolDefinitions,
         },
       );

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -130,6 +130,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
           requestScoped: serverConfig?.requestScoped,
           metadata,
           consumeOnly: serverConfig?.consumeOnly,
+          deferLoading: serverData.deferLoading ?? serverConfig?.deferLoading,
         });
       }
     }
@@ -167,6 +168,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
         ),
         requestScoped: serverConfig?.requestScoped,
         consumeOnly: serverConfig?.consumeOnly,
+        deferLoading: serverConfig?.deferLoading,
       });
     }
 

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -102,6 +102,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
           requestScoped: serverConfig?.requestScoped,
           metadata,
           consumeOnly: serverConfig?.consumeOnly,
+          deferLoading: serverData.deferLoading ?? serverConfig?.deferLoading,
         });
       }
     }
@@ -133,6 +134,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
         isConnected: connectionStatus?.[mcpServerName]?.connectionState === 'connected',
         requestScoped: serverConfig?.requestScoped,
         consumeOnly: serverConfig?.consumeOnly,
+        deferLoading: serverConfig?.deferLoading,
       });
     }
 

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -214,6 +214,8 @@ export interface MCPServerInfo {
   /** True when tools can only be discovered with live chat request fields. */
   requestScoped?: boolean;
   consumeOnly?: boolean;
+  /** Server-level default: when true, this server's tools defer by default */
+  deferLoading?: boolean;
   metadata: t.TPlugin;
 }
 

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -196,6 +196,8 @@ export interface MCPServerInfo {
   /** True when tools can only be discovered with live chat request fields. */
   requestScoped?: boolean;
   consumeOnly?: boolean;
+  /** Server-level default: when true, this server's tools defer by default */
+  deferLoading?: boolean;
   metadata: t.TPlugin;
 }
 

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -116,6 +116,7 @@ export default function McpSection({ item }: Props) {
   const liveServer = mcpServersMap.get(serverName) ?? item.server;
   const tools = useMemo(() => liveServer.tools ?? [], [liveServer.tools]);
   const hasTools = tools.length > 0;
+  const serverDefaultDefer = liveServer.deferLoading ?? false;
 
   /** Subscribe to the tools field so selection toggles re-render this section.
    * `getValues` is a non-reactive read and left the checkboxes visually stale. */
@@ -272,7 +273,7 @@ export default function McpSection({ item }: Props) {
 
   const selectedTools = getSelectedTools();
   const allSelected = hasTools && selectedTools.length === tools.length;
-  const allDeferred = areAllToolsDeferred(tools);
+  const allDeferred = areAllToolsDeferred(tools, serverDefaultDefer);
   const allProgrammatic = areAllToolsProgrammatic(tools);
   const allBackground = areAllToolsBackground(tools);
   /** Programmatic-only tools can never carry an intent label (the backend's
@@ -442,7 +443,7 @@ export default function McpSection({ item }: Props) {
                   pressed={allDeferred}
                   label={localize(allDeferred ? 'com_ui_mcp_undefer_all' : 'com_ui_mcp_defer_all')}
                   activeClass="text-amber-600 dark:text-amber-500"
-                  onToggle={() => toggleDeferAll(tools)}
+                  onToggle={() => toggleDeferAll(tools, serverDefaultDefer)}
                 />
               )}
               {hasTools && programmaticToolsEnabled && (
@@ -522,7 +523,9 @@ export default function McpSection({ item }: Props) {
                   key={tool.tool_id}
                   tool={tool}
                   isSelected={selectedTools.includes(tool.tool_id)}
-                  isDeferred={deferredToolsEnabled && isToolDeferred(tool.tool_id)}
+                  isDeferred={
+                    deferredToolsEnabled && isToolDeferred(tool.tool_id, serverDefaultDefer)
+                  }
                   isProgrammatic={programmaticToolsEnabled && isToolProgrammatic(tool.tool_id)}
                   isBackground={backgroundToolsEnabled && isToolBackground(tool.tool_id)}
                   isIntent={
@@ -536,7 +539,7 @@ export default function McpSection({ item }: Props) {
                   backgroundToolsEnabled={backgroundToolsEnabled}
                   toolIntentsEnabled={toolIntentsEnabled}
                   onToggleSelect={() => toggleToolSelect(tool.tool_id)}
-                  onToggleDefer={() => toggleToolDefer(tool.tool_id)}
+                  onToggleDefer={() => toggleToolDefer(tool.tool_id, serverDefaultDefer)}
                   onToggleProgrammatic={() => toggleToolProgrammatic(tool.tool_id)}
                   onToggleBackground={() => toggleToolBackground(tool.tool_id)}
                   onToggleIntent={() => toggleToolIntent(tool.tool_id)}

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -118,6 +118,7 @@ export default function McpSection({ item }: Props) {
   const liveServer = mcpServersMap.get(serverName) ?? item.server;
   const tools = useMemo(() => liveServer.tools ?? [], [liveServer.tools]);
   const hasTools = tools.length > 0;
+  const serverDefaultDefer = liveServer.deferLoading ?? false;
 
   /** Subscribe to the tools field so selection toggles re-render this section.
    * `getValues` is a non-reactive read and left the checkboxes visually stale. */
@@ -312,7 +313,7 @@ export default function McpSection({ item }: Props) {
 
   const selectedTools = getSelectedTools();
   const allSelected = hasTools && selectedTools.length === tools.length;
-  const allDeferred = areAllToolsDeferred(tools);
+  const allDeferred = areAllToolsDeferred(tools, serverDefaultDefer);
   const allProgrammatic = areAllToolsProgrammatic(tools);
   const programmaticBulkLabel = localize(
     allProgrammatic ? 'com_ui_mcp_unprogrammatic_all' : 'com_ui_mcp_programmatic_all',
@@ -495,7 +496,7 @@ export default function McpSection({ item }: Props) {
                   pressed={allDeferred}
                   label={localize(allDeferred ? 'com_ui_mcp_undefer_all' : 'com_ui_mcp_defer_all')}
                   activeBorderClass="border-series-4"
-                  onToggle={() => toggleDeferAll(tools)}
+                  onToggle={() => toggleDeferAll(tools, serverDefaultDefer)}
                 />
               )}
               {hasTools && programmaticToolsEnabled && (
@@ -573,7 +574,9 @@ export default function McpSection({ item }: Props) {
                   key={tool.tool_id}
                   tool={tool}
                   isSelected={selectedTools.includes(tool.tool_id)}
-                  isDeferred={deferredToolsEnabled && isToolDeferred(tool.tool_id)}
+                  isDeferred={
+                    deferredToolsEnabled && isToolDeferred(tool.tool_id, serverDefaultDefer)
+                  }
                   isProgrammatic={programmaticToolsEnabled && isToolProgrammatic(tool.tool_id)}
                   isBackground={backgroundToolsEnabled && isToolBackground(tool.tool_id)}
                   isIntent={
@@ -588,7 +591,7 @@ export default function McpSection({ item }: Props) {
                   backgroundToolsEnabled={backgroundToolsEnabled}
                   toolIntentsEnabled={toolIntentsEnabled}
                   onToggleSelect={() => toggleToolSelect(tool.tool_id)}
-                  onToggleDefer={() => toggleToolDefer(tool.tool_id)}
+                  onToggleDefer={() => toggleToolDefer(tool.tool_id, serverDefaultDefer)}
                   onToggleProgrammatic={() => toggleToolProgrammatic(tool.tool_id)}
                   onToggleBackground={() => toggleToolBackground(tool.tool_id)}
                   onToggleIntent={() => toggleToolIntent(tool.tool_id)}

--- a/client/src/hooks/Agents/__tests__/useMCPToolOptions.spec.ts
+++ b/client/src/hooks/Agents/__tests__/useMCPToolOptions.spec.ts
@@ -704,6 +704,128 @@ describe('useMCPToolOptions', () => {
     });
   });
 
+  describe('server-level deferLoading (three-state)', () => {
+    it('isToolDeferred inherits the server default when there is no explicit option', () => {
+      (useWatch as jest.Mock).mockReturnValue({});
+
+      const { result } = renderHook(() => useMCPToolOptions());
+
+      expect(result.current.isToolDeferred('tool1', true)).toBe(true);
+      expect(result.current.isToolDeferred('tool1', false)).toBe(false);
+    });
+
+    it('isToolDeferred lets an explicit false override an inherited true', () => {
+      (useWatch as jest.Mock).mockReturnValue({
+        tool1: { defer_loading: false },
+      });
+
+      const { result } = renderHook(() => useMCPToolOptions());
+
+      expect(result.current.isToolDeferred('tool1', true)).toBe(false);
+    });
+
+    it('isToolDeferred lets an explicit true override an inherited false', () => {
+      (useWatch as jest.Mock).mockReturnValue({
+        tool1: { defer_loading: true },
+      });
+
+      const { result } = renderHook(() => useMCPToolOptions());
+
+      expect(result.current.isToolDeferred('tool1', false)).toBe(true);
+    });
+
+    it('toggleToolDefer writes an explicit false when turning off an inherited-true tool', () => {
+      mockGetValues.mockReturnValue({});
+
+      const { result } = renderHook(() => useMCPToolOptions());
+
+      act(() => {
+        result.current.toggleToolDefer('tool1', true);
+      });
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'tool_options',
+        { tool1: { defer_loading: false } },
+        { shouldDirty: true },
+      );
+    });
+
+    it('toggleToolDefer deletes the explicit key when toggling back to match the server default', () => {
+      mockGetValues.mockReturnValue({
+        tool1: { defer_loading: false },
+      });
+
+      const { result } = renderHook(() => useMCPToolOptions());
+
+      act(() => {
+        result.current.toggleToolDefer('tool1', true);
+      });
+
+      expect(mockSetValue).toHaveBeenCalledWith('tool_options', {}, { shouldDirty: true });
+    });
+
+    it('areAllToolsDeferred honors inheritance from the server default', () => {
+      (useWatch as jest.Mock).mockReturnValue({
+        tool1: { defer_loading: false },
+      });
+
+      const { result } = renderHook(() => useMCPToolOptions());
+      const tools = [createMockTool('tool1'), createMockTool('tool2')];
+
+      expect(result.current.areAllToolsDeferred(tools, true)).toBe(false);
+    });
+
+    it('areAllToolsDeferred returns true when every tool inherits a true server default', () => {
+      (useWatch as jest.Mock).mockReturnValue({});
+
+      const { result } = renderHook(() => useMCPToolOptions());
+      const tools = [createMockTool('tool1'), createMockTool('tool2')];
+
+      expect(result.current.areAllToolsDeferred(tools, true)).toBe(true);
+    });
+
+    it('toggleDeferAll collapses to explicit false then back to the server default', () => {
+      (useWatch as jest.Mock).mockReturnValue({});
+      mockGetValues.mockReturnValue({});
+
+      const { result } = renderHook(() => useMCPToolOptions());
+      const tools = [createMockTool('tool1'), createMockTool('tool2')];
+
+      act(() => {
+        result.current.toggleDeferAll(tools, true);
+      });
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'tool_options',
+        {
+          tool1: { defer_loading: false },
+          tool2: { defer_loading: false },
+        },
+        { shouldDirty: true },
+      );
+    });
+
+    it('toggleDeferAll deletes explicit keys when bringing tools back to a true server default', () => {
+      (useWatch as jest.Mock).mockReturnValue({
+        tool1: { defer_loading: false },
+        tool2: { defer_loading: false },
+      });
+      mockGetValues.mockReturnValue({
+        tool1: { defer_loading: false },
+        tool2: { defer_loading: false },
+      });
+
+      const { result } = renderHook(() => useMCPToolOptions());
+      const tools = [createMockTool('tool1'), createMockTool('tool2')];
+
+      act(() => {
+        result.current.toggleDeferAll(tools, true);
+      });
+
+      expect(mockSetValue).toHaveBeenCalledWith('tool_options', {}, { shouldDirty: true });
+    });
+  });
+
   describe('formToolOptions', () => {
     it('should return undefined when useWatch returns undefined', () => {
       (useWatch as jest.Mock).mockReturnValue(undefined);

--- a/client/src/hooks/Agents/useMCPToolOptions.ts
+++ b/client/src/hooks/Agents/useMCPToolOptions.ts
@@ -7,10 +7,10 @@ import type { AgentForm } from '~/common';
 type BooleanToolOptionKey = 'defer_loading' | 'run_in_background' | 'describe_intent';
 
 interface BooleanOptionHandlers {
-  isSet: (toolId: string) => boolean;
-  toggle: (toolId: string) => void;
-  areAllSet: (tools: AgentToolType[]) => boolean;
-  toggleAll: (tools: AgentToolType[]) => void;
+  isSet: (toolId: string, serverDefault?: boolean) => boolean;
+  toggle: (toolId: string, serverDefault?: boolean) => void;
+  areAllSet: (tools: AgentToolType[], serverDefault?: boolean) => boolean;
+  toggleAll: (tools: AgentToolType[], serverDefault?: boolean) => void;
 }
 
 interface ToolOptionsFormContext {
@@ -21,20 +21,20 @@ interface ToolOptionsFormContext {
 
 interface UseMCPToolOptionsReturn {
   formToolOptions: AgentToolOptions | undefined;
-  isToolDeferred: (toolId: string) => boolean;
+  isToolDeferred: (toolId: string, serverDefault?: boolean) => boolean;
   isToolProgrammatic: (toolId: string) => boolean;
   isToolBackground: (toolId: string) => boolean;
   isToolIntent: (toolId: string) => boolean;
   isToolProgrammaticOnly: (toolId: string) => boolean;
-  toggleToolDefer: (toolId: string) => void;
+  toggleToolDefer: (toolId: string, serverDefault?: boolean) => void;
   toggleToolProgrammatic: (toolId: string) => void;
   toggleToolBackground: (toolId: string) => void;
   toggleToolIntent: (toolId: string) => void;
-  areAllToolsDeferred: (tools: AgentToolType[]) => boolean;
+  areAllToolsDeferred: (tools: AgentToolType[], serverDefault?: boolean) => boolean;
   areAllToolsProgrammatic: (tools: AgentToolType[]) => boolean;
   areAllToolsBackground: (tools: AgentToolType[]) => boolean;
   areAllToolsIntent: (tools: AgentToolType[]) => boolean;
-  toggleDeferAll: (tools: AgentToolType[]) => void;
+  toggleDeferAll: (tools: AgentToolType[], serverDefault?: boolean) => void;
   toggleProgrammaticAll: (tools: AgentToolType[]) => void;
   toggleBackgroundAll: (tools: AgentToolType[]) => void;
   toggleIntentAll: (tools: AgentToolType[]) => void;
@@ -43,18 +43,22 @@ interface UseMCPToolOptionsReturn {
 /**
  * Sets or clears a boolean flag on one tool's options without mutating the
  * previous objects (react-hook-form still holds them); dropping the last flag
- * removes the tool's entry entirely.
+ * removes the tool's entry entirely. A value matching `serverDefault` is
+ * expressed by clearing the explicit flag (inherit); a value differing from it
+ * is written explicitly — so with a server-level `true` default, opting out
+ * stores an explicit `false`.
  */
 export function withBooleanOption(
   options: AgentToolOptions,
   toolId: string,
   key: BooleanToolOptionKey,
   set: boolean,
+  serverDefault = false,
 ): AgentToolOptions {
   const updatedOptions: AgentToolOptions = { ...options };
   const currentToolOptions = updatedOptions[toolId];
-  if (set) {
-    updatedOptions[toolId] = { ...currentToolOptions, [key]: true };
+  if (set !== serverDefault) {
+    updatedOptions[toolId] = { ...currentToolOptions, [key]: set };
     return updatedOptions;
   }
   if (!currentToolOptions) {
@@ -99,21 +103,27 @@ export function withNativeBooleanOptOut(
   return updatedOptions;
 }
 
-/** Read/toggle handlers for one boolean per-tool option key (single + bulk). */
+/**
+ * Read/toggle handlers for one boolean per-tool option key (single + bulk).
+ * `serverDefault` is the value inherited when no explicit flag is stored
+ * (e.g. a server-level `deferLoading` config default); an explicit flag
+ * always wins over it.
+ */
 function useBooleanToolOption(
   key: BooleanToolOptionKey,
   { formToolOptions, getValues, setValue }: ToolOptionsFormContext,
 ): BooleanOptionHandlers {
   const isSet = useCallback(
-    (toolId: string): boolean => formToolOptions?.[toolId]?.[key] === true,
+    (toolId: string, serverDefault = false): boolean =>
+      formToolOptions?.[toolId]?.[key] ?? serverDefault,
     [formToolOptions, key],
   );
 
   const toggle = useCallback(
-    (toolId: string) => {
+    (toolId: string, serverDefault = false) => {
       const currentOptions = getValues('tool_options') || {};
-      const set = currentOptions[toolId]?.[key] !== true;
-      setValue('tool_options', withBooleanOption(currentOptions, toolId, key, set), {
+      const set = !(currentOptions[toolId]?.[key] ?? serverDefault);
+      setValue('tool_options', withBooleanOption(currentOptions, toolId, key, set, serverDefault), {
         shouldDirty: true,
       });
     },
@@ -121,20 +131,21 @@ function useBooleanToolOption(
   );
 
   const areAllSet = useCallback(
-    (tools: AgentToolType[]): boolean =>
-      tools.length > 0 && tools.every((tool) => formToolOptions?.[tool.tool_id]?.[key] === true),
+    (tools: AgentToolType[], serverDefault = false): boolean =>
+      tools.length > 0 &&
+      tools.every((tool) => (formToolOptions?.[tool.tool_id]?.[key] ?? serverDefault) === true),
     [formToolOptions, key],
   );
 
   const toggleAll = useCallback(
-    (tools: AgentToolType[]) => {
+    (tools: AgentToolType[], serverDefault = false) => {
       if (tools.length === 0) {
         return;
       }
-      const set = !areAllSet(tools);
+      const set = !areAllSet(tools, serverDefault);
       let updatedOptions = getValues('tool_options') || {};
       for (const tool of tools) {
-        updatedOptions = withBooleanOption(updatedOptions, tool.tool_id, key, set);
+        updatedOptions = withBooleanOption(updatedOptions, tool.tool_id, key, set, serverDefault);
       }
       setValue('tool_options', updatedOptions, { shouldDirty: true });
     },

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -403,6 +403,10 @@ actions:
 #     url: http://localhost:3001/sse
 #     # proxy: "${MCP_PROXY_URL}"  # optional outbound proxy (http/https/socks/socks5)
 #     timeout: 60000  # 1 minute timeout for this server, this is the default timeout for MCP servers.
+#     # deferLoading: true  # Defer every tool from this server by default: the model receives the
+#     #                     # `tool_search` tool plus a name-only listing instead of each tool's full
+#     #                     # schema. Saves context on large tool sets. A per-agent tool toggle overrides
+#     #                     # this. Requires the `deferred_tools` agent capability to be enabled.
 #   puppeteer:
 #     type: stdio
 #     command: npx

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -474,6 +474,10 @@ actions:
 #     url: http://localhost:3001/sse
 #     # proxy: "${MCP_PROXY_URL}"  # optional outbound proxy (http/https/socks/socks5)
 #     timeout: 60000  # 1 minute timeout for this server, this is the default timeout for MCP servers.
+#     # deferLoading: true  # Defer every tool from this server by default: the model receives the
+#     #                     # `tool_search` tool plus a name-only listing instead of each tool's full
+#     #                     # schema. Saves context on large tool sets. A per-agent tool toggle overrides
+#     #                     # this. Requires the `deferred_tools` agent capability to be enabled.
 #   private-openid:
 #     type: streamable-http
 #     url: https://mcp.example.com/mcp

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -384,6 +384,7 @@ describe('redactServerSecrets', () => {
       updatedAt: 1700000000000,
       consumeOnly: false,
       inspectionFailed: false,
+      deferLoading: true,
       customUserVars: { API_KEY: { title: 'API Key', description: 'Your key' } },
     };
     const redacted = redactServerSecrets(config);
@@ -398,6 +399,7 @@ describe('redactServerSecrets', () => {
     expect(redacted.updatedAt).toBe(1700000000000);
     expect(redacted.consumeOnly).toBe(false);
     expect(redacted.inspectionFailed).toBe(false);
+    expect(redacted.deferLoading).toBe(true);
     expect(redacted.customUserVars).toEqual(config.customUserVars);
   });
 

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -387,6 +387,7 @@ describe('redactServerSecrets', () => {
       updatedAt: 1700000000000,
       consumeOnly: false,
       inspectionFailed: false,
+      deferLoading: true,
       customUserVars: { API_KEY: { title: 'API Key', description: 'Your key' } },
     };
     const redacted = redactServerSecrets(config);
@@ -401,6 +402,7 @@ describe('redactServerSecrets', () => {
     expect(redacted.updatedAt).toBe(1700000000000);
     expect(redacted.consumeOnly).toBe(false);
     expect(redacted.inspectionFailed).toBe(false);
+    expect(redacted.deferLoading).toBe(true);
     expect(redacted.customUserVars).toEqual(config.customUserVars);
   });
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -114,6 +114,7 @@ const ADMIN_CONFIGURABLE_FIELDS = [
   'startup',
   'chatMenu',
   'serverInstructions',
+  'deferLoading',
   'customUserVars',
   'timeout',
   'sseReadTimeout',

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -85,6 +85,7 @@ const ADMIN_CONFIGURABLE_FIELDS = [
   'startup',
   'chatMenu',
   'serverInstructions',
+  'deferLoading',
   'customUserVars',
   'timeout',
   'sseReadTimeout',

--- a/packages/api/src/mcp/registry/__tests__/ensureConfigServers.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/ensureConfigServers.test.ts
@@ -153,6 +153,22 @@ describe('MCPServersRegistry — ensureConfigServers', () => {
     expect(inspectSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('should lazy-init YAML server when admin overrides only the deferLoading field', async () => {
+    await registry.addServer('yaml_remote', sseConfig, 'CACHE');
+    inspectSpy.mockClear();
+
+    const overrideConfig: t.MCPOptions = {
+      ...sseConfig,
+      deferLoading: true,
+    } as t.MCPOptions;
+    const result = await registry.ensureConfigServers({
+      yaml_remote: overrideConfig,
+    });
+
+    expect(result).toHaveProperty('yaml_remote');
+    expect(inspectSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should not re-init YAML server when only the difference is an inspector-derived field absent from rawConfig', async () => {
     const yamlWithInferred: t.MCPOptions = {
       ...sseConfig,

--- a/packages/api/src/mcp/registry/__tests__/ensureConfigServers.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/ensureConfigServers.test.ts
@@ -170,6 +170,22 @@ describe('MCPServersRegistry — ensureConfigServers', () => {
     expect(inspectSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('should lazy-init YAML server when admin overrides only the deferLoading field', async () => {
+    await registry.addServer('yaml_remote', sseConfig, 'CACHE');
+    inspectSpy.mockClear();
+
+    const overrideConfig: t.MCPOptions = {
+      ...sseConfig,
+      deferLoading: true,
+    } as t.MCPOptions;
+    const result = await registry.ensureConfigServers({
+      yaml_remote: overrideConfig,
+    });
+
+    expect(result).toHaveProperty('yaml_remote');
+    expect(inspectSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should not re-init YAML server when only the difference is an inspector-derived field absent from rawConfig', async () => {
     const yamlWithInferred: t.MCPOptions = {
       ...sseConfig,

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -494,6 +494,9 @@ export function redactServerSecrets(
     inspectionFailed: config.inspectionFailed,
     customUserVars: config.customUserVars,
     serverInstructions: config.serverInstructions,
+    /** Operator-set context-saving default; the agent panel renders it as the
+     *  inherited state of each tool's defer checkbox. */
+    deferLoading: config.deferLoading,
     /** Safe derived metadata: it exposes no placeholder-bearing value, but lets
      *  clients attach tools that can only be discovered during a chat turn. */
     requestScoped: requiresEphemeralUserConnection(config) || undefined,

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -624,6 +624,9 @@ export function redactServerSecrets(
     inspectionFailed: config.inspectionFailed,
     customUserVars: config.customUserVars,
     serverInstructions: config.serverInstructions,
+    /** Operator-set context-saving default; the agent panel renders it as the
+     *  inherited state of each tool's defer checkbox. */
+    deferLoading: config.deferLoading,
     /** Safe derived metadata: it exposes no placeholder-bearing value, but lets
      *  clients attach tools that can only be discovered during a chat turn. */
     requestScoped: requiresEphemeralUserConnection(config) || undefined,

--- a/packages/api/src/tools/classification.spec.ts
+++ b/packages/api/src/tools/classification.spec.ts
@@ -3,6 +3,7 @@ import type { AgentToolOptions } from 'librechat-data-provider';
 import type { GenericTool } from '@librechat/agents';
 import type { LCToolRegistry } from './classification';
 import {
+  extractMCPToolDefinition,
   buildToolRegistryFromAgentOptions,
   agentHasProgrammaticTools,
   buildToolClassification,
@@ -506,6 +507,147 @@ describe('classification.ts', () => {
       });
 
       expect(result.additionalTools.some((t) => t.name === 'tool_search')).toBe(true);
+    });
+  });
+
+  describe('server-level deferLoading', () => {
+    const TOOL_A = 'list_files_mcp_serverX';
+    const TOOL_B = 'read_file_mcp_serverY';
+
+    const createMCPTool = (name: string, serverDeferLoading?: boolean) =>
+      ({
+        name,
+        mcp: true,
+        mcpJsonSchema: { type: 'object', properties: {} },
+        ...(serverDeferLoading ? { mcpServerDeferLoading: true } : {}),
+      }) as unknown as GenericTool;
+
+    describe('extractMCPToolDefinition', () => {
+      it('case 9: carries the mcpServerDeferLoading stamp onto the definition', () => {
+        const def = extractMCPToolDefinition({ name: TOOL_A, mcpServerDeferLoading: true });
+        expect(def.serverDeferLoading).toBe(true);
+        expect(def.serverName).toBe('serverX');
+      });
+
+      it('case 9: omits serverDeferLoading when the tool is not stamped', () => {
+        const def = extractMCPToolDefinition({ name: TOOL_A });
+        expect(def.serverDeferLoading).toBeUndefined();
+      });
+    });
+
+    describe('buildToolRegistryFromAgentOptions (saved-agent path)', () => {
+      it('case 1: server default applies when there is no per-tool option', () => {
+        const tools = [{ name: TOOL_A, description: 'A', serverDeferLoading: true }];
+        const registry = buildToolRegistryFromAgentOptions(tools, {});
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(agentHasDeferredTools(registry)).toBe(true);
+      });
+
+      it('case 3: explicit per-agent false overrides server true', () => {
+        const tools = [{ name: TOOL_A, serverDeferLoading: true }];
+        const agentToolOptions: AgentToolOptions = { [TOOL_A]: { defer_loading: false } };
+        const registry = buildToolRegistryFromAgentOptions(tools, agentToolOptions);
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(false);
+      });
+
+      it('case 4: explicit per-agent true with no server default', () => {
+        const tools = [{ name: TOOL_A }];
+        const agentToolOptions: AgentToolOptions = { [TOOL_A]: { defer_loading: true } };
+        const registry = buildToolRegistryFromAgentOptions(tools, agentToolOptions);
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(true);
+      });
+
+      it('case 5: no server default and no per-agent option resolves to false', () => {
+        const tools = [{ name: TOOL_A }];
+        const registry = buildToolRegistryFromAgentOptions(tools, {});
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(false);
+      });
+
+      it('case 6: mixed servers - only the stamped tool defers', () => {
+        const tools = [{ name: TOOL_A, serverDeferLoading: true }, { name: TOOL_B }];
+        const registry = buildToolRegistryFromAgentOptions(tools, {});
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(registry.get(TOOL_B)?.defer_loading).toBe(false);
+      });
+    });
+
+    describe('buildToolClassification (ephemeral / event-driven path)', () => {
+      it('case 2 (headline): server default defers via the fallback branch when agentToolOptions is undefined', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(result.hasDeferredTools).toBe(true);
+      });
+
+      it('case 8: tool_search is injected when only a server default is present', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.additionalTools.some((t) => t.name === 'tool_search')).toBe(true);
+      });
+
+      it('case 6: mixed servers - only the stamped tool defers', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true), createMCPTool(TOOL_B)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(result.toolRegistry?.get(TOOL_B)?.defer_loading).toBe(false);
+      });
+
+      it('case 7: capability off clears the server-defaulted defer and skips tool_search', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: false,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(false);
+        expect(result.hasDeferredTools).toBe(false);
+        expect(result.additionalTools.some((t) => t.name === 'tool_search')).toBe(false);
+      });
+
+      it('case 3: explicit per-agent false overrides the server default stamp', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+        const agentToolOptions: AgentToolOptions = { [TOOL_A]: { defer_loading: false } };
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          agentToolOptions,
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(false);
+        expect(result.hasDeferredTools).toBe(false);
+      });
     });
   });
 });

--- a/packages/api/src/tools/classification.spec.ts
+++ b/packages/api/src/tools/classification.spec.ts
@@ -3,6 +3,7 @@ import type { AgentToolOptions } from 'librechat-data-provider';
 import type { GenericTool } from '@librechat/agents';
 import type { LCToolRegistry } from './classification';
 import {
+  extractMCPToolDefinition,
   buildToolRegistryFromAgentOptions,
   aliasMCPToolOptions,
   agentHasProgrammaticTools,
@@ -613,6 +614,147 @@ describe('classification.ts', () => {
       });
 
       expect(result.additionalTools.some((t) => t.name === 'tool_search')).toBe(true);
+    });
+  });
+
+  describe('server-level deferLoading', () => {
+    const TOOL_A = 'list_files_mcp_serverX';
+    const TOOL_B = 'read_file_mcp_serverY';
+
+    const createMCPTool = (name: string, serverDeferLoading?: boolean) =>
+      ({
+        name,
+        mcp: true,
+        mcpJsonSchema: { type: 'object', properties: {} },
+        ...(serverDeferLoading ? { mcpServerDeferLoading: true } : {}),
+      }) as unknown as GenericTool;
+
+    describe('extractMCPToolDefinition', () => {
+      it('case 9: carries the mcpServerDeferLoading stamp onto the definition', () => {
+        const def = extractMCPToolDefinition({ name: TOOL_A, mcpServerDeferLoading: true });
+        expect(def.serverDeferLoading).toBe(true);
+        expect(def.serverName).toBe('serverX');
+      });
+
+      it('case 9: omits serverDeferLoading when the tool is not stamped', () => {
+        const def = extractMCPToolDefinition({ name: TOOL_A });
+        expect(def.serverDeferLoading).toBeUndefined();
+      });
+    });
+
+    describe('buildToolRegistryFromAgentOptions (saved-agent path)', () => {
+      it('case 1: server default applies when there is no per-tool option', () => {
+        const tools = [{ name: TOOL_A, description: 'A', serverDeferLoading: true }];
+        const registry = buildToolRegistryFromAgentOptions(tools, {});
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(agentHasDeferredTools(registry)).toBe(true);
+      });
+
+      it('case 3: explicit per-agent false overrides server true', () => {
+        const tools = [{ name: TOOL_A, serverDeferLoading: true }];
+        const agentToolOptions: AgentToolOptions = { [TOOL_A]: { defer_loading: false } };
+        const registry = buildToolRegistryFromAgentOptions(tools, agentToolOptions);
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(false);
+      });
+
+      it('case 4: explicit per-agent true with no server default', () => {
+        const tools = [{ name: TOOL_A }];
+        const agentToolOptions: AgentToolOptions = { [TOOL_A]: { defer_loading: true } };
+        const registry = buildToolRegistryFromAgentOptions(tools, agentToolOptions);
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(true);
+      });
+
+      it('case 5: no server default and no per-agent option resolves to false', () => {
+        const tools = [{ name: TOOL_A }];
+        const registry = buildToolRegistryFromAgentOptions(tools, {});
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(false);
+      });
+
+      it('case 6: mixed servers - only the stamped tool defers', () => {
+        const tools = [{ name: TOOL_A, serverDeferLoading: true }, { name: TOOL_B }];
+        const registry = buildToolRegistryFromAgentOptions(tools, {});
+
+        expect(registry.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(registry.get(TOOL_B)?.defer_loading).toBe(false);
+      });
+    });
+
+    describe('buildToolClassification (ephemeral / event-driven path)', () => {
+      it('case 2 (headline): server default defers via the fallback branch when agentToolOptions is undefined', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(result.hasDeferredTools).toBe(true);
+      });
+
+      it('case 8: tool_search is injected when only a server default is present', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.additionalTools.some((t) => t.name === 'tool_search')).toBe(true);
+      });
+
+      it('case 6: mixed servers - only the stamped tool defers', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true), createMCPTool(TOOL_B)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(true);
+        expect(result.toolRegistry?.get(TOOL_B)?.defer_loading).toBe(false);
+      });
+
+      it('case 7: capability off clears the server-defaulted defer and skips tool_search', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          deferredToolsEnabled: false,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(false);
+        expect(result.hasDeferredTools).toBe(false);
+        expect(result.additionalTools.some((t) => t.name === 'tool_search')).toBe(false);
+      });
+
+      it('case 3: explicit per-agent false overrides the server default stamp', async () => {
+        const loadedTools: GenericTool[] = [createMCPTool(TOOL_A, true)];
+        const agentToolOptions: AgentToolOptions = { [TOOL_A]: { defer_loading: false } };
+
+        const result = await buildToolClassification({
+          loadedTools,
+          userId: 'user1',
+          agentId: 'agent1',
+          agentToolOptions,
+          deferredToolsEnabled: true,
+        });
+
+        expect(result.toolRegistry?.get(TOOL_A)?.defer_loading).toBe(false);
+        expect(result.hasDeferredTools).toBe(false);
+      });
     });
   });
 });

--- a/packages/api/src/tools/classification.ts
+++ b/packages/api/src/tools/classification.ts
@@ -37,6 +37,8 @@ export interface ToolDefinition {
   serverToolName?: string;
   /** Current catalog tool name when a LEGACY persisted key kept its pre-strip spelling */
   currentToolName?: string;
+  /** Server-level deferLoading default for this tool's MCP server. */
+  serverDeferLoading?: boolean;
 }
 
 /** An MCP tool name plus its OTHER spelling (legacy for stripped instances, current for legacy-named ones). */
@@ -137,7 +139,10 @@ export function buildToolRegistryFromAgentOptions(
         ? agentOptions.allowed_callers
         : ['direct'];
 
-    const defer_loading = agentOptions?.defer_loading === true;
+    const defer_loading =
+      agentOptions?.defer_loading !== undefined
+        ? agentOptions.defer_loading
+        : tool.serverDeferLoading === true;
 
     const toolDef: LCTool = {
       name,
@@ -174,6 +179,8 @@ interface MCPToolInstance {
   mcpServerToolName?: string;
   /** Current catalog tool name when a legacy persisted key kept its pre-strip spelling */
   mcpCurrentToolName?: string;
+  /** Server-level deferLoading default, stamped at tool creation time */
+  mcpServerDeferLoading?: boolean;
 }
 
 /**
@@ -205,6 +212,10 @@ export function extractMCPToolDefinition(tool: MCPToolInstance): ToolDefinition 
 
   if (tool.mcpCurrentToolName) {
     def.currentToolName = tool.mcpCurrentToolName;
+  }
+
+  if (tool.mcpServerDeferLoading) {
+    def.serverDeferLoading = true;
   }
 
   return def;
@@ -250,6 +261,7 @@ function buildToolRegistry(
       description: toolDef.description,
       parameters: toolDef.parameters,
       serverName: toolDef.serverName,
+      defer_loading: toolDef.serverDeferLoading === true,
       toolType: 'mcp',
     });
   }

--- a/packages/api/src/tools/classification.ts
+++ b/packages/api/src/tools/classification.ts
@@ -32,6 +32,8 @@ export interface ToolDefinition {
   parameters?: JsonSchemaType;
   /** MCP server name extracted from tool name */
   serverName?: string;
+  /** Server-level deferLoading default for this tool's MCP server. */
+  serverDeferLoading?: boolean;
 }
 
 /**
@@ -70,7 +72,10 @@ export function buildToolRegistryFromAgentOptions(
         ? agentOptions.allowed_callers
         : ['direct'];
 
-    const defer_loading = agentOptions?.defer_loading === true;
+    const defer_loading =
+      agentOptions?.defer_loading !== undefined
+        ? agentOptions.defer_loading
+        : tool.serverDeferLoading === true;
 
     const toolDef: LCTool = {
       name,
@@ -103,6 +108,8 @@ interface MCPToolInstance {
   mcpJsonSchema?: JsonSchemaType;
   /** Server this tool came from, carried from resolution instead of re-parsed */
   mcpRawServerName?: string;
+  /** Server-level deferLoading default, stamped at tool creation time */
+  mcpServerDeferLoading?: boolean;
 }
 
 /**
@@ -126,6 +133,10 @@ export function extractMCPToolDefinition(tool: MCPToolInstance): ToolDefinition 
   const serverName = tool.mcpRawServerName ?? getServerNameFromTool(tool.name);
   if (serverName) {
     def.serverName = serverName;
+  }
+
+  if (tool.mcpServerDeferLoading) {
+    def.serverDeferLoading = true;
   }
 
   return def;
@@ -171,6 +182,7 @@ function buildToolRegistry(
       description: toolDef.description,
       parameters: toolDef.parameters,
       serverName: toolDef.serverName,
+      defer_loading: toolDef.serverDeferLoading === true,
       toolType: 'mcp',
     });
   }

--- a/packages/api/src/tools/definitions.spec.ts
+++ b/packages/api/src/tools/definitions.spec.ts
@@ -1193,5 +1193,120 @@ describe('definitions.ts', () => {
         expect(registryEntry?.allowed_callers).toContain('direct');
       });
     });
+
+    describe('server-level deferLoading (event-driven parity)', () => {
+      const mcpAllTool = 'sys__all__sys_mcp_serverX';
+      const serverTools = {
+        list_files_mcp_serverX: {
+          function: {
+            name: 'list_files_mcp_serverX',
+            description: 'List files',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+        read_file_mcp_serverX: {
+          function: {
+            name: 'read_file_mcp_serverX',
+            description: 'Read a file',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      };
+
+      it("defers all of a server's tools and injects tool_search when getServerDeferLoading returns true and there are no per-agent options", async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+        const mockGetServerDeferLoading = jest.fn().mockResolvedValue(true);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            getServerDeferLoading: mockGetServerDeferLoading,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(mockGetServerDeferLoading).toHaveBeenCalledWith('user-123', 'serverX');
+        expect(result.hasDeferredTools).toBe(true);
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(true);
+        expect(result.toolRegistry.get('read_file_mcp_serverX')?.defer_loading).toBe(true);
+        expect(result.toolDefinitions.some((d) => d.name === 'tool_search')).toBe(true);
+        expect(result.toolRegistry.has('tool_search')).toBe(true);
+      });
+
+      it('does not defer when getServerDeferLoading returns false', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+        const mockGetServerDeferLoading = jest.fn().mockResolvedValue(false);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            getServerDeferLoading: mockGetServerDeferLoading,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(result.hasDeferredTools).toBe(false);
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(false);
+        expect(result.toolDefinitions.some((d) => d.name === 'tool_search')).toBe(false);
+      });
+
+      it('lets an explicit per-agent false override the server default', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+        const mockGetServerDeferLoading = jest.fn().mockResolvedValue(true);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+            toolOptions: {
+              list_files_mcp_serverX: { defer_loading: false },
+            },
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            getServerDeferLoading: mockGetServerDeferLoading,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(false);
+        expect(result.toolRegistry.get('read_file_mcp_serverX')?.defer_loading).toBe(true);
+        expect(result.hasDeferredTools).toBe(true);
+      });
+
+      it('treats a missing getServerDeferLoading dep as not deferred', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(result.hasDeferredTools).toBe(false);
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(false);
+      });
+    });
   });
 });

--- a/packages/api/src/tools/definitions.spec.ts
+++ b/packages/api/src/tools/definitions.spec.ts
@@ -1079,5 +1079,120 @@ describe('definitions.ts', () => {
         expect(registryEntry?.allowed_callers).toContain('direct');
       });
     });
+
+    describe('server-level deferLoading (event-driven parity)', () => {
+      const mcpAllTool = 'sys__all__sys_mcp_serverX';
+      const serverTools = {
+        list_files_mcp_serverX: {
+          function: {
+            name: 'list_files_mcp_serverX',
+            description: 'List files',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+        read_file_mcp_serverX: {
+          function: {
+            name: 'read_file_mcp_serverX',
+            description: 'Read a file',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      };
+
+      it("defers all of a server's tools and injects tool_search when getServerDeferLoading returns true and there are no per-agent options", async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+        const mockGetServerDeferLoading = jest.fn().mockResolvedValue(true);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            getServerDeferLoading: mockGetServerDeferLoading,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(mockGetServerDeferLoading).toHaveBeenCalledWith('user-123', 'serverX');
+        expect(result.hasDeferredTools).toBe(true);
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(true);
+        expect(result.toolRegistry.get('read_file_mcp_serverX')?.defer_loading).toBe(true);
+        expect(result.toolDefinitions.some((d) => d.name === 'tool_search')).toBe(true);
+        expect(result.toolRegistry.has('tool_search')).toBe(true);
+      });
+
+      it('does not defer when getServerDeferLoading returns false', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+        const mockGetServerDeferLoading = jest.fn().mockResolvedValue(false);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            getServerDeferLoading: mockGetServerDeferLoading,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(result.hasDeferredTools).toBe(false);
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(false);
+        expect(result.toolDefinitions.some((d) => d.name === 'tool_search')).toBe(false);
+      });
+
+      it('lets an explicit per-agent false override the server default', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+        const mockGetServerDeferLoading = jest.fn().mockResolvedValue(true);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+            toolOptions: {
+              list_files_mcp_serverX: { defer_loading: false },
+            },
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            getServerDeferLoading: mockGetServerDeferLoading,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(false);
+        expect(result.toolRegistry.get('read_file_mcp_serverX')?.defer_loading).toBe(true);
+        expect(result.hasDeferredTools).toBe(true);
+      });
+
+      it('treats a missing getServerDeferLoading dep as not deferred', async () => {
+        mockGetOrFetchMCPServerTools.mockResolvedValue(serverTools);
+
+        const result = await loadToolDefinitions(
+          {
+            userId: 'user-123',
+            agentId: 'agent-123',
+            tools: [mcpAllTool],
+            deferredToolsEnabled: true,
+          },
+          {
+            getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+            isBuiltInTool: mockIsBuiltInTool,
+          },
+        );
+
+        expect(result.hasDeferredTools).toBe(false);
+        expect(result.toolRegistry.get('list_files_mcp_serverX')?.defer_loading).toBe(false);
+      });
+    });
   });
 });

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -85,6 +85,8 @@ export interface LoadToolDefinitionsDeps {
   getOrFetchMCPServerTools: (userId: string, serverName: string) => Promise<MCPServerTools | null>;
   /** Bypasses a non-empty stale catalog when it does not contain a selected tool. */
   refreshMCPServerTools?: (userId: string, serverName: string) => Promise<MCPServerTools | null>;
+  /** Resolves the server-level `deferLoading` default from the merged MCP config */
+  getServerDeferLoading?: (userId: string, serverName: string) => Promise<boolean>;
   /** Checks if a tool name is a known built-in tool */
   isBuiltInTool: (toolName: string) => boolean;
   /** Loads action tool definitions (schemas) from OpenAPI specs */
@@ -135,6 +137,7 @@ export async function loadToolDefinitions(
   const {
     getOrFetchMCPServerTools,
     refreshMCPServerTools,
+    getServerDeferLoading,
     isBuiltInTool,
     getActionToolDefinitions,
   } = deps;
@@ -168,6 +171,7 @@ export async function loadToolDefinitions(
   const refreshedServerNames = new Set<string>();
   /** Parsed key segment → the RAW server name it resolved to (direct-first). */
   const resolvedServerNames = new Map<string, string>();
+  const mcpServerDeferLoadingCache = new Map<string, boolean>();
   const mcpToolDefs: ToolDefinition[] = [];
   const builtInToolDefs: ToolDefinition[] = [];
   let actionToolDefs: ToolDefinition[] = [];
@@ -251,6 +255,11 @@ export async function loadToolDefinitions(
       }
       mcpServerToolsCache.set(parsed, fetched || {});
       resolvedServerNames.set(parsed, resolvedName);
+      /** Config lookups are keyed by the resolved RAW server name. */
+      const deferLoading = getServerDeferLoading
+        ? await getServerDeferLoading(userId, resolvedName)
+        : false;
+      mcpServerDeferLoadingCache.set(parsed, deferLoading);
     }
 
     const serverName = resolvedServerNames.get(parsed) ?? parsed;
@@ -300,6 +309,8 @@ export async function loadToolDefinitions(
       }
     }
 
+    const serverDeferLoading = mcpServerDeferLoadingCache.get(parsed) === true;
+
     if (isMCPAllPlaceholder(toolName)) {
       for (const [actualToolName, toolDef] of Object.entries(serverTools)) {
         if (toolDef?.function) {
@@ -309,6 +320,7 @@ export async function loadToolDefinitions(
             parameters: buildMcpParameters(toolDef.function.parameters),
             serverName,
             serverToolName: toolDef.serverToolName,
+            serverDeferLoading,
           });
           resolvedMCPToolCount++;
         }
@@ -325,6 +337,7 @@ export async function loadToolDefinitions(
         serverName,
         serverToolName: toolMatch.def.serverToolName,
         currentToolName: toolMatch.currentToolName,
+        serverDeferLoading,
       });
       resolvedMCPToolCount++;
     }
@@ -353,6 +366,7 @@ export async function loadToolDefinitions(
     mcpRawServerName: def.serverName,
     mcpServerToolName: def.serverToolName,
     mcpCurrentToolName: def.currentToolName,
+    mcpServerDeferLoading: def.serverDeferLoading,
   })) as unknown as GenericTool[];
 
   const classificationResult = await buildToolClassification({

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -79,6 +79,8 @@ export interface LoadToolDefinitionsDeps {
   getOrFetchMCPServerTools: (userId: string, serverName: string) => Promise<MCPServerTools | null>;
   /** Bypasses a non-empty stale catalog when it does not contain a selected tool. */
   refreshMCPServerTools?: (userId: string, serverName: string) => Promise<MCPServerTools | null>;
+  /** Resolves the server-level `deferLoading` default from the merged MCP config */
+  getServerDeferLoading?: (userId: string, serverName: string) => Promise<boolean>;
   /** Checks if a tool name is a known built-in tool */
   isBuiltInTool: (toolName: string) => boolean;
   /** Loads action tool definitions (schemas) from OpenAPI specs */
@@ -125,6 +127,7 @@ export async function loadToolDefinitions(
   const {
     getOrFetchMCPServerTools,
     refreshMCPServerTools,
+    getServerDeferLoading,
     isBuiltInTool,
     getActionToolDefinitions,
   } = deps;
@@ -156,6 +159,7 @@ export async function loadToolDefinitions(
   const refreshedServerNames = new Set<string>();
   /** Parsed key segment → the RAW server name it resolved to (direct-first). */
   const resolvedServerNames = new Map<string, string>();
+  const mcpServerDeferLoadingCache = new Map<string, boolean>();
   const mcpToolDefs: ToolDefinition[] = [];
   const builtInToolDefs: ToolDefinition[] = [];
   let actionToolDefs: ToolDefinition[] = [];
@@ -239,6 +243,11 @@ export async function loadToolDefinitions(
       }
       mcpServerToolsCache.set(parsed, fetched || {});
       resolvedServerNames.set(parsed, resolvedName);
+      /** Config lookups are keyed by the resolved RAW server name. */
+      const deferLoading = getServerDeferLoading
+        ? await getServerDeferLoading(userId, resolvedName)
+        : false;
+      mcpServerDeferLoadingCache.set(parsed, deferLoading);
     }
 
     const serverName = resolvedServerNames.get(parsed) ?? parsed;
@@ -259,6 +268,8 @@ export async function loadToolDefinitions(
       }
     }
 
+    const serverDeferLoading = mcpServerDeferLoadingCache.get(parsed) === true;
+
     if (isMCPAllPlaceholder(toolName)) {
       for (const [actualToolName, toolDef] of Object.entries(serverTools)) {
         if (toolDef?.function) {
@@ -267,6 +278,7 @@ export async function loadToolDefinitions(
             description: toolDef.function.description || undefined,
             parameters: buildMcpParameters(toolDef.function.parameters),
             serverName,
+            serverDeferLoading,
           });
           resolvedMCPToolCount++;
         }
@@ -281,6 +293,7 @@ export async function loadToolDefinitions(
         description: toolDef.function.description || undefined,
         parameters: buildMcpParameters(toolDef.function.parameters),
         serverName,
+        serverDeferLoading,
       });
       resolvedMCPToolCount++;
     }
@@ -301,6 +314,7 @@ export async function loadToolDefinitions(
     mcp: true as const,
     mcpJsonSchema: def.parameters,
     mcpRawServerName: def.serverName,
+    mcpServerDeferLoading: def.serverDeferLoading,
   })) as unknown as GenericTool[];
 
   const classificationResult = await buildToolClassification({

--- a/packages/data-provider/src/mcp.spec.ts
+++ b/packages/data-provider/src/mcp.spec.ts
@@ -1,0 +1,38 @@
+import { StdioOptionsSchema, SSEOptionsSchema, MCPOptionsSchema } from './mcp';
+
+describe('mcp schema - deferLoading', () => {
+  const baseStdio = { command: 'node', args: ['server.js'] };
+
+  it('parses deferLoading: true on a stdio server', () => {
+    const result = StdioOptionsSchema.parse({ ...baseStdio, deferLoading: true });
+    expect(result.deferLoading).toBe(true);
+  });
+
+  it('parses deferLoading: false on a stdio server', () => {
+    const result = StdioOptionsSchema.parse({ ...baseStdio, deferLoading: false });
+    expect(result.deferLoading).toBe(false);
+  });
+
+  it('treats deferLoading as optional (absent -> undefined)', () => {
+    const result = StdioOptionsSchema.parse(baseStdio);
+    expect(result.deferLoading).toBeUndefined();
+  });
+
+  it('rejects a non-boolean deferLoading', () => {
+    const result = StdioOptionsSchema.safeParse({ ...baseStdio, deferLoading: 'yes' });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses deferLoading on a remote (SSE) server', () => {
+    const result = SSEOptionsSchema.parse({
+      url: 'https://example.com/sse',
+      deferLoading: true,
+    });
+    expect(result.deferLoading).toBe(true);
+  });
+
+  it('parses deferLoading through the MCPOptions union', () => {
+    const result = MCPOptionsSchema.parse({ ...baseStdio, deferLoading: true });
+    expect(result.deferLoading).toBe(true);
+  });
+});

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -184,6 +184,14 @@ const BaseOptionsSchema = z.object({
    */
   serverInstructions: z.union([z.boolean(), z.string()]).optional(),
   /**
+   * When true, every tool from this MCP server defaults to deferred loading:
+   * the model receives the `tool_search` tool plus a name-only listing instead
+   * of each tool's full schema. Sets the default for each tool's `defer_loading`;
+   * a per-agent `tool_options[toolId].defer_loading` (true OR false) overrides it.
+   * Requires the `deferred_tools` agent capability to be enabled.
+   */
+  deferLoading: z.boolean().optional(),
+  /**
    * Whether this server requires OAuth authentication
    * If not specified, will be auto-detected during construction
    */

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -202,6 +202,14 @@ const BaseOptionsSchema = z.object({
    */
   serverInstructions: z.union([z.boolean(), z.string()]).optional(),
   /**
+   * When true, every tool from this MCP server defaults to deferred loading:
+   * the model receives the `tool_search` tool plus a name-only listing instead
+   * of each tool's full schema. Sets the default for each tool's `defer_loading`;
+   * a per-agent `tool_options[toolId].defer_loading` (true OR false) overrides it.
+   * Requires the `deferred_tools` agent capability to be enabled.
+   */
+  deferLoading: z.boolean().optional(),
+  /**
    * Whether this server requires OAuth authentication
    * If not specified, will be auto-detected during construction
    */

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -128,6 +128,8 @@ export type MCPServer = {
   authenticated: boolean;
   authConfig: s.TPluginAuthConfig[];
   tools: MCPTool[];
+  /** Server-level default: when true, all tools from this server defer by default */
+  deferLoading?: boolean;
 };
 
 export type MCPServersResponse = {

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -142,6 +142,8 @@ export type MCPServer = {
   authenticated: boolean;
   authConfig: s.TPluginAuthConfig[];
   tools: MCPTool[];
+  /** Server-level default: when true, all tools from this server defer by default */
+  deferLoading?: boolean;
 };
 
 export type MCPServersResponse = {


### PR DESCRIPTION
## Summary

Adds an optional per-MCP-server **`deferLoading: boolean`** config flag (in `librechat.yaml` and config-tier overrides). When `true`, every tool from that server defaults to **deferred loading**: the model receives the `tool_search` tool plus a name-only listing instead of each tool's full JSON schema, saving context on large tool sets.

Unlike the existing per-agent `tool_options[toolId].defer_loading` toggle, this also applies to **ephemeral agents** (a plain model with an attached MCP server) which carry no `tool_options` and previously could never defer. It extends the existing `deferred_tools` capability (#11295) to the server-config level and the ephemeral path.

Builds on prior deferred-loading work: #11270 (Defer Loading MCP Tools), #11295 (Deferred Tools as Agents Capability), #11588 (Event-Driven Lazy Tool Loading). Complementary to the proposed MCP `toolFilter` (#13346 / issue #11088): filtering selects *which* tools exist; `deferLoading` defers *their schemas*.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Behavior

- **Schema:** `deferLoading` added to `BaseOptionsSchema` (optional; default `undefined`/false — fully backward compatible, no migration).
- **Precedence:** explicit per-agent `tool_options[toolId].defer_loading` (`true` OR `false`) wins; else the server `deferLoading` default; else `false`. Entirely gated by the `deferred_tools` agent capability — capability off ⇒ no deferral and no `tool_search`.
- **Mechanism:** a per-tool `serverDeferLoading` stamp applied at tool-registry build time. Both the live path (MCP tool factory) and the event-driven path (`getServerDeferLoading` resolver) source it from the resolved merged config (YAML + config-tier + DB), so saved agents, ephemeral agents, and the `mcp_all` placeholder defer uniformly.
- **Config-tier overrides:** `deferLoading` is included in `ADMIN_CONFIGURABLE_FIELDS`, so config-tier overrides of a YAML server's `deferLoading` are honored.
- **UI:** the agent panel's MCP tool list shows a three-state checkbox that reflects the inherited server default.

## Testing

Local unit tests (all green):
- `packages/api`: `src/tools/classification.spec.ts` (precedence matrix), `src/tools/definitions.spec.ts` (event-driven parity), `src/mcp/registry/__tests__/ensureConfigServers.test.ts` (config-tier override).
- `packages/data-provider`: `src/mcp.spec.ts` (schema parse for stdio/SSE/union).
- `client`: `src/hooks/Agents/__tests__/useMCPToolOptions.spec.ts` (three-state hook).

`tsc --noEmit` clean for data-provider, data-schemas, @librechat/api, @librechat/client, and the client app; ESLint, Prettier, and import-sort clean on all changed files.

Manual verification: a `deferLoading: true` server attached to an ephemeral agent on a small-context model does not trigger `empty_messages` — confirming deferred tools are excluded from the pre-flight context count.

### Test Configuration

`librechat.yaml` MCP server with `deferLoading: true`; `deferred_tools` agent capability enabled.

## Scope / follow-ups

- **DB-created servers:** `deferLoading` is honored at runtime, but the MCP Builder dialog does not yet expose a field for it — consistent with `consumeOnly` / `serverInstructions` / `chatMenu`, which it also doesn't surface. Deliberate scope boundary; follow-up.
- **Per-request overlay servers:** `deferLoading` on conversation-scoped MCP servers defined via `req.body.config.mcpConfig` is not resolved (the resolver reads merged YAML + config + DB, not the request overlay). Consistent across both code paths.
- **Token pre-count:** the deferred-tool exclusion from the pre-flight count lives in `@librechat/agents` (keyed off `defer_loading`); there is no LibreChat-repo seam to unit-test it, so the repo-boundary guard is the classification/definitions tests proving server-defaulted tools carry `defer_loading: true`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my feature works
- [x] Local unit tests pass with my changes
- [ ] This change requires a documentation update (see note below)

## Backward compatibility

Field optional; default `undefined`/false; no migration; existing agents and servers unaffected.

> Documentation: docs live in the [librechat.ai](https://github.com/LibreChat-AI/librechat.ai) repo. Happy to open a docs PR for the MCP server `deferLoading` option if desired; the option is also documented inline in `librechat.example.yaml`.
