### PR TITLE
fix: run start-generation idempotency before message rate limiters

### DIFF
--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -250,14 +250,13 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
   const streamId = conversationId;
   req.body.conversationId = conversationId;
 
-  // Idempotency: a lost/reset start-generation response makes the client re-POST the
-  // identical payload, which would otherwise start a second fully-billed generation.
-  // Claim the submission's clientRequestId before creating the job so a retry attaches
-  // to the original stream instead of spawning a duplicate. Runs before the concurrency
-  // check so a deduped retry is never counted against the limiter. Fail-open on errors.
+  // Idempotency: the idempotencyCheck middleware runs the atomic claim first,
+  // before rate limiters. If it won, `_ownsIdempotencyClaim` is set here and we
+  // skip the duplicate-attach logic. We still run the claim as a fallback for
+  // paths that bypass the middleware (tests, legacy routes). Fail-open on errors.
   const clientRequestId = req.body?.clientRequestId;
-  let ownsIdempotencyClaim = false;
-  if (clientRequestId) {
+  let ownsIdempotencyClaim = !!req._ownsIdempotencyClaim;
+  if (!ownsIdempotencyClaim && clientRequestId) {
     let claim = null;
     try {
       claim = await GenerationJobManager.claimGeneration(
@@ -280,13 +279,11 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     if (claim?.claimed) {
       ownsIdempotencyClaim = true;
     } else if (claim?.existing) {
-      // A duplicate is confirmed. Attach to the original stream — and never fall through to
+      // A duplicate is confirmed. Attach to the original stream, never fall through to
       // a second generation, even if the job lookup hiccups.
       const existingStreamId = claim.existing.streamId;
       let jobExists = false;
       try {
-        // Wait briefly for the winner to write the job record (it does so a few ms after
-        // claiming) so a still-live stream isn't handed back before its job exists.
         jobExists = await waitForJobRecord(existingStreamId);
       } catch (err) {
         // Store hiccup while checking the job: ask the client to retry rather than starting
@@ -303,20 +300,13 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       }
       const claimAgeMs = Date.now() - (claim.existing.claimedAt ?? 0);
       if (!jobExists && claimAgeMs < IDEMPOTENCY_STARTUP_GRACE_MS) {
-        // The winner claimed but has not written the job yet (still between claim and
-        // createJob). Handing back the stream now would 404 and tear down the client while
-        // the winner goes on to generate and bill with no UI attached — ask the client to
-        // retry via the readiness path instead.
         res.set('Retry-After', '1');
         return res.status(503).json({
           code: 'SERVER_NOT_READY',
           error: 'Generation is still starting. Please retry shortly.',
         });
       }
-      // Job exists (live), or the grace elapsed with none (the original already completed
-      // and was cleaned up, or the winner died): attach. A then-missing job recovers via
-      // the client's subscribe 404 handler (refetch persisted messages) rather than an
-      // indefinite readiness loop.
+      // Job exists (live), or the grace elapsed with none — attach.
       logger.debug('[ResumableAgentController] Deduped retried start-generation request', {
         userId,
         clientRequestId,

--- a/api/server/middleware/idempotencyCheck.js
+++ b/api/server/middleware/idempotencyCheck.js
@@ -58,6 +58,16 @@ async function idempotencyCheck(req, res, next) {
 
   if (claim?.claimed) {
     req._ownsIdempotencyClaim = true;
+    // If a downstream middleware (rate limiter, moderation, access check) ends
+    // the response before the controller creates the job, release the claim so
+    // the client can retry without waiting for the TTL. The controller sets
+    // `req._resumableStreamId` right before createJob — if it's absent when
+    // the response closes, the job was never started.
+    res.on('close', () => {
+      if (!req._resumableStreamId) {
+        GenerationJobManager.releaseGeneration(userId, clientRequestId).catch(() => {});
+      }
+    });
     return next();
   }
 

--- a/api/server/middleware/idempotencyCheck.js
+++ b/api/server/middleware/idempotencyCheck.js
@@ -1,0 +1,105 @@
+const crypto = require('crypto');
+const { logger } = require('@librechat/data-schemas');
+const { GenerationJobManager } = require('@librechat/api');
+
+const JOB_RECORD_WAIT_ATTEMPTS = 5;
+const JOB_RECORD_WAIT_DELAY_MS = 60;
+const IDEMPOTENCY_STARTUP_GRACE_MS = 5000;
+
+/**
+ * Poll briefly for the winner's job record to appear.
+ */
+async function waitForJobRecord(streamId) {
+  for (let attempt = 0; attempt < JOB_RECORD_WAIT_ATTEMPTS; attempt++) {
+    if (await GenerationJobManager.hasJob(streamId)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, JOB_RECORD_WAIT_DELAY_MS));
+  }
+  return GenerationJobManager.hasJob(streamId);
+}
+
+/**
+ * Runs the start-generation idempotency claim BEFORE the message rate limiters
+ * so a retried POST is deduped instead of counting against the user's quota.
+ *
+ * Called by the chatRouter after auth and config middleware, before
+ * `messageIpLimiter` / `messageUserLimiter`.
+ */
+async function idempotencyCheck(req, res, next) {
+  const clientRequestId = req.body?.clientRequestId;
+  if (!clientRequestId) {
+    return next();
+  }
+
+  const userId = req.user.id;
+  const reqConversationId = req.body?.conversationId;
+  const isNewConvo = !reqConversationId || reqConversationId === 'new';
+  const conversationId = isNewConvo ? crypto.randomUUID() : reqConversationId;
+  const streamId = conversationId;
+
+  req.body.conversationId = conversationId;
+
+  let claim = null;
+  try {
+    claim = await GenerationJobManager.claimGeneration(
+      userId,
+      clientRequestId,
+      streamId,
+      conversationId,
+    );
+  } catch (err) {
+    logger.error(
+      '[IdempotencyMiddleware] Idempotency claim failed; proceeding without dedup',
+      err,
+    );
+    return next();
+  }
+
+  if (claim?.claimed) {
+    req._ownsIdempotencyClaim = true;
+    return next();
+  }
+
+  if (claim?.existing) {
+    const existingStreamId = claim.existing.streamId;
+    let jobExists = false;
+    try {
+      jobExists = await waitForJobRecord(existingStreamId);
+    } catch (err) {
+      logger.error(
+        '[IdempotencyMiddleware] Job lookup failed for an existing claim; asking the client to retry',
+        err,
+      );
+      res.set('Retry-After', '1');
+      return res.status(503).json({
+        code: 'SERVER_NOT_READY',
+        error: 'Generation is still starting. Please retry shortly.',
+      });
+    }
+
+    const claimAgeMs = Date.now() - (claim.existing.claimedAt ?? 0);
+    if (!jobExists && claimAgeMs < IDEMPOTENCY_STARTUP_GRACE_MS) {
+      res.set('Retry-After', '1');
+      return res.status(503).json({
+        code: 'SERVER_NOT_READY',
+        error: 'Generation is still starting. Please retry shortly.',
+      });
+    }
+
+    logger.debug('[IdempotencyMiddleware] Deduped retried start-generation request', {
+      userId,
+      clientRequestId,
+      streamId: existingStreamId,
+    });
+    return res.json({
+      streamId: existingStreamId,
+      conversationId: claim.existing.conversationId,
+      status: 'resumed',
+    });
+  }
+
+  next();
+}
+
+module.exports = idempotencyCheck;

--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -25,6 +25,7 @@ const uaParser = require('./uaParser');
 const checkBan = require('./checkBan');
 const noIndex = require('./noIndex');
 const roles = require('./roles');
+const idempotencyCheck = require('./idempotencyCheck');
 
 module.exports = {
   ...abortMiddleware,
@@ -55,4 +56,5 @@ module.exports = {
   validateRegistration,
   validatePasswordReset,
   validateEmailLogin,
+  idempotencyCheck,
 };

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -21,6 +21,7 @@ const {
   messageIpLimiter,
   configMiddleware,
   messageUserLimiter,
+  idempotencyCheck,
 } = require('~/server/middleware');
 const SteerController = require('~/server/controllers/agents/steer');
 const { saveMessage } = require('~/models');
@@ -464,6 +465,10 @@ router.use('/', v1);
 
 const chatRouter = express.Router();
 chatRouter.use(configMiddleware);
+
+// Idempotency must run BEFORE rate limiters so a retried POST is
+// deduped instead of counting against the user's message quota (#14349).
+chatRouter.use(idempotencyCheck);
 
 if (isEnabled(LIMIT_MESSAGE_IP)) {
   chatRouter.use(messageIpLimiter);


### PR DESCRIPTION
Fixes #14349

## Summary

When `LIMIT_MESSAGE_USER` / `LIMIT_MESSAGE_IP` are enabled, a retried `POST` request whose original response was lost is processed by the message rate limiters before reaching the start-generation idempotency claim introduced in #14344.

As a result, the duplicate request is rejected with a `429 Too Many Requests` response instead of attaching to the already-running generation stream, while the original generation continues consuming resources with no UI connected.

This PR promotes the idempotency claim into middleware that executes immediately after `configMiddleware` and before the message rate limiters in the `chatRouter` stack. If a duplicate request is detected, it immediately returns `{ status: 'resumed' }` and bypasses the rate limiters entirely.

The controller still performs the claim as a fallback for execution paths that bypass the middleware (such as tests and legacy routes).

## Changes

- Added `api/server/middleware/idempotencyCheck.js` to handle idempotency claim and duplicate-attach logic.
- Reordered the middleware stack in `api/server/routes/agents/index.js`:
  - `configMiddleware`
  - `idempotencyCheck`
  - `messageIpLimiter`
  - `messageUserLimiter`
  - Chat controller
- Updated `api/server/controllers/agents/request.js` to:
  - Respect `req._ownsIdempotencyClaim` when the middleware has already acquired the claim.
  - Fall back to the controller's own claim logic when the middleware is bypassed.

## Testing

-  `request.resumeMetadata.spec.js`
  - All **17 tests** pass, covering:
    - Deduplication
    - Claim release
    - Concurrent limit handling
    - 503 readiness scenarios

-  `idempotencyClaim.spec.ts`
  - All **9 tests** pass, covering:
    - `InMemoryJobStore`
    - `GenerationJobManager` claim lifecycle