### PR TITLE
🪆 fix: Build RAG-API Chart Before Parent to Bundle PostgreSQL Dependency

### DIFF
--- a/.github/workflows/helmcharts.yml
+++ b/.github/workflows/helmcharts.yml
@@ -66,10 +66,10 @@ jobs:
       
       - name: Build Subchart Deps
         run: |
-          cd helm/librechat
-          helm dependency build  
-          cd ../librechat-rag-api
-          helm dependency build      
+          cd helm/librechat-rag-api
+          helm dependency build
+          cd ../librechat
+          helm dependency build
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
Fixes #14251 — PostgreSQL dependency missing from published Helm chart due to incorrect build order in CI.

  When helm dependency build ran on the parent chart first, it packaged the librechat-rag-api sub-chart before PostgreSQL had been fetched
  into its charts/ directory. The published OCI chart shipped without PostgreSQL, causing the RAG API to fail at startup. Swapping the order
  ensures the sub-chart's dependencies are fetched before the parent snapshots it.

  Change Type

  - [X]  Bug fix (non-breaking change which fixes an issue)

  Testing

  1. Run helm dependency build inside helm/librechat-rag-api — confirm charts/postgresql-*.tgz is created
  2. Run helm dependency build inside helm/librechat — confirm the packaged sub-chart under charts/ contains the PostgreSQL archive
  3. Verify with tar -tzf that the final chart includes librechat/charts/librechat-rag-api/charts/postgresql-*.tgz

  Test Configuration:

  - Helm 3.x
  - Chart versions: librechat 2.0.7, librechat-rag-api 0.5.3

  Checklist

  - [X]  My code adheres to this project's style guidelines
  - [X]  I have performed a self-review of my own code
  - [X]  My changes do not introduce new warnings
  - [X]  Local unit tests pass with my changes

  ───
  The rest (commented code, documentation, downstream modules, tests for the fix) don't apply since it's a two-line CI script reordering.