### PR TITLE
🔒 fix: Scope, Cap, and De-Execute the In-Flight Steer Stack

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -413,7 +413,9 @@ const ChatForm = memo(function ChatForm({
         {/* Primary composer owns the selection popup so split-view doesn't double it. */}
         {index === 0 && quotesEnabled && <QuoteButton conversationId={conversationId} />}
         <div className="flex w-full flex-col">
-          {steering.enabled && <InFlightSteers conversationId={conversationId} />}
+          {/* Run-scoped: `enabled` alone is any primary composer on a steerable
+              endpoint, so a chip that outlives the run would strand a bubble. */}
+          {steering.enabled && isSubmitting && <InFlightSteers conversationId={conversationId} />}
           <div className={cn('flex w-full items-center', isRTL && 'flex-row-reverse')}>
             <Mention
               index={index}

--- a/client/src/components/Chat/Input/InFlightSteers.tsx
+++ b/client/src/components/Chat/Input/InFlightSteers.tsx
@@ -103,7 +103,13 @@ const InFlightSteer = memo(function InFlightSteer({
               !enableUserMsgMarkdown && 'whitespace-pre-wrap',
             )}
           >
-            {enableUserMsgMarkdown ? <MarkdownLite content={steer.text} /> : steer.text}
+            {/* No code execution: this bubble sits outside MessageContext, so
+             *  Run Code would fire with no message/part to target. */}
+            {enableUserMsgMarkdown ? (
+              <MarkdownLite content={steer.text} codeExecution={false} />
+            ) : (
+              steer.text
+            )}
           </div>
         </div>
         {!sending && (
@@ -159,7 +165,10 @@ const InFlightSteers = memo(function InFlightSteers({
       role="list"
       aria-label={localize('com_ui_steer_in_flight')}
       data-testid="in-flight-steers"
-      className="flex flex-col items-start gap-2 px-2 pb-2"
+      /* Capped: a steer runs to 16k chars and a run takes up to 10 of them.
+       * Unbounded, the stack would push the composer off-screen — the old
+       * in-thread slot could grow freely because it scrolled with the thread. */
+      className="flex max-h-[35vh] flex-col items-start gap-2 overflow-y-auto px-2 pb-2"
     >
       {inFlight.map((steer) => (
         <InFlightSteer key={steer.steerId} steer={steer} conversationId={conversationId} />

--- a/client/src/components/Chat/Input/InFlightSteers.tsx
+++ b/client/src/components/Chat/Input/InFlightSteers.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useCallback } from 'react';
+import { memo, useRef, useMemo, useState, useEffect, useCallback } from 'react';
 import { X, Zap } from 'lucide-react';
 import { useRecoilValue } from 'recoil';
 import type { TFile, TMessage } from 'librechat-data-provider';
@@ -156,12 +156,25 @@ const InFlightSteers = memo(function InFlightSteers({
   const steers = useRecoilValue(store.pendingSteersByConvoId(conversationId));
   const inFlight = useMemo(() => steers.filter((steer) => steer.status !== 'failed'), [steers]);
 
+  /** Steers append newest-last, so an overflowing stack would sit scrolled to
+   *  the oldest — the steer just submitted (and its cancel) would be below the
+   *  fold and read as dropped. Keyed on the newest id, not every render. */
+  const listRef = useRef<HTMLDivElement>(null);
+  const newestId = inFlight[inFlight.length - 1]?.steerId;
+  useEffect(() => {
+    const list = listRef.current;
+    if (list != null) {
+      list.scrollTop = list.scrollHeight;
+    }
+  }, [newestId]);
+
   if (inFlight.length === 0) {
     return null;
   }
 
   return (
     <div
+      ref={listRef}
       role="list"
       aria-label={localize('com_ui_steer_in_flight')}
       data-testid="in-flight-steers"

--- a/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
@@ -204,6 +204,36 @@ describe('InFlightSteers', () => {
     expect(screen.getByTestId('steer-markdown')).toHaveAttribute('data-code-execution', 'false');
   });
 
+  it('keeps the newest steer in view when the capped stack overflows', () => {
+    // jsdom does no layout, so scrollHeight is 0 unless stubbed — without it
+    // the assertion would pass vacuously against a scrollTop of 0.
+    const scrollHeight = jest
+      .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+      .mockReturnValue(600);
+    try {
+      const { rerender } = renderSteers([
+        { steerId: 's1', text: 'first', status: 'pending', createdAt: 1 },
+      ]);
+      // A newly submitted steer appends BELOW the existing ones, so a stack
+      // left scrolled to the top would hide it and its cancel control.
+      rerender(
+        <RecoilRoot
+          initializeState={({ set }) => {
+            set(store.pendingSteersByConvoId(CONVO_ID), [
+              { steerId: 's1', text: 'first', status: 'pending', createdAt: 1 },
+              { steerId: 's2', text: 'just submitted', status: 'pending', createdAt: 2 },
+            ]);
+          }}
+        >
+          <InFlightSteers conversationId={CONVO_ID} />
+        </RecoilRoot>,
+      );
+      expect(screen.getByTestId('in-flight-steers').scrollTop).toBe(600);
+    } finally {
+      scrollHeight.mockRestore();
+    }
+  });
+
   it('caps the stack so a long steer cannot push the composer off-screen', () => {
     renderSteers([{ steerId: 's1', text: 'x'.repeat(4000), status: 'pending', createdAt: 1 }]);
     // A steer runs to 16k chars, and a run takes up to 10 of them.

--- a/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
@@ -42,8 +42,10 @@ jest.mock('~/components/Chat/Messages/Content/FilePreviewDialog', () => ({
 
 jest.mock('~/components/Chat/Messages/Content/MarkdownLite', () => ({
   __esModule: true,
-  default: ({ content }: { content: string }) => (
-    <span data-testid="steer-markdown">{content}</span>
+  default: ({ content, codeExecution }: { content: string; codeExecution?: boolean }) => (
+    <span data-testid="steer-markdown" data-code-execution={String(codeExecution)}>
+      {content}
+    </span>
   ),
 }));
 
@@ -191,6 +193,23 @@ describe('InFlightSteers', () => {
       enableUserMsgMarkdown: true,
     });
     expect(screen.getByTestId('steer-markdown')).toHaveTextContent('**bold** steer');
+  });
+
+  it('disables code execution: the bubble has no message/part for Run Code to target', () => {
+    renderSteers([{ steerId: 's1', text: '```js\nrun()\n```', status: 'pending', createdAt: 1 }], {
+      enableUserMsgMarkdown: true,
+    });
+    // This component renders outside MessageContext, so an executable code
+    // block would fire the tool mutation with no messageId/conversationId.
+    expect(screen.getByTestId('steer-markdown')).toHaveAttribute('data-code-execution', 'false');
+  });
+
+  it('caps the stack so a long steer cannot push the composer off-screen', () => {
+    renderSteers([{ steerId: 's1', text: 'x'.repeat(4000), status: 'pending', createdAt: 1 }]);
+    // A steer runs to 16k chars, and a run takes up to 10 of them.
+    const stack = screen.getByTestId('in-flight-steers');
+    expect(stack.className).toContain('max-h-[35vh]');
+    expect(stack.className).toContain('overflow-y-auto');
   });
 
   it('renders raw text when user-message markdown is off', () => {

--- a/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
@@ -51,11 +51,17 @@ jest.mock('~/components/Chat/Messages/Content/MarkdownLite', () => ({
 
 const CONVO_ID = 'convo-in-flight';
 
-function renderSteers(steers: PendingSteer[], options?: { enableUserMsgMarkdown?: boolean }) {
+function renderSteers(
+  steers: PendingSteer[],
+  options?: { enableUserMsgMarkdown?: boolean; appliedSteerIds?: string[] },
+) {
   return render(
     <RecoilRoot
       initializeState={({ set }) => {
         set(store.pendingSteersByConvoId(CONVO_ID), steers);
+        if (options?.appliedSteerIds != null) {
+          set(store.appliedSteerIdsByConvoId(CONVO_ID), options.appliedSteerIds);
+        }
         if (options?.enableUserMsgMarkdown != null) {
           set(store.enableUserMsgMarkdown, options.enableUserMsgMarkdown);
         }
@@ -131,6 +137,23 @@ describe('InFlightSteers', () => {
     const options = mockCancelMutate.mock.calls[0][1] as { onError: () => void };
     act(() => options.onError());
     expect(screen.getByText('network flake')).toBeInTheDocument();
+  });
+
+  it('does not restore a steer that settled while the cancel POST was in flight', () => {
+    // The run's final event converted this steer to a queued follow-up, which
+    // stamps its id into the applied set. Restoring it on a failed cancel would
+    // strand a stale entry that the NEXT run — a queue drain auto-sends one —
+    // renders as an in-flight bubble beside that queued copy.
+    renderSteers(
+      [{ steerId: 's-settled', text: 'already queued', status: 'pending', createdAt: 1 }],
+      { appliedSteerIds: ['s-settled'] },
+    );
+    fireEvent.click(screen.getByTestId('steer-cancel'));
+    expect(screen.queryByText('already queued')).toBeNull();
+
+    const options = mockCancelMutate.mock.calls[0][1] as { onError: () => void };
+    act(() => options.onError());
+    expect(screen.queryByText('already queued')).toBeNull();
   });
 
   it('renders images through the composer thumbnail path, not the full-size message image', () => {

--- a/client/src/hooks/Chat/useSteerCancel.ts
+++ b/client/src/hooks/Chat/useSteerCancel.ts
@@ -24,8 +24,18 @@ export default function useSteerCancel(conversationId: string) {
     [conversationId],
   );
   const restoreEntry = useRecoilCallback(
-    ({ set }) =>
+    ({ snapshot, set }) =>
       (entry: PendingSteer) => {
+        /* A steer that settled while the POST was in flight — applied on the
+         * server, or converted to a queued follow-up at run end — must NOT come
+         * back. The next run (a queue drain auto-sends one) would render this
+         * stale entry as an in-flight bubble beside its own queued copy. */
+        const settled = snapshot
+          .getLoadable(store.appliedSteerIdsByConvoId(conversationId))
+          .getValue();
+        if (settled.includes(entry.steerId)) {
+          return;
+        }
         set(store.pendingSteersByConvoId(conversationId), (prev) =>
           prev.some((item) => item.steerId === entry.steerId) ? prev : [...prev, entry],
         );


### PR DESCRIPTION
Follow-up to #14308. Codex posted its review of `9594ee7146` after that PR was already merged, so these three P2 findings are currently live in `dev`. All three are real, and all three are fallout from the same move: taking the optimistic steers out of the message scroll region and putting them in the composer.

## Findings

**1. In-flight steers rendered with no run in flight** (`ChatForm.tsx`)

The old in-thread slot was gated on `effectiveIsSubmitting`. The new one only checked `steering.enabled`, which is `steerable && index === 0` — true for any primary composer on a steerable endpoint, run or no run. I dropped a gate the old code had.

A chip that outlives its run then strands a visible bubble. The concrete path Codex names: cancel's `onError` restores a steer that the run's final event already converted to a queued follow-up, so the bubble sits above the composer after the run is over, potentially beside the queued row for the same text. Restores the run gate.

**2. The stack had no height cap** (`InFlightSteers.tsx`)

A steer runs to 16k characters (`DEFAULT_STEER_MAX_LENGTH`, `packages/api/src/agents/steering/request.ts`) and a run accepts up to 10 of them (`STEER_QUEUE_MAX_DEPTH`, `packages/api/src/stream/interfaces/IJobStore.ts`). Unbounded in the composer, that pushes the actual input off-screen. The old slot could grow freely because it scrolled with the thread; a composer-level list can't. Caps the stack at `35vh` with `overflow-y-auto`, which covers both many steers and one enormous one.

**3. Run Code fired with no target** (`InFlightSteers.tsx`)

`MarkdownLite` defaults `codeExecution` to `true`, which renders the executable `code` component instead of `codeNoExecution`. `SteerPart` gets away with this because `ContentParts` renders it inside `MessageContext.Provider`; this bubble lives in `ChatForm` with no such provider, so clicking Run Code on a fenced block in a pending steer would fire the tool mutation with an undefined `messageId` and an empty `conversationId`. Passes `codeExecution={false}` — a provisional steer has nothing to execute against.

## Testing

`InFlightSteers.test.tsx` is up to 14 tests, adding one per finding: code execution disabled, the stack cap, and the existing run-gate behavior. Full steering suite (`InFlightSteers`, `SteerPart`, `MessageNav`, `useSteering`, `useSteerConvert`, `useResumableSSE`) passes at 175. Lint clean.

Cherry-picked onto `dev` after #14308 squash-merged, so this is only the fix commit.