### PR TITLE
🐛 fix: Default GPT-5.6 to Responses API without explicit reasoning_effort

### DIFF
--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -729,7 +729,7 @@ describe('getOpenAILLMConfig', () => {
       },
     );
 
-    it('should NOT default to Responses API without reasoning params', () => {
+    it('should default to Responses API for gpt-5.6 even without explicit reasoning params', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',
         streaming: true,
@@ -739,8 +739,7 @@ describe('getOpenAILLMConfig', () => {
         },
       });
 
-      expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
-      expect(result.llmConfig).not.toHaveProperty('reasoning');
+      expect(result.llmConfig).toHaveProperty('useResponsesApi', true);
     });
 
     it('should NOT default to Responses API when reasoning_effort is none', () => {

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -121,11 +121,12 @@ function isOpenAIEndpoint(endpoint?: EModelEndpoint | string | null): boolean {
 }
 
 /**
- * GPT-5.6 models reject function tools combined with `reasoning_effort` in
- * `/v1/chat/completions` (400: "To use function tools, use /v1/responses or
- * set reasoning_effort to 'none'"). Reasoning without tools still works on
- * Chat Completions, but tools are bound after config time, so GPT-5.6
- * reasoning requests default to the Responses API to avoid tool failures.
+ * GPT-5.6 models reject function tools on `/v1/chat/completions` while the
+ * model is reasoning (400: "To use function tools, use /v1/responses or set
+ * reasoning_effort to 'none'"). GPT-5.6 reasons by default even when no
+ * explicit `reasoning_effort` is set, and tools are bound after config time,
+ * so first-party OpenAI GPT-5.6 requests default to the Responses API unless
+ * the user explicitly sets effort to `none` (or opts out of Responses).
  */
 const responsesApiRequiredPattern = /\bgpt-5\.6\b/;
 
@@ -139,11 +140,8 @@ function requiresResponsesApiForReasoning({
   if (typeof model !== 'string' || !responsesApiRequiredPattern.test(model)) {
     return false;
   }
-  return (
-    reasoningEffort != null &&
-    reasoningEffort !== ReasoningEffort.unset &&
-    reasoningEffort !== ReasoningEffort.none
-  );
+  // Only skip when the user explicitly disables reasoning.
+  return reasoningEffort !== ReasoningEffort.none;
 }
 
 /**


### PR DESCRIPTION
## Summary
- GPT-5.6 reasons by default, so function tools still 400 on `/v1/chat/completions` even when no `reasoning_effort` is set.
- Broaden `requiresResponsesApiForReasoning` so first-party OpenAI GPT-5.6 auto-switches to the Responses API unless effort is explicitly `none` (or Responses is opted out).
- Update the unit expectation for the no-explicit-effort case; keep the existing `none` / explicit-opt-out / non-canonical-base-URL guards.

Fixes #14355

## Test plan
- [ ] `packages/api` unit tests for `getOpenAILLMConfig` / GPT-5.6 Responses API Requirement
- [ ] First-party OpenAI `gpt-5.6` / `-terra` / `-luna` / `-sol` with a function tool and no explicit effort routes to Responses API
- [ ] Explicit `reasoning_effort: none` stays on Chat Completions
- [ ] `useResponsesApi: false` / dropParams opt-out still honored
- [ ] Custom / reverse-proxy / OpenRouter paths unchanged