### PR TITLE
feat: support custom GitHub API URL for skill sync

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -73,6 +73,9 @@ cache: true
 #     runOnStartup: true
 #     sources:
 #       - id: librechat-skills
+#         # Optional. GitHub API base URL for GitHub Enterprise instances.
+#         # Omit for github.com (default: https://api.github.com).
+#         # apiUrl: 'https://github.your-company.com/api/v3'
 #         owner: your-org
 #         repo: your-skills-repo
 #         ref: main

--- a/packages/api/src/skills/sync/github.spec.ts
+++ b/packages/api/src/skills/sync/github.spec.ts
@@ -2268,4 +2268,52 @@ describe('createGitHubSkillSyncRunner', () => {
       jest.useRealTimers();
     }
   });
+
+  it('uses custom apiUrl from source config when making GitHub API requests', async () => {
+    const customApiUrl = 'https://github.enterprise.example.com/api/v3';
+    const deps = createDeps({
+      getConfig: () => ({
+        github: {
+          enabled: true,
+          intervalMinutes: 60,
+          runOnStartup: false,
+          sources: [
+            {
+              id: 'librechat-skills',
+              owner: 'LibreChat',
+              repo: 'skills',
+              ref: 'main',
+              paths: ['skills'],
+              credentialKey: 'github-skills-prod',
+              apiUrl: customApiUrl,
+            },
+          ],
+        },
+      }),
+    });
+    const runner = createGitHubSkillSyncRunner(deps);
+    await runner.runOnce();
+    const fetchedUrls = (deps.fetchFn as unknown as jest.Mock).mock.calls.map(
+      ([input]: [RequestInfo | URL]) => input.toString(),
+    );
+
+    expect(fetchedUrls.length).toBeGreaterThan(0);
+    for (const url of fetchedUrls) {
+      expect(url).toMatch(/^https:\/\/github\.enterprise\.example\.com\/api\/v3\//);
+    }
+  });
+
+  it('uses default https://api.github.com when apiUrl is not set', async () => {
+    const deps = createDeps();
+    const runner = createGitHubSkillSyncRunner(deps);
+    await runner.runOnce();
+    const fetchedUrls = (deps.fetchFn as unknown as jest.Mock).mock.calls.map(
+      ([input]: [RequestInfo | URL]) => input.toString(),
+    );
+
+    expect(fetchedUrls.length).toBeGreaterThan(0);
+    for (const url of fetchedUrls) {
+      expect(url).toMatch(/^https:\/\/api\.github\.com\//);
+    }
+  });
 });

--- a/packages/api/src/skills/sync/github.ts
+++ b/packages/api/src/skills/sync/github.ts
@@ -25,7 +25,7 @@ import type { SkillSyncConfig, SkillSyncGitHubSourceConfig } from 'librechat-dat
 import { DEFAULT_SKILL_IMPORT_LIMITS } from '../limits';
 import { parseSkillMarkdown } from '../parse';
 
-const GITHUB_API_BASE = 'https://api.github.com';
+const DEFAULT_GITHUB_API_BASE = 'https://api.github.com';
 const SYSTEM_AUTHOR_ID = new Types.ObjectId('000000000000000000000000');
 const SYSTEM_AUTHOR_NAME = 'GitHub Sync';
 const PROVIDER: SkillSyncProvider = 'github';
@@ -472,8 +472,8 @@ function buildGitHubHeaders(token: string): HeadersInit {
   };
 }
 
-function buildGitHubUrl(pathname: string): string {
-  return `${GITHUB_API_BASE}${pathname}`;
+function buildGitHubUrl(pathname: string, apiBase?: string): string {
+  return `${apiBase ?? DEFAULT_GITHUB_API_BASE}${pathname}`;
 }
 
 function encodeGitHubPath(value: string): string {
@@ -506,8 +506,9 @@ async function githubJson<T>(params: {
   fetchFn: FetchFn;
   token: string;
   pathname: string;
+  apiBase?: string;
 }): Promise<T> {
-  const response = await params.fetchFn(buildGitHubUrl(params.pathname), {
+  const response = await params.fetchFn(buildGitHubUrl(params.pathname, params.apiBase), {
     headers: buildGitHubHeaders(params.token),
   });
   if (response.ok) {
@@ -548,6 +549,7 @@ async function fetchCommit(params: {
     fetchFn: params.fetchFn,
     token: params.token,
     pathname: `/repos/${owner}/${repo}/commits/${ref}`,
+    apiBase: params.source.apiUrl,
   });
 }
 
@@ -566,6 +568,7 @@ async function fetchTree(params: {
     fetchFn: params.fetchFn,
     token: params.token,
     pathname: `/repos/${owner}/${repo}/git/trees/${treeSha}${recursive ? '?recursive=1' : ''}`,
+    apiBase: params.source.apiUrl,
   });
 }
 
@@ -656,6 +659,7 @@ async function fetchBlob(params: {
     fetchFn: params.fetchFn,
     token: params.token,
     pathname: `/repos/${owner}/${repo}/git/blobs/${sha}`,
+    apiBase: params.source.apiUrl,
   });
   if (blob.encoding !== 'base64') {
     throw new SkillSyncError(

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -779,6 +779,53 @@ describe('configSchema skillSync', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts an optional apiUrl on a GitHub skill sync source', () => {
+    const result = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'librechat-skills',
+              owner: 'LibreChat',
+              repo: 'skills',
+              paths: ['skills'],
+              credentialKey: 'github-skills-prod',
+              apiUrl: 'https://github.example.com/api/v3',
+            },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.skillSync?.github?.sources[0]?.apiUrl).toBe(
+      'https://github.example.com/api/v3',
+    );
+  });
+
+  it('rejects an invalid apiUrl on a GitHub skill sync source', () => {
+    const result = configSchema.safeParse({
+      version: '1.3.11',
+      skillSync: {
+        github: {
+          enabled: true,
+          sources: [
+            {
+              id: 'librechat-skills',
+              owner: 'LibreChat',
+              repo: 'skills',
+              paths: ['skills'],
+              credentialKey: 'github-skills-prod',
+              apiUrl: 'not-a-url',
+            },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('rejects enabled GitHub skill sync without sources', () => {
     const result = configSchema.safeParse({
       version: '1.3.11',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -365,6 +365,7 @@ const skillSyncTenantIdSchema = z
 export const skillSyncGitHubSourceSchema = z
   .object({
     id: skillSyncIdentifierSchema,
+    apiUrl: z.string().url().optional(),
     owner: skillSyncGitHubOwnerSchema,
     repo: skillSyncGitHubRepoSchema,
     ref: skillSyncGitHubRefSchema.default('main'),


### PR DESCRIPTION
## Summary

Allow configuring a per-source `apiUrl` in `librechat.yaml` so the GitHub skill sync can target GitHub Enterprise instances instead of only github.com. Will still default to github.com

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Configured the new optional `apiUrl` with a custom github enterprise api endpoint and fetched a skill from a repository.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted: https://github.com/LibreChat-AI/librechat.ai/pull/681
