### PR TITLE
🥷 feat: Add `showInMenu` Option to Model Specs

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -6,6 +6,7 @@ const {
   resolveBuildInfo,
   resolveTitleTiming,
   sanitizeModelSpecs,
+  excludeHiddenModelSpecs,
   isFileSnapshotEnabled,
 } = require('@librechat/api');
 const { EModelEndpoint, defaultSocialLogins } = require('librechat-data-provider');
@@ -265,7 +266,7 @@ router.get('/', async function (req, res) {
         endpoint: EModelEndpoint.agents,
       }),
       turnstile: appConfig?.turnstileConfig,
-      modelSpecs: sanitizeModelSpecs(appConfig?.modelSpecs),
+      modelSpecs: sanitizeModelSpecs(excludeHiddenModelSpecs(appConfig?.modelSpecs)),
       balance: balanceConfig,
       bundlerURL: process.env.SANDPACK_BUNDLER_URL,
       staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,

--- a/packages/api/src/modelSpecs/excludeHiddenModelSpecs.test.ts
+++ b/packages/api/src/modelSpecs/excludeHiddenModelSpecs.test.ts
@@ -1,0 +1,49 @@
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { TModelSpec } from 'librechat-data-provider';
+import { excludeHiddenModelSpecs } from './index';
+
+const makeSpec = (name: string, showInMenu?: boolean): TModelSpec => ({
+  name,
+  label: name,
+  ...(showInMenu === undefined ? {} : { showInMenu }),
+  preset: {
+    endpoint: EModelEndpoint.bedrock,
+    model: 'claude-sonnet-4-6',
+  },
+});
+
+describe('excludeHiddenModelSpecs', () => {
+  it('drops specs marked showInMenu: false and keeps the rest', () => {
+    const modelSpecs = {
+      enforce: false,
+      prioritize: true,
+      list: [
+        makeSpec('listed-default'),
+        makeSpec('listed-explicit', true),
+        makeSpec('hidden', false),
+      ],
+    };
+
+    const result = excludeHiddenModelSpecs(modelSpecs);
+
+    expect(result.list.map((s) => s.name)).toEqual(['listed-default', 'listed-explicit']);
+  });
+
+  it('treats an omitted showInMenu as listed (backwards compatible)', () => {
+    const modelSpecs = { list: [makeSpec('no-flag')] };
+    expect(excludeHiddenModelSpecs(modelSpecs).list).toHaveLength(1);
+  });
+
+  it('does not mutate the input', () => {
+    const modelSpecs = { list: [makeSpec('keep'), makeSpec('hidden', false)] };
+    excludeHiddenModelSpecs(modelSpecs);
+    expect(modelSpecs.list).toHaveLength(2);
+  });
+
+  it('returns the config unchanged when there is no list', () => {
+    expect(excludeHiddenModelSpecs(undefined)).toBeUndefined();
+    expect(excludeHiddenModelSpecs(null)).toBeNull();
+    const noList = { enforce: false, prioritize: true };
+    expect(excludeHiddenModelSpecs(noList)).toBe(noList);
+  });
+});

--- a/packages/api/src/modelSpecs/index.ts
+++ b/packages/api/src/modelSpecs/index.ts
@@ -186,6 +186,25 @@ export function resolveModelSpecPromptPrefixVariables<T extends { promptPrefix?:
   };
 }
 
+/**
+ * Drops specs marked `showInMenu: false` so they are not advertised to clients
+ * (the model selector menu and the startup config). Such specs remain resolvable
+ * server-side by name, so a caller that sets `spec: "<name>"` can still use them.
+ * Returns the config unchanged when there is no list. Apply before `sanitizeModelSpecs`.
+ */
+export function excludeHiddenModelSpecs<T extends Partial<TSpecsConfig> | null | undefined>(
+  modelSpecs: T,
+): T {
+  if (!modelSpecs?.list || !Array.isArray(modelSpecs.list)) {
+    return modelSpecs;
+  }
+
+  return {
+    ...modelSpecs,
+    list: modelSpecs.list.filter((modelSpec) => modelSpec?.showInMenu !== false),
+  } as T;
+}
+
 export function sanitizeModelSpecs<T extends Partial<TSpecsConfig> | null | undefined>(
   modelSpecs: T,
 ): T {

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -37,6 +37,14 @@ export type TModelSpec = {
   showOnLanding?: boolean;
   /** Conversation starter prompts shown on the chat landing while this spec is active. */
   conversation_starters?: string[];
+  /**
+   * When false, the spec is omitted from the model selector menu and from the
+   * client startup config, but remains usable when invoked explicitly by name
+   * via the `spec` field (server-side resolution uses the full, unfiltered list).
+   * Unlike `showIconInMenu` (which only hides the icon), this hides the whole entry.
+   * Defaults to true (listed).
+   */
+  showInMenu?: boolean;
   iconURL?: string | EModelEndpoint; // Allow using project-included icons
   authType?: AuthType;
   /** Hide the chat input tool badge row while this model spec is active. */
@@ -70,6 +78,7 @@ export const tModelSpecSchema = z.object({
   showIconInHeader: z.boolean().optional(),
   showOnLanding: z.boolean().optional(),
   conversation_starters: z.array(z.string()).optional(),
+  showInMenu: z.boolean().optional(),
   iconURL: z.union([z.string(), eModelEndpointSchema]).optional(),
   authType: authTypeSchema.optional(),
   hideBadgeRow: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds an optional `showInMenu` flag to model specs. When set to `false`, the spec is dropped from the model selector menu and from the client startup config (`GET /api/config`), but it remains resolvable server-side **by name** — a request that sends `spec: "<name>"` still works, because server-side resolution uses the full, unfiltered list.

This is useful when an integration (or any external caller) needs to invoke a spec by name without exposing it to end users in the model picker.

Unlike `showIconInMenu` (which only hides the icon), `showInMenu` hides the whole entry. The flag is optional and defaults to listed, so existing specs are unaffected.

**Implementation**
- New `excludeHiddenModelSpecs()` helper in `packages/api/src/modelSpecs` that filters out `showInMenu: false` specs. It is non-mutating, treats an omitted flag as listed (backwards compatible), and returns the config unchanged when there is no `list`.
- Wired into `GET /api/config` (`api/server/routes/config.js`), applied **before** `sanitizeModelSpecs`.
- New optional `showInMenu` field on `TModelSpec` and its zod schema (`packages/data-provider/src/models.ts`).

No new dependencies. A corresponding docs update for the `librechat.ai` repo can follow if this is accepted.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

**Unit tests** — added `packages/api/src/modelSpecs/excludeHiddenModelSpecs.test.ts`, covering:
- drops specs marked `showInMenu: false`, keeps `true` and omitted-flag specs;
- an omitted flag is treated as listed (backwards compatible);
- the input config is not mutated;
- configs with no `list` (including `undefined`/`null`) are returned unchanged.

**Manual**
1. Add a spec with `showInMenu: false` to `librechat.yaml`, alongside at least one normal spec.
2. Load the app — confirm the hidden spec does **not** appear in the model selector, and is absent from the `modelSpecs.list` of the `GET /api/config` response.
3. Send a chat request with `spec: "<hidden spec name>"` — confirm it resolves and runs with that spec's preset/prompt.
4. Confirm specs with `showInMenu: true` or no flag still appear as before.

### **Test Configuration**:

- `librechat.yaml` with at least one `showInMenu: false` spec and one normal spec.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
