### PR TITLE
Fix configured text routing for document parser MIME types

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -798,7 +798,9 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       fileConfig.checkType(file.mimetype, fileConfig.ocr?.supportedMimeTypes || []);
 
     const shouldUseDocumentParser =
-      !shouldUseConfiguredOCR && documentParserMimeTypes.some((regex) => regex.test(file.mimetype));
+      !shouldUseConfiguredOCR &&
+      !fileConfig.checkType(file.mimetype, fileConfig.text?.supportedMimeTypes || []) &&
+      documentParserMimeTypes.some((regex) => regex.test(file.mimetype));
 
     const shouldUseOCR = shouldUseConfiguredOCR || shouldUseDocumentParser;
 

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -797,9 +797,13 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       appConfig?.ocr != null &&
       fileConfig.checkType(file.mimetype, fileConfig.ocr?.supportedMimeTypes || []);
 
+    const shouldUseConfiguredText =
+      !!process.env.RAG_API_URL &&
+      fileConfig.checkType(file.mimetype, fileConfig.text?.supportedMimeTypes || []);
+
     const shouldUseDocumentParser =
       !shouldUseConfiguredOCR &&
-      !fileConfig.checkType(file.mimetype, fileConfig.text?.supportedMimeTypes || []) &&
+      !shouldUseConfiguredText &&
       documentParserMimeTypes.some((regex) => regex.test(file.mimetype));
 
     const shouldUseOCR = shouldUseConfiguredOCR || shouldUseDocumentParser;

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -211,6 +211,7 @@ describe('processAgentFileUpload', () => {
     jest.clearAllMocks();
     mockRes.status.mockReturnThis();
     mockRes.json.mockReturnValue({});
+    process.env.RAG_API_URL = 'https://rag.example.com';
     checkCapability.mockResolvedValue(true);
     getStrategyFunctions.mockReturnValue({
       handleFileUpload: jest
@@ -251,6 +252,18 @@ describe('processAgentFileUpload', () => {
         file: req.file,
         file_id: 'file-uuid-123',
       });
+    });
+
+    test('falls back to document_parser for configured DOCX text MIME type when RAG_API_URL is unset', async () => {
+      delete process.env.RAG_API_URL;
+      mergeFileConfig.mockReturnValue(makeFileConfig({ textSupportedMimeTypes: [DOCX_MIME] }));
+      const req = makeReq({ mimetype: DOCX_MIME, ocrConfig: null });
+      const { parseText } = require('@librechat/api');
+
+      await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+      expect(getStrategyFunctions).toHaveBeenCalledWith(FileSources.document_parser);
+      expect(parseText).not.toHaveBeenCalled();
     });
 
     test('does not check OCR capability when using automatic document_parser fallback', async () => {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -188,11 +188,11 @@ const mockRes = {
   json: jest.fn().mockReturnValue({}),
 };
 
-const makeFileConfig = ({ ocrSupportedMimeTypes = [] } = {}) => ({
+const makeFileConfig = ({ ocrSupportedMimeTypes = [], textSupportedMimeTypes = [] } = {}) => ({
   checkType: (mime, types) => (types ?? []).includes(mime),
   ocr: { supportedMimeTypes: ocrSupportedMimeTypes },
   stt: { supportedMimeTypes: [] },
-  text: { supportedMimeTypes: [] },
+  text: { supportedMimeTypes: textSupportedMimeTypes },
 });
 
 const setupStoredFileUpload = (result = {}) => {
@@ -236,6 +236,21 @@ describe('processAgentFileUpload', () => {
       await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
 
       expect(getStrategyFunctions).toHaveBeenCalledWith(FileSources.document_parser);
+    });
+
+    test('routes configured DOCX text MIME type through parseText instead of document_parser', async () => {
+      mergeFileConfig.mockReturnValue(makeFileConfig({ textSupportedMimeTypes: [DOCX_MIME] }));
+      const req = makeReq({ mimetype: DOCX_MIME, ocrConfig: null });
+      const { parseText } = require('@librechat/api');
+
+      await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+      expect(getStrategyFunctions).not.toHaveBeenCalledWith(FileSources.document_parser);
+      expect(parseText).toHaveBeenCalledWith({
+        req,
+        file: req.file,
+        file_id: 'file-uuid-123',
+      });
     });
 
     test('does not check OCR capability when using automatic document_parser fallback', async () => {


### PR DESCRIPTION
## Summary

Fixes regression in agent "Upload as Text" routing for document MIME types tracked in #14245.

Before this change, `processAgentFileUpload` always sent DOCX and other document types through the built-in `document_parser` path first, even when `fileConfig.text.supportedMimeTypes` explicitly included those MIME types and `RAG_API_URL` was configured. That prevented the file from reaching the RAG API `/text` endpoint and changed extraction behavior unexpectedly.

This update makes configured text MIME types take precedence over the automatic document parser fallback for document uploads, restoring the expected routing behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified with a focused unit test for `processAgentFileUpload`:

- Added coverage asserting that a configured DOCX text MIME type routes through `parseText` instead of `document_parser`
- Ran the backend service test suite for the affected file successfully

### **Test Configuration**:

- `npm --prefix D:\LibreChat\api run test:ci -- server/services/Files/process.spec.js --runInBand`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes