### PR TITLE
docs: add TokenLab custom endpoint example

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -557,6 +557,37 @@ endpoints:
       titleModel: 'mixtral-8x7b-32768'
       modelDisplayLabel: 'groq'
 
+    # TokenLab Example
+    # TokenLab exposes an OpenAI-compatible `/v1` API and live model discovery
+    # at `/v1/models`. It also provides native endpoint families such as
+    # Responses, Anthropic Messages, and Gemini-compatible APIs for clients that
+    # support those request shapes.
+    - name: 'TokenLab'
+      apiKey: '${TOKENLAB_API_KEY}'
+      baseURL: 'https://api.tokenlab.sh/v1'
+      models:
+        default:
+          - 'gpt-5.5'
+          - 'gpt-5.4'
+          - 'gpt-5.4-mini'
+          - 'claude-opus-4-8'
+          - 'claude-sonnet-5'
+          - 'claude-fable-5'
+          - 'gemini-3.5-flash'
+          - 'gemini-3.1-flash-lite'
+          - 'grok-4.3'
+          - 'grok-4-fast'
+          - 'qwen3.7-max'
+          - 'deepseek-v4-pro'
+          - 'deepseek-v4-flash'
+          - 'glm-5.2'
+          - 'minimax-m3'
+          - 'kimi-k2.7-code'
+        fetch: true
+      titleConvo: true
+      titleModel: 'gpt-5.4-mini'
+      modelDisplayLabel: 'TokenLab'
+
     # Mistral AI Example
     - name: 'Mistral' # Unique name for the endpoint
       # For `apiKey` and `baseURL`, you can use environment variables that you define.


### PR DESCRIPTION
## Summary

Adds a TokenLab custom endpoint example to `librechat.example.yaml`, using TokenLab's OpenAI-compatible base URL and a curated set of current high-coverage models. The example enables `fetch: true` so LibreChat can use TokenLab's live `/v1/models` discovery while still giving operators a useful default list.

The comments also note that TokenLab exposes native endpoint families such as Responses, Anthropic Messages, and Gemini-compatible APIs for clients that support those request shapes.

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

## Testing

- `git diff --check`
- Parsed `librechat.example.yaml` with Python/PyYAML to verify the example remains valid YAML.

### **Test Configuration**:

Temporary local checkout; no TokenLab API key used.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.