### PR TITLE
🧽 fix: Clear Deleted Chats From Message Cache

### DIFF
--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -14,6 +14,7 @@ import {
   findConversationInInfinite,
   updateConvoInAllQueries,
   removeConvoFromAllQueries,
+  clearDeletedConversationMessagesCache,
 } from '~/utils';
 import useUpdateTagsInConvo from '~/hooks/Conversations/useUpdateTagsInConvo';
 import { updateConversationTag } from '~/utils/conversationTags';
@@ -544,6 +545,7 @@ export const useDeleteConversationMutation = (
 
         if (vars.conversationId) {
           removeConvoFromAllQueries(queryClient, vars.conversationId);
+          clearDeletedConversationMessagesCache(queryClient, vars.conversationId);
         }
 
         // Also remove from all archivedConversations caches

--- a/client/src/utils/__tests__/messages.test.ts
+++ b/client/src/utils/__tests__/messages.test.ts
@@ -4,6 +4,7 @@ import type { TMessage } from 'librechat-data-provider';
 import type { LocalizeFunction } from '~/common';
 import {
   clearMessagesCache,
+  clearDeletedConversationMessagesCache,
   isValidTimestamp,
   getMessageAriaLabel,
   getMessageTimestamp,
@@ -47,6 +48,57 @@ describe('clearMessagesCache', () => {
 
     expect(queryClient.getQueryData([QueryKeys.messages, conversationId])).toBeUndefined();
     expect(queryClient.getQueryData([QueryKeys.messages, Constants.NEW_CONVO])).toEqual([]);
+  });
+});
+
+describe('clearDeletedConversationMessagesCache', () => {
+  it('clears both message caches when the new-conversation cache aliases the deleted chat', () => {
+    const queryClient = new QueryClient();
+    const conversationId = 'conversation-1';
+    const messages = [makeMessage({ conversationId })];
+    queryClient.setQueryData([QueryKeys.messages, conversationId], messages);
+    queryClient.setQueryData(
+      [QueryKeys.messages, Constants.NEW_CONVO],
+      messages.map((message) => ({ ...message })),
+    );
+
+    clearDeletedConversationMessagesCache(queryClient, conversationId);
+
+    expect(queryClient.getQueryData([QueryKeys.messages, conversationId])).toBeUndefined();
+    expect(queryClient.getQueryData([QueryKeys.messages, Constants.NEW_CONVO])).toEqual([]);
+  });
+
+  it('clears a shared new-conversation cache before its message IDs are hydrated', () => {
+    const queryClient = new QueryClient();
+    const conversationId = 'conversation-1';
+    const messages = [makeMessage({ conversationId: Constants.NEW_CONVO as string })];
+    queryClient.setQueryData([QueryKeys.messages, conversationId], messages);
+    queryClient.setQueryData([QueryKeys.messages, Constants.NEW_CONVO], messages);
+
+    clearDeletedConversationMessagesCache(queryClient, conversationId);
+
+    expect(queryClient.getQueryData([QueryKeys.messages, conversationId])).toBeUndefined();
+    expect(queryClient.getQueryData([QueryKeys.messages, Constants.NEW_CONVO])).toEqual([]);
+  });
+
+  it('preserves an unrelated new-conversation message cache', () => {
+    const queryClient = new QueryClient();
+    const conversationId = 'conversation-1';
+    const newConversationMessages = [
+      makeMessage({ messageId: 'new-message', conversationId: Constants.NEW_CONVO as string }),
+    ];
+    queryClient.setQueryData(
+      [QueryKeys.messages, conversationId],
+      [makeMessage({ conversationId })],
+    );
+    queryClient.setQueryData([QueryKeys.messages, Constants.NEW_CONVO], newConversationMessages);
+
+    clearDeletedConversationMessagesCache(queryClient, conversationId);
+
+    expect(queryClient.getQueryData([QueryKeys.messages, conversationId])).toBeUndefined();
+    expect(queryClient.getQueryData([QueryKeys.messages, Constants.NEW_CONVO])).toEqual(
+      newConversationMessages,
+    );
   });
 });
 

--- a/client/src/utils/__tests__/messages.test.ts
+++ b/client/src/utils/__tests__/messages.test.ts
@@ -52,7 +52,7 @@ describe('clearMessagesCache', () => {
 });
 
 describe('clearDeletedConversationMessagesCache', () => {
-  it('clears both message caches when the new-conversation cache aliases the deleted chat', () => {
+  it('clears both caches when the new-conversation cache contains deleted chat messages', () => {
     const queryClient = new QueryClient();
     const conversationId = 'conversation-1';
     const messages = [makeMessage({ conversationId })];

--- a/client/src/utils/messages.ts
+++ b/client/src/utils/messages.ts
@@ -312,6 +312,33 @@ export const clearMessagesCache = (
   queryClient.setQueryData<TMessage[]>([QueryKeys.messages, Constants.NEW_CONVO], []);
 };
 
+/** Removes a deleted conversation's message cache and any matching new-chat cache alias. */
+export const clearDeletedConversationMessagesCache = (
+  queryClient: QueryClient,
+  conversationId: string,
+): void => {
+  const deletedMessages = queryClient.getQueryData<TMessage[]>([
+    QueryKeys.messages,
+    conversationId,
+  ]);
+  const newConversationMessages = queryClient.getQueryData<TMessage[]>([
+    QueryKeys.messages,
+    Constants.NEW_CONVO,
+  ]);
+  const newConversationAliasesDeleted =
+    newConversationMessages != null &&
+    (newConversationMessages === deletedMessages ||
+      newConversationMessages.some((message) => message.conversationId === conversationId));
+
+  queryClient.removeQueries([QueryKeys.messages, conversationId], { exact: true });
+
+  if (!newConversationAliasesDeleted) {
+    return;
+  }
+
+  queryClient.setQueryData<TMessage[]>([QueryKeys.messages, Constants.NEW_CONVO], []);
+};
+
 /** Returns a 1-based message number, or null if depth is absent or invalid. */
 const getMessageNumber = (message: TMessage): number | null => {
   if (message.depth == null || message.depth < 0) {

--- a/e2e/specs/mock/conversation-management.spec.ts
+++ b/e2e/specs/mock/conversation-management.spec.ts
@@ -84,7 +84,9 @@ test.describe('conversation management', () => {
     await expect(page.getByTestId('convo-item').filter({ hasText: renamedTitle })).toBeVisible();
   });
 
-  test('deletes a conversation from the sidebar and blocks direct URL access', async ({ page }) => {
+  test('deletes a conversation, clears its messages, and blocks direct URL access', async ({
+    page,
+  }) => {
     const label = uniqueLabel('sidebar-delete');
     const renamedTitle = `Delete ${label}`;
 
@@ -111,6 +113,8 @@ test.describe('conversation management', () => {
 
     await expect(page).toHaveURL(/\/c\/new$/);
     await expect(page.getByTestId('convo-item').filter({ hasText: renamedTitle })).toHaveCount(0);
+    await expect(messagesView(page).getByText(turn.prompt)).toHaveCount(0);
+    await expect(messagesView(page).getByText(turn.reply)).toHaveCount(0);
 
     await page.goto(conversationUrl, { timeout: 10000 });
     await expect(page.getByRole('textbox', { name: 'Message input' })).toBeVisible();


### PR DESCRIPTION
## Summary

I fixed deleted conversations remaining visible after navigation to a new chat by clearing the deleted conversation's React Query message cache and any matching `messages/new` alias.

- Evict the deleted conversation's message query after a successful deletion.
- Clear the new-conversation cache when it aliases or contains messages from the deleted conversation.
- Preserve an unrelated new-conversation cache.
- Cover hydrated, pre-hydration shared-cache, unrelated-cache, and rendered-view behavior with unit and Playwright regression tests.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `jest src/utils/__tests__/messages.test.ts src/data-provider/Messages/__tests__/queries.test.ts --runInBand --coverage=false` (43 tests passed).
- Ran `E2E_BASE_URL=http://localhost:3333 playwright test --config=e2e/playwright.config.mock.ts conversation-management.spec.ts` (3 tests passed).
- Ran targeted ESLint on the changed frontend and Playwright files.
- Ran `npm run typecheck` in `client`.

### **Test Configuration**:

- Node.js v24.16.0
- Jest 30.2.0
- Playwright 1.56.1 with Chromium
- TypeScript 5.9.3

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
