### PR TITLE
feat: add MCP resource list and read tool support

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -21,6 +21,8 @@ const {
   checkAccessWithRequestCache,
   requiresEphemeralUserConnection,
   containsGraphTokenPlaceholder,
+  MCPResourceListToolName,
+  MCPResourceReadToolName,
 } = require('@librechat/api');
 const {
   Time,
@@ -578,7 +580,15 @@ async function createMCPTools({
   }
 
   const serverTools = [];
-  for (const tool of result.tools) {
+  const toolKeys = result.tools.map((tool) => `${tool.name}${Constants.mcp_delimiter}${serverName}`);
+  for (const resourceToolName of [MCPResourceListToolName, MCPResourceReadToolName]) {
+    const resourceToolKey = `${resourceToolName}${Constants.mcp_delimiter}${serverName}`;
+    if (result.availableTools?.[resourceToolKey]) {
+      toolKeys.push(resourceToolKey);
+    }
+  }
+
+  for (const toolKey of toolKeys) {
     const toolInstance = await createMCPTool({
       res,
       mcpPermissionContext,
@@ -588,7 +598,7 @@ async function createMCPTools({
       configServers,
       streamId,
       availableTools: result.availableTools,
-      toolKey: `${tool.name}${Constants.mcp_delimiter}${serverName}`,
+      toolKey,
       requestBody,
       requestScopedConnections,
       config: serverConfig,
@@ -816,6 +826,72 @@ function createToolInstance({
 
       const customUserVars =
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
+
+      if (toolName === MCPResourceListToolName) {
+        const resources = await mcpManager.listResources({
+          serverName,
+          serverConfig: capturedServerConfig,
+          options: {
+            signal: derivedSignal,
+          },
+          user: effectiveUser,
+          requestBody: config?.configurable?.requestBody ?? capturedRequestBody,
+          requestScopedConnections:
+            config?.configurable?.requestScopedConnections ?? capturedRequestScopedConnections,
+          customUserVars,
+          flowManager,
+          tokenMethods: {
+            findToken,
+            createToken,
+            updateToken,
+            deleteTokens,
+          },
+          oauthStart,
+          oauthEnd,
+          graphTokenResolver: getGraphApiToken,
+          oboTokenResolver: exchangeOboToken,
+          oboTrustChecker: createOboTrustChecker(),
+        });
+        return [JSON.stringify({ resources }, null, 2), null];
+      }
+
+      if (toolName === MCPResourceReadToolName) {
+        const uri =
+          typeof toolArguments === 'string'
+            ? toolArguments
+            : typeof toolArguments?.uri === 'string'
+              ? toolArguments.uri
+              : '';
+        if (!uri.trim()) {
+          throw new Error('Missing required MCP resource URI.');
+        }
+        const resource = await mcpManager.readResource({
+          serverName,
+          serverConfig: capturedServerConfig,
+          uri: uri.trim(),
+          options: {
+            signal: derivedSignal,
+          },
+          user: effectiveUser,
+          requestBody: config?.configurable?.requestBody ?? capturedRequestBody,
+          requestScopedConnections:
+            config?.configurable?.requestScopedConnections ?? capturedRequestScopedConnections,
+          customUserVars,
+          flowManager,
+          tokenMethods: {
+            findToken,
+            createToken,
+            updateToken,
+            deleteTokens,
+          },
+          oauthStart,
+          oauthEnd,
+          graphTokenResolver: getGraphApiToken,
+          oboTokenResolver: exchangeOboToken,
+          oboTrustChecker: createOboTrustChecker(),
+        });
+        return [JSON.stringify(resource, null, 2), null];
+      }
 
       const result = await mcpManager.callTool({
         serverName,

--- a/api/server/services/MCP.spec.js
+++ b/api/server/services/MCP.spec.js
@@ -837,6 +837,55 @@ describe('User parameter passing tests', () => {
       expect(mockReinitMCPServer.mock.calls[0][0].user).toBe(mockUser);
     });
 
+    it('should include managed resource tools when reinit discovers resources', async () => {
+      const mockUser = { id: 'resource-user', name: 'Resource User' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+      const listKey = `resources/list${D}test-server`;
+      const readKey = `resources/read${D}test-server`;
+
+      mockReinitMCPServer.mockResolvedValue({
+        tools: [{ name: 'test-tool' }],
+        availableTools: {
+          [`test-tool${D}test-server`]: {
+            function: {
+              description: 'Test tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+          [listKey]: {
+            function: {
+              description: 'List resources',
+              parameters: { type: 'object', properties: {}, required: [] },
+            },
+          },
+          [readKey]: {
+            function: {
+              description: 'Read resource',
+              parameters: {
+                type: 'object',
+                properties: { uri: { type: 'string' } },
+                required: ['uri'],
+              },
+            },
+          },
+        },
+      });
+
+      const tools = await createMCPTools({
+        res: mockRes,
+        user: mockUser,
+        serverName: 'test-server',
+        provider: 'openai',
+        userMCPAuthMap: {},
+      });
+
+      expect(tools.map((createdTool) => createdTool.name)).toEqual([
+        `test-tool${D}test-server`,
+        listKey,
+        readKey,
+      ]);
+    });
+
     it('should fail tenant-scoped OAuth flows when tool loading is aborted', async () => {
       const mockUser = { id: 'tenant-user', name: 'Tenant User' };
       const mockRes = { write: jest.fn(), flush: jest.fn() };
@@ -1124,6 +1173,131 @@ describe('User parameter passing tests', () => {
 
       expect(getRoleByName).toHaveBeenCalledTimes(1);
       expect(mockCallTool).toHaveBeenCalledTimes(2);
+    });
+
+    it('should execute managed resources/list through MCPManager.listResources', async () => {
+      const mockUser = { id: 'resource-list-user', role: 'USER' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+      const { getRoleByName } = require('~/models');
+      getRoleByName.mockResolvedValue({
+        permissions: {
+          [PermissionTypes.MCP_SERVERS]: {
+            [Permissions.USE]: true,
+          },
+        },
+      });
+
+      const mockListResources = jest
+        .fn()
+        .mockResolvedValue([{ uri: 'file://a.md', name: 'A', mimeType: 'text/markdown' }]);
+      mockGetMCPManager.mockReturnValue({
+        listResources: mockListResources,
+      });
+
+      const resourceTool = await createMCPTool({
+        res: mockRes,
+        user: mockUser,
+        toolKey: `resources/list${D}test-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: {
+          [`resources/list${D}test-server`]: {
+            function: {
+              description: 'List resources',
+              parameters: { type: 'object', properties: {}, required: [] },
+            },
+          },
+        },
+      });
+
+      await expect(
+        resourceTool.invoke(
+          {},
+          {
+            configurable: {
+              user: mockUser,
+            },
+            metadata: {
+              provider: 'openai',
+              thread_id: 'thread-1',
+              run_id: 'run-1',
+            },
+            toolCall: {},
+          },
+        ),
+      ).resolves.toContain('"file://a.md"');
+
+      expect(mockListResources).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: 'test-server',
+          user: mockUser,
+        }),
+      );
+    });
+
+    it('should execute managed resources/read through MCPManager.readResource', async () => {
+      const mockUser = { id: 'resource-read-user', role: 'USER' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+      const { getRoleByName } = require('~/models');
+      getRoleByName.mockResolvedValue({
+        permissions: {
+          [PermissionTypes.MCP_SERVERS]: {
+            [Permissions.USE]: true,
+          },
+        },
+      });
+
+      const mockReadResource = jest.fn().mockResolvedValue({
+        contents: [{ uri: 'file://a.md', text: 'hello', mimeType: 'text/markdown' }],
+      });
+      mockGetMCPManager.mockReturnValue({
+        readResource: mockReadResource,
+      });
+
+      const resourceTool = await createMCPTool({
+        res: mockRes,
+        user: mockUser,
+        toolKey: `resources/read${D}test-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: {
+          [`resources/read${D}test-server`]: {
+            function: {
+              description: 'Read resource',
+              parameters: {
+                type: 'object',
+                properties: { uri: { type: 'string' } },
+                required: ['uri'],
+              },
+            },
+          },
+        },
+      });
+
+      await expect(
+        resourceTool.invoke(
+          { uri: 'file://a.md' },
+          {
+            configurable: {
+              user: mockUser,
+            },
+            metadata: {
+              provider: 'openai',
+              thread_id: 'thread-1',
+              run_id: 'run-1',
+            },
+            toolCall: {},
+          },
+        ),
+      ).resolves.toContain('"hello"');
+
+      expect(mockReadResource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: 'test-server',
+          uri: 'file://a.md',
+          user: mockUser,
+        }),
+      );
     });
 
     it('should pass the captured user to MCPManager.callTool when invocation config omits configurable.user', async () => {

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -50,6 +50,8 @@ async function reinitMCPServer({
   let availableTools = null;
   /** @type {ReturnType<MCPConnection['fetchTools']> | null} */
   let tools = null;
+  /** @type {import('@librechat/api').MCPResource[] | null} */
+  let resources = null;
   let oauthRequired = false;
   let oauthUrl = null;
   let ephemeralServer = false;
@@ -193,6 +195,7 @@ async function reinitMCPServer({
 
           if (discoveryResult.tools && discoveryResult.tools.length > 0) {
             tools = discoveryResult.tools;
+            resources = discoveryResult.resources ?? null;
             logger.info(
               `[MCP Reinitialize] Discovered ${tools.length} tools for ${serverName} without full auth`,
             );
@@ -211,14 +214,15 @@ async function reinitMCPServer({
     }
 
     if (connection && !oauthRequired) {
-      tools = await connection.fetchTools();
+      [tools, resources] = await Promise.all([connection.fetchTools(), connection.fetchResources()]);
     }
 
-    if (tools && tools.length > 0) {
+    if ((tools && tools.length > 0) || (resources && resources.length > 0)) {
       availableTools = await updateMCPServerTools({
         userId: user.id,
         serverName,
         tools,
+        resources,
         serverConfig,
       });
     }

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -80,7 +80,10 @@ describe('reinitMCPServer — customUserVars gating (issue #10969)', () => {
   });
 
   it('proceeds to connect once every required customUserVar is provided', async () => {
-    mockGetConnection.mockResolvedValue({ fetchTools: jest.fn().mockResolvedValue([]) });
+    mockGetConnection.mockResolvedValue({
+      fetchTools: jest.fn().mockResolvedValue([]),
+      fetchResources: jest.fn().mockResolvedValue([]),
+    });
 
     await reinitMCPServer({
       user,
@@ -101,7 +104,10 @@ describe('reinitMCPServer — customUserVars gating (issue #10969)', () => {
   });
 
   it('passes request body and Graph resolver into connection creation', async () => {
-    mockGetConnection.mockResolvedValue({ fetchTools: jest.fn().mockResolvedValue([]) });
+    mockGetConnection.mockResolvedValue({
+      fetchTools: jest.fn().mockResolvedValue([]),
+      fetchResources: jest.fn().mockResolvedValue([]),
+    });
     const requestBody = { conversationId: 'conv-123', messageId: 'msg-123' };
 
     await reinitMCPServer({
@@ -152,6 +158,7 @@ describe('reinitMCPServer — customUserVars gating (issue #10969)', () => {
     mockGetConnection.mockResolvedValue({
       disconnect,
       fetchTools: jest.fn().mockResolvedValue(tools),
+      fetchResources: jest.fn().mockResolvedValue([]),
     });
 
     await reinitMCPServer({
@@ -171,8 +178,33 @@ describe('reinitMCPServer — customUserVars gating (issue #10969)', () => {
     );
   });
 
+  it('passes discovered resources into the MCP tool cache update', async () => {
+    const resources = [{ uri: 'file://guide.md', name: 'Guide', mimeType: 'text/markdown' }];
+    mockGetConnection.mockResolvedValue({
+      fetchTools: jest.fn().mockResolvedValue([]),
+      fetchResources: jest.fn().mockResolvedValue(resources),
+    });
+
+    await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig: { type: 'streamable-http', url: 'https://thingy.example.com/mcp' },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockUpdateMCPServerTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [],
+        resources,
+      }),
+    );
+  });
+
   it('proceeds to connect when the server declares no customUserVars', async () => {
-    mockGetConnection.mockResolvedValue({ fetchTools: jest.fn().mockResolvedValue([]) });
+    mockGetConnection.mockResolvedValue({
+      fetchTools: jest.fn().mockResolvedValue([]),
+      fetchResources: jest.fn().mockResolvedValue([]),
+    });
 
     await reinitMCPServer({
       user,

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -28,6 +28,7 @@ import { mcpConfig } from './mcpConfig';
 
 export interface ToolDiscoveryResult {
   tools: Tool[] | null;
+  resources?: t.MCPResource[] | null;
   connection: MCPConnection | null;
   oauthRequired: boolean;
   oauthUrl: string | null;
@@ -200,9 +201,12 @@ export class MCPConnectionFactory {
       );
 
       if (await connection.isConnected()) {
-        const tools = await connection.fetchTools();
+        const [tools, resources] = await Promise.all([
+          connection.fetchTools(),
+          connection.fetchResources(),
+        ]);
         connection.removeListener('oauthRequired', oauthHandler);
-        return { tools, connection, oauthRequired: false, oauthUrl: null };
+        return { tools, resources, connection, oauthRequired: false, oauthUrl: null };
       }
     } catch {
       MCPConnection.decrementCycleCount(this.serverName);
@@ -223,7 +227,7 @@ export class MCPConnectionFactory {
         } catch {
           // Ignore cleanup errors
         }
-        return { tools, connection: null, oauthRequired, oauthUrl };
+        return { tools, resources: null, connection: null, oauthRequired, oauthUrl };
       }
       MCPConnection.decrementCycleCount(this.serverName);
     } catch (listError) {
@@ -239,7 +243,7 @@ export class MCPConnectionFactory {
       // Ignore cleanup errors
     }
 
-    return { tools: null, connection: null, oauthRequired, oauthUrl };
+    return { tools: null, resources: null, connection: null, oauthRequired, oauthUrl };
   }
 
   protected async attemptUnauthenticatedToolListing(): Promise<Tool[] | null> {

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -127,8 +127,11 @@ export class MCPManager extends UserConnectionManager {
     try {
       const existingAppConnection = await this.appConnections?.get(serverName);
       if (existingAppConnection && (await existingAppConnection.isConnected())) {
-        const tools = await existingAppConnection.fetchTools();
-        return { tools, oauthRequired: false, oauthUrl: null };
+        const [tools, resources] = await Promise.all([
+          existingAppConnection.fetchTools(),
+          existingAppConnection.fetchResources(),
+        ]);
+        return { tools, resources, oauthRequired: false, oauthUrl: null };
       }
     } catch {
       logger.debug(`${logPrefix} [Discovery] App connection not available, trying discovery mode`);
@@ -193,6 +196,7 @@ export class MCPManager extends UserConnectionManager {
       }
       return {
         tools: result.tools,
+        resources: result.resources,
         oauthRequired: result.oauthRequired,
         oauthUrl: result.oauthUrl,
       };
@@ -553,5 +557,293 @@ Please follow these instructions when using tools from the respective MCP server
         }
       }
     }
+  }
+
+  async listResources({
+    user,
+    serverName,
+    serverConfig: providedConfig,
+    options,
+    tokenMethods,
+    requestBody,
+    requestScopedConnections,
+    flowManager,
+    oauthStart,
+    oauthEnd,
+    customUserVars,
+    graphTokenResolver,
+    oboTokenResolver,
+    oboTrustChecker,
+  }: {
+    user?: IUser;
+    serverName: string;
+    serverConfig?: t.ParsedServerConfig;
+    options?: RequestOptions;
+    requestBody?: RequestBody;
+    requestScopedConnections?: t.RequestScopedMCPConnectionStore;
+    tokenMethods?: TokenMethods;
+    customUserVars?: Record<string, string>;
+    flowManager: FlowStateManager<MCPOAuthTokens | null>;
+    oauthStart?: t.OAuthStartHandler;
+    oauthEnd?: () => Promise<void>;
+    graphTokenResolver?: GraphTokenResolver;
+    oboTokenResolver?: OboTokenResolver;
+    oboTrustChecker?: OboTrustChecker;
+  }): Promise<t.MCPResource[]> {
+    const { connection, disconnectAfterCall, cleanup } = await this.getResourceConnection({
+      user,
+      serverName,
+      serverConfig: providedConfig,
+      options,
+      tokenMethods,
+      requestBody,
+      requestScopedConnections,
+      flowManager,
+      oauthStart,
+      oauthEnd,
+      customUserVars,
+      graphTokenResolver,
+      oboTokenResolver,
+      oboTrustChecker,
+      operation: 'resources/list',
+    });
+
+    try {
+      return await connection.fetchResources();
+    } finally {
+      cleanup?.();
+      if (disconnectAfterCall) {
+        await connection.disconnect();
+      }
+    }
+  }
+
+  async readResource({
+    user,
+    serverName,
+    serverConfig: providedConfig,
+    uri,
+    options,
+    tokenMethods,
+    requestBody,
+    requestScopedConnections,
+    flowManager,
+    oauthStart,
+    oauthEnd,
+    customUserVars,
+    graphTokenResolver,
+    oboTokenResolver,
+    oboTrustChecker,
+  }: {
+    user?: IUser;
+    serverName: string;
+    serverConfig?: t.ParsedServerConfig;
+    uri: string;
+    options?: RequestOptions;
+    requestBody?: RequestBody;
+    requestScopedConnections?: t.RequestScopedMCPConnectionStore;
+    tokenMethods?: TokenMethods;
+    customUserVars?: Record<string, string>;
+    flowManager: FlowStateManager<MCPOAuthTokens | null>;
+    oauthStart?: t.OAuthStartHandler;
+    oauthEnd?: () => Promise<void>;
+    graphTokenResolver?: GraphTokenResolver;
+    oboTokenResolver?: OboTokenResolver;
+    oboTrustChecker?: OboTrustChecker;
+  }): Promise<t.MCPReadResourceResult> {
+    const { connection, disconnectAfterCall, cleanup } = await this.getResourceConnection({
+      user,
+      serverName,
+      serverConfig: providedConfig,
+      options,
+      tokenMethods,
+      requestBody,
+      requestScopedConnections,
+      flowManager,
+      oauthStart,
+      oauthEnd,
+      customUserVars,
+      graphTokenResolver,
+      oboTokenResolver,
+      oboTrustChecker,
+      operation: 'resources/read',
+    });
+
+    try {
+      return await connection.readResource(uri);
+    } finally {
+      cleanup?.();
+      if (disconnectAfterCall) {
+        await connection.disconnect();
+      }
+    }
+  }
+
+  private async getResourceConnection({
+    user,
+    serverName,
+    serverConfig: providedConfig,
+    options,
+    tokenMethods,
+    requestBody,
+    requestScopedConnections,
+    flowManager,
+    oauthStart,
+    oauthEnd,
+    customUserVars,
+    graphTokenResolver,
+    oboTokenResolver,
+    oboTrustChecker,
+    operation,
+  }: {
+    user?: IUser;
+    serverName: string;
+    serverConfig?: t.ParsedServerConfig;
+    options?: RequestOptions;
+    requestBody?: RequestBody;
+    requestScopedConnections?: t.RequestScopedMCPConnectionStore;
+    tokenMethods?: TokenMethods;
+    customUserVars?: Record<string, string>;
+    flowManager: FlowStateManager<MCPOAuthTokens | null>;
+    oauthStart?: t.OAuthStartHandler;
+    oauthEnd?: () => Promise<void>;
+    graphTokenResolver?: GraphTokenResolver;
+    oboTokenResolver?: OboTokenResolver;
+    oboTrustChecker?: OboTrustChecker;
+    operation: 'resources/list' | 'resources/read';
+  }): Promise<{
+    connection: MCPConnection;
+    disconnectAfterCall: boolean;
+    cleanup?: () => void;
+  }> {
+    const userId = user?.id;
+    const logPrefix = userId ? `[MCP][User: ${userId}][${serverName}]` : `[MCP][${serverName}]`;
+
+    if (userId && user) this.updateUserLastActivity(userId);
+
+    const connection = await this.getConnection({
+      serverName,
+      user,
+      flowManager,
+      tokenMethods,
+      oauthStart,
+      oauthEnd,
+      oboTokenResolver,
+      oboTrustChecker,
+      graphTokenResolver,
+      signal: options?.signal,
+      customUserVars,
+      requestBody,
+      requestScopedConnections,
+      serverConfig: providedConfig,
+    });
+
+    if (!(await connection.isConnected())) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        `${logPrefix} Connection is not active. Cannot execute ${operation}.`,
+      );
+    }
+
+    const registry = MCPServersRegistry.getInstance();
+    const rawConfig = providedConfig ?? (await registry.getServerConfig(serverName, userId));
+    if (!rawConfig) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `${logPrefix} Configuration for server "${serverName}" not found.`,
+      );
+    }
+
+    const isDbSourced = isUserSourced(rawConfig);
+    const disconnectAfterCall =
+      !!userId && requiresEphemeralUserConnection(rawConfig) && !requestScopedConnections;
+    const graphProcessedConfig = isDbSourced
+      ? (rawConfig as t.MCPOptions)
+      : await preProcessGraphTokens(rawConfig as t.MCPOptions, {
+          user,
+          graphTokenResolver,
+          scopes: process.env.GRAPH_API_SCOPES,
+        });
+    const currentOptions = processMCPEnv({
+      user,
+      body: requestBody,
+      dbSourced: isDbSourced,
+      options: graphProcessedConfig,
+      customUserVars,
+    });
+
+    const resolvedHeaders: Record<string, string> =
+      'headers' in currentOptions ? { ...(currentOptions.headers || {}) } : {};
+
+    const oboConfig = rawConfig.obo;
+    if (oboConfig && oboTokenResolver && user) {
+      const oboTrusted = oboTrustChecker
+        ? await oboTrustChecker({
+            source: rawConfig.source,
+            author: rawConfig.author,
+            dbId: rawConfig.dbId,
+          })
+        : true;
+      if (!oboTrusted) {
+        logger.warn(
+          `${logPrefix} OBO config not trusted (author lacks ${PermissionTypes.MCP_SERVERS}.${Permissions.CONFIGURE_OBO}); refusing to mint a downstream token`,
+        );
+        throw new McpError(
+          ErrorCode.InternalError,
+          `${logPrefix} OBO is not permitted for server "${serverName}". The user who configured it no longer has permission to use OBO.`,
+        );
+      }
+      try {
+        const oboTokens = await resolveOboToken(user, oboConfig, oboTokenResolver);
+        if (!oboTokens.access_token) {
+          throw new McpError(
+            ErrorCode.InternalError,
+            `${logPrefix} OBO token refresh failed. Cannot execute ${operation}. Re-authenticate the user and retry.`,
+          );
+        }
+        resolvedHeaders['Authorization'] = `Bearer ${oboTokens.access_token}`;
+      } catch (error) {
+        if (error instanceof OboTokenResolutionError) {
+          throw new McpError(
+            ErrorCode.InternalError,
+            `${logPrefix} ${error.userMessage} Cannot execute ${operation}. Re-authenticate the user and retry.`,
+          );
+        }
+        throw error;
+      }
+    }
+
+    let cleanup: (() => void) | undefined;
+    if (userId && user && oauthStart && flowManager && isOAuthServer(currentOptions)) {
+      const registry = MCPServersRegistry.getInstance();
+      const { allowedDomains, allowedAddresses, useSSRFProtection } =
+        await registry.resolveAllowlists({ userId, role: user?.role });
+      cleanup = MCPConnectionFactory.attachRequestOAuthHandler(
+        {
+          serverName,
+          serverConfig: currentOptions,
+          dbSourced: isDbSourced,
+          skipEnvProcessing: true,
+          useSSRFProtection,
+          allowedDomains,
+          allowedAddresses,
+        },
+        {
+          useOAuth: true,
+          user,
+          flowManager,
+          tokenMethods,
+          signal: options?.signal,
+          oauthStart,
+          oauthEnd,
+          customUserVars,
+          requestBody,
+        },
+        connection,
+      );
+    }
+
+    connection.setRequestHeaders(resolvedHeaders);
+    return { connection, disconnectAfterCall, cleanup };
   }
 }

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -108,6 +108,7 @@ describe('MCPConnectionFactory', () => {
     mockConnectionInstance = {
       connect: jest.fn(),
       isConnected: jest.fn(),
+      fetchResources: jest.fn().mockResolvedValue([]),
       setOAuthTokens: jest.fn(),
       on: jest.fn().mockReturnValue(mockConnectionInstance),
       once: jest.fn().mockReturnValue(mockConnectionInstance),

--- a/packages/api/src/mcp/__tests__/MCPConnectionFetchTools.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFetchTools.test.ts
@@ -58,6 +58,19 @@ function createConnectionWithListTools(listTools: jest.Mock): MCPConnection {
   return conn;
 }
 
+function createConnectionWithResourceClient(client: {
+  listResources?: jest.Mock;
+  readResource?: jest.Mock;
+}): MCPConnection {
+  const conn = new MCPConnection({
+    serverName: 'resource-test',
+    serverConfig: { type: 'streamable-http', url: 'http://localhost/mcp' },
+    useSSRFProtection: false,
+  });
+  conn.client = client as unknown as MCPConnection['client'];
+  return conn;
+}
+
 function expectListToolsCall(
   listTools: jest.Mock,
   callNumber: number,
@@ -294,5 +307,53 @@ describe('MCPConnection.fetchTools pagination', () => {
     expect(tools).toEqual([]);
     expect(listTools).toHaveBeenCalledTimes(1);
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch tools'));
+  });
+});
+
+describe('MCPConnection resources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('follows resource nextCursor pages', async () => {
+    const listResources = jest.fn(async (params?: { cursor?: string }) => {
+      if (params?.cursor == null) {
+        return { resources: [{ uri: 'file://a.md', name: 'A' }], nextCursor: 'next' };
+      }
+      return { resources: [{ uri: 'file://b.md', name: 'B' }] };
+    });
+    const conn = createConnectionWithResourceClient({ listResources });
+
+    const resources = await conn.fetchResources();
+
+    expect(resources.map((resource) => resource.uri)).toEqual(['file://a.md', 'file://b.md']);
+    expect(listResources).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      expect.objectContaining({ timeout: undefined }),
+    );
+    expect(listResources).toHaveBeenNthCalledWith(
+      2,
+      { cursor: 'next' },
+      expect.objectContaining({ timeout: undefined }),
+    );
+  });
+
+  it('calls SDK readResource with the URI', async () => {
+    const readResource = jest.fn().mockResolvedValue({
+      contents: [{ uri: 'file://a.md', text: 'hello', mimeType: 'text/markdown' }],
+    });
+    const conn = createConnectionWithResourceClient({ readResource });
+
+    const result = await conn.readResource('file://a.md');
+
+    expect(result.contents[0]).toMatchObject({ uri: 'file://a.md', text: 'hello' });
+    expect(readResource).toHaveBeenCalledWith(
+      { uri: 'file://a.md' },
+      expect.objectContaining({
+        timeout: undefined,
+        resetTimeoutOnProgress: true,
+      }),
+    );
   });
 });

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -1272,6 +1272,7 @@ describe('MCPManager', () => {
     const mockConnection = {
       isConnected: jest.fn().mockResolvedValue(true),
       fetchTools: jest.fn().mockResolvedValue(mockTools),
+      fetchResources: jest.fn().mockResolvedValue([]),
       disconnect: jest.fn().mockResolvedValue(undefined),
     } as unknown as MCPConnection;
 

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -2212,12 +2212,45 @@ export class MCPConnection extends EventEmitter {
   }
 
   async fetchResources(): Promise<t.MCPResource[]> {
+    const resources: t.MCPResource[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+
     try {
-      const { resources } = await this.client.listResources();
-      return resources;
+      for (;;) {
+        const result = await this.client.listResources(cursor != null ? { cursor } : undefined, {
+          timeout: this.timeout,
+        });
+        resources.push(...result.resources);
+
+        if (!result.nextCursor) {
+          return resources;
+        }
+        if (seenCursors.has(result.nextCursor)) {
+          logger.warn(`${this.getLogPrefix()} Stopping resource pagination due to repeated cursor`);
+          return resources;
+        }
+        seenCursors.add(result.nextCursor);
+        cursor = result.nextCursor;
+      }
     } catch (error) {
       this.emitError(error, 'Failed to fetch resources');
-      return [];
+      return resources;
+    }
+  }
+
+  async readResource(uri: string): Promise<t.MCPReadResourceResult> {
+    try {
+      return await this.client.readResource(
+        { uri },
+        {
+          timeout: this.timeout,
+          resetTimeoutOnProgress: true,
+        },
+      );
+    } catch (error) {
+      this.emitError(error, `Failed to read resource ${uri}`);
+      throw error;
     }
   }
 

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -13,6 +13,7 @@ import { isMCPDomainAllowed, extractMCPServerDomain } from '~/auth/domain';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPDomainNotAllowedError } from '~/mcp/errors';
 import { detectOAuthRequirement } from '~/mcp/oauth';
+import { createMCPResourceTools } from '~/mcp/tools';
 import { isEnabled } from '~/utils';
 
 /**
@@ -177,7 +178,10 @@ export class MCPServerInspector {
     serverName: string,
     connection: MCPConnection,
   ): Promise<t.LCAvailableTools> {
-    const tools = await connection.fetchTools();
+    const [tools, resources] = await Promise.all([
+      connection.fetchTools(),
+      connection.fetchResources(),
+    ]);
 
     const toolFunctions: t.LCAvailableTools = {};
     tools.forEach((tool) => {
@@ -192,6 +196,6 @@ export class MCPServerInspector {
       };
     });
 
-    return toolFunctions;
+    return { ...toolFunctions, ...createMCPResourceTools(serverName, resources) };
   }
 }

--- a/packages/api/src/mcp/registry/__tests__/mcpConnectionsMock.helper.ts
+++ b/packages/api/src/mcp/registry/__tests__/mcpConnectionsMock.helper.ts
@@ -32,6 +32,8 @@ export function createMockConnection(serverName: string): jest.Mocked<MCPConnect
   return {
     client: mockClient,
     fetchTools: jest.fn().mockResolvedValue(tools),
+    fetchResources: jest.fn().mockResolvedValue([]),
+    readResource: jest.fn().mockResolvedValue({ contents: [] }),
     disconnect: jest.fn().mockResolvedValue(undefined),
   } as unknown as jest.Mocked<MCPConnection>;
 }

--- a/packages/api/src/mcp/tools.spec.ts
+++ b/packages/api/src/mcp/tools.spec.ts
@@ -1,7 +1,11 @@
 import { Constants } from 'librechat-data-provider';
 import type { LCAvailableTools, ParsedServerConfig } from './types';
 import type { MCPToolInput, MCPToolCacheDeps } from './tools';
-import { createMCPToolCacheService } from './tools';
+import {
+  MCPResourceListToolName,
+  MCPResourceReadToolName,
+  createMCPToolCacheService,
+} from './tools';
 
 const requestScopedConfig: ParsedServerConfig = {
   type: 'streamable-http',
@@ -70,6 +74,43 @@ describe('createMCPToolCacheService', () => {
       });
     });
 
+    it('constructs managed resource tool names when resources exist', async () => {
+      const deps = createMockDeps();
+      const { updateMCPServerTools } = createMCPToolCacheService(deps);
+
+      const result = await updateMCPServerTools({
+        userId: 'u1',
+        serverName: 'docs',
+        tools: [],
+        resources: [{ uri: 'file://a.md', name: 'A' }],
+      });
+
+      const listKey = `${MCPResourceListToolName}${Constants.mcp_delimiter}docs`;
+      const readKey = `${MCPResourceReadToolName}${Constants.mcp_delimiter}docs`;
+      expect(result[listKey]?.function.name).toBe(listKey);
+      expect(result[readKey]?.function.name).toBe(readKey);
+      expect(result[readKey]?.function.parameters?.required).toEqual(['uri']);
+      expect(deps.setCachedTools).toHaveBeenCalledWith(result, {
+        userId: 'u1',
+        serverName: 'docs',
+      });
+    });
+
+    it('does not construct managed resource tools when resources are empty', async () => {
+      const deps = createMockDeps();
+      const { updateMCPServerTools } = createMCPToolCacheService(deps);
+
+      const result = await updateMCPServerTools({
+        userId: 'u1',
+        serverName: 'docs',
+        tools: [],
+        resources: [],
+      });
+
+      expect(result).toEqual({});
+      expect(deps.setCachedTools).not.toHaveBeenCalled();
+    });
+
     it('builds tool names without caching when the resolved config is request-scoped', async () => {
       const deps = createMockDeps({
         getServerConfig: jest.fn().mockResolvedValue(requestScopedConfig),
@@ -92,6 +133,24 @@ describe('createMCPToolCacheService', () => {
       const expectedKey = `search${Constants.mcp_delimiter}body-scoped`;
       expect(result[expectedKey]).toBeDefined();
       expect(deps.getServerConfig).toHaveBeenCalledWith('body-scoped', 'u1');
+      expect(deps.setCachedTools).not.toHaveBeenCalled();
+    });
+
+    it('builds managed resource tools without caching for request-scoped servers', async () => {
+      const deps = createMockDeps({
+        getServerConfig: jest.fn().mockResolvedValue(requestScopedConfig),
+      });
+      const { updateMCPServerTools } = createMCPToolCacheService(deps);
+
+      const result = await updateMCPServerTools({
+        userId: 'u1',
+        serverName: 'body-scoped',
+        tools: [],
+        resources: [{ uri: 'file://request.md', name: 'Request' }],
+      });
+
+      const listKey = `${MCPResourceListToolName}${Constants.mcp_delimiter}body-scoped`;
+      expect(result[listKey]).toBeDefined();
       expect(deps.setCachedTools).not.toHaveBeenCalled();
     });
 

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -1,8 +1,11 @@
 import { logger } from '@librechat/data-schemas';
 import { Constants } from 'librechat-data-provider';
 import type { JsonSchemaType } from '@librechat/agents';
-import type { LCAvailableTools, LCFunctionTool, ParsedServerConfig } from './types';
+import type { LCAvailableTools, LCFunctionTool, MCPResource, ParsedServerConfig } from './types';
 import { requiresEphemeralUserConnection } from './utils';
+
+export const MCPResourceListToolName = 'resources/list';
+export const MCPResourceReadToolName = 'resources/read';
 
 export interface MCPToolInput {
   name: string;
@@ -27,6 +30,7 @@ export interface MCPToolCacheService {
     userId: string;
     serverName: string;
     tools: MCPToolInput[] | null;
+    resources?: MCPResource[] | null;
     serverConfig?: ParsedServerConfig;
   }) => Promise<LCAvailableTools>;
   mergeAppTools: (appTools: LCAvailableTools) => Promise<void>;
@@ -45,6 +49,72 @@ export interface MCPToolCacheService {
 
 export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheService {
   const { getCachedTools, setCachedTools, getServerConfig } = deps;
+
+  function createToolEntry(
+    name: string,
+    description: string,
+    parameters: JsonSchemaType,
+  ): LCFunctionTool {
+    return {
+      type: 'function',
+      ['function']: {
+        name,
+        description,
+        parameters,
+      },
+    };
+  }
+
+  function getResourceToolDefinitions(serverName: string, resources?: MCPResource[] | null) {
+    if (!resources?.length) {
+      return {};
+    }
+
+    const listName = `${MCPResourceListToolName}${Constants.mcp_delimiter}${serverName}`;
+    const readName = `${MCPResourceReadToolName}${Constants.mcp_delimiter}${serverName}`;
+
+    return {
+      [listName]: createToolEntry(
+        listName,
+        `List available MCP resources from server "${serverName}".`,
+        { type: 'object', properties: {}, required: [] } as JsonSchemaType,
+      ),
+      [readName]: createToolEntry(
+        readName,
+        `Read an MCP resource from server "${serverName}" by URI.`,
+        {
+          type: 'object',
+          properties: {
+            uri: {
+              type: 'string',
+              description: 'The URI of the MCP resource to read.',
+            },
+          },
+          required: ['uri'],
+        } as JsonSchemaType,
+      ),
+    } satisfies LCAvailableTools;
+  }
+
+  function buildServerTools(
+    serverName: string,
+    tools: MCPToolInput[] | null,
+    resources?: MCPResource[] | null,
+  ): LCAvailableTools {
+    const serverTools: LCAvailableTools = {};
+    const mcpDelimiter = Constants.mcp_delimiter;
+
+    for (const tool of tools ?? []) {
+      const name = `${tool.name}${mcpDelimiter}${serverName}`;
+      serverTools[name] = createToolEntry(
+        name,
+        tool.description ?? '',
+        tool.inputSchema ?? ({ type: 'object', properties: {} } as JsonSchemaType),
+      );
+    }
+
+    return { ...serverTools, ...getResourceToolDefinitions(serverName, resources) };
+  }
 
   /**
    * Request-scoped servers resolve runtime user/request placeholders per
@@ -76,42 +146,28 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheS
     userId: string;
     serverName: string;
     tools: MCPToolInput[] | null;
+    resources?: MCPResource[] | null;
     serverConfig?: ParsedServerConfig;
   }): Promise<LCAvailableTools> {
-    const { userId, serverName, tools, serverConfig } = params;
+    const { userId, serverName, tools, resources, serverConfig } = params;
     try {
-      const serverTools: LCAvailableTools = {};
-      const mcpDelimiter = Constants.mcp_delimiter;
+      const serverTools = buildServerTools(serverName, tools, resources);
+      const count = Object.keys(serverTools).length;
 
-      if (tools == null || tools.length === 0) {
+      if (count === 0) {
         logger.debug(`[MCP Cache] No tools to update for server ${serverName} (user: ${userId})`);
         return serverTools;
       }
 
-      for (const tool of tools) {
-        const name = `${tool.name}${mcpDelimiter}${serverName}`;
-        const entry: LCFunctionTool = {
-          type: 'function',
-          ['function']: {
-            name,
-            description: tool.description ?? '',
-            parameters: tool.inputSchema ?? ({ type: 'object', properties: {} } as JsonSchemaType),
-          },
-        };
-        serverTools[name] = entry;
-      }
-
       if (await isRequestScoped(userId, serverName, serverConfig)) {
         logger.debug(
-          `[MCP Cache] Built ${tools.length} tools for request-scoped server ${serverName} (user: ${userId}) without caching`,
+          `[MCP Cache] Built ${count} tools for request-scoped server ${serverName} (user: ${userId}) without caching`,
         );
         return serverTools;
       }
 
       await setCachedTools(serverTools, { userId, serverName });
-      logger.debug(
-        `[MCP Cache] Updated ${tools.length} tools for server ${serverName} (user: ${userId})`,
-      );
+      logger.debug(`[MCP Cache] Updated ${count} tools for server ${serverName} (user: ${userId})`);
       return serverTools;
     } catch (error) {
       logger.error(
@@ -181,4 +237,44 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheS
   }
 
   return { updateMCPServerTools, mergeAppTools, cacheMCPServerTools, getMCPServerTools };
+}
+
+export function createMCPResourceTools(
+  serverName: string,
+  resources?: MCPResource[] | null,
+): LCAvailableTools {
+  if (!resources?.length) {
+    return {};
+  }
+
+  const listName = `${MCPResourceListToolName}${Constants.mcp_delimiter}${serverName}`;
+  const readName = `${MCPResourceReadToolName}${Constants.mcp_delimiter}${serverName}`;
+
+  return {
+    [listName]: {
+      type: 'function',
+      ['function']: {
+        name: listName,
+        description: `List available MCP resources from server "${serverName}".`,
+        parameters: { type: 'object', properties: {}, required: [] } as JsonSchemaType,
+      },
+    },
+    [readName]: {
+      type: 'function',
+      ['function']: {
+        name: readName,
+        description: `Read an MCP resource from server "${serverName}" by URI.`,
+        parameters: {
+          type: 'object',
+          properties: {
+            uri: {
+              type: 'string',
+              description: 'The URI of the MCP resource to read.',
+            },
+          },
+          required: ['uri'],
+        } as JsonSchemaType,
+      },
+    },
+  };
 }

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -10,6 +10,8 @@ import {
 } from 'librechat-data-provider';
 import type {
   EmbeddedResource,
+  ReadResourceResult,
+  Resource,
   ListToolsResult,
   ImageContent,
   AudioContent,
@@ -39,12 +41,8 @@ export type MCPOptions = z.infer<typeof MCPOptionsSchema> & {
   >;
 };
 export type MCPServers = z.infer<typeof MCPServersSchema>;
-export interface MCPResource {
-  uri: string;
-  name: string;
-  description?: string;
-  mimeType?: string;
-}
+export type MCPResource = Resource;
+export type MCPReadResourceResult = ReadResourceResult;
 
 export interface LCFunctionTool {
   type: 'function';
@@ -266,6 +264,7 @@ export interface ToolDiscoveryOptions {
 
 export interface ToolDiscoveryResult {
   tools: Tool[] | null;
+  resources?: MCPResource[] | null;
   oauthRequired: boolean;
   oauthUrl: string | null;
 }


### PR DESCRIPTION
## Summary

Adds support for MCP resources by exposing managed `resources/list` and `resources/read` tools for MCP servers that advertise resources.

This change:
- Discovers MCP resources alongside tools during connection/reinitialization.
- Adds managed resource tool definitions to the MCP tool cache when resources are available.
- Executes resource listing and resource reads through `MCPManager` using the same auth, OAuth, OBO, Graph token, request-scoped connection, and cleanup flow used by MCP tools.
- Adds paginated resource discovery and resource reading on `MCPConnection`.
- Updates MCP server inspection to include resource tools.
- Extends tests for discovery, cache behavior, invocation, pagination, and request-scoped handling.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Ran targeted backend and package API tests for the changed MCP code paths, plus the package API build.

### **Test Configuration**:

- Branch: `feat/mcp-resources`
- Node/npm from local LibreChat workspace
- Commands:
  - `cd api && npx jest server/services/MCP.spec.js server/services/Tools/mcp.spec.js --runInBand`
  - `cd packages/api && npx jest src/mcp/tools.spec.ts src/mcp/__tests__/MCPConnectionFactory.test.ts src/mcp/__tests__/MCPConnectionFetchTools.test.ts src/mcp/__tests__/MCPManager.test.ts --runInBand --coverage=false`
  - `npm run build:api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes