### PR TITLE
fix: use CSS to resize Root for Banner instead of callback

### DIFF
--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -39,7 +39,6 @@ function KeyboardShortcutsProvider() {
 
 export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
-  const [bannerHeight, setBannerHeight] = useState(0);
   const sidebarExpanded = useRecoilValue(store.sidebarExpanded);
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
 
@@ -83,20 +82,24 @@ export default function Root() {
         <AssistantsMapContext.Provider value={assistantsMap}>
           <AgentsMapContext.Provider value={agentsMap}>
             <PromptGroupsProvider>
-              <Banner onHeightChange={setBannerHeight} />
-              <div className="flex" style={{ height: `calc(100dvh - ${bannerHeight}px)` }}>
-                <div className="relative z-0 flex h-full w-full overflow-hidden">
-                  <UnifiedSidebar />
-                  <div
-                    className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden"
-                    style={{
-                      transform:
-                        isSmallScreen && sidebarExpanded ? 'translateX(min(85vw, 380px))' : 'none',
-                      transition: 'transform 300ms cubic-bezier(0.2, 0, 0, 1)',
-                    }}
-                    inert={isSmallScreen && sidebarExpanded ? '' : undefined}
-                  >
-                    <Outlet />
+              <div className="flex h-dvh flex-col">
+                <Banner />
+                <div className="flex min-h-0 flex-1">
+                  <div className="relative z-0 flex h-full w-full overflow-hidden">
+                    <UnifiedSidebar />
+                    <div
+                      className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden"
+                      style={{
+                        transform:
+                          isSmallScreen && sidebarExpanded
+                            ? 'translateX(min(85vw, 380px))'
+                            : 'none',
+                        transition: 'transform 300ms cubic-bezier(0.2, 0, 0, 1)',
+                      }}
+                      inert={isSmallScreen && sidebarExpanded ? '' : undefined}
+                    >
+                      <Outlet />
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

The callback method was making some of our customizations of the homepage difficult to implement. The CSS method is both simpler and makes it easier to add more content Root.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I loaded the main page with a banner & without a banner, both before & after, checking to make sure there were no differences in how everything looked.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
