### PR TITLE
🚀 chore: Prepare v0.8.8-rc1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,6 +180,8 @@ NODE_MAX_OLD_SPACE_SIZE=6144
 # App-side switch: set true to tell the Langfuse SDK not to create media uploads
 # for central/fallback collector traces. Tenant-routed media uploads are unchanged.
 # LANGFUSE_FANOUT_CENTRAL_MEDIA_UPLOAD_DISABLED=false
+# Gateway HTTP listen address (default: :4318).
+# LANGFUSE_FANOUT_LISTEN_ADDR=:4318
 # Emergency switch: unset/false defaults enabled; set true to keep central fanout export but skip tenant trace/score export.
 # LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED=false
 # Langfuse Cloud base URL options: https://cloud.langfuse.com (EU),
@@ -478,7 +480,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=gpt-5,gpt-5-codex,gpt-5-mini,gpt-5-nano,o3-pro,o3,o4-mini,gpt-4.1,gpt-4.1-mini,gpt-4.1-nano,o3-mini,o1-pro,o1,gpt-4o,gpt-4o-mini
+# OPENAI_MODELS=gpt-5.6,gpt-5.6-terra,gpt-5.6-luna,gpt-5.5,gpt-5.5-pro,chat-latest,gpt-5.4,gpt-5.4-pro,gpt-5.4-mini,gpt-5.4-nano,gpt-5.3-codex,gpt-5.2,gpt-5,gpt-5-codex,gpt-5-mini,gpt-5-nano,o3-pro,o3,o4-mini,gpt-4.1,gpt-4.1-mini,gpt-4.1-nano,o3-mini,o1-pro,o1,gpt-4o,gpt-4o-mini
 
 DEBUG_OPENAI=false
 
@@ -674,11 +676,27 @@ STT_VIOLATION_SCORE=0
 FORK_VIOLATION_SCORE=0
 IMPORT_VIOLATION_SCORE=0
 FILE_UPLOAD_VIOLATION_SCORE=0
+# Password-reset and verification request/submission scores default to 1 when unset.
+# RESET_PASSWORD_VIOLATION_SCORE=1
+# VERIFY_EMAIL_VIOLATION_SCORE=1
+# RESET_PASSWORD_SUBMISSION_VIOLATION_SCORE=1
+# VERIFY_EMAIL_SUBMISSION_VIOLATION_SCORE=1
 
 LOGIN_MAX=7
 LOGIN_WINDOW=5
 REGISTER_MAX=5
 REGISTER_WINDOW=60
+
+# Password-reset email requests and token submissions are limited separately.
+# Submission values inherit the matching request value when omitted; all default to 2.
+# RESET_PASSWORD_MAX=2
+# RESET_PASSWORD_WINDOW=2
+# RESET_PASSWORD_SUBMISSION_MAX=2
+# RESET_PASSWORD_SUBMISSION_WINDOW=2
+# VERIFY_EMAIL_MAX=2
+# VERIFY_EMAIL_WINDOW=2
+# VERIFY_EMAIL_SUBMISSION_MAX=2
+# VERIFY_EMAIL_SUBMISSION_WINDOW=2
 
 LIMIT_CONCURRENT_MESSAGES=true
 CONCURRENT_MESSAGE_MAX=2

--- a/.env.example
+++ b/.env.example
@@ -614,6 +614,19 @@ STT_API_KEY=
 TTS_API_KEY=
 
 #==================================================#
+#                Code Interpreter                  #
+#==================================================#
+
+# LIBRECHAT_CODE_API_KEY=
+# LIBRECHAT_CODE_BASEURL=
+# Prewarm stateful per-conversation sandboxes in parallel with model generation (default: true).
+# CODE_SANDBOX_PREWARM=true
+# Time in milliseconds before LibreChat treats a tracked sandbox as cold (default: 2100000 / 35 minutes).
+# CODE_SANDBOX_COLD_AFTER_MS=2100000
+# Bytes read per sandbox image chunk; lower this if the runner has a small stdout limit (default: 32768).
+# LIBRECHAT_CODE_IMAGE_CHUNK_BYTES=32768
+
+#==================================================#
 #                        RAG                       #
 #==================================================#
 # More info: https://www.librechat.ai/docs/configuration/rag_api
@@ -627,10 +640,17 @@ TTS_API_KEY=
 
 # Stream upload responses with heartbeats during long-running file processing.
 # FILE_UPLOAD_SSE_ENABLED=false
+# Timeout in milliseconds for server-side remote file downloads (default: 15000).
+# REMOTE_FILE_FETCH_TIMEOUT_MS=15000
+# Maximum size in bytes for server-side remote file downloads (default: 536870912 / 512 MiB).
+# REMOTE_FILE_FETCH_MAX_BYTES=536870912
 
 #===================================================#
 #                    User System                    #
 #===================================================#
+
+# Maximum characters in one mid-run Agent steering message (default: 16000).
+# STEER_MAX_LENGTH=16000
 
 #========================#
 # Moderation             #
@@ -1071,6 +1091,10 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Defaults to CONFIG_STORE,APP_CONFIG so YAML-derived config stays per-container (safe for blue/green deployments)
 # Set to empty string to force all namespaces through Redis: FORCED_IN_MEMORY_CACHE_NAMESPACES=
 # FORCED_IN_MEMORY_CACHE_NAMESPACES=CONFIG_STORE,APP_CONFIG
+
+# Opt-in cache for authenticated user documents during request bursts. Requires Redis and
+# the AUTH_USER_DOC namespace to remain Redis-backed (default: off; set exactly to "on").
+# AUTH_USER_CACHE_MODE=off
 
 # TTL in milliseconds for cached group memberships used in ACL permission checks (default: 300000 / 5 minutes; 0 disables)
 # Membership changes invalidate affected entries immediately; the TTL bounds staleness from cross-process races.

--- a/.env.example
+++ b/.env.example
@@ -171,9 +171,9 @@ NODE_MAX_OLD_SPACE_SIZE=6144
 # Optional Langfuse fanout for tenant-scoped Langfuse projects.
 # The fanout gateway is opt-in: add docker-compose.langfuse-fanout.yml,
 # deploy-compose.langfuse-fanout.yml, or enable helm langfuseFanout.
-# Tenant public/secret keys and a destination key are read from LibreChat tenant
-# app configuration. Destination keys resolve against known startup URLs. Tenant
-# API keys can be added or changed at runtime through tenant app configuration.
+# Tenant public/secret keys and a destination key are managed through
+# Settings > Langfuse. Destination keys resolve against known startup URLs;
+# credentials can be added or changed at runtime without restarting the gateway.
 # See otel/langfuse-fanout/README.md.
 # LANGFUSE_FANOUT_ENABLED=false
 # LANGFUSE_FANOUT_COLLECTOR_URL=http://langfuse-fanout-collector:4318
@@ -676,6 +676,10 @@ STT_VIOLATION_SCORE=0
 FORK_VIOLATION_SCORE=0
 IMPORT_VIOLATION_SCORE=0
 FILE_UPLOAD_VIOLATION_SCORE=0
+# Per-user limiter for metadata-only /files/usage requests that renew the TTL
+# of attachments waiting in queued Agent messages (default: 120 per 15 minutes).
+# FILE_USAGE_USER_MAX=120
+# FILE_USAGE_USER_WINDOW=15
 # Password-reset and verification request/submission scores default to 1 when unset.
 # RESET_PASSWORD_VIOLATION_SCORE=1
 # VERIFY_EMAIL_VIOLATION_SCORE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# v0.8.7
+# v0.8.8-rc1
 
 # Base node image
 FROM node:24.16.0-alpine AS node

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,5 @@
 # Dockerfile.multi
-# v0.8.7
+# v0.8.8-rc1
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 ## 🚀 What's New in v0.8.8-rc1
 
 - **Agent run control:** Interrupt or steer an Agent mid-run, queue follow-up messages, and reclaim, edit, or escalate pending steers.
-- **Human-in-the-loop Agents:** Agents can ask users questions, request tool approval, pause durably, and resume after a decision.
+- **Human-in-the-loop Agents:** Agents stream question progress, ask users for input, request tool approval, pause durably, and resume after a decision.
 - **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
 - **Readable Agent activity:** Generated activity-group headers and live tool intent labels make long reasoning and tool runs easier to scan.
 - **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@
   </a>
 </p>
 
+## 🚀 What's New in v0.8.8-rc1
+
+- **Agent run control:** Interrupt or steer an Agent mid-run, queue follow-up messages, and reclaim, edit, or escalate pending steers.
+- **Human-in-the-loop Agents:** Agents can ask users questions, request tool approval, pause durably, and resume after a decision.
+- **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
+- **Readable Agent activity:** Generated activity-group headers and live tool intent labels make long reasoning and tool runs easier to scan.
+- **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.
+- **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
+- **Sharing and files:** Continue shared conversations as personal copies, upload `.eml` files, keep long uploads alive, and download original Office files from artifact previews.
+- **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
+- **Langfuse observability:** Configure encrypted Langfuse connections in-app, optionally fan out traces by tenant, and suppress central export per run.
+- **Administration and security:** Delegate individual config sections, encrypt registered secrets and custom endpoint keys, audit terms acceptance, and control model visibility.
+- **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, and faster Agent startup keep large workspaces responsive.
+- **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
+
+Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-rc1).
 
 # ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - **Langfuse observability:** Configure encrypted Langfuse connections in-app, optionally fan out traces by tenant, and suppress central export per run.
 - **Administration and security:** Delegate individual config sections, encrypt registered secrets and custom endpoint keys, audit terms acceptance, and control model visibility.
 - **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, and faster Agent startup keep large workspaces responsive.
+- **Streaming and tool reliability:** Adaptive provider stream smoothing, optional Redis delta batching, Agent stream circuit breakers, and cross-replica MCP OAuth readiness improve long-running tool workflows.
 - **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
 
 Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-rc1).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 - **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
 - **Artifact workflows:** Open previews fullscreen, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
 - **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
-- **Langfuse observability:** Configure encrypted Langfuse connections in-app, optionally fan out traces by tenant, and suppress central export per run.
+- **Langfuse observability:** Configure encrypted Langfuse connections in-app, let authorized admins open sampled sessions directly, optionally fan out traces by tenant, and suppress central export per run.
 - **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
 - **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, smooth streamed text, and faster Agent startup keep large workspaces responsive.
 - **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 - **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
 - **Langfuse observability:** Configure encrypted Langfuse connections in-app, let authorized admins open sampled sessions directly, optionally fan out traces by tenant, and suppress central export per run.
 - **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
-- **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, smooth streamed text, and faster Agent startup keep large workspaces responsive.
+- **Messages and navigation:** Right-aligned user turns, unified multi-part editing, full-message copy, a dock-style message rail, virtualized search, smooth streaming, and faster Agent startup.
 - **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
 - **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 - **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills, MCP servers, and opt-in command hooks, while explicit subagents initialize only when selected.
 - **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
 - **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
-- **Artifact workflows:** Open previews fullscreen, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
+- **Artifact workflows:** Open previews fullscreen, work with PowerPoint `.potx` templates across upload, search, and code execution, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
 - **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
 - **Langfuse observability:** Configure encrypted Langfuse connections in-app, let authorized admins open sampled sessions directly, optionally fan out traces by tenant, and suppress central export per run.
 - **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@
 - **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
 - **Readable Agent activity:** Generated activity-group headers, parent phase summaries, and live tool intent labels make long reasoning and tool runs easier to scan.
 - **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.
-- **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills and MCP servers, while explicit subagents initialize only when selected.
+- **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills, MCP servers, and opt-in command hooks, while explicit subagents initialize only when selected.
 - **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
 - **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
 - **Artifact workflows:** Open previews fullscreen, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
 - **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
 - **Langfuse observability:** Configure encrypted Langfuse connections in-app, optionally fan out traces by tenant, and suppress central export per run.
 - **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
-- **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, and faster Agent startup keep large workspaces responsive.
+- **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, smooth streamed text, and faster Agent startup keep large workspaces responsive.
 - **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
 - **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@
 - **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills, MCP servers, and opt-in command hooks, while explicit subagents initialize only when selected.
 - **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
 - **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
-- **Artifact workflows:** Open previews fullscreen, work with PowerPoint `.potx` templates across upload, search, and code execution, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
-- **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
+- **Artifact workflows:** Open previews fullscreen, work with PowerPoint `.potx` templates across upload, search, and code execution, upload shell scripts across common MIME variants, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
+- **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.7 and 3.6 Flash, and Gemini 3.5 Flash-Lite.
 - **Langfuse observability:** Configure encrypted Langfuse connections in-app, let authorized admins open sampled sessions directly, optionally fan out traces by tenant, and suppress central export per run.
 - **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
 - **Messages and navigation:** Right-aligned user turns, unified multi-part editing, full-message copy, a dock-style message rail, virtualized search, smooth streaming, and faster Agent startup.
-- **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
+- **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, parsed MCP response media types, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
 - **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
 
 Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-rc1).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 ## 🚀 What's New in v0.8.8-rc1
 
 - **Agent run control:** Interrupt or steer an Agent mid-run, queue follow-up messages, and reclaim, edit, or escalate pending steers.
-- **Human-in-the-loop Agents:** Agents stream question progress, ask users for input, request tool approval, pause durably, and resume after a decision.
+- **Human-in-the-loop Agents:** Agents stream question progress, ask up to four related questions in one form, pause for input or tool approval, and resume.
 - **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
 - **Readable Agent activity:** Generated activity-group headers, parent phase summaries, and live tool intent labels make long reasoning and tool runs easier to scan.
 - **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.

--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@
 - **Agent run control:** Interrupt or steer an Agent mid-run, queue follow-up messages, and reclaim, edit, or escalate pending steers.
 - **Human-in-the-loop Agents:** Agents stream question progress, ask users for input, request tool approval, pause durably, and resume after a decision.
 - **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
-- **Readable Agent activity:** Generated activity-group headers and live tool intent labels make long reasoning and tool runs easier to scan.
+- **Readable Agent activity:** Generated activity-group headers, parent phase summaries, and live tool intent labels make long reasoning and tool runs easier to scan.
 - **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.
+- **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills and MCP servers, while explicit subagents initialize only when selected.
 - **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
-- **Sharing and files:** Continue shared conversations as personal copies, upload `.eml` files, keep long uploads alive, and download original Office files from artifact previews.
+- **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
+- **Artifact workflows:** Open previews fullscreen, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
 - **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.6 Flash, and Gemini 3.5 Flash-Lite.
 - **Langfuse observability:** Configure encrypted Langfuse connections in-app, optionally fan out traces by tenant, and suppress central export per run.
-- **Administration and security:** Delegate individual config sections, encrypt registered secrets and custom endpoint keys, audit terms acceptance, and control model visibility.
+- **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
 - **Navigation and responsiveness:** A dock-style message rail, warmer conversation switches, virtualized search, and faster Agent startup keep large workspaces responsive.
-- **Streaming and tool reliability:** Adaptive provider stream smoothing, optional Redis delta batching, Agent stream circuit breakers, and cross-replica MCP OAuth readiness improve long-running tool workflows.
+- **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
 - **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
 
 Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-rc1).
@@ -93,6 +95,7 @@ Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-r
     - Collaborative Sharing: Share agents with specific users and groups
     - Flexible & Extensible: Use MCP Servers, tools, file search, code execution, and more
     - [Skills](https://www.librechat.ai/docs/features/skills): Create reusable `SKILL.md` instruction bundles for manual, automatic, or always-on agent workflows
+    - [Agent Plugins](https://www.librechat.ai/docs/features/agent_plugins): Experimentally bundle deployment Skills and MCP servers into startup-loaded packages
     - [Subagents](https://www.librechat.ai/docs/features/subagents): Delegate focused work to isolated child agent runs with their own context windows
     - Compatible with Custom Endpoints, OpenAI, Azure, Anthropic, AWS Bedrock, Google, Vertex AI, Responses API, and more
     - [Model Context Protocol (MCP) Support](https://modelcontextprotocol.io/clients#librechat) for Tools
@@ -104,7 +107,8 @@ Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-r
   - **[Learn More →](https://www.librechat.ai/docs/features/web_search)**
 
 - 🪄 **Generative UI with Code Artifacts**:  
-  - [Code Artifacts](https://youtu.be/GfTj7O4gmd0?si=WJbdnemZpJzBrJo3) allow creation of React, HTML, and Mermaid diagrams directly in chat
+  - [Code Artifacts](https://youtu.be/GfTj7O4gmd0?si=WJbdnemZpJzBrJo3) create React, HTML, and Mermaid content directly in chat
+  - Open previews fullscreen and export Mermaid diagrams as SVG or PNG
 
 - 🎨 **Image Generation & Editing**
   - Text-to-image and image-to-image with [GPT-Image-1](https://www.librechat.ai/docs/features/image_gen#1--openai-image-tools-recommended)

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "v0.8.7",
+  "version": "v0.8.8-rc1",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.7",
+      "version": "0.8.8-rc1",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1013.0",
@@ -148,7 +148,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.7",
+      "version": "0.8.8-rc1",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
         "@ariakit/react-components": "^0.1.2",
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.34",
+      "version": "1.7.35",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.63",
+      "version": "0.4.64",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.509",
+      "version": "0.8.510",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.56",
+      "version": "0.0.57",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.35",
+      "version": "1.7.36",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.64",
+      "version": "0.4.65",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.510",
+      "version": "0.8.511",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.36",
+      "version": "1.7.37",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.65",
+      "version": "0.4.66",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.511",
+      "version": "0.8.512",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.58",
+      "version": "0.0.59",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.40",
+      "version": "1.7.41",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.69",
+      "version": "0.4.70",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.515",
+      "version": "0.8.516",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.62",
+      "version": "0.0.63",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.38",
+      "version": "1.7.39",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.67",
+      "version": "0.4.68",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.513",
+      "version": "0.8.514",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.60",
+      "version": "0.0.61",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.37",
+      "version": "1.7.38",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.66",
+      "version": "0.4.67",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.512",
+      "version": "0.8.513",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.59",
+      "version": "0.0.60",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.45",
+      "version": "1.7.46",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.74",
+      "version": "0.4.75",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.520",
+      "version": "0.8.521",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.67",
+      "version": "0.0.68",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.44",
+      "version": "1.7.45",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.73",
+      "version": "0.4.74",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.519",
+      "version": "0.8.520",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.66",
+      "version": "0.0.67",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.42",
+      "version": "1.7.43",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.71",
+      "version": "0.4.72",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.517",
+      "version": "0.8.518",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.41",
+      "version": "1.7.42",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.70",
+      "version": "0.4.71",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.516",
+      "version": "0.8.517",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.63",
+      "version": "0.0.64",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.39",
+      "version": "1.7.40",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.68",
+      "version": "0.4.69",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.514",
+      "version": "0.8.515",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.61",
+      "version": "0.0.62",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -292,7 +292,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.43",
+      "version": "1.7.44",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -403,7 +403,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.72",
+      "version": "0.4.73",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -486,7 +486,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.518",
+      "version": "0.8.519",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -521,7 +521,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,4 @@
-/** v0.8.7 */
+/** v0.8.8-rc1 */
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "v0.8.7",
+  "version": "v0.8.8-rc1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/e2e/jestSetup.js
+++ b/e2e/jestSetup.js
@@ -1,3 +1,3 @@
-// v0.8.7
+// v0.8.8-rc1
 // See .env.test.example for an example of the '.env.test' file.
 require('dotenv').config({ path: './e2e/.env.test' });

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,7 +23,7 @@ version: 2.0.7
 # It is recommended to use it with quotes.
 
 # renovate: image=registry.librechat.ai/danny-avila/librechat
-appVersion: "v0.8.7"
+appVersion: "v0.8.8-rc1"
 
 home: https://www.librechat.ai
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -7,15 +7,10 @@ version: 1.3.14
 # Cache settings: Set to true to enable caching
 cache: true
 
-# Tenant-scoped Langfuse export (optional). Fanout also requires the deployment
-# services and environment variables documented in the Langfuse guide.
-# langfuse:
-#   enabled: true
-#   publicKey: '${TENANT_LANGFUSE_PUBLIC_KEY}'
-#   secretKey: '${TENANT_LANGFUSE_SECRET_KEY}'
-#   destination: 'us' # Must match an allowed LANGFUSE_FANOUT_TENANT_DESTINATIONS key
-#   fanout:
-#     enabled: true
+# Langfuse connections are managed through Settings > Langfuse when available.
+# That flow verifies the credentials and stores the secret key encrypted; do not
+# place a plaintext langfuse.secretKey in this file. Environment-managed central
+# credentials and optional fanout routing are documented in .env.example.
 
 # File storage configuration
 # Single strategy for all file types (legacy format, still supported)
@@ -469,6 +464,14 @@ endpoints:
   #   #   final: defer generation until the full response completes (legacy behavior).
   #   # Set under `endpoints.all` instead to apply as the global default for all endpoints.
   #   titleTiming: immediate
+  #   # (optional) Generate one-line headers for blocks of Agent reasoning and tool calls.
+  #   # Header generation is a separate model call whose usage and cost are recorded.
+  #   activityLabel: true
+  #   activityEndpoint: openAI
+  #   activityModel: gpt-4.1-nano
+  #   # activityPrompt: 'Write a short activity label...'
+  #   # activityMaxPerRun: 20
+  #   # activityCharLimit: 600
   #   # (optional) Maximum total citations to include in agent responses, defaults to 30
   #   maxCitations: 30
   #   # (optional) Maximum citations per file to include in agent responses, defaults to 7
@@ -485,8 +488,8 @@ endpoints:
   #   # The following capabilities are opt-in and must be added explicitly:
   #   # "programmatic_tools", "stateful_code_sessions", "run_in_background", "tool_intents"
   #   # "stateful_code_sessions" is highly experimental and may change substantially.
-  #   # "run_in_background" allows selected MCP and Code Interpreter tools to run as background tasks.
-  #   # "tool_intents" lets opted-in tools expose a model-written intent as their live status label.
+  #   # "run_in_background" makes Code Interpreter tools eligible by default and enables per-tool MCP opt-in.
+  #   # "tool_intents" enables live model-written labels for native tools and opted-in MCP tools.
   #   # (optional) Require user approval before matching tool calls. Disabled by default.
   #   toolApproval:
   #     enabled: true

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -485,6 +485,7 @@ endpoints:
   #   # The following capabilities are opt-in and must be added explicitly:
   #   # "programmatic_tools", "stateful_code_sessions", "run_in_background", "tool_intents"
   #   # "stateful_code_sessions" is highly experimental and may change substantially.
+  #   # "run_in_background" allows selected MCP and Code Interpreter tools to run as background tasks.
   #   # "tool_intents" lets opted-in tools expose a model-written intent as their live status label.
   #   # (optional) Require user approval before matching tool calls. Disabled by default.
   #   toolApproval:

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -484,6 +484,7 @@ endpoints:
   #   capabilities: ["deferred_tools", "execute_code", "file_search", "web_search", "artifacts", "subagents", "actions", "context", "skills", "memory", "ask_user_question", "tools", "chain", "ocr"]
   #   # The following capabilities are opt-in and must be added explicitly:
   #   # "programmatic_tools", "stateful_code_sessions", "run_in_background", "tool_intents"
+  #   # "stateful_code_sessions" is highly experimental and may change substantially.
   #   # "tool_intents" lets opted-in tools expose a model-written intent as their live status label.
   #   # (optional) Require user approval before matching tool calls. Disabled by default.
   #   toolApproval:

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -2,10 +2,20 @@
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.13
+version: 1.3.14
 
 # Cache settings: Set to true to enable caching
 cache: true
+
+# Tenant-scoped Langfuse export (optional). Fanout also requires the deployment
+# services and environment variables documented in the Langfuse guide.
+# langfuse:
+#   enabled: true
+#   publicKey: '${TENANT_LANGFUSE_PUBLIC_KEY}'
+#   secretKey: '${TENANT_LANGFUSE_SECRET_KEY}'
+#   destination: 'us' # Must match an allowed LANGFUSE_FANOUT_TENANT_DESTINATIONS key
+#   fanout:
+#     enabled: true
 
 # File storage configuration
 # Single strategy for all file types (legacy format, still supported)
@@ -471,10 +481,22 @@ endpoints:
   #   skills:
   #     maxCatalogSkills: 20
   #   # (optional) Agent Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
-  #   capabilities: ["deferred_tools", "execute_code", "file_search", "actions", "tools"]
-  #   # Off-by-default capabilities you can add to the list above:
-  #   # - "run_in_background": opted-in tools gain a `run_in_background` param so the model can dispatch them detached and poll via `check_background_task`.
-  #   # - "tool_intents": opted-in tools (native tools by default) gain an `intent` param — one model-written sentence per call, streamed into the tool-call arguments. Backend groundwork today: the chat UI renders it as each call's live status label in an upcoming release; opt tools in per agent via `tool_options[tool].describe_intent`.
+  #   capabilities: ["deferred_tools", "execute_code", "file_search", "web_search", "artifacts", "subagents", "actions", "context", "skills", "memory", "ask_user_question", "tools", "chain", "ocr"]
+  #   # The following capabilities are opt-in and must be added explicitly:
+  #   # "programmatic_tools", "stateful_code_sessions", "run_in_background", "tool_intents"
+  #   # "tool_intents" lets opted-in tools expose a model-written intent as their live status label.
+  #   # (optional) Require user approval before matching tool calls. Disabled by default.
+  #   toolApproval:
+  #     enabled: true
+  #     mode: default # default, dontAsk, or bypass
+  #     allow: ["mcp:trusted-server:read_*"]
+  #     deny: ["mcp:*:delete_*"] # Deny rules always take precedence
+  #     ask: ["mcp:*:*"]
+  #     reason: "Review {tool} before it runs."
+  #   # (optional) Persist Agent runs paused for approval or Ask User. MongoDB is the durable default.
+  #   checkpointer:
+  #     type: mongo # mongo (default) or memory (single-process development only)
+  #     ttl: 86400 # Approval window in seconds; defaults to 24 hours
 
   # (optional) Custom request headers for the built-in OpenAI / Google endpoints.
   # Forwarded on every request to the provider (or an AI gateway / reverse proxy
@@ -766,6 +788,7 @@ endpoints:
 #       description: "Most capable GPT-4 model with multimodal support"
 #       # default: true      # Hard admin default; takes precedence over prior user choices
 #       # softDefault: true  # First-time default only; skipped after a user selects a model/spec/agent
+#       # showInMenu: false  # Hide from the model selector while keeping explicit `spec` access
 #       group: "openAI"  # String value matching the endpoint name
 #       preset:
 #         endpoint: "openAI"
@@ -830,6 +853,15 @@ endpoints:
 #       preset:
 #         endpoint: "openAI"
 #         model: "gpt-4o-mini"
+
+# Automatic conversation summarization (optional)
+# summarization:
+#   enabled: true
+#   provider: "openAI"
+#   model: "gpt-4o-mini"
+#   retainRecent:
+#     turns: 2 # Keep the newest complete user/assistant turns outside the summary
+#     tokens: 2000 # Also preserve up to this many recent tokens
 
 # fileConfig:
 #   endpoints:

--- a/otel/langfuse-fanout/README.md
+++ b/otel/langfuse-fanout/README.md
@@ -129,6 +129,7 @@ LANGFUSE_FANOUT_TENANT_EU_BASE_URL=https://cloud.langfuse.com
 LANGFUSE_FANOUT_TENANT_US_BASE_URL=https://us.cloud.langfuse.com
 LANGFUSE_FANOUT_TENANT_JP_BASE_URL=https://jp.cloud.langfuse.com
 LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED=false
+LANGFUSE_FANOUT_LISTEN_ADDR=:4318
 LANGFUSE_FANOUT_UPSTREAM_TIMEOUT=30s
 LANGFUSE_FANOUT_PUBLIC_URL=http://langfuse-fanout-collector:4318
 LANGFUSE_FANOUT_REDIS_URI=redis://langfuse-fanout-redis:6379
@@ -170,6 +171,17 @@ The override builds the fanout gateway image, sets `LANGFUSE_FANOUT_ENABLED=true
 
 ## Helm
 
+The Compose overrides build the gateway image locally. For Kubernetes, build
+the same image from the repository root, push it to a registry available to
+the cluster, and set `langfuseFanout.image.repository` and `.tag` to match:
+
+```sh
+docker build \
+  -f otel/langfuse-fanout/Dockerfile \
+  -t registry.example.com/librechat-langfuse-fanout:<tag> .
+docker push registry.example.com/librechat-langfuse-fanout:<tag>
+```
+
 Create a secret containing the central Langfuse Basic auth header:
 
 ```sh
@@ -186,6 +198,10 @@ redis:
 
 langfuseFanout:
   enabled: true
+  image:
+    repository: registry.example.com/librechat-langfuse-fanout
+    tag: '<tag>'
+    pullPolicy: IfNotPresent
   central:
     baseUrl: https://cloud.langfuse.com
     authHeaderSecret:
@@ -204,14 +220,14 @@ langfuseFanout:
       jp:
         baseUrl: https://jp.cloud.langfuse.com
   upstreamTimeout: 30s
-  publicUrl: ""
+  publicUrl: ''
   otelCollector:
     receiverEndpoint: 127.0.0.1:4319
   redis:
-    uri: ""
-    username: ""
+    uri: ''
+    username: ''
     passwordSecret:
-      name: ""
+      name: ''
       key: REDIS_PASSWORD
     keyPrefix: langfuse-fanout
   memoryLimitMiB: 256
@@ -268,6 +284,8 @@ already uploaded.
 - Tenant destinations default to the three configured Langfuse Cloud regions. Add or
   override `langfuseFanout.tenant.destinations` in Helm for self-hosted or
   custom destinations.
+- `LANGFUSE_FANOUT_LISTEN_ADDR` controls the gateway HTTP bind address and
+  defaults to `:4318`.
 - `LANGFUSE_FANOUT_UPSTREAM_TIMEOUT` tunes the timeout for gateway calls to
   Langfuse APIs and presigned media upload URLs.
 - `LANGFUSE_FANOUT_PUBLIC_URL` pins the base URL returned for the SDK's

--- a/otel/langfuse-fanout/README.md
+++ b/otel/langfuse-fanout/README.md
@@ -45,17 +45,19 @@ The deployment is a hybrid:
   trace suppression uses a destination-scoped gateway path that also skips
   central media export for that run.
 - Tenant export is conditional. LibreChat uses a destination-scoped gateway URL
-  only when tenant keys are configured, the tenant base URL matches a configured
-  startup destination, and `LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED` is not true.
+  only when the saved connection is enabled with tenant keys, its destination
+  key matches a configured startup destination, and
+  `LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED` is not true.
   Other traces are still exported to central through the gateway without tenant
   auth.
 - User feedback scores use Langfuse's direct REST API from the LibreChat API
   process. Central scores use LibreChat's normal central Langfuse env config;
   tenant scores use tenant app configuration when tenant fanout is enabled.
 
-Tenant Langfuse keys are expected to come from LibreChat app configuration, for
-example from an admin panel or another configuration data source. They are not
-defined in this gateway config.
+Tenant Langfuse keys are expected to come from LibreChat app configuration.
+When available, an authorized administrator can configure and verify the
+connection under **Settings > Langfuse**; LibreChat encrypts the secret key at
+rest. The keys are not defined in this gateway config.
 
 ## Limitations
 
@@ -65,9 +67,9 @@ defined in this gateway config.
   destination.
 - Tenant Langfuse API keys can be added, changed, or disabled in tenant app
   configuration at runtime without restarting LibreChat or the gateway.
-- Tenant app configuration must set a Langfuse base URL matching one of the
-  startup destinations before tenant trace/score export is enabled; keys alone
-  are treated as central-only.
+- Tenant app configuration must select a destination key from
+  `LANGFUSE_FANOUT_TENANT_DESTINATIONS` before tenant trace/score export is
+  enabled; keys alone do not enable tenant export.
 - `LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED=true` can be set on LibreChat as an
   emergency switch to stop tenant trace and score export while keeping central
   gateway export active. When omitted, false, or blank, tenant export remains

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.35",
+      "version": "1.7.36",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.64",
+      "version": "0.4.65",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.510",
+      "version": "0.8.511",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.40",
+      "version": "1.7.41",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.69",
+      "version": "0.4.70",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.515",
+      "version": "0.8.516",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.62",
+      "version": "0.0.63",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.7",
+  "version": "v0.8.8-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.7",
+      "version": "v0.8.8-rc1",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -48,7 +48,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.7",
+      "version": "v0.8.8-rc1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -920,7 +920,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.7",
+      "version": "v0.8.8-rc1",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.34",
+      "version": "1.7.35",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.63",
+      "version": "0.4.64",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.509",
+      "version": "0.8.510",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.56",
+      "version": "0.0.57",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.41",
+      "version": "1.7.42",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.70",
+      "version": "0.4.71",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.516",
+      "version": "0.8.517",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.63",
+      "version": "0.0.64",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.44",
+      "version": "1.7.45",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.73",
+      "version": "0.4.74",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.519",
+      "version": "0.8.520",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.66",
+      "version": "0.0.67",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.42",
+      "version": "1.7.43",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.71",
+      "version": "0.4.72",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.517",
+      "version": "0.8.518",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.64",
+      "version": "0.0.65",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.39",
+      "version": "1.7.40",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.68",
+      "version": "0.4.69",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.514",
+      "version": "0.8.515",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.61",
+      "version": "0.0.62",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.36",
+      "version": "1.7.37",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.65",
+      "version": "0.4.66",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.511",
+      "version": "0.8.512",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.58",
+      "version": "0.0.59",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.38",
+      "version": "1.7.39",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.67",
+      "version": "0.4.68",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.513",
+      "version": "0.8.514",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.60",
+      "version": "0.0.61",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.43",
+      "version": "1.7.44",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.72",
+      "version": "0.4.73",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.518",
+      "version": "0.8.519",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.45",
+      "version": "1.7.46",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.74",
+      "version": "0.4.75",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.520",
+      "version": "0.8.521",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.67",
+      "version": "0.0.68",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42790,7 +42790,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.37",
+      "version": "1.7.38",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43494,7 +43494,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.66",
+      "version": "0.4.67",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44628,7 +44628,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.512",
+      "version": "0.8.513",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45236,7 +45236,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.59",
+      "version": "0.0.60",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.7",
+  "version": "v0.8.8-rc1",
   "description": "",
   "packageManager": "npm@11.13.0",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.34",
+  "version": "1.7.35",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.35",
+  "version": "1.7.36",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.36",
+  "version": "1.7.37",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.41",
+  "version": "1.7.42",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.44",
+  "version": "1.7.45",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.40",
+  "version": "1.7.41",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.38",
+  "version": "1.7.39",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.37",
+  "version": "1.7.38",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.39",
+  "version": "1.7.40",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.45",
+  "version": "1.7.46",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.43",
+  "version": "1.7.44",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.42",
+  "version": "1.7.43",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.63",
+  "version": "0.4.64",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.64",
+  "version": "0.4.65",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.72",
+  "version": "0.4.73",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.66",
+  "version": "0.4.67",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.73",
+  "version": "0.4.74",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.74",
+  "version": "0.4.75",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.71",
+  "version": "0.4.72",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.70",
+  "version": "0.4.71",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.69",
+  "version": "0.4.70",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.67",
+  "version": "0.4.68",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.68",
+  "version": "0.4.69",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.509",
+  "version": "0.8.510",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.510",
+  "version": "0.8.511",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.511",
+  "version": "0.8.512",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.520",
+  "version": "0.8.521",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.514",
+  "version": "0.8.515",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.513",
+  "version": "0.8.514",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.518",
+  "version": "0.8.519",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.512",
+  "version": "0.8.513",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.519",
+  "version": "0.8.520",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.517",
+  "version": "0.8.518",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.516",
+  "version": "0.8.517",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.515",
+  "version": "0.8.516",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -990,8 +990,8 @@ export const agentsEndpointSchema = baseEndpointSchema
       remoteApi: remoteApiSchema.optional(),
       /** Human-in-the-loop tool approval policy. Off by default. */
       toolApproval: toolApprovalPolicySchema,
-      /** Durable checkpointer backing HITL resume. Defaults to the app's MongoDB
-       *  when `toolApproval.enabled` is set; ignored otherwise. */
+      /** Durable checkpointer backing tool-approval and Ask User resume.
+       *  Defaults to the app's MongoDB when either flow needs it. */
       checkpointer: checkpointerSchema,
     }),
   )
@@ -2862,7 +2862,7 @@ export enum Constants {
    */
   VERSION = '__LIBRECHAT_VERSION__',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.3.13',
+  CONFIG_VERSION = '1.3.14',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value to use whatever the submission prelim. `responseMessageId` is */

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

I rebased the LibreChat `v0.8.8-rc1` release branch onto the synchronized `dev`/`main` head (`d4c64d485`) and refreshed every release surface for the changes merged since the previous pass.

- Preserved the app `v0.8.8-rc1`, Helm chart `2.0.8` with `appVersion: v0.8.8-rc1`, and config schema `1.3.14` targets.
- Bumped the publishable packages again to `@librechat/api@1.7.46`, `@librechat/client@0.4.75`, `librechat-data-provider@0.8.521`, and `@librechat/data-schemas@0.0.68`.
- Synchronized the npm and Bun workspace lockfile versions without dependency churn.
- Updated the near-top README summary for message editing, PowerPoint `.potx` templates, portable shell uploads, Gemini 3.7 Flash, and parsed MCP response media types.
- Audited the seventeen PRs added across the latest refreshes, including message layouts and editing, Agent activity-phase persistence and E2E stability, Agent save consistency, MCP instruction and stale-stream recovery, MCP SDK 1.30 response handling, PowerPoint templates, shell MIME aliases and clear upload errors, Gemini 3.7 Flash, dark-mode and steer-bubble styling, API build cleanup, and Locize CI hardening.
- Refreshed the companion durable documentation, config notes, categorized changelog, contributor list, and standalone GitHub release artifact.

Companion documentation PR: https://github.com/LibreChat-AI/librechat.ai/pull/699

## Change Type

- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- `npm run build:packages`
- `npm run test:ci --workspace=@librechat/api -- --runInBand --coverage=false src/mcp/__tests__/MCPManager.test.ts` (111 tests passed)
- `npm run test:ci --workspace=@librechat/api -- --runInBand --coverage=false src/mcp/__tests__/MCPConnection.test.ts src/mcp/__tests__/MCPConnectionSseConflict.test.ts` (77 tests passed)
- `npm run test:ci --workspace=@librechat/api -- --runInBand --coverage=false src/files/code/classify.spec.ts src/files/code/extract.spec.ts src/files/documents/html.spec.ts` (236 tests passed)
- `npm run test:ci --workspace=librechat-data-provider -- --runInBand --coverage=false --silent src/file-config.spec.ts` (182 tests passed)
- `npm run test:ci --workspace=@librechat/frontend -- --runInBand --coverage=false src/utils/__tests__/artifacts.test.ts src/utils/__tests__/getViableUploadOptions.spec.ts` (178 tests passed)
- `npm run test:ci --workspace=@librechat/api -- --runInBand --coverage=false src/endpoints/google/llm.spec.ts src/utils/headers.spec.ts src/mcp/__tests__/MCPConnectionSSRF.test.ts src/middleware/error.spec.ts src/utils/tokens.spec.ts` (208 tests passed)
- `npm run test:ci --workspace=@librechat/data-schemas -- --runInBand --coverage=false --silent src/methods/tx.spec.ts` (231 tests passed)
- `npm run test:ci --workspace=@librechat/backend -- --runInBand --coverage=false server/routes/files/multer.spec.js utils/tokens.spec.js` (233 tests passed)
- Verified the final build and late-change suites against an exact `npm ci` install with `@librechat/agents@3.4.7` and `@modelcontextprotocol/sdk@1.30.0`
- Verified app, chart, config, package-manifest, npm lockfile, and Bun lockfile version consistency
- Audited `v0.8.7..origin/dev`: 356 commits, all 355 PRs, and the non-PR commit are present in both release artifacts
- `git diff --check`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted
