### PR TITLE
fix: honor user-invocable and disable-model-invocation on skill import

### DIFF
--- a/packages/api/src/skills/__tests__/import.test.ts
+++ b/packages/api/src/skills/__tests__/import.test.ts
@@ -356,6 +356,14 @@ describe('parseFrontmatter', () => {
     expect(result.disableModelInvocation).toBeUndefined();
     expect(result.invalidBooleans).toEqual(['user-invocable', 'disable-model-invocation']);
   });
+
+  it('accepts quoted invocation keys (js-yaml parses them as booleans)', () => {
+    const raw = `---\nname: n\ndescription: d\n'user-invocable': false\n"disable-model-invocation": true\n---\n\nbody`;
+    const result = parseFrontmatter(raw);
+    expect(result.userInvocable).toBe(false);
+    expect(result.disableModelInvocation).toBe(true);
+    expect(result.invalidBooleans).toEqual([]);
+  });
 });
 
 describe('createImportHandler', () => {

--- a/packages/api/src/skills/__tests__/import.test.ts
+++ b/packages/api/src/skills/__tests__/import.test.ts
@@ -328,6 +328,34 @@ describe('parseFrontmatter', () => {
     expect(result.alwaysApply).toBe(false);
     expect(result.invalidBooleans).toEqual([]);
   });
+
+  it('extracts user-invocable and disable-model-invocation', () => {
+    const raw = `---\nname: manual-only\ndescription: demo.\nuser-invocable: false\ndisable-model-invocation: true\n---\n\nbody`;
+    const result = parseFrontmatter(raw);
+    expect(result.userInvocable).toBe(false);
+    expect(result.disableModelInvocation).toBe(true);
+    expect(result.invalidBooleans).toEqual([]);
+  });
+
+  it('leaves invocation fields undefined when absent', () => {
+    const raw = `---\nname: n\ndescription: d\n---\n\nbody`;
+    const result = parseFrontmatter(raw);
+    expect(result.userInvocable).toBeUndefined();
+    expect(result.disableModelInvocation).toBeUndefined();
+  });
+
+  it('is case-insensitive on the invocation keys', () => {
+    const raw = `---\nname: n\ndescription: d\nUser-Invocable: FALSE\n---\n\nbody`;
+    expect(parseFrontmatter(raw).userInvocable).toBe(false);
+  });
+
+  it('flags non-boolean invocation values as invalid (no silent drop)', () => {
+    const raw = `---\nname: n\ndescription: d\nuser-invocable: yes\ndisable-model-invocation: 1\n---\n\nbody`;
+    const result = parseFrontmatter(raw);
+    expect(result.userInvocable).toBeUndefined();
+    expect(result.disableModelInvocation).toBeUndefined();
+    expect(result.invalidBooleans).toEqual(['user-invocable', 'disable-model-invocation']);
+  });
 });
 
 describe('createImportHandler', () => {
@@ -386,6 +414,62 @@ describe('createImportHandler', () => {
           expect.objectContaining({
             field: 'frontmatter',
             code: 'INVALID_YAML',
+          }),
+        ]),
+      }),
+    );
+    expect(deps.createSkill).not.toHaveBeenCalled();
+  });
+
+  it('forwards user-invocable / disable-model-invocation to createSkill on markdown import', async () => {
+    const deps = mockImportDeps();
+    const handler = createImportHandler(deps);
+    const res = mockResponse();
+    const md = `---\nname: manual-only\ndescription: A manual-only skill.\nuser-invocable: false\ndisable-model-invocation: true\n---\n\nbody`;
+
+    await handler(mockMarkdownRequest(md, 'manual-only.md'), res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(deps.createSkill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frontmatter: {
+          'user-invocable': false,
+          'disable-model-invocation': true,
+        },
+      }),
+    );
+  });
+
+  it('omits the frontmatter bag when no invocation fields are present', async () => {
+    const deps = mockImportDeps();
+    const handler = createImportHandler(deps);
+    const res = mockResponse();
+    const md = `---\nname: plain\ndescription: A plain skill.\n---\n\nbody`;
+
+    await handler(mockMarkdownRequest(md, 'plain.md'), res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(deps.createSkill).toHaveBeenCalledWith(
+      expect.objectContaining({ frontmatter: undefined }),
+    );
+  });
+
+  it('rejects a non-boolean invocation field before creating the skill', async () => {
+    const deps = mockImportDeps();
+    const handler = createImportHandler(deps);
+    const res = mockResponse();
+    const md = `---\nname: n\ndescription: d\nuser-invocable: yes\n---\n\nbody`;
+
+    await handler(mockMarkdownRequest(md, 'bad.md'), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        error: 'Validation failed',
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            field: 'frontmatter.user-invocable',
+            code: 'INVALID_TYPE',
           }),
         ]),
       }),

--- a/packages/api/src/skills/import.ts
+++ b/packages/api/src/skills/import.ts
@@ -23,19 +23,19 @@ export type { ImportLimits } from './limits';
 
 /**
  * YAML frontmatter parser — extracts the first-class fields LibreChat
- * persists as columns (`name`, `description`, `alwaysApply`) out of a
+ * persists as columns (`name`, `description`, `alwaysApply`) plus the
+ * invocation-mode flags (`userInvocable`, `disableModelInvocation`) out of a
  * SKILL.md file. Intentionally narrow: the full frontmatter validator in
  * `packages/data-schemas/src/methods/skill.ts` covers the wire contract;
- * this parser only needs to hand `createSkill` the columns it populates.
+ * this parser only needs to hand `createSkill` the fields it derives.
  *
- * When a known boolean field (currently `always-apply` plus the accepted
- * `alwaysApply` alias) is present
- * with a value that isn't recognizable as `true`/`false`, the parser
- * records it on `invalidBooleans[]` so the import handler can surface
- * a 400 instead of silently dropping the flag. Without this signal,
- * authoring mistakes like `alwaysApply: yes` would be lossy-converted
- * to "not always-applied" and the user would never learn their
- * frontmatter was malformed.
+ * When a known boolean field (`always-apply` plus the accepted `alwaysApply`
+ * alias, `user-invocable`, `disable-model-invocation`) is present with a value
+ * that isn't recognizable as `true`/`false`, the parser records it on
+ * `invalidBooleans[]` so the import handler can surface a 400 instead of
+ * silently dropping the flag. Without this signal, authoring mistakes like
+ * `always-apply: yes` would be lossy-converted to the schema default and the
+ * user would never learn their frontmatter was malformed.
  *
  * Exported for unit testing only — prefer `createImportHandler` at runtime.
  */
@@ -43,6 +43,8 @@ export function parseFrontmatter(raw: string): {
   name: string;
   description: string;
   alwaysApply?: boolean;
+  userInvocable?: boolean;
+  disableModelInvocation?: boolean;
   /** Keys that carried non-boolean values for fields that must be boolean. */
   invalidBooleans: string[];
   parseError?: string;
@@ -52,6 +54,8 @@ export function parseFrontmatter(raw: string): {
     name: string;
     description: string;
     alwaysApply?: boolean;
+    userInvocable?: boolean;
+    disableModelInvocation?: boolean;
     invalidBooleans: string[];
     parseError?: string;
   } = {
@@ -65,7 +69,33 @@ export function parseFrontmatter(raw: string): {
   if ('alwaysApply' in parsed) {
     result.alwaysApply = parsed.alwaysApply;
   }
+  if ('userInvocable' in parsed) {
+    result.userInvocable = parsed.userInvocable;
+  }
+  if ('disableModelInvocation' in parsed) {
+    result.disableModelInvocation = parsed.disableModelInvocation;
+  }
   return result;
+}
+
+/**
+ * Assemble the frontmatter bag `createSkill` derives the invocation-mode
+ * columns from. Only canonical keys that were actually present flow through,
+ * so an import without these fields keeps the previous behavior (no bag) and
+ * never trips `validateSkillFrontmatter`.
+ */
+function buildInvocationFrontmatter(
+  userInvocable: boolean | undefined,
+  disableModelInvocation: boolean | undefined,
+): Record<string, unknown> | undefined {
+  const frontmatter: Record<string, unknown> = {};
+  if (userInvocable !== undefined) {
+    frontmatter['user-invocable'] = userInvocable;
+  }
+  if (disableModelInvocation !== undefined) {
+    frontmatter['disable-model-invocation'] = disableModelInvocation;
+  }
+  return Object.keys(frontmatter).length > 0 ? frontmatter : undefined;
 }
 
 function sendFrontmatterParseError(res: Response, parseError: string) {
@@ -260,7 +290,15 @@ async function handleMarkdown(
 ) {
   const content = file.buffer.toString('utf-8');
 
-  const { name, description, alwaysApply, invalidBooleans, parseError } = parseFrontmatter(content);
+  const {
+    name,
+    description,
+    alwaysApply,
+    userInvocable,
+    disableModelInvocation,
+    invalidBooleans,
+    parseError,
+  } = parseFrontmatter(content);
   if (parseError) {
     return sendFrontmatterParseError(res, parseError);
   }
@@ -296,6 +334,7 @@ async function handleMarkdown(
     author: authorId,
     authorName,
     alwaysApply,
+    frontmatter: buildInvocationFrontmatter(userInvocable, disableModelInvocation),
     tenantId,
   });
 
@@ -374,8 +413,15 @@ async function handleZip(
     return res.status(400).json({ error: 'SKILL.md exceeds maximum file size' });
   }
 
-  const { name, description, alwaysApply, invalidBooleans, parseError } =
-    parseFrontmatter(skillMdContent);
+  const {
+    name,
+    description,
+    alwaysApply,
+    userInvocable,
+    disableModelInvocation,
+    invalidBooleans,
+    parseError,
+  } = parseFrontmatter(skillMdContent);
   if (parseError) {
     return sendFrontmatterParseError(res, parseError);
   }
@@ -411,6 +457,7 @@ async function handleZip(
     author: authorId,
     authorName,
     alwaysApply,
+    frontmatter: buildInvocationFrontmatter(userInvocable, disableModelInvocation),
     tenantId,
   });
 

--- a/packages/api/src/skills/parse.ts
+++ b/packages/api/src/skills/parse.ts
@@ -4,6 +4,8 @@ export type ParsedSkillMarkdown = {
   name: string;
   description: string;
   alwaysApply?: boolean;
+  userInvocable?: boolean;
+  disableModelInvocation?: boolean;
   frontmatter?: Record<string, unknown>;
   invalidBooleans: string[];
   parseError?: string;
@@ -94,6 +96,29 @@ function hasBooleanPlaceholder(rawValue?: string): boolean {
   return rawValue !== undefined && stripInlineComment(rawValue).length === 0;
 }
 
+/**
+ * Extract a canonical boolean frontmatter field, applying the same strict
+ * true/false rules as `always-apply`: a present-but-non-boolean value is
+ * recorded on `invalidBooleans` so the import handler can 400 instead of
+ * silently dropping it, while an empty placeholder is treated as absent.
+ */
+function extractBooleanField(
+  frontmatter: Record<string, unknown>,
+  block: string,
+  key: string,
+  invalidBooleans: string[],
+): boolean | undefined {
+  if (!hasCaseInsensitive(frontmatter, key)) {
+    return undefined;
+  }
+  const rawValue = getRawFrontmatterValue(block, key);
+  const value = parseBoolean(getCaseInsensitive(frontmatter, key), rawValue);
+  if (value === undefined && !hasBooleanPlaceholder(rawValue)) {
+    invalidBooleans.push(key);
+  }
+  return value;
+}
+
 function toScalarString(value: unknown): string {
   if (typeof value === 'string') {
     return value;
@@ -150,10 +175,19 @@ export function parseSkillMarkdown(raw: string): ParsedSkillMarkdown {
       invalidBooleans.push('alwaysApply');
     }
   }
+  const userInvocable = extractBooleanField(frontmatter, block, 'user-invocable', invalidBooleans);
+  const disableModelInvocation = extractBooleanField(
+    frontmatter,
+    block,
+    'disable-model-invocation',
+    invalidBooleans,
+  );
   return {
     name,
     description,
     alwaysApply,
+    userInvocable,
+    disableModelInvocation,
     frontmatter,
     invalidBooleans,
   };

--- a/packages/api/src/skills/parse.ts
+++ b/packages/api/src/skills/parse.ts
@@ -45,10 +45,13 @@ function hasCaseInsensitive(frontmatter: Record<string, unknown>, key: string): 
 
 function getRawFrontmatterValue(block: string, key: string): string | undefined {
   const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(`^\\s*${escapedKey}\\s*:\\s*(.*)$`, 'i');
+  // Hyphenated keys are often quoted in YAML (`'user-invocable': false`);
+  // js-yaml parses the boolean either way, so match the raw line with or
+  // without a matching pair of surrounding quotes.
+  const pattern = new RegExp(`^\\s*(['"]?)${escapedKey}\\1\\s*:\\s*(.*)$`, 'i');
   const line = block.split('\n').find((candidate) => pattern.test(candidate));
   const match = line?.match(pattern);
-  return match?.[1];
+  return match?.[2];
 }
 
 function stripInlineComment(value: string): string {

--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -1517,6 +1517,89 @@ describe('Skill CRUD methods', () => {
     ).rejects.toMatchObject({ code: 'SKILL_VALIDATION_FAILED' });
   });
 
+  it('updateSkill restores user-invocable to the default when a body edit removes the imported line', async () => {
+    /* The reported regression: a skill imported with `user-invocable: false`
+       drives the column, but editing the SKILL.md body (which the UI sends
+       without a structured `frontmatter` object) to drop the line must make
+       the skill user-invocable again. Without the body-inline sync the column
+       would stick at `false` and the skill would stay hidden from the `$`
+       popover forever. */
+    const { skill } = await methods.createSkill(
+      makeSkillInput({
+        name: 'import-then-edit',
+        frontmatter: {
+          name: 'import-then-edit',
+          description: 'A small demo skill used in tests.',
+          'user-invocable': false,
+        },
+      }),
+    );
+    expect(skill.userInvocable).toBe(false);
+    const bodyWithoutFlag = `---\nname: import-then-edit\ndescription: user removed the invocation line.\n---\n\n# Body`;
+    const result = await methods.updateSkill({
+      id: skill._id.toString(),
+      expectedVersion: skill.version,
+      update: { body: bodyWithoutFlag },
+    });
+    expect(result.status).toBe('updated');
+    if (result.status === 'updated') {
+      expect(result.skill.userInvocable).toBeUndefined();
+    }
+  });
+
+  it('updateSkill syncs invocation columns from an inline body edit', async () => {
+    const { skill } = await methods.createSkill(makeSkillInput({ name: 'body-invocation' }));
+    expect(skill.userInvocable).toBe(true);
+    expect(skill.disableModelInvocation).toBe(false);
+    const newBody = `---\nname: body-invocation\ndescription: opting into manual-only.\nuser-invocable: false\ndisable-model-invocation: true\n---\n\n# Body`;
+    const result = await methods.updateSkill({
+      id: skill._id.toString(),
+      expectedVersion: skill.version,
+      update: { body: newBody },
+    });
+    expect(result.status).toBe('updated');
+    if (result.status === 'updated') {
+      expect(result.skill.userInvocable).toBe(false);
+      expect(result.skill.disableModelInvocation).toBe(true);
+    }
+  });
+
+  it('updateSkill lets a structured frontmatter bag win over inline body invocation flags', async () => {
+    /* When a caller sends a structured `frontmatter` object it is the
+       authoritative source for every derived column, so a conflicting
+       body-inline flag must not override it. */
+    const { skill } = await methods.createSkill(makeSkillInput({ name: 'fm-wins-invocation' }));
+    const body = `---\nname: fm-wins-invocation\ndescription: body says hidden.\nuser-invocable: false\n---\n\n# Body`;
+    const result = await methods.updateSkill({
+      id: skill._id.toString(),
+      expectedVersion: skill.version,
+      update: {
+        frontmatter: {
+          name: 'fm-wins-invocation',
+          description: 'A small demo skill used in tests.',
+          'user-invocable': true,
+        },
+        body,
+      },
+    });
+    expect(result.status).toBe('updated');
+    if (result.status === 'updated') {
+      expect(result.skill.userInvocable).toBe(true);
+    }
+  });
+
+  it('updateSkill rejects a non-boolean invocation flag in a body-only edit', async () => {
+    const { skill } = await methods.createSkill(makeSkillInput({ name: 'body-invocation-typo' }));
+    const bodyWithTypo = `---\nname: body-invocation-typo\ndescription: broken flag.\nuser-invocable: yes\n---\n\n# Body`;
+    await expect(
+      methods.updateSkill({
+        id: skill._id.toString(),
+        expectedVersion: skill.version,
+        update: { body: bodyWithTypo },
+      }),
+    ).rejects.toMatchObject({ code: 'SKILL_VALIDATION_FAILED' });
+  });
+
   it('createSkill accepts a body typo when an explicit top-level alwaysApply overrides it', async () => {
     /* Same precedence-aware validation on the create path: explicit
        top-level `alwaysApply` short-circuits body-inline validation. */

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -791,6 +791,75 @@ function extractAlwaysApplyFromBody(body: string | undefined): BodyAlwaysApplyRe
   return aliasResult ?? { status: 'absent' };
 }
 
+type BodyBooleanResult =
+  | { status: 'absent' }
+  | { status: 'valid'; value: boolean }
+  | { status: 'invalid' };
+
+/**
+ * Extract a single strict boolean flag (`user-invocable` /
+ * `disable-model-invocation`) from a SKILL.md body's YAML frontmatter block.
+ * Mirrors `extractAlwaysApplyFromBody`: the REST edit flow rewrites the full
+ * SKILL.md via `update.body` without a structured `frontmatter` object, so an
+ * inline flag flip is otherwise invisible to the derived columns. `key` is the
+ * canonical hyphenated frontmatter key; matching is case-insensitive and
+ * tolerant of quoted keys, quoted values, and YAML inline comments.
+ */
+function extractBooleanFlagFromBody(body: string | undefined, key: string): BodyBooleanResult {
+  if (typeof body !== 'string' || body.length === 0) {
+    return { status: 'absent' };
+  }
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('---')) {
+    return { status: 'absent' };
+  }
+  const after = trimmed.slice(3);
+  const closingIdx = after.indexOf('\n---');
+  if (closingIdx === -1) {
+    return { status: 'absent' };
+  }
+  const block = after.slice(0, closingIdx);
+  const target = key.toLowerCase();
+  for (const line of block.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) {
+      continue;
+    }
+    let rawKey = line.slice(0, colon).trim();
+    if (
+      rawKey.length >= 2 &&
+      ((rawKey[0] === '"' && rawKey.endsWith('"')) || (rawKey[0] === "'" && rawKey.endsWith("'")))
+    ) {
+      rawKey = rawKey.slice(1, -1).trim();
+    }
+    if (rawKey.toLowerCase() !== target) {
+      continue;
+    }
+    let value = stripYamlTrailingComment(line.slice(colon + 1).trim()).trim();
+    if (value === '') {
+      return { status: 'absent' };
+    }
+    if (
+      value.length >= 2 &&
+      ((value[0] === '"' && value.endsWith('"')) || (value[0] === "'" && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1).trim();
+    }
+    if (value === '') {
+      return { status: 'absent' };
+    }
+    const lowered = value.toLowerCase();
+    if (lowered === 'true') {
+      return { status: 'valid', value: true };
+    }
+    if (lowered === 'false') {
+      return { status: 'valid', value: false };
+    }
+    return { status: 'invalid' };
+  }
+  return { status: 'absent' };
+}
+
 /**
  * Resolve the effective `alwaysApply` boolean for a create/update call.
  *
@@ -1348,6 +1417,19 @@ export function createSkillMethods(
        update. */
     const bodyAlwaysApply =
       update.body !== undefined ? extractAlwaysApplyFromBody(update.body) : undefined;
+    /* Same story for the invocation flags: the UI edit flow sends only
+       `body`, so an inline `user-invocable:` / `disable-model-invocation:`
+       flip is invisible to the derived columns unless we read it back out
+       here. A structured `frontmatter` bag, when present, already drives
+       every derived column below, so body-inline is only consulted when it's
+       absent. */
+    const readBodyFlags = update.frontmatter === undefined && update.body !== undefined;
+    const bodyUserInvocable = readBodyFlags
+      ? extractBooleanFlagFromBody(update.body, 'user-invocable')
+      : undefined;
+    const bodyDisableModelInvocation = readBodyFlags
+      ? extractBooleanFlagFromBody(update.body, 'disable-model-invocation')
+      : undefined;
     const issues: ValidationIssue[] = [];
     if (update.name !== undefined) issues.push(...validateSkillName(update.name));
     if (update.description !== undefined)
@@ -1375,6 +1457,18 @@ export function createSkillMethods(
         message:
           '"always-apply" or "alwaysApply" in SKILL.md frontmatter must be a boolean (true or false)',
       });
+    }
+    for (const [field, result] of [
+      ['user-invocable', bodyUserInvocable],
+      ['disable-model-invocation', bodyDisableModelInvocation],
+    ] as const) {
+      if (result?.status === 'invalid') {
+        issues.push({
+          field: `body.frontmatter.${field}`,
+          code: 'INVALID_TYPE',
+          message: `"${field}" in SKILL.md frontmatter must be a boolean (true or false)`,
+        });
+      }
     }
     const { errors, warnings } = partitionIssues(issues);
     if (errors.length > 0) {
@@ -1407,6 +1501,22 @@ export function createSkillMethods(
           setPayload[key] = derived[key];
         } else {
           unsetPayload[key] = '';
+        }
+      }
+    } else if (update.body !== undefined) {
+      /* No structured frontmatter bag, but a body edit can still flip the
+         invocation flags inline. Mirror the frontmatter branch: a valid value
+         sets the column, and an absent flag unsets it back to the schema
+         default so removing `user-invocable: false` from a SKILL.md restores
+         it to the popover on the next save (`invalid` is rejected above). */
+      for (const [column, result] of [
+        ['userInvocable', bodyUserInvocable],
+        ['disableModelInvocation', bodyDisableModelInvocation],
+      ] as const) {
+        if (result?.status === 'valid') {
+          setPayload[column] = result.value;
+        } else if (result?.status === 'absent') {
+          unsetPayload[column] = '';
         }
       }
     }


### PR DESCRIPTION
Closes #14208. Importing a SKILL.md via `POST /api/skills/import` silently ignored the `user-invocable` and `disable-model-invocation` frontmatter fields — the created skill always landed on the schema defaults with no error, even though the file said otherwise.

The import parser only pulled `name`/`description`/`always-apply` out of the frontmatter, and the handler passed just those columns to `createSkill`. But `createSkill` derives `userInvocable`/`disableModelInvocation` solely from the `frontmatter` bag (same as the explicit `POST`/`PATCH /api/skills` path), which import never forwarded — so those two flags were dropped before the skill was created.

Now the parser reads both booleans with the same strict true/false handling as `always-apply` (a non-boolean value surfaces a 400 instead of being silently coerced), and the handler forwards them to `createSkill` through a minimal frontmatter bag containing only the keys that were actually present. An import with neither field behaves exactly as before (no bag), so there's no change for existing files and nothing new for `validateSkillFrontmatter` to reject.

Added parser coverage (extraction, case-insensitivity, invalid-value flagging) and handler tests asserting the flags reach `createSkill` and that a bad value 400s before creation. Full skills import suite passes (39), tsc/eslint/prettier clean.