### PR TITLE
🪟 feat: Faithful Over-Window Context Estimate via Prune Mirror and Overhead Reserve

### DIFF
--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -153,6 +153,9 @@ export default function Breakdown({ view, showCost, currency }: BreakdownProps) 
             {view.estimatedTokens > 0 && (
               <Row label={localize('com_ui_context_estimated')} value={view.estimatedTokens} />
             )}
+            {view.overheadTokens > 0 && (
+              <Row label={localize('com_ui_context_system')} value={view.overheadTokens} />
+            )}
             {maxTokens == null && (
               <p className="text-xs text-text-secondary">{localize('com_ui_context_unknown')}</p>
             )}

--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -145,13 +145,25 @@ export default function Breakdown({ view, showCost, currency }: BreakdownProps) 
                 max={maxTokens}
               />
             )}
-            <Row label={localize('com_ui_input')} value={view.branchTotals.input} />
-            <Row
-              label={localize('com_ui_output')}
-              value={view.branchTotals.output + view.liveTokens}
-            />
-            {view.estimatedTokens > 0 && (
-              <Row label={localize('com_ui_context_estimated')} value={view.estimatedTokens} />
+            {view.messagesPruned ? (
+              /** Over-window: the per-category split no longer describes what's
+               *  sent, so show the pruned message total (incl. in-flight). */
+              <Row
+                label={localize('com_ui_context_messages')}
+                value={view.messageTokens + view.liveTokens}
+                max={maxTokens}
+              />
+            ) : (
+              <>
+                <Row label={localize('com_ui_input')} value={view.branchTotals.input} />
+                <Row
+                  label={localize('com_ui_output')}
+                  value={view.branchTotals.output + view.liveTokens}
+                />
+                {view.estimatedTokens > 0 && (
+                  <Row label={localize('com_ui_context_estimated')} value={view.estimatedTokens} />
+                )}
+              </>
             )}
             {view.overheadTokens > 0 && (
               <Row label={localize('com_ui_context_system')} value={view.overheadTokens} />

--- a/client/src/hooks/Chat/useTokenUsage.ts
+++ b/client/src/hooks/Chat/useTokenUsage.ts
@@ -62,6 +62,12 @@ export interface TokenUsageView {
   /** Cached instruction + tool overhead applied to a snapshot-less estimate; 0 on
    *  snapshots (which carry their own breakdown) and until the agent has run. */
   overheadTokens: number;
+  /** Final message-token portion of a snapshot-less estimate (pruned when over
+   *  window, excludes live); 0 on snapshots. */
+  messageTokens: number;
+  /** True when over-window pruning replaced the raw message sum, so the breakdown
+   *  shows a single pruned Messages row instead of input/output/estimated. */
+  messagesPruned: boolean;
   rates?: TModelTokenomics;
 }
 
@@ -245,6 +251,8 @@ export default function useTokenUsage({
         liveTokens,
         estimatedTokens: 0,
         overheadTokens: 0,
+        messageTokens: 0,
+        messagesPruned: false,
         rates: limits.rates,
       };
     }
@@ -264,15 +272,20 @@ export default function useTokenUsage({
      *  already folded into `instructionTokens`), cached from live usage events. The
      *  client can't otherwise know it for a snapshot-less branch, so reserve it from
      *  the prune budget and add it to used — making over-window pruning faithful and
-     *  the gauge consistent with snapshots. 0 until the agent has run once this
+     *  the gauge consistent with snapshots. Skipped when a summary baseline exists:
+     *  `computeSummaryUsedTokens` already folds the overhead into that marker, so
+     *  adding it again would double-count. 0 until the agent has run once this
      *  session (then falls back to message-only, as before). */
-    const overheadTokens = getModelOverhead(
-      overheadKey(
-        limits.endpoint ?? conversation?.endpoint,
-        limits.model ?? conversation?.model,
-        conversation?.agent_id,
-      ),
-    );
+    const overheadTokens =
+      branchTotals.summaryBaseline > 0
+        ? 0
+        : getModelOverhead(
+            overheadKey(
+              limits.endpoint ?? conversation?.endpoint,
+              limits.model ?? conversation?.model,
+              conversation?.agent_id,
+            ),
+          );
     /** When a stream is live the tail is the in-flight response, already counted
      *  by `liveTokens`; drop its static estimate so a resumed/partial response
      *  isn't double-counted on the estimate path. */
@@ -280,13 +293,14 @@ export default function useTokenUsage({
       0,
       branchTotals.estTokens - (liveOnTail ? branchTotals.tailEstTokens : 0),
     );
-    let messageTokens = branchTotals.input + branchTotals.output + estimatedTokens;
+    const rawMessageTokens = branchTotals.input + branchTotals.output + estimatedTokens;
+    let messageTokens = rawMessageTokens;
     /** The send path prunes an over-window branch oldest-first before calling the
      *  model, so the next call can sit well under the window even when the full
-     *  branch exceeds it. Mirror that: when the raw sum overflows the message
-     *  window (max minus the always-sent summary baseline and instruction
-     *  overhead), report the newest messages that actually fit instead of clamping
-     *  the whole branch to 100%. */
+     *  branch exceeds it. Mirror that: when the raw sum overflows the message window
+     *  (max minus the always-sent summary baseline and instruction overhead), report
+     *  the newest messages that actually fit instead of clamping the whole branch to
+     *  100%. */
     if (maxTokens != null && maxTokens > 0) {
       const messageBudget = Math.max(0, maxTokens - branchTotals.summaryBaseline - overheadTokens);
       if (messageTokens > messageBudget) {
@@ -298,6 +312,10 @@ export default function useTokenUsage({
         );
       }
     }
+    /** When pruning replaced the raw sum, the per-category input/output/estimated
+     *  rows no longer describe what's sent, so the breakdown collapses them into a
+     *  single pruned Messages row to stay consistent with the gauge. */
+    const messagesPruned = messageTokens < rawMessageTokens;
     const usedTokens = overheadTokens + branchTotals.summaryBaseline + messageTokens + liveTokens;
     return {
       usedTokens,
@@ -316,6 +334,8 @@ export default function useTokenUsage({
       liveTokens,
       estimatedTokens,
       overheadTokens,
+      messageTokens,
+      messagesPruned,
       rates: limits.rates,
     };
   }, [

--- a/client/src/hooks/Chat/useTokenUsage.ts
+++ b/client/src/hooks/Chat/useTokenUsage.ts
@@ -6,6 +6,8 @@ import type { TMessage, TConversation, TModelTokenomics } from 'librechat-data-p
 import type { BranchTotals, BranchUsage } from '~/utils/tokens';
 import type { ContextSnapshot } from '~/store/usage';
 import {
+  overheadKey,
+  getModelOverhead,
   liveTokensFamily,
   totalUsageFamily,
   removeUsageAtoms,
@@ -57,6 +59,9 @@ export interface TokenUsageView {
   /** Estimated tokens for count-less messages (in-flight tail excluded while
    *  streaming); 0 on snapshots. Rendered as its own breakdown row. */
   estimatedTokens: number;
+  /** Cached instruction + tool overhead applied to a snapshot-less estimate; 0 on
+   *  snapshots (which carry their own breakdown) and until the agent has run. */
+  overheadTokens: number;
   rates?: TModelTokenomics;
 }
 
@@ -239,6 +244,7 @@ export default function useTokenUsage({
         totalCost: totalUsage.cost,
         liveTokens,
         estimatedTokens: 0,
+        overheadTokens: 0,
         rates: limits.rates,
       };
     }
@@ -254,6 +260,19 @@ export default function useTokenUsage({
      *  gauge at 100% after a compaction). */
     const maxTokens = limits.maxContextTokens;
     const liveOnTail = liveTokens > 0;
+    /** Fixed instruction + tool-schema overhead for this agent/model (the latter is
+     *  already folded into `instructionTokens`), cached from live usage events. The
+     *  client can't otherwise know it for a snapshot-less branch, so reserve it from
+     *  the prune budget and add it to used — making over-window pruning faithful and
+     *  the gauge consistent with snapshots. 0 until the agent has run once this
+     *  session (then falls back to message-only, as before). */
+    const overheadTokens = getModelOverhead(
+      overheadKey(
+        limits.endpoint ?? conversation?.endpoint,
+        limits.model ?? conversation?.model,
+        conversation?.agent_id,
+      ),
+    );
     /** When a stream is live the tail is the in-flight response, already counted
      *  by `liveTokens`; drop its static estimate so a resumed/partial response
      *  isn't double-counted on the estimate path. */
@@ -265,10 +284,11 @@ export default function useTokenUsage({
     /** The send path prunes an over-window branch oldest-first before calling the
      *  model, so the next call can sit well under the window even when the full
      *  branch exceeds it. Mirror that: when the raw sum overflows the message
-     *  window (max minus the always-sent summary baseline), report the newest
-     *  messages that actually fit instead of clamping the whole branch to 100%. */
+     *  window (max minus the always-sent summary baseline and instruction
+     *  overhead), report the newest messages that actually fit instead of clamping
+     *  the whole branch to 100%. */
     if (maxTokens != null && maxTokens > 0) {
-      const messageBudget = Math.max(0, maxTokens - branchTotals.summaryBaseline);
+      const messageBudget = Math.max(0, maxTokens - branchTotals.summaryBaseline - overheadTokens);
       if (messageTokens > messageBudget) {
         messageTokens = prunedBranchTokens(
           conversationKey,
@@ -278,7 +298,7 @@ export default function useTokenUsage({
         );
       }
     }
-    const usedTokens = messageTokens + branchTotals.summaryBaseline + liveTokens;
+    const usedTokens = overheadTokens + branchTotals.summaryBaseline + messageTokens + liveTokens;
     return {
       usedTokens,
       maxTokens,
@@ -295,6 +315,7 @@ export default function useTokenUsage({
       totalCost: totalUsage.cost,
       liveTokens,
       estimatedTokens,
+      overheadTokens,
       rates: limits.rates,
     };
   }, [
@@ -308,5 +329,6 @@ export default function useTokenUsage({
     limits,
     branchSnapshot,
     conversationKey,
+    conversation,
   ]);
 }

--- a/client/src/hooks/Chat/useTokenUsage.ts
+++ b/client/src/hooks/Chat/useTokenUsage.ts
@@ -21,6 +21,7 @@ import {
   clearIndex,
   mergeUsage,
   sumTotalUsage,
+  prunedBranchTokens,
   findBranchSnapshotAnchor,
 } from '~/utils';
 import { useLatestMessageId } from '~/hooks/Messages/useLatestMessage';
@@ -252,23 +253,32 @@ export default function useTokenUsage({
      *  from re-summing the discarded pre-summary history (which otherwise pins the
      *  gauge at 100% after a compaction). */
     const maxTokens = limits.maxContextTokens;
+    const liveOnTail = liveTokens > 0;
     /** When a stream is live the tail is the in-flight response, already counted
      *  by `liveTokens`; drop its static estimate so a resumed/partial response
      *  isn't double-counted on the estimate path. */
     const estimatedTokens = Math.max(
       0,
-      branchTotals.estTokens - (liveTokens > 0 ? branchTotals.tailEstTokens : 0),
+      branchTotals.estTokens - (liveOnTail ? branchTotals.tailEstTokens : 0),
     );
-    const rawUsed =
-      branchTotals.input +
-      branchTotals.output +
-      estimatedTokens +
-      branchTotals.summaryBaseline +
-      liveTokens;
-    /** The send path prunes an over-window branch before calling the model, so the
-     *  live gauge never actually exceeds the window; clamp the display to the
-     *  window rather than show impossible values (e.g. 50k / 8k). */
-    const usedTokens = maxTokens != null && maxTokens > 0 ? Math.min(rawUsed, maxTokens) : rawUsed;
+    let messageTokens = branchTotals.input + branchTotals.output + estimatedTokens;
+    /** The send path prunes an over-window branch oldest-first before calling the
+     *  model, so the next call can sit well under the window even when the full
+     *  branch exceeds it. Mirror that: when the raw sum overflows the message
+     *  window (max minus the always-sent summary baseline), report the newest
+     *  messages that actually fit instead of clamping the whole branch to 100%. */
+    if (maxTokens != null && maxTokens > 0) {
+      const messageBudget = Math.max(0, maxTokens - branchTotals.summaryBaseline);
+      if (messageTokens > messageBudget) {
+        messageTokens = prunedBranchTokens(
+          conversationKey,
+          branchTotals.tailId,
+          messageBudget,
+          liveOnTail,
+        );
+      }
+    }
+    const usedTokens = messageTokens + branchTotals.summaryBaseline + liveTokens;
     return {
       usedTokens,
       maxTokens,
@@ -297,5 +307,6 @@ export default function useTokenUsage({
     liveTokens,
     limits,
     branchSnapshot,
+    conversationKey,
   ]);
 }

--- a/client/src/hooks/SSE/useUsageHandler.ts
+++ b/client/src/hooks/SSE/useUsageHandler.ts
@@ -9,10 +9,12 @@ import type {
 } from 'librechat-data-provider';
 import type { ContextSnapshot } from '~/store/usage';
 import {
+  overheadKey,
   markUsageFolded,
   liveTokensFamily,
   totalUsageFamily,
   removeUsageAtoms,
+  setModelOverhead,
   clearUsageFolded,
   calibrationFamily,
   pendingUsageFamily,
@@ -150,6 +152,18 @@ export default function useUsageHandler(): UsageHandlers {
       if (data.calibrationRatio != null && data.calibrationRatio > 0) {
         jotai.set(calibrationFamily(convoKey), data.calibrationRatio);
       }
+      /** Cache the fixed instruction+tool overhead (already inclusive of tool
+       *  schemas) per agent/model so a snapshot-less branch of the same config can
+       *  reserve it in its prune budget and gauge. */
+      const overhead = data.effectiveInstructionTokens ?? data.breakdown?.instructionTokens ?? 0;
+      setModelOverhead(
+        overheadKey(
+          submission.conversation?.endpoint,
+          submission.conversation?.model,
+          data.agentId,
+        ),
+        overhead,
+      );
       streamCharsRef.current = 0;
       confirmedRef.current = 0;
       setLive(convoKey, 0);

--- a/client/src/store/usage.spec.ts
+++ b/client/src/store/usage.spec.ts
@@ -1,26 +1,34 @@
 import { overheadKey, setModelOverhead, getModelOverhead } from './usage';
 
 describe('model overhead cache', () => {
-  it('builds a stable key and round-trips overhead per config', () => {
-    const key = overheadKey('agents', 'gpt-5', 'agent_123');
-    /** Writer (usage handler) and reader (estimate) must build the same key. */
-    expect(key).toBe('agents::gpt-5::agent_123');
+  it('keys agents by agentId so the resolved reader and raw writer agree', () => {
+    /** The writer stores under the raw `agents` submission (no resolved model);
+     *  the reader resolves to the agent's real provider/model. Both must produce
+     *  the same key, or the cache misses for the main agents case. */
+    const writerKey = overheadKey('agents', '', 'agent_123');
+    const readerKey = overheadKey('openAI', 'gpt-4', 'agent_123');
+    expect(writerKey).toBe('agent:agent_123');
+    expect(readerKey).toBe('agent:agent_123');
+
+    setModelOverhead(writerKey, 1500);
+    expect(getModelOverhead(readerKey)).toBe(1500);
+  });
+
+  it('keys non-agent configs by endpoint:model and round-trips overhead', () => {
+    const key = overheadKey('openAI', 'gpt-4', null);
+    expect(key).toBe('openAI::gpt-4');
 
     /** Unknown config defaults to 0 (estimate falls back to message-only). */
     expect(getModelOverhead(key)).toBe(0);
 
-    setModelOverhead(key, 1500);
-    expect(getModelOverhead(key)).toBe(1500);
+    setModelOverhead(key, 800);
+    expect(getModelOverhead(key)).toBe(800);
 
     /** Non-positive overhead is ignored, keeping the last good value. */
     setModelOverhead(key, 0);
-    expect(getModelOverhead(key)).toBe(1500);
+    expect(getModelOverhead(key)).toBe(800);
 
-    /** A different agent/model is isolated. */
-    expect(getModelOverhead(overheadKey('openAI', 'gpt-4', null))).toBe(0);
-  });
-
-  it('treats missing endpoint/model/agentId as empty segments', () => {
-    expect(overheadKey(undefined, 'gpt-4', undefined)).toBe('::gpt-4::');
+    /** A different config is isolated. */
+    expect(getModelOverhead(overheadKey('google', 'gemini', null))).toBe(0);
   });
 });

--- a/client/src/store/usage.spec.ts
+++ b/client/src/store/usage.spec.ts
@@ -1,0 +1,26 @@
+import { overheadKey, setModelOverhead, getModelOverhead } from './usage';
+
+describe('model overhead cache', () => {
+  it('builds a stable key and round-trips overhead per config', () => {
+    const key = overheadKey('agents', 'gpt-5', 'agent_123');
+    /** Writer (usage handler) and reader (estimate) must build the same key. */
+    expect(key).toBe('agents::gpt-5::agent_123');
+
+    /** Unknown config defaults to 0 (estimate falls back to message-only). */
+    expect(getModelOverhead(key)).toBe(0);
+
+    setModelOverhead(key, 1500);
+    expect(getModelOverhead(key)).toBe(1500);
+
+    /** Non-positive overhead is ignored, keeping the last good value. */
+    setModelOverhead(key, 0);
+    expect(getModelOverhead(key)).toBe(1500);
+
+    /** A different agent/model is isolated. */
+    expect(getModelOverhead(overheadKey('openAI', 'gpt-4', null))).toBe(0);
+  });
+
+  it('treats missing endpoint/model/agentId as empty segments', () => {
+    expect(overheadKey(undefined, 'gpt-4', undefined)).toBe('::gpt-4::');
+  });
+});

--- a/client/src/store/usage.ts
+++ b/client/src/store/usage.ts
@@ -138,14 +138,20 @@ export function clearUsageFolded(conversationId: string): void {
  */
 const modelOverhead = new Map<string, number>();
 
-/** Stable cache key; the writer (usage handler) and reader (estimate) build it
- *  identically so a snapshot-less branch resolves the right config's overhead. */
+/** Stable cache key the writer (usage handler) and reader (estimate) build
+ *  identically. An agent resolves to its real provider/model only after its data
+ *  loads, so the reader (resolved) and writer (raw `agents` submission) would key
+ *  differently — key by `agentId` when present so both agree; non-agent configs
+ *  key by endpoint:model. */
 export function overheadKey(
   endpoint?: string | null,
   model?: string | null,
   agentId?: string | null,
 ): string {
-  return `${endpoint ?? ''}::${model ?? ''}::${agentId ?? ''}`;
+  if (agentId != null && agentId !== '') {
+    return `agent:${agentId}`;
+  }
+  return `${endpoint ?? ''}::${model ?? ''}`;
 }
 
 export function setModelOverhead(key: string, tokens: number): void {

--- a/client/src/store/usage.ts
+++ b/client/src/store/usage.ts
@@ -127,6 +127,37 @@ export function clearUsageFolded(conversationId: string): void {
   foldedUsageKeys.delete(conversationId);
 }
 
+/**
+ * Per-agent/model instruction+tool overhead — the system prompt + tool-schema
+ * tokens the next call always sends — cached from the breakdown the live
+ * `ON_CONTEXT_USAGE` event emits. Keyed by agent/model (NOT per conversation),
+ * so a snapshot-less branch (import / never-generated) can reuse the overhead
+ * once the same agent has run anywhere this session, making its prune budget and
+ * gauge account for the fixed overhead the client can't otherwise know. Never
+ * cleared on convo switch; bounded by the number of distinct configs used.
+ */
+const modelOverhead = new Map<string, number>();
+
+/** Stable cache key; the writer (usage handler) and reader (estimate) build it
+ *  identically so a snapshot-less branch resolves the right config's overhead. */
+export function overheadKey(
+  endpoint?: string | null,
+  model?: string | null,
+  agentId?: string | null,
+): string {
+  return `${endpoint ?? ''}::${model ?? ''}::${agentId ?? ''}`;
+}
+
+export function setModelOverhead(key: string, tokens: number): void {
+  if (tokens > 0) {
+    modelOverhead.set(key, tokens);
+  }
+}
+
+export function getModelOverhead(key: string): number {
+  return modelOverhead.get(key) ?? 0;
+}
+
 /** Jotai atomFamily entries are never GC'd — call on conversation switch/cleanup */
 export function removeUsageAtoms(conversationId: string): void {
   branchTotalsFamily.remove(conversationId);

--- a/client/src/utils/tokens.spec.ts
+++ b/client/src/utils/tokens.spec.ts
@@ -10,6 +10,7 @@ import {
   mergeUsage,
   setEntryUsage,
   sumTotalUsage,
+  prunedBranchTokens,
   findBranchSnapshotAnchor,
   estimateTokens,
   normalizeUsageUnits,
@@ -216,6 +217,34 @@ describe('token index', () => {
     /** a1 is the tail: 20 / 4 = 5, surfaced both in estTokens and tailEstTokens. */
     expect(totals.estTokens).toBe(5);
     expect(totals.tailEstTokens).toBe(5);
+  });
+
+  describe('prunedBranchTokens (over-window mirror of getMessagesWithinTokenLimit)', () => {
+    /** u1 ← a1(huge, old) ← u2 ← a2(tail). */
+    const buildChain = () =>
+      buildIndex(CONVO, [
+        msg('u1', Constants.NO_PARENT, true, 2),
+        msg('a1', 'u1', false, 10),
+        msg('u2', 'a1', true, 2),
+        msg('a2', 'u2', false, 2),
+      ]);
+
+    it('keeps the newest messages that fit and stops at the first overflow', () => {
+      buildChain();
+      /** Budget 8: a2(2)+u2(2)=4 fit; a1(10) would overflow → pruned. */
+      expect(prunedBranchTokens(CONVO, 'a2', 8, false)).toBe(4);
+    });
+
+    it('returns the full branch sum when it fits the budget', () => {
+      buildChain();
+      expect(prunedBranchTokens(CONVO, 'a2', 100, false)).toBe(16);
+    });
+
+    it('skips the in-flight tail when excludeTail is set', () => {
+      buildChain();
+      /** Skip a2; a1(10)+u2(2)+u1(2)=14 all fit under 100. */
+      expect(prunedBranchTokens(CONVO, 'a2', 100, true)).toBe(14);
+    });
   });
 
   it('caps the branch at a summary marker instead of re-summing compacted history', () => {

--- a/client/src/utils/tokens.ts
+++ b/client/src/utils/tokens.ts
@@ -388,6 +388,59 @@ export function sumBranch(
 }
 
 /**
+ * Message tokens that would actually be sent for an over-window branch. The send
+ * path prunes oldest-first to fit (`getMessagesWithinTokenLimit`), so walk the
+ * branch newest→oldest and stop once the next message would exceed `budget`,
+ * mirroring its "newest-that-fits" behavior for the gauge. Approximation: it omits
+ * the instruction/tool-schema overhead and tool-call pairing the real pruner also
+ * accounts for, which the client can't know for a snapshot-less branch — close
+ * enough for an estimate, and superseded by an exact snapshot once generated.
+ * `budget` is the message window (max minus the always-sent summary baseline);
+ * when `excludeTail`, the in-flight tail response is skipped (it rides on
+ * `liveTokens`). Per-message contribution matches `sumBranch`: stored `tokenCount`
+ * when counted, else the char-based `estTokens`.
+ */
+export function prunedBranchTokens(
+  conversationId: string,
+  tailId: string | null | undefined,
+  budget: number,
+  excludeTail: boolean,
+): number {
+  const index = registry.get(conversationId);
+  if (!index || !tailId || budget <= 0) {
+    return 0;
+  }
+
+  let total = 0;
+  let currentId: string | null = tailId;
+  let guard = index.size;
+  let isTail = true;
+
+  while (currentId && currentId !== Constants.NO_PARENT && guard-- > 0) {
+    const entry: TokenEntry | undefined = index.get(currentId);
+    if (!entry) {
+      break;
+    }
+    const skip = isTail && excludeTail;
+    isTail = false;
+    if (!skip) {
+      const contribution = entry.tokenCount > 0 ? entry.tokenCount : entry.estTokens;
+      if (total + contribution > budget) {
+        break;
+      }
+      total += contribution;
+    }
+    /** Pre-summary turns are subsumed by the baseline the caller already reserved,
+     *  so stop after counting the summarizing turn — mirrors `sumBranch`. */
+    if (entry.summaryUsedTokens != null && entry.summaryUsedTokens > 0) {
+      break;
+    }
+    currentId = entry.parentMessageId;
+  }
+  return total;
+}
+
+/**
  * Sums provider usage/cost across EVERY message in the conversation (all
  * branches, including regenerated/abandoned responses) — the conversation
  * total, shown alongside the branch figure when they differ.


### PR DESCRIPTION
## Summary

Follow-up to #13953 (client-side context gauge). For **snapshot-less branches** (imported / pre-feature / never-generated history), the gauge estimate is computed entirely client-side. This PR makes that estimate faithful to what the next call would actually send when the branch exceeds the context window, and accounts for the fixed instruction/tool overhead the client previously couldn't see.

## Changes

**1. Mirror the send-path pruning (over-window branches)**
Previously an over-window snapshot-less branch clamped `usedTokens` to the window (always 100%), hiding real headroom. The send path prunes oldest-first (`getMessagesWithinTokenLimit`), so a huge old turn followed by a small recent one actually sends far less than the window. New `prunedBranchTokens` walks the branch newest→oldest and stops at the first message that won't fit, mirroring that behavior, so the gauge shows the headroom the next call really has.

**2. Reserve cached instruction/tool overhead**
The client can't know a snapshot-less branch's instruction + tool-schema overhead. But the backend already emits it in the `ON_CONTEXT_USAGE` breakdown, so it's cached per agent/model (`endpoint::model::agentId`, already inclusive of tool schemas) from the live usage events, then **reserved from the prune budget and added to `used`** — making pruning accurate and the estimate consistent with real snapshots. Surfaced as a `System` row in the estimate breakdown.

## Behavior / scope

- Both only affect the **snapshot-less estimate path**; real snapshots (generated turns) stay authoritative and untouched.
- Overhead reserve activates once the agent has run at least once this session (cache warm); otherwise it falls back to message-only (prior behavior). A never-run imported agent has no overhead source client-side — a mid-run event can't cover a branch that never runs — so it degrades gracefully.
- Tool-call pairing is intentionally not modeled: it shifts the prune boundary by ≤1 message, negligible for a token-sum gauge.

## Tests

- `prunedBranchTokens`: keeps newest-that-fits / stops at first overflow, returns full sum when it fits, honors `excludeTail` (in-flight response).
- Overhead cache: key contract (writer/reader agree), positive-only set, default 0, per-config isolation.
- Content-preference and quote-recount estimate cases retained.