### PR TITLE
📛 feat: Add Client Name Header to Tavily Search Requests

### DIFF
--- a/api/app/clients/tools/structured/TavilySearchResults.js
+++ b/api/app/clients/tools/structured/TavilySearchResults.js
@@ -117,6 +117,7 @@ class TavilySearchResults extends Tool {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Client-Name': 'librechat',
       },
       body: JSON.stringify(requestBody),
     };


### PR DESCRIPTION
- Client name header set to `librechat` helps Tavily understand the volume of calls from LibreChat

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This PR adds the `X-Client-Name: librechat` header to outbound Tavily search requests from the built-in Tavily search tool.

The change helps Tavily attribute and understand request volume coming from LibreChat integrations without changing the user-facing tool schema, request body, authentication flow, or Tavily search behavior.

No new dependencies are required.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Verified the Tavily tool request construction path and confirmed that the outbound request now includes the fixed client attribution header:

```js
'X-Client-Name': 'librechat'
```

The change is limited to the HTTP headers for the existing Tavily search request. It does not modify the request body, tool schema, authentication flow, or search parameters.

### **Test Configuration**:

- Local LibreChat checkout
- Tavily search tool: `api/app/clients/tools/structured/TavilySearchResults.js`
- Tavily API key configured via `TAVILY_API_KEY`

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.