### PR TITLE
 chore: add label for token usage totals to context meter

### DIFF
--- a/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
+++ b/client/src/components/Chat/Input/TokenUsage/Breakdown.tsx
@@ -180,6 +180,9 @@ export default function Breakdown({ view, showCost, currency }: BreakdownProps) 
         <>
           <div className="border-t border-border-light" role="separator" />
           <div className="space-y-1.5" data-testid="token-usage-totals">
+            <span className="text-sm font-semibold text-text-primary">
+              {localize('com_ui_last_prompt_and_reply')}
+            </span>
             <Row label={localize('com_ui_input')} value={branchUsage.input} />
             <Row label={localize('com_ui_output')} value={branchUsage.output} />
             {branchUsage.cacheRead > 0 && (

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1303,6 +1303,7 @@
   "com_ui_key": "Key",
   "com_ui_key_required": "API key is required",
   "com_ui_labels": "Labels",
+  "com_ui_last_prompt_and_reply": "Last prompt and reply",
   "com_ui_late_night": "Happy late night",
   "com_ui_latest": "latest",
   "com_ui_latest_activity": "Latest activity",


### PR DESCRIPTION
## Summary
Add a label for token usage totals to the context meter to improve clarity of token usage information.

## Change Type
- [x] UI/UX Improvement 

## Testing
- Manually verified the new label appear correctly in the UI.
- No functional changes.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes