### PR TITLE
fix: preserve role SHARE permissions across boot in initializeRoles

### DIFF
--- a/packages/data-schemas/src/methods/config.spec.ts
+++ b/packages/data-schemas/src/methods/config.spec.ts
@@ -14,6 +14,7 @@ beforeAll(async () => {
   if (!mongoose.models.Config) {
     mongoose.model<IConfig>('Config', configSchema);
   }
+  await mongoose.models.Config.init();
   methods = createConfigMethods(mongoose);
 });
 

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -2,10 +2,10 @@ import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { SystemRoles, Permissions, roleDefaults, PermissionTypes } from 'librechat-data-provider';
 import type { IRole, IUser, RolePermissions } from '..';
-import { createRoleMethods } from './role';
-import { createModels } from '../models';
 import { _resetStrictCache } from '../models/plugins/tenantIsolation';
 import { tenantStorage } from '~/config/tenantContext';
+import { createRoleMethods } from './role';
+import { createModels } from '../models';
 
 jest.mock('~/config/winston', () => ({
   error: jest.fn(),

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -510,6 +510,7 @@ describe('initializeRoles', () => {
           [Permissions.USE]: false,
           [Permissions.CREATE]: true,
           [Permissions.SHARE]: true,
+          [Permissions.SHARE_PUBLIC]: false,
         },
         [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       },
@@ -575,6 +576,7 @@ describe('initializeRoles', () => {
           [Permissions.USE]: false,
           [Permissions.CREATE]: false,
           [Permissions.SHARE]: false,
+          [Permissions.SHARE_PUBLIC]: false,
         },
         [PermissionTypes.BOOKMARKS]:
           roleDefaults[SystemRoles.ADMIN].permissions[PermissionTypes.BOOKMARKS],
@@ -627,6 +629,177 @@ describe('initializeRoles', () => {
     const userRole = await getRoleByName(SystemRoles.USER);
     expect(userRole.permissions[PermissionTypes.MULTI_CONVO]).toBeDefined();
     expect(userRole.permissions[PermissionTypes.MULTI_CONVO]?.USE).toBeDefined();
+  });
+});
+
+describe('initializeRoles - SHARE permission preservation', () => {
+  beforeEach(async () => {
+    await Role.deleteMany({});
+  });
+
+  it('preserves a fully-populated USER AGENTS block (SHARE stays true)', async () => {
+    await new Role({
+      name: SystemRoles.USER,
+      permissions: {
+        [PermissionTypes.AGENTS]: {
+          [Permissions.USE]: true,
+          [Permissions.CREATE]: true,
+          [Permissions.SHARE]: true,
+          [Permissions.SHARE_PUBLIC]: false,
+        },
+      },
+    }).save();
+
+    await initializeRoles();
+
+    const userRole = await getRoleByName(SystemRoles.USER);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.SHARE).toBe(true);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.SHARE_PUBLIC).toBe(false);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.USE).toBe(true);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.CREATE).toBe(true);
+  });
+
+  it('fills missing fields without clobbering a present SHARE:true on USER AGENTS', async () => {
+    await new Role({
+      name: SystemRoles.USER,
+      permissions: {
+        [PermissionTypes.AGENTS]: {
+          [Permissions.SHARE]: true,
+        },
+      },
+    }).save();
+
+    await initializeRoles();
+
+    const userRole = await getRoleByName(SystemRoles.USER);
+    // Present field preserved.
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.SHARE).toBe(true);
+    // Genuinely-missing fields filled from the USER default.
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.USE).toBe(true);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.CREATE).toBe(true);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.SHARE_PUBLIC).toBe(false);
+  });
+
+  it('leaves an all-true ADMIN AGENTS block unchanged', async () => {
+    await new Role({
+      name: SystemRoles.ADMIN,
+      permissions: {
+        [PermissionTypes.AGENTS]: {
+          [Permissions.USE]: true,
+          [Permissions.CREATE]: true,
+          [Permissions.SHARE]: true,
+          [Permissions.SHARE_PUBLIC]: true,
+        },
+      },
+    }).save();
+
+    await initializeRoles();
+
+    const adminRole = await getRoleByName(SystemRoles.ADMIN);
+    expect(adminRole.permissions[PermissionTypes.AGENTS]).toEqual({
+      USE: true,
+      CREATE: true,
+      SHARE: true,
+      SHARE_PUBLIC: true,
+    });
+  });
+
+  it('documents that hardening alone does not rescue a stripped (empty) block', async () => {
+    // An empty block carries no SHARED_GLOBAL to migrate, so the per-field merge fills USER defaults (SHARE:false).
+    await new Role({
+      name: SystemRoles.USER,
+      permissions: {
+        [PermissionTypes.AGENTS]: {},
+      },
+    }).save();
+
+    await initializeRoles();
+
+    const userRole = await getRoleByName(SystemRoles.USER);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.SHARE).toBe(false);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.USE).toBe(true);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.CREATE).toBe(true);
+    expect(userRole.permissions[PermissionTypes.AGENTS]?.SHARE_PUBLIC).toBe(false);
+  });
+
+  it('migrates AGENTS.SHARED_GLOBAL:true to SHARE:true and removes SHARED_GLOBAL', async () => {
+    // Raw insert keeps the off-schema SHARED_GLOBAL field that strict mode would strip.
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: { AGENTS: { SHARED_GLOBAL: true } },
+    });
+
+    await initializeRoles();
+
+    const doc = await Role.collection.findOne({ name: SystemRoles.USER });
+    expect(doc?.permissions.AGENTS.SHARE).toBe(true);
+    expect(doc?.permissions.AGENTS.SHARED_GLOBAL).toBeUndefined();
+    // Migration maps SHARED_GLOBAL to SHARE only, never SHARE_PUBLIC.
+    expect(doc?.permissions.AGENTS.SHARE_PUBLIC).toBe(false);
+  });
+
+  it('migrates AGENTS.SHARED_GLOBAL:false to SHARE:false and removes SHARED_GLOBAL', async () => {
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: { AGENTS: { SHARED_GLOBAL: false } },
+    });
+
+    await initializeRoles();
+
+    const doc = await Role.collection.findOne({ name: SystemRoles.USER });
+    expect(doc?.permissions.AGENTS.SHARE).toBe(false);
+    expect(doc?.permissions.AGENTS.SHARED_GLOBAL).toBeUndefined();
+  });
+
+  it('preserves an existing SHARE:false when SHARED_GLOBAL:true is also present', async () => {
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: { AGENTS: { SHARE: false, SHARED_GLOBAL: true } },
+    });
+
+    await initializeRoles();
+
+    const doc = await Role.collection.findOne({ name: SystemRoles.USER });
+    expect(doc?.permissions.AGENTS.SHARE).toBe(false);
+    expect(doc?.permissions.AGENTS.SHARED_GLOBAL).toBeUndefined();
+  });
+
+  it('migrates PROMPTS.SHARED_GLOBAL:true to PROMPTS.SHARE:true', async () => {
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: { PROMPTS: { SHARED_GLOBAL: true } },
+    });
+
+    await initializeRoles();
+
+    const doc = await Role.collection.findOne({ name: SystemRoles.USER });
+    expect(doc?.permissions.PROMPTS.SHARE).toBe(true);
+    expect(doc?.permissions.PROMPTS.SHARED_GLOBAL).toBeUndefined();
+  });
+
+  it('is a no-op on a clean DB with no legacy SHARED_GLOBAL', async () => {
+    await initializeRoles();
+
+    const userDoc = await Role.collection.findOne({ name: SystemRoles.USER });
+    const adminDoc = await Role.collection.findOne({ name: SystemRoles.ADMIN });
+    expect('SHARED_GLOBAL' in (userDoc?.permissions.AGENTS ?? {})).toBe(false);
+    expect('SHARED_GLOBAL' in (userDoc?.permissions.PROMPTS ?? {})).toBe(false);
+    expect('SHARED_GLOBAL' in (adminDoc?.permissions.AGENTS ?? {})).toBe(false);
+    expect('SHARED_GLOBAL' in (adminDoc?.permissions.PROMPTS ?? {})).toBe(false);
+  });
+
+  it('keeps the migrated SHARE:true across a second initializeRoles run', async () => {
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: { AGENTS: { SHARED_GLOBAL: true } },
+    });
+
+    await initializeRoles();
+    await initializeRoles();
+
+    const doc = await Role.collection.findOne({ name: SystemRoles.USER });
+    expect(doc?.permissions.AGENTS.SHARE).toBe(true);
+    expect(doc?.permissions.AGENTS.SHARED_GLOBAL).toBeUndefined();
   });
 });
 

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -75,6 +75,30 @@ export function createRoleMethods(
     const Role = mongoose.models.Role;
 
     for (const roleName of [SystemRoles.ADMIN, SystemRoles.USER]) {
+      // Strict mode hides off-schema SHARED_GLOBAL and won't $unset it on save; migrate it via the raw driver.
+      // eslint-disable-next-line no-restricted-syntax -- Role is a global (non-tenant) collection; raw read is required to see the off-schema field.
+      const legacyDoc = await Role.collection.findOne({ name: roleName });
+      if (legacyDoc?.permissions) {
+        const set: Record<string, unknown> = {};
+        const unset: Record<string, ''> = {};
+        for (const permType of ['PROMPTS', 'AGENTS']) {
+          const block = legacyDoc.permissions[permType];
+          if (block && 'SHARED_GLOBAL' in block) {
+            if (!('SHARE' in block)) {
+              set[`permissions.${permType}.SHARE`] = block.SHARED_GLOBAL;
+            }
+            unset[`permissions.${permType}.SHARED_GLOBAL`] = '';
+          }
+        }
+        if (Object.keys(unset).length) {
+          const update: Record<string, unknown> = { $unset: unset };
+          if (Object.keys(set).length) {
+            update.$set = set;
+          }
+          // eslint-disable-next-line no-restricted-syntax -- Role is a global (non-tenant) collection; raw $unset is required to drop the off-schema field.
+          await Role.collection.updateOne({ name: roleName }, update);
+        }
+      }
       let role = await Role.findOne({ name: roleName });
       const defaultPerms = roleDefaults[roleName].permissions;
 
@@ -87,9 +111,22 @@ export function createRoleMethods(
         const permissions = role.toObject()?.permissions ?? {};
         role.permissions = role.permissions || {};
         for (const permType of Object.keys(defaultPerms)) {
-          if (permissions[permType] == null || Object.keys(permissions[permType]).length === 0) {
-            role.permissions[permType] = defaultPerms[permType as keyof typeof defaultPerms];
+          const defaultBlock = defaultPerms[permType as keyof typeof defaultPerms] as Record<
+            string,
+            unknown
+          >;
+          const existingBlock = permissions[permType] as Record<string, unknown> | null | undefined;
+          if (existingBlock == null) {
+            role.permissions[permType] = defaultBlock;
+            continue;
           }
+          const mergedBlock: Record<string, unknown> = { ...existingBlock };
+          for (const field of Object.keys(defaultBlock)) {
+            if (mergedBlock[field] == null) {
+              mergedBlock[field] = defaultBlock[field];
+            }
+          }
+          role.permissions[permType] = mergedBlock;
         }
       }
       await role.save();


### PR DESCRIPTION
## Summary

On every server boot, `initializeRoles` re-seeds the whole `PROMPTS`/`AGENTS` permission blocks, which silently resets the `USER` role's `SHARE` / `SHARE_PUBLIC` back to the schema defaults (`false`). Admins who enable user sharing find it turned off again after every restart.

Two things combine to cause it:

1. **Whole-block re-seed.** When a role's permission block is empty/absent, the loop replaces the entire block with the defaults. `USER`'s base schema defaults `SHARE`/`SHARE_PUBLIC` to `false` (only `ADMIN` defaults to `true`), which is why only `USER` is affected.
2. **Legacy field stripped by strict mode.** Older DBs still carry the pre-#11283 off-schema `SHARED_GLOBAL` field. The role schema is strict, so `role.toObject()` strips `SHARED_GLOBAL` before the loop reads it, so the sharing intent reads as "absent" and gets refilled from the (`false`) default. The existing `SHARED_GLOBAL → SHARE` migration in `updateAccessPermissions` only runs on explicit role/config edits, which happen _after_ seeding, so it never preempts the boot reset.

This PR (in `packages/data-schemas/src/methods/role.ts`):

1. Adds a boot-time, idempotent raw-driver migration that converts legacy `SHARED_GLOBAL` → `SHARE` **before** seeding (only when `SHARE` is absent; never touches `SHARE_PUBLIC`; no-op on a clean DB).
2. Replaces the whole-block re-seed with a **per-field merge** that only fills fields that are `null`/absent and never clobbers a value already present.

The two changes are coupled and ship together: the merge stops the clobber, and the migration restores the real intent the merge then reads.

## Notes for reviewers

The per-field merge is a deliberate behavior change from the old whole-block re-seed. Previously a non-empty permission block was left entirely untouched; now any field that is `null`/absent is filled from `roleDefaults`. For partial/hand-edited blocks this means a missing field is topped up on next boot (e.g. a `USER` block missing `CREATE` gets the `true` default). This does **not** widen sharing: `USER` `SHARE`/`SHARE_PUBLIC` default to `false`, so no sharing permission is ever silently granted. The behavior also backfills newly-added permission fields onto existing roles, which is the intended effect.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/data-schemas && npm run test:ci -- role.methods.spec.ts`: a new `describe('initializeRoles - SHARE permission preservation')` adds cases: `SHARED_GLOBAL: true` → `SHARE: true` (and `false → false`); an existing `SHARE` is preserved (not reset to the default); a fully-populated block is untouched; a partial block is filled without clobbering a present `SHARE`; an all-true `ADMIN` block is unchanged; both `PROMPTS` and `AGENTS`; clean-DB no-op; running twice is stable.
- Manual: seed a role doc with `permissions.AGENTS.SHARED_GLOBAL: true`, boot twice, confirm `AGENTS.SHARE` stays `true` and `SHARED_GLOBAL` is removed.