### PR TITLE
🧟 fix: Prevent Drained Steer From Re-Queuing After Run-End Race

### DIFF
--- a/client/src/hooks/Chat/__tests__/useSteerConvert.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteerConvert.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, renderHook } from '@testing-library/react';
-import { RecoilRoot, useRecoilValue, type MutableSnapshot } from 'recoil';
+import { RecoilRoot, useRecoilValue, useSetRecoilState, type MutableSnapshot } from 'recoil';
 import useSteerConvert from '../useSteerConvert';
 import store from '~/store';
 
@@ -16,12 +16,17 @@ function setup(initialize?: (snapshot: MutableSnapshot) => void) {
     <RecoilRoot initializeState={initialize}>{children}</RecoilRoot>
   );
   return renderHook(
-    () => ({
-      convert: useSteerConvert(),
-      chips: useRecoilValue(store.pendingSteersByConvoId(CONVO_ID)),
-      queue: useRecoilValue(store.queuedMessagesByConvoId(CONVO_ID)),
-      applied: useRecoilValue(store.appliedSteerIdsByConvoId(CONVO_ID)),
-    }),
+    () => {
+      const setQueue = useSetRecoilState(store.queuedMessagesByConvoId(CONVO_ID));
+      return {
+        convert: useSteerConvert(),
+        chips: useRecoilValue(store.pendingSteersByConvoId(CONVO_ID)),
+        queue: useRecoilValue(store.queuedMessagesByConvoId(CONVO_ID)),
+        applied: useRecoilValue(store.appliedSteerIdsByConvoId(CONVO_ID)),
+        // Mirrors `useQueueDrain` dequeuing the head item after auto-send.
+        drainQueue: () => setQueue((prev) => prev.slice(1)),
+      };
+    },
     { wrapper },
   );
 }
@@ -110,6 +115,29 @@ describe('useSteerConvert', () => {
     });
     expect(result.current.queue).toHaveLength(1);
     expect(result.current.applied).toEqual(['srv-2']);
+  });
+
+  it('does not re-queue a steer already drained after conversion', () => {
+    const { result } = setup();
+    const steers = [{ steerId: 'srv-drained', text: 'submitted once', createdAt: 5 }];
+    // First delivery converts the leftover steer into a queued chip.
+    act(() => {
+      result.current.convert(CONVO_ID, steers);
+    });
+    expect(result.current.queue).toEqual([expect.objectContaining({ id: 'srv-drained' })]);
+    // The run-end drain submits it and removes it from the queue.
+    act(() => {
+      result.current.drainQueue();
+    });
+    expect(result.current.queue).toEqual([]);
+    // A late redelivery of the SAME steer (claimParked /chat/status, abort
+    // response, or reconnect) must NOT resurrect a queued chip for a message
+    // that was already sent — the applied-id set marks it settled.
+    act(() => {
+      result.current.convert(CONVO_ID, steers);
+    });
+    expect(result.current.queue).toEqual([]);
+    expect(result.current.applied).toEqual(['srv-drained']);
   });
 
   describe('claimParked (clears the parked server copy of live-delivered steers)', () => {

--- a/client/src/hooks/Chat/useSteerConvert.ts
+++ b/client/src/hooks/Chat/useSteerConvert.ts
@@ -46,6 +46,15 @@ export default function useSteerConvert() {
           .getValue();
         const chipById = new Map(localChips.map((chip) => [chip.steerId, chip]));
         const steerIds = new Set(steers.map((steer) => steer.steerId));
+        // Steers already settled (applied on the server OR converted here on an
+        // earlier delivery) must not re-enter the queue. Read BEFORE the append
+        // below so a first-time conversion still queues, but a redelivery whose
+        // item was already DRAINED out of the queue is a no-op — without this,
+        // the queue-only dedup below misses a message the run-end drain already
+        // submitted and re-mints it as a stranded queued chip.
+        const settledSteerIds = new Set(
+          snapshot.getLoadable(store.appliedSteerIdsByConvoId(conversationId)).getValue(),
+        );
         set(store.appliedSteerIdsByConvoId(conversationId), (prev) =>
           appendAppliedSteerIds(
             prev,
@@ -57,7 +66,11 @@ export default function useSteerConvert() {
         );
         set(store.queuedMessagesByConvoId(conversationId), (prev) => {
           const fresh = steers
-            .filter((steer) => !prev.some((queued) => queued.id === steer.steerId))
+            .filter(
+              (steer) =>
+                !settledSteerIds.has(steer.steerId) &&
+                !prev.some((queued) => queued.id === steer.steerId),
+            )
             .map((steer) => ({
               id: steer.steerId,
               text: steer.text,


### PR DESCRIPTION
## Summary

Fixes a steering/queuing race where a message sent to **steer** a run gets both auto-submitted **and** left behind as a stale "queued" chip when the run ends at the same moment.

When the model/agent finishes just as a steer is sent, the server reports it as a *leftover* steer and the client converts it into a **queued** follow-up that auto-sends after the run ends. In the racing case, the message got submitted but still showed as queued afterward.

## Root cause

`useSteerConvert`'s `convert` adds a leftover steer to `queuedMessagesByConvoId`, deduping **only against the current queue**:

1. The `final` SSE event calls `convert(...)` → the steer lands in the queue and its id joins the `appliedSteerIdsByConvoId` "settled" set.
2. `runEnd` fires with `outcome: 'completed'` → `useQueueDrain` drains the head item: it auto-submits it and removes it from the queue.
3. A second delivery of the **same** steer arrives (the `claimParked` `/chat/status` fetch, the abort HTTP response, or a reconnect). `convert` runs again, but the item was already drained out of the queue, so the queue-only dedup sees nothing and re-adds it, resurrecting a queued chip for a message that was already sent.

## Fix

`convert` now reads `appliedSteerIdsByConvoId` **before** appending to it, and excludes already-settled steer ids from queue re-additions. A first-time conversion still queues normally (the id is not in the set yet); a later redelivery of a steer already converted-and-drained becomes a no-op. That set is the correct source of truth because it survives run end (capped, never cleared) precisely to mark steers as settled.

Bonus: this also closes a latent double-submit. If a steer was genuinely applied (injected as a STEER part) during the run but still leaked into `pendingSteers`, it will no longer also be queued as a new message.

## Testing

- New regression test (`does not re-queue a steer already drained after conversion`) reproducing the exact race: convert → drain → redeliver → assert the queue stays empty.
- `useSteerConvert.spec.tsx` (11 tests), `useQueueDrain.spec.tsx`, and `abort.spec.tsx` pass; ESLint and `sort-imports` clean.
