### PR TITLE
🔡 fix: Normalize Email Case When Issuing Verification Tokens

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -218,16 +218,17 @@ const createTokenHash = () => {
  */
 const sendVerificationEmail = async (user) => {
   const [verifyToken, hash] = createTokenHash();
+  const email = user.email.toLowerCase();
 
   const verificationLink = `${
     domains.client
-  }/verify?token=${verifyToken}&email=${encodeURIComponent(user.email)}`;
+  }/verify?token=${verifyToken}&email=${encodeURIComponent(email)}`;
   await sendEmail({
-    email: user.email,
+    email,
     subject: 'Verify your email',
     payload: {
       appName: process.env.APP_TITLE || 'LibreChat',
-      name: user.name || user.username || user.email,
+      name: user.name || user.username || email,
       verificationLink: verificationLink,
       year: new Date().getFullYear(),
     },
@@ -236,14 +237,14 @@ const sendVerificationEmail = async (user) => {
 
   await createToken({
     userId: user._id,
-    email: user.email,
+    email,
     type: AuthTokenTypes.EMAIL_VERIFICATION,
     token: hash,
     createdAt: Date.now(),
     expiresIn: 900,
   });
 
-  logger.info(`[sendVerificationEmail] Verification link issued. [Email: ${user.email}]`);
+  logger.info(`[sendVerificationEmail] Verification link issued. [Email: ${email}]`);
 };
 
 /**

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -471,6 +471,31 @@ describe('registerUser', () => {
       }),
     );
   });
+
+  it('normalizes mixed-case emails when issuing the verification token and link', async () => {
+    checkEmailConfig.mockReturnValue(true);
+
+    const result = await registerUser({
+      ...registrationPayload,
+      email: 'Mixed.Case@Example.com',
+    });
+
+    expect(result.status).toBe(200);
+    expect(createToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'mixed.case@example.com',
+        type: 'email_verification',
+      }),
+    );
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'mixed.case@example.com',
+        payload: expect.objectContaining({
+          verificationLink: expect.stringContaining(encodeURIComponent('mixed.case@example.com')),
+        }),
+      }),
+    );
+  });
 });
 
 describe('verifyEmail public response handling', () => {


### PR DESCRIPTION
## Summary

Fixes #14171

Registering with a mixed-case email (e.g. `Mixed.Case@example.com`) produced a verification link that always failed with `[verifyEmail] [No email verification data found]`, even when clicked immediately.

**Root cause:** the User schema lowercases `email` on save, but `sendVerificationEmail` received the raw registration email and stored the verification token with it as-is. `verifyEmail` then queried the tokens collection by the user's (lowercased) DB email, which never matched the mixed-case token row.

**Fix:** normalize the email once at the top of `sendVerificationEmail` and use it consistently for the verification link, the email recipient, the name fallback, and the token record. `resendVerificationEmail` is untouched — it already reads the lowercased email from the DB and was never affected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified on a live deployment (Azure VM, SMTP relay): before the patch, registering with a mixed-case email logged `[No email verification data found]` on every click of the verification link; after the patch, an identical mixed-case registration verified successfully.
- Added a regression test in `AuthService.spec.js`: registering through `registerUser` with `Mixed.Case@Example.com` asserts the verification token is created with the lowercased email and the emailed link contains the lowercased, URL-encoded address. The test fails against the unpatched code and passes with the fix.
- Full `AuthService` suite passes locally (58/58) and ESLint is clean on both changed files.

### Test Configuration

- Node v24, Jest via `cd api && npx jest AuthService`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
