### PR TITLE
fix: improve screenshot sharpness on low-DPI displays

### DIFF
--- a/client/src/hooks/ScreenshotContext.tsx
+++ b/client/src/hooks/ScreenshotContext.tsx
@@ -21,6 +21,7 @@ export const useScreenshot = () => {
 
     const canvas = await toCanvas(node, {
       backgroundColor,
+      pixelRatio: Math.max(window.devicePixelRatio || 1, 3),
       imagePlaceholder:
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=',
     });


### PR DESCRIPTION
fix(client): improve screenshot sharpness on low-DPI displays

By default, the `html-to-image` library uses `window.devicePixelRatio` to scale the generated canvas. On standard 1x displays or under low zoom levels, this results in a low-resolution screenshot (matching the element's CSS dimensions). When shared, printed, or viewed on high-DPI screens, the PNGs appear blurry.

This commit forces `html-to-image` to render screenshots with a minimum pixel ratio of 3 by setting the `pixelRatio` property. This ensures that the exported PNGs are always high-resolution and sharp.

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This PR resolves the issue where exported PNG conversation screenshots appear blurry or pixelated when exported from standard-DPI screens or under low zoom conditions.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

1. Export a conversation screenshot on a standard DPI screen (or simulate by setting browser zoom to 100% or less).
2. Check the dimensions of the downloaded PNG; it should be 3 times the CSS size of the captured element.
3. Open the image on a high-DPI device or zoom in; the text should remain crisp.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
