### PR TITLE
🙋 fix: Await `ask_user_question` Tool Factory in `loadTools`

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -372,7 +372,7 @@ const loadTools = async ({
       };
       continue;
     } else if (tool === ASK_USER_QUESTION_TOOL_NAME) {
-      requestedTools[tool] = () => createAskUserQuestionTool();
+      requestedTools[tool] = async () => createAskUserQuestionTool();
       continue;
     } else if (tool === SET_MEMORY_TOOL_NAME || tool === DELETE_MEMORY_TOOL_NAME) {
       requestedTools[tool] = () =>

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -52,6 +52,7 @@ jest.mock('~/config', () => ({
 
 const { Calculator } = require('@librechat/agents');
 const { Constants } = require('librechat-data-provider');
+const { ASK_USER_QUESTION_TOOL_NAME } = require('@librechat/api');
 
 const { User } = require('~/db/models');
 const PluginService = require('~/server/services/PluginService');
@@ -302,6 +303,16 @@ describe('Tool Handlers', () => {
       const structuredTool = await toolFunctions['stable-diffusion']();
       expect(structuredTool).toBeInstanceOf(StructuredSD);
       delete process.env.SD_WEBUI_URL;
+    });
+
+    it('loads the ask_user_question tool when not returning a map', async () => {
+      const { loadedTools } = await loadTools({
+        user: fakeUser._id,
+        tools: [ASK_USER_QUESTION_TOOL_NAME],
+        useSpecs: true,
+      });
+      expect(loadedTools).toHaveLength(1);
+      expect(loadedTools[0].name).toBe(ASK_USER_QUESTION_TOOL_NAME);
     });
 
     it('passes request body to chat MCP tool creation and skips stale cache for BODY-scoped servers', async () => {


### PR DESCRIPTION
## Summary

Agents with `ask_user_question` attached failed tool loading entirely with:

```
TypeError: validTool(...).catch is not a function
    at loadTools (api/app/clients/tools/util/handleTools.js:469)
    at async loadToolsForExecution (api/server/services/ToolService.js:1616)
    at async loadTools (api/server/services/Endpoints/agents/initialize.js:228)
```

`loadTools` contracts every `requestedTools` entry as `() => Promise<Tool>`, and the loader depends on that at the call site:

```js
validTool().catch((error) => {
  logger.error(`Error loading tool ${tool}:`, error);
  return null;
});
```

The `ask_user_question` factory was registered synchronously:

```js
requestedTools[tool] = () => createAskUserQuestionTool();
```

`createAskUserQuestionTool()` is sync and returns a `DynamicStructuredTool` directly, so `validTool()` handed back a tool object with no `.catch` on it. Adding `async` restores the contract.

The neighboring memory tools (`SET_MEMORY_TOOL_NAME` / `DELETE_MEMORY_TOOL_NAME`) look identical but are unaffected, because `buildInlineMemoryTool` is itself `async`.

## Blast radius

Worth noting this was not scoped to the one tool. The `TypeError` throws synchronously inside the `for` loop that builds `toolPromises`, before `Promise.all` and outside the per-tool `.catch`, so it aborted the whole tool load for the turn. Any agent with `ask_user_question` attached ran with **no tools at all**, and the error surfaced only in logs while the turn completed normally.

## Regression risk

Introduced in #14139. Not caught by existing tests because `handleTools.test.js` only exercised `loadTools` with `returnMap: true`, which returns the factory map before reaching the `.catch` call site. The runtime path (`loadToolsForExecution`) uses `returnMap: false`.

## Testing

Added a regression test that goes through the real runtime path (`returnMap: false`). Verified in both directions: it passes with the fix, and reverting the one-word change reproduces the exact reported `TypeError`. Full suite green at 16/16.

```
cd api && npx jest handleTools
```