### PR TITLE
🧷 fix: Flush Pending File Deletion on Unmount

### DIFF
--- a/client/src/hooks/Files/__tests__/useFileDeletion.spec.tsx
+++ b/client/src/hooks/Files/__tests__/useFileDeletion.spec.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { FileSources, EToolResources } from 'librechat-data-provider';
+import { render, screen, act, renderHook } from '@testing-library/react';
+import type { ExtendedFile } from '~/common';
+import FileRow from '~/components/Chat/Input/Files/FileRow';
+import useFileDeletion from '../useFileDeletion';
+
+const mockMutateAsync = jest.fn();
+
+jest.mock('~/data-provider', () => ({
+  useDeleteFilesMutation: () => ({ mutateAsync: mockMutateAsync }),
+}));
+
+jest.mock('@librechat/client', () => ({
+  useToastContext: () => ({ showToast: jest.fn() }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('~/utils', () => ({
+  ...jest.requireActual('~/utils'),
+  logger: { log: jest.fn() },
+  getCachedPreview: () => undefined,
+  deletePreview: jest.fn(),
+}));
+
+jest.mock('../useSetFilesToDelete', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('~/components/Chat/Input/Files/FileContainer', () => {
+  return function MockFileContainer({
+    file,
+    onDelete,
+  }: {
+    file: ExtendedFile;
+    onDelete: () => void;
+  }) {
+    return <button data-testid={`del-${file.file_id}`} onClick={onDelete} />;
+  };
+});
+
+jest.mock('~/components/Chat/Input/Files/Image', () => {
+  return function MockImage() {
+    return null;
+  };
+});
+
+/** Mirrors the shape `utils/forms.tsx` builds for agent Context/File Search panels */
+const makeFile = (file_id: string): ExtendedFile =>
+  ({
+    file_id,
+    type: 'application/pdf',
+    filepath: `/uploads/${file_id}.pdf`,
+    filename: `${file_id}.pdf`,
+    size: 1024,
+    progress: 1,
+    source: FileSources.local,
+  }) as ExtendedFile;
+
+/** Mirrors FileContext.tsx, which mounts FileRow only while `fileCount > 0` */
+function ConditionalPanel({ initial }: { initial: ExtendedFile[] }) {
+  const [files, setFiles] = useState(new Map(initial.map((f) => [f.file_id, f])));
+  return (
+    <>
+      {files.size > 0 && (
+        <FileRow
+          files={files}
+          setFiles={setFiles}
+          agent_id="agent-123"
+          tool_resource={EToolResources.context}
+        />
+      )}
+    </>
+  );
+}
+
+describe('useFileDeletion', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockMutateAsync.mockClear();
+  });
+  afterEach(() => jest.useRealTimers());
+
+  const clickDelete = (file_id: string) => {
+    act(() => {
+      screen.getByTestId(`del-${file_id}`).click();
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+  };
+
+  it('sends the unlink request when removing the last file from an agent panel', () => {
+    render(<ConditionalPanel initial={[makeFile('only-file')]} />);
+
+    clickDelete('only-file');
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      files: [expect.objectContaining({ file_id: 'only-file' })],
+      agent_id: 'agent-123',
+      tool_resource: EToolResources.context,
+    });
+  });
+
+  it('sends the unlink request when removing a non-last file from an agent panel', () => {
+    render(<ConditionalPanel initial={[makeFile('file-a'), makeFile('file-b')]} />);
+
+    clickDelete('file-a');
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: 'agent-123', tool_resource: EToolResources.context }),
+    );
+  });
+
+  it('does not delete a file that was attached from existing storage', () => {
+    const { result } = renderHook(() => useFileDeletion({ mutateAsync: mockMutateAsync }));
+
+    act(() => {
+      result.current.deleteFile({
+        file: { ...makeFile('stored-file'), attached: true } as ExtendedFile,
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/Files/useFileDeletion.ts
+++ b/client/src/hooks/Files/useFileDeletion.ts
@@ -1,8 +1,8 @@
+import { useCallback, useState, useEffect } from 'react';
 import debounce from 'lodash/debounce';
 import { FileSources, EToolResources, removeNullishValues } from 'librechat-data-provider';
-import { useCallback, useState, useEffect } from 'react';
-import type * as t from 'librechat-data-provider';
 import type { UseMutateAsyncFunction } from '@tanstack/react-query';
+import type * as t from 'librechat-data-provider';
 import type { ExtendedFile, GenericSetter } from '~/common';
 import useSetFilesToDelete from './useSetFilesToDelete';
 import { deletePreview } from '~/utils';
@@ -51,8 +51,9 @@ const useFileDeletion = ({
   const debouncedDelete = useCallback(debounce(executeBatchDelete, 1000), []);
 
   useEffect(() => {
-    // Cleanup function for debouncedDelete when component unmounts or before re-render
-    return () => debouncedDelete.cancel();
+    /** Flush, don't cancel: unmount is a normal outcome of removing the last file,
+     * and a cancelled batch silently drops a delete the user already confirmed. */
+    return () => debouncedDelete.flush();
   }, [debouncedDelete]);
 
   const deleteFile = useCallback(


### PR DESCRIPTION
Resolves #14288

## Summary

Removing the **last** file from an agent's **Context** panel fired no request, and the file reappeared on reload.

`FileContext` mounts `FileRow` only while `fileCount > 0`:

https://github.com/danny-avila/LibreChat/blob/dev/client/src/components/SidePanel/Agents/FileContext.tsx#L172

`useFileDeletion` lives *inside* `FileRow`, behind a 1s debounce whose unmount cleanup called `debouncedDelete.cancel()`. So deleting the last file drops `files.size` to 0 → `FileRow` unmounts → the cleanup cancels the delete the user had already confirmed. Deleting a *non-last* file kept the row mounted and worked fine, which is what made the failure look erratic.

The cancel was a broader latent issue than the reported repro: it also dropped a pending delete in **any** panel closed within the debounce window (File Search, Code Interpreter, assistants Knowledge). Flushing on unmount fixes the whole class.

## Notes on the issue's diagnosis

The report is accurate about the symptom but not the cause, and its proposed fix is unsafe. Recording this so the report doesn't get re-applied later:

- **Not a #14149 regression.** #14149 (`96367828e`) touched zero client files. The `attached` guard it fingers dates to `ecd63eb9f1` (Feb 2024). The conditional mount actually arrived in #13952 (`edd614bbff`, agent builder redesign) two days before #14149, which is likely why the bisect landed next door.
- **`attached` is never set on agent panel files.** `handleFile` in `client/src/utils/forms.tsx` doesn't set it; only the three composer sites do (`ChatForm`, `SidePanel/Files/PanelTable`, `hooks/Input/useAutoSave`). The guard never fires in this path — the mutation was already being sent with `agent_id` + `tool_resource`.
- **File Search was never affected** — `FileSearch.tsx` renders `FileRow` unconditionally.
- **The suggested fix (removing the `attached` early return) would delete user data.** `attached: true` marks a file that came from existing storage. The composer's `FileFormChat` renders `FileRow` with no `agent_id`/`tool_resource`, so its delete hits the owner-scoped *physical* delete branch. Dropping the guard would make dismissing a composer chip permanently delete the underlying file from My Files. The guard is load-bearing and is now pinned by a test.

## Change

```diff
-    return () => debouncedDelete.cancel();
+    return () => debouncedDelete.flush();
```

## Testing

New `client/src/hooks/Files/__tests__/useFileDeletion.spec.tsx` exercises the real `FileRow` + real `useFileDeletion` (no mocking of the hook under test), reproducing `FileContext`'s conditional-mount pattern:

- removing the **last** file from an agent panel sends the unlink request — **fails on `cancel()`, passes on `flush()`**
- removing a **non-last** file still sends it (guards the path that already worked)
- a file attached from existing storage is still never deleted (pins the `attached` guard against the issue's proposed fix)

All 125 tests across the 9 Files suites pass; lint clean.