### PR TITLE
🔍 refactor: Surface primary OpenID JWT failure reason in auth failure log

### DIFF
--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -564,12 +564,17 @@ describe('requireJwtAuth tenant context chaining', () => {
         fallback_strategy: 'jwt',
         fallback_attempted: true,
         fallback_succeeded: false,
+        // The real openidJwt failure is surfaced alongside the fallback's reason so a
+        // reused-token failure is not misattributed to the `jwt` fallback's error (#14311).
+        primary_failure_reason: 'jwt expired',
+        primary_failure_error_name: 'TokenExpiredError',
         reason: 'invalid signature',
         error_name: 'JsonWebTokenError',
         status: 401,
       }),
     );
     expect(logger.warn.mock.calls[0][0]).toContain('"reason":"invalid signature"');
+    expect(logger.warn.mock.calls[0][0]).toContain('"primary_failure_reason":"jwt expired"');
     expect(logger.warn.mock.calls[0][0]).toContain('"path":"/api/ask"');
   });
 

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -121,6 +121,14 @@ const requireJwtAuth = (req, res, next) => {
       fallback_succeeded: false,
       attempted_strategies: strategies,
       final_strategy: strategy,
+      // Surface the primary (openidJwt) failure alongside the final strategy's reason so a
+      // reused-token failure is not misattributed to the HS256 `jwt` fallback's "invalid
+      // algorithm" error, which is the fallback rejecting an RS256 provider token, not the
+      // real reason openidJwt did not authenticate.
+      ...(fallbackAttempted && {
+        primary_failure_reason: primaryFailureReason,
+        primary_failure_error_name: primaryFailureErrorName,
+      }),
       reason: getAuthFailureReason(err, info),
       error_name: getAuthFailureErrorName(err, info),
       status: status || 401,


### PR DESCRIPTION
## Summary

Refs #14311. Improves diagnosability of `OPENID_REUSE_TOKENS=true` auth failures. The reported "invalid algorithm" for Keycloak RS256 tokens is emitted by the **HS256 `jwt` fallback strategy** rejecting the provider token, not by the `openidJwt` strategy (which already accepts RS256, since jsonwebtoken 9.x derives the RSA algorithms from the JWKS public key). Until now the final "Authentication failed after all strategies" **warn** log reported only the fallback's reason, so the real `openidJwt` failure was misattributed and only visible at `debug` level.

## What changed

- `api/server/middleware/requireJwtAuth.js`: `logAuthenticationFailure` now includes the captured primary (`openidJwt`) failure reason and error name (`primary_failure_reason`, `primary_failure_error_name`) when a fallback was attempted, alongside the fallback's `reason`. Operators can now see why `openidJwt` actually failed (e.g. audience/issuer mismatch, or the openidJwt strategy not being selected) without enabling debug logging.

## Not included (on purpose)

The originally proposed fix — adding `algorithms: ['RS256']` to the `openidJwt` `JwtStrategy` — is a no-op: jsonwebtoken already derives `RS256` from the RSA JWKS key, so `openidJwt` accepts RS256 today, and that change does not touch the `jwt` fallback that emits the error. See the issue thread for the full analysis and next steps for affected reporters.

## Testing

- `api` — `requireJwtAuth.spec.js`: extended the "OpenID JWT + JWT fallback both fail" case to assert `primary_failure_reason`/`primary_failure_error_name` are surfaced in the warn log. 24 pass.
