### PR TITLE
⚡ perf: Skip Role Route Capability Probe for Own and Default Roles

### DIFF
--- a/api/server/routes/__tests__/roles.spec.js
+++ b/api/server/routes/__tests__/roles.spec.js
@@ -58,6 +58,7 @@ describe('GET /api/roles/:roleName — isOwnRole authorization', () => {
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('STAFF');
     expect(mockGetRoleByName).toHaveBeenCalledWith('STAFF', '-_id -__v');
+    expect(mockHasCapability).not.toHaveBeenCalled();
   });
 
   it('returns 403 when a custom role user requests a different custom role', async () => {
@@ -85,6 +86,17 @@ describe('GET /api/roles/:roleName — isOwnRole authorization', () => {
     const res = await request(app).get(`/api/roles/${SystemRoles.USER}`);
 
     expect(res.status).toBe(200);
+    expect(mockHasCapability).not.toHaveBeenCalled();
+  });
+
+  it('allows a custom role user to fetch a non-admin default role without a capability probe', async () => {
+    mockGetRoleByName.mockResolvedValue(userRole);
+    const app = createApp({ id: 'u1', role: 'STAFF' });
+
+    const res = await request(app).get(`/api/roles/${SystemRoles.USER}`);
+
+    expect(res.status).toBe(200);
+    expect(mockHasCapability).not.toHaveBeenCalled();
   });
 
   it('returns 403 when USER requests the ADMIN role', async () => {
@@ -103,6 +115,7 @@ describe('GET /api/roles/:roleName — isOwnRole authorization', () => {
     const res = await request(app).get(`/api/roles/${SystemRoles.ADMIN}`);
 
     expect(res.status).toBe(200);
+    expect(mockHasCapability).not.toHaveBeenCalled();
   });
 
   it('allows any user with READ_ROLES capability to fetch any role', async () => {
@@ -114,6 +127,21 @@ describe('GET /api/roles/:roleName — isOwnRole authorization', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('STAFF');
+  });
+
+  it('probes READ_ROLES with a coerced CapabilityUser for non-own-role lookups', async () => {
+    mockHasCapability.mockResolvedValue(true);
+    mockGetRoleByName.mockResolvedValue(staffRole);
+    const app = createApp({ id: 'u1', role: SystemRoles.USER });
+
+    const res = await request(app).get('/api/roles/STAFF');
+
+    expect(res.status).toBe(200);
+    expect(mockHasCapability).toHaveBeenCalledTimes(1);
+    expect(mockHasCapability).toHaveBeenCalledWith(
+      { id: 'u1', role: SystemRoles.USER, tenantId: undefined, idOnTheSource: null },
+      expect.any(String),
+    );
   });
 
   it('returns 404 when the requested role does not exist', async () => {
@@ -143,7 +171,7 @@ describe('GET /api/roles/:roleName — isOwnRole authorization', () => {
     expect(mockGetRoleByName).not.toHaveBeenCalled();
   });
 
-  it('treats hasCapability failure as no capability (does not 500)', async () => {
+  it('serves own role without probing even when hasCapability would fail', async () => {
     mockHasCapability.mockRejectedValue(new Error('capability check failed'));
     const app = createApp({ id: 'u1', role: 'STAFF' });
     mockGetRoleByName.mockResolvedValue(staffRole);
@@ -151,5 +179,16 @@ describe('GET /api/roles/:roleName — isOwnRole authorization', () => {
     const res = await request(app).get('/api/roles/STAFF');
 
     expect(res.status).toBe(200);
+    expect(mockHasCapability).not.toHaveBeenCalled();
+  });
+
+  it('treats hasCapability failure as no capability for other roles (403, not 500)', async () => {
+    mockHasCapability.mockRejectedValue(new Error('capability check failed'));
+    const app = createApp({ id: 'u1', role: 'STAFF' });
+
+    const res = await request(app).get('/api/roles/MANAGER');
+
+    expect(res.status).toBe(403);
+    expect(mockGetRoleByName).not.toHaveBeenCalled();
   });
 });

--- a/api/server/routes/roles.js
+++ b/api/server/routes/roles.js
@@ -117,16 +117,28 @@ router.get('/:roleName', async (req, res) => {
   const { roleName } = req.params;
 
   try {
-    let hasReadRoles = false;
-    try {
-      hasReadRoles = await hasCapability(req.user, SystemCapabilities.READ_ROLES);
-    } catch (err) {
-      logger.warn(`[GET /roles/:roleName] capability check failed: ${err.message}`);
-    }
     const isOwnRole = req.user?.role === roleName;
     const isDefaultRole = Object.hasOwn(roleDefaults, roleName);
-    if (!hasReadRoles && !isOwnRole && (roleName === SystemRoles.ADMIN || !isDefaultRole)) {
-      return res.status(403).send({ message: 'Unauthorized' });
+    /** READ_ROLES only gates reading other roles; own role and non-admin default roles skip the probe */
+    const requiresReadRoles = !isOwnRole && (roleName === SystemRoles.ADMIN || !isDefaultRole);
+    if (requiresReadRoles) {
+      let hasReadRoles = false;
+      try {
+        hasReadRoles = await hasCapability(
+          {
+            id: req.user?.id ?? req.user?._id?.toString() ?? '',
+            role: req.user?.role ?? '',
+            tenantId: req.user?.tenantId,
+            idOnTheSource: req.user?.idOnTheSource ?? null,
+          },
+          SystemCapabilities.READ_ROLES,
+        );
+      } catch (err) {
+        logger.warn(`[GET /roles/:roleName] capability check failed: ${err.message}`);
+      }
+      if (!hasReadRoles) {
+        return res.status(403).send({ message: 'Unauthorized' });
+      }
     }
 
     const role = await getRoleByName(roleName, '-_id -__v');


### PR DESCRIPTION
## Summary

I reordered the authorization gate on `GET /api/roles/:roleName` so the `READ_ROLES` capability probe only runs when it can actually affect the outcome. The route previously awaited `hasCapability` unconditionally before the own-role and default-role short-circuits, so every request paid a `getUserPrincipals` resolution plus a `SystemGrant` existence query. Since every client fetches its own role, prod telemetry showed a 1:1 ratio of `SystemGrant` queries to requests on this endpoint; those now skip the probe entirely.

- Computed `isOwnRole` and `isDefaultRole` first and gated the capability probe behind `requiresReadRoles = !isOwnRole && (roleName === ADMIN || !isDefaultRole)`, the exact condition under which the old code's probe result could influence the decision. Semantics are unchanged: users always read their own role and non-admin default roles, and `READ_ROLES` only gates reading other roles.
- Built an explicit `CapabilityUser` for the probe instead of passing `req.user` raw: `id` falls back to `_id.toString()`, `tenantId` is threaded, and `idOnTheSource` is coerced with `?? null` so local users skip the `User.findById` fallback inside principal resolution (follow-up to #14055).
- Preserved the fail-closed try/catch on the gated path: a probe failure is treated as no capability and returns 403.
- Kept response payloads, the `-_id -__v` projection, and the 403-before-lookup ordering untouched, so there is no information-disclosure change; the only observable difference is fewer database queries.
- Extended the route spec to assert the probe is not called for own-role, own-ADMIN, and default-role fetches (including a custom-role user fetching the USER default), is called exactly once with the coerced `CapabilityUser` for non-own-role lookups, and that a probe failure on the gated path returns 403 without hitting `getRoleByName`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the roles route spec (`cd api && npx jest routes/__tests__/roles.spec.js`): 14 tests pass, covering own-role, default-role, `READ_ROLES`-holder, denial, prototype-pollution, and probe-failure paths. ESLint and the sort-imports check are clean on both changed files.

### **Test Configuration**:

- Node.js v24.16.0, Jest per-workspace from `/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
