### PR TITLE
💂 fix: Enforce ALLOW_EMAIL_LOGIN on the Backend Login Route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -631,6 +631,7 @@ ILLEGAL_MODEL_REQ_SCORE=5
 #========================#
 
 ALLOW_EMAIL_LOGIN=true
+# ALLOW_EMAIL_LOGIN_OVERRIDE=false # note: permits direct API email login while ALLOW_EMAIL_LOGIN=false; each use is logged
 ALLOW_REGISTRATION=true
 ALLOW_SOCIAL_LOGIN=false
 ALLOW_SOCIAL_REGISTRATION=false

--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -2,6 +2,7 @@ const validatePasswordReset = require('./validatePasswordReset');
 const setTwoFactorTempUser = require('./setTwoFactorTempUser');
 const validateRegistration = require('./validateRegistration');
 const buildEndpointOption = require('./buildEndpointOption');
+const validateEmailLogin = require('./validateEmailLogin');
 const validateMessageReq = require('./validateMessageReq');
 const { prepareMessageRequestValidation, sendValidationResponse } = require('./messageValidation');
 const checkDomainAllowed = require('./checkDomainAllowed');
@@ -53,4 +54,5 @@ module.exports = {
   buildEndpointOption,
   validateRegistration,
   validatePasswordReset,
+  validateEmailLogin,
 };

--- a/api/server/middleware/validateEmailLogin.js
+++ b/api/server/middleware/validateEmailLogin.js
@@ -1,22 +1,3 @@
-const { isEnabled } = require('@librechat/api');
-const { logger } = require('@librechat/data-schemas');
-
-function validateEmailLogin(req, res, next) {
-  const emailLoginEnabled =
-    process.env.ALLOW_EMAIL_LOGIN === undefined || isEnabled(process.env.ALLOW_EMAIL_LOGIN);
-  if (emailLoginEnabled) {
-    return next();
-  }
-
-  if (isEnabled(process.env.ALLOW_EMAIL_LOGIN_OVERRIDE)) {
-    logger.warn(
-      `[validateEmailLogin] Email login is disabled; allowing login attempt via ALLOW_EMAIL_LOGIN_OVERRIDE. IP: ${req.ip}`,
-    );
-    return next();
-  }
-
-  logger.warn(`[validateEmailLogin] Login attempt while email login is disabled. IP: ${req.ip}`);
-  return res.status(403).json({ message: 'Email login is not allowed.' });
-}
+const { validateEmailLogin } = require('@librechat/api');
 
 module.exports = validateEmailLogin;

--- a/api/server/middleware/validateEmailLogin.js
+++ b/api/server/middleware/validateEmailLogin.js
@@ -1,0 +1,22 @@
+const { isEnabled } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
+
+function validateEmailLogin(req, res, next) {
+  const emailLoginEnabled =
+    process.env.ALLOW_EMAIL_LOGIN === undefined || isEnabled(process.env.ALLOW_EMAIL_LOGIN);
+  if (emailLoginEnabled) {
+    return next();
+  }
+
+  if (isEnabled(process.env.ALLOW_EMAIL_LOGIN_OVERRIDE)) {
+    logger.warn(
+      `[validateEmailLogin] Email login is disabled; allowing login attempt via ALLOW_EMAIL_LOGIN_OVERRIDE. IP: ${req.ip}`,
+    );
+    return next();
+  }
+
+  logger.warn(`[validateEmailLogin] Login attempt while email login is disabled. IP: ${req.ip}`);
+  return res.status(403).json({ message: 'Email login is not allowed.' });
+}
+
+module.exports = validateEmailLogin;

--- a/api/server/middleware/validateEmailLogin.spec.js
+++ b/api/server/middleware/validateEmailLogin.spec.js
@@ -1,0 +1,113 @@
+const { logger } = require('@librechat/data-schemas');
+const validateEmailLogin = require('./validateEmailLogin');
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    warn: jest.fn(),
+  },
+}));
+
+describe('validateEmailLogin', () => {
+  const originalEnv = {
+    ALLOW_EMAIL_LOGIN: process.env.ALLOW_EMAIL_LOGIN,
+    ALLOW_EMAIL_LOGIN_OVERRIDE: process.env.ALLOW_EMAIL_LOGIN_OVERRIDE,
+  };
+  let req, res, next;
+
+  beforeEach(() => {
+    delete process.env.ALLOW_EMAIL_LOGIN;
+    delete process.env.ALLOW_EMAIL_LOGIN_OVERRIDE;
+    req = { ip: '127.0.0.1' };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('should allow login when ALLOW_EMAIL_LOGIN is unset (default)', () => {
+    validateEmailLogin(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should allow login when ALLOW_EMAIL_LOGIN is true', () => {
+    process.env.ALLOW_EMAIL_LOGIN = 'true';
+
+    validateEmailLogin(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should reject login with 403 when ALLOW_EMAIL_LOGIN is false', () => {
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+
+    validateEmailLogin(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Email login is not allowed.' });
+  });
+
+  it('should log blocked login attempts with the request IP', () => {
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    req.ip = '10.0.0.42';
+
+    validateEmailLogin(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('10.0.0.42'));
+  });
+
+  it('should treat non-true values as disabled', () => {
+    process.env.ALLOW_EMAIL_LOGIN = 'no';
+
+    validateEmailLogin(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('should allow login when disabled but ALLOW_EMAIL_LOGIN_OVERRIDE is true', () => {
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    process.env.ALLOW_EMAIL_LOGIN_OVERRIDE = 'true';
+
+    validateEmailLogin(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should log override logins with the request IP', () => {
+    process.env.ALLOW_EMAIL_LOGIN = 'false';
+    process.env.ALLOW_EMAIL_LOGIN_OVERRIDE = 'true';
+    req.ip = '10.0.0.42';
+
+    validateEmailLogin(req, res, next);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('ALLOW_EMAIL_LOGIN_OVERRIDE'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('10.0.0.42'));
+  });
+
+  it('should ignore the override when email login is enabled', () => {
+    process.env.ALLOW_EMAIL_LOGIN_OVERRIDE = 'true';
+
+    validateEmailLogin(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -73,6 +73,7 @@ router.post(
   middleware.logHeaders,
   middleware.loginLimiter,
   middleware.checkBan,
+  middleware.validateEmailLogin,
   middleware.requireLocalAuth,
   tenantContextMiddleware,
   requireAdminAccess,

--- a/api/server/routes/admin/auth.refresh.test.js
+++ b/api/server/routes/admin/auth.refresh.test.js
@@ -97,6 +97,7 @@ jest.mock('~/server/middleware', () => ({
   logHeaders: jest.fn((req, res, next) => next()),
   loginLimiter: jest.fn((req, res, next) => next()),
   checkBan: jest.fn((req, res, next) => next()),
+  validateEmailLogin: jest.fn((req, res, next) => next()),
   requireLocalAuth: jest.fn((req, res, next) => next()),
   requireJwtAuth: jest.fn((req, res, next) => next()),
   checkDomainAllowed: jest.fn((req, res, next) => next()),
@@ -106,6 +107,7 @@ const openIdClient = require('openid-client');
 const { logger } = require('@librechat/data-schemas');
 const { isEnabled, applyAdminRefresh, buildOpenIDRefreshParams } = require('@librechat/api');
 const { getOpenIdConfig } = require('~/strategies');
+const middleware = require('~/server/middleware');
 const adminAuthRouter = require('./auth');
 
 const ORIGINAL_OPENID_SCOPE = process.env.OPENID_SCOPE;
@@ -246,5 +248,46 @@ describe('admin auth OpenID refresh route', () => {
     expect(debugOutput).not.toContain('new-admin-id');
     expect(debugOutput).not.toContain('new-admin-refresh');
     expect(debugOutput).not.toContain('https://api.example.com');
+  });
+});
+
+describe('admin local login route', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin', adminAuthRouter);
+  });
+
+  it('applies the email login gate before local auth', async () => {
+    const response = await request(app).post('/api/admin/login/local').send({
+      email: 'admin@example.com',
+      password: 'password',
+    });
+
+    expect(response.status).toBe(200);
+    expect(middleware.validateEmailLogin).toHaveBeenCalledTimes(1);
+    expect(middleware.requireLocalAuth).toHaveBeenCalledTimes(1);
+    expect(middleware.validateEmailLogin.mock.invocationCallOrder[0]).toBeLessThan(
+      middleware.requireLocalAuth.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('stops before local auth when the email login gate rejects the request', async () => {
+    middleware.validateEmailLogin.mockImplementationOnce((req, res) =>
+      res.status(403).json({ message: 'Email login is not allowed.' }),
+    );
+
+    const response = await request(app).post('/api/admin/login/local').send({
+      email: 'admin@example.com',
+      password: 'password',
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ message: 'Email login is not allowed.' });
+    expect(middleware.requireLocalAuth).not.toHaveBeenCalled();
   });
 });

--- a/api/server/routes/auth.2fa-ratelimit.test.js
+++ b/api/server/routes/auth.2fa-ratelimit.test.js
@@ -56,6 +56,7 @@ jest.mock('~/server/middleware', () => {
     setTwoFactorTempUser: (...args) => mockSetTwoFactorTempUser(...args),
     twoFactorTempLimiter: (...args) => mockTwoFactorTempLimiter(...args),
     checkBan: (...args) => mockCheckBan(...args),
+    validateEmailLogin: pass,
     requireLocalAuth: pass,
     requireLdapAuth: pass,
     registerLimiter: pass,

--- a/api/server/routes/auth.cloudfront.test.js
+++ b/api/server/routes/auth.cloudfront.test.js
@@ -53,6 +53,7 @@ jest.mock('~/server/middleware', () => {
     setTwoFactorTempUser: pass,
     twoFactorTempLimiter: pass,
     checkBan: pass,
+    validateEmailLogin: pass,
     requireLocalAuth: pass,
     requireLdapAuth: pass,
     registerLimiter: pass,

--- a/api/server/routes/auth.js
+++ b/api/server/routes/auth.js
@@ -45,6 +45,7 @@ router.post(
   middleware.logHeaders,
   middleware.loginLimiter,
   middleware.checkBan,
+  middleware.validateEmailLogin,
   ldapAuth ? middleware.requireLdapAuth : middleware.requireLocalAuth,
   setBalanceConfig,
   loginController,

--- a/api/server/routes/auth.reset-password-ratelimit.test.js
+++ b/api/server/routes/auth.reset-password-ratelimit.test.js
@@ -56,6 +56,7 @@ jest.mock('~/server/middleware', () => {
     setTwoFactorTempUser: pass,
     twoFactorTempLimiter: pass,
     checkBan: (...args) => mockCheckBan(...args),
+    validateEmailLogin: pass,
     requireLocalAuth: pass,
     requireLdapAuth: pass,
     registerLimiter: pass,

--- a/packages/api/src/middleware/email.spec.ts
+++ b/packages/api/src/middleware/email.spec.ts
@@ -1,5 +1,6 @@
-const { logger } = require('@librechat/data-schemas');
-const validateEmailLogin = require('./validateEmailLogin');
+import { logger } from '@librechat/data-schemas';
+import type { NextFunction, Request, Response } from 'express';
+import { validateEmailLogin } from './email';
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
@@ -13,18 +14,21 @@ describe('validateEmailLogin', () => {
     ALLOW_EMAIL_LOGIN: process.env.ALLOW_EMAIL_LOGIN,
     ALLOW_EMAIL_LOGIN_OVERRIDE: process.env.ALLOW_EMAIL_LOGIN_OVERRIDE,
   };
-  let req, res, next;
+
+  let req: Request;
+  let res: Response;
+  let next: jest.MockedFunction<NextFunction>;
 
   beforeEach(() => {
     delete process.env.ALLOW_EMAIL_LOGIN;
     delete process.env.ALLOW_EMAIL_LOGIN_OVERRIDE;
-    req = { ip: '127.0.0.1' };
+    req = { ip: '127.0.0.1' } as Request;
     res = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
-    };
+    } as Partial<Response> as Response;
     next = jest.fn();
-    jest.clearAllMocks();
+    (logger.warn as jest.Mock).mockClear();
   });
 
   afterAll(() => {

--- a/packages/api/src/middleware/email.spec.ts
+++ b/packages/api/src/middleware/email.spec.ts
@@ -19,10 +19,14 @@ describe('validateEmailLogin', () => {
   let res: Response;
   let next: jest.MockedFunction<NextFunction>;
 
+  function createRequest(ip = '127.0.0.1'): Request {
+    return { ip } as Request;
+  }
+
   beforeEach(() => {
     delete process.env.ALLOW_EMAIL_LOGIN;
     delete process.env.ALLOW_EMAIL_LOGIN_OVERRIDE;
-    req = { ip: '127.0.0.1' } as Request;
+    req = createRequest();
     res = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
@@ -69,7 +73,7 @@ describe('validateEmailLogin', () => {
 
   it('should log blocked login attempts with the request IP', () => {
     process.env.ALLOW_EMAIL_LOGIN = 'false';
-    req.ip = '10.0.0.42';
+    req = createRequest('10.0.0.42');
 
     validateEmailLogin(req, res, next);
 
@@ -98,7 +102,7 @@ describe('validateEmailLogin', () => {
   it('should log override logins with the request IP', () => {
     process.env.ALLOW_EMAIL_LOGIN = 'false';
     process.env.ALLOW_EMAIL_LOGIN_OVERRIDE = 'true';
-    req.ip = '10.0.0.42';
+    req = createRequest('10.0.0.42');
 
     validateEmailLogin(req, res, next);
 

--- a/packages/api/src/middleware/email.ts
+++ b/packages/api/src/middleware/email.ts
@@ -1,0 +1,27 @@
+import { logger } from '@librechat/data-schemas';
+import type { NextFunction, Request, Response } from 'express';
+import { isEnabled } from '~/utils';
+
+export function validateEmailLogin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Response | void {
+  const emailLoginEnabled =
+    process.env.ALLOW_EMAIL_LOGIN === undefined || isEnabled(process.env.ALLOW_EMAIL_LOGIN);
+  if (emailLoginEnabled) {
+    next();
+    return;
+  }
+
+  if (isEnabled(process.env.ALLOW_EMAIL_LOGIN_OVERRIDE)) {
+    logger.warn(
+      `[validateEmailLogin] Email login is disabled; allowing login attempt via ALLOW_EMAIL_LOGIN_OVERRIDE. IP: ${req.ip}`,
+    );
+    next();
+    return;
+  }
+
+  logger.warn(`[validateEmailLogin] Login attempt while email login is disabled. IP: ${req.ip}`);
+  return res.status(403).json({ message: 'Email login is not allowed.' });
+}

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -1,6 +1,7 @@
 export * from './access';
 export * from './admin';
 export * from './error';
+export * from './email';
 export * from './notFound';
 export * from './balance';
 export * from './json';


### PR DESCRIPTION
 ## Summary

  Fixes #14179.

  `ALLOW_EMAIL_LOGIN=false` currently only hides the email/password form (`api/server/routes/config.js` computes `emailLoginEnabled` for the frontend only). The backend `POST /api/auth/login` route stays mounted and neither the route nor the local strategy checks the flag, so valid credentials sent directly to the API still return a session. This is client-side-only enforcement of a server-side control: SSO-only deployments that rely on the flag can silently accept password logins — bypassing IdP controls (MFA, conditional access, account disablement) — if any account acquires a password hash.

  This PR makes the backend honor the flag, mirroring how `ALLOW_REGISTRATION` and `ALLOW_PASSWORD_RESET` are already enforced server-side:

  - New `validateEmailLogin` middleware on `POST /api/auth/login` (after `checkBan`, before the auth strategy): responds `403` when `ALLOW_EMAIL_LOGIN=false`. Unset keeps the existing default (enabled), matching the `config.js` computation exactly, so backend and UI can never disagree.
  - Blocked attempts are logged with the request IP.
  - `ALLOW_EMAIL_LOGIN_OVERRIDE=true` preserves the previous hidden-but-functional behavior as an explicit opt-in, for deployments intentionally using direct API login (e.g. API-only admin accounts) while keeping the form hidden. Each override use is logged with the request IP.
  - Documented in `.env.example`.

  The gate applies to the full `/login` route (local and LDAP strategies) — the client renders the login form purely off `emailLoginEnabled` (`client/src/components/Auth/Login.tsx`), so LDAP deployments already require the flag on for the form to appear; the backend now matches what the UI advertises. OAuth/OpenID/SAML routes are untouched.

  ## Change Type

  - [x] Bug fix (non-breaking change which fixes an issue)

  (Behavior note: deployments relying on the undocumented hidden-but-functional login can restore it explicitly with `ALLOW_EMAIL_LOGIN_OVERRIDE=true`.)

  ## Testing

  New spec `api/server/middleware/validateEmailLogin.spec.js` (8 tests): flag unset → allowed (default), `true` → allowed, `false` → 403 and the auth strategy never runs, blocked attempts logged with request IP, non-`true` values treated as disabled, override re-enables, override use logged, override ignored when login is enabled.

  Also updated the middleware mocks in the three existing auth route suites (`auth.cloudfront`, `auth.2fa-ratelimit`, `auth.reset-password-ratelimit`) to include the new middleware.

  Manual verification: set `ALLOW_EMAIL_LOGIN=false`, `POST /api/auth/login` with valid credentials → `403 {"message":"Email login is not allowed."}`; add `ALLOW_EMAIL_LOGIN_OVERRIDE=true` → login succeeds and a warning is logged; unset both → login works as before.

  ### **Test Configuration**:

  Node v24.16.0, `npm run test:api` from a fresh `npm run build`.

  ## Checklist

  - [x] My code adheres to this project's style guidelines
  - [x] I have performed a self-review of my own code
  - [x] My changes do not introduce new warnings
  - [x] I have written tests demonstrating that my changes are effective or that my feature works
  - [x] Local unit tests pass with my changes