### PR TITLE
🧾 ci: Skip Workflows for Markdown-Only Changes

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'client/src/**'
+      - '!**.md'
   workflow_dispatch:
     inputs:
       run_workflow:

--- a/.github/workflows/agents-integration-tests.yml
+++ b/.github/workflows/agents-integration-tests.yml
@@ -15,6 +15,7 @@ on:
       - 'packages/api/src/agents/**'
       - 'packages/api/package.json'
       - '.github/workflows/agents-integration-tests.yml'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'api/**'
       - 'packages/**'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/cache-integration-tests.yml
+++ b/.github/workflows/cache-integration-tests.yml
@@ -14,6 +14,7 @@ on:
       - 'packages/api/src/stream/**'
       - 'redis-config/**'
       - '.github/workflows/cache-integration-tests.yml'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/config-review.yml
+++ b/.github/workflows/config-review.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/data-provider/src/**'
       - 'packages/api/src/acl/**'
       - 'packages/api/src/shared-links/**'
+      - '!**.md'
 
 env:
   NODE_ENV: CI

--- a/.github/workflows/dev-branch-images.yml
+++ b/.github/workflows/dev-branch-images.yml
@@ -13,6 +13,7 @@ on:
       - 'package-lock.json'
       - 'Dockerfile'
       - 'Dockerfile.multi'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -13,6 +13,7 @@ on:
       - 'package-lock.json'
       - 'Dockerfile'
       - 'Dockerfile.multi'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -17,6 +17,7 @@ on:
       - 'packages/client/**'
       - 'packages/data-provider/**'
       - 'packages/data-schemas/**'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'client/**'
       - 'packages/**'
       - '.github/workflows/eslint-ci.yml'
+      - '!**.md'
 
 jobs:
   eslint_checks:

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -7,6 +7,7 @@ on:
       - 'packages/client/**'
       - 'packages/data-provider/**'
       - '.github/workflows/frontend-review.yml'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/i18n-unused-keys.yml
+++ b/.github/workflows/i18n-unused-keys.yml
@@ -13,6 +13,7 @@ on:
       - "packages/data-provider/src/**"
       - "packages/client/**"
       - "packages/data-schemas/src/**"
+      - "!**.md"
 
 jobs:
   detect-unused-i18n-keys:

--- a/.github/workflows/langfuse-fanout.yml
+++ b/.github/workflows/langfuse-fanout.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/langfuse-fanout.yml'
       - 'otel/langfuse-fanout/**'
+      - '!**.md'
 
 permissions:
   contents: read

--- a/.github/workflows/locize-i18n-sync.yml
+++ b/.github/workflows/locize-i18n-sync.yml
@@ -3,6 +3,8 @@ name: Sync Locize Translations & Create Translation PR
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
   repository_dispatch:
     types: [locize/versionPublished]
 

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -2,6 +2,8 @@ name: Playwright E2E Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/sync-helm-chart-tags.yml
+++ b/.github/workflows/sync-helm-chart-tags.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
     inputs:
       release_existing_tag:

--- a/.github/workflows/unused-packages.yml
+++ b/.github/workflows/unused-packages.yml
@@ -9,6 +9,7 @@ on:
       - 'api/**'
       - 'packages/client/**'
       - 'packages/api/**'
+      - '!**.md'
 
 jobs:
   detect-unused-packages:


### PR DESCRIPTION
## Summary

I updated LibreChat's automatic GitHub Actions triggers so Markdown-only changes do not consume CI and build resources.

- Excluded Markdown files from path-scoped pull request tests, linting, accessibility checks, and Docker smoke tests.
- Added a Markdown exclusion to the unconditional Playwright pull request workflow.
- Excluded Markdown-only branch pushes from development image builds, Locize synchronization, and Helm chart tag synchronization.
- Preserved the Markdown-driven documentation embeddings workflow.
- Preserved manual dispatches, release tag workflows, package publishers, and mixed changes containing non-Markdown files.
- Preserved GitNexus pull request cleanup because it is a close-event lifecycle workflow rather than CI.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I parsed every modified workflow as YAML, checked the diff for whitespace errors, and audited all pull request and branch-push triggers for intentional Markdown handling.

### **Test Configuration**:

- YAML syntax: `ruby -e "require 'yaml'; ARGV.each { |file| YAML.parse_file(file) }" <modified workflows>`
- Git diff validation: `git diff --cached --check`
- Trigger audit: confirmed only the GitNexus close-event cleanup omits the PR exclusion; confirmed docs embeddings and exact `package.json` publishers are the only branch-push exceptions.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
