### PR TITLE
🪜 style: Center scroll-to-bottom marker in MessageNav

### DIFF
--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -150,7 +150,7 @@ const MessageIndicator = memo(function MessageIndicator({
   label: string;
   onSelect: (id: string) => void;
 }) {
-  const baseSize = entry.isEnd ? 'mr-1.5 h-[3px] w-[3px]' : 'h-[3px] w-3';
+  const baseSize = entry.isEnd ? 'mr-[4.5px] h-[3px] w-[3px]' : 'h-[3px] w-3';
   return (
     <button
       type="button"


### PR DESCRIPTION
## Summary
- The `MessageNav` rib column was narrowed (`w-4` → `w-3`), shifting the column's visual center. The scroll-to-bottom end marker, positioned by its right margin (`mr-1.5`), was left ~1.5px off-center relative to the ribs and the up/down chevrons.
- Reduces the end-marker right margin to `mr-[4.5px]` so the 3px dot re-centers on the narrowed rib column (center at `R − 6`), matching the ribs and chevrons.

## Test plan
- [ ] Open a conversation long enough to show `MessageNav` (≥3 messages).
- [ ] Confirm the scroll-to-bottom dot is horizontally centered with the rib column and the up/down chevrons in both light and dark themes.
- [ ] Existing `MessageNav.spec.tsx` remains green (asserts `RIB_END`/`ribDimsFor` and `w-3`, unaffected by this margin-only change).