### PR TITLE
fix: align ownership terms with MIT license

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -119,7 +119,7 @@ interface:
 
       ## 1. Ownership
 
-      Upon purchasing a package from LibreChat, you are granted the right to download and use the code for accessing an admin panel for LibreChat. While you own the downloaded code, you are expressly prohibited from reselling, redistributing, or otherwise transferring the code to third parties without explicit permission from LibreChat.
+      Upon purchasing a package from LibreChat, you are granted the right to download and use the code for accessing an admin panel for LibreChat. While you own the downloaded code, you may use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies in accordance with LibreChat's MIT License, provided that the copyright notice and permission notice are included in all copies or substantial portions of the Software.
 
       ## 2. User Data
 


### PR DESCRIPTION
## Summary

Closes #14242.

The embedded `## 1. Ownership` section in `librechat.example.yaml` says LibreChat code may not be resold, redistributed, or transferred without permission. That contradicts the repository's MIT License, which permits use, modification, publishing, distribution, sublicensing, and sale, provided the copyright and permission notices are retained.

This PR changes only that ownership paragraph to reflect the MIT License permissions and notice requirement. All other example Terms of Service wording remains unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the final diff changes only the ownership paragraph in `librechat.example.yaml`.
- Confirmed the final branch contains one commit and one changed file, with one addition and one deletion.
- Confirmed the YAML indentation and block-scalar structure remain unchanged.
- Parsed the updated file as YAML successfully.

### Test Configuration

Configuration text-only change; no runtime code changed.

## Checklist

- [x] My changes adhere to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] The pull request is linked to the tracking issue