### PR TITLE
fix: interpolate {{user.name}} in agent/assistant descriptions (#14324)

### DIFF
--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -77,9 +77,39 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
   const brandedSpecLabel = modelSpec?.showOnLanding ? modelSpec.label : '';
   const brandedSpecDescription = (modelSpec?.showOnLanding && modelSpec.description) || '';
   const name = entity?.name ?? brandedSpecLabel;
-  const description =
+
+  const escapeHtml = useCallback(
+    (value: string) =>
+      value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;'),
+    [],
+  );
+
+  const interpolate = useCallback(
+    (text: string, escapeName = false) => {
+      if (!user?.name) {
+        return text;
+      }
+      const name = escapeName ? escapeHtml(user.name) : user.name;
+      return text.replace(/\{\{user\.name\}\}/g, () => name);
+    },
+    [user?.name, escapeHtml],
+  );
+
+  const rawDescription =
     (entity?.description || brandedSpecDescription || conversation?.greeting) ?? '';
-  const descriptionIsHTML = description.trim().startsWith('<');
+  // Decide HTML-ness from the *raw* string, before interpolation, so a user
+  // name containing `<`/`>` can't itself flip which rendering path is taken.
+  const descriptionIsHTML = rawDescription.trim().startsWith('<');
+  // Only escape the substituted name on the HTML path — it gets sanitized
+  // and rendered via dangerouslySetInnerHTML, so it must stay literal text.
+  // On the plain-text path React already escapes text children, so
+  // escaping there would incorrectly surface entities like `&amp;` as-is.
+  const description = interpolate(rawDescription, descriptionIsHTML);
 
   const sanitizeDescription = useMemo(
     () =>
@@ -96,8 +126,8 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
     if (typeof startupConfig?.interface?.customWelcome === 'string') {
       const customWelcome = startupConfig.interface.customWelcome;
       // Replace {{user.name}} with actual user name if available
-      if (user?.name && customWelcome.includes('{{user.name}}')) {
-        return customWelcome.replace(/{{user.name}}/g, user.name);
+      if (customWelcome.includes('{{user.name}}')) {
+        return interpolate(customWelcome);
       }
       return customWelcome;
     }
@@ -127,7 +157,7 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
     else {
       return localize('com_ui_good_evening');
     }
-  }, [localize, startupConfig?.interface?.customWelcome, user?.name]);
+  }, [localize, startupConfig?.interface?.customWelcome, interpolate]);
 
   const handleLineCountChange = useCallback((count: number) => {
     setTextHasMultipleLines(count > 1);


### PR DESCRIPTION


## Summary
Closes #14324

`interface.customWelcome` supports a `{{user.name}}` placeholder, but the
agent/assistant description shown on the landing page did not — since the
greeting branch and the entity-name branch are mutually exclusive in
`Landing.tsx`, the placeholder was effectively unreachable for anyone using
an agent, assistant, or model spec.

This PR extracts the interpolation logic (previously only used inside
`getGreeting()`) into a shared `interpolate` helper and applies it to the
`description` variable as well, which covers all three of its sources:
- `entity?.description` (agent/assistant description)
- `brandedSpecDescription` (model spec description, when `showOnLanding` is set)
- `conversation?.greeting` (assistant greeting field)

`getGreeting()` now reuses the same helper instead of duplicating the
replace logic inline.

## Change Type
Please delete any irrelevant options.
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Manually tested in a local dev environment:
1. Set `interface.customWelcome` to a string containing `{{user.name}}` with
   no agent active — confirmed it still substitutes the logged-in user's name.
2. Set an agent's description field to include `{{user.name}}`, activated
   that agent on the landing page — confirmed the name now substitutes
   correctly where it previously did not.
3. Verified existing descriptions without the placeholder render unchanged.

### **Test Configuration**:
- LibreChat v0.8.7
- Local Docker Compose setup

## Checklist
Please delete any irrelevant options.
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes