### PR TITLE
🚪 fix: Support Admin Redirect Detection for Same-Origin Subpaths

### DIFF
--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -36,7 +36,7 @@ function createOAuthHandler(redirectUri = domains.client) {
         return;
       }
 
-      /** Check if this is an admin panel redirect (cross-origin) */
+      /** Check if this is an admin panel redirect (cross-origin or same-origin subpath) */
       if (isAdminPanelRedirect(redirectUri, getAdminPanelUrl(), domains.client)) {
         /** For admin panel, generate exchange code instead of setting cookies */
         const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);

--- a/helm/librechat/readme.md
+++ b/helm/librechat/readme.md
@@ -38,8 +38,11 @@ kind: Secret
 
 ## Admin Panel SSO
 
-When deploying the admin panel at a separate URL, set `librechat.adminPanelUrl`
-to the external admin panel base URL. It may include a path, but it should not
+Set `librechat.adminPanelUrl` to the admin panel base URL used for OAuth/SSO
+redirect, whether the admin panel is deployed on a separate origin
+or on the same origin under an admin subpath.
+
+It may include a path, but it should not
 end with a trailing `/` because LibreChat appends `/auth/...` callback paths.
 
 ```yaml

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -13,7 +13,12 @@ jest.mock(
   { virtual: true },
 );
 
-import { exchangeAdminCode, generateAdminExchangeCode, verifyCodeChallenge } from './exchange';
+import {
+  exchangeAdminCode,
+  generateAdminExchangeCode,
+  isAdminPanelRedirect,
+  verifyCodeChallenge,
+} from './exchange';
 
 describe('admin OAuth code exchange', () => {
   const user = {
@@ -212,6 +217,78 @@ describe('admin OAuth code exchange', () => {
 
       expect(result).not.toBeNull();
       expect(result!.token).toBe('jwt-token');
+    });
+  });
+
+  describe('isAdminPanelRedirect', () => {
+    it('returns true for cross-origin admin callback redirects', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://admin.example.com/auth/openid/callback',
+          'https://admin.example.com',
+          'https://chat.example.com',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for same-origin callbacks under the admin subpath', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://chat.example.com/admin/auth/openid/callback',
+          'https://chat.example.com/admin',
+          'https://chat.example.com',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for same-origin callbacks outside the admin subpath', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://chat.example.com/oauth/openid/callback',
+          'https://chat.example.com/admin',
+          'https://chat.example.com',
+        ),
+      ).toBe(false);
+    });
+
+    it('does not treat similarly prefixed paths as admin subpaths', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://chat.example.com/administrator/auth/openid/callback',
+          'https://chat.example.com/admin',
+          'https://chat.example.com',
+        ),
+      ).toBe(false);
+    });
+
+    it('treats trailing slash variants of admin subpath as equivalent', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://chat.example.com/admin/auth/openid/callback',
+          'https://chat.example.com/admin/',
+          'https://chat.example.com',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true when redirect path exactly matches admin subpath', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://chat.example.com/admin',
+          'https://chat.example.com/admin',
+          'https://chat.example.com',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for same-origin root admin URL', () => {
+      expect(
+        isAdminPanelRedirect(
+          'https://chat.example.com/auth/openid/callback',
+          'https://chat.example.com/',
+          'https://chat.example.com',
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -274,14 +274,29 @@ export async function storeAndStripChallenge(
 }
 
 /**
- * Checks if the redirect URI is for the admin panel (cross-origin).
- * Uses proper URL parsing to compare origins, handling edge cases where
- * both URLs might share the same prefix (e.g., localhost:3000 vs localhost:3001).
+ * Normalizes a URL path by removing any trailing slash, except for the root path.
+ * @returns The normalized path.
+ */
+const normalizePath = (path: string): string => {
+  if (!path || path === '/') {
+    return '/';
+  }
+
+  return path.endsWith('/') ? path.slice(0, -1) : path;
+};
+
+/**
+ * Checks if the redirect URI targets the admin panel.
+ *
+ * Supported cases:
+ * - Cross-origin admin panel: redirect origin must match admin origin.
+ * - Same-origin admin panel under a subpath: redirect path must be within
+ *   the configured admin subpath.
  *
  * @param redirectUri - The redirect URI to check.
  * @param adminPanelUrl - The admin panel URL (defaults to ADMIN_PANEL_URL env var)
  * @param domainClient - The main client domain
- * @returns True if redirecting to admin panel (different origin from main client).
+ * @returns True if redirecting to admin panel.
  */
 export function isAdminPanelRedirect(
   redirectUri: string,
@@ -289,12 +304,30 @@ export function isAdminPanelRedirect(
   domainClient: string,
 ): boolean {
   try {
-    const redirectOrigin = new URL(redirectUri).origin;
-    const adminOrigin = new URL(adminPanelUrl).origin;
-    const clientOrigin = new URL(domainClient).origin;
+    const redirectURL = new URL(redirectUri);
+    const adminURL = new URL(adminPanelUrl);
+    const clientURL = new URL(domainClient);
 
-    /** Redirect is for admin panel if it matches admin origin but not main client origin */
-    return redirectOrigin === adminOrigin && redirectOrigin !== clientOrigin;
+    const redirectOrigin = redirectURL.origin;
+    const adminOrigin = adminURL.origin;
+    const clientOrigin = clientURL.origin;
+
+    if (redirectOrigin !== adminOrigin) {
+      return false;
+    }
+
+    if (adminOrigin !== clientOrigin) {
+      return true;
+    }
+
+    const adminPath = normalizePath(adminURL.pathname);
+    const redirectPath = normalizePath(redirectURL.pathname);
+
+    if (adminPath === '/') {
+      return false;
+    }
+
+    return redirectPath === adminPath || redirectPath.startsWith(`${adminPath}/`);
   } catch {
     /** If URL parsing fails, fall back to simple string comparison */
     return redirectUri.startsWith(adminPanelUrl) && !redirectUri.startsWith(domainClient);


### PR DESCRIPTION
## Summary

Fixes admin OAuth redirect classification when `ADMIN_PANEL_URL` is configured on the same origin as Librechat under an admin subpath.

This change supports both deployment models:
- Separate-origin admin panel URL.
- Same-origin admin panel URL under a configured subpath.

It also aligns comments and Helm chart documentation with the implemented behavior and adds missing redirect edge-case tests.

Fixes #14039
Related: ClickHouse/librechat-admin-panel#60

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Changes Included
- Update admin redirect detection logic to support same-origin subpath matching.
- Normalize path comparisons to handle trailing slash variants.
- Ensure similarly prefixed paths do not falsely match.
- Update controller comment language to reflect both redirect models.
- Update Helm chart admin SSO docs for separate-origin and same-origin subpath setups.
- Add focused unit tests for redirect edge cases.

## Testing
### Automated
Executed:
`cd packages/api && npx jest src/auth/exchange.spec.ts --runInBand`

Result:
- 1 test suite passed
- 19 tests passed

#### Test Configuration
- Node.js v24.16.0
- Local development workspace

### Manual
- Verified OpenID login flow with admin panel deployed on a same-origin subpath.
- Confirmed admin callback redirects are classified as admin redirects.
- Confirmed non-admin callback paths on the same origin are not treated as admin redirects.
- Confirmed similarly prefixed paths (for example `/administrator`) do not match the configured `/admin` subpath.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.

