### PR TITLE
feat: add model spec reasoning selector

### DIFF
--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -2,6 +2,7 @@ const {
   handleError,
   applyModelSpecPreset,
   findModelSpecByName,
+  getModelSpecReasoningOverride,
   isModelSpecEndpointMatch,
   resolveModelSpecPromptPrefixVariables,
 } = require('@librechat/api');
@@ -38,6 +39,15 @@ async function buildEndpointOption(req, res, next) {
   }
 
   const defaultParamsEndpoint = getDefaultParamsEndpoint(endpointsConfig, endpoint);
+  const getReasoningOverride = (modelSpec) =>
+    getModelSpecReasoningOverride({
+      modelSpec,
+      requestBody: req.body,
+      endpoint,
+      endpointType,
+      defaultParamsEndpoint,
+      paramDefinitions: endpointsConfig?.[endpoint]?.customParams?.paramDefinitions,
+    });
 
   let parsedBody;
   try {
@@ -86,6 +96,7 @@ async function buildEndpointOption(req, res, next) {
       const result = applyModelSpecPreset({
         modelSpec: currentModelSpec,
         parsedBody: parsedBodyForModelSpec,
+        reasoningOverride: getReasoningOverride(currentModelSpec),
         endpoint,
         endpointType,
         defaultParamsEndpoint,
@@ -108,6 +119,7 @@ async function buildEndpointOption(req, res, next) {
         const result = applyModelSpecPreset({
           modelSpec,
           parsedBody,
+          reasoningOverride: getReasoningOverride(modelSpec),
           endpoint,
           endpointType,
           defaultParamsEndpoint,

--- a/api/server/middleware/buildEndpointOption.spec.js
+++ b/api/server/middleware/buildEndpointOption.spec.js
@@ -11,7 +11,7 @@ jest.mock('librechat-data-provider', () => {
   };
 });
 
-const { EModelEndpoint, parseCompactConvo } = require('librechat-data-provider');
+const { EModelEndpoint, ReasoningEffort, parseCompactConvo } = require('librechat-data-provider');
 
 const mockBuildOptions = jest.fn((_endpoint, parsedBody) => ({
   ...parsedBody,
@@ -173,6 +173,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
 
     const modelSpec = {
       name: 'claude-opus-4.5',
+      reasoning: [1024, 8192],
       preset: {
         endpoint: 'AnthropicClaude',
         endpointType: EModelEndpoint.custom,
@@ -180,6 +181,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
         temperature: 0.7,
         maxOutputTokens: 8192,
         maxContextTokens: 50000,
+        thinkingBudget: 8192,
       },
     };
 
@@ -191,6 +193,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
         model: 'anthropic/claude-opus-4.5',
         temperature: 0.1,
         topP: 0.2,
+        thinkingBudget: 1024,
         chatProjectId: 'project-1',
       },
       {
@@ -216,8 +219,10 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
     expect(enforcedResult.temperature).toBe(0.7);
     expect(enforcedResult.topP).toBeUndefined();
     expect(enforcedResult.maxContextTokens).toBe(50000);
+    expect(enforcedResult.thinkingBudget).toBe(1024);
     expect(enforcedResult.chatProjectId).toBe('project-1');
     expect(req.body.endpointOption.chatProjectId).toBe('project-1');
+    expect(req.body.endpointOption.thinkingBudget).toBe(1024);
   });
 
   it('should rebuild enforced custom specs from the backend preset when compact parsing drops raw fields', async () => {
@@ -266,6 +271,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
     const modelSpec = {
       name: 'guarded-openai',
       iconURL: 'openAI',
+      reasoning: true,
       preset: {
         endpoint: EModelEndpoint.openAI,
         model: 'gpt-4o',
@@ -274,6 +280,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
         additional_instructions: 'private additional instructions',
         temperature: 0.2,
         maxContextTokens: 10000,
+        reasoning_effort: ReasoningEffort.high,
       },
     };
 
@@ -283,6 +290,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
         spec: 'guarded-openai',
         model: 'gpt-4o',
         temperature: 0.8,
+        reasoning_effort: ReasoningEffort.unset,
       },
       {
         modelSpecs: {
@@ -300,6 +308,7 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
     expect(req.body.endpointOption.additional_instructions).toBeUndefined();
     expect(req.body.endpointOption.temperature).toBe(0.8);
     expect(req.body.endpointOption.maxContextTokens).toBeUndefined();
+    expect(req.body.endpointOption.reasoning_effort).toBe(ReasoningEffort.unset);
     expect(req.body.endpointOption.iconURL).toBe('openAI');
   });
 

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -45,6 +45,7 @@ import TokenUsage from './TokenUsage';
 import StopButton from './StopButton';
 import SendButton from './SendButton';
 import EditBadges from './EditBadges';
+import Reasoning from './Reasoning';
 import BadgeRow from './BadgeRow';
 import Mention from './Mention';
 import store from '~/store';
@@ -559,6 +560,12 @@ const ChatForm = memo(function ChatForm({
                 }
               />
               <div className="mx-auto flex" />
+              <Reasoning
+                index={index}
+                modelSpec={modelSpec}
+                conversation={conversation}
+                disabled={disableInputs || isNotAppendable || isSubmitting || answerMode.active}
+              />
               <TokenUsage index={index} conversation={conversation} isSubmitting={isSubmitting} />
               {SpeechToText && (
                 <AudioRecorder
@@ -630,6 +637,10 @@ function ChatFormWrapper({ index = 0, placeholder }: { index?: number; placehold
       conversation?.useResponsesApi,
       conversation?.model,
       conversation?.maxContextTokens,
+      conversation?.reasoning_effort,
+      conversation?.thinkingBudget,
+      conversation?.thinkingLevel,
+      conversation?.effort,
       hasMessages,
     ],
   );

--- a/client/src/components/Chat/Input/Reasoning.tsx
+++ b/client/src/components/Chat/Input/Reasoning.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useMemo, useState } from 'react';
+import * as Ariakit from '@ariakit/react';
+import { Check, ChevronDown } from 'lucide-react';
+import { DropdownPopup, TooltipAnchor } from '@librechat/client';
+import {
+  getDefaultParamsEndpoint,
+  getEndpointField,
+  getModelSpecReasoningValue,
+  resolveModelSpecReasoning,
+} from 'librechat-data-provider';
+import type { TConversation, TModelSpec } from 'librechat-data-provider';
+import type { TranslationKeys } from '~/hooks';
+import type { MenuItemProps } from '~/common';
+import { useLocalize, useSetIndexOptions } from '~/hooks';
+import { useGetEndpointsQuery } from '~/data-provider';
+import { cn } from '~/utils';
+
+function Reasoning({
+  index,
+  disabled,
+  modelSpec,
+  conversation,
+}: {
+  index: number;
+  disabled: boolean;
+  modelSpec?: TModelSpec;
+  conversation: TConversation | null;
+}) {
+  const localize = useLocalize();
+  const { setOption } = useSetIndexOptions();
+  const { data: endpointsConfig } = useGetEndpointsQuery();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const setting = useMemo(() => {
+    const endpoint = conversation?.endpoint ?? modelSpec?.preset.endpoint;
+    const endpointType =
+      conversation?.endpointType ?? getEndpointField(endpointsConfig, endpoint, 'type');
+    return resolveModelSpecReasoning({
+      modelSpec,
+      endpoint,
+      endpointType,
+      defaultParamsEndpoint: getDefaultParamsEndpoint(endpointsConfig, endpoint),
+      paramDefinitions: endpointsConfig?.[endpoint ?? '']?.customParams?.paramDefinitions,
+    });
+  }, [conversation?.endpoint, conversation?.endpointType, endpointsConfig, modelSpec]);
+
+  const getLabel = useCallback(
+    (value: string | number) => {
+      const mappedValue = setting?.enumMappings?.[String(value)];
+      if (typeof mappedValue === 'string' && mappedValue.startsWith('com_')) {
+        return localize(mappedValue as TranslationKeys);
+      }
+      if (mappedValue != null) {
+        return String(mappedValue);
+      }
+      if (value === '') {
+        return localize('com_ui_auto');
+      }
+      return typeof value === 'number' ? value.toLocaleString() : value;
+    },
+    [localize, setting?.enumMappings],
+  );
+
+  const selectedValue = useMemo(
+    () => (setting ? getModelSpecReasoningValue(setting, conversation) : undefined),
+    [conversation, setting],
+  );
+  const selectedLabel = selectedValue == null ? '' : getLabel(selectedValue);
+
+  const items = useMemo<MenuItemProps[]>(
+    () =>
+      setting?.options.map((option, optionIndex) => {
+        const isSelected = Object.is(option, selectedValue);
+        return {
+          id: `reasoning-option-${index}-${optionIndex}`,
+          label: getLabel(option),
+          ariaChecked: isSelected,
+          icon: isSelected ? (
+            <Check className="size-4" aria-hidden="true" />
+          ) : (
+            <span className="size-4" />
+          ),
+          onClick: () => setOption(setting.key)(option),
+        };
+      }) ?? [],
+    [getLabel, index, selectedValue, setOption, setting],
+  );
+
+  if (!setting) {
+    return null;
+  }
+
+  const thinkingLabel = localize('com_endpoint_thinking');
+  const ariaLabel = `${thinkingLabel}: ${selectedLabel}`;
+  const trigger = (
+    <TooltipAnchor
+      description={ariaLabel}
+      disabled={disabled}
+      render={
+        <Ariakit.MenuButton
+          id={`reasoning-dropdown-button-${index}`}
+          aria-label={ariaLabel}
+          disabled={disabled}
+          data-testid="reasoning-dropdown-button"
+          className={cn(
+            'flex h-9 items-center justify-center gap-1.5 rounded-full px-2.5 text-text-secondary transition-colors hover:bg-surface-hover',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-opacity-50',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            isOpen && 'bg-surface-hover',
+          )}
+        >
+          <span className="text-sm font-medium text-text-primary">{selectedLabel}</span>
+          <ChevronDown className="size-3.5" aria-hidden="true" />
+        </Ariakit.MenuButton>
+      }
+    />
+  );
+
+  return (
+    <DropdownPopup
+      menuId={`reasoning-dropdown-menu-${index}`}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      trigger={trigger}
+      items={items}
+      itemClassName="min-w-36"
+      iconClassName="mr-0"
+      portal={true}
+      unmountOnHide={true}
+    />
+  );
+}
+
+export default Reasoning;

--- a/client/src/components/Chat/Input/__tests__/Reasoning.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/Reasoning.spec.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { EModelEndpoint, ReasoningEffort } from 'librechat-data-provider';
+import type { TConversation, TModelSpec } from 'librechat-data-provider';
+import Reasoning from '../Reasoning';
+
+const mockSetReasoning = jest.fn();
+const mockSetOption = jest.fn(() => mockSetReasoning);
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) =>
+    ({
+      com_endpoint_thinking: 'Thinking',
+      com_ui_auto: 'Auto',
+      com_ui_low: 'Low',
+      com_ui_high: 'High',
+    })[key] ?? key,
+  useSetIndexOptions: () => ({ setOption: mockSetOption }),
+}));
+
+jest.mock('~/data-provider', () => ({
+  useGetEndpointsQuery: () => ({ data: {} }),
+}));
+
+jest.mock('@librechat/client', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const R = require('react');
+  return {
+    TooltipAnchor: (props) => props.render,
+    DropdownPopup: (props) =>
+      R.createElement(
+        'div',
+        null,
+        props.trigger,
+        R.createElement(
+          'div',
+          { role: 'menu' },
+          props.items.map((item, index) =>
+            R.createElement(
+              'button',
+              {
+                key: item.id,
+                role: 'menuitemcheckbox',
+                'aria-checked': item.ariaChecked,
+                onClick: item.onClick,
+                'data-testid': `reasoning-option-${index}`,
+              },
+              item.label,
+            ),
+          ),
+        ),
+      ),
+  };
+});
+
+jest.mock('@ariakit/react', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const R = require('react');
+  return {
+    MenuButton: (props) => R.createElement('button', props, props.children),
+  };
+});
+
+function createModelSpec(reasoning: TModelSpec['reasoning']): TModelSpec {
+  return {
+    name: 'reasoning-spec',
+    label: 'Reasoning Spec',
+    reasoning,
+    preset: {
+      endpoint: EModelEndpoint.openAI,
+      model: 'o3',
+      reasoning_effort: ReasoningEffort.high,
+    },
+  };
+}
+
+function createConversation(
+  reasoningEffort: ReasoningEffort = ReasoningEffort.high,
+): TConversation {
+  return {
+    endpoint: EModelEndpoint.openAI,
+    model: 'o3',
+    spec: 'reasoning-spec',
+    reasoning_effort: reasoningEffort,
+  } as TConversation;
+}
+
+describe('Reasoning', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when the model spec has not opted in', () => {
+    const { container } = render(
+      <Reasoning
+        index={0}
+        disabled={false}
+        modelSpec={createModelSpec(false)}
+        conversation={createConversation()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the current value and only the configured options', () => {
+    render(
+      <Reasoning
+        index={0}
+        disabled={false}
+        modelSpec={createModelSpec([ReasoningEffort.low, ReasoningEffort.high])}
+        conversation={createConversation()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Thinking: High' })).toBeInTheDocument();
+    expect(screen.getAllByRole('menuitemcheckbox')).toHaveLength(2);
+    expect(screen.getByRole('menuitemcheckbox', { name: 'High' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('updates the provider-native conversation option', () => {
+    render(
+      <Reasoning
+        index={2}
+        disabled={false}
+        modelSpec={createModelSpec([ReasoningEffort.low, ReasoningEffort.high])}
+        conversation={createConversation()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'Low' }));
+
+    expect(mockSetOption).toHaveBeenCalledWith('reasoning_effort');
+    expect(mockSetReasoning).toHaveBeenCalledWith(ReasoningEffort.low);
+  });
+
+  it('disables the trigger with the rest of the composer controls', () => {
+    render(
+      <Reasoning
+        index={0}
+        disabled={true}
+        modelSpec={createModelSpec(true)}
+        conversation={createConversation()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Thinking: High' })).toBeDisabled();
+  });
+});

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -14,6 +14,9 @@ import {
   replaceSpecialVars,
   isAssistantsEndpoint,
   getDefaultParamsEndpoint,
+  resolveModelSpecReasoning,
+  getModelSpecReasoningValue,
+  createModelSpecReasoningOverride,
 } from 'librechat-data-provider';
 import type {
   TMessage,
@@ -453,6 +456,23 @@ export default function useChatFunctions({
       convo,
       chatProjectId ? { chatProjectId } : {},
     ) as TEndpointOption;
+    const modelSpec = startupConfig?.modelSpecs?.list?.find(
+      (candidate) => candidate.name === conversation?.spec,
+    );
+    const reasoningSetting = resolveModelSpecReasoning({
+      modelSpec,
+      endpoint,
+      endpointType,
+      defaultParamsEndpoint,
+      paramDefinitions: endpointsConfig?.[endpoint ?? '']?.customParams?.paramDefinitions,
+    });
+    if (reasoningSetting) {
+      const reasoningValue = getModelSpecReasoningValue(reasoningSetting, conversationForPayload);
+      const reasoningOverride = createModelSpecReasoningOverride(reasoningSetting, reasoningValue);
+      if (reasoningOverride) {
+        Object.assign(endpointOption, reasoningOverride);
+      }
+    }
     if (endpoint !== EModelEndpoint.agents) {
       endpointOption.key = getExpiry();
       endpointOption.thread_id = thread_id;

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -700,6 +700,11 @@ endpoints:
 #       preset:
 #         endpoint: "openAI"
 #         model: "gpt-4o"
+#       # Opt in to the composer reasoning selector. `true` uses the provider's
+#       # known categorical choices; an array restricts the choices or supplies
+#       # explicit numeric thinking budgets for models that use them.
+#       # reasoning: true
+#       # reasoning: ["low", "medium", "high"]
 #       # Skills can be enabled per model spec. Use true for the user's active
 #       # accessible skill catalog, false to force skills off, or a name list as
 #       # a strict allowlist for catalog, manual, and always-apply resolution.

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -1,6 +1,11 @@
 import { Providers } from '@librechat/agents';
 import { logger } from '@librechat/data-schemas';
-import { googleSettings, AuthKeys, removeNullishValues } from 'librechat-data-provider';
+import {
+  AuthKeys,
+  googleSettings,
+  removeNullishValues,
+  supportsGoogleThinkingLevel,
+} from 'librechat-data-provider';
 import type { GoogleClientOptions, VertexAIClientOptions } from '@librechat/agents';
 import type { GoogleAIToolType } from '@librechat/agents/langchain/google-common';
 import type * as t from '~/types';
@@ -454,7 +459,7 @@ export function getGoogleConfig(
    * `@librechat/agents/langchain/google-common`'s `formatGenerationConfig` reads it separately
    * from `thinkingConfig` — they serve different purposes in the request pipeline.
    */
-  const supportsThinkingLevel = /gemini-([3-9]|\d{2,})|gemma-([4-9]|\d{2,})/i.test(modelName);
+  const supportsThinkingLevel = supportsGoogleThinkingLevel(modelName);
 
   if (supportsThinkingLevel && thinking) {
     const thinkingConfig: GoogleThinkingConfig = {

--- a/packages/api/src/modelSpecs/index.ts
+++ b/packages/api/src/modelSpecs/index.ts
@@ -1,13 +1,19 @@
 import {
+  createModelSpecReasoningOverride,
   parseCompactConvo,
   replaceSpecialVars,
-  type EModelEndpoint,
-  type TConversation,
-  type TModelSpec,
-  type TModelSpecPreset,
-  type TPreset,
-  type TSpecsConfig,
-  type TUser,
+  resolveModelSpecReasoning,
+} from 'librechat-data-provider';
+import type {
+  EModelEndpoint,
+  ModelSpecReasoningValues,
+  SettingDefinition,
+  TConversation,
+  TModelSpec,
+  TModelSpecPreset,
+  TPreset,
+  TSpecsConfig,
+  TUser,
 } from 'librechat-data-provider';
 
 export const PRIVATE_MODEL_SPEC_PRESET_FIELDS: readonly [
@@ -37,10 +43,20 @@ export const ENFORCED_MODEL_SPEC_REQUEST_FIELDS: readonly ['chatProjectId'] = [
 export type ApplyModelSpecPresetParams = {
   modelSpec: TModelSpec;
   parsedBody: ModelSpecParsedBody;
+  reasoningOverride?: ModelSpecReasoningValues;
   endpoint?: string | null;
   endpointType?: string | null;
   defaultParamsEndpoint?: string | null;
   includePresetDefaults?: boolean;
+};
+
+export type GetModelSpecReasoningOverrideParams = {
+  modelSpec: TModelSpec;
+  requestBody: ModelSpecParsedBody;
+  endpoint?: string | null;
+  endpointType?: string | null;
+  defaultParamsEndpoint?: string | null;
+  paramDefinitions?: Partial<SettingDefinition>[];
 };
 
 export type ApplyModelSpecPresetResult = {
@@ -133,9 +149,33 @@ export function isModelSpecEndpointMatch(
   return Boolean(modelSpec && endpoint === modelSpec.preset?.endpoint);
 }
 
+/** Validates the raw selector value before reapplying it through model spec parsing. */
+export function getModelSpecReasoningOverride({
+  modelSpec,
+  requestBody,
+  endpoint,
+  endpointType,
+  defaultParamsEndpoint,
+  paramDefinitions,
+}: GetModelSpecReasoningOverrideParams): ModelSpecReasoningValues | undefined {
+  const setting = resolveModelSpecReasoning({
+    modelSpec,
+    endpoint,
+    endpointType,
+    defaultParamsEndpoint,
+    paramDefinitions,
+  });
+  if (!setting || !Object.prototype.hasOwnProperty.call(requestBody, setting.key)) {
+    return undefined;
+  }
+
+  return createModelSpecReasoningOverride(setting, requestBody[setting.key]);
+}
+
 export function applyModelSpecPreset({
   modelSpec,
   parsedBody,
+  reasoningOverride,
   endpoint,
   endpointType,
   defaultParamsEndpoint,
@@ -144,9 +184,7 @@ export function applyModelSpecPreset({
   const { parsedBody: conversation, appliedPrivateFields } = mergeModelSpecPreset(
     modelSpec,
     parsedBody,
-    {
-      includePresetDefaults,
-    },
+    { includePresetDefaults },
   );
   const reparsedBody = parseCompactConvo({
     endpoint: endpoint as EModelEndpoint | undefined,
@@ -160,6 +198,9 @@ export function applyModelSpecPreset({
   }
 
   const modelSpecParsedBody = reparsedBody as ModelSpecParsedBody;
+  if (reasoningOverride) {
+    Object.assign(modelSpecParsedBody, reasoningOverride);
+  }
   if (modelSpec.iconURL != null && modelSpec.iconURL !== '') {
     modelSpecParsedBody.iconURL = modelSpec.iconURL;
   }

--- a/packages/api/src/modelSpecs/modelSpecs.test.ts
+++ b/packages/api/src/modelSpecs/modelSpecs.test.ts
@@ -1,8 +1,9 @@
-import { EModelEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, ReasoningEffort } from 'librechat-data-provider';
 import type { TModelSpec } from 'librechat-data-provider';
 import {
   applyModelSpecPreset,
   findModelSpecByName,
+  getModelSpecReasoningOverride,
   isModelSpecEndpointMatch,
   resolveModelSpecPromptPrefixVariables,
   sanitizeModelSpecs,
@@ -86,6 +87,7 @@ describe('modelSpecs helpers', () => {
         additional_instructions: 'private additional instructions',
         temperature: 0.2,
         maxContextTokens: 10000,
+        reasoning_effort: ReasoningEffort.high,
       },
     };
 
@@ -96,6 +98,7 @@ describe('modelSpecs helpers', () => {
         spec: 'guarded-openai',
         model: 'gpt-4o',
         temperature: 0.8,
+        reasoning_effort: ReasoningEffort.low,
       },
       endpoint: EModelEndpoint.openAI,
     });
@@ -104,6 +107,7 @@ describe('modelSpecs helpers', () => {
     expect(parsedBody.instructions).toBeUndefined();
     expect(parsedBody.additional_instructions).toBeUndefined();
     expect(parsedBody.temperature).toBe(0.8);
+    expect(parsedBody.reasoning_effort).toBe(ReasoningEffort.low);
     expect(parsedBody.maxContextTokens).toBeUndefined();
     expect(parsedBody.iconURL).toBe(EModelEndpoint.openAI);
     expect(appliedPrivateFields.has('promptPrefix')).toBe(true);
@@ -118,6 +122,7 @@ describe('modelSpecs helpers', () => {
         model: 'gpt-4o',
         promptPrefix: 'private prompt prefix',
         temperature: 0.2,
+        reasoning_effort: ReasoningEffort.high,
       },
     };
 
@@ -129,6 +134,7 @@ describe('modelSpecs helpers', () => {
         model: 'client-model',
         temperature: 0.8,
         topP: 0.9,
+        reasoning_effort: ReasoningEffort.low,
         chatProjectId: 'project-1',
       },
       endpoint: EModelEndpoint.openAI,
@@ -139,8 +145,74 @@ describe('modelSpecs helpers', () => {
     expect(parsedBody.model).toBe('gpt-4o');
     expect(parsedBody.promptPrefix).toBe('private prompt prefix');
     expect(parsedBody.temperature).toBe(0.2);
+    expect(parsedBody.reasoning_effort).toBe(ReasoningEffort.high);
     expect(parsedBody.topP).toBeUndefined();
     expect(parsedBody.chatProjectId).toBe('project-1');
+  });
+
+  it('should only allow an advertised reasoning override through enforcement', () => {
+    const modelSpec: TModelSpec = {
+      name: 'enforced-reasoning',
+      label: 'Enforced Reasoning',
+      reasoning: [ReasoningEffort.low, ReasoningEffort.high],
+      preset: {
+        endpoint: EModelEndpoint.openAI,
+        model: 'o3',
+        reasoning_effort: ReasoningEffort.high,
+      },
+    };
+    const validOverride = getModelSpecReasoningOverride({
+      modelSpec,
+      requestBody: { reasoning_effort: ReasoningEffort.low },
+      endpoint: EModelEndpoint.openAI,
+    });
+
+    expect(validOverride).toEqual({ reasoning_effort: ReasoningEffort.low });
+    expect(
+      getModelSpecReasoningOverride({
+        modelSpec,
+        requestBody: { reasoning_effort: ReasoningEffort.medium },
+        endpoint: EModelEndpoint.openAI,
+      }),
+    ).toBeUndefined();
+
+    const { parsedBody } = applyModelSpecPreset({
+      modelSpec,
+      parsedBody: { endpoint: EModelEndpoint.openAI, spec: modelSpec.name },
+      reasoningOverride: validOverride,
+      endpoint: EModelEndpoint.openAI,
+      includePresetDefaults: true,
+    });
+
+    expect(parsedBody.reasoning_effort).toBe(ReasoningEffort.low);
+  });
+
+  it('should allow Auto to clear an enforced preset reasoning effort', () => {
+    const modelSpec: TModelSpec = {
+      name: 'enforced-auto-reasoning',
+      label: 'Enforced Auto Reasoning',
+      reasoning: true,
+      preset: {
+        endpoint: EModelEndpoint.openAI,
+        model: 'o3',
+        reasoning_effort: ReasoningEffort.high,
+      },
+    };
+    const reasoningOverride = getModelSpecReasoningOverride({
+      modelSpec,
+      requestBody: { reasoning_effort: ReasoningEffort.unset },
+      endpoint: EModelEndpoint.openAI,
+    });
+    const { parsedBody } = applyModelSpecPreset({
+      modelSpec,
+      parsedBody: { endpoint: EModelEndpoint.openAI, spec: modelSpec.name },
+      reasoningOverride,
+      endpoint: EModelEndpoint.openAI,
+      includePresetDefaults: true,
+    });
+
+    expect(reasoningOverride).toEqual({ reasoning_effort: ReasoningEffort.unset });
+    expect(parsedBody.reasoning_effort).toBe(ReasoningEffort.unset);
   });
 
   it('should restore private examples when parser supplies an empty default', () => {

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -13,6 +13,7 @@ export * from './parsers';
 /* custom/dynamic configurations  */
 export * from './generate';
 export * from './models';
+export * from './reasoning';
 /* mcp */
 export * from './mcp';
 /* RBAC */

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -49,6 +49,8 @@ export type TModelSpec = {
   authType?: AuthType;
   /** Hide the chat input tool badge row while this model spec is active. */
   hideBadgeRow?: boolean;
+  /** Show the composer reasoning selector. An array restricts values or sets budget choices. */
+  reasoning?: boolean | Array<string | number>;
   webSearch?: boolean;
   fileSearch?: boolean;
   executeCode?: boolean;
@@ -91,6 +93,7 @@ export const tModelSpecSchema = z.object({
   iconURL: z.union([z.string(), eModelEndpointSchema]).optional(),
   authType: authTypeSchema.optional(),
   hideBadgeRow: z.boolean().optional(),
+  reasoning: z.union([z.boolean(), z.array(z.union([z.string(), z.number()])).min(1)]).optional(),
   webSearch: z.boolean().optional(),
   fileSearch: z.boolean().optional(),
   executeCode: z.boolean().optional(),

--- a/packages/data-provider/src/reasoning.spec.ts
+++ b/packages/data-provider/src/reasoning.spec.ts
@@ -1,0 +1,181 @@
+import type { TModelSpec } from './models';
+import {
+  createModelSpecReasoningOverride,
+  getModelSpecReasoningValue,
+  resolveModelSpecReasoning,
+  supportsGoogleThinkingLevel,
+} from './reasoning';
+import { AnthropicEffort, EModelEndpoint, ReasoningEffort, ThinkingLevel } from './schemas';
+import { tModelSpecSchema } from './models';
+
+function createModelSpec(
+  endpoint: string,
+  model: string,
+  reasoning: TModelSpec['reasoning'] = true,
+): TModelSpec {
+  return {
+    name: `${endpoint}-${model}`,
+    label: model,
+    reasoning,
+    preset: { endpoint, model },
+  };
+}
+
+describe('model spec reasoning', () => {
+  it('accepts the opt-in flag and restricted option lists in model spec config', () => {
+    const baseSpec = createModelSpec(EModelEndpoint.openAI, 'o3');
+
+    expect(tModelSpecSchema.parse(baseSpec).reasoning).toBe(true);
+    expect(tModelSpecSchema.parse({ ...baseSpec, reasoning: ['low', 'high'] }).reasoning).toEqual([
+      'low',
+      'high',
+    ]);
+    expect(tModelSpecSchema.safeParse({ ...baseSpec, reasoning: [] }).success).toBe(false);
+  });
+
+  it('stays hidden unless the model spec opts in', () => {
+    const modelSpec = createModelSpec(EModelEndpoint.openAI, 'o3', false);
+
+    expect(
+      resolveModelSpecReasoning({ modelSpec, endpoint: EModelEndpoint.openAI }),
+    ).toBeUndefined();
+  });
+
+  it('uses the standard OpenAI options and supports a restricted subset', () => {
+    const modelSpec = createModelSpec(EModelEndpoint.openAI, 'o3');
+    const standard = resolveModelSpecReasoning({ modelSpec, endpoint: EModelEndpoint.openAI });
+
+    expect(standard?.key).toBe('reasoning_effort');
+    expect(standard?.options).toEqual(Object.values(ReasoningEffort));
+    expect(standard?.defaultValue).toBe(ReasoningEffort.unset);
+
+    const azure = resolveModelSpecReasoning({
+      modelSpec: createModelSpec(EModelEndpoint.azureOpenAI, 'o3'),
+      endpoint: EModelEndpoint.azureOpenAI,
+    });
+    expect(azure?.key).toBe('reasoning_effort');
+    expect(azure?.options).toEqual(Object.values(ReasoningEffort));
+
+    modelSpec.reasoning = [
+      ReasoningEffort.low,
+      'invalid',
+      ReasoningEffort.high,
+      ReasoningEffort.low,
+    ];
+    modelSpec.preset.reasoning_effort = ReasoningEffort.high;
+    const restricted = resolveModelSpecReasoning({
+      modelSpec,
+      endpoint: EModelEndpoint.openAI,
+    });
+
+    expect(restricted?.options).toEqual([ReasoningEffort.low, ReasoningEffort.high]);
+    expect(restricted?.defaultValue).toBe(ReasoningEffort.high);
+    expect(getModelSpecReasoningValue(restricted!, null)).toBe(ReasoningEffort.high);
+    expect(getModelSpecReasoningValue(restricted!, { reasoning_effort: ReasoningEffort.low })).toBe(
+      ReasoningEffort.low,
+    );
+  });
+
+  it('uses effort for adaptive Anthropic models and budget choices for older models', () => {
+    const adaptiveModelSpec = createModelSpec(EModelEndpoint.anthropic, 'claude-sonnet-4-6');
+    adaptiveModelSpec.preset.thinkingBudget = 4096;
+    const adaptive = resolveModelSpecReasoning({
+      modelSpec: adaptiveModelSpec,
+      endpoint: EModelEndpoint.anthropic,
+    });
+    const legacy = resolveModelSpecReasoning({
+      modelSpec: createModelSpec(EModelEndpoint.anthropic, 'claude-3-7-sonnet', [512, 1024, 4096]),
+      endpoint: EModelEndpoint.anthropic,
+    });
+
+    expect(adaptive?.key).toBe('effort');
+    expect(adaptive?.options).toEqual(Object.values(AnthropicEffort));
+    expect(legacy).toMatchObject({ key: 'thinkingBudget', options: [1024, 4096] });
+  });
+
+  it('uses levels for modern Google models and budget choices for older models', () => {
+    expect(supportsGoogleThinkingLevel('gemini-3-pro-preview')).toBe(true);
+    expect(supportsGoogleThinkingLevel('gemma-4-27b')).toBe(true);
+    expect(supportsGoogleThinkingLevel('gemini-2.5-pro')).toBe(false);
+
+    const modernModelSpec = createModelSpec(EModelEndpoint.google, 'gemini-3-pro-preview');
+    modernModelSpec.preset.thinkingBudget = 1024;
+    const modern = resolveModelSpecReasoning({
+      modelSpec: modernModelSpec,
+      endpoint: EModelEndpoint.google,
+    });
+    const legacy = resolveModelSpecReasoning({
+      modelSpec: createModelSpec(EModelEndpoint.google, 'gemini-2.5-pro', [-1, 1024]),
+      endpoint: EModelEndpoint.google,
+    });
+
+    expect(modern?.key).toBe('thinkingLevel');
+    expect(modern?.options).toEqual(Object.values(ThinkingLevel));
+    expect(legacy).toMatchObject({ key: 'thinkingBudget', options: [-1, 1024] });
+  });
+
+  it('uses a custom endpoint default parameter family and custom definitions', () => {
+    const modelSpec = createModelSpec('my-openai-compatible-endpoint', 'reasoner');
+    const setting = resolveModelSpecReasoning({
+      modelSpec,
+      endpoint: 'my-openai-compatible-endpoint',
+      defaultParamsEndpoint: EModelEndpoint.openAI,
+      paramDefinitions: [
+        {
+          key: 'reasoning_effort',
+          component: 'slider',
+          type: 'enum',
+          options: [ReasoningEffort.low, ReasoningEffort.high],
+          default: ReasoningEffort.low,
+        },
+      ],
+    });
+
+    expect(setting).toMatchObject({
+      key: 'reasoning_effort',
+      options: [ReasoningEffort.low, ReasoningEffort.high],
+      defaultValue: ReasoningEffort.low,
+    });
+
+    const budgetSetting = resolveModelSpecReasoning({
+      modelSpec: createModelSpec('my-budget-endpoint', 'reasoner', [1024, 4096]),
+      endpoint: 'my-budget-endpoint',
+      defaultParamsEndpoint: EModelEndpoint.openAI,
+      paramDefinitions: [
+        {
+          key: 'thinkingBudget',
+          component: 'input',
+          type: 'number',
+          range: { min: 1024, max: 8192 },
+        },
+      ],
+    });
+    expect(budgetSetting).toMatchObject({
+      key: 'thinkingBudget',
+      options: [1024, 4096],
+    });
+  });
+
+  it.each([
+    EModelEndpoint.agents,
+    EModelEndpoint.assistants,
+    EModelEndpoint.azureAssistants,
+    EModelEndpoint.bedrock,
+  ])('does not expose the selector for %s', (endpoint) => {
+    expect(
+      resolveModelSpecReasoning({ modelSpec: createModelSpec(endpoint, 'model'), endpoint }),
+    ).toBeUndefined();
+  });
+
+  it('only creates provider overrides advertised by the setting', () => {
+    const setting = resolveModelSpecReasoning({
+      modelSpec: createModelSpec(EModelEndpoint.openAI, 'o3', [ReasoningEffort.low]),
+      endpoint: EModelEndpoint.openAI,
+    });
+
+    expect(createModelSpecReasoningOverride(setting!, ReasoningEffort.low)).toEqual({
+      reasoning_effort: ReasoningEffort.low,
+    });
+    expect(createModelSpecReasoningOverride(setting!, ReasoningEffort.high)).toBeUndefined();
+  });
+});

--- a/packages/data-provider/src/reasoning.ts
+++ b/packages/data-provider/src/reasoning.ts
@@ -1,0 +1,250 @@
+import type { SettingDefinition } from './generate';
+import type { TConversation } from './schemas';
+import type { TModelSpec } from './models';
+import {
+  AnthropicEffort,
+  EModelEndpoint,
+  ReasoningEffort,
+  ThinkingLevel,
+  getSettingsKeys,
+  isAgentsEndpoint,
+  isAssistantsEndpoint,
+} from './schemas';
+import { supportsAdaptiveThinking } from './bedrock';
+import { paramSettings } from './parameterSettings';
+
+export type ReasoningParameterKey =
+  | 'reasoning_effort'
+  | 'effort'
+  | 'thinkingLevel'
+  | 'thinkingBudget';
+
+const reasoningParameterKeys: readonly ReasoningParameterKey[] = [
+  'reasoning_effort',
+  'effort',
+  'thinkingLevel',
+  'thinkingBudget',
+];
+
+export type ModelSpecReasoningValue = string | number;
+export type ModelSpecReasoningValues = Partial<Pick<TConversation, ReasoningParameterKey>>;
+
+export type ModelSpecReasoningSetting = {
+  key: ReasoningParameterKey;
+  options: ModelSpecReasoningValue[];
+  defaultValue?: ModelSpecReasoningValue;
+  enumMappings?: Record<string, number | boolean | string>;
+};
+
+type ResolveModelSpecReasoningParams = {
+  modelSpec?: TModelSpec;
+  endpoint?: string | null;
+  endpointType?: string | null;
+  defaultParamsEndpoint?: string | null;
+  paramDefinitions?: Partial<SettingDefinition>[];
+};
+
+const reasoningEfforts = new Set<string>(Object.values(ReasoningEffort));
+const anthropicEfforts = new Set<string>(Object.values(AnthropicEffort));
+const thinkingLevels = new Set<string>(Object.values(ThinkingLevel));
+const nativeReasoningEndpoints = new Set<string>([
+  EModelEndpoint.openAI,
+  EModelEndpoint.azureOpenAI,
+  EModelEndpoint.anthropic,
+  EModelEndpoint.google,
+  EModelEndpoint.bedrock,
+]);
+
+export function supportsGoogleThinkingLevel(model: string): boolean {
+  return /gemini-([3-9]|\d{2,})|gemma-([4-9]|\d{2,})/i.test(model);
+}
+
+function isValidReasoningValue(
+  key: ReasoningParameterKey,
+  value: unknown,
+): value is ModelSpecReasoningValue {
+  if (key === 'thinkingBudget') {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+  if (typeof value !== 'string') {
+    return false;
+  }
+  if (key === 'reasoning_effort') {
+    return reasoningEfforts.has(value);
+  }
+  if (key === 'effort') {
+    return anthropicEfforts.has(value);
+  }
+  return thinkingLevels.has(value);
+}
+
+function getPreferredReasoningKey(
+  endpoint: string | undefined,
+  model: string,
+): ReasoningParameterKey | undefined {
+  if (endpoint === EModelEndpoint.bedrock) {
+    return undefined;
+  }
+  if (endpoint === EModelEndpoint.anthropic) {
+    return supportsAdaptiveThinking(model) ? 'effort' : 'thinkingBudget';
+  }
+  if (endpoint === EModelEndpoint.google) {
+    return supportsGoogleThinkingLevel(model) ? 'thinkingLevel' : 'thinkingBudget';
+  }
+  return 'reasoning_effort';
+}
+
+function resolveReasoningKey({
+  modelSpec,
+  endpoint,
+  paramEndpoint,
+  paramDefinitions,
+}: {
+  modelSpec: TModelSpec;
+  endpoint?: string;
+  paramEndpoint?: string;
+  paramDefinitions?: Partial<SettingDefinition>[];
+}): ReasoningParameterKey | undefined {
+  const preferredKey = getPreferredReasoningKey(paramEndpoint, modelSpec.preset.model ?? '');
+  if (!preferredKey) {
+    return undefined;
+  }
+
+  if (endpoint && nativeReasoningEndpoints.has(endpoint)) {
+    return preferredKey;
+  }
+
+  const configuredKeys = reasoningParameterKeys.filter((key) => modelSpec.preset[key] != null);
+  const definedKeys = reasoningParameterKeys.filter((key) =>
+    paramDefinitions?.some((definition) => definition.key === key),
+  );
+  const explicitKeys = configuredKeys.length > 0 ? configuredKeys : definedKeys;
+  if (explicitKeys.includes(preferredKey) || explicitKeys.length !== 1) {
+    return preferredKey;
+  }
+  return explicitKeys[0];
+}
+
+/** Resolves the single provider parameter represented by a model spec's composer selector. */
+export function resolveModelSpecReasoning({
+  modelSpec,
+  endpoint,
+  endpointType,
+  defaultParamsEndpoint,
+  paramDefinitions,
+}: ResolveModelSpecReasoningParams): ModelSpecReasoningSetting | undefined {
+  const targetEndpoint = endpoint ?? modelSpec?.preset.endpoint;
+  if (
+    !modelSpec?.reasoning ||
+    isAgentsEndpoint(targetEndpoint) ||
+    isAssistantsEndpoint(targetEndpoint)
+  ) {
+    return undefined;
+  }
+
+  const paramEndpoint =
+    targetEndpoint && nativeReasoningEndpoints.has(targetEndpoint)
+      ? targetEndpoint
+      : (defaultParamsEndpoint ?? endpointType ?? targetEndpoint ?? undefined);
+  const key = resolveReasoningKey({
+    modelSpec,
+    endpoint: targetEndpoint ?? undefined,
+    paramEndpoint,
+    paramDefinitions,
+  });
+  if (!key || !paramEndpoint) {
+    return undefined;
+  }
+
+  const [combinedKey, endpointKey] = getSettingsKeys(paramEndpoint, modelSpec.preset.model ?? '');
+  const definitions = paramSettings[combinedKey] ?? paramSettings[endpointKey] ?? [];
+  const baseDefinition = definitions.find((definition) => definition.key === key);
+  const customDefinition = paramDefinitions?.find((definition) => definition.key === key);
+  const configuredOptions = Array.isArray(modelSpec.reasoning) ? modelSpec.reasoning : undefined;
+  const rawOptions = configuredOptions ?? customDefinition?.options ?? baseDefinition?.options;
+  const range = customDefinition?.range ?? baseDefinition?.range;
+  if (!rawOptions) {
+    return undefined;
+  }
+
+  const options = rawOptions.reduce<ModelSpecReasoningValue[]>((result, value) => {
+    const isOutOfRange =
+      key === 'thinkingBudget' &&
+      typeof value === 'number' &&
+      range != null &&
+      (value < range.min || value > range.max);
+    if (
+      isValidReasoningValue(key, value) &&
+      !isOutOfRange &&
+      !result.some((existingValue) => Object.is(existingValue, value))
+    ) {
+      result.push(value);
+    }
+    return result;
+  }, []);
+  if (options.length === 0) {
+    return undefined;
+  }
+
+  const presetDefault = modelSpec.preset[key];
+  const configuredDefault = customDefinition?.default ?? baseDefinition?.default;
+  let defaultValue: ModelSpecReasoningValue | undefined;
+  if (isValidReasoningValue(key, presetDefault)) {
+    defaultValue = presetDefault;
+  } else if (isValidReasoningValue(key, configuredDefault)) {
+    defaultValue = configuredDefault;
+  }
+
+  return {
+    key,
+    options,
+    defaultValue,
+    enumMappings: {
+      ...baseDefinition?.enumMappings,
+      ...customDefinition?.enumMappings,
+    },
+  };
+}
+
+export function getModelSpecReasoningValue(
+  setting: ModelSpecReasoningSetting,
+  values?: ModelSpecReasoningValues | null,
+): ModelSpecReasoningValue {
+  const currentValue = values?.[setting.key];
+  if (
+    (typeof currentValue === 'string' || typeof currentValue === 'number') &&
+    setting.options.some((option) => Object.is(option, currentValue))
+  ) {
+    return currentValue;
+  }
+  if (
+    (typeof setting.defaultValue === 'string' || typeof setting.defaultValue === 'number') &&
+    setting.options.some((option) => Object.is(option, setting.defaultValue))
+  ) {
+    return setting.defaultValue;
+  }
+  return setting.options[0];
+}
+
+/** Creates a provider-native override only when the value is one of the advertised options. */
+export function createModelSpecReasoningOverride(
+  setting: ModelSpecReasoningSetting,
+  value: unknown,
+): ModelSpecReasoningValues | undefined {
+  if (!setting.options.some((option) => Object.is(option, value))) {
+    return undefined;
+  }
+  if (setting.key === 'thinkingBudget' && typeof value === 'number') {
+    return { thinkingBudget: value };
+  }
+  if (setting.key === 'reasoning_effort' && typeof value === 'string') {
+    return { reasoning_effort: value as ReasoningEffort };
+  }
+  if (setting.key === 'effort' && typeof value === 'string') {
+    return { effort: value as AnthropicEffort };
+  }
+  if (setting.key === 'thinkingLevel' && typeof value === 'string') {
+    return { thinkingLevel: value as ThinkingLevel };
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Adds an opt-in reasoning selector for model specs in the chat composer, positioned before the context, microphone, and send controls.

Model specs can use:

- `reasoning: true` to expose LibreChat's existing provider-defined options.
- `reasoning: [...]` to restrict categorical options or define numeric thinking budgets.

The selector maps to the provider-native parameter for OpenAI/Azure OpenAI, Anthropic, Google, and compatible custom endpoints. Selected values are persisted per conversation, validated server-side, and supported when model-spec enforcement is enabled.

When `reasoning` is omitted or set to `false`, existing UI and request behavior remain unchanged. Agents and Assistants are intentionally excluded.

Related discussion: #14286 .

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Built `librechat-data-provider` and `@librechat/api`.
- Passed client TypeScript validation.
- Passed focused shared, API, Google adapter, and composer tests.
- Passed ESLint, Prettier, import-order, and diff checks.
- [x] Docker build and manual provider verification. (Verified azureOpenAI, google with old thinkingBudget and new gemini models with Auto, Minimal, Low, Medium, and High)

### Manual test

1. Add `reasoning: true` to a model spec.
2. Select that model spec and verify the reasoning dropdown appears.
3. Change the level and verify it is retained for subsequent messages.
4. Verify model specs without `reasoning` show no dropdown.

## Checklist

- [x] Code follows the project style and workspace conventions.
- [x] Self-review completed.
- [x] Example configuration updated.
- [x] Tests added for the new behavior.
- [x] No new lint or type warnings introduced.

## Disclosure
 Full disclosure, if not apparent, AI coding tools were used to generate this PR as js & ts is not my main programming Language. If something should be reviews I'd be happy to personally review it or if this should be implemented in a different way that would be alright, perhaps I can help with that! I just wanted this PR as reference for the discussion I opened regarding the feature.