### PR TITLE
⏳ fix: Defer MCP Connection for Request-Scoped Placeholders on Reinitialize

### DIFF
--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -1,5 +1,9 @@
 const { logger } = require('@librechat/data-schemas');
-const { getMissingCustomUserVars, requiresEphemeralUserConnection } = require('@librechat/api');
+const {
+  getMissingCustomUserVars,
+  requiresEphemeralUserConnection,
+  getMissingRuntimeBodyPlaceholderFields,
+} = require('@librechat/api');
 const { CacheKeys, Constants } = require('librechat-data-provider');
 const { getMCPManager, getMCPServersRegistry, getFlowStateManager } = require('~/config');
 const { findToken, createToken, updateToken, deleteTokens } = require('~/models');
@@ -114,6 +118,28 @@ async function reinitMCPServer({
         message: `MCP server '${serverName}' requires user-provided variable(s) [${missingUserVars.join(
           ', ',
         )}] which are not set`,
+        oauthRequired: false,
+        serverName,
+        oauthUrl: null,
+        tools: null,
+      };
+    }
+
+    /** `{{LIBRECHAT_BODY_*}}` placeholders only resolve during a chat turn; connecting
+     *  without them would fail, so defer the connection instead of reporting a failure. */
+    const missingBodyFields = serverConfig
+      ? getMissingRuntimeBodyPlaceholderFields(serverConfig, requestBody)
+      : [];
+    if (missingBodyFields.length > 0) {
+      logger.info(
+        `[MCP Reinitialize] Server '${serverName}' requires request body field(s) [${missingBodyFields.join(
+          ', ',
+        )}] for runtime placeholders; connection deferred to first use in a chat turn`,
+      );
+      return {
+        availableTools: null,
+        success: true,
+        message: `MCP server '${serverName}' uses request-scoped placeholders; connection will be established on first use in a chat turn`,
         oauthRequired: false,
         serverName,
         oauthUrl: null,

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -184,3 +184,100 @@ describe('reinitMCPServer — customUserVars gating (issue #10969)', () => {
     expect(mockGetConnection).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('reinitMCPServer — runtime BODY placeholder pre-check (issue #14074)', () => {
+  const user = { id: 'user-123' };
+  const serverName = 'Thingy';
+  const serverConfig = {
+    type: 'streamable-http',
+    url: 'https://thingy.example.com/mcp',
+    source: 'yaml',
+    headers: { 'X-Conversation-Id': '{{LIBRECHAT_BODY_CONVERSATIONID}}' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateMCPServerTools.mockResolvedValue({});
+  });
+
+  it('defers connection without failing when body placeholders cannot resolve outside a chat turn', async () => {
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig,
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockGetConnection).not.toHaveBeenCalled();
+    expect(mockDiscoverServerTools).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      availableTools: null,
+      success: true,
+      tools: null,
+      oauthRequired: false,
+      serverName,
+    });
+    expect(result.message).toContain('first use in a chat turn');
+  });
+
+  it('treats an empty-string body field as missing', async () => {
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig,
+      requestBody: { conversationId: '  ' },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockGetConnection).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  it('connects normally when the request body provides the placeholder fields', async () => {
+    const disconnect = jest.fn().mockResolvedValue(undefined);
+    mockGetConnection.mockResolvedValue({
+      disconnect,
+      fetchTools: jest.fn().mockResolvedValue([]),
+    });
+
+    await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig,
+      requestBody: { conversationId: 'convo-1' },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockGetConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports missing customUserVars before deferring on body placeholders', async () => {
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig: {
+        ...serverConfig,
+        customUserVars: { THINGY_TOKEN: { title: 'Thingy Access Token' } },
+      },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('THINGY_TOKEN');
+  });
+
+  it('still treats unrelated connection errors as real failures', async () => {
+    mockGetConnection.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await reinitMCPServer({
+      user,
+      serverName,
+      serverConfig: { type: 'streamable-http', url: 'https://thingy.example.com/mcp' },
+      userMCPAuthMap: undefined,
+    });
+
+    expect(mockDiscoverServerTools).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.message).toBe(`Failed to reinitialize MCP server '${serverName}'`);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #14074. Supersedes #14078 (credited via `Co-authored-by`, since its root-cause analysis was correct).

Since #13626, `getUserConnection` throws when a server config uses `{{LIBRECHAT_BODY_*}}` placeholders (e.g. `{{LIBRECHAT_BODY_CONVERSATIONID}}`) that cannot resolve outside an active chat turn. `reinitMCPServer` treated that throw as a hard failure, so every server using this documented placeholder pattern surfaced as `Failed to initialize MCP server` from the Reinitialize button, the MCP panel, and Agent Builder tool discovery, even though the config is perfectly valid and connects fine on the next chat message.

I fixed this with a pre-check instead of error classification: the exact predicate `getUserConnection` uses (`getMissingRuntimeBodyPlaceholderFields`) is a pure, already-exported helper, so `reinitMCPServer` now evaluates it before attempting a connection and returns a deferred-success response when body fields are unavailable.

- Added a pre-check in `reinitMCPServer` after the `customUserVars` gate: when required body fields are missing, skip `getConnection` entirely and return `success: true` with an explanatory message (`connection will be established on first use in a chat turn`), `tools: null`, and `oauthRequired: false`.
- Returned `success: true` deliberately: the client keys toasts purely on `success` and never renders `message` (`useMCPServerManager` shows the localized `com_ui_mcp_init_failed` on any non-success), so a message-only change would still surface as a failure toast. #14078's fallback-to-discovery approach could not fix this either, because `discoverServerTools` performs the same missing-fields check and always returns `tools: null` for these servers, leaving `success: false`. Codex flagged the same gap on that PR.
- Skipped any cached-tools lookup on purpose: request-scoped servers are intentionally excluded from the persistent tool cache (`createMCPToolCacheService#isRequestScoped`), so `tools: null` is the correct, design-consistent payload here.
- Left the chat-turn path untouched: when `requestBody` carries the placeholder fields (every real chat turn, including the `reconnectServer` flows), the pre-check passes and the normal connect path runs. The `getUserConnection` throw from #13626 remains the load-bearing security behavior for actual tool calls, and both `reconnectServer` consumers key on `result.tools`/`result.availableTools`, so the deferred response degrades identically to the previous behavior there, minus the spurious error.
- Ordered the pre-check after the `customUserVars` gate so missing user credentials still report first.
- Avoided the message-string classifier from #14078 entirely: matching on error text couples the fallback to the exact wording in `UserConnectionManager` and silently regresses if it changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added 5 tests to `api/server/services/Tools/mcp.spec.js`: deferred success without connecting or discovering when body fields are unavailable, empty-string body fields counting as missing, normal connection when the request body provides the fields, `customUserVars` gating taking precedence, and unrelated connection errors (`ECONNREFUSED`) still reporting as real failures.
- Ran the full `reinitMCPServer` suite (12 tests) plus MCP-adjacent suites (`server/services/MCP.spec.js`, `server/services/__tests__/MCP.spec.js`, `server/routes/__tests__/mcp.spec.js`, 180 tests) with no regressions.
- ESLint and sort-imports clean via lint-staged.

### **Test Configuration**:
- Node v24.16.0, MongoDB via mongodb-memory-server, fresh `npm install` + `npm run build` in a clean worktree off `main` (`8fcb77fe6`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes