### PR TITLE
🗄️ fix: Return Cached Transaction-Support Value on Cache Hit

### DIFF
--- a/packages/data-schemas/src/utils/transactions.spec.ts
+++ b/packages/data-schemas/src/utils/transactions.spec.ts
@@ -1,0 +1,11 @@
+import { getTransactionSupport } from './transactions';
+
+describe('getTransactionSupport', () => {
+  // The cache-hit path does not touch the database, so a stub mongoose is fine.
+  const mongoose = {} as unknown as typeof import('mongoose');
+
+  it('returns the cached value on a cache hit (does not re-probe)', async () => {
+    await expect(getTransactionSupport(mongoose, true)).resolves.toBe(true);
+    await expect(getTransactionSupport(mongoose, false)).resolves.toBe(false);
+  });
+});

--- a/packages/data-schemas/src/utils/transactions.ts
+++ b/packages/data-schemas/src/utils/transactions.ts
@@ -55,9 +55,8 @@ export const getTransactionSupport = async (
   mongoose: typeof import('mongoose'),
   transactionSupportCache: boolean | null,
 ): Promise<boolean> => {
-  let transactionsSupported = false;
-  if (transactionSupportCache === null) {
-    transactionsSupported = await supportsTransactions(mongoose);
+  if (transactionSupportCache !== null) {
+    return transactionSupportCache;
   }
-  return transactionsSupported;
+  return await supportsTransactions(mongoose);
 };


### PR DESCRIPTION
## Summary

`getTransactionSupport` (`packages/data-schemas/src/utils/transactions.ts`) is a memoization wrapper around the `supportsTransactions()` DB probe, but it never returns the cached value:

```ts
let transactionsSupported = false;
if (transactionSupportCache === null) {
  transactionsSupported = await supportsTransactions(mongoose);
}
return transactionsSupported;
```

On a cache **hit** (`transactionSupportCache` non-null) the `if` is skipped, so it returns the initialized `false` regardless of the cached value.

## Impact

The only caller, `PermissionService.bulkUpdateResourcePermissions`, caches the result: the **first** call probes correctly (`true`) and uses a real MongoDB transaction; on **every subsequent** call `getTransactionSupport` returns `false`, so the bulk grant/revoke writes silently stop running inside a transaction — losing atomicity (partial permission updates can persist on error). The cache, meant as a perf optimization, instead permanently disables transactions after first use.

## Fix

Return the cached boolean on a cache hit; the cache-miss path still probes via `supportsTransactions`:

```ts
if (transactionSupportCache !== null) {
  return transactionSupportCache;
}
return await supportsTransactions(mongoose);
```

## Testing

Added `packages/data-schemas/src/utils/transactions.spec.ts` asserting a cache hit returns the cached value (`true`→`true`, `false`→`false`). Verified RED on current code (cache `true` → `false`) → GREEN after the fix.

(The existing `PermissionService`/`systemGrant` specs mock `getTransactionSupport`, which is why this went unnoticed.)