### PR TITLE
📈 feat: Live MCP Progress on the Tool-Call Card

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -20,6 +20,7 @@ const {
   isUserSourced,
   checkAccessWithRequestCache,
   BACKGROUND_PROGRESS_SINK,
+  createToolProgressEmitter,
   requiresEphemeralUserConnection,
   containsGraphTokenPlaceholder,
 } = require('@librechat/api');
@@ -818,10 +819,22 @@ function createToolInstance({
       const customUserVars =
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
 
-      /** Set per-dispatch by the background executor: forwarding it as the
-       *  SDK's `onprogress` attaches a progressToken to the request, so a
-       *  server emitting `notifications/progress` updates the task mid-flight. */
+      /** Progress routing for `notifications/progress` (the SDK attaches a
+       *  progressToken whenever `onprogress` is passed). A background dispatch
+       *  sets the sink (its card already settled with the synthetic handle),
+       *  so progress feeds the poll registry; a foreground call streams a
+       *  throttled transient event to the live tool-call card instead. */
       const progressSink = config?.configurable?.[BACKGROUND_PROGRESS_SINK];
+      let onToolProgress = typeof progressSink === 'function' ? progressSink : undefined;
+      if (onToolProgress == null && toolCall.id != null) {
+        onToolProgress = createToolProgressEmitter({
+          toolCallId: toolCall.id,
+          emit: (eventData) =>
+            streamId
+              ? GenerationJobManager.emitChunk(streamId, eventData)
+              : sendEvent(res, eventData),
+        });
+      }
 
       const result = await mcpManager.callTool({
         serverName,
@@ -831,7 +844,7 @@ function createToolInstance({
         toolArguments,
         options: {
           signal: derivedSignal,
-          ...(typeof progressSink === 'function' ? { onprogress: progressSink } : {}),
+          ...(onToolProgress ? { onprogress: onToolProgress } : {}),
         },
         user: effectiveUser,
         requestBody: config?.configurable?.requestBody ?? capturedRequestBody,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -19,6 +19,7 @@ const {
   buildMCPAuthRunStepEndDeltaEvent,
   isUserSourced,
   checkAccessWithRequestCache,
+  BACKGROUND_PROGRESS_SINK,
   requiresEphemeralUserConnection,
   containsGraphTokenPlaceholder,
 } = require('@librechat/api');
@@ -817,6 +818,11 @@ function createToolInstance({
       const customUserVars =
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
 
+      /** Set per-dispatch by the background executor: forwarding it as the
+       *  SDK's `onprogress` attaches a progressToken to the request, so a
+       *  server emitting `notifications/progress` updates the task mid-flight. */
+      const progressSink = config?.configurable?.[BACKGROUND_PROGRESS_SINK];
+
       const result = await mcpManager.callTool({
         serverName,
         serverConfig: capturedServerConfig,
@@ -825,6 +831,7 @@ function createToolInstance({
         toolArguments,
         options: {
           signal: derivedSignal,
+          ...(typeof progressSink === 'function' ? { onprogress: progressSink } : {}),
         },
         user: effectiveUser,
         requestBody: config?.configurable?.requestBody ?? capturedRequestBody,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -829,6 +829,7 @@ function createToolInstance({
       if (onToolProgress == null && toolCall.id != null) {
         onToolProgress = createToolProgressEmitter({
           toolCallId: toolCall.id,
+          runId: config.metadata?.run_id,
           /** Transient emit: progress must never land in the Redis chunk log
            *  or resume reconstruction — live subscribers only. */
           emit: (eventData) =>

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -829,9 +829,11 @@ function createToolInstance({
       if (onToolProgress == null && toolCall.id != null) {
         onToolProgress = createToolProgressEmitter({
           toolCallId: toolCall.id,
+          /** Transient emit: progress must never land in the Redis chunk log
+           *  or resume reconstruction — live subscribers only. */
           emit: (eventData) =>
             streamId
-              ? GenerationJobManager.emitChunk(streamId, eventData)
+              ? GenerationJobManager.emitTransientEvent(streamId, eventData)
               : sendEvent(res, eventData),
         });
       }

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -310,6 +310,7 @@ const Part = memo(function Part({
             args={toolCall.args ?? ''}
             name={toolCall.name || ''}
             output={toolCall.output ?? ''}
+            toolCallId={toolCall.id}
             initialProgress={toolCall.progress ?? 0.1}
             isSubmitting={isSubmitting}
             attachments={attachments}

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -11,12 +11,12 @@ import {
 import type { TAttachment } from 'librechat-data-provider';
 import { useLocalize, useProgress, useExpandCollapse } from '~/hooks';
 import { ToolIcon, getToolIconType, isError } from './ToolOutput';
+import store, { toolProgressByToolCallId } from '~/store';
 import { useMCPIconMap } from '~/hooks/MCP';
 import { AttachmentGroup } from './Parts';
 import ToolCallInfo from './ToolCallInfo';
 import ProgressText from './ProgressText';
 import { logger } from '~/utils';
-import store from '~/store';
 
 export default function ToolCall({
   initialProgress = 0.1,
@@ -27,6 +27,7 @@ export default function ToolCall({
   output,
   attachments,
   auth,
+  toolCallId,
   hideAttachments = false,
   onExpand,
 }: {
@@ -38,6 +39,7 @@ export default function ToolCall({
   output?: string | null;
   attachments?: TAttachment[];
   auth?: string;
+  toolCallId?: string;
   hideAttachments?: boolean;
   onExpand?: () => void;
 }) {
@@ -165,6 +167,24 @@ export default function ToolCall({
   const progress = useProgress(initialProgress);
   const showCancelled = cancelled || (errorState && !output);
 
+  /** Live MCP progress (`notifications/progress`) for this call, when streamed. */
+  const liveProgress = useRecoilValue(toolProgressByToolCallId(toolCallId ?? ''));
+  const inProgressText = useMemo(() => {
+    if (liveProgress?.message) {
+      return liveProgress.message;
+    }
+    if (liveProgress != null && liveProgress.total != null && liveProgress.total > 0) {
+      const asLabel = (value: number) => (Number.isInteger(value) ? `${value}` : value.toFixed(1));
+      return localize('com_ui_tool_progress', {
+        0: asLabel(liveProgress.progress),
+        1: asLabel(liveProgress.total),
+      });
+    }
+    return function_name
+      ? localize('com_assistants_running_var', { 0: function_name })
+      : localize('com_assistants_running_action');
+  }, [liveProgress, function_name, localize]);
+
   const handleToggleInfo = useCallback(() => {
     setShowInfo((prev) => {
       const next = !prev;
@@ -207,9 +227,7 @@ export default function ToolCall({
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {(() => {
           if (progress < 1 && !showCancelled) {
-            return function_name
-              ? localize('com_assistants_running_var', { 0: function_name })
-              : localize('com_assistants_running_action');
+            return inProgressText;
           }
           return getFinishedText();
         })()}
@@ -218,11 +236,7 @@ export default function ToolCall({
         <ProgressText
           progress={progress}
           onClick={handleToggleInfo}
-          inProgressText={
-            function_name
-              ? localize('com_assistants_running_var', { 0: function_name })
-              : localize('com_assistants_running_action')
-          }
+          inProgressText={inProgressText}
           authText={
             !showCancelled && authDomain.length > 0 ? localize('com_ui_requires_auth') : undefined
           }

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -174,7 +174,12 @@ export default function ToolCall({
       return liveProgress.message;
     }
     if (liveProgress != null && liveProgress.total != null && liveProgress.total > 0) {
-      const asLabel = (value: number) => (Number.isInteger(value) ? `${value}` : value.toFixed(1));
+      const asLabel = (value: number) => {
+        if (Number.isInteger(value) || !Number.isFinite(value)) {
+          return `${value}`;
+        }
+        return value.toFixed(1);
+      };
       return localize('com_ui_tool_progress', {
         0: asLabel(liveProgress.progress),
         1: asLabel(liveProgress.total),

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -9,9 +9,10 @@ import {
   actionDomainSeparator,
 } from 'librechat-data-provider';
 import type { TAttachment } from 'librechat-data-provider';
+import store, { toolProgressByToolCallId, toolProgressKey } from '~/store';
 import { useLocalize, useProgress, useExpandCollapse } from '~/hooks';
 import { ToolIcon, getToolIconType, isError } from './ToolOutput';
-import store, { toolProgressByToolCallId } from '~/store';
+import { useMessageContext } from '~/Providers';
 import { useMCPIconMap } from '~/hooks/MCP';
 import { AttachmentGroup } from './Parts';
 import ToolCallInfo from './ToolCallInfo';
@@ -167,8 +168,12 @@ export default function ToolCall({
   const progress = useProgress(initialProgress);
   const showCancelled = cancelled || (errorState && !output);
 
-  /** Live MCP progress (`notifications/progress`) for this call, when streamed. */
-  const liveProgress = useRecoilValue(toolProgressByToolCallId(toolCallId ?? ''));
+  /** Live MCP progress (`notifications/progress`) for this call, when streamed;
+   *  scoped by the message id since providers reuse tool-call ids across agents. */
+  const { messageId } = useMessageContext();
+  const liveProgress = useRecoilValue(
+    toolProgressByToolCallId(toolCallId ? toolProgressKey(messageId, toolCallId) : ''),
+  );
   const inProgressText = useMemo(() => {
     if (liveProgress?.message) {
       return liveProgress.message;
@@ -184,6 +189,9 @@ export default function ToolCall({
         0: asLabel(liveProgress.progress),
         1: asLabel(liveProgress.total),
       });
+    }
+    if (liveProgress != null && liveProgress.progress >= 0 && liveProgress.progress <= 1) {
+      return `${Math.round(liveProgress.progress * 100)}%`;
     }
     return function_name
       ? localize('com_assistants_running_var', { 0: function_name })

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { Tools, Constants } from 'librechat-data-provider';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { toolProgressByToolCallId } from '~/store';
 import ToolCall from '../ToolCall';
 
 // Mock dependencies
@@ -19,6 +20,7 @@ jest.mock('~/hooks', () => ({
       com_assistants_allow_sites_you_trust: 'Only allow sites you trust',
       com_ui_via_server: `via ${values?.[0]}`,
       com_ui_tool_failed: 'failed',
+      com_ui_tool_progress: `${values?.[0]} of ${values?.[1]}`,
     };
     return translations[key] || key;
   },
@@ -66,6 +68,7 @@ jest.mock('../ProgressText', () => ({
   }) => (
     <div data-testid="progress-text" onClick={onClick}>
       {finishedText || inProgressText}
+      <span data-testid="in-progress-text">{inProgressText}</span>
       {subtitle && <span data-testid="subtitle">{subtitle}</span>}
     </div>
   ),
@@ -99,6 +102,44 @@ jest.mock('~/utils', () => ({
 }));
 
 describe('ToolCall', () => {
+  describe('live MCP progress', () => {
+    const renderRunningToolCall = (
+      liveState: { progress: number; total?: number; message?: string } | null,
+    ) =>
+      render(
+        <RecoilRoot
+          initializeState={({ set }) => {
+            if (liveState) {
+              set(toolProgressByToolCallId('call_live'), liveState);
+            }
+          }}
+        >
+          <ToolCall
+            name={`search${Constants.mcp_delimiter}docs`}
+            args=""
+            initialProgress={0.1}
+            isSubmitting={true}
+            toolCallId="call_live"
+          />
+        </RecoilRoot>,
+      );
+
+    it('renders the reported progress message while running', () => {
+      renderRunningToolCall({ progress: 3, total: 10, message: 'crunching records' });
+      expect(screen.getByTestId('in-progress-text')).toHaveTextContent('crunching records');
+    });
+
+    it('renders a localized count when only progress/total are reported', () => {
+      renderRunningToolCall({ progress: 3, total: 10 });
+      expect(screen.getByTestId('in-progress-text')).toHaveTextContent('3 of 10');
+    });
+
+    it('falls back to the running label without live progress', () => {
+      renderRunningToolCall(null);
+      expect(screen.getByTestId('in-progress-text')).toHaveTextContent('Running search');
+    });
+  });
+
   const mockProps = {
     args: '{"test": "input"}',
     name: 'testFunction',

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { Tools, Constants } from 'librechat-data-provider';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { toolProgressByToolCallId } from '~/store';
+import { toolProgressByToolCallId, toolProgressKey } from '~/store';
+import { MessageContext } from '~/Providers';
 import ToolCall from '../ToolCall';
 
 // Mock dependencies
@@ -110,17 +111,19 @@ describe('ToolCall', () => {
         <RecoilRoot
           initializeState={({ set }) => {
             if (liveState) {
-              set(toolProgressByToolCallId('call_live'), liveState);
+              set(toolProgressByToolCallId(toolProgressKey('msg_live', 'call_live')), liveState);
             }
           }}
         >
-          <ToolCall
-            name={`search${Constants.mcp_delimiter}docs`}
-            args=""
-            initialProgress={0.1}
-            isSubmitting={true}
-            toolCallId="call_live"
-          />
+          <MessageContext.Provider value={{ messageId: 'msg_live' } as never}>
+            <ToolCall
+              name={`search${Constants.mcp_delimiter}docs`}
+              args=""
+              initialProgress={0.1}
+              isSubmitting={true}
+              toolCallId="call_live"
+            />
+          </MessageContext.Provider>
         </RecoilRoot>,
       );
 
@@ -132,6 +135,11 @@ describe('ToolCall', () => {
     it('renders a localized count when only progress/total are reported', () => {
       renderRunningToolCall({ progress: 3, total: 10 });
       expect(screen.getByTestId('in-progress-text')).toHaveTextContent('3 of 10');
+    });
+
+    it('renders a percentage for fraction-only progress (no total, no message)', () => {
+      renderRunningToolCall({ progress: 0.4 });
+      expect(screen.getByTestId('in-progress-text')).toHaveTextContent('40%');
     });
 
     it('falls back to the running label without live progress', () => {

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -292,7 +292,24 @@ export default function useStepHandler({
     [],
   );
 
-  /** Also clears the live tool-progress atoms — same transient lifecycle. */
+  /**
+   * Live tool progress is meaningful only for the run that produced it, and
+   * providers reuse tool-call ids (e.g. `call_0`) across turns — so these
+   * atoms clear at the start of every new submission (`clearStepMaps`),
+   * unlike the subagent atoms which persist until conversation switch.
+   */
+  const resetToolProgressAtoms = useRecoilCallback(
+    ({ reset }) =>
+      (): void => {
+        for (const toolCallId of knownToolProgressAtomKeys.current) {
+          reset(toolProgressByToolCallId(toolCallId));
+        }
+        knownToolProgressAtomKeys.current.clear();
+      },
+    [],
+  );
+
+  /** Also clears the live tool-progress atoms (conversation-switch boundary). */
   const resetSubagentAtoms = useRecoilCallback(
     ({ reset }) =>
       (): void => {
@@ -300,12 +317,9 @@ export default function useStepHandler({
           reset(subagentProgressByToolCallId(toolCallId));
         }
         knownSubagentAtomKeys.current.clear();
-        for (const toolCallId of knownToolProgressAtomKeys.current) {
-          reset(toolProgressByToolCallId(toolCallId));
-        }
-        knownToolProgressAtomKeys.current.clear();
+        resetToolProgressAtoms();
       },
-    [],
+    [resetToolProgressAtoms],
   );
 
   /**
@@ -1125,6 +1139,7 @@ export default function useStepHandler({
     subagentRunToToolCallId.current.clear();
     claimedSubagentToolCallIds.current.clear();
     pendingSubagentBuffer.current.clear();
+    resetToolProgressAtoms();
     /** Intentionally NOT calling `resetSubagentAtoms()` here — users need
      *  to be able to reopen the SubagentCall dialog after completion to
      *  audit what the child did. `resetSubagentAtoms` is returned below
@@ -1133,7 +1148,7 @@ export default function useStepHandler({
      *  persisted `subagent_content` takes over for historical messages
      *  once the conversation is saved, and we prevent unbounded
      *  atomFamily growth across multi-conversation sessions. */
-  }, []);
+  }, [resetToolProgressAtoms]);
 
   /**
    * Sync a message into the step handler's messageMap.

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -27,7 +27,7 @@ import {
   initSubagentAggregatorState,
   initSubagentTickerState,
 } from '~/utils/subagentContent';
-import { subagentProgressByToolCallId, toolProgressByToolCallId } from '~/store';
+import { subagentProgressByToolCallId, toolProgressByToolCallId, toolProgressKey } from '~/store';
 import { isAskUserQuestionPart } from '~/utils/approval';
 import { MESSAGE_UPDATE_INTERVAL } from '~/common';
 
@@ -282,8 +282,9 @@ export default function useStepHandler({
         if (!payload?.toolCallId) {
           return;
         }
-        knownToolProgressAtomKeys.current.add(payload.toolCallId);
-        set(toolProgressByToolCallId(payload.toolCallId), {
+        const atomKey = toolProgressKey(payload.runId, payload.toolCallId);
+        knownToolProgressAtomKeys.current.add(atomKey);
+        set(toolProgressByToolCallId(atomKey), {
           progress: payload.progress,
           total: payload.total,
           message: payload.message,

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -17,6 +17,7 @@ import type {
   SummaryContentPart,
   TMessageContentParts,
   SubagentUpdateEvent,
+  ToolProgressEvent,
 } from 'librechat-data-provider';
 import type { SetterOrUpdater } from 'recoil';
 import type { AnnounceOptions } from '~/common';
@@ -26,8 +27,8 @@ import {
   initSubagentAggregatorState,
   initSubagentTickerState,
 } from '~/utils/subagentContent';
+import { subagentProgressByToolCallId, toolProgressByToolCallId } from '~/store';
 import { isAskUserQuestionPart } from '~/utils/approval';
-import { subagentProgressByToolCallId } from '~/store';
 import { MESSAGE_UPDATE_INTERVAL } from '~/common';
 
 type TUseStepHandler = {
@@ -55,7 +56,8 @@ type TStepEvent =
   | { event: StepEvents.ON_SUMMARIZE_START; data: Agents.SummarizeStartEvent }
   | { event: StepEvents.ON_SUMMARIZE_DELTA; data: Agents.SummarizeDeltaEvent }
   | { event: StepEvents.ON_SUMMARIZE_COMPLETE; data: Agents.SummarizeCompleteEvent }
-  | { event: StepEvents.ON_SUBAGENT_UPDATE; data: SubagentUpdateEvent };
+  | { event: StepEvents.ON_SUBAGENT_UPDATE; data: SubagentUpdateEvent }
+  | { event: StepEvents.ON_TOOL_PROGRESS; data: ToolProgressEvent };
 
 type MessageDeltaUpdate = { type: ContentTypes.TEXT; text: string; tool_call_ids?: string[] };
 
@@ -147,6 +149,7 @@ export default function useStepHandler({
    * `atomFamily` — atoms persist for the app lifetime.
    */
   const knownSubagentAtomKeys = useRef(new Set<string>());
+  const knownToolProgressAtomKeys = useRef(new Set<string>());
 
   const getCurrentMessages = useCallback(
     (messages: TMessage[]) => {
@@ -273,6 +276,23 @@ export default function useStepHandler({
    * subagent spawn), so growth is proportional to messages — the same
    * growth profile as the rest of the conversation state.
    */
+  const applyToolProgress = useRecoilCallback(
+    ({ set }) =>
+      (payload: ToolProgressEvent): void => {
+        if (!payload?.toolCallId) {
+          return;
+        }
+        knownToolProgressAtomKeys.current.add(payload.toolCallId);
+        set(toolProgressByToolCallId(payload.toolCallId), {
+          progress: payload.progress,
+          total: payload.total,
+          message: payload.message,
+        });
+      },
+    [],
+  );
+
+  /** Also clears the live tool-progress atoms — same transient lifecycle. */
   const resetSubagentAtoms = useRecoilCallback(
     ({ reset }) =>
       (): void => {
@@ -280,6 +300,10 @@ export default function useStepHandler({
           reset(subagentProgressByToolCallId(toolCallId));
         }
         knownSubagentAtomKeys.current.clear();
+        for (const toolCallId of knownToolProgressAtomKeys.current) {
+          reset(toolProgressByToolCallId(toolCallId));
+        }
+        knownToolProgressAtomKeys.current.clear();
       },
     [],
   );
@@ -977,6 +1001,8 @@ export default function useStepHandler({
             }),
           );
         }
+      } else if (stepEvent.event === StepEvents.ON_TOOL_PROGRESS) {
+        applyToolProgress(stepEvent.data);
       } else if (stepEvent.event === StepEvents.ON_SUBAGENT_UPDATE) {
         applySubagentUpdate(stepEvent.data);
       } else if (stepEvent.event === StepEvents.ON_SUMMARIZE_START) {
@@ -1082,6 +1108,7 @@ export default function useStepHandler({
       calculateContentIndex,
       getCurrentMessages,
       applySubagentUpdate,
+      applyToolProgress,
       onSkillAuthoringComplete,
     ],
   );

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -294,6 +294,27 @@ export default function useStepHandler({
   );
 
   /**
+   * Clears live progress for the tool calls of a freshly-started run step:
+   * providers reissue ids (e.g. `call_0`) across tool turns within one run,
+   * so a new call must never inherit a prior call's progress state.
+   */
+  const clearToolProgressForStep = useRecoilCallback(
+    ({ set }) =>
+      (runId: string, toolCallIds: Array<string | undefined>): void => {
+        for (const toolCallId of toolCallIds) {
+          if (!toolCallId) {
+            continue;
+          }
+          const atomKey = toolProgressKey(runId, toolCallId);
+          if (knownToolProgressAtomKeys.current.has(atomKey)) {
+            set(toolProgressByToolCallId(atomKey), null);
+          }
+        }
+      },
+    [],
+  );
+
+  /**
    * Live tool progress is meaningful only for the run that produced it, and
    * providers reuse tool-call ids (e.g. `call_0`) across turns — so these
    * atoms clear at the start of every new submission (`clearStepMaps`),
@@ -657,6 +678,13 @@ export default function useStepHandler({
         }
 
         stepMap.current.set(runStep.id, runStep);
+
+        if (runStep.stepDetails?.type === StepTypes.TOOL_CALLS) {
+          clearToolProgressForStep(
+            responseMessageId,
+            (runStep.stepDetails.tool_calls ?? []).map((toolCall) => toolCall.id),
+          );
+        }
 
         // Calculate content index - use server index, offset by initialContent for edit scenarios
         const contentIndex = runStep.index + initialContent.length;
@@ -1124,6 +1152,7 @@ export default function useStepHandler({
       getCurrentMessages,
       applySubagentUpdate,
       applyToolProgress,
+      clearToolProgressForStep,
       onSkillAuthoringComplete,
     ],
   );

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1905,6 +1905,7 @@
   "com_ui_tool_name_image_edit": "Image Edit",
   "com_ui_tool_name_image_gen": "Image Generation",
   "com_ui_tool_name_web_search": "Web Search",
+  "com_ui_tool_progress": "{{0}} of {{1}}",
   "com_ui_tool_response_placeholder": "Type a substitute result to return to the agent",
   "com_ui_tools": "Tools",
   "com_ui_tools_configure": "Configure",

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -16,6 +16,7 @@ export * from './agents';
 export * from './mcp';
 export * from './favorites';
 export * from './subagents';
+export * from './toolProgress';
 export * from './usage';
 
 export default {

--- a/client/src/store/toolProgress.ts
+++ b/client/src/store/toolProgress.ts
@@ -1,0 +1,13 @@
+import { atomFamily } from 'recoil';
+import type { ToolProgressEvent } from 'librechat-data-provider';
+
+export type ToolProgressState = Pick<ToolProgressEvent, 'progress' | 'total' | 'message'>;
+
+/**
+ * Live MCP progress per tool call id (transient — populated from
+ * `on_tool_progress` stream events, reset alongside the subagent atoms).
+ */
+export const toolProgressByToolCallId = atomFamily<ToolProgressState | null, string>({
+  key: 'toolProgressByToolCallId',
+  default: null,
+});

--- a/client/src/store/toolProgress.ts
+++ b/client/src/store/toolProgress.ts
@@ -3,6 +3,11 @@ import type { ToolProgressEvent } from 'librechat-data-provider';
 
 export type ToolProgressState = Pick<ToolProgressEvent, 'progress' | 'total' | 'message'>;
 
+/** Providers reuse tool-call ids across parallel agents, so live progress is
+ *  scoped by the run's response message id as well. */
+export const toolProgressKey = (runId: string | undefined, toolCallId: string): string =>
+  `${runId ?? ''}:${toolCallId}`;
+
 /**
  * Live MCP progress per tool call id (transient — populated from
  * `on_tool_progress` stream events, reset alongside the subagent atoms).

--- a/packages/api/src/agents/background.spec.ts
+++ b/packages/api/src/agents/background.spec.ts
@@ -559,11 +559,57 @@ describe('BackgroundTaskRegistryClass', () => {
     if ('atCapacity' in created) {
       throw new Error('unexpected capacity');
     }
-    // backdate creation past the 30-min running TTL, then trigger a sweep
+    // backdate all activity past the 30-min running-silence TTL, then sweep
     created.task.createdAt = Date.now() - 31 * 60 * 1000;
+    created.task.updatedAt = created.task.createdAt;
     registry.list('u1', 'c1');
     expect(created.task.status).toBe('error');
     expect(created.task.error).toBe('Background task timed out');
+  });
+
+  it('keeps a silent-but-reporting long task alive, up to the absolute age cap', () => {
+    const registry = new BackgroundTaskRegistryClass();
+    const created = registry.create({
+      userId: 'u1',
+      conversationId: 'c1',
+      toolCallId: 'call_long',
+      toolName: 'search_mcp_docs',
+    });
+    if ('atCapacity' in created) {
+      throw new Error('unexpected capacity');
+    }
+    // 31 minutes old but progress arrived recently: stays running
+    created.task.createdAt = Date.now() - 31 * 60 * 1000;
+    registry.setProgress('u1', 'c1', created.task.id, { progress: 5, total: 10 });
+    registry.list('u1', 'c1');
+    expect(created.task.status).toBe('running');
+
+    // past the absolute 6h cap: reaped even with fresh progress
+    created.task.createdAt = Date.now() - 6 * 60 * 60 * 1000 - 1000;
+    registry.setProgress('u1', 'c1', created.task.id, { progress: 6, total: 10 });
+    registry.list('u1', 'c1');
+    expect(created.task.status).toBe('error');
+  });
+
+  it('rejects non-finite and clamps out-of-range background progress', () => {
+    const registry = new BackgroundTaskRegistryClass();
+    const created = registry.create({
+      userId: 'u1',
+      conversationId: 'c1',
+      toolCallId: 'call_badprog',
+      toolName: 'search_mcp_docs',
+    });
+    if ('atCapacity' in created) {
+      throw new Error('unexpected capacity');
+    }
+    registry.setProgress('u1', 'c1', created.task.id, { progress: Infinity, total: 10 });
+    expect(created.task.progress).toBeUndefined();
+    registry.setProgress('u1', 'c1', created.task.id, { progress: -1, total: 10 });
+    expect(created.task.progress).toBe(0);
+    registry.setProgress('u1', 'c1', created.task.id, { progress: 5, total: Infinity });
+    expect(created.task.progress).toBe(0);
+    registry.setProgress('u1', 'c1', created.task.id, { progress: 5, total: 10 });
+    expect(created.task.progress).toBe(0.5);
   });
 
   it('sweeps an expired completed task on direct get() (no indefinite retention)', () => {

--- a/packages/api/src/agents/background.spec.ts
+++ b/packages/api/src/agents/background.spec.ts
@@ -454,6 +454,55 @@ describe('BackgroundTaskRegistryClass', () => {
     expect(registry.get('u1', 'c1', created.task.id)?.artifact).toBeUndefined();
   });
 
+  it('records MCP progress on a running task and serializes it for the poll tool', () => {
+    /** The singleton, because runCheckBackgroundTask serializes through it. */
+    const registry = backgroundTaskRegistry;
+    const created = registry.create({
+      userId: 'u1',
+      conversationId: 'c_progress',
+      toolCallId: 'call_prog',
+      toolName: 'search_mcp_docs',
+    });
+    if ('atCapacity' in created) {
+      throw new Error('unexpected capacity');
+    }
+
+    registry.setProgress('u1', 'c_progress', created.task.id, {
+      progress: 5,
+      total: 10,
+      message: 'halfway there',
+    });
+    const running = JSON.parse(
+      runCheckBackgroundTask({
+        userId: 'u1',
+        conversationId: 'c_progress',
+        args: { background_task_id: created.task.id },
+      }),
+    );
+    expect(running.status).toBe('running');
+    expect(running.progress).toBe(0.5);
+    expect(running.progress_message).toBe('halfway there');
+
+    // absolute count without a total: no derivable fraction, message still updates
+    registry.setProgress('u1', 'c_progress', created.task.id, { progress: 7, message: 'step 7' });
+    expect(registry.get('u1', 'c_progress', created.task.id)?.progress).toBe(0.5);
+    expect(registry.get('u1', 'c_progress', created.task.id)?.progressMessage).toBe('step 7');
+
+    // settling wins: progress serializes as 1 and the message is dropped
+    registry.complete('u1', 'c_progress', created.task.id, { content: 'DONE' });
+    registry.setProgress('u1', 'c_progress', created.task.id, { progress: 0.1, message: 'late' });
+    const settled = JSON.parse(
+      runCheckBackgroundTask({
+        userId: 'u1',
+        conversationId: 'c_progress',
+        args: { background_task_id: created.task.id },
+      }),
+    );
+    expect(settled.progress).toBe(1);
+    expect(settled.progress_message).toBeUndefined();
+    expect(registry.get('u1', 'c_progress', created.task.id)?.progressMessage).toBe('step 7');
+  });
+
   it('truncates an oversized stored result with an explicit marker (not a silent cut)', () => {
     const registry = new BackgroundTaskRegistryClass();
     const created = registry.create({

--- a/packages/api/src/agents/background.ts
+++ b/packages/api/src/agents/background.ts
@@ -456,10 +456,13 @@ interface TaskBucket {
 
 const COMPLETED_TASK_TTL_MS = 60 * 60 * 1000;
 const IDLE_BUCKET_TTL_MS = 6 * 60 * 60 * 1000;
-/** Max wall-clock a task may stay `running` before being reaped as timed-out,
- *  so a detached call that never settles (hung network / lost MCP connection)
- *  can't hold a running slot and exhaust the per-conversation cap forever. */
+/** Max SILENCE (no completion, no progress) before a running task is reaped as
+ *  timed-out, so a detached call that never settles (hung network / lost MCP
+ *  connection) can't hold a running slot forever — while a long task that keeps
+ *  reporting progress stays alive up to the absolute cap below. */
 const RUNNING_TASK_TTL_MS = 30 * 60 * 1000;
+/** Absolute running-age ceiling regardless of progress chatter. */
+const MAX_RUNNING_AGE_MS = 6 * 60 * 60 * 1000;
 const MAX_RUNNING_PER_BUCKET = 10;
 const MAX_TASKS_PER_BUCKET = 200;
 const MAX_RESULT_CHARS = 100_000;
@@ -514,7 +517,10 @@ export class BackgroundTaskRegistryClass {
 
   private sweepBucketTasks(bucket: TaskBucket, now: number): void {
     for (const [taskId, task] of bucket.tasks) {
-      if (task.status === 'running' && now - task.createdAt > RUNNING_TASK_TTL_MS) {
+      if (
+        task.status === 'running' &&
+        (now - task.updatedAt > RUNNING_TASK_TTL_MS || now - task.createdAt > MAX_RUNNING_AGE_MS)
+      ) {
         /** Reap a stuck task: freeing the running slot (it no longer counts
          *  toward the cap) and letting the completed-task TTL evict it. */
         task.status = 'error';
@@ -685,21 +691,23 @@ export class BackgroundTaskRegistryClass {
   ): void {
     const bucket = this.buckets.get(this.key(userId, conversationId));
     const task = bucket?.tasks.get(taskId);
-    if (!task || task.status !== 'running') {
+    if (!task || task.status !== 'running' || !Number.isFinite(update.progress)) {
       return;
     }
     let fraction: number | undefined;
-    if (update.total != null && update.total > 0) {
-      fraction = Math.min(update.progress / update.total, 1);
+    if (Number.isFinite(update.total) && (update.total as number) > 0) {
+      fraction = update.progress / (update.total as number);
     } else if (update.progress >= 0 && update.progress <= 1) {
       fraction = update.progress;
     }
     if (fraction != null) {
-      task.progress = fraction;
+      task.progress = Math.min(Math.max(fraction, 0), 1);
     }
     if (typeof update.message === 'string' && update.message !== '') {
       task.progressMessage = update.message.slice(0, MAX_PROGRESS_MESSAGE_CHARS);
     }
+    /** Also treated as liveness: the running reap is silence-based, so an
+     *  actively-reporting long task isn't timed out mid-flight. */
     task.updatedAt = Date.now();
   }
 

--- a/packages/api/src/agents/background.ts
+++ b/packages/api/src/agents/background.ts
@@ -45,6 +45,21 @@ export const RUN_IN_BACKGROUND_ARG = 'run_in_background';
 export const CHECK_BACKGROUND_TASK_NAME: string = Constants.CHECK_BACKGROUND_TASK;
 
 /**
+ * Per-dispatch `configurable` key carrying a progress sink into the detached
+ * invoke. MCP tools forward it as the SDK's `onprogress` request option (which
+ * auto-attaches a `progressToken`), so servers that emit
+ * `notifications/progress` update the task mid-flight. Non-MCP tools ignore it.
+ */
+export const BACKGROUND_PROGRESS_SINK: string = 'backgroundProgressSink';
+
+/** Shape of MCP `notifications/progress` params forwarded by the SDK. */
+export interface BackgroundProgressUpdate {
+  progress: number;
+  total?: number;
+  message?: string;
+}
+
+/**
  * Tools that must never be backgrounded — they either run through the SDK's
  * direct/host-special path (so the host `ON_TOOL_EXECUTE` interception never
  * sees them), depend on synchronous artifact/code-session continuity, or are
@@ -247,7 +262,7 @@ export function stripBackgroundFromToolRegistry(
 
 const CHECK_BACKGROUND_TASK_DESCRIPTION = `Check the status and retrieve the result of tool calls previously dispatched in the background (with run_in_background: true).
 
-Provide a background_task_id to poll one task; omit it to list every background task in this conversation. A task is only finished when its status is "completed" or "error" — never assume completion without polling. Results are not pushed to you; you must call this tool to collect them. Background tasks persist on this server across turns, so you can collect a result in a later turn; they do not survive a server restart.`;
+Provide a background_task_id to poll one task; omit it to list every background task in this conversation. A task is only finished when its status is "completed" or "error" — never assume completion without polling. Running tasks may include progress (a 0..1 fraction) and progress_message when the tool reports them. Results are not pushed to you; you must call this tool to collect them. Background tasks persist on this server across turns, so you can collect a result in a later turn; they do not survive a server restart.`;
 
 const CHECK_BACKGROUND_TASK_PARAMETERS: JsonSchemaType = Object.freeze<JsonSchemaType>({
   type: 'object',
@@ -411,6 +426,11 @@ export interface BackgroundTask {
   toolName: string;
   toolCallId: string;
   status: BackgroundTaskStatus;
+  /** Latest reported completion fraction (0..1) while running, when the tool
+   *  emits MCP progress notifications; settled tasks serialize as 1. */
+  progress?: number;
+  /** Latest human-readable progress message from the tool, when reported. */
+  progressMessage?: string;
   /** Tool result content once completed. */
   result?: string;
   /**
@@ -444,6 +464,7 @@ const MAX_RUNNING_PER_BUCKET = 10;
 const MAX_TASKS_PER_BUCKET = 200;
 const MAX_RESULT_CHARS = 100_000;
 const MAX_ARTIFACT_CHARS = 10_000_000;
+const MAX_PROGRESS_MESSAGE_CHARS = 1_000;
 const GLOBAL_SWEEP_INTERVAL_MS = 60 * 1000;
 
 function toStoredContent(content: unknown): string {
@@ -651,6 +672,38 @@ export class BackgroundTaskRegistryClass {
   }
 
   /**
+   * Records an MCP progress notification on a still-running task. Normalizes
+   * the SDK's `{progress, total?}` pair to a 0..1 fraction (absolute counts
+   * without a total carry no derivable fraction and update only the message).
+   * Late notifications after settle/sweep are dropped.
+   */
+  setProgress(
+    userId: string,
+    conversationId: string,
+    taskId: string,
+    update: BackgroundProgressUpdate,
+  ): void {
+    const bucket = this.buckets.get(this.key(userId, conversationId));
+    const task = bucket?.tasks.get(taskId);
+    if (!task || task.status !== 'running') {
+      return;
+    }
+    let fraction: number | undefined;
+    if (update.total != null && update.total > 0) {
+      fraction = Math.min(update.progress / update.total, 1);
+    } else if (update.progress >= 0 && update.progress <= 1) {
+      fraction = update.progress;
+    }
+    if (fraction != null) {
+      task.progress = fraction;
+    }
+    if (typeof update.message === 'string' && update.message !== '') {
+      task.progressMessage = update.message.slice(0, MAX_PROGRESS_MESSAGE_CHARS);
+    }
+    task.updatedAt = Date.now();
+  }
+
+  /**
    * Returns a completed task's artifact exactly once, marking it delivered and
    * clearing it. The poll turn routes it to a live `toolEndCallback` so the
    * artifact isn't lost with the finalized dispatch turn. If handing it to the
@@ -721,7 +774,8 @@ export class BackgroundTaskRegistryClass {
   }
 }
 
-export const backgroundTaskRegistry = new BackgroundTaskRegistryClass();
+export const backgroundTaskRegistry: BackgroundTaskRegistryClass =
+  new BackgroundTaskRegistryClass();
 
 /** Content for the synthetic ToolMessage returned when a call is backgrounded. */
 export function buildBackgroundHandleContent(task: BackgroundTask): string {
@@ -752,8 +806,9 @@ interface SerializedBackgroundTask {
   background_task_id: string;
   tool: string;
   status: BackgroundTaskStatus;
-  /** Coarse 0..1: no intermediate progress exists, only running vs settled. */
+  /** 0..1: reported fraction while running (0 when the tool reports none), 1 once settled. */
   progress: number;
+  progress_message?: string;
   result?: string;
   result_available?: boolean;
   result_chars?: number;
@@ -782,7 +837,10 @@ function serializeTask(
     background_task_id: task.id,
     tool: task.toolName,
     status: task.status,
-    progress: task.status === 'running' ? 0 : 1,
+    progress: task.status === 'running' ? (task.progress ?? 0) : 1,
+    ...(task.status === 'running' && task.progressMessage != null
+      ? { progress_message: task.progressMessage }
+      : {}),
     ...resultFields(task, includeResult),
     ...(task.artifact != null || task.artifactDelivered === true
       ? { note: 'The tool produced an artifact that is not included inline.' }

--- a/packages/api/src/agents/handlers.background.spec.ts
+++ b/packages/api/src/agents/handlers.background.spec.ts
@@ -330,6 +330,80 @@ describe('createToolExecuteHandler — background tool calls', () => {
     expect(toolEndCalls).toHaveLength(1);
   });
 
+  it('threads a per-dispatch progress sink so a running task reports progress on poll', async () => {
+    let releaseTool: (() => void) | undefined;
+    const progressTool = {
+      name: 'search_mcp_docs',
+      description: 'reports progress mid-flight',
+      schema: z.object({ q: z.string() }),
+      invoke: async (
+        _input: Record<string, unknown>,
+        config?: { configurable?: Record<string, unknown> },
+      ) => {
+        const sink = config?.configurable?.backgroundProgressSink as
+          | ((update: { progress: number; total?: number; message?: string }) => void)
+          | undefined;
+        sink?.({ progress: 3, total: 4, message: 'crunching' });
+        await new Promise<void>((resolve) => {
+          releaseTool = resolve;
+        });
+        return { content: 'PROGRESS_DONE' };
+      },
+    } as unknown as StructuredToolInterface;
+    const handler = createToolExecuteHandler({
+      loadTools: async () => ({ loadedTools: [progressTool] }),
+    });
+    const configurable = buildConfig(['search_mcp_docs']);
+
+    const dispatch = await runBatch(handler, {
+      toolCalls: [
+        { id: 'call_prog', name: 'search_mcp_docs', args: { q: 'x', run_in_background: true } },
+      ],
+      agentId: 'a',
+      configurable,
+      metadata: { thread_id: 'exec_convo_progress', run_id: 'run-progress' },
+    });
+    await flushMicrotasks();
+    const handleId = JSON.parse(dispatch[0].content).background_task_id;
+
+    const running = await runBatch(handler, {
+      toolCalls: [
+        {
+          id: 'call_prog_poll',
+          name: CHECK_BACKGROUND_TASK_NAME,
+          args: { background_task_id: handleId },
+        },
+      ],
+      agentId: 'a',
+      configurable,
+      metadata: { thread_id: 'exec_convo_progress', run_id: 'run-progress-poll' },
+    });
+    const midFlight = JSON.parse(running[0].content);
+    expect(midFlight.status).toBe('running');
+    expect(midFlight.progress).toBe(0.75);
+    expect(midFlight.progress_message).toBe('crunching');
+
+    releaseTool?.();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    const done = await runBatch(handler, {
+      toolCalls: [
+        {
+          id: 'call_prog_poll2',
+          name: CHECK_BACKGROUND_TASK_NAME,
+          args: { background_task_id: handleId },
+        },
+      ],
+      agentId: 'a',
+      configurable,
+      metadata: { thread_id: 'exec_convo_progress', run_id: 'run-progress-poll2' },
+    });
+    const settled = JSON.parse(done[0].content);
+    expect(settled.status).toBe('completed');
+    expect(settled.progress).toBe(1);
+    expect(settled.result).toContain('PROGRESS_DONE');
+  });
+
   it('scopes tasks by configurable user_id when req is absent (external service hosts)', async () => {
     const state = { calls: 0 } as { calls: number; lastInput?: Record<string, unknown> };
     const handler = createToolExecuteHandler({

--- a/packages/api/src/agents/handlers.background.spec.ts
+++ b/packages/api/src/agents/handlers.background.spec.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { StructuredToolInterface } from '@librechat/agents/langchain/tools';
-import { CHECK_BACKGROUND_TASK_NAME } from './background';
+import { BACKGROUND_PROGRESS_SINK, CHECK_BACKGROUND_TASK_NAME } from './background';
 import { createToolExecuteHandler } from './handlers';
 
 interface BatchInput {
@@ -340,7 +340,7 @@ describe('createToolExecuteHandler — background tool calls', () => {
         _input: Record<string, unknown>,
         config?: { configurable?: Record<string, unknown> },
       ) => {
-        const sink = config?.configurable?.backgroundProgressSink as
+        const sink = config?.configurable?.[BACKGROUND_PROGRESS_SINK] as
           | ((update: { progress: number; total?: number; message?: string }) => void)
           | undefined;
         sink?.({ progress: 3, total: 4, message: 'crunching' });

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -13,6 +13,7 @@ import type {
 } from '@librechat/agents';
 import type { StructuredToolInterface } from '@librechat/agents/langchain/tools';
 import type { CodeEnvRef } from 'librechat-data-provider';
+import type { BackgroundProgressUpdate } from './background';
 import type { SkillFileRecord } from './skillFiles';
 import type { ServerRequest } from '~/types';
 import {
@@ -26,6 +27,7 @@ import {
   buildBackgroundHandleContent,
   buildBackgroundCapacityContent,
   stripBackgroundFromToolDefinitions,
+  BACKGROUND_PROGRESS_SINK,
   CHECK_BACKGROUND_TASK_NAME,
   RUN_IN_BACKGROUND_ARG,
 } from './background';
@@ -3355,11 +3357,24 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
               const { task, isNew } = created;
               if (isNew) {
                 const strippedArgs = stripRunInBackgroundArg(tc.args);
+                /** MCP tools forward this as the SDK's `onprogress` request
+                 *  option, so servers emitting `notifications/progress` update
+                 *  the running task's progress/message for the poll tool. */
+                const onProgress = (update: BackgroundProgressUpdate): void =>
+                  backgroundTaskRegistry.setProgress(
+                    backgroundUserId,
+                    backgroundConversationId,
+                    task.id,
+                    update,
+                  );
                 void (async () => {
                   try {
                     const result = (await tool.invoke(normalizeToolInvokeArgs(strippedArgs, tool), {
                       toolCall: { id: tc.id, stepId: tc.stepId, turn: tc.turn },
-                      configurable: mergedConfigurable,
+                      configurable: {
+                        ...mergedConfigurable,
+                        [BACKGROUND_PROGRESS_SINK]: onProgress,
+                      },
                       metadata,
                     } as Record<string, unknown>)) as { content?: unknown; artifact?: unknown };
                     /** Hold any artifact (images, files, UI resources,

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -1,5 +1,6 @@
 export * from './avatars';
 export * from './attachments';
+export * from './background';
 export * from './chain';
 export * from './client';
 export * from './config';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,6 +14,7 @@ export * from './mcp/registry/MCPServersRegistry';
 export * from './mcp/MCPManager';
 export * from './mcp/connection';
 export * from './mcp/oauth';
+export * from './mcp/progress';
 export * from './mcp/auth';
 export * from './mcp/zod';
 export * from './mcp/errors';

--- a/packages/api/src/mcp/progress.spec.ts
+++ b/packages/api/src/mcp/progress.spec.ts
@@ -14,6 +14,10 @@ describe('buildToolProgressEvent', () => {
       event: StepEvents.ON_TOOL_PROGRESS,
       data: { toolCallId: 'call_1', progress: 0.4 },
     });
+    expect(buildToolProgressEvent('call_1', { progress: 0.4 }, 'msg_run')).toEqual({
+      event: StepEvents.ON_TOOL_PROGRESS,
+      data: { toolCallId: 'call_1', runId: 'msg_run', progress: 0.4 },
+    });
   });
 
   it('caps oversized messages', () => {

--- a/packages/api/src/mcp/progress.spec.ts
+++ b/packages/api/src/mcp/progress.spec.ts
@@ -52,6 +52,14 @@ describe('createToolProgressEmitter', () => {
     emit({ progress: 10, total: 10 });
     expect(emitted).toHaveLength(3);
     expect((emitted[2].data as { progress: number }).progress).toBe(10);
+
+    // repeated terminal notifications no longer bypass the throttle
+    emit({ progress: 10, total: 10 });
+    emit({ progress: 10, total: 10 });
+    expect(emitted).toHaveLength(3);
+    jest.setSystemTime(600);
+    emit({ progress: 10, total: 10 });
+    expect(emitted).toHaveLength(4);
   });
 
   it('never throws when the emit sink fails', () => {

--- a/packages/api/src/mcp/progress.spec.ts
+++ b/packages/api/src/mcp/progress.spec.ts
@@ -62,6 +62,23 @@ describe('createToolProgressEmitter', () => {
     expect(emitted).toHaveLength(4);
   });
 
+  it('drops non-finite wire values instead of forwarding them', () => {
+    const emitted: StreamEvent[] = [];
+    const emit = createToolProgressEmitter({
+      toolCallId: 'call_1',
+      emit: (event) => {
+        emitted.push(event);
+      },
+      minIntervalMs: 0,
+    });
+    emit({ progress: Infinity, total: 10 });
+    emit({ progress: NaN });
+    expect(emitted).toHaveLength(0);
+    emit({ progress: 2, total: Infinity });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].data).toEqual({ toolCallId: 'call_1', progress: 2 });
+  });
+
   it('never throws when the emit sink fails', () => {
     const emit = createToolProgressEmitter({
       toolCallId: 'call_1',

--- a/packages/api/src/mcp/progress.spec.ts
+++ b/packages/api/src/mcp/progress.spec.ts
@@ -1,0 +1,66 @@
+import { StepEvents } from 'librechat-data-provider';
+import type { StreamEvent } from '~/types';
+import { buildToolProgressEvent, createToolProgressEmitter } from './progress';
+
+describe('buildToolProgressEvent', () => {
+  it('builds the transient event with only the reported fields', () => {
+    expect(
+      buildToolProgressEvent('call_1', { progress: 3, total: 10, message: 'crunching' }),
+    ).toEqual({
+      event: StepEvents.ON_TOOL_PROGRESS,
+      data: { toolCallId: 'call_1', progress: 3, total: 10, message: 'crunching' },
+    });
+    expect(buildToolProgressEvent('call_1', { progress: 0.4 })).toEqual({
+      event: StepEvents.ON_TOOL_PROGRESS,
+      data: { toolCallId: 'call_1', progress: 0.4 },
+    });
+  });
+
+  it('caps oversized messages', () => {
+    const event = buildToolProgressEvent('call_1', { progress: 1, message: 'x'.repeat(2_000) });
+    expect((event.data as { message: string }).message).toHaveLength(500);
+  });
+});
+
+describe('createToolProgressEmitter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: 0 });
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('throttles bursts but always passes the terminal notification', () => {
+    const emitted: StreamEvent[] = [];
+    const emit = createToolProgressEmitter({
+      toolCallId: 'call_1',
+      emit: (event) => {
+        emitted.push(event);
+      },
+      minIntervalMs: 200,
+    });
+
+    emit({ progress: 1, total: 10 });
+    emit({ progress: 2, total: 10 });
+    emit({ progress: 3, total: 10 });
+    expect(emitted).toHaveLength(1);
+
+    jest.setSystemTime(250);
+    emit({ progress: 4, total: 10 });
+    expect(emitted).toHaveLength(2);
+
+    emit({ progress: 10, total: 10 });
+    expect(emitted).toHaveLength(3);
+    expect((emitted[2].data as { progress: number }).progress).toBe(10);
+  });
+
+  it('never throws when the emit sink fails', () => {
+    const emit = createToolProgressEmitter({
+      toolCallId: 'call_1',
+      emit: () => {
+        throw new Error('stream closed');
+      },
+    });
+    expect(() => emit({ progress: 1, total: 2 })).not.toThrow();
+  });
+});

--- a/packages/api/src/mcp/progress.ts
+++ b/packages/api/src/mcp/progress.ts
@@ -30,9 +30,10 @@ export function buildToolProgressEvent(
 /**
  * Per-call emitter for streaming MCP progress to the live tool-call card.
  * Throttles to one event per `minIntervalMs` so a chatty server can't flood
- * the stream; the terminal notification (`progress >= total`) always passes.
- * Emission failures are swallowed — progress is best-effort and must never
- * fail the tool call.
+ * the stream; the FIRST terminal notification (`progress >= total`) bypasses
+ * the throttle so completion is never dropped, while repeated terminal spam
+ * falls back to the normal interval. Emission failures are swallowed —
+ * progress is best-effort and must never fail the tool call.
  */
 export function createToolProgressEmitter(params: {
   toolCallId: string;
@@ -41,11 +42,15 @@ export function createToolProgressEmitter(params: {
 }): (update: ToolProgressUpdate) => void {
   const minIntervalMs = params.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
   let lastEmitAt = Number.NEGATIVE_INFINITY;
+  let emittedFinal = false;
   return (update: ToolProgressUpdate): void => {
     const now = Date.now();
     const isFinal = update.total != null && update.total > 0 && update.progress >= update.total;
-    if (!isFinal && now - lastEmitAt < minIntervalMs) {
+    if (!(isFinal && !emittedFinal) && now - lastEmitAt < minIntervalMs) {
       return;
+    }
+    if (isFinal) {
+      emittedFinal = true;
     }
     lastEmitAt = now;
     try {

--- a/packages/api/src/mcp/progress.ts
+++ b/packages/api/src/mcp/progress.ts
@@ -15,9 +15,11 @@ const DEFAULT_MIN_INTERVAL_MS = 200;
 export function buildToolProgressEvent(
   toolCallId: string,
   update: ToolProgressUpdate,
+  runId?: string,
 ): StreamEvent {
   const data: ToolProgressEvent = {
     toolCallId,
+    ...(runId != null && runId !== '' ? { runId } : {}),
     progress: update.progress,
     ...(Number.isFinite(update.total) ? { total: update.total } : {}),
     ...(typeof update.message === 'string' && update.message !== ''
@@ -37,6 +39,7 @@ export function buildToolProgressEvent(
  */
 export function createToolProgressEmitter(params: {
   toolCallId: string;
+  runId?: string;
   emit: (event: StreamEvent) => void | Promise<void>;
   minIntervalMs?: number;
 }): (update: ToolProgressUpdate) => void {
@@ -62,9 +65,9 @@ export function createToolProgressEmitter(params: {
     }
     lastEmitAt = now;
     try {
-      void Promise.resolve(params.emit(buildToolProgressEvent(params.toolCallId, update))).catch(
-        () => undefined,
-      );
+      void Promise.resolve(
+        params.emit(buildToolProgressEvent(params.toolCallId, update, params.runId)),
+      ).catch(() => undefined);
     } catch {
       /* progress is best-effort */
     }

--- a/packages/api/src/mcp/progress.ts
+++ b/packages/api/src/mcp/progress.ts
@@ -1,0 +1,59 @@
+import { StepEvents } from 'librechat-data-provider';
+import type { ToolProgressEvent } from 'librechat-data-provider';
+import type { StreamEvent } from '~/types';
+
+/** Params forwarded from MCP `notifications/progress` by the SDK's `onprogress`. */
+export interface ToolProgressUpdate {
+  progress: number;
+  total?: number;
+  message?: string;
+}
+
+const MAX_PROGRESS_MESSAGE_CHARS = 500;
+const DEFAULT_MIN_INTERVAL_MS = 200;
+
+export function buildToolProgressEvent(
+  toolCallId: string,
+  update: ToolProgressUpdate,
+): StreamEvent {
+  const data: ToolProgressEvent = {
+    toolCallId,
+    progress: update.progress,
+    ...(update.total != null ? { total: update.total } : {}),
+    ...(typeof update.message === 'string' && update.message !== ''
+      ? { message: update.message.slice(0, MAX_PROGRESS_MESSAGE_CHARS) }
+      : {}),
+  };
+  return { event: StepEvents.ON_TOOL_PROGRESS, data };
+}
+
+/**
+ * Per-call emitter for streaming MCP progress to the live tool-call card.
+ * Throttles to one event per `minIntervalMs` so a chatty server can't flood
+ * the stream; the terminal notification (`progress >= total`) always passes.
+ * Emission failures are swallowed — progress is best-effort and must never
+ * fail the tool call.
+ */
+export function createToolProgressEmitter(params: {
+  toolCallId: string;
+  emit: (event: StreamEvent) => void | Promise<void>;
+  minIntervalMs?: number;
+}): (update: ToolProgressUpdate) => void {
+  const minIntervalMs = params.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  let lastEmitAt = Number.NEGATIVE_INFINITY;
+  return (update: ToolProgressUpdate): void => {
+    const now = Date.now();
+    const isFinal = update.total != null && update.total > 0 && update.progress >= update.total;
+    if (!isFinal && now - lastEmitAt < minIntervalMs) {
+      return;
+    }
+    lastEmitAt = now;
+    try {
+      void Promise.resolve(params.emit(buildToolProgressEvent(params.toolCallId, update))).catch(
+        () => undefined,
+      );
+    } catch {
+      /* progress is best-effort */
+    }
+  };
+}

--- a/packages/api/src/mcp/progress.ts
+++ b/packages/api/src/mcp/progress.ts
@@ -19,7 +19,7 @@ export function buildToolProgressEvent(
   const data: ToolProgressEvent = {
     toolCallId,
     progress: update.progress,
-    ...(update.total != null ? { total: update.total } : {}),
+    ...(Number.isFinite(update.total) ? { total: update.total } : {}),
     ...(typeof update.message === 'string' && update.message !== ''
       ? { message: update.message.slice(0, MAX_PROGRESS_MESSAGE_CHARS) }
       : {}),
@@ -44,8 +44,16 @@ export function createToolProgressEmitter(params: {
   let lastEmitAt = Number.NEGATIVE_INFINITY;
   let emittedFinal = false;
   return (update: ToolProgressUpdate): void => {
+    /** JSON.parse admits non-finite numbers (`1e999` → Infinity), so guard the
+     *  wire values before they reach clients or the throttle arithmetic. */
+    if (!Number.isFinite(update.progress)) {
+      return;
+    }
     const now = Date.now();
-    const isFinal = update.total != null && update.total > 0 && update.progress >= update.total;
+    const isFinal =
+      Number.isFinite(update.total) && (update.total as number) > 0
+        ? update.progress >= (update.total as number)
+        : false;
     if (!(isFinal && !emittedFinal) && now - lastEmitAt < minIntervalMs) {
       return;
     }

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -1209,7 +1209,11 @@ class GenerationJobManagerClass {
     if (!runtime.hasSubscriber && !this._isRedis) {
       return;
     }
-    await this.eventTransport.emitChunk(streamId, event);
+    if (this.eventTransport.emitTransient) {
+      await this.eventTransport.emitTransient(streamId, event);
+    } else {
+      await this.eventTransport.emitChunk(streamId, event);
+    }
   }
 
   /**

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -1206,6 +1206,9 @@ class GenerationJobManagerClass {
     if (!runtime || runtime.abortController.signal.aborted) {
       return;
     }
+    /** A long tool call may emit ONLY progress for minutes: refresh liveness so
+     *  the stale-job reaper doesn't abort an actively-reporting run. */
+    this.jobStore.recordActivity?.(streamId);
     if (!runtime.hasSubscriber && !this._isRedis) {
       return;
     }

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -1195,6 +1195,24 @@ class GenerationJobManagerClass {
   }
 
   /**
+   * Emit a transient event to live subscribers only: no trackers, no chunk
+   * persistence, no early-event buffering — dropped when nobody can hear it.
+   * For high-frequency ephemeral events (e.g. MCP tool progress) that must
+   * not bloat the Redis chunk log or resume reconstruction. In Redis mode the
+   * subscriber may live on another instance, so the publish always goes out.
+   */
+  async emitTransientEvent(streamId: string, event: t.ServerSentEvent): Promise<void> {
+    const runtime = this.runtimeState.get(streamId);
+    if (!runtime || runtime.abortController.signal.aborted) {
+      return;
+    }
+    if (!runtime.hasSubscriber && !this._isRedis) {
+      return;
+    }
+    await this.eventTransport.emitChunk(streamId, event);
+  }
+
+  /**
    * Extract and save run step from event data.
    * The data is already the run step object from the event payload.
    */

--- a/packages/api/src/stream/implementations/InMemoryEventTransport.ts
+++ b/packages/api/src/stream/implementations/InMemoryEventTransport.ts
@@ -74,6 +74,10 @@ export class InMemoryEventTransport implements IEventTransport {
     state?.emitter.emit('chunk', event);
   }
 
+  emitTransient(streamId: string, event: unknown): void {
+    this.emitChunk(streamId, event);
+  }
+
   emitDone(streamId: string, event: unknown): void {
     const state = this.streams.get(streamId);
     state?.emitter.emit('done', event);

--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -530,6 +530,22 @@ export class RedisEventTransport implements IEventTransport {
   }
 
   /**
+   * Publish an ephemeral chunk without allocating a sequence number: the
+   * subscriber's seq-less fallback delivers it immediately, bypassing the
+   * reorder buffer, so a transient missed pre-subscribe can never leave a
+   * sequence gap that stalls durable chunks. Also skips the INCR round-trip.
+   */
+  async emitTransient(streamId: string, event: unknown): Promise<void> {
+    try {
+      const channel = CHANNELS.events(streamId);
+      const message: PubSubMessage = { type: EventTypes.CHUNK, data: event };
+      await this.publisher.publish(channel, JSON.stringify(message));
+    } catch (err) {
+      logger.error(`[RedisEventTransport] Failed to publish transient chunk:`, err);
+    }
+  }
+
+  /**
    * Publish a done event to all subscribers.
    * Includes sequence number to ensure delivery after all chunks.
    */

--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -1,5 +1,5 @@
-import type { Redis, Cluster } from 'ioredis';
 import { logger } from '@librechat/data-schemas';
+import type { Redis, Cluster } from 'ioredis';
 import type { IEventTransport } from '~/stream/interfaces/IJobStore';
 
 /**

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -488,6 +488,15 @@ export interface IEventTransport {
   /** Publish a chunk event - returns Promise in Redis mode for ordered delivery */
   emitChunk(streamId: string, event: unknown): void | Promise<void>;
 
+  /**
+   * Publish an ephemeral chunk OUTSIDE the ordered sequence (best-effort,
+   * unordered relative to durable chunks). Sequenced delivery reorders
+   * strictly by seq, so a transient that consumed a sequence number but was
+   * never persisted/buffered would leave a permanent gap for any subscriber
+   * that missed it live, stalling durable chunks behind the reorder buffer.
+   */
+  emitTransient?(streamId: string, event: unknown): void | Promise<void>;
+
   /** Publish a done event - returns Promise in Redis mode for ordered delivery */
   emitDone(streamId: string, event: unknown): void | Promise<void>;
 

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -40,7 +40,21 @@ export enum StepEvents {
   ON_SUMMARIZE_DELTA = 'on_summarize_delta',
   ON_SUMMARIZE_COMPLETE = 'on_summarize_complete',
   ON_SUBAGENT_UPDATE = 'on_subagent_update',
+  ON_TOOL_PROGRESS = 'on_tool_progress',
 }
+
+/**
+ * Live MCP `notifications/progress` for a running foreground tool call,
+ * correlated by the tool call id. Transient: streamed to live subscribers
+ * only — never persisted or replayed on resume.
+ */
+export type ToolProgressEvent = {
+  toolCallId: string;
+  /** Raw progress value; a completion fraction when `total` is absent. */
+  progress: number;
+  total?: number;
+  message?: string;
+};
 
 /** Token-tracking event names streamed to the client (separate from StepEvents dispatch). */
 export enum UsageEvents {

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -50,6 +50,9 @@ export enum StepEvents {
  */
 export type ToolProgressEvent = {
   toolCallId: string;
+  /** Response message id of the run — scopes progress when providers reuse
+   *  tool-call ids (e.g. `call_0`) across parallel agents in one submission. */
+  runId?: string;
   /** Raw progress value; a completion fraction when `total` is absent. */
   progress: number;
   total?: number;


### PR DESCRIPTION
## Summary

The user-facing half of MCP progress: while a foreground MCP tool runs, the tool-call card shows the server's live `notifications/progress` — the reported message when present, otherwise a localized `X of Y` count — replacing the generic "Running …" label. Together with #14240 (model-facing progress for backgrounded calls, which this branch stacks on), this makes MCP progress support feature-complete.

Credit: this follows the direction of #11510 (@changkun) and #12535 (@SpectralOne), rebuilt on current dev with a substantially smaller footprint.

## Design

- **Zero connection/manager plumbing**: the MCP SDK attaches a `progressToken` and routes notifications **per request** whenever `onprogress` is passed in request options (and `MCPManager.callTool` already spreads options and sets `resetTimeoutOnProgress`). This also makes the parallel-call cross-talk seen in #12535 impossible by construction — no hand-rolled token registry needed.
- **Server emit** reuses the MCP OAuth event seam verbatim: a throttled per-call emitter (200ms min interval, terminal notification exempt, failures swallowed) builds a transient `on_tool_progress` event and routes it via `GenerationJobManager.emitChunk(streamId, …)` or `sendEvent(res, …)`.
- **Background vs foreground are disjoint**: a background dispatch (its card settles immediately with the synthetic handle) keeps feeding the poll registry sink from #14240; only foreground calls stream to the card.
- **Client** mirrors the `ON_SUBAGENT_UPDATE` precedent: `toolProgressByToolCallId` Recoil atomFamily written from the step handler (reset together with the subagent atoms on conversation switch), read by `ToolCall` via a threaded `toolCallId` — surgical re-renders, no transient state written into message content, and no SSE route changes (the generic `data.event` dispatch already routes it).
- **Deliberately transient**: progress is never persisted, aggregated, or replayed on resume — after a refresh the card shows the plain running label until the next notification. Replay-persistence (the resumable `replayEvents` allowlist) is a possible follow-up if wanted.

## Tests

- `packages/api`: event shape + message cap; throttle behavior (burst suppression, interval pass, terminal exemption — caught a real init bug where the first event could be throttled); emit-failure safety. Background + MCP suites still green.
- `client`: ToolCall renders the live message, the `X of Y` count, and the fallback label (29→32 suite green incl. Part routing).
- tsc / eslint / sort-imports / dist builds clean across data-provider, packages/api, client.

## Note

Stacked on #14240 — merge that first; this diff then collapses to the foreground-only changes.