### PR TITLE
📏 fix: Make create_file Missing-Content Error Truncation-Aware

### DIFF
--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -2274,7 +2274,12 @@ async function handleCreateFileCall(
     return errorResult(tc, 'path is required');
   }
   if (typeof args.content !== 'string') {
-    return errorResult(tc, 'content is required');
+    return errorResult(
+      tc,
+      'content is required. If the file is large, your response may have been cut off at the ' +
+        'output token limit before content finished. Keep the main file lean and move bulky ' +
+        'sections (templates, schemas, long docs) into separate files written in their own calls.',
+    );
   }
   if (Buffer.byteLength(args.content, 'utf8') > MAX_AUTHORING_BYTES) {
     return errorResult(tc, `content exceeds ${MAX_AUTHORING_BYTES} byte limit`);


### PR DESCRIPTION
## Problem

When an agent authors a large file (e.g. a comprehensive `SKILL.md`) in a single `create_file` call, the response can exceed the model's max output token budget. The response is cut off **before the `content` argument finishes**, so the streamed tool-call args arrive without `content`, and the handler returns a bare `content is required`. The model reads that as a forgotten field and retries the same oversized write — looping.

This was diagnosed from a real Bedrock (`claude-sonnet-5`) agent transcript where a ClickHouse agent tried to persist a warehouse-mapping skill and got stuck repeating `create_file` against `content is required`. Confirmed with live Bedrock tests: with the output budget exceeded, the tool call arrives as a valid `{path}` with `content` dropped.

## Change

Make the missing-content error **actionable**: tell the model the response may have been truncated at the output token limit, and to keep the main file lean while moving bulky sections (templates, schemas, long docs) into separate files written in their own calls — which the tool descriptions already recommend.

This is the LibreChat-side half of the fix and helps immediately on the currently-published agents SDK. The companion SDK change (danny-avila/agents#280) detects the truncation stop reason and fails fast with a clear error instead of looping, so once that lands and is bumped here, a genuinely-truncated authoring turn surfaces an explicit error rather than relying on the handler hint.

## Follow-up (not in this PR)

Raising the default max output-token headroom for file-authoring agents on Bedrock (which silently defaults to 4096 when unset) so large authoring fits in the first place. Flagged for a separate, scoped change since it touches provider defaults.
