### PR TITLE
🚪 fix: Keep Owners From Being Locked Out of Their Own Resource When Sharing

### DIFF
--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -758,6 +758,19 @@ const bulkUpdateResourcePermissions = async ({
 
     const bulkWrites = [];
 
+    /**
+     * Tracks principals granted in this same request so their revoke is skipped below. Grants are
+     * flushed before deletes, so a principal present in both `updatedPrincipals` and
+     * `revokedPrincipals` would be upserted and then deleted, stripping access the caller just set
+     * (e.g. a resource owner landing in both lists from a client `id`/`idOnTheSource` mismatch).
+     * Granting wins to make owner lockout impossible regardless of the client-side diff (#14316).
+     */
+    const grantedPrincipalKeys = new Set();
+    const principalKey = (principal) =>
+      principal.type === PrincipalType.PUBLIC
+        ? PrincipalType.PUBLIC
+        : `${principal.type}:${principal.id}`;
+
     for (const principal of updatedPrincipals) {
       try {
         if (!principal.accessRoleId) {
@@ -838,6 +851,7 @@ const bulkUpdateResourcePermissions = async ({
           memberCount: principal.memberCount,
           memberIds: principal.memberIds,
         });
+        grantedPrincipalKeys.add(principalKey(principal));
       } catch (error) {
         results.errors.push({
           principal,
@@ -852,6 +866,9 @@ const bulkUpdateResourcePermissions = async ({
 
     const deleteQueries = [];
     for (const principal of revokedPrincipals) {
+      if (grantedPrincipalKeys.has(principalKey(principal))) {
+        continue;
+      }
       try {
         const query = {
           principalType: principal.type,

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -759,17 +759,18 @@ const bulkUpdateResourcePermissions = async ({
     const bulkWrites = [];
 
     /**
-     * Tracks principals granted in this same request so their revoke is skipped below. Grants are
-     * flushed before deletes, so a principal present in both `updatedPrincipals` and
+     * Tracks non-public principals granted in this same request so their revoke is skipped below.
+     * Grants are flushed before deletes, so a principal present in both `updatedPrincipals` and
      * `revokedPrincipals` would be upserted and then deleted, stripping access the caller just set
      * (e.g. a resource owner landing in both lists from a client `id`/`idOnTheSource` mismatch).
      * Granting wins to make owner lockout impossible regardless of the client-side diff (#14316).
+     *
+     * PUBLIC is deliberately excluded: an explicit `public: false` disable adds the public principal
+     * to the revoke list, and disabling public access must always win over a stale/contradictory
+     * grant so a resource is never left public when the caller asked to make it private.
      */
     const grantedPrincipalKeys = new Set();
-    const principalKey = (principal) =>
-      principal.type === PrincipalType.PUBLIC
-        ? PrincipalType.PUBLIC
-        : `${principal.type}:${principal.id}`;
+    const principalKey = (principal) => `${principal.type}:${principal.id}`;
 
     for (const principal of updatedPrincipals) {
       try {
@@ -851,7 +852,9 @@ const bulkUpdateResourcePermissions = async ({
           memberCount: principal.memberCount,
           memberIds: principal.memberIds,
         });
-        grantedPrincipalKeys.add(principalKey(principal));
+        if (principal.type !== PrincipalType.PUBLIC) {
+          grantedPrincipalKeys.add(principalKey(principal));
+        }
       } catch (error) {
         results.errors.push({
           principal,
@@ -866,7 +869,10 @@ const bulkUpdateResourcePermissions = async ({
 
     const deleteQueries = [];
     for (const principal of revokedPrincipals) {
-      if (grantedPrincipalKeys.has(principalKey(principal))) {
+      if (
+        principal.type !== PrincipalType.PUBLIC &&
+        grantedPrincipalKeys.has(principalKey(principal))
+      ) {
         continue;
       }
       try {

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -869,13 +869,15 @@ const bulkUpdateResourcePermissions = async ({
 
     const deleteQueries = [];
     for (const principal of revokedPrincipals) {
-      if (
-        principal.type !== PrincipalType.PUBLIC &&
-        grantedPrincipalKeys.has(principalKey(principal))
-      ) {
-        continue;
-      }
       try {
+        // Inside the try so a malformed revoke entry (e.g. a nullish principal) is recorded in
+        // results.errors and skipped, rather than throwing out after grants were already flushed.
+        if (
+          principal.type !== PrincipalType.PUBLIC &&
+          grantedPrincipalKeys.has(principalKey(principal))
+        ) {
+          continue;
+        }
         const query = {
           principalType: principal.type,
           resourceType,

--- a/api/server/services/PermissionService.spec.js
+++ b/api/server/services/PermissionService.spec.js
@@ -894,6 +894,45 @@ describe('PermissionService', () => {
       expect(remainingEntries[0].principalId.toString()).toBe(userId.toString());
     });
 
+    test('grant wins over revoke when a principal is in both lists (prevents owner lockout, #14316)', async () => {
+      // Simulates the share dialog sending the owner in both updatedPrincipals (grant OWNER) and
+      // revokedPrincipals (e.g. from a client id/idOnTheSource mismatch). Grants flush before
+      // deletes, so without the guard the owner would be upserted and then deleted. The owner
+      // must keep access.
+      const results = await bulkUpdateResourcePermissions({
+        resourceType: ResourceType.AGENT,
+        resourceId,
+        updatedPrincipals: [
+          {
+            type: PrincipalType.USER,
+            id: userId,
+            accessRoleId: AccessRoleIds.AGENT_OWNER,
+          },
+        ],
+        revokedPrincipals: [
+          {
+            type: PrincipalType.USER,
+            id: userId,
+          },
+        ],
+        grantedBy: grantedById,
+      });
+
+      expect(results.granted).toHaveLength(1);
+      // The revoke for the same principal is skipped, not applied, so it is absent from results.
+      expect(results.revoked).toHaveLength(0);
+      expect(results.errors).toHaveLength(0);
+
+      const userEntry = await AclEntry.findOne({
+        principalType: PrincipalType.USER,
+        principalId: userId,
+        resourceType: ResourceType.AGENT,
+        resourceId,
+      }).populate('roleId', 'accessRoleId');
+      expect(userEntry).not.toBeNull();
+      expect(userEntry.roleId.accessRoleId).toBe(AccessRoleIds.AGENT_OWNER);
+    });
+
     test('should handle mixed operations (grant, update, revoke)', async () => {
       const updatedPrincipals = [
         {

--- a/api/server/services/PermissionService.spec.js
+++ b/api/server/services/PermissionService.spec.js
@@ -965,6 +965,32 @@ describe('PermissionService', () => {
       expect(publicEntry).toBeNull();
     });
 
+    test('records a malformed revoke entry in errors instead of throwing after grants flush (#14316)', async () => {
+      // A nullish/malformed entry in revokedPrincipals must not throw out of the function after
+      // grants have already been flushed; it is captured in results.errors and processing continues.
+      const results = await bulkUpdateResourcePermissions({
+        resourceType: ResourceType.AGENT,
+        resourceId,
+        updatedPrincipals: [
+          { type: PrincipalType.USER, id: otherUserId, accessRoleId: AccessRoleIds.AGENT_VIEWER },
+        ],
+        revokedPrincipals: [null],
+        grantedBy: grantedById,
+      });
+
+      expect(results.errors).toHaveLength(1);
+      expect(results.granted).toHaveLength(1);
+
+      // The valid grant still landed despite the malformed revoke entry.
+      const grantedEntry = await AclEntry.findOne({
+        principalType: PrincipalType.USER,
+        principalId: otherUserId,
+        resourceType: ResourceType.AGENT,
+        resourceId,
+      });
+      expect(grantedEntry).not.toBeNull();
+    });
+
     test('should handle mixed operations (grant, update, revoke)', async () => {
       const updatedPrincipals = [
         {

--- a/api/server/services/PermissionService.spec.js
+++ b/api/server/services/PermissionService.spec.js
@@ -933,6 +933,38 @@ describe('PermissionService', () => {
       expect(userEntry.roleId.accessRoleId).toBe(AccessRoleIds.AGENT_OWNER);
     });
 
+    test('revoke wins for PUBLIC so an explicit public disable is honored (#14316)', async () => {
+      // A contradictory payload that both grants public and disables it puts the public principal
+      // in both lists. Unlike user/group principals, disabling public access must win so the
+      // resource is never left public when the caller asked to make it private.
+      const results = await bulkUpdateResourcePermissions({
+        resourceType: ResourceType.AGENT,
+        resourceId,
+        updatedPrincipals: [
+          {
+            type: PrincipalType.PUBLIC,
+            accessRoleId: AccessRoleIds.AGENT_VIEWER,
+          },
+        ],
+        revokedPrincipals: [
+          {
+            type: PrincipalType.PUBLIC,
+          },
+        ],
+        grantedBy: grantedById,
+      });
+
+      expect(results.revoked).toHaveLength(1);
+      expect(results.errors).toHaveLength(0);
+
+      const publicEntry = await AclEntry.findOne({
+        principalType: PrincipalType.PUBLIC,
+        resourceType: ResourceType.AGENT,
+        resourceId,
+      });
+      expect(publicEntry).toBeNull();
+    });
+
     test('should handle mixed operations (grant, update, revoke)', async () => {
       const updatedPrincipals = [
         {


### PR DESCRIPTION
## Summary

Refs #14316. Adds a server-side guard so sharing a resource can never revoke a principal's access that the same request just granted.

`bulkUpdateResourcePermissions` (`api/server/services/PermissionService.js`) flushes grants (upserts) **before** revokes (deletes). If a principal appears in both `updatedPrincipals` and `revokedPrincipals`, the ACL entry is granted and then immediately deleted. The reported case (#14316) is a resource owner landing in both lists from a client `id`/`idOnTheSource` mismatch under OpenID/Entra, which would strip the owner's own `agent_owner` grant and 403 them out of their own resource.

## What changed

- `api/server/services/PermissionService.js`: track the set of principals granted in the same request and skip any revoke for a principal in that set. Granting wins, making owner lockout impossible regardless of how the client computes the share diff.

## Relationship to #14317

This is defense-in-depth on the server. It complements the client-side fix in #14317 (keying the share diff by the stable `id`). With this guard, the lockout is impossible even if a client sends a principal in both lists. Note: I could not reproduce the original owner-revocation flow against current `main` (both `currentShares` and `allShares` derive from the same `getResourcePermissions` payload, so the owner's `idOnTheSource` matches on both sides); this guard hardens the write path against any such client keying mistake regardless.

## Testing

- `api` — `PermissionService.spec.js`: new case asserting that a principal present in both `updatedPrincipals` (grant OWNER) and `revokedPrincipals` keeps its granted ACL entry and the revoke is skipped. Full `bulkUpdateResourcePermissions` suite passes (real `mongodb-memory-server`).
