### PR TITLE
fix: Fall Back to Tool Discovery for Reinitialize When BODY Placeholders Are Unresolvable

### DIFF
--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -1,5 +1,9 @@
 const { logger } = require('@librechat/data-schemas');
-const { getMissingCustomUserVars, requiresEphemeralUserConnection } = require('@librechat/api');
+const {
+  getMissingCustomUserVars,
+  requiresEphemeralUserConnection,
+  isMissingRuntimeBodyPlaceholderMessage,
+} = require('@librechat/api');
 const { CacheKeys, Constants } = require('librechat-data-provider');
 const { getMCPManager, getMCPServersRegistry, getFlowStateManager } = require('~/config');
 const { findToken, createToken, updateToken, deleteTokens } = require('~/models');
@@ -53,6 +57,9 @@ async function reinitMCPServer({
   let oauthRequired = false;
   let oauthUrl = null;
   let ephemeralServer = false;
+  /** Set when `getConnection` failed only because runtime body placeholders (e.g.
+   *  `{{LIBRECHAT_BODY_CONVERSATIONID}}`) could not be resolved outside a chat turn. */
+  let missingRuntimeBodyPlaceholder = false;
 
   try {
     const registry = getMCPServersRegistry();
@@ -168,11 +175,27 @@ async function reinitMCPServer({
 
       const isOAuthFlowInitiated = err.message === 'OAuth flow initiated - return early';
 
-      if (isOAuthError || oauthRequired || isOAuthFlowInitiated) {
-        logger.info(
-          `[MCP Reinitialize] OAuth required for ${serverName}, attempting tool discovery without auth`,
-        );
-        oauthRequired = true;
+      /**
+       * Servers using `{{LIBRECHAT_BODY_*}}` placeholders can only resolve them during
+       * an active chat turn. Reinitialize (e.g. from the Admin Panel, or agent/tool-panel
+       * discovery) runs without a request body, so `getConnection` throws instead of
+       * connecting. This is not a real failure — fall back to `discoverServerTools`,
+       * which already handles missing body fields gracefully (returns no tools instead
+       * of throwing), the same way OAuth-required servers are handled below.
+       */
+      missingRuntimeBodyPlaceholder = isMissingRuntimeBodyPlaceholderMessage(err.message ?? '');
+
+      if (isOAuthError || oauthRequired || isOAuthFlowInitiated || missingRuntimeBodyPlaceholder) {
+        if (missingRuntimeBodyPlaceholder) {
+          logger.info(
+            `[MCP Reinitialize] ${serverName} uses runtime body placeholders unavailable outside a chat turn; attempting tool discovery instead`,
+          );
+        } else {
+          logger.info(
+            `[MCP Reinitialize] OAuth required for ${serverName}, attempting tool discovery without auth`,
+          );
+          oauthRequired = true;
+        }
 
         try {
           const discoveryResult = await mcpManager.discoverServerTools({
@@ -236,6 +259,12 @@ async function reinitMCPServer({
       }
       if (connection) {
         return `MCP server '${serverName}' reinitialized successfully`;
+      }
+      if (missingRuntimeBodyPlaceholder && tools && tools.length > 0) {
+        return `MCP server '${serverName}' tools discovered; connection will be established on first use in a chat turn`;
+      }
+      if (missingRuntimeBodyPlaceholder) {
+        return `MCP server '${serverName}' uses request-scoped placeholders and will connect on first use in a chat turn`;
       }
       return `Failed to reinitialize MCP server '${serverName}'`;
     };

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -184,3 +184,81 @@ describe('reinitMCPServer — customUserVars gating (issue #10969)', () => {
     expect(mockGetConnection).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('reinitMCPServer — runtime BODY placeholder fallback (issue #14074)', () => {
+  const user = { id: 'user-123' };
+  const serverName = 'Thingy';
+  /** Matches the error `UserConnectionManager#getUserConnection` throws when a
+   *  server config needs `{{LIBRECHAT_BODY_*}}` fields the request doesn't have. */
+  const missingBodyPlaceholderError = new Error(
+    `[MCP][User: ${user.id}][${serverName}] Request body field(s) required to resolve runtime MCP placeholders: conversationId.`,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateMCPServerTools.mockResolvedValue({});
+  });
+
+  it('falls back to tool discovery instead of failing outright when body placeholders are unavailable', async () => {
+    mockGetConnection.mockRejectedValue(missingBodyPlaceholderError);
+    const tools = [{ name: 'search', inputSchema: { type: 'object', properties: {} } }];
+    mockDiscoverServerTools.mockResolvedValue({ tools, oauthRequired: false, oauthUrl: null });
+
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig: {
+        type: 'streamable-http',
+        url: 'https://thingy.example.com/mcp',
+        headers: { 'X-Conversation-Id': '{{LIBRECHAT_BODY_CONVERSATIONID}}' },
+      },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockDiscoverServerTools).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      success: true,
+      oauthRequired: false,
+      tools,
+    });
+    expect(result.message).not.toMatch(/^Failed to reinitialize/);
+  });
+
+  it('reports a non-failure state (not the generic "Failed to reinitialize" message) when no tools are found yet', async () => {
+    mockGetConnection.mockRejectedValue(missingBodyPlaceholderError);
+    mockDiscoverServerTools.mockResolvedValue({
+      tools: null,
+      oauthRequired: false,
+      oauthUrl: null,
+    });
+
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig: {
+        type: 'streamable-http',
+        url: 'https://thingy.example.com/mcp',
+        headers: { 'X-Conversation-Id': '{{LIBRECHAT_BODY_CONVERSATIONID}}' },
+      },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(result.oauthRequired).toBe(false);
+    expect(result.message).not.toMatch(/^Failed to reinitialize/);
+  });
+
+  it('still treats unrelated connection errors as real failures', async () => {
+    mockGetConnection.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig: { type: 'streamable-http', url: 'https://thingy.example.com/mcp' },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockDiscoverServerTools).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.message).toBe(`Failed to reinitialize MCP server '${serverName}'`);
+  });
+});

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -14,6 +14,7 @@ import {
   hasRuntimeContextPlaceholders,
   getRuntimeBodyPlaceholderFields,
   getMissingRuntimeBodyPlaceholderFields,
+  isMissingRuntimeBodyPlaceholderMessage,
   isUserSourced,
   requiresEphemeralUserConnection,
 } from '~/mcp/utils';
@@ -682,6 +683,22 @@ describe('getMissingRuntimeBodyPlaceholderFields', () => {
         url: 'https://example.com/{{LIBRECHAT_BODY_MESSAGEID}}/mcp',
       }),
     ).toEqual([]);
+  });
+});
+
+describe('isMissingRuntimeBodyPlaceholderMessage', () => {
+  it('matches the error UserConnectionManager#getUserConnection throws for missing BODY fields', () => {
+    const message =
+      '[MCP][User: user-123][Thingy] Request body field(s) required to resolve runtime MCP placeholders: conversationId, parentMessageId.';
+    expect(isMissingRuntimeBodyPlaceholderMessage(message)).toBe(true);
+  });
+
+  it('does not match unrelated InvalidRequest errors', () => {
+    expect(isMissingRuntimeBodyPlaceholderMessage('[MCP] User object missing id property')).toBe(
+      false,
+    );
+    expect(isMissingRuntimeBodyPlaceholderMessage('OAuth authentication required')).toBe(false);
+    expect(isMissingRuntimeBodyPlaceholderMessage('')).toBe(false);
   });
 });
 

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -177,6 +177,19 @@ export function getMissingRuntimeBodyPlaceholderFields(
 }
 
 /**
+ * Checks whether an error message indicates a connection attempt failed because
+ * required `{{LIBRECHAT_BODY_*}}` placeholder fields were missing from the request
+ * (thrown by `UserConnectionManager#getUserConnection`). This happens whenever a
+ * server using body placeholders is contacted outside of an active chat turn
+ * (e.g. Reinitialize, tool discovery, or admin-panel operations), where there is
+ * no request body to resolve `conversationId`/`parentMessageId`/`messageId` from.
+ * Distinct from other `InvalidRequest` errors the same call can throw.
+ */
+export function isMissingRuntimeBodyPlaceholderMessage(message: string): boolean {
+  return message.includes('Request body field(s) required to resolve runtime MCP placeholders');
+}
+
+/**
  * `BODY` placeholders vary by chat request, so the normal userId:serverName
  * cache would reuse a connection built with stale request context.
  *


### PR DESCRIPTION
## Summary

Fixes #14074.

`reinitMCPServer` (used by Reinitialize, the Admin Panel, and Agent Builder/MCP-panel tool discovery) treats **any** non-OAuth error from `getConnection` as a hard failure. Since #13626, `getUserConnection` throws when a server config needs `{{LIBRECHAT_BODY_*}}` placeholders (e.g. `{{LIBRECHAT_BODY_CONVERSATIONID}}`) that aren't available outside an active chat turn — so any server using this documented, officially-supported placeholder pattern now always fails to (re)initialize with `Failed to reinitialize MCP server '<name>'`, even though `discoverServerTools` already handles this exact case gracefully (it returns `{ tools: null }` instead of throwing when body fields are missing).

This PR widens `reinitMCPServer`'s existing OAuth-error fallback to also cover this case, so it reuses the already-correct `discoverServerTools` path instead of surfacing a false failure:

- Added `isMissingRuntimeBodyPlaceholderMessage()` to `packages/api/src/mcp/utils.ts` (same pattern as the existing `isInvalidClientMessage`/`isClientRejectionMessage` message-classifier helpers) to detect this specific `McpError` by its message.
- In `reinitMCPServer`'s catch block, when this error is detected, fall back to `discoverServerTools` (same as the OAuth-required path) instead of treating it as an unexpected failure.
- Added a `missingRuntimeBodyPlaceholder` state so `getResponseMessage()` returns an accurate message (`... tools discovered; connection will be established on first use in a chat turn` / `... will connect on first use in a chat turn`) instead of `Failed to reinitialize ...` when this fallback fires — `success` was already computed correctly from `tools.length > 0` in this case, only the message text was misleading.
- Unrelated connection errors (e.g. `ECONNREFUSED`) are untouched and still reported as real failures (covered by a new test).

No behavior changes to servers that don't use `{{LIBRECHAT_BODY_*}}` placeholders, and no changes to the actual tool-call path (`getUserConnection` still throws correctly there, which is the load-bearing security behavior from #13626).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added `isMissingRuntimeBodyPlaceholderMessage` unit tests in `packages/api/src/mcp/__tests__/utils.test.ts`.
- Added 3 tests in `api/server/services/Tools/mcp.spec.js` covering: (1) fallback to discovery + tools found → `success: true` with the new message, (2) fallback + no tools found → non-"Failed to reinitialize" message, (3) unrelated connection errors (`ECONNREFUSED`) still report as real failures (regression guard).
- Ran the full existing `reinitMCPServer` suite plus MCP-adjacent suites (`server/services/MCP.spec.js`, `server/services/__tests__/MCP.spec.js`, `server/routes/__tests__/mcp.spec.js`) — all pass, no regressions.
- `npx tsc --noEmit` clean on `packages/api`.
- `npm run build` succeeds.
- `eslint` clean (ran with `--fix` for formatting only).

### **Test Configuration**:
- Node v24.11.0, npm 11.6.1
- `npm ci` + `npm run build` from a fresh clone of `main` (`e452a130e`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
