### PR TITLE
fix: Resolve Placeholders in MCP serverInstructions

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -762,6 +762,7 @@ class AgentClient extends BaseClient {
           logger,
           mcpManager,
           configServers,
+          user: this.options.req.user,
           sharedRunContext: agentRunContextParts.filter(Boolean).join('\n\n'),
           ephemeralAgent: agentId === this.options.agent.id ? ephemeralAgent : undefined,
         });

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -593,6 +593,7 @@ const createResponse = async (req, res) => {
           logger,
           mcpManager,
           configServers,
+          user: req.user,
           sharedRunContext: agentScopedContext.get(runAgent.id) ?? '',
         }),
       ),

--- a/packages/api/src/agents/context.spec.ts
+++ b/packages/api/src/agents/context.spec.ts
@@ -159,6 +159,7 @@ describe('Agent Context Utilities', () => {
       expect(mockMCPManager.formatInstructionsForContext).toHaveBeenCalledWith(
         ['server1', 'server2'],
         undefined,
+        undefined,
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         '[AgentContext] Fetched MCP instructions for servers:',
@@ -365,6 +366,7 @@ describe('Agent Context Utilities', () => {
       expect(mockMCPManager.formatInstructionsForContext).toHaveBeenCalledWith(
         ['ephemeral-server'],
         undefined,
+        undefined,
       );
       expect(agent.instructions).toBe('Base instructions\n\nEphemeral MCP');
       expect(agent.additional_instructions).toBe('Context');
@@ -397,6 +399,39 @@ describe('Agent Context Utilities', () => {
       expect(mockMCPManager.formatInstructionsForContext).toHaveBeenCalledWith(
         ['agent-server'],
         undefined,
+        undefined,
+      );
+    });
+
+    it('should forward the requesting user so instruction placeholders resolve', async () => {
+      const agent: AgentWithTools = {
+        id: 'test-agent',
+        instructions: 'Base',
+        tools: [
+          new DynamicStructuredTool({
+            name: `tool${Constants.mcp_delimiter}agent-server`,
+            description: 'Test tool',
+            schema: testSchema,
+            func: async () => 'result',
+          }),
+        ],
+      };
+
+      mockMCPManager.formatInstructionsForContext.mockResolvedValue('Agent MCP');
+      const user = { id: 'user-1', name: 'Ada' };
+
+      await applyContextToAgent({
+        agent,
+        sharedRunContext: '',
+        mcpManager: mockMCPManager,
+        logger: mockLogger,
+        user,
+      });
+
+      expect(mockMCPManager.formatInstructionsForContext).toHaveBeenCalledWith(
+        ['agent-server'],
+        undefined,
+        user,
       );
     });
 

--- a/packages/api/src/agents/context.ts
+++ b/packages/api/src/agents/context.ts
@@ -2,6 +2,7 @@ import { Constants } from 'librechat-data-provider';
 import { DynamicStructuredTool } from '@librechat/agents/langchain/tools';
 import type { Agent, TEphemeralAgent } from 'librechat-data-provider';
 import type { LCTool } from '@librechat/agents';
+import type { IUser } from '@librechat/data-schemas';
 import type { Logger } from 'winston';
 import type { ParsedServerConfig } from '~/mcp/types';
 import type { MCPManager } from '~/mcp/MCPManager';
@@ -58,6 +59,7 @@ export function extractMCPServers(agent: AgentWithTools): string[] {
  * @param {string[]} mcpServers - Array of MCP server names
  * @param {MCPManager} mcpManager - MCP manager instance
  * @param {Logger} [logger] - Optional logger instance
+ * @param {Object} [user] - Optional requesting user, used to resolve instruction placeholders
  * @returns {Promise<string>} MCP instructions string, empty if none
  */
 export async function getMCPInstructionsForServers(
@@ -65,6 +67,7 @@ export async function getMCPInstructionsForServers(
   mcpManager: MCPManager,
   logger?: Logger,
   configServers?: Record<string, ParsedServerConfig>,
+  user?: Partial<IUser>,
 ): Promise<string> {
   if (!mcpServers.length) {
     return '';
@@ -73,6 +76,7 @@ export async function getMCPInstructionsForServers(
     const mcpInstructions = await mcpManager.formatInstructionsForContext(
       mcpServers,
       configServers,
+      user,
     );
     if (mcpInstructions && logger) {
       logger.debug('[AgentContext] Fetched MCP instructions for servers:', mcpServers);
@@ -134,6 +138,7 @@ export function buildAgentAdditionalInstructions({
  * @param {Object} [params.ephemeralAgent] - Ephemeral agent config (for MCP override)
  * @param {string} [params.agentId] - Agent ID for logging
  * @param {Logger} [params.logger] - Optional logger instance
+ * @param {Object} [params.user] - Requesting user, used to resolve MCP instruction placeholders
  * @returns {Promise<void>}
  */
 export async function applyContextToAgent({
@@ -144,6 +149,7 @@ export async function applyContextToAgent({
   agentId,
   logger,
   configServers,
+  user,
 }: {
   agent: AgentWithTools;
   sharedRunContext: string;
@@ -152,6 +158,7 @@ export async function applyContextToAgent({
   agentId?: string;
   logger?: Logger;
   configServers?: Record<string, ParsedServerConfig>;
+  user?: Partial<IUser>;
 }): Promise<void> {
   const baseInstructions = agent.instructions || '';
   const additionalInstructions = agent.additional_instructions || '';
@@ -163,6 +170,7 @@ export async function applyContextToAgent({
       mcpManager,
       logger,
       configServers,
+      user,
     );
 
     agent.instructions = buildAgentInstructions({

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -277,11 +277,13 @@ export class MCPManager extends UserConnectionManager {
   /**
    * Get instructions for MCP servers
    * @param serverNames Optional array of server names. If not provided or empty, returns all servers.
+   * @param user Optional requesting user, used to resolve placeholders in custom instructions.
    * @returns Object mapping server names to their instructions
    */
   private async getInstructions(
     serverNames?: string[],
     configServers?: Record<string, t.ParsedServerConfig>,
+    user?: Partial<IUser>,
   ): Promise<Record<string, string>> {
     const instructions: Record<string, string> = {};
     const configs = await MCPServersRegistry.getInstance().getAllServerConfigs(
@@ -289,9 +291,26 @@ export class MCPManager extends UserConnectionManager {
       configServers,
     );
     for (const [serverName, config] of Object.entries(configs)) {
-      if (config.serverInstructions != null) {
-        instructions[serverName] = config.serverInstructions as string;
+      if (config.serverInstructions == null) {
+        continue;
       }
+      /**
+       * Custom instructions are resolved per-user so `{{LIBRECHAT_USER_*}}` reflects the
+       * requesting user. A non-string value means "fetch from the server" and is left as-is.
+       * Only the instructions and `dbId` are passed through, so the sandboxing applied to
+       * DB-sourced servers is preserved without cloning the rest of the parsed config.
+       */
+      const { serverInstructions } =
+        typeof config.serverInstructions === 'string'
+          ? processMCPEnv({
+              options: {
+                serverInstructions: config.serverInstructions,
+                dbId: config.dbId,
+              } as t.ParsedServerConfig,
+              user,
+            })
+          : config;
+      instructions[serverName] = serverInstructions as string;
     }
     if (!serverNames) return instructions;
     return pick(instructions, serverNames);
@@ -300,13 +319,15 @@ export class MCPManager extends UserConnectionManager {
   /**
    * Format MCP server instructions for injection into context
    * @param serverNames Optional array of server names to include. If not provided, includes all servers.
+   * @param user Optional requesting user, used to resolve placeholders in custom instructions.
    * @returns Formatted instructions string ready for context injection
    */
   public async formatInstructionsForContext(
     serverNames?: string[],
     configServers?: Record<string, t.ParsedServerConfig>,
+    user?: Partial<IUser>,
   ): Promise<string> {
-    const instructionsToInclude = await this.getInstructions(serverNames, configServers);
+    const instructionsToInclude = await this.getInstructions(serverNames, configServers, user);
 
     if (Object.keys(instructionsToInclude).length === 0) {
       return '';

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -348,6 +348,81 @@ describe('MCPManager', () => {
 
       expect(result).toBe('');
     });
+
+    describe('placeholder resolution', () => {
+      const actualEnv = jest.requireActual<typeof import('~/utils/env')>('~/utils/env');
+
+      beforeEach(() => {
+        mockProcessMCPEnv.mockImplementation(actualEnv.processMCPEnv);
+      });
+
+      it('should resolve user and environment placeholders in serverInstructions', async () => {
+        process.env.TEST_MCP_INSTRUCTIONS_REGION = 'eu-west-1';
+        (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
+          github: {
+            type: 'sse',
+            url: 'https://api.github.com',
+            serverInstructions:
+              'Address the user as {{LIBRECHAT_USER_NAME}} and query ${TEST_MCP_INSTRUCTIONS_REGION}.',
+          },
+        });
+
+        const manager = await MCPManager.createInstance(newMCPServersConfig());
+        const result = await manager.formatInstructionsForContext(['github'], undefined, {
+          id: 'user-1',
+          name: 'Ada',
+        } as Partial<IUser>);
+
+        expect(result).toContain('Address the user as Ada and query eu-west-1.');
+        expect(result).not.toContain('{{LIBRECHAT_USER_NAME}}');
+        expect(result).not.toContain('${TEST_MCP_INSTRUCTIONS_REGION}');
+
+        delete process.env.TEST_MCP_INSTRUCTIONS_REGION;
+      });
+
+      it('should only resolve custom user variables for user-sourced servers', async () => {
+        process.env.TEST_MCP_INSTRUCTIONS_REGION = 'eu-west-1';
+        (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
+          personal: {
+            type: 'sse',
+            url: 'https://example.com',
+            dbId: 'db-1',
+            source: 'user',
+            serverInstructions:
+              'Address the user as {{LIBRECHAT_USER_NAME}} and query ${TEST_MCP_INSTRUCTIONS_REGION}.',
+          },
+        });
+
+        const manager = await MCPManager.createInstance(newMCPServersConfig());
+        const result = await manager.formatInstructionsForContext(['personal'], undefined, {
+          id: 'user-1',
+          name: 'Ada',
+        } as Partial<IUser>);
+
+        expect(result).toContain('{{LIBRECHAT_USER_NAME}}');
+        expect(result).toContain('${TEST_MCP_INSTRUCTIONS_REGION}');
+
+        delete process.env.TEST_MCP_INSTRUCTIONS_REGION;
+      });
+
+      it('should leave non-string serverInstructions untouched', async () => {
+        (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
+          github: {
+            type: 'sse',
+            url: 'https://api.github.com',
+            serverInstructions: true,
+          },
+        });
+
+        const manager = await MCPManager.createInstance(newMCPServersConfig());
+        const result = await manager.formatInstructionsForContext(['github'], undefined, {
+          id: 'user-1',
+          name: 'Ada',
+        } as Partial<IUser>);
+
+        expect(result).toContain('## github MCP Server Instructions');
+      });
+    });
   });
 
   describe('getServerToolFunctions', () => {

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -414,6 +414,19 @@ export function processMCPEnv(params: {
     });
   }
 
+  // Process server instructions if they exist (all transport types).
+  // Only the custom-string form is processed: a boolean (or the YAML string "true")
+  // means "fetch instructions from the server" and must be left untouched.
+  if ('serverInstructions' in newObj && typeof newObj.serverInstructions === 'string') {
+    newObj.serverInstructions = processSingleValue({
+      user,
+      body,
+      dbSourced,
+      customUserVars,
+      originalValue: newObj.serverInstructions,
+    });
+  }
+
   // Process outbound proxy if it exists (for SSE and StreamableHTTP types)
   if ('proxy' in newObj && newObj.proxy) {
     newObj.proxy = processAdminValue(newObj.proxy, dbSourced);


### PR DESCRIPTION
## Summary

Fixes #9949

MCP server configs already support placeholders — `processMCPEnv` resolves `{{LIBRECHAT_USER_*}}` and `${ENV_VAR}` in `env`, `args`, `headers` and `url`, and this is [documented behaviour](https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/mcp_servers#headers).

`serverInstructions` was the one field left out. In `MCPManager.getInstructions` the configured value was copied straight into the instruction map:

```ts
if (config.serverInstructions != null) {
  instructions[serverName] = config.serverInstructions as string;
}
```

So a config like:

```yaml
mcpServers:
  jira:
    url: https://example.com/mcp
    serverInstructions: |
      You are acting on behalf of {{LIBRECHAT_USER_NAME}} ({{LIBRECHAT_USER_EMAIL}}).
      Default project board is ${JIRA_DEFAULT_BOARD}.
```

sent the literal text `{{LIBRECHAT_USER_NAME}}` to the model instead of the user's name. That is surprising given the same placeholders work one field above in the same YAML block, and it blocks the main use case for per-user instructions.

### The fix

Two small changes:

1. `processMCPEnv` now processes `serverInstructions`, alongside the fields it already walks.
2. `MCPManager.getInstructions` resolves it with the requesting user's context and threads that user down from the agent-context call sites (`applyContextToAgent` in `client.js` / `responses.js`, both of which already have `req`).

**Why resolve at instruction-assembly time rather than at config load:** server configs are loaded once and shared, and at that point there is no user. Instructions are injected per request, so resolving there is what makes `{{LIBRECHAT_USER_NAME}}` actually mean the person sending the message. The `user` parameter is optional and trailing, so existing callers are unaffected.

**Boolean vs string preserved:** `serverInstructions` can also be `true` (or the YAML string `"true"`), meaning "fetch instructions from the server". Only the custom-string form is substituted; non-string values pass through untouched, so the fetch path in `MCPServerInspector` is unchanged.

**DB-sourced servers stay sandboxed:** because this reuses `processMCPEnv` rather than a new substitution helper, user-authored (DB-stored) servers keep the existing `dbSourced` restriction — no `${ENV_VAR}` and no user-field resolution. There is a test covering that.

One known gap, for transparency: this resolves user fields and env vars, not `customUserVars` (headers do resolve those). Those aren't available at this call site and wiring them in would be a larger change; happy to follow up if you'd like it.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

The MCP docs page that lists placeholder-supporting fields could mention `serverInstructions` — I can open a PR on `LibreChat-AI/librechat.ai` if that's wanted.

## Testing

Added three tests to `MCPManager.test.ts` under `formatInstructionsForContext`, using the real `processMCPEnv` rather than the file's pass-through mock:

- user-field and env-var placeholders in `serverInstructions` resolve
- a user-sourced (`dbId`/`source: 'user'`) server leaves both unresolved
- a non-string (`true`) `serverInstructions` still produces its section

The first test fails on `main` (output contains the literal `{{LIBRECHAT_USER_NAME}}` and `${...}`) and passes with this change. Also added a case to `context.spec.ts` asserting `applyContextToAgent` forwards the user.

### **Test Configuration**:

```
cd packages/api && npx jest src/agents/context.spec.ts src/mcp/__tests__/MCPManager.test.ts src/utils/env src/mcp/registry/__tests__/MCPServerInspector.test.ts --watchAll=false
# Test Suites: 4 passed, Tests: 223 passed

cd api && npx jest server/controllers/agents/client.test.js --watchAll=false
# Test Suites: 1 passed, Tests: 87 passed
```

`npx tsc --noEmit` is clean for `packages/api`, and `npx eslint` passes on all changed files. The wider `src/mcp` run has some failing suites in my environment (the Redis/cache integration specs, plus `agents/hitl/hookLoader.spec.ts`), but they are unrelated to this change and fail identically on unmodified `main`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes

