### PR TITLE
🌏 fix: guard IME composition on Enter in prompt name/labels and dynamic tag inputs

### DIFF
--- a/client/src/components/Prompts/fields/PromptName.tsx
+++ b/client/src/components/Prompts/fields/PromptName.tsx
@@ -53,7 +53,8 @@ const PromptName: React.FC<Props> = ({ name, isLoading = false, isError = false,
         setNewName(name);
         setIsEditing(false);
       }
-      if (e.key === 'Enter') {
+      // Ignore the Enter that commits an IME composition (see useTextarea.ts).
+      if (e.key === 'Enter' && !(e.nativeEvent.isComposing || e.keyCode === 229)) {
         e.preventDefault();
         skipBlurRef.current = true;
         commitName();

--- a/client/src/components/Prompts/forms/PromptLabelsForm.tsx
+++ b/client/src/components/Prompts/forms/PromptLabelsForm.tsx
@@ -16,7 +16,12 @@ const PromptLabelsForm = ({ selectedPrompt }: { selectedPrompt?: TPrompt }) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && labelInput.trim()) {
+    // Ignore the Enter that commits an IME composition (see useTextarea.ts).
+    if (
+      e.key === 'Enter' &&
+      !(e.nativeEvent.isComposing || e.keyCode === 229) &&
+      labelInput.trim()
+    ) {
       const newLabels = [...labels, labelInput.trim()];
       setLabels(newLabels);
       setLabelInput('');

--- a/client/src/components/SidePanel/Parameters/DynamicTags.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicTags.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
-import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, Input, HoverCard, HoverCardTrigger, Tag, useToastContext } from '@librechat/client';
+import type { DynamicSettingProps } from 'librechat-data-provider';
 import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
 import { useChatContext } from '~/Providers';
 import OptionHover from './OptionHover';

--- a/client/src/components/SidePanel/Parameters/DynamicTags.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicTags.tsx
@@ -155,7 +155,8 @@ function DynamicTags({
                   if (e.key === 'Backspace' && !tagText) {
                     onTagRemove(currentTags.length - 1);
                   }
-                  if (e.key === 'Enter') {
+                  // Ignore the Enter that commits an IME composition (see useTextarea.ts).
+                  if (e.key === 'Enter' && !(e.nativeEvent.isComposing || e.keyCode === 229)) {
                     onTagAdd();
                   }
                 }}


### PR DESCRIPTION
## Summary

The chat composer already ignores the Enter that commits an IME composition. `useTextarea.ts` tracks `isComposing` and also checks `e.key === 'Process'` / `e.keyCode === 229`, with a note about Safari behaving differently (PRs #3103 and #5496 added this).

A few other free-text inputs run their Enter action without that guard, so for languages that compose text (Japanese, Chinese, Korean) the keystroke that confirms a conversion candidate also fires the action:

- **Prompt name** (`PromptName.tsx`): the confirming Enter commits the rename mid-conversion (it also calls `preventDefault()`, so it can swallow the IME confirmation itself).
- **Prompt labels** (`PromptLabelsForm.tsx`): the confirming Enter adds a label from the half-converted text.
- **Dynamic tags** in agent/parameter settings (`DynamicTags.tsx`): same thing for tags.

Example: in the labels field, type a word in Japanese, press Space to convert, then Enter to accept the candidate. That first Enter currently adds the label instead of just confirming the conversion, so you end up with a label of the unconfirmed text.

## Fix

Skip the Enter action when the keydown is the composition-commit, using the same check the composer already relies on (`e.nativeEvent.isComposing`, plus `e.keyCode === 229` for Safari). I left out the `e.key === 'Process'` part of the composer's check because it can't co-occur with `e.key === 'Enter'` in these branches.

For a normal (non-IME) Enter, `isComposing` is `false` and `keyCode` is `13`, so the guard is a no-op and existing input is unaffected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual, with a Japanese IME:

1. Open the prompt labels field (or the prompt name / a dynamic tag input).
2. Type a word, press Space to convert, then Enter to confirm the candidate.
3. Before: the label/tag is added (or the name is saved) on that Enter, using the unconfirmed text.
4. After: that Enter only confirms the conversion; a separate Enter then performs the action.

I didn't add a unit test because jsdom doesn't dispatch `isComposing` / `compositionstart`/`end` the way a real IME does, which is also why the existing composer composition fixes were verified manually. Happy to add a test if you'd prefer one.

## Checklist

- [x] My code adheres to this project's style guidelines (Prettier clean)
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
