### PR TITLE
🍽️ chore: Drop Pending Composer Draft When Steering or Queuing

### DIFF
--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { RecoilRoot, useRecoilValue, type MutableSnapshot } from 'recoil';
-import { Constants, ContentTypes, EModelEndpoint } from 'librechat-data-provider';
+import { Constants, ContentTypes, EModelEndpoint, LocalStorageKeys } from 'librechat-data-provider';
 import type { TConversation, TMessage } from 'librechat-data-provider';
 import useSteering from '../useSteering';
 import store from '~/store';
@@ -803,6 +803,62 @@ describe('useSteering', () => {
       expect(result.current.queue[0].manualSkills).toBeUndefined();
       expect(result.current.pendingQuotes).toEqual(['quoted excerpt']);
       expect(result.current.pendingSkills).toEqual(['skill-1']);
+    });
+  });
+
+  describe('composer draft consumption', () => {
+    /** `useAutoSave` drafts under PENDING_CONVO for the whole run, and the
+     *  composer clears via the form's programmatic `reset()` — which fires no
+     *  `input` event, so nothing else drops the draft. Left behind, run end
+     *  migrates it onto the conversation and restores it into the textarea,
+     *  resurfacing text the user already sent. */
+    const pendingDraftKey = `${LocalStorageKeys.TEXT_DRAFT}${Constants.PENDING_CONVO}`;
+
+    const stageDraft = () => localStorage.setItem(pendingDraftKey, 'ZHJhZnRlZCB0ZXh0');
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('drops the pending draft when queueing from the composer', () => {
+      stageDraft();
+      const { result } = setup();
+      act(() => {
+        result.current.queueFromComposer('queued follow up');
+      });
+      expect(result.current.queueKey).toBe(CONVO_ID);
+      expect(localStorage.getItem(pendingDraftKey)).toBeNull();
+    });
+
+    it('drops the pending draft when steering from the composer', () => {
+      stageDraft();
+      const { result } = setup();
+      act(() => {
+        result.current.steerFromComposer('steered text');
+      });
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem(pendingDraftKey)).toBeNull();
+    });
+
+    it('drops the pending draft on interrupt & send', () => {
+      stageDraft();
+      const { result } = setup();
+      act(() => {
+        result.current.interruptAndSend('interrupting text');
+      });
+      expect(localStorage.getItem(pendingDraftKey)).toBeNull();
+    });
+
+    it('keeps the pending draft when the submit is refused', () => {
+      // Nothing left the composer, so its draft must survive: an empty
+      // submission and an in-flight upload both refuse without consuming.
+      stageDraft();
+      const { result } = setup({ filesLoading: true });
+      act(() => {
+        expect(result.current.queueFromComposer('held by upload')).toBe(false);
+        expect(result.current.submitDuringRun('   ')).toBe(false);
+      });
+      expect(localStorage.getItem(pendingDraftKey)).toBe('ZHJhZnRlZCB0ZXh0');
     });
   });
 });

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -11,8 +11,8 @@ import {
   useSteerMessageMutation,
   useMarkFilesUsageMutation,
 } from '~/data-provider';
+import { carriedSteerContext, clearAllDrafts } from '~/utils';
 import { useSetFilesToDelete } from '~/hooks/Files';
-import { carriedSteerContext } from '~/utils';
 import useLocalize from '~/hooks/useLocalize';
 import store from '~/store';
 
@@ -331,6 +331,18 @@ export default function useSteering({
     [conversationId],
   );
 
+  /** Consumes the composer's autosaved draft once its text has been taken into
+   *  a steer or queued item. The composer clears via the form's `reset()`,
+   *  which is programmatic and never fires the `input` event `useAutoSave`
+   *  listens on — so the draft would outlive the submit. It is keyed under
+   *  `PENDING_CONVO` here (every caller is gated on `duringRunActive`, which
+   *  requires `isSubmitting` and rules out the answer-mode draft key), and
+   *  run end migrates a surviving pending draft onto the conversation and
+   *  restores it — resurfacing text the user already sent. */
+  const takeComposerDraft = useCallback(() => {
+    clearAllDrafts(Constants.PENDING_CONVO);
+  }, []);
+
   const removeQueued = useRecoilCallback(
     ({ set }) =>
       (id: string) => {
@@ -484,9 +496,13 @@ export default function useSteering({
       if (trimmed.length === 0 || filesLoading || !hasRealConvoId) {
         return false;
       }
-      return submitSteer(trimmed, takeComposerFiles());
+      const consumed = submitSteer(trimmed, takeComposerFiles());
+      if (consumed) {
+        takeComposerDraft();
+      }
+      return consumed;
     },
-    [filesLoading, hasRealConvoId, takeComposerFiles, submitSteer],
+    [filesLoading, hasRealConvoId, takeComposerFiles, takeComposerDraft, submitSteer],
   );
 
   /** Composer-originated queue: carries the composer's attachments, quote
@@ -498,9 +514,10 @@ export default function useSteering({
         return false;
       }
       enqueue(trimmed, { files: takeComposerFiles(), ...takeComposerContext() });
+      takeComposerDraft();
       return true;
     },
-    [filesLoading, enqueue, takeComposerFiles, takeComposerContext],
+    [filesLoading, enqueue, takeComposerFiles, takeComposerContext, takeComposerDraft],
   );
 
   /** Retry a failed chip through the normal steer path. */
@@ -596,6 +613,7 @@ export default function useSteering({
         return false;
       }
       enqueue(trimmed, { front: true, files: takeComposerFiles(), ...takeComposerContext() });
+      takeComposerDraft();
       armDrainAfterAbort();
       stopGenerating();
       return true;
@@ -605,6 +623,7 @@ export default function useSteering({
       enqueue,
       takeComposerFiles,
       takeComposerContext,
+      takeComposerDraft,
       armDrainAfterAbort,
       stopGenerating,
     ],

--- a/client/src/hooks/Input/useAutoSave.spec.ts
+++ b/client/src/hooks/Input/useAutoSave.spec.ts
@@ -215,3 +215,67 @@ describe('useAutoSave — ask-answer draft swap', () => {
     expect(mockSetValue).toHaveBeenLastCalledWith('text', 'half-typed answer');
   });
 });
+
+describe('useAutoSave — debounced autosave', () => {
+  /** Grabs the `input` listener the hook registered on the textarea. */
+  const getInputListener = (textAreaRef: React.RefObject<HTMLTextAreaElement>) =>
+    (textAreaRef.current!.addEventListener as unknown as jest.Mock).mock.calls.find(
+      ([event]) => event === 'input',
+    )![1] as (e: unknown) => void;
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('flushes the live composer value, not the value captured when typing', () => {
+    jest.useFakeTimers();
+    // A run is active, so the draft is keyed under PENDING_CONVO.
+    const textAreaRef = makeTextAreaRef('queued follow up');
+    renderHook(() =>
+      useAutoSave({
+        isSubmitting: true,
+        conversationId: 'convo-1',
+        textAreaRef,
+        files: new Map(),
+        setFiles: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      getInputListener(textAreaRef)({ target: { value: 'queued follow up' } });
+    });
+
+    // A during-run steer/queue took the text and cleared the composer inside
+    // the 25ms debounce window. The in-flight write must not resurrect it:
+    // run end migrates a surviving pending draft back into the textarea.
+    textAreaRef.current!.value = '';
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+
+    expect(mockSetDraft).toHaveBeenLastCalledWith({
+      id: Constants.PENDING_CONVO,
+      value: '',
+    });
+  });
+
+  it('still saves typed text when the composer is untouched', () => {
+    jest.useFakeTimers();
+    const textAreaRef = makeTextAreaRef('still typing');
+    renderHook(() =>
+      useAutoSave({
+        conversationId: 'convo-1',
+        textAreaRef,
+        files: new Map(),
+        setFiles: jest.fn(),
+      }),
+    );
+
+    act(() => {
+      getInputListener(textAreaRef)({ target: { value: 'still typing' } });
+      jest.advanceTimersByTime(50);
+    });
+
+    expect(mockSetDraft).toHaveBeenLastCalledWith({ id: 'convo-1', value: 'still typing' });
+  });
+});

--- a/client/src/hooks/Input/useAutoSave.ts
+++ b/client/src/hooks/Input/useAutoSave.ts
@@ -109,17 +109,18 @@ export const useAutoSave = ({
       return;
     }
 
+    /** Saves the composer's value AT FLUSH TIME rather than the value captured
+     *  when the event fired. A during-run steer/queue consumes the text and
+     *  clears the composer programmatically, so a write still in flight would
+     *  otherwise land after the submit and restore the just-sent text. */
+    const saveLatest = () =>
+      setDraft({ id: conversationId, value: textAreaRef?.current?.value ?? '' });
+
     /** Use shorter debounce for saving text (25ms) to capture rapid typing */
-    const handleInputFast = debounce(
-      (value: string) => setDraft({ id: conversationId, value }),
-      25,
-    );
+    const handleInputFast = debounce(saveLatest, 25);
 
     /** Use longer debounce for clearing empty values (850ms) to prevent accidental draft loss */
-    const handleInputSlow = debounce(
-      (value: string) => setDraft({ id: conversationId, value }),
-      850,
-    );
+    const handleInputSlow = debounce(saveLatest, 850);
 
     const eventListener = (e: Event) => {
       const target = e.target as HTMLTextAreaElement;
@@ -132,9 +133,9 @@ export const useAutoSave = ({
       /** If empty, use long delay to prevent accidental clearing
        * Otherwise use short delay to capture rapid typing */
       if (value === '') {
-        handleInputSlow(value);
+        handleInputSlow();
       } else {
-        handleInputFast(value);
+        handleInputFast();
       }
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #14276. A message that was queued during a run and then successfully auto-sent by the run-end drain **resurfaced as the composer draft** right after it was submitted.

`useAutoSave` keys the composer draft under `PENDING_CONVO` for the duration of a run:

```ts
const conversationId = draftId ?? (isSubmitting ? Constants.PENDING_CONVO : _conversationId);
```

A during-run submit takes the composer text into a steer or a queued item, and `ChatForm` clears the composer with the form's `reset()`. That clear is **programmatic**, so it never fires the `input` event `useAutoSave`'s listener depends on — the autosaved `PENDING_CONVO` draft survives the submit. Nothing else drops it: `clearAllDrafts` is only ever called with the real conversation id (or `NEW_CONVO`), never `PENDING_CONVO`.

When the run ends and `isSubmitting` flips false, the draft key swaps `PENDING_CONVO` → real id, and `useAutoSave`'s migration branch copies the stale pending draft onto the conversation and restores it into the textarea — so the text the user already sent comes back, and now persists under the conversation key across reloads. The migration also lands *after* the final handler's `clearAllDrafts(realConvoId)`, so it effectively undoes that clear.

Verified against the real hook before fixing (`TextEncoder` polyfilled, since jsdom lacks it and `encodeBase64` silently returns `''` without it):

```
setValue calls: [["text","queued follow up"], ["text","queued follow up"]]
TEXT_DRAFT[convo-real-id] = cXVldWVkIGZvbGxvdyB1cA==   ← "queued follow up"
TEXT_DRAFT[PENDING] = null
```

…with an empty textarea, confirming the text came from the orphaned draft rather than the composer.

## Fix

Consume the pending draft at the three composer-origin entry points in `useSteering` — `steerFromComposer`, `queueFromComposer`, `interruptAndSend` — mirroring the existing `takeComposerFiles` / `takeComposerContext` consumption helpers that already live there. Every caller is gated on `duringRunActive` (`enabled && isSubmitting && !answerModeActive`), so `PENDING_CONVO` is provably the right key at each site and the answer-mode draft key is ruled out.

Only a **consumed** submit clears the draft; a refused one (empty text, uploads in flight) leaves it intact. The files draft needs no equivalent — its effect already removes the key when `fileIds` empties.

## Test plan

- 4 new cases in `useSteering.spec.tsx` covering all three consumption paths plus a negative control for refused submits.
- Fails-before verified: the 3 positive tests fail without the fix; the negative control passes both ways.
- Full `src/hooks/Chat/__tests__/` + `useAutoSave.spec.ts` green (9 suites, 45 tests in `useSteering`); eslint + sort-imports clean.