### PR TITLE
feat: add plumbing for webSearch config options

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -807,6 +807,10 @@ endpoints:
 #   # Content scrapers
 #   firecrawlApiKey: '${FIRECRAWL_API_KEY}'
 #   firecrawlApiUrl: '${FIRECRAWL_API_URL}'
+#   topResults: 5  # Highlights (relevant chunks) kept per source after reranking
+#   maxContentLength: 50000  # Max scraped characters per source, applied before chunking
+#   mainExpandBy: 300  # Padding added on each side of a highlight, in chars
+#   separatorExpandBy: 150  # Extra range searched for a sentence/paragraph boundary when trimming the expanded highlight
 #
 # Tavily as both search and scraper provider example:
 # webSearch:

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -390,6 +390,56 @@ describe('web.ts', () => {
       expect(result.authResult).toHaveProperty('safeSearch', SafeSearchTypes.OFF);
     });
 
+    it('should pass through content-processing options from webSearchConfig', async () => {
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] = 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const configWithOptions = {
+        ...webSearchConfig,
+        topResults: 8,
+        maxContentLength: 50000,
+        mainExpandBy: 400,
+        separatorExpandBy: 200,
+      } as TWebSearchConfig;
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig: configWithOptions,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult).toHaveProperty('topResults', 8);
+      expect(result.authResult).toHaveProperty('maxContentLength', 50000);
+      expect(result.authResult).toHaveProperty('mainExpandBy', 400);
+      expect(result.authResult).toHaveProperty('separatorExpandBy', 200);
+    });
+
+    it('should leave content-processing options undefined when not configured', async () => {
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] = 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.topResults).toBeUndefined();
+      expect(result.authResult.maxContentLength).toBeUndefined();
+      expect(result.authResult.mainExpandBy).toBeUndefined();
+      expect(result.authResult.separatorExpandBy).toBeUndefined();
+    });
+
     it('should set the correct service types in authResult', async () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -288,6 +288,10 @@ export async function loadWebSearchAuth({
   authResult.firecrawlOptions = webSearchConfig?.firecrawlOptions;
   authResult.tavilySearchOptions = webSearchConfig?.tavilySearchOptions;
   authResult.tavilyScraperOptions = webSearchConfig?.tavilyScraperOptions;
+  authResult.topResults = webSearchConfig?.topResults;
+  authResult.maxContentLength = webSearchConfig?.maxContentLength;
+  authResult.mainExpandBy = webSearchConfig?.mainExpandBy;
+  authResult.separatorExpandBy = webSearchConfig?.separatorExpandBy;
 
   return {
     authTypes,

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -525,6 +525,39 @@ describe('webSearchSchema', () => {
     expect(result.tavilyScraperOptions?.timeout).toBe(15000);
   });
 
+  it('accepts content-processing options within bounds', () => {
+    const result = webSearchSchema.parse({
+      topResults: 10,
+      maxContentLength: 25000,
+      mainExpandBy: 300,
+      separatorExpandBy: 150,
+    });
+
+    expect(result.topResults).toBe(10);
+    expect(result.maxContentLength).toBe(25000);
+    expect(result.mainExpandBy).toBe(300);
+    expect(result.separatorExpandBy).toBe(150);
+  });
+
+  it('accepts zero for expansion options', () => {
+    const result = webSearchSchema.parse({
+      mainExpandBy: 0,
+      separatorExpandBy: 0,
+    });
+
+    expect(result.mainExpandBy).toBe(0);
+    expect(result.separatorExpandBy).toBe(0);
+  });
+
+  it('rejects out-of-range content-processing options', () => {
+    expect(() => webSearchSchema.parse({ topResults: 0 })).toThrow();
+    expect(() => webSearchSchema.parse({ topResults: 21 })).toThrow();
+    expect(() => webSearchSchema.parse({ topResults: 5.5 })).toThrow();
+    expect(() => webSearchSchema.parse({ maxContentLength: 0 })).toThrow();
+    expect(() => webSearchSchema.parse({ mainExpandBy: -1 })).toThrow();
+    expect(() => webSearchSchema.parse({ separatorExpandBy: -1 })).toThrow();
+  });
+
   it('rejects invalid Tavily search options', () => {
     expect(() =>
       webSearchSchema.parse({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1520,6 +1520,10 @@ export const webSearchSchema = z.object({
   rerankerType: z.nativeEnum(RerankerTypes).optional(),
   scraperTimeout: z.number().int().nonnegative().optional(),
   safeSearch: z.nativeEnum(SafeSearchTypes).default(SafeSearchTypes.MODERATE),
+  topResults: z.number().int().min(1).max(20).optional(),
+  maxContentLength: z.number().int().positive().optional(),
+  mainExpandBy: z.number().int().nonnegative().optional(),
+  separatorExpandBy: z.number().int().nonnegative().optional(),
   firecrawlOptions: z
     .object({
       formats: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Several `webSearch` tuning knobs accepted by `@librechat/agents`'
`createSearchTool` are not threaded from `librechat.yaml`:

- **`topResults`** — declared in `data-provider`'s web types but never assigned
  into the config passed to `createSearchTool`; currently has no effect from YAML.
- **`maxContentLength`** — reachable only via the `SEARCH_MAX_CONTENT_LENGTH`
  env var (added in [agents #234](https://github.com/danny-avila/agents/pull/234)), not via `librechat.yaml`.
- **`mainExpandBy` / `separatorExpandBy`** — highlight expansion size, the
  dominant contributor to web search payload size for small context windows
  (see [agents PR #276](https://github.com/danny-avila/agents/pull/276)). Configurable in agents, but not surfaced here.

`loadWebSearchAuth` builds `authResult` by explicitly copying a fixed allowlist
of fields from `webSearchConfig` (`firecrawlOptions`, `safeSearch`,
`scraperTimeout`, etc.). Fields outside that list — including the four above —
never reach `createSearchTool`. This PR adds them to the `webSearch` schema and
to the `authResult` assembly.

`topResults` and `maxContentLength` take effect against the current pinned
agents version immediately. The expansion params require the agents bump that
includes [#276](https://github.com/danny-avila/agents/pull/276); until then they validate and pass through harmlessly (the
installed agents version ignores unknown config fields).

## Changes

- `packages/data-provider/src/config.ts`: add `topResults`, `maxContentLength`,
  `mainExpandBy`, `separatorExpandBy` to `webSearchSchema`.
- `packages/api/src/web/web.ts`: assign each from `webSearchConfig` into
  `authResult`, beside the existing `firecrawlOptions` / `tavily*` assignments.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Built a local `@librechat/agents` with [agents PR #276](https://github.com/danny-avila/agents/pull/276),
  pointed `package.json` at the tarball, set the new keys in `librechat.yaml`, and
  confirmed via debug logging that the YAML values reach `expandHighlights`
  and `getHighlights` (highlight expansion size and result count change as configured).
- `topResults` / `maxContentLength` verified against the released agents version
  without the tarball.
- `npm run test:api` for the affected packages; `tsc`/eslint clean.

### **Test Configuration**:

- **LibreChat:** v0.8.7, built from fork (this PR's changes) with a locally-built
  `@librechat/agents` containing the companion change [agents PR #276](https://github.com/danny-avila/agents/pull/276) 
  injected as a `file:` tarball dependency.
- **Search provider:** SearXNG (self-hosted)
- **Scraper:** Firecrawl-compatible API (self-hosted), `firecrawlVersion: v2`
- **Reranker:** Jina-compatible endpoint (self-hosted CrossEncoder,
  `BAAI/bge-reranker-v2-m3`)
- **Model:** Ollama (qwen3.6:27b), 131072 context, via agents endpoint
- **Deployment:** Docker / Portainer on Linux

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
