### PR TITLE
fix: verify job clientRequestId before attaching deduped retry

### DIFF
--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -670,7 +670,7 @@ describe('ResumableAgentController resume metadata', () => {
     expect(initializeClient).not.toHaveBeenCalled();
   });
 
-  it('returns 409 when the deduped job belongs to a different submission', async () => {
+  it('returns 503 SERVER_NOT_READY when the deduped job belongs to a different submission', async () => {
     mockGenerationJobManager.claimGeneration.mockResolvedValue({
       claimed: false,
       existing: { streamId: 'orig-stream', conversationId: 'orig-convo' },
@@ -696,9 +696,9 @@ describe('ResumableAgentController resume metadata', () => {
 
     await AgentController(req, res, jest.fn(), jest.fn(), null);
 
-    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.status).toHaveBeenCalledWith(503);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ error: 'This generation was superseded. Please reload.' }),
+      expect.objectContaining({ code: 'SERVER_NOT_READY' }),
     );
     expect(mockGenerationJobManager.createJob).not.toHaveBeenCalled();
   });

--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -16,6 +16,9 @@ const mockGenerationJobManager = {
   claimGeneration: jest.fn(),
   releaseGeneration: jest.fn(),
   hasJob: jest.fn(),
+  getJobStore: jest.fn(() => ({
+    getJob: jest.fn().mockResolvedValue(null),
+  })),
 };
 
 const mockCheckAndIncrementPendingRequest = jest.fn();
@@ -199,6 +202,9 @@ describe('ResumableAgentController resume metadata', () => {
     mockGenerationJobManager.claimGeneration.mockResolvedValue({ claimed: true });
     mockGenerationJobManager.releaseGeneration.mockResolvedValue(undefined);
     mockGenerationJobManager.hasJob.mockResolvedValue(true);
+    mockGenerationJobManager.getJobStore.mockReturnValue({
+      getJob: jest.fn().mockResolvedValue(null),
+    });
     mockSaveMessage.mockResolvedValue({});
   });
 
@@ -662,6 +668,39 @@ describe('ResumableAgentController resume metadata', () => {
     expect(mockGenerationJobManager.createJob).not.toHaveBeenCalled();
     expect(mockCheckAndIncrementPendingRequest).not.toHaveBeenCalled();
     expect(initializeClient).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the deduped job belongs to a different submission', async () => {
+    mockGenerationJobManager.claimGeneration.mockResolvedValue({
+      claimed: false,
+      existing: { streamId: 'orig-stream', conversationId: 'orig-convo' },
+    });
+    mockGenerationJobManager.hasJob.mockResolvedValue(true);
+    mockGenerationJobManager.getJobStore.mockReturnValue({
+      getJob: jest.fn().mockResolvedValue({
+        clientRequestId: 'req-other',
+      }),
+    });
+    const req = {
+      user: { id: 'user-123' },
+      body: {
+        text: 'Retry that lost the race.',
+        messageId: 'user-msg',
+        clientRequestId: 'req-abc',
+        conversationId: 'conversation-123',
+        endpointOption: { endpoint: 'agents', modelOptions: { model: 'gpt-4.1' } },
+      },
+      config: {},
+    };
+    const res = { json: jest.fn(), status: jest.fn(() => res), set: jest.fn() };
+
+    await AgentController(req, res, jest.fn(), jest.fn(), null);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'This generation was superseded. Please reload.' }),
+    );
+    expect(mockGenerationJobManager.createJob).not.toHaveBeenCalled();
   });
 
   it('resumes when the job is missing but the claim is old (original completed and was cleaned up)', async () => {

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -301,6 +301,30 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           error: 'Generation is still starting. Please retry shortly.',
         });
       }
+
+      // Verify the job at the claimed streamId still belongs to this submission.
+      // streamId === conversationId, so a new request to the same conversation can
+      // replace the job before this retry arrives, causing a wrong-render (#14348).
+      if (jobExists && clientRequestId) {
+        try {
+          const existingJob = await GenerationJobManager.getJobStore().getJob(existingStreamId);
+          if (existingJob?.clientRequestId && existingJob.clientRequestId !== clientRequestId) {
+            logger.warn(
+              '[ResumableAgentController] Claimed streamId belongs to a different submission',
+              { existingStreamId, claimClientRequestId: clientRequestId, jobClientRequestId: existingJob.clientRequestId },
+            );
+            return res.status(409).json({
+              error: 'This generation was superseded. Please reload.',
+            });
+          }
+        } catch (err) {
+          logger.warn(
+            '[ResumableAgentController] Failed to verify job ownership; proceeding with attach',
+            err,
+          );
+        }
+      }
+
       const claimAgeMs = Date.now() - (claim.existing.claimedAt ?? 0);
       if (!jobExists && claimAgeMs < IDEMPOTENCY_STARTUP_GRACE_MS) {
         // The winner claimed but has not written the job yet (still between claim and
@@ -378,6 +402,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       isTemporary: req.body?.isTemporary,
       responseMessageId: preliminaryResponseMessageId,
       userMessage: preliminaryUserMessage,
+      clientRequestId: req.body?.clientRequestId,
     });
 
     // Note: We no longer use res.on('close') to abort since we send JSON immediately.

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -317,8 +317,9 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
                 jobClientRequestId: existingJob.clientRequestId,
               },
             );
-            return res.status(409).json({
-              error: 'This generation was superseded. Please reload.',
+            return res.status(503).json({
+              code: 'SERVER_NOT_READY',
+              error: 'This generation was superseded. Please retry shortly.',
             });
           }
         } catch (err) {
@@ -382,6 +383,12 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     const jobCreatedAt = job.createdAt; // Capture creation time to detect job replacement
     req._resumableStreamId = streamId;
     getMCPRequestContext(req, undefined, { cleanupOnResponse: false });
+
+    // Persist clientRequestId before exposing the stream so a retry whose old claim
+    // points here never reads a job without it (or a stale one from a prior hash reuse).
+    await GenerationJobManager.updateMetadata(streamId, {
+      clientRequestId: req.body?.clientRequestId,
+    });
 
     // Send JSON response IMMEDIATELY so client can connect to SSE stream
     // This is critical: tool loading (MCP OAuth) may emit events that the client needs to receive

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -311,7 +311,11 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           if (existingJob?.clientRequestId && existingJob.clientRequestId !== clientRequestId) {
             logger.warn(
               '[ResumableAgentController] Claimed streamId belongs to a different submission',
-              { existingStreamId, claimClientRequestId: clientRequestId, jobClientRequestId: existingJob.clientRequestId },
+              {
+                existingStreamId,
+                claimClientRequestId: clientRequestId,
+                jobClientRequestId: existingJob.clientRequestId,
+              },
             );
             return res.status(409).json({
               error: 'This generation was superseded. Please reload.',

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -1649,6 +1649,9 @@ class GenerationJobManagerClass {
     if (metadata.discoveredTools) {
       updates.discoveredTools = metadata.discoveredTools;
     }
+    if (metadata.clientRequestId) {
+      updates.clientRequestId = metadata.clientRequestId;
+    }
     await this.jobStore.updateJob(streamId, updates);
   }
 

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -1801,6 +1801,7 @@ export class RedisJobStore implements IJobStore {
       pendingAction: this.parsePendingAction(data.pendingAction),
       pendingActionId: data.pendingActionId || undefined,
       lastActiveAt: data.lastActiveAt ? parseInt(data.lastActiveAt, 10) : undefined,
+      clientRequestId: data.clientRequestId || undefined,
     };
   }
 

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -82,6 +82,13 @@ export interface SerializableJobData {
   promptTokens?: number;
 
   /**
+   * The clientRequestId that originated this generation. Set once at creation so a
+   * deduped retry can verify the job at the claimed streamId belongs to the same
+   * submission rather than a newer generation that replaced it (#14348).
+   */
+  clientRequestId?: string;
+
+  /**
    * Agent that initiated the run. Persisted so a HITL resume can verify it rebuilds
    * the SAME agent that paused — resuming Agent A's checkpoint on Agent B's graph
    * would mis-execute the paused tool calls.

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -30,6 +30,10 @@ export interface GenerationJobMetadata {
    * without them the paused deferred tool would be missing from the schema-only toolMap.
    */
   discoveredTools?: string[];
+  /** ClientRequestId that originated this generation. Stored so a deduped retry
+   *  can verify the job at the claimed streamId belongs to the same submission
+   *  rather than a newer generation that replaced it. */
+  clientRequestId?: string;
   /** Set when the job is paused for human review (status === 'requires_action') */
   pendingAction?: Agents.PendingAction;
 }


### PR DESCRIPTION
Fixes #14348

streamId equals conversationId, so a new submission to the same conversation replaces the job before a retried start-response can attach. The deduped retry can then subscribe to a different generation and render the wrong response.

Stores the originating `clientRequestId` on the job at creation and verifies it matches before returning `{ status: 'resumed' }`. On mismatch, returns 409 so the client refetches instead of showing the wrong output. Store-read errors fail open (proceed with attach).

Changes:
    - Added `clientRequestId` to `SerializableJobData` and `GenerationJobMetadata`
    - Wired through `GenerationJobManager.updateMetadata`
    - Stored on the job in `request.js` after `createJob()`
    - Verified in the dedup attach path before returning `status: 'resumed'`