### PR TITLE
security: pin the deploy-dev.yml actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,10 +19,10 @@ jobs:
        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'dev'))
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install SSH Key
-      uses: shimataro/ssh-key-action@v2
+      uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 # v2.7.0
       with:
         key: ${{ secrets.DO_SSH_PRIVATE_KEY }}
         known_hosts: ${{ secrets.DO_KNOWN_HOSTS }}


### PR DESCRIPTION
`deploy-dev.yml` installs the DigitalOcean SSH deploy key and SSHes to the droplet. Two of its actions were pinned to mutable tags:

```
actions/checkout@v4
shimataro/ssh-key-action@v2   # receives secrets.DO_SSH_PRIVATE_KEY (line 27)
```

A mutable tag can be repointed by whoever controls the action, so a compromise (as in the `tj-actions/changed-files` incident earlier this year) would execute with the SSH private key and known-hosts in scope. This pins both to the commit SHA their tag currently resolves to, with the version in a trailing comment:

```
actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 # v2.7.0
```

2 lines, no behavior change. If it'd be useful, I'm happy to also add a Dependabot config for `github-actions` so these stay current automatically.

<sub>AI-assisted; I verified the workflow and resolved each SHA against the action's tag myself.</sub>
