### PR TITLE
🪭 feat(helm): add Langfuse fanout PodMonitor

### DIFF
--- a/helm/librechat/readme.md
+++ b/helm/librechat/readme.md
@@ -88,10 +88,11 @@ only the gateway sidecar should send traces to it.
 
 The gateway exposes Prometheus metrics at `/metrics`. Configure
 `langfuseFanout.metrics.secret.name` and `.key` to pass a bearer token secret to
-the gateway; if omitted, `/metrics` returns 401. Use
-`langfuseFanout.service.annotations` for scrape annotations when your cluster
-uses annotation-based discovery. The gateway container also has configurable
-`/healthz` liveness and readiness probes under `langfuseFanout`.
+the gateway; if omitted, `/metrics` returns 401. Set
+`langfuseFanout.metrics.podMonitor.enabled=true` to create a Prometheus Operator
+`PodMonitor` that scrapes the gateway pods with the same bearer token secret.
+The gateway container also has configurable `/healthz` liveness and readiness
+probes under `langfuseFanout`.
 
 See [`otel/langfuse-fanout/README.md`](../../otel/langfuse-fanout/README.md)
 for the central Langfuse secret and values example.

--- a/helm/librechat/templates/langfuse-fanout-podmonitor.yaml
+++ b/helm/librechat/templates/langfuse-fanout-podmonitor.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.langfuseFanout.enabled .Values.langfuseFanout.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "librechat.langfuseFanout.fullname" . }}
+  labels:
+    {{- include "librechat.langfuseFanout.labels" . | nindent 4 }}
+    {{- with .Values.langfuseFanout.metrics.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.langfuseFanout.metrics.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "librechat.langfuseFanout.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - path: {{ .Values.langfuseFanout.metrics.podMonitor.path | quote }}
+      port: {{ .Values.langfuseFanout.metrics.podMonitor.port | quote }}
+      scheme: {{ .Values.langfuseFanout.metrics.podMonitor.scheme | quote }}
+      {{- with .Values.langfuseFanout.metrics.podMonitor.interval }}
+      interval: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.langfuseFanout.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . | quote }}
+      {{- end }}
+      bearerTokenSecret:
+        name: {{ required "langfuseFanout.metrics.secret.name is required when langfuseFanout.metrics.podMonitor.enabled=true" .Values.langfuseFanout.metrics.secret.name | quote }}
+        key: {{ required "langfuseFanout.metrics.secret.key is required when langfuseFanout.metrics.podMonitor.enabled=true" .Values.langfuseFanout.metrics.secret.key | quote }}
+{{- end }}

--- a/helm/librechat/tests/langfuse_fanout_selector_test.sh
+++ b/helm/librechat/tests/langfuse_fanout_selector_test.sh
@@ -13,7 +13,8 @@ RENDER_CHART_DIR="$(mktemp -d -t librechat-fanout-chart.XXXXXX)"
 RENDERED_FILE="$(mktemp -t librechat-fanout-render.XXXXXX)"
 INVALID_RENDER_ERROR="$(mktemp -t librechat-fanout-invalid-key.XXXXXX)"
 COLLISION_RENDER_ERROR="$(mktemp -t librechat-fanout-colliding-key.XXXXXX)"
-trap 'rm -rf "${RENDER_CHART_DIR}"; rm -f "${RENDERED_FILE}" "${INVALID_RENDER_ERROR}" "${COLLISION_RENDER_ERROR}"' EXIT
+MISSING_METRICS_SECRET_ERROR="$(mktemp -t librechat-fanout-missing-metrics-secret.XXXXXX)"
+trap 'rm -rf "${RENDER_CHART_DIR}"; rm -f "${RENDERED_FILE}" "${INVALID_RENDER_ERROR}" "${COLLISION_RENDER_ERROR}" "${MISSING_METRICS_SECRET_ERROR}"' EXIT
 
 if ! command -v helm >/dev/null 2>&1; then
   echo "FAIL: helm not on PATH" >&2
@@ -29,14 +30,19 @@ cp "${CHART_DIR}/templates/langfuse-fanout-service.yaml" \
   "${RENDER_CHART_DIR}/templates/langfuse-fanout-service.yaml"
 cp "${CHART_DIR}/templates/langfuse-fanout-deployment.yaml" \
   "${RENDER_CHART_DIR}/templates/langfuse-fanout-deployment.yaml"
+cp "${CHART_DIR}/templates/langfuse-fanout-podmonitor.yaml" \
+  "${RENDER_CHART_DIR}/templates/langfuse-fanout-podmonitor.yaml"
 
 helm template librechat "${RENDER_CHART_DIR}" \
   --set langfuseFanout.enabled=true \
   --set langfuseFanout.central.authHeaderSecret.name=langfuse-central \
   --set langfuseFanout.redis.uri=redis://langfuse-fanout-redis:6379 \
+  --set langfuseFanout.metrics.secret.name=librechat-metrics \
+  --set langfuseFanout.metrics.podMonitor.enabled=true \
   --show-only templates/service.yaml \
   --show-only templates/langfuse-fanout-service.yaml \
   --show-only templates/langfuse-fanout-deployment.yaml \
+  --show-only templates/langfuse-fanout-podmonitor.yaml \
   > "${RENDERED_FILE}"
 
 if helm template librechat "${RENDER_CHART_DIR}" \
@@ -71,6 +77,23 @@ fi
 if ! grep -q 'both render LANGFUSE_FANOUT_TENANT_FOO_BAR_BASE_URL' "${COLLISION_RENDER_ERROR}"; then
   echo "FAIL: colliding destination key render did not explain the env var collision" >&2
   cat "${COLLISION_RENDER_ERROR}" >&2
+  exit 1
+fi
+
+if helm template librechat "${RENDER_CHART_DIR}" \
+  --set langfuseFanout.enabled=true \
+  --set langfuseFanout.central.authHeaderSecret.name=langfuse-central \
+  --set langfuseFanout.redis.uri=redis://langfuse-fanout-redis:6379 \
+  --set langfuseFanout.metrics.podMonitor.enabled=true \
+  --show-only templates/langfuse-fanout-podmonitor.yaml \
+  > /dev/null 2> "${MISSING_METRICS_SECRET_ERROR}"; then
+  echo "FAIL: Helm accepted Langfuse fanout PodMonitor without a metrics bearer token secret" >&2
+  exit 1
+fi
+
+if ! grep -q 'langfuseFanout.metrics.secret.name is required' "${MISSING_METRICS_SECRET_ERROR}"; then
+  echo "FAIL: missing metrics secret render did not explain the PodMonitor secret requirement" >&2
+  cat "${MISSING_METRICS_SECRET_ERROR}" >&2
   exit 1
 fi
 
@@ -112,6 +135,7 @@ function envValue(env, name) {
 const mainService = find('Service', 'librechat-librechat');
 const fanoutService = find('Service', 'librechat-librechat-langfuse-fanout');
 const fanoutDeployment = find('Deployment', 'librechat-librechat-langfuse-fanout');
+const fanoutPodMonitor = find('PodMonitor', 'librechat-librechat-langfuse-fanout');
 const fanoutContainer = fanoutDeployment.spec?.template?.spec?.containers?.find(
   (container) => container.name === 'langfuse-fanout',
 );
@@ -124,6 +148,8 @@ const fanoutSelector = fanoutService.spec?.selector ?? {};
 const fanoutMatchLabels = fanoutDeployment.spec?.selector?.matchLabels ?? {};
 const fanoutPodLabels = fanoutDeployment.spec?.template?.metadata?.labels ?? {};
 const fanoutMetadataLabels = fanoutDeployment.metadata?.labels ?? {};
+const fanoutPodMonitorSelector = fanoutPodMonitor.spec?.selector?.matchLabels ?? {};
+const fanoutPodMonitorEndpoint = fanoutPodMonitor.spec?.podMetricsEndpoints?.[0] ?? {};
 
 if (isSubset(mainSelector, fanoutPodLabels)) {
   fail('main Service selector matches fanout pod labels');
@@ -139,6 +165,21 @@ if (mainSelector['app.kubernetes.io/name'] === fanoutSelector['app.kubernetes.io
 }
 if (fanoutMetadataLabels['app.kubernetes.io/name'] !== fanoutSelector['app.kubernetes.io/name']) {
   fail('fanout Deployment metadata labels do not use fanout app name');
+}
+if (!isSubset(fanoutPodMonitorSelector, fanoutPodLabels)) {
+  fail('fanout PodMonitor selector does not match fanout pod labels');
+}
+if (fanoutPodMonitorEndpoint.path !== '/metrics') {
+  fail('fanout PodMonitor does not scrape /metrics');
+}
+if (fanoutPodMonitorEndpoint.port !== 'otlp-http') {
+  fail('fanout PodMonitor does not scrape the otlp-http port');
+}
+if (fanoutPodMonitorEndpoint.bearerTokenSecret?.name !== 'librechat-metrics') {
+  fail('fanout PodMonitor did not render configured metrics bearer token secret name');
+}
+if (fanoutPodMonitorEndpoint.bearerTokenSecret?.key !== 'METRICS_SECRET') {
+  fail('fanout PodMonitor did not render configured metrics bearer token secret key');
 }
 if (envValue(fanoutContainer.env, 'LANGFUSE_FANOUT_REDIS_URI') !== 'redis://langfuse-fanout-redis:6379') {
   fail('fanout Deployment did not render configured Redis URI');

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -313,6 +313,17 @@ langfuseFanout:
       # When omitted, /metrics returns 401.
       name: ""
       key: METRICS_SECRET
+    podMonitor:
+      # Create a Prometheus Operator PodMonitor for the fanout gateway.
+      # Requires metrics.secret.name/key so Prometheus can send the bearer token.
+      enabled: false
+      path: /metrics
+      port: otlp-http
+      scheme: http
+      interval: 30s
+      scrapeTimeout: 10s
+      labels: {}
+      annotations: {}
   redis:
     # Redis stores short-lived Langfuse media upload plans so multiple gateway
     # replicas can handle create/upload requests. If empty and redis.enabled is


### PR DESCRIPTION
## Summary

Adds an optional Prometheus Operator `PodMonitor` for the Langfuse fanout gateway. The monitor scrapes gateway pods at `/metrics` on the `otlp-http` port and uses the configured `langfuseFanout.metrics.secret` as a bearer token, matching the gateway metrics auth behavior.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- `NODE_PATH=/Users/rlazar/code/LibreChat/node_modules bash helm/librechat/tests/langfuse_fanout_selector_test.sh`

### **Test Configuration**:

Local Helm render test using `upstream/dev` at `186b738d2`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
