### PR TITLE
📐 test: Guard Web Search Description Length

### DIFF
--- a/packages/api/src/tools/definitions.spec.ts
+++ b/packages/api/src/tools/definitions.spec.ts
@@ -1,4 +1,4 @@
-import { Providers } from '@librechat/agents';
+import { Providers, WebSearchToolDefinition } from '@librechat/agents';
 import type {
   LoadToolDefinitionsParams,
   LoadToolDefinitionsDeps,
@@ -8,12 +8,28 @@ import { toolkitExpansion, toolkitParent } from './toolkits/mapping';
 import { getToolDefinition } from './registry/definitions';
 import { loadToolDefinitions } from './definitions';
 
+const MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH = 1024;
+
 describe('definitions.ts', () => {
   const mockGetOrFetchMCPServerTools = jest.fn().mockResolvedValue(null);
   const mockIsBuiltInTool = jest.fn().mockReturnValue(false);
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('keeps the registered web_search description within common API limits', () => {
+    const definition = getToolDefinition(WebSearchToolDefinition.name);
+
+    if (definition == null) {
+      throw new Error('Expected web_search tool definition to be registered');
+    }
+
+    expect(definition.description).toBe(WebSearchToolDefinition.description);
+    expect(definition.description).toMatch(/search/i);
+    expect(definition.description.length).toBeLessThanOrEqual(
+      MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH,
+    );
   });
 
   describe('loadToolDefinitions', () => {

--- a/packages/api/src/tools/definitions.spec.ts
+++ b/packages/api/src/tools/definitions.spec.ts
@@ -27,9 +27,7 @@ describe('definitions.ts', () => {
 
     expect(definition.description).toBe(WebSearchToolDefinition.description);
     expect(definition.description).toMatch(/search/i);
-    expect(definition.description.length).toBeLessThanOrEqual(
-      MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH,
-    );
+    expect(definition.description.length).toBeLessThanOrEqual(MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH);
   });
 
   describe('loadToolDefinitions', () => {

--- a/packages/api/src/tools/toolkits/web.spec.ts
+++ b/packages/api/src/tools/toolkits/web.spec.ts
@@ -1,14 +1,5 @@
 import { buildWebSearchContext, buildWebSearchDynamicContext } from './web';
 
-const MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH = 1024;
-
-function getToolDescription(context: string): string {
-  const [headerAndDescription = ''] = context.split('\n\n');
-  const [, ...descriptionLines] = headerAndDescription.split('\n');
-
-  return descriptionLines.join('\n').trim();
-}
-
 jest.mock('librechat-data-provider', () => ({
   Tools: { web_search: 'web_search' },
   replaceSpecialVars: jest.fn(({ now }: { now?: string }) => now ?? 'NOW'),
@@ -31,12 +22,5 @@ describe('web search context', () => {
       '# `web_search` Runtime Context\nConversation Date & Time: 2024-01-02T03:04:05.000Z',
     );
     expect(secondContext).toBe(context);
-  });
-
-  it('keeps provider-facing tool description within common API limits', () => {
-    const description = getToolDescription(buildWebSearchContext());
-
-    expect(description).toContain('search');
-    expect(description.length).toBeLessThanOrEqual(MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH);
   });
 });

--- a/packages/api/src/tools/toolkits/web.spec.ts
+++ b/packages/api/src/tools/toolkits/web.spec.ts
@@ -1,5 +1,14 @@
 import { buildWebSearchContext, buildWebSearchDynamicContext } from './web';
 
+const MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH = 1024;
+
+function getToolDescription(context: string): string {
+  const [headerAndDescription = ''] = context.split('\n\n');
+  const [, ...descriptionLines] = headerAndDescription.split('\n');
+
+  return descriptionLines.join('\n').trim();
+}
+
 jest.mock('librechat-data-provider', () => ({
   Tools: { web_search: 'web_search' },
   replaceSpecialVars: jest.fn(({ now }: { now?: string }) => now ?? 'NOW'),
@@ -22,5 +31,12 @@ describe('web search context', () => {
       '# `web_search` Runtime Context\nConversation Date & Time: 2024-01-02T03:04:05.000Z',
     );
     expect(secondContext).toBe(context);
+  });
+
+  it('keeps provider-facing tool description within common API limits', () => {
+    const description = getToolDescription(buildWebSearchContext());
+
+    expect(description).toContain('search');
+    expect(description.length).toBeLessThanOrEqual(MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH);
   });
 });


### PR DESCRIPTION
## Summary

I added a focused regression guard for the web search tool description length so provider-facing wording stays within the 1,024-character compatibility ceiling.

- Added a `MAX_PROVIDER_TOOL_DESCRIPTION_LENGTH` assertion to the web search toolkit spec.
- Extracted the first descriptive paragraph after the `web_search` header so the guard checks provider-facing wording without constraining citation-format instructions.
- Kept the test scoped to `buildWebSearchContext` to catch future prompt-description growth close to the source.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the focused Jest spec for the web search toolkit.

### **Test Configuration**:

- `cd packages/api && npx jest src/tools/toolkits/web.spec.ts --coverage=false`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
