### PR TITLE
fix: fall back to `_id` for user id in `createSafeUser`

### DIFF
--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -3,11 +3,11 @@ import { TokenExchangeMethodEnum } from 'librechat-data-provider';
 import type { MCPOptions } from 'librechat-data-provider';
 import type { IUser } from '@librechat/data-schemas';
 import {
-  resolveHeaders,
   resolveNestedObject,
-  processMCPEnv,
   encodeHeaderValue,
+  resolveHeaders,
   createSafeUser,
+  processMCPEnv,
 } from './env';
 
 function isStdioOptions(options: MCPOptions): options is Extract<MCPOptions, { type?: 'stdio' }> {

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -2,7 +2,13 @@ import { Types } from 'mongoose';
 import { TokenExchangeMethodEnum } from 'librechat-data-provider';
 import type { MCPOptions } from 'librechat-data-provider';
 import type { IUser } from '@librechat/data-schemas';
-import { resolveHeaders, resolveNestedObject, processMCPEnv, encodeHeaderValue } from './env';
+import {
+  resolveHeaders,
+  resolveNestedObject,
+  processMCPEnv,
+  encodeHeaderValue,
+  createSafeUser,
+} from './env';
 
 function isStdioOptions(options: MCPOptions): options is Extract<MCPOptions, { type?: 'stdio' }> {
   return !options.type || options.type === 'stdio';
@@ -2122,5 +2128,64 @@ describe('processMCPEnv', () => {
         throw new Error('Expected streamable-http options');
       }
     });
+  });
+});
+
+describe('createSafeUser', () => {
+  it('returns an empty object for null/undefined users', () => {
+    expect(createSafeUser(null)).toEqual({});
+    expect(createSafeUser(undefined)).toEqual({});
+  });
+
+  it('falls back to _id (ObjectId) when the virtual id is absent', () => {
+    const objectId = new Types.ObjectId();
+    const user = { _id: objectId, email: 'lean@example.com' } as unknown as IUser;
+
+    const safeUser = createSafeUser(user);
+
+    expect(safeUser.id).toBe(objectId.toString());
+    expect(safeUser.email).toBe('lean@example.com');
+  });
+
+  it('falls back to a string _id when the virtual id is absent', () => {
+    const user = { _id: 'string-id-123', email: 'lean@example.com' } as unknown as IUser;
+
+    const safeUser = createSafeUser(user);
+
+    expect(safeUser.id).toBe('string-id-123');
+  });
+
+  it('leaves a truthy id untouched and does not use _id', () => {
+    const objectId = new Types.ObjectId();
+    const user = { _id: objectId, id: 'real-id', email: 'user@example.com' } as unknown as IUser;
+
+    const safeUser = createSafeUser(user);
+
+    expect(safeUser.id).toBe('real-id');
+    expect(safeUser.id).not.toBe(objectId.toString());
+  });
+
+  it('replaces a falsy (empty-string) id with _id', () => {
+    const objectId = new Types.ObjectId();
+    const user = { _id: objectId, id: '', email: 'user@example.com' } as unknown as IUser;
+
+    const safeUser = createSafeUser(user);
+
+    expect(safeUser.id).toBe(objectId.toString());
+  });
+
+  it('leaves id undefined when _id is absent', () => {
+    const user = { email: 'no-id@example.com' } as unknown as IUser;
+
+    const safeUser = createSafeUser(user);
+
+    expect(safeUser.id).toBeUndefined();
+  });
+
+  it('leaves id undefined when _id is nullish and does not throw', () => {
+    const user = { _id: null, email: 'null-id@example.com' } as unknown as IUser;
+
+    expect(() => createSafeUser(user)).not.toThrow();
+    expect(createSafeUser(user).id).toBeUndefined();
   });
 });

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -104,6 +104,13 @@ export function createSafeUser(
     }
   }
 
+  // Fall back to `_id` when the mongoose virtual `id` is absent (e.g. lean/plain
+  // user objects), so `{{LIBRECHAT_USER_ID}}` placeholders still resolve.
+  if (!safeUser.id && '_id' in user) {
+    const _id = (user as unknown as { _id: { toString?: () => string } | string })._id;
+    safeUser.id = typeof _id === 'string' ? _id : _id?.toString?.();
+  }
+
   if ('federatedTokens' in user) {
     safeUser.federatedTokens = user.federatedTokens;
   }


### PR DESCRIPTION
## Summary

`createSafeUser` copies only `ALLOWED_USER_FIELDS`, which includes `id`. On a Mongoose document `id` is a **virtual** getter derived from `_id`, not an own field. For lean query results or plain objects that carry `_id` but not the virtual `id`, `'id' in user` is false, so `safeUser.id` is left `undefined`. Downstream consumers that interpolate `{{LIBRECHAT_USER_ID}}` (MCP env/header placeholders) then silently resolve to nothing.

This PR adds a four-line fallback after the field loop in `packages/api/src/utils/env.ts`: when `safeUser.id` is unset but `_id` is present, derive `id` from `_id` (string as-is, otherwise `_id.toString()`). No change when a truthy `id` is present.

This is defensive normalization of `createSafeUser` for its full documented input type (`IUser | null | undefined`), not a fix for one specific caller. Most callers pass `req.user`, whose `id` is set by the auth strategies (`jwtStrategy`/`openIdJwtStrategy` assign `user.id = user._id.toString()` before the request handler runs), so the fallback does not fire on that hot path. It hardens the helper for any caller that passes a lean/plain user object — `.lean()` results, `.toObject()` without virtuals, a re-fetched user that skipped the strategy assignment, or a manually built `{ _id }` — which would otherwise silently drop the id and break `{{LIBRECHAT_USER_ID}}` interpolation.

## Change Type

- [x] Bug fix (non-breaking)

## Testing

- `cd packages/api && npx jest src/utils/env`: `createSafeUser({ _id })` (no `id`) yields `id === _id.toString()`; a string `_id` yields that string; a falsy (empty-string) `id` falls back to `_id`; a truthy `id` is unchanged; an absent or nullish `_id` leaves `id` undefined without throwing.
- `npx tsc --noEmit`, `npx eslint src/utils/env.ts`.
