### PR TITLE
🧹 chore: Prune Dangling Images After deployed-update Pull

### DIFF
--- a/config/deployed-update.js
+++ b/config/deployed-update.js
@@ -61,6 +61,15 @@ const shouldRebase = process.argv.includes('--rebase');
   console.orange(pullCommand);
   execSync(pullCommand, { stdio: 'inherit' });
 
+  /* The tag-removal above only covers the stock repositories; any overridden
+   * `api` image (or other freshly pulled service) leaves its previous version
+   * dangling — ~1.7GB per update that nothing reclaimed. Prune AFTER the pull
+   * so the just-superseded layers are already untagged, mirroring update.js. */
+  console.purple('Removing all unused dangling Docker images...');
+  const pruneCommand = 'sudo docker image prune -f';
+  console.orange(pruneCommand);
+  execSync(pruneCommand, { stdio: 'inherit' });
+
   const startCommand = 'sudo docker compose -f ./deploy-compose.yml up -d';
   console.green('Your LibreChat app is now up to date! Start the app with the following command:');
   console.purple(startCommand);


### PR DESCRIPTION
## Summary

I added a `docker image prune -f` step to `config/deployed-update.js` after the image pull, mirroring what `config/update.js` already does. The script's pre-pull tag removal only covers the two stock repositories (`registry.librechat.ai/danny-avila/librechat-dev-api`, `librechat-client`), so any deployment overriding the `api` image (e.g. via `docker-compose.override.yml`) — or any other service updated in the same pull — left its superseded image dangling: ~1.7GB per update that nothing reclaimed. Observed in the field as ~4GB of dangling images after a handful of updates on a 34GB droplet.

- Prune runs AFTER the pull so the just-superseded `:latest` layers are already untagged and get caught.
- `docker image prune -f` only removes dangling (untagged) images — identical semantics to the existing prune in `update.js`, no tagged/in-use images are touched.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `node --check` + ESLint clean.
- Verified the failure mode and the fix's equivalent manually on the affected droplet: `docker image prune -f` reclaimed 4.06GB of exactly the images this step would have caught, with all 18 running containers unaffected.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes