### PR TITLE
🖼️ feat: Auto-Prime Conversation Images Into Code Environment

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -37,6 +37,7 @@ const {
   getDefaultHandlers,
 } = require('~/server/controllers/agents/callbacks');
 const { loadAgentTools, loadToolsForExecution } = require('~/server/services/ToolService');
+const { primeConversationImages } = require('~/server/services/Files/Code/primeImages');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const {
   getSkillToolDeps,
@@ -471,6 +472,16 @@ const initializeClient = async ({ req, res, signal, endpointOption, jobCreatedAt
       getUserCodeFiles: db.getUserCodeFiles,
       getToolFilesByIds: db.getToolFilesByIds,
       getCodeGeneratedFiles: db.getCodeGeneratedFiles,
+      /* Auto-prime conversation images (MCP tool results, etc.) into the code
+       * environment — see primeConversationImages: getFiles/updateFile are
+       * closed over here so packages/api doesn't depend on models directly. */
+      primeConversationImages: ({ req: primeReq, threadFileIds }) =>
+        primeConversationImages({
+          req: primeReq,
+          threadFileIds,
+          getFiles: db.getFiles,
+          updateFile: db.updateFile,
+        }),
       filterFilesByAgentAccess,
       listSkillsByAccess: skillDbMethods.listSkillsByAccess,
       listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,

--- a/api/server/services/Files/Code/primeImages.js
+++ b/api/server/services/Files/Code/primeImages.js
@@ -1,0 +1,151 @@
+const { logger } = require('@librechat/data-schemas');
+const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { batchUploadCodeEnvFiles } = require('~/server/services/Files/Code/crud');
+
+/**
+ * Maximum number of conversation images primed into the code environment per
+ * run. Report-style skills use a handful of images; the cap protects against
+ * conversations where tools produced dozens of them (e.g. batch detection).
+ */
+const DEFAULT_IMAGE_LIMIT = 8;
+
+/**
+ * Prime the current thread's images (MCP tool results, assistant
+ * attachments) into the code environment so code/skills can access them
+ * in the sandbox WITHOUT the user manually re-uploading them via
+ * "Upload to Code Environment".
+ *
+ * Only runs when Run Code is enabled (invoked behind the execute_code
+ * gate in initialize.js). Idempotent: once a file has
+ * `metadata.codeEnvRef` set, the `$exists:false` filter excludes it and
+ * the regular `getUserCodeFiles` path picks it up on subsequent turns —
+ * no repeated uploads.
+ *
+ * Files that already have a `codeEnvRef` (manual uploads, code outputs)
+ * are untouched — the existing pipeline carries those; this only handles
+ * "orphan" image attachments that have no ref yet.
+ *
+ * @param {object} params
+ * @param {import('express').Request & { user: { id: string } }} params.req
+ * @param {string[]} params.threadFileIds - file_ids referenced by messages in the thread.
+ * @param {(filter: object, sort: object|null, select: object) => Promise<Array>} params.getFiles
+ * @param {(data: object) => Promise<object|null>} params.updateFile
+ * @param {number} [params.limit=DEFAULT_IMAGE_LIMIT]
+ * @returns {Promise<Array>} updated file documents with codeEnvRef set
+ *   (empty array when there is nothing to prime or all uploads failed).
+ */
+async function primeConversationImages({
+  req,
+  threadFileIds,
+  getFiles,
+  updateFile,
+  limit = DEFAULT_IMAGE_LIMIT,
+}) {
+  const userId = req?.user?.id;
+  if (!userId || !Array.isArray(threadFileIds) || threadFileIds.length === 0) {
+    return [];
+  }
+
+  let candidates;
+  try {
+    candidates = await getFiles(
+      {
+        file_id: { $in: threadFileIds },
+        type: { $regex: '^image/' },
+        'metadata.codeEnvRef': { $exists: false },
+      },
+      { createdAt: -1 },
+      { text: 0 },
+    );
+  } catch (error) {
+    logger.error('[primeConversationImages] getFiles failed:', error);
+    return [];
+  }
+  if (!candidates || candidates.length === 0) {
+    return [];
+  }
+
+  const capped = candidates.slice(0, limit);
+  if (candidates.length > capped.length) {
+    logger.debug(
+      `[primeConversationImages] capped ${candidates.length} -> ${capped.length} (limit=${limit})`,
+    );
+  }
+
+  /* Open streams from storage. Sandbox name = file_id + extension:
+   * guaranteed unique (MCP image names already embed the file_id, but
+   * code-output names could collide), so matching results after the
+   * batch upload is unambiguous. */
+  const staged = [];
+  for (const file of capped) {
+    if (!file.filepath || !file.source) {
+      continue;
+    }
+    let strategy;
+    try {
+      strategy = getStrategyFunctions(file.source);
+    } catch (error) {
+      logger.warn(`[primeConversationImages] no strategy for source=${file.source}: ${error.message}`);
+      continue;
+    }
+    if (!strategy?.getDownloadStream) {
+      continue;
+    }
+    const ext = (file.type && file.type.split('/')[1]) || 'bin';
+    const sandboxName = `${file.file_id}.${ext}`;
+    try {
+      const stream = await strategy.getDownloadStream(req, file.filepath);
+      staged.push({ file, stream, filename: sandboxName });
+    } catch (error) {
+      logger.warn(`[primeConversationImages] stream failed for ${file.file_id}: ${error.message}`);
+    }
+  }
+  if (staged.length === 0) {
+    return [];
+  }
+
+  let uploaded;
+  try {
+    uploaded = await batchUploadCodeEnvFiles({
+      req,
+      files: staged.map((s) => ({ stream: s.stream, filename: s.filename })),
+      kind: 'user',
+      id: userId,
+    });
+  } catch (error) {
+    logger.error('[primeConversationImages] batch upload failed:', error);
+    return [];
+  }
+
+  const byName = new Map((uploaded.files || []).map((f) => [f.filename, f.fileId]));
+  const primed = [];
+  for (const s of staged) {
+    const fileId = byName.get(s.filename);
+    if (!fileId) {
+      continue;
+    }
+    const codeEnvRef = {
+      kind: 'user',
+      id: userId,
+      storage_session_id: uploaded.storage_session_id,
+      file_id: fileId,
+    };
+    const metadata = { ...(s.file.metadata || {}), codeEnvRef };
+    try {
+      await updateFile({ file_id: s.file.file_id, metadata });
+    } catch (error) {
+      logger.warn(`[primeConversationImages] updateFile failed for ${s.file.file_id}: ${error.message}`);
+      continue;
+    }
+    primed.push({ ...(s.file.toObject ? s.file.toObject() : s.file), metadata });
+  }
+
+  if (primed.length > 0) {
+    logger.debug(
+      `[primeConversationImages] primed ${primed.length} image(s) into code env (session=${uploaded.storage_session_id})`,
+    );
+  }
+  return primed;
+}
+
+module.exports = { primeConversationImages, DEFAULT_IMAGE_LIMIT };

--- a/api/server/services/Files/Code/primeImages.spec.js
+++ b/api/server/services/Files/Code/primeImages.spec.js
@@ -1,0 +1,197 @@
+const { Readable } = require('stream');
+
+jest.mock('~/server/services/Files/strategies', () => ({
+  getStrategyFunctions: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/Code/crud', () => ({
+  batchUploadCodeEnvFiles: jest.fn(),
+}));
+
+const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { batchUploadCodeEnvFiles } = require('~/server/services/Files/Code/crud');
+const {
+  primeConversationImages,
+  DEFAULT_IMAGE_LIMIT,
+} = require('~/server/services/Files/Code/primeImages');
+
+const makeReq = (userId = 'user-1') => ({ user: { id: userId } });
+
+const makeFile = (overrides = {}) => ({
+  file_id: 'file-1',
+  type: 'image/jpeg',
+  filepath: '/uploads/user-1/file-1.jpeg',
+  source: 'local',
+  metadata: {},
+  ...overrides,
+});
+
+describe('primeConversationImages', () => {
+  let getFiles;
+  let updateFile;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getFiles = jest.fn();
+    updateFile = jest.fn().mockResolvedValue({});
+    getStrategyFunctions.mockReturnValue({
+      getDownloadStream: jest.fn().mockResolvedValue(Readable.from(['bytes'])),
+    });
+    batchUploadCodeEnvFiles.mockResolvedValue({
+      storage_session_id: 'session-abc',
+      files: [{ filename: 'file-1.jpeg', fileId: 'code-env-id-1' }],
+    });
+  });
+
+  it('returns [] without touching the DB when there are no thread files', async () => {
+    const result = await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: [],
+      getFiles,
+      updateFile,
+    });
+    expect(result).toEqual([]);
+    expect(getFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when the request has no user', async () => {
+    const result = await primeConversationImages({
+      req: {},
+      threadFileIds: ['file-1'],
+      getFiles,
+      updateFile,
+    });
+    expect(result).toEqual([]);
+    expect(getFiles).not.toHaveBeenCalled();
+  });
+
+  it('queries only thread images that have no codeEnvRef yet', async () => {
+    getFiles.mockResolvedValue([]);
+    await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: ['file-1', 'file-2'],
+      getFiles,
+      updateFile,
+    });
+    expect(getFiles).toHaveBeenCalledWith(
+      {
+        file_id: { $in: ['file-1', 'file-2'] },
+        type: { $regex: '^image/' },
+        'metadata.codeEnvRef': { $exists: false },
+      },
+      { createdAt: -1 },
+      { text: 0 },
+    );
+  });
+
+  it('uploads orphan images and persists codeEnvRef in metadata', async () => {
+    getFiles.mockResolvedValue([makeFile()]);
+
+    const result = await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: ['file-1'],
+      getFiles,
+      updateFile,
+    });
+
+    expect(batchUploadCodeEnvFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'user',
+        id: 'user-1',
+        files: [expect.objectContaining({ filename: 'file-1.jpeg' })],
+      }),
+    );
+    expect(updateFile).toHaveBeenCalledWith({
+      file_id: 'file-1',
+      metadata: {
+        codeEnvRef: {
+          kind: 'user',
+          id: 'user-1',
+          storage_session_id: 'session-abc',
+          file_id: 'code-env-id-1',
+        },
+      },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].metadata.codeEnvRef.file_id).toBe('code-env-id-1');
+  });
+
+  it('caps the number of primed images at the limit', async () => {
+    const files = Array.from({ length: DEFAULT_IMAGE_LIMIT + 3 }, (_, i) =>
+      makeFile({ file_id: `file-${i}`, filepath: `/uploads/user-1/file-${i}.jpeg` }),
+    );
+    getFiles.mockResolvedValue(files);
+    batchUploadCodeEnvFiles.mockResolvedValue({
+      storage_session_id: 'session-abc',
+      files: files
+        .slice(0, DEFAULT_IMAGE_LIMIT)
+        .map((f) => ({ filename: `${f.file_id}.jpeg`, fileId: `env-${f.file_id}` })),
+    });
+
+    await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: files.map((f) => f.file_id),
+      getFiles,
+      updateFile,
+    });
+
+    const uploaded = batchUploadCodeEnvFiles.mock.calls[0][0].files;
+    expect(uploaded).toHaveLength(DEFAULT_IMAGE_LIMIT);
+  });
+
+  it('skips files whose download stream fails and continues with the rest', async () => {
+    getFiles.mockResolvedValue([
+      makeFile(),
+      makeFile({ file_id: 'file-2', filepath: '/uploads/user-1/file-2.jpeg' }),
+    ]);
+    const getDownloadStream = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('stream failed'))
+      .mockResolvedValueOnce(Readable.from(['bytes']));
+    getStrategyFunctions.mockReturnValue({ getDownloadStream });
+    batchUploadCodeEnvFiles.mockResolvedValue({
+      storage_session_id: 'session-abc',
+      files: [{ filename: 'file-2.jpeg', fileId: 'env-file-2' }],
+    });
+
+    const result = await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: ['file-1', 'file-2'],
+      getFiles,
+      updateFile,
+    });
+
+    expect(batchUploadCodeEnvFiles.mock.calls[0][0].files).toHaveLength(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].file_id).toBe('file-2');
+  });
+
+  it('returns [] and leaves metadata untouched when the batch upload fails', async () => {
+    getFiles.mockResolvedValue([makeFile()]);
+    batchUploadCodeEnvFiles.mockRejectedValue(new Error('upload failed'));
+
+    const result = await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: ['file-1'],
+      getFiles,
+      updateFile,
+    });
+
+    expect(result).toEqual([]);
+    expect(updateFile).not.toHaveBeenCalled();
+  });
+
+  it('does not return a file whose metadata update failed', async () => {
+    getFiles.mockResolvedValue([makeFile()]);
+    updateFile.mockRejectedValue(new Error('db down'));
+
+    const result = await primeConversationImages({
+      req: makeReq(),
+      threadFileIds: ['file-1'],
+      getFiles,
+      updateFile,
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -474,6 +474,15 @@ export interface InitializeAgentDbMethods extends EndpointDbMethods {
   ) => Promise<unknown[]>;
   /** Get user-uploaded execute_code files by file IDs (from message.files in thread) */
   getUserCodeFiles?: (fileIds: string[], ownerScope: FileOwnerScope) => Promise<unknown[]>;
+  /** Prime conversation image attachments (MCP tool results, assistant
+   *  attachments) into the code environment by setting their `codeEnvRef`,
+   *  so code/skills can access them in the sandbox without a manual
+   *  re-upload. Returns the updated file documents. Only invoked when
+   *  execute_code is enabled. */
+  primeConversationImages?: (params: {
+    req: unknown;
+    threadFileIds: string[];
+  }) => Promise<IMongoFile[]>;
   /** Get messages for a conversation (supports select for field projection) */
   getMessages?: (
     filter: { conversationId: string },
@@ -726,6 +735,29 @@ export async function initializeAgent(
           threadFileIds,
           requestFileOwnerScope,
         )) as IMongoFile[];
+      }
+
+      /** Conversation images (MCP tool results, assistant attachments) don't
+       *  have a `codeEnvRef` yet, so the standard lookups above can't see
+       *  them. Prime them into the code environment here, once per file:
+       *  after upload the ref is persisted in metadata, and subsequent turns
+       *  pick them up via the regular `getUserCodeFiles` path. Errors never
+       *  block the run — this is best-effort. */
+      if (db.primeConversationImages && threadFileIds && threadFileIds.length > 0) {
+        try {
+          const primedImages = await db.primeConversationImages({
+            req,
+            threadFileIds,
+          });
+          if (primedImages.length > 0) {
+            userCodeFiles = userCodeFiles.concat(primedImages);
+          }
+        } catch (error) {
+          logger.warn(
+            '[initializeAgent] primeConversationImages failed (non-blocking):',
+            error instanceof Error ? error.message : error,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

When an agent has **Run Code** enabled, images that already exist in the conversation — MCP tool results, assistant-generated attachments — are not accessible to the code interpreter: they live in the app's file storage without a `codeEnvRef`, so the code-files pipeline never uploads them. The user has to manually re-attach every image with "Upload to Code Environment", which is especially painful for skills that build documents (e.g. a pptx report from detection snapshots produced by an MCP tool earlier in the chat).

This PR adds a small, best-effort priming step that closes that gap:

- On agent initialization (behind the existing `execute_code` gate), thread files are checked for **orphan images**: `type: image/*` with no `metadata.codeEnvRef`.
- Orphans (newest first, capped at 8 per run) are streamed from their storage strategy and uploaded through the existing `batchUploadCodeEnvFiles({ kind: 'user' })` path — the exact same mechanism as a manual "Upload to Code Environment".
- The resulting `codeEnvRef` is persisted to the file's metadata, which makes the step **idempotent**: on subsequent turns the `$exists: false` filter excludes the file and the regular `getUserCodeFiles` path carries it, so nothing is uploaded twice.
- Failures are logged and never block the run (the feature is strictly additive).

No new endpoints, no schema changes, no changes to the code interpreter contract — the feature reuses the existing upload/priming infrastructure end to end. Files with an existing `codeEnvRef` (manual uploads, code outputs) are untouched.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Unit tests: `api/server/services/Files/Code/primeImages.spec.js` covers the no-op guards (no user / no thread files), the Mongo filter shape, upload + `codeEnvRef` persistence, the per-run cap, per-file stream-failure resilience, batch-upload failure, and metadata-update failure.

Manual e2e (self-hosted code interpreter): in a conversation where an MCP tool returned images as message attachments, enabling Run Code and asking the agent to run `ls /mnt/data` shows the images present in the sandbox (byte-identical to the originals) without any manual attachment; a second run does not re-upload them (`codeEnvRef` already set).

### **Test Configuration**:

- Agents endpoint with `execute_code` capability, Run Code badge enabled
- Self-hosted code interpreter via `LIBRECHAT_CODE_BASEURL`
- Images injected as message attachments (`type: image/jpeg`, `source: local`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes