### PR TITLE
✨ feat: Config-Defined Global Agents

### DIFF
--- a/api/server/controllers/PermissionsController.js
+++ b/api/server/controllers/PermissionsController.js
@@ -3,7 +3,7 @@
  */
 
 const mongoose = require('mongoose');
-const { logger, getTenantId, SYSTEM_TENANT_ID } = require('@librechat/data-schemas');
+const { logger, getTenantId, runAsSystem, SYSTEM_TENANT_ID } = require('@librechat/data-schemas');
 const { ResourceType, PrincipalType, PermissionBits } = require('librechat-data-provider');
 const { enrichRemoteAgentPrincipals, backfillRemoteAgentPermissions } = require('@librechat/api');
 const {
@@ -60,6 +60,21 @@ const updateResourcePermissions = async (req, res) => {
   try {
     const { resourceType, resourceId } = req.params;
     validateResourceType(resourceType);
+
+    /* Config-defined global agents own their access via server config; reject post-boot permission
+     * edits (an admin/sharer would otherwise re-grant/revoke until the next restart). The `_id` is
+     * globally unique, so the system-context fallback resolves tenantless globals without leaking. */
+    if (resourceType === ResourceType.AGENT && mongoose.isValidObjectId(resourceId)) {
+      const agent =
+        (await db.getAgent({ _id: resourceId })) ??
+        (await runAsSystem(() => db.getAgent({ _id: resourceId, tenantId: { $exists: false } })));
+      if (agent?.isSystem) {
+        return res.status(403).json({
+          error:
+            'Global agents are managed by server configuration and their access cannot be modified.',
+        });
+      }
+    }
 
     /** @type {TUpdateResourcePermissionsRequest} */
     const { updated, removed, public: isPublic, publicAccessRoleId } = req.body;

--- a/api/server/controllers/PermissionsController.js
+++ b/api/server/controllers/PermissionsController.js
@@ -62,9 +62,13 @@ const updateResourcePermissions = async (req, res) => {
     validateResourceType(resourceType);
 
     /* Config-defined global agents own their access via server config; reject post-boot permission
-     * edits (an admin/sharer would otherwise re-grant/revoke until the next restart). The `_id` is
-     * globally unique, so the system-context fallback resolves tenantless globals without leaking. */
-    if (resourceType === ResourceType.AGENT && mongoose.isValidObjectId(resourceId)) {
+     * edits (an admin/sharer would otherwise re-grant/revoke until the next restart). Covers the
+     * remote-agent sharing endpoint too, which shares the same agent `_id`. The `_id` is globally
+     * unique, so the system-context fallback resolves tenantless globals without leaking. */
+    if (
+      (resourceType === ResourceType.AGENT || resourceType === ResourceType.REMOTE_AGENT) &&
+      mongoose.isValidObjectId(resourceId)
+    ) {
       const agent =
         (await db.getAgent({ _id: resourceId })) ??
         (await runAsSystem(() => db.getAgent({ _id: resourceId, tenantId: { $exists: false } })));

--- a/api/server/controllers/__tests__/PermissionsController.spec.js
+++ b/api/server/controllers/__tests__/PermissionsController.spec.js
@@ -6,6 +6,7 @@ const mockGetTenantId = jest.fn();
 jest.mock('@librechat/data-schemas', () => ({
   logger: mockLogger,
   getTenantId: mockGetTenantId,
+  runAsSystem: (fn) => fn(),
   SYSTEM_TENANT_ID: '__SYSTEM__',
 }));
 
@@ -40,6 +41,7 @@ jest.mock('~/models', () => ({
   searchPrincipals: jest.fn(),
   sortPrincipalsByRelevance: jest.fn(),
   calculateRelevanceScore: jest.fn(),
+  getAgent: jest.fn().mockResolvedValue(null),
   removeAgentFromUserFavorites: (...args) => mockRemoveAgentFromUserFavorites(...args),
 }));
 
@@ -282,6 +284,24 @@ describe('PermissionsController', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(mockRemoveAgentFromUserFavorites).toHaveBeenCalledWith(agentObjectId, [revokedUserId]);
+    });
+
+    it('rejects permission edits for a config-managed (isSystem) agent', async () => {
+      db.getAgent.mockResolvedValueOnce({ _id: agentObjectId, isSystem: true });
+      const req = createMockReq({
+        params: { resourceType: ResourceType.AGENT, resourceId: agentObjectId },
+        body: {
+          updated: [{ type: PrincipalType.USER, id: revokedUserId, accessRoleId: 'agent_viewer' }],
+          removed: [],
+          public: false,
+        },
+      });
+      const res = createMockRes();
+
+      await updateResourcePermissions(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockBulkUpdateResourcePermissions).not.toHaveBeenCalled();
     });
 
     it('removes agent from revoked users favorites on REMOTE_AGENT resource type', async () => {

--- a/api/server/controllers/__tests__/PermissionsController.spec.js
+++ b/api/server/controllers/__tests__/PermissionsController.spec.js
@@ -304,6 +304,24 @@ describe('PermissionsController', () => {
       expect(mockBulkUpdateResourcePermissions).not.toHaveBeenCalled();
     });
 
+    it('rejects remote-agent permission edits for a config-managed (isSystem) agent', async () => {
+      db.getAgent.mockResolvedValueOnce({ _id: agentObjectId, isSystem: true });
+      const req = createMockReq({
+        params: { resourceType: ResourceType.REMOTE_AGENT, resourceId: agentObjectId },
+        body: {
+          updated: [{ type: PrincipalType.USER, id: revokedUserId, accessRoleId: 'agent_viewer' }],
+          removed: [],
+          public: false,
+        },
+      });
+      const res = createMockRes();
+
+      await updateResourcePermissions(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockBulkUpdateResourcePermissions).not.toHaveBeenCalled();
+    });
+
     it('removes agent from revoked users favorites on REMOTE_AGENT resource type', async () => {
       const req = createMockReq({
         params: { resourceType: ResourceType.REMOTE_AGENT, resourceId: agentObjectId },

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -834,7 +834,11 @@ const duplicateAgentHandler = async (req, res) => {
   const sensitiveFields = ['api_key', 'oauth_client_id', 'oauth_client_secret'];
 
   try {
-    const agent = await db.getAgent({ id });
+    const agent = await withSystemGlobalFallback(
+      id,
+      () => db.getAgent({ id }),
+      () => db.getAgent({ id, tenantId: { $exists: false } }),
+    );
     if (!agent) {
       return res.status(404).json({
         error: 'Agent not found',

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -162,7 +162,9 @@ const classifyAgentReferences = async (agentIds, userId, userRole) => {
       const result = await authorizeSystemGlobalAgent({
         agentId: id,
         requiredPermission: PermissionBits.VIEW,
-        req: { user: { id: userId, role: userRole } },
+        /* Preserve the request tenant so hasCapability's tenant-keyed MANAGE_AGENTS bypass applies
+         * (read here in the request context — inside authorize it runs under the system context). */
+        req: { user: { id: userId, role: userRole, tenantId: getTenantId() } },
       });
       if (result.status === 'not_found') continue;
       stillMissing.delete(id);

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -50,6 +50,7 @@ const {
   userCanUseMCPServers,
 } = require('~/server/services/MCP');
 const { attachOwnerContacts } = require('~/server/services/Agents/ownerContact');
+const { withSystemGlobalFallback } = require('~/server/services/Agents/systemGlobal');
 const { getMCPServersRegistry } = require('~/config');
 const { getLogStores } = require('~/cache');
 const db = require('~/models');
@@ -518,7 +519,11 @@ const getAgentHandler = async (req, res, expandProperties = false) => {
     // Permissions are validated by middleware before calling this function.
     // Load the agent with a `version` count but without the heavy `versions`
     // array; version history is fetched lazily via GET /agents/:id/versions.
-    const agent = await db.getAgentWithVersionCount({ id });
+    const agent = await withSystemGlobalFallback(
+      id,
+      () => db.getAgentWithVersionCount({ id }),
+      () => db.getAgentWithVersionCount({ id, tenantId: { $exists: false } }),
+    );
 
     if (!agent) {
       return res.status(404).json({ error: 'Agent not found' });
@@ -603,7 +608,11 @@ const getAgentHandler = async (req, res, expandProperties = false) => {
 const getAgentVersionsHandler = async (req, res) => {
   try {
     const id = req.params.id;
-    const versions = await db.getAgentVersions({ id });
+    const versions = await withSystemGlobalFallback(
+      id,
+      () => db.getAgentVersions({ id }),
+      () => db.getAgentVersions({ id, tenantId: { $exists: false } }),
+    );
 
     if (versions == null) {
       return res.status(404).json({ error: 'Agent not found' });
@@ -1017,8 +1026,9 @@ const deleteAgentHandler = async (req, res) => {
  * Resolve the `tenants: 'system'` global agents this user is entitled to. Their rows and ACL
  * grants are tenantless, so a tenant-scoped list query can't see them — we read under the system
  * context and intersect the user's accessible ids with the known tenantless system agents (so no
- * other tenant's agents can leak in). Single-tenant deployments never call this; the tenantless
- * rows already surface through the normal query.
+ * other tenant's agents can leak in). The user's principals are built in the request tenant context
+ * first (so group memberships reflect this tenant, not every tenant); only the agent/ACL lookup runs
+ * as system. Single-tenant deployments never call this; the tenantless rows already surface normally.
  */
 async function getEntitledSystemGlobalAgents({
   userId,
@@ -1027,18 +1037,21 @@ async function getEntitledSystemGlobalAgents({
   includeSkillConfig,
   requiredPermission,
 }) {
+  const principals = await db.getUserPrincipals({ userId, role });
+  if (!principals.length) {
+    return [];
+  }
   return runAsSystem(async () => {
     const systemAgents = await db.getAgents({ isSystem: true, tenantId: { $exists: false } });
     if (!systemAgents.length) {
       return [];
     }
     const systemIdSet = new Set(systemAgents.map((agent) => agent._id.toString()));
-    const entitledIds = await findAccessibleResources({
-      userId,
-      role,
-      resourceType: ResourceType.AGENT,
-      requiredPermissions: requiredPermission,
-    });
+    const entitledIds = await db.findAccessibleResources(
+      principals,
+      ResourceType.AGENT,
+      requiredPermission,
+    );
     const accessibleIds = entitledIds.filter((oid) => systemIdSet.has(oid.toString()));
     if (!accessibleIds.length) {
       return [];

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -50,7 +50,11 @@ const {
   userCanUseMCPServers,
 } = require('~/server/services/MCP');
 const { attachOwnerContacts } = require('~/server/services/Agents/ownerContact');
-const { withSystemGlobalFallback } = require('~/server/services/Agents/systemGlobal');
+const {
+  isSystemGlobalId,
+  withSystemGlobalFallback,
+  authorizeSystemGlobalAgent,
+} = require('~/server/services/Agents/systemGlobal');
 const { getMCPServersRegistry } = require('~/config');
 const { getLogStores } = require('~/cache');
 const db = require('~/models');
@@ -145,9 +149,29 @@ const classifyAgentReferences = async (agentIds, userId, userRole) => {
 
   const agents = await db.getAgents({ id: { $in: ids } });
   const foundIds = new Set(agents.map((a) => a.id));
-  const missing = ids.filter((id) => !foundIds.has(id));
+  let missing = ids.filter((id) => !foundIds.has(id));
 
-  if (agents.length === 0) return { missing, unauthorized: [] };
+  /* Tenantless `tenants: 'system'` globals are invisible to the tenant-scoped query above; resolve
+   * and authorize any global-prefixed missing id under the system context so a normal agent can
+   * reference a global agent as a subagent/edge without a false 400. */
+  const systemUnauthorized = [];
+  const globalMissing = missing.filter((id) => isSystemGlobalId(id));
+  if (globalMissing.length > 0) {
+    const stillMissing = new Set(missing);
+    for (const id of globalMissing) {
+      const result = await authorizeSystemGlobalAgent({
+        agentId: id,
+        requiredPermission: PermissionBits.VIEW,
+        req: { user: { id: userId, role: userRole } },
+      });
+      if (result.status === 'not_found') continue;
+      stillMissing.delete(id);
+      if (result.status !== 'ok') systemUnauthorized.push(id);
+    }
+    missing = [...stillMissing];
+  }
+
+  if (agents.length === 0) return { missing, unauthorized: systemUnauthorized };
 
   const permissionsMap = await getResourcePermissionsMap({
     userId,
@@ -163,7 +187,7 @@ const classifyAgentReferences = async (agentIds, userId, userRole) => {
     })
     .map((a) => a.id);
 
-  return { missing, unauthorized };
+  return { missing, unauthorized: [...unauthorized, ...systemUnauthorized] };
 };
 
 /**

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -1,7 +1,7 @@
 const { z } = require('zod');
 const fs = require('fs').promises;
 const { nanoid } = require('nanoid');
-const { logger } = require('@librechat/data-schemas');
+const { logger, getTenantId, runAsSystem } = require('@librechat/data-schemas');
 const {
   refreshS3Url,
   agentCreateSchema,
@@ -550,6 +550,7 @@ const getAgentHandler = async (req, res, expandProperties = false) => {
         model: agent.model,
         model_parameters: getSafeModelParameters(agent.model_parameters),
         isPublic: agent.isPublic,
+        isSystem: agent.isSystem ?? false,
         version: agent.version,
         // Safe metadata
         createdAt: agent.createdAt,
@@ -678,6 +679,12 @@ const updateAgentHandler = async (req, res) => {
 
     if (!existingAgent) {
       return res.status(404).json({ error: 'Agent not found' });
+    }
+
+    if (existingAgent.isSystem) {
+      return res.status(403).json({
+        error: 'Global agents are managed by server configuration and cannot be modified.',
+      });
     }
 
     // Convert legacy OCR tool resource to context format in existing agent
@@ -821,6 +828,7 @@ const duplicateAgentHandler = async (req, res) => {
       updatedAt: _updatedAt,
       tool_resources: _tool_resources = {},
       versions: _versions,
+      isSystem: _isSystem,
       __v: _v,
       ...cloneData
     } = agent;
@@ -979,6 +987,11 @@ const deleteAgentHandler = async (req, res) => {
     if (!agent) {
       return res.status(404).json({ error: 'Agent not found' });
     }
+    if (agent.isSystem) {
+      return res.status(403).json({
+        error: 'Global agents are managed by server configuration and cannot be deleted.',
+      });
+    }
     await db.deleteAgent({ id });
     return res.json({ message: 'Agent deleted' });
   } catch (error) {
@@ -986,6 +999,41 @@ const deleteAgentHandler = async (req, res) => {
     res.status(500).json({ error: error.message });
   }
 };
+
+/**
+ * Resolve the `tenants: 'system'` global agents this user is entitled to. Their rows and ACL
+ * grants are tenantless, so a tenant-scoped list query can't see them — we read under the system
+ * context and intersect the user's accessible ids with the known tenantless system agents (so no
+ * other tenant's agents can leak in). Single-tenant deployments never call this; the tenantless
+ * rows already surface through the normal query.
+ */
+async function getEntitledSystemGlobalAgents({ userId, role, filter, includeSkillConfig }) {
+  return runAsSystem(async () => {
+    const systemAgents = await db.getAgents({ isSystem: true, tenantId: { $exists: false } });
+    if (!systemAgents.length) {
+      return [];
+    }
+    const systemIdSet = new Set(systemAgents.map((agent) => agent._id.toString()));
+    const entitledIds = await findAccessibleResources({
+      userId,
+      role,
+      resourceType: ResourceType.AGENT,
+      requiredPermissions: PermissionBits.VIEW,
+    });
+    const accessibleIds = entitledIds.filter((oid) => systemIdSet.has(oid.toString()));
+    if (!accessibleIds.length) {
+      return [];
+    }
+    const list = await db.getListAgentsByAccess({
+      accessibleIds,
+      otherParams: filter,
+      limit: null,
+      after: null,
+      includeSkillConfig,
+    });
+    return list?.data ?? [];
+  });
+}
 
 /**
  * Lists agents using ACL-aware permissions (ownership + explicit shares).
@@ -1086,6 +1134,29 @@ const getListAgentsHandler = async (req, res) => {
     });
 
     const agents = data?.data ?? [];
+
+    /* Multi-tenant only: surface `tenants: 'system'` global agents (tenantless rows/grants the
+     * tenant-scoped query above can't see) on the first page. Single-tenant deployments have no
+     * active tenant context and resolve these through the normal query. */
+    if (getTenantId() && !cursor) {
+      try {
+        const systemGlobals = await getEntitledSystemGlobalAgents({
+          userId,
+          role: req.user.role,
+          filter,
+          includeSkillConfig: true,
+        });
+        const seen = new Set(agents.map((agent) => agent.id));
+        for (const systemAgent of systemGlobals) {
+          if (!seen.has(systemAgent.id)) {
+            agents.push(systemAgent);
+          }
+        }
+      } catch (err) {
+        logger.error('[/Agents] Error merging system global agents: %o', err);
+      }
+    }
+
     if (!agents.length) {
       return res.json(data);
     }

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -69,6 +69,21 @@ const getSafeModelParameters = (modelParameters) => {
 };
 const hasEditBit = (permission) => (permission & PermissionBits.EDIT) === PermissionBits.EDIT;
 
+/**
+ * Rejects mutations of config-defined global agents. Enforced in every mutating handler (not the
+ * route middleware) because admins/managers bypass the ACL via the MANAGE_AGENTS capability.
+ * @returns {boolean} true when the response was written (caller should return).
+ */
+const rejectImmutableSystemAgent = (agent, res) => {
+  if (agent?.isSystem) {
+    res
+      .status(403)
+      .json({ error: 'Global agents are managed by server configuration and cannot be modified.' });
+    return true;
+  }
+  return false;
+};
+
 const sanitizeViewerSkillScope = (agent, accessibleSkillSet) => {
   const skillScopeEnabled = agent.skills_enabled === true;
   delete agent.skills_enabled;
@@ -681,10 +696,8 @@ const updateAgentHandler = async (req, res) => {
       return res.status(404).json({ error: 'Agent not found' });
     }
 
-    if (existingAgent.isSystem) {
-      return res.status(403).json({
-        error: 'Global agents are managed by server configuration and cannot be modified.',
-      });
+    if (rejectImmutableSystemAgent(existingAgent, res)) {
+      return;
     }
 
     // Convert legacy OCR tool resource to context format in existing agent
@@ -1007,7 +1020,13 @@ const deleteAgentHandler = async (req, res) => {
  * other tenant's agents can leak in). Single-tenant deployments never call this; the tenantless
  * rows already surface through the normal query.
  */
-async function getEntitledSystemGlobalAgents({ userId, role, filter, includeSkillConfig }) {
+async function getEntitledSystemGlobalAgents({
+  userId,
+  role,
+  filter,
+  includeSkillConfig,
+  requiredPermission,
+}) {
   return runAsSystem(async () => {
     const systemAgents = await db.getAgents({ isSystem: true, tenantId: { $exists: false } });
     if (!systemAgents.length) {
@@ -1018,7 +1037,7 @@ async function getEntitledSystemGlobalAgents({ userId, role, filter, includeSkil
       userId,
       role,
       resourceType: ResourceType.AGENT,
-      requiredPermissions: PermissionBits.VIEW,
+      requiredPermissions: requiredPermission,
     });
     const accessibleIds = entitledIds.filter((oid) => systemIdSet.has(oid.toString()));
     if (!accessibleIds.length) {
@@ -1144,7 +1163,8 @@ const getListAgentsHandler = async (req, res) => {
           userId,
           role: req.user.role,
           filter,
-          includeSkillConfig: true,
+          includeSkillConfig: canReturnSkillConfig,
+          requiredPermission,
         });
         const seen = new Set(agents.map((agent) => agent.id));
         for (const systemAgent of systemGlobals) {
@@ -1233,6 +1253,10 @@ const uploadAgentAvatarHandler = async (req, res) => {
 
     if (!existingAgent) {
       return res.status(404).json({ error: 'Agent not found' });
+    }
+
+    if (rejectImmutableSystemAgent(existingAgent, res)) {
+      return;
     }
 
     const buffer = await fs.readFile(req.file.path);
@@ -1340,6 +1364,10 @@ const revertAgentVersionHandler = async (req, res) => {
 
     if (!existingAgent) {
       return res.status(404).json({ error: 'Agent not found' });
+    }
+
+    if (rejectImmutableSystemAgent(existingAgent, res)) {
+      return;
     }
 
     // Permissions are enforced via route middleware (ACL EDIT)

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -85,6 +85,15 @@ const rejectImmutableSystemAgent = (agent, res) => {
   return false;
 };
 
+/** Load an agent by id, falling back to the tenantless system-global row on a tenant-scoped miss, so
+ *  mutating handlers reach the isSystem immutability guard (403) instead of returning 404. */
+const loadAgentWithSystemFallback = (searchId) =>
+  withSystemGlobalFallback(
+    searchId,
+    () => db.getAgent({ id: searchId }),
+    () => db.getAgent({ id: searchId, tenantId: { $exists: false } }),
+  );
+
 const sanitizeViewerSkillScope = (agent, accessibleSkillSet) => {
   const skillScopeEnabled = agent.skills_enabled === true;
   delete agent.skills_enabled;
@@ -699,7 +708,7 @@ const updateAgentHandler = async (req, res) => {
     // Convert OCR to context in incoming updateData
     convertOcrToContextInPlace(updateData);
 
-    const existingAgent = await db.getAgent({ id });
+    const existingAgent = await loadAgentWithSystemFallback(id);
 
     if (!existingAgent) {
       return res.status(404).json({ error: 'Agent not found' });
@@ -1009,7 +1018,7 @@ const duplicateAgentHandler = async (req, res) => {
 const deleteAgentHandler = async (req, res) => {
   try {
     const id = req.params.id;
-    const agent = await db.getAgent({ id });
+    const agent = await loadAgentWithSystemFallback(id);
     if (!agent) {
       return res.status(404).json({ error: 'Agent not found' });
     }
@@ -1266,7 +1275,7 @@ const uploadAgentAvatarHandler = async (req, res) => {
       return res.status(400).json({ message: 'Agent ID is required' });
     }
 
-    const existingAgent = await db.getAgent({ id: agent_id });
+    const existingAgent = await loadAgentWithSystemFallback(agent_id);
 
     if (!existingAgent) {
       return res.status(404).json({ error: 'Agent not found' });
@@ -1377,7 +1386,7 @@ const revertAgentVersionHandler = async (req, res) => {
       return res.status(400).json({ error: 'version_index is required' });
     }
 
-    const existingAgent = await db.getAgent({ id });
+    const existingAgent = await loadAgentWithSystemFallback(id);
 
     if (!existingAgent) {
       return res.status(404).json({ error: 'Agent not found' });

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -83,6 +83,7 @@ const {
   duplicateAgent: duplicateAgentHandler,
   revertAgentVersion: revertAgentVersionHandler,
   updateAgent: updateAgentHandler,
+  deleteAgent: deleteAgentHandler,
   getListAgents: getListAgentsHandler,
 } = require('./v1');
 
@@ -1389,6 +1390,58 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
     });
   });
 
+  describe('Global (system) agent immutability', () => {
+    let systemAgentId;
+
+    beforeEach(async () => {
+      const agent = await Agent.create({
+        id: `agent_global_${nanoid()}`,
+        name: 'Global Agent',
+        provider: 'openai',
+        model: 'gpt-4o',
+        author: new mongoose.Types.ObjectId('000000000000000000000000'),
+        isSystem: true,
+      });
+      systemAgentId = agent.id;
+      mockReq.user.id = new mongoose.Types.ObjectId().toString();
+    });
+
+    test('updateAgentHandler returns 403 for a system agent', async () => {
+      mockReq.params.id = systemAgentId;
+      mockReq.body = { name: 'Hijacked' };
+
+      await updateAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+      const agentInDb = await Agent.findOne({ id: systemAgentId });
+      expect(agentInDb.name).toBe('Global Agent');
+    });
+
+    test('deleteAgentHandler returns 403 for a system agent', async () => {
+      mockReq.params.id = systemAgentId;
+
+      await deleteAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(await Agent.countDocuments({ id: systemAgentId })).toBe(1);
+    });
+
+    test('duplicateAgentHandler is allowed and produces a non-system, user-owned copy', async () => {
+      const db = require('~/models');
+      jest.spyOn(db, 'getActions').mockResolvedValueOnce([]);
+      mockReq.params.id = systemAgentId;
+
+      await duplicateAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+      const { agent } = mockRes.json.mock.calls[0][0];
+      expect(agent.id).not.toBe(systemAgentId);
+      expect(agent.id.startsWith('agent_global_')).toBe(false);
+      expect(agent.isSystem).toBeFalsy();
+      expect(agent.author.toString()).toBe(mockReq.user.id);
+    });
+  });
+
   describe('getListAgentsHandler - Security Tests', () => {
     let userA, userB;
     let agentA1, agentA2, agentA3, agentB1;
@@ -1650,6 +1703,7 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
           'description',
           'id',
           'is_promoted',
+          'isSystem',
           'name',
           'support_contact',
           'updatedAt',

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -1440,6 +1440,15 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(agent.isSystem).toBeFalsy();
       expect(agent.author.toString()).toBe(mockReq.user.id);
     });
+
+    test('revertAgentVersionHandler returns 403 for a system agent', async () => {
+      mockReq.params.id = systemAgentId;
+      mockReq.body = { version_index: 0 };
+
+      await revertAgentVersionHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+    });
   });
 
   describe('getListAgentsHandler - Security Tests', () => {

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -41,6 +41,7 @@ const {
   sweepOrphanedPreviews,
 } = require('~/models');
 const { checkMigrations } = require('./services/start/migration');
+const { seedGlobalAgents } = require('./services/start/globalAgents');
 const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
 const createSpaFallback = require('./utils/fallback');
@@ -333,6 +334,9 @@ if (cluster.isMaster) {
     startExpiredFileSweepOnce();
     await performStartupChecks(appConfig);
     await updateInterfacePerms({ appConfig, getRoleByName, updateAccessPermissions });
+
+    /* Materialize config-defined global agents (mirrors server/index.js) before accepting requests. */
+    await seedGlobalAgents(appConfig);
 
     /** Load index.html for SPA serving */
     const indexPath = path.join(appConfig.paths.dist, 'index.html');

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -44,6 +44,7 @@ const { startExpiredFileSweep } = require('./services/Files/process');
 const { initializeGitHubSkillSync } = require('./services/Skills/sync');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
 const { checkMigrations } = require('./services/start/migration');
+const { seedGlobalAgents } = require('./services/start/globalAgents');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
 const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
@@ -153,6 +154,10 @@ const startServer = async () => {
     await performStartupChecks(appConfig);
     await updateInterfacePermissions({ appConfig, getRoleByName, updateAccessPermissions });
   });
+
+  /* Materialize config-defined global agents to stable ids with reconciled ACL grants.
+   * Idempotent; manages its own tenant contexts. Runs before the server accepts requests. */
+  await seedGlobalAgents(appConfig);
 
   const indexPath = path.join(appConfig.paths.dist, 'index.html');
   let indexHTML = fs.readFileSync(indexPath, 'utf8');

--- a/api/server/middleware/accessResources/canAccessAgentFromBody.js
+++ b/api/server/middleware/accessResources/canAccessAgentFromBody.js
@@ -113,12 +113,10 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
       return next();
     }
 
-    const tenantAgent = await resolveAgentIdFromBody(addedAgentId);
-
-    /* System-scope globals are tenantless; resolve them under the system context and cache the doc
-     * so loadAddedAgent doesn't re-fetch via the tenant-scoped path (which misses it). Admins bypass
-     * the permission check but must still populate the cache. */
-    if (!tenantAgent && isSystemGlobalId(addedAgentId)) {
+    /* Tenantless system-scope globals: resolve/authorize under the system context and cache the doc
+     * (admins included) so loadAddedAgent doesn't re-fetch via the tenant-scoped path, which misses
+     * the row. Regular agents and in-tenant globals fall through to the original flow below. */
+    if (isSystemGlobalId(addedAgentId) && !(await resolveAgentIdFromBody(addedAgentId))) {
       if (req.user.role === SystemRoles.ADMIN) {
         const agent = await resolveSystemGlobalAgent(addedAgentId);
         if (agent) {
@@ -139,13 +137,11 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
     }
 
     if (req.user.role === SystemRoles.ADMIN) {
-      if (tenantAgent) {
-        req.resolvedAddedAgent = tenantAgent;
-      }
       return next();
     }
 
-    if (!tenantAgent) {
+    const agent = await resolveAgentIdFromBody(addedAgentId);
+    if (!agent) {
       return res.status(404).json({
         error: 'Not Found',
         message: `${ResourceType.AGENT} not found`,
@@ -156,7 +152,7 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
       userId: req.user.id,
       role: req.user.role,
       resourceType: ResourceType.AGENT,
-      resourceId: tenantAgent._id,
+      resourceId: agent._id,
       requiredPermission,
     });
 
@@ -167,7 +163,7 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
       });
     }
 
-    req.resolvedAddedAgent = tenantAgent;
+    req.resolvedAddedAgent = agent;
     return next();
   } catch (error) {
     logger.error('Failed to validate addedConvo access permissions', error);

--- a/api/server/middleware/accessResources/canAccessAgentFromBody.js
+++ b/api/server/middleware/accessResources/canAccessAgentFromBody.js
@@ -1,4 +1,4 @@
-const { logger, runAsSystem, ResourceCapabilityMap } = require('@librechat/data-schemas');
+const { logger } = require('@librechat/data-schemas');
 const {
   Constants,
   Permissions,
@@ -8,47 +8,32 @@ const {
   isAgentsEndpoint,
   isEphemeralAgentId,
 } = require('librechat-data-provider');
+const {
+  isSystemGlobalId,
+  resolveSystemGlobalAgent,
+  authorizeSystemGlobalAgent,
+} = require('~/server/services/Agents/systemGlobal');
 const { checkPermission } = require('~/server/services/PermissionService');
-const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const { canAccessResource } = require('./canAccessResource');
 const db = require('~/models');
 
 const { getRoleByName, getAgent } = db;
 
-/**
- * Authorizes a `tenants: 'system'` global agent whose tenantless row/grants are invisible to the
- * tenant-scoped access path. Resolves and checks entirely under the system context, pinned to the
- * tenantless row so it can never authorize another tenant's explicit-scope row of the same id.
- * Preserves the MANAGE_AGENTS capability bypass for parity with `canAccessResource`.
- * @returns {Promise<{status:'ok'|'not_found'|'forbidden', agent?: object}>}
- */
-const checkSystemGlobalAgentAccess = (agentId, requiredPermission, req) =>
-  runAsSystem(async () => {
-    const agent = await getAgent({ id: agentId, tenantId: { $exists: false } });
-    if (!agent) {
-      return { status: 'not_found' };
-    }
-    const cap = ResourceCapabilityMap[ResourceType.AGENT];
-    let hasCap = false;
-    try {
-      hasCap = cap != null && (await hasCapability(req.user, cap));
-    } catch (err) {
-      logger.warn(
-        `[canAccessAgentFromBody] capability check failed, denying bypass: ${err.message}`,
-      );
-    }
-    if (hasCap) {
-      return { status: 'ok', agent };
-    }
-    const allowed = await checkPermission({
-      userId: req.user.id,
-      role: req.user.role,
-      resourceType: ResourceType.AGENT,
-      resourceId: agent._id,
-      requiredPermission,
+/** Write a 404/403 for a system-global authorization result; returns true when handled. */
+const respondSystemGlobalDenied = (result, res) => {
+  if (result.status === 'not_found') {
+    res.status(404).json({ error: 'Not Found', message: `${ResourceType.AGENT} not found` });
+    return true;
+  }
+  if (result.status === 'forbidden') {
+    res.status(403).json({
+      error: 'Forbidden',
+      message: `Insufficient permissions to access this ${ResourceType.AGENT}`,
     });
-    return { status: allowed ? 'ok' : 'forbidden', agent };
-  });
+    return true;
+  }
+  return false;
+};
 
 /**
  * Resolves custom agent ID (e.g., "agent_abc123") to a MongoDB document.
@@ -128,31 +113,39 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
       return next();
     }
 
-    if (req.user.role === SystemRoles.ADMIN) {
-      return next();
-    }
+    const tenantAgent = await resolveAgentIdFromBody(addedAgentId);
 
-    const agent = await resolveAgentIdFromBody(addedAgentId);
-
-    /* System-scope global agents are tenantless; resolve + authorize them under the system context. */
-    if (!agent && addedAgentId.startsWith(Constants.GLOBAL_AGENT_PREFIX)) {
-      const result = await checkSystemGlobalAgentAccess(addedAgentId, requiredPermission, req);
-      if (result.status === 'not_found') {
-        return res
-          .status(404)
-          .json({ error: 'Not Found', message: `${ResourceType.AGENT} not found` });
+    /* System-scope globals are tenantless; resolve them under the system context and cache the doc
+     * so loadAddedAgent doesn't re-fetch via the tenant-scoped path (which misses it). Admins bypass
+     * the permission check but must still populate the cache. */
+    if (!tenantAgent && isSystemGlobalId(addedAgentId)) {
+      if (req.user.role === SystemRoles.ADMIN) {
+        const agent = await resolveSystemGlobalAgent(addedAgentId);
+        if (agent) {
+          req.resolvedAddedAgent = agent;
+        }
+        return next();
       }
-      if (result.status === 'forbidden') {
-        return res.status(403).json({
-          error: 'Forbidden',
-          message: `Insufficient permissions to access this ${ResourceType.AGENT}`,
-        });
+      const result = await authorizeSystemGlobalAgent({
+        agentId: addedAgentId,
+        requiredPermission,
+        req,
+      });
+      if (respondSystemGlobalDenied(result, res)) {
+        return;
       }
       req.resolvedAddedAgent = result.agent;
       return next();
     }
 
-    if (!agent) {
+    if (req.user.role === SystemRoles.ADMIN) {
+      if (tenantAgent) {
+        req.resolvedAddedAgent = tenantAgent;
+      }
+      return next();
+    }
+
+    if (!tenantAgent) {
       return res.status(404).json({
         error: 'Not Found',
         message: `${ResourceType.AGENT} not found`,
@@ -163,7 +156,7 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
       userId: req.user.id,
       role: req.user.role,
       resourceType: ResourceType.AGENT,
-      resourceId: agent._id,
+      resourceId: tenantAgent._id,
       requiredPermission,
     });
 
@@ -174,7 +167,7 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
       });
     }
 
-    req.resolvedAddedAgent = agent;
+    req.resolvedAddedAgent = tenantAgent;
     return next();
   } catch (error) {
     logger.error('Failed to validate addedConvo access permissions', error);
@@ -232,18 +225,10 @@ const canAccessAgentFromBody = (options) => {
         return afterPrimaryCheck();
       }
 
-      if (agentId.startsWith(Constants.GLOBAL_AGENT_PREFIX) && !(await getAgent({ id: agentId }))) {
-        const result = await checkSystemGlobalAgentAccess(agentId, requiredPermission, req);
-        if (result.status === 'not_found') {
-          return res
-            .status(404)
-            .json({ error: 'Not Found', message: `${ResourceType.AGENT} not found` });
-        }
-        if (result.status === 'forbidden') {
-          return res.status(403).json({
-            error: 'Forbidden',
-            message: `Insufficient permissions to access this ${ResourceType.AGENT}`,
-          });
+      if (isSystemGlobalId(agentId) && !(await getAgent({ id: agentId }))) {
+        const result = await authorizeSystemGlobalAgent({ agentId, requiredPermission, req });
+        if (respondSystemGlobalDenied(result, res)) {
+          return;
         }
         return afterPrimaryCheck();
       }

--- a/api/server/middleware/accessResources/canAccessAgentFromBody.js
+++ b/api/server/middleware/accessResources/canAccessAgentFromBody.js
@@ -1,4 +1,4 @@
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem, ResourceCapabilityMap } = require('@librechat/data-schemas');
 const {
   Constants,
   Permissions,
@@ -9,10 +9,46 @@ const {
   isEphemeralAgentId,
 } = require('librechat-data-provider');
 const { checkPermission } = require('~/server/services/PermissionService');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const { canAccessResource } = require('./canAccessResource');
 const db = require('~/models');
 
 const { getRoleByName, getAgent } = db;
+
+/**
+ * Authorizes a `tenants: 'system'` global agent whose tenantless row/grants are invisible to the
+ * tenant-scoped access path. Resolves and checks entirely under the system context, pinned to the
+ * tenantless row so it can never authorize another tenant's explicit-scope row of the same id.
+ * Preserves the MANAGE_AGENTS capability bypass for parity with `canAccessResource`.
+ * @returns {Promise<{status:'ok'|'not_found'|'forbidden', agent?: object}>}
+ */
+const checkSystemGlobalAgentAccess = (agentId, requiredPermission, req) =>
+  runAsSystem(async () => {
+    const agent = await getAgent({ id: agentId, tenantId: { $exists: false } });
+    if (!agent) {
+      return { status: 'not_found' };
+    }
+    const cap = ResourceCapabilityMap[ResourceType.AGENT];
+    let hasCap = false;
+    try {
+      hasCap = cap != null && (await hasCapability(req.user, cap));
+    } catch (err) {
+      logger.warn(
+        `[canAccessAgentFromBody] capability check failed, denying bypass: ${err.message}`,
+      );
+    }
+    if (hasCap) {
+      return { status: 'ok', agent };
+    }
+    const allowed = await checkPermission({
+      userId: req.user.id,
+      role: req.user.role,
+      resourceType: ResourceType.AGENT,
+      resourceId: agent._id,
+      requiredPermission,
+    });
+    return { status: allowed ? 'ok' : 'forbidden', agent };
+  });
 
 /**
  * Resolves custom agent ID (e.g., "agent_abc123") to a MongoDB document.
@@ -97,6 +133,25 @@ const checkAddedConvoAccess = (requiredPermission) => async (req, res, next) => 
     }
 
     const agent = await resolveAgentIdFromBody(addedAgentId);
+
+    /* System-scope global agents are tenantless; resolve + authorize them under the system context. */
+    if (!agent && addedAgentId.startsWith(Constants.GLOBAL_AGENT_PREFIX)) {
+      const result = await checkSystemGlobalAgentAccess(addedAgentId, requiredPermission, req);
+      if (result.status === 'not_found') {
+        return res
+          .status(404)
+          .json({ error: 'Not Found', message: `${ResourceType.AGENT} not found` });
+      }
+      if (result.status === 'forbidden') {
+        return res.status(403).json({
+          error: 'Forbidden',
+          message: `Insufficient permissions to access this ${ResourceType.AGENT}`,
+        });
+      }
+      req.resolvedAddedAgent = result.agent;
+      return next();
+    }
+
     if (!agent) {
       return res.status(404).json({
         error: 'Not Found',
@@ -174,6 +229,22 @@ const canAccessAgentFromBody = (options) => {
       const afterPrimaryCheck = () => addedConvoMiddleware(req, res, next);
 
       if (isEphemeralAgentId(agentId)) {
+        return afterPrimaryCheck();
+      }
+
+      if (agentId.startsWith(Constants.GLOBAL_AGENT_PREFIX) && !(await getAgent({ id: agentId }))) {
+        const result = await checkSystemGlobalAgentAccess(agentId, requiredPermission, req);
+        if (result.status === 'not_found') {
+          return res
+            .status(404)
+            .json({ error: 'Not Found', message: `${ResourceType.AGENT} not found` });
+        }
+        if (result.status === 'forbidden') {
+          return res.status(403).json({
+            error: 'Forbidden',
+            message: `Insufficient permissions to access this ${ResourceType.AGENT}`,
+          });
+        }
         return afterPrimaryCheck();
       }
 

--- a/api/server/middleware/accessResources/canAccessAgentResource.js
+++ b/api/server/middleware/accessResources/canAccessAgentResource.js
@@ -1,4 +1,8 @@
 const { ResourceType } = require('librechat-data-provider');
+const {
+  isSystemGlobalId,
+  authorizeSystemGlobalAgent,
+} = require('~/server/services/Agents/systemGlobal');
 const { canAccessResource } = require('./canAccessResource');
 const { getAgent } = require('~/models');
 
@@ -46,12 +50,35 @@ const canAccessAgentResource = (options) => {
     throw new Error('canAccessAgentResource: requiredPermission is required and must be a number');
   }
 
-  return canAccessResource({
+  const baseMiddleware = canAccessResource({
     resourceType: ResourceType.AGENT,
     requiredPermission,
     resourceIdParam,
     idResolver: resolveAgentId,
   });
+
+  /* System-scope globals are tenantless; when the tenant-scoped resolve misses one, authorize it
+   * under the system context so entitled users can view/select the shared agent from detail routes.
+   * Everything else (including explicit-tenant globals) flows through the generic middleware. */
+  return async (req, res, next) => {
+    const agentId = req.params?.[resourceIdParam];
+    if (req.user?.id && isSystemGlobalId(agentId) && !(await resolveAgentId(agentId))) {
+      const result = await authorizeSystemGlobalAgent({ agentId, requiredPermission, req });
+      if (result.status === 'not_found') {
+        return res
+          .status(404)
+          .json({ error: 'Not Found', message: `${ResourceType.AGENT} not found` });
+      }
+      if (result.status === 'forbidden') {
+        return res.status(403).json({
+          error: 'Forbidden',
+          message: `Insufficient permissions to access this ${ResourceType.AGENT}`,
+        });
+      }
+      return next();
+    }
+    return baseMiddleware(req, res, next);
+  };
 };
 
 module.exports = {

--- a/api/server/middleware/accessResources/fileAccess.js
+++ b/api/server/middleware/accessResources/fileAccess.js
@@ -1,36 +1,36 @@
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const { PermissionBits, hasPermissions, ResourceType } = require('librechat-data-provider');
 const { getEffectivePermissions } = require('~/server/services/PermissionService');
+const { authorizeSystemGlobalAgent } = require('~/server/services/Agents/systemGlobal');
 const { getAgents, getFiles } = require('~/models');
+
+/** Query matching agents that have the given file id in any tool_resource. */
+const fileResourceFilter = (fileId) => ({
+  $or: [
+    { 'tool_resources.execute_code.file_ids': fileId },
+    { 'tool_resources.file_search.file_ids': fileId },
+    { 'tool_resources.image_edit.file_ids': fileId },
+    { 'tool_resources.context.file_ids': fileId },
+    { 'tool_resources.ocr.file_ids': fileId },
+  ],
+});
 
 /**
  * Checks if user has access to a file through agent permissions
  * Files inherit permissions from agents they are attached to.
  */
-const checkAgentBasedFileAccess = async ({ userId, role, fileId, fileOwner }) => {
+const checkAgentBasedFileAccess = async ({ userId, role, fileId, fileOwner, tenantId }) => {
   try {
     const fileOwnerId = fileOwner?.toString();
     if (!fileOwnerId) {
       return false;
     }
 
-    /** Agents that have this file in their tool_resources */
-    const agentsWithFile = await getAgents({
-      $or: [
-        { 'tool_resources.execute_code.file_ids': fileId },
-        { 'tool_resources.file_search.file_ids': fileId },
-        { 'tool_resources.image_edit.file_ids': fileId },
-        { 'tool_resources.context.file_ids': fileId },
-        { 'tool_resources.ocr.file_ids': fileId },
-      ],
-    });
-
-    if (!agentsWithFile || agentsWithFile.length === 0) {
-      return false;
-    }
-
     const userIdStr = userId.toString();
-    for (const agent of agentsWithFile) {
+
+    /** Tenant-scoped agents that have this file in their tool_resources */
+    const agentsWithFile = await getAgents(fileResourceFilter(fileId));
+    for (const agent of agentsWithFile ?? []) {
       const agentAuthorId = agent.author?.toString();
       if (!agentAuthorId) {
         continue;
@@ -58,6 +58,29 @@ const checkAgentBasedFileAccess = async ({ userId, role, fileId, fileOwner }) =>
           `[fileAccess] Permission check failed for agent ${agent.id}:`,
           permissionError.message,
         );
+      }
+    }
+
+    /* Files attached to a tenantless `tenants: 'system'` global are invisible to the tenant-scoped
+     * query above, so a citation/preview/download would 403. Resolve those globals under the system
+     * context and authorize VIEW there (principals in the request tenant). */
+    const systemGlobalsWithFile = await runAsSystem(async () => {
+      const agents = await getAgents({
+        isSystem: true,
+        tenantId: { $exists: false },
+        ...fileResourceFilter(fileId),
+      });
+      return agents;
+    });
+    for (const agent of systemGlobalsWithFile ?? []) {
+      const result = await authorizeSystemGlobalAgent({
+        agentId: agent.id,
+        requiredPermission: PermissionBits.VIEW,
+        req: { user: { id: userId, role, tenantId } },
+      });
+      if (result.status === 'ok') {
+        logger.debug(`[fileAccess] User ${userId} authorized via system global ${agent.id}`);
+        return true;
       }
     }
 
@@ -129,6 +152,7 @@ const fileAccess = async (req, res, next) => {
       role: userRole,
       fileId,
       fileOwner: file.user,
+      tenantId: userTenantId,
     });
     if (hasAgentAccess) {
       req.fileAccess = { file };

--- a/api/server/middleware/accessResources/fileAccess.js
+++ b/api/server/middleware/accessResources/fileAccess.js
@@ -122,7 +122,17 @@ const fileAccess = async (req, res, next) => {
       });
     }
 
-    const [file] = await getFiles({ file_id: fileId });
+    let [file] = await getFiles({ file_id: fileId });
+    if (!file) {
+      /* A tenantless file attached to a `tenants: 'system'` global isn't found by the tenant-scoped
+       * lookup; retry under the system context pinned to tenantless (never another concrete tenant).
+       * Agent-based access below still gates whether this user may actually read it. */
+      const systemFiles = await runAsSystem(async () => {
+        const rows = await getFiles({ file_id: fileId, tenantId: { $exists: false } });
+        return rows;
+      });
+      file = systemFiles?.[0];
+    }
     if (!file) {
       return res.status(404).json({
         error: 'Not Found',

--- a/api/server/routes/agents/actions.js
+++ b/api/server/routes/agents/actions.js
@@ -160,6 +160,12 @@ router.post(
         return res.status(404).json({ message: 'Agent not found for adding action' });
       }
 
+      if (agent.isSystem) {
+        return res.status(403).json({
+          message: 'Global agents are managed by server configuration and cannot be modified.',
+        });
+      }
+
       const storedAction = actions_result?.[0];
       if (storedAction) {
         if (storedAction.agent_id !== agent_id) {
@@ -267,6 +273,12 @@ router.delete(
       const agent = await db.getAgent({ id: agent_id });
       if (!agent) {
         return res.status(404).json({ message: 'Agent not found for deleting action' });
+      }
+
+      if (agent.isSystem) {
+        return res.status(403).json({
+          message: 'Global agents are managed by server configuration and cannot be modified.',
+        });
       }
 
       const { tools = [], actions = [] } = agent;

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -29,6 +29,7 @@ const { fileAccess } = require('~/server/middleware/accessResources/fileAccess')
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 const { hasCapability } = require('~/server/middleware/roles/capabilities');
+const { withSystemGlobalFallback } = require('~/server/services/Agents/systemGlobal');
 const { checkPermission } = require('~/server/services/PermissionService');
 const { cleanFileName, getContentDisposition } = require('~/server/utils/files');
 const { getLogStores } = require('~/cache');
@@ -177,6 +178,12 @@ router.delete('/', async (req, res) => {
 
       if (!agent) {
         return res.status(404).json({ message: 'Agent not found' });
+      }
+
+      if (agent.isSystem) {
+        return res.status(403).json({
+          message: 'Global agents are managed by server configuration and cannot be modified.',
+        });
       }
 
       const hasAgentEditAccess =
@@ -639,6 +646,19 @@ router.post('/', async (req, res) => {
       });
       if (denied) {
         return;
+      }
+    }
+
+    if (metadata.agent_id) {
+      const targetAgent = await withSystemGlobalFallback(
+        metadata.agent_id,
+        () => db.getAgent({ id: metadata.agent_id }),
+        () => db.getAgent({ id: metadata.agent_id, tenantId: { $exists: false } }),
+      );
+      if (targetAgent?.isSystem) {
+        return res.status(403).json({
+          message: 'Global agents are managed by server configuration and cannot be modified.',
+        });
       }
     }
 

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -650,8 +650,10 @@ router.post('/', async (req, res) => {
     }
 
     /* Only agent-resource uploads mutate the agent; per-message attachments (message_file) reuse the
-     * conversation's agent_id but don't touch agent resources, so they must stay allowed for globals. */
-    if (metadata.agent_id && metadata.message_file !== true) {
+     * conversation's agent_id but don't touch agent resources, so they must stay allowed for globals.
+     * Multipart sends the flag as the string 'true', so normalize both forms (matches upload auth). */
+    const isMessageAttachment = metadata.message_file === true || metadata.message_file === 'true';
+    if (metadata.agent_id && !isMessageAttachment) {
       const targetAgent = await withSystemGlobalFallback(
         metadata.agent_id,
         () => db.getAgent({ id: metadata.agent_id }),

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -649,7 +649,9 @@ router.post('/', async (req, res) => {
       }
     }
 
-    if (metadata.agent_id) {
+    /* Only agent-resource uploads mutate the agent; per-message attachments (message_file) reuse the
+     * conversation's agent_id but don't touch agent resources, so they must stay allowed for globals. */
+    if (metadata.agent_id && metadata.message_file !== true) {
       const targetAgent = await withSystemGlobalFallback(
         metadata.agent_id,
         () => db.getAgent({ id: metadata.agent_id }),

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -10,6 +10,7 @@ const {
   filterFile,
 } = require('~/server/services/Files/process');
 const { checkPermission } = require('~/server/services/PermissionService');
+const { withSystemGlobalFallback } = require('~/server/services/Agents/systemGlobal');
 const db = require('~/models');
 
 const router = express.Router();
@@ -34,6 +35,20 @@ router.post('/', async (req, res) => {
       });
       if (denied) {
         return;
+      }
+      /* This path mutates the agent's tool_resources; reject config-managed globals with a clean 403
+       * before writing to storage (otherwise addAgentResourceFile throws 500 + orphans the upload). */
+      if (metadata.agent_id) {
+        const targetAgent = await withSystemGlobalFallback(
+          metadata.agent_id,
+          () => db.getAgent({ id: metadata.agent_id }),
+          () => db.getAgent({ id: metadata.agent_id, tenantId: { $exists: false } }),
+        );
+        if (targetAgent?.isSystem) {
+          return res.status(403).json({
+            message: 'Global agents are managed by server configuration and cannot be modified.',
+          });
+        }
       }
       return await processAgentFileUpload({ req, res, metadata });
     }

--- a/api/server/routes/files/preview.spec.js
+++ b/api/server/routes/files/preview.spec.js
@@ -12,6 +12,7 @@
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+  runAsSystem: (fn) => fn(),
   SystemCapabilities: {},
 }));
 

--- a/api/server/services/Agents/systemGlobal.js
+++ b/api/server/services/Agents/systemGlobal.js
@@ -1,0 +1,78 @@
+const { logger, runAsSystem, ResourceCapabilityMap } = require('@librechat/data-schemas');
+const { Constants, ResourceType } = require('librechat-data-provider');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
+const db = require('~/models');
+
+const { getAgent, getUserPrincipals, hasPermission } = db;
+
+/**
+ * Config-defined `tenants: 'system'` global agents are stored as a single tenantless row/grant that
+ * a tenant-scoped read can't see. This module centralizes the cross-tenant handling so every access
+ * and read path routes through one correct implementation instead of scattered fallbacks.
+ */
+
+const isSystemGlobalId = (agentId) =>
+  typeof agentId === 'string' && agentId.startsWith(Constants.GLOBAL_AGENT_PREFIX);
+
+/**
+ * Refetch a global agent under the system context, pinned to the tenantless row, when the
+ * tenant-scoped fetch missed it. `fetchTenant`/`fetchSystem` let callers reuse their own accessor
+ * (getAgent, getAgentWithVersionCount, getAgentVersions, …).
+ * @template T
+ * @param {string} agentId
+ * @param {() => Promise<T>} fetchTenant - tenant-scoped fetch
+ * @param {() => Promise<T>} fetchSystem - fetch pinned to `{ tenantId: { $exists: false } }`
+ * @returns {Promise<T>}
+ */
+const withSystemGlobalFallback = async (agentId, fetchTenant, fetchSystem) => {
+  const doc = await fetchTenant();
+  if (doc || !isSystemGlobalId(agentId)) {
+    return doc;
+  }
+  return runAsSystem(fetchSystem);
+};
+
+/** Resolve the tenantless system-scope row for a global id (or null). */
+const resolveSystemGlobalAgent = (agentId) =>
+  runAsSystem(() => getAgent({ id: agentId, tenantId: { $exists: false } }));
+
+/**
+ * Authorize a tenantless system-scope global agent. Principals are built in the REQUEST tenant
+ * context (so group memberships reflect the current tenant); the agent + ACL lookup run under the
+ * system context (so the tenantless row/grants resolve). Preserves the MANAGE_AGENTS capability
+ * bypass for parity with `canAccessResource`.
+ * @returns {Promise<{status:'ok'|'not_found'|'forbidden', agent?: object}>}
+ */
+const authorizeSystemGlobalAgent = async ({ agentId, requiredPermission, req }) => {
+  const principals = await getUserPrincipals({ userId: req.user.id, role: req.user.role });
+  return runAsSystem(async () => {
+    const agent = await getAgent({ id: agentId, tenantId: { $exists: false } });
+    if (!agent) {
+      return { status: 'not_found' };
+    }
+    const cap = ResourceCapabilityMap[ResourceType.AGENT];
+    let hasCap = false;
+    try {
+      hasCap = cap != null && (await hasCapability(req.user, cap));
+    } catch (err) {
+      logger.warn(`[systemGlobalAgent] capability check failed, denying bypass: ${err.message}`);
+    }
+    if (hasCap) {
+      return { status: 'ok', agent };
+    }
+    const allowed = await hasPermission(
+      principals,
+      ResourceType.AGENT,
+      agent._id,
+      requiredPermission,
+    );
+    return { status: allowed ? 'ok' : 'forbidden', agent };
+  });
+};
+
+module.exports = {
+  isSystemGlobalId,
+  withSystemGlobalFallback,
+  resolveSystemGlobalAgent,
+  authorizeSystemGlobalAgent,
+};

--- a/api/server/services/Agents/systemGlobal.js
+++ b/api/server/services/Agents/systemGlobal.js
@@ -1,74 +1,22 @@
-const { logger, runAsSystem, ResourceCapabilityMap } = require('@librechat/data-schemas');
-const { Constants, ResourceType } = require('librechat-data-provider');
+const {
+  isSystemGlobalId,
+  withSystemGlobalFallback,
+  resolveSystemGlobalAgent: resolveSystemGlobalAgentImpl,
+  authorizeSystemGlobalAgent: authorizeSystemGlobalAgentImpl,
+} = require('@librechat/api');
 const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const db = require('~/models');
 
-const { getAgent, getUserPrincipals, hasPermission } = db;
-
-/**
- * Config-defined `tenants: 'system'` global agents are stored as a single tenantless row/grant that
- * a tenant-scoped read can't see. This module centralizes the cross-tenant handling so every access
- * and read path routes through one correct implementation instead of scattered fallbacks.
- */
-
-const isSystemGlobalId = (agentId) =>
-  typeof agentId === 'string' && agentId.startsWith(Constants.GLOBAL_AGENT_PREFIX);
-
-/**
- * Refetch a global agent under the system context, pinned to the tenantless row, when the
- * tenant-scoped fetch missed it. `fetchTenant`/`fetchSystem` let callers reuse their own accessor
- * (getAgent, getAgentWithVersionCount, getAgentVersions, …).
- * @template T
- * @param {string} agentId
- * @param {() => Promise<T>} fetchTenant - tenant-scoped fetch
- * @param {() => Promise<T>} fetchSystem - fetch pinned to `{ tenantId: { $exists: false } }`
- * @returns {Promise<T>}
- */
-const withSystemGlobalFallback = async (agentId, fetchTenant, fetchSystem) => {
-  const doc = await fetchTenant();
-  if (doc || !isSystemGlobalId(agentId)) {
-    return doc;
-  }
-  return runAsSystem(fetchSystem);
+/** Runtime dependencies for the cross-tenant global-agent logic in `@librechat/api`. */
+const deps = {
+  getAgent: db.getAgent,
+  getUserPrincipals: db.getUserPrincipals,
+  hasPermission: db.hasPermission,
+  hasCapability,
 };
 
-/** Resolve the tenantless system-scope row for a global id (or null). */
-const resolveSystemGlobalAgent = (agentId) =>
-  runAsSystem(() => getAgent({ id: agentId, tenantId: { $exists: false } }));
-
-/**
- * Authorize a tenantless system-scope global agent. Principals are built in the REQUEST tenant
- * context (so group memberships reflect the current tenant); the agent + ACL lookup run under the
- * system context (so the tenantless row/grants resolve). Preserves the MANAGE_AGENTS capability
- * bypass for parity with `canAccessResource`.
- * @returns {Promise<{status:'ok'|'not_found'|'forbidden', agent?: object}>}
- */
-const authorizeSystemGlobalAgent = async ({ agentId, requiredPermission, req }) => {
-  const principals = await getUserPrincipals({ userId: req.user.id, role: req.user.role });
-  return runAsSystem(async () => {
-    const agent = await getAgent({ id: agentId, tenantId: { $exists: false } });
-    if (!agent) {
-      return { status: 'not_found' };
-    }
-    const cap = ResourceCapabilityMap[ResourceType.AGENT];
-    let hasCap = false;
-    try {
-      hasCap = cap != null && (await hasCapability(req.user, cap));
-    } catch (err) {
-      logger.warn(`[systemGlobalAgent] capability check failed, denying bypass: ${err.message}`);
-    }
-    if (hasCap) {
-      return { status: 'ok', agent };
-    }
-    const allowed = await hasPermission(
-      principals,
-      ResourceType.AGENT,
-      agent._id,
-      requiredPermission,
-    );
-    return { status: allowed ? 'ok' : 'forbidden', agent };
-  });
-};
+const resolveSystemGlobalAgent = (agentId) => resolveSystemGlobalAgentImpl(deps, agentId);
+const authorizeSystemGlobalAgent = (args) => authorizeSystemGlobalAgentImpl(deps, args);
 
 module.exports = {
   isSystemGlobalId,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -45,6 +45,7 @@ const {
 } = require('./skillDeps');
 const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { checkPermission, findAccessibleResources } = require('~/server/services/PermissionService');
+const { authorizeSystemGlobalAgent } = require('~/server/services/Agents/systemGlobal');
 const AgentClient = require('~/server/controllers/agents/client');
 const { processAddedConvo } = require('./addedConvo');
 const { logViolation } = require('~/cache');
@@ -486,6 +487,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     {
       getAgent: db.getAgent,
       checkPermission,
+      authorizeSystemGlobalAgent,
       logViolation,
       db: {
         getFiles: db.getFiles,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -45,7 +45,11 @@ const {
 } = require('./skillDeps');
 const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { checkPermission, findAccessibleResources } = require('~/server/services/PermissionService');
-const { authorizeSystemGlobalAgent } = require('~/server/services/Agents/systemGlobal');
+const {
+  isSystemGlobalId,
+  resolveSystemGlobalAgent,
+  authorizeSystemGlobalAgent,
+} = require('~/server/services/Agents/systemGlobal');
 const AgentClient = require('~/server/controllers/agents/client');
 const { processAddedConvo } = require('./addedConvo');
 const { logViolation } = require('~/cache');
@@ -616,7 +620,14 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     if (existing) return existing;
 
     try {
-      const agent = await db.getAgent({ id: agentId });
+      // A subagent referenced only via `subagents.agent_ids` may be a tenantless `tenants: 'system'`
+      // global; resolve + authorize it under the system context (a tenant-scoped read/check misses it).
+      let agent = await db.getAgent({ id: agentId });
+      let viaSystemFallback = false;
+      if (!agent && isSystemGlobalId(agentId)) {
+        agent = await resolveSystemGlobalAgent(agentId);
+        viaSystemFallback = agent != null;
+      }
       if (!agent) {
         skippedAgentIds.add(agentId);
         return null;
@@ -626,13 +637,21 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
         skippedAgentIds.add(agentId);
         return null;
       }
-      const hasAccess = await checkPermission({
-        userId,
-        role: req.user?.role,
-        resourceType: ResourceType.AGENT,
-        resourceId: agent._id,
-        requiredPermission: PermissionBits.VIEW,
-      });
+      const hasAccess = viaSystemFallback
+        ? (
+            await authorizeSystemGlobalAgent({
+              agentId,
+              requiredPermission: PermissionBits.VIEW,
+              req,
+            })
+          ).status === 'ok'
+        : await checkPermission({
+            userId,
+            role: req.user?.role,
+            resourceType: ResourceType.AGENT,
+            resourceId: agent._id,
+            requiredPermission: PermissionBits.VIEW,
+          });
       if (!hasAccess) {
         logger.warn(
           `[processAgent] User ${userId} lacks VIEW access to subagent ${agentId}, skipping`,

--- a/api/server/services/Files/permissions.js
+++ b/api/server/services/Files/permissions.js
@@ -1,6 +1,10 @@
-const { logger } = require('@librechat/data-schemas');
+const { logger, getTenantId } = require('@librechat/data-schemas');
 const { PermissionBits, ResourceType, isEphemeralAgentId } = require('librechat-data-provider');
 const { checkPermission } = require('~/server/services/PermissionService');
+const {
+  withSystemGlobalFallback,
+  authorizeSystemGlobalAgent,
+} = require('~/server/services/Agents/systemGlobal');
 const { getAgent, getFiles } = require('~/models');
 
 /**
@@ -49,11 +53,34 @@ const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDele
   fileIds.forEach((fileId) => accessMap.set(fileId, false));
 
   try {
-    const agent = await getAgent({ id: agentId });
+    const agent = await withSystemGlobalFallback(
+      agentId,
+      () => getAgent({ id: agentId }),
+      () => getAgent({ id: agentId, tenantId: { $exists: false } }),
+    );
 
     if (!agent) {
       return accessMap;
     }
+
+    /* A tenantless `tenants: 'system'` global's ACL grants are invisible to a tenant-scoped check;
+     * authorize it under the system context so its admin-provided context/OCR files aren't filtered
+     * out at runtime. In-tenant agents (incl. explicit-tenant globals) keep the normal check. */
+    const viaSystemGlobal = agent.isSystem === true && agent.tenantId == null;
+    const hasAgentPermission = (requiredPermission) =>
+      viaSystemGlobal
+        ? authorizeSystemGlobalAgent({
+            agentId,
+            requiredPermission,
+            req: { user: { id: userId, role, tenantId: getTenantId() } },
+          }).then((result) => result.status === 'ok')
+        : checkPermission({
+            userId,
+            role,
+            resourceType: ResourceType.AGENT,
+            resourceId: agent._id,
+            requiredPermission,
+          });
 
     const attachedFileIds = getAttachedFileIds(agent);
     const agentAuthorId = agent.author?.toString();
@@ -75,26 +102,14 @@ const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDele
       return accessMap;
     }
 
-    const hasViewPermission = await checkPermission({
-      userId,
-      role,
-      resourceType: ResourceType.AGENT,
-      resourceId: agent._id,
-      requiredPermission: PermissionBits.VIEW,
-    });
+    const hasViewPermission = await hasAgentPermission(PermissionBits.VIEW);
 
     if (!hasViewPermission) {
       return accessMap;
     }
 
     if (isDelete) {
-      const hasEditPermission = await checkPermission({
-        userId,
-        role,
-        resourceType: ResourceType.AGENT,
-        resourceId: agent._id,
-        requiredPermission: PermissionBits.EDIT,
-      });
+      const hasEditPermission = await hasAgentPermission(PermissionBits.EDIT);
 
       if (!hasEditPermission) {
         return accessMap;

--- a/api/server/services/Files/permissions.js
+++ b/api/server/services/Files/permissions.js
@@ -1,4 +1,4 @@
-const { logger, getTenantId } = require('@librechat/data-schemas');
+const { logger, getTenantId, runAsSystem } = require('@librechat/data-schemas');
 const { PermissionBits, ResourceType, isEphemeralAgentId } = require('librechat-data-provider');
 const { checkPermission } = require('~/server/services/PermissionService');
 const {
@@ -84,12 +84,24 @@ const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDele
 
     const attachedFileIds = getAttachedFileIds(agent);
     const agentAuthorId = agent.author?.toString();
-    const filesById =
-      files != null
-        ? getFilesById(files)
-        : getFilesById(
-            await getFiles({ file_id: { $in: fileIds } }, null, { file_id: 1, user: 1 }),
-          );
+    /* A tenantless system global's admin-provided files are invisible to the caller's tenant-scoped
+     * `files`/getFiles lookup, so load their metadata under the system context (the ids are already
+     * scoped to this authorized agent's tool_resources). */
+    let fileMetadata;
+    if (viaSystemGlobal) {
+      fileMetadata = await runAsSystem(async () => {
+        const systemFiles = await getFiles({ file_id: { $in: fileIds } }, null, {
+          file_id: 1,
+          user: 1,
+        });
+        return systemFiles;
+      });
+    } else if (files != null) {
+      fileMetadata = files;
+    } else {
+      fileMetadata = await getFiles({ file_id: { $in: fileIds } }, null, { file_id: 1, user: 1 });
+    }
+    const filesById = getFilesById(fileMetadata);
     const canInheritFromAgent = (fileId) =>
       attachedFileIds.has(fileId) && filesById.get(fileId)?.user != null;
 

--- a/api/server/services/start/globalAgents.js
+++ b/api/server/services/start/globalAgents.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+const { logger } = require('@librechat/data-schemas');
+const { reconcileGlobalAgents } = require('@librechat/api');
+const {
+  grantPermission,
+  deleteAclEntries,
+  findRoleByIdentifier,
+  findEntriesByResource,
+} = require('~/models');
+
+/**
+ * Seed config-defined global agents (`endpoints.agents.globalAgents`) into the database.
+ * Idempotent; safe to run on every boot. The reconciler manages its own tenant contexts.
+ * @param {import('@librechat/data-schemas').AppConfig} appConfig
+ */
+async function seedGlobalAgents(appConfig) {
+  try {
+    await reconcileGlobalAgents({
+      globalAgents: appConfig?.endpoints?.agents?.globalAgents,
+      methods: { grantPermission, deleteAclEntries, findRoleByIdentifier, findEntriesByResource },
+      AgentModel: mongoose.models.Agent,
+    });
+  } catch (error) {
+    logger.error('[seedGlobalAgents] Failed to seed global agents:', error);
+  }
+}
+
+module.exports = { seedGlobalAgents };

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -473,9 +473,15 @@ export default function AgentPanel() {
     }
   }, [agent_id, onSelectAgent]);
 
+  const isSystemAgent = agentQuery.data?.isSystem === true;
+
   const canEditAgent = useMemo(() => {
     if (!agentQuery.data?.id) {
       return true;
+    }
+
+    if (agentQuery.data?.isSystem === true) {
+      return false;
     }
 
     if (user?.role === SystemRoles.ADMIN) {
@@ -483,7 +489,7 @@ export default function AgentPanel() {
     }
 
     return canEdit;
-  }, [agentQuery.data?.id, user?.role, canEdit]);
+  }, [agentQuery.data?.id, agentQuery.data?.isSystem, user?.role, canEdit]);
 
   return (
     <FormProvider {...methods}>
@@ -537,9 +543,11 @@ export default function AgentPanel() {
             <div className="flex h-[30vh] w-full items-center justify-center">
               <div className="text-center">
                 <h2 className="text-token-text-primary m-2 text-xl font-semibold">
-                  {localize('com_agents_not_available')}
+                  {localize(isSystemAgent ? 'com_agents_global_title' : 'com_agents_not_available')}
                 </h2>
-                <p className="text-token-text-secondary">{localize('com_agents_no_access')}</p>
+                <p className="text-token-text-secondary">
+                  {localize(isSystemAgent ? 'com_agents_global_readonly' : 'com_agents_no_access')}
+                </p>
               </div>
             </div>
           )}

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -29,6 +29,7 @@ import { useAgentPanelContext } from '~/Providers/AgentPanelContext';
 import AgentPanelSkeleton from './AgentPanelSkeleton';
 import AdvancedPanel from './Advanced/AdvancedPanel';
 import { Panel, isEphemeralAgent } from '~/common';
+import DuplicateAgent from './DuplicateAgent';
 import AgentConfig from './AgentConfig';
 import AgentSelect from './AgentSelect';
 import AgentFooter from './AgentFooter';
@@ -548,6 +549,13 @@ export default function AgentPanel() {
                 <p className="text-token-text-secondary">
                   {localize(isSystemAgent ? 'com_agents_global_readonly' : 'com_agents_no_access')}
                 </p>
+                {isSystemAgent &&
+                  agentQuery.data?.id &&
+                  (canEdit || user?.role === SystemRoles.ADMIN) && (
+                    <div className="mt-4 flex justify-center">
+                      <DuplicateAgent agent_id={agentQuery.data.id} />
+                    </div>
+                  )}
               </div>
             </div>
           )}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -70,6 +70,8 @@
   "com_agents_file_context_label": "File Context",
   "com_agents_file_search_disabled": "Agent must be created before uploading files for File Search.",
   "com_agents_file_search_info": "Turns uploaded files into a searchable knowledge base. The agent retrieves the most relevant passages on demand, so it works well even with large document sets.",
+  "com_agents_global_readonly": "This is a global agent managed by your administrator and can't be edited.",
+  "com_agents_global_title": "Global Agent",
   "com_agents_grid_announcement": "Showing {{count}} agents in {{category}} category",
   "com_agents_instructions_placeholder": "The system instructions that the agent uses",
   "com_agents_link_copied": "Link copied",

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -428,6 +428,25 @@ endpoints:
   #     maxCatalogSkills: 20
   #   # (optional) Agent Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
   #   capabilities: ["deferred_tools", "execute_code", "file_search", "actions", "tools"]
+  #   # (optional) Global agents: server-defined agents seeded to a stable id at startup and
+  #   # immutable in the app. The body is the same payload the agent builder posts, so an entry
+  #   # can be minimal (id + provider + model) or override any agent field.
+  #   globalAgents:
+  #     - id: agent_global_assistant   # required; must start with `agent_global_`
+  #       name: Company Assistant
+  #       provider: openAI
+  #       model: gpt-4o
+  #       instructions: You are the shared company assistant.
+  #       # (optional) Visibility, using the existing ACL granularity. Omit to seed but not share.
+  #       access:
+  #         level: viewer               # viewer (default) | editor
+  #         roles: ["USER"]             # visible to every user with this account role
+  #         # public: true              # visible to everyone, including public/share contexts
+  #         # groups: ["<groupId>"]
+  #         # users: ["<userId>"]
+  #       # (optional) Tenant reach. 'system' (default) = one shared row for all tenants;
+  #       # a list scopes it to specific tenants. Ignored in single-tenant deployments.
+  #       # tenants: system
 
   # (optional) Custom request headers for the built-in OpenAI / Google endpoints.
   # Forwarded on every request to the provider (or an AI gateway / reverse proxy

--- a/packages/api/src/agents/discovery.ts
+++ b/packages/api/src/agents/discovery.ts
@@ -12,6 +12,7 @@ import type { ServerRequest } from '~/types';
 import { validateAgentModel as defaultValidateAgentModel } from './validation';
 import { initializeAgent as defaultInitializeAgent } from './initialize';
 import { createEdgeCollector, filterOrphanedEdges } from './edges';
+import { withSystemGlobalFallback } from './systemGlobal';
 import { createSequentialChainEdges } from './chain';
 
 /**
@@ -98,7 +99,7 @@ export interface DiscoverConnectedAgentsParams {
 
 export interface DiscoverConnectedAgentsDeps {
   /** Fetch an agent by string id from the database. */
-  getAgent: (filter: { id: string }) => Promise<Agent | null>;
+  getAgent: (filter: { id: string; tenantId?: { $exists: boolean } }) => Promise<Agent | null>;
   /** Permission check (typically a wrapper around PermissionService.checkPermission). */
   checkPermission: CheckAgentPermission;
   /** Violation logger passed through to validateAgentModel. */
@@ -190,7 +191,14 @@ export async function discoverConnectedAgents(
   };
 
   const processAgent = async (agentId: string): Promise<Agent | null> => {
-    const agent = await getAgent({ id: agentId });
+    /* A connected agent (edge/subagent target) may be a `tenants: 'system'` global — a tenantless
+     * row a tenant-scoped read misses. Fall back to the system context so configured handoffs and
+     * subagents pointing at a global agent resolve instead of being silently pruned. */
+    const agent = await withSystemGlobalFallback(
+      agentId,
+      () => getAgent({ id: agentId }),
+      () => getAgent({ id: agentId, tenantId: { $exists: false } }),
+    );
     if (!agent) {
       logger.warn(
         `[discoverConnectedAgents] Handoff agent ${agentId} not found, skipping (orphaned reference)`,

--- a/packages/api/src/agents/discovery.ts
+++ b/packages/api/src/agents/discovery.ts
@@ -110,7 +110,7 @@ export interface DiscoverConnectedAgentsDeps {
   authorizeSystemGlobalAgent?: (params: {
     agentId: string;
     requiredPermission: number;
-    req: { user: { id: string; role: string } };
+    req: { user: { id: string; role: string; tenantId?: string } };
   }) => Promise<{ status: 'ok' | 'not_found' | 'forbidden'; agent?: Agent }>;
   /** Violation logger passed through to validateAgentModel. */
   logViolation: ValidateAgentModelParams['logViolation'];
@@ -238,7 +238,11 @@ export async function discoverConnectedAgents(
             await authorizeSystemGlobalAgent({
               agentId,
               requiredPermission: PermissionBits.VIEW,
-              req: { user: { id: userId, role: req.user?.role ?? '' } },
+              // Preserve tenantId: hasCapability keys its cache/principals on it, so dropping it
+              // would skip tenant-scoped managers/admins relying on the MANAGE_AGENTS bypass.
+              req: {
+                user: { id: userId, role: req.user?.role ?? '', tenantId: req.user?.tenantId },
+              },
             })
           ).status === 'ok'
         : await checkPermission({

--- a/packages/api/src/agents/discovery.ts
+++ b/packages/api/src/agents/discovery.ts
@@ -229,8 +229,11 @@ export async function discoverConnectedAgents(
       return null;
     }
 
+    /* The system-global authorizer only checks AGENT ACL grants. Restrict it to `resourceType: AGENT`
+     * so REMOTE_AGENT callers (OpenAI/Responses controllers) still enforce their remote sharing
+     * boundary via `checkPermission` — a global agent isn't remote-accessible unless granted so. */
     const hasAccess =
-      viaSystemFallback && authorizeSystemGlobalAgent
+      viaSystemFallback && authorizeSystemGlobalAgent && resourceType === ResourceType.AGENT
         ? (
             await authorizeSystemGlobalAgent({
               agentId,

--- a/packages/api/src/agents/discovery.ts
+++ b/packages/api/src/agents/discovery.ts
@@ -1,4 +1,4 @@
-import { logger } from '@librechat/data-schemas';
+import { logger, runAsSystem } from '@librechat/data-schemas';
 import { ResourceType, PermissionBits, EModelEndpoint } from 'librechat-data-provider';
 import type { Agent, GraphEdge, TModelsConfig, TEndpointOption } from 'librechat-data-provider';
 import type { Response as ServerResponse } from 'express';
@@ -12,8 +12,8 @@ import type { ServerRequest } from '~/types';
 import { validateAgentModel as defaultValidateAgentModel } from './validation';
 import { initializeAgent as defaultInitializeAgent } from './initialize';
 import { createEdgeCollector, filterOrphanedEdges } from './edges';
-import { withSystemGlobalFallback } from './systemGlobal';
 import { createSequentialChainEdges } from './chain';
+import { isSystemGlobalId } from './systemGlobal';
 
 /**
  * Callback invoked after a sub-agent is successfully initialized.
@@ -102,6 +102,16 @@ export interface DiscoverConnectedAgentsDeps {
   getAgent: (filter: { id: string; tenantId?: { $exists: boolean } }) => Promise<Agent | null>;
   /** Permission check (typically a wrapper around PermissionService.checkPermission). */
   checkPermission: CheckAgentPermission;
+  /**
+   * Authorize a tenantless `tenants: 'system'` global connected agent — principals built in the
+   * request tenant context, ACL lookup under the system context. Optional: when absent, such agents
+   * fall back to the tenant-scoped `checkPermission` and are skipped if their grants are tenantless.
+   */
+  authorizeSystemGlobalAgent?: (params: {
+    agentId: string;
+    requiredPermission: number;
+    req: { user: { id: string; role: string } };
+  }) => Promise<{ status: 'ok' | 'not_found' | 'forbidden'; agent?: Agent }>;
   /** Violation logger passed through to validateAgentModel. */
   logViolation: ValidateAgentModelParams['logViolation'];
   /** DB methods consumed by initializeAgent for each sub-agent. */
@@ -170,6 +180,7 @@ export async function discoverConnectedAgents(
   const {
     getAgent,
     checkPermission,
+    authorizeSystemGlobalAgent,
     logViolation,
     db,
     onAgentInitialized,
@@ -192,13 +203,15 @@ export async function discoverConnectedAgents(
 
   const processAgent = async (agentId: string): Promise<Agent | null> => {
     /* A connected agent (edge/subagent target) may be a `tenants: 'system'` global — a tenantless
-     * row a tenant-scoped read misses. Fall back to the system context so configured handoffs and
-     * subagents pointing at a global agent resolve instead of being silently pruned. */
-    const agent = await withSystemGlobalFallback(
-      agentId,
-      () => getAgent({ id: agentId }),
-      () => getAgent({ id: agentId, tenantId: { $exists: false } }),
-    );
+     * row a tenant-scoped read misses. Resolve it under the system context (pinned tenantless) and
+     * flag it so its authorization runs there too; its grants are tenantless and a tenant-scoped
+     * permission check would wrongly deny access. */
+    let agent = await getAgent({ id: agentId });
+    let viaSystemFallback = false;
+    if (!agent && isSystemGlobalId(agentId)) {
+      agent = await runAsSystem(() => getAgent({ id: agentId, tenantId: { $exists: false } }));
+      viaSystemFallback = agent != null;
+    }
     if (!agent) {
       logger.warn(
         `[discoverConnectedAgents] Handoff agent ${agentId} not found, skipping (orphaned reference)`,
@@ -216,13 +229,22 @@ export async function discoverConnectedAgents(
       return null;
     }
 
-    const hasAccess = await checkPermission({
-      userId,
-      role: req.user?.role,
-      resourceType,
-      resourceId: agent._id,
-      requiredPermission: PermissionBits.VIEW,
-    });
+    const hasAccess =
+      viaSystemFallback && authorizeSystemGlobalAgent
+        ? (
+            await authorizeSystemGlobalAgent({
+              agentId,
+              requiredPermission: PermissionBits.VIEW,
+              req: { user: { id: userId, role: req.user?.role ?? '' } },
+            })
+          ).status === 'ok'
+        : await checkPermission({
+            userId,
+            role: req.user?.role,
+            resourceType,
+            resourceId: agent._id,
+            requiredPermission: PermissionBits.VIEW,
+          });
 
     if (!hasAccess) {
       logger.warn(

--- a/packages/api/src/agents/global.spec.ts
+++ b/packages/api/src/agents/global.spec.ts
@@ -192,4 +192,21 @@ describe('reconcileGlobalAgents', () => {
       await Agent.countDocuments({ id: 'agent_global_support', tenantId: { $exists: false } }),
     ).toBe(0);
   });
+
+  test('hard-deletes a tenant-scoped shadow when a global moves to system scope', async () => {
+    await reconcile([baseAgent({ tenants: ['tenant-a'], access: { roles: ['USER'] } })]);
+    expect(await Agent.countDocuments({ id: 'agent_global_support', tenantId: 'tenant-a' })).toBe(
+      1,
+    );
+
+    await reconcile([baseAgent({ tenants: 'system', access: { roles: ['USER'] } })]);
+
+    // The old tenant row must be removed (not soft-retired) so it can't shadow the tenantless row.
+    expect(await Agent.countDocuments({ id: 'agent_global_support', tenantId: 'tenant-a' })).toBe(
+      0,
+    );
+    expect(
+      await Agent.countDocuments({ id: 'agent_global_support', tenantId: { $exists: false } }),
+    ).toBe(1);
+  });
 });

--- a/packages/api/src/agents/global.spec.ts
+++ b/packages/api/src/agents/global.spec.ts
@@ -178,4 +178,18 @@ describe('reconcileGlobalAgents', () => {
     );
     expect(await grantsFor(agent!._id as Types.ObjectId)).toHaveLength(0);
   });
+
+  test('skips empty and reserved tenant ids without creating an unscoped row', async () => {
+    await reconcile([
+      baseAgent({ tenants: ['', '__SYSTEM__', 'tenant-a'], access: { roles: ['USER'] } }),
+    ]);
+
+    expect(await Agent.countDocuments({ id: 'agent_global_support', tenantId: 'tenant-a' })).toBe(
+      1,
+    );
+    // The empty/reserved ids must not fall through to a tenantless (system) upsert.
+    expect(
+      await Agent.countDocuments({ id: 'agent_global_support', tenantId: { $exists: false } }),
+    ).toBe(0);
+  });
 });

--- a/packages/api/src/agents/global.spec.ts
+++ b/packages/api/src/agents/global.spec.ts
@@ -142,4 +142,40 @@ describe('reconcileGlobalAgents', () => {
     expect(await Agent.countDocuments({ id: 'agent_global_broken' })).toBe(0);
     expect(await Agent.countDocuments({ id: 'agent_global_support' })).toBe(1);
   });
+
+  test('derives mcpServerNames from configured MCP tools', async () => {
+    await reconcile([baseAgent({ tools: ['search_mcp_tavily'], access: { public: true } })]);
+
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    expect(agent?.mcpServerNames).toEqual(['tavily']);
+  });
+
+  test('ignores invalid principal ids but still grants valid ones', async () => {
+    const validUser = new Types.ObjectId().toString();
+    await reconcile([baseAgent({ access: { users: [validUser, 'not-an-objectid'] } })]);
+
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    const grants = await grantsFor(agent!._id as Types.ObjectId);
+    expect(grants).toHaveLength(1);
+    expect(String(grants[0].principalId)).toBe(validUser);
+  });
+
+  test('seeds tenant-scoped agents with grants and retires them when the tenant leaves config', async () => {
+    await reconcile([baseAgent({ tenants: ['tenant-a'], access: { roles: ['USER'] } })]);
+
+    const agent = await Agent.findOne({
+      id: 'agent_global_support',
+      tenantId: 'tenant-a',
+    }).lean<IAgent>();
+    expect(agent).toBeTruthy();
+    // Role resolves under the system context even though the write ran in the tenant context.
+    expect(await grantsFor(agent!._id as Types.ObjectId)).toHaveLength(1);
+
+    await reconcile([]);
+
+    expect(await Agent.countDocuments({ id: 'agent_global_support', tenantId: 'tenant-a' })).toBe(
+      1,
+    );
+    expect(await grantsFor(agent!._id as Types.ObjectId)).toHaveLength(0);
+  });
 });

--- a/packages/api/src/agents/global.spec.ts
+++ b/packages/api/src/agents/global.spec.ts
@@ -1,0 +1,145 @@
+import mongoose, { Types, Model } from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createModels, createMethods } from '@librechat/data-schemas';
+import { ResourceType, PrincipalType } from 'librechat-data-provider';
+import type { TGlobalAgent } from 'librechat-data-provider';
+import type { IAgent } from '@librechat/data-schemas';
+import { reconcileGlobalAgents } from './global';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: { error: jest.fn(), warn: jest.fn(), debug: jest.fn(), info: jest.fn() },
+}));
+
+let mongoServer: MongoMemoryServer;
+let Agent: Model<IAgent>;
+let AclEntry: Model<Record<string, unknown>>;
+let dbMethods: ReturnType<typeof createMethods>;
+
+const methods = () => ({
+  findRoleByIdentifier: dbMethods.findRoleByIdentifier,
+  grantPermission: dbMethods.grantPermission,
+  findEntriesByResource: dbMethods.findEntriesByResource,
+  deleteAclEntries: dbMethods.deleteAclEntries,
+});
+
+const reconcile = (globalAgents: TGlobalAgent[]) =>
+  reconcileGlobalAgents({ globalAgents, methods: methods(), AgentModel: Agent });
+
+const grantsFor = async (resourceId: Types.ObjectId) =>
+  AclEntry.find({ resourceType: ResourceType.AGENT, resourceId }).lean();
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  Agent = mongoose.models.Agent as Model<IAgent>;
+  AclEntry = mongoose.models.AclEntry as Model<Record<string, unknown>>;
+  dbMethods = createMethods(mongoose);
+  await dbMethods.seedDefaultRoles();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await Agent.deleteMany({});
+  await AclEntry.deleteMany({});
+});
+
+const baseAgent = (overrides: Partial<TGlobalAgent> = {}): TGlobalAgent =>
+  ({
+    id: 'agent_global_support',
+    name: 'Support',
+    provider: 'openAI',
+    model: 'gpt-4o',
+    instructions: 'Help the user.',
+    ...overrides,
+  }) as TGlobalAgent;
+
+describe('reconcileGlobalAgents', () => {
+  test('seeds an immutable, system-authored agent doc', async () => {
+    await reconcile([baseAgent({ access: { roles: ['USER'] } })]);
+
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    expect(agent).toBeTruthy();
+    expect(agent?.isSystem).toBe(true);
+    expect(agent?.author?.toString()).toBe('000000000000000000000000');
+    expect(agent?.provider).toBe('openAI');
+    expect(agent?.model).toBe('gpt-4o');
+    expect(agent?.instructions).toBe('Help the user.');
+    expect(agent?.tenantId).toBeUndefined();
+  });
+
+  test('grants ACL entries matching the visibility spec', async () => {
+    const groupId = new Types.ObjectId().toString();
+    const userId = new Types.ObjectId().toString();
+    await reconcile([
+      baseAgent({ access: { public: true, roles: ['USER'], groups: [groupId], users: [userId] } }),
+    ]);
+
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    const grants = await grantsFor(agent!._id as Types.ObjectId);
+    const byType = grants.map((g) => g.principalType).sort();
+    expect(byType).toEqual(
+      [PrincipalType.GROUP, PrincipalType.PUBLIC, PrincipalType.ROLE, PrincipalType.USER].sort(),
+    );
+    const roleGrant = grants.find((g) => g.principalType === PrincipalType.ROLE);
+    expect(roleGrant?.principalId).toBe('USER');
+  });
+
+  test('is idempotent across re-runs (no duplicate docs or grants)', async () => {
+    const cfg = [baseAgent({ access: { public: true } })];
+    await reconcile(cfg);
+    await reconcile(cfg);
+
+    expect(await Agent.countDocuments({ id: 'agent_global_support' })).toBe(1);
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    const grants = await grantsFor(agent!._id as Types.ObjectId);
+    expect(grants).toHaveLength(1);
+    expect(grants[0].principalType).toBe(PrincipalType.PUBLIC);
+  });
+
+  test('reconciles grants when the visibility spec changes', async () => {
+    const groupId = new Types.ObjectId().toString();
+    await reconcile([baseAgent({ access: { public: true } })]);
+    await reconcile([baseAgent({ access: { groups: [groupId] } })]);
+
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    const grants = await grantsFor(agent!._id as Types.ObjectId);
+    expect(grants).toHaveLength(1);
+    expect(grants[0].principalType).toBe(PrincipalType.GROUP);
+    expect(String(grants[0].principalId)).toBe(groupId);
+  });
+
+  test('merges config field overrides onto the existing doc', async () => {
+    await reconcile([baseAgent({ access: { public: true } })]);
+    await reconcile([
+      baseAgent({ instructions: 'Updated instructions.', access: { public: true } }),
+    ]);
+
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    expect(agent?.instructions).toBe('Updated instructions.');
+  });
+
+  test('soft-retires an agent removed from config (revokes grants, keeps doc)', async () => {
+    await reconcile([baseAgent({ access: { public: true } })]);
+    const agent = await Agent.findOne({ id: 'agent_global_support' }).lean<IAgent>();
+    expect(await grantsFor(agent!._id as Types.ObjectId)).toHaveLength(1);
+
+    await reconcile([]);
+
+    expect(await Agent.countDocuments({ id: 'agent_global_support' })).toBe(1);
+    expect(await grantsFor(agent!._id as Types.ObjectId)).toHaveLength(0);
+  });
+
+  test('skips invalid entries without throwing, still seeds valid ones', async () => {
+    const invalid = { id: 'agent_global_broken', name: 'Broken' } as unknown as TGlobalAgent;
+    await reconcile([invalid, baseAgent({ access: { public: true } })]);
+
+    expect(await Agent.countDocuments({ id: 'agent_global_broken' })).toBe(0);
+    expect(await Agent.countDocuments({ id: 'agent_global_support' })).toBe(1);
+  });
+});

--- a/packages/api/src/agents/global.ts
+++ b/packages/api/src/agents/global.ts
@@ -1,0 +1,286 @@
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import { logger, runAsSystem, tenantStorage } from '@librechat/data-schemas';
+import { AccessRoleIds, ResourceType, PrincipalType } from 'librechat-data-provider';
+import type {
+  IAgent,
+  IAccessRole,
+  AclEntryMethods,
+  AccessRoleMethods,
+} from '@librechat/data-schemas';
+import type { TGlobalAgent, TGlobalAgentAccess } from 'librechat-data-provider';
+import type { Model, FilterQuery } from 'mongoose';
+import { agentCreateSchema } from './validation';
+
+/** Zero ObjectId used as the author of config-defined system agents (no human owner). */
+const SYSTEM_USER_ID = '000000000000000000000000';
+
+type AgentCreateData = z.infer<typeof agentCreateSchema>;
+
+/** DB methods the reconciler needs, injected from `/api` (mirrors `migration.ts`). */
+export interface GlobalAgentMethods {
+  findRoleByIdentifier: AccessRoleMethods['findRoleByIdentifier'];
+  grantPermission: AclEntryMethods['grantPermission'];
+  findEntriesByResource: AclEntryMethods['findEntriesByResource'];
+  deleteAclEntries: AclEntryMethods['deleteAclEntries'];
+}
+
+export interface ReconcileGlobalAgentsParams {
+  globalAgents?: TGlobalAgent[] | null;
+  methods: GlobalAgentMethods;
+  AgentModel: Model<IAgent>;
+}
+
+type AgentScope = 'system' | 'tenant';
+
+interface ParsedGlobalAgent {
+  id: string;
+  access?: TGlobalAgentAccess;
+  tenants: 'system' | string[];
+  agentData: AgentCreateData;
+}
+
+interface DesiredPrincipal {
+  type: PrincipalType;
+  principalId: string | null;
+  accessRoleId: string;
+}
+
+interface ReconcileScopeParams {
+  entries: ParsedGlobalAgent[];
+  scope: AgentScope;
+  methods: GlobalAgentMethods;
+  AgentModel: Model<IAgent>;
+  roleCache: Map<string, IAccessRole | null>;
+}
+
+/** Validate one config entry: split control fields off, validate the agent body with the same
+ *  `agentCreateSchema` the UI posts to `POST /agents`. Returns `null` (logged) on invalid entries. */
+function validateEntry(raw: TGlobalAgent): ParsedGlobalAgent | null {
+  const { id, access, tenants, ...body } = raw;
+  try {
+    const agentData = agentCreateSchema.parse(body);
+    return { id, access, tenants: tenants ?? 'system', agentData };
+  } catch (error) {
+    logger.error(`[GlobalAgents] Skipping invalid global agent "${id}":`, error);
+    return null;
+  }
+}
+
+function principalKey(type: string, principalId: string | null): string {
+  return `${type}:${principalId ?? ''}`;
+}
+
+/** Translate the config visibility spec into the desired ACL principal grants. */
+function buildDesiredPrincipals(access?: TGlobalAgentAccess): DesiredPrincipal[] {
+  if (!access) {
+    return [];
+  }
+  const accessRoleId =
+    access.level === 'editor' ? AccessRoleIds.AGENT_EDITOR : AccessRoleIds.AGENT_VIEWER;
+  const principals: DesiredPrincipal[] = [];
+  if (access.public === true) {
+    principals.push({ type: PrincipalType.PUBLIC, principalId: null, accessRoleId });
+  }
+  for (const role of access.roles ?? []) {
+    principals.push({ type: PrincipalType.ROLE, principalId: role, accessRoleId });
+  }
+  for (const group of access.groups ?? []) {
+    principals.push({ type: PrincipalType.GROUP, principalId: group, accessRoleId });
+  }
+  for (const user of access.users ?? []) {
+    principals.push({ type: PrincipalType.USER, principalId: user, accessRoleId });
+  }
+  return principals;
+}
+
+/** System-scope rows are tenantless (`$exists: false`); tenant-scope rows are matched by id and the
+ *  tenant-isolation plugin injects the tenantId equality for the active context. */
+function buildAgentFilter(id: string, scope: AgentScope): FilterQuery<IAgent> {
+  return scope === 'system' ? { id, tenantId: { $exists: false } } : { id };
+}
+
+/** Idempotent upsert of the agent doc. `$set` merges the config body so operators can override
+ *  specific fields; `author`/`isSystem` are always enforced. Returns the resource `_id`. */
+async function upsertAgent({
+  AgentModel,
+  entry,
+  scope,
+}: {
+  AgentModel: Model<IAgent>;
+  entry: ParsedGlobalAgent;
+  scope: AgentScope;
+}): Promise<Types.ObjectId | null> {
+  const now = new Date();
+  const doc = await AgentModel.findOneAndUpdate(
+    buildAgentFilter(entry.id, scope),
+    {
+      $set: {
+        ...entry.agentData,
+        isSystem: true,
+        author: new Types.ObjectId(SYSTEM_USER_ID),
+      },
+      $setOnInsert: { id: entry.id, createdAt: now },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  )
+    .select('_id')
+    .lean<{ _id: Types.ObjectId }>();
+  return doc?._id ?? null;
+}
+
+async function resolveRole(
+  methods: GlobalAgentMethods,
+  roleCache: Map<string, IAccessRole | null>,
+  accessRoleId: string,
+): Promise<IAccessRole | null> {
+  if (roleCache.has(accessRoleId)) {
+    return roleCache.get(accessRoleId) ?? null;
+  }
+  const role = await methods.findRoleByIdentifier(accessRoleId);
+  roleCache.set(accessRoleId, role);
+  return role;
+}
+
+/** Grant the desired principals and revoke any existing grant no longer in the config. */
+async function reconcileGrants({
+  methods,
+  resourceId,
+  access,
+  roleCache,
+}: {
+  methods: GlobalAgentMethods;
+  resourceId: Types.ObjectId;
+  access?: TGlobalAgentAccess;
+  roleCache: Map<string, IAccessRole | null>;
+}): Promise<void> {
+  const desired = buildDesiredPrincipals(access);
+  const desiredKeys = new Set<string>();
+
+  for (const principal of desired) {
+    const role = await resolveRole(methods, roleCache, principal.accessRoleId);
+    if (!role) {
+      logger.warn(
+        `[GlobalAgents] Access role "${principal.accessRoleId}" not found; skipping grant.`,
+      );
+      continue;
+    }
+    desiredKeys.add(principalKey(principal.type, principal.principalId));
+    await methods.grantPermission(
+      principal.type,
+      principal.principalId,
+      ResourceType.AGENT,
+      resourceId,
+      role.permBits,
+      undefined,
+      undefined,
+      role._id as Types.ObjectId,
+    );
+  }
+
+  const existing = await methods.findEntriesByResource(ResourceType.AGENT, resourceId);
+  const staleIds = existing
+    .filter(
+      (entry) =>
+        !desiredKeys.has(
+          principalKey(entry.principalType, entry.principalId ? String(entry.principalId) : null),
+        ),
+    )
+    .map((entry) => entry._id);
+
+  if (staleIds.length > 0) {
+    await methods.deleteAclEntries({ _id: { $in: staleIds } });
+  }
+}
+
+/** Soft-retire seeded agents no longer present in config: revoke every grant (invisible to all)
+ *  while keeping the doc so chat history survives and re-adding to config re-enables it. */
+async function retireOrphans({
+  AgentModel,
+  methods,
+  expectedIds,
+  scope,
+}: {
+  AgentModel: Model<IAgent>;
+  methods: GlobalAgentMethods;
+  expectedIds: Set<string>;
+  scope: AgentScope;
+}): Promise<void> {
+  const filter: FilterQuery<IAgent> =
+    scope === 'system' ? { isSystem: true, tenantId: { $exists: false } } : { isSystem: true };
+  const seeded = await AgentModel.find(filter)
+    .select('_id id')
+    .lean<{ _id: Types.ObjectId; id: string }[]>();
+
+  for (const agent of seeded) {
+    if (expectedIds.has(agent.id)) {
+      continue;
+    }
+    await methods.deleteAclEntries({ resourceType: ResourceType.AGENT, resourceId: agent._id });
+    logger.info(`[GlobalAgents] Retired global agent no longer in config: ${agent.id}`);
+  }
+}
+
+async function reconcileScope({
+  entries,
+  scope,
+  methods,
+  AgentModel,
+  roleCache,
+}: ReconcileScopeParams): Promise<void> {
+  const expectedIds = new Set(entries.map((entry) => entry.id));
+  for (const entry of entries) {
+    const resourceId = await upsertAgent({ AgentModel, entry, scope });
+    if (!resourceId) {
+      continue;
+    }
+    await reconcileGrants({ methods, resourceId, access: entry.access, roleCache });
+    logger.info(`[GlobalAgents] Reconciled global agent: ${entry.id}`);
+  }
+  await retireOrphans({ AgentModel, methods, expectedIds, scope });
+}
+
+/**
+ * Reconcile config-defined global agents at boot: upsert each to its stable id, reconcile its ACL
+ * grants to match the visibility spec, and soft-retire any seeded agent dropped from config.
+ * Manages its own tenant contexts — `runAsSystem` for `tenants: 'system'` (a single tenantless row)
+ * and a per-tenant context for explicit tenant lists — so callers need not wrap it.
+ */
+export async function reconcileGlobalAgents({
+  globalAgents,
+  methods,
+  AgentModel,
+}: ReconcileGlobalAgentsParams): Promise<void> {
+  const entries = (globalAgents ?? [])
+    .map(validateEntry)
+    .filter((entry): entry is ParsedGlobalAgent => entry !== null);
+
+  const roleCache = new Map<string, IAccessRole | null>();
+
+  const systemEntries = entries.filter((entry) => entry.tenants === 'system');
+  const tenantEntries = new Map<string, ParsedGlobalAgent[]>();
+  for (const entry of entries) {
+    if (entry.tenants === 'system') {
+      continue;
+    }
+    for (const tenantId of entry.tenants) {
+      const list = tenantEntries.get(tenantId) ?? [];
+      list.push(entry);
+      tenantEntries.set(tenantId, list);
+    }
+  }
+
+  try {
+    await runAsSystem(() =>
+      reconcileScope({ entries: systemEntries, scope: 'system', methods, AgentModel, roleCache }),
+    );
+
+    for (const [tenantId, list] of tenantEntries) {
+      await tenantStorage.run({ tenantId }, () =>
+        reconcileScope({ entries: list, scope: 'tenant', methods, AgentModel, roleCache }),
+      );
+    }
+  } catch (error) {
+    logger.error('[GlobalAgents] Failed to reconcile global agents:', error);
+  }
+}

--- a/packages/api/src/agents/global.ts
+++ b/packages/api/src/agents/global.ts
@@ -61,6 +61,7 @@ interface ReconcileScopeParams {
   methods: GlobalAgentMethods;
   AgentModel: Model<IAgent>;
   roleCache: Map<string, IAccessRole | null>;
+  systemScopedIds: Set<string>;
 }
 
 /** Validate one config entry: split control fields off, validate the agent body with the same
@@ -225,11 +226,13 @@ async function retireOrphans({
   AgentModel,
   methods,
   expectedIds,
+  systemScopedIds,
   scope,
 }: {
   AgentModel: Model<IAgent>;
   methods: GlobalAgentMethods;
   expectedIds: Set<string>;
+  systemScopedIds: Set<string>;
   scope: AgentScope;
 }): Promise<void> {
   const filter: FilterQuery<IAgent> =
@@ -240,6 +243,15 @@ async function retireOrphans({
 
   for (const agent of seeded) {
     if (expectedIds.has(agent.id)) {
+      continue;
+    }
+    /* If a tenant-scoped orphan's id is now configured as a `tenants: 'system'` global, hard-delete
+     * it: a soft-retired (grant-revoked) tenant row would still be found by tenant-scoped reads and
+     * shadow the tenantless system row, so the miss-only access fallback would never resolve it. */
+    if (scope === 'tenant' && systemScopedIds.has(agent.id)) {
+      await AgentModel.deleteOne({ _id: agent._id });
+      await methods.deleteAclEntries({ resourceType: ResourceType.AGENT, resourceId: agent._id });
+      logger.info(`[GlobalAgents] Removed tenant-scoped shadow of system global: ${agent.id}`);
       continue;
     }
     await methods.deleteAclEntries({ resourceType: ResourceType.AGENT, resourceId: agent._id });
@@ -253,6 +265,7 @@ async function reconcileScope({
   methods,
   AgentModel,
   roleCache,
+  systemScopedIds,
 }: ReconcileScopeParams): Promise<void> {
   const expectedIds = new Set(entries.map((entry) => entry.id));
   for (const entry of entries) {
@@ -267,7 +280,7 @@ async function reconcileScope({
       logger.error(`[GlobalAgents] Failed to reconcile global agent "${entry.id}":`, error);
     }
   }
-  await retireOrphans({ AgentModel, methods, expectedIds, scope });
+  await retireOrphans({ AgentModel, methods, expectedIds, systemScopedIds, scope });
 }
 
 /**
@@ -288,6 +301,7 @@ export async function reconcileGlobalAgents({
   const roleCache = new Map<string, IAccessRole | null>();
 
   const systemEntries = entries.filter((entry) => entry.tenants === 'system');
+  const systemScopedIds = new Set(systemEntries.map((entry) => entry.id));
   const tenantEntries = new Map<string, ParsedGlobalAgent[]>();
   for (const entry of entries) {
     if (entry.tenants === 'system') {
@@ -309,7 +323,14 @@ export async function reconcileGlobalAgents({
 
   try {
     await runAsSystem(() =>
-      reconcileScope({ entries: systemEntries, scope: 'system', methods, AgentModel, roleCache }),
+      reconcileScope({
+        entries: systemEntries,
+        scope: 'system',
+        methods,
+        AgentModel,
+        roleCache,
+        systemScopedIds,
+      }),
     );
 
     /* Visit every tenant that either has config entries now OR was previously seeded, so a tenant
@@ -328,7 +349,14 @@ export async function reconcileGlobalAgents({
     for (const tenantId of tenantIds) {
       const list = tenantEntries.get(tenantId) ?? [];
       await tenantStorage.run({ tenantId }, () =>
-        reconcileScope({ entries: list, scope: 'tenant', methods, AgentModel, roleCache }),
+        reconcileScope({
+          entries: list,
+          scope: 'tenant',
+          methods,
+          AgentModel,
+          roleCache,
+          systemScopedIds,
+        }),
       );
     }
   } catch (error) {

--- a/packages/api/src/agents/global.ts
+++ b/packages/api/src/agents/global.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import { AccessRoleIds, ResourceType, PrincipalType } from 'librechat-data-provider';
-import { logger, runAsSystem, tenantStorage, extractMCPServerNames } from '@librechat/data-schemas';
+import {
+  logger,
+  runAsSystem,
+  tenantStorage,
+  SYSTEM_TENANT_ID,
+  extractMCPServerNames,
+} from '@librechat/data-schemas';
 import type {
   IAgent,
   IAccessRole,
@@ -288,6 +294,13 @@ export async function reconcileGlobalAgents({
       continue;
     }
     for (const tenantId of entry.tenants) {
+      /* An empty/whitespace or reserved sentinel tenant id resolves to an unscoped/system context
+       * in tenantStorage — which would upsert across tenants and let retireOrphans revoke every
+       * system agent's grants. Skip them so a misconfig can't nuke unrelated tenants. */
+      if (!tenantId.trim() || tenantId === SYSTEM_TENANT_ID) {
+        logger.warn(`[GlobalAgents] Ignoring invalid tenant id for global agent "${entry.id}".`);
+        continue;
+      }
       const list = tenantEntries.get(tenantId) ?? [];
       list.push(entry);
       tenantEntries.set(tenantId, list);

--- a/packages/api/src/agents/global.ts
+++ b/packages/api/src/agents/global.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Types } from 'mongoose';
-import { logger, runAsSystem, tenantStorage } from '@librechat/data-schemas';
 import { AccessRoleIds, ResourceType, PrincipalType } from 'librechat-data-provider';
+import { logger, runAsSystem, tenantStorage, extractMCPServerNames } from '@librechat/data-schemas';
 import type {
   IAgent,
   IAccessRole,
@@ -14,6 +14,9 @@ import { agentCreateSchema } from './validation';
 
 /** Zero ObjectId used as the author of config-defined system agents (no human owner). */
 const SYSTEM_USER_ID = '000000000000000000000000';
+
+/** User/group principals in the config must be 24-char ObjectId hex; grantPermission casts them. */
+const OBJECT_ID_RE = /^[a-f\d]{24}$/i;
 
 type AgentCreateData = z.infer<typeof agentCreateSchema>;
 
@@ -86,9 +89,21 @@ function buildDesiredPrincipals(access?: TGlobalAgentAccess): DesiredPrincipal[]
     principals.push({ type: PrincipalType.ROLE, principalId: role, accessRoleId });
   }
   for (const group of access.groups ?? []) {
+    if (!OBJECT_ID_RE.test(group)) {
+      logger.warn(
+        `[GlobalAgents] Ignoring invalid group id "${group}" (expected a 24-char ObjectId).`,
+      );
+      continue;
+    }
     principals.push({ type: PrincipalType.GROUP, principalId: group, accessRoleId });
   }
   for (const user of access.users ?? []) {
+    if (!OBJECT_ID_RE.test(user)) {
+      logger.warn(
+        `[GlobalAgents] Ignoring invalid user id "${user}" (expected a 24-char ObjectId).`,
+      );
+      continue;
+    }
     principals.push({ type: PrincipalType.USER, principalId: user, accessRoleId });
   }
   return principals;
@@ -118,6 +133,9 @@ async function upsertAgent({
       $set: {
         ...entry.agentData,
         isSystem: true,
+        /* The direct upsert skips createAgent's derivation, so keep mcpServerNames in sync with
+         * tools — the MCP registry exposes servers to users via shared agents through this field. */
+        mcpServerNames: extractMCPServerNames(entry.agentData.tools),
         author: new Types.ObjectId(SYSTEM_USER_ID),
       },
       $setOnInsert: { id: entry.id, createdAt: now },
@@ -137,7 +155,9 @@ async function resolveRole(
   if (roleCache.has(accessRoleId)) {
     return roleCache.get(accessRoleId) ?? null;
   }
-  const role = await methods.findRoleByIdentifier(accessRoleId);
+  /* Default access roles are seeded tenantless; AccessRole is tenant-isolated, so a lookup inside a
+   * tenant context misses them. Always resolve under the system context regardless of agent scope. */
+  const role = await runAsSystem(() => methods.findRoleByIdentifier(accessRoleId));
   roleCache.set(accessRoleId, role);
   return role;
 }
@@ -230,12 +250,16 @@ async function reconcileScope({
 }: ReconcileScopeParams): Promise<void> {
   const expectedIds = new Set(entries.map((entry) => entry.id));
   for (const entry of entries) {
-    const resourceId = await upsertAgent({ AgentModel, entry, scope });
-    if (!resourceId) {
-      continue;
+    try {
+      const resourceId = await upsertAgent({ AgentModel, entry, scope });
+      if (!resourceId) {
+        continue;
+      }
+      await reconcileGrants({ methods, resourceId, access: entry.access, roleCache });
+      logger.info(`[GlobalAgents] Reconciled global agent: ${entry.id}`);
+    } catch (error) {
+      logger.error(`[GlobalAgents] Failed to reconcile global agent "${entry.id}":`, error);
     }
-    await reconcileGrants({ methods, resourceId, access: entry.access, roleCache });
-    logger.info(`[GlobalAgents] Reconciled global agent: ${entry.id}`);
   }
   await retireOrphans({ AgentModel, methods, expectedIds, scope });
 }
@@ -275,7 +299,14 @@ export async function reconcileGlobalAgents({
       reconcileScope({ entries: systemEntries, scope: 'system', methods, AgentModel, roleCache }),
     );
 
-    for (const [tenantId, list] of tenantEntries) {
+    /* Visit every tenant that either has config entries now OR was previously seeded, so a tenant
+     * (or entry) removed from config still gets its stale grants retired in that tenant's context. */
+    const seededTenantIds = (await runAsSystem(() =>
+      AgentModel.distinct('tenantId', { isSystem: true, tenantId: { $exists: true, $ne: null } }),
+    )) as string[];
+    const tenantIds = new Set<string>([...tenantEntries.keys(), ...seededTenantIds]);
+    for (const tenantId of tenantIds) {
+      const list = tenantEntries.get(tenantId) ?? [];
       await tenantStorage.run({ tenantId }, () =>
         reconcileScope({ entries: list, scope: 'tenant', methods, AgentModel, roleCache }),
       );

--- a/packages/api/src/agents/global.ts
+++ b/packages/api/src/agents/global.ts
@@ -313,10 +313,17 @@ export async function reconcileGlobalAgents({
     );
 
     /* Visit every tenant that either has config entries now OR was previously seeded, so a tenant
-     * (or entry) removed from config still gets its stale grants retired in that tenant's context. */
-    const seededTenantIds = (await runAsSystem(() =>
-      AgentModel.distinct('tenantId', { isSystem: true, tenantId: { $exists: true, $ne: null } }),
-    )) as string[];
+     * (or entry) removed from config still gets its stale grants retired in that tenant's context.
+     * Await the query INSIDE the callback: runAsSystem only holds the ALS system context while the
+     * callback runs, so returning the lazy Mongoose thenable would execute it without that context
+     * (and throw under TENANT_ISOLATION_STRICT). */
+    const seededTenantIds = (await runAsSystem(async () => {
+      const ids = await AgentModel.distinct('tenantId', {
+        isSystem: true,
+        tenantId: { $exists: true, $ne: null },
+      });
+      return ids;
+    })) as string[];
     const tenantIds = new Set<string>([...tenantEntries.keys(), ...seededTenantIds]);
     for (const tenantId of tenantIds) {
       const list = tenantEntries.get(tenantId) ?? [];

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -14,6 +14,7 @@ export * from './legacy';
 export * from './memory';
 export * from './orphans';
 export * from './migration';
+export * from './global';
 export * from './parameters';
 export * from './openai';
 export * from './transactions';

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -15,6 +15,7 @@ export * from './memory';
 export * from './orphans';
 export * from './migration';
 export * from './global';
+export * from './systemGlobal';
 export * from './parameters';
 export * from './openai';
 export * from './transactions';

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -1,4 +1,4 @@
-import { logger } from '@librechat/data-schemas';
+import { logger, runAsSystem } from '@librechat/data-schemas';
 import {
   Tools,
   Constants,
@@ -185,7 +185,14 @@ export async function loadAgent(
   if (isEphemeralAgentId(agent_id)) {
     return loadEphemeralAgent({ req, spec, endpoint, model_parameters }, deps);
   }
-  const agent = await deps.getAgent({ id: agent_id });
+  let agent = await deps.getAgent({ id: agent_id });
+
+  /* Config-defined global agents scoped `tenants: 'system'` are stored as a single tenantless
+   * row that a tenant-scoped read can't see. On a miss for a global id, retry under the system
+   * context so the shared row resolves across every tenant. */
+  if (!agent && agent_id.startsWith(Constants.GLOBAL_AGENT_PREFIX)) {
+    agent = await runAsSystem(() => deps.getAgent({ id: agent_id }));
+  }
 
   if (!agent) {
     return null;

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -21,7 +21,10 @@ const { mcp_all, mcp_delimiter } = Constants;
 type ModelParametersWithPromptPrefix = AgentModelParameters & { promptPrefix?: string | null };
 
 export interface LoadAgentDeps {
-  getAgent: (searchParameter: { id: string }) => Promise<Agent | null>;
+  getAgent: (searchParameter: {
+    id: string;
+    tenantId?: { $exists: boolean };
+  }) => Promise<Agent | null>;
   getMCPServerTools: (
     userId: string,
     serverName: string,
@@ -189,9 +192,10 @@ export async function loadAgent(
 
   /* Config-defined global agents scoped `tenants: 'system'` are stored as a single tenantless
    * row that a tenant-scoped read can't see. On a miss for a global id, retry under the system
-   * context so the shared row resolves across every tenant. */
+   * context — pinned to the tenantless row so it can never resolve another tenant's explicit-scope
+   * row of the same id. */
   if (!agent && agent_id.startsWith(Constants.GLOBAL_AGENT_PREFIX)) {
-    agent = await runAsSystem(() => deps.getAgent({ id: agent_id }));
+    agent = await runAsSystem(() => deps.getAgent({ id: agent_id, tenantId: { $exists: false } }));
   }
 
   if (!agent) {

--- a/packages/api/src/agents/systemGlobal.ts
+++ b/packages/api/src/agents/systemGlobal.ts
@@ -1,0 +1,99 @@
+import { Constants, ResourceType } from 'librechat-data-provider';
+import { logger, runAsSystem, ResourceCapabilityMap } from '@librechat/data-schemas';
+import type { Agent } from 'librechat-data-provider';
+import type { Types } from 'mongoose';
+
+/**
+ * Config-defined `tenants: 'system'` global agents are stored as a single tenantless row/grant that
+ * a tenant-scoped read can't see. This module centralizes the cross-tenant resolution/authorization
+ * so every access and read path routes through one correct implementation. The `/api` service is a
+ * thin wrapper that binds the runtime dependencies.
+ */
+
+type AgentFilter = { id: string; tenantId?: { $exists: boolean } };
+type Principal = { principalType: string; principalId?: string | Types.ObjectId };
+type AccessRequestUser = { id: string; role: string };
+
+export interface SystemGlobalAccessDeps {
+  getAgent: (filter: AgentFilter) => Promise<Agent | null>;
+  getUserPrincipals: (params: { userId: string; role: string }) => Promise<Principal[]>;
+  hasPermission: (
+    principals: Principal[],
+    resourceType: string,
+    resourceId: string | Types.ObjectId,
+    permissionBit: number,
+  ) => Promise<boolean>;
+  hasCapability: (user: AccessRequestUser, capability: string) => Promise<boolean>;
+}
+
+export type SystemGlobalAuthResult =
+  | { status: 'not_found' }
+  | { status: 'forbidden' }
+  | { status: 'ok'; agent: Agent };
+
+export const isSystemGlobalId = (agentId?: string | null): boolean =>
+  typeof agentId === 'string' && agentId.startsWith(Constants.GLOBAL_AGENT_PREFIX);
+
+/**
+ * Refetch a global agent under the system context, pinned to the tenantless row, when the
+ * tenant-scoped fetch missed it. `fetchTenant`/`fetchSystem` let callers reuse their own accessor.
+ */
+export async function withSystemGlobalFallback<T>(
+  agentId: string,
+  fetchTenant: () => Promise<T>,
+  fetchSystem: () => Promise<T>,
+): Promise<T> {
+  const doc = await fetchTenant();
+  if (doc || !isSystemGlobalId(agentId)) {
+    return doc;
+  }
+  return runAsSystem(fetchSystem);
+}
+
+/** Resolve the tenantless system-scope row for a global id (or null). */
+export const resolveSystemGlobalAgent = (
+  deps: SystemGlobalAccessDeps,
+  agentId: string,
+): Promise<Agent | null> =>
+  runAsSystem(() => deps.getAgent({ id: agentId, tenantId: { $exists: false } }));
+
+/**
+ * Authorize a tenantless system-scope global agent. Principals are built in the REQUEST tenant
+ * context (so group memberships reflect the current tenant); the agent + ACL lookup run under the
+ * system context. Preserves the MANAGE_AGENTS capability bypass for parity with `canAccessResource`.
+ */
+export async function authorizeSystemGlobalAgent(
+  deps: SystemGlobalAccessDeps,
+  {
+    agentId,
+    requiredPermission,
+    req,
+  }: { agentId: string; requiredPermission: number; req: { user: AccessRequestUser } },
+): Promise<SystemGlobalAuthResult> {
+  const principals = await deps.getUserPrincipals({ userId: req.user.id, role: req.user.role });
+  return runAsSystem(async () => {
+    const agent = await deps.getAgent({ id: agentId, tenantId: { $exists: false } });
+    if (!agent?._id) {
+      return { status: 'not_found' };
+    }
+    const cap = ResourceCapabilityMap[ResourceType.AGENT];
+    let hasCap = false;
+    try {
+      hasCap = cap != null && (await deps.hasCapability(req.user, cap));
+    } catch (err) {
+      logger.warn(
+        `[systemGlobalAgent] capability check failed, denying bypass: ${(err as Error).message}`,
+      );
+    }
+    if (hasCap) {
+      return { status: 'ok', agent };
+    }
+    const allowed = await deps.hasPermission(
+      principals,
+      ResourceType.AGENT,
+      agent._id,
+      requiredPermission,
+    );
+    return { status: allowed ? 'ok' : 'forbidden', agent };
+  });
+}

--- a/packages/api/src/agents/systemGlobal.ts
+++ b/packages/api/src/agents/systemGlobal.ts
@@ -12,7 +12,7 @@ import type { Types } from 'mongoose';
 
 type AgentFilter = { id: string; tenantId?: { $exists: boolean } };
 type Principal = { principalType: string; principalId?: string | Types.ObjectId };
-type AccessRequestUser = { id: string; role: string };
+type AccessRequestUser = { id: string; role: string; tenantId?: string };
 
 export interface SystemGlobalAccessDeps {
   getAgent: (filter: AgentFilter) => Promise<Agent | null>;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -898,7 +898,7 @@ export const globalAgentSchema = z
   .object({
     id: z.string().regex(/^agent_global_[A-Za-z0-9_-]+$/),
     access: globalAgentAccessSchema.optional(),
-    tenants: z.union([z.literal('system'), z.array(z.string())]).optional(),
+    tenants: z.union([z.literal('system'), z.array(z.string().trim().min(1))]).optional(),
   })
   .passthrough();
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -876,6 +876,34 @@ export const checkpointerSchema = z
 
 export type TCheckpointerConfig = z.infer<typeof checkpointerSchema>;
 
+/** Visibility spec for a config-defined global agent, mirroring the ACL principal model. */
+export const globalAgentAccessSchema = z.object({
+  public: z.boolean().optional(),
+  roles: z.array(z.string()).optional(),
+  groups: z.array(z.string()).optional(),
+  users: z.array(z.string()).optional(),
+  level: z.enum(['viewer', 'editor']).optional(),
+});
+
+export type TGlobalAgentAccess = z.infer<typeof globalAgentAccessSchema>;
+
+/**
+ * A global agent declared in `librechat.yaml`. Only the control fields (`id`, `access`,
+ * `tenants`) are pinned here; the agent body is the same payload the UI sends to
+ * `POST /agents` and passes through untouched — an entry may be minimal (`id` + `provider`
+ * + `model`) or extensively override any field. The body is validated with `agentCreateSchema`
+ * in the boot-time reconciler, the single source of truth for the agent shape.
+ */
+export const globalAgentSchema = z
+  .object({
+    id: z.string().regex(/^agent_global_[A-Za-z0-9_-]+$/),
+    access: globalAgentAccessSchema.optional(),
+    tenants: z.union([z.literal('system'), z.array(z.string())]).optional(),
+  })
+  .passthrough();
+
+export type TGlobalAgent = z.infer<typeof globalAgentSchema>;
+
 export const agentsEndpointSchema = baseEndpointSchema
   .omit({ baseURL: true })
   .merge(
@@ -898,6 +926,8 @@ export const agentsEndpointSchema = baseEndpointSchema
         })
         .optional(),
       remoteApi: remoteApiSchema.optional(),
+      /** Config-defined global agents, seeded to stable ids at startup and immutable in the app. */
+      globalAgents: z.array(globalAgentSchema).optional(),
       /** Human-in-the-loop tool approval policy. Off by default. */
       toolApproval: toolApprovalPolicySchema,
       /** Durable checkpointer backing HITL resume. Defaults to the app's MongoDB
@@ -2712,6 +2742,8 @@ export enum Constants {
   LC_TRANSFER_TO_ = 'lc_transfer_to_',
   /** Placeholder Agent ID for Ephemeral Agents */
   EPHEMERAL_AGENT_ID = 'ephemeral',
+  /** Reserved id prefix marking a config-defined global agent. Still `agent_`-prefixed so it is treated as a real, persisted agent. */
+  GLOBAL_AGENT_PREFIX = 'agent_global_',
   /** Programmatic Tool Calling tool name */
   PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_code',
   /** Bash Programmatic Tool Calling tool name */

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -288,6 +288,8 @@ export type Agent = {
   artifacts?: ArtifactModes;
   recursion_limit?: number;
   isPublic?: boolean;
+  /** Config-defined global agent, seeded at boot and immutable in the app. */
+  isSystem?: boolean;
   version?: number;
   category?: string;
   support_contact?: SupportContact;

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -42,6 +42,7 @@ export {
   AUDIT_ACTION_CATEGORY,
 } from './types/admin';
 export { GENESIS_HASH, PLATFORM_CHAIN_KEY } from './schema/auditLog';
+export { extractMCPServerNames } from './methods/agent';
 export { default as logger } from './config/winston';
 export { default as meiliLogger } from './config/meiliLogger';
 export { redactMessage } from './config/parsers';

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -154,6 +154,22 @@ describe('Agent Methods', () => {
       expect(count).toBe(1);
     });
 
+    test('rejects file resource mutations on system (global) agents', async () => {
+      const agent = await createBasicAgent();
+      await Agent.updateOne({ id: agent.id }, { $set: { isSystem: true } });
+      const fileId = uuidv4();
+
+      await expect(
+        addAgentResourceFile({ agent_id: agent.id, tool_resource: 'file_search', file_id: fileId }),
+      ).rejects.toThrow(/managed by server configuration/);
+      await expect(
+        removeAgentResourceFiles({
+          agent_id: agent.id,
+          files: [{ tool_resource: 'file_search', file_id: fileId }],
+        }),
+      ).rejects.toThrow(/managed by server configuration/);
+    });
+
     test('should not duplicate tool_resource in tools if already present', async () => {
       const agent = await createBasicAgent();
       const fileId1 = uuidv4();

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -910,6 +910,7 @@ export function createAgentMethods(
       category: 1,
       support_contact: 1,
       is_promoted: 1,
+      isSystem: 1,
     };
 
     if (includeSkillConfig) {

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -611,6 +611,9 @@ export function createAgentMethods(
     if (!agent) {
       throw new Error('Agent not found for adding resource file');
     }
+    if (agent.isSystem) {
+      throw new Error('Global agents are managed by server configuration and cannot be modified');
+    }
     const fileIdsPath = `tool_resources.${tool_resource}.file_ids`;
     await Agent.updateOne(
       {
@@ -653,6 +656,11 @@ export function createAgentMethods(
   }): Promise<IAgent> {
     const Agent = mongoose.models.Agent as Model<IAgent>;
     const searchParameter = { id: agent_id };
+
+    const targetAgent = await getAgent(searchParameter);
+    if (targetAgent?.isSystem) {
+      throw new Error('Global agents are managed by server configuration and cannot be modified');
+    }
 
     const filesByResource = files.reduce(
       (acc: Record<string, string[]>, { tool_resource, file_id }) => {

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -47,7 +47,7 @@ export interface AgentDeps {
  * Extracts unique MCP server names from tools array.
  * Tools format: "toolName_mcp_serverName" or "sys__server__sys_mcp_serverName"
  */
-function extractMCPServerNames(tools: string[] | undefined | null): string[] {
+export function extractMCPServerNames(tools: string[] | undefined | null): string[] {
   if (!tools || !Array.isArray(tools)) {
     return [];
   }

--- a/packages/data-schemas/src/schema/agent.ts
+++ b/packages/data-schemas/src/schema/agent.ts
@@ -109,6 +109,12 @@ const agentSchema: Schema<IAgent> = new Schema<IAgent>(
       default: false,
       index: true,
     },
+    /** Config-defined global agent, seeded at boot and immutable in the app. */
+    isSystem: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
     /** MCP server names extracted from tools for efficient querying */
     mcpServerNames: {
       type: [String],

--- a/packages/data-schemas/src/types/agent.ts
+++ b/packages/data-schemas/src/types/agent.ts
@@ -44,6 +44,8 @@ export interface IAgent extends Omit<Document, 'model'> {
   category: string;
   support_contact?: ISupportContact;
   is_promoted?: boolean;
+  /** Config-defined global agent, seeded at boot and immutable in the app. */
+  isSystem?: boolean;
   /** MCP server names extracted from tools for efficient querying */
   mcpServerNames?: string[];
   /** Per-tool configuration (defer_loading, allowed_callers) */


### PR DESCRIPTION
## Summary

Adds **config-defined global agents**: server-managed agents declared in `librechat.yaml` under `endpoints.agents.globalAgents`, seeded to a stable id at startup, immutable in the app, shared via the existing ACL granularity, and tenant-scoped.

The config body is the **same payload the agent builder posts to `POST /agents`**, so an entry can be minimal (`id` + `provider` + `model`) or extensively override any agent field.

```yaml
endpoints:
  agents:
    globalAgents:
      - id: agent_global_assistant      # must start with `agent_global_`
        name: Company Assistant
        provider: openAI
        model: gpt-4o
        instructions: You are the shared company assistant.
        access:                          # existing ACL granularity; omit to seed but not share
          level: viewer                  # viewer (default) | editor
          roles: ["USER"]
          # public: true
          # groups: ["<groupId>"]
          # users: ["<userId>"]
        tenants: system                  # 'system' (default) | ["<tenantId>", ...]
```

## How it works

- **Config** (`data-provider`): `globalAgentSchema` pins only the control fields (`id`, `access`, `tenants`) and passes the agent body through; `agentCreateSchema` performs the authoritative validation in the reconciler (keeps `data-provider` free of the `@librechat/api` dependency). New `Constants.GLOBAL_AGENT_PREFIX`.
- **Immutability**: new indexed `isSystem` flag on the agent schema/type + `403` guards in the update/delete handlers. Guards are required because admins bypass per-resource ACL via the `MANAGE_AGENTS` capability. **Duplicate is allowed** and strips `isSystem` → a normal, editable user-owned copy.
- **Reconciler** (`@librechat/api` `reconcileGlobalAgents`, wired via `api/server/services/start/globalAgents.js` at boot): idempotent `$set`-merge upsert (author = system user), ACL grant/revoke diff to match the visibility spec, and **soft-retire** (revoke grants, keep the doc + history) for agents dropped from config. Manages its own tenant contexts.
- **Tenant scope**: `tenants: 'system'` = one tenantless row shared by all tenants; an explicit list seeds one row per tenant. Because `Agent` **and** `AclEntry` are exact-equality tenant-isolated (and there is no tenant registry to enumerate), system-scope resolution uses a `runAsSystem` fallback in `loadAgent` (on-miss, prefix-gated) and a first-page merge in the list handler — both **multi-tenant only**; single-tenant deployments resolve the tenantless row through the normal path with zero added cost.
- **Frontend**: system agents render read-only in the builder (even for admins) with dedicated "Global Agent" messaging.

## Config semantics

- `$set`-merge: config overrides specific fields on the seeded doc (per design intent).
- Omitting `access` seeds the agent but shares it with no one (least privilege).
- Removing an entry from config soft-retires it (revokes grants; the doc and any chat history remain; re-adding re-enables).

## Testing

All against real MongoDB (`mongodb-memory-server`, real ACL/agent methods — no heavy mocking):

- **`reconcileGlobalAgents`** (`packages/api/src/agents/global.spec.ts`): immutable seeding, per-principal grants, idempotency, grant reconciliation on config change, field-override merge, soft-retire, invalid-entry skip.
- **Controller guards** (`api/server/controllers/agents/v1.spec.js`): update → 403, delete → 403, duplicate → allowed & produces a non-system, user-owned copy.
- Config validates end-to-end through the real `configSchema.strict()` (passthrough preserves the body; bad id prefixes rejected).
- No regressions in adjacent suites; clean `tsc` + ESLint.

## Notes / decisions (flippable)

- Immutable to admins too (via the `isSystem` guard, not just VIEW-only grants).
- Removal from config = soft-retire (preserve history) rather than hard-delete.
- Default ACL level = viewer.