### PR TITLE
feat: Implement placeholder resolution for modelKwargs in LLM config

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -529,6 +529,12 @@ endpoints:
   # `endpoints.all` to apply globally across endpoints (endpoint values win on key
   # collisions). NOTE: send metadata headers like these only behind a gateway that
   # consumes them — native provider APIs ignore unknown headers.
+  #
+  # The same placeholders ({{LIBRECHAT_BODY_CONVERSATIONID}}, {{LIBRECHAT_BODY_MESSAGEID}},
+  # {{LIBRECHAT_BODY_PARENTMESSAGEID}}, {{LIBRECHAT_USER_*}}) also resolve inside
+  # `addParams` values for OpenAI-compatible endpoints (built-in and custom), not
+  # just headers — see the `addParams.metadata` example under the custom endpoints
+  # section below.
   # openAI:
   #   headers:
   #     cf-aig-metadata: '{"user_email":"{{LIBRECHAT_USER_EMAIL}}","app":"librechat"}'
@@ -722,8 +728,15 @@ endpoints:
       modelDisplayLabel: 'Mistral' # Default is "AI" when not set.
 
       # Add additional parameters to the request. Default params will be overwritten.
+      # addParams values support the same placeholders as `headers` above
+      # ({{LIBRECHAT_BODY_*}}, {{LIBRECHAT_USER_*}}), resolved at request time —
+      # useful for forwarding chat/user/message correlation IDs to the provider:
       # addParams:
-      # safe_prompt: true # This field is specific to Mistral AI: https://docs.mistral.ai/api/
+      #   safe_prompt: true # This field is specific to Mistral AI: https://docs.mistral.ai/api/
+      #   metadata:
+      #     chat_id: '{{LIBRECHAT_BODY_CONVERSATIONID}}'
+      #     user_id: '{{LIBRECHAT_USER_ID}}'
+      #     message_id: '{{LIBRECHAT_BODY_MESSAGEID}}'
 
       # Drop Default params parameters from the request. See default params in guide linked below.
       # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:

--- a/packages/api/src/agents/run.spec.ts
+++ b/packages/api/src/agents/run.spec.ts
@@ -8,7 +8,25 @@ import {
   isDeepSeekReasoningProvider,
   shouldReplayReasoningContent,
   anyAgentReplaysReasoningContent,
+  createRun,
 } from './run';
+
+// Mock Run.create to capture the graphConfig it receives, so the placeholder
+// resolution test below can inspect the built `clientOptions.modelKwargs`
+// without spinning up a real provider run.
+jest.mock('@librechat/agents', () => {
+  const actual = jest.requireActual('@librechat/agents');
+  return {
+    ...actual,
+    Run: {
+      create: jest.fn().mockResolvedValue({
+        processStream: jest.fn().mockResolvedValue(undefined),
+      }),
+    },
+  };
+});
+
+import { Run } from '@librechat/agents';
 
 describe('getRunDiscoveredTools', () => {
   it('uses the run discovery snapshot instead of reconstructing it from messages', () => {
@@ -407,5 +425,57 @@ describe('anyAgentReplaysReasoningContent', () => {
     (x as { subagentAgentConfigs?: unknown[] }).subagentAgentConfigs = [y];
     (y as { subagentAgentConfigs?: unknown[] }).subagentAgentConfigs = [x];
     expect(anyAgentReplaysReasoningContent([x])).toBe(false);
+  });
+});
+
+describe('createRun body/user placeholder resolution in modelKwargs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves {{LIBRECHAT_BODY_*}}/{{LIBRECHAT_USER_*}} placeholders inside llmConfig.modelKwargs', async () => {
+    const agent = {
+      id: 'agent_1',
+      provider: 'openAI',
+      endpoint: 'openAI',
+      model: 'gpt-4o',
+      tools: [],
+      model_parameters: {
+        model: 'gpt-4o',
+        modelKwargs: {
+          metadata: {
+            chat_id: '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+            user_id: '{{LIBRECHAT_USER_ID}}',
+            message_id: '{{LIBRECHAT_BODY_MESSAGEID}}',
+          },
+        },
+      },
+      maxContextTokens: 100_000,
+      toolContextMap: {},
+    } as unknown as Parameters<typeof createRun>[0]['agents'][number];
+
+    await createRun({
+      agents: [agent],
+      signal: new AbortController().signal,
+      streaming: true,
+      streamUsage: true,
+      user: { id: 'user-123' } as unknown as Parameters<typeof createRun>[0]['user'],
+      requestBody: { conversationId: 'convo-abc', messageId: 'msg-xyz' },
+    });
+
+    const createMock = Run.create as jest.Mock;
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const graphConfigAgents = createMock.mock.calls[0][0].graphConfig.agents as Array<
+      Record<string, unknown>
+    >;
+    const clientOptions = graphConfigAgents[0].clientOptions as {
+      modelKwargs: Record<string, unknown>;
+    };
+
+    expect(clientOptions.modelKwargs.metadata).toEqual({
+      chat_id: 'convo-abc',
+      user_id: 'user-123',
+      message_id: 'msg-xyz',
+    });
   });
 });

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -54,6 +54,7 @@ import { stripIntentFromToolRegistry, stripIntentFromToolDefinitions } from '~/a
 import { isSteeringSupported, isSteerPreemptSupported } from '~/agents/steering/runtime';
 import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm';
 import { resolveStreamLimits, resolveSubagentMaxTurns } from '~/agents/config';
+import { resolveConfigHeaders, resolveConfigModelKwargs } from '~/utils/headers';
 import { CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME } from '~/agents/tools';
 import { buildAgentInitialToolSessions } from '~/agents/codeFilesSession';
 import { getProviderConfig } from '~/endpoints/config/providers';
@@ -64,7 +65,6 @@ import { getPluginHookSource } from '~/agents/hooks/source';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
 import { buildHITLRunWiring } from '~/agents/hitl/runtime';
 import { buildLangfuseConfig } from '~/langfuse/config';
-import { resolveConfigHeaders } from '~/utils/headers';
 import { applyTestRunHook } from '~/agents/testHook';
 import { isUserProvided } from '~/utils/common';
 
@@ -1333,12 +1333,19 @@ export async function createRun({
 
     /**
      * Resolve request-based headers across provider-specific header locations
-     * (OpenAI `configuration.defaultHeaders`, Anthropic `clientOptions.defaultHeaders`,
-     * Google `customHeaders`). Done at this step because the request body may
-     * contain dynamic values (e.g. conversationId) that are only known after
-     * agent initialization.
+     * (OpenAI `configuration.defaultHeaders`, Anthropic `clientOptions.defaultHeaders`),
+     * and request-based placeholders inside the outbound JSON body (`modelKwargs`,
+     * where custom endpoint `addParams`/unrecognized params land). Native Google
+     * `customHeaders` are intentionally NOT touched here — see `resolveConfigHeaders`.
+     * Done at this step because the request body may contain dynamic values (e.g.
+     * conversationId) that are only known after agent initialization.
      */
     resolveConfigHeaders({
+      llmConfig,
+      user: createSafeUser(user),
+      body: requestBody,
+    });
+    resolveConfigModelKwargs({
       llmConfig,
       user: createSafeUser(user),
       body: requestBody,

--- a/packages/api/src/utils/headers.spec.ts
+++ b/packages/api/src/utils/headers.spec.ts
@@ -1,5 +1,5 @@
 import type { RunLLMConfig } from '~/types';
-import { mediaTypeEssence, mergeHeaders, resolveConfigHeaders } from './headers';
+import { mediaTypeEssence, mergeHeaders, resolveConfigHeaders, resolveConfigModelKwargs } from './headers';
 
 describe('mediaTypeEssence', () => {
   it('returns the bare type for a header with no parameters', () => {
@@ -215,5 +215,64 @@ describe('resolveConfigHeaders', () => {
     resolveConfigHeaders({ llmConfig, user, body });
 
     expect(llmConfig.configuration?.defaultHeaders).toEqual({ 'X-LibreChat-User': '' });
+  });
+});
+
+describe('resolveConfigModelKwargs', () => {
+  const user = { id: 'user-123', email: 'person@example.com' };
+  const body = { conversationId: 'convo-abc', messageId: 'msg-xyz' };
+
+  it('is a no-op when llmConfig is null/undefined', () => {
+    expect(() => resolveConfigModelKwargs({ llmConfig: null, user, body })).not.toThrow();
+    expect(() => resolveConfigModelKwargs({ llmConfig: undefined, user, body })).not.toThrow();
+  });
+
+  it('is a no-op when modelKwargs is absent', () => {
+    const llmConfig = { model: 'gpt-4o' } as unknown as RunLLMConfig;
+    expect(() => resolveConfigModelKwargs({ llmConfig, user, body })).not.toThrow();
+    expect((llmConfig as unknown as { modelKwargs?: unknown }).modelKwargs).toBeUndefined();
+  });
+
+  it('resolves placeholders inside nested modelKwargs objects and arrays', () => {
+    const llmConfig = {
+      modelKwargs: {
+        metadata: {
+          chat_id: '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+          user_id: '{{LIBRECHAT_USER_ID}}',
+          message_id: '{{LIBRECHAT_BODY_MESSAGEID}}',
+        },
+        tags: ['{{LIBRECHAT_USER_ID}}', 'static-tag'],
+        max_tokens: 100,
+      },
+    } as unknown as RunLLMConfig;
+
+    resolveConfigModelKwargs({ llmConfig, user, body });
+
+    expect((llmConfig as unknown as { modelKwargs: Record<string, unknown> }).modelKwargs).toEqual({
+      metadata: {
+        chat_id: 'convo-abc',
+        user_id: 'user-123',
+        message_id: 'msg-xyz',
+      },
+      tags: ['user-123', 'static-tag'],
+      max_tokens: 100,
+    });
+  });
+
+  it('resolves each modelKwargs object only once across repeated calls (idempotent under reuse)', () => {
+    process.env.HEADERS_SPEC_MODELKWARGS_IDEMPOTENT = 'env-value';
+    const reusedUser = { id: 'u', name: '${HEADERS_SPEC_MODELKWARGS_IDEMPOTENT}' };
+    const llmConfig = {
+      modelKwargs: { metadata: { name: '{{LIBRECHAT_USER_NAME}}' } },
+    } as unknown as RunLLMConfig;
+
+    resolveConfigModelKwargs({ llmConfig, user: reusedUser, body });
+    // Second pass must NOT re-expand the now-substituted ${...} from the user name
+    resolveConfigModelKwargs({ llmConfig, user: reusedUser, body });
+
+    expect((llmConfig as unknown as { modelKwargs: Record<string, unknown> }).modelKwargs).toEqual({
+      metadata: { name: '${HEADERS_SPEC_MODELKWARGS_IDEMPOTENT}' },
+    });
+    delete process.env.HEADERS_SPEC_MODELKWARGS_IDEMPOTENT;
   });
 });

--- a/packages/api/src/utils/headers.ts
+++ b/packages/api/src/utils/headers.ts
@@ -1,7 +1,7 @@
 import type { AnthropicClientOptions } from '@librechat/agents';
 import type { IUser } from '@librechat/data-schemas';
 import type { RequestBody, RunLLMConfig } from '~/types';
-import { resolveHeaders } from './env';
+import { resolveHeaders, resolveNestedObject } from './env';
 
 /**
  * The media type of a `Content-Type` header — the lowercased `type/subtype` pair with any
@@ -150,4 +150,62 @@ export function resolveConfigHeaders({
   if (clientOptions?.defaultHeaders != null) {
     clientOptions.defaultHeaders = resolveOnce(clientOptions.defaultHeaders);
   }
+}
+
+type ModelKwargsContainer = { modelKwargs?: Record<string, unknown> };
+
+/**
+ * `modelKwargs` maps already resolved by `resolveConfigModelKwargs`. Same reuse
+ * concern as `resolvedHeaderMaps`: the same initialized agent (hence the same
+ * nested `modelKwargs` object) can flow through `buildAgentInput` more than once
+ * (root + subagent, multiple parents), so resolution is tracked by object
+ * identity to stay idempotent across reuse.
+ */
+const resolvedModelKwargs = new WeakSet<object>();
+
+/**
+ * Resolves placeholder templates inside the outbound request body of a built LLM
+ * config's `modelKwargs`, replacing it with a resolved copy on the config object.
+ * This is where unrecognized/custom `addParams` values land for
+ * OpenAI-compatible custom endpoints (see `transformToOpenAIConfig`), so this
+ * generalizes the same `{{LIBRECHAT_BODY_*}}` / `{{LIBRECHAT_USER_*}}`
+ * placeholder mechanism used for headers to arbitrary JSON body fields (e.g.
+ * `addParams.metadata.chat_id`).
+ *
+ * Resolution runs at request time so request-body placeholders (e.g.
+ * `{{LIBRECHAT_BODY_CONVERSATIONID}}`) resolve against the live request. It is a
+ * no-op when `modelKwargs` is absent, and idempotent under config reuse.
+ */
+export function resolveConfigModelKwargs({
+  llmConfig,
+  user,
+  body,
+  customUserVars,
+}: {
+  llmConfig?: RunLLMConfig | null;
+  user?: Partial<IUser> | { id: string };
+  body?: RequestBody;
+  customUserVars?: Record<string, string>;
+}): void {
+  if (llmConfig == null) {
+    return;
+  }
+
+  const container = llmConfig as ModelKwargsContainer;
+  if (container.modelKwargs == null) {
+    return;
+  }
+
+  if (resolvedModelKwargs.has(container.modelKwargs)) {
+    return;
+  }
+
+  const resolved = resolveNestedObject({
+    obj: container.modelKwargs,
+    user,
+    body,
+    customUserVars,
+  });
+  resolvedModelKwargs.add(resolved);
+  container.modelKwargs = resolved;
 }


### PR DESCRIPTION
## Summary

Adds support for `{{LIBRECHAT_BODY_*}}` / `{{LIBRECHAT_USER_*}}` placeholders inside addParams values (OpenAI-compatible endpoints), matching what `headers` already supports.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Added unit tests
- Did a local end-to-end test with a mock llm provider logging the request.

### **Test Configuration**:

```yaml
version: 1.3.6

cache: true
endpoints:
  custom:
    - name: 'Mock'
      apiKey: '-'
      baseURL: 'http://localhost:3100/v1'
      models:
        default: ['my-model']
        fetch: false
      titleConvo: false
      titleModel: 'current_model'
      modelDisplayLabel: 'mock'
      forcePrompt: false
      addParams:
        metadata:
          chat_id: '{{LIBRECHAT_BODY_CONVERSATIONID}}'
          user_id: '{{LIBRECHAT_USER_ID}}'
          message_id: '{{LIBRECHAT_BODY_MESSAGEID}}'
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
