### PR TITLE
✋ fix: Enable Submit on First Tool-Approval Decision

### DIFF
--- a/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
+++ b/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
@@ -50,6 +50,13 @@ export function useAskSubmitStatus(): {
 }
 
 interface ApprovalContextValue {
+  /**
+   * Bumped whenever registrations or decisions change. Decisions live in refs
+   * (synchronous reads), so this is what makes the context value a NEW reference
+   * on each change; without it, consumers never re-render and never re-read
+   * `isReady`/`getLeadToolCallId` after an update.
+   */
+  version: number;
   /** Record (or clear) a card's decision for its tool_call within an action. */
   setDecision: (
     actionId: string,
@@ -88,6 +95,7 @@ export const useApprovalContext = (): ApprovalContextValue => {
 };
 
 const FALLBACK: ApprovalContextValue = {
+  version: 0,
   setDecision: () => undefined,
   getDecision: () => undefined,
   getDecisions: () => [],
@@ -120,11 +128,14 @@ const isExpiredError = (error: unknown): boolean => {
  * and the cards only render inside a live chat view where those providers exist.
  */
 export default function ApprovalProvider({ children }: { children: React.ReactNode }) {
-  /** actionId → (tool_call_id → resolution). Mutable ref + a version bump so
-   *  reads are synchronous for `isReady`/submit while renders stay cheap. */
+  /** actionId → (tool_call_id → resolution). Mutable refs so reads are
+   *  synchronous for `isReady`/submit; `version` is threaded into the context
+   *  value so each bump produces a new value reference and consumers re-render
+   *  (the callbacks alone are referentially stable, so without it a bump would
+   *  never propagate past the memoized value). */
   const decisionsRef = useRef(new Map<string, Map<string, Agents.ToolApprovalResolution>>());
   const registeredRef = useRef(new Map<string, Set<string>>());
-  const [, bump] = useState(0);
+  const [version, bump] = useState(0);
   const rerender = useCallback(() => bump((v) => v + 1), []);
   const [statusByAction, setStatusByAction] = useState<Record<string, ActionStatus>>({});
 
@@ -220,6 +231,7 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
 
   const value = useMemo<ApprovalContextValue>(
     () => ({
+      version,
       setDecision,
       getDecision,
       getDecisions,
@@ -232,6 +244,7 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
       setStatus,
     }),
     [
+      version,
       setDecision,
       getDecision,
       getDecisions,

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolApproval.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolApproval.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Agents } from 'librechat-data-provider';
+import ApprovalProvider from '../ApprovalContext';
+import ToolApproval from '../ToolApproval';
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string, values?: Record<string | number, string | number>) => {
+    if (key === 'com_ui_submit_decisions') {
+      return `Submit ${values?.[0]} decisions`;
+    }
+    const map: Record<string, string> = {
+      com_ui_approve: 'Approve',
+      com_ui_reject: 'Reject',
+      com_ui_edit: 'Edit',
+      com_ui_respond: 'Respond',
+      com_ui_submit: 'Submit',
+      com_ui_submitting: 'Submitting',
+      com_ui_invalid_json: 'Invalid JSON',
+      com_ui_reject_reason_placeholder: 'Reason',
+      com_ui_tool_response_placeholder: 'Response',
+    };
+    return map[key] ?? key;
+  },
+}));
+
+jest.mock('~/data-provider', () => ({
+  useSubmitToolApprovalMutation: () => ({ mutate: jest.fn() }),
+  useSubmitAskAnswerMutation: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock('~/Providers/ChatContext', () => ({
+  ChatContext: jest.requireActual('react').createContext(null),
+}));
+
+const approval = (
+  allowed: Agents.ToolApprovalDecisionType[] = ['approve', 'reject'],
+): NonNullable<Agents.ToolCall['approval']> => ({
+  actionId: 'action-1',
+  allowed_decisions: allowed,
+});
+
+const renderCards = (cards: React.ReactNode) =>
+  render(
+    <RecoilRoot>
+      <ApprovalProvider>{cards}</ApprovalProvider>
+    </RecoilRoot>,
+  );
+
+describe('ToolApproval', () => {
+  test('enables Submit immediately after Approve is the first decision (#14390)', () => {
+    renderCards(<ToolApproval approval={approval()} toolCallId="call-1" args={{ a: 1 }} />);
+
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(submit).toBeEnabled();
+  });
+
+  test('deselecting the active decision disables Submit again', () => {
+    renderCards(<ToolApproval approval={approval()} toolCallId="call-1" args={{ a: 1 }} />);
+
+    const approve = screen.getByRole('button', { name: 'Approve' });
+    fireEvent.click(approve);
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+
+    fireEvent.click(approve);
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  test('a respond decision only counts once its text is non-empty', () => {
+    renderCards(<ToolApproval approval={approval(['respond'])} toolCallId="call-1" args={{}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Respond' }));
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Respond' }), {
+      target: { value: 'use the staging table' },
+    });
+    expect(submit).toBeEnabled();
+  });
+
+  test('multiple paused calls share one Submit that requires every decision', () => {
+    renderCards(
+      <>
+        <ToolApproval approval={approval()} toolCallId="call-1" args={{ a: 1 }} />
+        <ToolApproval approval={approval()} toolCallId="call-2" args={{ b: 2 }} />
+      </>,
+    );
+
+    const submit = screen.getByRole('button', { name: 'Submit 2 decisions' });
+    expect(submit).toBeDisabled();
+
+    const [approveFirst, approveSecond] = screen.getAllByRole('button', { name: 'Approve' });
+    fireEvent.click(approveFirst);
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(approveSecond);
+    expect(submit).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #14390

I fixed the human-in-the-loop tool review card so Submit enables immediately after the first decision. Previously, clicking Approve first left Submit disabled, and it only enabled after switching to Reject and back.

The root cause was in `ApprovalContext`: decisions and registrations live in mutable refs, and a `useState` counter bump was meant to notify consumers of changes. But the context value was memoized over referentially stable callbacks, so a bump re-rendered the provider with the identical value reference and React bailed out. No consumer ever re-rendered from a bump, so `isReady` was always evaluated one decision behind. The Reject-then-Approve path only "worked" because the card's own re-render read the stale approve decision from the previous click. The same defect left sibling cards unaware of each other's registrations when multiple tool calls pause under one action (stale lead card and "Submit N decisions" count).

- Threaded the `version` counter through the context value, as an interface field and a `useMemo` dependency, so every registration or decision change mints a new value reference and consumers re-render and re-read the refs.
- Added `ToolApproval.test.tsx` covering the regression: first Approve enables Submit, deselecting disables it, a respond decision requires non-empty text, and two paused calls share one Submit gated on both decisions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All four new tests fail on the previous code and pass with the fix. In an isolated render of the card, the old code never even showed the Submit button, since it only appeared thanks to unrelated SSE-driven parent re-renders during streaming.

- `cd client && npx jest ToolApproval.test`: 4/4 pass
- eslint and tsc clean on the touched files

### **Test Configuration**:

- Node v24, jest from the client workspace

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
