### PR TITLE
feat: redirect keystrokes on chat-page to composer

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -78,11 +78,63 @@ const ChatForm = memo(function ChatForm({
   handleStopGenerating,
   stopGenerating,
 }: ChatFormProps) {
-  const submitButtonRef = useRef<HTMLButtonElement>(null);
+
+const submitButtonRef = useRef<HTMLButtonElement>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   useFocusChatEffect(textAreaRef);
-  const localize = useLocalize();
 
+  useFocusChatEffect(textAreaRef);
+
+  /* fynnelsner: redirect any printable keystroke on the chat page back to the composer
+     so the user can start typing without first clicking the textarea, like on leading web-UIs like https://chatgpt.com/ */
+  useEffect(() => {
+    const textarea = textAreaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    const focusComposerOnTyping = (event: KeyboardEvent) => {
+      // Respect existing focus in interactive elements.
+      const active = document.activeElement;
+      const tag = active?.tagName ?? '';
+      const isInteractive =
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'BUTTON' ||
+        tag === 'A' ||
+        active?.closest('button') ||
+        active?.closest('a') ||
+        active?.closest('[role="menu"]') ||
+        active?.closest('[role="dialog"]') ||
+        active?.closest('[role="listbox"]') ||
+        active?.closest('[role="combobox"]') ||
+        active?.closest('[role="option"]') ||
+        (active as HTMLElement | null)?.isContentEditable;
+
+      if (isInteractive) {
+        return;
+      }
+
+      // Only intercept actual text input, not shortcuts or navigation keys.
+      if (
+        event.key.length !== 1 ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        event.isComposing
+      ) {
+        return;
+      }
+
+      textarea.focus({ preventScroll: true });
+    };
+
+    window.addEventListener('keydown', focusComposerOnTyping);
+    return () => window.removeEventListener('keydown', focusComposerOnTyping);
+  }, []);
+
+  const localize = useLocalize();
+  
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [, setIsScrollable] = useState(false);
   const [visualRowCount, setVisualRowCount] = useState(1);


### PR DESCRIPTION
## Summary

This PR improves the chat-page UX by redirecting keystrokes to the composer/text input area. Users can now start typing immediately without needing to manually tab or click into the input field first. This makes the chat interface feel more responsive and convenient, especially for keyboard-heavy users.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Open any chat page.
2. Without clicking or tabbing into the text input, start typing.
3. Verify the typed text appears in the composer input field.
4. Confirm existing shortcuts and focus behavior still work as expected (e.g., Tab navigation, existing input focus states).

### **Test Configuration**:

- Browser: Firefox 127
- OS: Ubuntu 24.04 LTS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes