### PR TITLE
🗺️ refactor: Light Up In-Viewport Ribs at Rest in Message Nav

### DIFF
--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -130,9 +130,12 @@ export function magnifyFalloff(distance: number, influence: number): number {
 }
 
 const indicatorButtonClasses = cn(
-  'flex h-1.5 w-full items-center justify-end rounded-sm',
+  'flex h-1.5 w-full items-center justify-end rounded-sm transition-opacity duration-300',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy',
 );
+
+const dimIndicatorClasses =
+  'opacity-40 group-hover/nav:opacity-100 group-focus-within/nav:opacity-100';
 
 const MessageIndicator = memo(function MessageIndicator({
   entry,
@@ -155,7 +158,7 @@ const MessageIndicator = memo(function MessageIndicator({
         e.stopPropagation();
         onSelect(entry.id);
       }}
-      className={indicatorButtonClasses}
+      className={cn(indicatorButtonClasses, isHighlighted ? 'opacity-100' : dimIndicatorClasses)}
       aria-label={label}
       aria-current={isCurrent ? 'true' : undefined}
       data-msg-id={entry.id}
@@ -172,8 +175,9 @@ const MessageIndicator = memo(function MessageIndicator({
 });
 
 const chevronButtonClasses = cn(
-  'rounded-md p-0.5 text-text-tertiary transition-colors',
-  'group-hover/nav:text-text-secondary group-focus-within/nav:text-text-secondary',
+  'rounded-md p-0.5 text-text-tertiary opacity-40 transition-[color,opacity] duration-300',
+  'group-hover/nav:text-text-secondary group-hover/nav:opacity-100',
+  'group-focus-within/nav:text-text-secondary group-focus-within/nav:opacity-100',
   'group-hover/nav:hover:text-text-primary',
   'group-hover/nav:disabled:opacity-30 group-focus-within/nav:disabled:opacity-30',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy',
@@ -1113,8 +1117,6 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       className={cn(
         'group/nav absolute right-2 top-1/2 z-40 hidden max-h-[min(24rem,calc(100%-2rem))]',
         '-translate-y-1/2 flex-col items-end gap-1.5 px-1.5 py-2 md:flex',
-        'opacity-30 transition-opacity duration-300',
-        'focus-within:opacity-100 hover:opacity-100',
       )}
     >
       <button

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -303,6 +303,26 @@ describe('MessageNav', () => {
       expect(userLine?.className).toContain('w-4');
       expect(assistantLine?.className).toContain('w-4');
     });
+
+    it('lights up only the in-viewport ribs at rest (no hover)', () => {
+      const messages = [
+        buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),
+        buildMessage({ messageId: 'b', text: 'bravo' }),
+        buildMessage({ messageId: 'c', text: 'charlie', isCreatedByUser: true }),
+      ];
+      const { container } = renderNav(messages);
+      const io = MockIntersectionObserver.last();
+      act(() => {
+        io!.trigger([{ target: document.getElementById('a')!, isIntersecting: true }]);
+        jest.advanceTimersByTime(32);
+      });
+
+      const ribA = container.querySelector('[data-msg-id="a"]') as HTMLElement;
+      const ribB = container.querySelector('[data-msg-id="b"]') as HTMLElement;
+      expect(ribA.className).toContain('opacity-100');
+      expect(ribA.className).not.toContain('opacity-40');
+      expect(ribB.className).toContain('opacity-40');
+    });
   });
 
   describe('preview text', () => {


### PR DESCRIPTION
## Summary

Follow-up to the dock-fisheye message nav rail ([#14021](https://github.com/danny-avila/LibreChat/pull/14021)). At rest the rail now reads like a **minimap**: only the in-viewport message ribs light up, the rest fade back, and it updates live as you scroll.

The viewport-visibility highlight already existed (the `IntersectionObserver`-driven `isHighlighted` that colors in-view ribs white). It just wasn't legible because the whole `<nav>` sat at `opacity-30` until hover, crushing the white-vs-gray distinction to a uniform faint strip.

## Change

- Removed the blanket `opacity-30` (+ `hover/focus:opacity-100`) from the `<nav>`.
- Drive opacity **per rib** instead: highlighted (in-viewport) ribs at `opacity-100`, the rest at `opacity-40`, all coming to full on `group-hover`/`group-focus-within`.
- Chevrons get the same dim-at-rest / full-on-hover treatment.
- Opacity sits on the rib **button** (not the line `<span>`), so it never collides with the inline `transition`/`width`/`height` the fisheye writes each frame.

Net effect: at rest the rail is a subtle position indicator showing where you are in the conversation; on hover/focus everything comes up to full opacity and the fisheye + preview behave exactly as before. Pure presentation — no change to the magnify, click, keyboard, or preview logic.

## Tests

Added a rest-state test: with one message intersecting, its rib is `opacity-100` while the others are `opacity-40`. 59 tests pass, lint/types clean.
