### PR TITLE
🔒 fix: apply Action domain validation to Assistant route and harden Action headers

### DIFF
--- a/api/server/routes/assistants/actions.js
+++ b/api/server/routes/assistants/actions.js
@@ -2,7 +2,13 @@ const express = require('express');
 const { nanoid } = require('nanoid');
 const { logger } = require('@librechat/data-schemas');
 const { isActionDomainAllowed, validateActionOAuthMetadata } = require('@librechat/api');
-const { actionDelimiter, EModelEndpoint, removeNullishValues } = require('librechat-data-provider');
+const {
+  actionDelimiter,
+  EModelEndpoint,
+  removeNullishValues,
+  validateActionDomain,
+  validateAndParseOpenAPISpec,
+} = require('librechat-data-provider');
 const {
   legacyDomainEncode,
   encryptMetadata,
@@ -34,6 +40,32 @@ router.post('/:assistant_id', async (req, res) => {
     }
 
     let metadata = await encryptMetadata(removeNullishValues(_metadata, true));
+
+    // SECURITY: Validate the OpenAPI spec and extract the server URL
+    if (metadata.raw_spec) {
+      const validationResult = validateAndParseOpenAPISpec(metadata.raw_spec);
+      if (!validationResult.status || !validationResult.serverUrl) {
+        return res.status(400).json({
+          message: validationResult.message || 'Invalid OpenAPI specification',
+        });
+      }
+
+      // SECURITY: Validate the client-provided domain matches the spec's server URL domain
+      // This prevents SSRF attacks where an attacker provides a whitelisted domain
+      // but uses a different (potentially internal) URL in the raw_spec
+      const domainValidation = validateActionDomain(metadata.domain, validationResult.serverUrl);
+      if (!domainValidation.isValid) {
+        logger.warn(`Domain mismatch detected: ${domainValidation.message}`, {
+          userId: req.user.id,
+          assistant_id,
+        });
+        return res.status(400).json({
+          message:
+            'Domain mismatch: The domain in the OpenAPI spec does not match the provided domain',
+        });
+      }
+    }
+
     const isDomainAllowed = await isActionDomainAllowed(
       metadata.domain,
       appConfig?.actions?.allowedDomains,

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -3,11 +3,24 @@ import { URL } from 'url';
 import _axios from 'axios';
 import crypto from 'crypto';
 import { load } from 'js-yaml';
+import type { OpenAPIV3 } from 'openapi-types';
 import type { ActionMetadata, ActionMetadataRuntime } from './types/agents';
 import type { FunctionTool, Schema, Reference } from './types/assistants';
 import { AuthTypeEnum, AuthorizationTypeEnum } from './types/agents';
-import type { OpenAPIV3 } from 'openapi-types';
 import { Tools } from './types/assistants';
+
+/**
+ * Header names that must never be set from user-supplied OpenAPI parameters,
+ * to prevent overriding authentication/proxy headers set by the action config.
+ */
+const RESERVED_ACTION_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'host',
+  'content-length',
+  'connection',
+]);
 
 export type ParametersSchema = {
   type: string;
@@ -325,7 +338,20 @@ class RequestExecutor {
         if (loc === 'query') {
           queryParams[key] = val;
         } else if (loc === 'header') {
-          headers[key] = String(val);
+          // SECURITY: Drop header params that would override reserved/auth headers
+          // (e.g. Authorization) or inject additional headers via CR/LF sequences.
+          const headerName = key.toLowerCase();
+          const value = String(val);
+          const collidesWithExisting = Object.keys(headers).some(
+            (existing) => existing.toLowerCase() === headerName,
+          );
+          if (
+            !RESERVED_ACTION_HEADERS.has(headerName) &&
+            !collidesWithExisting &&
+            !/[\r\n]/.test(value)
+          ) {
+            headers[key] = value;
+          }
         } else if (loc === 'body') {
           bodyParams[key] = val;
         }


### PR DESCRIPTION
 ## Summary

  Brings the **Assistant** actions save path to parity with the **Agent** actions route, and hardens outbound Action request headers. Both are consistency/hardening changes in the Actions subsystem — no new behavior on the happy path. Motivated by the existing Action SSRF hardening (GHSA-rgjq-4q58-m3q8, GHSA-f92m-jpv7-55p2); this closes the remaining Agent/Assistant parity gap.

  **1. Assistant actions: validate the OpenAPI `raw_spec` domain**

  `api/server/routes/agents/actions.js` already validates a submitted action's OpenAPI spec — it parses `raw_spec`, extracts the `servers` URL, and confirms that URL's domain matches the client-provided `metadata.domain` (`validateAndParseOpenAPISpec` + `validateActionDomain`).

  The sibling route `api/server/routes/assistants/actions.js` performed only `isActionDomainAllowed(metadata.domain, ...)` and never inspected `raw_spec`. This PR applies the same existing validation to the Assistant route, so a request can no longer pass the domain allowlist while the stored spec's server URL points elsewhere. No new validation semantics are introduced — it reuses the helpers already used by the Agent route.

  **2. Action headers: drop reserved / CR-LF header params**

  `packages/data-provider/src/actions.ts` builds outbound Action request headers as `{ ...authHeaders, ...contentType }` and then lets user-supplied OpenAPI header parameters overwrite them (`headers[key] = String(val)`). This PR drops header params that collide with reserved/auth headers (`authorization`, `proxy-authorization`, `cookie`, `host`, `content-length`, `connection`) or with any header already set by the action config, or that contain CR/LF sequences.

  No dependencies are required for this change.

  ## Change Type

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Testing

  - ESLint clean on both changed files.
  - `packages/data-provider` typecheck passes (`tsc --noEmit`).
  - `packages/data-provider` `actions` Jest suite passes (188 tests, covering `validateActionDomain` / OpenAPI spec parsing).
  - No frontend surface changed.

  To reproduce the Assistant-route behavior change:

  1. Enable the Assistants endpoint.
  2. `POST /actions/:assistant_id` with `metadata.domain` set to an allowed domain and `metadata.raw_spec.servers[0].url` pointing at a different host → expect `400` "Domain mismatch" (previously accepted).
  3. Submit with a matching domain/spec → saved as before.

  ### **Test Configuration**:

  - Node.js v24.16.0
  - No special environment variables required.

  ## Checklist

  - [x] My code adheres to this project's style guidelines
  - [x] I have performed a self-review of my own code
  - [x] I have commented in any complex areas of my code
  - [x] My changes do not introduce new warnings
  - [x] Local unit tests pass with my changes