### PR TITLE
🔍 fix: Sync Conversation Title Updates to MeiliSearch

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.findOneAndUpdate.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.findOneAndUpdate.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * `meiliEnabled` is a module-level constant evaluated when `mongoMeili` is first
+ * imported, so these env vars must be set before the plugin module is loaded.
+ * The plugin is therefore imported lazily inside `beforeAll`.
+ *
+ * This suite covers the `saveConvo` code path, which calls `findOneAndUpdate`
+ * with `includeResultMetadata: true`. Mongoose then resolves the query to the raw
+ * `{ value, ok, lastErrorObject }` wrapper, and the post hook must unwrap `value`
+ * before invoking the indexing hook (regression test for conversation titles not
+ * syncing to MeiliSearch).
+ */
+process.env.SEARCH = 'true';
+process.env.MEILI_HOST = 'foo';
+process.env.MEILI_MASTER_KEY = 'bar';
+
+import mongoose from 'mongoose';
+import { EModelEndpoint } from 'librechat-data-provider';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const waitForMock = async (mock: jest.Mock, timeoutMs = 2000): Promise<void> => {
+  const start = Date.now();
+  while (mock.mock.calls.length === 0) {
+    if (Date.now() - start > timeoutMs) {
+      return;
+    }
+    await wait(10);
+  }
+};
+
+const mockAddDocuments = jest.fn();
+const mockUpdateDocuments = jest.fn();
+const mockDeleteDocument = jest.fn();
+const mockGetDocument = jest.fn();
+const mockIndex = jest.fn().mockReturnValue({
+  getRawInfo: jest.fn(),
+  updateSettings: jest.fn(),
+  addDocuments: mockAddDocuments,
+  addDocumentsInBatches: jest.fn(),
+  updateDocuments: mockUpdateDocuments,
+  deleteDocument: mockDeleteDocument,
+  deleteDocuments: jest.fn(),
+  getDocument: mockGetDocument,
+  getDocuments: jest.fn().mockReturnValue({ results: [] }),
+});
+jest.mock('meilisearch', () => ({
+  MeiliSearch: jest.fn().mockImplementation(() => ({ index: mockIndex })),
+}));
+
+describe('mongoMeili findOneAndUpdate with includeResultMetadata (saveConvo path)', () => {
+  let mongoServer: MongoMemoryServer;
+  let createConversationModel: (typeof import('~/models/convo'))['createConversationModel'];
+  let conversationModel: SchemaWithMeiliMethods;
+
+  beforeAll(async () => {
+    ({ createConversationModel } = await import('~/models/convo'));
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    conversationModel = createConversationModel(mongoose) as unknown as SchemaWithMeiliMethods;
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await conversationModel.deleteMany({});
+    mockAddDocuments.mockClear();
+    mockUpdateDocuments.mockClear();
+    mockDeleteDocument.mockClear();
+    mockGetDocument.mockClear();
+    mockGetDocument.mockReset();
+  });
+
+  const updateTitle = (conversationId: string, user: string, title: string) =>
+    conversationModel.findOneAndUpdate(
+      { conversationId, user },
+      { $set: { title } },
+      { new: true, upsert: true, includeResultMetadata: true },
+    );
+
+  test('re-indexes the updated title when the raw result wrapper is returned', async () => {
+    const conversationId = new mongoose.Types.ObjectId().toString();
+    const user = new mongoose.Types.ObjectId().toString();
+    await conversationModel.create({
+      conversationId,
+      user,
+      title: 'Original Title',
+      endpoint: EModelEndpoint.openAI,
+    });
+    mockAddDocuments.mockClear();
+
+    const result = await updateTitle(conversationId, user, 'Renamed Title');
+
+    // `includeResultMetadata: true` resolves to the raw wrapper, not the document.
+    expect((result as unknown as { value: unknown }).value).toBeTruthy();
+
+    await waitForMock(mockAddDocuments);
+    expect(mockAddDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ conversationId, title: 'Renamed Title' })],
+      { primaryKey: 'conversationId' },
+    );
+  });
+
+  test('upserting a new conversation via the raw result wrapper indexes it', async () => {
+    const conversationId = new mongoose.Types.ObjectId().toString();
+    const user = new mongoose.Types.ObjectId().toString();
+
+    await conversationModel.findOneAndUpdate(
+      { conversationId, user },
+      { $set: { title: 'Fresh Conversation', endpoint: EModelEndpoint.openAI } },
+      { new: true, upsert: true, includeResultMetadata: true },
+    );
+
+    await waitForMock(mockAddDocuments);
+    expect(mockAddDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ conversationId, title: 'Fresh Conversation' })],
+      { primaryKey: 'conversationId' },
+    );
+  });
+
+  test('persists the _meiliIndex flag after indexing via the wrapper', async () => {
+    const conversationId = new mongoose.Types.ObjectId().toString();
+    const user = new mongoose.Types.ObjectId().toString();
+
+    await updateTitle(conversationId, user, 'Indexed Conversation');
+    await waitForMock(mockAddDocuments);
+    await wait(50);
+
+    const storedDoc = await conversationModel.collection.findOne({ conversationId });
+    expect(storedDoc?._meiliIndex).toBe(true);
+  });
+
+  test('skips re-indexing when the title already matches the MeiliSearch document', async () => {
+    const conversationId = new mongoose.Types.ObjectId().toString();
+    const user = new mongoose.Types.ObjectId().toString();
+    await conversationModel.create({
+      conversationId,
+      user,
+      title: 'Same Title',
+      endpoint: EModelEndpoint.openAI,
+    });
+    mockAddDocuments.mockClear();
+    mockGetDocument.mockResolvedValueOnce({ conversationId, title: 'Same Title' });
+
+    await updateTitle(conversationId, user, 'Same Title');
+
+    await wait(50);
+    expect(mockGetDocument).toHaveBeenCalledWith(conversationId);
+    expect(mockAddDocuments).not.toHaveBeenCalled();
+    expect(mockUpdateDocuments).not.toHaveBeenCalled();
+  });
+
+  test('does NOT index temporary conversations updated via the raw result wrapper', async () => {
+    const conversationId = new mongoose.Types.ObjectId().toString();
+    const user = new mongoose.Types.ObjectId().toString();
+    await conversationModel.collection.insertOne({
+      conversationId,
+      user,
+      title: 'Temporary Conversation',
+      endpoint: EModelEndpoint.openAI,
+      isTemporary: true,
+      expiredAt: new Date(Date.now() + 60 * 60 * 1000),
+      _meiliIndex: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await updateTitle(conversationId, user, 'Renamed Temporary Conversation');
+
+    await wait(50);
+    expect(mockAddDocuments).not.toHaveBeenCalled();
+    expect(mockUpdateDocuments).not.toHaveBeenCalled();
+  });
+});

--- a/packages/data-schemas/src/models/plugins/mongoMeili.findOneAndUpdate.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.findOneAndUpdate.spec.ts
@@ -1,7 +1,10 @@
 /**
  * `meiliEnabled` is a module-level constant evaluated when `mongoMeili` is first
- * imported, so these env vars must be set before the plugin module is loaded.
- * The plugin is therefore imported lazily inside `beforeAll`.
+ * imported, so the MeiliSearch env vars must be set before the plugin module is
+ * loaded. The plugin is therefore imported lazily inside `beforeAll`, after the
+ * env is set, and the prior values are restored in `afterAll` so this suite does
+ * not leak `meiliEnabled: true` into other test files that share the Jest
+ * worker's `process.env`.
  *
  * This suite covers the `saveConvo` code path, which calls `findOneAndUpdate`
  * with `includeResultMetadata: true`. Mongoose then resolves the query to the raw
@@ -9,14 +12,13 @@
  * before invoking the indexing hook (regression test for conversation titles not
  * syncing to MeiliSearch).
  */
-process.env.SEARCH = 'true';
-process.env.MEILI_HOST = 'foo';
-process.env.MEILI_MASTER_KEY = 'bar';
-
 import mongoose from 'mongoose';
 import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
+
+const MEILI_ENV_KEYS = ['SEARCH', 'MEILI_HOST', 'MEILI_MASTER_KEY'] as const;
+const savedMeiliEnv: Partial<Record<(typeof MEILI_ENV_KEYS)[number], string | undefined>> = {};
 
 const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -55,6 +57,13 @@ describe('mongoMeili findOneAndUpdate with includeResultMetadata (saveConvo path
   let conversationModel: SchemaWithMeiliMethods;
 
   beforeAll(async () => {
+    for (const key of MEILI_ENV_KEYS) {
+      savedMeiliEnv[key] = process.env[key];
+    }
+    process.env.SEARCH = 'true';
+    process.env.MEILI_HOST = 'foo';
+    process.env.MEILI_MASTER_KEY = 'bar';
+
     ({ createConversationModel } = await import('~/models/convo'));
     mongoServer = await MongoMemoryServer.create();
     await mongoose.connect(mongoServer.getUri());
@@ -64,6 +73,13 @@ describe('mongoMeili findOneAndUpdate with includeResultMetadata (saveConvo path
   afterAll(async () => {
     await mongoose.disconnect();
     await mongoServer.stop();
+    for (const key of MEILI_ENV_KEYS) {
+      if (savedMeiliEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedMeiliEnv[key];
+      }
+    }
   });
 
   beforeEach(async () => {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { parseTextParts } from 'librechat-data-provider';
 import { MeiliSearch, MeiliSearchTimeOutError } from 'meilisearch';
-import type { SearchResponse, SearchParams, Index, MeiliSearchErrorInfo } from 'meilisearch';
 import type {
   CallbackWithoutResultAndOptionalError,
   FilterQuery,
@@ -11,9 +10,10 @@ import type {
   Types,
   Model,
 } from 'mongoose';
+import type { SearchResponse, SearchParams, Index, MeiliSearchErrorInfo } from 'meilisearch';
 import type { IConversation, IMessage } from '~/types';
-import logger from '~/config/meiliLogger';
 import { buildRetentionVisibilityFilter, legacyPermanentExpirationFilter } from '~/utils/retention';
+import logger from '~/config/meiliLogger';
 
 interface MongoMeiliOptions {
   host: string;
@@ -792,32 +792,47 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
   });
 
   // Post-findOneAndUpdate hook
-  schema.post('findOneAndUpdate', async function (doc: DocumentWithMeiliIndex, next) {
-    if (!meiliEnabled) {
-      return next();
-    }
-
-    if (doc.unfinished) {
-      return next();
-    }
-
-    let meiliDoc: Record<string, unknown> | undefined;
-    if (doc.messages) {
-      try {
-        meiliDoc = await client.index('convos').getDocument(doc.conversationId as string);
-      } catch (error: unknown) {
-        logger.debug(
-          '[MeiliMongooseModel.findOneAndUpdate] Convo not found in MeiliSearch and will index ' +
-            doc.conversationId,
-          error as Record<string, unknown>,
-        );
+  schema.post(
+    'findOneAndUpdate',
+    async function (
+      res: DocumentWithMeiliIndex | { value: DocumentWithMeiliIndex | null } | null,
+      next: CallbackWithoutResultAndOptionalError,
+    ) {
+      if (!meiliEnabled) {
+        return next();
       }
-    }
 
-    if (meiliDoc && meiliDoc.title === doc.title) {
+      // `saveConvo` issues `findOneAndUpdate` with `includeResultMetadata: true`, so
+      // the hook receives the raw `{ value, ok, lastErrorObject }` result instead of
+      // the document. Unwrap `value` so indexing runs for that path too.
+      const doc = res instanceof mongoose.Document ? res : (res?.value ?? null);
+
+      if (!doc || doc.unfinished) {
+        return next();
+      }
+
+      let meiliDoc: Record<string, unknown> | undefined;
+      if (doc.messages) {
+        try {
+          meiliDoc = await client.index('convos').getDocument(doc.conversationId as string);
+        } catch (error: unknown) {
+          logger.debug(
+            '[MeiliMongooseModel.findOneAndUpdate] Convo not found in MeiliSearch and will index ' +
+              doc.conversationId,
+            error as Record<string, unknown>,
+          );
+        }
+      }
+
+      if (meiliDoc && meiliDoc.title === doc.title) {
+        return next();
+      }
+
+      if (typeof doc.postSaveHook === 'function') {
+        return doc.postSaveHook(next);
+      }
+
       return next();
-    }
-
-    doc.postSaveHook?.(next);
-  });
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Fixes conversation titles going stale in MeiliSearch while messages continued to index correctly (#14204).

`saveConvo` calls `Conversation.findOneAndUpdate` with `includeResultMetadata: true`, so Mongoose resolves the query to the raw `{ value, ok, lastErrorObject }` wrapper and passes that wrapper (not the document) to the `post('findOneAndUpdate')` hook in `mongoMeili`. The hook treated the wrapper as the document, so `doc.postSaveHook` was `undefined`, `doc.postSaveHook?.(next)` silently no-op'd, and the conversation was never (re)indexed. Messages were unaffected because `saveMessage` uses a plain `{ upsert, new }` update, which passes the hydrated document to the same hook.

- Unwrapped the query result in the `post('findOneAndUpdate')` hook, using `res instanceof mongoose.Document` to distinguish the hydrated document (the `{ new: true }` path) from the raw metadata wrapper (the `includeResultMetadata` path), falling back to `res.value`.
- Guarded against a `null` result and always call `next()` (including when `postSaveHook` is absent) so the middleware chain never stalls.
- Preserved existing behavior for the `{ new: true }` path and the shared message schema, plus the title-unchanged short-circuit that skips redundant re-indexing.
- Added a dedicated `mongoMeili.findOneAndUpdate.spec.ts` that sets `SEARCH=true` before the plugin module loads so `meiliEnabled` is active. The existing suite never exercised this hook with indexing enabled, so the regression path had zero real coverage.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced the bug with a real MongoDB (`mongodb-memory-server`) test before fixing: with `meiliEnabled` active, updating a conversation title via `findOneAndUpdate({ ..., includeResultMetadata: true })` never called `addDocuments`. Confirmed 4 of 5 new tests fail against the pre-fix hook and all pass after the fix.

New spec covers: re-indexing a renamed title through the wrapper, upserting a new conversation, the `_meiliIndex` flag persisting after indexing, skipping re-indexing when the MeiliSearch title already matches, and temporary conversations staying out of the index.

- `cd packages/data-schemas && npx jest --no-cache mongoMeili` -> 60 passed (55 existing + 5 new).
- `npx jest conversation.spec.ts` and full plugin suite pass; `tsc --noEmit` and `eslint` clean.
- Ran a local Codex review (`codex exec review --uncommitted`) which executed the tests and lint itself and returned no findings.

### **Test Configuration**:

- Node v24.16.0, MongoDB via `mongodb-memory-server`, MeiliSearch client mocked at the SDK boundary; real Mongoose hooks and schema exercised end to end.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes