### PR TITLE
📇 fix: Index sharedlinks updatedAt for Cosmos DB Sorts

### DIFF
--- a/packages/data-schemas/src/schema/share.ts
+++ b/packages/data-schemas/src/schema/share.ts
@@ -84,5 +84,6 @@ const shareSchema: Schema<ISharedLink> = new Schema(
 
 shareSchema.index({ expiredAt: 1 }, { expireAfterSeconds: 0 });
 shareSchema.index({ conversationId: 1, user: 1, targetMessageId: 1, tenantId: 1 });
+shareSchema.index({ updatedAt: -1 });
 
 export default shareSchema;


### PR DESCRIPTION
## Summary

Fixes #13960.

v0.8.6 added `.sort({ updatedAt: -1 })` to the `getSharedLink` query, but the `sharedlinks` collection has no `updatedAt` index. Azure Cosmos DB for MongoDB (RU-based) rejects sorts on non-indexed fields, returning an immediate 500 on `GET /api/share/link/:conversationId` — which fires whenever a conversation is opened. Standard MongoDB is unaffected (it sorts non-indexed fields fine).

## Change

One-line index addition in `packages/data-schemas/src/schema/share.ts`:

```ts
shareSchema.index({ updatedAt: -1 });
```

This makes the sort path indexable on Cosmos, matching the user-confirmed workaround (`db.sharedlinks.createIndex({ updatedAt: -1 })`) and the same pattern already used for the conversation (#1731) and `agentCategory` (#9428) schemas.

## Verification

- `tsc --noEmit` on `packages/data-schemas` is clean.
- The data-schemas `shareSchema` is the single source — `api/models` consumes it via `createSharedLinkModel`, so no duplicate schema needs the change.

## Test plan

- [x] Type check passes
- [x] Index is created on existing deployments (Mongoose builds it on model init); new sort queries on `sharedlinks` succeed on Cosmos RU-based backends
