### PR TITLE
🚦 ci: Gate Playwright Runs to Maintainers

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -24,6 +24,9 @@ env:
 
 jobs:
   e2e:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -26,7 +26,9 @@ jobs:
   e2e:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request != null &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
I restricted automatic Playwright E2E runs to trusted repository roles while preserving manual execution, allowing lightweight contributor checks to run broadly without automatically consuming Playwright capacity.

- Restrict the Playwright pull-request job to PR authors associated as `OWNER`, `MEMBER`, or `COLLABORATOR`.
- Preserve manual `workflow_dispatch` runs for maintainers.
- Leave ESLint, TypeScript/unit-test, and Docker smoke workflows on their existing read-only `pull_request` triggers.
- Prepare the repository for changing its fork-workflow approval policy from `all_external_contributors` to `first_time_contributors_new_to_github` after this PR merges.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Parsed the modified workflow with Ruby's YAML parser.
- Ran `git diff --check` before committing.

### **Test Configuration**:

- macOS
- GitHub Actions workflow syntax validation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
