### PR TITLE
🛗 perf: Fetch Pinned Agents Directly Past the Global Agents Map

### DIFF
--- a/client/src/common/agents-types.ts
+++ b/client/src/common/agents-types.ts
@@ -10,8 +10,6 @@ import type {
 } from 'librechat-data-provider';
 import type { OptionWithIcon, ExtendedFile } from './types';
 
-export type AgentQueryResult = { found: true; agent: Agent } | { found: false };
-
 export type TAgentOption = OptionWithIcon &
   Agent & {
     knowledge_files?: Array<[string, ExtendedFile]>;

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -31,7 +31,10 @@ const isMissingAgentError = (error: unknown): boolean => {
 
 /** Height intentionally matches FavoriteItem (px-3 py-2 + h-5 icon) to keep the CellMeasurerCache valid across the isAgentsLoading transition. */
 const FavoriteItemSkeleton = () => (
-  <div className="flex w-full items-center rounded-lg px-3 py-2">
+  <div
+    className="flex w-full items-center rounded-lg px-3 py-2"
+    data-testid="favorite-item-skeleton"
+  >
     <Skeleton className="mr-2 h-5 w-5 rounded-full" />
     <Skeleton className="h-4 w-24" />
   </div>
@@ -141,7 +144,8 @@ export default function FavoritesList({
   const { newConversation } = useNewConvo();
   const assistantsMap = useAssistantsMapContext();
   const agentsMap = useAgentsMapContext();
-  const { data: endpointsConfig = {} as TEndpointsConfig } = useGetEndpointsQuery();
+  const { data: endpointsConfig = {} as TEndpointsConfig, isLoading: isEndpointsLoading } =
+    useGetEndpointsQuery();
   const { data: startupConfig } = useGetStartupConfig();
 
   const modelSpecs = useMemo(
@@ -238,7 +242,8 @@ export default function FavoritesList({
       queryKey: [QueryKeys.agent, agentId],
       queryFn: (): Promise<Agent> => dataService.getAgentById({ agent_id: agentId }),
       staleTime: 1000 * 60 * 5,
-      retry: false,
+      retry: (failureCount: number, error: unknown) =>
+        !isMissingAgentError(error) && failureCount < 3,
     })),
   });
 
@@ -310,10 +315,12 @@ export default function FavoritesList({
   }, [agentsMap, agentQueries]);
 
   const isAgentsLoading =
-    agentIdsToFetch.length > 0 &&
-    agentQueries.some(
-      (q) => q.isLoading || (agentsMap === undefined && q.isError && !isMissingAgentError(q.error)),
-    );
+    allAgentIds.length > 0 &&
+    (isEndpointsLoading ||
+      agentQueries.some(
+        (q) =>
+          q.isLoading || (agentsMap === undefined && q.isError && !isMissingAgentError(q.error)),
+      ));
 
   const draggedFavoritesRef = useRef(safeFavorites);
 

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -248,6 +248,11 @@ export default function FavoritesList({
   });
 
   const staleAgentIdsKey = useMemo(() => {
+    // Only persist cleanup once the global map has loaded. A revoked AGENTS.USE role
+    // makes every getAgentById return a global 403, which must not delete favorites.
+    if (agentsMap === undefined) {
+      return '';
+    }
     const ids: string[] = [];
     for (let i = 0; i < agentIdsToFetch.length; i++) {
       const query = agentQueries[i];
@@ -256,7 +261,7 @@ export default function FavoritesList({
       }
     }
     return ids.sort().join(',');
-  }, [agentIdsToFetch, agentQueries]);
+  }, [agentIdsToFetch, agentQueries, agentsMap]);
 
   const cleanupAttemptedRef = useRef('');
 

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -5,9 +5,8 @@ import { useDrag, useDrop } from 'react-dnd';
 import { Skeleton } from '@librechat/client';
 import { useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
-import { QueryKeys, dataService } from 'librechat-data-provider';
+import { QueryKeys, EModelEndpoint, dataService } from 'librechat-data-provider';
 import type { Agent, TEndpointsConfig, TModelSpec } from 'librechat-data-provider';
-import type { AgentQueryResult } from '~/common';
 import {
   useGetConversation,
   useFavorites,
@@ -20,6 +19,15 @@ import { useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
 import useSelectMention from '~/hooks/Input/useSelectMention';
 import FavoriteItem from './FavoriteItem';
 import store from '~/store';
+
+/** A 404/403 from getAgentById means the agent is gone or inaccessible; other errors are transient. */
+const isMissingAgentError = (error: unknown): boolean => {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const status = (error as { response?: { status?: number } }).response?.status;
+    return status === 404 || status === 403;
+  }
+  return false;
+};
 
 /** Height intentionally matches FavoriteItem (px-3 py-2 + h-5 icon) to keep the CellMeasurerCache valid across the isAgentsLoading transition. */
 const FavoriteItemSkeleton = () => (
@@ -213,32 +221,24 @@ export default function FavoritesList({
     [safeFavorites],
   );
 
+  const agentsEndpointEnabled = !!endpointsConfig?.[EModelEndpoint.agents];
+
   const agentIdsToFetch = useMemo(() => {
+    if (!agentsEndpointEnabled) {
+      return [];
+    }
     if (agentsMap === undefined) {
       return allAgentIds;
     }
     return allAgentIds.filter((id) => !agentsMap[id]);
-  }, [allAgentIds, agentsMap]);
+  }, [allAgentIds, agentsMap, agentsEndpointEnabled]);
 
   const agentQueries = useQueries({
     queries: agentIdsToFetch.map((agentId) => ({
       queryKey: [QueryKeys.agent, agentId],
-      queryFn: async (): Promise<AgentQueryResult> => {
-        try {
-          const agent = await dataService.getAgentById({ agent_id: agentId });
-          return { found: true, agent };
-        } catch (error) {
-          if (error && typeof error === 'object' && 'response' in error) {
-            const axiosError = error as { response?: { status?: number } };
-            const status = axiosError.response?.status;
-            if (status === 404 || status === 403) {
-              return { found: false };
-            }
-          }
-          throw error;
-        }
-      },
+      queryFn: (): Promise<Agent> => dataService.getAgentById({ agent_id: agentId }),
       staleTime: 1000 * 60 * 5,
+      retry: false,
     })),
   });
 
@@ -246,7 +246,7 @@ export default function FavoritesList({
     const ids: string[] = [];
     for (let i = 0; i < agentIdsToFetch.length; i++) {
       const query = agentQueries[i];
-      if (query.data && !query.data.found) {
+      if (query.isError && isMissingAgentError(query.error)) {
         ids.push(agentIdsToFetch[i]);
       }
     }
@@ -302,14 +302,18 @@ export default function FavoritesList({
       }
     }
     agentQueries.forEach((query) => {
-      if (query.data?.found) {
-        combined[query.data.agent.id] = query.data.agent;
+      if (query.data) {
+        combined[query.data.id] = query.data;
       }
     });
     return combined;
   }, [agentsMap, agentQueries]);
 
-  const isAgentsLoading = agentIdsToFetch.length > 0 && agentQueries.some((q) => q.isLoading);
+  const isAgentsLoading =
+    agentIdsToFetch.length > 0 &&
+    agentQueries.some(
+      (q) => q.isLoading || (agentsMap === undefined && q.isError && !isMissingAgentError(q.error)),
+    );
 
   const draggedFavoritesRef = useRef(safeFavorites);
 

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback, useMemo, useEffect } from 'react';
-import { LayoutGrid } from 'lucide-react';
 import { useRecoilValue } from 'recoil';
+import { LayoutGrid } from 'lucide-react';
 import { useDrag, useDrop } from 'react-dnd';
 import { Skeleton } from '@librechat/client';
 import { useNavigate } from 'react-router-dom';
@@ -213,15 +213,15 @@ export default function FavoritesList({
     [safeFavorites],
   );
 
-  const missingAgentIds = useMemo(() => {
+  const agentIdsToFetch = useMemo(() => {
     if (agentsMap === undefined) {
-      return [];
+      return allAgentIds;
     }
     return allAgentIds.filter((id) => !agentsMap[id]);
   }, [allAgentIds, agentsMap]);
 
-  const missingAgentQueries = useQueries({
-    queries: missingAgentIds.map((agentId) => ({
+  const agentQueries = useQueries({
+    queries: agentIdsToFetch.map((agentId) => ({
       queryKey: [QueryKeys.agent, agentId],
       queryFn: async (): Promise<AgentQueryResult> => {
         try {
@@ -244,14 +244,14 @@ export default function FavoritesList({
 
   const staleAgentIdsKey = useMemo(() => {
     const ids: string[] = [];
-    for (let i = 0; i < missingAgentIds.length; i++) {
-      const query = missingAgentQueries[i];
+    for (let i = 0; i < agentIdsToFetch.length; i++) {
+      const query = agentQueries[i];
       if (query.data && !query.data.found) {
-        ids.push(missingAgentIds[i]);
+        ids.push(agentIdsToFetch[i]);
       }
     }
     return ids.sort().join(',');
-  }, [missingAgentIds, missingAgentQueries]);
+  }, [agentIdsToFetch, agentQueries]);
 
   const cleanupAttemptedRef = useRef('');
 
@@ -293,26 +293,23 @@ export default function FavoritesList({
   }, [staleSpecNamesKey, safeFavorites, reorderFavorites]);
 
   const combinedAgentsMap = useMemo(() => {
-    if (agentsMap === undefined) {
-      return undefined;
-    }
     const combined: Record<string, Agent> = {};
-    for (const [key, value] of Object.entries(agentsMap)) {
-      if (value) {
-        combined[key] = value;
+    if (agentsMap) {
+      for (const [key, value] of Object.entries(agentsMap)) {
+        if (value) {
+          combined[key] = value;
+        }
       }
     }
-    missingAgentQueries.forEach((query) => {
+    agentQueries.forEach((query) => {
       if (query.data?.found) {
         combined[query.data.agent.id] = query.data.agent;
       }
     });
     return combined;
-  }, [agentsMap, missingAgentQueries]);
+  }, [agentsMap, agentQueries]);
 
-  const isAgentsLoading =
-    (allAgentIds.length > 0 && agentsMap === undefined) ||
-    (missingAgentIds.length > 0 && missingAgentQueries.some((q) => q.isLoading));
+  const isAgentsLoading = agentIdsToFetch.length > 0 && agentQueries.some((q) => q.isLoading);
 
   const draggedFavoritesRef = useRef(safeFavorites);
 

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -76,9 +76,11 @@ const mockUseGetStartupConfig = jest.fn((): { data?: { modelSpecs: { list: unkno
   data: { modelSpecs: { list: [] as unknown[] } },
 }));
 
-const mockUseGetEndpointsQuery = jest.fn((): { data: Record<string, unknown> } => ({
-  data: { [EModelEndpoint.agents]: { order: 0 } },
-}));
+const mockUseGetEndpointsQuery = jest.fn(
+  (): { data?: Record<string, unknown>; isLoading?: boolean } => ({
+    data: { [EModelEndpoint.agents]: { order: 0 } },
+  }),
+);
 
 jest.mock('~/data-provider', () => ({
   useGetEndpointsQuery: () => mockUseGetEndpointsQuery(),
@@ -253,6 +255,20 @@ describe('FavoritesList', () => {
 
       await new Promise((r) => setTimeout(r, 50));
       expect(dataService.getAgentById as jest.Mock).not.toHaveBeenCalled();
+      expect(queryAllByTestId('favorite-item')).toHaveLength(0);
+    });
+
+    it('keeps skeletons (not an empty row) while the endpoints config is still loading', async () => {
+      mockUseGetEndpointsQuery.mockImplementation(() => ({ data: undefined, isLoading: true }));
+      mockUseAgentsMapContext.mockImplementation(() => undefined);
+      mockFavorites.push({ agentId: 'pinned-agent' });
+
+      const { queryAllByTestId } = renderWithProviders(<FavoritesList />);
+
+      await new Promise((r) => setTimeout(r, 50));
+      // Endpoint gate is undecided, so no direct fetch yet, but the row stays as a skeleton.
+      expect(dataService.getAgentById as jest.Mock).not.toHaveBeenCalled();
+      expect(queryAllByTestId('favorite-item-skeleton').length).toBeGreaterThan(0);
       expect(queryAllByTestId('favorite-item')).toHaveLength(0);
     });
 

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -272,6 +272,30 @@ describe('FavoritesList', () => {
       expect(queryAllByTestId('favorite-item')).toHaveLength(0);
     });
 
+    it('does not delete favorites on a global 403 while the agents map is unavailable', async () => {
+      const mockReorderFavorites = jest.fn();
+      // A revoked AGENTS.USE role makes the list query (and thus the map) fail, so the
+      // map stays undefined and every getAgentById returns a global 403.
+      mockUseAgentsMapContext.mockImplementation(() => undefined);
+      mockUseFavorites.mockImplementation(() => ({
+        favorites: [{ agentId: 'agent-a' }, { agentId: 'agent-b' }],
+        reorderFavorites: mockReorderFavorites,
+        isLoading: false,
+      }));
+
+      (dataService.getAgentById as jest.Mock).mockRejectedValue({ response: { status: 403 } });
+
+      const { queryAllByTestId } = renderWithProviders(<FavoritesList />);
+
+      await waitFor(() => {
+        expect(dataService.getAgentById as jest.Mock).toHaveBeenCalledWith({ agent_id: 'agent-a' });
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockReorderFavorites).not.toHaveBeenCalled();
+      expect(queryAllByTestId('favorite-item')).toHaveLength(0);
+    });
+
     it('keeps a pinned agent as a skeleton on a transient error while the map is still loading', async () => {
       const mockReorderFavorites = jest.fn();
       mockUseAgentsMapContext.mockImplementation(() => undefined);

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -4,8 +4,8 @@ import '@testing-library/jest-dom';
 import { RecoilRoot } from 'recoil';
 import { DndProvider } from 'react-dnd';
 import { BrowserRouter } from 'react-router-dom';
-import { dataService } from 'librechat-data-provider';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { dataService, EModelEndpoint } from 'librechat-data-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Agent } from 'librechat-data-provider';
 
@@ -76,8 +76,12 @@ const mockUseGetStartupConfig = jest.fn((): { data?: { modelSpecs: { list: unkno
   data: { modelSpecs: { list: [] as unknown[] } },
 }));
 
+const mockUseGetEndpointsQuery = jest.fn((): { data: Record<string, unknown> } => ({
+  data: { [EModelEndpoint.agents]: { order: 0 } },
+}));
+
 jest.mock('~/data-provider', () => ({
-  useGetEndpointsQuery: () => ({ data: {} }),
+  useGetEndpointsQuery: () => mockUseGetEndpointsQuery(),
   useGetStartupConfig: () => mockUseGetStartupConfig(),
 }));
 
@@ -125,6 +129,9 @@ describe('FavoritesList', () => {
     jest.clearAllMocks();
     mockFavorites.length = 0;
     mockUseAgentsMapContext.mockImplementation(() => ({}));
+    mockUseGetEndpointsQuery.mockImplementation(() => ({
+      data: { [EModelEndpoint.agents]: { order: 0 } },
+    }));
     mockUseFavorites.mockImplementation(() => ({
       favorites: mockFavorites,
       reorderFavorites: jest.fn(),
@@ -235,6 +242,42 @@ describe('FavoritesList', () => {
       expect(dataService.getAgentById as jest.Mock).toHaveBeenCalledWith({
         agent_id: 'pinned-agent',
       });
+    });
+
+    it('does not fetch or render agents when the agents endpoint is disabled', async () => {
+      mockUseGetEndpointsQuery.mockImplementation(() => ({ data: {} }));
+      mockUseAgentsMapContext.mockImplementation(() => undefined);
+      mockFavorites.push({ agentId: 'pinned-agent' });
+
+      const { queryAllByTestId } = renderWithProviders(<FavoritesList />);
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(dataService.getAgentById as jest.Mock).not.toHaveBeenCalled();
+      expect(queryAllByTestId('favorite-item')).toHaveLength(0);
+    });
+
+    it('keeps a pinned agent as a skeleton on a transient error while the map is still loading', async () => {
+      const mockReorderFavorites = jest.fn();
+      mockUseAgentsMapContext.mockImplementation(() => undefined);
+      mockUseFavorites.mockImplementation(() => ({
+        favorites: [{ agentId: 'flaky-agent' }],
+        reorderFavorites: mockReorderFavorites,
+        isLoading: false,
+      }));
+
+      (dataService.getAgentById as jest.Mock).mockRejectedValue({ response: { status: 500 } });
+
+      const { queryAllByTestId } = renderWithProviders(<FavoritesList />);
+
+      await waitFor(() => {
+        expect(dataService.getAgentById as jest.Mock).toHaveBeenCalledWith({
+          agent_id: 'flaky-agent',
+        });
+      });
+
+      // Item is neither rendered nor cleaned up — it stays in the loading skeleton state.
+      expect(queryAllByTestId('favorite-item')).toHaveLength(0);
+      expect(mockReorderFavorites).not.toHaveBeenCalled();
     });
 
     it('should treat 403 the same as 404 — agent not rendered', async () => {

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -60,9 +60,10 @@ jest.mock('~/hooks', () => ({
   useGetConversation: () => () => null,
 }));
 
+const mockUseAgentsMapContext = jest.fn((): Record<string, Agent> | undefined => ({}));
 jest.mock('~/Providers', () => ({
   useAssistantsMapContext: () => ({}),
-  useAgentsMapContext: () => ({}),
+  useAgentsMapContext: () => mockUseAgentsMapContext(),
 }));
 
 const mockOnSelectSpec = jest.fn();
@@ -123,6 +124,7 @@ describe('FavoritesList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFavorites.length = 0;
+    mockUseAgentsMapContext.mockImplementation(() => ({}));
     mockUseFavorites.mockImplementation(() => ({
       favorites: mockFavorites,
       reorderFavorites: jest.fn(),
@@ -211,6 +213,28 @@ describe('FavoritesList', () => {
 
       // No favorite items should be rendered (deleted agent is filtered out)
       expect(queryAllByTestId('favorite-item')).toHaveLength(0);
+    });
+
+    it('renders pinned agents via direct fetch while the global agents map is still loading', async () => {
+      const validAgent: Agent = {
+        id: 'pinned-agent',
+        name: 'Pinned Agent',
+        author: 'test-author',
+      } as Agent;
+
+      mockUseAgentsMapContext.mockImplementation(() => undefined);
+      mockFavorites.push({ agentId: 'pinned-agent' });
+
+      (dataService.getAgentById as jest.Mock).mockResolvedValue(validAgent);
+
+      const { findAllByTestId } = renderWithProviders(<FavoritesList />);
+
+      const favoriteItems = await findAllByTestId('favorite-item');
+      expect(favoriteItems).toHaveLength(1);
+      expect(favoriteItems[0]).toHaveTextContent('Pinned Agent');
+      expect(dataService.getAgentById as jest.Mock).toHaveBeenCalledWith({
+        agent_id: 'pinned-agent',
+      });
     });
 
     it('should treat 403 the same as 404 — agent not rendered', async () => {


### PR DESCRIPTION
## Summary

Fixes #13967. Pinned/favorite agents in the sidebar could take a long time to appear during startup because `FavoritesList` derived their data from the **full global agents map** (`useListAgentsQuery`, which walks every pagination cursor). In environments with many agents, pinned items stayed in a loading skeleton even though their IDs were already known.

## Change

`client/src/components/Nav/Favorites/FavoritesList.tsx`:

- When the global agents map is still loading (`agentsMap === undefined`), fetch the pinned agent IDs **directly** via the existing `dataService.getAgentById` instead of returning an empty set and waiting. Once the map is available, fall back to fetching only the IDs missing from it.
- `combinedAgentsMap` now builds from whatever is available (map entries when present, plus the direct-fetch results) and is never `undefined`.
- `isAgentsLoading` tracks only the small set of pinned-agent queries rather than the entire catalog, so pinned agents render as soon as their own data resolves.

The per-agent queries are keyed `[QueryKeys.agent, id]`, so React Query dedupes — no double-fetching when the full catalog later resolves.

## Safety

Confirmed `GET /api/agents/:id` and `GET /api/agents` apply identical VIEW-permission checks against the same ACL layer, so fetching pinned agents individually can't wrongly trip the existing 404/403 stale-favorite cleanup.

## Tests

- Added a test asserting pinned agents render via direct fetch while the global map is still `undefined` (loading).
- Existing `FavoritesList` suite (13 tests) passes.