### PR TITLE
📱 fix: Don't Connect the Favorites Drag Source on Touch Pointers

### DIFF
--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -2,9 +2,9 @@ import React, { useRef, useCallback, useMemo, useEffect, memo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LayoutGrid } from 'lucide-react';
 import { useDrag, useDrop } from 'react-dnd';
-import { Skeleton } from '@librechat/client';
 import { useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
+import { Skeleton, useMediaQuery } from '@librechat/client';
 import { QueryKeys, EModelEndpoint, dataService } from 'librechat-data-provider';
 import type { Agent, TEndpointsConfig, TModelSpec } from 'librechat-data-provider';
 import {
@@ -63,6 +63,13 @@ const DraggableFavoriteItem = ({
   children,
 }: DraggableFavoriteItemProps) => {
   const ref = useRef<HTMLDivElement>(null);
+  /**
+   * HTML5 drag needs a hover-capable pointer. Connecting the drag source on touch would
+   * stamp `draggable="true"` on this wrapper, and iOS Safari hands a touch on a draggable
+   * element to the drag recognizer instead of synthesizing a click, so the row underneath
+   * only selects on the second tap.
+   */
+  const canDrag = useMediaQuery('(hover: hover)');
   const [{ handlerId }, drop] = useDrop<{ index: number; id: string }, unknown, { handlerId: any }>(
     {
       accept: 'favorite-item',
@@ -118,7 +125,8 @@ const DraggableFavoriteItem = ({
   });
 
   const opacity = isDragging ? 0 : 1;
-  drag(drop(ref));
+  drop(ref);
+  drag(canDrag ? ref : null);
 
   return (
     <div ref={ref} style={{ opacity }} data-handler-id={handlerId}>

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -526,4 +526,44 @@ describe('FavoritesList', () => {
       expect(types).toEqual(['agent', 'model', 'spec']);
     });
   });
+
+  describe('drag source by pointer capability', () => {
+    const mockHover = (hasHover: boolean) => {
+      (window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+        matches: query === '(hover: hover)' ? hasHover : false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+    };
+
+    const renderFavoriteWrapper = async () => {
+      mockFavorites.push({ model: 'gpt-5', endpoint: 'openai' });
+      const { findByTestId } = renderWithProviders(<FavoritesList />);
+      const item = await findByTestId('favorite-item');
+      return item.closest('[data-handler-id]');
+    };
+
+    it('connects the drag source on a hover-capable pointer', async () => {
+      mockHover(true);
+
+      const wrapper = await renderFavoriteWrapper();
+
+      await waitFor(() => expect(wrapper).toHaveAttribute('draggable', 'true'));
+    });
+
+    it('leaves the row undraggable on touch so the first tap selects it', async () => {
+      mockHover(false);
+
+      const wrapper = await renderFavoriteWrapper();
+
+      /** iOS Safari gives a touch on a draggable element to the drag recognizer
+       * instead of synthesizing a click, costing the row its first tap. */
+      expect(wrapper).not.toHaveAttribute('draggable', 'true');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #14272. That PR gated the hover-revealed "⋯" button on hover capability, but **pinned agents in the sidebar still take two taps on iOS**. The hover reveal was the wrong mechanism for this list.

Every favorite row is wrapped by `DraggableFavoriteItem`, and react-dnd's `HTML5Backend` stamps `draggable="true"` on that wrapper unconditionally:

```js
// react-dnd-html5-backend/dist/HTML5BackendImpl.js:101
connectDragSource(sourceId, node, options) {
    node.setAttribute('draggable', 'true');
```

`canDrag: false` would not suppress it either — the attribute is set regardless of the spec ([react-dnd#2909](https://github.com/react-dnd/react-dnd/issues/2909)). iOS Safari hands a touch on a `draggable` element to the drag recognizer rather than synthesizing a click, so the row underneath only selects on the second tap ([the same behavior react-beautiful-dnd hit](https://github.com/atlassian/react-beautiful-dnd/issues/1367)).

**Why the draggable wrapper and not the hover reveal:** it is the one thing that separates favorites from every other row in the sidebar. Conversation rows are *more* hover-dependent than favorites ever were — an ungated `opacity-0 group-hover:opacity-100` plus an `onMouseEnter` that mounts `ConvoOptions` into the DOM ([Convo.tsx:198](https://github.com/danny-avila/LibreChat/blob/dev/client/src/components/Conversations/Convo.tsx#L198)) — and they select on the first tap.

The fix connects the drag source only under `(hover: hover)`. Nothing is lost on touch: `HTML5Backend` has no touch support, so drag-to-reorder never worked there to begin with. Passing `null` to the connector unsubscribes cleanly and resets the attribute, so a hybrid pointer that flips the query re-arms drag without a remount.

#14272's CSS gate is left in place — it is correct for the model menu, and harmless here.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Two tests added to `FavoritesList.spec.tsx`, driving the real `HTML5Backend` through a real `DndProvider` and asserting the attribute the backend actually writes:

- `(hover: hover)` matches → wrapper gets `draggable="true"` (reorder still armed on desktop)
- no hover capability → wrapper is not draggable (first tap selects)

The touch test fails on the pre-fix `drag(drop(ref))` and passes after, so it guards the regression rather than restating the implementation. Full `Nav/Favorites` suite green (31 tests); ESLint and import order clean.

Caveat worth stating plainly: the iOS behavior itself lives in WebKit's iOS-only `ContentChangeObserver`/drag recognizer, which Playwright's WebKit build does not reproduce, so **the single-tap outcome still wants one confirmation on a real device**. The reasoning above is what the code and the attribute make verifiable from here.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings