### PR TITLE
🧹 fix: Strip OpenAI Flag From Bedrock Parameters

### DIFF
--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -144,7 +144,7 @@ describe('initializeBedrock', () => {
         | undefined;
 
       expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
-      expect(additionalModelRequestFields).not.toHaveProperty('useResponsesApi');
+      expect(additionalModelRequestFields?.useResponsesApi).toBeUndefined();
     });
 
     it('should handle session token when provided', async () => {

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -131,6 +131,22 @@ describe('initializeBedrock', () => {
       expect(result.llmConfig).toHaveProperty('maxTokens', 4096);
     });
 
+    it('should strip stale OpenAI Responses API parameters', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+          useResponsesApi: true,
+        },
+      });
+      const result = await initializeBedrock(params);
+      const additionalModelRequestFields = result.llmConfig.additionalModelRequestFields as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
+      expect(additionalModelRequestFields).not.toHaveProperty('useResponsesApi');
+    });
+
     it('should handle session token when provided', async () => {
       process.env.BEDROCK_AWS_SESSION_TOKEN = 'test-session-token';
       const params = createMockParams();

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -1456,6 +1456,26 @@ describe('bedrockInputParser', () => {
   });
 
   describe('Model switching cleanup', () => {
+    test.each([
+      ['top-level', { useResponsesApi: true }],
+      ['additionalModelRequestFields', { additionalModelRequestFields: { useResponsesApi: true } }],
+    ])('should strip stale OpenAI useResponsesApi from %s', (_source, staleParameters) => {
+      const parsed = bedrockInputParser.parse({
+        model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        ...staleParameters,
+      }) as Record<string, unknown>;
+      const parsedAmrf = parsed.additionalModelRequestFields as Record<string, unknown> | undefined;
+
+      expect(parsed.useResponsesApi).toBeUndefined();
+      expect(parsedAmrf?.useResponsesApi).toBeUndefined();
+
+      const output = bedrockOutputParser(parsed);
+      const outputAmrf = output.additionalModelRequestFields as Record<string, unknown> | undefined;
+
+      expect(output.useResponsesApi).toBeUndefined();
+      expect(outputAmrf?.useResponsesApi).toBeUndefined();
+    });
+
     test('should strip anthropic_beta when switching from Anthropic to non-Anthropic model', () => {
       const staleConversationData = {
         model: 'openai.gpt-oss-120b-1:0',

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -571,12 +571,14 @@ export const bedrockInputParser = s.tConversationSchema
     const isAnthropicModel =
       typeof typedData.model === 'string' && isBedrockClaudeModel(typedData.model);
 
-    /** Strip stale fields from previously-persisted additionalModelRequestFields */
+    /** Strip stale provider-specific fields from switched and persisted model parameters */
+    delete additionalFields.useResponsesApi;
     if (
       typeof typedData.additionalModelRequestFields === 'object' &&
       typedData.additionalModelRequestFields != null
     ) {
       const amrf = typedData.additionalModelRequestFields as Record<string, unknown>;
+      delete amrf.useResponsesApi;
       if (!isAnthropicModel) {
         delete amrf.anthropic_beta;
         delete amrf.thinking;


### PR DESCRIPTION
## Summary

I fixed Bedrock agent initialization so stale OpenAI Responses API settings no longer leak across provider switches and cause request validation failures.

- Strip `useResponsesApi` from top-level model parameters before Bedrock builds `additionalModelRequestFields`.
- Remove previously persisted nested copies while preserving supported Bedrock passthrough parameters.
- Add parser and endpoint initialization regression coverage for both stale parameter shapes.

Closes #14381

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `packages/data-provider/specs/bedrock.spec.ts`: 198 tests passed.
- Ran `packages/api/src/endpoints/bedrock/initialize.spec.ts`: 59 tests passed.
- Ran ESLint on all changed source and test files.
- Ran Prettier checks on all changed source and test files.

### **Test Configuration**:

- Node.js v24.16.0
- Jest 30.2.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes