### PR TITLE
fix: add updatedAt index to sharedLinks schema

### DIFF
--- a/packages/data-schemas/src/schema/share.ts
+++ b/packages/data-schemas/src/schema/share.ts
@@ -84,5 +84,6 @@ const shareSchema: Schema<ISharedLink> = new Schema(
 
 shareSchema.index({ expiredAt: 1 }, { expireAfterSeconds: 0 });
 shareSchema.index({ conversationId: 1, user: 1, targetMessageId: 1, tenantId: 1 });
+shareSchema.index({ updatedAt: -1, _id: 1 });
 
 export default shareSchema;


### PR DESCRIPTION
Closes #13960. `getSharedLink` sorts by `updatedAt` (`.sort({ updatedAt: -1 })`), but `shareSchema` has no index on that field. Azure Cosmos DB for MongoDB (RU-based) rejects sort queries on a non-indexed field outright, so `GET /api/share/link/:conversationId` returns an immediate 500 with `BadValue: "The index path corresponding to the specified order-by item is excluded."`

Added `shareSchema.index({ updatedAt: -1, _id: 1 })`, matching the same updatedAt index already on the agent, skill and mcpServer schemas.