### PR TITLE
📌 fix: Pin Scroll-to-Bottom Rib in Message Nav

### DIFF
--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -1315,7 +1315,8 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
 
       {endEntry && (
         <div
-          className="flex w-14 flex-col items-stretch"
+          className="flex w-14 cursor-pointer touch-none select-none flex-col items-stretch"
+          onPointerDown={handlePointerDown}
           onPointerEnter={handleEndPointerEnter}
           onPointerLeave={clearTooltip}
           onFocus={handleEndFocus}

--- a/client/src/components/Chat/Messages/MessageNav.tsx
+++ b/client/src/components/Chat/Messages/MessageNav.tsx
@@ -313,6 +313,16 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
     return map;
   }, [entries]);
 
+  /** The terminus rib is pinned beside the down chevron rather than living in
+   *  the scrolling column, so it stays reachable however far the rail scrolls. */
+  const { messageEntries, endEntry } = useMemo(() => {
+    const last = entries[entries.length - 1];
+    if (last?.isEnd === true) {
+      return { messageEntries: entries.slice(0, -1), endEntry: last };
+    }
+    return { messageEntries: entries, endEntry: null };
+  }, [entries]);
+
   const getCurrentVisibleId = useCallback((): string | null => {
     const container = scrollableRef.current;
     if (!container) {
@@ -518,10 +528,11 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
   const scrubTo = useCallback(
     (clientY: number) => {
       const col = columnRef.current;
-      if (!col) {
+      const nav = navRef.current;
+      if (!col || !nav) {
         return;
       }
-      const ribs = col.querySelectorAll<HTMLElement>('[data-msg-id]');
+      const ribs = nav.querySelectorAll<HTMLElement>('[data-msg-id]');
       const count = ribs.length;
       if (count === 0) {
         return;
@@ -713,6 +724,38 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
       }, TOOLTIP_OPEN_DELAY);
     },
     [positionTip, revealTip],
+  );
+
+  /** The pinned terminus lives outside the column, so it drives the shared
+   *  preview itself instead of through the rail's pointer magnification. */
+  const showEndTip = useCallback(
+    (el: HTMLElement) => {
+      const rect = el.getBoundingClientRect();
+      const left = columnRef.current?.getBoundingClientRect().left ?? rect.left;
+      focusTooltip(MESSAGES_END_ID, rect.top + rect.height / 2, window.innerWidth - left + 8);
+    },
+    [focusTooltip],
+  );
+
+  const handleEndPointerEnter = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => showEndTip(e.currentTarget),
+    [showEndTip],
+  );
+
+  const handleEndFocus = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => showEndTip(e.currentTarget),
+    [showEndTip],
+  );
+
+  const handleEndBlur = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      const next = e.relatedTarget as Node | null;
+      if (next && e.currentTarget.contains(next)) {
+        return;
+      }
+      clearTooltip();
+    },
+    [clearTooltip],
   );
 
   const applyMagnify = useCallback(() => {
@@ -1209,9 +1252,7 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [focusNav]);
 
-  const hasEnd = entries.length > 0 && entries[entries.length - 1].isEnd === true;
-  const messageCount = hasEnd ? entries.length - 1 : entries.length;
-  if (messageCount < 3) {
+  if (messageEntries.length < 3) {
     return null;
   }
 
@@ -1252,15 +1293,11 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
         className="flex min-h-0 w-14 cursor-pointer touch-none select-none flex-col items-stretch gap-1.5 overflow-y-auto [&::-webkit-scrollbar]:hidden"
         style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
       >
-        {entries.map((entry) => {
-          const label = entry.isEnd
-            ? localize('com_ui_scroll_to_bottom')
-            : localize(
-                entry.isUser
-                  ? 'com_ui_message_nav_go_to_user'
-                  : 'com_ui_message_nav_go_to_assistant',
-                { 0: entry.preview.slice(0, 30) },
-              );
+        {messageEntries.map((entry) => {
+          const label = localize(
+            entry.isUser ? 'com_ui_message_nav_go_to_user' : 'com_ui_message_nav_go_to_assistant',
+            { 0: entry.preview.slice(0, 30) },
+          );
           const isHighlighted =
             hoveredId != null ? hoveredId === entry.id : visibleIds.has(entry.id);
           return (
@@ -1275,6 +1312,26 @@ function MessageNav({ scrollableRef }: { scrollableRef: React.RefObject<HTMLDivE
           );
         })}
       </div>
+
+      {endEntry && (
+        <div
+          className="flex w-14 flex-col items-stretch"
+          onPointerEnter={handleEndPointerEnter}
+          onPointerLeave={clearTooltip}
+          onFocus={handleEndFocus}
+          onBlur={handleEndBlur}
+        >
+          <MessageIndicator
+            entry={endEntry}
+            isHighlighted={
+              hoveredId != null ? hoveredId === endEntry.id : visibleIds.has(endEntry.id)
+            }
+            isCurrent={currentId === endEntry.id}
+            onSelect={handleSelect}
+            label={localize('com_ui_scroll_to_bottom')}
+          />
+        </div>
+      )}
 
       <button
         type="button"

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -1645,6 +1645,27 @@ describe('MessageNav', () => {
       expect(column.scrollTop).toBe(13);
     });
 
+    it('starts a scrub drag from the pinned terminus', () => {
+      const messages = Array.from({ length: 5 }, (_, i) =>
+        buildMessage({ messageId: `m-${i}`, text: `message ${i}`, isCreatedByUser: i % 2 === 0 }),
+      );
+      const { container, scrollable } = renderNavWithEnd(messages);
+      const column = container.querySelector('nav > div') as HTMLDivElement;
+      column.getBoundingClientRect = () => ({ top: 0, bottom: 50, height: 50 }) as DOMRect;
+      const wrapper = container.querySelector('[data-msg-id="messages-end"]')!
+        .parentElement as HTMLElement;
+      const getById = jest.spyOn(document, 'getElementById');
+
+      act(() => {
+        fireEvent.pointerDown(wrapper, { pointerId: 1, button: 0, buttons: 1, clientY: 60 });
+        fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientY: 0 });
+      });
+
+      expect(getById.mock.calls.map((c) => c[0])).toContain('m-0');
+      getById.mockRestore();
+      expect(scrollable).toBeDefined();
+    });
+
     it('previews the terminus on hover even though it sits outside the column', () => {
       const { container } = renderNavWithEnd(threeMessages());
       const wrapper = container.querySelector('[data-msg-id="messages-end"]')!

--- a/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx
@@ -1590,6 +1590,100 @@ describe('MessageNav', () => {
       expect(ribs[3].getAttribute('aria-label')).toBe('com_ui_scroll_to_bottom');
     });
 
+    it('pins the terminus outside the scrolling column, between it and the next chevron', () => {
+      const { container } = renderNavWithEnd(threeMessages());
+      const nav = container.querySelector('nav') as HTMLElement;
+      const column = container.querySelector('nav > div') as HTMLDivElement;
+
+      expect(column.querySelector('[data-msg-id="messages-end"]')).toBeNull();
+      expect(nav.querySelector('[data-msg-id="messages-end"]')).not.toBeNull();
+
+      const kids = Array.from(nav.children);
+      const endIndex = kids.findIndex((k) => k.querySelector('[data-msg-id="messages-end"]'));
+      const nextIndex = kids.findIndex(
+        (k) => k.getAttribute('aria-label') === 'com_ui_message_nav_next',
+      );
+      expect(endIndex).toBe(kids.indexOf(column) + 1);
+      expect(nextIndex).toBe(endIndex + 1);
+    });
+
+    it('keeps column children aligned with message entries once the terminus is pinned', () => {
+      const messages = Array.from({ length: 5 }, (_, i) =>
+        buildMessage({ messageId: `m-${i}`, text: `message ${i}`, isCreatedByUser: i % 2 === 0 }),
+      );
+      const { container } = renderNavWithEnd(messages);
+      const column = container.querySelector('nav > div') as HTMLDivElement;
+
+      expect(column.children).toHaveLength(messages.length);
+      for (let i = 0; i < messages.length; i++) {
+        expect(column.children[i].getAttribute('data-msg-id')).toBe(`m-${i}`);
+      }
+    });
+
+    it('centers the column on the visible window using the pinned-out child indices', () => {
+      const messages = Array.from({ length: 10 }, (_, i) =>
+        buildMessage({ messageId: `m-${i}`, text: `message ${i}`, isCreatedByUser: i % 2 === 0 }),
+      );
+      const { container, scrollable } = renderNavWithEnd(messages);
+      const column = container.querySelector('nav > div') as HTMLDivElement;
+
+      Object.defineProperty(column, 'clientHeight', { value: 30, configurable: true });
+      Object.defineProperty(column, 'scrollHeight', { value: 200, configurable: true });
+      Object.defineProperty(column, 'scrollTop', { value: 0, writable: true, configurable: true });
+      for (let i = 0; i < column.children.length; i++) {
+        Object.defineProperty(column.children[i], 'offsetTop', { value: i * 10 });
+        Object.defineProperty(column.children[i], 'offsetHeight', { value: 6 });
+      }
+      (scrollable as HTMLElement).scrollTop = 400;
+
+      act(() => {
+        fireEvent.scroll(scrollable);
+        jest.advanceTimersByTime(32);
+      });
+
+      /** Visible rows m-1..m-4 → mid of ribs 1 and 4, minus half the column height. */
+      expect(column.scrollTop).toBe(13);
+    });
+
+    it('previews the terminus on hover even though it sits outside the column', () => {
+      const { container } = renderNavWithEnd(threeMessages());
+      const wrapper = container.querySelector('[data-msg-id="messages-end"]')!
+        .parentElement as HTMLElement;
+
+      act(() => {
+        fireEvent.pointerEnter(wrapper, { pointerId: 1, clientY: 5 });
+        jest.advanceTimersByTime(80);
+      });
+      expect(document.body.querySelector('[role="tooltip"]')).toHaveTextContent(
+        'com_ui_scroll_to_bottom',
+      );
+
+      act(() => {
+        fireEvent.pointerLeave(wrapper, { pointerId: 1 });
+      });
+      expect(document.body.querySelector('[role="tooltip"]')).toBeNull();
+    });
+
+    it('previews the terminus when it takes keyboard focus', () => {
+      const { container } = renderNavWithEnd(threeMessages());
+      const endRib = container.querySelector('[data-msg-id="messages-end"]') as HTMLElement;
+
+      act(() => {
+        endRib.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        jest.advanceTimersByTime(80);
+      });
+      expect(document.body.querySelector('[role="tooltip"]')).toHaveTextContent(
+        'com_ui_scroll_to_bottom',
+      );
+
+      act(() => {
+        endRib.dispatchEvent(
+          new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }),
+        );
+      });
+      expect(document.body.querySelector('[role="tooltip"]')).toBeNull();
+    });
+
     it('omits the terminus indicator and the nav when there are fewer than 3 messages', () => {
       const messages = [
         buildMessage({ messageId: 'a', text: 'alpha', isCreatedByUser: true }),


### PR DESCRIPTION
## Summary

The message nav rail's scroll-to-bottom rib (the terminus dot) lived inside the scrolling indicator column, so it scrolled out of view as soon as the rail scrolled away from the end of a long thread. The down chevron stayed put while the affordance it pairs with disappeared.

This renders the terminus rib outside the column, between the column and the down chevron, so it is always in view alongside that chevron.

## Changes

- `MessageNav` splits its entries into `messageEntries` (rendered in the scrolling column) and `endEntry` (pinned below it). The column's fisheye centering and bottom-snap are untouched: they only index column children for non-final entries, so the index mapping stays aligned.
- `scrubTo` enumerates ribs from the nav rather than the column, so dragging to the bottom of the rail still lands on the terminus exactly as before.
- The pinned rib drives the shared preview tooltip itself on hover and on keyboard focus, since it is no longer covered by the column's pointer magnification. Highlighting, `aria-current`, and click-to-scroll (without stealing focus) are unchanged.

## Testing

`client/src/components/Chat/Messages/__tests__/MessageNav.spec.tsx` — 69 passing, 5 new:

- terminus renders outside the column and sits between the column and the next chevron
- column children stay index-aligned with message entries
- column centering math with the terminus pinned out (fails on an off-by-one in the child indices)
- terminus preview on hover
- terminus preview on keyboard focus

`npx tsc --noEmit` and `eslint` clean on the changed files.