### PR TITLE
🧪 ci: De-flake ConversationsSection Memoization Spec on Slow Runners

### DIFF
--- a/client/src/components/UnifiedSidebar/__tests__/ConversationsSection.spec.tsx
+++ b/client/src/components/UnifiedSidebar/__tests__/ConversationsSection.spec.tsx
@@ -144,6 +144,12 @@ describe('ConversationsSection streaming re-renders', () => {
     // data hook firing is the deterministic signal that the chunk resolved).
     await waitFor(() => expect(mockUseGetConversationTags).toHaveBeenCalled());
 
+    // waitFor resolves as soon as the hook has fired once, but the Suspense
+    // resolution commit can still have a trailing render pass pending on slow
+    // runners (Windows CI shards). Flush it before capturing baselines so the
+    // first stream tick doesn't carry it and inflate the children's counts.
+    await act(async () => {});
+
     expect(mockUseFavorites.mock.calls.length).toBeGreaterThan(0);
     expect(mockUseGetConversationTags.mock.calls.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

De-flakes `ConversationsSection.spec.tsx › does not re-render FavoritesList or BookmarkNav when the section re-renders mid-stream` (added in #14011), which intermittently fails on Windows CI shards with:

```
Expected: 1
Received: 2
```

## Root cause

`BookmarkNav` is `lazy()`-loaded inside `<Suspense fallback={null}>`. The test waits for its data hook to fire, then immediately snapshots baseline render counts:

```ts
await waitFor(() => expect(mockUseGetConversationTags).toHaveBeenCalled());
const favBaseline = mockUseFavorites.mock.calls.length; // ...
```

`waitFor` resolves as soon as the hook has fired **once** — but on slow runners the Suspense resolution commit can still have a trailing render pass pending. The first `act(() => setStreamTick(...))` then flushes that leftover pass together with the tick, the memoized children render one extra time, and the count lands at baseline + 1.

Fast machines flush everything before the snapshot (the test is reliably green locally); slow Windows shards lose the race often enough to have failed two consecutive CI runs downstream.

## Fix

Flush pending commits with an empty async `act()` before capturing baselines:

```ts
await act(async () => {});
```

One-liner (plus comment); no component changes. The assertion itself is unchanged — the memoized children still must not re-render across the 5 stream ticks.

## Verification

- Patched test run 5×5 green locally.
- Failure reproduced on Windows shard CI runs (twice, including the in-job retry) prior to this fix; passes on rerun — consistent with the trailing-commit race above.