### PR TITLE
fix: send input_audio to all OpenAI-compatible providers, not only OpenRouter

### DIFF
--- a/packages/api/src/files/encode/audio.spec.ts
+++ b/packages/api/src/files/encode/audio.spec.ts
@@ -1,0 +1,94 @@
+import { Providers } from '@librechat/agents';
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { IMongoFile } from '@librechat/data-schemas';
+import type { ServerRequest } from '~/types';
+import { encodeAndFormatAudios } from './audio';
+
+jest.mock('~/files/validation', () => ({
+  validateAudio: jest.fn(),
+}));
+
+jest.mock('./utils', () => ({
+  getFileStream: jest.fn(),
+  getConfiguredFileSizeLimit: jest.fn(),
+}));
+
+import { validateAudio } from '~/files/validation';
+import { getFileStream, getConfiguredFileSizeLimit } from './utils';
+import { Types } from 'mongoose';
+
+const mockedValidateAudio = validateAudio as jest.MockedFunction<typeof validateAudio>;
+const mockedGetFileStream = getFileStream as jest.MockedFunction<typeof getFileStream>;
+const mockedGetConfiguredFileSizeLimit = getConfiguredFileSizeLimit as jest.MockedFunction<
+  typeof getConfiguredFileSizeLimit
+>;
+
+describe('encodeAndFormatAudios - provider formatting', () => {
+  const mockStrategyFunctions = jest.fn();
+  const content = Buffer.from('fake-audio-bytes').toString('base64');
+
+  const createMockAudioFile = (filename = 'voice.mp3', type = 'audio/mp3'): IMongoFile =>
+    ({
+      _id: new Types.ObjectId(),
+      user: new Types.ObjectId(),
+      file_id: new Types.ObjectId().toString(),
+      filename,
+      type,
+      bytes: 2048,
+      object: 'file',
+      usage: 0,
+      source: 'test',
+      filepath: `/test/${filename}`,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }) as unknown as IMongoFile;
+
+  const encodeFor = (provider: Providers) => {
+    const file = createMockAudioFile();
+    mockedGetFileStream.mockResolvedValue({ file, content, metadata: file });
+    return encodeAndFormatAudios({} as ServerRequest, [file], { provider }, mockStrategyFunctions);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetConfiguredFileSizeLimit.mockReturnValue(undefined);
+    mockedValidateAudio.mockResolvedValue({ isValid: true });
+  });
+
+  it.each([
+    Providers.OPENAI,
+    Providers.OPENROUTER,
+    Providers.MISTRALAI,
+    Providers.DEEPSEEK,
+    Providers.XAI,
+    Providers.MOONSHOT,
+  ])('sends input_audio to OpenAI-compatible provider %s', async (provider) => {
+    const result = await encodeFor(provider);
+    expect(result.audios).toHaveLength(1);
+    expect(result.audios[0]).toEqual({
+      type: 'input_audio',
+      input_audio: { data: content, format: 'mp3' },
+    });
+  });
+
+  it('sends input_audio to an OpenAI-compatible custom endpoint', async () => {
+    const result = await encodeFor(EModelEndpoint.custom as unknown as Providers);
+    expect(result.audios).toHaveLength(1);
+    expect(result.audios[0]).toMatchObject({
+      type: 'input_audio',
+      input_audio: { format: 'mp3' },
+    });
+  });
+
+  it.each([Providers.GOOGLE, Providers.VERTEXAI])('sends a media block to %s', async (provider) => {
+    const result = await encodeFor(provider);
+    expect(result.audios).toHaveLength(1);
+    expect(result.audios[0]).toEqual({ type: 'media', mimeType: 'audio/mp3', data: content });
+  });
+
+  it('does not send audio to a document-supported provider that has no audio input (anthropic)', async () => {
+    const result = await encodeFor(Providers.ANTHROPIC);
+    expect(result.audios).toHaveLength(0);
+    expect(result.files).toHaveLength(1);
+  });
+});

--- a/packages/api/src/files/encode/audio.ts
+++ b/packages/api/src/files/encode/audio.ts
@@ -1,5 +1,5 @@
 import { Providers } from '@librechat/agents';
-import { isDocumentSupportedProvider } from 'librechat-data-provider';
+import { isDocumentSupportedProvider, isOpenAILikeProvider } from 'librechat-data-provider';
 import type { IMongoFile } from '@librechat/data-schemas';
 import type { ServerRequest, StrategyFunctions, AudioResult } from '~/types';
 import { getFileStream, getConfiguredFileSizeLimit } from './utils';
@@ -11,7 +11,7 @@ import { runGuardedEncode } from './memoryGuard';
  * @param req - The request object
  * @param files - Array of audio files
  * @param params - Object containing provider and optional endpoint
- * @param params.provider - The provider to format for (currently only google is supported)
+ * @param params.provider - The provider to format for (Google/Vertex use media blocks; OpenAI-compatible providers use input_audio)
  * @param params.endpoint - Optional endpoint name for file config lookup
  * @param getStrategyFunctions - Function to get strategy functions
  * @returns Promise that resolves to audio and file metadata
@@ -84,10 +84,11 @@ export async function encodeAndFormatAudios(
         mimeType: file.type,
         data: content,
       });
-    } else if (provider === Providers.OPENROUTER) {
-      // Extract format from filename extension (e.g., 'audio.mp3' -> 'mp3')
-      // OpenRouter expects format values like: wav, mp3, aiff, aac, ogg, flac, m4a, pcm16, pcm24
-      // Note: MIME types don't always match (e.g., 'audio/mpeg' is mp3, not mpeg), so that is why we are using the file extension instead
+    } else if (isOpenAILikeProvider(provider)) {
+      // input_audio is the OpenAI-standard audio content part, so it applies to every
+      // OpenAI-compatible provider (OpenAI, Azure, custom endpoints, OpenRouter, etc.).
+      // Format is taken from the filename extension (e.g. 'audio.mp3' -> 'mp3'); MIME types
+      // don't always match (e.g. 'audio/mpeg' is mp3, not mpeg), so the extension is more reliable.
       const format = file.filename.split('.').pop()?.toLowerCase();
       if (!format) {
         throw new Error(`Could not extract audio format from filename: ${file.filename}`);


### PR DESCRIPTION
## Summary

`encodeAndFormatAudios` (`packages/api/src/files/encode/audio.ts`) only emits the OpenAI-standard `input_audio` content part when the provider is **OpenRouter**:

```ts
if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
  // media block
} else if (provider === Providers.OPENROUTER) {
  // input_audio
}
// every other provider: nothing
```

`input_audio` (`{ type: 'input_audio', input_audio: { data, format } }`) is the **OpenAI standard** audio content part, used by OpenAI's own audio models and every OpenAI-compatible endpoint. But audio is only emitted for OpenRouter. Other OpenAI-compatible providers — `openAI`, **custom endpoints**, `mistral`/`mistralai`, `deepseek`, `xai`, `moonshot` — pass the `isDocumentSupportedProvider` gate yet match no branch, so their audio uploads are silently dropped and never reach the model.

This is most visible with **custom endpoints**: e.g. an OpenAI-compatible provider serving an audio-capable model (Voxtral, GPT-4o-audio-class models, etc.) can never receive audio through LibreChat, even though the provider supports it.

## Fix

Reuse the existing `isOpenAILikeProvider()` predicate (already used elsewhere in `data-provider`) instead of hardcoding `=== Providers.OPENROUTER`:

```ts
} else if (isOpenAILikeProvider(provider)) {
  // input_audio for every OpenAI-compatible provider
}
```

Google/Vertex keep their `media` block. Providers that are document-supported but have no audio input (e.g. `anthropic`) still fall through and the audio is dropped, exactly as before — no regression.

## Tests

Adds `audio.spec.ts` (mirrors the existing `document.spec.ts` style) covering the provider formatting matrix:
- `input_audio` for OpenAI / OpenRouter / Mistral / DeepSeek / xAI / Moonshot and a custom endpoint
- `media` block for Google / Vertex
- audio dropped for a document-supported, non-audio provider (anthropic)

`packages/api` jest green (`src/files/encode`), eslint/prettier clean.

## Scope

Audio only. `video.ts` has a similar OpenRouter-only branch, but it emits a non-standard `video_url` data URL that only OpenRouter/Gemini accept (video isn't a standard OpenAI chat content part), so generalizing video is intentionally left out of this PR.

Draft pending maintainer review.