### PR TITLE
🗂️ fix: Route read_file Through the Stateful Code Session

### DIFF
--- a/packages/api/src/agents/__tests__/run-codeTools.test.ts
+++ b/packages/api/src/agents/__tests__/run-codeTools.test.ts
@@ -104,10 +104,10 @@ describe('createRun code-tool eager/session wiring', () => {
     );
   });
 
-  it('declares create_file/edit_file as code-session participants', async () => {
+  it('declares create_file/edit_file/read_file as code-session participants', async () => {
     const runConfig = await captureRunConfig();
     expect(runConfig.codeSessionToolNames).toEqual(
-      expect.arrayContaining(['create_file', 'edit_file']),
+      expect.arrayContaining(['create_file', 'edit_file', 'read_file']),
     );
   });
 });

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1495,13 +1495,17 @@ export async function createRun({
         ...agents.flatMap((agent) => agent.backgroundToolNames ?? []),
       ],
     },
-    // Let host file-authoring tools share the code-execution sandbox session so
-    // a file created with create_file/edit_file is visible to later
+    // Let host file tools share the code-execution sandbox session so a file
+    // created with create_file/edit_file is visible to later
     // execute_code/bash_tool calls (and vice versa). The SDK folds these tools'
     // returned exec session/files into the shared code session and injects the
-    // existing session into their requests. Requires @librechat/agents with
-    // codeSessionToolNames support (agents#283); older versions ignore it.
-    codeSessionToolNames: [CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME],
+    // existing session into their requests. Membership here also stamps the
+    // stateful `runtimeSessionHint` and excludes the tool from eager execution
+    // — read_file needs both, or its sandbox `cat` runs hintless on the Code
+    // API's per-user default runtime session and cannot see files bash_tool
+    // just wrote in the conversation's session. Requires @librechat/agents
+    // with codeSessionToolNames support (agents#283); older versions ignore it.
+    codeSessionToolNames: [CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME, Constants.READ_FILE],
     // Derive the Langfuse trace id deterministically from runId so message
     // feedback can be scored against the trace without a lookup (see the
     // feedback route in api/server/routes/messages.js). No-op unless Langfuse


### PR DESCRIPTION
## Summary

I fixed `read_file` failing with "No such file or directory" on files that demonstrably exist in the stateful code sandbox (written by `bash_tool` in the same conversation). Root cause: `read_file` was missing from `codeSessionToolNames`, so its internal sandbox `cat` was issued without the stateful `runtime_session_hint` and executed on the Code API's per-user **default** runtime session — a different MicroVM than the conversation's session where the file lives. Verified at the hash level against a live stateful backend: the failing `cat` execs landed on `hash(namespace, user, "default")` while `bash_tool` ran on `hash(namespace, user, conversationId)`.

- Added `Constants.READ_FILE` to `codeSessionToolNames` in `createRun`: membership stamps `runtimeSessionHint` on the tool call (the SDK's `participatesInCodeSession` gate), excludes `read_file` from eager execution (whose request plan omits the hint entirely), and folds session context — all with zero SDK changes.
- `read_file` was doubly exposed before this: the ToolNode request builder grants it `codeSessionContext` but not the hint, and the eager path neither excludes it nor stamps hints for anyone.
- Updated the wiring comment to document why membership matters for reads, and extended `run-codeTools.test.ts` to pin `read_file` as a code-session participant.

Note for reviewers: a same-turn repro of `edit_file` "File not found" traced to a different cause — parallel tool calls in one model turn (bash write + edit read) execute concurrently and the Code API's per-session lock serializes without ordering, so the edit's read can precede the write it depends on. `edit_file` carries the correct hint (it was already in `codeSessionToolNames`); intra-turn ordering for code-session tools is a separate follow-up.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest run-codeTools` — 2/2 pass (expectation now pins `read_file`).
- ESLint clean on touched files.
- Live-backend verification of the diagnosis: derived runtime-session ids for the default hint and the conversation hint match Redis session keys exactly; failing `cat` execs correlate with the default session.
- Manual pass after deploy: `bash_tool: echo test > /mnt/data/probe.txt` in one turn, `read_file /mnt/data/probe.txt` in the next — should return the content instead of "No such file or directory".

### **Test Configuration**:

- Code API: lambda-microvm backend, `CODEAPI_RUNTIME_SESSION_MODE=affinity`, S3 checkpoints; `librechat.yaml` agents capabilities include `stateful_code_sessions`, agent toggle on

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
