### PR TITLE
🪆 fix: Preserve Nested Subagent Delegation

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -81,7 +81,7 @@ jest.mock('~/agents/checkpointer', () => ({
   getAgentCheckpointer: jest.fn().mockResolvedValue({}),
 }));
 
-import { Run } from '@librechat/agents';
+import { Run, buildChildInputs } from '@librechat/agents';
 
 /** Minimal RunAgent factory */
 function makeAgent(
@@ -1018,6 +1018,36 @@ describe('subagentConfigs', () => {
     });
     expect(configs[0].agentInputs).toBeDefined();
     expect(configs[0].self).toBeUndefined();
+  });
+
+  it('preserves explicit nested subagents across the SDK child graph boundary', async () => {
+    const grandchild = makeAgent({ id: 'agent_grandchild', name: 'Grandchild' });
+    const child = makeAgent({
+      id: 'agent_child',
+      name: 'Child',
+      subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_grandchild'] },
+      subagentAgentConfigs: [grandchild],
+    });
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_child'] },
+          subagentAgentConfigs: [child],
+        }),
+      ],
+    });
+
+    expect(agents[0].maxSubagentDepth).toBe(MAX_SUBAGENT_DEPTH);
+    const childConfig = (agents[0].subagentConfigs as Parameters<typeof buildChildInputs>[0][])[0];
+    expect(childConfig.allowNested).toBe(true);
+
+    const childInputs = buildChildInputs(childConfig, 'agent_child', MAX_SUBAGENT_DEPTH);
+    expect(childInputs.maxSubagentDepth).toBe(MAX_SUBAGENT_DEPTH - 1);
+    expect(childInputs.subagentConfigs).toHaveLength(1);
+    expect(childInputs.subagentConfigs?.[0]).toMatchObject({
+      type: 'agent_grandchild',
+      allowNested: true,
+    });
   });
 
   it('combines self-spawn and explicit subagents when both enabled', async () => {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -991,6 +991,8 @@ function buildSubagentConfigs(
         child.description ??
         `Delegate a subtask to the ${child.name ?? child.id} agent in an isolated context.`,
       agentInputs: childInputs,
+      /** Preserve the child's resolved subagent configs when the SDK builds its isolated graph. */
+      allowNested: true,
       /** Honor each child agent's own resolved recursion limit. */
       maxTurns: resolveSubagentMaxTurns(agentsEConfig, child),
     });
@@ -1350,6 +1352,8 @@ export async function createRun({
     );
     if (subagentConfigs.length > 0) {
       agentInput.subagentConfigs = subagentConfigs;
+      /** Seed the SDK countdown that bounds nested delegation across isolated child graphs. */
+      agentInput.maxSubagentDepth = MAX_SUBAGENT_DEPTH;
     }
     agentInputs.push(agentInput);
   }


### PR DESCRIPTION
## Summary

I preserved nested explicit subagent delegation across isolated SDK graph boundaries and added a runtime-contract regression for #14100. This rebases and strengthens #14007 against current `dev`, with the original fix credited through commit co-authorship.

- Set `allowNested` on explicit subagent configurations so the SDK retains each child's resolved `subagentConfigs`.
- Seed `maxSubagentDepth` from LibreChat's shared depth limit so the SDK can decrement the runtime countdown across child graphs.
- Exercise the real SDK `buildChildInputs` boundary with an A → B → C regression that verifies target retention and depth consumption.
- Preserve existing explicit-cycle pruning and non-nested self-spawn behavior.

Fixes #14100.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `npm run build:data-provider`
- [x] `npm run build:data-schemas`
- [x] `npm run build:api`
- [x] `cd packages/api && npx jest src/agents/__tests__/run-summarization.test.ts --runInBand --coverage=false` — 114 passed
- [x] `npx eslint packages/api/src/agents/run.ts packages/api/src/agents/__tests__/run-summarization.test.ts`
- [x] `npx prettier --check packages/api/src/agents/run.ts packages/api/src/agents/__tests__/run-summarization.test.ts`
- [x] `git diff --check`

### **Test Configuration**:

- Node.js v24.16.0
- `@librechat/agents` v3.2.68

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Dependent nested event-tool support is merged and published in `@librechat/agents` v3.2.68