### PR TITLE
fix(agents): Responses API store:true persists no messages ("User not authenticated")

### DIFF
--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -4,6 +4,7 @@ const { logger } = require('@librechat/data-schemas');
 const { Callback, ToolEndHandler, formatAgentMessages } = require('@librechat/agents');
 const {
   EModelEndpoint,
+  Constants,
   ResourceType,
   PermissionBits,
   hasPermissions,
@@ -163,15 +164,22 @@ async function loadPreviousMessages(conversationId, userId) {
  * @param {string} agentId
  * @returns {Promise<void>}
  */
-async function saveInputMessages(req, conversationId, inputMessages, agentId) {
+async function saveInputMessages(req, conversationId, inputMessages, agentId, initialParentId) {
+  const userContext = {
+    userId: req?.user?.id,
+    isTemporary: req?.body?.isTemporary,
+    interfaceConfig: req?.config?.interfaceConfig,
+  };
+  let parentMessageId = initialParentId ?? Constants.NO_PARENT;
   for (const msg of inputMessages) {
     if (msg.role === 'user') {
+      const messageId = msg.messageId || nanoid();
       await db.saveMessage(
-        req,
+        userContext,
         {
-          messageId: msg.messageId || nanoid(),
+          messageId,
           conversationId,
-          parentMessageId: null,
+          parentMessageId,
           isCreatedByUser: true,
           text: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
           sender: 'User',
@@ -180,8 +188,10 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId) {
         },
         { context: 'Responses API - save user input' },
       );
+      parentMessageId = messageId;
     }
   }
+  return parentMessageId;
 }
 
 /**
@@ -193,7 +203,7 @@ async function saveInputMessages(req, conversationId, inputMessages, agentId) {
  * @param {string} agentId
  * @returns {Promise<void>}
  */
-async function saveResponseOutput(req, conversationId, responseId, response, agentId) {
+async function saveResponseOutput(req, conversationId, responseId, response, agentId, parentMessageId) {
   // Extract text content from output items
   let responseText = '';
   for (const item of response.output) {
@@ -208,11 +218,15 @@ async function saveResponseOutput(req, conversationId, responseId, response, age
 
   // Save the assistant message
   await db.saveMessage(
-    req,
+    {
+      userId: req?.user?.id,
+      isTemporary: req?.body?.isTemporary,
+      interfaceConfig: req?.config?.interfaceConfig,
+    },
     {
       messageId: responseId,
       conversationId,
-      parentMessageId: null,
+      parentMessageId: parentMessageId ?? Constants.NO_PARENT,
       isCreatedByUser: false,
       text: responseText,
       sender: 'Agent',
@@ -243,7 +257,7 @@ async function saveConversation(req, conversationId, agentId, agent) {
     {
       conversationId,
       endpoint: EModelEndpoint.agents,
-      agentId,
+      agent_id: agentId,
       title: agent?.name || 'Open Responses Conversation',
       model: agent?.model,
     },
@@ -848,15 +862,34 @@ const createResponse = async (req, res) => {
       // Save to database if store: true
       if (request.store === true) {
         try {
-          // Save conversation
-          await saveConversation(req, conversationId, agentId, agent);
+          // Thread parent: last prior message (continuation) or NO_PARENT (new conversation)
+          const initialParentId =
+            previousMessages.length > 0
+              ? previousMessages[previousMessages.length - 1].messageId
+              : Constants.NO_PARENT;
 
-          // Save input messages
-          await saveInputMessages(req, conversationId, inputMessages, agentId);
+          // Save messages first so saveConversation's getMessages() picks them up
+          const lastUserMessageId = await saveInputMessages(
+            req,
+            conversationId,
+            inputMessages,
+            agentId,
+            initialParentId,
+          );
 
           // Build response for saving (use tracker with buildResponse for streaming)
           const finalResponse = buildResponse(context, tracker, 'completed');
-          await saveResponseOutput(req, conversationId, responseId, finalResponse, agentId);
+          await saveResponseOutput(
+            req,
+            conversationId,
+            responseId,
+            finalResponse,
+            agentId,
+            lastUserMessageId,
+          );
+
+          // Save conversation last so its message list reflects the new messages
+          await saveConversation(req, conversationId, agentId, agent);
 
           logger.debug(
             `[Responses API] Stored response ${responseId} in conversation ${conversationId}`,
@@ -1027,11 +1060,29 @@ const createResponse = async (req, res) => {
 
       if (request.store === true) {
         try {
+          const initialParentId =
+            previousMessages.length > 0
+              ? previousMessages[previousMessages.length - 1].messageId
+              : Constants.NO_PARENT;
+
+          const lastUserMessageId = await saveInputMessages(
+            req,
+            conversationId,
+            inputMessages,
+            agentId,
+            initialParentId,
+          );
+
+          await saveResponseOutput(
+            req,
+            conversationId,
+            responseId,
+            response,
+            agentId,
+            lastUserMessageId,
+          );
+
           await saveConversation(req, conversationId, agentId, agent);
-
-          await saveInputMessages(req, conversationId, inputMessages, agentId);
-
-          await saveResponseOutput(req, conversationId, responseId, response, agentId);
 
           logger.debug(
             `[Responses API] Stored response ${responseId} in conversation ${conversationId}`,


### PR DESCRIPTION
# fix(agents): Responses API `store: true` persists no messages ("User not authenticated")

## Summary

`POST /api/agents/v1/responses` with `store: true` runs the agent correctly but **persists zero messages** — the conversation record is created but is empty (the UI shows an endless spinner; `GET /api/messages/:conversationId` returns `[]`). Three defects in `api/server/controllers/agents/responses.js`, all in the `store: true` save path:

1. **Messages never save (the blocker).** `saveInputMessages` and `saveResponseOutput` pass the raw Express `req` as the first argument to `db.saveMessage`, but the method signature is `saveMessage({ userId, isTemporary, interfaceConfig }, message, metadata)`. So `userId` is `undefined` and `packages/data-schemas/src/methods/message.ts` throws `Error('User not authenticated')`. The controller's `try/catch` swallows it (`// Don't fail the request if saving fails`), so the request succeeds while nothing persists. `saveConversation` already does this correctly (`{ userId: req?.user?.id, … }`), which is why the empty **conversation record** is created but no **messages**.

2. **`parentMessageId: null` on every stored message.** Even after (1), the client `buildTree` makes every message a sibling root, so a stored conversation renders as a one-at-a-time carousel instead of a linear thread. Fixed by chaining: first user message → `Constants.NO_PARENT` (or the last prior message on a `previous_response_id` continuation), assistant → the user message, and across turns.

3. **`agentId` vs `agent_id`.** `saveConversation` writes `agentId`, but the `convo` schema field is `agent_id`, so it's dropped by strict mode and the stored conversation isn't associated with its agent in the UI.

Also reorders the saves (messages before conversation) so `saveConversation`'s `getMessages()` populates the conversation's `messages` list, matching the normal chat flow.

## Reproduction

1. Enable `interface.remoteAgents: { use: true, create: true }`, grant an agent remote access, create an API key.
2. `POST /api/agents/v1/responses` `{ "model": "<agentId>", "input": "hello", "store": true }`.
3. Observe: response is `200`, but the conversation opens empty in the UI, `GET /api/messages/:conversationId` → `[]`, and the server logs `error: [Responses API] Error saving response: User not authenticated`.

## Fix

`api/server/controllers/agents/responses.js`:
- `saveInputMessages` / `saveResponseOutput`: pass `{ userId: req?.user?.id, isTemporary: req?.body?.isTemporary, interfaceConfig: req?.config?.interfaceConfig }` as the first argument to `db.saveMessage` (mirrors `saveConversation`).
- Chain `parentMessageId` (thread from the last prior message on a continuation, else `Constants.NO_PARENT`); `saveInputMessages` returns the last user messageId which becomes the assistant's parent.
- `saveConversation`: `agentId` → `agent_id: agentId`.
- Save messages before the conversation.

## Testing

Verified end-to-end against a deployed instance (`v0.8.7`):

- **Before:** `store: true` call returns `200`, but `GET /api/messages/:conversationId` → `0` messages; server logs `Error saving response: User not authenticated`; the conversation opens empty in the UI.
- **After:** the same call persists **2** messages (`parentMessageId`: user → `NO_PARENT`, assistant → the user message); the conversation record carries `agent_id`; the UI renders it as a linear thread under the correct agent.
- **Multi-turn:** a follow-up with `previous_response_id` grows the conversation to **4** correctly-chained messages and the agent retains prior-turn context (before this fix it responded "this appears to be the start of our conversation").
