### PR TITLE
🚰 perf: Suppress No-Op Conversation Writes and Widen-Proof Atom Subscriptions

### DIFF
--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -104,6 +104,10 @@ export default function Parameters() {
         }
       });
 
+      if (updatedKeys.length === 0) {
+        return prev;
+      }
+
       logger.log('parameters', 'parameters effect, updated keys:', updatedKeys);
 
       return updatedConversation;

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -22,7 +22,7 @@ const NewChatButton = memo(function NewChatButton({
   const localize = useLocalize();
   const queryClient = useQueryClient();
   const { newConversation } = useNewConvo();
-  const conversation = useRecoilValue(store.conversationByIndex(0));
+  const conversationId = useRecoilValue(store.conversationIdByIndex(0));
   const switchToHistory = useRecoilValue(store.newChatSwitchToHistory);
   const tooltipDescription = useShortcutHint('newChat', localize('com_ui_new_chat'));
   const ariaKey = useShortcutAriaKey('newChat');
@@ -31,7 +31,7 @@ const NewChatButton = memo(function NewChatButton({
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (e.button === 0 && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
-        clearMessagesCache(queryClient, conversation?.conversationId);
+        clearMessagesCache(queryClient, conversationId);
         queryClient.invalidateQueries([QueryKeys.messages]);
         newConversation();
         if (switchToHistory) {
@@ -39,7 +39,7 @@ const NewChatButton = memo(function NewChatButton({
         }
       }
     },
-    [queryClient, conversation?.conversationId, newConversation, switchToHistory, setActive],
+    [queryClient, conversationId, newConversation, switchToHistory, setActive],
   );
 
   return (

--- a/client/src/components/UnifiedSidebar/__tests__/ExpandedPanel.spec.tsx
+++ b/client/src/components/UnifiedSidebar/__tests__/ExpandedPanel.spec.tsx
@@ -26,6 +26,8 @@ jest.mock('~/store', () => {
     default: {
       conversationByIndex: () =>
         atom({ key: `mock-conversationByIndex-${counter++}`, default: null }),
+      conversationIdByIndex: () =>
+        atom({ key: `mock-conversationIdByIndex-${counter++}`, default: null }),
       newChatSwitchToHistory: switchAtom,
       customShortcuts: customShortcutsAtom,
     },

--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -32,7 +32,7 @@ const useNavigateToConvo = (index = 0) => {
   const clearAllConversations = store.useClearConvoState();
   const applyModelSpecEffects = useApplyModelSpecEffects();
   const setSubmission = useSetRecoilState(store.submissionByIndex(index));
-  const { hasSetConversation, setConversation: setConvo } = store.useCreateConversationAtom(index);
+  const { hasSetConversation, setConversation: setConvo } = store.useSetConversationAtom(index);
 
   const setConversation = useCallback(
     (conversation: TConversation) => {

--- a/client/src/hooks/Conversations/useSetIndexOptions.ts
+++ b/client/src/hooks/Conversations/useSetIndexOptions.ts
@@ -47,13 +47,15 @@ const useSetIndexOptions: TUseSetOptions = (preset = false) => {
       }
     }
 
-    setConversation(
-      (prevState) =>
-        tConvoUpdateSchema.parse({
-          ...prevState,
-          ...update,
-        }) as TConversation,
-    );
+    setConversation((prevState) => {
+      if (prevState && Object.keys(update).every((key) => Object.is(prevState[key], update[key]))) {
+        return prevState;
+      }
+      return tConvoUpdateSchema.parse({
+        ...prevState,
+        ...update,
+      }) as TConversation;
+    });
   };
 
   const setExample: TSetExample = (i, type, newValue = null) => {

--- a/client/src/hooks/Nav/useUnifiedSidebarLinks.ts
+++ b/client/src/hooks/Nav/useUnifiedSidebarLinks.ts
@@ -13,8 +13,9 @@ import store from '~/store';
 const defaultInterface = getConfigDefaults().interface;
 
 export default function useUnifiedSidebarLinks() {
-  const conversation = useRecoilValue(store.conversationByIndex(0));
-  const endpoint = conversation?.endpoint;
+  /** Selector instead of the full conversation atom: the links only depend on
+   * the endpoint, so parameter edits and other conversation writes stay out. */
+  const endpoint = useRecoilValue(store.conversationEndpointByIndex(0)) ?? undefined;
   const { data: startupConfig } = useGetStartupConfig();
   const { data: endpointsConfig = {} as TEndpointsConfig } = useGetEndpointsQuery();
 

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -454,10 +454,13 @@ const messagesSiblingIdxFamily = atomFamily<number, string | null | undefined>({
   default: 0,
 });
 
-function useCreateConversationAtom(key: string | number) {
+/** Setter-only access to the conversation atom: registers the key like
+ * `useCreateConversationAtom` but never subscribes to the value, so callers
+ * that only write (navigation, per-row actions) don't re-render on every
+ * conversation update. */
+function useSetConversationAtom(key: string | number) {
   const hasSetConversation = useSetConvoContext();
   const setKeys = useSetRecoilState(conversationKeysAtom);
-  const conversation = useRecoilValue(conversationByIndex(key));
   const setConversation = useSetRecoilState(conversationByIndex(key));
 
   useEffect(() => {
@@ -469,12 +472,14 @@ function useCreateConversationAtom(key: string | number) {
     });
   }, [key, setKeys]);
 
-  return { hasSetConversation, conversation, setConversation };
+  return { hasSetConversation, setConversation };
 }
 
-function useSetConversationAtom(key: string | number) {
-  const { setConversation } = useCreateConversationAtom(key);
-  return { setConversation };
+function useCreateConversationAtom(key: string | number) {
+  const { hasSetConversation, setConversation } = useSetConversationAtom(key);
+  const conversation = useRecoilValue(conversationByIndex(key));
+
+  return { hasSetConversation, conversation, setConversation };
 }
 
 function useClearConvoState() {


### PR DESCRIPTION
## Summary

I traced react-scan profiling data (12 scenarios against a seeded 80-message conversation, main @ `8e5ef1fb3`) showing that any write to `conversationByIndex(0)` cascades app-wide: ChatRoute/ChatView, the sidebar shell, and all 80 message rows re-render. Two writer-side bugs made these cascades fire constantly, and three reader-side subscriptions were far broader than the data they consume. Editing a single Parameters field measured 21,976 renders for 15 keystrokes; a verifier measured the setter-only navigation fix alone dropping renders per conversation write from 1,559 to 1,065 in the 80-row conversation.

- Bailed out of the Parameters `Panel.tsx` mount effect with `return prev` when no keys changed; it previously returned a fresh `{ ...prev }` unconditionally, minting a spurious conversation identity (and one guaranteed full-app cascade) on every panel open.
- Bailed out of `setOption` in `useSetIndexOptions` when every updated key is `Object.is`-equal to the current value, so repeated writes of the same parameter value no longer produce new conversation objects.
- Made `useSetConversationAtom` genuinely setter-only (key registration + `useSetRecoilState`, no `useRecoilValue`) and rebuilt `useCreateConversationAtom` on top of it; the previous layering subscribed setter-only callers to every conversation write.
- Switched `useNavigateToConvo` to `useSetConversationAtom`; it never reads the atom value, yet its subscription re-rendered every mounted caller, including the per-message-row Fork buttons (80 rows x Fork/GitFork/PopoverAnchor/Dialog per write).
- Narrowed `useUnifiedSidebarLinks` to the existing `conversationEndpointByIndex(0)` selector; the links only depend on the endpoint.
- Narrowed the ExpandedPanel new-chat button to `conversationIdByIndex(0)`; it only needs the id for cache clearing.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx eslint` on all six files: clean.
- `npx tsc --noEmit` in `client`: clean.
- `npx jest` on ExpandedPanel, Parameters, families, useNewConvo, Conversations, useSetIndexOptions suites: 48/48 passing (added the new selector to ExpandedPanel's store mock).
- Manual: opened/closed the Parameters panel, edited sliders/switches, navigated between conversations, forked from a message row; behavior unchanged.

### **Test Configuration**:

- Node v24, local dev stack, react-scan instrumentation for render counts.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
