### PR TITLE
👋 fix: Terminate Streamable HTTP MCP Sessions on Teardown

### DIFF
--- a/packages/api/src/mcp/__tests__/MCPConnectionSessionTermination.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionSessionTermination.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Integration tests for Streamable HTTP session termination.
+ *
+ * Per the MCP spec, a client that discards a Streamable HTTP connection SHOULD
+ * send an `HTTP DELETE` with the `Mcp-Session-Id` header so stateful servers can
+ * free the session. These tests spin up a real in-process
+ * StreamableHTTPServerTransport and assert that MCPConnection issues that DELETE
+ * on both teardown paths (`disconnect()` and the reconnect transport swap),
+ * while leaving non-streamable transports untouched.
+ */
+
+import * as net from 'net';
+import * as http from 'http';
+import { randomUUID } from 'crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { Server as McpServerCore } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Socket } from 'net';
+import { MCPConnection } from '~/mcp/connection';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('~/auth', () => ({
+  createSSRFSafeUndiciConnect: jest.fn(() => undefined),
+  isOAuthUrlAllowed: jest.fn(() => false),
+  isSSRFTarget: jest.fn(() => false),
+  resolveHostnameSSRF: jest.fn(async () => false),
+}));
+
+jest.mock('~/mcp/mcpConfig', () => ({
+  mcpConfig: {
+    CONNECTION_CHECK_TTL: 0,
+    TOOLS_LIST_MAX_PAGES: 50,
+    TOOLS_LIST_MAX_TOOLS: 1000,
+    TOOLS_LIST_MAX_BYTES: 5 * 1024 * 1024,
+    TOOLS_LIST_TIMEOUT_MS: 30000,
+  },
+}));
+
+interface DeleteRecord {
+  sessionId?: string;
+}
+
+interface StreamableTestServer {
+  url: string;
+  deletes: DeleteRecord[];
+  liveSessionCount: () => number;
+  close: () => Promise<void>;
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address() as net.AddressInfo;
+      srv.close((err) => (err ? reject(err) : resolve(addr.port)));
+    });
+  });
+}
+
+function trackSockets(httpServer: http.Server): () => Promise<void> {
+  const sockets = new Set<Socket>();
+  httpServer.on('connection', (socket: Socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  return () =>
+    new Promise<void>((resolve) => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      sockets.clear();
+      httpServer.close(() => resolve());
+    });
+}
+
+/**
+ * Streamable HTTP server that records every DELETE it receives. `rejectDelete`
+ * simulates a server that opts out of termination by replying 405 before the SDK
+ * transport handles the request.
+ */
+async function createStreamableServer(
+  options: { rejectDelete?: boolean } = {},
+): Promise<StreamableTestServer> {
+  const sessions = new Map<string, StreamableHTTPServerTransport>();
+  const deletes: DeleteRecord[] = [];
+
+  const httpServer = http.createServer(async (req, res) => {
+    const sid = req.headers['mcp-session-id'] as string | undefined;
+
+    if (req.method === 'DELETE') {
+      deletes.push({ sessionId: sid });
+      if (options.rejectDelete) {
+        res.writeHead(405).end();
+        return;
+      }
+    }
+
+    let transport = sid ? sessions.get(sid) : undefined;
+    const isNewTransport = !transport;
+
+    if (!transport) {
+      transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+      const mcp = new McpServer({ name: 'test-streamable', version: '0.0.1' });
+      await mcp.connect(transport);
+    }
+
+    await transport.handleRequest(req, res);
+
+    /**
+     * Register the session exactly once, on the initialize request that created
+     * it. Reusing this guard for every request would let a long-lived GET stream
+     * (or any later request) re-add a session the SDK already closed and removed
+     * via `onclose` when it handled the client's DELETE.
+     */
+    if (isNewTransport && transport.sessionId) {
+      const registeredId = transport.sessionId;
+      sessions.set(registeredId, transport);
+      transport.onclose = () => sessions.delete(registeredId);
+    }
+  });
+
+  const destroySockets = trackSockets(httpServer);
+  const port = await getFreePort();
+  await new Promise<void>((resolve) => httpServer.listen(port, '127.0.0.1', resolve));
+
+  return {
+    url: `http://127.0.0.1:${port}/`,
+    deletes,
+    liveSessionCount: () => sessions.size,
+    close: async () => {
+      const closing = [...sessions.values()].map((t) => t.close().catch(() => undefined));
+      sessions.clear();
+      await Promise.all(closing);
+      await destroySockets();
+    },
+  };
+}
+
+interface SSETestServer {
+  url: string;
+  deletes: string[];
+  close: () => Promise<void>;
+}
+
+async function createSSEServer(): Promise<SSETestServer> {
+  const transports = new Map<string, SSEServerTransport>();
+  const mcpServer = new McpServerCore({ name: 'test-sse', version: '0.0.1' }, { capabilities: {} });
+  const deletes: string[] = [];
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.method === 'DELETE') {
+      deletes.push(req.url ?? '');
+      res.writeHead(405).end();
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/sse') {
+      const t = new SSEServerTransport('/messages', res);
+      transports.set(t.sessionId, t);
+      t.onclose = () => transports.delete(t.sessionId);
+      await mcpServer.connect(t);
+      return;
+    }
+
+    if (req.method === 'POST' && req.url?.startsWith('/messages')) {
+      const sid = new URL(req.url, 'http://x').searchParams.get('sessionId') ?? '';
+      const t = transports.get(sid);
+      if (!t) {
+        res.writeHead(404).end();
+        return;
+      }
+      await t.handlePostMessage(req, res);
+      return;
+    }
+
+    res.writeHead(404).end();
+  });
+
+  const destroySockets = trackSockets(httpServer);
+  const port = await getFreePort();
+  await new Promise<void>((resolve) => httpServer.listen(port, '127.0.0.1', resolve));
+
+  return {
+    url: `http://127.0.0.1:${port}/sse`,
+    deletes,
+    close: async () => {
+      const closing = [...transports.values()].map((t) => t.close().catch(() => undefined));
+      transports.clear();
+      await Promise.all(closing);
+      await destroySockets();
+    },
+  };
+}
+
+/**
+ * Server-side session cleanup runs in the transport's `onclose`, which fires
+ * shortly after the client's DELETE resolves. Poll instead of asserting
+ * synchronously so the end-to-end effect is verified without a timing flake.
+ */
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error('Timed out waiting for condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+async function safeDisconnect(conn: MCPConnection | null): Promise<void> {
+  if (!conn) {
+    return;
+  }
+  (conn as unknown as { shouldStopReconnecting: boolean }).shouldStopReconnecting = true;
+  conn.removeAllListeners();
+  await conn.disconnect();
+}
+
+/** Read the session id the client transport negotiated with the server. */
+function getClientSessionId(conn: MCPConnection): string | undefined {
+  const transport = (conn as unknown as { transport?: { sessionId?: string } }).transport;
+  return transport?.sessionId;
+}
+
+describe('MCPConnection Streamable HTTP session termination', () => {
+  let server: StreamableTestServer;
+  let conn: MCPConnection | null;
+
+  beforeEach(() => {
+    conn = null;
+  });
+
+  afterEach(async () => {
+    MCPConnection.clearCooldown('test');
+    await safeDisconnect(conn);
+    conn = null;
+    await server.close();
+  });
+
+  it('sends an HTTP DELETE with the session id and frees the server-side session on disconnect', async () => {
+    server = await createStreamableServer();
+    conn = new MCPConnection({
+      serverName: 'test',
+      serverConfig: { type: 'streamable-http', url: server.url },
+      useSSRFProtection: false,
+    });
+
+    await conn.connect();
+    const sessionId = getClientSessionId(conn);
+    expect(sessionId).toBeTruthy();
+    expect(server.liveSessionCount()).toBe(1);
+
+    await safeDisconnect(conn);
+    conn = null;
+
+    expect(server.deletes).toEqual([{ sessionId }]);
+    await waitForCondition(() => server.liveSessionCount() === 0);
+  });
+
+  it('terminates the prior session before swapping in a fresh transport on reconnect', async () => {
+    server = await createStreamableServer();
+    conn = new MCPConnection({
+      serverName: 'test',
+      serverConfig: { type: 'streamable-http', url: server.url },
+      useSSRFProtection: false,
+    });
+
+    await conn.connect();
+    const firstSessionId = getClientSessionId(conn);
+    expect(firstSessionId).toBeTruthy();
+
+    await conn.connect();
+    const secondSessionId = getClientSessionId(conn);
+
+    expect(secondSessionId).toBeTruthy();
+    expect(secondSessionId).not.toBe(firstSessionId);
+    expect(server.deletes).toContainEqual({ sessionId: firstSessionId });
+    await waitForCondition(() => server.liveSessionCount() === 1);
+  });
+
+  it('does not throw when the server rejects termination with 405', async () => {
+    server = await createStreamableServer({ rejectDelete: true });
+    conn = new MCPConnection({
+      serverName: 'test',
+      serverConfig: { type: 'streamable-http', url: server.url },
+      useSSRFProtection: false,
+    });
+
+    await conn.connect();
+    const sessionId = getClientSessionId(conn);
+
+    await expect(safeDisconnect(conn)).resolves.toBeUndefined();
+    conn = null;
+
+    expect(server.deletes).toEqual([{ sessionId }]);
+  });
+});
+
+describe('MCPConnection SSE session termination', () => {
+  let server: SSETestServer;
+  let conn: MCPConnection | null;
+
+  afterEach(async () => {
+    MCPConnection.clearCooldown('test-sse');
+    await safeDisconnect(conn);
+    conn = null;
+    jest.restoreAllMocks();
+    await server.close();
+  });
+
+  it('does not send a DELETE for a non-streamable transport', async () => {
+    server = await createSSEServer();
+    conn = new MCPConnection({
+      serverName: 'test-sse',
+      serverConfig: { type: 'sse', url: server.url },
+      useSSRFProtection: false,
+    });
+
+    await conn.connect();
+    await safeDisconnect(conn);
+    conn = null;
+
+    expect(server.deletes).toEqual([]);
+  });
+});

--- a/packages/api/src/mcp/__tests__/MCPConnectionSessionTermination.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionSessionTermination.test.ts
@@ -53,15 +53,20 @@ interface StreamableTestServer {
   url: string;
   deletes: DeleteRecord[];
   liveSessionCount: () => number;
+  sessionsCreated: () => number;
   close: () => Promise<void>;
 }
 
-function getFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    srv.listen(0, '127.0.0.1', () => {
-      const addr = srv.address() as net.AddressInfo;
-      srv.close((err) => (err ? reject(err) : resolve(addr.port)));
+/**
+ * Bind directly to an ephemeral port and read the assigned port after the server
+ * is listening. Probing for a free port first and reusing it leaves a
+ * bind/listen race where a parallel CI process can claim the port in between.
+ */
+function listenOnEphemeralPort(httpServer: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address() as net.AddressInfo;
+      resolve(addr.port);
     });
   });
 }
@@ -83,23 +88,24 @@ function trackSockets(httpServer: http.Server): () => Promise<void> {
 }
 
 /**
- * Streamable HTTP server that records every DELETE it receives. `rejectDelete`
- * simulates a server that opts out of termination by replying 405 before the SDK
- * transport handles the request.
+ * Streamable HTTP server that records every DELETE it receives. `deleteStatus`
+ * intercepts DELETE with that status before the SDK transport handles it, to
+ * simulate a server that opts out of termination (405) or fails it (500).
  */
 async function createStreamableServer(
-  options: { rejectDelete?: boolean } = {},
+  options: { deleteStatus?: number } = {},
 ): Promise<StreamableTestServer> {
   const sessions = new Map<string, StreamableHTTPServerTransport>();
   const deletes: DeleteRecord[] = [];
+  let sessionsCreated = 0;
 
   const httpServer = http.createServer(async (req, res) => {
     const sid = req.headers['mcp-session-id'] as string | undefined;
 
     if (req.method === 'DELETE') {
       deletes.push({ sessionId: sid });
-      if (options.rejectDelete) {
-        res.writeHead(405).end();
+      if (options.deleteStatus != null) {
+        res.writeHead(options.deleteStatus).end();
         return;
       }
     }
@@ -122,6 +128,7 @@ async function createStreamableServer(
      * via `onclose` when it handled the client's DELETE.
      */
     if (isNewTransport && transport.sessionId) {
+      sessionsCreated += 1;
       const registeredId = transport.sessionId;
       sessions.set(registeredId, transport);
       transport.onclose = () => sessions.delete(registeredId);
@@ -129,13 +136,13 @@ async function createStreamableServer(
   });
 
   const destroySockets = trackSockets(httpServer);
-  const port = await getFreePort();
-  await new Promise<void>((resolve) => httpServer.listen(port, '127.0.0.1', resolve));
+  const port = await listenOnEphemeralPort(httpServer);
 
   return {
     url: `http://127.0.0.1:${port}/`,
     deletes,
     liveSessionCount: () => sessions.size,
+    sessionsCreated: () => sessionsCreated,
     close: async () => {
       const closing = [...sessions.values()].map((t) => t.close().catch(() => undefined));
       sessions.clear();
@@ -186,8 +193,7 @@ async function createSSEServer(): Promise<SSETestServer> {
   });
 
   const destroySockets = trackSockets(httpServer);
-  const port = await getFreePort();
-  await new Promise<void>((resolve) => httpServer.listen(port, '127.0.0.1', resolve));
+  const port = await listenOnEphemeralPort(httpServer);
 
   return {
     url: `http://127.0.0.1:${port}/sse`,
@@ -236,10 +242,11 @@ function getClientSessionId(conn: MCPConnection): string | undefined {
 }
 
 describe('MCPConnection Streamable HTTP session termination', () => {
-  let server: StreamableTestServer;
+  let server: StreamableTestServer | null;
   let conn: MCPConnection | null;
 
   beforeEach(() => {
+    server = null;
     conn = null;
   });
 
@@ -247,34 +254,37 @@ describe('MCPConnection Streamable HTTP session termination', () => {
     MCPConnection.clearCooldown('test');
     await safeDisconnect(conn);
     conn = null;
-    await server.close();
+    jest.restoreAllMocks();
+    await server?.close();
   });
 
   it('sends an HTTP DELETE with the session id and frees the server-side session on disconnect', async () => {
-    server = await createStreamableServer();
+    const srv = await createStreamableServer();
+    server = srv;
     conn = new MCPConnection({
       serverName: 'test',
-      serverConfig: { type: 'streamable-http', url: server.url },
+      serverConfig: { type: 'streamable-http', url: srv.url },
       useSSRFProtection: false,
     });
 
     await conn.connect();
     const sessionId = getClientSessionId(conn);
     expect(sessionId).toBeTruthy();
-    expect(server.liveSessionCount()).toBe(1);
+    expect(srv.liveSessionCount()).toBe(1);
 
     await safeDisconnect(conn);
     conn = null;
 
-    expect(server.deletes).toEqual([{ sessionId }]);
-    await waitForCondition(() => server.liveSessionCount() === 0);
+    expect(srv.deletes).toEqual([{ sessionId }]);
+    await waitForCondition(() => srv.liveSessionCount() === 0);
   });
 
   it('terminates the prior session before swapping in a fresh transport on reconnect', async () => {
-    server = await createStreamableServer();
+    const srv = await createStreamableServer();
+    server = srv;
     conn = new MCPConnection({
       serverName: 'test',
-      serverConfig: { type: 'streamable-http', url: server.url },
+      serverConfig: { type: 'streamable-http', url: srv.url },
       useSSRFProtection: false,
     });
 
@@ -287,15 +297,16 @@ describe('MCPConnection Streamable HTTP session termination', () => {
 
     expect(secondSessionId).toBeTruthy();
     expect(secondSessionId).not.toBe(firstSessionId);
-    expect(server.deletes).toContainEqual({ sessionId: firstSessionId });
-    await waitForCondition(() => server.liveSessionCount() === 1);
+    expect(srv.deletes).toContainEqual({ sessionId: firstSessionId });
+    await waitForCondition(() => srv.liveSessionCount() === 1);
   });
 
   it('does not throw when the server rejects termination with 405', async () => {
-    server = await createStreamableServer({ rejectDelete: true });
+    const srv = await createStreamableServer({ deleteStatus: 405 });
+    server = srv;
     conn = new MCPConnection({
       serverName: 'test',
-      serverConfig: { type: 'streamable-http', url: server.url },
+      serverConfig: { type: 'streamable-http', url: srv.url },
       useSSRFProtection: false,
     });
 
@@ -305,27 +316,65 @@ describe('MCPConnection Streamable HTTP session termination', () => {
     await expect(safeDisconnect(conn)).resolves.toBeUndefined();
     conn = null;
 
-    expect(server.deletes).toEqual([{ sessionId }]);
+    expect(srv.deletes).toEqual([{ sessionId }]);
+  });
+
+  it('does not trigger reconnection when the termination DELETE fails', async () => {
+    const srv = await createStreamableServer({ deleteStatus: 500 });
+    server = srv;
+    conn = new MCPConnection({
+      serverName: 'test',
+      serverConfig: { type: 'streamable-http', url: srv.url },
+      useSSRFProtection: false,
+    });
+
+    await conn.connect();
+    const sessionId = getClientSessionId(conn);
+    expect(srv.sessionsCreated()).toBe(1);
+
+    /**
+     * A failed DELETE makes the SDK invoke `transport.onerror`. If that were
+     * still wired to our handler it would emit `connectionChange('error')` and
+     * reconnect mid-teardown, so spy on the reconnection entrypoint. Disconnect
+     * directly (not `safeDisconnect`, which sets `shouldStopReconnecting` and
+     * would mask the bug).
+     */
+    const reconnectSpy = jest
+      .spyOn(conn as unknown as { handleReconnection: () => Promise<void> }, 'handleReconnection')
+      .mockResolvedValue(undefined);
+
+    await conn.disconnect();
+
+    expect(srv.deletes).toEqual([{ sessionId }]);
+    expect(reconnectSpy).not.toHaveBeenCalled();
+    expect(srv.sessionsCreated()).toBe(1);
+    conn = null;
   });
 });
 
 describe('MCPConnection SSE session termination', () => {
-  let server: SSETestServer;
+  let server: SSETestServer | null;
   let conn: MCPConnection | null;
+
+  beforeEach(() => {
+    server = null;
+    conn = null;
+  });
 
   afterEach(async () => {
     MCPConnection.clearCooldown('test-sse');
     await safeDisconnect(conn);
     conn = null;
     jest.restoreAllMocks();
-    await server.close();
+    await server?.close();
   });
 
   it('does not send a DELETE for a non-streamable transport', async () => {
-    server = await createSSEServer();
+    const srv = await createSSEServer();
+    server = srv;
     conn = new MCPConnection({
       serverName: 'test-sse',
-      serverConfig: { type: 'sse', url: server.url },
+      serverConfig: { type: 'sse', url: srv.url },
       useSSRFProtection: false,
     });
 
@@ -333,6 +382,6 @@ describe('MCPConnection SSE session termination', () => {
     await safeDisconnect(conn);
     conn = null;
 
-    expect(server.deletes).toEqual([]);
+    expect(srv.deletes).toEqual([]);
   });
 });

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -2205,11 +2205,20 @@ export class MCPConnection extends EventEmitter {
    * `terminateSession()` no-ops when there is no session id and already tolerates
    * a 405 (server opts out of termination). Any other failure is non-fatal to
    * teardown, so it is bounded by a timeout and swallowed.
+   *
+   * The transport's `onerror` is detached first: on any non-405 failure (the
+   * session already expired, a network error, or `client.close()` aborting the
+   * request after the timeout) `terminateSession()` invokes `onerror` before
+   * rejecting. Left attached, our handler would emit `connectionChange('error')`
+   * and trigger `handleReconnection()`, reopening the connection we are tearing
+   * down and re-leaking the session. The transport is discarded right after, so
+   * clearing the handler is safe.
    */
   private async terminateStreamableSession(): Promise<void> {
     if (!(this.transport instanceof StreamableHTTPClientTransport)) {
       return;
     }
+    this.transport.onerror = undefined;
     try {
       await withTimeout(
         this.transport.terminateSession(),

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -119,6 +119,8 @@ const DEFAULT_TIMEOUT = 60000;
 /** SSE connections through proxies may need longer initial handshake time */
 const SSE_CONNECT_TIMEOUT = 120000;
 const DEFAULT_INIT_TIMEOUT = 30000;
+/** Upper bound on the spec-mandated Streamable HTTP session DELETE so teardown never blocks on a hung server */
+const SESSION_TERMINATION_TIMEOUT = 5000;
 /** Max 307/308 redirects to follow per request (prevents redirect loops) */
 const MAX_REDIRECTS = 5;
 const DEFAULT_MCP_STREAMABLE_HTTP_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
@@ -1877,6 +1879,7 @@ export class MCPConnection extends EventEmitter {
       try {
         if (this.transport) {
           try {
+            await this.terminateStreamableSession();
             await this.client.close();
           } catch (error) {
             logger.warn(`${this.getLogPrefix()} Error closing connection:`, error);
@@ -2191,9 +2194,37 @@ export class MCPConnection extends EventEmitter {
     await Promise.all(closing);
   }
 
+  /**
+   * Ends a Streamable HTTP session with the spec-mandated `HTTP DELETE` before
+   * the transport is discarded. Stateful MCP servers (the SDK default) keep each
+   * session's transport, tasks, and buffers in memory with no TTL, so without an
+   * explicit DELETE every idle eviction, reconnect, or restart leaks one
+   * server-side session. Must run before `client.close()`, which aborts the
+   * transport's controller and would cancel the in-flight DELETE.
+   *
+   * `terminateSession()` no-ops when there is no session id and already tolerates
+   * a 405 (server opts out of termination). Any other failure is non-fatal to
+   * teardown, so it is bounded by a timeout and swallowed.
+   */
+  private async terminateStreamableSession(): Promise<void> {
+    if (!(this.transport instanceof StreamableHTTPClientTransport)) {
+      return;
+    }
+    try {
+      await withTimeout(
+        this.transport.terminateSession(),
+        SESSION_TERMINATION_TIMEOUT,
+        `Streamable HTTP session termination timed out after ${SESSION_TERMINATION_TIMEOUT}ms`,
+      );
+    } catch (error) {
+      logger.debug(`${this.getLogPrefix()} Error terminating streamable HTTP session:`, error);
+    }
+  }
+
   public async disconnect(resetCycleTracking = true): Promise<void> {
     try {
       if (this.transport) {
+        await this.terminateStreamableSession();
         await this.client.close();
         this.transport = null;
       }


### PR DESCRIPTION
## Summary

Fixes #14248.

LibreChat's MCP client never called `terminateSession()` when discarding a Streamable HTTP connection — it only called `client.close()`. Per the [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management), a client that no longer needs a session SHOULD send an `HTTP DELETE` with the `Mcp-Session-Id` header. Without it, stateful MCP servers (the SDK default) keep every session's transport, tasks, and buffers in memory with no server-side TTL, so **every idle eviction, reconnect, or restart leaks one server-side session**. The reporter observed a small FastMCP web-search server grow to ~3 GB RSS from orphaned sessions.

## Changes

**`packages/api/src/mcp/connection.ts`**

- New private `terminateStreamableSession()` helper that, when the transport is a `StreamableHTTPClientTransport`, calls the SDK's `terminateSession()` (which issues the spec DELETE). It is:
  - **Ordered before `client.close()`** — `close()` aborts the transport's `AbortController`, which would otherwise cancel the in-flight DELETE.
  - **Bounded by a 5s timeout** (`withTimeout`) so teardown never blocks on a hung/unreachable server during idle eviction or reconnect.
  - **Non-fatal** — `terminateSession()` already no-ops without a session id and tolerates a `405` (server opts out of termination); any other error is logged at debug and swallowed.
- Wired into **both** teardown paths the issue identified:
  - `disconnect()` — the funnel for idle eviction (`UserConnectionManager`), `ConnectionsRepository`, and request-scoped cleanup.
  - The reconnect transport-swap inside `connectClient()`, where a fresh transport (new session) replaces the old one.

## Tests

New `MCPConnectionSessionTermination.test.ts` runs against a real in-process `StreamableHTTPServerTransport` and asserts the client:

1. Sends `DELETE` with the negotiated session id on disconnect, and the server frees the session end-to-end.
2. Terminates the prior session before swapping in a fresh transport on reconnect.
3. Doesn't throw when the server rejects termination with `405`.
4. Sends no `DELETE` for a non-streamable (SSE) transport.

## Verification

- New suite: 4/4 pass.
- Existing MCP connection suites: 248 pass. (`MCPConnectionFactory.oauthSdk.integration` has 2 failures that are **pre-existing** — they fail identically on the base with these changes stashed.)
- `tsc` and `eslint` clean on both changed files.