### PR TITLE
🪜 fix: Apply Recursion Limit Config to Subagents

### DIFF
--- a/packages/api/src/agents/config.spec.ts
+++ b/packages/api/src/agents/config.spec.ts
@@ -90,4 +90,23 @@ describe('resolveSubagentMaxTurns', () => {
     const config = { recursionLimit: 100 } as TAgentsEndpoint;
     expect(resolveSubagentMaxTurns(config, { recursion_limit: 200 })).toBe(67);
   });
+
+  it('clamps the default floor so it never exceeds a small maxRecursionLimit', () => {
+    const config = { maxRecursionLimit: 20 } as TAgentsEndpoint;
+    const turns = resolveSubagentMaxTurns(config, {});
+    expect(turns).toBe(6);
+    expect(turns * 3).toBeLessThanOrEqual(20);
+  });
+
+  it('clamps ceil overshoot so it never exceeds maxRecursionLimit', () => {
+    const config = { recursionLimit: 200, maxRecursionLimit: 200 } as TAgentsEndpoint;
+    const turns = resolveSubagentMaxTurns(config, {});
+    expect(turns).toBe(66);
+    expect(turns * 3).toBeLessThanOrEqual(200);
+  });
+
+  it('keeps at least one turn when maxRecursionLimit is smaller than the multiplier', () => {
+    const config = { maxRecursionLimit: 2 } as TAgentsEndpoint;
+    expect(resolveSubagentMaxTurns(config, {})).toBe(1);
+  });
 });

--- a/packages/api/src/agents/config.spec.ts
+++ b/packages/api/src/agents/config.spec.ts
@@ -1,5 +1,5 @@
 import type { TAgentsEndpoint } from 'librechat-data-provider';
-import { resolveRecursionLimit } from './config';
+import { resolveRecursionLimit, resolveSubagentMaxTurns } from './config';
 
 describe('resolveRecursionLimit', () => {
   it('returns default 50 when no config or agent provided', () => {
@@ -58,5 +58,36 @@ describe('resolveRecursionLimit', () => {
   it('does not cap when agent.recursion_limit equals maxRecursionLimit', () => {
     const config = { recursionLimit: 50, maxRecursionLimit: 150 } as TAgentsEndpoint;
     expect(resolveRecursionLimit(config, { recursion_limit: 150 })).toBe(150);
+  });
+});
+
+describe('resolveSubagentMaxTurns', () => {
+  it('floors at the SDK default (25 turns / 75 graph steps) with no config', () => {
+    expect(resolveSubagentMaxTurns(undefined, undefined)).toBe(25);
+  });
+
+  it('floors at 25 when the resolved limit divided by 3 is below the default', () => {
+    const config = { recursionLimit: 50 } as TAgentsEndpoint;
+    expect(resolveSubagentMaxTurns(config, {})).toBe(25);
+  });
+
+  it('derives maxTurns from the per-agent recursion_limit so the graph limit tracks it', () => {
+    const config = { recursionLimit: 50, maxRecursionLimit: 1000 } as TAgentsEndpoint;
+    expect(resolveSubagentMaxTurns(config, { recursion_limit: 500 })).toBe(167);
+  });
+
+  it('derives maxTurns from the yaml recursionLimit default', () => {
+    const config = { recursionLimit: 300 } as TAgentsEndpoint;
+    expect(resolveSubagentMaxTurns(config, {})).toBe(100);
+  });
+
+  it('respects maxRecursionLimit when capping the resolved limit', () => {
+    const config = { recursionLimit: 100, maxRecursionLimit: 150 } as TAgentsEndpoint;
+    expect(resolveSubagentMaxTurns(config, { recursion_limit: 600 })).toBe(50);
+  });
+
+  it('rounds up so the derived graph limit is never below the resolved limit', () => {
+    const config = { recursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveSubagentMaxTurns(config, { recursion_limit: 200 })).toBe(67);
   });
 });

--- a/packages/api/src/agents/config.spec.ts
+++ b/packages/api/src/agents/config.spec.ts
@@ -104,8 +104,10 @@ describe('resolveSubagentMaxTurns', () => {
     expect(turns * 3).toBeLessThanOrEqual(20);
   });
 
-  it('keeps at least one turn when the resolved limit is smaller than the multiplier', () => {
+  it('yields 0 turns when the resolved cap is below the multiplier (never exceeds it)', () => {
     const config = { maxRecursionLimit: 2 } as TAgentsEndpoint;
-    expect(resolveSubagentMaxTurns(config, {})).toBe(1);
+    const turns = resolveSubagentMaxTurns(config, {});
+    expect(turns).toBe(0);
+    expect(turns * 3).toBeLessThanOrEqual(2);
   });
 });

--- a/packages/api/src/agents/config.spec.ts
+++ b/packages/api/src/agents/config.spec.ts
@@ -62,18 +62,13 @@ describe('resolveRecursionLimit', () => {
 });
 
 describe('resolveSubagentMaxTurns', () => {
-  it('floors at the SDK default (25 turns / 75 graph steps) with no config', () => {
-    expect(resolveSubagentMaxTurns(undefined, undefined)).toBe(25);
-  });
-
-  it('floors at 25 when the resolved limit divided by 3 is below the default', () => {
-    const config = { recursionLimit: 50 } as TAgentsEndpoint;
-    expect(resolveSubagentMaxTurns(config, {})).toBe(25);
+  it('tracks the default resolved limit (50 -> 16 turns / 48 graph steps)', () => {
+    expect(resolveSubagentMaxTurns(undefined, undefined)).toBe(16);
   });
 
   it('derives maxTurns from the per-agent recursion_limit so the graph limit tracks it', () => {
     const config = { recursionLimit: 50, maxRecursionLimit: 1000 } as TAgentsEndpoint;
-    expect(resolveSubagentMaxTurns(config, { recursion_limit: 500 })).toBe(167);
+    expect(resolveSubagentMaxTurns(config, { recursion_limit: 500 })).toBe(166);
   });
 
   it('derives maxTurns from the yaml recursionLimit default', () => {
@@ -81,31 +76,35 @@ describe('resolveSubagentMaxTurns', () => {
     expect(resolveSubagentMaxTurns(config, {})).toBe(100);
   });
 
-  it('respects maxRecursionLimit when capping the resolved limit', () => {
+  it('honors an explicit recursion limit below the historical 75-step default', () => {
+    const config = { recursionLimit: 45 } as TAgentsEndpoint;
+    const turns = resolveSubagentMaxTurns(config, {});
+    expect(turns).toBe(15);
+    expect(turns * 3).toBeLessThanOrEqual(45);
+  });
+
+  it('honors a per-agent recursion_limit lowered below the yaml default', () => {
+    const config = { recursionLimit: 300 } as TAgentsEndpoint;
+    const turns = resolveSubagentMaxTurns(config, { recursion_limit: 30 });
+    expect(turns).toBe(10);
+    expect(turns * 3).toBeLessThanOrEqual(30);
+  });
+
+  it('never exceeds maxRecursionLimit when it caps the resolved limit', () => {
     const config = { recursionLimit: 100, maxRecursionLimit: 150 } as TAgentsEndpoint;
-    expect(resolveSubagentMaxTurns(config, { recursion_limit: 600 })).toBe(50);
+    const turns = resolveSubagentMaxTurns(config, { recursion_limit: 600 });
+    expect(turns).toBe(50);
+    expect(turns * 3).toBeLessThanOrEqual(150);
   });
 
-  it('rounds up so the derived graph limit is never below the resolved limit', () => {
-    const config = { recursionLimit: 100 } as TAgentsEndpoint;
-    expect(resolveSubagentMaxTurns(config, { recursion_limit: 200 })).toBe(67);
-  });
-
-  it('clamps the default floor so it never exceeds a small maxRecursionLimit', () => {
+  it('never exceeds a small maxRecursionLimit', () => {
     const config = { maxRecursionLimit: 20 } as TAgentsEndpoint;
     const turns = resolveSubagentMaxTurns(config, {});
     expect(turns).toBe(6);
     expect(turns * 3).toBeLessThanOrEqual(20);
   });
 
-  it('clamps ceil overshoot so it never exceeds maxRecursionLimit', () => {
-    const config = { recursionLimit: 200, maxRecursionLimit: 200 } as TAgentsEndpoint;
-    const turns = resolveSubagentMaxTurns(config, {});
-    expect(turns).toBe(66);
-    expect(turns * 3).toBeLessThanOrEqual(200);
-  });
-
-  it('keeps at least one turn when maxRecursionLimit is smaller than the multiplier', () => {
+  it('keeps at least one turn when the resolved limit is smaller than the multiplier', () => {
     const config = { maxRecursionLimit: 2 } as TAgentsEndpoint;
     expect(resolveSubagentMaxTurns(config, {})).toBe(1);
   });

--- a/packages/api/src/agents/config.ts
+++ b/packages/api/src/agents/config.ts
@@ -11,13 +11,6 @@ const DEFAULT_RECURSION_LIMIT = 50;
 const SUBAGENT_RECURSION_MULTIPLIER = 3;
 
 /**
- * Mirrors `DEFAULT_MAX_TURNS` in `@librechat/agents` `SubagentExecutor`. Used as
- * a floor so a subagent never drops below the SDK's historical default of 75
- * graph steps (25 turns) when the resolved recursion limit is small.
- */
-const DEFAULT_SUBAGENT_MAX_TURNS = 25;
-
-/**
  * Resolves the effective recursion limit for an agent run via a 3-step cascade:
  * 1. YAML endpoint config default (falls back to 50)
  * 2. Per-agent DB override (if set and positive)
@@ -51,27 +44,15 @@ export function resolveRecursionLimit(
  * both the YAML `recursionLimit`/`maxRecursionLimit` and the per-agent
  * `recursion_limit`, always running at the SDK default of 75 graph steps.
  *
- * Floored at {@link DEFAULT_SUBAGENT_MAX_TURNS} so a small resolved limit never
- * reduces subagent capacity below the historical default. When an explicit
- * `maxRecursionLimit` cap is set it wins over that floor: `maxTurns` is clamped
- * to `floor(maxRecursionLimit / SUBAGENT_RECURSION_MULTIPLIER)` so the effective
- * graph limit never exceeds the admin cap (the SDK's `* 3` would otherwise let
- * the floor or `ceil` overshoot it, e.g. cap 20 → 75 steps, cap 200 → 201).
+ * `floor` keeps the effective graph limit at or below the resolved value, which
+ * (since `resolveRecursionLimit` already caps at `maxRecursionLimit`) also keeps
+ * it within the admin cap — so a lowered limit applies to subagents too, and
+ * `maxTurns * 3` never overshoots the ceiling. Never returns below 1 turn.
  */
 export function resolveSubagentMaxTurns(
   agentsEConfig: Partial<TAgentsEndpoint> | undefined,
   agent: { recursion_limit?: number } | undefined,
 ): number {
   const limit = resolveRecursionLimit(agentsEConfig, agent);
-  let turns = Math.max(
-    DEFAULT_SUBAGENT_MAX_TURNS,
-    Math.ceil(limit / SUBAGENT_RECURSION_MULTIPLIER),
-  );
-
-  const maxCap = agentsEConfig?.maxRecursionLimit;
-  if (typeof maxCap === 'number' && maxCap > 0) {
-    turns = Math.min(turns, Math.floor(maxCap / SUBAGENT_RECURSION_MULTIPLIER));
-  }
-
-  return Math.max(1, turns);
+  return Math.max(1, Math.floor(limit / SUBAGENT_RECURSION_MULTIPLIER));
 }

--- a/packages/api/src/agents/config.ts
+++ b/packages/api/src/agents/config.ts
@@ -51,14 +51,27 @@ export function resolveRecursionLimit(
  * both the YAML `recursionLimit`/`maxRecursionLimit` and the per-agent
  * `recursion_limit`, always running at the SDK default of 75 graph steps.
  *
- * Floored at {@link DEFAULT_SUBAGENT_MAX_TURNS} so resolved limits below the
- * historical default never reduce subagent capacity.
+ * Floored at {@link DEFAULT_SUBAGENT_MAX_TURNS} so a small resolved limit never
+ * reduces subagent capacity below the historical default. When an explicit
+ * `maxRecursionLimit` cap is set it wins over that floor: `maxTurns` is clamped
+ * to `floor(maxRecursionLimit / SUBAGENT_RECURSION_MULTIPLIER)` so the effective
+ * graph limit never exceeds the admin cap (the SDK's `* 3` would otherwise let
+ * the floor or `ceil` overshoot it, e.g. cap 20 → 75 steps, cap 200 → 201).
  */
 export function resolveSubagentMaxTurns(
   agentsEConfig: Partial<TAgentsEndpoint> | undefined,
   agent: { recursion_limit?: number } | undefined,
 ): number {
   const limit = resolveRecursionLimit(agentsEConfig, agent);
-  const turns = Math.ceil(limit / SUBAGENT_RECURSION_MULTIPLIER);
-  return Math.max(DEFAULT_SUBAGENT_MAX_TURNS, turns);
+  let turns = Math.max(
+    DEFAULT_SUBAGENT_MAX_TURNS,
+    Math.ceil(limit / SUBAGENT_RECURSION_MULTIPLIER),
+  );
+
+  const maxCap = agentsEConfig?.maxRecursionLimit;
+  if (typeof maxCap === 'number' && maxCap > 0) {
+    turns = Math.min(turns, Math.floor(maxCap / SUBAGENT_RECURSION_MULTIPLIER));
+  }
+
+  return Math.max(1, turns);
 }

--- a/packages/api/src/agents/config.ts
+++ b/packages/api/src/agents/config.ts
@@ -3,13 +3,28 @@ import type { TAgentsEndpoint } from 'librechat-data-provider';
 const DEFAULT_RECURSION_LIMIT = 50;
 
 /**
+ * Mirrors `RECURSION_MULTIPLIER` in `@librechat/agents` `SubagentExecutor`,
+ * which derives a subagent's graph `recursionLimit` as `maxTurns * 3`. Keep in
+ * sync with the SDK so a subagent's effective recursion limit matches the
+ * resolved value it is configured for.
+ */
+const SUBAGENT_RECURSION_MULTIPLIER = 3;
+
+/**
+ * Mirrors `DEFAULT_MAX_TURNS` in `@librechat/agents` `SubagentExecutor`. Used as
+ * a floor so a subagent never drops below the SDK's historical default of 75
+ * graph steps (25 turns) when the resolved recursion limit is small.
+ */
+const DEFAULT_SUBAGENT_MAX_TURNS = 25;
+
+/**
  * Resolves the effective recursion limit for an agent run via a 3-step cascade:
  * 1. YAML endpoint config default (falls back to 50)
  * 2. Per-agent DB override (if set and positive)
  * 3. Global max cap from YAML (if set and positive)
  */
 export function resolveRecursionLimit(
-  agentsEConfig: TAgentsEndpoint | undefined,
+  agentsEConfig: Partial<TAgentsEndpoint> | undefined,
   agent: { recursion_limit?: number } | undefined,
 ): number {
   let limit = agentsEConfig?.recursionLimit ?? DEFAULT_RECURSION_LIMIT;
@@ -27,4 +42,23 @@ export function resolveRecursionLimit(
   }
 
   return limit;
+}
+
+/**
+ * Resolves a subagent's `maxTurns` so its graph `recursionLimit`
+ * (`maxTurns * SUBAGENT_RECURSION_MULTIPLIER` in the SDK) tracks the same
+ * resolved recursion limit as a top-level run. Without this, subagents ignore
+ * both the YAML `recursionLimit`/`maxRecursionLimit` and the per-agent
+ * `recursion_limit`, always running at the SDK default of 75 graph steps.
+ *
+ * Floored at {@link DEFAULT_SUBAGENT_MAX_TURNS} so resolved limits below the
+ * historical default never reduce subagent capacity.
+ */
+export function resolveSubagentMaxTurns(
+  agentsEConfig: Partial<TAgentsEndpoint> | undefined,
+  agent: { recursion_limit?: number } | undefined,
+): number {
+  const limit = resolveRecursionLimit(agentsEConfig, agent);
+  const turns = Math.ceil(limit / SUBAGENT_RECURSION_MULTIPLIER);
+  return Math.max(DEFAULT_SUBAGENT_MAX_TURNS, turns);
 }

--- a/packages/api/src/agents/config.ts
+++ b/packages/api/src/agents/config.ts
@@ -47,12 +47,15 @@ export function resolveRecursionLimit(
  * `floor` keeps the effective graph limit at or below the resolved value, which
  * (since `resolveRecursionLimit` already caps at `maxRecursionLimit`) also keeps
  * it within the admin cap — so a lowered limit applies to subagents too, and
- * `maxTurns * 3` never overshoots the ceiling. Never returns below 1 turn.
+ * `maxTurns * 3` never overshoots the ceiling. A resolved limit below the
+ * multiplier yields 0 turns: like a top-level run with `recursionLimit < 3`, the
+ * child can't take a full step, and the SDK returns a graceful recursion error
+ * rather than silently granting more steps than the cap allows.
  */
 export function resolveSubagentMaxTurns(
   agentsEConfig: Partial<TAgentsEndpoint> | undefined,
   agent: { recursion_limit?: number } | undefined,
 ): number {
   const limit = resolveRecursionLimit(agentsEConfig, agent);
-  return Math.max(1, Math.floor(limit / SUBAGENT_RECURSION_MULTIPLIER));
+  return Math.floor(limit / SUBAGENT_RECURSION_MULTIPLIER);
 }

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -25,6 +25,7 @@ import type {
 } from '@librechat/agents';
 import type {
   Agent,
+  TAgentsEndpoint,
   AgentModelParameters,
   AgentSubagentsConfig,
   ReasoningResponseKey,
@@ -47,6 +48,7 @@ import { resolveHeaders, createSafeUser } from '~/utils/env';
 import { getAgentCheckpointer } from '~/agents/checkpointer';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
 import { buildHITLRunWiring } from '~/agents/hitl/runtime';
+import { resolveSubagentMaxTurns } from '~/agents/config';
 import { buildLangfuseConfig } from '~/langfuse/config';
 import { resolveConfigHeaders } from '~/utils/headers';
 import { applyTestRunHook } from '~/agents/testHook';
@@ -816,6 +818,7 @@ function buildSubagentConfigs(
   agentInput: AgentInputs,
   toInput: (child: RunAgent, opts?: { isSubagent?: boolean }) => AgentInputs,
   state: SubagentBuildState,
+  agentsEConfig: Partial<TAgentsEndpoint> | undefined,
   ancestors: Set<string> = new Set(),
   depth = 0,
 ): SubagentConfig[] {
@@ -834,6 +837,8 @@ function buildSubagentConfigs(
       type: SELF_SUBAGENT_TYPE,
       name: selfName,
       description: `Spawn ${selfName} in an isolated context to handle a focused subtask. Verbose tool output stays in the child's context; only a summary returns.`,
+      /** Self-spawn reuses the parent's config, so mirror the parent's recursion limit. */
+      maxTurns: resolveSubagentMaxTurns(agentsEConfig, agent),
     });
   }
 
@@ -882,6 +887,7 @@ function buildSubagentConfigs(
       childInputs,
       toInput,
       state,
+      agentsEConfig,
       nextAncestors,
       childDepth,
     );
@@ -895,6 +901,8 @@ function buildSubagentConfigs(
         child.description ??
         `Delegate a subtask to the ${child.name ?? child.id} agent in an isolated context.`,
       agentInputs: childInputs,
+      /** Honor each child agent's own resolved recursion limit. */
+      maxTurns: resolveSubagentMaxTurns(agentsEConfig, child),
     });
   }
 
@@ -1213,6 +1221,8 @@ export async function createRun({
     return agentInput;
   };
 
+  const agentsEndpointConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
+
   const agentInputs: AgentInputs[] = [];
   const subagentBuildState: SubagentBuildState = {
     configCount: 0,
@@ -1225,6 +1235,7 @@ export async function createRun({
       agentInput,
       buildAgentInput,
       subagentBuildState,
+      agentsEndpointConfig,
     );
     if (subagentConfigs.length > 0) {
       agentInput.subagentConfigs = subagentConfigs;
@@ -1271,7 +1282,6 @@ export async function createRun({
    * and the resume route). When disabled, nothing attaches and the run is identical
    * to before this feature shipped.
    */
-  const agentsEndpointConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
   // Resolve the effective policy through the single seam so per-agent / per-skill
   // sources can layer in later without touching this call site (see
   // `resolveToolApprovalPolicy`). Only the endpoint layer is wired today, so this


### PR DESCRIPTION
## Summary

Fixes #14181. Subagents always errored at `Recursion limit of 75 reached` regardless of the Agent Builder "Max Agent Steps" (`recursion_limit`) or the YAML `recursionLimit` / `maxRecursionLimit` settings.

## Root cause

Subagents run through a separate recursion path than top-level agents in `@librechat/agents`:

- **Top-level agents:** `resolveRecursionLimit()` is passed straight to langgraph's `recursionLimit`, so all config knobs apply.
- **Subagents:** the SDK's `SubagentExecutor` derives the child graph limit as `maxTurns * RECURSION_MULTIPLIER` (3), where `maxTurns` defaults to `DEFAULT_MAX_TURNS` (25), giving 75.

`buildSubagentConfigs` in `packages/api/src/agents/run.ts` built each `SubagentConfig` but never set `maxTurns`, so every subagent silently ran at the SDK default of 75 steps and ignored all recursion config.

## Fix

- Add `resolveSubagentMaxTurns` in `packages/api/src/agents/config.ts`. It reuses the existing `resolveRecursionLimit` cascade (YAML default -> per-agent `recursion_limit` -> `maxRecursionLimit` cap), then converts the resolved limit to `maxTurns` as `max(1, floor(limit / 3))`.
  - `floor` keeps the effective graph limit (`maxTurns * 3`) at or below the resolved value. Since `resolveRecursionLimit` already caps at `maxRecursionLimit`, this also keeps subagents within the admin ceiling with no separate clamp, and makes a lowered `recursionLimit` / `recursion_limit` apply to subagents (cost / runaway control works downward, not just up).
  - Minimum of one turn so a tiny cap never yields a zero recursion limit.
- Set `maxTurns` on each `SubagentConfig`: the self-spawn mirrors the parent's limit, explicit child agents use their own `recursion_limit`. Thread the endpoint config through the recursion.

Examples: `recursion_limit: 500` -> 166 turns (498 steps, was 75); `recursionLimit: 45` -> 15 turns (45 steps).

**Intentional behavior change:** an unconfigured subagent now tracks the default resolved limit (50 -> 48 steps) instead of the SDK's internal 75-step default, matching top-level semantics. Configure `recursion_limit` / YAML `recursionLimit` to raise it.

## Notes

- `SUBAGENT_RECURSION_MULTIPLIER = 3` mirrors the internal `@librechat/agents` `SubagentExecutor` constant; kept in sync via a comment. A future SDK change could add a `recursionLimit` field to `SubagentConfig` so hosts pass it directly.
- `resolveRecursionLimit`'s `agentsEConfig` param was loosened from `TAgentsEndpoint` to `Partial<TAgentsEndpoint>`, which is the actual shape of `appConfig.endpoints[agents]` (it was previously only called from JS, so never type-checked here).

## Testing

- Unit tests for `resolveSubagentMaxTurns` in `config.spec.ts` covering the default, per-agent / YAML overrides, lowered limits below 75, and the `maxRecursionLimit` cap (asserting `turns * 3 <= cap`).
- `packages/api` typecheck, lint, and build all clean.
