### PR TITLE
🐛 fix: strip $-prefixed schema keywords from MCP tool params before storage

### DIFF
--- a/packages/api/src/mcp/__tests__/zod.spec.ts
+++ b/packages/api/src/mcp/__tests__/zod.spec.ts
@@ -2298,6 +2298,70 @@ describe('normalizeJsonSchema', () => {
     expect(result.properties.name).toEqual({ type: 'string' });
   });
 
+  it('should strip the spec-compliant $schema keyword (MongoDB rejects $-prefixed keys)', () => {
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+      },
+      required: ['title'],
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result).not.toHaveProperty('$schema');
+    expect(result.type).toBe('object');
+    expect(result.properties.title).toEqual({ type: 'string' });
+    expect(result.required).toEqual(['title']);
+    // Nothing left behind that MongoDB would reject.
+    expect(Object.keys(result).some((k) => k.startsWith('$'))).toBe(false);
+  });
+
+  it('should strip $-prefixed annotation keywords at all nesting levels', () => {
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'urn:tool:create_citation',
+      $comment: 'root comment',
+      type: 'object',
+      properties: {
+        note: {
+          type: 'string',
+          $comment: 'nested comment',
+          $anchor: 'note',
+        },
+        items: {
+          type: 'array',
+          items: { type: 'string', $id: 'urn:item' },
+        },
+      },
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result).not.toHaveProperty('$schema');
+    expect(result).not.toHaveProperty('$id');
+    expect(result).not.toHaveProperty('$comment');
+    expect(result.properties.note).toEqual({ type: 'string' });
+    expect(result.properties.items.items).toEqual({ type: 'string' });
+  });
+
+  it('should preserve property names that begin with $', () => {
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        $ref: { type: 'string', description: 'a property literally named $ref' },
+      },
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result).not.toHaveProperty('$schema');
+    // A `$`-prefixed name under `properties` is a data field, not a keyword.
+    expect(result.properties.$ref).toEqual({
+      type: 'string',
+      description: 'a property literally named $ref',
+    });
+  });
+
   it('should strip x-* fields inside oneOf/anyOf/allOf', () => {
     const schema = {
       type: 'object',

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -10,6 +10,7 @@ import {
   isUserSourced,
 } from '~/mcp/utils';
 import { isMCPDomainAllowed, extractMCPServerDomain } from '~/auth/domain';
+import { normalizeJsonSchema, resolveJsonSchemaRefs } from '~/mcp/zod';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPDomainNotAllowedError } from '~/mcp/errors';
 import { detectOAuthRequirement } from '~/mcp/oauth';
@@ -187,7 +188,13 @@ export class MCPServerInspector {
         ['function']: {
           name,
           description: tool.description,
-          parameters: tool.inputSchema as JsonSchemaType,
+          // Normalize before persisting: resolves `$ref`s and strips
+          // `$`-prefixed keywords (e.g. a spec-compliant `$schema`), which
+          // MongoDB rejects as field names and would otherwise crash storage
+          // of this `parameters` blob during server registration.
+          parameters: normalizeJsonSchema(
+            resolveJsonSchemaRefs(tool.inputSchema as Record<string, unknown>),
+          ) as JsonSchemaType,
         },
       };
     });

--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -302,7 +302,13 @@ export function resolveJsonSchemaRefs<T extends Record<string, unknown>>(
  * Transformations applied:
  * - Converts `const` values to `enum` arrays (Gemini/Vertex AI rejects `const`)
  * - Strips vendor extension fields (`x-*` prefixed keys, e.g. `x-google-enum-descriptions`)
- * - Strips leftover `$defs`/`definitions` blocks that may survive ref resolution
+ * - Strips `definitions` and `$`-prefixed schema keywords (`$defs`, `$schema`,
+ *   `$id`, `$comment`, ...) that may survive ref resolution
+ *
+ * Beyond LLM compatibility, dropping every `$`-prefixed keyword also makes the
+ * output safe to persist: MongoDB rejects field names beginning with `$`, so a
+ * standard, spec-compliant `$schema` keyword in an MCP tool's `inputSchema`
+ * would otherwise crash storage of the tool's `parameters` blob.
  *
  * @param schema - The JSON schema to normalize
  * @returns The normalized schema
@@ -327,9 +333,14 @@ export function normalizeJsonSchema<T extends Record<string, unknown>>(schema: T
       continue;
     }
 
-    // Strip leftover $defs/definitions (should already be resolved by resolveJsonSchemaRefs,
-    // but strip as a safety net for schemas that bypass ref resolution).
-    if (key === '$defs' || key === 'definitions') {
+    // Strip `definitions` and any `$`-prefixed JSON Schema keyword (`$defs`,
+    // `$schema`, `$id`, `$comment`, ...). `$defs`/`$ref` should already be
+    // resolved away by resolveJsonSchemaRefs; the remaining `$`-prefixed keys
+    // are informational annotations the LLM function schema doesn't need — and
+    // MongoDB rejects `$`-prefixed field names, so leaving them in a stored MCP
+    // tool `parameters` blob breaks persistence. Property names (which live
+    // under `properties` and are handled below) are never reached here.
+    if (key === 'definitions' || key.startsWith('$')) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #14323.

Connecting an MCP server whose tool `inputSchema` includes a standard, spec-compliant `$schema` keyword fails to register its tools. The MCP connection succeeds, but persisting the tool definitions to MongoDB throws, because MongoDB reserves `$`-prefixed field names:

```
error: [updateMCPServer] The dollar ($) prefixed field
'$schema' in 'config.toolFunctions.create_citation_mcp_gramps-web-mcp.function.parameters.$schema'
is not valid for storage.
```

`$schema` (which declares the JSON Schema draft version) is standard JSON Schema — the MCP server isn't doing anything nonstandard — so any such server currently can't have its tools registered.

### Root cause

`MCPServerInspector.getToolFunctions()` stored the raw MCP `inputSchema` verbatim as the tool's `parameters`:

```ts
parameters: tool.inputSchema as JsonSchemaType,
```

If that schema carries `$schema` (or any other `$`-prefixed keyword), the resulting `toolFunctions` document can't be written to Mongo. The existing `normalizeJsonSchema()` already strips `$defs`/`definitions`/`x-*` for LLM API compatibility, but it left other `$`-prefixed keywords (notably `$schema`) intact, and it was only applied at request time — after the doc had already failed to persist.

### The fix

- **`MCPServerInspector.getToolFunctions`** — normalize the schema before persisting, reusing the same trusted `normalizeJsonSchema(resolveJsonSchemaRefs(...))` pipeline the request path already runs. This resolves `$ref`s and drops every `$`-prefixed keyword, so the stored `parameters` blob is MongoDB-safe.
- **`normalizeJsonSchema`** — generalize the existing `$defs`/`definitions` strip to drop `definitions` plus any `$`-prefixed keyword (`$schema`, `$id`, `$comment`, `$anchor`, …). These are informational annotations that LLM function schemas don't need. Property names living under `properties` are handled by a separate branch, so a property literally named e.g. `$ref` is preserved.

Because storage now runs the same normalization the request path applies, re-running it at request time is idempotent — no behavioral change to how tools are presented to the model.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added unit tests in `packages/api/src/mcp/__tests__/zod.spec.ts` covering `normalizeJsonSchema`:

- strips a top-level spec-compliant `$schema` while preserving `type`/`properties`/`required`, leaving no `$`-prefixed keys behind
- strips `$`-prefixed annotation keywords (`$schema`, `$id`, `$comment`, `$anchor`) at all nesting levels
- preserves a property whose **name** begins with `$` (data field, not a keyword)
- existing `const → enum` and `x-*` stripping behavior is unchanged (no regressions)

Verified the normalization logic against the reported `create_citation`-style schema (a `$schema`-bearing object): the `$schema` keyword is dropped and the rest of the schema is preserved intact, making the `toolFunctions` document safe to store.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
