### PR TITLE
🔑 fix: Honor User-Provided MCP API Key Instead of Forcing OAuth

### DIFF
--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -643,7 +643,7 @@ export abstract class UserConnectionManager {
   }): Promise<t.ParsedServerConfig> {
     if (
       config.requiresOAuth != null ||
-      config.apiKey?.source === 'admin' ||
+      config.apiKey != null ||
       !hasRuntimeUrlPlaceholders(config)
     ) {
       return config;

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -643,7 +643,7 @@ export abstract class UserConnectionManager {
   }): Promise<t.ParsedServerConfig> {
     if (
       config.requiresOAuth != null ||
-      config.apiKey != null ||
+      (config.apiKey != null && config.oauth == null) ||
       !hasRuntimeUrlPlaceholders(config)
     ) {
       return config;

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -126,8 +126,10 @@ export class MCPServerInspector {
       return;
     }
 
-    // Admin-provided API key means no OAuth flow is needed
-    if (this.config.apiKey?.source === 'admin') {
+    // API key auth (admin- or user-provided) is mutually exclusive with OAuth. A
+    // credential-less probe of a bearer server returns the same 401 challenge as an
+    // OAuth server, so detection would misclassify it; trust the configured auth method.
+    if (this.config.apiKey != null) {
       this.config.requiresOAuth = false;
       return;
     }

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -76,6 +76,9 @@ export class MCPServerInspector {
       this.config.startup !== false &&
       !this.config.requiresOAuth &&
       !hasCustomUserVars(this.config) &&
+      // user-provided API key is supplied per-user at connect time; an unauthenticated
+      // probe here would 401 against a bearer server and fail inspection
+      this.config.apiKey?.source !== 'user' &&
       !hasRuntimeContextPlaceholders(this.config) &&
       !this.config.obo
     ) {
@@ -126,10 +129,11 @@ export class MCPServerInspector {
       return;
     }
 
-    // API key auth (admin- or user-provided) is mutually exclusive with OAuth. A
-    // credential-less probe of a bearer server returns the same 401 challenge as an
-    // OAuth server, so detection would misclassify it; trust the configured auth method.
-    if (this.config.apiKey != null) {
+    // API key auth (admin- or user-provided) is API-key, not OAuth. A credential-less
+    // probe of a bearer server returns the same 401 challenge as an OAuth server, so
+    // detection would misclassify it; trust the configured auth method. An explicit
+    // `oauth` block still wins if both are somehow set.
+    if (this.config.apiKey != null && this.config.oauth == null) {
       this.config.requiresOAuth = false;
       return;
     }

--- a/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
@@ -341,7 +341,7 @@ describe('MCPServerInspector', () => {
       expect(result.apiKey?.source).toBe('admin');
     });
 
-    it('should still detect OAuth when apiKey.source is user', async () => {
+    it('should set requiresOAuth to false when apiKey.source is user', async () => {
       const rawConfig: t.MCPOptions = {
         type: 'sse',
         url: 'https://api.example.com/sse',
@@ -351,16 +351,20 @@ describe('MCPServerInspector', () => {
         },
       };
 
+      // A credential-less probe of a bearer server returns the same 401 challenge as
+      // an OAuth server. Detection must be skipped so the user's API key is honored
+      // instead of forcing an OAuth flow.
       mockDetectOAuthRequirement.mockResolvedValue({
-        requiresOAuth: true,
+        requiresOAuth: true, // This would be returned if called, but it shouldn't be
         method: 'protected-resource-metadata',
       });
 
       const result = await MCPServerInspector.inspect('test_server', rawConfig, mockConnection);
 
-      // Should call OAuth detection for user-provided API key
-      expect(mockDetectOAuthRequirement).toHaveBeenCalled();
-      expect(result.requiresOAuth).toBe(true);
+      // Should NOT call OAuth detection for user-provided API key
+      expect(mockDetectOAuthRequirement).not.toHaveBeenCalled();
+      expect(result.requiresOAuth).toBe(false);
+      expect(result.apiKey?.source).toBe('user');
     });
 
     it('should fetch capabilities when server has no tools', async () => {

--- a/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
@@ -341,7 +341,7 @@ describe('MCPServerInspector', () => {
       expect(result.apiKey?.source).toBe('admin');
     });
 
-    it('should set requiresOAuth to false when apiKey.source is user', async () => {
+    it('should set requiresOAuth to false and skip probing when apiKey.source is user', async () => {
       const rawConfig: t.MCPOptions = {
         type: 'sse',
         url: 'https://api.example.com/sse',
@@ -359,12 +359,41 @@ describe('MCPServerInspector', () => {
         method: 'protected-resource-metadata',
       });
 
-      const result = await MCPServerInspector.inspect('test_server', rawConfig, mockConnection);
+      // No connection provided: the user's key is supplied per-user at connect time, so
+      // inspection must NOT open an unauthenticated connection (it would 401 and fail save).
+      const result = await MCPServerInspector.inspect('test_server', rawConfig);
 
-      // Should NOT call OAuth detection for user-provided API key
       expect(mockDetectOAuthRequirement).not.toHaveBeenCalled();
+      expect(MCPConnectionFactory.create).not.toHaveBeenCalled();
       expect(result.requiresOAuth).toBe(false);
       expect(result.apiKey?.source).toBe('user');
+    });
+
+    it('should honor an explicit oauth block even when a user apiKey is present', async () => {
+      const rawConfig: t.MCPOptions = {
+        type: 'sse',
+        url: 'https://api.example.com/sse',
+        apiKey: {
+          source: 'user',
+          authorization_type: 'bearer',
+        },
+        oauth: {
+          authorization_url: 'https://api.example.com/oauth/authorize',
+          token_url: 'https://api.example.com/oauth/token',
+          scope: 'read',
+        },
+      };
+
+      mockDetectOAuthRequirement.mockResolvedValue({
+        requiresOAuth: true,
+        method: 'protected-resource-metadata',
+      });
+
+      const result = await MCPServerInspector.inspect('test_server', rawConfig, mockConnection);
+
+      // An explicit oauth config must take precedence over the apiKey short-circuit.
+      expect(mockDetectOAuthRequirement).toHaveBeenCalled();
+      expect(result.requiresOAuth).toBe(true);
     });
 
     it('should fetch capabilities when server has no tools', async () => {


### PR DESCRIPTION
## Summary

Fixes a bug where an MCP server configured with **API Key → "Each user provides their own" → Bearer** cannot be used at all: the user enters and saves their key, "Authenticate" succeeds, but the connection stays yellow and any tool call fails demanding OAuth (logs show an OAuth flow being attempted).

### Root cause

OAuth auto-detection probes the server **without credentials** and treats a `401` carrying `WWW-Authenticate: Bearer` as proof the server needs OAuth ([`detectOAuth.ts`](https://github.com/danny-avila/LibreChat/blob/dev/packages/api/src/mcp/oauth/detectOAuth.ts) → [`resourceHint.ts`](https://github.com/danny-avila/LibreChat/blob/dev/packages/api/src/mcp/oauth/resourceHint.ts)). A static **bearer API-key** server answers an unauthenticated probe with that exact same challenge (RFC 6750), so it is indistinguishable from an OAuth server at probe time.

The exemption that says "an API key is configured, so skip OAuth detection" was scoped to `apiKey.source === 'admin'` only. For `source === 'user'` the credential-less probe ran, returned a Bearer challenge, and the server was persisted as `requiresOAuth: true`. From then on the connection is built through the OAuth path and the user's saved key is never injected.

### Fix

Broaden the exemption from `source === 'admin'` to **any `apiKey` config present**, in both detection sites:

- `MCPServerInspector.detectOAuth()` — startup/inspection detection (the path the reported scenario hits, since admin-panel servers are inspected on save).
- `UserConnectionManager.applyRuntimeOAuthDetection()` — runtime detection for placeholder URLs (same bug for a user-key server with a per-user URL).

`apiKey` and `oauth` are mutually exclusive in the config schema, so the presence of an `apiKey` block is an explicit declaration of API-key auth. The user's key continues to be injected via the existing `Authorization: Bearer {{MCP_API_KEY}}` header placeholder set up by `transformUserApiKeyConfig`.

## Note for existing deployments

Servers already inspected and persisted with `requiresOAuth: true` keep that value. Re-saving the server in the admin panel re-runs inspection and clears it.

## Testing

- Flipped the inspector test that codified the old behavior (`should still detect OAuth when apiKey.source is user`) to assert detection is skipped and `requiresOAuth` is `false`.
- `MCPServerInspector.test.ts` suite passes (19/19).

> The pre-existing `MCPReinitRecovery.integration.test.ts` failures reproduce on clean `dev` without this change and are unrelated.

## Change Type

- [x] Bug fix (non-breaking change which resolves an issue)
