### PR TITLE
🪢 fix: Persist Failed Turns for Preliminary-Parent Follow-Ups

### DIFF
--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -700,7 +700,9 @@ describe('ResumableAgentController resume metadata', () => {
       expect(mockSaveMessage.mock.invocationCallOrder[1]).toBeLessThan(
         mockGenerationJobManager.emitError.mock.invocationCallOrder[0],
       );
-      expect(mockSaveConvo).not.toHaveBeenCalled();
+      expect(mockSaveConvo).toHaveBeenCalledTimes(1);
+      const [, convoUpdate] = mockSaveConvo.mock.calls[0];
+      expect(convoUpdate).toEqual({ conversationId });
     });
 
     it('allows a follow-up chaining from the persisted error turn (issue 14095)', async () => {
@@ -793,6 +795,11 @@ describe('ResumableAgentController resume metadata', () => {
       const req = createFailedRequest({
         conversationId: undefined,
         parentMessageId: '00000000-0000-0000-0000-000000000000',
+        endpointOption: {
+          endpoint: 'azureOpenAI',
+          modelOptions: { model: 'gpt-4o' },
+          chatProjectId: '507f1f77bcf86cd799439011',
+        },
       });
       const res = createResumableResponse();
 
@@ -810,6 +817,7 @@ describe('ResumableAgentController resume metadata', () => {
           conversationId: mintedId,
           endpoint: 'azureOpenAI',
           model: 'gpt-4o',
+          chatProjectId: '507f1f77bcf86cd799439011',
         }),
         expect.any(Object),
       );

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -706,8 +706,9 @@ describe('ResumableAgentController resume metadata', () => {
         mockGenerationJobManager.emitError.mock.invocationCallOrder[0],
       );
       expect(mockSaveConvo).toHaveBeenCalledTimes(1);
-      const [, convoUpdate] = mockSaveConvo.mock.calls[0];
+      const [, convoUpdate, convoMetadata] = mockSaveConvo.mock.calls[0];
       expect(convoUpdate).toEqual({ conversationId });
+      expect(convoMetadata).toEqual(expect.objectContaining({ noUpsert: true }));
     });
 
     it('allows a follow-up chaining from the persisted error turn (issue 14095)', async () => {
@@ -845,10 +846,20 @@ describe('ResumableAgentController resume metadata', () => {
       );
     });
 
-    it('does not persist failed replay turns', async () => {
+    it('does not persist failed edit or continue turns', async () => {
       const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
       await AgentController(
-        createFailedRequest({ isRegenerate: true, responseMessageId: 'prior-response_' }),
+        createFailedRequest({
+          editedContent: { type: 'text', text: 'edited' },
+          responseMessageId: 'prior-response_',
+        }),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+      await AgentController(
+        createFailedRequest({ isContinued: true, responseMessageId: 'prior-response_' }),
         createSentResponse(),
         jest.fn(),
         initializeClient,
@@ -858,6 +869,86 @@ describe('ResumableAgentController resume metadata', () => {
       expect(mockSaveMessage).not.toHaveBeenCalled();
       expect(mockSaveConvo).not.toHaveBeenCalled();
       expect(mockGenerationJobManager.emitError).toHaveBeenCalled();
+    });
+
+    it('persists only the error row for a failed regenerate', async () => {
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      await AgentController(
+        createFailedRequest({
+          isRegenerate: true,
+          responseMessageId: 'original-response_',
+          overrideParentMessageId: 'original-user',
+        }),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage).toHaveBeenCalledTimes(1);
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'original-response_',
+          parentMessageId: 'original-user',
+          text: 'model unavailable',
+          error: true,
+          isCreatedByUser: false,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('does not persist a failed regenerate whose placeholder collides with the original row', async () => {
+      mockGetMessages.mockResolvedValue([{ _id: 'original-underscore-row' }]);
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      await AgentController(
+        createFailedRequest({
+          isRegenerate: true,
+          responseMessageId: 'legacy-response_',
+          overrideParentMessageId: 'original-user',
+        }),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage).not.toHaveBeenCalled();
+    });
+
+    it('skips the error row when a partial response was already saved on disconnect', async () => {
+      const serverUserMessage = {
+        messageId: 'server-user',
+        parentMessageId: 'prior-response',
+        conversationId,
+        sender: 'User',
+        text: 'Hello with a removed model.',
+        isCreatedByUser: true,
+      };
+      const sendMessage = jest.fn(async (text, opts) => {
+        opts.onStart(serverUserMessage, 'live-response-id');
+        throw new Error('failed after partial save');
+      });
+      const initializeClient = jest.fn().mockResolvedValue({ client: { sendMessage } });
+      mockGetMessages.mockImplementation(async (filter) =>
+        filter.messageId === 'live-response-id' ? [{ _id: 'partial-row' }] : [],
+      );
+
+      await AgentController(
+        createFailedRequest(),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+      await flushBackgroundGeneration();
+
+      expect(mockSaveMessage).not.toHaveBeenCalled();
+      expect(mockGenerationJobManager.emitError).toHaveBeenCalledWith(
+        conversationId,
+        'failed after partial save',
+      );
     });
 
     it('does not overwrite an already-persisted response row', async () => {

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -8,11 +8,14 @@ const mockLogger = {
 };
 
 const mockGenerationJobManager = {
+  getJob: jest.fn(),
   createJob: jest.fn(),
   emitError: jest.fn(),
+  emitChunk: jest.fn(),
   completeJob: jest.fn(),
   getResumeState: jest.fn(),
   updateMetadata: jest.fn(),
+  setContentParts: jest.fn(),
 };
 
 const mockCheckAndIncrementPendingRequest = jest.fn();
@@ -185,9 +188,11 @@ describe('ResumableAgentController resume metadata', () => {
       abortController: new AbortController(),
       emitter: { on: jest.fn() },
     });
+    mockGenerationJobManager.getJob.mockResolvedValue({ createdAt: 1000, status: 'running' });
     mockGenerationJobManager.getResumeState.mockResolvedValue(null);
     mockGenerationJobManager.updateMetadata.mockResolvedValue(undefined);
     mockGenerationJobManager.emitError.mockResolvedValue(undefined);
+    mockGenerationJobManager.emitChunk.mockResolvedValue(undefined);
     mockSaveMessage.mockResolvedValue({});
     mockSaveConvo.mockResolvedValue({});
   });
@@ -757,6 +762,86 @@ describe('ResumableAgentController resume metadata', () => {
       expect(mockGenerationJobManager.emitError).toHaveBeenCalledWith(
         conversationId,
         'provider exploded',
+      );
+    });
+
+    it('persists the failed turn under the live ids when generation fails after onStart', async () => {
+      const serverUserMessage = {
+        messageId: 'server-user',
+        parentMessageId: 'prior-response',
+        conversationId,
+        sender: 'User',
+        text: 'Hello with a removed model.',
+        isCreatedByUser: true,
+      };
+      const sendMessage = jest.fn(async (text, opts) => {
+        opts.onStart(serverUserMessage, 'server-response-uuid');
+        throw new Error('failed after onStart');
+      });
+      const initializeClient = jest.fn().mockResolvedValue({ client: { sendMessage } });
+      const res = createSentResponse();
+
+      await AgentController(createFailedRequest(), res, jest.fn(), initializeClient, null);
+      await flushBackgroundGeneration();
+
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'server-user',
+          parentMessageId: 'prior-response',
+          isCreatedByUser: true,
+        }),
+        expect.any(Object),
+      );
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'server-user_',
+          parentMessageId: 'server-user',
+          text: 'failed after onStart',
+          error: true,
+        }),
+        expect.any(Object),
+      );
+      const savedIds = mockSaveMessage.mock.calls.map(([, message]) => message.messageId);
+      expect(savedIds).not.toContain('user-message_');
+    });
+
+    it('does not persist turns from a superseded generation', async () => {
+      mockGenerationJobManager.getJob.mockResolvedValue({ createdAt: 2000, status: 'running' });
+      const initializeClient = jest.fn().mockRejectedValue(new Error('stale failure'));
+      await AgentController(
+        createFailedRequest(),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage).not.toHaveBeenCalled();
+      expect(mockSaveConvo).not.toHaveBeenCalled();
+      expect(mockGenerationJobManager.emitError).toHaveBeenCalled();
+    });
+
+    it('seeds conversation fields when the existing conversation was deleted', async () => {
+      mockGetConvo.mockResolvedValue(null);
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      await AgentController(
+        createFailedRequest(),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveConvo).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          conversationId,
+          endpoint: 'azureOpenAI',
+          model: 'gpt-4o',
+        }),
+        expect.any(Object),
       );
     });
 

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -692,6 +692,7 @@ describe('ResumableAgentController resume metadata', () => {
           conversationId,
           endpoint: 'azureOpenAI',
           model: 'gpt-4o',
+          sender: 'AI',
           text: 'The model "gpt-4o" is not available.',
           error: true,
           isCreatedByUser: false,
@@ -767,6 +768,7 @@ describe('ResumableAgentController resume metadata', () => {
     });
 
     it('persists the failed turn under the live ids when generation fails after onStart', async () => {
+      const normalizedFiles = [{ file_id: 'file-1', filepath: '/uploads/normalized.png' }];
       const serverUserMessage = {
         messageId: 'server-user',
         parentMessageId: 'prior-response',
@@ -774,6 +776,7 @@ describe('ResumableAgentController resume metadata', () => {
         sender: 'User',
         text: 'Hello with a removed model.',
         isCreatedByUser: true,
+        files: normalizedFiles,
       };
       const sendMessage = jest.fn(async (text, opts) => {
         opts.onStart(serverUserMessage, 'server-response-uuid');
@@ -782,7 +785,13 @@ describe('ResumableAgentController resume metadata', () => {
       const initializeClient = jest.fn().mockResolvedValue({ client: { sendMessage } });
       const res = createSentResponse();
 
-      await AgentController(createFailedRequest(), res, jest.fn(), initializeClient, null);
+      await AgentController(
+        createFailedRequest({ files: [{ file_id: 'file-1' }] }),
+        res,
+        jest.fn(),
+        initializeClient,
+        null,
+      );
       await flushBackgroundGeneration();
 
       expect(mockSaveMessage).toHaveBeenCalledWith(
@@ -791,6 +800,7 @@ describe('ResumableAgentController resume metadata', () => {
           messageId: 'server-user',
           parentMessageId: 'prior-response',
           isCreatedByUser: true,
+          files: normalizedFiles,
         }),
         expect.any(Object),
       );
@@ -806,6 +816,48 @@ describe('ResumableAgentController resume metadata', () => {
       );
       const savedIds = mockSaveMessage.mock.calls.map(([, message]) => message.messageId);
       expect(savedIds).not.toContain('user-message_');
+    });
+
+    it('settles the created publish before emitting the error', async () => {
+      const events = [];
+      mockGenerationJobManager.emitChunk.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setImmediate(() => {
+              events.push('created-delivered');
+              resolve();
+            });
+          }),
+      );
+      mockGenerationJobManager.emitError.mockImplementation(async () => {
+        events.push('error-emitted');
+      });
+      const sendMessage = jest.fn(async (text, opts) => {
+        opts.onStart(
+          {
+            messageId: 'server-user',
+            parentMessageId: 'prior-response',
+            conversationId,
+            sender: 'User',
+            text,
+            isCreatedByUser: true,
+          },
+          'server-response-uuid',
+        );
+        throw new Error('failed right after onStart');
+      });
+      const initializeClient = jest.fn().mockResolvedValue({ client: { sendMessage } });
+
+      await AgentController(
+        createFailedRequest(),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+      await flushBackgroundGeneration();
+
+      expect(events).toEqual(['created-delivered', 'error-emitted']);
     });
 
     it('does not persist turns from a superseded generation', async () => {

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -23,6 +23,7 @@ const mockFilterPersistableAbortContent = jest.fn((content) =>
 const mockGetConvo = jest.fn();
 const mockGetMessages = jest.fn();
 const mockSaveMessage = jest.fn();
+const mockSaveConvo = jest.fn();
 let mockMCPContexts = new WeakMap();
 
 const mockCreateMCPRequestContext = jest.fn(() => ({
@@ -143,6 +144,7 @@ jest.mock('~/models', () => ({
   saveMessage: (...args) => mockSaveMessage(...args),
   getMessages: (...args) => mockGetMessages(...args),
   getConvo: (...args) => mockGetConvo(...args),
+  saveConvo: (...args) => mockSaveConvo(...args),
 }));
 
 const AgentController = require('../request');
@@ -187,6 +189,7 @@ describe('ResumableAgentController resume metadata', () => {
     mockGenerationJobManager.updateMetadata.mockResolvedValue(undefined);
     mockGenerationJobManager.emitError.mockResolvedValue(undefined);
     mockSaveMessage.mockResolvedValue({});
+    mockSaveConvo.mockResolvedValue({});
   });
 
   it('rejects an underscore-suffixed parent that is not persisted', async () => {
@@ -617,5 +620,199 @@ describe('ResumableAgentController resume metadata', () => {
       }),
       expect.any(Object),
     );
+  });
+
+  describe('failed-turn persistence', () => {
+    const conversationId = 'conversation-123';
+
+    const createFailedRequest = (bodyOverrides = {}) => ({
+      user: { id: 'user-123' },
+      body: {
+        text: 'Hello with a removed model.',
+        messageId: 'user-message',
+        parentMessageId: 'prior-response',
+        conversationId,
+        endpointOption: {
+          endpoint: 'azureOpenAI',
+          modelOptions: { model: 'gpt-4o' },
+        },
+        ...bodyOverrides,
+      },
+      config: {},
+    });
+
+    const createSentResponse = () => {
+      const res = {
+        headersSent: true,
+        json: jest.fn(() => {
+          res.headersSent = true;
+        }),
+        status: jest.fn(() => res),
+      };
+      return res;
+    };
+
+    async function flushBackgroundGeneration() {
+      for (let i = 0; i < 10; i++) {
+        await nextTick();
+      }
+    }
+
+    it('persists the failed turn before emitting when initialization fails after headers are sent', async () => {
+      const initializeClient = jest
+        .fn()
+        .mockRejectedValue(new Error('The model "gpt-4o" is not available.'));
+      const req = createFailedRequest();
+      const res = createSentResponse();
+
+      await AgentController(req, res, jest.fn(), initializeClient, null);
+
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'user-message',
+          parentMessageId: 'prior-response',
+          conversationId,
+          text: 'Hello with a removed model.',
+          isCreatedByUser: true,
+          error: false,
+        }),
+        expect.any(Object),
+      );
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'user-message_',
+          parentMessageId: 'user-message',
+          conversationId,
+          endpoint: 'azureOpenAI',
+          model: 'gpt-4o',
+          text: 'The model "gpt-4o" is not available.',
+          error: true,
+          isCreatedByUser: false,
+        }),
+        expect.any(Object),
+      );
+      expect(mockGenerationJobManager.emitError).toHaveBeenCalledWith(
+        conversationId,
+        'The model "gpt-4o" is not available.',
+      );
+      expect(mockSaveMessage.mock.invocationCallOrder[1]).toBeLessThan(
+        mockGenerationJobManager.emitError.mock.invocationCallOrder[0],
+      );
+      expect(mockSaveConvo).not.toHaveBeenCalled();
+    });
+
+    it('allows a follow-up chaining from the persisted error turn (issue 14095)', async () => {
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      await AgentController(
+        createFailedRequest(),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      const savedIds = mockSaveMessage.mock.calls.map(([, message]) => message.messageId);
+      expect(savedIds).toContain('user-message_');
+
+      mockGetMessages.mockResolvedValue([{ _id: 'persisted-error-turn' }]);
+      const followUpRes = createSentResponse();
+      await AgentController(
+        createFailedRequest({
+          text: 'Retry with a valid model.',
+          messageId: 'follow-up-user',
+          parentMessageId: 'user-message_',
+        }),
+        followUpRes,
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(followUpRes.status).not.toHaveBeenCalledWith(409);
+      expect(mockCheckAndIncrementPendingRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('persists the failed turn when generation fails before any message save', async () => {
+      const sendMessage = jest.fn().mockRejectedValue(new Error('provider exploded'));
+      const initializeClient = jest.fn().mockResolvedValue({ client: { sendMessage } });
+      const res = createSentResponse();
+
+      await AgentController(createFailedRequest(), res, jest.fn(), initializeClient, null);
+      await flushBackgroundGeneration();
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'user-message_',
+          text: 'provider exploded',
+          error: true,
+        }),
+        expect.any(Object),
+      );
+      expect(mockGenerationJobManager.emitError).toHaveBeenCalledWith(
+        conversationId,
+        'provider exploded',
+      );
+    });
+
+    it('does not persist failed replay turns', async () => {
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      await AgentController(
+        createFailedRequest({ isRegenerate: true, responseMessageId: 'prior-response_' }),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage).not.toHaveBeenCalled();
+      expect(mockSaveConvo).not.toHaveBeenCalled();
+      expect(mockGenerationJobManager.emitError).toHaveBeenCalled();
+    });
+
+    it('does not overwrite an already-persisted response row', async () => {
+      mockGetMessages.mockResolvedValue([{ _id: 'already-saved' }]);
+      const initializeClient = jest.fn().mockRejectedValue(new Error('late failure'));
+      await AgentController(
+        createFailedRequest(),
+        createSentResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage).not.toHaveBeenCalled();
+      expect(mockGenerationJobManager.emitError).toHaveBeenCalled();
+    });
+
+    it('saves a conversation row when a new conversation fails at initialization', async () => {
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      const req = createFailedRequest({
+        conversationId: undefined,
+        parentMessageId: '00000000-0000-0000-0000-000000000000',
+      });
+      const res = createResumableResponse();
+
+      await AgentController(req, res, jest.fn(), initializeClient, null);
+
+      const { conversationId: mintedId } = res.json.mock.calls[0][0];
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({ messageId: 'user-message_', conversationId: mintedId }),
+        expect.any(Object),
+      );
+      expect(mockSaveConvo).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          conversationId: mintedId,
+          endpoint: 'azureOpenAI',
+          model: 'gpt-4o',
+        }),
+        expect.any(Object),
+      );
+    });
   });
 });

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -63,6 +63,7 @@ const mockFilterPersistableAbortContent = jest.fn((content) =>
 const mockGetConvo = jest.fn();
 const mockGetMessages = jest.fn();
 const mockSaveMessage = jest.fn();
+const mockSaveConvo = jest.fn();
 const mockIsAgentTriggerPrincipalActive = jest.fn();
 const mockIsSubagentOwnerAdmissible = jest.fn();
 const mockAcquireEventChildGenerationLease = jest.fn();
@@ -224,6 +225,7 @@ jest.mock('~/cache', () => ({
 
 jest.mock('~/models', () => ({
   saveMessage: (...args) => mockSaveMessage(...args),
+  saveConvo: (...args) => mockSaveConvo(...args),
   getMessages: (...args) => mockGetMessages(...args),
   getConvo: (...args) => mockGetConvo(...args),
   isAgentTriggerPrincipalActive: (...args) => mockIsAgentTriggerPrincipalActive(...args),
@@ -319,7 +321,12 @@ describe('ResumableAgentController resume metadata', () => {
       }),
     );
     mockGenerationJobManager.finishTerminalJob.mockResolvedValue(undefined);
-    mockGenerationJobManager.completeJob.mockResolvedValue(true);
+    mockGenerationJobManager.completeJob.mockImplementation(
+      async (_streamId, _error, _createdAt, options) => {
+        await options?.beforeErrorPublication?.();
+        return true;
+      },
+    );
     mockGenerationJobManager.beginProviderExecution.mockResolvedValue(true);
     mockGenerationJobManager.markProviderExecutionDrained.mockResolvedValue(true);
     mockGenerationJobManager.failPausePersistence.mockResolvedValue(true);
@@ -334,6 +341,7 @@ describe('ResumableAgentController resume metadata', () => {
     mockGenerationJobManager.steering.park.mockResolvedValue(undefined);
     mockGenerationJobManager.steering.consumeRecovered.mockResolvedValue(true);
     mockSaveMessage.mockResolvedValue({});
+    mockSaveConvo.mockResolvedValue({});
     mockDeleteAgentCheckpoint.mockResolvedValue(undefined);
   });
 
@@ -1362,6 +1370,8 @@ describe('ResumableAgentController resume metadata', () => {
 
     await AgentController(req, res, jest.fn(), initializeClient, null);
     expect(allSubscribersLeftHandler).toEqual(expect.any(Function));
+    mockSaveMessage.mockClear();
+    mockSaveConvo.mockClear();
 
     const oauthPart = {
       type: 'tool_call',
@@ -2289,6 +2299,7 @@ describe('ResumableAgentController resume metadata', () => {
         error: 'Attached resources could not be restored',
       }),
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
   });
 
@@ -2326,6 +2337,7 @@ describe('ResumableAgentController resume metadata', () => {
         error: 'Stateful code environment is not allowed by this deployment: conversation',
       }),
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
   });
 
@@ -2516,6 +2528,7 @@ describe('ResumableAgentController resume metadata', () => {
       'conversation-123',
       'provider init failed',
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
   });
 
@@ -2552,6 +2565,7 @@ describe('ResumableAgentController resume metadata', () => {
       'conversation-123',
       'Recovered steer cannot skip user message persistence',
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
   });
 
@@ -3024,6 +3038,247 @@ describe('ResumableAgentController resume metadata', () => {
     expect(mockGenerationJobManager.claimTerminalJob).not.toHaveBeenCalled();
   });
 
+  describe('failed-turn persistence', () => {
+    const conversationId = 'conversation-123';
+
+    const createFailedRequest = (bodyOverrides = {}) => ({
+      user: { id: 'user-123' },
+      body: {
+        text: 'Hello with a removed model.',
+        messageId: 'user-message',
+        parentMessageId: 'prior-response',
+        conversationId,
+        endpointOption: {
+          endpoint: 'azureOpenAI',
+          modelOptions: { model: 'gpt-4o' },
+        },
+        ...bodyOverrides,
+      },
+      config: {},
+    });
+
+    async function flushBackgroundGeneration() {
+      for (let i = 0; i < 10; i++) {
+        await nextTick();
+      }
+    }
+
+    it('persists an initialization failure before terminal error publication', async () => {
+      const events = [];
+      mockSaveConvo.mockImplementation(async () => {
+        events.push('turn-persisted');
+        return {};
+      });
+      mockGenerationJobManager.completeJob.mockImplementation(
+        async (_streamId, _error, _createdAt, options) => {
+          await options.beforeErrorPublication();
+          events.push('error-published');
+          return true;
+        },
+      );
+      const initializeClient = jest
+        .fn()
+        .mockRejectedValue(new Error('The model "gpt-4o" is not available.'));
+
+      await AgentController(
+        createFailedRequest(),
+        createResumableResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'user-message',
+          parentMessageId: 'prior-response',
+          conversationId,
+          text: 'Hello with a removed model.',
+          isCreatedByUser: true,
+          error: false,
+        }),
+        expect.any(Object),
+      );
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'user-message_',
+          parentMessageId: 'user-message',
+          conversationId,
+          endpoint: 'azureOpenAI',
+          model: 'gpt-4o',
+          text: 'The model "gpt-4o" is not available.',
+          error: true,
+          isCreatedByUser: false,
+        }),
+        expect.any(Object),
+      );
+      expect(events).toEqual(['turn-persisted', 'error-published']);
+      expect(mockSaveConvo).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        { conversationId },
+        expect.objectContaining({ noUpsert: true }),
+      );
+    });
+
+    it('allows a follow-up to chain from the persisted failed response', async () => {
+      const initializeClient = jest.fn().mockRejectedValue(new Error('model unavailable'));
+      await AgentController(
+        createFailedRequest(),
+        createResumableResponse(),
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(mockSaveMessage.mock.calls.map(([, message]) => message.messageId)).toContain(
+        'user-message_',
+      );
+      mockGetMessages.mockResolvedValue([{ _id: 'persisted-error-turn' }]);
+      const followUpRes = createResumableResponse();
+
+      await AgentController(
+        createFailedRequest({
+          text: 'Retry with a valid model.',
+          messageId: 'follow-up-user',
+          parentMessageId: 'user-message_',
+        }),
+        followUpRes,
+        jest.fn(),
+        initializeClient,
+        null,
+      );
+
+      expect(followUpRes.status).not.toHaveBeenCalledWith(409);
+      expect(mockCheckAndIncrementPendingRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('persists failures raised before generation saves any message', async () => {
+      const client = {
+        options: {},
+        sendMessage: jest.fn().mockRejectedValue(new Error('provider exploded')),
+      };
+
+      await AgentController(
+        createFailedRequest(),
+        createResumableResponse(),
+        jest.fn(),
+        jest.fn().mockResolvedValue({ client }),
+        null,
+      );
+      await flushBackgroundGeneration();
+
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          messageId: 'user-message_',
+          text: 'provider exploded',
+          error: true,
+        }),
+        expect.any(Object),
+      );
+      expect(mockGenerationJobManager.completeJob).toHaveBeenCalledWith(
+        conversationId,
+        'provider exploded',
+        1000,
+        expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
+      );
+    });
+
+    it('uses the live user identity after generation starts', async () => {
+      const serverUserMessage = {
+        messageId: 'server-user',
+        parentMessageId: 'prior-response',
+        conversationId,
+        sender: 'User',
+        text: 'Hello with a removed model.',
+        isCreatedByUser: true,
+      };
+      const client = {
+        options: {},
+        sendMessage: jest.fn(async (_text, options) => {
+          options.onStart(serverUserMessage, 'server-response-uuid');
+          throw new Error('failed after onStart');
+        }),
+      };
+
+      await AgentController(
+        createFailedRequest(),
+        createResumableResponse(),
+        jest.fn(),
+        jest.fn().mockResolvedValue({ client }),
+        null,
+      );
+      await flushBackgroundGeneration();
+
+      const savedIds = mockSaveMessage.mock.calls.map(([, message]) => message.messageId);
+      expect(savedIds).toEqual(expect.arrayContaining(['server-user', 'server-user_']));
+      expect(savedIds).not.toContain('user-message_');
+    });
+
+    it('does not overwrite an existing response row', async () => {
+      mockGetMessages.mockResolvedValue([{ _id: 'already-saved' }]);
+
+      await AgentController(
+        createFailedRequest(),
+        createResumableResponse(),
+        jest.fn(),
+        jest.fn().mockRejectedValue(new Error('late failure')),
+        null,
+      );
+
+      expect(mockSaveMessage).not.toHaveBeenCalled();
+      expect(mockSaveConvo).not.toHaveBeenCalled();
+    });
+
+    it('creates the conversation row for a failed first turn', async () => {
+      const res = createResumableResponse();
+      mockGenerationJobManager.claimGeneration.mockImplementation(
+        async (_userId, _clientRequestId, streamId, claimedConversationId) =>
+          wonGenerationClaim({ streamId, conversationId: claimedConversationId }),
+      );
+      const req = createFailedRequest({
+        conversationId: undefined,
+        clientRequestId: 'failed-new-conversation',
+        parentMessageId: '00000000-0000-0000-0000-000000000000',
+        endpointOption: {
+          endpoint: 'azureOpenAI',
+          modelOptions: { model: 'gpt-4o' },
+          chatProjectId: '507f1f77bcf86cd799439011',
+        },
+      });
+
+      await AgentController(
+        req,
+        res,
+        jest.fn(),
+        jest.fn().mockRejectedValue(new Error('model unavailable')),
+        null,
+      );
+
+      const mintedConversationId = res.json.mock.calls[0][0].conversationId;
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          messageId: 'user-message_',
+          conversationId: mintedConversationId,
+        }),
+        expect.any(Object),
+      );
+      expect(mockSaveConvo).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-123' }),
+        expect.objectContaining({
+          conversationId: mintedConversationId,
+          endpoint: 'azureOpenAI',
+          model: 'gpt-4o',
+          chatProjectId: '507f1f77bcf86cd799439011',
+        }),
+        expect.any(Object),
+      );
+    });
+  });
+
   it('finalizes the failed job before releasing the idempotency claim', async () => {
     mockGenerationJobManager.claimGeneration.mockResolvedValue(wonGenerationClaim());
     const initializeClient = jest.fn().mockRejectedValue(new Error('init boom after res.json'));
@@ -3046,6 +3301,7 @@ describe('ResumableAgentController resume metadata', () => {
       'conversation-123',
       expect.any(String),
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
     expect(mockGenerationJobManager.releaseGeneration).toHaveBeenCalledWith(
       'user-123',
@@ -3112,6 +3368,7 @@ describe('ResumableAgentController resume metadata', () => {
       'conversation-123',
       'init boom after res.json',
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
     expect(mockGenerationJobManager.releaseGeneration).toHaveBeenCalledWith(
       'user-123',
@@ -3227,6 +3484,7 @@ describe('ResumableAgentController resume metadata', () => {
       'conversation-123',
       generationError.message,
       1000,
+      expect.objectContaining({ beforeErrorPublication: expect.any(Function) }),
     );
     expect(mockGenerationJobManager.completeJob.mock.invocationCallOrder[0]).toBeLessThan(
       mockDecrementPendingRequest.mock.invocationCallOrder[0],

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -20,7 +20,7 @@ const {
 } = require('~/server/services/MCPRequestContext');
 const { handleAbortError } = require('~/server/middleware');
 const { logViolation } = require('~/cache');
-const { saveMessage, getMessages, getConvo } = require('~/models');
+const { saveMessage, getMessages, getConvo, saveConvo } = require('~/models');
 
 function createCloseHandler(abortController) {
   return function (manual) {
@@ -172,6 +172,101 @@ async function finishResumableRequest(req, userId) {
     await cleanupMCPRequestContextForReq(req);
   } finally {
     await decrementPendingRequest(userId);
+  }
+}
+
+/**
+ * Persists a failed turn (user message + `error: true` response) when generation
+ * fails before anything reached the database, e.g. `initializeClient` rejecting
+ * on an unavailable model. Follow-ups chain from the preliminary response id
+ * (`${userMessageId}_`) and `isUnpersistedPreliminaryParent` 409s them until that
+ * row exists; without this write it never would, dead-ending the conversation.
+ * Replay turns (regenerate/edit/continue) are skipped: their rows already exist,
+ * and upserting here could clobber a completed response.
+ */
+async function saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, errorText }) {
+  try {
+    const { isContinued, isRegenerate, editedContent, responseMessageId } = req.body ?? {};
+    if (isContinued || isRegenerate || editedContent != null || responseMessageId) {
+      return;
+    }
+
+    const userMessage = getPreliminaryUserMessage(req.body, conversationId);
+    const errorMessageId = getPreliminaryResponseMessageId(req.body);
+    if (!userMessage || !errorMessageId) {
+      return;
+    }
+
+    const userId = req.user.id;
+    const existing = await getMessages(
+      { user: userId, messageId: errorMessageId, conversationId },
+      '_id',
+    );
+    if (existing.length > 0) {
+      return;
+    }
+
+    const reqCtx = {
+      userId,
+      isTemporary: req?.body?.isTemporary,
+      interfaceConfig: req?.config?.interfaceConfig,
+    };
+    const context = 'api/server/controllers/agents/request.js - failed turn';
+    const endpoint = endpointOption?.endpoint;
+    const model = getAgentResponseModel(req, endpointOption);
+    const iconURL = getEndpointIconURL(req, endpointOption);
+
+    await saveMessage(
+      reqCtx,
+      {
+        ...userMessage,
+        user: userId,
+        sender: 'User',
+        isCreatedByUser: true,
+        error: false,
+        unfinished: false,
+      },
+      { context },
+    );
+    await saveMessage(
+      reqCtx,
+      {
+        messageId: errorMessageId,
+        conversationId,
+        parentMessageId: userMessage.messageId,
+        ...(endpoint != null && { endpoint }),
+        ...(model != null && { model }),
+        ...(iconURL != null && { iconURL }),
+        user: userId,
+        text: errorText,
+        error: true,
+        unfinished: false,
+        isCreatedByUser: false,
+      },
+      { context },
+    );
+
+    if (isNewConvo) {
+      await saveConvo(
+        reqCtx,
+        {
+          conversationId,
+          ...(endpoint != null && { endpoint }),
+          ...(endpointOption?.endpointType != null && {
+            endpointType: endpointOption.endpointType,
+          }),
+          ...(model != null && { model }),
+          ...(iconURL != null && { iconURL }),
+          ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
+          ...((endpointOption?.agent_id ?? req.body?.agent_id) != null && {
+            agent_id: endpointOption?.agent_id ?? req.body?.agent_id,
+          }),
+        },
+        { context },
+      );
+    }
+  } catch (err) {
+    logger.error('[AgentController] Failed to persist error turn', err);
   }
 }
 
@@ -849,7 +944,9 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           // abortJob already handled emitDone and completeJob
         } else {
           logger.error(`[ResumableAgentController] Generation error for ${streamId}:`, error);
-          await GenerationJobManager.emitError(streamId, error.message || 'Generation failed');
+          const errorText = error.message || 'Generation failed';
+          await saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, errorText });
+          await GenerationJobManager.emitError(streamId, errorText);
           GenerationJobManager.completeJob(streamId, error.message);
         }
 
@@ -884,8 +981,11 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     if (!res.headersSent) {
       res.status(500).json({ error: error.message || 'Failed to start generation' });
     } else {
-      // JSON already sent, emit error to stream so client can receive it
-      await GenerationJobManager.emitError(streamId, error.message || 'Failed to start generation');
+      // JSON already sent; persist the failed turn before emitting the error so
+      // the preliminary response row exists by the time the user can retry.
+      const errorText = error.message || 'Failed to start generation';
+      await saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, errorText });
+      await GenerationJobManager.emitError(streamId, errorText);
     }
     GenerationJobManager.completeJob(streamId, error.message);
     await finishResumableRequest(req, userId);

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -194,6 +194,7 @@ async function saveErrorTurn(
     jobCreatedAt,
     liveUserMessage,
     liveResponseMessageId,
+    sender,
   },
 ) {
   try {
@@ -231,15 +232,21 @@ async function saveErrorTurn(
        *  (the `created` event replaces its optimistic ids), so the persisted turn
        *  must use the live ids; the preliminary req.body ids only match failures
        *  that happen before `onStart`. */
+      /** Request-body fields only fill gaps: BaseClient may have already set
+       *  normalized values (e.g. `buildMessageFiles` output) on the live message,
+       *  which must not be clobbered with the raw request entries. */
       userMessage =
         liveUserMessage != null
           ? {
               ...liveUserMessage,
-              ...(Array.isArray(req.body?.files) &&
+              ...(liveUserMessage.files == null &&
+                Array.isArray(req.body?.files) &&
                 req.body.files.length > 0 && { files: req.body.files }),
-              ...(Array.isArray(req.body?.manualSkills) &&
+              ...(liveUserMessage.manualSkills == null &&
+                Array.isArray(req.body?.manualSkills) &&
                 req.body.manualSkills.length > 0 && { manualSkills: req.body.manualSkills }),
-              ...(Array.isArray(req.body?.alwaysAppliedSkills) &&
+              ...(liveUserMessage.alwaysAppliedSkills == null &&
+                Array.isArray(req.body?.alwaysAppliedSkills) &&
                 req.body.alwaysAppliedSkills.length > 0 && {
                   alwaysAppliedSkills: req.body.alwaysAppliedSkills,
                 }),
@@ -308,6 +315,7 @@ async function saveErrorTurn(
         messageId: errorMessageId,
         conversationId,
         parentMessageId: errorParentMessageId,
+        sender: sender ?? 'AI',
         ...(endpoint != null && { endpoint }),
         ...(model != null && { model }),
         ...(iconURL != null && { iconURL }),
@@ -567,6 +575,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
 
     let userMessage;
     let liveResponseMessageId;
+    let createdEmitPromise;
 
     const getReqData = (data = {}) => {
       if (data.userMessage) {
@@ -678,7 +687,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             },
           });
 
-          GenerationJobManager.emitChunk(streamId, {
+          createdEmitPromise = GenerationJobManager.emitChunk(streamId, {
             created: true,
             // Skill selections aren't on `userMessage` yet at onStart (BaseClient adds
             // them later), so attach them from the request — this is the message
@@ -1035,6 +1044,12 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         } else {
           logger.error(`[ResumableAgentController] Generation error for ${streamId}:`, error);
           const errorText = error.message || 'Generation failed';
+          /** Settle the fire-and-forget `created` publish first so the error
+           *  event cannot overtake it and leave the client handling the failure
+           *  on its optimistic ids while the turn persists under the live ids. */
+          if (createdEmitPromise != null) {
+            await Promise.resolve(createdEmitPromise).catch(() => {});
+          }
           await saveErrorTurn(req, {
             conversationId,
             endpointOption,
@@ -1043,6 +1058,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             jobCreatedAt,
             liveUserMessage: userMessage,
             liveResponseMessageId,
+            sender: client?.sender,
           });
           await GenerationJobManager.emitError(streamId, errorText);
           GenerationJobManager.completeJob(streamId, error.message);

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -181,16 +181,25 @@ async function finishResumableRequest(req, userId) {
  * on an unavailable model. Follow-ups chain from the preliminary response id
  * (`${userMessageId}_`) and `isUnpersistedPreliminaryParent` 409s them until that
  * row exists; without this write it never would, dead-ending the conversation.
- * Replay turns (regenerate/edit/continue) are skipped: their rows already exist,
- * and upserting here could clobber a completed response.
+ * Regenerates persist only the error row under the client's regen placeholder id;
+ * edit/continue turns are skipped since their rows already exist.
  */
 async function saveErrorTurn(
   req,
-  { conversationId, endpointOption, isNewConvo, errorText, jobCreatedAt, liveUserMessage },
+  {
+    conversationId,
+    endpointOption,
+    isNewConvo,
+    errorText,
+    jobCreatedAt,
+    liveUserMessage,
+    liveResponseMessageId,
+  },
 ) {
   try {
-    const { isContinued, isRegenerate, editedContent, responseMessageId } = req.body ?? {};
-    if (isContinued || isRegenerate || editedContent != null || responseMessageId) {
+    const { isContinued, isRegenerate, editedContent, responseMessageId, overrideParentMessageId } =
+      req.body ?? {};
+    if (isContinued || editedContent != null || (responseMessageId && !isRegenerate)) {
       return;
     }
 
@@ -203,28 +212,48 @@ async function saveErrorTurn(
       }
     }
 
-    /** After `onStart`, the client tracks BaseClient's generated user message id
-     *  (the `created` event replaces its optimistic ids), so the persisted turn
-     *  must use the live ids; the preliminary req.body ids only match failures
-     *  that happen before `onStart`. */
-    const userMessage =
-      liveUserMessage != null
-        ? {
-            ...liveUserMessage,
-            ...(Array.isArray(req.body?.files) &&
-              req.body.files.length > 0 && { files: req.body.files }),
-            ...(Array.isArray(req.body?.manualSkills) &&
-              req.body.manualSkills.length > 0 && { manualSkills: req.body.manualSkills }),
-            ...(Array.isArray(req.body?.alwaysAppliedSkills) &&
-              req.body.alwaysAppliedSkills.length > 0 && {
-                alwaysAppliedSkills: req.body.alwaysAppliedSkills,
-              }),
-          }
-        : getPreliminaryUserMessage(req.body, conversationId);
-    const errorMessageId = getPreliminaryResponseMessageId(
-      liveUserMessage != null ? { messageId: liveUserMessage.messageId } : req.body,
-    );
-    if (!userMessage || !errorMessageId) {
+    let userMessage = null;
+    let errorMessageId = null;
+    let errorParentMessageId = null;
+    if (isRegenerate) {
+      /** The regen placeholder (`${originalResponseId}_`) is where the client
+       *  renders the failed attempt; the original user message already exists,
+       *  so only the error row is written. A legacy `_`-suffixed original id
+       *  collides with its own placeholder, and the existence check below then
+       *  skips the write instead of clobbering the completed response. */
+      errorMessageId =
+        typeof responseMessageId === 'string' && responseMessageId.length > 0
+          ? responseMessageId
+          : null;
+      errorParentMessageId = liveUserMessage?.messageId ?? overrideParentMessageId ?? null;
+    } else {
+      /** After `onStart`, the client tracks BaseClient's generated user message id
+       *  (the `created` event replaces its optimistic ids), so the persisted turn
+       *  must use the live ids; the preliminary req.body ids only match failures
+       *  that happen before `onStart`. */
+      userMessage =
+        liveUserMessage != null
+          ? {
+              ...liveUserMessage,
+              ...(Array.isArray(req.body?.files) &&
+                req.body.files.length > 0 && { files: req.body.files }),
+              ...(Array.isArray(req.body?.manualSkills) &&
+                req.body.manualSkills.length > 0 && { manualSkills: req.body.manualSkills }),
+              ...(Array.isArray(req.body?.alwaysAppliedSkills) &&
+                req.body.alwaysAppliedSkills.length > 0 && {
+                  alwaysAppliedSkills: req.body.alwaysAppliedSkills,
+                }),
+            }
+          : getPreliminaryUserMessage(req.body, conversationId);
+      if (!userMessage) {
+        return;
+      }
+      errorMessageId = getPreliminaryResponseMessageId(
+        liveUserMessage != null ? { messageId: liveUserMessage.messageId } : req.body,
+      );
+      errorParentMessageId = userMessage.messageId;
+    }
+    if (!errorMessageId || !errorParentMessageId) {
       return;
     }
 
@@ -235,6 +264,18 @@ async function saveErrorTurn(
     );
     if (existing.length > 0) {
       return;
+    }
+    /** A disconnect may have already persisted this turn's partial response under
+     *  the live response id (`allSubscribersLeft`); a reload re-anchors the client
+     *  on that row, so also writing the error row would fork a duplicate branch. */
+    if (liveResponseMessageId != null && liveResponseMessageId !== errorMessageId) {
+      const partial = await getMessages(
+        { user: userId, messageId: liveResponseMessageId, conversationId },
+        '_id',
+      );
+      if (partial.length > 0) {
+        return;
+      }
     }
 
     const reqCtx = {
@@ -247,24 +288,26 @@ async function saveErrorTurn(
     const model = getAgentResponseModel(req, endpointOption);
     const iconURL = getEndpointIconURL(req, endpointOption);
 
-    await saveMessage(
-      reqCtx,
-      {
-        ...userMessage,
-        user: userId,
-        sender: 'User',
-        isCreatedByUser: true,
-        error: false,
-        unfinished: false,
-      },
-      { context },
-    );
+    if (userMessage) {
+      await saveMessage(
+        reqCtx,
+        {
+          ...userMessage,
+          user: userId,
+          sender: 'User',
+          isCreatedByUser: true,
+          error: false,
+          unfinished: false,
+        },
+        { context },
+      );
+    }
     await saveMessage(
       reqCtx,
       {
         messageId: errorMessageId,
         conversationId,
-        parentMessageId: userMessage.messageId,
+        parentMessageId: errorParentMessageId,
         ...(endpoint != null && { endpoint }),
         ...(model != null && { model }),
         ...(iconURL != null && { iconURL }),
@@ -285,21 +328,27 @@ async function saveErrorTurn(
      *  conversation that no longer exists (`req.resolvedConversation === null`,
      *  e.g. deleted from another tab) gets the full seed so the upsert doesn't
      *  create an unusable endpoint-less row. */
-    const convoFields =
-      isNewConvo || req.resolvedConversation === null
-        ? {
-            ...(endpoint != null && { endpoint }),
-            ...(endpointOption?.endpointType != null && {
-              endpointType: endpointOption.endpointType,
-            }),
-            ...(model != null && { model }),
-            ...(iconURL != null && { iconURL }),
-            ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
-            ...(agentId != null && { agent_id: agentId }),
-            ...(typeof chatProjectId === 'string' && chatProjectId.length > 0 && { chatProjectId }),
-          }
-        : {};
-    await saveConvo(reqCtx, { conversationId, ...convoFields }, { context });
+    const seedConvo = isNewConvo || req.resolvedConversation === null;
+    const convoFields = seedConvo
+      ? {
+          ...(endpoint != null && { endpoint }),
+          ...(endpointOption?.endpointType != null && {
+            endpointType: endpointOption.endpointType,
+          }),
+          ...(model != null && { model }),
+          ...(iconURL != null && { iconURL }),
+          ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
+          ...(agentId != null && { agent_id: agentId }),
+          ...(typeof chatProjectId === 'string' && chatProjectId.length > 0 && { chatProjectId }),
+        }
+      : {};
+    /** noUpsert: a conversation deleted between `attachConversationCreatedAt`
+     *  reading it and this refresh must not be recreated as an endpoint-less row. */
+    await saveConvo(
+      reqCtx,
+      { conversationId, ...convoFields },
+      seedConvo ? { context } : { context, noUpsert: true },
+    );
   } catch (err) {
     logger.error('[AgentController] Failed to persist error turn', err);
   }
@@ -517,10 +566,14 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     }
 
     let userMessage;
+    let liveResponseMessageId;
 
     const getReqData = (data = {}) => {
       if (data.userMessage) {
         userMessage = data.userMessage;
+      }
+      if (data.responseMessageId) {
+        liveResponseMessageId = data.responseMessageId;
       }
       // conversationId is pre-generated, no need to update from callback
     };
@@ -595,6 +648,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       try {
         const onStart = (userMsg, respMsgId, _isNewConvo) => {
           userMessage = userMsg;
+          liveResponseMessageId = respMsgId;
 
           // Store userMessage and responseMessageId upfront for resume capability
           GenerationJobManager.updateMetadata(streamId, {
@@ -988,6 +1042,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             errorText,
             jobCreatedAt,
             liveUserMessage: userMessage,
+            liveResponseMessageId,
           });
           await GenerationJobManager.emitError(streamId, errorText);
           GenerationJobManager.completeJob(streamId, error.message);

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -246,11 +246,13 @@ async function saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, 
       { context },
     );
 
-    if (isNewConvo) {
-      await saveConvo(
-        reqCtx,
-        {
-          conversationId,
+    const agentId = endpointOption?.agent_id ?? req.body?.agent_id;
+    const chatProjectId = endpointOption?.chatProjectId ?? req.body?.chatProjectId;
+    /** Existing conversations get a minimal update that preserves their fields:
+     *  saveConvo recomputes `messages` and bumps `updatedAt` so the saved failed
+     *  turn is reflected in the conversation doc and chat-list ordering. */
+    const convoFields = isNewConvo
+      ? {
           ...(endpoint != null && { endpoint }),
           ...(endpointOption?.endpointType != null && {
             endpointType: endpointOption.endpointType,
@@ -258,13 +260,11 @@ async function saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, 
           ...(model != null && { model }),
           ...(iconURL != null && { iconURL }),
           ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
-          ...((endpointOption?.agent_id ?? req.body?.agent_id) != null && {
-            agent_id: endpointOption?.agent_id ?? req.body?.agent_id,
-          }),
-        },
-        { context },
-      );
-    }
+          ...(agentId != null && { agent_id: agentId }),
+          ...(typeof chatProjectId === 'string' && chatProjectId.length > 0 && { chatProjectId }),
+        }
+      : {};
+    await saveConvo(reqCtx, { conversationId, ...convoFields }, { context });
   } catch (err) {
     logger.error('[AgentController] Failed to persist error turn', err);
   }

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -184,15 +184,46 @@ async function finishResumableRequest(req, userId) {
  * Replay turns (regenerate/edit/continue) are skipped: their rows already exist,
  * and upserting here could clobber a completed response.
  */
-async function saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, errorText }) {
+async function saveErrorTurn(
+  req,
+  { conversationId, endpointOption, isNewConvo, errorText, jobCreatedAt, liveUserMessage },
+) {
   try {
     const { isContinued, isRegenerate, editedContent, responseMessageId } = req.body ?? {};
     if (isContinued || isRegenerate || editedContent != null || responseMessageId) {
       return;
     }
 
-    const userMessage = getPreliminaryUserMessage(req.body, conversationId);
-    const errorMessageId = getPreliminaryResponseMessageId(req.body);
+    /** A replaced/superseded generation is no longer authoritative for this
+     *  conversation; mirror the success path's liveness check before writing. */
+    if (jobCreatedAt != null) {
+      const liveJob = await GenerationJobManager.getJob(conversationId);
+      if (!liveJob || liveJob.createdAt !== jobCreatedAt) {
+        return;
+      }
+    }
+
+    /** After `onStart`, the client tracks BaseClient's generated user message id
+     *  (the `created` event replaces its optimistic ids), so the persisted turn
+     *  must use the live ids; the preliminary req.body ids only match failures
+     *  that happen before `onStart`. */
+    const userMessage =
+      liveUserMessage != null
+        ? {
+            ...liveUserMessage,
+            ...(Array.isArray(req.body?.files) &&
+              req.body.files.length > 0 && { files: req.body.files }),
+            ...(Array.isArray(req.body?.manualSkills) &&
+              req.body.manualSkills.length > 0 && { manualSkills: req.body.manualSkills }),
+            ...(Array.isArray(req.body?.alwaysAppliedSkills) &&
+              req.body.alwaysAppliedSkills.length > 0 && {
+                alwaysAppliedSkills: req.body.alwaysAppliedSkills,
+              }),
+          }
+        : getPreliminaryUserMessage(req.body, conversationId);
+    const errorMessageId = getPreliminaryResponseMessageId(
+      liveUserMessage != null ? { messageId: liveUserMessage.messageId } : req.body,
+    );
     if (!userMessage || !errorMessageId) {
       return;
     }
@@ -250,20 +281,24 @@ async function saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, 
     const chatProjectId = endpointOption?.chatProjectId ?? req.body?.chatProjectId;
     /** Existing conversations get a minimal update that preserves their fields:
      *  saveConvo recomputes `messages` and bumps `updatedAt` so the saved failed
-     *  turn is reflected in the conversation doc and chat-list ordering. */
-    const convoFields = isNewConvo
-      ? {
-          ...(endpoint != null && { endpoint }),
-          ...(endpointOption?.endpointType != null && {
-            endpointType: endpointOption.endpointType,
-          }),
-          ...(model != null && { model }),
-          ...(iconURL != null && { iconURL }),
-          ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
-          ...(agentId != null && { agent_id: agentId }),
-          ...(typeof chatProjectId === 'string' && chatProjectId.length > 0 && { chatProjectId }),
-        }
-      : {};
+     *  turn is reflected in the conversation doc and chat-list ordering. A
+     *  conversation that no longer exists (`req.resolvedConversation === null`,
+     *  e.g. deleted from another tab) gets the full seed so the upsert doesn't
+     *  create an unusable endpoint-less row. */
+    const convoFields =
+      isNewConvo || req.resolvedConversation === null
+        ? {
+            ...(endpoint != null && { endpoint }),
+            ...(endpointOption?.endpointType != null && {
+              endpointType: endpointOption.endpointType,
+            }),
+            ...(model != null && { model }),
+            ...(iconURL != null && { iconURL }),
+            ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
+            ...(agentId != null && { agent_id: agentId }),
+            ...(typeof chatProjectId === 'string' && chatProjectId.length > 0 && { chatProjectId }),
+          }
+        : {};
     await saveConvo(reqCtx, { conversationId, ...convoFields }, { context });
   } catch (err) {
     logger.error('[AgentController] Failed to persist error turn', err);
@@ -328,6 +363,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
   req.body.conversationId = conversationId;
 
   let client = null;
+  let jobCreatedAt = null;
 
   try {
     logger.debug(`[ResumableAgentController] Creating job`, {
@@ -338,7 +374,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     });
 
     const job = await GenerationJobManager.createJob(streamId, userId, conversationId);
-    const jobCreatedAt = job.createdAt; // Capture creation time to detect job replacement
+    jobCreatedAt = job.createdAt; // Capture creation time to detect job replacement
     req._resumableStreamId = streamId;
     getMCPRequestContext(req, undefined, { cleanupOnResponse: false });
 
@@ -945,7 +981,14 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         } else {
           logger.error(`[ResumableAgentController] Generation error for ${streamId}:`, error);
           const errorText = error.message || 'Generation failed';
-          await saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, errorText });
+          await saveErrorTurn(req, {
+            conversationId,
+            endpointOption,
+            isNewConvo,
+            errorText,
+            jobCreatedAt,
+            liveUserMessage: userMessage,
+          });
           await GenerationJobManager.emitError(streamId, errorText);
           GenerationJobManager.completeJob(streamId, error.message);
         }
@@ -984,7 +1027,13 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       // JSON already sent; persist the failed turn before emitting the error so
       // the preliminary response row exists by the time the user can retry.
       const errorText = error.message || 'Failed to start generation';
-      await saveErrorTurn(req, { conversationId, endpointOption, isNewConvo, errorText });
+      await saveErrorTurn(req, {
+        conversationId,
+        endpointOption,
+        isNewConvo,
+        errorText,
+        jobCreatedAt,
+      });
       await GenerationJobManager.emitError(streamId, errorText);
     }
     GenerationJobManager.completeJob(streamId, error.message);

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -4,23 +4,23 @@ const {
   sendEvent,
   getViolationInfo,
   buildMessageFiles,
-  getReferencedQuotes,
   resolveTitleTiming,
+  getReferencedQuotes,
   GenerationJobManager,
-  filterPersistableAbortContent,
   decrementPendingRequest,
   sanitizeMessageForTransmit,
-  checkAndIncrementPendingRequest,
+  filterPersistableAbortContent,
   isUnpersistedPreliminaryParent,
+  checkAndIncrementPendingRequest,
 } = require('@librechat/api');
 const { disposeClient, clientRegistry, requestDataMap } = require('~/server/cleanup');
+const { saveMessage, getMessages, getConvo, saveConvo } = require('~/models');
 const {
-  getMCPRequestContext,
   cleanupMCPRequestContextForReq,
+  getMCPRequestContext,
 } = require('~/server/services/MCPRequestContext');
 const { handleAbortError } = require('~/server/middleware');
 const { logViolation } = require('~/cache');
-const { saveMessage, getMessages, getConvo, saveConvo } = require('~/models');
 
 function createCloseHandler(abortController) {
   return function (manual) {

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -40,6 +40,7 @@ const { logViolation } = require('~/cache');
 const { recordScheduleOutcome, isScheduleLive } = require('~/server/services/Schedules');
 const {
   saveMessage,
+  saveConvo,
   getMessages,
   getConvo,
   isAgentTriggerPrincipalActive,
@@ -105,6 +106,18 @@ async function attachConversationCreatedAt(req, conversationId, conversationAnch
   if (resolved.conversation !== undefined) {
     req.resolvedConversation = resolved.conversation ?? null;
   }
+}
+
+function getPreliminaryResponseMessageId({ messageId, responseMessageId }) {
+  if (typeof responseMessageId === 'string' && responseMessageId.length > 0) {
+    return responseMessageId;
+  }
+
+  if (typeof messageId !== 'string' || messageId.length === 0) {
+    return null;
+  }
+
+  return `${messageId.replace(/_+$/, '')}_`;
 }
 
 function getPreliminaryUserMessage(
@@ -187,6 +200,165 @@ async function finishResumableRequest(req, userId) {
     if (req._scheduleConcurrencyExempt !== true) {
       await decrementPendingRequest(userId);
     }
+  }
+}
+
+async function saveErrorTurn(
+  req,
+  {
+    conversationId,
+    endpointOption,
+    isNewConvo,
+    errorText,
+    liveUserMessage,
+    liveResponseMessageId,
+    sender,
+  },
+) {
+  try {
+    const { isContinued, isRegenerate, editedContent, responseMessageId, overrideParentMessageId } =
+      req.body ?? {};
+    if (
+      isContinued ||
+      editedContent != null ||
+      (responseMessageId && !isRegenerate) ||
+      req.body?.recoverySteerId != null ||
+      req.body?.clientRequestId?.startsWith?.('steer-recovery:') === true
+    ) {
+      return;
+    }
+
+    let userMessage = null;
+    let errorMessageId = null;
+    let errorParentMessageId = null;
+    if (isRegenerate) {
+      errorMessageId =
+        typeof responseMessageId === 'string' && responseMessageId.length > 0
+          ? responseMessageId
+          : null;
+      errorParentMessageId = liveUserMessage?.messageId ?? overrideParentMessageId ?? null;
+    } else {
+      userMessage =
+        liveUserMessage != null
+          ? {
+              ...liveUserMessage,
+              ...(liveUserMessage.files == null &&
+                Array.isArray(req.body?.files) &&
+                req.body.files.length > 0 && { files: req.body.files }),
+              ...(liveUserMessage.manualSkills == null &&
+                Array.isArray(req.body?.manualSkills) &&
+                req.body.manualSkills.length > 0 && { manualSkills: req.body.manualSkills }),
+              ...(liveUserMessage.alwaysAppliedSkills == null &&
+                Array.isArray(req.body?.alwaysAppliedSkills) &&
+                req.body.alwaysAppliedSkills.length > 0 && {
+                  alwaysAppliedSkills: req.body.alwaysAppliedSkills,
+                }),
+            }
+          : getPreliminaryUserMessage(req.body, conversationId);
+      if (!userMessage) {
+        return;
+      }
+      errorMessageId = getPreliminaryResponseMessageId(
+        liveUserMessage != null ? { messageId: liveUserMessage.messageId } : req.body,
+      );
+      errorParentMessageId = userMessage.messageId;
+    }
+    if (!errorMessageId || !errorParentMessageId) {
+      return;
+    }
+
+    const userId = req.user.id;
+    const existing = await getMessages(
+      { user: userId, messageId: errorMessageId, conversationId },
+      '_id',
+    );
+    if (existing.length > 0) {
+      return;
+    }
+    if (liveResponseMessageId != null && liveResponseMessageId !== errorMessageId) {
+      const partial = await getMessages(
+        { user: userId, messageId: liveResponseMessageId, conversationId },
+        '_id',
+      );
+      if (partial.length > 0) {
+        return;
+      }
+    }
+
+    const reqCtx = {
+      userId,
+      isTemporary: req?._agentEventBindingRetention?.isTemporary ?? req?.body?.isTemporary,
+      expiredAt: req?._agentEventBindingRetention?.expiredAt,
+      interfaceConfig: req?.config?.interfaceConfig,
+    };
+    const context = 'api/server/controllers/agents/request.js - failed turn';
+    const endpoint = endpointOption?.endpoint;
+    const model = getAgentResponseModel(req, endpointOption);
+    const iconURL = getEndpointIconURL(req, endpointOption);
+
+    if (userMessage) {
+      const savedUserMessage = await saveMessage(
+        reqCtx,
+        {
+          ...userMessage,
+          user: userId,
+          sender: 'User',
+          isCreatedByUser: true,
+          error: false,
+          unfinished: false,
+        },
+        { context },
+      );
+      if (!savedUserMessage) {
+        throw new Error('Failed user message could not be persisted');
+      }
+    }
+    const savedErrorMessage = await saveMessage(
+      reqCtx,
+      {
+        messageId: errorMessageId,
+        conversationId,
+        parentMessageId: errorParentMessageId,
+        sender: sender ?? 'AI',
+        ...(endpoint != null && { endpoint }),
+        ...(model != null && { model }),
+        ...(iconURL != null && { iconURL }),
+        user: userId,
+        text: errorText,
+        error: true,
+        unfinished: false,
+        isCreatedByUser: false,
+      },
+      { context },
+    );
+    if (!savedErrorMessage) {
+      throw new Error('Failed response message could not be persisted');
+    }
+
+    const agentId = endpointOption?.agent_id ?? req.body?.agent_id;
+    const chatProjectId = endpointOption?.chatProjectId ?? req.body?.chatProjectId;
+    const seedConvo = isNewConvo || req.resolvedConversation === null;
+    const convoFields = seedConvo
+      ? {
+          ...(endpoint != null && { endpoint }),
+          ...(endpointOption?.endpointType != null && {
+            endpointType: endpointOption.endpointType,
+          }),
+          ...(model != null && { model }),
+          ...(iconURL != null && { iconURL }),
+          ...(endpointOption?.spec != null && { spec: endpointOption.spec }),
+          ...(agentId != null && { agent_id: agentId }),
+          ...(typeof chatProjectId === 'string' && chatProjectId.length > 0 && { chatProjectId }),
+        }
+      : {};
+    await saveConvo(
+      reqCtx,
+      { conversationId, ...convoFields },
+      seedConvo ? { context } : { context, noUpsert: true },
+    );
+  } catch (err) {
+    logger.error('[AgentController] Failed to persist error turn', err);
+    throw err;
   }
 }
 
@@ -1450,10 +1622,14 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     }
 
     let userMessage;
+    let liveResponseMessageId = preallocatedResponseMessageId;
 
     const getReqData = (data = {}) => {
       if (data.userMessage) {
         userMessage = data.userMessage;
+      }
+      if (data.responseMessageId) {
+        liveResponseMessageId = data.responseMessageId;
       }
       // conversationId is pre-generated, no need to update from callback
     };
@@ -1593,6 +1769,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       try {
         const onStart = (userMsg, respMsgId, _isNewConvo) => {
           userMessage = userMsg;
+          liveResponseMessageId = respMsgId;
 
           // Store userMessage and responseMessageId upfront for resume capability
           GenerationJobManager.updateMetadata(
@@ -2179,8 +2356,18 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             // completeJob first wins running -> error and atomically parks
             // steers, then publishes. A competing abort/pause emits nothing.
             ownsScheduledFailure =
-              (await GenerationJobManager.completeJob(streamId, generationError, jobCreatedAt)) ===
-              true;
+              (await GenerationJobManager.completeJob(streamId, generationError, jobCreatedAt, {
+                beforeErrorPublication: () =>
+                  saveErrorTurn(req, {
+                    conversationId,
+                    endpointOption,
+                    isNewConvo,
+                    errorText: generationError,
+                    liveUserMessage: userMessage,
+                    liveResponseMessageId,
+                    sender: client?.sender,
+                  }),
+              })) === true;
           } catch (completeErr) {
             logger.warn(
               '[ResumableAgentController] completeJob failed during generation-error cleanup',
@@ -2262,6 +2449,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
   } catch (error) {
     logger.error('[ResumableAgentController] Initialization error:', error);
     const initializationFailure = getInitializationFailure(error);
+    const streamStarted = res.headersSent;
     try {
       if (!res.headersSent) {
         if (error?.code === 'GENERATION_PREDECESSOR_MISMATCH') {
@@ -2354,16 +2542,25 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       const initializationError = initializationFailure
         ? JSON.stringify(initializationFailure)
         : error.message || 'Failed to start generation';
+      const completionPromise = streamStarted
+        ? GenerationJobManager.completeJob(streamId, initializationError, jobCreatedAt, {
+            beforeErrorPublication: () =>
+              saveErrorTurn(req, {
+                conversationId,
+                endpointOption,
+                isNewConvo,
+                errorText: initializationError,
+              }),
+          })
+        : GenerationJobManager.completeJob(streamId, initializationError, jobCreatedAt);
       initializationFinalized =
-        (await GenerationJobManager.completeJob(streamId, initializationError, jobCreatedAt).catch(
-          (completeErr) => {
-            logger.warn(
-              '[ResumableAgentController] completeJob failed during init-error cleanup',
-              completeErr,
-            );
-            return false;
-          },
-        )) === true;
+        (await completionPromise.catch((completeErr) => {
+          logger.warn(
+            '[ResumableAgentController] completeJob failed during init-error cleanup',
+            completeErr,
+          );
+          return false;
+        })) === true;
     }
     if (initializationFinalized && !scheduleTerminalOutcomeRecorded) {
       await settleScheduledRun(classifyScheduledFailure(error));

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -710,6 +710,10 @@ class GenerationJobManagerClass {
    * reconnect can replay that authoritative final payload. */
   private terminalPublicationFailures = new WeakSet<TerminalJobClaim>();
 
+  /** Persistence-pending error claims whose terminal output was already
+   * reconciled by a competing owner or stale-owner recovery. */
+  private terminalErrorPublicationSuppressions = new WeakSet<TerminalJobClaim>();
+
   private cleanupInterval: NodeJS.Timeout | null = null;
 
   /** Generation-scoped retirement callbacks must not outlive the configured
@@ -3535,7 +3539,7 @@ class GenerationJobManagerClass {
     // Error jobs stay durable long enough for late subscribers to receive the
     // stored error. A publication failure must never bypass the finally cleanup.
     try {
-      if (status === 'error') {
+      if (status === 'error' && !this.terminalErrorPublicationSuppressions.has(claim)) {
         const terminalError = error ?? 'Generation failed';
         if (runtime) {
           runtime.errorEvent = terminalError;
@@ -3606,6 +3610,7 @@ class GenerationJobManagerClass {
 
       this.releaseJobOwnership(streamId, createdAt);
       this.terminalPublicationFailures.delete(claim);
+      this.terminalErrorPublicationSuppressions.delete(claim);
       let metricStatus: 'completed' | 'error' | 'aborted' = 'aborted';
       if (status === 'complete') {
         metricStatus = 'completed';
@@ -3640,16 +3645,55 @@ class GenerationJobManagerClass {
     streamId: string,
     error?: string,
     expectedCreatedAt?: number,
+    options: { beforeErrorPublication?: () => Promise<void> } = {},
   ): Promise<boolean> {
+    const beforeErrorPublication = error ? options.beforeErrorPublication : undefined;
     const claim = await this.claimTerminalJob(
       streamId,
       error ? 'error' : 'complete',
       error,
       expectedCreatedAt,
+      beforeErrorPublication ? { persistencePending: true } : undefined,
     );
     if (!claim) {
       return false;
     }
+
+    if (beforeErrorPublication) {
+      let persistenceFinalized = false;
+      try {
+        await beforeErrorPublication();
+        persistenceFinalized = await this.jobStore.finalizeTerminalPersistence(
+          streamId,
+          claim.createdAt,
+          JSON.stringify(
+            buildTerminalPersistenceReconcile({
+              createdAt: claim.createdAt,
+              conversationId: claim.conversationId,
+              status: claim.status,
+            }),
+          ),
+        );
+      } catch (persistenceError) {
+        logger.error(
+          `[GenerationJobManager] Failed required error persistence for ${streamId}:`,
+          persistenceError,
+        );
+        try {
+          await this.publishTerminalClaim(claim, null);
+        } catch (publishError) {
+          logger.error(
+            `[GenerationJobManager] Failed to publish error persistence reconciliation for ${streamId}:`,
+            publishError,
+          );
+        }
+      }
+
+      if (!persistenceFinalized) {
+        this.terminalErrorPublicationSuppressions.add(claim);
+      }
+    }
+
     await this.finishTerminalJob(claim);
     return true;
   }

--- a/packages/api/src/stream/__tests__/startup.spec.ts
+++ b/packages/api/src/stream/__tests__/startup.spec.ts
@@ -2783,6 +2783,86 @@ describe('GenerationJobManager startup telemetry', () => {
     await manager.destroy();
   });
 
+  it('holds terminal error publication until required persistence finishes', async () => {
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    const manager = new GenerationJobManagerClass();
+    manager.configure({
+      jobStore,
+      eventTransport: new InMemoryEventTransport(),
+      isRedis: false,
+      cleanupOnComplete: false,
+    });
+    manager.initialize();
+    const streamId = 'stream-error-persistence-barrier';
+    const job = await manager.createJob(streamId, 'user-1');
+    const onError = jest.fn();
+    const subscription = await manager.subscribe(streamId, () => undefined, undefined, onError);
+    let releasePersistence!: () => void;
+    const persistence = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+
+    const completing = manager.completeJob(streamId, 'initialization failed', job.createdAt, {
+      beforeErrorPublication: () => persistence,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onError).not.toHaveBeenCalled();
+    await expect(jobStore.getJob(streamId)).resolves.toMatchObject({
+      status: 'error',
+      error: 'initialization failed',
+      terminalPersistencePending: true,
+    });
+
+    releasePersistence();
+    await expect(completing).resolves.toBe(true);
+
+    expect(onError).toHaveBeenCalledWith('initialization failed');
+    await expect(jobStore.getJob(streamId)).resolves.toMatchObject({
+      status: 'error',
+      error: 'initialization failed',
+      terminalPersistencePending: false,
+    });
+    subscription?.unsubscribe();
+    await manager.destroy();
+  });
+
+  it('publishes reconciliation when required error persistence fails', async () => {
+    const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
+    const manager = new GenerationJobManagerClass();
+    manager.configure({
+      jobStore,
+      eventTransport: new InMemoryEventTransport(),
+      isRedis: false,
+      cleanupOnComplete: false,
+    });
+    manager.initialize();
+    const streamId = 'stream-error-persistence-fails';
+    const job = await manager.createJob(streamId, 'user-1');
+    const onDone = jest.fn();
+    const onError = jest.fn();
+    const subscription = await manager.subscribe(streamId, () => undefined, onDone, onError);
+
+    await expect(
+      manager.completeJob(streamId, 'initialization failed', job.createdAt, {
+        beforeErrorPublication: async () => {
+          throw new Error('message store unavailable');
+        },
+      }),
+    ).resolves.toBe(true);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        final: true,
+        reconcile: true,
+        terminalStatus: 'error',
+      }),
+    );
+    subscription?.unsubscribe();
+    await manager.destroy();
+  });
+
   it('atomically terminalizes a paused job when post-HITL persistence fails', async () => {
     const jobStore = new InMemoryJobStore({ ttlAfterComplete: 60_000 });
     const manager = new GenerationJobManagerClass();


### PR DESCRIPTION
## Summary

I fixed the preliminary-parent follow-up dead-end reported in discussion [#14135](https://github.com/danny-avila/LibreChat/discussions/14135) by adapting failed-turn persistence to the current resumable generation lifecycle on the latest `dev`.

When agent initialization or early generation fails before a response reaches the database, the client still anchors its error bubble on the preliminary response ID (`${userMessageId}_`). A follow-up then uses that ID as its parent and is rejected by `isUnpersistedPreliminaryParent`, leaving the conversation unable to continue.

- Persisted the user message and an `error: true` response before publishing terminal initialization and background-generation errors.
- Added a terminal persistence barrier to `GenerationJobManager.completeJob` so only the winning generation epoch performs the required write and subscribers cannot observe the raw error first.
- Published a conservative reconciliation event when required persistence fails or another terminal owner wins the persistence race.
- Preserved live user identities and request files or skill selections while retaining the client-compatible preliminary response ID.
- Avoided overwriting saved or partial responses and skipped continued, edited, response-reuse, and recovery-steer requests.
- Updated existing conversation metadata without recreating deleted conversations and seeded new conversation metadata for failed first turns.
- Added regression coverage for initialization and background failures, write-before-publication ordering, follow-up chaining, live IDs, idempotency, new conversations, and persistence-barrier failure handling.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `server/controllers/agents/__tests__/request.resumeMetadata.spec.js`: 107 tests pass.
- Ran `src/stream/__tests__/startup.spec.ts`: 99 tests pass.
- Verified ESLint, Prettier, changed-file import ordering, and `git diff --check` on all four changed files.
- Deferred the broad package type check to CI because the shared local dependency tree predates current `dev` and reports unrelated quote-steering type errors.

### **Test Configuration**:

- Node.js v24
- Jest per workspace from `api` and `packages/api`

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
