### PR TITLE
perf(acl): cache resolved user principals for permission checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -994,6 +994,15 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Set to empty string to force all namespaces through Redis: FORCED_IN_MEMORY_CACHE_NAMESPACES=
 # FORCED_IN_MEMORY_CACHE_NAMESPACES=CONFIG_STORE,APP_CONFIG
 
+# TTL in milliseconds for resolved ACL user principals cache (default: 300000 / 5 minutes; 0 disables)
+# USER_PRINCIPALS_CACHE_TTL_MS=300000
+# Redis lock TTL in milliseconds for cross-container user principals cache builds (default: 5000)
+# Only used when Redis is enabled; non-Redis deployments use in-process deduplication.
+# USER_PRINCIPALS_LOCK_TTL_MS=5000
+# Maximum time in milliseconds to wait for another container to fill the user principals cache
+# after it acquired the Redis lock (default: USER_PRINCIPALS_LOCK_TTL_MS)
+# USER_PRINCIPALS_LOCK_WAIT_MS=5000
+
 # Leader Election Configuration (for multi-instance deployments with Redis)
 # Duration in seconds that the leader lease is valid before it expires (default: 25)
 # LEADER_LEASE_DURATION=25

--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -1,7 +1,10 @@
+const { randomUUID } = require('crypto');
 const { Keyv } = require('keyv');
 const { Time, CacheKeys, ViolationTypes } = require('librechat-data-provider');
 const {
+  math,
   logFile,
+  ioredisClient,
   keyvMongo,
   cacheConfig,
   sessionCache,
@@ -9,6 +12,43 @@ const {
   violationCache,
   registerShutdownTask,
 } = require('@librechat/api');
+
+const userPrincipalsCacheTtl = math(process.env.USER_PRINCIPALS_CACHE_TTL_MS, Time.ONE_MINUTE * 5);
+const userPrincipalsLockTtl = math(process.env.USER_PRINCIPALS_LOCK_TTL_MS, 5000);
+const userPrincipalsLockWait = math(
+  process.env.USER_PRINCIPALS_LOCK_WAIT_MS,
+  userPrincipalsLockTtl,
+);
+const disabledCache = {
+  get: async () => undefined,
+  set: async () => undefined,
+  delete: async () => true,
+};
+
+const releaseLockScript = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+`;
+
+function userPrincipalsCache() {
+  const cache = standardCache(CacheKeys.USER_PRINCIPALS, userPrincipalsCacheTtl);
+  if (!cacheConfig.USE_REDIS || !ioredisClient || userPrincipalsLockTtl <= 0) {
+    return cache;
+  }
+  return Object.assign(cache, {
+    lockWaitMs: userPrincipalsLockWait,
+    acquireLock: async (key) => {
+      const token = randomUUID();
+      const result = await ioredisClient.set(key, token, 'PX', userPrincipalsLockTtl, 'NX');
+      return result === 'OK' ? token : null;
+    },
+    releaseLock: async (key, token) => {
+      await ioredisClient.eval(releaseLockScript, 1, key, token);
+    },
+  });
+}
 
 const namespaces = {
   [ViolationTypes.GENERAL]: new Keyv({ store: logFile, namespace: 'violations' }),
@@ -36,6 +76,7 @@ const namespaces = {
   [CacheKeys.SAML_SESSION]: sessionCache(CacheKeys.SAML_SESSION),
 
   [CacheKeys.ROLES]: standardCache(CacheKeys.ROLES),
+  [CacheKeys.USER_PRINCIPALS]: userPrincipalsCacheTtl > 0 ? userPrincipalsCache() : disabledCache,
   [CacheKeys.APP_CONFIG]: standardCache(CacheKeys.APP_CONFIG),
   [CacheKeys.CONFIG_STORE]: standardCache(CacheKeys.CONFIG_STORE),
   [CacheKeys.TOOL_CACHE]: standardCache(CacheKeys.TOOL_CACHE),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2250,6 +2250,10 @@ export enum CacheKeys {
    */
   ROLES = 'ROLES',
   /**
+   * Key for resolved ACL user principals.
+   */
+  USER_PRINCIPALS = 'USER_PRINCIPALS',
+  /**
    * Key for the title generation cache.
    */
   GEN_TITLE = 'GEN_TITLE',

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -17,7 +17,7 @@ import { createMCPServerMethods, type MCPServerMethods } from './mcpServer';
 import { createPluginAuthMethods, type PluginAuthMethods } from './pluginAuth';
 /* Permissions */
 import { createAccessRoleMethods, type AccessRoleMethods } from './accessRole';
-import { createUserGroupMethods, type UserGroupMethods } from './userGroup';
+import { createUserGroupMethods, type UserGroupMethods, type UserGroupDeps } from './userGroup';
 import { createAclEntryMethods, permissionBitSupersets, type AclEntryMethods } from './aclEntry';
 import { createSystemGrantMethods, type SystemGrantMethods } from './systemGrant';
 import {
@@ -224,6 +224,7 @@ export function createMethods(
 
   // Role methods with optional cache injection
   const roleDeps: RoleDeps = { getCache: deps.getCache };
+  const userGroupDeps: UserGroupDeps = { getCache: deps.getCache };
   const roleMethods = createRoleMethods(mongoose, roleDeps);
 
   // Tier 1: action methods (created as variable for agent dependency)
@@ -249,7 +250,7 @@ export function createMethods(
     ...createAgentApiKeyMethods(mongoose),
     ...createMCPServerMethods(mongoose),
     ...createAccessRoleMethods(mongoose),
-    ...createUserGroupMethods(mongoose),
+    ...createUserGroupMethods(mongoose, userGroupDeps),
     ...aclEntryMethods,
     ...systemGrantMethods,
     ...createAuditLogMethods(mongoose),

--- a/packages/data-schemas/src/methods/userGroup.spec.ts
+++ b/packages/data-schemas/src/methods/userGroup.spec.ts
@@ -382,6 +382,107 @@ describe('userGroup methods', () => {
       const rolePrincipal = principals.find((p) => p.principalType === PrincipalType.ROLE);
       expect(rolePrincipal).toBeUndefined();
     });
+
+    it('deduplicates concurrent cache builds for the same user principals key', async () => {
+      const user = await createTestUser({ role: SystemRoles.ADMIN });
+      const cache = {
+        get: jest.fn(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return undefined;
+        }),
+        set: jest.fn(async () => undefined),
+      };
+      const cachedMethods = createUserGroupMethods(mongoose, {
+        getCache: jest.fn(() => cache),
+      });
+
+      const [first, second, third] = await Promise.all([
+        cachedMethods.getUserPrincipals({ userId: user._id.toString() }),
+        cachedMethods.getUserPrincipals({ userId: user._id.toString() }),
+        cachedMethods.getUserPrincipals({ userId: user._id.toString() }),
+      ]);
+
+      expect(first).toEqual(second);
+      expect(second).toEqual(third);
+      expect(cache.get).toHaveBeenCalledTimes(3);
+      expect(cache.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for a Redis-locked principal cache build from another process', async () => {
+      const user = await createTestUser({ role: SystemRoles.ADMIN });
+      const cachedPrincipals = [
+        { principalType: PrincipalType.USER, principalId: user._id.toString() },
+        { principalType: PrincipalType.ROLE, principalId: SystemRoles.ADMIN },
+        { principalType: PrincipalType.PUBLIC },
+      ];
+      const cache = {
+        get: jest.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce(cachedPrincipals),
+        set: jest.fn(async () => undefined),
+        acquireLock: jest.fn(async () => null),
+        releaseLock: jest.fn(async () => undefined),
+        lockWaitMs: 5000,
+      };
+      const cachedMethods = createUserGroupMethods(mongoose, {
+        getCache: jest.fn(() => cache),
+      });
+
+      const principals = await cachedMethods.getUserPrincipals({ userId: user._id.toString() });
+
+      expect(principals).toEqual([
+        { principalType: PrincipalType.USER, principalId: user._id },
+        { principalType: PrincipalType.ROLE, principalId: SystemRoles.ADMIN },
+        { principalType: PrincipalType.PUBLIC },
+      ]);
+      expect(cache.acquireLock).toHaveBeenCalledTimes(1);
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(cache.releaseLock).not.toHaveBeenCalled();
+    });
+
+    it('builds principals immediately when Redis lock acquisition fails', async () => {
+      const user = await createTestUser({ role: SystemRoles.ADMIN });
+      const cache = {
+        get: jest.fn(async () => undefined),
+        set: jest.fn(async () => undefined),
+        acquireLock: jest.fn(async () => {
+          throw new Error('redis unavailable');
+        }),
+        releaseLock: jest.fn(async () => undefined),
+      };
+      const cachedMethods = createUserGroupMethods(mongoose, {
+        getCache: jest.fn(() => cache),
+      });
+
+      const principals = await cachedMethods.getUserPrincipals({ userId: user._id.toString() });
+
+      expect(principals).toContainEqual({
+        principalType: PrincipalType.ROLE,
+        principalId: SystemRoles.ADMIN,
+      });
+      expect(cache.get).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      expect(cache.releaseLock).not.toHaveBeenCalled();
+    });
+
+    it('ignores cached non-role principals with invalid ObjectId strings', async () => {
+      const user = await createTestUser({ role: SystemRoles.ADMIN });
+      const cache = {
+        get: jest.fn(async () => [
+          { principalType: PrincipalType.GROUP, principalId: 'not-an-object-id' },
+        ]),
+        set: jest.fn(async () => undefined),
+      };
+      const cachedMethods = createUserGroupMethods(mongoose, {
+        getCache: jest.fn(() => cache),
+      });
+
+      const principals = await cachedMethods.getUserPrincipals({ userId: user._id.toString() });
+
+      expect(principals).toContainEqual({
+        principalType: PrincipalType.ROLE,
+        principalId: SystemRoles.ADMIN,
+      });
+      expect(cache.set).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('syncUserEntraGroups', () => {

--- a/packages/data-schemas/src/methods/userGroup.spec.ts
+++ b/packages/data-schemas/src/methods/userGroup.spec.ts
@@ -1,6 +1,6 @@
 import mongoose, { Types } from 'mongoose';
-import { PrincipalType, SystemRoles } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { PrincipalType, SystemRoles } from 'librechat-data-provider';
 import type * as t from '~/types';
 import { createUserGroupMethods } from './userGroup';
 import groupSchema from '~/schema/group';

--- a/packages/data-schemas/src/methods/userGroup.spec.ts
+++ b/packages/data-schemas/src/methods/userGroup.spec.ts
@@ -408,6 +408,36 @@ describe('userGroup methods', () => {
       expect(cache.set).toHaveBeenCalledTimes(1);
     });
 
+    it('shares one lock and DB build across concurrent same-process callers', async () => {
+      const user = await createTestUser({ role: SystemRoles.ADMIN });
+      const cache = {
+        get: jest.fn(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return undefined;
+        }),
+        set: jest.fn(async () => undefined),
+        acquireLock: jest.fn(async () => 'lock-token'),
+        releaseLock: jest.fn(async () => undefined),
+        lockWaitMs: 5000,
+      };
+      const cachedMethods = createUserGroupMethods(mongoose, {
+        getCache: jest.fn(() => cache),
+      });
+
+      const [first, second, third] = await Promise.all([
+        cachedMethods.getUserPrincipals({ userId: user._id.toString() }),
+        cachedMethods.getUserPrincipals({ userId: user._id.toString() }),
+        cachedMethods.getUserPrincipals({ userId: user._id.toString() }),
+      ]);
+
+      expect(first).toEqual(second);
+      expect(second).toEqual(third);
+      // Only the shared flow acquires the lock, builds, writes, and releases once.
+      expect(cache.acquireLock).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      expect(cache.releaseLock).toHaveBeenCalledTimes(1);
+    });
+
     it('waits for a Redis-locked principal cache build from another process', async () => {
       const user = await createTestUser({ role: SystemRoles.ADMIN });
       const cachedPrincipals = [

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -1,11 +1,72 @@
 import { Types } from 'mongoose';
-import { PrincipalType } from 'librechat-data-provider';
+import { CacheKeys, PrincipalType } from 'librechat-data-provider';
 import type { TUser, TPrincipalSearchResult } from 'librechat-data-provider';
 import type { Model, ClientSession, FilterQuery } from 'mongoose';
 import type { IGroup, IRole, IUser } from '~/types';
+import { getTenantId } from '~/config/tenantContext';
 import { escapeRegExp } from '~/utils/string';
 
-export function createUserGroupMethods(mongoose: typeof import('mongoose')): {
+type Principal = { principalType: PrincipalType; principalId?: string | Types.ObjectId };
+type CachedPrincipal = { principalType: PrincipalType; principalId?: string };
+type CacheStore = {
+  get: (key: string) => Promise<unknown>;
+  set: (key: string, value: unknown) => Promise<void>;
+  acquireLock?: (key: string) => Promise<string | null>;
+  releaseLock?: (key: string, token: string) => Promise<void>;
+  lockWaitMs?: number;
+};
+const pendingPrincipalLookups = new Map<string, Promise<Principal[]>>();
+const USER_PRINCIPALS_LOCK_POLL_MS = 50;
+
+export interface UserGroupDeps {
+  getCache?: (key: string) => CacheStore;
+}
+
+function isCachedPrincipal(value: unknown): value is CachedPrincipal {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const principal = value as { principalType?: unknown; principalId?: unknown };
+  if (
+    typeof principal.principalType !== 'string' ||
+    !Object.values(PrincipalType).includes(principal.principalType as PrincipalType)
+  ) {
+    return false;
+  }
+  if (principal.principalType === PrincipalType.PUBLIC) {
+    return principal.principalId === undefined;
+  }
+  if (principal.principalType === PrincipalType.ROLE) {
+    return principal.principalId === undefined || typeof principal.principalId === 'string';
+  }
+  return typeof principal.principalId === 'string' && Types.ObjectId.isValid(principal.principalId);
+}
+
+function serializePrincipals(principals: Principal[]): CachedPrincipal[] {
+  return principals.map((principal) => ({
+    principalType: principal.principalType,
+    ...(principal.principalId ? { principalId: principal.principalId.toString() } : {}),
+  }));
+}
+
+function hydratePrincipals(cached: CachedPrincipal[]): Principal[] {
+  return cached.map((principal) => ({
+    principalType: principal.principalType,
+    ...(principal.principalId
+      ? {
+          principalId:
+            principal.principalType === PrincipalType.ROLE
+              ? principal.principalId
+              : new Types.ObjectId(principal.principalId),
+        }
+      : {}),
+  }));
+}
+
+export function createUserGroupMethods(
+  mongoose: typeof import('mongoose'),
+  deps: UserGroupDeps = {},
+): {
   findGroupById: (
     groupId: string | Types.ObjectId,
     projection?: Record<string, 0 | 1>,
@@ -71,7 +132,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')): {
       role?: string | null;
     },
     session?: ClientSession,
-  ) => Promise<Array<{ principalType: PrincipalType; principalId?: string | Types.ObjectId }>>;
+  ) => Promise<Principal[]>;
   syncUserEntraGroups: (
     userId: string | Types.ObjectId,
     entraGroups: Array<{ id: string; name: string; description?: string; email?: string }>,
@@ -398,42 +459,132 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')): {
       role?: string | null;
     },
     session?: ClientSession,
-  ): Promise<Array<{ principalType: PrincipalType; principalId?: string | Types.ObjectId }>> {
+  ): Promise<Principal[]> {
     const { userId, role } = params;
     /** `userId` must be an `ObjectId` for USER principal since ACL entries store `ObjectId`s */
     const userObjectId = typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
-    const principals: Array<{
-      principalType: PrincipalType;
-      principalId?: string | Types.ObjectId;
-    }> = [{ principalType: PrincipalType.USER, principalId: userObjectId }];
+    const cache = session ? undefined : deps.getCache?.(CacheKeys.USER_PRINCIPALS);
+    let cacheKey: string | undefined;
+    let lockToken: string | null | undefined;
 
-    // If role is not provided, query user to get it
-    let userRole = role;
-    if (userRole === undefined) {
-      const User = mongoose.models.User as Model<IUser>;
-      const query = User.findById(userId).select('role');
-      if (session) {
-        query.session(session);
+    if (cache) {
+      // Keep role modes distinct because `undefined` means "load DB role" while `null` means "skip role".
+      let roleCacheKey = role;
+      if (roleCacheKey === undefined) {
+        roleCacheKey = '__lookup__';
+      } else if (roleCacheKey === null) {
+        roleCacheKey = '__none__';
       }
-      const user = await query.lean<IUser>();
-      userRole = user?.role;
+      cacheKey = `user-principals:${getTenantId() || 'base'}:${userObjectId.toString()}:${roleCacheKey}`;
+
+      // Fast path: use a completed cache entry when it has the expected serialized shape.
+      try {
+        const cached = await cache.get(cacheKey);
+        if (Array.isArray(cached) && cached.every(isCachedPrincipal)) {
+          return hydratePrincipals(cached);
+        }
+      } catch {
+        // Cache failures should not block permission checks.
+      }
+
+      // Same-process dedup: concurrent misses in this Node process share one DB lookup.
+      const pending = pendingPrincipalLookups.get(cacheKey);
+      if (pending) {
+        return pending;
+      }
+
+      // Cross-process dedup: Redis-backed caches can wait while another container fills this key.
+      if (cache.acquireLock) {
+        let lockFailed = false;
+        try {
+          lockToken = await cache.acquireLock(`${cacheKey}:lock`);
+        } catch {
+          lockToken = undefined;
+          lockFailed = true;
+        }
+        if (!lockToken && !lockFailed) {
+          const lockWaitMs = Math.max(cache.lockWaitMs ?? 0, 0);
+          const waitUntil = Date.now() + lockWaitMs;
+          while (Date.now() < waitUntil) {
+            await new Promise((resolve) => setTimeout(resolve, USER_PRINCIPALS_LOCK_POLL_MS));
+            try {
+              const cached = await cache.get(cacheKey);
+              if (Array.isArray(cached) && cached.every(isCachedPrincipal)) {
+                return hydratePrincipals(cached);
+              }
+            } catch {
+              // Cache failures should not block permission checks.
+            }
+          }
+        }
+      }
     }
 
-    // Add role as a principal if user has one
-    if (userRole && userRole.trim()) {
-      principals.push({ principalType: PrincipalType.ROLE, principalId: userRole });
+    // Build principals from source of truth: user id, optional role, groups, and public access.
+    const lookup = (async (): Promise<Principal[]> => {
+      const principals: Principal[] = [
+        { principalType: PrincipalType.USER, principalId: userObjectId },
+      ];
+
+      // If role is not provided, query user to get it
+      let userRole = role;
+      if (userRole === undefined) {
+        const User = mongoose.models.User as Model<IUser>;
+        const query = User.findById(userId).select('role');
+        if (session) {
+          query.session(session);
+        }
+        const user = await query.lean<IUser>();
+        userRole = user?.role;
+      }
+
+      // Add role as a principal if user has one
+      if (userRole && userRole.trim()) {
+        principals.push({ principalType: PrincipalType.ROLE, principalId: userRole });
+      }
+
+      const userGroups = await getUserGroups(userId, session);
+      if (userGroups && userGroups.length > 0) {
+        userGroups.forEach((group) => {
+          principals.push({ principalType: PrincipalType.GROUP, principalId: group._id });
+        });
+      }
+
+      principals.push({ principalType: PrincipalType.PUBLIC });
+
+      // Store a cache-safe representation; ObjectIds are serialized and hydrated on read.
+      try {
+        if (cache && cacheKey) {
+          await cache.set(cacheKey, serializePrincipals(principals));
+        }
+      } catch {
+        // Cache failures should not block permission checks.
+      }
+      return principals;
+    })();
+
+    if (!cache) {
+      return lookup;
     }
 
-    const userGroups = await getUserGroups(userId, session);
-    if (userGroups && userGroups.length > 0) {
-      userGroups.forEach((group) => {
-        principals.push({ principalType: PrincipalType.GROUP, principalId: group._id });
-      });
+    if (!cacheKey) {
+      return lookup;
     }
 
-    principals.push({ principalType: PrincipalType.PUBLIC });
-
-    return principals;
+    // Keep the in-process pending entry alive until the DB lookup and cache write finish.
+    pendingPrincipalLookups.set(cacheKey, lookup);
+    try {
+      return await lookup;
+    } finally {
+      pendingPrincipalLookups.delete(cacheKey);
+      if (cache && lockToken) {
+        try {
+          await cache.releaseLock?.(`${cacheKey}:lock`, lockToken);
+        } catch {
+          // Lock cleanup failures expire by TTL and should not block permission checks.
+        }
+      }
+    }
   }
 
   /**

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -464,64 +464,9 @@ export function createUserGroupMethods(
     /** `userId` must be an `ObjectId` for USER principal since ACL entries store `ObjectId`s */
     const userObjectId = typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
     const cache = session ? undefined : deps.getCache?.(CacheKeys.USER_PRINCIPALS);
-    let cacheKey: string | undefined;
-    let lockToken: string | null | undefined;
-
-    if (cache) {
-      // Keep role modes distinct because `undefined` means "load DB role" while `null` means "skip role".
-      let roleCacheKey = role;
-      if (roleCacheKey === undefined) {
-        roleCacheKey = '__lookup__';
-      } else if (roleCacheKey === null) {
-        roleCacheKey = '__none__';
-      }
-      cacheKey = `user-principals:${getTenantId() || 'base'}:${userObjectId.toString()}:${roleCacheKey}`;
-
-      // Fast path: use a completed cache entry when it has the expected serialized shape.
-      try {
-        const cached = await cache.get(cacheKey);
-        if (Array.isArray(cached) && cached.every(isCachedPrincipal)) {
-          return hydratePrincipals(cached);
-        }
-      } catch {
-        // Cache failures should not block permission checks.
-      }
-
-      // Same-process dedup: concurrent misses in this Node process share one DB lookup.
-      const pending = pendingPrincipalLookups.get(cacheKey);
-      if (pending) {
-        return pending;
-      }
-
-      // Cross-process dedup: Redis-backed caches can wait while another container fills this key.
-      if (cache.acquireLock) {
-        let lockFailed = false;
-        try {
-          lockToken = await cache.acquireLock(`${cacheKey}:lock`);
-        } catch {
-          lockToken = undefined;
-          lockFailed = true;
-        }
-        if (!lockToken && !lockFailed) {
-          const lockWaitMs = Math.max(cache.lockWaitMs ?? 0, 0);
-          const waitUntil = Date.now() + lockWaitMs;
-          while (Date.now() < waitUntil) {
-            await new Promise((resolve) => setTimeout(resolve, USER_PRINCIPALS_LOCK_POLL_MS));
-            try {
-              const cached = await cache.get(cacheKey);
-              if (Array.isArray(cached) && cached.every(isCachedPrincipal)) {
-                return hydratePrincipals(cached);
-              }
-            } catch {
-              // Cache failures should not block permission checks.
-            }
-          }
-        }
-      }
-    }
 
     // Build principals from source of truth: user id, optional role, groups, and public access.
-    const lookup = (async (): Promise<Principal[]> => {
+    const buildPrincipals = async (): Promise<Principal[]> => {
       const principals: Principal[] = [
         { principalType: PrincipalType.USER, principalId: userObjectId },
       ];
@@ -552,38 +497,100 @@ export function createUserGroupMethods(
 
       principals.push({ principalType: PrincipalType.PUBLIC });
 
-      // Store a cache-safe representation; ObjectIds are serialized and hydrated on read.
+      return principals;
+    };
+
+    // No cache (e.g., session-scoped reads): build directly from the source of truth.
+    if (!cache) {
+      return buildPrincipals();
+    }
+
+    // Keep role modes distinct because `undefined` means "load DB role" while `null` means "skip role".
+    let roleCacheKey = role;
+    if (roleCacheKey === undefined) {
+      roleCacheKey = '__lookup__';
+    } else if (roleCacheKey === null) {
+      roleCacheKey = '__none__';
+    }
+    const cacheKey = `user-principals:${getTenantId() || 'base'}:${userObjectId.toString()}:${roleCacheKey}`;
+
+    const readCachedPrincipals = async (): Promise<Principal[] | undefined> => {
       try {
-        if (cache && cacheKey) {
-          await cache.set(cacheKey, serializePrincipals(principals));
+        const cached = await cache.get(cacheKey);
+        if (Array.isArray(cached) && cached.every(isCachedPrincipal)) {
+          return hydratePrincipals(cached);
         }
       } catch {
         // Cache failures should not block permission checks.
       }
-      return principals;
+      return undefined;
+    };
+
+    // Fast path: use a completed cache entry when it has the expected serialized shape.
+    const fastPath = await readCachedPrincipals();
+    if (fastPath) {
+      return fastPath;
+    }
+
+    // Same-process dedup: concurrent misses in this Node process attach to one shared flow
+    // that owns the cross-process lock, the poll loop, the DB lookup, and the cache write.
+    const pending = pendingPrincipalLookups.get(cacheKey);
+    if (pending) {
+      return pending;
+    }
+
+    const lookup = (async (): Promise<Principal[]> => {
+      let lockToken: string | null | undefined;
+      try {
+        // Cross-process dedup: Redis-backed caches can wait while another container fills this key.
+        if (cache.acquireLock) {
+          let lockFailed = false;
+          try {
+            lockToken = await cache.acquireLock(`${cacheKey}:lock`);
+          } catch {
+            lockToken = undefined;
+            lockFailed = true;
+          }
+          if (!lockToken && !lockFailed) {
+            const lockWaitMs = Math.max(cache.lockWaitMs ?? 0, 0);
+            const waitUntil = Date.now() + lockWaitMs;
+            while (Date.now() < waitUntil) {
+              await new Promise((resolve) => setTimeout(resolve, USER_PRINCIPALS_LOCK_POLL_MS));
+              const cached = await readCachedPrincipals();
+              if (cached) {
+                return cached;
+              }
+            }
+          }
+        }
+
+        const principals = await buildPrincipals();
+
+        // Store a cache-safe representation; ObjectIds are serialized and hydrated on read.
+        try {
+          await cache.set(cacheKey, serializePrincipals(principals));
+        } catch {
+          // Cache failures should not block permission checks.
+        }
+        return principals;
+      } finally {
+        if (lockToken) {
+          try {
+            await cache.releaseLock?.(`${cacheKey}:lock`, lockToken);
+          } catch {
+            // Lock cleanup failures expire by TTL and should not block permission checks.
+          }
+        }
+      }
     })();
 
-    if (!cache) {
-      return lookup;
-    }
-
-    if (!cacheKey) {
-      return lookup;
-    }
-
-    // Keep the in-process pending entry alive until the DB lookup and cache write finish.
+    // Register synchronously (no await between the pending check and this set) so every
+    // concurrent same-process caller attaches to this single flow rather than starting its own.
     pendingPrincipalLookups.set(cacheKey, lookup);
     try {
       return await lookup;
     } finally {
       pendingPrincipalLookups.delete(cacheKey);
-      if (cache && lockToken) {
-        try {
-          await cache.releaseLock?.(`${cacheKey}:lock`, lockToken);
-        } catch {
-          // Lock cleanup failures expire by TTL and should not block permission checks.
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a cache for resolved ACL user principals returned by `getUserPrincipals({ userId, role })` as addressed in https://github.com/danny-avila/LibreChat/issues/14020

This reduces repeated database work during parallel permission checks for agents, prompts, MCP servers, app config, and other resource catalogs. The cache stores the resolved principal set for a user: user principal, optional role principal, group principals, and public principal.

## Details

- Adds `CacheKeys.USER_PRINCIPALS`.
- Registers a configurable `USER_PRINCIPALS` cache namespace.
- Caches at the shared `getUserPrincipals` source so all ACL callers benefit.
- Uses tenant-aware cache keys to avoid cross-tenant principal leakage.
- Keeps `role === undefined` distinct from `role === null`.
- Serializes cached ObjectIds as strings and hydrates them back on read.
- Skips caching for session-scoped reads.
- Adds same-process promise deduplication for concurrent misses.
- Adds optional Redis lock-based deduplication to reduce cross-container cold-key stampedes.
- Treats cache failures as non-fatal so permission checks fall back to source-of-truth DB reads.

## Configuration

```env
# TTL in milliseconds for resolved ACL user principals cache
# Default: 300000 / 5 minutes
# Set to 0 to disable
USER_PRINCIPALS_CACHE_TTL_MS=300000

# Redis lock TTL for cross-container cache builds
USER_PRINCIPALS_LOCK_TTL_MS=5000

# Max wait for another container to fill the cache after acquiring the lock
USER_PRINCIPALS_LOCK_WAIT_MS=5000

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Runs sucessfully in prod with 15000 users

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

Peter Rothlaender [ginkgo.rothlaender@external.daimlertruck.com](mailto:ginkgo.rothlaender@external.daimlertruck.com) on behalf of Daimler Truck AG.
[Provider & Legal Notice | Daimler Truck](https://www.daimlertruck.com/en/provider-legal-notice)
Copyright (c) {2026} Daimler Truck AG