### PR TITLE
fix: use `logAxiosError` at the RAG file_search/context call sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ helm/**/.values.yaml
 /.openai/
 /.tabnine/
 /.codeium
+/.pi/
 *.local.md
 
 # Removed Windows wrapper files per user request

--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -1,6 +1,5 @@
 const axios = require('axios');
-const { logger } = require('@librechat/data-schemas');
-const { isEnabled, generateShortLivedToken } = require('@librechat/api');
+const { isEnabled, generateShortLivedToken, logAxiosError } = require('@librechat/api');
 
 const footer = `Use the context as your learned knowledge to better answer the user.
 
@@ -54,7 +53,7 @@ function createContextHandlers(req, userMessageContent) {
         processedFiles.push(file);
         processedIds.add(file.file_id);
       } catch (error) {
-        logger.error(`Error processing file ${file.filename}:`, error);
+        logAxiosError({ message: `Error processing file ${file.filename}`, error });
       }
     }
   };
@@ -146,7 +145,7 @@ function createContextHandlers(req, userMessageContent) {
 
       return prompt;
     } catch (error) {
-      logger.error('Error creating context:', error);
+      logAxiosError({ message: 'Error creating context', error });
       throw error;
     }
   };

--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
 const { tool } = require('@librechat/agents/langchain/tools');
-const { generateShortLivedToken } = require('@librechat/api');
+const { generateShortLivedToken, logAxiosError } = require('@librechat/api');
 const { Tools, EToolResources } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { getFiles } = require('~/models');
@@ -131,7 +131,10 @@ const createFileSearchTool = async ({ userId, files, entity_id, fileCitations = 
             },
           })
           .catch((error) => {
-            logger.error('Error encountered in `file_search` while querying file:', error);
+            logAxiosError({
+              message: 'Error encountered in `file_search` while querying file',
+              error,
+            });
             return null;
           }),
       );

--- a/api/test/app/clients/tools/util/fileSearch.test.js
+++ b/api/test/app/clients/tools/util/fileSearch.test.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 jest.mock('axios');
 jest.mock('@librechat/api', () => ({
   generateShortLivedToken: jest.fn(),
+  logAxiosError: jest.fn(),
 }));
 
 jest.mock('@librechat/data-schemas', () => ({


### PR DESCRIPTION
## Summary

- Related: https://github.com/danny-avila/LibreChat/pull/14018

The RAG call sites log Axios failures with `logger.error('...', error)`, passing the raw `AxiosError`. Winston then serializes the **entire** error object graph, including `error.config.httpsAgent`, which holds every pooled socket and TLS session as byte arrays. A single failed call produces hundreds of KB of log output, and because the keep-alive agent accumulates sockets, it grows with load. 

When the RAG `/query` endpoint returns errors at any volume, this synchronous serialization on the logging path **starves the Node event loop**, showing up as latency spikes, dropped requests, and health-check failures rather than as an obvious logging problem.

This swaps the three RAG call sites to the existing `logAxiosError({ message, error })` helper (`@librechat/api`), which logs only `status` / `headers` / safe `data` / `message` / `stack` and never touches `config` / `httpsAgent`. The same helper is already used elsewhere for Axios errors (e.g. image tools, email, OAuth token refresh), so this just makes the RAG paths consistent.

- `api/app/clients/tools/util/fileSearch.js`: import `logAxiosError`; swap the `.catch`
  logging call (keeps the `logger` import, still used by `logger.debug`).
- `api/app/clients/prompts/createContextHandlers.js`: import `logAxiosError`; swap both catch
  sites; remove the now-unused `logger` import.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd api && npm run test:ci`: `fileSearch.test.js` passes (the `@librechat/api` mock now
  includes `logAxiosError`).
- Manual: force a RAG `/query` / `/embed` failure and confirm the log record is small and
  contains status/message/stack with no `config`/`httpsAgent` payload.