### PR TITLE
📊 feat: MCP Progress Notifications for Background Tool Calls

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -19,6 +19,7 @@ const {
   buildMCPAuthRunStepEndDeltaEvent,
   isUserSourced,
   checkAccessWithRequestCache,
+  BACKGROUND_PROGRESS_SINK,
   requiresEphemeralUserConnection,
   containsGraphTokenPlaceholder,
 } = require('@librechat/api');
@@ -817,6 +818,11 @@ function createToolInstance({
       const customUserVars =
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
 
+      /** Set per-dispatch by the background executor: forwarding it as the
+       *  SDK's `onprogress` attaches a progressToken to the request, so a
+       *  server emitting `notifications/progress` updates the task mid-flight. */
+      const progressSink = config?.configurable?.[BACKGROUND_PROGRESS_SINK];
+
       const result = await mcpManager.callTool({
         serverName,
         serverConfig: capturedServerConfig,
@@ -825,6 +831,7 @@ function createToolInstance({
         toolArguments,
         options: {
           signal: derivedSignal,
+          ...(typeof progressSink === 'function' ? { onprogress: progressSink } : {}),
         },
         user: effectiveUser,
         requestBody: config?.configurable?.requestBody ?? capturedRequestBody,

--- a/packages/api/src/agents/background.spec.ts
+++ b/packages/api/src/agents/background.spec.ts
@@ -454,6 +454,55 @@ describe('BackgroundTaskRegistryClass', () => {
     expect(registry.get('u1', 'c1', created.task.id)?.artifact).toBeUndefined();
   });
 
+  it('records MCP progress on a running task and serializes it for the poll tool', () => {
+    /** The singleton, because runCheckBackgroundTask serializes through it. */
+    const registry = backgroundTaskRegistry;
+    const created = registry.create({
+      userId: 'u1',
+      conversationId: 'c_progress',
+      toolCallId: 'call_prog',
+      toolName: 'search_mcp_docs',
+    });
+    if ('atCapacity' in created) {
+      throw new Error('unexpected capacity');
+    }
+
+    registry.setProgress('u1', 'c_progress', created.task.id, {
+      progress: 5,
+      total: 10,
+      message: 'halfway there',
+    });
+    const running = JSON.parse(
+      runCheckBackgroundTask({
+        userId: 'u1',
+        conversationId: 'c_progress',
+        args: { background_task_id: created.task.id },
+      }),
+    );
+    expect(running.status).toBe('running');
+    expect(running.progress).toBe(0.5);
+    expect(running.progress_message).toBe('halfway there');
+
+    // absolute count without a total: no derivable fraction, message still updates
+    registry.setProgress('u1', 'c_progress', created.task.id, { progress: 7, message: 'step 7' });
+    expect(registry.get('u1', 'c_progress', created.task.id)?.progress).toBe(0.5);
+    expect(registry.get('u1', 'c_progress', created.task.id)?.progressMessage).toBe('step 7');
+
+    // settling wins: progress serializes as 1 and the message is dropped
+    registry.complete('u1', 'c_progress', created.task.id, { content: 'DONE' });
+    registry.setProgress('u1', 'c_progress', created.task.id, { progress: 0.1, message: 'late' });
+    const settled = JSON.parse(
+      runCheckBackgroundTask({
+        userId: 'u1',
+        conversationId: 'c_progress',
+        args: { background_task_id: created.task.id },
+      }),
+    );
+    expect(settled.progress).toBe(1);
+    expect(settled.progress_message).toBeUndefined();
+    expect(registry.get('u1', 'c_progress', created.task.id)?.progressMessage).toBe('step 7');
+  });
+
   it('truncates an oversized stored result with an explicit marker (not a silent cut)', () => {
     const registry = new BackgroundTaskRegistryClass();
     const created = registry.create({

--- a/packages/api/src/agents/background.ts
+++ b/packages/api/src/agents/background.ts
@@ -45,6 +45,21 @@ export const RUN_IN_BACKGROUND_ARG = 'run_in_background';
 export const CHECK_BACKGROUND_TASK_NAME: string = Constants.CHECK_BACKGROUND_TASK;
 
 /**
+ * Per-dispatch `configurable` key carrying a progress sink into the detached
+ * invoke. MCP tools forward it as the SDK's `onprogress` request option (which
+ * auto-attaches a `progressToken`), so servers that emit
+ * `notifications/progress` update the task mid-flight. Non-MCP tools ignore it.
+ */
+export const BACKGROUND_PROGRESS_SINK: string = 'backgroundProgressSink';
+
+/** Shape of MCP `notifications/progress` params forwarded by the SDK. */
+export interface BackgroundProgressUpdate {
+  progress: number;
+  total?: number;
+  message?: string;
+}
+
+/**
  * Tools that must never be backgrounded — they either run through the SDK's
  * direct/host-special path (so the host `ON_TOOL_EXECUTE` interception never
  * sees them), depend on synchronous artifact/code-session continuity, or are
@@ -247,7 +262,7 @@ export function stripBackgroundFromToolRegistry(
 
 const CHECK_BACKGROUND_TASK_DESCRIPTION = `Check the status and retrieve the result of tool calls previously dispatched in the background (with run_in_background: true).
 
-Provide a background_task_id to poll one task; omit it to list every background task in this conversation. A task is only finished when its status is "completed" or "error" — never assume completion without polling. Results are not pushed to you; you must call this tool to collect them. Background tasks persist on this server across turns, so you can collect a result in a later turn; they do not survive a server restart.`;
+Provide a background_task_id to poll one task; omit it to list every background task in this conversation. A task is only finished when its status is "completed" or "error" — never assume completion without polling. Running tasks may include progress (a 0..1 fraction) and progress_message when the tool reports them. Results are not pushed to you; you must call this tool to collect them. Background tasks persist on this server across turns, so you can collect a result in a later turn; they do not survive a server restart.`;
 
 const CHECK_BACKGROUND_TASK_PARAMETERS: JsonSchemaType = Object.freeze<JsonSchemaType>({
   type: 'object',
@@ -411,6 +426,11 @@ export interface BackgroundTask {
   toolName: string;
   toolCallId: string;
   status: BackgroundTaskStatus;
+  /** Latest reported completion fraction (0..1) while running, when the tool
+   *  emits MCP progress notifications; settled tasks serialize as 1. */
+  progress?: number;
+  /** Latest human-readable progress message from the tool, when reported. */
+  progressMessage?: string;
   /** Tool result content once completed. */
   result?: string;
   /**
@@ -444,6 +464,7 @@ const MAX_RUNNING_PER_BUCKET = 10;
 const MAX_TASKS_PER_BUCKET = 200;
 const MAX_RESULT_CHARS = 100_000;
 const MAX_ARTIFACT_CHARS = 10_000_000;
+const MAX_PROGRESS_MESSAGE_CHARS = 1_000;
 const GLOBAL_SWEEP_INTERVAL_MS = 60 * 1000;
 
 function toStoredContent(content: unknown): string {
@@ -651,6 +672,38 @@ export class BackgroundTaskRegistryClass {
   }
 
   /**
+   * Records an MCP progress notification on a still-running task. Normalizes
+   * the SDK's `{progress, total?}` pair to a 0..1 fraction (absolute counts
+   * without a total carry no derivable fraction and update only the message).
+   * Late notifications after settle/sweep are dropped.
+   */
+  setProgress(
+    userId: string,
+    conversationId: string,
+    taskId: string,
+    update: BackgroundProgressUpdate,
+  ): void {
+    const bucket = this.buckets.get(this.key(userId, conversationId));
+    const task = bucket?.tasks.get(taskId);
+    if (!task || task.status !== 'running') {
+      return;
+    }
+    let fraction: number | undefined;
+    if (update.total != null && update.total > 0) {
+      fraction = Math.min(update.progress / update.total, 1);
+    } else if (update.progress >= 0 && update.progress <= 1) {
+      fraction = update.progress;
+    }
+    if (fraction != null) {
+      task.progress = fraction;
+    }
+    if (typeof update.message === 'string' && update.message !== '') {
+      task.progressMessage = update.message.slice(0, MAX_PROGRESS_MESSAGE_CHARS);
+    }
+    task.updatedAt = Date.now();
+  }
+
+  /**
    * Returns a completed task's artifact exactly once, marking it delivered and
    * clearing it. The poll turn routes it to a live `toolEndCallback` so the
    * artifact isn't lost with the finalized dispatch turn. If handing it to the
@@ -721,7 +774,8 @@ export class BackgroundTaskRegistryClass {
   }
 }
 
-export const backgroundTaskRegistry = new BackgroundTaskRegistryClass();
+export const backgroundTaskRegistry: BackgroundTaskRegistryClass =
+  new BackgroundTaskRegistryClass();
 
 /** Content for the synthetic ToolMessage returned when a call is backgrounded. */
 export function buildBackgroundHandleContent(task: BackgroundTask): string {
@@ -752,8 +806,9 @@ interface SerializedBackgroundTask {
   background_task_id: string;
   tool: string;
   status: BackgroundTaskStatus;
-  /** Coarse 0..1: no intermediate progress exists, only running vs settled. */
+  /** 0..1: reported fraction while running (0 when the tool reports none), 1 once settled. */
   progress: number;
+  progress_message?: string;
   result?: string;
   result_available?: boolean;
   result_chars?: number;
@@ -782,7 +837,10 @@ function serializeTask(
     background_task_id: task.id,
     tool: task.toolName,
     status: task.status,
-    progress: task.status === 'running' ? 0 : 1,
+    progress: task.status === 'running' ? (task.progress ?? 0) : 1,
+    ...(task.status === 'running' && task.progressMessage != null
+      ? { progress_message: task.progressMessage }
+      : {}),
     ...resultFields(task, includeResult),
     ...(task.artifact != null || task.artifactDelivered === true
       ? { note: 'The tool produced an artifact that is not included inline.' }

--- a/packages/api/src/agents/handlers.background.spec.ts
+++ b/packages/api/src/agents/handlers.background.spec.ts
@@ -330,6 +330,80 @@ describe('createToolExecuteHandler — background tool calls', () => {
     expect(toolEndCalls).toHaveLength(1);
   });
 
+  it('threads a per-dispatch progress sink so a running task reports progress on poll', async () => {
+    let releaseTool: (() => void) | undefined;
+    const progressTool = {
+      name: 'search_mcp_docs',
+      description: 'reports progress mid-flight',
+      schema: z.object({ q: z.string() }),
+      invoke: async (
+        _input: Record<string, unknown>,
+        config?: { configurable?: Record<string, unknown> },
+      ) => {
+        const sink = config?.configurable?.backgroundProgressSink as
+          | ((update: { progress: number; total?: number; message?: string }) => void)
+          | undefined;
+        sink?.({ progress: 3, total: 4, message: 'crunching' });
+        await new Promise<void>((resolve) => {
+          releaseTool = resolve;
+        });
+        return { content: 'PROGRESS_DONE' };
+      },
+    } as unknown as StructuredToolInterface;
+    const handler = createToolExecuteHandler({
+      loadTools: async () => ({ loadedTools: [progressTool] }),
+    });
+    const configurable = buildConfig(['search_mcp_docs']);
+
+    const dispatch = await runBatch(handler, {
+      toolCalls: [
+        { id: 'call_prog', name: 'search_mcp_docs', args: { q: 'x', run_in_background: true } },
+      ],
+      agentId: 'a',
+      configurable,
+      metadata: { thread_id: 'exec_convo_progress', run_id: 'run-progress' },
+    });
+    await flushMicrotasks();
+    const handleId = JSON.parse(dispatch[0].content).background_task_id;
+
+    const running = await runBatch(handler, {
+      toolCalls: [
+        {
+          id: 'call_prog_poll',
+          name: CHECK_BACKGROUND_TASK_NAME,
+          args: { background_task_id: handleId },
+        },
+      ],
+      agentId: 'a',
+      configurable,
+      metadata: { thread_id: 'exec_convo_progress', run_id: 'run-progress-poll' },
+    });
+    const midFlight = JSON.parse(running[0].content);
+    expect(midFlight.status).toBe('running');
+    expect(midFlight.progress).toBe(0.75);
+    expect(midFlight.progress_message).toBe('crunching');
+
+    releaseTool?.();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    const done = await runBatch(handler, {
+      toolCalls: [
+        {
+          id: 'call_prog_poll2',
+          name: CHECK_BACKGROUND_TASK_NAME,
+          args: { background_task_id: handleId },
+        },
+      ],
+      agentId: 'a',
+      configurable,
+      metadata: { thread_id: 'exec_convo_progress', run_id: 'run-progress-poll2' },
+    });
+    const settled = JSON.parse(done[0].content);
+    expect(settled.status).toBe('completed');
+    expect(settled.progress).toBe(1);
+    expect(settled.result).toContain('PROGRESS_DONE');
+  });
+
   it('scopes tasks by configurable user_id when req is absent (external service hosts)', async () => {
     const state = { calls: 0 } as { calls: number; lastInput?: Record<string, unknown> };
     const handler = createToolExecuteHandler({

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -13,6 +13,7 @@ import type {
 } from '@librechat/agents';
 import type { StructuredToolInterface } from '@librechat/agents/langchain/tools';
 import type { CodeEnvRef } from 'librechat-data-provider';
+import type { BackgroundProgressUpdate } from './background';
 import type { SkillFileRecord } from './skillFiles';
 import type { ServerRequest } from '~/types';
 import {
@@ -26,6 +27,7 @@ import {
   buildBackgroundHandleContent,
   buildBackgroundCapacityContent,
   stripBackgroundFromToolDefinitions,
+  BACKGROUND_PROGRESS_SINK,
   CHECK_BACKGROUND_TASK_NAME,
   RUN_IN_BACKGROUND_ARG,
 } from './background';
@@ -3355,11 +3357,24 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
               const { task, isNew } = created;
               if (isNew) {
                 const strippedArgs = stripRunInBackgroundArg(tc.args);
+                /** MCP tools forward this as the SDK's `onprogress` request
+                 *  option, so servers emitting `notifications/progress` update
+                 *  the running task's progress/message for the poll tool. */
+                const onProgress = (update: BackgroundProgressUpdate): void =>
+                  backgroundTaskRegistry.setProgress(
+                    backgroundUserId,
+                    backgroundConversationId,
+                    task.id,
+                    update,
+                  );
                 void (async () => {
                   try {
                     const result = (await tool.invoke(normalizeToolInvokeArgs(strippedArgs, tool), {
                       toolCall: { id: tc.id, stepId: tc.stepId, turn: tc.turn },
-                      configurable: mergedConfigurable,
+                      configurable: {
+                        ...mergedConfigurable,
+                        [BACKGROUND_PROGRESS_SINK]: onProgress,
+                      },
                       metadata,
                     } as Record<string, unknown>)) as { content?: unknown; artifact?: unknown };
                     /** Hold any artifact (images, files, UI resources,

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -1,5 +1,6 @@
 export * from './avatars';
 export * from './attachments';
+export * from './background';
 export * from './chain';
 export * from './client';
 export * from './config';


### PR DESCRIPTION
## Summary

Follow-up to #14197: backgrounded MCP tool calls now report **real mid-flight progress** through the existing `check_background_task` poll contract.

- The detached dispatch threads a per-call progress sink into the invoke `configurable` (`BACKGROUND_PROGRESS_SINK`); the MCP tool forwards it as the SDK's `onprogress` request option, which auto-attaches a `progressToken` — servers emitting `notifications/progress` update the running task.
- The registry normalizes the SDK's `{progress, total?}` pair to a 0..1 fraction (absolute counts without a total update only the message), caps the message at 1k chars, and ignores late notifications after the task settles.
- `check_background_task` now returns `progress` as the reported fraction while running (0 when the tool reports none, 1 once settled) plus `progress_message`; the tool description tells the model these fields may appear.

## Non-goals / notes

- **Zero SDK or MCPManager changes**: `callTool` already spreads request options into the SDK call (and already sets `resetTimeoutOnProgress`, so these notifications were flowing — just not surfaced).
- Non-MCP tools ignore the sink; MCP servers that never emit progress behave exactly as before (coarse 0/1).
- Foreground calls are unchanged — progress surfacing only makes sense where a poll can read it.

## Tests

- Registry: fraction normalization (`progress/total`), message-only updates for absolute counts, late-notification drop after settle, serializer precedence (settled ⇒ `progress: 1`, message omitted).
- Executor: a dispatched tool calls the sink mid-flight → poll while running returns `progress: 0.75` + message; after completion the poll returns `progress: 1` with the result.
- Full `packages/api` agents suite (1253) + MCP service suite green; eslint + sort-imports + tsc + dist build clean.