### PR TITLE
🃏 fix: Attach Request-Scoped MCP Servers From the Builder via the `mcp_all` Wildcard

### DIFF
--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -718,7 +718,7 @@ router.post(
         return res.status(500).json({ error: 'Failed to reinitialize MCP server for user' });
       }
 
-      const { success, message, oauthRequired, oauthUrl } = result;
+      const { success, message, oauthRequired, oauthUrl, connectionDeferred } = result;
 
       if (oauthRequired) {
         const flowId = getOAuthFlowId(user.id, serverName);
@@ -731,6 +731,7 @@ router.post(
         oauthUrl,
         serverName,
         oauthRequired,
+        connectionDeferred,
       });
     } catch (error) {
       logger.error('[MCP Reinitialize] Unexpected error', error);

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -139,6 +139,10 @@ async function reinitMCPServer({
       return {
         availableTools: null,
         success: true,
+        /** Lets clients distinguish "connection deferred to a chat turn" from a
+         *  plain success with no tools, e.g. to attach the server at the server
+         *  level instead of waiting for a tool list that never arrives. */
+        connectionDeferred: true,
         message: `MCP server '${serverName}' uses request-scoped placeholders; connection will be established on first use in a chat turn`,
         oauthRequired: false,
         serverName,

--- a/api/server/services/Tools/mcp.spec.js
+++ b/api/server/services/Tools/mcp.spec.js
@@ -213,6 +213,7 @@ describe('reinitMCPServer — runtime BODY placeholder pre-check (issue #14074)'
     expect(result).toMatchObject({
       availableTools: null,
       success: true,
+      connectionDeferred: true,
       tools: null,
       oauthRequired: false,
       serverName,
@@ -240,7 +241,7 @@ describe('reinitMCPServer — runtime BODY placeholder pre-check (issue #14074)'
       fetchTools: jest.fn().mockResolvedValue([]),
     });
 
-    await reinitMCPServer({
+    const result = await reinitMCPServer({
       user,
       serverName,
       serverConfig,
@@ -249,6 +250,7 @@ describe('reinitMCPServer — runtime BODY placeholder pre-check (issue #14074)'
     });
 
     expect(mockGetConnection).toHaveBeenCalledTimes(1);
+    expect(result.connectionDeferred).toBeUndefined();
   });
 
   it('reports missing customUserVars before deferring on body placeholders', async () => {

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { McpItem } from '../../items/types';
 import McpSection from '../sections/McpSection';
@@ -211,5 +211,51 @@ describe('McpSection', () => {
     };
     render(<McpSection item={empty} />);
     expect(screen.getByText('com_ui_tools_mcp_no_tools')).toBeInTheDocument();
+  });
+
+  test('connectionDeferred attaches the whole server via the mcp_all wildcard', async () => {
+    // Request-scoped servers (runtime {{LIBRECHAT_BODY_*}} placeholders) defer
+    // their connection to the next chat turn, so no tool list arrives here —
+    // Connect should attach the server-wide wildcard instead of waiting.
+    mockInitializeServer.mockResolvedValue({ success: true, connectionDeferred: true });
+    const empty: McpItem = {
+      ...item,
+      server: { ...item.server, tools: [] } as never,
+      toolCount: 0,
+    };
+    render(<McpSection item={empty} />);
+    fireEvent.click(screen.getByText('com_nav_mcp_connect_server'));
+    await waitFor(() =>
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'tools',
+        ['sys__server__sys_mcp_srv', 'sys__all__sys_mcp_srv'],
+        expect.objectContaining({ shouldDirty: true }),
+      ),
+    );
+  });
+
+  test('connectionDeferred does not duplicate an already-attached wildcard', async () => {
+    mockInitializeServer.mockResolvedValue({ success: true, connectionDeferred: true });
+    mockGetValues.mockReturnValue(['sys__server__sys_mcp_srv', 'sys__all__sys_mcp_srv']);
+    const empty: McpItem = {
+      ...item,
+      server: { ...item.server, tools: [] } as never,
+      toolCount: 0,
+    };
+    render(<McpSection item={empty} />);
+    fireEvent.click(screen.getByText('com_nav_mcp_connect_server'));
+    await waitFor(() => expect(mockInitializeServer).toHaveBeenCalled());
+    expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  test('shows the runtime-tools hint when attached via the wildcard', () => {
+    mockGetValues.mockReturnValue(['sys__all__sys_mcp_srv']);
+    const empty: McpItem = {
+      ...item,
+      server: { ...item.server, tools: [] } as never,
+      toolCount: 0,
+    };
+    render(<McpSection item={empty} />);
+    expect(screen.getByText('com_ui_tools_mcp_runtime_tools')).toBeInTheDocument();
   });
 });

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
@@ -36,6 +36,7 @@ jest.mock('~/hooks', () => ({
     getConfigDialogProps: () => null,
     initializeServer: mockInitializeServer,
     isConnectionDeferred: mockIsConnectionDeferred,
+    resetConnectionDeferred: jest.fn(),
     getOAuthUrl: () => undefined,
     isCancellable: () => false,
     cancelOAuthFlow: jest.fn(),
@@ -254,16 +255,26 @@ describe('McpSection', () => {
     expect(mockSetValue).not.toHaveBeenCalled();
   });
 
-  test('per-tool selection replaces a stale wildcard', () => {
-    // If a formerly request-scoped server starts exposing a normal tool list,
-    // picking individual tools must drop the mcp_all wildcard — otherwise the
-    // runtime would still grant every tool while the UI shows a subset.
+  test('wildcard attachment shows every enumerable tool as selected', () => {
+    // The mcp_all wildcard grants every tool at runtime; if the server's tools
+    // become enumerable, the display must reflect that instead of showing
+    // unchecked boxes while runtime grants everything.
+    mockGetValues.mockReturnValue(['sys__all__sys_mcp_srv']);
+    render(<McpSection item={item} />);
+    expect(screen.getByTestId('tool-mcp:srv:a')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('tool-mcp:srv:b')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('touching a selection converts the wildcard to concrete tool ids', () => {
+    // With a wildcard attached and tools enumerable, deselecting one tool must
+    // rewrite the form with the remaining concrete ids and drop the wildcard —
+    // otherwise runtime would still grant every tool while the UI shows a subset.
     mockGetValues.mockReturnValue(['sys__all__sys_mcp_srv']);
     render(<McpSection item={item} />);
     fireEvent.click(screen.getByTestId('tool-mcp:srv:a'));
     expect(mockSetValue).toHaveBeenCalledWith(
       'tools',
-      ['sys__server__sys_mcp_srv', 'mcp:srv:a'],
+      ['sys__server__sys_mcp_srv', 'mcp:srv:b'],
       expect.objectContaining({ shouldDirty: true }),
     );
   });

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/__tests__/McpSection.spec.tsx
@@ -7,6 +7,7 @@ import McpSection from '../sections/McpSection';
 const mockSetValue = jest.fn();
 const mockGetValues = jest.fn((): string[] => []);
 const mockInitializeServer = jest.fn();
+const mockIsConnectionDeferred = jest.fn((): boolean => false);
 
 jest.mock('react-hook-form', () => ({
   useFormContext: () => ({ control: {}, setValue: mockSetValue, getValues: mockGetValues }),
@@ -34,6 +35,7 @@ jest.mock('~/hooks', () => ({
     getServerStatusIconProps: () => null,
     getConfigDialogProps: () => null,
     initializeServer: mockInitializeServer,
+    isConnectionDeferred: mockIsConnectionDeferred,
     getOAuthUrl: () => undefined,
     isCancellable: () => false,
     cancelOAuthFlow: jest.fn(),
@@ -132,6 +134,8 @@ describe('McpSection', () => {
     mockSetValue.mockClear();
     mockGetValues.mockReturnValue([]);
     mockInitializeServer.mockReset();
+    mockIsConnectionDeferred.mockReset();
+    mockIsConnectionDeferred.mockReturnValue(false);
   });
 
   test('renders one row per tool', () => {
@@ -213,11 +217,12 @@ describe('McpSection', () => {
     expect(screen.getByText('com_ui_tools_mcp_no_tools')).toBeInTheDocument();
   });
 
-  test('connectionDeferred attaches the whole server via the mcp_all wildcard', async () => {
+  test('deferred connect attaches the whole server via the mcp_all wildcard', async () => {
     // Request-scoped servers (runtime {{LIBRECHAT_BODY_*}} placeholders) defer
     // their connection to the next chat turn, so no tool list arrives here —
     // Connect should attach the server-wide wildcard instead of waiting.
     mockInitializeServer.mockResolvedValue({ success: true, connectionDeferred: true });
+    mockIsConnectionDeferred.mockReturnValue(true);
     const empty: McpItem = {
       ...item,
       server: { ...item.server, tools: [] } as never,
@@ -234,8 +239,9 @@ describe('McpSection', () => {
     );
   });
 
-  test('connectionDeferred does not duplicate an already-attached wildcard', async () => {
+  test('deferred connect does not duplicate an already-attached wildcard', async () => {
     mockInitializeServer.mockResolvedValue({ success: true, connectionDeferred: true });
+    mockIsConnectionDeferred.mockReturnValue(true);
     mockGetValues.mockReturnValue(['sys__server__sys_mcp_srv', 'sys__all__sys_mcp_srv']);
     const empty: McpItem = {
       ...item,
@@ -246,6 +252,20 @@ describe('McpSection', () => {
     fireEvent.click(screen.getByText('com_nav_mcp_connect_server'));
     await waitFor(() => expect(mockInitializeServer).toHaveBeenCalled());
     expect(mockSetValue).not.toHaveBeenCalled();
+  });
+
+  test('per-tool selection replaces a stale wildcard', () => {
+    // If a formerly request-scoped server starts exposing a normal tool list,
+    // picking individual tools must drop the mcp_all wildcard — otherwise the
+    // runtime would still grant every tool while the UI shows a subset.
+    mockGetValues.mockReturnValue(['sys__all__sys_mcp_srv']);
+    render(<McpSection item={item} />);
+    fireEvent.click(screen.getByTestId('tool-mcp:srv:a'));
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'tools',
+      ['sys__server__sys_mcp_srv', 'mcp:srv:a'],
+      expect.objectContaining({ shouldDirty: true }),
+    );
   });
 
   test('shows the runtime-tools hint when attached via the wildcard', () => {

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -61,8 +61,13 @@ interface Props {
 export default function McpSection({ item }: Props) {
   const localize = useLocalize();
   const { control, getValues, setValue } = useFormContext<AgentForm>();
-  const { getServerStatusIconProps, getConfigDialogProps, initializeServer, getOAuthUrl } =
-    useMCPServerManager();
+  const {
+    getServerStatusIconProps,
+    getConfigDialogProps,
+    initializeServer,
+    isConnectionDeferred,
+    getOAuthUrl,
+  } = useMCPServerManager();
   const [oauthOpen, setOauthOpen] = useState(false);
   const [oauthUrl, setOauthUrl] = useState<string | null>(null);
   const [prevConnected, setPrevConnected] = useState(false);
@@ -104,16 +109,19 @@ export default function McpSection({ item }: Props) {
 
   /** Replace this server's tool selection while keeping the server attached: the
    * placeholder token is always rewritten, so deselect-all leaves the server
-   * pinned with zero tools; only an explicit remove detaches it. */
+   * pinned with zero tools; only an explicit remove detaches it. The `mcp_all`
+   * wildcard is also stripped unless explicitly re-passed in `next`, so a
+   * per-tool selection always supersedes a stale wildcard (e.g. after a server
+   * stops being request-scoped and its tools become enumerable). */
   const updateFormTools = useCallback(
     (next: string[]) => {
       const current = (getValues('tools') ?? []) as string[];
       const otherTools = current.filter(
-        (t) => t !== serverToken && !tools.some((st) => st.tool_id === t),
+        (t) => t !== serverToken && t !== serverAllToken && !tools.some((st) => st.tool_id === t),
       );
       setValue('tools', [...otherTools, serverToken, ...next], { shouldDirty: true });
     },
-    [getValues, setValue, serverToken, tools],
+    [getValues, setValue, serverToken, serverAllToken, tools],
   );
 
   const toggleToolSelect = (toolId: string) => {
@@ -159,14 +167,42 @@ export default function McpSection({ item }: Props) {
   /** Connecting from this dialog implies the user wants the server's tools:
    * once the connection settles and the tools arrive (query refetch for direct
    * connects, polling for OAuth), select them all — an effect because both
-   * signals come from external systems, not from anything rendered here. */
+   * signals come from external systems, not from anything rendered here.
+   *
+   * Request-scoped servers (runtime `{{LIBRECHAT_BODY_*}}` placeholders) defer
+   * their connection to the next chat turn, so no tool list will ever arrive —
+   * attach the whole server via the `mcp_all` wildcard instead; the backend
+   * resolves it into the server's full tool set at turn time. Keying on the
+   * manager's init state (not the awaited response) also covers connects that
+   * happen behind the customUserVars config dialog, which this component does
+   * not await. */
+  const serverDeferred = isConnectionDeferred(serverName);
   useEffect(() => {
-    if (!autoSelectPending || !isConnected || !hasTools) {
+    if (!autoSelectPending) {
+      return;
+    }
+    if (serverDeferred && !hasTools) {
+      setAutoSelectPending(false);
+      if (!isWildcardAttached) {
+        updateFormTools([serverAllToken]);
+      }
+      return;
+    }
+    if (!isConnected || !hasTools) {
       return;
     }
     setAutoSelectPending(false);
     updateFormTools(tools.map((t) => t.tool_id));
-  }, [autoSelectPending, isConnected, hasTools, tools, updateFormTools]);
+  }, [
+    autoSelectPending,
+    serverDeferred,
+    isConnected,
+    hasTools,
+    tools,
+    updateFormTools,
+    isWildcardAttached,
+    serverAllToken,
+  ]);
 
   /** Connect inline from this first dialog. Servers with custom user variables are
    * routed to the config dialog (which sets the vars and initializes); others
@@ -182,17 +218,6 @@ export default function McpSection({ item }: Props) {
       const res = await initializeServer(serverName, false);
       if (res == null || !res.success) {
         setAutoSelectPending(false);
-        return;
-      }
-      /** Request-scoped servers (runtime `{{LIBRECHAT_BODY_*}}` placeholders)
-       * defer their connection to the next chat turn, so no tool list will ever
-       * arrive here. Attach the whole server via the `mcp_all` wildcard instead
-       * — the backend resolves it into the server's full tool set at turn time. */
-      if (res.connectionDeferred) {
-        setAutoSelectPending(false);
-        if (!isWildcardAttached) {
-          updateFormTools([serverAllToken]);
-        }
         return;
       }
       if (res.oauthRequired && res.oauthUrl) {

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -15,7 +15,7 @@ import {
 import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import McpOAuthDialog from '~/components/MCP/McpOAuthDialog';
-import { mcpServerToken } from '../../items/selectors';
+import { mcpAllToken, mcpServerToken } from '../../items/selectors';
 import { useAgentPanelContext } from '~/Providers';
 import { getIconForItem } from '../../items/icons';
 import MCPToolItem from '../../../MCPToolItem';
@@ -85,6 +85,7 @@ export default function McpSection({ item }: Props) {
 
   const serverName = item.server.serverName;
   const serverToken = mcpServerToken(serverName);
+  const serverAllToken = mcpAllToken(serverName);
   /** Live server data — `item.server` is a snapshot from card click and goes stale once
    * the MCP query refetches (e.g., after a server connects), so read from the live map. */
   const liveServer = mcpServersMap.get(serverName) ?? item.server;
@@ -94,6 +95,9 @@ export default function McpSection({ item }: Props) {
   /** Subscribe to the tools field so selection toggles re-render this section.
    * `getValues` is a non-reactive read and left the checkboxes visually stale. */
   const formTools = (useWatch({ control, name: 'tools' }) ?? []) as string[];
+  /** Attached via the server-wide `mcp_all` wildcard — used by request-scoped
+   * servers whose tools resolve at chat-turn time and can't be listed here. */
+  const isWildcardAttached = formTools.includes(serverAllToken);
 
   const getSelectedTools = (): string[] =>
     tools.filter((t) => formTools.includes(t.tool_id)).map((t) => t.tool_id);
@@ -178,6 +182,17 @@ export default function McpSection({ item }: Props) {
       const res = await initializeServer(serverName, false);
       if (res == null || !res.success) {
         setAutoSelectPending(false);
+        return;
+      }
+      /** Request-scoped servers (runtime `{{LIBRECHAT_BODY_*}}` placeholders)
+       * defer their connection to the next chat turn, so no tool list will ever
+       * arrive here. Attach the whole server via the `mcp_all` wildcard instead
+       * — the backend resolves it into the server's full tool set at turn time. */
+      if (res.connectionDeferred) {
+        setAutoSelectPending(false);
+        if (!isWildcardAttached) {
+          updateFormTools([serverAllToken]);
+        }
         return;
       }
       if (res.oauthRequired && res.oauthUrl) {
@@ -361,7 +376,9 @@ export default function McpSection({ item }: Props) {
           </Collapse>
           <Collapse open={!hasTools && !toolsLoading}>
             <p className="rounded-xl border border-dashed border-border-light p-3 text-center text-xs text-text-tertiary">
-              {localize('com_ui_tools_mcp_no_tools')}
+              {localize(
+                isWildcardAttached ? 'com_ui_tools_mcp_runtime_tools' : 'com_ui_tools_mcp_no_tools',
+              )}
             </p>
           </Collapse>
         </div>

--- a/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ItemDialog/sections/McpSection.tsx
@@ -13,9 +13,9 @@ import {
   useMCPToolOptions,
 } from '~/hooks';
 import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
+import { mcpAllToken, mcpServerToken } from '../../items/selectors';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 import McpOAuthDialog from '~/components/MCP/McpOAuthDialog';
-import { mcpAllToken, mcpServerToken } from '../../items/selectors';
 import { useAgentPanelContext } from '~/Providers';
 import { getIconForItem } from '../../items/icons';
 import MCPToolItem from '../../../MCPToolItem';
@@ -66,6 +66,7 @@ export default function McpSection({ item }: Props) {
     getConfigDialogProps,
     initializeServer,
     isConnectionDeferred,
+    resetConnectionDeferred,
     getOAuthUrl,
   } = useMCPServerManager();
   const [oauthOpen, setOauthOpen] = useState(false);
@@ -104,8 +105,16 @@ export default function McpSection({ item }: Props) {
    * servers whose tools resolve at chat-turn time and can't be listed here. */
   const isWildcardAttached = formTools.includes(serverAllToken);
 
+  /** The `mcp_all` wildcard grants every server tool at runtime, so when the
+   * server's tools ARE enumerable (e.g. it stopped being request-scoped), fold
+   * the wildcard into the display as "all selected" — otherwise the dialog
+   * would show unchecked boxes while runtime grants everything. Any selection
+   * interaction then rewrites the form with concrete tool ids (the wildcard is
+   * stripped by `updateFormTools`), converting the attachment on first touch. */
   const getSelectedTools = (): string[] =>
-    tools.filter((t) => formTools.includes(t.tool_id)).map((t) => t.tool_id);
+    isWildcardAttached
+      ? tools.map((t) => t.tool_id)
+      : tools.filter((t) => formTools.includes(t.tool_id)).map((t) => t.tool_id);
 
   /** Replace this server's tool selection while keeping the server attached: the
    * placeholder token is always rewritten, so deselect-all leaves the server
@@ -211,6 +220,11 @@ export default function McpSection({ item }: Props) {
   const handleConnect = async (e: MouseEvent) => {
     setAutoSelectPending(true);
     if (statusIconProps != null && statusIconProps.hasCustomUserVars) {
+      /** A stale deferred flag from an earlier attempt must not fire the
+       * auto-attach effect while the config dialog is open — only this
+       * attempt's outcome (recorded on save → initialize) counts. The direct
+       * path below needs no reset: initializeServer clears it up front. */
+      resetConnectionDeferred(serverName);
       statusIconProps.onConfigClick(e);
       return;
     }

--- a/client/src/components/SidePanel/Agents/Tools/items/selectors.ts
+++ b/client/src/components/SidePanel/Agents/Tools/items/selectors.ts
@@ -66,6 +66,18 @@ export function mcpServerToken(serverName: string): string {
 }
 
 /**
+ * Server-wide wildcard token (`sys__all__sys_mcp_<serverName>`). Unlike the
+ * UI-only `mcp_server` placeholder (skipped at runtime), `mcp_all` is resolved
+ * by the backend into ALL of the server's tools at chat-turn time. Used for
+ * request-scoped servers (runtime `{{LIBRECHAT_BODY_*}}` placeholders) whose
+ * tools cannot be enumerated outside a chat turn, so per-tool selection is
+ * impossible and the server must be attached as a whole.
+ */
+export function mcpAllToken(serverName: string): string {
+  return `${Constants.mcp_all}${Constants.mcp_delimiter}${serverName}`;
+}
+
+/**
  * Whether a form `tools` token references the given MCP server, across every
  * format ever persisted: the server placeholder token, the raw server name,
  * the exact `mcp_<server>` pluginKey form, and delimiter-suffixed per-tool

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -348,6 +348,12 @@ export function useMCPServerManager({
       updateServerInitState(serverName, { isInitializing: true });
       try {
         const response = await reinitializeMutation.mutateAsync(serverName);
+        /** Record whether this attempt deferred to a chat turn (request-scoped
+         * server) so consumers that didn't await this call — e.g. the agent
+         * builder behind the customUserVars config dialog — can react to it. */
+        updateServerInitState(serverName, {
+          connectionDeferred: Boolean(response.connectionDeferred),
+        });
         if (!response.success) {
           showToast({
             message: localize('com_ui_mcp_init_failed', { 0: serverName }),
@@ -452,6 +458,13 @@ export function useMCPServerManager({
   const isCancellable = useCallback(
     (serverName: string) => {
       return getServerInitState(serverInitStates, serverName).isCancellable;
+    },
+    [serverInitStates],
+  );
+
+  const isConnectionDeferred = useCallback(
+    (serverName: string) => {
+      return getServerInitState(serverInitStates, serverName).connectionDeferred;
     },
     [serverInitStates],
   );
@@ -678,6 +691,7 @@ export function useMCPServerManager({
     cancelOAuthFlow,
     isInitializing,
     isCancellable,
+    isConnectionDeferred,
     getOAuthUrl,
     mcpValues,
     setMCPValues,

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -345,7 +345,9 @@ export function useMCPServerManager({
 
   const initializeServer = useCallback(
     async (serverName: string, autoOpenOAuth: boolean = true) => {
-      updateServerInitState(serverName, { isInitializing: true });
+      /** connectionDeferred is reset up front so a stale value from a previous
+       * attempt can never be mistaken for this attempt's outcome. */
+      updateServerInitState(serverName, { isInitializing: true, connectionDeferred: false });
       try {
         const response = await reinitializeMutation.mutateAsync(serverName);
         /** Record whether this attempt deferred to a chat turn (request-scoped
@@ -467,6 +469,16 @@ export function useMCPServerManager({
       return getServerInitState(serverInitStates, serverName).connectionDeferred;
     },
     [serverInitStates],
+  );
+
+  /** Clear a recorded deferred outcome without starting a new attempt — used
+   * before routing into the customUserVars config dialog so a stale flag from
+   * an earlier attempt can't trigger consumers while the dialog is open. */
+  const resetConnectionDeferred = useCallback(
+    (serverName: string) => {
+      updateServerInitState(serverName, { connectionDeferred: false });
+    },
+    [updateServerInitState],
   );
 
   const getOAuthUrl = useCallback(
@@ -692,6 +704,7 @@ export function useMCPServerManager({
     isInitializing,
     isCancellable,
     isConnectionDeferred,
+    resetConnectionDeferred,
     getOAuthUrl,
     mcpValues,
     setMCPValues,

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1908,6 +1908,7 @@
   "com_ui_tools_marketplace_search": "Search tools…",
   "com_ui_tools_mcp_deselect_all": "Deselect all",
   "com_ui_tools_mcp_no_tools": "This server has not exposed any tools yet.",
+  "com_ui_tools_mcp_runtime_tools": "All of this server's tools are attached; they are resolved at runtime, during chat.",
   "com_ui_tools_mcp_select_all": "Select all",
   "com_ui_tools_mcp_status_unconfigured": "Needs configuration",
   "com_ui_tools_mcp_tools_section": "Tools in this server",

--- a/client/src/store/mcp.ts
+++ b/client/src/store/mcp.ts
@@ -39,6 +39,11 @@ export interface MCPServerInitState {
   isCancellable: boolean;
   oauthUrl: string | null;
   oauthStartTime: number | null;
+  /** Last initialize attempt reported a request-scoped server whose connection
+   * is deferred to the next chat turn (runtime body placeholders) — its tools
+   * cannot be enumerated up front. Consumers attach such servers wholesale via
+   * the `mcp_all` wildcard instead of waiting for a tool list. */
+  connectionDeferred: boolean;
 }
 
 const defaultServerInitState: MCPServerInitState = {
@@ -46,6 +51,7 @@ const defaultServerInitState: MCPServerInitState = {
   isCancellable: false,
   oauthUrl: null,
   oauthStartTime: null,
+  connectionDeferred: false,
 };
 
 /**

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -340,6 +340,9 @@ export const useReinitializeMCPServerMutation = (): UseMutationResult<
     serverName: string;
     oauthRequired?: boolean;
     oauthUrl?: string;
+    /** True when the server uses request-scoped placeholders and the connection
+     *  was deferred to the next chat turn (tools are not enumerable up front). */
+    connectionDeferred?: boolean;
   },
   unknown,
   string,


### PR DESCRIPTION
## Summary

Follow-up to #14148 (and #14074): request-scoped MCP servers — those using `{{LIBRECHAT_BODY_*}}` placeholder headers — now defer their connection gracefully on reinitialize, but they still **cannot be attached to an agent from the builder UI**. The server dialog shows "This server has not exposed any tools yet." with no way to add it, because the attach flow waits for a tool list that, by design, never arrives outside a chat turn.

This PR completes the story: connecting a request-scoped server from the agent builder now attaches it at the **server level** via the existing `mcp_all` wildcard, whose tools are resolved at chat-turn time — exactly the mechanism the runtime already supports.

### Problem

Given a server config like:

```yaml
mcpServers:
  my-context-server:
    type: streamable-http
    url: https://example.com/mcp
    startup: false
    headers:
      X-Conversation-Id: '{{LIBRECHAT_BODY_CONVERSATIONID}}'
      X-User-Id: '{{LIBRECHAT_USER_ID}}'
```

- The body placeholder makes the server request-scoped (`requiresEphemeralUserConnection`), so reinitialize defers with `success: true, tools: null` (per #14148), and its tool definitions are deliberately excluded from the persistent tool cache.
- In the agent builder's server dialog (`McpSection.tsx`), the auto-attach effect requires `isConnected && hasTools`. A deferred server satisfies neither, so clicking **Connect** succeeds but attaches nothing — the user has no path to add the server to an agent.
- Meanwhile the runtime *fully supports* this case: `handleTools.js` resolves an `mcp_all` (`sys__all__sys_mcp_<server>`) tool entry into the server's complete tool set during the chat turn, where the body placeholders resolve correctly.

So the gap is purely in the builder: it never writes the token that the backend already knows how to honour.

### Changes

- **`api/server/services/Tools/mcp.js`** — the deferred-connection branch from #14148 now returns `connectionDeferred: true`, so clients can distinguish "deferred to a chat turn" from a plain success with no tools. (The client cannot infer this from config, since server configs are sanitized before reaching the browser.)
- **`api/server/routes/mcp.js`** — forwards `connectionDeferred` in the reinitialize response.
- **`packages/data-provider`** — adds the optional field to the reinitialize mutation's response type.
- **`client/.../McpSection.tsx`** — on a deferred connect, attaches the server as `[mcp_server token, mcp_all token]` (idempotent — no duplicate if already attached) instead of waiting for tools; when attached this way, the empty tools list shows "All of this server's tools are attached; they are resolved at runtime, during chat." instead of the misleading "no tools yet".
- **`client/.../items/selectors.ts`** — adds an `mcpAllToken()` helper beside `mcpServerToken()`.
- **Locale** — one new key, `com_ui_tools_mcp_runtime_tools`.

Removal already works: `matchesMcpServer()` strips any `_mcp_<server>`-suffixed token on explicit remove, which covers the wildcard.

### Behaviour

| | before | after |
|---|---|---|
| Connect a request-scoped server in the builder | succeeds, attaches nothing | attaches the server via `mcp_all`; tools resolve at turn time |
| Normal (non-placeholder) servers | — | unchanged (`connectionDeferred` is additive) |
| Tools list on an attached deferred server | "has not exposed any tools yet" | "resolved at runtime, during chat" |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `api/server/services/Tools/mcp.spec.js` — the deferred branch asserts `connectionDeferred: true`; the connect-normally path asserts the flag is absent (12/12 passing).
- `client/.../__tests__/McpSection.spec.tsx` — deferred connect writes the wildcard pair into `agent.tools`; no duplicate when already attached; runtime-tools hint renders when wildcard-attached (12/12 passing, incl. 3 new).
- Manual: verified end-to-end on a deployment running `dev` — an agent whose tools include `sys__all__sys_mcp_<server>` receives the server's full tool set in-turn, with `{{LIBRECHAT_BODY_CONVERSATIONID}}` resolving to the correct conversation, including under concurrent conversations (each turn's request body carries its own IDs).

### **Test Configuration**:

- streamable-http MCP server with `{{LIBRECHAT_BODY_*}}` + `{{LIBRECHAT_USER_*}}` header placeholders, `startup: false`
- LibreChat at `dev` (post-#14148)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes