### PR TITLE
feat: instance-wide mandatory two-factor authentication

### DIFF
--- a/api/server/routes/__tests__/config.spec.js
+++ b/api/server/routes/__tests__/config.spec.js
@@ -321,6 +321,27 @@ describe('GET /api/config', () => {
       expect(response.body.webSearch).toEqual({ searchProvider: 'tavily' });
     });
 
+    it('should report mandatoryTwoFactorEnabled false when registration.mandatoryTwoFactor is unset', async () => {
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      const app = createApp(mockUser);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body.mandatoryTwoFactorEnabled).toBe(false);
+    });
+
+    it('should report mandatoryTwoFactorEnabled true when registration.mandatoryTwoFactor is set', async () => {
+      mockGetAppConfig.mockResolvedValue({
+        ...baseAppConfig,
+        registration: { ...baseAppConfig.registration, mandatoryTwoFactor: true },
+      });
+      const app = createApp(mockUser);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body.mandatoryTwoFactorEnabled).toBe(true);
+    });
+
     it('should strip private prompt fields from model spec presets', async () => {
       mockGetAppConfig.mockResolvedValue({
         ...baseAppConfig,

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -260,6 +260,7 @@ router.get('/', async function (req, res) {
       ...buildPostLoginPayload(),
       sharedLinksSnapshotFilesEnabled: sharedLinksEnabled && isFileSnapshotEnabled(appConfig),
       socialLogins: appConfig?.registration?.socialLogins ?? defaultSocialLogins,
+      mandatoryTwoFactorEnabled: appConfig?.registration?.mandatoryTwoFactor === true,
       interface: appConfig?.interfaceConfig,
       titleGenerationTiming: resolveTitleTiming({
         appConfig,

--- a/client/src/components/Auth/__tests__/LoginForm.spec.tsx
+++ b/client/src/components/Auth/__tests__/LoginForm.spec.tsx
@@ -40,6 +40,7 @@ const mockStartupConfig: TStartupConfig = {
   sharedLinksEnabled: true,
   publicSharedLinksEnabled: true,
   allowAccountDeletion: true,
+  mandatoryTwoFactorEnabled: false,
 };
 
 const setup = ({

--- a/client/src/components/Nav/SettingsTabs/Account/Mandatory2FAModal.spec.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/Mandatory2FAModal.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import Mandatory2FAModal from './Mandatory2FAModal';
+
+const mockShowToast = jest.fn();
+const mockEnableMutate = jest.fn();
+const mockVerifyMutate = jest.fn();
+const mockConfirmMutate = jest.fn();
+
+jest.mock('@librechat/client', () => ({
+  ...jest.requireActual('@librechat/client'),
+  useToastContext: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock('~/data-provider', () => ({
+  ...jest.requireActual('~/data-provider'),
+  useEnableTwoFactorMutation: () => ({ mutate: mockEnableMutate, isLoading: false }),
+  useVerifyTwoFactorMutation: () => ({ mutate: mockVerifyMutate, isLoading: false }),
+  useConfirmTwoFactorMutation: () => ({ mutate: mockConfirmMutate, isLoading: false }),
+}));
+
+function renderModal() {
+  return render(
+    <RecoilRoot>
+      <Mandatory2FAModal />
+    </RecoilRoot>,
+  );
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Mandatory2FAModal', () => {
+  it('renders the blocking setup phase with no way to dismiss', () => {
+    renderModal();
+
+    expect(screen.getByText('Two-factor authentication required')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This instance requires two-factor authentication for every account. Set it up now with your authenticator app to continue.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+  });
+
+  it('requests a QR code and advances to the QR phase on success', async () => {
+    mockEnableMutate.mockImplementation((_payload, { onSuccess }) => {
+      onSuccess({
+        otpauthUrl: 'otpauth://totp/test?secret=ABCDEF&issuer=Test',
+        backupCodes: ['a', 'b'],
+      });
+    });
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate QR Code' }));
+
+    await waitFor(() => expect(mockEnableMutate).toHaveBeenCalled());
+  });
+
+  it('shows an error toast when QR generation fails', async () => {
+    mockEnableMutate.mockImplementation((_payload, { onError }) => {
+      onError();
+    });
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate QR Code' }));
+
+    await waitFor(() =>
+      expect(mockShowToast).toHaveBeenCalledWith({
+        message: 'There was an error generating two-factor authentication settings',
+        status: 'error',
+      }),
+    );
+  });
+});

--- a/client/src/components/Nav/SettingsTabs/Account/Mandatory2FAModal.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/Mandatory2FAModal.tsx
@@ -1,0 +1,222 @@
+import React, { useCallback, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { ShieldCheck } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  OGDialog,
+  useToastContext,
+  OGDialogContent,
+  OGDialogHeader,
+  OGDialogTitle,
+  Progress,
+} from '@librechat/client';
+import type { TUser } from 'librechat-data-provider';
+import type { Variants } from 'framer-motion';
+import {
+  useConfirmTwoFactorMutation,
+  useEnableTwoFactorMutation,
+  useVerifyTwoFactorMutation,
+} from '~/data-provider';
+import { SetupPhase, QRPhase, VerifyPhase, BackupPhase } from './TwoFactorPhases';
+import { useLocalize } from '~/hooks';
+import store from '~/store';
+
+type SetupOnlyPhase = 'setup' | 'qr' | 'verify' | 'backup';
+
+const phaseVariants: Variants = {
+  initial: { opacity: 0, scale: 0.95 },
+  animate: { opacity: 1, scale: 1, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, scale: 0.95, transition: { duration: 0.3, ease: 'easeIn' } },
+};
+
+const phasesLabel: Record<SetupOnlyPhase, string> = {
+  setup: 'Setup',
+  qr: 'Scan QR',
+  verify: 'Verify',
+  backup: 'Backup',
+};
+const steps = Object.values(phasesLabel);
+
+/**
+ * Blocking 2FA setup gate rendered in `Root` when the instance sets
+ * `registration.mandatoryTwoFactor` and the signed-in user hasn't completed
+ * TOTP setup yet. Reuses the same phase components as the optional
+ * Settings-page flow (`TwoFactorAuthentication`), but with no trigger, no
+ * disable path, and no way to dismiss before finishing setup.
+ */
+const Mandatory2FAModal: React.FC = () => {
+  const localize = useLocalize();
+  const setUser = useSetRecoilState(store.user);
+  const { showToast } = useToastContext();
+
+  const [phase, setPhase] = useState<SetupOnlyPhase>('setup');
+  const [secret, setSecret] = useState<string>('');
+  const [otpauthUrl, setOtpauthUrl] = useState<string>('');
+  const [downloaded, setDownloaded] = useState<boolean>(false);
+  const [backupCodes, setBackupCodes] = useState<string[]>([]);
+  const [verificationToken, setVerificationToken] = useState<string>('');
+
+  const { mutate: confirm2FAMutate } = useConfirmTwoFactorMutation();
+  const { mutate: enable2FAMutate, isLoading: isGenerating } = useEnableTwoFactorMutation();
+  const { mutate: verify2FAMutate, isLoading: isVerifying } = useVerifyTwoFactorMutation();
+
+  const currentStep = steps.indexOf(phasesLabel[phase]);
+
+  const handleGenerateQRCode = useCallback(() => {
+    enable2FAMutate(undefined, {
+      onSuccess: ({ otpauthUrl: url, backupCodes: codes }) => {
+        setOtpauthUrl(url);
+        setSecret(url.split('secret=')[1].split('&')[0]);
+        setBackupCodes(codes);
+        setPhase('qr');
+      },
+      onError: () => showToast({ message: localize('com_ui_2fa_generate_error'), status: 'error' }),
+    });
+  }, [enable2FAMutate, localize, showToast]);
+
+  const handleVerify = useCallback(() => {
+    if (!verificationToken) {
+      return;
+    }
+    verify2FAMutate(
+      { token: verificationToken },
+      {
+        onSuccess: () => {
+          showToast({ message: localize('com_ui_2fa_verified') });
+          confirm2FAMutate(
+            { token: verificationToken },
+            {
+              onSuccess: () => setPhase('backup'),
+              onError: () =>
+                showToast({ message: localize('com_ui_2fa_invalid'), status: 'error' }),
+            },
+          );
+        },
+        onError: () => showToast({ message: localize('com_ui_2fa_invalid'), status: 'error' }),
+      },
+    );
+  }, [verificationToken, verify2FAMutate, confirm2FAMutate, localize, showToast]);
+
+  const handleDownload = useCallback(() => {
+    if (!backupCodes.length) {
+      return;
+    }
+    const blob = new Blob([backupCodes.join('\n')], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'backup-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+    setDownloaded(true);
+  }, [backupCodes]);
+
+  const handleConfirm = useCallback(() => {
+    showToast({ message: localize('com_ui_2fa_enabled') });
+    setUser(
+      (prev) =>
+        ({
+          ...prev,
+          backupCodes: backupCodes.map((code) => ({
+            code,
+            codeHash: code,
+            used: false,
+            usedAt: null,
+          })),
+          twoFactorEnabled: true,
+        }) as TUser,
+    );
+  }, [setUser, localize, showToast, backupCodes]);
+
+  return (
+    <OGDialog open onOpenChange={() => {}}>
+      <OGDialogContent
+        className="w-11/12 max-w-lg p-6"
+        showCloseButton={false}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={phase}
+            variants={phaseVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="space-y-6"
+          >
+            <OGDialogHeader>
+              <OGDialogTitle className="mb-2 flex items-center gap-3 text-2xl font-bold">
+                <ShieldCheck className="h-6 w-6 text-primary" aria-hidden="true" />
+                {localize('com_ui_2fa_mandatory_title')}
+              </OGDialogTitle>
+              <p className="mt-2 text-sm text-text-secondary">
+                {localize('com_ui_2fa_mandatory_description')}
+              </p>
+              <div className="mt-4 space-y-3">
+                <Progress
+                  value={(currentStep / (steps.length - 1)) * 100}
+                  className="h-2 rounded-full"
+                />
+                <div className="flex justify-between text-sm">
+                  {steps.map((step, index) => (
+                    <span
+                      key={step}
+                      className="font-medium"
+                      style={{
+                        color:
+                          currentStep >= index ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                      }}
+                    >
+                      {step}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </OGDialogHeader>
+
+            <AnimatePresence mode="wait">
+              {phase === 'setup' && (
+                <SetupPhase
+                  isGenerating={isGenerating}
+                  onGenerate={handleGenerateQRCode}
+                  onNext={() => setPhase('qr')}
+                  onError={(error) => showToast({ message: error.message, status: 'error' })}
+                />
+              )}
+              {phase === 'qr' && (
+                <QRPhase
+                  secret={secret}
+                  otpauthUrl={otpauthUrl}
+                  onNext={() => setPhase('verify')}
+                  onError={(error) => showToast({ message: error.message, status: 'error' })}
+                />
+              )}
+              {phase === 'verify' && (
+                <VerifyPhase
+                  token={verificationToken}
+                  onTokenChange={setVerificationToken}
+                  isVerifying={isVerifying}
+                  onNext={handleVerify}
+                  onError={(error) => showToast({ message: error.message, status: 'error' })}
+                />
+              )}
+              {phase === 'backup' && (
+                <BackupPhase
+                  backupCodes={backupCodes}
+                  onDownload={handleDownload}
+                  downloaded={downloaded}
+                  onNext={handleConfirm}
+                  onError={(error) => showToast({ message: error.message, status: 'error' })}
+                />
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </AnimatePresence>
+      </OGDialogContent>
+    </OGDialog>
+  );
+};
+
+export default React.memo(Mandatory2FAModal);

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -697,6 +697,8 @@
   "com_ui_2fa_enabled": "2FA has been enabled",
   "com_ui_2fa_generate_error": "There was an error generating two-factor authentication settings",
   "com_ui_2fa_invalid": "Invalid two-factor authentication code",
+  "com_ui_2fa_mandatory_description": "This instance requires two-factor authentication for every account. Set it up now with your authenticator app to continue.",
+  "com_ui_2fa_mandatory_title": "Two-factor authentication required",
   "com_ui_2fa_setup": "Setup 2FA",
   "com_ui_2fa_verification_required": "Enter your 2FA code to continue",
   "com_ui_2fa_verified": "Successfully verified Two-Factor Authentication",

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -22,6 +22,7 @@ import { useUserTermsQuery, useGetStartupConfig } from '~/data-provider';
 import useKeyboardShortcuts from '~/hooks/useKeyboardShortcuts';
 import { UnifiedSidebar } from '~/components/UnifiedSidebar';
 import { TermsAndConditionsModal } from '~/components/ui';
+import Mandatory2FAModal from '~/components/Nav/SettingsTabs/Account/Mandatory2FAModal';
 import { useHealthCheck } from '~/data-provider';
 import { Banner } from '~/components/Banners';
 import store from '~/store';
@@ -43,7 +44,7 @@ export default function Root() {
   const sidebarExpanded = useRecoilValue(store.sidebarExpanded);
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
 
-  const { isAuthenticated, logout } = useAuthContext();
+  const { isAuthenticated, logout, user } = useAuthContext();
 
   useHealthCheck(isAuthenticated);
 
@@ -76,6 +77,9 @@ export default function Root() {
   if (!isAuthenticated) {
     return null;
   }
+
+  const mustSetUpTwoFactor =
+    config?.mandatoryTwoFactorEnabled === true && user?.twoFactorEnabled !== true;
 
   return (
     <SetConvoProvider>
@@ -112,6 +116,7 @@ export default function Root() {
               modalContent={config.interface.termsOfService.modalContent}
             />
           )}
+          {mustSetUpTwoFactor && <Mandatory2FAModal />}
           <KeyboardShortcutsProvider />
         </AssistantsMapContext.Provider>
       </FileMapContext.Provider>

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1539,6 +1539,8 @@ export type TStartupConfig = {
   openidReuseTokens?: boolean;
   allowAccountDeletion: boolean;
   minPasswordLength?: number;
+  /** Whether the instance requires every account to complete TOTP setup. */
+  mandatoryTwoFactorEnabled: boolean;
   webSearch?: {
     searchProvider?: SearchProviders;
     scraperProvider?: ScraperProviders;
@@ -1880,6 +1882,8 @@ export const configSchema = z.object({
     .object({
       socialLogins: z.array(z.string()).optional(),
       allowedDomains: z.array(z.string()).optional(),
+      /** When `true`, every account must complete TOTP setup before using the app. */
+      mandatoryTwoFactor: z.boolean().optional(),
     })
     .default({ socialLogins: defaultSocialLogins }),
   balance: balanceSchema.optional(),


### PR DESCRIPTION
## Summary

Adds an instance-level `registration.mandatoryTwoFactor` config flag. When set, any signed-in user who hasn't completed TOTP setup is shown a blocking setup modal until they finish enrollment — no way to dismiss or use the app until 2FA is configured.

2FA itself already exists as a mature, well-tested opt-in feature (`TwoFactorAuthentication.tsx`, `TwoFactorController`, `twoFactorService`, etc.). This PR only adds the missing instance-wide *enforcement* path on top of that existing infrastructure; it does not touch the underlying TOTP/backup-code logic at all.

- `packages/data-provider/src/config.ts`: new `registration.mandatoryTwoFactor` boolean (config schema) and `mandatoryTwoFactorEnabled` on `TStartupConfig`.
- `api/server/routes/config.js`: exposes the resolved flag in the authenticated `/api/config` payload.
- `client/src/components/Nav/SettingsTabs/Account/Mandatory2FAModal.tsx`: new blocking dialog, reusing the existing `SetupPhase`/`QRPhase`/`VerifyPhase`/`BackupPhase` components from the optional settings-page flow.
- `client/src/routes/Root.tsx`: renders the modal (mirroring the existing `TermsAndConditionsModal` gating pattern) when `mandatoryTwoFactorEnabled` is true and the signed-in user doesn't have 2FA enabled yet.

## Test plan

- [x] `api`: `npx jest server/routes/__tests__/config.spec.js` — 45/45 passing, including two new cases for `mandatoryTwoFactorEnabled` (unset → `false`, set → `true`)
- [x] `packages/data-provider`: `npx jest src/config` — 119/119 passing (schema change didn't break existing config validation tests)
- [x] `client`: new `Mandatory2FAModal.spec.tsx` — covers the blocking initial render (no dismiss control), successful QR-code generation, and the error-toast path
- [x] `client`: `LoginForm.spec.tsx` and `src/routes/**` — all passing (updated one existing `TStartupConfig` test fixture for the new required field)
- [x] `tsc --noEmit` clean on `client`
- [x] `eslint` clean on all changed files