### PR TITLE
🛞 style: Reveal the Steered "?" on Message Hover/Focus

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
@@ -105,9 +105,13 @@ const SteerPart = memo(function SteerPart({
         <h2 className={cn('flex select-none items-center gap-1.5 font-semibold', fontSize)}>
           {label}
           {/* Subtle "?" explaining why a user message appears inside the
-           *  response — revealed on message hover/focus, like the hover
-           *  buttons, so it doesn't sit on every steered message at rest. */}
-          <span className="opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+           *  response. Like the message hover buttons, it's revealed on
+           *  hover/focus on hover-capable pointers, but stays visible on
+           *  touch (no hover to reveal it) via [@media(hover:hover)]:opacity-0. */}
+          <span
+            data-testid="steer-info-affordance"
+            className="transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100 [@media(hover:hover)]:opacity-0"
+          >
             <InfoHoverCard side={ESide.Top} text={localize('com_ui_steered_info')} />
           </span>
           <MessageTimestamp value={timestamp} />

--- a/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
@@ -104,8 +104,12 @@ const SteerPart = memo(function SteerPart({
       <div className="user-turn relative flex w-11/12 flex-col">
         <h2 className={cn('flex select-none items-center gap-1.5 font-semibold', fontSize)}>
           {label}
-          {/* Subtle "?" explaining why a user message appears inside the response. */}
-          <InfoHoverCard side={ESide.Top} text={localize('com_ui_steered_info')} />
+          {/* Subtle "?" explaining why a user message appears inside the
+           *  response — revealed on message hover/focus, like the hover
+           *  buttons, so it doesn't sit on every steered message at rest. */}
+          <span className="opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+            <InfoHoverCard side={ESide.Top} text={localize('com_ui_steered_info')} />
+          </span>
           <MessageTimestamp value={timestamp} />
           {onCancel != null && (
             <button

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -79,4 +79,14 @@ describe('SteerPart author label', () => {
     // assistant response (its text is the trigger's accessible label).
     expect(screen.getByLabelText('com_ui_steered_info')).toBeInTheDocument();
   });
+
+  it('hides the info affordance at rest, revealing it on message hover/focus', () => {
+    renderPart();
+    // Wrapped like the hover buttons: transparent until the message is
+    // hovered (group-hover) or the trigger is focused (focus-within).
+    const wrapper = screen.getByLabelText('com_ui_steered_info').closest('span.opacity-0');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('group-hover:opacity-100');
+    expect(wrapper?.className).toContain('focus-within:opacity-100');
+  });
 });

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -80,13 +80,13 @@ describe('SteerPart author label', () => {
     expect(screen.getByLabelText('com_ui_steered_info')).toBeInTheDocument();
   });
 
-  it('hides the info affordance at rest, revealing it on message hover/focus', () => {
+  it('reveals on hover/focus on hover-capable pointers but stays visible on touch', () => {
     renderPart();
-    // Wrapped like the hover buttons: transparent until the message is
-    // hovered (group-hover) or the trigger is focused (focus-within).
-    const wrapper = screen.getByLabelText('com_ui_steered_info').closest('span.opacity-0');
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.className).toContain('group-hover:opacity-100');
-    expect(wrapper?.className).toContain('focus-within:opacity-100');
+    // Like the hover buttons: hidden-at-rest ONLY on hover-capable pointers
+    // ([@media(hover:hover)]:opacity-0), so touch devices keep it visible.
+    const wrapper = screen.getByTestId('steer-info-affordance');
+    expect(wrapper.className).toContain('[@media(hover:hover)]:opacity-0');
+    expect(wrapper.className).toContain('group-hover:opacity-100');
+    expect(wrapper.className).toContain('focus-within:opacity-100');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the steering info-cards work (#14260). The steered-message `?` `InfoHoverCard` was visible on every steered message at rest. I wrapped it to reveal only on message hover/focus — the same pattern the message hover buttons use — so it doesn't clutter the thread.

- `SteerPart.tsx`: the `?` is now wrapped in `opacity-0 … group-hover:opacity-100 focus-within:opacity-100`, matching the steered message's cancel button. It stays transparent at rest, appears when the message is hovered, and reveals when the trigger receives keyboard focus (still fully accessible / tabbable).

No copy or behavior changes beyond visibility.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Client typechecks clean; ESLint + import-order clean. `SteerPart.test.tsx` extended (asserts the affordance is present but wrapped with the hover/focus-reveal classes); suite green. Relying on repo CI for the full matrix.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes