### PR TITLE
🛟 fix: Keep File Uploads Alive With SSE Heartbeats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -577,6 +577,9 @@ TTS_API_KEY=
 # EMBEDDINGS_PROVIDER=openai
 # EMBEDDINGS_MODEL=text-embedding-3-small
 
+# Stream upload responses with heartbeats during long-running file processing.
+# FILE_UPLOAD_SSE_ENABLED=false
+
 #===================================================#
 #                    User System                    #
 #===================================================#

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -276,6 +276,7 @@ router.get('/', async function (req, res) {
         : 0,
       ...(cloudFront ? { cloudFront } : {}),
       ...(rum ? { rum } : {}),
+      fileUploadSseEnabled: isEnabled(process.env.FILE_UPLOAD_SSE_ENABLED),
     };
 
     const webSearch = buildWebSearchConfig(appConfig);

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -2,9 +2,11 @@ const fs = require('fs').promises;
 const express = require('express');
 const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
+  isEnabled,
   logAxiosError,
   refreshS3FileUrls,
   handleFilesUsageRequest,
+  startUploadSseStream,
   resolveUploadErrorMessage,
   verifyAgentUploadPermission,
 } = require('@librechat/api');
@@ -633,6 +635,15 @@ router.post('/', async (req, res) => {
   const metadata = req.body;
   let cleanup = true;
 
+  /** Opened only once auth/validation has passed, right before the potentially
+   * long-running upload processing begins — see `startUploadSseStream`. */
+  let sseStream = null;
+  const openSseStreamIfEnabled = () => {
+    if (isEnabled(process.env.FILE_UPLOAD_SSE_ENABLED)) {
+      sseStream = startUploadSseStream(req, res);
+    }
+  };
+
   try {
     filterFile({ req });
 
@@ -640,7 +651,8 @@ router.post('/', async (req, res) => {
     metadata.file_id = req.file_id;
 
     if (isAssistantsEndpoint(metadata.endpoint)) {
-      return await processFileUpload({ req, res, metadata });
+      openSseStreamIfEnabled();
+      return await processFileUpload({ req, res, metadata, sseStream });
     }
 
     let skipUploadAuth = false;
@@ -663,7 +675,8 @@ router.post('/', async (req, res) => {
       }
     }
 
-    return await processAgentFileUpload({ req, res, metadata });
+    openSseStreamIfEnabled();
+    return await processAgentFileUpload({ req, res, metadata, sseStream });
   } catch (error) {
     const message = resolveUploadErrorMessage(error);
     logger.error('[/files] Error processing file:', error);
@@ -674,7 +687,17 @@ router.post('/', async (req, res) => {
     } catch (error) {
       logger.error('[/files] Error deleting file:', error);
     }
-    res.status(500).json({ message });
+
+    let errorStatusCode = 500;
+    if (error.userErrorStatusCode) {
+      errorStatusCode = error.userErrorStatusCode;
+    }
+
+    if (sseStream) {
+      sseStream.sendError({ message, display_to_user: true, ...metadata });
+    } else {
+      res.status(errorStatusCode).json({ message });
+    }
   } finally {
     if (cleanup) {
       try {
@@ -684,6 +707,9 @@ router.post('/', async (req, res) => {
       }
     } else {
       logger.debug('[/files] File processing completed without cleanup');
+    }
+    if (sseStream) {
+      sseStream.close();
     }
   }
 });

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -2,10 +2,10 @@ const fs = require('fs').promises;
 const express = require('express');
 const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
-  isEnabled,
   logAxiosError,
   refreshS3FileUrls,
   handleFilesUsageRequest,
+  shouldUseUploadSse,
   startUploadSseStream,
   resolveUploadErrorMessage,
   verifyAgentUploadPermission,
@@ -638,9 +638,9 @@ router.post('/', async (req, res) => {
   /** Opened only once auth/validation has passed, right before the potentially
    * long-running upload processing begins — see `startUploadSseStream`. */
   let sseStream = null;
-  const openSseStreamIfEnabled = () => {
-    if (isEnabled(process.env.FILE_UPLOAD_SSE_ENABLED)) {
-      sseStream = startUploadSseStream(req, res);
+  const openSseStreamIfRequested = () => {
+    if (shouldUseUploadSse(req)) {
+      sseStream = startUploadSseStream(res);
     }
   };
 
@@ -651,7 +651,7 @@ router.post('/', async (req, res) => {
     metadata.file_id = req.file_id;
 
     if (isAssistantsEndpoint(metadata.endpoint)) {
-      openSseStreamIfEnabled();
+      openSseStreamIfRequested();
       return await processFileUpload({ req, res, metadata, sseStream });
     }
 
@@ -675,7 +675,7 @@ router.post('/', async (req, res) => {
       }
     }
 
-    openSseStreamIfEnabled();
+    openSseStreamIfRequested();
     return await processAgentFileUpload({ req, res, metadata, sseStream });
   } catch (error) {
     const message = resolveUploadErrorMessage(error);
@@ -694,7 +694,13 @@ router.post('/', async (req, res) => {
     }
 
     if (sseStream) {
-      sseStream.sendError({ message, display_to_user: true, ...metadata });
+      sseStream.sendError({
+        message,
+        code: errorStatusCode,
+        temp_file_id: metadata.temp_file_id,
+        tool_resource: metadata.tool_resource,
+        display_to_user: true,
+      });
     } else {
       res.status(errorStatusCode).json({ message });
     }

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -3,7 +3,7 @@ const fs = require('fs').promises;
 const express = require('express');
 const { logger } = require('@librechat/data-schemas');
 const {
-  isEnabled,
+  shouldUseUploadSse,
   startUploadSseStream,
   resolveUploadErrorMessage,
   verifyAgentUploadPermission,
@@ -26,9 +26,9 @@ router.post('/', async (req, res) => {
   /** Opened only once auth/validation has passed, right before the potentially
    * long-running upload processing begins — see `startUploadSseStream`. */
   let sseStream = null;
-  const openSseStreamIfEnabled = () => {
-    if (isEnabled(process.env.FILE_UPLOAD_SSE_ENABLED)) {
-      sseStream = startUploadSseStream(req, res);
+  const openSseStreamIfRequested = () => {
+    if (shouldUseUploadSse(req)) {
+      sseStream = startUploadSseStream(res);
     }
   };
 
@@ -49,11 +49,11 @@ router.post('/', async (req, res) => {
       if (denied) {
         return;
       }
-      openSseStreamIfEnabled();
+      openSseStreamIfRequested();
       return await processAgentFileUpload({ req, res, metadata, sseStream });
     }
 
-    openSseStreamIfEnabled();
+    openSseStreamIfRequested();
     await processImageFile({ req, res, metadata, sseStream });
   } catch (error) {
     // TODO: delete remote file if it exists
@@ -72,7 +72,13 @@ router.post('/', async (req, res) => {
       logger.error('[/files/images] Error deleting file:', error);
     }
     if (sseStream) {
-      sseStream.sendError({ message, display_to_user: true, ...metadata });
+      sseStream.sendError({
+        message,
+        code: 500,
+        temp_file_id: metadata.temp_file_id,
+        tool_resource: metadata.tool_resource,
+        display_to_user: true,
+      });
     } else {
       res.status(500).json({ message });
     }

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -2,7 +2,12 @@ const path = require('path');
 const fs = require('fs').promises;
 const express = require('express');
 const { logger } = require('@librechat/data-schemas');
-const { verifyAgentUploadPermission, resolveUploadErrorMessage } = require('@librechat/api');
+const {
+  isEnabled,
+  startUploadSseStream,
+  resolveUploadErrorMessage,
+  verifyAgentUploadPermission,
+} = require('@librechat/api');
 const { isAssistantsEndpoint } = require('librechat-data-provider');
 const {
   processAgentFileUpload,
@@ -17,6 +22,15 @@ const router = express.Router();
 router.post('/', async (req, res) => {
   const metadata = req.body;
   const appConfig = req.config;
+
+  /** Opened only once auth/validation has passed, right before the potentially
+   * long-running upload processing begins — see `startUploadSseStream`. */
+  let sseStream = null;
+  const openSseStreamIfEnabled = () => {
+    if (isEnabled(process.env.FILE_UPLOAD_SSE_ENABLED)) {
+      sseStream = startUploadSseStream(req, res);
+    }
+  };
 
   try {
     filterFile({ req, image: true });
@@ -35,10 +49,12 @@ router.post('/', async (req, res) => {
       if (denied) {
         return;
       }
-      return await processAgentFileUpload({ req, res, metadata });
+      openSseStreamIfEnabled();
+      return await processAgentFileUpload({ req, res, metadata, sseStream });
     }
 
-    await processImageFile({ req, res, metadata });
+    openSseStreamIfEnabled();
+    await processImageFile({ req, res, metadata, sseStream });
   } catch (error) {
     // TODO: delete remote file if it exists
     logger.error('[/files/images] Error processing file:', error);
@@ -55,13 +71,20 @@ router.post('/', async (req, res) => {
     } catch (error) {
       logger.error('[/files/images] Error deleting file:', error);
     }
-    res.status(500).json({ message });
+    if (sseStream) {
+      sseStream.sendError({ message, display_to_user: true, ...metadata });
+    } else {
+      res.status(500).json({ message });
+    }
   } finally {
     try {
       await fs.unlink(req.file.path);
       logger.debug('[/files/images] Temp. image upload file deleted');
     } catch {
       logger.debug('[/files/images] Temp. image upload file already deleted');
+    }
+    if (sseStream) {
+      sseStream.close();
     }
   }
 });

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -24,6 +24,7 @@ const {
   sanitizeFilename,
   parseText,
   processAudioFile,
+  sendUploadSuccess,
   getStorageMetadata,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
@@ -447,9 +448,10 @@ const processFileURL = async ({
  * @param {Express.Response} [params.res] - The Express response object.
  * @param {ImageMetadata} params.metadata - Additional metadata for the file.
  * @param {boolean} params.returnFile - Whether to return the file metadata or return response as normal.
+ * @param {import('@librechat/api').UploadSseStream | null} [params.sseStream] - Active upload SSE stream, if enabled.
  * @returns {Promise<void>}
  */
-const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
+const processImageFile = async ({ req, res, metadata, returnFile = false, sseStream }) => {
   const { file } = req;
   const appConfig = req.config;
   const source = getFileStrategy(appConfig, { isImage: true });
@@ -487,7 +489,7 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
   if (returnFile) {
     return result;
   }
-  res.status(200).json({ message: 'File uploaded and processed successfully', ...result });
+  sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
 
 /**
@@ -554,9 +556,10 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
  * @param {ServerRequest} params.req - The Express request object.
  * @param {Express.Response} params.res - The Express response object.
  * @param {FileMetadata} params.metadata - Additional metadata for the file.
+ * @param {import('@librechat/api').UploadSseStream | null} [params.sseStream] - Active upload SSE stream, if enabled.
  * @returns {Promise<void>}
  */
-const processFileUpload = async ({ req, res, metadata }) => {
+const processFileUpload = async ({ req, res, metadata, sseStream }) => {
   const appConfig = req.config;
   const isAssistantUpload = isAssistantsEndpoint(metadata.endpoint);
   const assistantSource =
@@ -649,7 +652,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
     },
     true,
   );
-  res.status(200).json({ message: 'File uploaded and processed successfully', ...result });
+  sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
 
 /**
@@ -661,9 +664,10 @@ const processFileUpload = async ({ req, res, metadata }) => {
  * @param {ServerRequest} params.req - The Express request object.
  * @param {Express.Response} params.res - The Express response object.
  * @param {FileMetadata} params.metadata - Additional metadata for the file.
+ * @param {import('@librechat/api').UploadSseStream | null} [params.sseStream] - Active upload SSE stream, if enabled.
  * @returns {Promise<void>}
  */
-const processAgentFileUpload = async ({ req, res, metadata }) => {
+const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
   const { file } = req;
   const appConfig = req.config;
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
@@ -787,9 +791,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
         });
       }
       const result = await db.createFile(fileInfo, true);
-      return res
-        .status(200)
-        .json({ message: 'Agent file uploaded and processed successfully', ...result });
+      sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
     };
 
     const fileConfig = mergeFileConfig(appConfig.fileConfig);
@@ -1035,7 +1037,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
 
   const result = await db.createFile(fileInfo, true);
 
-  res.status(200).json({ message: 'Agent file uploaded and processed successfully', ...result });
+  sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
 };
 
 /**

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -41,6 +41,13 @@ jest.mock('@librechat/api', () => {
     sanitizeFilename: jest.fn((n) => n),
     parseText: jest.fn().mockResolvedValue({ text: '', bytes: 0 }),
     processAudioFile: jest.fn(),
+    sendUploadSuccess: jest.fn((res, sseStream, message, result) => {
+      if (sseStream) {
+        sseStream.sendData({ message, ...result });
+        return;
+      }
+      res.status(200).json({ message, ...result });
+    }),
     getStorageMetadata: jest.fn(() => ({})),
     getRetentionExpiry,
     getAgentFileRetentionExpiry: jest.fn(({ req, messageAttachment, toolResource }) => {

--- a/client/src/data-provider/Files/mutations.ts
+++ b/client/src/data-provider/Files/mutations.ts
@@ -10,9 +10,8 @@ import {
 } from 'librechat-data-provider';
 import type { UseMutationResult } from '@tanstack/react-query';
 import type * as t from 'librechat-data-provider';
+import { useGetStartupConfig } from '../Endpoints';
 import { useLocalize } from '~/hooks';
-import { useAuthContext } from '~/hooks';
-import { useGetStartupConfig } from '~/data-provider';
 
 export const useUploadFileMutation = (
   _options?: t.UploadMutationOptions,
@@ -23,8 +22,8 @@ export const useUploadFileMutation = (
   FormData, // request
   unknown // context
 > => {
-  const { token } = useAuthContext();
   const { data: startupConfig } = useGetStartupConfig();
+  const sseEnabled = startupConfig?.fileUploadSseEnabled === true;
   const queryClient = useQueryClient();
   const { onSuccess, ...options } = _options || {};
   return useMutation([MutationKeys.fileUpload], {
@@ -34,14 +33,14 @@ export const useUploadFileMutation = (
       const version = body.get('version') ?? '';
       const endpoint = (body.get('endpoint') ?? '') as string;
       if (isAssistantsEndpoint(endpoint) && version === '2') {
-        return dataService.uploadFile(body, startupConfig, token, signal);
+        return dataService.uploadFile(body, signal, sseEnabled);
       }
 
       if (width !== '' && height !== '') {
-        return dataService.uploadImage(body, startupConfig, token, signal);
+        return dataService.uploadImage(body, signal, sseEnabled);
       }
 
-      return dataService.uploadFile(body, startupConfig, token, signal);
+      return dataService.uploadFile(body, signal, sseEnabled);
     },
     ...options,
     onSuccess: (data, formData, context) => {

--- a/client/src/data-provider/Files/mutations.ts
+++ b/client/src/data-provider/Files/mutations.ts
@@ -11,6 +11,8 @@ import {
 import type { UseMutationResult } from '@tanstack/react-query';
 import type * as t from 'librechat-data-provider';
 import { useLocalize } from '~/hooks';
+import { useAuthContext } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 
 export const useUploadFileMutation = (
   _options?: t.UploadMutationOptions,
@@ -21,6 +23,8 @@ export const useUploadFileMutation = (
   FormData, // request
   unknown // context
 > => {
+  const { token } = useAuthContext();
+  const { data: startupConfig } = useGetStartupConfig();
   const queryClient = useQueryClient();
   const { onSuccess, ...options } = _options || {};
   return useMutation([MutationKeys.fileUpload], {
@@ -30,14 +34,14 @@ export const useUploadFileMutation = (
       const version = body.get('version') ?? '';
       const endpoint = (body.get('endpoint') ?? '') as string;
       if (isAssistantsEndpoint(endpoint) && version === '2') {
-        return dataService.uploadFile(body, signal);
+        return dataService.uploadFile(body, startupConfig, token, signal);
       }
 
       if (width !== '' && height !== '') {
-        return dataService.uploadImage(body, signal);
+        return dataService.uploadImage(body, startupConfig, token, signal);
       }
 
-      return dataService.uploadFile(body, signal);
+      return dataService.uploadFile(body, startupConfig, token, signal);
     },
     ...options,
     onSuccess: (data, formData, context) => {

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -10,6 +10,7 @@ export * from './ocr';
 export * from './parse';
 export * from './rag';
 export * from './retention';
+export * from './sse';
 export * from './sweep';
 export * from './usage';
 export * from './validation';

--- a/packages/api/src/files/sse.spec.ts
+++ b/packages/api/src/files/sse.spec.ts
@@ -1,17 +1,10 @@
 import { EventEmitter } from 'events';
-import type { Response } from 'express';
-import type { ServerRequest } from '~/types';
-import { sendUploadSuccess, startUploadSseStream } from './sse';
-
-jest.mock('@librechat/data-schemas', () => ({
-  ...jest.requireActual('@librechat/data-schemas'),
-  logger: {
-    debug: jest.fn(),
-  },
-}));
+import type { Request, Response } from 'express';
+import { sendUploadSuccess, shouldUseUploadSse, startUploadSseStream } from './sse';
 
 describe('sse', () => {
-  const createMockReq = (): ServerRequest => new EventEmitter() as unknown as ServerRequest;
+  const createMockReq = (accept?: string): Request =>
+    ({ headers: accept ? { accept } : {} }) as Request;
 
   const createMockRes = (): jest.Mocked<Response> => {
     const res = new EventEmitter() as unknown as jest.Mocked<Response>;
@@ -22,6 +15,7 @@ describe('sse', () => {
     res.status = jest.fn().mockReturnValue(res);
     res.json = jest.fn().mockReturnValue(res);
     Object.defineProperty(res, 'writableEnded', { value: false, writable: true });
+    Object.defineProperty(res, 'destroyed', { value: false, writable: true });
     return res;
   };
 
@@ -35,6 +29,34 @@ describe('sse', () => {
       };
     });
 
+  describe('shouldUseUploadSse', () => {
+    const originalValue = process.env.FILE_UPLOAD_SSE_ENABLED;
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env.FILE_UPLOAD_SSE_ENABLED;
+        return;
+      }
+      process.env.FILE_UPLOAD_SSE_ENABLED = originalValue;
+    });
+
+    it('requires both the feature flag and an explicit event-stream accept value', () => {
+      process.env.FILE_UPLOAD_SSE_ENABLED = 'true';
+
+      expect(shouldUseUploadSse(createMockReq('application/json, text/event-stream'))).toBe(true);
+      expect(shouldUseUploadSse(createMockReq('text/event-stream; charset=utf-8'))).toBe(true);
+      expect(shouldUseUploadSse(createMockReq('application/json'))).toBe(false);
+      expect(shouldUseUploadSse(createMockReq('*/*'))).toBe(false);
+      expect(shouldUseUploadSse(createMockReq())).toBe(false);
+    });
+
+    it('keeps JSON responses when the server feature flag is disabled', () => {
+      process.env.FILE_UPLOAD_SSE_ENABLED = 'false';
+
+      expect(shouldUseUploadSse(createMockReq('text/event-stream'))).toBe(false);
+    });
+  });
+
   describe('startUploadSseStream', () => {
     beforeEach(() => {
       jest.useFakeTimers();
@@ -45,10 +67,8 @@ describe('sse', () => {
     });
 
     it('writes the SSE headers and flushes them immediately', () => {
-      const req = createMockReq();
       const res = createMockRes();
-
-      startUploadSseStream(req, res);
+      const stream = startUploadSseStream(res);
 
       expect(res.writeHead).toHaveBeenCalledWith(
         200,
@@ -58,17 +78,14 @@ describe('sse', () => {
         }),
       );
       expect(res.flushHeaders).toHaveBeenCalledTimes(1);
+      stream.close();
     });
 
     it('emits a heartbeat event on every interval tick', () => {
-      const req = createMockReq();
       const res = createMockRes();
+      const stream = startUploadSseStream(res);
 
-      startUploadSseStream(req, res);
-
-      jest.advanceTimersByTime(1000);
-      jest.advanceTimersByTime(1000);
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(3000);
 
       const heartbeats = parseEvents(res).filter((e) => e.event === 'heartbeat');
       expect(heartbeats).toHaveLength(3);
@@ -77,64 +94,55 @@ describe('sse', () => {
         { keepAlive: 2 },
         { keepAlive: 3 },
       ]);
+      stream.close();
     });
 
     it('stops the heartbeat once the response has already ended', () => {
-      const req = createMockReq();
       const res = createMockRes();
-
-      startUploadSseStream(req, res);
+      startUploadSseStream(res);
 
       jest.advanceTimersByTime(1000);
       Object.defineProperty(res, 'writableEnded', { value: true });
-      jest.advanceTimersByTime(1000);
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(2000);
 
       const heartbeats = parseEvents(res).filter((e) => e.event === 'heartbeat');
       expect(heartbeats).toHaveLength(1);
       expect(jest.getTimerCount()).toBe(0);
     });
 
-    it('clears the heartbeat interval when the client disconnects early', () => {
-      const req = createMockReq();
+    it('clears the heartbeat interval on response disconnect and stops writes', () => {
       const res = createMockRes();
-
-      startUploadSseStream(req, res);
+      const stream = startUploadSseStream(res);
       expect(jest.getTimerCount()).toBe(1);
 
-      req.emit('close');
+      Object.defineProperty(res, 'destroyed', { value: true });
+      res.emit('close');
+      stream.sendData({ file_id: 'ignored' });
 
       expect(jest.getTimerCount()).toBe(0);
+      expect(res.write).not.toHaveBeenCalled();
     });
 
-    it('sendData emits an event:data message with the payload', () => {
-      const req = createMockReq();
+    it('emits data and error events', () => {
       const res = createMockRes();
+      const stream = startUploadSseStream(res);
 
-      const stream = startUploadSseStream(req, res);
       stream.sendData({ file_id: 'abc' });
-
-      const [dataEvent] = parseEvents(res).filter((e) => e.event === 'data');
-      expect(dataEvent.data).toEqual({ file_id: 'abc' });
-    });
-
-    it('sendError emits an event:error message with the payload', () => {
-      const req = createMockReq();
-      const res = createMockRes();
-
-      const stream = startUploadSseStream(req, res);
       stream.sendError({ message: 'failed' });
 
-      const [errorEvent] = parseEvents(res).filter((e) => e.event === 'error');
-      expect(errorEvent.data).toEqual({ message: 'failed' });
+      const events = parseEvents(res);
+      expect(events.find((event) => event.event === 'data')?.data).toEqual({ file_id: 'abc' });
+      expect(events.find((event) => event.event === 'error')?.data).toEqual({
+        message: 'failed',
+      });
+      stream.close();
     });
 
     describe('close', () => {
       it('emits a close event, ends the response, and clears the heartbeat', () => {
-        const req = createMockReq();
         const res = createMockRes();
+        const stream = startUploadSseStream(res);
 
-        const stream = startUploadSseStream(req, res);
         stream.close();
 
         const closeEvents = parseEvents(res).filter((e) => e.event === 'close');
@@ -146,31 +154,26 @@ describe('sse', () => {
         expect(jest.getTimerCount()).toBe(0);
       });
 
-      it('is a no-op for the close-event write when the response already ended', () => {
-        const req = createMockReq();
+      it('does not write after the response already ended', () => {
         const res = createMockRes();
-
-        const stream = startUploadSseStream(req, res);
+        const stream = startUploadSseStream(res);
         Object.defineProperty(res, 'writableEnded', { value: true });
+
         stream.close();
 
-        const closeEvents = parseEvents(res).filter((e) => e.event === 'close');
-        expect(closeEvents).toHaveLength(0);
+        expect(parseEvents(res).filter((e) => e.event === 'close')).toHaveLength(0);
         expect(res.end).not.toHaveBeenCalled();
         expect(jest.getTimerCount()).toBe(0);
       });
 
       it('does not emit further heartbeats after close', () => {
-        const req = createMockReq();
         const res = createMockRes();
+        const stream = startUploadSseStream(res);
 
-        const stream = startUploadSseStream(req, res);
         stream.close();
-
         jest.advanceTimersByTime(5000);
 
-        const heartbeats = parseEvents(res).filter((e) => e.event === 'heartbeat');
-        expect(heartbeats).toHaveLength(0);
+        expect(parseEvents(res).filter((e) => e.event === 'heartbeat')).toHaveLength(0);
       });
     });
   });

--- a/packages/api/src/files/sse.spec.ts
+++ b/packages/api/src/files/sse.spec.ts
@@ -1,0 +1,215 @@
+import { EventEmitter } from 'events';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types';
+import { sendUploadSuccess, startUploadSseStream } from './sse';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+  },
+}));
+
+describe('sse', () => {
+  const createMockReq = (): ServerRequest => new EventEmitter() as unknown as ServerRequest;
+
+  const createMockRes = (): jest.Mocked<Response> => {
+    const res = new EventEmitter() as unknown as jest.Mocked<Response>;
+    res.writeHead = jest.fn().mockReturnValue(res);
+    res.flushHeaders = jest.fn().mockReturnValue(res);
+    res.write = jest.fn().mockReturnValue(true);
+    res.end = jest.fn().mockReturnValue(res);
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    Object.defineProperty(res, 'writableEnded', { value: false, writable: true });
+    return res;
+  };
+
+  const parseEvents = (res: jest.Mocked<Response>): Array<{ event: string; data: unknown }> =>
+    (res.write as jest.Mock).mock.calls.map(([chunk]: [string]) => {
+      const eventMatch = /event:(.*)\n/.exec(chunk);
+      const dataMatch = /data:(.*)\n\n/.exec(chunk);
+      return {
+        event: eventMatch ? eventMatch[1] : '',
+        data: dataMatch ? JSON.parse(dataMatch[1]) : undefined,
+      };
+    });
+
+  describe('startUploadSseStream', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('writes the SSE headers and flushes them immediately', () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      startUploadSseStream(req, res);
+
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'Content-Type': 'text/event-stream',
+          Connection: 'keep-alive',
+        }),
+      );
+      expect(res.flushHeaders).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits a heartbeat event on every interval tick', () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      startUploadSseStream(req, res);
+
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1000);
+
+      const heartbeats = parseEvents(res).filter((e) => e.event === 'heartbeat');
+      expect(heartbeats).toHaveLength(3);
+      expect(heartbeats.map((e) => e.data)).toEqual([
+        { keepAlive: 1 },
+        { keepAlive: 2 },
+        { keepAlive: 3 },
+      ]);
+    });
+
+    it('stops the heartbeat once the response has already ended', () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      startUploadSseStream(req, res);
+
+      jest.advanceTimersByTime(1000);
+      Object.defineProperty(res, 'writableEnded', { value: true });
+      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1000);
+
+      const heartbeats = parseEvents(res).filter((e) => e.event === 'heartbeat');
+      expect(heartbeats).toHaveLength(1);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('clears the heartbeat interval when the client disconnects early', () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      startUploadSseStream(req, res);
+      expect(jest.getTimerCount()).toBe(1);
+
+      req.emit('close');
+
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('sendData emits an event:data message with the payload', () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      const stream = startUploadSseStream(req, res);
+      stream.sendData({ file_id: 'abc' });
+
+      const [dataEvent] = parseEvents(res).filter((e) => e.event === 'data');
+      expect(dataEvent.data).toEqual({ file_id: 'abc' });
+    });
+
+    it('sendError emits an event:error message with the payload', () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      const stream = startUploadSseStream(req, res);
+      stream.sendError({ message: 'failed' });
+
+      const [errorEvent] = parseEvents(res).filter((e) => e.event === 'error');
+      expect(errorEvent.data).toEqual({ message: 'failed' });
+    });
+
+    describe('close', () => {
+      it('emits a close event, ends the response, and clears the heartbeat', () => {
+        const req = createMockReq();
+        const res = createMockRes();
+
+        const stream = startUploadSseStream(req, res);
+        stream.close();
+
+        const closeEvents = parseEvents(res).filter((e) => e.event === 'close');
+        expect(closeEvents).toHaveLength(1);
+        expect(closeEvents[0].data).toEqual(
+          expect.objectContaining({ closedAt: expect.any(String) }),
+        );
+        expect(res.end).toHaveBeenCalledTimes(1);
+        expect(jest.getTimerCount()).toBe(0);
+      });
+
+      it('is a no-op for the close-event write when the response already ended', () => {
+        const req = createMockReq();
+        const res = createMockRes();
+
+        const stream = startUploadSseStream(req, res);
+        Object.defineProperty(res, 'writableEnded', { value: true });
+        stream.close();
+
+        const closeEvents = parseEvents(res).filter((e) => e.event === 'close');
+        expect(closeEvents).toHaveLength(0);
+        expect(res.end).not.toHaveBeenCalled();
+        expect(jest.getTimerCount()).toBe(0);
+      });
+
+      it('does not emit further heartbeats after close', () => {
+        const req = createMockReq();
+        const res = createMockRes();
+
+        const stream = startUploadSseStream(req, res);
+        stream.close();
+
+        jest.advanceTimersByTime(5000);
+
+        const heartbeats = parseEvents(res).filter((e) => e.event === 'heartbeat');
+        expect(heartbeats).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('sendUploadSuccess', () => {
+    it('sends the payload over the SSE stream when a stream is active', () => {
+      const res = createMockRes();
+      const sseStream = {
+        sendData: jest.fn(),
+        sendError: jest.fn(),
+        close: jest.fn(),
+      };
+
+      sendUploadSuccess(res, sseStream, 'Upload complete', { file_id: 'abc' });
+
+      expect(sseStream.sendData).toHaveBeenCalledWith({
+        message: 'Upload complete',
+        file_id: 'abc',
+      });
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a plain JSON response when no stream is provided', () => {
+      const res = createMockRes();
+
+      sendUploadSuccess(res, null, 'Upload complete', { file_id: 'abc' });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Upload complete', file_id: 'abc' });
+    });
+
+    it('falls back to a plain JSON response when the stream is undefined', () => {
+      const res = createMockRes();
+
+      sendUploadSuccess(res, undefined, 'Upload complete', { file_id: 'abc' });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Upload complete', file_id: 'abc' });
+    });
+  });
+});

--- a/packages/api/src/files/sse.ts
+++ b/packages/api/src/files/sse.ts
@@ -1,0 +1,84 @@
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types';
+import { logger } from '@librechat/data-schemas';
+
+const HEARTBEAT_INTERVAL_MS = 1000;
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache, no-transform',
+  'Access-Control-Allow-Origin': '*',
+  Connection: 'keep-alive',
+  /** Required so Nginx/other proxies don't buffer the stream. */
+  'X-Accel-Buffering': 'no',
+};
+
+function writeSseEvent<T>(res: Response, event: string, data: T): void {
+  res.write(`event:${event}\nid:${Date.now()}\ndata:${JSON.stringify(data)}\n\n`);
+}
+
+export interface UploadSseStream {
+  /** Emits the successful upload payload as an `event:data` message. */
+  sendData: <T>(data: T) => void;
+  /** Emits a failure payload as an `event:error` message. */
+  sendError: <T>(data: T) => void;
+  /** Emits the terminal `event:close` message, stops the heartbeat, and ends the response. */
+  close: () => void;
+}
+
+/**
+ * Opens a keep-alive SSE stream for a file-upload response: sends the SSE headers, starts a
+ * heartbeat interval so proxies/clients don't time out the connection during long-running
+ * uploads, and stops the heartbeat when the client disconnects early.
+ *
+ * Callers must only invoke this once all synchronous validation and permission checks that
+ * might still need to send a normal (non-SSE) response have already passed — once the headers
+ * are flushed here, the HTTP status is committed to 200 and can no longer be changed.
+ */
+export function startUploadSseStream(req: ServerRequest, res: Response): UploadSseStream {
+  res.writeHead(200, SSE_HEADERS);
+  res.flushHeaders();
+
+  let counter = 1;
+  const intervalId = setInterval(() => {
+    if (res.writableEnded) {
+      clearInterval(intervalId);
+      return;
+    }
+    writeSseEvent(res, 'heartbeat', { keepAlive: counter++ });
+  }, HEARTBEAT_INTERVAL_MS);
+
+  req.on('close', () => {
+    clearInterval(intervalId);
+    logger.debug('[uploadSseStream] Client disconnected');
+  });
+
+  return {
+    sendData: (data) => writeSseEvent(res, 'data', data),
+    sendError: (data) => writeSseEvent(res, 'error', data),
+    close: () => {
+      if (!res.writableEnded) {
+        writeSseEvent(res, 'close', { closedAt: new Date().toISOString() });
+        res.end();
+      }
+      clearInterval(intervalId);
+    },
+  };
+}
+
+/**
+ * Sends a successful upload response, either as an SSE `event:data` message (when an upload
+ * stream is active) or as a plain JSON response.
+ */
+export function sendUploadSuccess<T extends object>(
+  res: Response,
+  sseStream: UploadSseStream | null | undefined,
+  message: string,
+  result: T,
+): void {
+  if (sseStream) {
+    sseStream.sendData({ message, ...result });
+    return;
+  }
+  res.status(200).json({ message, ...result });
+}

--- a/packages/api/src/files/sse.ts
+++ b/packages/api/src/files/sse.ts
@@ -1,20 +1,35 @@
-import type { Response } from 'express';
-import type { ServerRequest } from '~/types';
-import { logger } from '@librechat/data-schemas';
+import type { Request, Response } from 'express';
+import { isEnabled } from '~/utils';
 
 const HEARTBEAT_INTERVAL_MS = 1000;
+const EVENT_STREAM_MEDIA_TYPE = 'text/event-stream';
 
 const SSE_HEADERS = {
-  'Content-Type': 'text/event-stream',
+  'Content-Type': EVENT_STREAM_MEDIA_TYPE,
   'Cache-Control': 'no-cache, no-transform',
-  'Access-Control-Allow-Origin': '*',
   Connection: 'keep-alive',
   /** Required so Nginx/other proxies don't buffer the stream. */
   'X-Accel-Buffering': 'no',
 };
 
 function writeSseEvent<T>(res: Response, event: string, data: T): void {
+  if (res.writableEnded || res.destroyed) {
+    return;
+  }
   res.write(`event:${event}\nid:${Date.now()}\ndata:${JSON.stringify(data)}\n\n`);
+}
+
+export function shouldUseUploadSse(req: Request): boolean {
+  if (!isEnabled(process.env.FILE_UPLOAD_SSE_ENABLED)) {
+    return false;
+  }
+
+  return (
+    req.headers.accept?.split(',').some((value) => {
+      const [mediaType] = value.split(';', 1);
+      return mediaType.trim().toLowerCase() === EVENT_STREAM_MEDIA_TYPE;
+    }) ?? false
+  );
 }
 
 export interface UploadSseStream {
@@ -35,33 +50,34 @@ export interface UploadSseStream {
  * might still need to send a normal (non-SSE) response have already passed — once the headers
  * are flushed here, the HTTP status is committed to 200 and can no longer be changed.
  */
-export function startUploadSseStream(req: ServerRequest, res: Response): UploadSseStream {
+export function startUploadSseStream(res: Response): UploadSseStream {
   res.writeHead(200, SSE_HEADERS);
   res.flushHeaders();
 
   let counter = 1;
   const intervalId = setInterval(() => {
-    if (res.writableEnded) {
+    if (res.writableEnded || res.destroyed) {
       clearInterval(intervalId);
       return;
     }
     writeSseEvent(res, 'heartbeat', { keepAlive: counter++ });
   }, HEARTBEAT_INTERVAL_MS);
 
-  req.on('close', () => {
+  const stopHeartbeat = () => {
     clearInterval(intervalId);
-    logger.debug('[uploadSseStream] Client disconnected');
-  });
+  };
+  res.once('close', stopHeartbeat);
 
   return {
     sendData: (data) => writeSseEvent(res, 'data', data),
     sendError: (data) => writeSseEvent(res, 'error', data),
     close: () => {
-      if (!res.writableEnded) {
+      clearInterval(intervalId);
+      res.off('close', stopHeartbeat);
+      if (!res.writableEnded && !res.destroyed) {
         writeSseEvent(res, 'close', { closedAt: new Date().toISOString() });
         res.end();
       }
-      clearInterval(intervalId);
     },
   };
 }

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -20,6 +20,7 @@ import { setTokenHeader } from '../src/headers-helpers';
 const mockAdapter = jest.fn();
 let originalAdapter: typeof axios.defaults.adapter;
 let savedLocation: Location;
+let dataRequest: typeof import('../src/request').default;
 
 type RetryableAdapterConfig = InternalAxiosRequestConfig & { _retry?: boolean };
 
@@ -74,7 +75,7 @@ beforeAll(async () => {
   originalAdapter = axios.defaults.adapter;
   axios.defaults.adapter = mockAdapter;
 
-  await import('../src/request');
+  dataRequest = (await import('../src/request')).default;
 });
 
 beforeEach(() => {
@@ -657,6 +658,69 @@ describe('axios 401 interceptor — Authorization header guard', () => {
     expect(mockAdapter.mock.calls[0][0].url).toContain('/api/auth/refresh');
     expect(mockAdapter.mock.calls[1][0].url).toBe('/api/messages');
     expect(mockAdapter.mock.calls[1][0].headers?.Authorization).toBe('Bearer fresh-token');
+  });
+
+  it('uses shared proactive refresh for authenticated fetch requests', async () => {
+    expect.assertions(4);
+    setTokenHeader(createJwt(Date.now() + 60_000));
+
+    mockAdapter.mockImplementation((config: InternalAxiosRequestConfig) => {
+      if (config.url?.includes('/api/auth/refresh') === true) {
+        return createAdapterResponse(config, { token: 'fresh-token' });
+      }
+      return createAdapterResponse(config, { ok: true });
+    });
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    await dataRequest.authenticatedFetch('/api/files', {
+      method: 'POST',
+      body: new FormData(),
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    expect(getCallsForUrl('/api/auth/refresh')).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const uploadHeaders = new Headers(fetchSpy.mock.calls[0][1]?.headers);
+    expect(uploadHeaders.get('Authorization')).toBe('Bearer fresh-token');
+    expect(uploadHeaders.get('Accept')).toBe('text/event-stream');
+  });
+
+  it('refreshes and retries an authenticated fetch request after a 401', async () => {
+    expect.assertions(4);
+    setTokenHeader('expired-token');
+
+    mockAdapter.mockImplementation((config: InternalAxiosRequestConfig) => {
+      if (config.url?.includes('/api/auth/refresh') === true) {
+        return createAdapterResponse(config, { token: 'fresh-token' });
+      }
+      return createAdapterResponse(config, { ok: true });
+    });
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+      );
+
+    await dataRequest.authenticatedFetch('/api/files', {
+      method: 'POST',
+      body: new FormData(),
+    });
+
+    expect(getCallsForUrl('/api/auth/refresh')).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const firstHeaders = new Headers(fetchSpy.mock.calls[0][1]?.headers);
+    const retriedHeaders = new Headers(fetchSpy.mock.calls[1][1]?.headers);
+    expect(firstHeaders.get('Authorization')).toBe('Bearer expired-token');
+    expect(retriedHeaders.get('Authorization')).toBe('Bearer fresh-token');
   });
 
   it('does not wait on the in-flight recovery when the refresh request itself fails', async () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1578,6 +1578,7 @@ export type TStartupConfig = {
     branch?: string | null;
     buildDate?: string | null;
   };
+  fileUploadSseEnabled: boolean;
 };
 
 export type TSharedLinkStartupInterface = Pick<

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1578,7 +1578,7 @@ export type TStartupConfig = {
     branch?: string | null;
     buildDate?: string | null;
   };
-  fileUploadSseEnabled: boolean;
+  fileUploadSseEnabled?: boolean;
 };
 
 export type TSharedLinkStartupInterface = Pick<

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -454,15 +454,26 @@ export const getFileConfig = (): Promise<TFileConfig> => {
 
 export const uploadImage = (
   data: FormData,
+  startupConfig: config.TStartupConfig | undefined,
+  token: string | undefined,
   signal?: AbortSignal | null,
 ): Promise<f.TFileUpload> => {
   const requestConfig = signal ? { signal } : undefined;
-  return request.postMultiPart(endpoints.images(), data, requestConfig);
+  if (startupConfig?.fileUploadSseEnabled && token)
+    return fetchSseWithPost(endpoints.images(), data, token, requestConfig);
+  else return request.postMultiPart(endpoints.images(), data, requestConfig);
 };
 
-export const uploadFile = (data: FormData, signal?: AbortSignal | null): Promise<f.TFileUpload> => {
+export const uploadFile = (
+  data: FormData,
+  startupConfig: config.TStartupConfig | undefined,
+  token: string | undefined,
+  signal?: AbortSignal | null,
+): Promise<f.TFileUpload> => {
   const requestConfig = signal ? { signal } : undefined;
-  return request.postMultiPart(endpoints.files(), data, requestConfig);
+  if (startupConfig?.fileUploadSseEnabled && token)
+    return fetchSseWithPost(endpoints.files(), data, token, requestConfig);
+  else return request.postMultiPart(endpoints.files(), data, requestConfig);
 };
 
 /**
@@ -1400,3 +1411,216 @@ export interface ActiveJobsResponse {
 export const getActiveJobs = (): Promise<ActiveJobsResponse> => {
   return request.get(endpoints.activeJobs());
 };
+
+class FileUploadError extends Error {
+  public code?: number = 0;
+  public file_id: string;
+  public tool_resource?: a.EToolResources;
+  public display_to_user: boolean = false;
+  public response = { data: { message: '' } };
+
+  constructor(
+    message: string,
+    file_id: string,
+    tool_resource?: a.EToolResources,
+    display_to_user = false,
+    code = 0,
+  ) {
+    super(message);
+    this.name = 'CustomAppError'; // Set the name for clarity
+    this.file_id = file_id;
+    this.tool_resource = tool_resource;
+    this.code = code;
+    this.display_to_user = display_to_user;
+    // response.data.messages are displayed to the user
+    if (display_to_user) this.response.data.message = message;
+
+    // Maintain proper prototype chain for 'instanceof' checks
+    Object.setPrototypeOf(this, FileUploadError.prototype);
+  }
+}
+
+/** Thrown when a fetch-based SSE upload is aborted by the caller (e.g. a user-initiated cancel).
+ * Mirrors axios's `ERR_CANCELED` code so existing cancel-upload UI handling keeps working. */
+class UploadCanceledError extends Error {
+  public code = 'ERR_CANCELED' as const;
+}
+
+interface SseErrorData {
+  message: string;
+  temp_file_id: string;
+  tool_resource?: a.EToolResources;
+  display_to_user: boolean;
+}
+
+interface SseHeartbeatData {
+  keepAlive: number;
+}
+
+interface SseCloseData {
+  closedAt: string;
+}
+
+type SseEvent =
+  | { eventType: 'data'; id: string; message: string; data: f.TFileUpload }
+  | { eventType: 'error'; id: string; message: string; data: SseErrorData }
+  | { eventType: 'heartbeat'; id: string; message: string; data: SseHeartbeatData }
+  | { eventType: 'close'; id: string; message: string; data: SseCloseData }
+  | { eventType: 'message'; id: string; message: string; data: { message: string } };
+
+async function fetchSseWithPost(
+  url: string,
+  formData: FormData,
+  token: string,
+  options?: RequestInit,
+): Promise<f.TFileUpload> {
+  let ret: f.TFileUpload | null = null;
+  let close = false;
+  const onClose = () => {
+    console.log('SSE connection closed.');
+    close = true;
+  };
+
+  try {
+    const onEvent = (event: SseEvent) => {
+      console.debug('SSE Event:', event);
+      if (event.eventType === 'data') {
+        console.log('Data event received.');
+        ret = event.data;
+        close = true;
+      } else if (event.eventType === 'error') {
+        console.error('Error event received:', event.data);
+        throw new FileUploadError(
+          event.data.message,
+          event.data.temp_file_id,
+          event.data.tool_resource,
+          event.data.display_to_user,
+        );
+      } else if (event.eventType === 'heartbeat') {
+        console.debug('Heartbeat received.');
+        // Reset the heartbeat timer
+        clearTimeout(heartBeatTimer);
+        // Start a new heartbeat check timer
+        heartBeatTimer = setTimeout(onNoHeartbeat, 3000);
+      }
+    };
+
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+      headers: {
+        authorization: 'Bearer ' + token,
+        // Fetch with FormData automatically sets the correct 'multipart/form-data' header.
+      },
+      ...options,
+    });
+
+    if (!response.ok) {
+      let message = `Server responded with status: ${response.status}`;
+      try {
+        const errorBody: { message?: string } = await response.json();
+        if (errorBody.message) {
+          message = errorBody.message;
+        }
+      } catch {
+        // Response body wasn't JSON; fall back to the generic message.
+      }
+      throw new FileUploadError(
+        message,
+        String(formData.get('file_id') ?? ''),
+        (formData.get('tool_resource') as a.EToolResources | null) ?? undefined,
+        true,
+        response.status,
+      );
+    }
+
+    if (!response.body) {
+      throw new Error('No response body received.');
+    }
+
+    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+
+    const onNoHeartbeat = () => {
+      console.error('No heartbeat detected, closing connection.');
+      reader.cancel('No heartbeat detected from server.');
+    };
+
+    let heartBeatTimer = setTimeout(onNoHeartbeat, 3000);
+
+    let buffer = '';
+    while (!close) {
+      const { value, done } = await reader.read();
+      if (done) {
+        // `reader.cancel()` (heartbeat timeout, or an early server close) resolves the
+        // pending read with `done: true` instead of rejecting — treat it as a failure
+        // rather than silently returning with no data.
+        throw new Error('Upload connection closed unexpectedly before completion.');
+      }
+
+      if (typeof value !== 'string') {
+        console.error('Unexpected chunk type:', typeof value);
+        continue;
+      }
+
+      buffer += value;
+
+      // Split the buffer by double newlines, which terminate an SSE message.
+      const messages = buffer.split('\n\n');
+      buffer = messages.pop() || ''; // Keep the last, incomplete message part in the buffer.
+
+      for (const message of messages) {
+        console.debug('message:', message);
+        const eventData = parseSseMessage(message);
+        if (eventData) {
+          onEvent(eventData);
+          if (eventData.eventType === 'data' || eventData.eventType === 'error') {
+            onClose();
+            break;
+          }
+        }
+      }
+    }
+
+    clearTimeout(heartBeatTimer);
+  } catch (error) {
+    console.error('Fetch SSE Error:');
+    console.error(error);
+    onClose();
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new UploadCanceledError('Upload canceled.');
+    }
+    throw error;
+  }
+
+  if (ret === null) {
+    throw new Error('Upload did not complete: no data received.');
+  }
+  return ret;
+}
+
+// Helper function to parse raw SSE messages.
+function parseSseMessage(message: string): SseEvent | null {
+  const lines = message.split('\n');
+  let id: string | undefined;
+  let data = '';
+  let eventType = 'message';
+
+  for (const line of lines) {
+    if (line.startsWith('id:')) {
+      id = line.substring(3).trim();
+    } else if (line.startsWith('event:')) {
+      eventType = line.substring(6).trim();
+    } else if (line.startsWith('data:')) {
+      data += line.substring(5); // Concatenate multi-line data fields.
+    }
+  }
+
+  try {
+    const parsedData = JSON.parse(data);
+    return { data: parsedData, id: id || 'unknown', eventType, message } as SseEvent;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    console.debug('data was not json, returning as object with message');
+    return { data: { message: data }, id: id || 'unknown', eventType, message } as SseEvent;
+  }
+}

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -3,6 +3,7 @@ import type { TFileConfig } from './file-config';
 import type * as t from './types';
 import * as permissions from './accessPermissions';
 import * as endpoints from './api-endpoints';
+import { uploadEventStream } from './upload';
 import * as mcp from './types/mcpServers';
 import * as a from './types/assistants';
 import * as m from './types/mutations';
@@ -12,7 +13,6 @@ import * as sk from './types/skills';
 import * as f from './types/files';
 import * as config from './config';
 import request from './request';
-import { uploadEventStream } from './upload';
 import * as s from './schemas';
 import * as r from './roles';
 

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -12,6 +12,7 @@ import * as sk from './types/skills';
 import * as f from './types/files';
 import * as config from './config';
 import request from './request';
+import { uploadEventStream } from './upload';
 import * as s from './schemas';
 import * as r from './roles';
 
@@ -454,26 +455,26 @@ export const getFileConfig = (): Promise<TFileConfig> => {
 
 export const uploadImage = (
   data: FormData,
-  startupConfig: config.TStartupConfig | undefined,
-  token: string | undefined,
   signal?: AbortSignal | null,
+  sseEnabled = false,
 ): Promise<f.TFileUpload> => {
   const requestConfig = signal ? { signal } : undefined;
-  if (startupConfig?.fileUploadSseEnabled && token)
-    return fetchSseWithPost(endpoints.images(), data, token, requestConfig);
-  else return request.postMultiPart(endpoints.images(), data, requestConfig);
+  if (sseEnabled) {
+    return uploadEventStream(endpoints.images(), data, signal);
+  }
+  return request.postMultiPart(endpoints.images(), data, requestConfig);
 };
 
 export const uploadFile = (
   data: FormData,
-  startupConfig: config.TStartupConfig | undefined,
-  token: string | undefined,
   signal?: AbortSignal | null,
+  sseEnabled = false,
 ): Promise<f.TFileUpload> => {
   const requestConfig = signal ? { signal } : undefined;
-  if (startupConfig?.fileUploadSseEnabled && token)
-    return fetchSseWithPost(endpoints.files(), data, token, requestConfig);
-  else return request.postMultiPart(endpoints.files(), data, requestConfig);
+  if (sseEnabled) {
+    return uploadEventStream(endpoints.files(), data, signal);
+  }
+  return request.postMultiPart(endpoints.files(), data, requestConfig);
 };
 
 /**
@@ -1411,216 +1412,3 @@ export interface ActiveJobsResponse {
 export const getActiveJobs = (): Promise<ActiveJobsResponse> => {
   return request.get(endpoints.activeJobs());
 };
-
-class FileUploadError extends Error {
-  public code?: number = 0;
-  public file_id: string;
-  public tool_resource?: a.EToolResources;
-  public display_to_user: boolean = false;
-  public response = { data: { message: '' } };
-
-  constructor(
-    message: string,
-    file_id: string,
-    tool_resource?: a.EToolResources,
-    display_to_user = false,
-    code = 0,
-  ) {
-    super(message);
-    this.name = 'CustomAppError'; // Set the name for clarity
-    this.file_id = file_id;
-    this.tool_resource = tool_resource;
-    this.code = code;
-    this.display_to_user = display_to_user;
-    // response.data.messages are displayed to the user
-    if (display_to_user) this.response.data.message = message;
-
-    // Maintain proper prototype chain for 'instanceof' checks
-    Object.setPrototypeOf(this, FileUploadError.prototype);
-  }
-}
-
-/** Thrown when a fetch-based SSE upload is aborted by the caller (e.g. a user-initiated cancel).
- * Mirrors axios's `ERR_CANCELED` code so existing cancel-upload UI handling keeps working. */
-class UploadCanceledError extends Error {
-  public code = 'ERR_CANCELED' as const;
-}
-
-interface SseErrorData {
-  message: string;
-  temp_file_id: string;
-  tool_resource?: a.EToolResources;
-  display_to_user: boolean;
-}
-
-interface SseHeartbeatData {
-  keepAlive: number;
-}
-
-interface SseCloseData {
-  closedAt: string;
-}
-
-type SseEvent =
-  | { eventType: 'data'; id: string; message: string; data: f.TFileUpload }
-  | { eventType: 'error'; id: string; message: string; data: SseErrorData }
-  | { eventType: 'heartbeat'; id: string; message: string; data: SseHeartbeatData }
-  | { eventType: 'close'; id: string; message: string; data: SseCloseData }
-  | { eventType: 'message'; id: string; message: string; data: { message: string } };
-
-async function fetchSseWithPost(
-  url: string,
-  formData: FormData,
-  token: string,
-  options?: RequestInit,
-): Promise<f.TFileUpload> {
-  let ret: f.TFileUpload | null = null;
-  let close = false;
-  const onClose = () => {
-    console.log('SSE connection closed.');
-    close = true;
-  };
-
-  try {
-    const onEvent = (event: SseEvent) => {
-      console.debug('SSE Event:', event);
-      if (event.eventType === 'data') {
-        console.log('Data event received.');
-        ret = event.data;
-        close = true;
-      } else if (event.eventType === 'error') {
-        console.error('Error event received:', event.data);
-        throw new FileUploadError(
-          event.data.message,
-          event.data.temp_file_id,
-          event.data.tool_resource,
-          event.data.display_to_user,
-        );
-      } else if (event.eventType === 'heartbeat') {
-        console.debug('Heartbeat received.');
-        // Reset the heartbeat timer
-        clearTimeout(heartBeatTimer);
-        // Start a new heartbeat check timer
-        heartBeatTimer = setTimeout(onNoHeartbeat, 3000);
-      }
-    };
-
-    const response = await fetch(url, {
-      method: 'POST',
-      body: formData,
-      headers: {
-        authorization: 'Bearer ' + token,
-        // Fetch with FormData automatically sets the correct 'multipart/form-data' header.
-      },
-      ...options,
-    });
-
-    if (!response.ok) {
-      let message = `Server responded with status: ${response.status}`;
-      try {
-        const errorBody: { message?: string } = await response.json();
-        if (errorBody.message) {
-          message = errorBody.message;
-        }
-      } catch {
-        // Response body wasn't JSON; fall back to the generic message.
-      }
-      throw new FileUploadError(
-        message,
-        String(formData.get('file_id') ?? ''),
-        (formData.get('tool_resource') as a.EToolResources | null) ?? undefined,
-        true,
-        response.status,
-      );
-    }
-
-    if (!response.body) {
-      throw new Error('No response body received.');
-    }
-
-    const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-
-    const onNoHeartbeat = () => {
-      console.error('No heartbeat detected, closing connection.');
-      reader.cancel('No heartbeat detected from server.');
-    };
-
-    let heartBeatTimer = setTimeout(onNoHeartbeat, 3000);
-
-    let buffer = '';
-    while (!close) {
-      const { value, done } = await reader.read();
-      if (done) {
-        // `reader.cancel()` (heartbeat timeout, or an early server close) resolves the
-        // pending read with `done: true` instead of rejecting — treat it as a failure
-        // rather than silently returning with no data.
-        throw new Error('Upload connection closed unexpectedly before completion.');
-      }
-
-      if (typeof value !== 'string') {
-        console.error('Unexpected chunk type:', typeof value);
-        continue;
-      }
-
-      buffer += value;
-
-      // Split the buffer by double newlines, which terminate an SSE message.
-      const messages = buffer.split('\n\n');
-      buffer = messages.pop() || ''; // Keep the last, incomplete message part in the buffer.
-
-      for (const message of messages) {
-        console.debug('message:', message);
-        const eventData = parseSseMessage(message);
-        if (eventData) {
-          onEvent(eventData);
-          if (eventData.eventType === 'data' || eventData.eventType === 'error') {
-            onClose();
-            break;
-          }
-        }
-      }
-    }
-
-    clearTimeout(heartBeatTimer);
-  } catch (error) {
-    console.error('Fetch SSE Error:');
-    console.error(error);
-    onClose();
-    if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new UploadCanceledError('Upload canceled.');
-    }
-    throw error;
-  }
-
-  if (ret === null) {
-    throw new Error('Upload did not complete: no data received.');
-  }
-  return ret;
-}
-
-// Helper function to parse raw SSE messages.
-function parseSseMessage(message: string): SseEvent | null {
-  const lines = message.split('\n');
-  let id: string | undefined;
-  let data = '';
-  let eventType = 'message';
-
-  for (const line of lines) {
-    if (line.startsWith('id:')) {
-      id = line.substring(3).trim();
-    } else if (line.startsWith('event:')) {
-      eventType = line.substring(6).trim();
-    } else if (line.startsWith('data:')) {
-      data += line.substring(5); // Concatenate multi-line data fields.
-    }
-  }
-
-  try {
-    const parsedData = JSON.parse(data);
-    return { data: parsedData, id: id || 'unknown', eventType, message } as SseEvent;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
-    console.debug('data was not json, returning as object with message');
-    return { data: { message: data }, id: id || 'unknown', eventType, message } as SseEvent;
-  }
-}

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import axios, { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
 import type * as t from './types';
 import { setTokenHeader } from './headers-helpers';
 import * as endpoints from './api-endpoints';
@@ -280,22 +281,63 @@ const shouldRefreshBeforeRequest = (url?: string) => {
   return timeUntilExpiry > 0 && timeUntilExpiry <= TOKEN_REFRESH_BUFFER_MS;
 };
 
+const refreshBeforeRequest = async (url?: string) => {
+  const state = getAuthRecoveryState();
+  if (state.refreshPromise && !isAuthRecoveryEndpoint(url)) {
+    return state.refreshPromise.catch(() => null);
+  }
+
+  if (!shouldRefreshBeforeRequest(url)) {
+    return null;
+  }
+
+  return startAuthRecovery(false).catch(() => null);
+};
+
+const withAuthorization = (options: RequestInit | undefined, token: string | null): RequestInit => {
+  const headers = new Headers(options?.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return { ...options, headers };
+};
+
+async function _authenticatedFetch(url: string, options?: RequestInit): Promise<Response> {
+  if (typeof window === 'undefined') {
+    return fetch(url, options);
+  }
+
+  const token = (await refreshBeforeRequest(url)) ?? getBearerToken();
+  const response = await fetch(url, withAuthorization(options, token));
+  if (
+    response.status !== 401 ||
+    isAuthRecoveryEndpoint(url) ||
+    isAuthRedirectInProgress() ||
+    !getBearerToken()
+  ) {
+    return response;
+  }
+
+  let refreshedToken: string | null;
+  try {
+    refreshedToken = await startAuthRecovery(false);
+  } catch {
+    redirectToLoginOnce();
+    return response;
+  }
+
+  if (!refreshedToken) {
+    redirectToLoginOnce();
+    return response;
+  }
+
+  await response.body?.cancel().catch(() => undefined);
+  return fetch(url, withAuthorization(options, refreshedToken));
+}
+
 if (typeof window !== 'undefined') {
   axios.interceptors.request.use(async (config) => {
-    const state = getAuthRecoveryState();
-    if (state.refreshPromise && !isAuthRecoveryEndpoint(config.url)) {
-      const token = await state.refreshPromise.catch(() => null);
-      if (token) {
-        setRequestAuthorizationHeader(config, token);
-      }
-      return config;
-    }
-
-    if (!shouldRefreshBeforeRequest(config.url)) {
-      return config;
-    }
-
-    const token = await startAuthRecovery(false).catch(() => null);
+    const token = await refreshBeforeRequest(config.url);
     if (token) {
       setRequestAuthorizationHeader(config, token);
     }
@@ -384,6 +426,7 @@ export default {
   delete: _delete,
   deleteWithOptions: _deleteWithOptions,
   patch: _patch,
+  authenticatedFetch: _authenticatedFetch,
   refreshToken,
   dispatchTokenUpdatedEvent,
 };

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -10,11 +10,11 @@ import type {
   ReasoningResponseKey,
   ReasoningParameterFormat,
 } from './schemas';
+import type { Agent, EToolResources } from './types/assistants';
 import type { RefillIntervalUnit } from './balance';
 import type { SettingDefinition } from './generate';
 import type { TMinimalFeedback } from './feedback';
 import type { ContentTypes } from './types/runs';
-import type { Agent, EToolResources } from './types/assistants';
 
 export * from './schemas';
 

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -14,7 +14,7 @@ import type { RefillIntervalUnit } from './balance';
 import type { SettingDefinition } from './generate';
 import type { TMinimalFeedback } from './feedback';
 import type { ContentTypes } from './types/runs';
-import type { Agent } from './types/assistants';
+import type { Agent, EToolResources } from './types/assistants';
 
 export * from './schemas';
 
@@ -217,6 +217,8 @@ export type TMarketplaceCategory = TCategory & {
 export type TError = {
   message: string;
   code?: number | string;
+  file_id?: string;
+  tool_resource?: EToolResources;
   response?: {
     data?: {
       message?: string;

--- a/packages/data-provider/src/upload.spec.ts
+++ b/packages/data-provider/src/upload.spec.ts
@@ -1,0 +1,152 @@
+import { uploadEventStream } from './upload';
+import request from './request';
+
+jest.mock('./request', () => ({
+  __esModule: true,
+  default: {
+    authenticatedFetch: jest.fn(),
+  },
+}));
+
+const authenticatedFetch = request.authenticatedFetch as jest.Mock;
+
+const createStream = (...chunks: string[]) =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+const createFormData = () => {
+  const formData = new FormData();
+  formData.set('file_id', 'temporary-id');
+  return formData;
+};
+
+describe('uploadEventStream', () => {
+  beforeEach(() => {
+    authenticatedFetch.mockReset();
+  });
+
+  it('parses SSE events split across chunks and waits for the terminal close event', async () => {
+    authenticatedFetch.mockResolvedValue(
+      new Response(
+        createStream(
+          'event:heartbeat\r\ndata:{"keepAlive":1}\r\n\r\nevent:da',
+          'ta\r\ndata:{"file_id":"stored-id","temp_file_id":"temporary-id"}\r\n\r\n',
+          'event:close\r\ndata:{}\r\n\r\n',
+        ),
+        { headers: { 'Content-Type': 'text/event-stream; charset=utf-8' } },
+      ),
+    );
+
+    await expect(uploadEventStream('/api/files', createFormData())).resolves.toMatchObject({
+      file_id: 'stored-id',
+      temp_file_id: 'temporary-id',
+    });
+  });
+
+  it('falls back to a JSON upload response for mixed-version servers', async () => {
+    authenticatedFetch.mockResolvedValue(
+      new Response('{"file_id":"stored-id","temp_file_id":"temporary-id"}', {
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      }),
+    );
+
+    await expect(uploadEventStream('/api/files', createFormData())).resolves.toMatchObject({
+      file_id: 'stored-id',
+      temp_file_id: 'temporary-id',
+    });
+  });
+
+  it('maps streamed failures to the existing upload error shape', async () => {
+    authenticatedFetch.mockResolvedValue(
+      new Response(
+        createStream(
+          'event:error\n',
+          'data:{"message":"Unsupported file","temp_file_id":"temporary-id","code":422,"display_to_user":true}\n\n',
+        ),
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    );
+
+    await expect(uploadEventStream('/api/files', createFormData())).rejects.toMatchObject({
+      name: 'CustomAppError',
+      code: 422,
+      file_id: 'temporary-id',
+      display_to_user: true,
+      response: { data: { message: 'Unsupported file' } },
+    });
+  });
+
+  it('maps pre-stream HTTP failures to the existing upload error shape', async () => {
+    authenticatedFetch.mockResolvedValue(
+      new Response('{"message":"File is too large"}', {
+        status: 413,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(uploadEventStream('/api/files', createFormData())).rejects.toMatchObject({
+      name: 'CustomAppError',
+      code: 413,
+      file_id: 'temporary-id',
+      response: { data: { message: 'File is too large' } },
+    });
+  });
+
+  it('cancels a stalled stream when heartbeats stop', async () => {
+    jest.useFakeTimers();
+    try {
+      authenticatedFetch.mockResolvedValue(
+        new Response(new ReadableStream<Uint8Array>(), {
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+      );
+
+      const result = uploadEventStream('/api/files', createFormData()).catch(
+        (error: Error) => error,
+      );
+      await jest.advanceTimersByTimeAsync(15_000);
+
+      await expect(result).resolves.toMatchObject({
+        message: expect.stringContaining('timed out waiting for a heartbeat'),
+      });
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('preserves the canceled-upload error contract when the signal aborts', async () => {
+    const controller = new AbortController();
+    controller.abort('User aborted upload');
+    authenticatedFetch.mockRejectedValue('User aborted upload');
+
+    await expect(
+      uploadEventStream('/api/files', createFormData(), controller.signal),
+    ).rejects.toMatchObject({ code: 'ERR_CANCELED' });
+  });
+
+  it('preserves the upload abort signal', async () => {
+    const controller = new AbortController();
+    authenticatedFetch.mockResolvedValue(
+      new Response('{"file_id":"stored-id","temp_file_id":"temporary-id"}', {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await uploadEventStream('/api/files', createFormData(), controller.signal);
+
+    expect(authenticatedFetch).toHaveBeenCalledWith('/api/files', {
+      method: 'POST',
+      body: expect.any(FormData),
+      headers: { Accept: 'text/event-stream' },
+      signal: controller.signal,
+    });
+  });
+});

--- a/packages/data-provider/src/upload.ts
+++ b/packages/data-provider/src/upload.ts
@@ -1,0 +1,212 @@
+import type { EToolResources } from './types/assistants';
+import type { TFileUpload } from './types/files';
+import request from './request';
+
+const EVENT_STREAM_MEDIA_TYPE = 'text/event-stream';
+const HEARTBEAT_TIMEOUT_MS = 15_000;
+
+interface UploadErrorData {
+  message?: string;
+  code?: number;
+  temp_file_id?: string;
+  tool_resource?: EToolResources;
+  display_to_user?: boolean;
+}
+
+interface ParsedEvent {
+  type: string;
+  data: string;
+}
+
+class FileUploadError extends Error {
+  public code: number;
+  public file_id: string;
+  public tool_resource?: EToolResources;
+  public display_to_user: boolean;
+  public response: { data: { message: string } };
+
+  constructor(
+    message: string,
+    fileId: string,
+    toolResource?: EToolResources,
+    displayToUser = false,
+    code = 0,
+  ) {
+    super(message);
+    this.name = 'CustomAppError';
+    this.code = code;
+    this.file_id = fileId;
+    this.tool_resource = toolResource;
+    this.display_to_user = displayToUser;
+    this.response = { data: { message: displayToUser ? message : '' } };
+  }
+}
+
+class UploadCanceledError extends Error {
+  public code = 'ERR_CANCELED' as const;
+}
+
+const getFileId = (formData: FormData) => String(formData.get('file_id') ?? '');
+
+const getToolResource = (formData: FormData) =>
+  (formData.get('tool_resource') as EToolResources | null) ?? undefined;
+
+const parseEvent = (message: string): ParsedEvent => {
+  let type = 'message';
+  const data: string[] = [];
+
+  for (const line of message.split(/\r?\n/)) {
+    if (line.startsWith('event:')) {
+      type = line.slice('event:'.length).trim();
+      continue;
+    }
+    if (line.startsWith('data:')) {
+      data.push(line.slice('data:'.length).trimStart());
+    }
+  }
+
+  return { type, data: data.join('\n') };
+};
+
+const createHttpError = async (response: Response, formData: FormData) => {
+  let message = `Server responded with status: ${response.status}`;
+  try {
+    const data = (await response.json()) as { message?: string };
+    message = data.message || message;
+  } catch {
+    // Preserve the status-based fallback for non-JSON responses.
+  }
+
+  return new FileUploadError(
+    message,
+    getFileId(formData),
+    getToolResource(formData),
+    true,
+    response.status,
+  );
+};
+
+const createStreamError = (data: string, formData: FormData) => {
+  let error: UploadErrorData;
+  try {
+    error = JSON.parse(data) as UploadErrorData;
+  } catch {
+    error = { message: data };
+  }
+
+  return new FileUploadError(
+    error.message || 'File upload failed.',
+    error.temp_file_id || getFileId(formData),
+    error.tool_resource || getToolResource(formData),
+    error.display_to_user ?? false,
+    error.code ?? 0,
+  );
+};
+
+const readEventStream = async (
+  stream: ReadableStream<Uint8Array>,
+  formData: FormData,
+): Promise<TFileUpload> => {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result: TFileUpload | null = null;
+  let streamEnded = false;
+  let timeoutError: Error | null = null;
+  let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const resetHeartbeatTimer = () => {
+    clearTimeout(heartbeatTimer);
+    heartbeatTimer = setTimeout(() => {
+      timeoutError = new Error('Upload connection timed out waiting for a heartbeat.');
+      void reader.cancel(timeoutError);
+    }, HEARTBEAT_TIMEOUT_MS);
+  };
+
+  resetHeartbeatTimer();
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        streamEnded = true;
+        if (timeoutError) {
+          throw timeoutError;
+        }
+        if (result) {
+          return result;
+        }
+        throw new Error('Upload connection closed before completion.');
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const messages = buffer.split(/\r?\n\r?\n/);
+      buffer = messages.pop() ?? '';
+
+      for (const message of messages) {
+        const event = parseEvent(message);
+        if (event.type === 'heartbeat') {
+          resetHeartbeatTimer();
+          continue;
+        }
+        if (event.type === 'error') {
+          throw createStreamError(event.data, formData);
+        }
+        if (event.type === 'data') {
+          result = JSON.parse(event.data) as TFileUpload;
+          continue;
+        }
+        if (event.type === 'close') {
+          if (result) {
+            return result;
+          }
+          throw new Error('Upload stream closed without a result.');
+        }
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new UploadCanceledError('Upload canceled.');
+    }
+    throw error;
+  } finally {
+    clearTimeout(heartbeatTimer);
+    if (!streamEnded) {
+      await reader.cancel().catch(() => undefined);
+    }
+    reader.releaseLock();
+  }
+};
+
+export async function uploadEventStream(
+  url: string,
+  formData: FormData,
+  signal?: AbortSignal | null,
+): Promise<TFileUpload> {
+  try {
+    const response = await request.authenticatedFetch(url, {
+      method: 'POST',
+      body: formData,
+      headers: { Accept: EVENT_STREAM_MEDIA_TYPE },
+      signal: signal ?? undefined,
+    });
+    if (!response.ok) {
+      throw await createHttpError(response, formData);
+    }
+
+    const contentType = response.headers.get('Content-Type')?.toLowerCase() ?? '';
+    if (!contentType.includes(EVENT_STREAM_MEDIA_TYPE)) {
+      return (await response.json()) as TFileUpload;
+    }
+    if (!response.body) {
+      throw new Error('No upload response body received.');
+    }
+
+    return await readEventStream(response.body, formData);
+  } catch (error) {
+    if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+      throw new UploadCanceledError('Upload canceled.');
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

I rebased the SSE file-upload fix onto the latest `dev` branch and hardened the upload path against auth expiry, rolling deployments, disconnects, and stalled streams. This fixes [#14294](https://github.com/danny-avila/LibreChat/issues/14294); the companion documentation is in [LibreChat-AI/librechat.ai#696](https://github.com/LibreChat-AI/librechat.ai/pull/696).

- Add opt-in upload heartbeats behind `FILE_UPLOAD_SSE_ENABLED`.
- Negotiate SSE per request with `Accept: text/event-stream` and fall back to JSON by response content type.
- Reuse authenticated request recovery for proactive token refresh and one retry after a 401.
- Preserve the existing upload API and abort-signal behavior.
- Tie heartbeat cleanup to the response lifecycle and guard writes after disconnects.
- Normalize streamed failures to the existing upload error contract.
- Cover server lifecycle, route negotiation, parser behavior, auth recovery, timeouts, and cancellation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

- Ran the API SSE helper suite: 13 tests passed.
- Ran the affected API process and upload-route suites: 83 tests passed.
- Ran the full data-provider suite: 1,353 tests passed and 1 skipped.
- Ran the client TypeScript check.
- Built the data-provider, API, client package, and data schemas.
- Ran TypeScript checks for the API and data-provider packages.
- Ran ESLint and Prettier checks across the touched files.

### **Test Configuration**:

- Base branch: `dev` at `7406f5d79e64617ed7f386820e6360da9617718f`
- Feature flag exercised: `FILE_UPLOAD_SSE_ENABLED=true`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes