### PR TITLE
🎯 style: Center Scroll-to-Bottom Rib in Message Nav Rail

### DIFF
--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -175,7 +175,7 @@ const MessageIndicator = memo(function MessageIndicator({
 });
 
 const chevronButtonClasses = cn(
-  'rounded-md p-0.5 text-text-tertiary opacity-40 transition-[color,opacity] duration-300',
+  '-mr-0.5 rounded-md p-0.5 text-text-tertiary opacity-40 transition-[color,opacity] duration-300',
   'group-hover/nav:text-text-secondary group-hover/nav:opacity-100',
   'group-focus-within/nav:text-text-secondary group-focus-within/nav:opacity-100',
   'group-hover/nav:hover:text-text-primary',

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -150,7 +150,7 @@ const MessageIndicator = memo(function MessageIndicator({
   label: string;
   onSelect: (id: string) => void;
 }) {
-  const baseSize = entry.isEnd ? 'h-1 w-1' : 'h-[3px] w-4';
+  const baseSize = entry.isEnd ? 'mr-1.5 h-1 w-1' : 'h-[3px] w-4';
   return (
     <button
       type="button"


### PR DESCRIPTION
## Summary

I aligned the message navigation rail onto a single vertical axis. The nav right-aligns all of its children to one edge: the 16px message ribs sit flush against it (centerline 8px in), but the scroll-to-bottom terminus dot was also flush right (centerline 2px in) and the chevron icons carry 2px of button padding (centerline 10px in), so all three elements sat on different axes.

- Added a 6px right margin (`mr-1.5`) to the 4px terminus dot so its center lands on the rib centerline, 8px from the rail edge.
- Added a -2px right margin (`-mr-0.5`) to the chevron buttons so the 16px icons occupy the same horizontal strip as the rib bars, putting their centers on the same axis.
- Left the hover magnification untouched; ribs still grow leftward from the rail edge.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the MessageNav unit suite: `npx jest MessageNav` — 59/59 tests pass.
- Verified ESLint and import-order checks pass on the changed file.

### **Test Configuration**:

- Node.js v24.16.0, Jest via the `client` workspace.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes