### PR TITLE
📱 fix: Single-Tap Select for Pinned Agents, Model Specs & Models on Touch

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -117,7 +117,12 @@ export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps)
           'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary',
           isFavorite
             ? 'visible'
-            : 'invisible group-focus-within:visible group-hover:visible group-data-[active-item]:visible',
+            : // Visible by default so it's tappable on touch (no hover to
+              // reveal it); only hidden-until-hover on hover-capable pointers.
+              // A hover-gated child would otherwise make the whole item
+              // hover-dependent, so the first tap only reveals it and a second
+              // tap is needed to select (the iOS double-tap).
+              'group-focus-within:visible group-hover:visible group-data-[active-item]:visible [@media(hover:hover)]:invisible',
         )}
       >
         {isFavorite ? (

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -61,7 +61,12 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
           'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary',
           isFavorite
             ? 'visible'
-            : 'invisible group-focus-within:visible group-hover:visible group-data-[active-item]:visible',
+            : // Visible by default so it's tappable on touch (no hover to
+              // reveal it); only hidden-until-hover on hover-capable pointers.
+              // A hover-gated child would otherwise make the whole item
+              // hover-dependent, so the first tap only reveals it and a second
+              // tap is needed to select (the iOS double-tap).
+              'group-focus-within:visible group-hover:visible group-data-[active-item]:visible [@media(hover:hover)]:invisible',
         )}
       >
         {isFavorite ? (

--- a/client/src/components/Nav/Favorites/FavoriteItem.tsx
+++ b/client/src/components/Nav/Favorites/FavoriteItem.tsx
@@ -152,7 +152,11 @@ export default function FavoriteItem(props: FavoriteItemProps) {
           'absolute right-2 flex items-center',
           isPopoverActive
             ? 'pointer-events-auto opacity-100'
-            : 'pointer-events-none opacity-0 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100',
+            : // Interactive by default so it's tappable on touch; only
+              // hidden-until-hover on hover-capable pointers. Otherwise the
+              // whole row is hover-dependent and the first tap just reveals
+              // this instead of selecting (the iOS double-tap).
+              'group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0',
         )}
         onClick={(e) => e.stopPropagation()}
       >
@@ -168,7 +172,7 @@ export default function FavoriteItem(props: FavoriteItemProps) {
                 'inline-flex h-7 w-7 items-center justify-center rounded-md border-none p-0 text-sm font-medium ring-ring-primary transition-all duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50',
                 isPopoverActive
                   ? 'opacity-100'
-                  : 'opacity-0 focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 data-[open]:opacity-100',
+                  : 'focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 data-[open]:opacity-100 [@media(hover:hover)]:opacity-0',
               )}
               aria-label={localize('com_nav_convo_menu_options')}
               data-testid="favorite-options-button"


### PR DESCRIPTION
## Summary

On touch devices, selecting a **model spec**, a **model**, or a **pinned/favorite agent** required two taps — the first tap only applied the hover state, the second actually selected.

Root cause: each of these items has a hover-revealed secondary control (the pin button, or the "⋯" options button) styled `invisible` / `opacity-0` on **all** pointer types until `group-hover`. A hover-revealed child makes the whole item's rendering hover-dependent, which triggers the well-known iOS behavior where the first tap reveals the `:hover` state and a second tap is needed to activate.

The fix is the same one #13712 applied to the message hover buttons: gate the hover-reveal on hover **capability**, not on the hover state. The control is visible/tappable by default and only hidden-until-hover on hover-capable pointers via `[@media(hover:hover)]`. On touch the item is no longer hover-dependent, so the first tap selects; on desktop the reveal-on-hover behavior is unchanged.

- `ModelSpecItem.tsx` / `EndpointModelItem.tsx`: the pin/unpin button reveal (this is also where agents are pinned from the model menu).
- `FavoriteItem.tsx` (sidebar pinned agents): the "⋯" options button and its wrapper reveal.

Out of scope: `EndpointItem`'s settings label (scoped to `group/button`, doesn't gate item-select) and `PresetItems` (already visible on phones via the `sm:` proxy — only a tablet concern).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Client typechecks clean; ESLint + import-order clean. CSS-capability change (no logic); best verified on a real touch device — pinned agents, model specs, and models now select on a single tap while desktop hover-reveal is unchanged. Relying on repo CI for the matrix.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings