### PR TITLE
🫙 fix: Preserve Loaded Message Content When Resume Snapshot Is Empty

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1360,6 +1360,41 @@ describe('useResumableSSE', () => {
       unmount();
     });
 
+    /**
+     * A row with no `content` array must still be assigned the snapshot's array. Handing it
+     * `undefined` would flip which renderer `MultiMessage` selects (it branches on
+     * `message.content` truthiness, and `[]` is truthy while `undefined` is not).
+     */
+    it('assigns the snapshot when the matched row has no content array', async () => {
+      const submission = buildSubmission();
+      const chatHelpers = buildChatHelpers();
+      chatHelpers.getMessages.mockReturnValue([
+        {
+          messageId: 'msg-1',
+          conversationId: CONV_ID,
+          isCreatedByUser: true,
+          text: 'Hello',
+        },
+        {
+          messageId: 'resp-1',
+          parentMessageId: 'msg-1',
+          conversationId: CONV_ID,
+          isCreatedByUser: false,
+          text: 'legacy text-only row',
+        },
+      ] as unknown as TMessage[]);
+
+      const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await emitSync([]);
+
+      expect(syncedResponse(chatHelpers)?.content).toEqual([]);
+      unmount();
+    });
+
     it('still applies the resume snapshot when it carries content', async () => {
       const { submission, chatHelpers } = renderWithLoadedResponse();
       const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1239,6 +1239,88 @@ describe('useResumableSSE', () => {
     unmount();
   });
 
+  describe('sync content reconciliation', () => {
+    const DB_CONTENT = [{ type: 'text', text: 'streamed before the reload' }];
+
+    const renderWithLoadedResponse = () => {
+      const submission = buildSubmission();
+      const chatHelpers = buildChatHelpers();
+      chatHelpers.getMessages.mockReturnValue([
+        {
+          messageId: 'msg-1',
+          conversationId: CONV_ID,
+          isCreatedByUser: true,
+          text: 'Hello',
+        },
+        {
+          messageId: 'resp-1',
+          parentMessageId: 'msg-1',
+          conversationId: CONV_ID,
+          isCreatedByUser: false,
+          text: '',
+          content: DB_CONTENT,
+        },
+      ] as unknown as TMessage[]);
+      return { submission, chatHelpers };
+    };
+
+    const emitSync = async (aggregatedContent: unknown[]) => {
+      const sse = getLastSSE();
+      await act(async () => {
+        sse._emit('message', {
+          data: JSON.stringify({
+            sync: true,
+            resumeState: {
+              runSteps: [],
+              aggregatedContent,
+              responseMessageId: 'resp-1',
+            },
+          }),
+        });
+      });
+    };
+
+    const syncedResponse = (chatHelpers: ReturnType<typeof buildChatHelpers>) => {
+      const call = chatHelpers.setMessages.mock.calls
+        .map(([messages]) => messages as TMessage[])
+        .reverse()
+        .find((messages) => messages?.some((m) => m.messageId === 'resp-1'));
+      return call?.find((m) => m.messageId === 'resp-1');
+    };
+
+    /**
+     * An empty snapshot is what a resuming client gets when the conversation's job was
+     * replaced mid-flight. Assigning it erased the content the messages query had already
+     * loaded, leaving a message that renders as a bare cursor forever.
+     */
+    it('keeps already-loaded content when the resume snapshot is empty', async () => {
+      const { submission, chatHelpers } = renderWithLoadedResponse();
+      const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await emitSync([]);
+
+      expect(syncedResponse(chatHelpers)?.content).toEqual(DB_CONTENT);
+      unmount();
+    });
+
+    it('still applies the resume snapshot when it carries content', async () => {
+      const { submission, chatHelpers } = renderWithLoadedResponse();
+      const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const resumed = [{ type: 'text', text: 'authoritative resumed content' }];
+      await emitSync(resumed);
+
+      expect(syncedResponse(chatHelpers)?.content).toEqual(resumed);
+      unmount();
+    });
+  });
+
   it('replays OAuth run step delta events from resume state sync', async () => {
     const submission = buildSubmission();
     const chatHelpers = buildChatHelpers();

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1306,6 +1306,60 @@ describe('useResumableSSE', () => {
       unmount();
     });
 
+    /**
+     * Regenerate: the new run's response id is not in the loaded history yet, so the
+     * parent-based fallback lands on the answer being REPLACED. Preserving that row's
+     * content would make the regenerated run's deltas append to the stale answer, so an
+     * empty snapshot must still clear a row we only matched heuristically.
+     */
+    it('does not preserve content on a row matched only by the parent fallback', async () => {
+      const submission = buildSubmission();
+      const chatHelpers = buildChatHelpers();
+      chatHelpers.getMessages.mockReturnValue([
+        {
+          messageId: 'msg-1',
+          conversationId: CONV_ID,
+          isCreatedByUser: true,
+          text: 'Hello',
+        },
+        {
+          messageId: 'resp-previous',
+          parentMessageId: 'msg-1',
+          conversationId: CONV_ID,
+          isCreatedByUser: false,
+          text: '',
+          content: [{ type: 'text', text: 'the answer being regenerated' }],
+        },
+      ] as unknown as TMessage[]);
+
+      const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const sse = getLastSSE();
+      await act(async () => {
+        sse._emit('message', {
+          data: JSON.stringify({
+            sync: true,
+            resumeState: {
+              runSteps: [],
+              aggregatedContent: [],
+              responseMessageId: 'resp-regenerated',
+            },
+          }),
+        });
+      });
+
+      const synced = chatHelpers.setMessages.mock.calls
+        .map(([messages]) => messages as TMessage[])
+        .reverse()
+        .find((messages) => messages?.some((m) => m.messageId === 'resp-previous'))
+        ?.find((m) => m.messageId === 'resp-previous');
+      expect(synced?.content).toEqual([]);
+      unmount();
+    });
+
     it('still applies the resume snapshot when it carries content', async () => {
       const { submission, chatHelpers } = renderWithLoadedResponse();
       const { unmount } = renderHook(() => useResumableSSE(submission, chatHelpers));

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -1038,8 +1038,13 @@ export default function useResumableSSE(
                 /** An EMPTY resume snapshot is not authoritative over content we already loaded
                  *  for the SAME response: assigning it would erase that content and leave a bare
                  *  cursor. Restricted to an id match — preserving a fallback-matched row would
-                 *  make a regenerated run append to the answer it is replacing. */
-                const preserveLoadedContent = !hasResumedContent && matchedByResponseId;
+                 *  make a regenerated run append to the answer it is replacing — and to a row
+                 *  that actually HAS parts, so the array is never swapped for `undefined`. */
+                const preserveLoadedContent =
+                  !hasResumedContent &&
+                  matchedByResponseId &&
+                  Array.isArray(oldContent) &&
+                  oldContent.length > 0;
                 const responseMessage = {
                   ...messages[responseIdx],
                   content: preserveLoadedContent ? oldContent : data.resumeState.aggregatedContent,

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -1009,8 +1009,12 @@ export default function useResumableSSE(
               const hasResumedContent = data.resumeState.aggregatedContent.length > 0;
 
               let responseIdx = -1;
+              /** Only an id match proves the row belongs to THIS generation; the parent-based
+               *  fallback below can land on a prior sibling (e.g. the answer being regenerated). */
+              let matchedByResponseId = false;
               if (serverResponseId) {
                 responseIdx = messages.findIndex((m) => m.messageId === serverResponseId);
+                matchedByResponseId = responseIdx >= 0;
               }
               if (responseIdx < 0) {
                 responseIdx = messages.findIndex(
@@ -1031,12 +1035,14 @@ export default function useResumableSSE(
 
               if (responseIdx >= 0) {
                 const oldContent = messages[responseIdx]?.content;
-                /** An EMPTY resume snapshot is not authoritative over what we already have:
-                 *  assigning it would erase content the messages query loaded, leaving a bare
-                 *  cursor. Keep the loaded content and let live deltas take over. */
+                /** An EMPTY resume snapshot is not authoritative over content we already loaded
+                 *  for the SAME response: assigning it would erase that content and leave a bare
+                 *  cursor. Restricted to an id match — preserving a fallback-matched row would
+                 *  make a regenerated run append to the answer it is replacing. */
+                const preserveLoadedContent = !hasResumedContent && matchedByResponseId;
                 const responseMessage = {
                   ...messages[responseIdx],
-                  content: hasResumedContent ? data.resumeState.aggregatedContent : oldContent,
+                  content: preserveLoadedContent ? oldContent : data.resumeState.aggregatedContent,
                   iconURL: preferDefinedString(
                     messages[responseIdx]?.iconURL,
                     data.resumeState.iconURL,
@@ -1048,7 +1054,8 @@ export default function useResumableSSE(
                   messageId: responseMessage.messageId,
                   oldContentLength: Array.isArray(oldContent) ? oldContent.length : 0,
                   newContentLength: data.resumeState.aggregatedContent?.length,
-                  preservedExistingContent: !hasResumedContent,
+                  preservedExistingContent: preserveLoadedContent,
+                  matchedByResponseId,
                 });
                 setMessages(updated);
                 resetContentHandler();

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -1006,6 +1006,7 @@ export default function useResumableSSE(
               const messages = getMessages() ?? [];
               const userMsgId = userMessage.messageId;
               const serverResponseId = data.resumeState.responseMessageId;
+              const hasResumedContent = data.resumeState.aggregatedContent.length > 0;
 
               let responseIdx = -1;
               if (serverResponseId) {
@@ -1030,9 +1031,12 @@ export default function useResumableSSE(
 
               if (responseIdx >= 0) {
                 const oldContent = messages[responseIdx]?.content;
+                /** An EMPTY resume snapshot is not authoritative over what we already have:
+                 *  assigning it would erase content the messages query loaded, leaving a bare
+                 *  cursor. Keep the loaded content and let live deltas take over. */
                 const responseMessage = {
                   ...messages[responseIdx],
-                  content: data.resumeState.aggregatedContent,
+                  content: hasResumedContent ? data.resumeState.aggregatedContent : oldContent,
                   iconURL: preferDefinedString(
                     messages[responseIdx]?.iconURL,
                     data.resumeState.iconURL,
@@ -1044,6 +1048,7 @@ export default function useResumableSSE(
                   messageId: responseMessage.messageId,
                   oldContentLength: Array.isArray(oldContent) ? oldContent.length : 0,
                   newContentLength: data.resumeState.aggregatedContent?.length,
+                  preservedExistingContent: !hasResumedContent,
                 });
                 setMessages(updated);
                 resetContentHandler();


### PR DESCRIPTION
## Summary

The resumable-stream sync handler guarded on `data.resumeState?.aggregatedContent` and then assigned it unconditionally. An empty array is truthy, so a resume snapshot carrying no content **overwrote** content already loaded for that same response — the message then rendered as a bare cursor even though the conversation's own history had the text.

An empty snapshot is now treated as non-authoritative for a response we can identify, and the loaded content is kept.

```diff
+ const hasResumedContent = data.resumeState.aggregatedContent.length > 0;
+ const preserveLoadedContent = !hasResumedContent && matchedByResponseId;
...
- content: data.resumeState.aggregatedContent,
+ content: preserveLoadedContent ? oldContent : data.resumeState.aggregatedContent,
```

## Scope

Behavior differs from `dev` only when **both** conditions hold:

1. the row was located by an exact `resumeState.responseMessageId` match, **and**
2. `aggregatedContent` is empty

In that case the loaded content is preserved instead of cleared. Every other path is unchanged — non-empty snapshots, the `else` branch that creates a new response row, and any row located by the parent-based fallback all behave exactly as before. The change can only ever *skip* a write that previously happened; it never writes anything new.

Concretely, this covers a response whose partial was persisted under the same id and whose snapshot subsequently comes back empty. It is a robustness guard on the resume path, not a fix for any one root cause: an empty snapshot on a live run is itself worth investigating separately (see the note below), and this only ensures that when it happens, already-visible content is not destroyed.

## Why preservation is restricted to an id match

Regenerate makes the parent-based fallback unsafe. The client derives the regenerated response id by **padding** the previous one (`useChatFunctions.ts`):

```ts
return `${responseMessageId.replace(/_+$/, '')}_`;
```

and the server adopts that value verbatim (`getPreliminaryResponseMessageId` in `request.js`). So mid-regenerate the job carries `oldRespId_` while loaded history still holds `oldRespId`. The exact-id lookup cannot match, the fallback fires, and it selects the answer being replaced. Preserving that row's content would seed `syncStepMessage` with the stale response and make the regenerated run's deltas append to it.

Requiring an id match is what makes preservation safe: it is the only condition proving the row belongs to the generation the snapshot describes. Deliberately **not** done here: teaching the lookup to also try the unpadded id. That would widen behavior on this hot path without evidence demanding it, and regenerate is precisely where that would go wrong.

Thanks @chatgpt-codex-connector for catching the regenerate interaction — it was a real regression in the first revision of this PR.

## Related

A resume snapshot can go empty when a conversation's job is replaced mid-flight: because `streamId === conversationId`, a second submission calls `createJob` on the same key while the first run is still streaming. On the in-memory job store the first run's content then becomes unreachable (`appendChunk` is gated behind `if (this._isRedis)`, and `setContentParts` replaces the stored array reference), so `getResumeState` reports `aggregatedContent: []` and `runSteps: []` while `active` stays `true`. On Redis the same replacement is survivable, since `JOB_CREATE_LUA` clears only the steer keys and the chunk log is reconstructed.

That is the ambiguity tracked in #14348, whose clean fix (per-generation stream ids) remains open. This PR does **not** address it — a replacement carries its own `responseMessageId`, so the preserve path above does not apply to it.

## Test plan

Three tests in `useResumableSSE.spec.ts`:
- empty snapshot preserves loaded content on an id-matched row
- empty snapshot still clears a row matched only by the parent fallback (the regenerate case)
- a snapshot carrying content still applies

Each guard verified non-vacuous by reverting the corresponding change and confirming the test fails, then passes with it restored.

`npx jest src/hooks/SSE` → 7 suites, 149 tests passing.
