### PR TITLE
🧩 fix: Allow `compatibility` Field in Skill Frontmatter

### DIFF
--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -286,10 +286,27 @@ describe('skill validation helpers', () => {
           effort: 5,
           version: '1.0.0',
           license: 'MIT',
+          compatibility: 'Requires GitHub MCP to access the repository content.',
           hooks: { 'pre-run': 'echo hi' },
           metadata: { owner: 'data-team' },
         }),
       ).toEqual([]);
+    });
+
+    it('accepts the spec-defined compatibility field as a string', () => {
+      expect(
+        validateSkillFrontmatter({
+          compatibility: 'Designed for Claude Code (or similar products)',
+        }),
+      ).toEqual([]);
+    });
+
+    it('rejects a non-string compatibility field', () => {
+      expect(
+        validateSkillFrontmatter({ compatibility: ['a', 'b'] }).some(
+          (i) => i.code === 'INVALID_TYPE',
+        ),
+      ).toBe(true);
     });
 
     it('rejects known keys with wrong types', () => {

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -261,6 +261,7 @@ const ALLOWED_FRONTMATTER_KEYS = new Set<string>([
   'hooks',
   'version',
   'license',
+  'compatibility',
   'metadata',
 ]);
 
@@ -289,6 +290,7 @@ const FRONTMATTER_KIND: Record<string, FrontmatterKind | FrontmatterKind[]> = {
   shell: 'string',
   version: 'string',
   license: 'string',
+  compatibility: 'string',
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

Skill frontmatter validation rejected the `compatibility` field, causing otherwise-valid `SKILL.md` files to fail with `Skill validation failed` (e.g. via GitHubSkillSync). `compatibility` is a field defined in the [Agent Skills specification](https://agentskills.io/specification#compatibility-field), so it should be accepted.

This adds `compatibility` to the frontmatter allowlist and type map. It was the only spec-defined field we were missing — the spec defines `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools`; the other five were already accepted.

Resolves #14168.

## Changes

- `packages/data-schemas/src/methods/skill.ts`
  - Add `'compatibility'` to `ALLOWED_FRONTMATTER_KEYS` (previously rejected as `UNKNOWN_KEY`).
  - Add `compatibility: 'string'` to `FRONTMATTER_KIND`, type-checked like other string fields (capped at the shared 2000-char limit, which covers the spec's 500-char guidance).
- `packages/data-schemas/src/methods/skill.spec.ts`
  - Extend the "accepts known keys" case with a `compatibility` string.
  - Add focused cases: accepts a `compatibility` string, rejects a non-string `compatibility`.

## Test plan

- [x] `cd packages/data-schemas && npx jest skill.spec -t "validateSkillFrontmatter"` — passes
- [x] New `compatibility` cases pass; existing frontmatter cases unaffected
- [x] eslint clean on changed files

## Notes / follow-ups (not in this PR)

- The runner surfaces only a generic `Skill validation failed` message; `validateSkillFrontmatter` already returns structured issues (`field`, `code`, `message`) that could be included to name the offending key.
- Docs (`skills.mdx`) live in the separate `librechat.ai` repo and should be updated to list `compatibility`.
