### PR TITLE
🧠 fix: Default Bedrock thinking `maxTokens` to model max output

### DIFF
--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -922,7 +922,7 @@ describe('initializeBedrock', () => {
   });
 
   describe('Opus 4.6 Adaptive Thinking', () => {
-    it('should configure adaptive thinking with no default maxTokens for Opus 4.6', async () => {
+    it('should default adaptive maxTokens to the model max output for Opus 4.6', async () => {
       const params = createMockParams({
         model_parameters: {
           model: 'anthropic.claude-opus-4-6-v1',
@@ -933,7 +933,7 @@ describe('initializeBedrock', () => {
       const amrf = result.llmConfig.additionalModelRequestFields as Record<string, unknown>;
 
       expect(amrf.thinking).toEqual({ type: 'adaptive' });
-      expect(result.llmConfig.maxTokens).toBeUndefined();
+      expect(result.llmConfig.maxTokens).toBe(128000);
       expect(amrf.anthropic_beta).toEqual(expect.arrayContaining(BEDROCK_CLAUDE_4_BETAS));
     });
 
@@ -1009,7 +1009,7 @@ describe('initializeBedrock', () => {
 
       expect(amrf.thinking).toEqual({ type: 'enabled', budget_tokens: 2000 });
       expect(amrf.output_config).toBeUndefined();
-      expect(result.llmConfig.maxTokens).toBe(8192);
+      expect(result.llmConfig.maxTokens).toBe(64000);
     });
 
     it('should not include output_config when effort is empty', async () => {

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -1285,6 +1285,21 @@ describe('bedrockInputParser', () => {
       expect(output.maxTokens).toBe(128000);
     });
 
+    // Number-first aliases (claude-4-7-sonnet, claude-5-sonnet) are gated as
+    // thinking models here but are not matched by the family-first reset()
+    // regex; they must still resolve to the real ceiling, not the 8192 fallback.
+    test.each([
+      ['anthropic.claude-4-7-sonnet', 64000],
+      ['claude-5-sonnet', 128000],
+      ['anthropic.claude-4-8-opus', 128000],
+    ])('defaults number-first adaptive alias %s to its real max output', (model, expected) => {
+      const parsed = bedrockInputParser.parse({ model }) as Record<string, unknown>;
+      const output = bedrockOutputParser(parsed as Record<string, unknown>);
+      const amrf = output.additionalModelRequestFields as Record<string, unknown>;
+      expect((amrf.thinking as { type: string }).type).toBe('adaptive');
+      expect(output.maxTokens).toBe(expected);
+    });
+
     test('defaults non-adaptive thinking maxTokens to the model max output', () => {
       const parsed = bedrockInputParser.parse({
         model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -1211,14 +1211,14 @@ describe('bedrockInputParser', () => {
   });
 
   describe('bedrockOutputParser with configureThinking', () => {
-    test('should preserve adaptive thinking config without setting default maxTokens', () => {
+    test('defaults adaptive maxTokens to the model max output when unset', () => {
       const parsed = bedrockInputParser.parse({
         model: 'anthropic.claude-opus-4-6-v1',
       }) as Record<string, unknown>;
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
       const amrf = output.additionalModelRequestFields as Record<string, unknown>;
       expect(amrf.thinking).toEqual({ type: 'adaptive' });
-      expect(output.maxTokens).toBeUndefined();
+      expect(output.maxTokens).toBe(128000);
       expect(output.maxOutputTokens).toBeUndefined();
     });
 
@@ -1248,7 +1248,7 @@ describe('bedrockInputParser', () => {
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
       const amrf = output.additionalModelRequestFields as Record<string, unknown>;
       expect(amrf.thinking).toEqual({ type: 'enabled', budget_tokens: 2000 });
-      expect(output.maxTokens).toBe(8192);
+      expect(output.maxTokens).toBe(64000);
     });
 
     test('should pass output_config through for adaptive model with effort', () => {
@@ -1262,24 +1262,37 @@ describe('bedrockInputParser', () => {
       expect(amrf.output_config).toEqual({ effort: 'low' });
     });
 
-    test('should not set maxTokens for adaptive models when neither maxTokens nor maxOutputTokens are provided', () => {
+    test('defaults adaptive maxTokens to the model max when neither maxTokens nor maxOutputTokens are provided', () => {
       const parsed = bedrockInputParser.parse({
         model: 'anthropic.claude-opus-4-6-v1',
       }) as Record<string, unknown>;
       parsed.maxOutputTokens = undefined;
       (parsed as Record<string, unknown>).maxTokens = undefined;
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
-      expect(output.maxTokens).toBeUndefined();
+      expect(output.maxTokens).toBe(128000);
     });
 
-    test('should use enabled default maxTokens (8192) for non-adaptive thinking models', () => {
+    // Regression: a bare inference-profile adaptive model (e.g. claude-sonnet-5)
+    // with no explicit maxTokens must get the model's full output budget so
+    // reasoning + a large create_file argument does not truncate mid-stream.
+    test('defaults a bare adaptive inference-profile model to its full max output', () => {
+      const parsed = bedrockInputParser.parse({
+        model: 'claude-sonnet-5',
+      }) as Record<string, unknown>;
+      const output = bedrockOutputParser(parsed as Record<string, unknown>);
+      const amrf = output.additionalModelRequestFields as Record<string, unknown>;
+      expect(amrf.thinking).toEqual({ type: 'adaptive', display: 'summarized' });
+      expect(output.maxTokens).toBe(128000);
+    });
+
+    test('defaults non-adaptive thinking maxTokens to the model max output', () => {
       const parsed = bedrockInputParser.parse({
         model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
       }) as Record<string, unknown>;
       parsed.maxOutputTokens = undefined;
       (parsed as Record<string, unknown>).maxTokens = undefined;
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
-      expect(output.maxTokens).toBe(8192);
+      expect(output.maxTokens).toBe(64000);
     });
 
     test('should use default thinking budget (2000) when no custom budget is set', () => {

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -673,6 +673,17 @@ export const bedrockInputParser = s.tConversationSchema
  * @returns The object with thinking configured appropriately
  */
 /**
+ * `anthropicSettings.maxOutputTokens.reset` only matches the canonical
+ * family-first id (`claude-sonnet-5`); Bedrock also accepts number-first
+ * aliases (`claude-5-sonnet`, `claude-4-7-sonnet`) that this file gates as
+ * thinking models. Canonicalize to family-first so those aliases resolve to the
+ * real ceiling instead of the 8192 fallback.
+ */
+function toFamilyFirstClaudeId(model: string): string {
+  return model.replace(/claude-(\d+(?:[-.]\d+)?)-(sonnet|opus|haiku)/, 'claude-$2-$1');
+}
+
+/**
  * Thinking tokens share the `maxTokens` output budget with tool-call arguments
  * (e.g. a `create_file` `content`), so a low default truncates large authored
  * files mid-argument. Mirror the direct-Anthropic path and default to the
@@ -684,7 +695,7 @@ function resolveThinkingMaxTokens(data: AnthropicInput): number {
     return explicit;
   }
   const model = typeof data.model === 'string' ? data.model : '';
-  return s.anthropicSettings.maxOutputTokens.reset(model);
+  return s.anthropicSettings.maxOutputTokens.reset(toFamilyFirstClaudeId(model));
 }
 
 function configureThinking(data: AnthropicInput): AnthropicInput {

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import * as s from './schemas';
 
-const DEFAULT_ENABLED_MAX_TOKENS = 8192;
 const DEFAULT_THINKING_BUDGET = 2000;
 export const BEDROCK_OUTPUT_128K_BETA = 'output-128k-2025-02-19';
 export const BEDROCK_FINE_GRAINED_TOOL_STREAMING_BETA = 'fine-grained-tool-streaming-2025-05-14';
@@ -673,13 +672,27 @@ export const bedrockInputParser = s.tConversationSchema
  * @param data - The parsed Bedrock request options object
  * @returns The object with thinking configured appropriately
  */
+/**
+ * Thinking tokens share the `maxTokens` output budget with tool-call arguments
+ * (e.g. a `create_file` `content`), so a low default truncates large authored
+ * files mid-argument. Mirror the direct-Anthropic path and default to the
+ * model's full max output when the request does not set one explicitly.
+ */
+function resolveThinkingMaxTokens(data: AnthropicInput): number {
+  const explicit = data.maxTokens ?? data.maxOutputTokens;
+  if (typeof explicit === 'number' && explicit > 0) {
+    return explicit;
+  }
+  const model = typeof data.model === 'string' ? data.model : '';
+  return s.anthropicSettings.maxOutputTokens.reset(model);
+}
+
 function configureThinking(data: AnthropicInput): AnthropicInput {
   const updatedData = { ...data };
   const thinking = updatedData.additionalModelRequestFields?.thinking;
 
   if (thinking === true) {
-    updatedData.maxTokens =
-      updatedData.maxTokens ?? updatedData.maxOutputTokens ?? DEFAULT_ENABLED_MAX_TOKENS;
+    updatedData.maxTokens = resolveThinkingMaxTokens(updatedData);
     delete updatedData.maxOutputTokens;
     const thinkingConfig: ThinkingConfig = {
       type: 'enabled',
@@ -697,9 +710,7 @@ function configureThinking(data: AnthropicInput): AnthropicInput {
     thinking != null &&
     (thinking as { type: string }).type === 'adaptive'
   ) {
-    if (updatedData.maxTokens == null && updatedData.maxOutputTokens != null) {
-      updatedData.maxTokens = updatedData.maxOutputTokens;
-    }
+    updatedData.maxTokens = resolveThinkingMaxTokens(updatedData);
     delete updatedData.maxOutputTokens;
     delete updatedData.additionalModelRequestFields!.thinkingBudget;
   }


### PR DESCRIPTION
## Summary

Follow-up to #14054. Now that Bedrock reasoning actually emits on bare inference-profile IDs, users hit `OutputTruncationError` (agents#280) when an agent authored a large file: the `create_file` `content` argument was cut off mid-stream at the `max_tokens` ceiling.

Root cause: **thinking tokens and tool-call arguments share the same `maxTokens` output budget**, and the Bedrock thinking path used low defaults:
- `thinking === true` (3.7 / early Claude 4): defaulted `maxTokens` to a hardcoded `8192`, with a 2000-token thinking budget carved out of it.
- adaptive (Sonnet 5, Opus 4.7+): set no default at all when `maxTokens` was unset, so Bedrock Converse applied its low server-side default (~4096).

Reasoning + a multi-thousand-word file, escaped as a JSON tool argument, against a ~4–8K ceiling truncates.

## Fix

Default `maxTokens` to the model's full max output via `anthropicSettings.maxOutputTokens.reset(model)` — the exact resolver the **direct-Anthropic path already uses** ([`anthropic/llm.ts`](https://github.com/danny-avila/LibreChat/blob/dev/packages/api/src/endpoints/anthropic/llm.ts)). The Bedrock path was the outlier. This yields model-aware ceilings (Sonnet 5 / Opus 4.6+ → 128K, Claude 4 → 64K, Opus 4.x → 32K, older → 8192) and applies to both the enabled and adaptive branches.

Explicitly-set `maxTokens` / `maxOutputTokens` are still respected — this only changes the *default when unset*. It's a ceiling, not a forced length, so it costs nothing unless the model needs the room.

## Testing

- `packages/data-provider` bedrock spec: 178 pass (updated the now-outdated 8192/undefined-default expectations; added a regression test for a bare adaptive `claude-sonnet-5` defaulting to its full 128K output).
- `packages/api` bedrock `initialize.spec`: 58 pass (updated the two thinking-default assertions).
- Lint + tsc clean.