### PR TITLE
fix: verify email links for mixed-case registrations

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -219,15 +219,20 @@ const createTokenHash = () => {
 const sendVerificationEmail = async (user) => {
   const [verifyToken, hash] = createTokenHash();
 
+  // The user schema lowercases email on save, but the tokens collection does not,
+  // so a mixed-case registration email would store a token that verifyEmail can
+  // never match (it looks tokens up by the user's lowercased email). Normalize once.
+  const email = user.email.toLowerCase();
+
   const verificationLink = `${
     domains.client
-  }/verify?token=${verifyToken}&email=${encodeURIComponent(user.email)}`;
+  }/verify?token=${verifyToken}&email=${encodeURIComponent(email)}`;
   await sendEmail({
-    email: user.email,
+    email,
     subject: 'Verify your email',
     payload: {
       appName: process.env.APP_TITLE || 'LibreChat',
-      name: user.name || user.username || user.email,
+      name: user.name || user.username || email,
       verificationLink: verificationLink,
       year: new Date().getFullYear(),
     },
@@ -236,14 +241,14 @@ const sendVerificationEmail = async (user) => {
 
   await createToken({
     userId: user._id,
-    email: user.email,
+    email,
     type: AuthTokenTypes.EMAIL_VERIFICATION,
     token: hash,
     createdAt: Date.now(),
     expiresIn: 900,
   });
 
-  logger.info(`[sendVerificationEmail] Verification link issued. [Email: ${user.email}]`);
+  logger.info(`[sendVerificationEmail] Verification link issued. [Email: ${email}]`);
 };
 
 /**

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -471,6 +471,24 @@ describe('registerUser', () => {
       }),
     );
   });
+
+  it('issues the verification token against the lowercased email for mixed-case registrations', async () => {
+    checkEmailConfig.mockReturnValue(true);
+    createUser.mockResolvedValue({ _id: 'new-user-id', emailVerified: false });
+
+    const result = await registerUser({
+      ...registrationPayload,
+      email: 'Mixed.Case@Example.com',
+    });
+
+    expect(result.status).toBe(200);
+    expect(createToken).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'mixed.case@example.com' }),
+    );
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'mixed.case@example.com' }),
+    );
+  });
 });
 
 describe('verifyEmail public response handling', () => {


### PR DESCRIPTION
Closes #14171. Registering with a mixed-case email like `Mixed.Case@example.com` produced a verification link that always failed with "No email verification data found", even clicked immediately.

The user schema lowercases email on save, but the tokens collection has no such coercion. `sendVerificationEmail` was called with the raw registration email, so the token row was stored mixed-case. At verification, `verifyEmail` finds the user (Mongoose lowercases the query) and then looks the token up by the user's lowercased email — which never matches the mixed-case token. The resend path was unaffected because it reads `user.email` back from the DB, already lowercased.

Fixed by normalizing the email once in `sendVerificationEmail` and using it for the link, recipient, and token, so the stored token matches what verification queries with. Added a regression test asserting the token and email go out lowercased for a mixed-case registration (fails without the change).