### PR TITLE
fix: use consistent "Web Search" label for pinned tool

### DIFF
--- a/client/src/components/Chat/Input/WebSearch.tsx
+++ b/client/src/components/Chat/Input/WebSearch.tsx
@@ -29,7 +29,7 @@ function WebSearch() {
         className="max-w-fit"
         checked={webSearch}
         setValue={debouncedChange}
-        label={localize('com_ui_search')}
+        label={localize('com_ui_web_search')}
         isCheckedClassName="border-blue-600/40 bg-blue-500/10 hover:bg-blue-700/10"
         icon={<Globe className="icon-md" aria-hidden="true" />}
       />


### PR DESCRIPTION
## Summary

Updates the pinned Web Search tool label to use the same localized string as the tool selector.

This changes the pinned button label from "Search" to "Web Search" for consistency with the rest of the UI.

Closes #14092.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Test Configuration

- OS: Windows 11
- Node.js: v24.16.0
- npm: v11.16.0

### Tested

- Verified the pinned tool now displays "Web Search".
- Confirmed the label matches the tool selection dropdown.
- Ran `npm run build` successfully.
- Ran ESLint on the modified file:
  `npx eslint client/src/components/Chat/Input/WebSearch.tsx`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.