### PR TITLE
🎣 fix: Surface Resumable Stream Start Errors

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1052,6 +1052,39 @@ describe('useResumableSSE - 404 error path', () => {
     unmount();
   });
 
+  it('uses only the error event data from multi-event SSE start failures', async () => {
+    (request.post as jest.Mock).mockResolvedValueOnce(
+      [
+        'event: message',
+        'data: {"created":true,"message":{"messageId":"msg-1"}}',
+        '',
+        'event: error',
+        'data: {"text":"Request was blocked"}',
+        '',
+        '',
+      ].join('\n'),
+    );
+    const submission = buildSubmission();
+    const chatHelpers = buildChatHelpers();
+
+    const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+
+    await waitFor(() => {
+      expect(mockSetSubmission).toHaveBeenCalledWith(null);
+    });
+
+    expect(mockErrorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          text: 'Request was blocked',
+          metadata: { streamStartFailed: true },
+        },
+        submission,
+      }),
+    );
+    unmount();
+  });
+
   it('replays title events from resume state sync', async () => {
     const submission = buildSubmission();
     const chatHelpers = buildChatHelpers();

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1027,6 +1027,31 @@ describe('useResumableSSE - 404 error path', () => {
     unmount();
   });
 
+  it('surfaces CRLF SSE error bodies returned while starting generation', async () => {
+    (request.post as jest.Mock).mockResolvedValueOnce(
+      'event: error\r\ndata: {"text":"No model spec selected"}\r\n\r\n',
+    );
+    const submission = buildSubmission();
+    const chatHelpers = buildChatHelpers();
+
+    const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+
+    await waitFor(() => {
+      expect(mockSetSubmission).toHaveBeenCalledWith(null);
+    });
+
+    expect(mockErrorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          text: 'No model spec selected',
+          metadata: { streamStartFailed: true },
+        },
+        submission,
+      }),
+    );
+    unmount();
+  });
+
   it('replays title events from resume state sync', async () => {
     const submission = buildSubmission();
     const chatHelpers = buildChatHelpers();

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -999,6 +999,34 @@ describe('useResumableSSE - 404 error path', () => {
     unmount();
   });
 
+  it('surfaces SSE error bodies returned while starting generation', async () => {
+    (request.post as jest.Mock).mockResolvedValueOnce(
+      'event: error\ndata: {"text":"No model spec selected"}\n\n',
+    );
+    const submission = buildSubmission();
+    const chatHelpers = buildChatHelpers();
+
+    const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+
+    await waitFor(() => {
+      expect(mockSetSubmission).toHaveBeenCalledWith(null);
+    });
+
+    expect(mockSSEInstances).toHaveLength(0);
+    expect(mockErrorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          text: 'No model spec selected',
+          metadata: { streamStartFailed: true },
+        },
+        submission,
+      }),
+    );
+    expect(mockSetIsSubmitting).toHaveBeenCalledWith(false);
+    expect(mockSetShowStopButton).toHaveBeenCalledWith(false);
+    unmount();
+  });
+
   it('replays title events from resume state sync', async () => {
     const submission = buildSubmission();
     const chatHelpers = buildChatHelpers();

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -81,12 +81,12 @@ const getStartGenerationStreamId = (data: unknown): string | null => {
 };
 
 const parseSSEErrorData = (body: string): unknown | null => {
-  if (!/^event:\s*error$/m.test(body)) {
+  const lines = body.split(/\r?\n/);
+  if (!lines.some((line) => line.trim() === 'event: error')) {
     return null;
   }
 
-  const data = body
-    .split(/\r?\n/)
+  const data = lines
     .filter((line) => line.startsWith('data:'))
     .map((line) => line.slice('data:'.length).trimStart())
     .join('\n')

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -54,14 +54,6 @@ type ChatHelpers = Pick<
   'setMessages' | 'getMessages' | 'setConversation' | 'setIsSubmitting' | 'newConversation'
 >;
 
-const getStreamStartFailureData = (errorData?: Record<string, unknown>): TResData =>
-  ({
-    text: errorData
-      ? JSON.stringify(errorData)
-      : 'Error connecting to server, try refreshing the page.',
-    metadata: markStreamStartFailedMetadata(),
-  }) as unknown as TResData;
-
 const MAX_RETRIES = 5;
 const START_GENERATION_NETWORK_RETRIES = 3;
 const START_GENERATION_READINESS_TIMEOUT_MS = 120000;
@@ -71,15 +63,80 @@ type StartGenerationError = {
   code?: string;
   response?: {
     status?: number;
-    data?: {
-      code?: string;
-    };
+    data?: unknown;
     headers?: Record<string, string | number | string[] | undefined>;
   };
 };
 
 const toStartGenerationError = (error: unknown): StartGenerationError | undefined =>
   error != null && typeof error === 'object' ? (error as StartGenerationError) : undefined;
+
+const getStartGenerationStreamId = (data: unknown): string | null => {
+  if (data == null || typeof data !== 'object' || !('streamId' in data)) {
+    return null;
+  }
+
+  const streamId = (data as { streamId?: unknown }).streamId;
+  return typeof streamId === 'string' && streamId.length > 0 ? streamId : null;
+};
+
+const parseSSEErrorData = (body: string): unknown | null => {
+  if (!/^event:\s*error$/m.test(body)) {
+    return null;
+  }
+
+  const data = body
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice('data:'.length).trimStart())
+    .join('\n')
+    .trim();
+
+  if (!data) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(data);
+  } catch {
+    return data;
+  }
+};
+
+const getSSEErrorText = (payload: unknown): string | null => {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload == null || typeof payload !== 'object') {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const text = record.text ?? record.message ?? record.error;
+  return typeof text === 'string' && text.length > 0 ? text : null;
+};
+
+const getStreamStartFailureText = (errorData?: unknown): string => {
+  if (typeof errorData === 'string') {
+    const sseErrorData = parseSSEErrorData(errorData);
+    if (sseErrorData != null) {
+      return getSSEErrorText(sseErrorData) ?? JSON.stringify(sseErrorData);
+    }
+
+    return errorData || 'Error connecting to server, try refreshing the page.';
+  }
+
+  return errorData
+    ? JSON.stringify(errorData)
+    : 'Error connecting to server, try refreshing the page.';
+};
+
+const getStreamStartFailureData = (errorData?: unknown): TResData =>
+  ({
+    text: getStreamStartFailureText(errorData),
+    metadata: markStreamStartFailedMetadata(),
+  }) as unknown as TResData;
 
 const isRetryableNetworkError = (error: unknown) => {
   if (!(error instanceof Error)) {
@@ -92,8 +149,13 @@ const isRetryableNetworkError = (error: unknown) => {
 
 const isServerNotReadyError = (error: unknown) => {
   const candidate = toStartGenerationError(error);
+  const data = candidate?.response?.data;
+  const code =
+    data != null && typeof data === 'object' && 'code' in data
+      ? (data as { code?: unknown }).code
+      : undefined;
   return (
-    candidate?.response?.status === 503 && candidate.response?.data?.code === SERVER_NOT_READY_CODE
+    candidate?.response?.status === 503 && code === SERVER_NOT_READY_CODE
   );
 };
 
@@ -1216,12 +1278,18 @@ export default function useResumableSSE(
         requestAttempts += 1;
         try {
           // Use request.post which handles auth token refresh via axios interceptors
-          const data = (await request.post(url, payload)) as { streamId: string };
+          const data = await request.post(url, payload);
           if (signal?.aborted) {
             return null;
           }
-          logger.log('ResumableSSE', 'Generation started:', { streamId: data.streamId });
-          return data.streamId;
+          const streamId = getStartGenerationStreamId(data);
+          if (streamId) {
+            logger.log('ResumableSSE', 'Generation started:', { streamId });
+            return streamId;
+          }
+
+          lastError = { response: { data } };
+          break;
         } catch (error) {
           if (signal?.aborted) {
             return null;
@@ -1269,8 +1337,7 @@ export default function useResumableSSE(
 
       logger.error('ResumableSSE', 'Error starting generation:', lastError);
 
-      const axiosError = lastError as { response?: { data?: Record<string, unknown> } };
-      const errorData = axiosError?.response?.data;
+      const errorData = toStartGenerationError(lastError)?.response?.data;
       errorHandler({
         data: getStreamStartFailureData(errorData),
         submission: currentSubmission as EventSubmission,

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -154,9 +154,7 @@ const isServerNotReadyError = (error: unknown) => {
     data != null && typeof data === 'object' && 'code' in data
       ? (data as { code?: unknown }).code
       : undefined;
-  return (
-    candidate?.response?.status === 503 && code === SERVER_NOT_READY_CODE
-  );
+  return candidate?.response?.status === 503 && code === SERVER_NOT_READY_CODE;
 };
 
 const getRetryAfterDelay = (error: unknown, fallbackDelay: number) => {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -81,26 +81,35 @@ const getStartGenerationStreamId = (data: unknown): string | null => {
 };
 
 const parseSSEErrorData = (body: string): unknown | null => {
-  const lines = body.split(/\r?\n/);
-  if (!lines.some((line) => line.trim() === 'event: error')) {
-    return null;
+  const blocks = body.split(/\r?\n\r?\n/);
+  for (const block of blocks) {
+    const lines = block.split(/\r?\n/);
+    const event = lines
+      .find((line) => line.startsWith('event:'))
+      ?.slice('event:'.length)
+      .trim();
+    if (event !== 'error') {
+      continue;
+    }
+
+    const data = lines
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice('data:'.length).trimStart())
+      .join('\n')
+      .trim();
+
+    if (!data) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(data);
+    } catch {
+      return data;
+    }
   }
 
-  const data = lines
-    .filter((line) => line.startsWith('data:'))
-    .map((line) => line.slice('data:'.length).trimStart())
-    .join('\n')
-    .trim();
-
-  if (!data) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(data);
-  } catch {
-    return data;
-  }
+  return null;
 };
 
 const getSSEErrorText = (payload: unknown): string | null => {


### PR DESCRIPTION
## Summary

Fix resumable agent chat start failures so server-sent error bodies are surfaced to the user instead of leaving the UI waiting for a stream that never starts.

## Root Cause

`buildEndpointOption` can reject an agent chat start before a stream ID exists and return an SSE-formatted error body such as:

```text
event: error
data: {"text":"No model spec selected"}
```

The resumable SSE start path assumed a successful POST always returned `{ streamId }`, and the existing failure handling serialized raw response data instead of extracting the useful error text.

## Changes

- Validate that the start-generation POST returns a concrete `streamId` before subscribing.
- Parse SSE-formatted start error bodies and extract `text`, `message`, or `error` for the visible chat error.
- Keep existing JSON failure handling intact and mark these failures as `streamStartFailed`.
- Add regression coverage for `No model spec selected`.

## Validation

- `npm run test:ci -- useResumableSSE.spec.ts --runInBand`
- `npm run typecheck`
- `git diff --check`