### PR TITLE
feat: Preserve Responses API annotations in agent message metadata

### DIFF
--- a/api/server/controllers/agents/__tests__/callbacks.spec.js
+++ b/api/server/controllers/agents/__tests__/callbacks.spec.js
@@ -1,4 +1,5 @@
 const { Tools } = require('librechat-data-provider');
+const { ModelEndHandler } = require('~/server/controllers/agents/callbacks');
 
 // Mock all dependencies before requiring the module
 jest.mock('nanoid', () => ({
@@ -471,6 +472,55 @@ describe('createToolEndCallback', () => {
       expect(phase2.type).toBe('text/csv');
       expect(phase2.conversationId).toBe('thread789');
       expect(phase2.textFormat).toBe('html');
+    });
+
+    it('collects annotations from output and enriches them with provider and model', () => {
+      const collectedAnnotations = [];
+      const collectedUsage = []; // Ensure this is an array
+
+      const handler = new ModelEndHandler(collectedUsage, null, null, collectedAnnotations);
+
+      const agentContext = {
+        provider: 'openai',
+        clientOptions: { model: 'gpt-5.5' },
+      };
+
+      const metadata = {};
+
+      handler.handle(
+        'model_end',
+        {
+          output: {
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+                annotations: [
+                  {
+                    type: 'url_citation',
+                    url: 'https://example.com',
+                    title: 'Example',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        metadata,
+        {
+          getAgentContext: () => agentContext,
+        },
+      );
+
+      expect(collectedAnnotations).toEqual([
+        {
+          type: 'url_citation',
+          url: 'https://example.com',
+          title: 'Example',
+          provider: 'openai',
+          model: 'gpt-5.5',
+        },
+      ]);
     });
 
     it('the preview update emit is skipped when finalize resolves to null (no DB update happened)', async () => {

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -66,7 +66,6 @@ function isCodeArtifactToolOutput(output) {
 class ModelEndHandler {
   /**
    * @param {Array<UsageMetadata>} collectedUsage
-   * @param {Array<Object>} [collectedAnnotations]
    * @param {Record<string, string> | null} [collectedThoughtSignatures] Map of
    *   `tool_call_id → thoughtSignature` accumulated across `chat_model_end`
    *   events. Used to persist Vertex Gemini 3 thought signatures across DB
@@ -80,6 +79,7 @@ class ModelEndHandler {
    *   a no-op for them even when the map is provided.
    * @param {(data: Record<string, unknown>) => Promise<void> | void} [emitUsage] Optional
    *   callback to stream per-call token usage to the client.
+   * @param {Array<Object>} [collectedAnnotations]
    */
   constructor(
     collectedUsage,
@@ -92,7 +92,7 @@ class ModelEndHandler {
     }
     this.collectedUsage = collectedUsage;
     this.collectedThoughtSignatures = collectedThoughtSignatures;
-    this.collectedAnnotations = collectedAnnotations || [];
+    this.collectedAnnotations = Array.isArray(collectedAnnotations) ? collectedAnnotations : null;
     this.emitUsage = emitUsage;
   }
 

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -55,7 +55,6 @@ function collectAnnotationsFromValue(value, collected = []) {
   return collected;
 }
 
-
 function isHostFileAuthoringArtifact(artifact) {
   return artifact?.[HOST_FILE_AUTHORING_ARTIFACT_KEY] === true;
 }
@@ -82,14 +81,18 @@ class ModelEndHandler {
    * @param {(data: Record<string, unknown>) => Promise<void> | void} [emitUsage] Optional
    *   callback to stream per-call token usage to the client.
    */
-  constructor(collectedUsage, collectedThoughtSignatures = null, emitUsage = null, collectedAnnotations = null) {
+  constructor(
+    collectedUsage,
+    collectedThoughtSignatures = null,
+    emitUsage = null,
+    collectedAnnotations = null,
+  ) {
     if (!Array.isArray(collectedUsage)) {
       throw new Error('collectedUsage must be an array');
     }
     this.collectedUsage = collectedUsage;
     this.collectedThoughtSignatures = collectedThoughtSignatures;
     this.collectedAnnotations = collectedAnnotations || [];
-
     this.emitUsage = emitUsage;
   }
 
@@ -117,7 +120,7 @@ class ModelEndHandler {
     let errorMessage;
     try {
       const agentContext = graph.getAgentContext(metadata);
-          if (Array.isArray(this.collectedAnnotations)) {
+      if (Array.isArray(this.collectedAnnotations)) {
         const annotations = collectAnnotationsFromValue(data?.output);
         if (annotations.length > 0) {
           const model = metadata?.ls_model_name || agentContext.clientOptions?.model;
@@ -395,7 +398,7 @@ function getDefaultHandlers({
       collectedUsage,
       collectedThoughtSignatures,
       emitTokenUsage,
-      collectedAnnotations
+      collectedAnnotations,
     ),
     [GraphEvents.TOOL_END]: new ToolEndHandler(toolEndCallback, logger),
     [GraphEvents.ON_RUN_STEP]: {
@@ -773,6 +776,28 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null }) 
           return attachment;
         })().catch((error) => {
           logger.error('Error processing artifact content:', error);
+          return null;
+        }),
+      );
+    }
+
+    if (output.artifact[Tools.memory]) {
+      artifactPromises.push(
+        (async () => {
+          const attachment = {
+            type: Tools.memory,
+            messageId: metadata.run_id,
+            toolCallId: output.tool_call_id,
+            conversationId: metadata.thread_id,
+            [Tools.memory]: output.artifact[Tools.memory],
+          };
+          if (!streamId && !res.headersSent) {
+            return attachment;
+          }
+          writeAttachment(res, streamId, attachment);
+          return attachment;
+        })().catch((error) => {
+          logger.error('Error processing memory artifact content:', error);
           return null;
         }),
       );

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -26,6 +26,36 @@ const { processFileCitations } = require('~/server/services/Files/Citations');
 const { processCodeOutput, runPreviewFinalize } = require('~/server/services/Files/Code/process');
 const { saveBase64Image } = require('~/server/services/Files/process');
 
+function collectAnnotationsFromValue(value, collected = []) {
+  if (!value || typeof value !== 'object') {
+    return collected;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectAnnotationsFromValue(item, collected);
+    }
+    return collected;
+  }
+
+  if (Array.isArray(value.annotations)) {
+    for (const annotation of value.annotations) {
+      if (annotation && typeof annotation === 'object') {
+        collected.push(annotation);
+      }
+    }
+  }
+
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === 'object') {
+      collectAnnotationsFromValue(nested, collected);
+    }
+  }
+
+  return collected;
+}
+
+
 function isHostFileAuthoringArtifact(artifact) {
   return artifact?.[HOST_FILE_AUTHORING_ARTIFACT_KEY] === true;
 }
@@ -37,6 +67,7 @@ function isCodeArtifactToolOutput(output) {
 class ModelEndHandler {
   /**
    * @param {Array<UsageMetadata>} collectedUsage
+   * @param {Array<Object>} [collectedAnnotations]
    * @param {Record<string, string> | null} [collectedThoughtSignatures] Map of
    *   `tool_call_id → thoughtSignature` accumulated across `chat_model_end`
    *   events. Used to persist Vertex Gemini 3 thought signatures across DB
@@ -51,12 +82,14 @@ class ModelEndHandler {
    * @param {(data: Record<string, unknown>) => Promise<void> | void} [emitUsage] Optional
    *   callback to stream per-call token usage to the client.
    */
-  constructor(collectedUsage, collectedThoughtSignatures = null, emitUsage = null) {
+  constructor(collectedUsage, collectedThoughtSignatures = null, emitUsage = null, collectedAnnotations = null) {
     if (!Array.isArray(collectedUsage)) {
       throw new Error('collectedUsage must be an array');
     }
     this.collectedUsage = collectedUsage;
     this.collectedThoughtSignatures = collectedThoughtSignatures;
+    this.collectedAnnotations = collectedAnnotations || [];
+
     this.emitUsage = emitUsage;
   }
 
@@ -84,6 +117,20 @@ class ModelEndHandler {
     let errorMessage;
     try {
       const agentContext = graph.getAgentContext(metadata);
+          if (Array.isArray(this.collectedAnnotations)) {
+        const annotations = collectAnnotationsFromValue(data?.output);
+        if (annotations.length > 0) {
+          const model = metadata?.ls_model_name || agentContext.clientOptions?.model;
+          this.collectedAnnotations.push(
+            ...annotations.map((annotation) => ({
+              ...annotation,
+              provider: agentContext.provider,
+              model,
+            })),
+          );
+        }
+      }
+
       if (data?.output?.additional_kwargs?.stop_reason === 'refusal') {
         const info = { ...data.output.additional_kwargs };
         errorMessage = JSON.stringify({
@@ -279,6 +326,7 @@ function feedSubagentAggregator(aggregator, event) {
  * @param {ContentAggregator} options.aggregateContent - Content aggregator function.
  * @param {ToolEndCallback} options.toolEndCallback - Callback to use when tool ends.
  * @param {Array<UsageMetadata>} options.collectedUsage - The list of collected usage metadata.
+ * @param {Array<Object>} [options.collectedAnnotations] - Provider annotations/citations to persist on message metadata.
  * @param {string | null} [options.streamId] - The stream ID for resumable mode, or null for standard mode.
  * @param {ToolExecuteOptions} [options.toolExecuteOptions] - Options for event-driven tool execution.
  * @param {UsageCostDeps} [options.usageCost] - Pricing context for authoritative per-event cost.
@@ -295,6 +343,7 @@ function getDefaultHandlers({
   aggregateContent,
   toolEndCallback,
   collectedUsage,
+  collectedAnnotations = null,
   collectedThoughtSignatures = null,
   streamId = null,
   toolExecuteOptions = null,
@@ -346,6 +395,7 @@ function getDefaultHandlers({
       collectedUsage,
       collectedThoughtSignatures,
       emitTokenUsage,
+      collectedAnnotations
     ),
     [GraphEvents.TOOL_END]: new ToolEndHandler(toolEndCallback, logger),
     [GraphEvents.ON_RUN_STEP]: {
@@ -723,28 +773,6 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null }) 
           return attachment;
         })().catch((error) => {
           logger.error('Error processing artifact content:', error);
-          return null;
-        }),
-      );
-    }
-
-    if (output.artifact[Tools.memory]) {
-      artifactPromises.push(
-        (async () => {
-          const attachment = {
-            type: Tools.memory,
-            messageId: metadata.run_id,
-            toolCallId: output.tool_call_id,
-            conversationId: metadata.thread_id,
-            [Tools.memory]: output.artifact[Tools.memory],
-          };
-          if (!streamId && !res.headersSent) {
-            return attachment;
-          }
-          writeAttachment(res, streamId, attachment);
-          return attachment;
-        })().catch((error) => {
-          logger.error('Error processing memory artifact content:', error);
           return null;
         }),
       );

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -40,7 +40,12 @@ function collectAnnotationsFromValue(value, collected = []) {
 
   if (Array.isArray(value.annotations)) {
     for (const annotation of value.annotations) {
-      if (annotation && typeof annotation === 'object') {
+      if (
+        annotation &&
+        typeof annotation === 'object' &&
+        annotation.type === 'citation' &&
+        !collected.includes(annotation)
+      ) {
         collected.push(annotation);
       }
     }
@@ -1269,7 +1274,9 @@ const agentLogHandlerObj = { handle: agentLogHandler };
  */
 function buildSummarizationHandlers({ isStreaming, res }) {
   if (!isStreaming) {
-    const noop = { handle: () => {} };
+    const noop = {
+      handle: () => {},
+    };
     return { on_summarize_start: noop, on_summarize_delta: noop, on_summarize_complete: noop };
   }
   const writeEvent = (name) => ({

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -33,16 +33,7 @@ const {
   GenerationJobManager,
   getTransactionsConfig,
   resolveRecursionLimit,
-  buildPendingAction,
-  computeAgentRequestFingerprint,
-  extractDiscoveredToolsFromHistory,
-  pickResumeContext,
-  getApprovalTtlMs,
-  isHITLEnabled,
-  deleteAgentCheckpoint,
-  getRequestMemories,
   createMemoryProcessor,
-  agentHasInlineMemoryTools,
   loadAgent: loadAgentFn,
   createMultiAgentMapper,
   filterMalformedContentParts,
@@ -61,7 +52,6 @@ const {
   hasUrlContextTool,
   appendYouTubeVideoParts,
   resolveYouTubeInjectionConfig,
-  decrementPendingRequest,
 } = require('@librechat/api');
 const {
   Callback,
@@ -77,7 +67,6 @@ const {
   Permissions,
   VisionModes,
   ContentTypes,
-  ApprovalEvents,
   EModelEndpoint,
   PermissionTypes,
   AgentCapabilities,
@@ -124,6 +113,7 @@ class AgentClient extends BaseClient {
       agentConfigs,
       contentParts,
       collectedUsage,
+      collectedAnnotations,
       collectedThoughtSignatures,
       artifactPromises,
       maxContextTokens,
@@ -148,6 +138,8 @@ class AgentClient extends BaseClient {
     this.contentParts = contentParts;
     /** @type {Array<UsageMetadata>} */
     this.collectedUsage = collectedUsage;
+    /** @type {Array<Object>} */
+    this.collectedAnnotations = collectedAnnotations;
     /** Vertex Gemini 3 thought signatures captured during the run, keyed by
      *  `tool_call_id`. Persisted on `responseMessage.metadata.thoughtSignatures`
      *  and restored as `additional_kwargs.signatures` on subsequent turns to
@@ -233,13 +225,13 @@ class AgentClient extends BaseClient {
     buffer.clear();
   }
 
-  setOptions(_options) {}
+  setOptions(_options) { }
 
   /**
    * `AgentClient` is not opinionated about vision requests, so we don't do anything here
    * @param {MongoFile[]} attachments
    */
-  checkVisionRequest() {}
+  checkVisionRequest() { }
 
   getSaveOptions() {
     let runOptions = {};
@@ -326,9 +318,9 @@ class AgentClient extends BaseClient {
       { agent: normalizeInstructions(this.options.agent), agentId: this.options.agent.id },
       ...(this.agentConfigs?.size > 0
         ? Array.from(this.agentConfigs.entries()).map(([agentId, agent]) => ({
-            agent: normalizeInstructions(agent),
-            agentId,
-          }))
+          agent: normalizeInstructions(agent),
+          agentId,
+        }))
         : []),
     ];
     const sharedRunAttachmentIds = new Set();
@@ -527,14 +519,11 @@ class AgentClient extends BaseClient {
       }
     }
 
-    /** Memory context (user preferences/memories). Keyed context (with memory
-     *  keys + token metadata) is reserved for agents that can call
-     *  `delete_memory`; everyone else gets the unkeyed values only. */
-    const memories = await this.useMemory();
-    const buildMemoryContext = (text) =>
-      text ? `${memoryInstructions}\n\n# Existing memory about the user:\n${text}` : undefined;
-    const memoryContext = buildMemoryContext(memories?.withoutKeys);
-    const keyedMemoryContext = buildMemoryContext(memories?.withKeys);
+    /** Memory context (user preferences/memories) */
+    const withoutKeys = await this.useMemory();
+    const memoryContext = withoutKeys
+      ? `${memoryInstructions}\n\n# Existing memory about the user:\n${withoutKeys}`
+      : undefined;
 
     const sharedRunContext = sharedRunContextParts.join('\n\n');
     const memoryAgentEnabled = isMemoryAgentEnabled(this.options.req.config?.memory);
@@ -585,13 +574,8 @@ class AgentClient extends BaseClient {
     await Promise.all(
       allAgents.map(({ agent, agentId }) => {
         const agentRunContextParts = [sharedRunContext];
-        const agentHasMemory = agentHasInlineMemoryTools(agent);
-        const agentMemoryContext = agentHasMemory ? keyedMemoryContext : memoryContext;
-        if (
-          agentMemoryContext &&
-          (agentId === this.options.agent.id || memoryAgentEnabled || agentHasMemory)
-        ) {
-          agentRunContextParts.push(agentMemoryContext);
+        if (memoryContext && (agentId === this.options.agent.id || memoryAgentEnabled)) {
+          agentRunContextParts.push(memoryContext);
         }
         const scopedContext = agentScopedContext.get(agentId);
         if (scopedContext) {
@@ -642,7 +626,7 @@ class AgentClient extends BaseClient {
   }
 
   /**
-   * @returns {Promise<{ withKeys?: string; withoutKeys?: string } | undefined>}
+   * @returns {Promise<string | undefined>}
    */
   async useMemory() {
     const user = this.options.req.user;
@@ -673,12 +657,8 @@ class AgentClient extends BaseClient {
 
     if (!isMemoryAgentEnabled(memoryConfig)) {
       try {
-        const { withKeys, withoutKeys } = await getRequestMemories({
-          req: this.options.req,
-          userId,
-          getFormattedMemories: db.getFormattedMemories,
-        });
-        return { withKeys, withoutKeys };
+        const { withoutKeys } = await db.getFormattedMemories({ userId });
+        return withoutKeys;
       } catch (error) {
         logger.error(
           '[api/server/controllers/agents/client.js #useMemory] Error loading memories',
@@ -795,20 +775,7 @@ class AgentClient extends BaseClient {
     });
 
     this.processMemory = processMemory;
-    let withKeys = withoutKeys;
-    try {
-      ({ withKeys } = await getRequestMemories({
-        req: this.options.req,
-        userId,
-        getFormattedMemories: db.getFormattedMemories,
-      }));
-    } catch (error) {
-      logger.error(
-        '[api/server/controllers/agents/client.js #useMemory] Error loading keyed memories',
-        error,
-      );
-    }
-    return { withKeys, withoutKeys };
+    return withoutKeys;
   }
 
   /**
@@ -892,13 +859,12 @@ class AgentClient extends BaseClient {
           : DEFAULT_MEMORY_MAX_INPUT_TOKENS;
       const maxInputChars = maxInputTokens * MEMORY_INPUT_CHARS_PER_TOKEN;
       const isCharTruncated = bufferString.length > maxInputChars;
-      const memoryInput = `# Current Chat:\n\n${
-        isCharTruncated
-          ? `[Earlier chat content omitted due to memory input limit]\n\n${bufferString.slice(
-              -maxInputChars,
-            )}`
-          : bufferString
-      }`;
+      const memoryInput = `# Current Chat:\n\n${isCharTruncated
+        ? `[Earlier chat content omitted due to memory input limit]\n\n${bufferString.slice(
+          -maxInputChars,
+        )}`
+        : bufferString
+        }`;
       const {
         text: limitedMemoryInput,
         tokenCount,
@@ -948,6 +914,7 @@ class AgentClient extends BaseClient {
    * Returns undefined when nothing was captured.
    * @returns {{
    *   thoughtSignatures?: Record<string, string>,
+   *   annotations?: Array<Object>,
    *   contextUsage?: import('librechat-data-provider').TContextUsageEvent,
    *   usage?: import('librechat-data-provider').TResponseUsage,
    * } | undefined}
@@ -957,6 +924,7 @@ class AgentClient extends BaseClient {
      *   thoughtSignatures?: Record<string, string>,
      *   contextUsage?: import('librechat-data-provider').TContextUsageEvent,
      *   usage?: import('librechat-data-provider').TResponseUsage,
+     *   annotations?: Array<Annotation>,
      * }} */
     const metadata = {};
     const signatures = this.collectedThoughtSignatures;
@@ -1012,6 +980,12 @@ class AgentClient extends BaseClient {
     if (usage) {
       metadata.usage = usage;
     }
+
+    if (Array.isArray(this.collectedAnnotations) && this.collectedAnnotations.length > 0) {
+      metadata.annotations = this.collectedAnnotations;
+    }
+
+
     return Object.keys(metadata).length > 0 ? metadata : undefined;
   }
 
@@ -1114,10 +1088,10 @@ class AgentClient extends BaseClient {
          *  differ from the parent's); `usage.agentId` is tagged by the sink. */
         cost: includeCost
           ? computeUsageCostUSD(
-              usage,
-              { getMultiplier: db.getMultiplier, getCacheMultiplier: db.getCacheMultiplier },
-              this.resolveAgentEndpointTokenConfig(usage),
-            )
+            usage,
+            { getMultiplier: db.getMultiplier, getCacheMultiplier: db.getCacheMultiplier },
+            this.resolveAgentEndpointTokenConfig(usage),
+          )
           : undefined,
       };
       /** Fold into the response's usage rollup (synchronously, regardless of
@@ -1174,150 +1148,6 @@ class AgentClient extends BaseClient {
    * @param {Record<string, Record<string, string>>} [params.userMCPAuthMap]
    * @param {AbortController} [params.abortController]
    */
-  /**
-   * @deprecated Agent Chain — strip hidden intermediate sequential-agent content
-   * before persistence, keeping only the last part + tool_call parts. Mirrors the
-   * chat path so a HITL resume doesn't persist/emit intermediate outputs the
-   * agent's `hide_sequential_outputs` setting is meant to hide.
-   */
-  applyHideSequentialOutputsFilter() {
-    if (!this.options.agent?.hide_sequential_outputs || !Array.isArray(this.contentParts)) {
-      return;
-    }
-    this.contentParts = this.contentParts.filter(
-      (part, index) =>
-        index >= this.contentParts.length - 1 ||
-        part.type === ContentTypes.TOOL_CALL ||
-        part.tool_call_ids,
-    );
-  }
-
-  /**
-   * Surface any human-in-the-loop interrupt the SDK captured during the most
-   * recent `processStream` / `resume`. When the run paused for tool approval (or
-   * an ask-user question), mark the job `requires_action`, persist the pending
-   * review record, and emit it to live clients — then set `this.pendingApproval`
-   * so the controller leaves the turn unfinalized for the resume route to continue.
-   *
-   * No-op when the run completed without an interrupt, or when the job was aborted
-   * between the interrupt firing and this mark (a late interrupt must not pause a
-   * dead job — the atomic `pause` transition returns false and we drop it).
-   *
-   * @param {AgentRun} run
-   * @param {string} [streamId]
-   */
-  async handleRunInterrupt(run, streamId) {
-    if (!streamId || typeof run?.getInterrupt !== 'function') {
-      return;
-    }
-    const interrupt = run.getInterrupt();
-    if (!interrupt?.payload) {
-      return;
-    }
-
-    const appConfig = this.options.req?.config;
-    const checkpointerCfg = appConfig?.endpoints?.[EModelEndpoint.agents]?.checkpointer;
-    // Persist the resolved model parameters (temperature, max tokens, custom endpoint
-    // params, …) so an ephemeral-agent resume continues with the SAME settings the run
-    // paused on. The resume payload omits them and they aren't part of the fingerprint, so
-    // without this the rebuilt ephemeral run falls back to defaults. (Saved agents source
-    // these from the DB record server-side, so this is belt-and-suspenders for them.)
-    const resumeContext = pickResumeContext(this.options.req?.body);
-    const resolvedModelParameters = this.options.agent?.model_parameters;
-    if (resolvedModelParameters && typeof resolvedModelParameters === 'object') {
-      resumeContext.model_parameters = resolvedModelParameters;
-    }
-    const pendingAction = buildPendingAction(interrupt.payload, {
-      streamId,
-      conversationId: this.conversationId,
-      // runId mirrors the LangGraph checkpoint namespace when the SDK provides it
-      // (its documented meaning), falling back to the response message id.
-      runId: interrupt.checkpointNs ?? this.responseMessageId,
-      responseMessageId: this.responseMessageId,
-      interruptId: interrupt.interruptId,
-      // thread_id was bound to conversationId at run config (config.configurable);
-      // fall back to it when the SDK doesn't echo threadId on the interrupt.
-      threadId: interrupt.threadId ?? this.conversationId,
-      ttlMs: getApprovalTtlMs(checkpointerCfg),
-      // Pin the graph-determining request fields so resume can't rebuild this paused
-      // run on a different agent/tool set (esp. ephemeral agents, whose agent_id is
-      // undefined so the id guard can't tell two configs apart).
-      requestFingerprint: computeAgentRequestFingerprint(this.options.req?.body ?? {}),
-      // Persist those same fields verbatim so the resume route can REPLAY them — a
-      // reload/cross-replica resume can't reconstruct the ephemeral config client-side,
-      // so the server restores it and rebuilds the same graph (and the fingerprint matches).
-      resumeContext,
-    });
-
-    // Job-replacement guard: streamId == conversationId is reused per conversation, so a
-    // newer request can replace this run's job. If this (older) run hits an interrupt
-    // after a replacement, pausing would flip the NEWER job to requires_action with this
-    // stale run's pending action, blocking fresh work behind the wrong approval. Only
-    // pause when the live job is still the one THIS run created (mirrors request.js).
-    if (this.jobCreatedAt != null) {
-      const liveJob = await GenerationJobManager.getJobStore().getJob(streamId);
-      if (!liveJob || liveJob.createdAt !== this.jobCreatedAt) {
-        logger.debug(`[AgentClient] Interrupt fired but job ${streamId} was replaced; not pausing`);
-        return;
-      }
-    }
-
-    const paused = await GenerationJobManager.approvals.pause(streamId, pendingAction);
-    if (!paused) {
-      logger.debug(
-        `[AgentClient] Interrupt fired but job ${streamId} was not running; not pausing`,
-      );
-      return;
-    }
-
-    // Capture deferred tools discovered (via tool_search) earlier in THIS turn so resume
-    // can replay them into createRun. The resumed graph is rebuilt with `messages: []`
-    // (state comes from the checkpoint), so the in-turn tool_search results that mark a
-    // deferred tool discovered aren't present there — without this the paused deferred
-    // tool would be missing from the rebuilt schema-only toolMap and resume would fail
-    // with "unknown tool". Inert for non-deferred turns (the set comes back empty).
-    try {
-      const runMessages =
-        typeof run.getRunMessages === 'function' ? run.getRunMessages() : undefined;
-      if (Array.isArray(runMessages) && runMessages.length > 0) {
-        const discovered = extractDiscoveredToolsFromHistory(runMessages);
-        if (discovered.size > 0) {
-          await GenerationJobManager.updateMetadata(streamId, {
-            discoveredTools: Array.from(discovered),
-          });
-        }
-      }
-    } catch (err) {
-      logger.warn(
-        `[AgentClient] Failed to capture discovered tools for resume on ${streamId}`,
-        err?.message ?? err,
-      );
-    }
-
-    this.pendingApproval = pendingAction;
-    // Release the concurrency slot this request held the MOMENT the turn is durably
-    // paused — before the approval card is emitted — so the user's `/resume` can
-    // re-acquire one immediately. Otherwise a fast Approve races the HTTP-driver
-    // teardown (request.js pause branch / resume.js finally) that would otherwise
-    // release it, and `/resume` 429s under LIMIT_CONCURRENT_MESSAGES. Idempotent via
-    // the flag; if it fails here, the teardown still releases (it checks the flag).
-    if (!this.pendingRequestReleased) {
-      try {
-        await decrementPendingRequest(this.options.req?.user?.id);
-        this.pendingRequestReleased = true;
-      } catch (err) {
-        logger.error(`[AgentClient] Failed to release request slot on pause ${streamId}`, err);
-      }
-    }
-    await GenerationJobManager.emitChunk(streamId, {
-      event: ApprovalEvents.ON_PENDING_ACTION,
-      data: pendingAction,
-    });
-    logger.debug(
-      `[AgentClient] Paused ${streamId} for ${interrupt.payload.type} (action ${pendingAction.actionId})`,
-    );
-  }
-
   async chatCompletion({ payload, userMCPAuthMap, abortController = null }) {
     /** @type {Partial<GraphRunnableConfig>} */
     let config;
@@ -1405,11 +1235,11 @@ class AgentClient extends BaseClient {
       const formatOptions =
         needsReasoningContentFormat || freshSkillPrimeNames.size > 0
           ? {
-              ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
-              ...(freshSkillPrimeNames.size > 0
-                ? { skipSkillBodyNames: freshSkillPrimeNames }
-                : {}),
-            }
+            ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
+            ...(freshSkillPrimeNames.size > 0
+              ? { skipSkillBodyNames: freshSkillPrimeNames }
+              : {}),
+          }
           : undefined;
       let {
         messages: initialMessages,
@@ -1491,12 +1321,12 @@ class AgentClient extends BaseClient {
       const memoryMessages =
         this.processMemory && this.memoryPayload
           ? formatAgentMessages(
-              this.memoryPayload,
-              undefined,
-              toolSet,
-              skillPrimeResult?.skills,
-              formatOptions,
-            ).messages
+            this.memoryPayload,
+            undefined,
+            toolSet,
+            skillPrimeResult?.skills,
+            formatOptions,
+          ).messages
           : initialMessages;
 
       /**
@@ -1558,11 +1388,6 @@ class AgentClient extends BaseClient {
         run = await createRun({
           agents,
           messages,
-          // This controller implements the full HITL pause/resume lifecycle (handleRunInterrupt
-          // persists the pending action; the /resume route rebuilds + continues the run), so it
-          // opts into the tool-approval wiring. Non-resumable callers (OpenAI-compat, Responses)
-          // leave this off so an approval-gated tool can't pause where there's no resume path.
-          hitlCapable: true,
           indexTokenCountMap,
           initialSummary,
           initialSessions,
@@ -1610,29 +1435,16 @@ class AgentClient extends BaseClient {
 
         /** @deprecated Agent Chain */
         config.configurable.last_agent_id = agents[agents.length - 1].id;
-
-        // HITL: clear any checkpoint orphaned by a prior paused turn in this
-        // conversation (one that expired or was aborted while paused) so this fresh
-        // turn starts clean instead of rehydrating a stale interrupt — thread_id is
-        // the stable conversationId. No-op when HITL is off or nothing is orphaned.
-        if (streamId && isHITLEnabled(agentsEConfig?.toolApproval)) {
-          await deleteAgentCheckpoint(this.conversationId, agentsEConfig?.checkpointer);
-        }
-
         await run.processStream({ messages }, config, {
           callbacks: {
             [Callback.TOOL_ERROR]: logToolError,
           },
         });
 
-        // HITL: if the run paused for tool approval, mark the job
-        // `requires_action` + emit the prompt and leave the turn unfinalized
-        // (the resume route continues it). No-op when the run completed.
-        await this.handleRunInterrupt(run, streamId);
-
         config.signal = null;
       };
 
+      const hideSequentialOutputs = config.configurable.hide_sequential_outputs;
       await runAgents(initialMessages);
 
       /**
@@ -1672,7 +1484,20 @@ class AgentClient extends BaseClient {
         this.contentParts.unshift(...manualParts);
       }
 
-      this.applyHideSequentialOutputsFilter();
+      /** @deprecated Agent Chain */
+      if (hideSequentialOutputs) {
+        this.contentParts = this.contentParts.filter((part, index) => {
+          // Include parts that are either:
+          // 1. At or after the finalContentStart index
+          // 2. Of type tool_call
+          // 3. Have tool_call_ids property
+          return (
+            index >= this.contentParts.length - 1 ||
+            part.type === ContentTypes.TOOL_CALL ||
+            part.tool_call_ids
+          );
+        });
+      }
     } catch (err) {
       if (abortController.signal.aborted) {
         logger.debug(
@@ -1742,289 +1567,9 @@ class AgentClient extends BaseClient {
         this._resolveRun(this.run ?? null);
         this._resolveRun = null;
       }
-
-      // HITL: a turn that completed (or errored) without pausing leaves a dead
-      // checkpoint. thread_id is the conversationId — stable across turns — so it
-      // MUST be pruned before the next turn, or LangGraph would resume this turn's
-      // state instead of starting fresh. Skip when paused (the checkpoint is needed
-      // to resume) or when HITL is off (none was written). The Mongo TTL is the backstop.
-      const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
-      if (!this.pendingApproval && isHITLEnabled(agentsEConfig?.toolApproval)) {
-        try {
-          // Job-replacement guard: only prune if THIS generation is still the live job.
-          // A newer request can replace this one on the same conversationId; if this
-          // (older) run's finally lands after the newer run paused, pruning by
-          // conversationId would delete the NEWER run's checkpoint and break its /resume.
-          const resumableStreamId = this.options.req?._resumableStreamId;
-          let replaced = false;
-          if (resumableStreamId && this.jobCreatedAt != null) {
-            const liveJob = await GenerationJobManager.getJobStore().getJob(resumableStreamId);
-            replaced = !liveJob || liveJob.createdAt !== this.jobCreatedAt;
-          }
-          if (replaced) {
-            logger.debug('[AgentClient] Skipping checkpoint prune — job was replaced', {
-              streamId: resumableStreamId,
-            });
-          } else {
-            await deleteAgentCheckpoint(this.conversationId, agentsEConfig?.checkpointer);
-          }
-        } catch (err) {
-          logger.warn('[AgentClient] Failed to prune checkpoint after completion', err);
-        }
-      }
-
       run = null;
       config = null;
       memoryPromise = null;
-    }
-  }
-
-  /**
-   * Resume a run that paused for human-in-the-loop review.
-   *
-   * The original run lives in a detached background task that exits when the run
-   * pauses, so resume REBUILDS the run on a fresh graph bound to the same
-   * `thread_id` (= conversationId) and the durable checkpointer. LangGraph rehydrates
-   * the paused graph state from the checkpoint; `run.resume(value)` re-enters the
-   * interrupted node with the user's decision. State comes from the checkpoint, so
-   * no message history is rebuilt here — `createRun` only needs the agent(s) to
-   * reconstruct the graph structure.
-   *
-   * `seedContent` is the content streamed before the pause (the assistant message +
-   * its tool call). In Redis mode the job store's append log already spans the pause,
-   * so the finalized message is complete regardless; seeding keeps the in-memory store
-   * complete too. The run drives events through the same `streamId`, so the client's
-   * open SSE receives the continuation live.
-   *
-   * Unlike `chatCompletion`, this does NOT prune the checkpoint in its `finally` — the
-   * resume controller owns checkpoint lifecycle (it must also clean up on failures that
-   * happen before this method runs, and keep the checkpoint on a re-pause).
-   *
-   * @param {object} params
-   * @param {Agents.ToolApprovalDecisionMap | { answer: string }} params.resumeValue
-   * @param {Array} [params.seedContent] - content aggregated before the pause
-   * @param {AbortController} [params.abortController]
-   * @param {Pick<import('@langchain/langgraph').Command, 'update' | 'goto'>} [params.commandOptions]
-   */
-  async resumeCompletion({
-    resumeValue,
-    seedContent = [],
-    abortController = null,
-    commandOptions,
-    userMCPAuthMap,
-    discoveredToolNames,
-  }) {
-    /** @type {Partial<GraphRunnableConfig>} */
-    let config;
-    /** @type {ReturnType<createRun>} */
-    let run;
-    const appConfig = this.options.req.config;
-    const balanceConfig = getBalanceConfig(appConfig);
-    const transactionsConfig = getTransactionsConfig(appConfig);
-    try {
-      if (!abortController) {
-        abortController = new AbortController();
-      }
-
-      /** @type {AppConfig['endpoints']['agents']} */
-      const agentsEConfig = appConfig.endpoints?.[EModelEndpoint.agents];
-
-      config = {
-        runName: 'AgentRun',
-        configurable: {
-          thread_id: this.conversationId,
-          last_agent_index: this.agentConfigs?.size ?? 0,
-          user_id: this.user ?? this.options.req.user?.id,
-          hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
-          requestBody: {
-            messageId: this.responseMessageId,
-            conversationId: this.conversationId,
-            parentMessageId: this.parentMessageId,
-          },
-          user: createSafeUser(this.options.req.user),
-        },
-        recursionLimit: resolveRecursionLimit(agentsEConfig, this.options.agent),
-        signal: abortController.signal,
-        streamMode: 'values',
-        version: 'v2',
-      };
-
-      // Seed pre-pause content so the in-memory job store reports the complete turn
-      // (Redis aggregates across the pause via its append log; this covers in-memory).
-      if (Array.isArray(seedContent) && seedContent.length > 0) {
-        this.contentParts.push(...seedContent);
-      }
-
-      const tokenCounter = createTokenCounter(this.getEncoding());
-      const agents = [this.options.agent];
-      if (this.agentConfigs && this.agentConfigs.size > 0) {
-        agents.push(...this.agentConfigs.values());
-      }
-
-      // Re-prime skill files invoked in the pre-pause segment (mirrors the normal path's
-      // `primeInvokedSkills(payload)`), so an approved code/file-backed tool keeps the
-      // injected skill-file session refs instead of running without them. The pre-pause
-      // content carries the `skill` tool_calls, so it stands in for the message payload.
-      let skillSessions;
-      if (
-        typeof this.options.primeInvokedSkills === 'function' &&
-        Array.isArray(seedContent) &&
-        seedContent.length > 0
-      ) {
-        try {
-          const primed = await this.options.primeInvokedSkills([
-            { role: 'assistant', content: seedContent },
-          ]);
-          skillSessions = primed?.initialSessions;
-        } catch (err) {
-          logger.warn(
-            '[api/server/controllers/agents/client.js #resumeCompletion] Failed to re-prime skill sessions',
-            err?.message ?? err,
-          );
-        }
-      }
-
-      // Seed code-env / skill tool sessions so an approved code/file/skill-backed tool
-      // runs with the same uploaded-file context the pre-pause run had — the rebuilt
-      // graph otherwise has no `Graph.sessions` entries (especially cross-replica).
-      const initialSessions = buildInitialToolSessions({ skillSessions, agents });
-
-      run = await createRun({
-        agents,
-        // State (messages, tool calls) is rehydrated from the checkpoint by
-        // run.resume; createRun only needs the agents to rebuild the graph.
-        messages: [],
-        // The resumed run can pause AGAIN (another tool, a follow-up question), and this
-        // controller owns that lifecycle, so it must keep the HITL wiring on the rebuilt run.
-        hitlCapable: true,
-        // Replay deferred tools discovered before the pause. With `messages: []` the
-        // discovery scan finds nothing, so a deferred tool the paused call targets
-        // would be absent from the rebuilt toolMap; these names (captured at pause)
-        // force it back in. Undefined/empty for non-deferred turns — a harmless no-op.
-        discoveredToolNames,
-        initialSessions,
-        runId: this.responseMessageId,
-        signal: abortController.signal,
-        customHandlers: this.options.eventHandlers,
-        requestBody: config.configurable.requestBody,
-        user: createSafeUser(this.options.req?.user),
-        tenantId: this.options.req?.user?.tenantId,
-        summarizationConfig: appConfig?.summarization,
-        appConfig,
-        tokenCounter,
-        subagentUsageSink: createSubagentUsageSink(
-          this.collectedUsage,
-          this.buildSubagentUsageEmitter(appConfig),
-        ),
-      });
-
-      if (!run) {
-        throw new Error('Failed to create run for resume');
-      }
-
-      this.run = run;
-      if (this._resolveRun) {
-        this._resolveRun(run);
-        this._resolveRun = null;
-      }
-
-      const streamId = this.options.req?._resumableStreamId;
-      // Do NOT cache the rebuilt graph on resume: it was created with `messages: []`, so
-      // RedisJobStore.getContentParts() (which prefers a cached graph over reconstructing
-      // from the chunk log) would return only the resumed segment and drop the pre-pause
-      // assistant/tool-call content on a same-replica reload/status poll. Skipping it makes
-      // introspection fall back to the durable chunk reconstruction, which is complete.
-      // `setContentParts` still points the in-memory store at the seeded client content.
-      if (streamId && this.contentParts) {
-        GenerationJobManager.setContentParts(streamId, this.contentParts);
-      }
-
-      // Carry the user's MCP auth into the rebuilt run so an approved MCP tool executes
-      // with the same OAuth/user credentials it had before the pause.
-      if (userMCPAuthMap != null) {
-        config.configurable.userMCPAuthMap = userMCPAuthMap;
-      }
-
-      /** @deprecated Agent Chain */
-      config.configurable.last_agent_id = agents[agents.length - 1].id;
-
-      await run.resume(
-        resumeValue,
-        config,
-        { callbacks: { [Callback.TOOL_ERROR]: logToolError } },
-        commandOptions,
-      );
-
-      config.signal = null;
-
-      // The model may pause AGAIN (another tool needs approval, or a follow-up
-      // question). Re-arm the same interrupt gate so the cycle can repeat.
-      await this.handleRunInterrupt(run, streamId);
-
-      // Mirror chatCompletion: strip hidden intermediate sequential-agent content
-      // before resume finalize/re-pause persistence reads `this.contentParts`, so a
-      // resumed sequential chain doesn't persist/emit outputs hide_sequential_outputs
-      // is meant to hide.
-      this.applyHideSequentialOutputsFilter();
-    } catch (err) {
-      if (abortController.signal.aborted) {
-        logger.debug(
-          '[api/server/controllers/agents/client.js #resumeCompletion] Aborted by user',
-          {
-            conversationId: this.conversationId,
-            name: err?.name,
-            code: err?.code,
-          },
-        );
-      } else {
-        logger.error(
-          '[api/server/controllers/agents/client.js #resumeCompletion] Unhandled error',
-          err,
-        );
-        this.contentParts.push({
-          type: ContentTypes.ERROR,
-          [ContentTypes.ERROR]: `An error occurred while resuming the request${err?.message ? `: ${err.message}` : ''}`,
-        });
-      }
-    } finally {
-      const ratio = this.run?.getCalibrationRatio() ?? 0;
-      if (ratio > 0 && ratio !== 1) {
-        this.contextMeta = {
-          calibrationRatio: Math.round(ratio * 1000) / 1000,
-          encoding: this.getEncoding(),
-        };
-      } else {
-        this.contextMeta = undefined;
-      }
-
-      this.finalizeSubagentContent();
-
-      if (this.pendingSubagentEmits.length > 0) {
-        await Promise.allSettled(this.pendingSubagentEmits);
-        this.pendingSubagentEmits = [];
-      }
-
-      try {
-        const wasAborted = abortController?.signal?.aborted;
-        if (!wasAborted) {
-          await this.recordCollectedUsage({
-            context: 'message',
-            balance: balanceConfig,
-            transactions: transactionsConfig,
-          });
-        }
-      } catch (err) {
-        logger.error(
-          '[api/server/controllers/agents/client.js #resumeCompletion] Error in cleanup phase',
-          err,
-        );
-      }
-      if (this._resolveRun) {
-        this._resolveRun(this.run ?? null);
-        this._resolveRun = null;
-      }
-      run = null;
-      config = null;
     }
   }
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -961,7 +961,7 @@ class AgentClient extends BaseClient {
      *   thoughtSignatures?: Record<string, string>,
      *   contextUsage?: import('librechat-data-provider').TContextUsageEvent,
      *   usage?: import('librechat-data-provider').TResponseUsage,
-     *   annotations?: Array<Annotation>,
+     *   annotations?: Array<Object>,
      * }} */
     const metadata = {};
     const signatures = this.collectedThoughtSignatures;

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -33,7 +33,16 @@ const {
   GenerationJobManager,
   getTransactionsConfig,
   resolveRecursionLimit,
+  buildPendingAction,
+  computeAgentRequestFingerprint,
+  extractDiscoveredToolsFromHistory,
+  pickResumeContext,
+  getApprovalTtlMs,
+  isHITLEnabled,
+  deleteAgentCheckpoint,
+  getRequestMemories,
   createMemoryProcessor,
+  agentHasInlineMemoryTools,
   loadAgent: loadAgentFn,
   createMultiAgentMapper,
   filterMalformedContentParts,
@@ -52,6 +61,7 @@ const {
   hasUrlContextTool,
   appendYouTubeVideoParts,
   resolveYouTubeInjectionConfig,
+  decrementPendingRequest,
 } = require('@librechat/api');
 const {
   Callback,
@@ -67,6 +77,7 @@ const {
   Permissions,
   VisionModes,
   ContentTypes,
+  ApprovalEvents,
   EModelEndpoint,
   PermissionTypes,
   AgentCapabilities,
@@ -225,13 +236,13 @@ class AgentClient extends BaseClient {
     buffer.clear();
   }
 
-  setOptions(_options) { }
+  setOptions(_options) {}
 
   /**
    * `AgentClient` is not opinionated about vision requests, so we don't do anything here
    * @param {MongoFile[]} attachments
    */
-  checkVisionRequest() { }
+  checkVisionRequest() {}
 
   getSaveOptions() {
     let runOptions = {};
@@ -318,9 +329,9 @@ class AgentClient extends BaseClient {
       { agent: normalizeInstructions(this.options.agent), agentId: this.options.agent.id },
       ...(this.agentConfigs?.size > 0
         ? Array.from(this.agentConfigs.entries()).map(([agentId, agent]) => ({
-          agent: normalizeInstructions(agent),
-          agentId,
-        }))
+            agent: normalizeInstructions(agent),
+            agentId,
+          }))
         : []),
     ];
     const sharedRunAttachmentIds = new Set();
@@ -519,11 +530,14 @@ class AgentClient extends BaseClient {
       }
     }
 
-    /** Memory context (user preferences/memories) */
-    const withoutKeys = await this.useMemory();
-    const memoryContext = withoutKeys
-      ? `${memoryInstructions}\n\n# Existing memory about the user:\n${withoutKeys}`
-      : undefined;
+    /** Memory context (user preferences/memories). Keyed context (with memory
+     *  keys + token metadata) is reserved for agents that can call
+     *  `delete_memory`; everyone else gets the unkeyed values only. */
+    const memories = await this.useMemory();
+    const buildMemoryContext = (text) =>
+      text ? `${memoryInstructions}\n\n# Existing memory about the user:\n${text}` : undefined;
+    const memoryContext = buildMemoryContext(memories?.withoutKeys);
+    const keyedMemoryContext = buildMemoryContext(memories?.withKeys);
 
     const sharedRunContext = sharedRunContextParts.join('\n\n');
     const memoryAgentEnabled = isMemoryAgentEnabled(this.options.req.config?.memory);
@@ -574,8 +588,13 @@ class AgentClient extends BaseClient {
     await Promise.all(
       allAgents.map(({ agent, agentId }) => {
         const agentRunContextParts = [sharedRunContext];
-        if (memoryContext && (agentId === this.options.agent.id || memoryAgentEnabled)) {
-          agentRunContextParts.push(memoryContext);
+        const agentHasMemory = agentHasInlineMemoryTools(agent);
+        const agentMemoryContext = agentHasMemory ? keyedMemoryContext : memoryContext;
+        if (
+          agentMemoryContext &&
+          (agentId === this.options.agent.id || memoryAgentEnabled || agentHasMemory)
+        ) {
+          agentRunContextParts.push(agentMemoryContext);
         }
         const scopedContext = agentScopedContext.get(agentId);
         if (scopedContext) {
@@ -626,7 +645,7 @@ class AgentClient extends BaseClient {
   }
 
   /**
-   * @returns {Promise<string | undefined>}
+   * @returns {Promise<{ withKeys?: string; withoutKeys?: string } | undefined>}
    */
   async useMemory() {
     const user = this.options.req.user;
@@ -657,8 +676,12 @@ class AgentClient extends BaseClient {
 
     if (!isMemoryAgentEnabled(memoryConfig)) {
       try {
-        const { withoutKeys } = await db.getFormattedMemories({ userId });
-        return withoutKeys;
+        const { withKeys, withoutKeys } = await getRequestMemories({
+          req: this.options.req,
+          userId,
+          getFormattedMemories: db.getFormattedMemories,
+        });
+        return { withKeys, withoutKeys };
       } catch (error) {
         logger.error(
           '[api/server/controllers/agents/client.js #useMemory] Error loading memories',
@@ -775,7 +798,20 @@ class AgentClient extends BaseClient {
     });
 
     this.processMemory = processMemory;
-    return withoutKeys;
+    let withKeys = withoutKeys;
+    try {
+      ({ withKeys } = await getRequestMemories({
+        req: this.options.req,
+        userId,
+        getFormattedMemories: db.getFormattedMemories,
+      }));
+    } catch (error) {
+      logger.error(
+        '[api/server/controllers/agents/client.js #useMemory] Error loading keyed memories',
+        error,
+      );
+    }
+    return { withKeys, withoutKeys };
   }
 
   /**
@@ -859,12 +895,13 @@ class AgentClient extends BaseClient {
           : DEFAULT_MEMORY_MAX_INPUT_TOKENS;
       const maxInputChars = maxInputTokens * MEMORY_INPUT_CHARS_PER_TOKEN;
       const isCharTruncated = bufferString.length > maxInputChars;
-      const memoryInput = `# Current Chat:\n\n${isCharTruncated
-        ? `[Earlier chat content omitted due to memory input limit]\n\n${bufferString.slice(
-          -maxInputChars,
-        )}`
-        : bufferString
-        }`;
+      const memoryInput = `# Current Chat:\n\n${
+        isCharTruncated
+          ? `[Earlier chat content omitted due to memory input limit]\n\n${bufferString.slice(
+              -maxInputChars,
+            )}`
+          : bufferString
+      }`;
       const {
         text: limitedMemoryInput,
         tokenCount,
@@ -985,7 +1022,6 @@ class AgentClient extends BaseClient {
       metadata.annotations = this.collectedAnnotations;
     }
 
-
     return Object.keys(metadata).length > 0 ? metadata : undefined;
   }
 
@@ -1088,10 +1124,10 @@ class AgentClient extends BaseClient {
          *  differ from the parent's); `usage.agentId` is tagged by the sink. */
         cost: includeCost
           ? computeUsageCostUSD(
-            usage,
-            { getMultiplier: db.getMultiplier, getCacheMultiplier: db.getCacheMultiplier },
-            this.resolveAgentEndpointTokenConfig(usage),
-          )
+              usage,
+              { getMultiplier: db.getMultiplier, getCacheMultiplier: db.getCacheMultiplier },
+              this.resolveAgentEndpointTokenConfig(usage),
+            )
           : undefined,
       };
       /** Fold into the response's usage rollup (synchronously, regardless of
@@ -1148,6 +1184,150 @@ class AgentClient extends BaseClient {
    * @param {Record<string, Record<string, string>>} [params.userMCPAuthMap]
    * @param {AbortController} [params.abortController]
    */
+  /**
+   * @deprecated Agent Chain — strip hidden intermediate sequential-agent content
+   * before persistence, keeping only the last part + tool_call parts. Mirrors the
+   * chat path so a HITL resume doesn't persist/emit intermediate outputs the
+   * agent's `hide_sequential_outputs` setting is meant to hide.
+   */
+  applyHideSequentialOutputsFilter() {
+    if (!this.options.agent?.hide_sequential_outputs || !Array.isArray(this.contentParts)) {
+      return;
+    }
+    this.contentParts = this.contentParts.filter(
+      (part, index) =>
+        index >= this.contentParts.length - 1 ||
+        part.type === ContentTypes.TOOL_CALL ||
+        part.tool_call_ids,
+    );
+  }
+
+  /**
+   * Surface any human-in-the-loop interrupt the SDK captured during the most
+   * recent `processStream` / `resume`. When the run paused for tool approval (or
+   * an ask-user question), mark the job `requires_action`, persist the pending
+   * review record, and emit it to live clients — then set `this.pendingApproval`
+   * so the controller leaves the turn unfinalized for the resume route to continue.
+   *
+   * No-op when the run completed without an interrupt, or when the job was aborted
+   * between the interrupt firing and this mark (a late interrupt must not pause a
+   * dead job — the atomic `pause` transition returns false and we drop it).
+   *
+   * @param {AgentRun} run
+   * @param {string} [streamId]
+   */
+  async handleRunInterrupt(run, streamId) {
+    if (!streamId || typeof run?.getInterrupt !== 'function') {
+      return;
+    }
+    const interrupt = run.getInterrupt();
+    if (!interrupt?.payload) {
+      return;
+    }
+
+    const appConfig = this.options.req?.config;
+    const checkpointerCfg = appConfig?.endpoints?.[EModelEndpoint.agents]?.checkpointer;
+    // Persist the resolved model parameters (temperature, max tokens, custom endpoint
+    // params, …) so an ephemeral-agent resume continues with the SAME settings the run
+    // paused on. The resume payload omits them and they aren't part of the fingerprint, so
+    // without this the rebuilt ephemeral run falls back to defaults. (Saved agents source
+    // these from the DB record server-side, so this is belt-and-suspenders for them.)
+    const resumeContext = pickResumeContext(this.options.req?.body);
+    const resolvedModelParameters = this.options.agent?.model_parameters;
+    if (resolvedModelParameters && typeof resolvedModelParameters === 'object') {
+      resumeContext.model_parameters = resolvedModelParameters;
+    }
+    const pendingAction = buildPendingAction(interrupt.payload, {
+      streamId,
+      conversationId: this.conversationId,
+      // runId mirrors the LangGraph checkpoint namespace when the SDK provides it
+      // (its documented meaning), falling back to the response message id.
+      runId: interrupt.checkpointNs ?? this.responseMessageId,
+      responseMessageId: this.responseMessageId,
+      interruptId: interrupt.interruptId,
+      // thread_id was bound to conversationId at run config (config.configurable);
+      // fall back to it when the SDK doesn't echo threadId on the interrupt.
+      threadId: interrupt.threadId ?? this.conversationId,
+      ttlMs: getApprovalTtlMs(checkpointerCfg),
+      // Pin the graph-determining request fields so resume can't rebuild this paused
+      // run on a different agent/tool set (esp. ephemeral agents, whose agent_id is
+      // undefined so the id guard can't tell two configs apart).
+      requestFingerprint: computeAgentRequestFingerprint(this.options.req?.body ?? {}),
+      // Persist those same fields verbatim so the resume route can REPLAY them — a
+      // reload/cross-replica resume can't reconstruct the ephemeral config client-side,
+      // so the server restores it and rebuilds the same graph (and the fingerprint matches).
+      resumeContext,
+    });
+
+    // Job-replacement guard: streamId == conversationId is reused per conversation, so a
+    // newer request can replace this run's job. If this (older) run hits an interrupt
+    // after a replacement, pausing would flip the NEWER job to requires_action with this
+    // stale run's pending action, blocking fresh work behind the wrong approval. Only
+    // pause when the live job is still the one THIS run created (mirrors request.js).
+    if (this.jobCreatedAt != null) {
+      const liveJob = await GenerationJobManager.getJobStore().getJob(streamId);
+      if (!liveJob || liveJob.createdAt !== this.jobCreatedAt) {
+        logger.debug(`[AgentClient] Interrupt fired but job ${streamId} was replaced; not pausing`);
+        return;
+      }
+    }
+
+    const paused = await GenerationJobManager.approvals.pause(streamId, pendingAction);
+    if (!paused) {
+      logger.debug(
+        `[AgentClient] Interrupt fired but job ${streamId} was not running; not pausing`,
+      );
+      return;
+    }
+
+    // Capture deferred tools discovered (via tool_search) earlier in THIS turn so resume
+    // can replay them into createRun. The resumed graph is rebuilt with `messages: []`
+    // (state comes from the checkpoint), so the in-turn tool_search results that mark a
+    // deferred tool discovered aren't present there — without this the paused deferred
+    // tool would be missing from the rebuilt schema-only toolMap and resume would fail
+    // with "unknown tool". Inert for non-deferred turns (the set comes back empty).
+    try {
+      const runMessages =
+        typeof run.getRunMessages === 'function' ? run.getRunMessages() : undefined;
+      if (Array.isArray(runMessages) && runMessages.length > 0) {
+        const discovered = extractDiscoveredToolsFromHistory(runMessages);
+        if (discovered.size > 0) {
+          await GenerationJobManager.updateMetadata(streamId, {
+            discoveredTools: Array.from(discovered),
+          });
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        `[AgentClient] Failed to capture discovered tools for resume on ${streamId}`,
+        err?.message ?? err,
+      );
+    }
+
+    this.pendingApproval = pendingAction;
+    // Release the concurrency slot this request held the MOMENT the turn is durably
+    // paused — before the approval card is emitted — so the user's `/resume` can
+    // re-acquire one immediately. Otherwise a fast Approve races the HTTP-driver
+    // teardown (request.js pause branch / resume.js finally) that would otherwise
+    // release it, and `/resume` 429s under LIMIT_CONCURRENT_MESSAGES. Idempotent via
+    // the flag; if it fails here, the teardown still releases (it checks the flag).
+    if (!this.pendingRequestReleased) {
+      try {
+        await decrementPendingRequest(this.options.req?.user?.id);
+        this.pendingRequestReleased = true;
+      } catch (err) {
+        logger.error(`[AgentClient] Failed to release request slot on pause ${streamId}`, err);
+      }
+    }
+    await GenerationJobManager.emitChunk(streamId, {
+      event: ApprovalEvents.ON_PENDING_ACTION,
+      data: pendingAction,
+    });
+    logger.debug(
+      `[AgentClient] Paused ${streamId} for ${interrupt.payload.type} (action ${pendingAction.actionId})`,
+    );
+  }
+
   async chatCompletion({ payload, userMCPAuthMap, abortController = null }) {
     /** @type {Partial<GraphRunnableConfig>} */
     let config;
@@ -1235,11 +1415,11 @@ class AgentClient extends BaseClient {
       const formatOptions =
         needsReasoningContentFormat || freshSkillPrimeNames.size > 0
           ? {
-            ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
-            ...(freshSkillPrimeNames.size > 0
-              ? { skipSkillBodyNames: freshSkillPrimeNames }
-              : {}),
-          }
+              ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
+              ...(freshSkillPrimeNames.size > 0
+                ? { skipSkillBodyNames: freshSkillPrimeNames }
+                : {}),
+            }
           : undefined;
       let {
         messages: initialMessages,
@@ -1321,12 +1501,12 @@ class AgentClient extends BaseClient {
       const memoryMessages =
         this.processMemory && this.memoryPayload
           ? formatAgentMessages(
-            this.memoryPayload,
-            undefined,
-            toolSet,
-            skillPrimeResult?.skills,
-            formatOptions,
-          ).messages
+              this.memoryPayload,
+              undefined,
+              toolSet,
+              skillPrimeResult?.skills,
+              formatOptions,
+            ).messages
           : initialMessages;
 
       /**
@@ -1388,6 +1568,11 @@ class AgentClient extends BaseClient {
         run = await createRun({
           agents,
           messages,
+          // This controller implements the full HITL pause/resume lifecycle (handleRunInterrupt
+          // persists the pending action; the /resume route rebuilds + continues the run), so it
+          // opts into the tool-approval wiring. Non-resumable callers (OpenAI-compat, Responses)
+          // leave this off so an approval-gated tool can't pause where there's no resume path.
+          hitlCapable: true,
           indexTokenCountMap,
           initialSummary,
           initialSessions,
@@ -1435,16 +1620,29 @@ class AgentClient extends BaseClient {
 
         /** @deprecated Agent Chain */
         config.configurable.last_agent_id = agents[agents.length - 1].id;
+
+        // HITL: clear any checkpoint orphaned by a prior paused turn in this
+        // conversation (one that expired or was aborted while paused) so this fresh
+        // turn starts clean instead of rehydrating a stale interrupt — thread_id is
+        // the stable conversationId. No-op when HITL is off or nothing is orphaned.
+        if (streamId && isHITLEnabled(agentsEConfig?.toolApproval)) {
+          await deleteAgentCheckpoint(this.conversationId, agentsEConfig?.checkpointer);
+        }
+
         await run.processStream({ messages }, config, {
           callbacks: {
             [Callback.TOOL_ERROR]: logToolError,
           },
         });
 
+        // HITL: if the run paused for tool approval, mark the job
+        // `requires_action` + emit the prompt and leave the turn unfinalized
+        // (the resume route continues it). No-op when the run completed.
+        await this.handleRunInterrupt(run, streamId);
+
         config.signal = null;
       };
 
-      const hideSequentialOutputs = config.configurable.hide_sequential_outputs;
       await runAgents(initialMessages);
 
       /**
@@ -1484,20 +1682,7 @@ class AgentClient extends BaseClient {
         this.contentParts.unshift(...manualParts);
       }
 
-      /** @deprecated Agent Chain */
-      if (hideSequentialOutputs) {
-        this.contentParts = this.contentParts.filter((part, index) => {
-          // Include parts that are either:
-          // 1. At or after the finalContentStart index
-          // 2. Of type tool_call
-          // 3. Have tool_call_ids property
-          return (
-            index >= this.contentParts.length - 1 ||
-            part.type === ContentTypes.TOOL_CALL ||
-            part.tool_call_ids
-          );
-        });
-      }
+      this.applyHideSequentialOutputsFilter();
     } catch (err) {
       if (abortController.signal.aborted) {
         logger.debug(
@@ -1567,9 +1752,289 @@ class AgentClient extends BaseClient {
         this._resolveRun(this.run ?? null);
         this._resolveRun = null;
       }
+
+      // HITL: a turn that completed (or errored) without pausing leaves a dead
+      // checkpoint. thread_id is the conversationId — stable across turns — so it
+      // MUST be pruned before the next turn, or LangGraph would resume this turn's
+      // state instead of starting fresh. Skip when paused (the checkpoint is needed
+      // to resume) or when HITL is off (none was written). The Mongo TTL is the backstop.
+      const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
+      if (!this.pendingApproval && isHITLEnabled(agentsEConfig?.toolApproval)) {
+        try {
+          // Job-replacement guard: only prune if THIS generation is still the live job.
+          // A newer request can replace this one on the same conversationId; if this
+          // (older) run's finally lands after the newer run paused, pruning by
+          // conversationId would delete the NEWER run's checkpoint and break its /resume.
+          const resumableStreamId = this.options.req?._resumableStreamId;
+          let replaced = false;
+          if (resumableStreamId && this.jobCreatedAt != null) {
+            const liveJob = await GenerationJobManager.getJobStore().getJob(resumableStreamId);
+            replaced = !liveJob || liveJob.createdAt !== this.jobCreatedAt;
+          }
+          if (replaced) {
+            logger.debug('[AgentClient] Skipping checkpoint prune — job was replaced', {
+              streamId: resumableStreamId,
+            });
+          } else {
+            await deleteAgentCheckpoint(this.conversationId, agentsEConfig?.checkpointer);
+          }
+        } catch (err) {
+          logger.warn('[AgentClient] Failed to prune checkpoint after completion', err);
+        }
+      }
+
       run = null;
       config = null;
       memoryPromise = null;
+    }
+  }
+
+  /**
+   * Resume a run that paused for human-in-the-loop review.
+   *
+   * The original run lives in a detached background task that exits when the run
+   * pauses, so resume REBUILDS the run on a fresh graph bound to the same
+   * `thread_id` (= conversationId) and the durable checkpointer. LangGraph rehydrates
+   * the paused graph state from the checkpoint; `run.resume(value)` re-enters the
+   * interrupted node with the user's decision. State comes from the checkpoint, so
+   * no message history is rebuilt here — `createRun` only needs the agent(s) to
+   * reconstruct the graph structure.
+   *
+   * `seedContent` is the content streamed before the pause (the assistant message +
+   * its tool call). In Redis mode the job store's append log already spans the pause,
+   * so the finalized message is complete regardless; seeding keeps the in-memory store
+   * complete too. The run drives events through the same `streamId`, so the client's
+   * open SSE receives the continuation live.
+   *
+   * Unlike `chatCompletion`, this does NOT prune the checkpoint in its `finally` — the
+   * resume controller owns checkpoint lifecycle (it must also clean up on failures that
+   * happen before this method runs, and keep the checkpoint on a re-pause).
+   *
+   * @param {object} params
+   * @param {Agents.ToolApprovalDecisionMap | { answer: string }} params.resumeValue
+   * @param {Array} [params.seedContent] - content aggregated before the pause
+   * @param {AbortController} [params.abortController]
+   * @param {Pick<import('@langchain/langgraph').Command, 'update' | 'goto'>} [params.commandOptions]
+   */
+  async resumeCompletion({
+    resumeValue,
+    seedContent = [],
+    abortController = null,
+    commandOptions,
+    userMCPAuthMap,
+    discoveredToolNames,
+  }) {
+    /** @type {Partial<GraphRunnableConfig>} */
+    let config;
+    /** @type {ReturnType<createRun>} */
+    let run;
+    const appConfig = this.options.req.config;
+    const balanceConfig = getBalanceConfig(appConfig);
+    const transactionsConfig = getTransactionsConfig(appConfig);
+    try {
+      if (!abortController) {
+        abortController = new AbortController();
+      }
+
+      /** @type {AppConfig['endpoints']['agents']} */
+      const agentsEConfig = appConfig.endpoints?.[EModelEndpoint.agents];
+
+      config = {
+        runName: 'AgentRun',
+        configurable: {
+          thread_id: this.conversationId,
+          last_agent_index: this.agentConfigs?.size ?? 0,
+          user_id: this.user ?? this.options.req.user?.id,
+          hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
+          requestBody: {
+            messageId: this.responseMessageId,
+            conversationId: this.conversationId,
+            parentMessageId: this.parentMessageId,
+          },
+          user: createSafeUser(this.options.req.user),
+        },
+        recursionLimit: resolveRecursionLimit(agentsEConfig, this.options.agent),
+        signal: abortController.signal,
+        streamMode: 'values',
+        version: 'v2',
+      };
+
+      // Seed pre-pause content so the in-memory job store reports the complete turn
+      // (Redis aggregates across the pause via its append log; this covers in-memory).
+      if (Array.isArray(seedContent) && seedContent.length > 0) {
+        this.contentParts.push(...seedContent);
+      }
+
+      const tokenCounter = createTokenCounter(this.getEncoding());
+      const agents = [this.options.agent];
+      if (this.agentConfigs && this.agentConfigs.size > 0) {
+        agents.push(...this.agentConfigs.values());
+      }
+
+      // Re-prime skill files invoked in the pre-pause segment (mirrors the normal path's
+      // `primeInvokedSkills(payload)`), so an approved code/file-backed tool keeps the
+      // injected skill-file session refs instead of running without them. The pre-pause
+      // content carries the `skill` tool_calls, so it stands in for the message payload.
+      let skillSessions;
+      if (
+        typeof this.options.primeInvokedSkills === 'function' &&
+        Array.isArray(seedContent) &&
+        seedContent.length > 0
+      ) {
+        try {
+          const primed = await this.options.primeInvokedSkills([
+            { role: 'assistant', content: seedContent },
+          ]);
+          skillSessions = primed?.initialSessions;
+        } catch (err) {
+          logger.warn(
+            '[api/server/controllers/agents/client.js #resumeCompletion] Failed to re-prime skill sessions',
+            err?.message ?? err,
+          );
+        }
+      }
+
+      // Seed code-env / skill tool sessions so an approved code/file/skill-backed tool
+      // runs with the same uploaded-file context the pre-pause run had — the rebuilt
+      // graph otherwise has no `Graph.sessions` entries (especially cross-replica).
+      const initialSessions = buildInitialToolSessions({ skillSessions, agents });
+
+      run = await createRun({
+        agents,
+        // State (messages, tool calls) is rehydrated from the checkpoint by
+        // run.resume; createRun only needs the agents to rebuild the graph.
+        messages: [],
+        // The resumed run can pause AGAIN (another tool, a follow-up question), and this
+        // controller owns that lifecycle, so it must keep the HITL wiring on the rebuilt run.
+        hitlCapable: true,
+        // Replay deferred tools discovered before the pause. With `messages: []` the
+        // discovery scan finds nothing, so a deferred tool the paused call targets
+        // would be absent from the rebuilt toolMap; these names (captured at pause)
+        // force it back in. Undefined/empty for non-deferred turns — a harmless no-op.
+        discoveredToolNames,
+        initialSessions,
+        runId: this.responseMessageId,
+        signal: abortController.signal,
+        customHandlers: this.options.eventHandlers,
+        requestBody: config.configurable.requestBody,
+        user: createSafeUser(this.options.req?.user),
+        tenantId: this.options.req?.user?.tenantId,
+        summarizationConfig: appConfig?.summarization,
+        appConfig,
+        tokenCounter,
+        subagentUsageSink: createSubagentUsageSink(
+          this.collectedUsage,
+          this.buildSubagentUsageEmitter(appConfig),
+        ),
+      });
+
+      if (!run) {
+        throw new Error('Failed to create run for resume');
+      }
+
+      this.run = run;
+      if (this._resolveRun) {
+        this._resolveRun(run);
+        this._resolveRun = null;
+      }
+
+      const streamId = this.options.req?._resumableStreamId;
+      // Do NOT cache the rebuilt graph on resume: it was created with `messages: []`, so
+      // RedisJobStore.getContentParts() (which prefers a cached graph over reconstructing
+      // from the chunk log) would return only the resumed segment and drop the pre-pause
+      // assistant/tool-call content on a same-replica reload/status poll. Skipping it makes
+      // introspection fall back to the durable chunk reconstruction, which is complete.
+      // `setContentParts` still points the in-memory store at the seeded client content.
+      if (streamId && this.contentParts) {
+        GenerationJobManager.setContentParts(streamId, this.contentParts);
+      }
+
+      // Carry the user's MCP auth into the rebuilt run so an approved MCP tool executes
+      // with the same OAuth/user credentials it had before the pause.
+      if (userMCPAuthMap != null) {
+        config.configurable.userMCPAuthMap = userMCPAuthMap;
+      }
+
+      /** @deprecated Agent Chain */
+      config.configurable.last_agent_id = agents[agents.length - 1].id;
+
+      await run.resume(
+        resumeValue,
+        config,
+        { callbacks: { [Callback.TOOL_ERROR]: logToolError } },
+        commandOptions,
+      );
+
+      config.signal = null;
+
+      // The model may pause AGAIN (another tool needs approval, or a follow-up
+      // question). Re-arm the same interrupt gate so the cycle can repeat.
+      await this.handleRunInterrupt(run, streamId);
+
+      // Mirror chatCompletion: strip hidden intermediate sequential-agent content
+      // before resume finalize/re-pause persistence reads `this.contentParts`, so a
+      // resumed sequential chain doesn't persist/emit outputs hide_sequential_outputs
+      // is meant to hide.
+      this.applyHideSequentialOutputsFilter();
+    } catch (err) {
+      if (abortController.signal.aborted) {
+        logger.debug(
+          '[api/server/controllers/agents/client.js #resumeCompletion] Aborted by user',
+          {
+            conversationId: this.conversationId,
+            name: err?.name,
+            code: err?.code,
+          },
+        );
+      } else {
+        logger.error(
+          '[api/server/controllers/agents/client.js #resumeCompletion] Unhandled error',
+          err,
+        );
+        this.contentParts.push({
+          type: ContentTypes.ERROR,
+          [ContentTypes.ERROR]: `An error occurred while resuming the request${err?.message ? `: ${err.message}` : ''}`,
+        });
+      }
+    } finally {
+      const ratio = this.run?.getCalibrationRatio() ?? 0;
+      if (ratio > 0 && ratio !== 1) {
+        this.contextMeta = {
+          calibrationRatio: Math.round(ratio * 1000) / 1000,
+          encoding: this.getEncoding(),
+        };
+      } else {
+        this.contextMeta = undefined;
+      }
+
+      this.finalizeSubagentContent();
+
+      if (this.pendingSubagentEmits.length > 0) {
+        await Promise.allSettled(this.pendingSubagentEmits);
+        this.pendingSubagentEmits = [];
+      }
+
+      try {
+        const wasAborted = abortController?.signal?.aborted;
+        if (!wasAborted) {
+          await this.recordCollectedUsage({
+            context: 'message',
+            balance: balanceConfig,
+            transactions: transactionsConfig,
+          });
+        }
+      } catch (err) {
+        logger.error(
+          '[api/server/controllers/agents/client.js #resumeCompletion] Error in cleanup phase',
+          err,
+        );
+      }
+      if (this._resolveRun) {
+        this._resolveRun(this.run ?? null);
+        this._resolveRun = null;
+      }
+      run = null;
+      config = null;
     }
   }
 

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -1,10 +1,8 @@
 const { logger } = require('@librechat/data-schemas');
 const { createContentAggregator } = require('@librechat/agents');
 const {
-  checkAccess,
   loadSkillStates,
   initializeAgent,
-  isMemoryEnabled,
   primeInvokedSkills,
   validateAgentModel,
   extractManualSkills,
@@ -17,11 +15,9 @@ const {
   buildAgentContextAttachmentsByAgentId,
 } = require('@librechat/api');
 const {
-  Permissions,
   ResourceType,
   EModelEndpoint,
   PermissionBits,
-  PermissionTypes,
   MAX_SUBAGENT_DEPTH,
   isAgentsEndpoint,
   getResponseSender,
@@ -121,6 +117,8 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
 
   /** @type {Array<UsageMetadata>} */
   const collectedUsage = [];
+  /** @type {Array<Object>} */
+  const collectedAnnotations = [];
   /**
    * Vertex Gemini 3 thought signatures captured from `chat_model_end` events,
    * keyed by `tool_call_id`. Persisted on
@@ -151,24 +149,6 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
   const codeEnvAvailable = enabledCapabilities.has(AgentCapabilities.execute_code);
   const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
   const skillDbMethods = getSkillDbMethods();
-
-  /** Run-level gate for inline memory tools: the `memory` capability must be
-   *  enabled, memory must be configured, and the user must not have opted out.
-   *  Requires the memory WRITE permissions (CREATE + UPDATE) — both inline tools
-   *  mutate memory — so the tools aren't registered (and shown to the model) for
-   *  read-only-memory roles that the runtime loader would then refuse to build.
-   *  Agents (or the ephemeral memory badge) opt in per-agent via the `memory`
-   *  marker on `tools`. */
-  const memoryAvailable =
-    enabledCapabilities.has(AgentCapabilities.memory) &&
-    isMemoryEnabled(appConfig?.memory) &&
-    req.user?.personalization?.memories !== false &&
-    (await checkAccess({
-      user: req.user,
-      permissionType: PermissionTypes.MEMORIES,
-      permissions: [Permissions.USE, Permissions.CREATE, Permissions.UPDATE],
-      getRoleByName: db.getRoleByName,
-    }));
 
   const accessibleSkillIds = skillsCapabilityEnabled
     ? withDeploymentSkillIds(
@@ -290,6 +270,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     aggregateContent,
     toolEndCallback,
     collectedUsage,
+    collectedAnnotations,
     collectedThoughtSignatures,
     streamId,
     subagentAggregatorsByToolCallId,
@@ -405,7 +386,6 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       accessibleSkillIds: primaryScopedSkillIds,
       skillAuthoringAvailable: primarySkillAuthoringAvailable,
       codeEnvAvailable,
-      memoryAvailable,
       skillStates,
       defaultActiveOnShare,
       manualSkills,
@@ -481,7 +461,6 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       skillStates,
       defaultActiveOnShare,
       codeEnvAvailable,
-      memoryAvailable,
     },
     {
       getAgent: db.getAgent,
@@ -553,7 +532,6 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     skillStates,
     defaultActiveOnShare,
     codeEnvAvailable,
-    memoryAvailable,
   });
 
   if (updatedMCPAuthMap) {
@@ -692,7 +670,6 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
            *  false`, so `bash_tool` / `read_file` sandbox fallback are
            *  silently gated off even though the seed walk found it. */
           codeEnvAvailable,
-          memoryAvailable,
           skillStates,
           defaultActiveOnShare,
         },
@@ -961,6 +938,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     agentConfigs,
     eventHandlers,
     collectedUsage,
+    collectedAnnotations,
     collectedThoughtSignatures,
     aggregateContent,
     artifactPromises,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -1,8 +1,10 @@
 const { logger } = require('@librechat/data-schemas');
 const { createContentAggregator } = require('@librechat/agents');
 const {
+  checkAccess,
   loadSkillStates,
   initializeAgent,
+  isMemoryEnabled,
   primeInvokedSkills,
   validateAgentModel,
   extractManualSkills,
@@ -15,9 +17,11 @@ const {
   buildAgentContextAttachmentsByAgentId,
 } = require('@librechat/api');
 const {
+  Permissions,
   ResourceType,
   EModelEndpoint,
   PermissionBits,
+  PermissionTypes,
   MAX_SUBAGENT_DEPTH,
   isAgentsEndpoint,
   getResponseSender,
@@ -149,6 +153,24 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
   const codeEnvAvailable = enabledCapabilities.has(AgentCapabilities.execute_code);
   const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
   const skillDbMethods = getSkillDbMethods();
+
+  /** Run-level gate for inline memory tools: the `memory` capability must be
+   *  enabled, memory must be configured, and the user must not have opted out.
+   *  Requires the memory WRITE permissions (CREATE + UPDATE) — both inline tools
+   *  mutate memory — so the tools aren't registered (and shown to the model) for
+   *  read-only-memory roles that the runtime loader would then refuse to build.
+   *  Agents (or the ephemeral memory badge) opt in per-agent via the `memory`
+   *  marker on `tools`. */
+  const memoryAvailable =
+    enabledCapabilities.has(AgentCapabilities.memory) &&
+    isMemoryEnabled(appConfig?.memory) &&
+    req.user?.personalization?.memories !== false &&
+    (await checkAccess({
+      user: req.user,
+      permissionType: PermissionTypes.MEMORIES,
+      permissions: [Permissions.USE, Permissions.CREATE, Permissions.UPDATE],
+      getRoleByName: db.getRoleByName,
+    }));
 
   const accessibleSkillIds = skillsCapabilityEnabled
     ? withDeploymentSkillIds(
@@ -386,6 +408,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       accessibleSkillIds: primaryScopedSkillIds,
       skillAuthoringAvailable: primarySkillAuthoringAvailable,
       codeEnvAvailable,
+      memoryAvailable,
       skillStates,
       defaultActiveOnShare,
       manualSkills,
@@ -461,6 +484,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       skillStates,
       defaultActiveOnShare,
       codeEnvAvailable,
+      memoryAvailable,
     },
     {
       getAgent: db.getAgent,
@@ -532,6 +556,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     skillStates,
     defaultActiveOnShare,
     codeEnvAvailable,
+    memoryAvailable,
   });
 
   if (updatedMCPAuthMap) {
@@ -670,6 +695,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
            *  false`, so `bash_tool` / `read_file` sandbox fallback are
            *  silently gated off even though the seed walk found it. */
           codeEnvAvailable,
+          memoryAvailable,
           skillStates,
           defaultActiveOnShare,
         },


### PR DESCRIPTION
## Summary
 
This PR preserves structured `annotations` returned by Responses API-compatible providers and stores them on the assistant message metadata.
 
Currently, Responses API annotations such as `url_citation` can be present in the raw provider output, but they are lost when the response is normalized into LibreChat's internal `contentParts` format. The visible assistant text and inline citation links remain, but the structured annotation objects are no longer available to the UI.
 
This change collects provider annotations during the model end event and carries them through the agent response lifecycle so they can be persisted as message metadata.
 
## Changes
 
- Collects nested `annotations` from model output in the agent model-end handler.
- Adds a per-response `collectedAnnotations` array shared between handlers and `AgentClient`.
- Persists collected annotations on assistant message metadata as:
  - `metadata.annotations`
- Keeps visible assistant content unchanged.
 
## Why
 
Responses API annotations contain structured citation data such as:
 
- citation type
- URL
- title
- start/end indices
- provider-specific fields
 
Keeping this data separate from the visible assistant text allows the UI to render citations more reliably without reparsing markdown links from the response text.
 
## Notes
 
This does not add a new database field. LibreChat already persists message `metadata`, so annotations are stored there as provider metadata.
 
Related discussion: https://github.com/danny-avila/LibreChat/discussions/13963