### PR TITLE
🧊 fix: Include Conversation Starters in Agent View and List Responses

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -534,6 +534,7 @@ const getAgentHandler = async (req, res, expandProperties = false) => {
         id: agent.id,
         name: agent.name,
         description: agent.description,
+        conversation_starters: agent.conversation_starters,
         avatar: agent.avatar,
         author: agent.author,
         provider: agent.provider,

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -1620,6 +1620,7 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
           'author',
           'avatar',
           'category',
+          'conversation_starters',
           'description',
           'id',
           'is_promoted',

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -634,6 +634,27 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       });
       expect(response.owner_contact).toBeUndefined();
     });
+
+    test('should include conversation_starters in the basic VIEW response', async () => {
+      const starters = ['Summarize this page', 'What can you do?'];
+      const agent = await Agent.create({
+        id: `agent_${uuidv4()}`,
+        name: 'Starter Agent',
+        description: 'Exposes conversation starters',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: mockReq.user.id,
+        conversation_starters: starters,
+      });
+
+      mockReq.params = { id: agent.id };
+
+      await getAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      const response = mockRes.json.mock.calls[0][0];
+      expect(response.conversation_starters).toEqual(starters);
+    });
   });
 
   describe('getAgentVersionsHandler', () => {

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -3620,6 +3620,27 @@ describe('Support Contact Field', () => {
       expect(result.data[0].skills_enabled).toBe(true);
     });
 
+    test('should include conversation_starters in the default list projection', async () => {
+      const starters = ['Summarize this page', 'What can you do?'];
+      const scopedAgent = await createAgent({
+        id: `agent_${uuidv4().slice(0, 12)}`,
+        name: 'Agent With Starters',
+        description: 'Agent exposing conversation starters',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: userA,
+        conversation_starters: starters,
+      });
+
+      const result = await getListAgentsByAccess({
+        accessibleIds: [scopedAgent._id] as mongoose.Types.ObjectId[],
+        otherParams: {},
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].conversation_starters).toEqual(starters);
+    });
+
     test('should return multiple accessible agents when provided', async () => {
       // Give User B access to two of User A's agents
       const accessibleIds = [agentA1._id, agentA3._id] as mongoose.Types.ObjectId[];

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -905,6 +905,7 @@ export function createAgentMethods(
       avatar: 1,
       author: 1,
       description: 1,
+      conversation_starters: 1,
       updatedAt: 1,
       category: 1,
       support_contact: 1,


### PR DESCRIPTION
Fixes #14140. Conversation starters configured on an agent don't render on the new-chat screen — only the name and description show up.

The starters are stored fine, but they get stripped from the two endpoints the chat UI reads. `getListAgentsByAccess` (which feeds `agentsMap`, the source `ConversationStarters` reads its `entity` from) doesn't list `conversation_starters` in its projection, and the non-expanded VIEW branch of `getAgentHandler` returns a fixed field whitelist that omits it too. So the client never receives them and renders no chips. Only `GET /agents/:id/expanded` returns the full document, which is why the starters briefly flash right after editing (from the cached expanded object) and then vanish once the stripped `GET /agents/:id` response overwrites state. This worked in older versions where the view endpoint returned the full agent, so it's a regression.

Added `conversation_starters` to the list projection and to the VIEW whitelist. It's non-sensitive display data, same category as `description`, so it's safe to expose at VIEW permission. Added tests on both paths.