### PR TITLE
🧷 chore: Expose Retain Recent Summarization Config

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -398,6 +398,7 @@ describe('summarizationConfig field passthrough', () => {
         updatePrompt: 'Update the existing summary with new messages',
         reserveRatio: 0.1,
         maxSummaryTokens: 4096,
+        retainRecent: { turns: 5, tokens: 40000 },
       },
     });
     const config = agents[0].summarizationConfig as Record<string, unknown>;
@@ -413,6 +414,7 @@ describe('summarizationConfig field passthrough', () => {
     expect(config.updatePrompt).toBe('Update the existing summary with new messages');
     expect(config.reserveRatio).toBe(0.1);
     expect(config.maxSummaryTokens).toBe(4096);
+    expect(config.retainRecent).toEqual({ turns: 5, tokens: 40000 });
   });
 
   it('uses self-summarize default when no config provided', async () => {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -633,6 +633,7 @@ function shapeSummarizationConfig(
       updatePrompt: config?.updatePrompt,
       reserveRatio: config?.reserveRatio,
       maxSummaryTokens: config?.maxSummaryTokens,
+      retainRecent: config?.retainRecent,
     } satisfies AgentSummarizationConfig,
     contextPruning: config?.contextPruning as ContextPruningConfig | undefined,
     reserveRatio: config?.reserveRatio,

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -11,6 +11,7 @@ import {
   SKILL_SYNC_MAX_INTERVAL_MINUTES,
   summarizationTriggerSchema,
   summarizationConfigSchema,
+  retainRecentConfigSchema,
   MAX_SUBAGENTS,
 } from '../src/config';
 import {
@@ -1110,6 +1111,35 @@ describe('summarizationTriggerSchema', () => {
       trigger: { type: 'token_ratio', value: 0.8 },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('retainRecentConfigSchema', () => {
+  it('accepts turn and token retention limits', () => {
+    const result = retainRecentConfigSchema.safeParse({
+      turns: 5,
+      tokens: 40000,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid turn and token retention limits', () => {
+    expect(retainRecentConfigSchema.safeParse({ turns: -1 }).success).toBe(false);
+    expect(retainRecentConfigSchema.safeParse({ turns: 21 }).success).toBe(false);
+    expect(retainRecentConfigSchema.safeParse({ tokens: 0 }).success).toBe(false);
+  });
+
+  it('parses inside the full summarization config', () => {
+    const result = summarizationConfigSchema.safeParse({
+      enabled: true,
+      retainRecent: { turns: 5, tokens: 40000 },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.retainRecent).toEqual({ turns: 5, tokens: 40000 });
+    }
   });
 });
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1781,6 +1781,11 @@ export const contextPruningSchema = z.object({
   minPrunableToolChars: z.number().min(0).optional(),
 });
 
+export const retainRecentConfigSchema = z.object({
+  turns: z.number().min(0).max(20).optional(),
+  tokens: z.number().positive().optional(),
+});
+
 export const summarizationConfigSchema = z.object({
   enabled: z.boolean().optional(),
   provider: z.string().optional(),
@@ -1792,6 +1797,7 @@ export const summarizationConfigSchema = z.object({
   reserveRatio: z.number().min(0).max(1).optional(),
   maxSummaryTokens: z.number().positive().optional(),
   contextPruning: contextPruningSchema.optional(),
+  retainRecent: retainRecentConfigSchema.optional(),
 });
 
 export type SummarizationConfig = z.infer<typeof summarizationConfigSchema>;


### PR DESCRIPTION
## Summary

I exposed `summarization.retainRecent` from `librechat.yaml` through LibreChat's config validation and agent run setup so the agents SDK can receive configured recent-turn retention.

- Added `retainRecentConfigSchema` with `turns` and `tokens` validation and included it in `summarizationConfigSchema`.
- Passed `retainRecent` through `shapeSummarizationConfig` to the SDK-facing `AgentSummarizationConfig` object.
- Added schema coverage for valid and invalid retention limits.
- Extended the agent run summarization passthrough test to assert `retainRecent` reaches `Run.create` inputs.

Fixes #14127.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] `npm ci`
- [x] `npm run build` in `packages/data-provider`
- [x] `npm run build` in `packages/data-schemas`
- [x] `npm run build` in `packages/api`
- [x] `npx jest specs/config-schemas.spec.ts --coverage=false --runInBand` in `packages/data-provider`
- [x] `npx jest src/agents/__tests__/run-summarization.test.ts --coverage=false --runInBand` in `packages/api`
- [x] `git diff --check`

### **Test Configuration**:

- Node.js: v24.16.0
- npm: 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes