### PR TITLE
🏁 fix: Ignore Finalized SSE Transport Errors

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1612,6 +1612,59 @@ describe('useResumableSSE - 404 error path', () => {
     unmount();
   });
 
+  it('ignores responseCode === 0 after FINAL instead of reconnecting a completed stream', async () => {
+    jest.useFakeTimers();
+    const submission = buildSubmission();
+    const chatHelpers = buildChatHelpers();
+
+    const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const sse = getLastSSE();
+    const sseCount = mockSSEInstances.length;
+    const finalPayload = {
+      final: true,
+      conversation: { conversationId: CONV_ID },
+      requestMessage: {
+        messageId: 'msg-1',
+        conversationId: CONV_ID,
+        text: 'Hello',
+        isCreatedByUser: true,
+      },
+      responseMessage: {
+        messageId: 'resp-1',
+        parentMessageId: 'msg-1',
+        conversationId: CONV_ID,
+        text: 'Done',
+        isCreatedByUser: false,
+      },
+    };
+
+    await act(async () => {
+      sse._emit('message', {
+        data: JSON.stringify(finalPayload),
+      });
+    });
+
+    expect(sse.close).toHaveBeenCalled();
+    mockSetIsSubmitting.mockClear();
+    mockSetShowStopButton.mockClear();
+
+    await act(async () => {
+      sse._emit('error', { responseCode: 0 });
+    });
+    await advanceRetryTimer(1000);
+
+    expect(mockSSEInstances).toHaveLength(sseCount);
+    expect(mockSetIsSubmitting).not.toHaveBeenCalledWith(true);
+    expect(mockSetShowStopButton).not.toHaveBeenCalledWith(true);
+    expect(mockErrorHandler).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it('parses and surfaces server-sent error events (no responseCode, JSON data)', async () => {
     const submission = buildSubmission();
     const chatHelpers = buildChatHelpers();

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -236,7 +236,7 @@ const advanceRetryTimer = async (ms: number) => {
   await flushMicrotasks();
 };
 
-describe('useResumableSSE - 404 error path', () => {
+describe('useResumableSSE', () => {
   beforeEach(() => {
     mockSSEInstances.length = 0;
     localStorage.clear();

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -573,6 +573,7 @@ export default function useResumableSSE(
     (currentStreamId: string, currentSubmission: TSubmission, isResume = false) => {
       let { userMessage } = currentSubmission;
       let textIndex: number | null = null;
+      let finalReceived = false;
       const preCreatedStepEvents: Array<Parameters<typeof stepHandler>[0]> = [];
       const replayPreCreatedStepEvents = () => {
         if (preCreatedStepEvents.length === 0) {
@@ -663,6 +664,12 @@ export default function useResumableSSE(
           const data = JSON.parse(e.data);
 
           if (data.final != null) {
+            finalReceived = true;
+            if (reconnectTimeoutRef.current) {
+              clearTimeout(reconnectTimeoutRef.current);
+              reconnectTimeoutRef.current = null;
+            }
+            reconnectAttemptRef.current = 0;
             logger.log('ResumableSSE', 'Received FINAL event', {
               aborted: data.aborted,
               conversationId: data.conversation?.conversationId,
@@ -996,10 +1003,18 @@ export default function useResumableSSE(
        * Order matters: check responseCode first since HTTP errors may also include data
        */
       sse.addEventListener('error', async (e: MessageEvent) => {
-        (startupConfig?.balance?.enabled ?? false) && balanceQuery.refetch();
-
         /* @ts-ignore - sse.js types don't expose responseCode */
         const responseCode = e.responseCode;
+
+        if (finalReceived) {
+          logger.log('ResumableSSE', 'Ignoring error after FINAL event', {
+            responseCode,
+            hasData: !!e.data,
+          });
+          return;
+        }
+
+        (startupConfig?.balance?.enabled ?? false) && balanceQuery.refetch();
 
         // 404 → job completed & was cleaned up; messages are persisted in DB.
         // Invalidate cache once so react-query refetches instead of showing an error.


### PR DESCRIPTION
## Summary

I fixed a Firefox-specific resumable SSE completion edge case where a post-FINAL XHR status-0 error could be treated as a reconnectable network failure and clear draft composer text.

- Added a per-subscription `FINAL` guard in `useResumableSSE` so late transport errors from an already-completed stream are ignored.
- Cleared any pending reconnect timer and reset reconnect attempts when a stream reaches `FINAL`.
- Moved balance refetching after the terminal-stream guard so ignored post-FINAL errors do not cause side effects.
- Added a regression test that simulates `FINAL` followed by `responseCode: 0` and verifies no resume subscription, submitting-state flip, or error handling occurs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check -- client/src/hooks/SSE/useResumableSSE.ts client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts`.
- Attempted `npx jest client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts --runInBand`, but this worktree has no installed test dependencies and Jest failed with `Test environment jest-environment-jsdom cannot be found`.

### **Test Configuration**:

- Local worktree: `/Users/danny/.codex/worktrees/139a/LibreChat`
- Node dependency state: no usable local `node_modules` for client Jest execution

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works