### PR TITLE
🩹 fix: Coerce Stringified `edit_file` Edits (JSON-in-JSON)

### DIFF
--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -1544,6 +1544,127 @@ describe('createToolExecuteHandler', () => {
       );
     });
 
+    it('coerces a stringified edits array (JSON-in-JSON) so the edit still applies', async () => {
+      const saveSkillFileContent = jest.fn();
+      const handler = makeAuthoringHandler({
+        getSkillByName: jest.fn(async () => ({
+          _id: SKILL_ID,
+          name: 'edit-skill',
+          body: '# Existing',
+          fileCount: 1,
+          version: 1,
+        })),
+        getSkillFileByPath: jest.fn(async () => ({
+          content: 'hello old\n',
+          isBinary: false,
+          mimeType: 'text/markdown',
+          bytes: 10,
+          filepath: '/tmp/a.md',
+          source: 'local',
+          relativePath: 'references/a.md',
+        })),
+        saveSkillFileContent,
+      });
+
+      const [result] = await invokeHandler(handler, [
+        {
+          id: 'call_edit_file_stringified_array',
+          name: 'edit_file',
+          args: {
+            path: 'skills/edit-skill/references/a.md',
+            edits: JSON.stringify([{ old_text: 'hello old', new_text: 'hello new' }]),
+          },
+        },
+      ]);
+
+      expect(result.status).toBe('success');
+      expect(result.artifact).toMatchObject({
+        path: 'skills/edit-skill/references/a.md',
+        edits: 1,
+        strategies: ['exact'],
+      });
+      expect(saveSkillFileContent).toHaveBeenCalledWith(
+        expect.objectContaining({ relativePath: 'references/a.md', content: 'hello new\n' }),
+      );
+    });
+
+    it('coerces stringified entries inside an edits array', async () => {
+      const saveSkillFileContent = jest.fn();
+      const handler = makeAuthoringHandler({
+        getSkillByName: jest.fn(async () => ({
+          _id: SKILL_ID,
+          name: 'edit-skill',
+          body: '# Existing',
+          fileCount: 1,
+          version: 1,
+        })),
+        getSkillFileByPath: jest.fn(async () => ({
+          content: 'hello old\n',
+          isBinary: false,
+          mimeType: 'text/markdown',
+          bytes: 10,
+          filepath: '/tmp/a.md',
+          source: 'local',
+          relativePath: 'references/a.md',
+        })),
+        saveSkillFileContent,
+      });
+
+      const [result] = await invokeHandler(handler, [
+        {
+          id: 'call_edit_file_stringified_entry',
+          name: 'edit_file',
+          args: {
+            path: 'skills/edit-skill/references/a.md',
+            edits: [JSON.stringify({ old_text: 'hello old', new_text: 'hello new' })],
+          },
+        },
+      ]);
+
+      expect(result.status).toBe('success');
+      expect(saveSkillFileContent).toHaveBeenCalledWith(
+        expect.objectContaining({ relativePath: 'references/a.md', content: 'hello new\n' }),
+      );
+    });
+
+    it('still rejects an unparseable edits string with the explicit error', async () => {
+      const saveSkillFileContent = jest.fn();
+      const handler = makeAuthoringHandler({
+        getSkillByName: jest.fn(async () => ({
+          _id: SKILL_ID,
+          name: 'edit-skill',
+          body: '# Existing',
+          fileCount: 1,
+          version: 1,
+        })),
+        getSkillFileByPath: jest.fn(async () => ({
+          content: 'hello old\n',
+          isBinary: false,
+          mimeType: 'text/markdown',
+          bytes: 10,
+          filepath: '/tmp/a.md',
+          source: 'local',
+          relativePath: 'references/a.md',
+        })),
+        saveSkillFileContent,
+      });
+
+      const [result] = await invokeHandler(handler, [
+        {
+          id: 'call_edit_file_bad_edits',
+          name: 'edit_file',
+          args: {
+            path: 'skills/edit-skill/references/a.md',
+            edits: 'not valid json',
+          },
+        },
+      ]);
+
+      expect(result.status).toBe('error');
+      expect(result.errorMessage).toContain('non-empty edits array');
+      expect(saveSkillFileContent).not.toHaveBeenCalled();
+    });
+
     it('rejects bundled skill file writes when the skill version changed after reading', async () => {
       const getSkillByName = jest
         .fn()

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -793,14 +793,31 @@ function getAuthorInfo(req: ServerRequest): {
   };
 }
 
+/* Models often stringify nested JSON (JSON-in-JSON) instead of passing a
+   real array/object, which would otherwise fail validation and cost a retry
+   round-trip. Parse a JSON string back to its value; leave non-strings and
+   unparseable strings untouched so the explicit errors below still fire. */
+function coerceJsonValue(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
 function normalizeEditArgs(args: {
   old_text?: unknown;
   new_text?: unknown;
   edits?: unknown;
 }): TextEdit[] | string {
-  if (Array.isArray(args.edits) && args.edits.length > 0) {
+  const coercedEdits = coerceJsonValue(args.edits);
+  if (Array.isArray(coercedEdits) && coercedEdits.length > 0) {
     const edits: TextEdit[] = [];
-    for (const edit of args.edits) {
+    for (const rawEdit of coercedEdits) {
+      const edit = coerceJsonValue(rawEdit);
       if (!edit || typeof edit !== 'object') {
         return 'Each edit must be an object with old_text and new_text.';
       }


### PR DESCRIPTION
## Summary

`edit_file` (host file-authoring tool) rejected calls where the model passed `edits` as a **JSON-encoded string** instead of a real array — a common LLM mistake when nesting JSON. The call failed with:

```
Error: Provide old_text and new_text, or a non-empty edits array.
```

and the model had to burn a full retry round-trip re-sending the same edits as an array (observed live: first call failed, identical retry with a real array succeeded).

## Fix

`normalizeEditArgs` now JSON-parses a stringified `edits` value (and stringified individual entries) before validating, via a small `coerceJsonValue` helper. Non-strings and unparseable strings are left untouched, so the existing explicit validation errors still fire unchanged.

This is a robustness improvement in the spirit of the other host-tool fixes: reduce avoidable LLM retry loops without loosening validation.

## Behavior

| `edits` input | Before | After |
|---|---|---|
| `[{old_text, new_text}]` (array) | ✅ applies | ✅ applies |
| `"[{...}]"` (stringified array) | ❌ error + retry | ✅ applies |
| `["{...}"]` (stringified entries) | ❌ error | ✅ applies |
| top-level `old_text`/`new_text` | ✅ applies | ✅ applies |
| `"not json"` (unparseable) | ❌ explicit error | ❌ explicit error (unchanged) |
| stringified array of non-objects | ❌ error | ❌ per-entry error (unchanged) |

## Tests

Added three cases to `handlers.spec.ts` (`file authoring tools for skills`): stringified array applies, stringified entries apply, and an unparseable `edits` string still returns the explicit error without writing. Logic also validated against the exact repro from the reported conversation.

Typecheck, prettier, and eslint clean.