### PR TITLE
🎭 ci: Scope Playwright Runs to Relevant Changes

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -2,8 +2,11 @@ name: Playwright E2E Tests
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
+    paths:
+      - '**'
+      - '!**.md'
+      - '!.github/workflows/**'
+      - '.github/workflows/playwright-mock.yml'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
## Summary

I narrowed the Playwright pull request trigger so unrelated workflow-only and Markdown-only changes do not start the full E2E suite.

- Include pull requests with non-Markdown repository changes by default.
- Exclude Markdown files and unrelated GitHub Actions workflow files.
- Re-include `playwright-mock.yml` so changes to the E2E workflow still validate themselves.
- Preserve manual Playwright runs through `workflow_dispatch`.
- Preserve E2E runs for mixed changes containing relevant files.

The previous trigger ignored only Markdown, so changes isolated to unrelated automation workflows still consumed the full Playwright runner.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I parsed the modified workflow as YAML, verified its formatting, checked the diff for whitespace errors, and confirmed the ordered path patterns contain no repository-specific references.

### **Test Configuration**:

- YAML syntax validation with Ruby
- Prettier workflow validation
- `git diff --cached --check`
- GitHub Actions ordered path-filter audit

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
