### PR TITLE
perf(auth): prime user cache during token refresh

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -2,12 +2,16 @@ const cookies = require('cookie');
 const jwt = require('jsonwebtoken');
 const openIdClient = require('openid-client');
 const { logger } = require('@librechat/data-schemas');
+const { CacheKeys } = require('librechat-data-provider');
 const {
   math,
   isEnabled,
   findOpenIDUser,
   getOpenIdIssuer,
   buildOpenIDRefreshParams,
+  buildAuthUserDocCacheKey,
+  getAuthUserDocCacheMode,
+  primeCachedAuthUserDoc,
 } = require('@librechat/api');
 const {
   requestPasswordReset,
@@ -26,6 +30,7 @@ const {
 } = require('~/models');
 const { getGraphApiToken } = require('~/server/services/GraphTokenService');
 const { getOpenIdConfig, getOpenIdEmail } = require('~/strategies');
+const getLogStores = require('~/cache/getLogStores');
 
 const AUTH_REFRESH_USER_PROJECTION = '-password -__v -totpSecret -backupCodes -federatedTokens';
 const OPENID_REUSE_EXPIRY_BUFFER_SECONDS = 30;
@@ -41,6 +46,42 @@ const OPENID_REUSE_MAX_SESSION_AGE_MS = math(
   process.env.OPENID_REUSE_MAX_SESSION_AGE_MS,
   15 * 60 * 1000,
 );
+
+const primeOpenIDRefreshUser = async ({ user, claims, openidIssuer }) => {
+  try {
+    if (
+      !user ||
+      getAuthUserDocCacheMode() !== 'on' ||
+      typeof claims?.sub !== 'string' ||
+      user.openidId !== claims.sub
+    ) {
+      return;
+    }
+
+    const cacheKey = buildAuthUserDocCacheKey({
+      strategy: 'openid-jwt',
+      subject: claims.sub,
+      issuer: openidIssuer,
+    });
+    if (!cacheKey) {
+      return;
+    }
+
+    const cacheUser = typeof user.toObject === 'function' ? user.toObject() : user;
+    const result = await primeCachedAuthUserDoc(
+      getLogStores(CacheKeys.AUTH_USER_DOC),
+      cacheKey,
+      cacheUser,
+    );
+    if (result === 'deadline') {
+      logger.debug('[refreshController] Auth user cache priming exceeded deadline');
+    }
+  } catch (error) {
+    logger.warn('[refreshController] Auth user cache priming failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
 
 const registrationController = async (req, res) => {
   try {
@@ -175,6 +216,12 @@ const refreshController = async (req, res) => {
       if (reuseUserId) {
         const user = await getUserById(reuseUserId, AUTH_REFRESH_USER_PROJECTION);
         if (user) {
+          const claims = jwt.decode(reusableSessionToken.token);
+          await primeOpenIDRefreshUser({
+            user,
+            claims,
+            openidIssuer: getOpenIdIssuer(claims),
+          });
           const cloudFrontCookiesSet = setCloudFrontAuthCookies(req, res, user);
           logger.debug('[refreshController] OpenID session token reused', {
             token_type: reusableSessionToken.type,
@@ -232,14 +279,20 @@ const refreshController = async (req, res) => {
       // Also handle case where user has mismatched openidId (e.g., after database switch)
       if (migration || user.openidId !== claims.sub) {
         const reason = migration ? 'migration' : 'openidId mismatch';
+        const previousOpenidId = user.openidId;
         await updateUser(user._id.toString(), {
           provider: 'openid',
           openidId: claims.sub,
           ...(openidIssuer ? { openidIssuer } : {}),
         });
         logger.info(
-          `[refreshController] Updated user ${user.email} openidId (${reason}): ${user.openidId ?? 'null'} -> ${claims.sub}`,
+          `[refreshController] Updated user ${user.email} openidId (${reason}): ${previousOpenidId ?? 'null'} -> ${claims.sub}`,
         );
+        user.provider = 'openid';
+        user.openidId = claims.sub;
+        if (openidIssuer) {
+          user.openidIssuer = openidIssuer;
+        }
       }
 
       const token = setOpenIDAuthTokens(tokenset, req, res, {
@@ -247,6 +300,8 @@ const refreshController = async (req, res) => {
         existingRefreshToken: refreshToken,
         tenantId: user.tenantId,
       });
+
+      await primeOpenIDRefreshUser({ user, claims, openidIssuer });
 
       return res.status(200).send({ token, user: sanitizeUserForAuthResponse(user) });
     } catch (error) {

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -14,6 +14,7 @@ jest.mock('~/server/services/AuthService', () => ({
 }));
 jest.mock('~/strategies', () => ({ getOpenIdConfig: jest.fn(), getOpenIdEmail: jest.fn() }));
 jest.mock('openid-client', () => ({ refreshTokenGrant: jest.fn() }));
+jest.mock('~/cache/getLogStores', () => jest.fn());
 jest.mock('~/models', () => ({
   deleteAllUserSessions: jest.fn(),
   getUserById: jest.fn(),
@@ -26,6 +27,9 @@ jest.mock('@librechat/api', () => ({
   isEnabled: jest.fn(),
   findOpenIDUser: jest.fn(),
   getOpenIdIssuer: jest.fn(() => 'https://issuer.example.com'),
+  getAuthUserDocCacheMode: jest.fn(() => 'off'),
+  buildAuthUserDocCacheKey: jest.fn(),
+  primeCachedAuthUserDoc: jest.fn(),
   buildOpenIDRefreshParams: jest.fn(() => {
     const params = {};
     if (process.env.OPENID_SCOPE) {
@@ -41,7 +45,14 @@ jest.mock('@librechat/api', () => ({
 const openIdClient = require('openid-client');
 const jwt = require('jsonwebtoken');
 const { logger } = require('@librechat/data-schemas');
-const { isEnabled, findOpenIDUser, buildOpenIDRefreshParams } = require('@librechat/api');
+const {
+  isEnabled,
+  findOpenIDUser,
+  buildOpenIDRefreshParams,
+  getAuthUserDocCacheMode,
+  buildAuthUserDocCacheKey,
+  primeCachedAuthUserDoc,
+} = require('@librechat/api');
 const { graphTokenController, refreshController } = require('./AuthController');
 const { getGraphApiToken } = require('~/server/services/GraphTokenService');
 const {
@@ -51,6 +62,7 @@ const {
 } = require('~/server/services/AuthService');
 const { getOpenIdConfig, getOpenIdEmail } = require('~/strategies');
 const { getUserById, findSession, updateUser } = require('~/models');
+const getLogStores = require('~/cache/getLogStores');
 
 const ORIGINAL_OPENID_SCOPE = process.env.OPENID_SCOPE;
 const ORIGINAL_OPENID_REFRESH_AUDIENCE = process.env.OPENID_REFRESH_AUDIENCE;
@@ -243,6 +255,10 @@ describe('refreshController – OpenID path', () => {
       openidId: baseClaims.sub,
     });
     updateUser.mockResolvedValue({});
+    getAuthUserDocCacheMode.mockReturnValue('off');
+    buildAuthUserDocCacheKey.mockReturnValue('auth-cache-key');
+    primeCachedAuthUserDoc.mockResolvedValue('completed');
+    getLogStores.mockReturnValue({});
 
     req = {
       headers: { cookie: 'token_provider=openid; refreshToken=stored-refresh' },
@@ -302,6 +318,84 @@ describe('refreshController – OpenID path', () => {
       }),
     );
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('primes the resolved OpenID user before returning the refresh response', async () => {
+    getAuthUserDocCacheMode.mockReturnValue('on');
+
+    await refreshController(req, res);
+
+    expect(buildAuthUserDocCacheKey).toHaveBeenCalledWith({
+      strategy: 'openid-jwt',
+      subject: baseClaims.sub,
+      issuer: baseClaims.iss,
+    });
+    expect(primeCachedAuthUserDoc).toHaveBeenCalledWith({}, 'auth-cache-key', defaultUser);
+    expect(primeCachedAuthUserDoc.mock.invocationCallOrder[0]).toBeLessThan(
+      res.send.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('primes the updated subject after repairing an OpenID mismatch', async () => {
+    getAuthUserDocCacheMode.mockReturnValue('on');
+    findOpenIDUser.mockResolvedValue({
+      user: { ...defaultUser, openidId: 'different-subject' },
+      error: null,
+      migration: false,
+    });
+
+    await refreshController(req, res);
+
+    expect(primeCachedAuthUserDoc).toHaveBeenCalledWith(
+      {},
+      'auth-cache-key',
+      expect.objectContaining({ openidId: baseClaims.sub }),
+    );
+  });
+
+  it('does not prime a reused session user under a different OpenID subject', async () => {
+    getAuthUserDocCacheMode.mockReturnValue('on');
+    const reusableIdToken = makeSessionToken();
+    setOpenIDReuseCookies();
+    req.session = {
+      openidTokens: {
+        accessToken: 'session-access-token',
+        idToken: reusableIdToken,
+        refreshToken: 'stored-refresh',
+        lastRefreshedAt: Date.now(),
+      },
+    };
+    getUserById.mockResolvedValue({ ...defaultUser, openidId: 'different-subject' });
+
+    await refreshController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(primeCachedAuthUserDoc).not.toHaveBeenCalled();
+  });
+
+  it('continues authentication when cache priming setup fails', async () => {
+    getAuthUserDocCacheMode.mockImplementation(() => {
+      throw new Error('redis setup failed');
+    });
+
+    await refreshController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(logger.warn).toHaveBeenCalledWith('[refreshController] Auth user cache priming failed', {
+      error: 'redis setup failed',
+    });
+  });
+
+  it('continues authentication when cache priming exceeds its deadline', async () => {
+    getAuthUserDocCacheMode.mockReturnValue('on');
+    primeCachedAuthUserDoc.mockResolvedValue('deadline');
+
+    await refreshController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[refreshController] Auth user cache priming exceeded deadline',
+    );
   });
 
   it('reuses valid OpenID session tokens and refreshes CloudFront cookies', async () => {

--- a/packages/api/src/auth/userDocCache.spec.ts
+++ b/packages/api/src/auth/userDocCache.spec.ts
@@ -3,11 +3,13 @@ import { logger } from '@librechat/data-schemas';
 import { CacheKeys } from 'librechat-data-provider';
 import {
   AUTH_USER_DOC_CACHE_TTL_MS,
+  AUTH_USER_DOC_PRIME_DEADLINE_MS,
   buildAuthUserDocCacheKey,
   buildAuthUserDocReverseIndexKey,
   getAuthUserDocCacheMode,
   getCachedAuthUserDoc,
   invalidateCachedAuthUserDoc,
+  primeCachedAuthUserDoc,
   setCachedAuthUserDoc,
 } from './userDocCache';
 import { cacheConfig } from '~/cache/cacheConfig';
@@ -183,6 +185,41 @@ describe('auth user document cache helpers', () => {
     expect(indexed).not.toContain('existing-key-0');
     expect(indexed).toContain('existing-key-10');
     expect(indexed).toContain('new-key');
+  });
+
+  it('waits for successful cache priming', async () => {
+    const store = makeStore();
+
+    await expect(
+      primeCachedAuthUserDoc(store, 'auth-user-doc:v1:key', {
+        _id: new Types.ObjectId(),
+        email: 'user@example.com',
+      }),
+    ).resolves.toBe('completed');
+
+    expect(store.values.has('auth-user-doc:v1:key')).toBe(true);
+  });
+
+  it('stops waiting when cache priming exceeds its deadline', async () => {
+    jest.useFakeTimers();
+    try {
+      const never = new Promise<never>(() => {});
+      const store = {
+        get: async <T = unknown>(): Promise<T | undefined> => undefined,
+        set: jest.fn(() => never),
+        delete: jest.fn(),
+      };
+
+      const result = primeCachedAuthUserDoc(store, 'auth-user-doc:v1:key', {
+        _id: new Types.ObjectId(),
+        email: 'user@example.com',
+      });
+      await jest.advanceTimersByTimeAsync(AUTH_USER_DOC_PRIME_DEADLINE_MS);
+
+      await expect(result).resolves.toBe('deadline');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('returns cached user documents only for the current cache version', async () => {

--- a/packages/api/src/auth/userDocCache.ts
+++ b/packages/api/src/auth/userDocCache.ts
@@ -6,6 +6,7 @@ import { cacheConfig } from '~/cache/cacheConfig';
 
 const AUTH_USER_DOC_CACHE_VERSION = 1;
 export const AUTH_USER_DOC_CACHE_TTL_MS = 5000;
+export const AUTH_USER_DOC_PRIME_DEADLINE_MS = 25;
 
 export type AuthUserDocCacheMode = 'off' | 'on';
 
@@ -180,6 +181,29 @@ export async function setCachedAuthUserDoc(
     logger.warn('[authUserDocCache] Cache write failed', {
       error: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+export async function primeCachedAuthUserDoc(
+  store: AuthUserDocCacheStore,
+  cacheKey: string,
+  user: Partial<IUser>,
+): Promise<'completed' | 'deadline'> {
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<'deadline'>((resolve) => {
+    deadlineTimer = setTimeout(() => resolve('deadline'), AUTH_USER_DOC_PRIME_DEADLINE_MS);
+    deadlineTimer.unref?.();
+  });
+
+  try {
+    return await Promise.race([
+      setCachedAuthUserDoc(store, cacheKey, user).then(() => 'completed' as const),
+      deadline,
+    ]);
+  } finally {
+    if (deadlineTimer) {
+      clearTimeout(deadlineTimer);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Prime the Redis-backed auth user document cache from the user already resolved by OpenID token refresh. This prevents concurrent startup requests from repeating the same Mongo user lookup.

Cache priming is subject-bound, remains gated by `AUTH_USER_CACHE_MODE=on`, and waits at most 25 ms. Redis failures and timeouts never change the authentication response.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- OpenID refresh controller tests: 41 passed
- Auth user cache tests: 9 passed
- Prettier and ESLint passed for changed files

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes