### PR TITLE
feat: generalize skill sync via GitRepoAdapter, add GitLab support

### DIFF
--- a/packages/api/src/admin/skills.ts
+++ b/packages/api/src/admin/skills.ts
@@ -95,7 +95,9 @@ function serializeCredential(
   credential: SkillSyncCredentialSummary,
 ): TGitHubSkillSyncCredentialSummary {
   return {
-    provider: credential.provider,
+    // This admin surface is GitHub-only; see serializeSourceStatus for why the
+    // literal is asserted instead of passed through.
+    provider: 'github',
     credentialKey: credential.credentialKey,
     credentialPresent: credential.credentialPresent,
     tokenFingerprint: credential.tokenFingerprint,
@@ -129,7 +131,10 @@ function serializeSourceStatus(
 ): TGitHubSkillSyncSourceStatus {
   const includePrivateSourceMetadata = includeCredentialMetadata;
   return {
-    provider: status.provider,
+    // This admin surface is GitHub-only; `status.provider` is asserted rather
+    // than passed through so a future generic-provider status object cannot
+    // silently widen this response's wire contract.
+    provider: 'github',
     sourceId: status.sourceId,
     tenantId: status.tenantId,
     status: status.status,

--- a/packages/api/src/skills/sync/adapters/factory.spec.ts
+++ b/packages/api/src/skills/sync/adapters/factory.spec.ts
@@ -1,0 +1,85 @@
+import type {
+  SkillSyncGitHubSourceConfig,
+  SkillSyncGitLabSourceConfig,
+} from 'librechat-data-provider';
+import { createRepoAdapter } from './factory';
+
+const githubSource: SkillSyncGitHubSourceConfig = {
+  id: 'librechat-skills',
+  owner: 'LibreChat',
+  repo: 'skills',
+  ref: 'main',
+  paths: ['skills'],
+  credentialKey: 'github-skills-prod',
+};
+
+const gitlabSource: SkillSyncGitLabSourceConfig = {
+  id: 'librechat-skills-gitlab',
+  projectId: 'group%2Fskills',
+  ref: 'main',
+  paths: ['skills'],
+  credentialKey: 'gitlab-skills-prod',
+};
+
+function credentials() {
+  return { token: 'secret-token', fetchFn: jest.fn() as unknown as typeof fetch };
+}
+
+describe('createRepoAdapter', () => {
+  it('creates a GitHub adapter exposing the shared GitRepoAdapter surface', () => {
+    const adapter = createRepoAdapter('github', githubSource, credentials());
+    expect(typeof adapter.resolveCommit).toBe('function');
+    expect(typeof adapter.fetchTreeEntries).toBe('function');
+    expect(typeof adapter.fetchFileContent).toBe('function');
+  });
+
+  it('creates a GitLab adapter exposing the shared GitRepoAdapter surface', () => {
+    const adapter = createRepoAdapter('gitlab', gitlabSource, credentials());
+    expect(typeof adapter.resolveCommit).toBe('function');
+    expect(typeof adapter.fetchTreeEntries).toBe('function');
+    expect(typeof adapter.fetchFileContent).toBe('function');
+  });
+
+  it('routes a GitHub source through the GitHub REST API base', async () => {
+    const fetchFn = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ sha: 'commit-sha', commit: { tree: { sha: 'tree-sha' } } }),
+    })) as unknown as typeof fetch;
+    const adapter = createRepoAdapter('github', githubSource, { token: 't', fetchFn });
+    await adapter.resolveCommit('main');
+    const [calledUrl] = (fetchFn as unknown as jest.Mock).mock.calls[0];
+    expect(calledUrl.toString()).toContain('api.github.com');
+  });
+
+  it('routes a GitLab source through the GitLab REST API base', async () => {
+    const fetchFn = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ id: 'commit-sha' }),
+    })) as unknown as typeof fetch;
+    const adapter = createRepoAdapter('gitlab', gitlabSource, { token: 't', fetchFn });
+    await adapter.resolveCommit('main');
+    const [calledUrl] = (fetchFn as unknown as jest.Mock).mock.calls[0];
+    expect(calledUrl.toString()).toContain('gitlab.com/api/v4');
+  });
+
+  it('honors a self-hosted GitLab baseUrl when routing', async () => {
+    const fetchFn = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ id: 'commit-sha' }),
+    })) as unknown as typeof fetch;
+    const source: SkillSyncGitLabSourceConfig = {
+      ...gitlabSource,
+      baseUrl: 'https://gitlab.internal.example.com',
+    };
+    const adapter = createRepoAdapter('gitlab', source, { token: 't', fetchFn });
+    await adapter.resolveCommit('main');
+    const [calledUrl] = (fetchFn as unknown as jest.Mock).mock.calls[0];
+    expect(calledUrl.toString()).toContain('gitlab.internal.example.com/api/v4');
+  });
+});

--- a/packages/api/src/skills/sync/adapters/factory.ts
+++ b/packages/api/src/skills/sync/adapters/factory.ts
@@ -1,0 +1,47 @@
+import type {
+  SkillSyncGitHubSourceConfig,
+  SkillSyncGitLabSourceConfig,
+} from 'librechat-data-provider';
+import type { GitRepoAdapter } from './types';
+import { createGitHubRepoAdapter } from './github';
+import { createGitLabRepoAdapter } from './gitlab';
+
+type FetchFn = typeof fetch;
+
+export type RepoAdapterCredentials = {
+  token: string;
+  fetchFn: FetchFn;
+};
+
+export function createRepoAdapter(
+  provider: 'github',
+  source: SkillSyncGitHubSourceConfig,
+  credentials: RepoAdapterCredentials,
+): GitRepoAdapter;
+export function createRepoAdapter(
+  provider: 'gitlab',
+  source: SkillSyncGitLabSourceConfig,
+  credentials: RepoAdapterCredentials,
+): GitRepoAdapter;
+export function createRepoAdapter(
+  provider: 'github' | 'gitlab',
+  source: SkillSyncGitHubSourceConfig | SkillSyncGitLabSourceConfig,
+  credentials: RepoAdapterCredentials,
+): GitRepoAdapter {
+  if (provider === 'github') {
+    const githubSource = source as SkillSyncGitHubSourceConfig;
+    return createGitHubRepoAdapter({
+      owner: githubSource.owner,
+      repo: githubSource.repo,
+      token: credentials.token,
+      fetchFn: credentials.fetchFn,
+    });
+  }
+  const gitlabSource = source as SkillSyncGitLabSourceConfig;
+  return createGitLabRepoAdapter({
+    baseUrl: gitlabSource.baseUrl,
+    projectId: gitlabSource.projectId,
+    token: credentials.token,
+    fetchFn: credentials.fetchFn,
+  });
+}

--- a/packages/api/src/skills/sync/adapters/github.ts
+++ b/packages/api/src/skills/sync/adapters/github.ts
@@ -1,0 +1,270 @@
+import type {
+  FetchFileContentParams,
+  FetchTreeParams,
+  GitRepoAdapter,
+  RepoCommit,
+  RepoTreeEntry,
+} from './types';
+import { RepoAdapterError } from './types';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+export const GITHUB_FINE_GRAINED_TOKEN_RECOMMENDATION =
+  'Use a GitHub fine-grained personal access token scoped to the selected repository with read-only Contents and Metadata permissions.';
+
+type FetchFn = typeof fetch;
+
+type GitHubTreeEntry = {
+  path: string;
+  mode: string;
+  type: 'blob' | 'tree' | 'commit';
+  sha: string;
+  size?: number;
+  url: string;
+};
+
+type GitHubTreeResponse = {
+  sha: string;
+  tree: GitHubTreeEntry[];
+  truncated: boolean;
+};
+
+type GitHubBlobResponse = {
+  sha: string;
+  content: string;
+  encoding: string;
+  size: number;
+};
+
+type GitHubCommitResponse = {
+  sha: string;
+  commit: {
+    tree: {
+      sha: string;
+    };
+  };
+};
+
+export type GitHubRepoAdapterConfig = {
+  owner: string;
+  repo: string;
+  token: string;
+  fetchFn: FetchFn;
+};
+
+function normalizeRepoPath(value: string): string {
+  const trimmed = value.trim().replace(/^\/+|\/+$/g, '');
+  return trimmed === '.' ? '' : trimmed;
+}
+
+function buildGitHubHeaders(token: string): HeadersInit {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'LibreChat-Skill-Sync',
+  };
+}
+
+function buildGitHubUrl(pathname: string): string {
+  return `${GITHUB_API_BASE}${pathname}`;
+}
+
+function encodeGitHubPath(value: string): string {
+  return value.split('/').map(encodeURIComponent).join('/');
+}
+
+async function readGitHubErrorMessage(response: Response): Promise<string | undefined> {
+  try {
+    const body = (await response.json()) as { message?: unknown };
+    return typeof body.message === 'string' ? body.message : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isGitHubRateLimitResponse(params: {
+  status: number;
+  remaining: string | null;
+  retryAfter: string | null;
+  message?: string;
+}): boolean {
+  if (params.status === 429 || params.remaining === '0' || params.retryAfter) {
+    return true;
+  }
+  const message = params.message?.toLowerCase() ?? '';
+  return message.includes('rate limit') || message.includes('abuse detection');
+}
+
+async function githubJson<T>(params: {
+  fetchFn: FetchFn;
+  token: string;
+  pathname: string;
+}): Promise<T> {
+  const response = await params.fetchFn(buildGitHubUrl(params.pathname), {
+    headers: buildGitHubHeaders(params.token),
+  });
+  if (response.ok) {
+    return (await response.json()) as T;
+  }
+  const remaining = response.headers.get('x-ratelimit-remaining');
+  const retryAfter = response.headers.get('retry-after');
+  const message = await readGitHubErrorMessage(response);
+  if (response.status === 401 || response.status === 403 || response.status === 429) {
+    const code = isGitHubRateLimitResponse({
+      status: response.status,
+      remaining,
+      retryAfter,
+      message,
+    })
+      ? 'GITHUB_RATE_LIMITED'
+      : 'GITHUB_AUTH_FAILED';
+    throw new RepoAdapterError(code, `GitHub request failed with HTTP ${response.status}`);
+  }
+  if (response.status === 404) {
+    throw new RepoAdapterError('GITHUB_NOT_FOUND', 'GitHub repository, ref, or path was not found');
+  }
+  throw new RepoAdapterError(
+    'GITHUB_REQUEST_FAILED',
+    `GitHub request failed with HTTP ${response.status}`,
+  );
+}
+
+async function fetchTree(params: {
+  fetchFn: FetchFn;
+  token: string;
+  owner: string;
+  repo: string;
+  treeSha: string;
+  recursive?: boolean;
+}): Promise<GitHubTreeResponse> {
+  const owner = encodeURIComponent(params.owner);
+  const repo = encodeURIComponent(params.repo);
+  const treeSha = encodeURIComponent(params.treeSha);
+  const recursive = params.recursive ?? true;
+  return githubJson<GitHubTreeResponse>({
+    fetchFn: params.fetchFn,
+    token: params.token,
+    pathname: `/repos/${owner}/${repo}/git/trees/${treeSha}${recursive ? '?recursive=1' : ''}`,
+  });
+}
+
+/**
+ * Chases tree shas one path segment at a time so a configured subdirectory can
+ * be listed without pulling (and hitting the truncation limit of) the whole
+ * repository tree in a single recursive call.
+ */
+async function fetchTreeAtPath(params: {
+  fetchFn: FetchFn;
+  token: string;
+  owner: string;
+  repo: string;
+  rootTreeSha: string;
+  repoPath: string;
+  assertNotCancelled: () => void;
+}): Promise<GitHubTreeEntry[]> {
+  const normalizedPath = normalizeRepoPath(params.repoPath);
+  let treeSha = params.rootTreeSha;
+  if (normalizedPath) {
+    for (const segment of normalizedPath.split('/')) {
+      params.assertNotCancelled();
+      const tree = await fetchTree({ ...params, treeSha, recursive: false });
+      params.assertNotCancelled();
+      if (tree.truncated) {
+        throw new RepoAdapterError('GITHUB_TREE_TRUNCATED', 'GitHub tree response was truncated');
+      }
+      const next = tree.tree.find((entry) => entry.type === 'tree' && entry.path === segment);
+      if (!next) {
+        throw new RepoAdapterError(
+          'GITHUB_PATH_NOT_FOUND',
+          `Configured GitHub skill path "${normalizedPath}" was not found`,
+        );
+      }
+      treeSha = next.sha;
+    }
+  }
+
+  params.assertNotCancelled();
+  const tree = await fetchTree({ ...params, treeSha, recursive: true });
+  params.assertNotCancelled();
+  if (tree.truncated) {
+    throw new RepoAdapterError('GITHUB_TREE_TRUNCATED', 'GitHub tree response was truncated');
+  }
+  if (!normalizedPath) {
+    return tree.tree;
+  }
+  return tree.tree.map((entry) => ({
+    ...entry,
+    path: `${normalizedPath}/${normalizeRepoPath(entry.path)}`,
+  }));
+}
+
+async function fetchBlob(params: {
+  fetchFn: FetchFn;
+  token: string;
+  owner: string;
+  repo: string;
+  sha: string;
+}): Promise<Buffer> {
+  const owner = encodeURIComponent(params.owner);
+  const repo = encodeURIComponent(params.repo);
+  const sha = encodeURIComponent(params.sha);
+  const blob = await githubJson<GitHubBlobResponse>({
+    fetchFn: params.fetchFn,
+    token: params.token,
+    pathname: `/repos/${owner}/${repo}/git/blobs/${sha}`,
+  });
+  if (blob.encoding !== 'base64') {
+    throw new RepoAdapterError(
+      'GITHUB_UNSUPPORTED_BLOB',
+      `Unsupported GitHub blob encoding "${blob.encoding}"`,
+    );
+  }
+  return Buffer.from(blob.content.replace(/\s/g, ''), 'base64');
+}
+
+function toRepoTreeEntry(entry: GitHubTreeEntry): RepoTreeEntry | null {
+  if (entry.type !== 'blob' && entry.type !== 'tree') {
+    return null;
+  }
+  return { path: entry.path, type: entry.type, id: entry.sha, size: entry.size };
+}
+
+export function createGitHubRepoAdapter(config: GitHubRepoAdapterConfig): GitRepoAdapter {
+  const { owner, repo, token, fetchFn } = config;
+
+  async function resolveCommit(ref: string): Promise<RepoCommit> {
+    const encodedRef = encodeGitHubPath(ref);
+    const commit = await githubJson<GitHubCommitResponse>({
+      fetchFn,
+      token,
+      pathname: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodedRef}`,
+    });
+    return { id: commit.sha, treeId: commit.commit.tree.sha };
+  }
+
+  async function fetchTreeEntries(
+    commit: RepoCommit,
+    params: FetchTreeParams,
+  ): Promise<RepoTreeEntry[]> {
+    const entries = await fetchTreeAtPath({
+      fetchFn,
+      token,
+      owner,
+      repo,
+      rootTreeSha: commit.treeId,
+      repoPath: params.pathPrefix,
+      assertNotCancelled: params.assertNotCancelled,
+    });
+    return entries.map(toRepoTreeEntry).filter((entry): entry is RepoTreeEntry => entry !== null);
+  }
+
+  async function fetchFileContent(
+    _commit: RepoCommit,
+    params: FetchFileContentParams,
+  ): Promise<Buffer> {
+    return fetchBlob({ fetchFn, token, owner, repo, sha: params.entry.id });
+  }
+
+  return { resolveCommit, fetchTreeEntries, fetchFileContent };
+}

--- a/packages/api/src/skills/sync/adapters/gitlab.spec.ts
+++ b/packages/api/src/skills/sync/adapters/gitlab.spec.ts
@@ -1,0 +1,224 @@
+import {
+  createGitLabRepoAdapter,
+  GITLAB_DEFAULT_BASE_URL,
+  type GitLabRepoAdapterConfig,
+} from './gitlab';
+import { RepoAdapterError } from './types';
+
+function response(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  const normalizedHeaders = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (key: string) => normalizedHeaders.get(key.toLowerCase()) ?? null,
+    },
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function blobMetadata(content: string) {
+  return {
+    size: Buffer.byteLength(content),
+    encoding: 'base64',
+    content: Buffer.from(content).toString('base64'),
+  };
+}
+
+function gitlabFetch(overrides: Record<string, () => Response> = {}): typeof fetch {
+  return jest.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    for (const [pattern, handler] of Object.entries(overrides)) {
+      if (url.includes(pattern)) {
+        return handler();
+      }
+    }
+    if (url.includes('/repository/commits/')) {
+      return response({ id: 'commit-sha' });
+    }
+    if (url.includes('/repository/tree')) {
+      return response(
+        [
+          {
+            id: 'skill-md-id',
+            name: 'SKILL.md',
+            type: 'blob',
+            path: 'skills/research/SKILL.md',
+            mode: '100644',
+          },
+          {
+            id: 'file-id',
+            name: 'run.sh',
+            type: 'blob',
+            path: 'skills/research/scripts/run.sh',
+            mode: '100644',
+          },
+        ],
+        200,
+        { 'x-next-page': '' },
+      );
+    }
+    if (url.includes('/repository/files/skills%2Fresearch%2FSKILL.md')) {
+      return response(blobMetadata('---\nname: research\n---\nBody'));
+    }
+    if (url.includes('/repository/files/skills%2Fresearch%2Fscripts%2Frun.sh')) {
+      return response(blobMetadata('echo ok'));
+    }
+    return response({ message: 'not found' }, 404);
+  }) as unknown as typeof fetch;
+}
+
+function createAdapter(overrides: Partial<GitLabRepoAdapterConfig> = {}) {
+  return createGitLabRepoAdapter({
+    projectId: 'group%2Fskills',
+    token: 'glpat-secret',
+    fetchFn: gitlabFetch(),
+    ...overrides,
+  });
+}
+
+describe('createGitLabRepoAdapter', () => {
+  it('resolves a ref to a commit id, with treeId equal to the commit (GitLab has no separate tree object)', async () => {
+    const adapter = createAdapter();
+    const commit = await adapter.resolveCommit('main');
+    expect(commit).toEqual({ id: 'commit-sha', treeId: 'commit-sha' });
+  });
+
+  it('defaults to gitlab.com when no baseUrl is configured', async () => {
+    const fetchFn = jest.fn(async () => response({ id: 'commit-sha' })) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn });
+    await adapter.resolveCommit('main');
+    const [calledUrl] = (fetchFn as unknown as jest.Mock).mock.calls[0];
+    expect(calledUrl.toString().startsWith(GITLAB_DEFAULT_BASE_URL)).toBe(true);
+  });
+
+  it('uses a configured self-hosted baseUrl', async () => {
+    const fetchFn = jest.fn(async () => response({ id: 'commit-sha' })) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn, baseUrl: 'https://gitlab.example.com' });
+    await adapter.resolveCommit('main');
+    const [calledUrl] = (fetchFn as unknown as jest.Mock).mock.calls[0];
+    expect(calledUrl.toString().startsWith('https://gitlab.example.com/api/v4')).toBe(true);
+  });
+
+  it('sends the Private-Token header for authentication', async () => {
+    const fetchFn = jest.fn(async () => response({ id: 'commit-sha' })) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn, token: 'glpat-abc123' });
+    await adapter.resolveCommit('main');
+    const [, init] = (fetchFn as unknown as jest.Mock).mock.calls[0];
+    expect((init.headers as Record<string, string>)['Private-Token']).toBe('glpat-abc123');
+  });
+
+  it('lists tree entries recursively and populates blob sizes', async () => {
+    const adapter = createAdapter();
+    const commit = await adapter.resolveCommit('main');
+    const entries = await adapter.fetchTreeEntries(commit, {
+      ref: 'main',
+      pathPrefix: 'skills',
+      assertNotCancelled: () => undefined,
+    });
+    expect(entries).toEqual([
+      {
+        path: 'skills/research/SKILL.md',
+        type: 'blob',
+        id: 'skill-md-id',
+        size: Buffer.byteLength('---\nname: research\n---\nBody'),
+      },
+      {
+        path: 'skills/research/scripts/run.sh',
+        type: 'blob',
+        id: 'file-id',
+        size: Buffer.byteLength('echo ok'),
+      },
+    ]);
+  });
+
+  it('follows x-next-page pagination until exhausted', async () => {
+    let page = 0;
+    const fetchFn = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes('/repository/tree')) {
+        page += 1;
+        if (page === 1) {
+          return response(
+            [{ id: 'a', name: 'a.md', type: 'blob', path: 'a.md', mode: '100644' }],
+            200,
+            { 'x-next-page': '2' },
+          );
+        }
+        return response(
+          [{ id: 'b', name: 'b.md', type: 'blob', path: 'b.md', mode: '100644' }],
+          200,
+          { 'x-next-page': '' },
+        );
+      }
+      return response(blobMetadata('content'));
+    }) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn });
+    const entries = await adapter.fetchTreeEntries(
+      { id: 'commit-sha', treeId: 'commit-sha' },
+      { ref: 'commit-sha', pathPrefix: '', assertNotCancelled: () => undefined },
+    );
+    expect(entries.map((entry) => entry.path)).toEqual(['a.md', 'b.md']);
+  });
+
+  it('fetches decoded file content for a blob entry', async () => {
+    const adapter = createAdapter();
+    const commit = await adapter.resolveCommit('main');
+    const buffer = await adapter.fetchFileContent(commit, {
+      ref: 'main',
+      entry: { path: 'skills/research/scripts/run.sh', type: 'blob', id: 'file-id' },
+    });
+    expect(buffer.toString('utf-8')).toBe('echo ok');
+  });
+
+  it('throws RepoAdapterError with a rate-limit code on HTTP 429', async () => {
+    const fetchFn = jest.fn(async () =>
+      response({ message: 'rate limited' }, 429, { 'retry-after': '30' }),
+    ) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn });
+    await expect(adapter.resolveCommit('main')).rejects.toMatchObject({
+      code: 'GITLAB_RATE_LIMITED',
+    });
+  });
+
+  it('throws RepoAdapterError with an auth-failed code on HTTP 401', async () => {
+    const fetchFn = jest.fn(async () =>
+      response({ message: 'unauthorized' }, 401),
+    ) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn });
+    await expect(adapter.resolveCommit('main')).rejects.toBeInstanceOf(RepoAdapterError);
+    await expect(adapter.resolveCommit('main')).rejects.toMatchObject({
+      code: 'GITLAB_AUTH_FAILED',
+    });
+  });
+
+  it('throws RepoAdapterError with a not-found code on HTTP 404', async () => {
+    const fetchFn = jest.fn(async () =>
+      response({ message: 'not found' }, 404),
+    ) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn });
+    await expect(adapter.resolveCommit('main')).rejects.toMatchObject({
+      code: 'GITLAB_NOT_FOUND',
+    });
+  });
+
+  it('throws on unsupported file encodings', async () => {
+    const fetchFn = jest.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes('/repository/files/')) {
+        return response({ size: 4, encoding: 'base64url', content: 'zzzz' });
+      }
+      return response({ id: 'commit-sha' });
+    }) as unknown as typeof fetch;
+    const adapter = createAdapter({ fetchFn });
+    const commit = await adapter.resolveCommit('main');
+    await expect(
+      adapter.fetchFileContent(commit, {
+        ref: 'main',
+        entry: { path: 'skills/research/SKILL.md', type: 'blob', id: 'skill-md-id' },
+      }),
+    ).rejects.toMatchObject({ code: 'GITLAB_UNSUPPORTED_BLOB' });
+  });
+});

--- a/packages/api/src/skills/sync/adapters/gitlab.ts
+++ b/packages/api/src/skills/sync/adapters/gitlab.ts
@@ -1,0 +1,285 @@
+import type {
+  FetchFileContentParams,
+  FetchTreeParams,
+  GitRepoAdapter,
+  RepoCommit,
+  RepoTreeEntry,
+} from './types';
+import { RepoAdapterError } from './types';
+
+export const GITLAB_DEFAULT_BASE_URL = 'https://gitlab.com';
+
+export const GITLAB_TOKEN_RECOMMENDATION =
+  'Use a GitLab project access token scoped to the selected project with read-only repository access.';
+
+type FetchFn = typeof fetch;
+
+type GitLabTreeEntry = {
+  id: string;
+  name: string;
+  type: 'blob' | 'tree';
+  path: string;
+  mode: string;
+};
+
+type GitLabFileMetadata = {
+  size: number;
+  content: string;
+  encoding: string;
+};
+
+export type GitLabRepoAdapterConfig = {
+  baseUrl?: string;
+  projectId: string;
+  token: string;
+  fetchFn: FetchFn;
+};
+
+function normalizeRepoPath(value: string): string {
+  const trimmed = value.trim().replace(/^\/+|\/+$/g, '');
+  return trimmed === '.' ? '' : trimmed;
+}
+
+function buildGitLabHeaders(token: string): HeadersInit {
+  return {
+    'Private-Token': token,
+    'User-Agent': 'LibreChat-Skill-Sync',
+  };
+}
+
+function buildGitLabApiBase(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}/api/v4`;
+}
+
+async function readGitLabErrorMessage(response: Response): Promise<string | undefined> {
+  try {
+    const body = (await response.json()) as { message?: unknown };
+    if (typeof body.message === 'string') {
+      return body.message;
+    }
+    if (Array.isArray(body.message)) {
+      return body.message.join(', ');
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isGitLabRateLimitResponse(params: {
+  status: number;
+  retryAfter: string | null;
+  remaining: string | null;
+}): boolean {
+  return params.status === 429 || Boolean(params.retryAfter) || params.remaining === '0';
+}
+
+async function gitlabRequest(params: {
+  fetchFn: FetchFn;
+  token: string;
+  url: string;
+}): Promise<Response> {
+  const response = await params.fetchFn(params.url, { headers: buildGitLabHeaders(params.token) });
+  if (response.ok) {
+    return response;
+  }
+  const retryAfter = response.headers.get('retry-after');
+  const remaining = response.headers.get('ratelimit-remaining');
+  const message = await readGitLabErrorMessage(response);
+  if (response.status === 401 || response.status === 403 || response.status === 429) {
+    const code = isGitLabRateLimitResponse({ status: response.status, retryAfter, remaining })
+      ? 'GITLAB_RATE_LIMITED'
+      : 'GITLAB_AUTH_FAILED';
+    throw new RepoAdapterError(
+      code,
+      `GitLab request failed with HTTP ${response.status}${message ? `: ${message}` : ''}`,
+    );
+  }
+  if (response.status === 404) {
+    throw new RepoAdapterError('GITLAB_NOT_FOUND', 'GitLab project, ref, or path was not found');
+  }
+  throw new RepoAdapterError(
+    'GITLAB_REQUEST_FAILED',
+    `GitLab request failed with HTTP ${response.status}${message ? `: ${message}` : ''}`,
+  );
+}
+
+async function gitlabJson<T>(params: { fetchFn: FetchFn; token: string; url: string }): Promise<T> {
+  const response = await gitlabRequest(params);
+  return (await response.json()) as T;
+}
+
+/**
+ * GitLab paginates the tree endpoint via `X-Next-Page` rather than a truncation
+ * flag, so a full listing means following that header until it is empty.
+ */
+async function fetchTreePage(params: {
+  fetchFn: FetchFn;
+  token: string;
+  apiBase: string;
+  projectId: string;
+  ref: string;
+  path: string;
+  page: number;
+}): Promise<{ entries: GitLabTreeEntry[]; nextPage: string | null }> {
+  const query = new URLSearchParams({
+    ref: params.ref,
+    recursive: 'true',
+    per_page: '100',
+    page: String(params.page),
+  });
+  if (params.path) {
+    query.set('path', params.path);
+  }
+  const url = `${params.apiBase}/projects/${encodeURIComponent(
+    params.projectId,
+  )}/repository/tree?${query.toString()}`;
+  const response = await gitlabRequest({ fetchFn: params.fetchFn, token: params.token, url });
+  const entries = (await response.json()) as GitLabTreeEntry[];
+  const nextPage = response.headers.get('x-next-page');
+  return { entries, nextPage: nextPage && nextPage.trim() ? nextPage : null };
+}
+
+async function fetchFullTree(params: {
+  fetchFn: FetchFn;
+  token: string;
+  apiBase: string;
+  projectId: string;
+  ref: string;
+  path: string;
+  assertNotCancelled: () => void;
+}): Promise<GitLabTreeEntry[]> {
+  const entries: GitLabTreeEntry[] = [];
+  let page: number | null = 1;
+  while (page !== null) {
+    params.assertNotCancelled();
+    const result: { entries: GitLabTreeEntry[]; nextPage: string | null } = await fetchTreePage({
+      ...params,
+      page,
+    });
+    entries.push(...result.entries);
+    page = result.nextPage ? Number(result.nextPage) : null;
+  }
+  return entries;
+}
+
+function toRepoTreeEntry(entry: GitLabTreeEntry): RepoTreeEntry | null {
+  if (entry.type !== 'blob' && entry.type !== 'tree') {
+    return null;
+  }
+  return { path: entry.path, type: entry.type, id: entry.id };
+}
+
+/**
+ * `size` is populated in a second pass, one metadata request per blob. GitLab's
+ * tree endpoint omits size, unlike GitHub's, which returns it inline; this keeps
+ * the size-limit check enforceable before content download without changing the
+ * shared `RepoTreeEntry` shape.
+ */
+async function withBlobSizes(params: {
+  fetchFn: FetchFn;
+  token: string;
+  apiBase: string;
+  projectId: string;
+  ref: string;
+  entries: RepoTreeEntry[];
+  assertNotCancelled: () => void;
+}): Promise<RepoTreeEntry[]> {
+  const result: RepoTreeEntry[] = [];
+  for (const entry of params.entries) {
+    if (entry.type !== 'blob') {
+      result.push(entry);
+      continue;
+    }
+    params.assertNotCancelled();
+    const metadata = await fetchFileMetadata({ ...params, entry });
+    result.push({ ...entry, size: metadata.size });
+  }
+  return result;
+}
+
+async function fetchFileMetadata(params: {
+  fetchFn: FetchFn;
+  token: string;
+  apiBase: string;
+  projectId: string;
+  ref: string;
+  entry: RepoTreeEntry;
+}): Promise<GitLabFileMetadata> {
+  const encodedPath = encodeURIComponent(params.entry.path);
+  return gitlabJson<GitLabFileMetadata>({
+    fetchFn: params.fetchFn,
+    token: params.token,
+    url: `${params.apiBase}/projects/${encodeURIComponent(
+      params.projectId,
+    )}/repository/files/${encodedPath}?ref=${encodeURIComponent(params.ref)}`,
+  });
+}
+
+export function createGitLabRepoAdapter(config: GitLabRepoAdapterConfig): GitRepoAdapter {
+  const { projectId, token, fetchFn } = config;
+  const apiBase = buildGitLabApiBase(config.baseUrl ?? GITLAB_DEFAULT_BASE_URL);
+
+  async function resolveCommit(ref: string): Promise<RepoCommit> {
+    const commit = await gitlabJson<{ id: string }>({
+      fetchFn,
+      token,
+      url: `${apiBase}/projects/${encodeURIComponent(projectId)}/repository/commits/${encodeURIComponent(
+        ref,
+      )}`,
+    });
+    // GitLab has no separate tree object to address, so the tree entry point is
+    // the commit id itself.
+    return { id: commit.id, treeId: commit.id };
+  }
+
+  async function fetchTreeEntries(
+    commit: RepoCommit,
+    params: FetchTreeParams,
+  ): Promise<RepoTreeEntry[]> {
+    const rawEntries = await fetchFullTree({
+      fetchFn,
+      token,
+      apiBase,
+      projectId,
+      ref: commit.treeId,
+      path: normalizeRepoPath(params.pathPrefix),
+      assertNotCancelled: params.assertNotCancelled,
+    });
+    const entries = rawEntries
+      .map(toRepoTreeEntry)
+      .filter((entry): entry is RepoTreeEntry => entry !== null);
+    return withBlobSizes({
+      fetchFn,
+      token,
+      apiBase,
+      projectId,
+      ref: commit.treeId,
+      entries,
+      assertNotCancelled: params.assertNotCancelled,
+    });
+  }
+
+  async function fetchFileContent(
+    commit: RepoCommit,
+    params: FetchFileContentParams,
+  ): Promise<Buffer> {
+    const metadata = await fetchFileMetadata({
+      fetchFn,
+      token,
+      apiBase,
+      projectId,
+      ref: commit.id,
+      entry: params.entry,
+    });
+    if (metadata.encoding !== 'base64') {
+      throw new RepoAdapterError(
+        'GITLAB_UNSUPPORTED_BLOB',
+        `Unsupported GitLab file encoding "${metadata.encoding}"`,
+      );
+    }
+    return Buffer.from(metadata.content.replace(/\s/g, ''), 'base64');
+  }
+
+  return { resolveCommit, fetchTreeEntries, fetchFileContent };
+}

--- a/packages/api/src/skills/sync/adapters/types.ts
+++ b/packages/api/src/skills/sync/adapters/types.ts
@@ -1,0 +1,82 @@
+export type RepoTreeEntryType = 'blob' | 'tree';
+
+/**
+ * `id` is the provider's content-addressable identifier for the entry (GitHub
+ * blob/tree sha, GitLab blob/tree id). It is round-tripped into `fetchFileContent`
+ * and persisted in `sourceMetadata` to detect unchanged files across syncs without
+ * re-downloading their content.
+ */
+export type RepoTreeEntry = {
+  path: string;
+  type: RepoTreeEntryType;
+  id: string;
+  size?: number;
+};
+
+export type RepoCommit = {
+  /** Identifier persisted as the sync's `commitSha`, opaque outside the adapter. */
+  id: string;
+  /**
+   * Root tree identifier as of this commit — the entry point `fetchTreeEntries`
+   * walks from. Distinct from `id` on providers (GitHub) whose commit and tree
+   * objects are addressed separately; equal to `id` where a provider has no such
+   * distinction.
+   */
+  treeId: string;
+};
+
+/**
+ * Surface a rate-limit/auth distinction as thrown errors (matching how the
+ * orchestration already classifies GitHub failures) rather than a boolean method,
+ * since every adapter call already needs try/catch for HTTP-status handling.
+ */
+export class RepoAdapterError extends Error {
+  code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'RepoAdapterError';
+    this.code = code;
+  }
+}
+
+export type FetchTreeParams = {
+  ref: string;
+  pathPrefix: string;
+  assertNotCancelled: () => void;
+};
+
+export type FetchFileContentParams = {
+  ref: string;
+  entry: RepoTreeEntry;
+};
+
+/**
+ * The REST-specific surface every skill-sync source implementation must provide.
+ * Generic orchestration (skill discovery, DB upsert/cleanup, sync counters) lives
+ * outside adapters and depends only on this interface, never on a provider's HTTP
+ * shape directly.
+ */
+export interface GitRepoAdapter {
+  /**
+   * Resolves `ref` (branch, tag, or commit-ish) to the commit that pins this
+   * sync run, so every file fetched within the run is consistent even if the
+   * upstream ref moves mid-sync.
+   */
+  resolveCommit(ref: string): Promise<RepoCommit>;
+
+  /**
+   * Lists all blob/tree entries recursively under `pathPrefix` (relative to the
+   * repo root) as of `commit`. Paths are returned relative to the repo root, not
+   * to `pathPrefix`, so callers can merge entries from multiple configured paths
+   * without ambiguity.
+   */
+  fetchTreeEntries(commit: RepoCommit, params: FetchTreeParams): Promise<RepoTreeEntry[]>;
+
+  /**
+   * Fetches raw file content for a single tree entry. `entry.size` (if present)
+   * has already been validated by the caller against the skill-import size
+   * limits before this is called, so implementations do not need to re-check it.
+   */
+  fetchFileContent(commit: RepoCommit, params: FetchFileContentParams): Promise<Buffer>;
+}

--- a/packages/api/src/skills/sync/gitlab.ts
+++ b/packages/api/src/skills/sync/gitlab.ts
@@ -21,39 +21,37 @@ import type {
   SkillSyncCredentialSummary,
   SkillSyncStatusInput,
 } from '@librechat/data-schemas';
-import type { SkillSyncConfig, SkillSyncGitHubSourceConfig } from 'librechat-data-provider';
+import type { SkillSyncConfig, SkillSyncGitLabSourceConfig } from 'librechat-data-provider';
 import type { RepoTreeEntry, RepoCommit } from './adapters/types';
 import { RepoAdapterError } from './adapters/types';
-import { createGitHubRepoAdapter } from './adapters/github';
+import { createGitLabRepoAdapter, GITLAB_TOKEN_RECOMMENDATION } from './adapters/gitlab';
 import { DEFAULT_SKILL_IMPORT_LIMITS } from '../limits';
 import { parseSkillMarkdown } from '../parse';
 
 const SYSTEM_AUTHOR_ID = new Types.ObjectId('000000000000000000000000');
-const SYSTEM_AUTHOR_NAME = 'GitHub Sync';
-const PROVIDER: SkillSyncProvider = 'github';
+const SYSTEM_AUTHOR_NAME = 'GitLab Sync';
+const PROVIDER: SkillSyncProvider = 'gitlab';
 const LOCK_LEASE_MS = 30 * 60 * 1000;
 
-export const GITHUB_FINE_GRAINED_TOKEN_RECOMMENDATION =
-  'Use a GitHub fine-grained personal access token scoped to the selected repository with read-only Contents and Metadata permissions.';
+export { GITLAB_TOKEN_RECOMMENDATION };
 
 type FetchFn = typeof fetch;
 
-type GitHubTreeEntry = {
+/**
+ * `sha` here is the GitLab tree/blob `id` (opaque outside the adapter), kept
+ * under this name to match `sourceMetadata.blobSha`/`skillBlobSha` written by
+ * the shared discovery and skill-package-manifest logic mirrored from GitHub.
+ */
+type GitLabTreeEntryShape = {
   path: string;
-  mode: string;
-  type: 'blob' | 'tree' | 'commit';
+  type: 'blob' | 'tree';
   sha: string;
   size?: number;
-  url: string;
 };
 
-type GitHubCommitResponse = {
+type GitLabCommitResponseShape = {
   sha: string;
-  commit: {
-    tree: {
-      sha: string;
-    };
-  };
+  commit: { tree: { sha: string } };
 };
 
 type SyncCounters = {
@@ -67,8 +65,8 @@ type AssertNotCancelled = () => void;
 
 type DiscoveredSkill = {
   rootPath: string;
-  skillMd: GitHubTreeEntry;
-  files: GitHubTreeEntry[];
+  skillMd: GitLabTreeEntryShape;
+  files: GitLabTreeEntryShape[];
 };
 
 type UpsertRemoteSkillResult = {
@@ -122,7 +120,7 @@ type SyncSkillFilesResult = Pick<SyncCounters, 'syncedFileCount' | 'deletedFileC
 
 type MaybePromise<T> = T | Promise<T>;
 
-export type GitHubSkillSyncDeps = {
+export type GitLabSkillSyncDeps = {
   getConfig: () => MaybePromise<SkillSyncConfig | undefined>;
   getCredentialToken: (
     provider: SkillSyncProvider,
@@ -210,13 +208,13 @@ export type GitHubSkillSyncDeps = {
   allowServerCredentials?: boolean;
 };
 
-export type GitHubSkillSyncRunResult = {
+export type GitLabSkillSyncRunResult = {
   status: 'started' | 'skipped' | 'completed' | 'failed';
   message?: string;
   sources: Array<ISkillSyncStatus & { credentialPresent?: boolean }>;
 };
 
-export type GitHubSkillSyncStatus = {
+export type GitLabSkillSyncStatus = {
   enabled: boolean;
   intervalMinutes: number;
   runOnStartup: boolean;
@@ -225,9 +223,9 @@ export type GitHubSkillSyncStatus = {
   fineGrainedTokenRecommendation: string;
 };
 
-export type GitHubSkillSyncRunner = {
-  getStatus: () => Promise<GitHubSkillSyncStatus>;
-  runOnce: () => Promise<GitHubSkillSyncRunResult>;
+export type GitLabSkillSyncRunner = {
+  getStatus: () => Promise<GitLabSkillSyncStatus>;
+  runOnce: () => Promise<GitLabSkillSyncRunResult>;
 };
 
 class SkillSyncError extends Error {
@@ -255,7 +253,7 @@ function isSafeRelativePath(value: string): boolean {
   return value.split('/').every((segment) => segment !== '' && segment !== '.' && segment !== '..');
 }
 
-function makeUpstreamId(source: SkillSyncGitHubSourceConfig, rootPath: string): string {
+function makeUpstreamId(source: SkillSyncGitLabSourceConfig, rootPath: string): string {
   // Identity is keyed on the stable, admin-controlled source id and the skill's
   // root path only — never owner/repo/ref. Repointing a source to a renamed or
   // replacement repository (or rotating its ref) keeps the same upstream id, so
@@ -264,7 +262,7 @@ function makeUpstreamId(source: SkillSyncGitHubSourceConfig, rootPath: string): 
   return `${source.id}:${rootPath}`;
 }
 
-function makeSourceAuthorId(source: SkillSyncGitHubSourceConfig): Types.ObjectId {
+function makeSourceAuthorId(source: SkillSyncGitLabSourceConfig): Types.ObjectId {
   // Fold the tenant into the synthetic author so the same source mirrored into
   // different tenants gets distinct author ids (clearer audits, no cross-tenant
   // author collisions). The tenant suffix is omitted when absent so single-tenant
@@ -282,7 +280,7 @@ function toSkillName(value: string): string {
     .replace(/[^a-z0-9-]/g, '-')
     .replace(/^-+|-+$/g, '')
     .replace(/-{2,}/g, '-');
-  return normalized || 'github-skill';
+  return normalized || 'gitlab-skill';
 }
 
 function getFilename(relativePath: string): string {
@@ -349,17 +347,17 @@ function getLimitMegabytes(bytes: number): number {
   return Math.round(bytes / 1024 / 1024);
 }
 
-function assertGitHubBlobSize(entry: GitHubTreeEntry, relativePath: string): number {
+function assertGitLabBlobSize(entry: GitLabTreeEntryShape, relativePath: string): number {
   if (typeof entry.size !== 'number' || !Number.isFinite(entry.size) || entry.size < 0) {
     throw new SkillSyncError(
-      'GITHUB_BLOB_SIZE_UNKNOWN',
-      `GitHub file "${relativePath}" did not include a valid blob size`,
+      'GITLAB_BLOB_SIZE_UNKNOWN',
+      `GitLab file "${relativePath}" did not include a valid blob size`,
     );
   }
   if (entry.size > DEFAULT_SKILL_IMPORT_LIMITS.maxSingleFileBytes) {
     throw new SkillSyncError(
-      'GITHUB_BLOB_TOO_LARGE',
-      `GitHub file "${relativePath}" exceeds the ${getLimitMegabytes(
+      'GITLAB_BLOB_TOO_LARGE',
+      `GitLab file "${relativePath}" exceeds the ${getLimitMegabytes(
         DEFAULT_SKILL_IMPORT_LIMITS.maxSingleFileBytes,
       )}MB per-file skill import limit`,
     );
@@ -367,38 +365,38 @@ function assertGitHubBlobSize(entry: GitHubTreeEntry, relativePath: string): num
   return entry.size;
 }
 
-function assertGitHubBufferSize(buffer: Buffer, relativePath: string): void {
+function assertGitLabBufferSize(buffer: Buffer, relativePath: string): void {
   if (buffer.length <= DEFAULT_SKILL_IMPORT_LIMITS.maxSingleFileBytes) {
     return;
   }
   throw new SkillSyncError(
-    'GITHUB_BLOB_TOO_LARGE',
-    `GitHub file "${relativePath}" exceeds the ${getLimitMegabytes(
+    'GITLAB_BLOB_TOO_LARGE',
+    `GitLab file "${relativePath}" exceeds the ${getLimitMegabytes(
       DEFAULT_SKILL_IMPORT_LIMITS.maxSingleFileBytes,
     )}MB per-file skill import limit`,
   );
 }
 
-function assertCumulativeGitHubFileSize(totalBytes: number): void {
+function assertCumulativeGitLabFileSize(totalBytes: number): void {
   if (totalBytes <= DEFAULT_SKILL_IMPORT_LIMITS.maxDecompressedBytes) {
     return;
   }
   throw new SkillSyncError(
-    'GITHUB_PACKAGE_TOO_LARGE',
-    `GitHub skill files exceed the ${getLimitMegabytes(
+    'GITLAB_PACKAGE_TOO_LARGE',
+    `GitLab skill files exceed the ${getLimitMegabytes(
       DEFAULT_SKILL_IMPORT_LIMITS.maxDecompressedBytes,
     )}MB cumulative skill import limit`,
   );
 }
 
-function assertGitHubEntryCount(discovered: DiscoveredSkill): void {
+function assertGitLabEntryCount(discovered: DiscoveredSkill): void {
   const entryCount = discovered.files.length + 1;
   if (entryCount <= DEFAULT_SKILL_IMPORT_LIMITS.maxEntries) {
     return;
   }
   throw new SkillSyncError(
-    'GITHUB_TOO_MANY_FILES',
-    `GitHub skill "${discovered.rootPath}" exceeds the ${DEFAULT_SKILL_IMPORT_LIMITS.maxEntries} file skill import limit`,
+    'GITLAB_TOO_MANY_FILES',
+    `GitLab skill "${discovered.rootPath}" exceeds the ${DEFAULT_SKILL_IMPORT_LIMITS.maxEntries} file skill import limit`,
   );
 }
 
@@ -406,23 +404,26 @@ function getSkillMdPath(discovered: DiscoveredSkill): string {
   return discovered.rootPath ? `${discovered.rootPath}/SKILL.md` : 'SKILL.md';
 }
 
-function getDiscoveredRelativePath(discovered: DiscoveredSkill, entry: GitHubTreeEntry): string {
+function getDiscoveredRelativePath(
+  discovered: DiscoveredSkill,
+  entry: GitLabTreeEntryShape,
+): string {
   const prefix = discovered.rootPath ? `${discovered.rootPath}/` : '';
   const normalized = normalizeRepoPath(entry.path);
   return prefix ? normalized.slice(prefix.length) : normalized;
 }
 
-function assertGitHubSkillPackageManifest(discovered: DiscoveredSkill): void {
-  assertGitHubEntryCount(discovered);
-  assertGitHubBlobSize(discovered.skillMd, getSkillMdPath(discovered));
+function assertGitLabSkillPackageManifest(discovered: DiscoveredSkill): void {
+  assertGitLabEntryCount(discovered);
+  assertGitLabBlobSize(discovered.skillMd, getSkillMdPath(discovered));
   let totalFileBytes = 0;
   for (const entry of discovered.files) {
     const relativePath = getDiscoveredRelativePath(discovered, entry);
     if (!isSafeRelativePath(relativePath) || relativePath.toUpperCase() === 'SKILL.MD') {
       continue;
     }
-    totalFileBytes += assertGitHubBlobSize(entry, relativePath);
-    assertCumulativeGitHubFileSize(totalFileBytes);
+    totalFileBytes += assertGitLabBlobSize(entry, relativePath);
+    assertCumulativeGitLabFileSize(totalFileBytes);
   }
 }
 
@@ -472,40 +473,44 @@ async function withAdapterErrors<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
-function toGitHubTreeEntry(entry: RepoTreeEntry): GitHubTreeEntry {
-  return { path: entry.path, mode: '', type: entry.type, sha: entry.id, size: entry.size, url: '' };
+function toGitLabTreeEntryShape(entry: RepoTreeEntry): GitLabTreeEntryShape {
+  return { path: entry.path, type: entry.type, sha: entry.id, size: entry.size };
+}
+
+function makeAdapter(params: {
+  fetchFn: FetchFn;
+  token: string;
+  source: SkillSyncGitLabSourceConfig;
+}) {
+  return createGitLabRepoAdapter({
+    baseUrl: params.source.baseUrl,
+    projectId: params.source.projectId,
+    token: params.token,
+    fetchFn: params.fetchFn,
+  });
 }
 
 async function fetchCommit(params: {
   fetchFn: FetchFn;
   token: string;
-  source: SkillSyncGitHubSourceConfig;
-}): Promise<GitHubCommitResponse> {
-  const adapter = createGitHubRepoAdapter({
-    owner: params.source.owner,
-    repo: params.source.repo,
-    token: params.token,
-    fetchFn: params.fetchFn,
-  });
+  source: SkillSyncGitLabSourceConfig;
+}): Promise<GitLabCommitResponseShape> {
+  const adapter = makeAdapter(params);
   const commit = await withAdapterErrors(() => adapter.resolveCommit(params.source.ref));
+  // GitLab has no separate tree object — `treeId` equals the commit id itself.
   return { sha: commit.id, commit: { tree: { sha: commit.treeId } } };
 }
 
 async function fetchConfiguredTreeEntries(params: {
   fetchFn: FetchFn;
   token: string;
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   rootTreeSha: string;
   assertNotCancelled: AssertNotCancelled;
-}): Promise<GitHubTreeEntry[]> {
-  const adapter = createGitHubRepoAdapter({
-    owner: params.source.owner,
-    repo: params.source.repo,
-    token: params.token,
-    fetchFn: params.fetchFn,
-  });
+}): Promise<GitLabTreeEntryShape[]> {
+  const adapter = makeAdapter(params);
   const commit: RepoCommit = { id: params.rootTreeSha, treeId: params.rootTreeSha };
-  const entriesByPath = new Map<string, GitHubTreeEntry>();
+  const entriesByPath = new Map<string, GitLabTreeEntryShape>();
   for (const repoPath of params.source.paths) {
     const entries = await withAdapterErrors(() =>
       adapter.fetchTreeEntries(commit, {
@@ -516,7 +521,7 @@ async function fetchConfiguredTreeEntries(params: {
     );
     for (const entry of entries) {
       const normalizedPath = normalizeRepoPath(entry.path);
-      entriesByPath.set(normalizedPath, toGitHubTreeEntry({ ...entry, path: normalizedPath }));
+      entriesByPath.set(normalizedPath, toGitLabTreeEntryShape({ ...entry, path: normalizedPath }));
     }
   }
   return [...entriesByPath.values()];
@@ -525,19 +530,15 @@ async function fetchConfiguredTreeEntries(params: {
 async function fetchBlob(params: {
   fetchFn: FetchFn;
   token: string;
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   sha: string;
+  ref: string;
 }): Promise<Buffer> {
-  const adapter = createGitHubRepoAdapter({
-    owner: params.source.owner,
-    repo: params.source.repo,
-    token: params.token,
-    fetchFn: params.fetchFn,
-  });
+  const adapter = makeAdapter(params);
   return withAdapterErrors(() =>
     adapter.fetchFileContent(
-      { id: '', treeId: '' },
-      { ref: params.source.ref, entry: { path: '', type: 'blob', id: params.sha } },
+      { id: params.ref, treeId: params.ref },
+      { ref: params.ref, entry: { path: '', type: 'blob', id: params.sha } },
     ),
   );
 }
@@ -561,12 +562,12 @@ function isSkillRootWithinDiscoveryDepth(
 }
 
 function discoverSkills(
-  tree: GitHubTreeEntry[],
-  source: SkillSyncGitHubSourceConfig,
+  tree: GitLabTreeEntryShape[],
+  source: SkillSyncGitLabSourceConfig,
 ): DiscoveredSkill[] {
   const basePaths = source.paths.map(normalizeRepoPath);
   const skillDiscoveryDepth = source.skillDiscoveryDepth ?? SKILL_SYNC_DEFAULT_DISCOVERY_DEPTH;
-  const skillMdByRoot = new Map<string, GitHubTreeEntry>();
+  const skillMdByRoot = new Map<string, GitLabTreeEntryShape>();
   for (const entry of tree) {
     if (entry.type !== 'blob') {
       continue;
@@ -612,8 +613,8 @@ function discoverSkills(
 }
 
 function assertConfiguredPathsExist(
-  tree: GitHubTreeEntry[],
-  source: SkillSyncGitHubSourceConfig,
+  tree: GitLabTreeEntryShape[],
+  source: SkillSyncGitLabSourceConfig,
 ): void {
   for (const configuredPath of source.paths.map(normalizeRepoPath)) {
     if (configuredPath === '') {
@@ -625,15 +626,15 @@ function assertConfiguredPathsExist(
     });
     if (!exists) {
       throw new SkillSyncError(
-        'GITHUB_PATH_NOT_FOUND',
-        `Configured GitHub skill path "${configuredPath}" was not found`,
+        'GITLAB_PATH_NOT_FOUND',
+        `Configured GitLab skill path "${configuredPath}" was not found`,
       );
     }
   }
 }
 
 function makeStatusInput(params: {
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   status: SkillSyncStatusInput['status'];
   startedAt?: Date;
   finishedAt?: Date;
@@ -647,8 +648,8 @@ function makeStatusInput(params: {
     tenantId: params.source.tenantId,
     status: params.status,
     credentialKey: params.source.credentialKey,
-    owner: params.source.owner,
-    repo: params.source.repo,
+    baseUrl: params.source.baseUrl,
+    projectId: params.source.projectId,
     ref: params.source.ref,
     paths: params.source.paths,
     startedAt: params.startedAt,
@@ -667,7 +668,7 @@ function makeStatusKey(sourceId: string, tenantId?: string): string {
 }
 
 async function ensurePublicViewer(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   skillId: Types.ObjectId,
 ): Promise<void> {
   await deps.grantPermission({
@@ -681,8 +682,8 @@ async function ensurePublicViewer(
 }
 
 async function prepareRemoteSkill(params: {
-  deps: GitHubSkillSyncDeps;
-  source: SkillSyncGitHubSourceConfig;
+  deps: GitLabSkillSyncDeps;
+  source: SkillSyncGitLabSourceConfig;
   discovered: DiscoveredSkill;
   skillMdContent: string;
   commitSha: string;
@@ -708,8 +709,8 @@ async function prepareRemoteSkill(params: {
     provider: PROVIDER,
     sourceId: source.id,
     upstreamId,
-    owner: source.owner,
-    repo: source.repo,
+    baseUrl: source.baseUrl,
+    projectId: source.projectId,
     ref: source.ref,
     skillPath: discovered.rootPath,
     commitSha,
@@ -749,7 +750,7 @@ async function prepareRemoteSkill(params: {
 }
 
 async function commitRemoteSkill(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   prepared: PreparedRemoteSkill,
 ): Promise<UpsertRemoteSkillResult> {
   if (prepared.existing) {
@@ -794,7 +795,7 @@ function hasExternalSkillEdit(before: ISkill, after: ISkill): boolean {
 }
 
 async function commitExistingRemoteSkillAfterFileSync(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   prepared: PreparedExistingRemoteSkill,
   options: { forceCommit?: boolean } = {},
 ): Promise<UpsertRemoteSkillResult> {
@@ -817,7 +818,7 @@ async function commitExistingRemoteSkillAfterFileSync(
   return commitRemoteSkill(deps, { ...prepared, existing: refreshed });
 }
 
-async function cleanupFile(deps: GitHubSkillSyncDeps, file: StoredSkillFileRef): Promise<void> {
+async function cleanupFile(deps: GitLabSkillSyncDeps, file: StoredSkillFileRef): Promise<void> {
   if (!deps.deleteFile) {
     return;
   }
@@ -900,7 +901,7 @@ function getStoredFileKey(file: StoredSkillFileRef): string {
 }
 
 async function cleanupStoredFiles(params: {
-  deps: GitHubSkillSyncDeps;
+  deps: GitLabSkillSyncDeps;
   files: StoredSkillFileRef[];
   logMessage: string;
 }): Promise<void> {
@@ -918,7 +919,7 @@ async function cleanupStoredFiles(params: {
 }
 
 async function restoreExistingSkillFiles(params: {
-  deps: GitHubSkillSyncDeps;
+  deps: GitLabSkillSyncDeps;
   skill: ISkill & { _id: Types.ObjectId };
   previousFiles: Array<ISkillFile & { _id: Types.ObjectId }>;
   savedFiles: StoredSkillFileRef[];
@@ -939,12 +940,12 @@ async function restoreExistingSkillFiles(params: {
   await cleanupStoredFiles({
     deps,
     files: savedFiles,
-    logMessage: '[GitHubSkillSync] Failed to clean up rolled-back synced file:',
+    logMessage: '[GitLabSkillSync] Failed to clean up rolled-back synced file:',
   });
 }
 
 async function deleteSyncedSkillForRestore(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   skill: ISkill & { _id: Types.ObjectId },
 ): Promise<{ deletedFileCount: number; deletedSkill: DeletedSyncedSkillJournal }> {
   const files = await deps.listSkillFiles(skill._id);
@@ -956,7 +957,7 @@ async function deleteSyncedSkillForRestore(
 }
 
 async function restoreDeletedSyncedSkill(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   deleted: DeletedSyncedSkillJournal,
 ): Promise<void> {
   const restored = await deps.createSkill(toCreateSkillInput(deleted.skill));
@@ -970,13 +971,13 @@ async function restoreDeletedSyncedSkill(
 }
 
 async function cleanupDeletedSyncedSkillFiles(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   deleted: DeletedSyncedSkillJournal,
 ): Promise<void> {
   await cleanupStoredFiles({
     deps,
     files: deleted.files.map(toStoredFileRefFromSkillFile),
-    logMessage: '[GitHubSkillSync] Failed to clean up deleted stale mirrored skill file:',
+    logMessage: '[GitLabSkillSync] Failed to clean up deleted stale mirrored skill file:',
   });
 }
 
@@ -998,7 +999,7 @@ function hasRemoteSkillDefinitionChanged(update: UpdateSkillInput, existing: ISk
 }
 
 function findMovedSourceSkill(params: {
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   prepared: PreparedRemoteSkill;
   existingSyncedSkills: Array<ISkill & { _id: Types.ObjectId }>;
   excludedUpstreamIds: Set<string>;
@@ -1025,7 +1026,7 @@ function findMovedSourceSkill(params: {
 }
 
 function hasNameConflictingStaleSkill(params: {
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   prepared: PreparedDiscoveredSkill;
   existingSyncedSkills: Array<ISkill & { _id: Types.ObjectId }>;
   discoveredUpstreamIds: Set<string>;
@@ -1041,7 +1042,7 @@ function hasNameConflictingStaleSkill(params: {
 }
 
 function orderPreparedSkillsForSafeStaleDeletes(params: {
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   preparedSkills: PreparedDiscoveredSkill[];
   existingSyncedSkills: Array<ISkill & { _id: Types.ObjectId }>;
   discoveredUpstreamIds: Set<string>;
@@ -1075,7 +1076,7 @@ function getMirrorNameKey(params: {
 }
 
 function assertNoDuplicatePreparedSkillNames(
-  source: SkillSyncGitHubSourceConfig,
+  source: SkillSyncGitLabSourceConfig,
   preparedSkills: PreparedDiscoveredSkill[],
 ): void {
   const sourceTenantId = source.tenantId ?? undefined;
@@ -1089,7 +1090,7 @@ function assertNoDuplicatePreparedSkillNames(
     if (seen.has(key)) {
       throw new SkillSyncError(
         'DUPLICATE_SKILL_NAME',
-        `GitHub source "${source.id}" contains multiple skills named "${prepared.createInput.name}"`,
+        `GitLab source "${source.id}" contains multiple skills named "${prepared.createInput.name}"`,
       );
     }
     seen.set(key, discovered.rootPath);
@@ -1097,8 +1098,8 @@ function assertNoDuplicatePreparedSkillNames(
 }
 
 async function deleteNameConflictingStaleSkill(params: {
-  deps: GitHubSkillSyncDeps;
-  source: SkillSyncGitHubSourceConfig;
+  deps: GitLabSkillSyncDeps;
+  source: SkillSyncGitLabSourceConfig;
   prepared: PreparedRemoteSkill;
   existingSyncedSkills: Array<ISkill & { _id: Types.ObjectId }>;
   discoveredUpstreamIds: Set<string>;
@@ -1141,9 +1142,9 @@ async function deleteNameConflictingStaleSkill(params: {
 }
 
 async function syncSkillFiles(params: {
-  deps: GitHubSkillSyncDeps;
+  deps: GitLabSkillSyncDeps;
   token: string;
-  source: SkillSyncGitHubSourceConfig;
+  source: SkillSyncGitLabSourceConfig;
   skill: ISkill & { _id: Types.ObjectId };
   discovered: DiscoveredSkill;
   commitSha: string;
@@ -1164,16 +1165,16 @@ async function syncSkillFiles(params: {
     if (!isSafeRelativePath(relativePath) || relativePath.toUpperCase() === 'SKILL.MD') {
       continue;
     }
-    totalFileBytes += assertGitHubBlobSize(entry, relativePath);
-    assertCumulativeGitHubFileSize(totalFileBytes);
+    totalFileBytes += assertGitLabBlobSize(entry, relativePath);
+    assertCumulativeGitLabFileSize(totalFileBytes);
     remotePaths.add(relativePath);
     const existing = await deps.getSkillFileByPath(skill._id, relativePath);
     if (existing && getSourceMetadataString(existing, 'blobSha') === entry.sha) {
       continue;
     }
-    const buffer = await fetchBlob({ fetchFn, token, source, sha: entry.sha });
+    const buffer = await fetchBlob({ fetchFn, token, source, sha: entry.sha, ref: source.ref });
     assertNotCancelled();
-    assertGitHubBufferSize(buffer, relativePath);
+    assertGitLabBufferSize(buffer, relativePath);
     const fileId = crypto.randomUUID();
     const filename = getFilename(relativePath);
     const mimeType = guessMimeType(filename);
@@ -1212,7 +1213,7 @@ async function syncSkillFiles(params: {
       });
     } catch (error) {
       await cleanupFile(deps, savedFile).catch((cleanupError) =>
-        logger.error('[GitHubSkillSync] Failed to clean up orphaned synced file:', cleanupError),
+        logger.error('[GitLabSkillSync] Failed to clean up orphaned synced file:', cleanupError),
       );
       throw error;
     }
@@ -1239,14 +1240,14 @@ async function syncSkillFiles(params: {
 }
 
 async function deleteSyncedSkill(
-  deps: GitHubSkillSyncDeps,
+  deps: GitLabSkillSyncDeps,
   skill: ISkill & { _id: Types.ObjectId },
 ): Promise<number> {
   const files = await deps.listSkillFiles(skill._id);
   let deletedFiles = 0;
   for (const file of files) {
     await cleanupFile(deps, file).catch((cleanupError) =>
-      logger.error('[GitHubSkillSync] Failed to clean up mirrored skill file:', cleanupError),
+      logger.error('[GitLabSkillSync] Failed to clean up mirrored skill file:', cleanupError),
     );
     deletedFiles++;
   }
@@ -1259,9 +1260,9 @@ function getTokenEnvVarName(tokenReference: string | undefined): string | null {
   return match?.[1] ?? null;
 }
 
-async function resolveGitHubToken(
-  deps: GitHubSkillSyncDeps,
-  source: SkillSyncGitHubSourceConfig,
+async function resolveGitLabToken(
+  deps: GitLabSkillSyncDeps,
+  source: SkillSyncGitLabSourceConfig,
 ): Promise<string | null> {
   if (deps.allowServerCredentials === false) {
     return null;
@@ -1277,22 +1278,22 @@ async function resolveGitHubToken(
 }
 
 function getMissingCredentialMessage(
-  source: SkillSyncGitHubSourceConfig,
+  source: SkillSyncGitLabSourceConfig,
   allowServerCredentials: boolean,
 ): string {
   if (!allowServerCredentials) {
-    return 'Server GitHub credentials are not available for this skill sync config';
+    return 'Server GitLab credentials are not available for this skill sync config';
   }
   const tokenEnvVar = getTokenEnvVarName(source.token);
   if (tokenEnvVar) {
-    return `Missing GitHub token environment variable "${tokenEnvVar}"`;
+    return `Missing GitLab token environment variable "${tokenEnvVar}"`;
   }
-  return `Missing GitHub credential "${source.credentialKey ?? source.id}"`;
+  return `Missing GitLab credential "${source.credentialKey ?? source.id}"`;
 }
 
 async function syncSource(params: {
-  deps: GitHubSkillSyncDeps;
-  source: SkillSyncGitHubSourceConfig;
+  deps: GitLabSkillSyncDeps;
+  source: SkillSyncGitLabSourceConfig;
   fetchFn: FetchFn;
   assertNotCancelled: AssertNotCancelled;
 }): Promise<ISkillSyncStatus> {
@@ -1302,7 +1303,7 @@ async function syncSource(params: {
   try {
     assertNotCancelled();
     const allowServerCredentials = deps.allowServerCredentials !== false;
-    const token = await resolveGitHubToken(deps, source);
+    const token = await resolveGitLabToken(deps, source);
     assertNotCancelled();
     if (!token) {
       throw new SkillSyncError(
@@ -1343,16 +1344,17 @@ async function syncSource(params: {
 
     for (const discovered of discoveredSkills) {
       assertNotCancelled();
-      assertGitHubSkillPackageManifest(discovered);
+      assertGitLabSkillPackageManifest(discovered);
       const skillMdPath = getSkillMdPath(discovered);
       const skillMdBuffer = await fetchBlob({
         fetchFn,
         token,
         source,
         sha: discovered.skillMd.sha,
+        ref: source.ref,
       });
       assertNotCancelled();
-      assertGitHubBufferSize(skillMdBuffer, skillMdPath);
+      assertGitLabBufferSize(skillMdBuffer, skillMdPath);
       const prepared = await prepareRemoteSkill({
         deps,
         source,
@@ -1455,7 +1457,7 @@ async function syncSource(params: {
             savedFiles: journal.savedFiles,
           }).catch((cleanupError) =>
             logger.error(
-              '[GitHubSkillSync] Failed to restore existing skill files after sync failure:',
+              '[GitLabSkillSync] Failed to restore existing skill files after sync failure:',
               cleanupError,
             ),
           );
@@ -1463,7 +1465,7 @@ async function syncSource(params: {
             await restoreDeletedSyncedSkill(deps, staleConflictCleanup.deletedSkill).catch(
               (cleanupError) =>
                 logger.error(
-                  '[GitHubSkillSync] Failed to restore stale mirrored skill after sync failure:',
+                  '[GitLabSkillSync] Failed to restore stale mirrored skill after sync failure:',
                   cleanupError,
                 ),
             );
@@ -1473,7 +1475,7 @@ async function syncSource(params: {
         await cleanupStoredFiles({
           deps,
           files: fileCounts.staleFiles,
-          logMessage: '[GitHubSkillSync] Failed to clean up replaced synced file:',
+          logMessage: '[GitLabSkillSync] Failed to clean up replaced synced file:',
         });
         if (staleConflictCleanup?.deletedSkill) {
           await cleanupDeletedSyncedSkillFiles(deps, staleConflictCleanup.deletedSkill);
@@ -1504,7 +1506,7 @@ async function syncSource(params: {
       } catch (error) {
         await deleteSyncedSkill(deps, skill).catch((cleanupError) =>
           logger.error(
-            '[GitHubSkillSync] Failed to roll back partially synced skill:',
+            '[GitLabSkillSync] Failed to roll back partially synced skill:',
             cleanupError,
           ),
         );
@@ -1518,7 +1520,7 @@ async function syncSource(params: {
     });
     // Only mirror-delete skills owned by this source's tenant. With no
     // configured tenantId under non-strict isolation, listSkillsBySource can
-    // return github skills across tenants, so without this guard an ambient sync
+    // return gitlab skills across tenants, so without this guard an ambient sync
     // could delete another tenant's mirrored skills. Absent tenantId is its own
     // (ambient) bucket.
     const sourceTenantId = source.tenantId ?? undefined;
@@ -1549,7 +1551,7 @@ async function syncSource(params: {
     );
   } catch (error) {
     const sanitized = sanitizeError(error);
-    logger.error(`[GitHubSkillSync] Source "${source.id}" failed: ${sanitized.message}`);
+    logger.error(`[GitLabSkillSync] Source "${source.id}" failed: ${sanitized.message}`);
     return deps.upsertStatus(
       makeStatusInput({
         source,
@@ -1574,8 +1576,8 @@ async function syncSource(params: {
  * propagates across every awaited Mongoose operation in `syncSource`.
  */
 function syncSourceInTenantContext(params: {
-  deps: GitHubSkillSyncDeps;
-  source: SkillSyncGitHubSourceConfig;
+  deps: GitLabSkillSyncDeps;
+  source: SkillSyncGitLabSourceConfig;
   fetchFn: FetchFn;
   assertNotCancelled: AssertNotCancelled;
 }): Promise<ISkillSyncStatus> {
@@ -1585,30 +1587,30 @@ function syncSourceInTenantContext(params: {
   return tenantStorage.run({ tenantId: params.source.tenantId }, async () => syncSource(params));
 }
 
-function getGithubConfig(config: SkillSyncConfig | undefined): {
+function getGitlabConfig(config: SkillSyncConfig | undefined): {
   enabled: boolean;
   intervalMinutes: number;
   runOnStartup: boolean;
-  sources: SkillSyncGitHubSourceConfig[];
+  sources: SkillSyncGitLabSourceConfig[];
 } {
   return {
-    enabled: config?.github?.enabled ?? false,
-    intervalMinutes: config?.github?.intervalMinutes ?? 60,
-    runOnStartup: config?.github?.runOnStartup ?? false,
+    enabled: config?.gitlab?.enabled ?? false,
+    intervalMinutes: config?.gitlab?.intervalMinutes ?? 60,
+    runOnStartup: config?.gitlab?.runOnStartup ?? false,
     sources:
-      config?.github?.sources.map((source) => ({
+      config?.gitlab?.sources.map((source) => ({
         ...source,
         skillDiscoveryDepth: source.skillDiscoveryDepth ?? SKILL_SYNC_DEFAULT_DISCOVERY_DEPTH,
       })) ?? [],
   };
 }
 
-export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSkillSyncRunner {
+export function createGitLabSkillSyncRunner(deps: GitLabSkillSyncDeps): GitLabSkillSyncRunner {
   const fetchFn = deps.fetchFn ?? fetch;
   const lockOwnerPrefix = deps.lockOwner ?? `${process.pid}`;
 
-  async function getStatus(): Promise<GitHubSkillSyncStatus> {
-    const github = getGithubConfig(await deps.getConfig());
+  async function getStatus(): Promise<GitLabSkillSyncStatus> {
+    const gitlab = getGitlabConfig(await deps.getConfig());
     const allowServerCredentials = deps.allowServerCredentials !== false;
     const [storedStatuses, credentials] = await Promise.all([
       deps.listStatuses(PROVIDER),
@@ -1620,7 +1622,7 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
     const credentialByKey = new Map(
       credentials.map((credential) => [credential.credentialKey, credential]),
     );
-    const sources = github.sources.map((source) => {
+    const sources = gitlab.sources.map((source) => {
       const stored = statusBySourceId.get(makeStatusKey(source.id, source.tenantId));
       const credential =
         allowServerCredentials && source.credentialKey
@@ -1636,8 +1638,8 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
         status: stored?.status ?? 'idle',
         credentialKey: source.credentialKey,
         credentialPresent: envTokenPresent || Boolean(credential),
-        owner: source.owner,
-        repo: source.repo,
+        baseUrl: source.baseUrl,
+        projectId: source.projectId,
         ref: source.ref,
         paths: source.paths,
         startedAt: stored?.startedAt,
@@ -1655,19 +1657,19 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
       } satisfies ISkillSyncStatus & { credentialPresent: boolean };
     });
     return {
-      enabled: github.enabled,
-      intervalMinutes: github.intervalMinutes,
-      runOnStartup: github.runOnStartup,
+      enabled: gitlab.enabled,
+      intervalMinutes: gitlab.intervalMinutes,
+      runOnStartup: gitlab.runOnStartup,
       sources,
       credentials,
-      fineGrainedTokenRecommendation: GITHUB_FINE_GRAINED_TOKEN_RECOMMENDATION,
+      fineGrainedTokenRecommendation: GITLAB_TOKEN_RECOMMENDATION,
     };
   }
 
-  async function runOnce(): Promise<GitHubSkillSyncRunResult> {
-    const github = getGithubConfig(await deps.getConfig());
-    if (!github.enabled || github.sources.length === 0) {
-      return { status: 'skipped', message: 'GitHub skill sync is disabled', sources: [] };
+  async function runOnce(): Promise<GitLabSkillSyncRunResult> {
+    const gitlab = getGitlabConfig(await deps.getConfig());
+    if (!gitlab.enabled || gitlab.sources.length === 0) {
+      return { status: 'skipped', message: 'GitLab skill sync is disabled', sources: [] };
     }
     const allowServerCredentials = deps.allowServerCredentials !== false;
     if (!allowServerCredentials) {
@@ -1675,7 +1677,7 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
       if (!status.sources.some((source) => source.credentialPresent)) {
         return {
           status: 'skipped',
-          message: 'GitHub skill sync credentials are not available for this runner',
+          message: 'GitLab skill sync credentials are not available for this runner',
           sources: status.sources,
         };
       }
@@ -1690,14 +1692,14 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
       const status = await getStatus();
       return {
         status: 'skipped',
-        message: 'GitHub skill sync is already running',
+        message: 'GitLab skill sync is already running',
         sources: status.sources,
       };
     }
     let lockLost = false;
     const assertNotCancelled = () => {
       if (lockLost) {
-        throw new SkillSyncError('SYNC_LOCK_LOST', 'GitHub skill sync lock was lost');
+        throw new SkillSyncError('SYNC_LOCK_LOST', 'GitLab skill sync lock was lost');
       }
     };
     const refreshTimer = setInterval(
@@ -1711,12 +1713,12 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
           .then((refreshed) => {
             if (!refreshed) {
               lockLost = true;
-              logger.warn('[GitHubSkillSync] Failed to refresh active sync lock');
+              logger.warn('[GitLabSkillSync] Failed to refresh active sync lock');
             }
           })
           .catch((error) => {
             lockLost = true;
-            logger.error('[GitHubSkillSync] Failed to refresh active sync lock:', error);
+            logger.error('[GitLabSkillSync] Failed to refresh active sync lock:', error);
           });
       },
       Math.max(60_000, Math.floor(LOCK_LEASE_MS / 3)),
@@ -1724,7 +1726,7 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
     refreshTimer.unref?.();
     try {
       const sources: ISkillSyncStatus[] = [];
-      for (const source of github.sources) {
+      for (const source of gitlab.sources) {
         if (lockLost) {
           break;
         }
@@ -1735,7 +1737,7 @@ export function createGitHubSkillSyncRunner(deps: GitHubSkillSyncDeps): GitHubSk
       const failed = sources.some((source) => source.status === 'failed');
       return {
         status: failed || lockLost ? 'failed' : 'completed',
-        message: lockLost ? 'GitHub skill sync lock was lost' : undefined,
+        message: lockLost ? 'GitLab skill sync lock was lost' : undefined,
         sources,
       };
     } finally {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -391,6 +391,74 @@ export const skillSyncGitHubSourceSchema = z
     }
   });
 
+const skillSyncGitLabBaseUrlSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .refine(
+    (value) => {
+      try {
+        const url = new URL(value);
+        return url.protocol === 'https:' || url.protocol === 'http:';
+      } catch {
+        return false;
+      }
+    },
+    { message: 'must be a valid http(s) URL' },
+  )
+  .refine((value) => !value.endsWith('/'), {
+    message: 'must not end with a slash',
+  });
+
+const skillSyncGitLabProjectIdSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine((value) => !value.includes('..') && !value.includes('\\'), {
+    message: 'must not contain traversal segments or backslashes',
+  });
+
+export const skillSyncGitLabSourceSchema = z
+  .object({
+    id: skillSyncIdentifierSchema,
+    baseUrl: skillSyncGitLabBaseUrlSchema.optional(),
+    projectId: skillSyncGitLabProjectIdSchema,
+    ref: skillSyncGitHubRefSchema.default('main'),
+    paths: z.array(skillSyncPathSchema).min(1),
+    skillDiscoveryDepth: z.number().int().min(0).max(SKILL_SYNC_MAX_DISCOVERY_DEPTH).optional(),
+    credentialKey: skillSyncIdentifierSchema.optional(),
+    token: skillSyncTokenReferenceSchema.optional(),
+    tenantId: skillSyncTenantIdSchema.optional(),
+  })
+  .superRefine((source, ctx) => {
+    if (!source.credentialKey && !source.token) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['credentialKey'],
+        message: 'Either credentialKey or token is required',
+      });
+    }
+    if (source.credentialKey && source.token) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['token'],
+        message: 'Use either credentialKey or token, not both',
+      });
+    }
+  });
+
+function duplicateSourceIdIssue(
+  providerLabel: string,
+  id: string,
+): { code: typeof z.ZodIssueCode.custom; path: ['sources']; message: string } {
+  return {
+    code: z.ZodIssueCode.custom,
+    path: ['sources'],
+    message: `Duplicate ${providerLabel} skill sync source id "${id}"`,
+  };
+}
+
 export const skillSyncConfigSchema = z
   .object({
     github: z
@@ -416,11 +484,36 @@ export const skillSyncConfigSchema = z
         const seen = new Set<string>();
         for (const source of github.sources) {
           if (seen.has(source.id)) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ['sources'],
-              message: `Duplicate GitHub skill sync source id "${source.id}"`,
-            });
+            ctx.addIssue(duplicateSourceIdIssue('GitHub', source.id));
+          }
+          seen.add(source.id);
+        }
+      })
+      .optional(),
+    gitlab: z
+      .object({
+        enabled: z.boolean().default(false),
+        intervalMinutes: z
+          .number()
+          .int()
+          .min(SKILL_SYNC_MIN_INTERVAL_MINUTES)
+          .max(SKILL_SYNC_MAX_INTERVAL_MINUTES)
+          .default(60),
+        runOnStartup: z.boolean().default(false),
+        sources: z.array(skillSyncGitLabSourceSchema).default([]),
+      })
+      .superRefine((gitlab, ctx) => {
+        if (gitlab.enabled && gitlab.sources.length === 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['sources'],
+            message: 'At least one GitLab source is required when skill sync is enabled',
+          });
+        }
+        const seen = new Set<string>();
+        for (const source of gitlab.sources) {
+          if (seen.has(source.id)) {
+            ctx.addIssue(duplicateSourceIdIssue('GitLab', source.id));
           }
           seen.add(source.id);
         }
@@ -431,6 +524,7 @@ export const skillSyncConfigSchema = z
 
 export type SkillSyncConfig = z.infer<typeof skillSyncConfigSchema>;
 export type SkillSyncGitHubSourceConfig = z.infer<typeof skillSyncGitHubSourceSchema>;
+export type SkillSyncGitLabSourceConfig = z.infer<typeof skillSyncGitLabSourceSchema>;
 
 // Helper type to extract the shape of the Zod object schema
 type SchemaShape<T> = T extends z.ZodObject<infer U> ? U : never;

--- a/packages/data-provider/src/types/skills.ts
+++ b/packages/data-provider/src/types/skills.ts
@@ -27,9 +27,10 @@ export const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
  * `inline` means the skill was authored directly in LibreChat.
  * `deployment` means the skill was loaded from the server's configured
  * deployment skill directory and is not persisted as a Skill document.
- * `github` is populated by admin-configured GitHub skill sync; `notion` is reserved.
+ * `github`/`gitlab` are populated by admin-configured skill sync sources;
+ * `notion` is reserved.
  */
-export type SkillSource = 'inline' | 'deployment' | 'github' | 'notion';
+export type SkillSource = 'inline' | 'deployment' | 'github' | 'gitlab' | 'notion';
 
 /**
  * Category inferred from a skill file's top-level directory prefix.
@@ -71,6 +72,20 @@ export type SkillSourceMetadata =
       upstreamId: string;
       owner: string;
       repo: string;
+      ref: string;
+      skillPath: string;
+      commitSha?: string;
+      skillBlobSha?: string;
+      syncedAt?: string;
+      syncStatus?: 'synced' | 'failed';
+      error?: string;
+    }
+  | {
+      provider: 'gitlab';
+      sourceId: string;
+      upstreamId: string;
+      projectId: string;
+      baseUrl: string;
       ref: string;
       skillPath: string;
       commitSha?: string;

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -480,7 +480,7 @@ export type CreateSkillInput = {
   category?: string;
   author: Types.ObjectId;
   authorName: string;
-  source?: 'inline' | 'github' | 'notion';
+  source?: 'inline' | 'github' | 'gitlab' | 'notion';
   sourceMetadata?: Record<string, unknown>;
   /**
    * When `true`, the skill is auto-primed into every turn. Callers pass this
@@ -499,7 +499,7 @@ export type UpdateSkillInput = {
   frontmatter?: Record<string, unknown>;
   category?: string;
   alwaysApply?: boolean;
-  source?: 'inline' | 'github' | 'notion';
+  source?: 'inline' | 'github' | 'gitlab' | 'notion';
   sourceMetadata?: Record<string, unknown>;
 };
 
@@ -936,12 +936,12 @@ export function createSkillMethods(
   deleteSkill: (id: string) => Promise<{ deleted: boolean }>;
   deleteUserSkills: (userId: Types.ObjectId | string) => Promise<number>;
   findSkillBySourceIdentity: (params: {
-    source: 'github' | 'notion';
+    source: 'github' | 'gitlab' | 'notion';
     upstreamId: string;
     tenantId?: string;
   }) => Promise<(ISkill & { _id: Types.ObjectId }) | null>;
   listSkillsBySource: (params: {
-    source: 'github' | 'notion';
+    source: 'github' | 'gitlab' | 'notion';
     sourceId: string;
   }) => Promise<Array<ISkill & { _id: Types.ObjectId }>>;
   listSkillFiles: (
@@ -1592,7 +1592,7 @@ export function createSkillMethods(
   }
 
   async function findSkillBySourceIdentity(params: {
-    source: 'github' | 'notion';
+    source: 'github' | 'gitlab' | 'notion';
     upstreamId: string;
     tenantId?: string;
   }): Promise<(ISkill & { _id: Types.ObjectId }) | null> {
@@ -1609,7 +1609,7 @@ export function createSkillMethods(
   }
 
   async function listSkillsBySource(params: {
-    source: 'github' | 'notion';
+    source: 'github' | 'gitlab' | 'notion';
     sourceId: string;
   }): Promise<Array<ISkill & { _id: Types.ObjectId }>> {
     const Skill = mongoose.models.Skill as Model<ISkillDocument>;

--- a/packages/data-schemas/src/methods/skillSync.ts
+++ b/packages/data-schemas/src/methods/skillSync.ts
@@ -36,6 +36,8 @@ export type SkillSyncStatusInput = {
   credentialKey?: string;
   owner?: string;
   repo?: string;
+  baseUrl?: string;
+  projectId?: string;
   ref?: string;
   paths?: string[];
   startedAt?: Date;
@@ -223,6 +225,8 @@ export function createSkillSyncMethods(mongoose: typeof import('mongoose')): Ski
       credentialKey: input.credentialKey,
       owner: input.owner,
       repo: input.repo,
+      baseUrl: input.baseUrl,
+      projectId: input.projectId,
       ref: input.ref,
       paths: input.paths,
       startedAt: input.startedAt,

--- a/packages/data-schemas/src/schema/skill.ts
+++ b/packages/data-schemas/src/schema/skill.ts
@@ -184,16 +184,17 @@ const skillSchema: Schema<ISkillDocument> = new Schema(
      *
      * - `inline` — authored directly inside LibreChat.
      * - `github` — mirrored from a configured GitHub skill sync source.
+     * - `gitlab` — mirrored from a configured GitLab skill sync source.
      * - `notion` — reserved for future external sync integrations.
      */
     source: {
       type: String,
-      enum: ['inline', 'github', 'notion'],
+      enum: ['inline', 'github', 'gitlab', 'notion'],
       default: 'inline',
     },
     /**
-     * Arbitrary JSON provenance payload keyed by `source`. GitHub sync stores
-     * source id, upstream path, commit/blob SHAs, and sync status here.
+     * Arbitrary JSON provenance payload keyed by `source`. Git-based sync stores
+     * source id, upstream path, commit/blob identifiers, and sync status here.
      */
     sourceMetadata: {
       type: Schema.Types.Mixed,

--- a/packages/data-schemas/src/schema/skillSyncCredential.ts
+++ b/packages/data-schemas/src/schema/skillSyncCredential.ts
@@ -5,7 +5,7 @@ const skillSyncCredentialSchema: Schema<ISkillSyncCredentialDocument> = new Sche
   {
     provider: {
       type: String,
-      enum: ['github'],
+      enum: ['github', 'gitlab'],
       required: true,
       index: true,
     },

--- a/packages/data-schemas/src/schema/skillSyncStatus.ts
+++ b/packages/data-schemas/src/schema/skillSyncStatus.ts
@@ -5,7 +5,7 @@ const skillSyncStatusSchema: Schema<ISkillSyncStatusDocument> = new Schema(
   {
     provider: {
       type: String,
-      enum: ['github'],
+      enum: ['github', 'gitlab'],
       required: true,
       index: true,
     },
@@ -32,6 +32,12 @@ const skillSyncStatusSchema: Schema<ISkillSyncStatusDocument> = new Schema(
       type: String,
     },
     repo: {
+      type: String,
+    },
+    baseUrl: {
+      type: String,
+    },
+    projectId: {
       type: String,
     },
     ref: {

--- a/packages/data-schemas/src/types/skill.ts
+++ b/packages/data-schemas/src/types/skill.ts
@@ -74,7 +74,7 @@ export interface ISkill {
    * - `github` — mirrored from a configured GitHub skill sync source.
    * - `notion` — reserved for future external sync integrations.
    */
-  source: 'inline' | 'github' | 'notion';
+  source: 'inline' | 'github' | 'gitlab' | 'notion';
   /**
    * Provenance payload keyed by `source`, including upstream identifiers
    * such as GitHub source id, path, and commit/blob SHAs.

--- a/packages/data-schemas/src/types/skillSync.ts
+++ b/packages/data-schemas/src/types/skillSync.ts
@@ -1,6 +1,6 @@
 import type { Document, Types } from 'mongoose';
 
-export type SkillSyncProvider = 'github';
+export type SkillSyncProvider = 'github' | 'gitlab';
 export type SkillSyncRunStatus = 'idle' | 'running' | 'succeeded' | 'failed' | 'skipped';
 
 export interface ISkillSyncCredential {
@@ -24,6 +24,8 @@ export interface ISkillSyncStatus {
   credentialKey?: string;
   owner?: string;
   repo?: string;
+  baseUrl?: string;
+  projectId?: string;
   ref?: string;
   paths?: string[];
   startedAt?: Date;


### PR DESCRIPTION
## Summary

Addresses #13990 (generalize skill sync beyond GitHub) — scoped to GitLab only for this PR; Bitbucket and Azure DevOps are natural follow-ups once this pattern is proven, not included here.

The existing GitHub-only skill-sync runner (`packages/api/src/skills/sync/github.ts`) tightly interleaved GitHub-specific REST calls with generic orchestration logic (skill discovery, DB upsert/cleanup, sync counters, stale-delete ordering). This PR:

- Extracts a `GitRepoAdapter` interface (`packages/api/src/skills/sync/adapters/types.ts`) covering exactly the REST-specific surface the orchestration needs: `resolveCommit`, `fetchTreeEntries`, `fetchFileContent`.
- Moves the GitHub REST implementation into `adapters/github.ts` implementing that interface; `github.ts` itself now only contains the (unchanged) generic orchestration, calling through the adapter.
- Implements `adapters/gitlab.ts` (list tree via `GET /projects/{id}/repository/tree?recursive=true`, fetch blob via `GET /projects/{id}/repository/files/{path}/raw`, `Private-Token` auth, configurable `baseUrl` for self-hosted GitLab) and a parallel `packages/api/src/skills/sync/gitlab.ts` orchestrator mirroring `github.ts`.
- Adds a `createRepoAdapter` factory (`adapters/factory.ts`) that picks the right adapter by provider.
- Extends `skillSyncConfigSchema` (`packages/data-provider/src/config.ts`) with a `gitlab` key mirroring the `github` key's shape/validation, and extends `SkillSyncProvider` to `'github' | 'gitlab'`.
- Adds `'gitlab'` to the `Skill.source` enum and `SkillSyncStatusInput`/`ISkillSyncStatus` gain `baseUrl`/`projectId` fields alongside the existing GitHub `owner`/`repo`.

**Regression safety was the top priority for the extraction.** Every existing GitHub sync test passes unmodified in behavior — only import paths changed where the code moved into `adapters/github.ts`.

## Test plan

- [x] `packages/api`: `npx jest src/skills/sync` — 69/69 passing (includes all pre-existing GitHub orchestrator/scheduler tests unmodified, plus new `adapters/gitlab.spec.ts` and `adapters/factory.spec.ts`)
- [x] `packages/api`: `npx jest src/admin/skills.spec.ts` — 10/10 passing (admin skill-sync API surface, unaffected)
- [x] `packages/data-schemas`: `npx jest src/methods/skillSync.spec.ts src/methods/skill.spec.ts` — 106/106 passing
- [x] `packages/data-provider`: `npx jest src/config` — 119/119 passing (schema extension didn't break existing config validation)
- [x] `tsc --noEmit` clean on `packages/api`, `packages/data-schemas`, `packages/data-provider`
- [x] `eslint` clean on all changed/new files