### PR TITLE
🧵 fix: Realign Resumable Stream Reorder Buffer on Generation Change

### DIFF
--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -328,6 +328,10 @@ class GenerationJobManagerClass {
     const safeTenantId = tenantId && tenantId !== SYSTEM_TENANT_ID ? tenantId : undefined;
     const jobData = await this.jobStore.createJob(streamId, userId, conversationId, safeTenantId);
 
+    // Allocate this generation's epoch before any chunk is published so a reused streamId's
+    // new turn is delivered rather than dropped against a stale consumer nextSeq.
+    await this.eventTransport.beginGeneration?.(streamId);
+
     /**
      * Create runtime state with readyPromise.
      *

--- a/packages/api/src/stream/__tests__/reconnect-reorder-desync.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/reconnect-reorder-desync.stream_integration.spec.ts
@@ -407,6 +407,7 @@ describe('Reconnect Reorder Buffer Desync (Regression)', () => {
       const epochKey = `stream:{${streamId}}:epoch`;
 
       transport.subscribe(streamId, { onChunk: () => {} });
+      await transport.beginGeneration(streamId);
       await transport.emitChunk(streamId, { index: 0 });
 
       expect(await mockPublisher.get(seqKey)).not.toBeNull();
@@ -416,6 +417,85 @@ describe('Reconnect Reorder Buffer Desync (Regression)', () => {
 
       expect(await mockPublisher.get(seqKey)).toBeNull();
       expect(await mockPublisher.get(epochKey)).not.toBeNull();
+
+      transport.destroy();
+    });
+
+    test('beginGeneration allocates a distinct, persisted epoch per generation and stamps it on emits', async () => {
+      /**
+       * Allocating the epoch once at generation start (not on the seq===0 emit) means every
+       * chunk of a generation carries the same epoch regardless of emit ordering, and the
+       * epoch key is persisted so a reused streamId's next generation is strictly higher.
+       */
+      const mockPublisher = createMockPublisher();
+      const mockSubscriber = {
+        on: jest.fn(),
+        subscribe: jest.fn().mockResolvedValue(undefined),
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+      const transport = new RedisEventTransport(
+        mockPublisher as unknown as Redis,
+        mockSubscriber as unknown as Redis,
+      );
+      const streamId = 'epoch-alloc-test';
+
+      const epochOf = () =>
+        (JSON.parse(mockPublisher.publish.mock.calls.at(-1)?.[1] as string) as { epoch?: number })
+          .epoch;
+
+      await transport.beginGeneration(streamId);
+      await transport.emitChunk(streamId, { index: 0 });
+      await transport.emitChunk(streamId, { index: 1 });
+      const gen1Epoch = epochOf();
+      // Every chunk of the generation carries the same epoch, including seq > 0.
+      await transport.emitChunk(streamId, { index: 2 });
+      expect(epochOf()).toBe(gen1Epoch);
+
+      // Reused streamId (cleanup deleted only :seq): next generation gets a higher epoch.
+      transport.cleanup(streamId);
+      await transport.beginGeneration(streamId);
+      await transport.emitChunk(streamId, { index: 0 });
+      expect(epochOf()).toBeGreaterThan(gen1Epoch as number);
+
+      transport.destroy();
+    });
+
+    test('realigns when the first epoch-tagged message follows untagged traffic', () => {
+      /**
+       * Rolling-upgrade transition: a consumer advanced nextSeq on untagged (pre-upgrade)
+       * messages, then the reused streamId's new generation arrives epoch-tagged from seq 0.
+       * The first epoch-tagged message must realign rather than drop the new generation.
+       */
+      const mockPublisher = createMockPublisher();
+      const mockSubscriber = {
+        on: jest.fn(),
+        subscribe: jest.fn().mockResolvedValue(undefined),
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+      const transport = new RedisEventTransport(
+        mockPublisher as unknown as Redis,
+        mockSubscriber as unknown as Redis,
+      );
+      const streamId = 'epoch-transition-test';
+      const channel = `stream:{${streamId}}:events`;
+      const chunks: unknown[] = [];
+      transport.subscribe(streamId, { onChunk: (event) => chunks.push(event) });
+      const messageHandler = mockSubscriber.on.mock.calls.find(
+        (call) => call[0] === 'message',
+      )?.[1] as (channel: string, message: string) => void;
+
+      // Untagged (no epoch) traffic advances nextSeq to 3.
+      for (let i = 0; i < 3; i++) {
+        messageHandler(channel, JSON.stringify({ type: 'chunk', seq: i, data: { index: i } }));
+      }
+      expect(chunks.map((c) => (c as { index: number }).index)).toEqual([0, 1, 2]);
+
+      // New generation, now epoch-tagged, restarts at seq 0 while nextSeq is still 3.
+      messageHandler(
+        channel,
+        JSON.stringify({ type: 'chunk', seq: 0, epoch: 1, data: { index: 100 } }),
+      );
+      expect(chunks.map((c) => (c as { index: number }).index)).toEqual([0, 1, 2, 100]);
 
       transport.destroy();
     });

--- a/packages/api/src/stream/__tests__/reconnect-reorder-desync.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/reconnect-reorder-desync.stream_integration.spec.ts
@@ -439,9 +439,10 @@ describe('Reconnect Reorder Buffer Desync (Regression)', () => {
       );
       const streamId = 'epoch-alloc-test';
 
-      const epochOf = () =>
-        (JSON.parse(mockPublisher.publish.mock.calls.at(-1)?.[1] as string) as { epoch?: number })
-          .epoch;
+      const epochOf = () => {
+        const calls = mockPublisher.publish.mock.calls;
+        return (JSON.parse(calls[calls.length - 1][1] as string) as { epoch?: number }).epoch;
+      };
 
       await transport.beginGeneration(streamId);
       await transport.emitChunk(streamId, { index: 0 });

--- a/packages/api/src/stream/__tests__/reconnect-reorder-desync.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/reconnect-reorder-desync.stream_integration.spec.ts
@@ -1,14 +1,14 @@
 import { logger } from '@librechat/data-schemas';
 import type { Redis, Cluster } from 'ioredis';
-import { RedisEventTransport } from '~/stream/implementations/RedisEventTransport';
-import { GenerationJobManagerClass } from '~/stream/GenerationJobManager';
-import { createStreamServices } from '~/stream/createStreamServices';
-import { createMockPublisher } from './helpers/publisher';
 import {
   ioredisClient as staticRedisClient,
   keyvRedisClient as staticKeyvClient,
   keyvRedisClientReady,
 } from '~/cache/redisClients';
+import { RedisEventTransport } from '~/stream/implementations/RedisEventTransport';
+import { GenerationJobManagerClass } from '~/stream/GenerationJobManager';
+import { createStreamServices } from '~/stream/createStreamServices';
+import { createMockPublisher } from './helpers/publisher';
 
 logger.silent = true;
 
@@ -285,6 +285,137 @@ describe('Reconnect Reorder Buffer Desync (Regression)', () => {
       messageHandler(channel, JSON.stringify({ type: 'chunk', seq: 0, data: { index: 0 } }));
 
       expect(secondRunChunks.map((c) => (c as { index: number }).index)).toEqual([0]);
+
+      transport.destroy();
+    });
+
+    test('realigns the reorder buffer when a newer generation epoch arrives on a reused streamId', () => {
+      /**
+       * A reused streamId (regenerate or next turn) restarts the sequence counter, so the
+       * new generation's chunks arrive at seq 0 while a lingering subscriber still holds the
+       * prior generation's high nextSeq. The higher generation epoch realigns the buffer, so
+       * the chunks are delivered rather than dropped as seq < nextSeq.
+       */
+      const mockPublisher = createMockPublisher();
+      const mockSubscriber = {
+        on: jest.fn(),
+        subscribe: jest.fn().mockResolvedValue(undefined),
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const transport = new RedisEventTransport(
+        mockPublisher as unknown as Redis,
+        mockSubscriber as unknown as Redis,
+      );
+
+      const streamId = 'reorder-epoch-realign-test';
+      const channel = `stream:{${streamId}}:events`;
+
+      // A subscriber attaches and never unsubscribes, so its count stays above 0.
+      const chunks: unknown[] = [];
+      transport.subscribe(streamId, { onChunk: (event) => chunks.push(event) });
+
+      const messageHandler = mockSubscriber.on.mock.calls.find(
+        (call) => call[0] === 'message',
+      )?.[1] as (channel: string, message: string) => void;
+
+      // Generation 1 (epoch 1): seq 0..4 advance nextSeq to 5.
+      for (let i = 0; i < 5; i++) {
+        messageHandler(
+          channel,
+          JSON.stringify({ type: 'chunk', seq: i, epoch: 1, data: { index: i } }),
+        );
+      }
+      expect(chunks.map((c) => (c as { index: number }).index)).toEqual([0, 1, 2, 3, 4]);
+
+      // Generation 2 (epoch 2): counter restarted, chunks arrive from seq 0.
+      for (let i = 0; i < 3; i++) {
+        messageHandler(
+          channel,
+          JSON.stringify({ type: 'chunk', seq: i, epoch: 2, data: { index: 100 + i } }),
+        );
+      }
+      expect(chunks.map((c) => (c as { index: number }).index)).toEqual([
+        0, 1, 2, 3, 4, 100, 101, 102,
+      ]);
+
+      transport.destroy();
+    });
+
+    test('ignores stragglers from a prior generation epoch', () => {
+      /**
+       * After advancing to a newer generation, a late message carrying a lower epoch is a
+       * straggler from the prior generation and must be ignored, not delivered.
+       */
+      const mockPublisher = createMockPublisher();
+      const mockSubscriber = {
+        on: jest.fn(),
+        subscribe: jest.fn().mockResolvedValue(undefined),
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const transport = new RedisEventTransport(
+        mockPublisher as unknown as Redis,
+        mockSubscriber as unknown as Redis,
+      );
+
+      const streamId = 'reorder-epoch-straggler-test';
+      const channel = `stream:{${streamId}}:events`;
+      const chunks: unknown[] = [];
+      transport.subscribe(streamId, { onChunk: (event) => chunks.push(event) });
+
+      const messageHandler = mockSubscriber.on.mock.calls.find(
+        (call) => call[0] === 'message',
+      )?.[1] as (channel: string, message: string) => void;
+
+      // Generation 2 is active; a late generation-1 chunk arrives afterward.
+      messageHandler(
+        channel,
+        JSON.stringify({ type: 'chunk', seq: 0, epoch: 2, data: { index: 200 } }),
+      );
+      messageHandler(
+        channel,
+        JSON.stringify({ type: 'chunk', seq: 9, epoch: 1, data: { index: 999 } }),
+      );
+
+      expect(chunks.map((c) => (c as { index: number }).index)).toEqual([200]);
+
+      transport.destroy();
+    });
+
+    test('cleanup deletes the sequence key but preserves the epoch key', async () => {
+      /**
+       * The epoch must keep incrementing across generations of a reused streamId, so cleanup
+       * has to delete the sequence key (restart ordering) while keeping the epoch key. If the
+       * epoch key were also deleted, the next generation would restart at epoch 1, collide with
+       * the prior generation's epoch, and its chunks would be dropped again.
+       */
+      const mockPublisher = createMockPublisher();
+      const mockSubscriber = {
+        on: jest.fn(),
+        subscribe: jest.fn().mockResolvedValue(undefined),
+        unsubscribe: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const transport = new RedisEventTransport(
+        mockPublisher as unknown as Redis,
+        mockSubscriber as unknown as Redis,
+      );
+
+      const streamId = 'cleanup-epoch-key-test';
+      const seqKey = `stream:{${streamId}}:seq`;
+      const epochKey = `stream:{${streamId}}:epoch`;
+
+      transport.subscribe(streamId, { onChunk: () => {} });
+      await transport.emitChunk(streamId, { index: 0 });
+
+      expect(await mockPublisher.get(seqKey)).not.toBeNull();
+      expect(await mockPublisher.get(epochKey)).not.toBeNull();
+
+      transport.cleanup(streamId);
+
+      expect(await mockPublisher.get(seqKey)).toBeNull();
+      expect(await mockPublisher.get(epochKey)).not.toBeNull();
 
       transport.destroy();
     });
@@ -676,6 +807,75 @@ describe('Reconnect Reorder Buffer Desync (Regression)', () => {
       }
 
       await manager.destroy();
+    });
+
+    /**
+     * Two managers sharing one Redis model two replicas with no session affinity.
+     * A subscriber on the consumer replica never disconnects (count stays > 0), so its
+     * reorder buffer is never reset. A new generation reuses the streamId after the
+     * shared sequence counter has been deleted, so it republishes from seq 0. The
+     * regenerated turn must still reach the client through the real subscribe() path.
+     */
+    test('regenerated turn reaches a lingering cross-replica subscriber after a counter reset', async () => {
+      if (!ioredisClient) {
+        console.warn('Redis not available, skipping test');
+        return;
+      }
+
+      const producer = new GenerationJobManagerClass();
+      producer.configure(createStreamServices({ useRedis: true, redisClient: ioredisClient }));
+      producer.initialize();
+
+      const consumer = new GenerationJobManagerClass();
+      consumer.configure(createStreamServices({ useRedis: true, redisClient: ioredisClient }));
+      consumer.initialize();
+
+      const streamId = `xrep-regen-${Date.now()}`;
+      const seqKey = `stream:{${streamId}}:seq`;
+
+      await producer.createJob(streamId, 'user-1');
+
+      // Generation 1: the client streams on the consumer replica and never unsubscribes.
+      const gen1: unknown[] = [];
+      const lingering = await consumer.subscribe(streamId, (e) => gen1.push(e));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      for (let i = 0; i < 10; i++) {
+        await producer.emitChunk(streamId, {
+          event: 'on_message_delta',
+          data: { gen: 1, index: i },
+        });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      expect(gen1.filter((e) => JSON.stringify(e).includes('"gen":1')).length).toBe(10);
+
+      // Generation 1 completes on the producer; the consumer's subscriber lingers (count > 0).
+      await producer.completeJob(streamId);
+
+      // A new generation reuses the streamId; another replica's cleanup deleted the seq key,
+      // so the shared counter restarts at 0.
+      await ioredisClient.del(seqKey);
+      await producer.createJob(streamId, 'user-1');
+
+      // The client opens the regenerated stream on the same consumer replica (count now > 1).
+      const gen2: unknown[] = [];
+      const regen = await consumer.subscribe(streamId, (e) => gen2.push(e));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      for (let i = 0; i < 5; i++) {
+        await producer.emitChunk(streamId, {
+          event: 'on_message_delta',
+          data: { gen: 2, index: i },
+        });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      // The regenerated turn must reach the client, not be dropped as stale.
+      const gen2Seen = gen2.filter((e) => JSON.stringify(e).includes('"gen":2')).length;
+      expect(gen2Seen).toBeGreaterThan(0);
+
+      lingering!.unsubscribe();
+      regen!.unsubscribe();
+      await producer.destroy();
+      await consumer.destroy();
     });
   });
 });

--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -151,27 +151,33 @@ export class RedisEventTransport implements IEventTransport {
   }
 
   /**
-   * Resolve the generation epoch to stamp on outgoing messages. seq === 0 increments the
-   * shared epoch counter so a reused streamId gets a strictly higher epoch; the value is
-   * cached to avoid a Redis read per chunk (a mid-generation start reads it once).
+   * Allocate a fresh generation epoch at generation start, before any chunk is published.
+   * INCR gives a reused streamId a strictly higher epoch than the prior generation, and the
+   * key is persisted (with TTL) so it survives cleanup deleting only the sequence key.
+   * Allocating here (once) rather than on the first emit avoids a race where concurrent
+   * startup emits let a later seq read the previous generation's epoch.
    */
-  private async getGenerationEpoch(streamId: string, seq: number): Promise<number> {
+  async beginGeneration(streamId: string): Promise<void> {
     const epochKey = KEYS.epoch(streamId);
-    if (seq === 0) {
-      const epoch = await this.publisher.incr(epochKey);
-      this.publisher.expire(epochKey, RedisEventTransport.SEQUENCE_TTL_SECONDS).catch((err) => {
-        logger.warn(`[RedisEventTransport] Failed to set TTL on epoch key ${epochKey}:`, err);
-      });
-      this.producerEpochs.set(streamId, epoch);
-      return epoch;
-    }
+    const epoch = await this.publisher.incr(epochKey);
+    this.publisher.expire(epochKey, RedisEventTransport.SEQUENCE_TTL_SECONDS).catch((err) => {
+      logger.warn(`[RedisEventTransport] Failed to set TTL on epoch key ${epochKey}:`, err);
+    });
+    this.producerEpochs.set(streamId, epoch);
+  }
+
+  /**
+   * Epoch to stamp on outgoing messages. Uses the value allocated by beginGeneration; a
+   * producer that resumes emitting mid-generation without a cached value reads the key once.
+   */
+  private async getGenerationEpoch(streamId: string): Promise<number> {
     const cached = this.producerEpochs.get(streamId);
     if (cached != null) {
       return cached;
     }
-    const rawStr = await this.publisher.get(epochKey);
-    const parsed = rawStr != null ? parseInt(rawStr, 10) : 1;
-    const epoch = Number.isNaN(parsed) ? 1 : parsed;
+    const rawStr = await this.publisher.get(KEYS.epoch(streamId));
+    const parsed = rawStr != null ? parseInt(rawStr, 10) : 0;
+    const epoch = Number.isNaN(parsed) ? 0 : parsed;
     this.producerEpochs.set(streamId, epoch);
     return epoch;
   }
@@ -272,6 +278,11 @@ export class RedisEventTransport implements IEventTransport {
       if (parsed.epoch != null) {
         if (streamState.currentEpoch == null) {
           streamState.currentEpoch = parsed.epoch;
+          // First epoch-tagged message after untagged (pre-upgrade) traffic: if the buffer
+          // already advanced past this seq, it is a new generation and nextSeq is stale.
+          if (parsed.seq != null && parsed.seq < streamState.reorderBuffer.nextSeq) {
+            this.resetReorderBuffer(streamId);
+          }
         } else if (parsed.epoch > streamState.currentEpoch) {
           streamState.currentEpoch = parsed.epoch;
           this.resetReorderBuffer(streamId);
@@ -570,7 +581,7 @@ export class RedisEventTransport implements IEventTransport {
     try {
       const channel = CHANNELS.events(streamId);
       const seq = await this.getNextSequence(streamId);
-      const epoch = await this.getGenerationEpoch(streamId, seq);
+      const epoch = await this.getGenerationEpoch(streamId);
       const message: PubSubMessage = { type: EventTypes.CHUNK, seq, epoch, data: event };
       await this.publisher.publish(channel, JSON.stringify(message));
     } catch (err) {
@@ -585,7 +596,7 @@ export class RedisEventTransport implements IEventTransport {
   async emitDone(streamId: string, event: unknown): Promise<void> {
     const channel = CHANNELS.events(streamId);
     const seq = await this.getNextSequence(streamId);
-    const epoch = await this.getGenerationEpoch(streamId, seq);
+    const epoch = await this.getGenerationEpoch(streamId);
     const message: PubSubMessage = { type: EventTypes.DONE, seq, epoch, data: event };
 
     try {
@@ -603,7 +614,7 @@ export class RedisEventTransport implements IEventTransport {
   async emitError(streamId: string, error: string): Promise<void> {
     const channel = CHANNELS.events(streamId);
     const seq = await this.getNextSequence(streamId);
-    const epoch = await this.getGenerationEpoch(streamId, seq);
+    const epoch = await this.getGenerationEpoch(streamId);
     const message: PubSubMessage = { type: EventTypes.ERROR, seq, epoch, error };
 
     try {

--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -1,5 +1,5 @@
-import type { Redis, Cluster } from 'ioredis';
 import { logger } from '@librechat/data-schemas';
+import type { Redis, Cluster } from 'ioredis';
 import type { IEventTransport } from '~/stream/interfaces/IJobStore';
 
 /**
@@ -16,6 +16,8 @@ const CHANNELS = {
 const KEYS = {
   /** Atomic sequence counter: shared across all replicas for a given stream */
   sequence: (streamId: string) => `stream:{${streamId}}:seq`,
+  /** Generation epoch: incremented once per generation so consumers can detect stream reuse */
+  epoch: (streamId: string) => `stream:{${streamId}}:epoch`,
 };
 
 /**
@@ -32,6 +34,8 @@ interface PubSubMessage {
   type: (typeof EventTypes)[keyof typeof EventTypes];
   /** Sequence number for ordering (critical for Redis Cluster) */
   seq?: number;
+  /** Per-generation epoch; a value above the consumer's means the stream was reused and the reorder buffer must realign */
+  epoch?: number;
   data?: unknown;
   error?: string;
 }
@@ -72,6 +76,8 @@ interface StreamSubscribers {
   abortCallbacks: Array<() => void>;
   /** Reorder buffer for handling out-of-order delivery in Redis Cluster */
   reorderBuffer: ReorderBuffer;
+  /** Highest generation epoch delivered to this consumer; null until the first epoch-tagged message */
+  currentEpoch: number | null;
 }
 
 /**
@@ -104,6 +110,8 @@ export class RedisEventTransport implements IEventTransport {
   private channelSubscriptions = new Map<string, Promise<void>>();
   /** Counter for generating unique subscriber IDs */
   private subscriberIdCounter = 0;
+  /** Producer-side cache of the current generation epoch per stream (avoids a Redis read per chunk) */
+  private producerEpochs = new Map<string, number>();
 
   /**
    * Create a new Redis event transport.
@@ -140,6 +148,32 @@ export class RedisEventTransport implements IEventTransport {
       });
     }
     return val - 1;
+  }
+
+  /**
+   * Resolve the generation epoch to stamp on outgoing messages. seq === 0 increments the
+   * shared epoch counter so a reused streamId gets a strictly higher epoch; the value is
+   * cached to avoid a Redis read per chunk (a mid-generation start reads it once).
+   */
+  private async getGenerationEpoch(streamId: string, seq: number): Promise<number> {
+    const epochKey = KEYS.epoch(streamId);
+    if (seq === 0) {
+      const epoch = await this.publisher.incr(epochKey);
+      this.publisher.expire(epochKey, RedisEventTransport.SEQUENCE_TTL_SECONDS).catch((err) => {
+        logger.warn(`[RedisEventTransport] Failed to set TTL on epoch key ${epochKey}:`, err);
+      });
+      this.producerEpochs.set(streamId, epoch);
+      return epoch;
+    }
+    const cached = this.producerEpochs.get(streamId);
+    if (cached != null) {
+      return cached;
+    }
+    const rawStr = await this.publisher.get(epochKey);
+    const parsed = rawStr != null ? parseInt(rawStr, 10) : 1;
+    const epoch = Number.isNaN(parsed) ? 1 : parsed;
+    this.producerEpochs.set(streamId, epoch);
+    return epoch;
   }
 
   /** Reset subscriber reorder buffer state to initial values */
@@ -232,6 +266,19 @@ export class RedisEventTransport implements IEventTransport {
 
     try {
       const parsed = JSON.parse(message) as PubSubMessage;
+
+      // A higher epoch means the streamId was reused for a new generation (counter restarted
+      // from 0), so realign the buffer; a lower epoch is a stale straggler and is dropped.
+      if (parsed.epoch != null) {
+        if (streamState.currentEpoch == null) {
+          streamState.currentEpoch = parsed.epoch;
+        } else if (parsed.epoch > streamState.currentEpoch) {
+          streamState.currentEpoch = parsed.epoch;
+          this.resetReorderBuffer(streamId);
+        } else if (parsed.epoch < streamState.currentEpoch) {
+          return;
+        }
+      }
 
       if (parsed.type === EventTypes.CHUNK && parsed.seq != null) {
         this.handleOrderedChunk(streamId, streamState, parsed);
@@ -435,6 +482,7 @@ export class RedisEventTransport implements IEventTransport {
           pending: new Map(),
           flushTimeout: null,
         },
+        currentEpoch: null,
       });
     }
 
@@ -522,7 +570,8 @@ export class RedisEventTransport implements IEventTransport {
     try {
       const channel = CHANNELS.events(streamId);
       const seq = await this.getNextSequence(streamId);
-      const message: PubSubMessage = { type: EventTypes.CHUNK, seq, data: event };
+      const epoch = await this.getGenerationEpoch(streamId, seq);
+      const message: PubSubMessage = { type: EventTypes.CHUNK, seq, epoch, data: event };
       await this.publisher.publish(channel, JSON.stringify(message));
     } catch (err) {
       logger.error(`[RedisEventTransport] Failed to publish chunk:`, err);
@@ -536,7 +585,8 @@ export class RedisEventTransport implements IEventTransport {
   async emitDone(streamId: string, event: unknown): Promise<void> {
     const channel = CHANNELS.events(streamId);
     const seq = await this.getNextSequence(streamId);
-    const message: PubSubMessage = { type: EventTypes.DONE, seq, data: event };
+    const epoch = await this.getGenerationEpoch(streamId, seq);
+    const message: PubSubMessage = { type: EventTypes.DONE, seq, epoch, data: event };
 
     try {
       await this.publisher.publish(channel, JSON.stringify(message));
@@ -553,7 +603,8 @@ export class RedisEventTransport implements IEventTransport {
   async emitError(streamId: string, error: string): Promise<void> {
     const channel = CHANNELS.events(streamId);
     const seq = await this.getNextSequence(streamId);
-    const message: PubSubMessage = { type: EventTypes.ERROR, seq, error };
+    const epoch = await this.getGenerationEpoch(streamId, seq);
+    const message: PubSubMessage = { type: EventTypes.ERROR, seq, epoch, error };
 
     try {
       await this.publisher.publish(channel, JSON.stringify(message));
@@ -599,6 +650,7 @@ export class RedisEventTransport implements IEventTransport {
           pending: new Map(),
           flushTimeout: null,
         },
+        currentEpoch: null,
       });
     }
   }
@@ -639,6 +691,7 @@ export class RedisEventTransport implements IEventTransport {
           pending: new Map(),
           flushTimeout: null,
         },
+        currentEpoch: null,
       };
       this.streams.set(streamId, state);
     }
@@ -679,8 +732,11 @@ export class RedisEventTransport implements IEventTransport {
 
     this.resetReorderBuffer(streamId);
 
-    // Delete the shared sequence key — safe because cleanup() is only called
-    // when the stream's job is complete (no more publishes will happen).
+    // Delete the shared sequence key so a reused streamId restarts chunk ordering from 0.
+    // The epoch key is intentionally kept: it must keep incrementing across generations so a
+    // consumer can tell a reused stream's new generation from the current one. Its TTL,
+    // refreshed on each generation, caps orphan lifetime.
+    this.producerEpochs.delete(streamId);
     const seqKey = KEYS.sequence(streamId);
     this.publisher.del(seqKey).catch((err) => {
       logger.error(`[RedisEventTransport] Failed to delete sequence key ${seqKey}:`, err);

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -477,6 +477,13 @@ export interface IEventTransport {
     },
   ): { unsubscribe: () => void; ready?: Promise<void> };
 
+  /**
+   * Allocate a fresh generation epoch at generation start (Redis mode).
+   * Called once per generation before any chunk is published so all of a
+   * generation's messages carry one epoch. Optional - only in Redis transport.
+   */
+  beginGeneration?(streamId: string): void | Promise<void>;
+
   /** Publish a chunk event - returns Promise in Redis mode for ordered delivery */
   emitChunk(streamId: string, event: unknown): void | Promise<void>;
 


### PR DESCRIPTION
## Summary

With Redis-backed resumable streams (`USE_REDIS_STREAMS`, which defaults to `USE_REDIS`) across multiple replicas and no session affinity, streamed chunks relay cross-replica through Redis with a per-stream sequence counter (`stream:{id}:seq`), and each consumer tracks `nextSeq` in its reorder buffer. Because `streamId` is reused across turns and regenerations of the same conversation, the producer counter and a consumer's `nextSeq` can belong to different generations.

When a stream is reused, its sequence counter restarts at 0. If a consumer's subscriber count never returned to 0 across the boundary (for example a still-open SSE connection or a second browser tab), its buffer is not reset, so `nextSeq` still holds the previous generation's high value. Every chunk of the new generation (`seq 0,1,2,...`) then falls below `nextSeq` and is dropped as a duplicate in `handleOrderedChunk()`. The new turn renders nothing, which users experience as the response stopping partway through and regeneration producing no output.

Fix: stamp each generation with a per-stream epoch (a Redis `INCR` allocated once per generation, on `seq 0`). The producer includes the epoch on every published message; the consumer realigns its reorder buffer when it sees an epoch higher than the one it is tracking, and ignores stragglers carrying a lower epoch. This makes the generation boundary explicit rather than inferred from sequence magnitude, so a reused stream's new generation is delivered rather than dropped. The epoch key is kept across generations (the sequence key is still deleted on cleanup) so it stays monotonic, and its TTL is refreshed each generation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Automated

`cd packages/api && npx jest reconnect-reorder-desync`

- Adds a cross-replica integration test (two managers over one Redis, a lingering subscriber across a generation change) that fails on `dev` (the regenerated turn delivers 0 chunks) and passes with this change.
- Adds transport-level tests for epoch realignment, prior-generation straggler handling, and the cleanup invariant that the epoch key is preserved while the sequence key is deleted.
- The full `reconnect-reorder-desync` suite passes against a local Redis; the wider `src/stream` suite passes. ESLint clean.

### Test Configuration

- Node.js 20+, with a local Redis instance for the integration specs.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
