### PR TITLE
📎 fix: Reflect Finite supportedMimeTypes Allowlists in Provider File Picker

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -19,6 +19,7 @@ import {
   Providers,
   EToolResources,
   EModelEndpoint,
+  mimeTypesToAccept,
   isPermissiveMimeConfig,
   defaultAgentCapabilities,
   bedrockDocumentExtensions,
@@ -120,11 +121,14 @@ const AttachFileMenu = ({
         return;
       }
       inputRef.current.value = '';
+      const configAccept = mimeTypesToAccept(endpointFileConfig?.supportedMimeTypes);
       if (
         fileType !== undefined &&
         isPermissiveMimeConfig(endpointFileConfig?.supportedMimeTypes)
       ) {
         inputRef.current.accept = '';
+      } else if (fileType !== undefined && configAccept !== '') {
+        inputRef.current.accept = configAccept;
       } else if (fileType === 'image') {
         inputRef.current.accept = 'image/*,.heif,.heic';
       } else if (fileType === 'document') {

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -3,6 +3,7 @@ import {
   fileConfig as baseFileConfig,
   isPermissiveMimeConfig,
   convertStringsToRegex,
+  mimeTypesToAccept,
   documentParserMimeTypes,
   getEndpointFileConfig,
   applicationMimeTypes,
@@ -1357,5 +1358,63 @@ describe('isPermissiveMimeConfig', () => {
   it('returns true for regex produced by convertStringsToRegex with .*', () => {
     const converted = convertStringsToRegex(['.*']);
     expect(isPermissiveMimeConfig(converted)).toBe(true);
+  });
+});
+
+describe('mimeTypesToAccept', () => {
+  it('maps an image + pdf + Office allowlist to a finite accept string', () => {
+    const converted = convertStringsToRegex([
+      'image/.*',
+      'application/pdf',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ]);
+    expect(mimeTypesToAccept(converted)).toBe(
+      'image/*,.heif,.heic,' +
+        '.pdf,application/pdf,' +
+        '.doc,application/msword,' +
+        '.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,' +
+        '.xls,application/vnd.ms-excel,' +
+        '.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+  });
+
+  it('maps an image + pdf allowlist to a finite accept string', () => {
+    const converted = convertStringsToRegex(['image/.*', 'application/pdf']);
+    expect(mimeTypesToAccept(converted)).toBe('image/*,.heif,.heic,.pdf,application/pdf');
+  });
+
+  it('recognizes anchored and escaped pattern variants', () => {
+    expect(mimeTypesToAccept([/^application\/pdf$/, /^application\/vnd\.ms-excel$/])).toBe(
+      '.pdf,application/pdf,.xls,application/vnd.ms-excel',
+    );
+  });
+
+  it('deduplicates repeated patterns', () => {
+    const converted = convertStringsToRegex(['application/pdf', 'application/pdf']);
+    expect(mimeTypesToAccept(converted)).toBe('.pdf,application/pdf');
+  });
+
+  it('returns empty string for the default supportedMimeTypes', () => {
+    expect(mimeTypesToAccept(supportedMimeTypes)).toBe('');
+  });
+
+  it('returns empty string when any pattern is unrecognized', () => {
+    const converted = convertStringsToRegex(['image/.*', 'application/pdf', 'application/zip']);
+    expect(mimeTypesToAccept(converted)).toBe('');
+  });
+
+  it('returns empty string for permissive patterns', () => {
+    expect(mimeTypesToAccept(convertStringsToRegex(['.*']))).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(mimeTypesToAccept(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(mimeTypesToAccept([])).toBe('');
   });
 });

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -528,6 +528,44 @@ export const isPermissiveMimeConfig = (types?: RegExp[]): boolean => {
   return types.some((regex) => regex.test('x-librechat/x-probe'));
 };
 
+const mimeAcceptTokens: Record<string, string> = {
+  'image/.*': 'image/*,.heif,.heic',
+  'application/pdf': '.pdf,application/pdf',
+  'application/msword': '.doc,application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    '.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel': '.xls,application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+    '.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+/**
+ * Converts recognized finite MIME regex allowlists into a browser file input
+ * `accept` string. Returns '' when any pattern is unrecognized, so callers can
+ * fall back to provider-specific defaults.
+ */
+export const mimeTypesToAccept = (types?: RegExp[]): string => {
+  if (!types || types.length === 0) {
+    return '';
+  }
+
+  const tokens: string[] = [];
+  for (const regex of types) {
+    const normalized = regex.source
+      .replace(/^\^/, '')
+      .replace(/\$$/, '')
+      .replace(/\\([/.])/g, '$1');
+    const accept = mimeAcceptTokens[normalized];
+    if (accept === undefined) {
+      return '';
+    }
+    if (!tokens.includes(accept)) {
+      tokens.push(accept);
+    }
+  }
+  return tokens.join(',');
+};
+
 /**
  * Gets the appropriate endpoint file configuration with standardized lookup logic.
  *


### PR DESCRIPTION
## Summary

Closes #14175

PR #12596 clears the file input `accept` filter when an endpoint's `supportedMimeTypes` config is permissive (e.g. `['.*']`), but finite allowlists still fall back to the hardcoded provider picker filters, so files the backend would accept (e.g. Word/Excel on a document-supported provider) cannot be selected in the **Upload to Provider** picker.

This PR adds `mimeTypesToAccept` to `packages/data-provider/src/file-config.ts`, which converts recognized finite MIME regex allowlists into a browser file input `accept` string, and uses it in `AttachFileMenu.tsx` between the existing permissive check and the hardcoded provider fallbacks:

- Each configured pattern's `regex.source` (anchors stripped, `\/` and `\.` unescaped) is looked up in a table of recognized literal MIME patterns (`image/.*`, PDF, and the four common Word/Excel types), each mapping to extension + MIME accept tokens.
- If **any** pattern is unrecognized, the helper returns `''` and the picker keeps today's hardcoded provider filters. Because the default composite patterns (`textMimeTypes`, `applicationMimeTypes`, …) are not literal MIME strings, endpoints without an explicit `supportedMimeTypes` config are unaffected.
- Permissive configs keep the #12596 behavior (checked first, `accept` cleared).

The recognized-pattern table is intentionally conservative and easy to extend with further literal MIME patterns.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added `mimeTypesToAccept` cases to `packages/data-provider/src/file-config.spec.ts`: finite image+PDF+Office allowlist maps to the expected accept string, image+PDF-only maps correctly, anchored/escaped regex variants are recognized, duplicates are deduped, and the default `supportedMimeTypes`, permissive `.*`, partially-unrecognized lists, `undefined`, and `[]` all return `''` (fallback preserved).
- `npx jest` in `packages/data-provider`: 24 suites, all passing.
- Manually verified on a v0.8.7 deployment (self-built image with this patch) against a custom OpenAI-compatible endpoint with the finite allowlist from #14175: the picker's `accept` becomes `image/*,.heif,.heic,.pdf,application/pdf,.doc,application/msword,.docx,…,.xls,…,.xlsx,…`; `.docx`/`.xlsx` upload and are received by the model; OCR/file-search/code upload flows (no fileType) and permissive configs are unchanged; endpoints without `supportedMimeTypes` config keep the stock hardcoded filters.

### **Test Configuration**:

Custom endpoint (OpenAI-compatible proxy) with `fileConfig.endpoints.<name>.supportedMimeTypes` set to `image/.*`, `application/pdf`, and the four Word/Excel MIME types.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes