### PR TITLE
feat: support MCP-generated file attachments

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -29,6 +29,8 @@ const {
 const { processFileCitations } = require('~/server/services/Files/Citations');
 const { processCodeOutput, runPreviewFinalize } = require('~/server/services/Files/Code/process');
 const { saveBase64Image } = require('~/server/services/Files/process');
+const { addPendingAttachment } = require('~/server/services/pendingAttachments');
+const db = require('~/models');
 
 function isHostFileAuthoringArtifact(artifact) {
   return artifact?.[HOST_FILE_AUTHORING_ARTIFACT_KEY] === true;
@@ -721,12 +723,24 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null }) 
    * @type {ToolEndCallback}
    */
   return async (data, metadata) => {
+    // DEBUG: Log all tool end callback data
+    logger.debug('[ToolEndCallback] Called with data:', JSON.stringify({
+      hasOutput: !!data?.output,
+      outputKeys: data?.output ? Object.keys(data.output) : [],
+      hasArtifact: !!data?.output?.artifact,
+      artifactKeys: data?.output?.artifact ? Object.keys(data.output.artifact) : [],
+      toolName: data?.output?.name || 'unknown',
+      toolCallId: data?.output?.tool_call_id || 'unknown',
+    }));
+    
     const output = data?.output;
     if (!output) {
+      logger.debug('[ToolEndCallback] No output, returning early');
       return;
     }
 
     if (!output.artifact) {
+      logger.debug('[ToolEndCallback] No artifact in output, returning early');
       return;
     }
 
@@ -867,6 +881,73 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null }) 
         );
       }
       return;
+    }
+
+    /**
+     * Handle MCP tool file artifacts.
+     * MCP tools can return file artifacts with file_id (already uploaded via service endpoint).
+     * These are processed differently from code execution files - they don't need downloading,
+     * just attachment metadata for the message.
+     */
+    if (output.artifact.files && output.artifact.file_ids) {
+      const isMCPFileArtifact = output.artifact.files.some(f => f.file_id);
+      if (isMCPFileArtifact) {
+        for (const file of output.artifact.files) {
+          if (!file.file_id) {
+            continue;
+          }
+          artifactPromises.push(
+            (async () => {
+              const fileMetadata = {
+                file_id: file.file_id,
+                filename: file.filename || file.name,
+                filepath: file.filepath,
+                type: file.mimeType || file.type,
+                bytes: file.bytes,
+                source: file.source || 'local',
+                user: req?.user?.id,
+                messageId: metadata.run_id,
+                toolCallId: output.tool_call_id,
+                conversationId: metadata.thread_id,
+              };
+              
+              if (!streamId && !res.headersSent) {
+                return fileMetadata;
+              }
+              
+              if (fileMetadata) {
+                writeAttachment(res, streamId, fileMetadata);
+                
+                // Store attachment in pending registry for deferred update
+                // Message doesn't exist during tool execution, so we store the attachment
+                // and apply it when the message is created
+                if (metadata.run_id) {
+                  const attachmentData = {
+                    type: 'file',
+                    file_id: fileMetadata.file_id,
+                    filename: fileMetadata.filename,
+                    filepath: fileMetadata.filepath,
+                    mimeType: fileMetadata.type,
+                    bytes: fileMetadata.bytes,
+                    source: fileMetadata.source,
+                    toolCallId: output.tool_call_id,
+                    conversationId: metadata.thread_id,
+                    userId: req?.user?.id,
+                  };
+                  
+                  addPendingAttachment(metadata.run_id, attachmentData);
+                  logger.debug(`[MCP] Stored pending attachment ${fileMetadata.file_id} for message ${metadata.run_id}`);
+                }
+              }
+              return fileMetadata;
+            })().catch((error) => {
+              logger.error('Error processing MCP file artifact:', error);
+              return null;
+            }),
+          );
+        }
+        return;
+      }
     }
 
     if (!isCodeArtifactToolOutput(output)) {

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -22,6 +22,7 @@ const {
 const { handleAbortError } = require('~/server/middleware');
 const { logViolation } = require('~/cache');
 const { saveMessage, getMessages, getConvo } = require('~/models');
+const { applyPendingAttachments, hasPendingAttachments } = require('~/server/services/pendingAttachments');
 
 function createCloseHandler(abortController) {
   return function (manual) {
@@ -1340,6 +1341,20 @@ const _LegacyAgentController = async (req, res, next, initializeClient, addTitle
           { ...finalResponse, user: userId },
           { context: 'api/server/controllers/agents/request.js - response end' },
         );
+        
+        // Apply any pending attachments from MCP tools
+        // MCP tools execute before the message exists, so attachments are stored
+        // temporarily and applied here after the message is saved
+        if (hasPendingAttachments(messageId)) {
+          try {
+            const applied = await applyPendingAttachments(userId, messageId);
+            if (applied > 0) {
+              logger.debug(`[AgentController] Applied ${applied} pending attachments to message ${messageId}`);
+            }
+          } catch (attachmentError) {
+            logger.error('[AgentController] Error applying pending attachments:', attachmentError);
+          }
+        }
       }
     }
     // Edge case: sendMessage completed but abort happened during sendCompletion

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -59,7 +59,6 @@ const { PORT, HOST, ALLOW_SOCIAL_LOGIN, DISABLE_COMPRESSION, TRUST_PROXY } = pro
 const port = isNaN(Number(PORT)) ? 3080 : Number(PORT);
 const host = HOST || 'localhost';
 const trusted_proxy = Number(TRUST_PROXY) || 1; /* trust first proxy by default */
-
 const app = express();
 let serverReady = false;
 
@@ -300,6 +299,8 @@ const startServer = async () => {
   app.use('/api/mcp', routes.mcp);
   app.use('/api/rum', routes.rum);
 
+ /* Service-to-service file upload endpoint for MCP servers */
+  app.use('/api/service/files', routes.serviceFiles);
   app.use('/metrics', metricsRouter);
 
   /** 404 for unmatched API routes */

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -35,6 +35,7 @@ const auth = require('./auth');
 const keys = require('./keys');
 const user = require('./user');
 const mcp = require('./mcp');
+const serviceFiles = require('./serviceFiles');
 const rum = require('./rum');
 
 module.exports = {
@@ -76,4 +77,5 @@ module.exports = {
   categories,
   staticRoute,
   accessPermissions,
+  serviceFiles
 };

--- a/api/server/routes/serviceFiles.js
+++ b/api/server/routes/serviceFiles.js
@@ -1,0 +1,293 @@
+/**
+ * Service-to-Service File Upload Endpoint
+ * 
+ * This endpoint allows MCP servers to upload files on behalf of authenticated users.
+ * It uses a service token for authentication and accepts the user ID via headers.
+ * 
+ * Security:
+ * - Service token validation (shared secret between LibreChat and MCP servers)
+ * - User ID must be provided and validated against the database
+ * - Files are stored using the configured file strategy
+ */
+
+const express = require('express');
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const { logger } = require('@librechat/data-schemas');
+const { FileSources, FileContext } = require('librechat-data-provider');
+const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { sanitizeFilename, getStorageMetadata } = require('@librechat/api');
+const { getAppConfig } = require('~/server/services/Config');
+const db = require('~/models');
+
+const router = express.Router();
+
+/**
+ * Service token validation middleware
+ * Validates the X-Service-Token header against MCP_SERVICE_TOKEN env var
+ */
+const validateServiceToken = (req, res, next) => {
+  const serviceToken = req.headers['x-service-token'];
+  const expectedToken = process.env.MCP_SERVICE_TOKEN;
+
+  if (!expectedToken) {
+    logger.error('[ServiceFiles] MCP_SERVICE_TOKEN environment variable not configured');
+    return res.status(500).json({ 
+      success: false,
+      error: 'Service not configured',
+      message: 'MCP_SERVICE_TOKEN is not set on the server'
+    });
+  }
+
+  if (!serviceToken) {
+    logger.warn('[ServiceFiles] Missing X-Service-Token header');
+    return res.status(401).json({ 
+      success: false,
+      error: 'Unauthorized',
+      message: 'X-Service-Token header is required'
+    });
+  }
+
+  if (serviceToken !== expectedToken) {
+    logger.warn('[ServiceFiles] Invalid service token attempt');
+    return res.status(401).json({ 
+      success: false,
+      error: 'Unauthorized',
+      message: 'Invalid service token'
+    });
+  }
+
+  next();
+};
+
+// Configure multer for file uploads
+// Files are temporarily stored before being processed by the file strategy
+const uploadDir = '/tmp/service-uploads/';
+
+// Ensure upload directory exists
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const upload = multer({
+  dest: uploadDir,
+  limits: { 
+    fileSize: 100 * 1024 * 1024, // 100MB max file size
+    files: 1 // Only one file at a time
+  },
+});
+
+/**
+ * POST /api/service/files
+ * 
+ * Service-to-service file upload endpoint for MCP servers.
+ * Allows MCP servers to upload files that will be associated with a specific user.
+ * 
+ * Required Headers:
+ * - X-Service-Token: The service authentication token
+ * - X-User-Id: The LibreChat user ID to associate the file with
+ * 
+ * Optional Headers:
+ * - X-User-Email: User's email (for logging purposes)
+ * - X-Conversation-Id: Associate file with a conversation
+ * - X-Message-Id: Associate file with a message
+ * 
+ * Request Body:
+ * - file: The file to upload (multipart/form-data)
+ * 
+ * Response:
+ * {
+ *   success: true,
+ *   file: {
+ *     file_id: "uuid",
+ *     filename: "document.docx",
+ *     filepath: "/path/to/file",
+ *     type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+ *     bytes: 12345
+ *   }
+ * }
+ */
+router.post('/', validateServiceToken, upload.single('file'), async (req, res) => {
+  const tempFilePath = req.file?.path;
+  
+  try {
+    // Extract user context from headers
+    const userId = req.headers['x-user-id'];
+    const userEmail = req.headers['x-user-email'];
+    const conversationId = req.headers['x-conversation-id'];
+    const messageId = req.headers['x-message-id'];
+
+    // Validate required headers
+    if (!userId) {
+      logger.warn('[ServiceFiles] Missing X-User-Id header');
+      return res.status(400).json({ 
+        success: false,
+        error: 'Bad Request',
+        message: 'X-User-Id header is required'
+      });
+    }
+
+    if (!req.file) {
+      logger.warn('[ServiceFiles] No file provided in request');
+      return res.status(400).json({ 
+        success: false,
+        error: 'Bad Request',
+        message: 'No file provided'
+      });
+    }
+
+    logger.info(`[ServiceFiles] Processing file upload for user: ${userId}, email: ${userEmail || 'N/A'}`);
+    logger.debug(`[ServiceFiles] File: ${req.file.originalname}, size: ${req.file.size}, type: ${req.file.mimetype}`);
+
+    // Get app config for file strategy
+    const appConfig = await getAppConfig();
+    const fileStrategy = appConfig?.fileStrategy || FileSources.local;
+
+    logger.debug(`[ServiceFiles] Using file strategy: ${fileStrategy}`);
+
+    // Generate unique file ID
+    const file_id = uuidv4();
+    const sanitizedFilename = sanitizeFilename(req.file.originalname);
+
+    // Get upload function for configured strategy
+    const { handleFileUpload } = getStrategyFunctions(fileStrategy);
+
+    if (!handleFileUpload) {
+      throw new Error(`No upload handler found for strategy: ${fileStrategy}`);
+    }
+
+    // Create a mock request object for the upload function
+    // This mimics what the regular file upload route provides
+    const mockReq = {
+      user: { id: userId },
+      config: appConfig,
+    };
+
+    // Prepare file object matching what multer provides
+    const fileObject = {
+      path: tempFilePath,
+      originalname: sanitizedFilename,
+      mimetype: req.file.mimetype,
+      size: req.file.size,
+      buffer: fs.readFileSync(tempFilePath),
+    };
+
+    // Upload file using configured strategy
+    logger.debug(`[ServiceFiles] Uploading file using ${fileStrategy} strategy`);
+    
+    const uploadResult = await handleFileUpload({
+      req: mockReq,
+      file: fileObject,
+      file_id,
+    });
+
+    logger.debug(`[ServiceFiles] Upload result:`, uploadResult);
+
+    // Get storage metadata for the file
+    const storageMetadata = getStorageMetadata({
+      filepath: uploadResult.filepath,
+      source: fileStrategy,
+      storageKey: uploadResult.storageKey,
+      storageRegion: uploadResult.storageRegion,
+    });
+
+    // Create file record in database
+    const fileRecord = await db.createFile(
+      {
+        user: userId,
+        file_id: uploadResult.id || file_id,
+        bytes: uploadResult.bytes || req.file.size,
+        filepath: uploadResult.filepath,
+        ...storageMetadata,
+        filename: sanitizedFilename,
+        source: fileStrategy,
+        type: req.file.mimetype,
+        context: FileContext.message_attachment,
+        // Optional: associate with conversation/message if provided
+        ...(conversationId && { conversationId }),
+        ...(messageId && { messageId }),
+      },
+      true, // disableTTL - don't auto-expire service-uploaded files
+    );
+
+    logger.info(`[ServiceFiles] File uploaded successfully: ${fileRecord.file_id} for user: ${userId}`);
+
+    // If conversationId is provided, add file to conversation.files array
+    if (conversationId) {
+      try {
+        const Conversation = mongoose.models.Conversation;
+        if (Conversation) {
+          const updateResult = await Conversation.updateOne(
+            { conversationId, user: userId },
+            { $addToSet: { files: fileRecord.file_id } }
+          );
+          
+          if (updateResult.matchedCount > 0) {
+            logger.info(`[ServiceFiles] Added file ${fileRecord.file_id} to conversation ${conversationId}`);
+          } else {
+            logger.warn(`[ServiceFiles] Conversation ${conversationId} not found for user ${userId}`);
+          }
+        } else {
+          logger.warn('[ServiceFiles] Conversation model not available');
+        }
+      } catch (convError) {
+        // Log but don't fail the request - file was uploaded successfully
+        logger.error('[ServiceFiles] Error adding file to conversation:', convError);
+      }
+    }
+
+    // Return success response
+    res.status(200).json({
+      success: true,
+      file: {
+        file_id: fileRecord.file_id,
+        filename: fileRecord.filename,
+        filepath: fileRecord.filepath,
+        type: fileRecord.type,
+        bytes: fileRecord.bytes,
+        source: fileRecord.source,
+      },
+      user_id: userId,
+    });
+
+  } catch (error) {
+    logger.error('[ServiceFiles] Upload error:', error);
+    res.status(500).json({ 
+      success: false,
+      error: 'Upload Failed',
+      message: error.message || 'An error occurred during file upload'
+    });
+  } finally {
+    // Clean up temp file
+    if (tempFilePath && fs.existsSync(tempFilePath)) {
+      try {
+        fs.unlinkSync(tempFilePath);
+        logger.debug(`[ServiceFiles] Cleaned up temp file: ${tempFilePath}`);
+      } catch (cleanupErr) {
+        logger.warn(`[ServiceFiles] Failed to clean up temp file: ${tempFilePath}`, cleanupErr);
+      }
+    }
+  }
+});
+
+/**
+ * GET /api/service/files/health
+ * 
+ * Health check endpoint for the service files API.
+ * Can be used by MCP servers to verify connectivity.
+ */
+router.get('/health', (req, res) => {
+  const hasServiceToken = !!process.env.MCP_SERVICE_TOKEN;
+  
+  res.status(200).json({
+    status: 'ok',
+    service: 'service-files',
+    configured: hasServiceToken,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+module.exports = router;

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -44,6 +44,7 @@ const { createOboTrustChecker } = require('./OboPolicyService');
 const { reinitMCPServer } = require('./Tools/mcp');
 const { getAppConfig } = require('./Config');
 const { getLogStores } = require('~/cache');
+const { addPendingAttachment } = require('./pendingAttachments');
 
 const MAX_CACHE_SIZE = 1000;
 const lastReconnectAttempts = new Map();
@@ -845,8 +846,159 @@ function createToolInstance({
         oboTrustChecker: createOboTrustChecker(),
       });
 
-      if (isAssistantsEndpoint(provider) && Array.isArray(result)) {
-        return result[0];
+      // DEBUG: Log the result structure from mcpManager.callTool()
+      logger.info(`[MCP][${serverName}][${toolName}] Result type: ${typeof result}, isArray: ${Array.isArray(result)}`);
+      if (Array.isArray(result)) {
+        logger.info(`[MCP][${serverName}][${toolName}] Result array length: ${result.length}`);
+        logger.info(`[MCP][${serverName}][${toolName}] Result[0] type: ${typeof result[0]}`);
+        logger.info(`[MCP][${serverName}][${toolName}] Result[1] (artifacts): ${JSON.stringify(result[1])}`);
+      } else {
+        logger.info(`[MCP][${serverName}][${toolName}] Result (non-array): ${JSON.stringify(result).substring(0, 500)}`);
+      }
+      
+      // MCP tools return [content, artifacts] from formatToolContent
+      // Need to structure this properly for toolEndCallback in handlers.ts
+      if (Array.isArray(result)) {
+        let [content, artifacts] = result;
+        
+        // WORKAROUND: Handle malformed MCP server responses where content is a JSON string
+        // Some MCP servers return [json_string, null] instead of [content_array, artifacts_object]
+        // The JSON string may contain various structures depending on the MCP server implementation:
+        // - {_meta, content, structuredContent: {files: [...]}, isError}
+        // - {result: {message, file: {...}}} or {result: {message, files: [...]}}
+        if (typeof content === 'string' && (artifacts === null || artifacts === undefined)) {
+          try {
+            const parsed = JSON.parse(content);
+            logger.info(`[MCP][${serverName}][${toolName}] Parsed malformed response, keys: ${Object.keys(parsed).join(', ')}`);
+            
+            let extractedFiles = [];
+            
+            // Try different possible file locations in the response structure
+            
+            // 1. Check structuredContent.files (original format)
+            if (parsed.structuredContent?.files && Array.isArray(parsed.structuredContent.files)) {
+              extractedFiles = parsed.structuredContent.files;
+              logger.info(`[MCP][${serverName}][${toolName}] Found files in structuredContent.files`);
+            }
+            
+            // 2. Check result.file (single file in result)
+            if (parsed.result?.file && parsed.result.file.file_id) {
+              extractedFiles = [parsed.result.file];
+              logger.info(`[MCP][${serverName}][${toolName}] Found file in result.file`);
+            }
+            
+            // 3. Check result.files (array of files in result)
+            if (parsed.result?.files && Array.isArray(parsed.result.files)) {
+              extractedFiles = parsed.result.files;
+              logger.info(`[MCP][${serverName}][${toolName}] Found files in result.files`);
+            }
+            
+            // 4. Check top-level file
+            if (parsed.file && parsed.file.file_id) {
+              extractedFiles = [parsed.file];
+              logger.info(`[MCP][${serverName}][${toolName}] Found file at top level`);
+            }
+            
+            // 5. Check top-level files array
+            if (parsed.files && Array.isArray(parsed.files)) {
+              extractedFiles = parsed.files;
+              logger.info(`[MCP][${serverName}][${toolName}] Found files array at top level`);
+            }
+            
+            // If we found files, create artifacts
+            if (extractedFiles.length > 0) {
+              artifacts = {
+                files: extractedFiles,
+                file_ids: extractedFiles.map(f => f.file_id).filter(Boolean),
+              };
+              logger.info(`[MCP][${serverName}][${toolName}] Extracted ${artifacts.files.length} files from parsed response`);
+            }
+            
+            // Use the actual content array from parsed response if available
+            if (parsed.content && Array.isArray(parsed.content)) {
+              content = parsed.content;
+            } else if (parsed.result?.message) {
+              // Use result.message as content if available
+              content = parsed.result.message;
+            }
+          } catch (parseError) {
+            logger.warn(`[MCP][${serverName}][${toolName}] Failed to parse content as JSON: ${parseError.message}`);
+          }
+        }
+        
+        // DEBUG: Log artifacts structure
+        logger.info(`[MCP][${serverName}][${toolName}] Artifacts: ${JSON.stringify(artifacts)}`);
+        logger.info(`[MCP][${serverName}][${toolName}] Has files: ${!!(artifacts?.files && artifacts.files.length > 0)}`);
+        
+        // Handle MCP file artifacts directly since on_tool_end events don't fire for MCP tools
+        if (artifacts?.files && artifacts.files.length > 0) {
+          const messageId = config?.metadata?.run_id;
+          const conversationId = config?.metadata?.thread_id;
+          const user = config?.configurable?.user;
+          
+          for (const file of artifacts.files) {
+            if (!file.file_id) {
+              continue;
+            }
+            
+            const fileMetadata = {
+              file_id: file.file_id,
+              filename: file.filename || file.name,
+              filepath: file.filepath,
+              type: file.mimeType || file.type,
+              bytes: file.bytes,
+              source: file.source || 'local',
+              messageId: messageId,
+              toolCallId: config?.toolCall?.id,
+              conversationId: conversationId,
+            };
+            
+            // Stream attachment via SSE
+            // Note: For SSE streams, headersSent is ALWAYS true because the stream is active
+            // We should write to the stream as long as res exists and streamId is valid
+            logger.info(`[MCP][${serverName}][${toolName}] SSE conditions: res=${!!res}, headersSent=${res?.headersSent}, streamId=${streamId}, writableEnded=${res?.writableEnded}`);
+            if (res && streamId !== null && !res.writableEnded) {
+              try {
+                const attachmentEvent = `event: attachment\ndata: ${JSON.stringify(fileMetadata)}\n\n`;
+                res.write(attachmentEvent);
+                logger.info(`[MCP][${serverName}][${toolName}] Streamed file attachment via SSE: ${file.file_id}`);
+              } catch (sseError) {
+                logger.error(`[MCP][${serverName}][${toolName}] Failed to write SSE attachment: ${sseError.message}`);
+              }
+            } else {
+              logger.warn(`[MCP][${serverName}][${toolName}] Cannot stream SSE attachment - res=${!!res}, streamId=${streamId}, writableEnded=${res?.writableEnded}`);
+            }
+            
+            // Store attachment in pending registry for deferred update
+            // Message doesn't exist during tool execution, so we store the attachment
+            // and apply it when the message is created
+            if (messageId) {
+              const attachmentData = {
+                type: 'file',
+                file_id: fileMetadata.file_id,
+                filename: fileMetadata.filename,
+                filepath: fileMetadata.filepath,
+                mimeType: fileMetadata.type,
+                bytes: fileMetadata.bytes,
+                source: fileMetadata.source,
+                toolCallId: config?.toolCall?.id,
+                conversationId: conversationId,
+                userId: user?.id,
+              };
+              
+              addPendingAttachment(messageId, attachmentData);
+              logger.info(`[MCP][${serverName}][${toolName}] Stored pending attachment ${file.file_id} for message ${messageId}`);
+            } else {
+              logger.warn(`[MCP][${serverName}][${toolName}] Cannot store pending attachment - missing messageId`);
+            }
+          }
+        }
+        
+        // Return proper two-tuple format [content, artifacts] that LangGraph expects
+        // For content_and_artifact response format
+        const finalContent = isAssistantsEndpoint(provider) ? content : result;
+        logger.info(`[MCP][${serverName}][${toolName}] Returning two-tuple: content type=${typeof finalContent}, artifacts=${!!artifacts}`);
+        return [finalContent, artifacts];
       }
       return result;
     } catch (error) {

--- a/api/server/services/pendingAttachments.js
+++ b/api/server/services/pendingAttachments.js
@@ -1,0 +1,173 @@
+/**
+ * Pending Attachments Registry
+ * 
+ * This module manages pending file attachments that need to be added to messages
+ * after the message is created. MCP tools execute before the message exists in
+ * the database, so we store attachment data here and apply it when the message
+ * is saved.
+ * 
+ * Flow:
+ * 1. MCP tool executes and creates file artifact
+ * 2. MCP.js stores pending attachment via addPendingAttachment()
+ * 3. Message is created and saved to MongoDB
+ * 4. Post-save hook or explicit call retrieves and applies pending attachments
+ * 5. Attachments are cleared from registry after successful application
+ */
+
+const { logger } = require('@librechat/data-schemas');
+
+// In-memory store for pending attachments
+// Key: messageId, Value: Array of attachment objects
+const pendingAttachmentsMap = new Map();
+
+// TTL for pending attachments (5 minutes)
+const PENDING_ATTACHMENT_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Add a pending attachment for a message that doesn't exist yet.
+ * @param {string} messageId - The message ID to attach to
+ * @param {Object} attachment - The attachment data
+ * @returns {void}
+ */
+function addPendingAttachment(messageId, attachment) {
+  if (!messageId || !attachment?.file_id) {
+    logger.warn('[PendingAttachments] Invalid messageId or attachment:', { messageId, attachment });
+    return;
+  }
+
+  if (!pendingAttachmentsMap.has(messageId)) {
+    pendingAttachmentsMap.set(messageId, []);
+  }
+
+  const attachments = pendingAttachmentsMap.get(messageId);
+  
+  // Avoid duplicates
+  const exists = attachments.some(a => a.file_id === attachment.file_id);
+  if (!exists) {
+    attachments.push({
+      ...attachment,
+      _addedAt: Date.now(),
+    });
+    logger.info(`[PendingAttachments] Added pending attachment ${attachment.file_id} for message ${messageId}`);
+  }
+
+  // Schedule cleanup after TTL
+  setTimeout(() => {
+    cleanupPendingAttachment(messageId, attachment.file_id);
+  }, PENDING_ATTACHMENT_TTL_MS);
+}
+
+/**
+ * Get and remove pending attachments for a message.
+ * @param {string} messageId - The message ID
+ * @returns {Array} Array of pending attachments, or empty array
+ */
+function getPendingAttachments(messageId) {
+  if (!messageId || !pendingAttachmentsMap.has(messageId)) {
+    return [];
+  }
+
+  const attachments = pendingAttachmentsMap.get(messageId);
+  pendingAttachmentsMap.delete(messageId);
+  
+  logger.info(`[PendingAttachments] Retrieved ${attachments.length} pending attachments for message ${messageId}`);
+  return attachments;
+}
+
+/**
+ * Check if there are pending attachments for a message without removing them.
+ * @param {string} messageId - The message ID
+ * @returns {boolean}
+ */
+function hasPendingAttachments(messageId) {
+  return pendingAttachmentsMap.has(messageId) && pendingAttachmentsMap.get(messageId).length > 0;
+}
+
+/**
+ * Remove a specific pending attachment.
+ * @param {string} messageId - The message ID
+ * @param {string} fileId - The file ID to remove
+ */
+function cleanupPendingAttachment(messageId, fileId) {
+  if (!pendingAttachmentsMap.has(messageId)) {
+    return;
+  }
+
+  const attachments = pendingAttachmentsMap.get(messageId);
+  const index = attachments.findIndex(a => a.file_id === fileId);
+  
+  if (index !== -1) {
+    attachments.splice(index, 1);
+    logger.debug(`[PendingAttachments] Cleaned up expired attachment ${fileId} for message ${messageId}`);
+  }
+
+  if (attachments.length === 0) {
+    pendingAttachmentsMap.delete(messageId);
+  }
+}
+
+/**
+ * Apply pending attachments to a message in MongoDB.
+ * @param {string} userId - User ID for authorization
+ * @param {string} messageId - Message ID to update
+ * @returns {Promise<number>} Number of attachments applied
+ */
+async function applyPendingAttachments(userId, messageId) {
+  const attachments = getPendingAttachments(messageId);
+  
+  if (attachments.length === 0) {
+    return 0;
+  }
+
+  try {
+    const mongoose = require('mongoose');
+    const Message = mongoose.models.Message;
+    if (!Message) {
+      logger.error('[PendingAttachments] Message model not available');
+      return 0;
+    }
+
+    // Clean up internal fields before saving
+    const cleanedAttachments = attachments.map(({ _addedAt, ...rest }) => rest);
+
+    const result = await Message.findOneAndUpdate(
+      { messageId: messageId, user: userId },
+      { $push: { attachments: { $each: cleanedAttachments } } },
+      { new: true }
+    );
+
+    if (result) {
+      logger.info(`[PendingAttachments] Applied ${cleanedAttachments.length} attachments to message ${messageId}`);
+      return cleanedAttachments.length;
+    } else {
+      logger.warn(`[PendingAttachments] Message ${messageId} not found when applying attachments`);
+      return 0;
+    }
+  } catch (error) {
+    logger.error(`[PendingAttachments] Error applying attachments to message ${messageId}:`, error);
+    return 0;
+  }
+}
+
+/**
+ * Get registry stats for debugging.
+ * @returns {Object}
+ */
+function getStats() {
+  let totalAttachments = 0;
+  for (const attachments of pendingAttachmentsMap.values()) {
+    totalAttachments += attachments.length;
+  }
+  return {
+    pendingMessages: pendingAttachmentsMap.size,
+    totalAttachments,
+  };
+}
+
+module.exports = {
+  addPendingAttachment,
+  getPendingAttachments,
+  hasPendingAttachments,
+  applyPendingAttachments,
+  getStats,
+};

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -153,17 +153,41 @@ export function formatToolContent(
 
   const imageUrls: t.FormattedContent[] = [];
   const uiResources: UIResource[] = [];
+  const fileArtifacts: Array<{ id: string; name: string; file_id?: string; filename?: string; filepath?: string; mimeType?: string; bytes?: number; source?: string }> = [];
   let currentTextBlock = '';
 
   type ContentHandler = undefined | ((item: t.ToolContentPart) => void);
 
+  // Extended content handlers type to include 'file' for MCP file artifacts
   const contentHandlers: {
     text: (item: Extract<t.ToolContentPart, { type: 'text' }>) => void;
     image: (item: t.ToolContentPart) => void;
     resource: (item: Extract<t.ToolContentPart, { type: 'resource' }>) => void;
+    file: (item: { type: 'file'; file_id: string; filename: string; filepath?: string; mimeType?: string; bytes?: number; source?: string }) => void;
   } = {
     text: (item) => {
       currentTextBlock += (currentTextBlock ? '\n\n' : '') + item.text;
+    },
+
+    /**
+     * Handler for 'file' content type from MCP tools.
+     * Extracts file metadata into artifacts.files for attachment processing.
+     * MCP servers should return file content as:
+     * { type: 'file', file_id: 'uuid', filename: 'doc.pdf', filepath: '/path', type: 'mime', bytes: 123, source: 'local' }
+     */
+    file: (item) => {
+      fileArtifacts.push({
+        id: item.file_id,
+        name: item.filename,
+        file_id: item.file_id,
+        filename: item.filename,
+        filepath: item.filepath,
+        mimeType: item.mimeType,
+        bytes: item.bytes,
+        source: item.source,
+      });
+      // Add text notification about the file
+      currentTextBlock += (currentTextBlock ? '\n\n' : '') + `File attached: ${item.filename}`;
     },
 
     image: (item) => {
@@ -247,6 +271,15 @@ UI Resource Markers Available:
     artifacts = {
       ...artifacts,
       [Tools.ui_resources]: { data: uiResources },
+    };
+  }
+
+  // Add file artifacts from MCP tool responses
+  if (fileArtifacts.length > 0) {
+    artifacts = {
+      ...artifacts,
+      files: fileArtifacts,
+      file_ids: fileArtifacts.map(f => f.file_id).filter(Boolean) as string[],
     };
   }
 

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -64,7 +64,22 @@ export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'err
 
 export type MCPTool = Tool;
 export type MCPToolListResponse = ListToolsResult;
-export type ToolContentPart = TextContent | ImageContent | EmbeddedResource | AudioContent;
+
+/**
+ * File content type from MCP tools.
+ * Used when MCP servers return file artifacts in tool responses.
+ */
+export interface FileContent {
+  type: 'file';
+  file_id: string;
+  filename: string;
+  filepath?: string;
+  mimeType?: string;
+  bytes?: number;
+  source?: string;
+}
+
+export type ToolContentPart = TextContent | ImageContent | EmbeddedResource | AudioContent | FileContent;
 export type { TextContent, ImageContent, EmbeddedResource, AudioContent };
 export type MCPToolCallResponse =
   | undefined
@@ -123,6 +138,21 @@ export type FileSearchSource = {
   [key: string]: unknown;
 };
 
+/**
+ * File artifact structure for MCP tool file responses.
+ * Contains full metadata for file attachments.
+ */
+export interface FileArtifact {
+  id: string;
+  name: string;
+  file_id?: string;
+  filename?: string;
+  filepath?: string;
+  mimeType?: string;
+  bytes?: number;
+  source?: string;
+}
+
 export type Artifacts =
   | {
       content?: FormattedContent[];
@@ -134,7 +164,7 @@ export type Artifacts =
         fileCitations?: boolean;
       };
       [Tools.web_search]?: SearchResultData;
-      files?: Array<{ id: string; name: string }>;
+      files?: FileArtifact[];
       session_id?: string;
       file_ids?: string[];
     }

--- a/packages/data-schemas/src/methods/message.ts
+++ b/packages/data-schemas/src/methods/message.ts
@@ -162,6 +162,35 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
         message.isTemporary = false;
       }
 
+      // Apply pending attachments if any exist for this message
+      // This handles deferred attachment updates from MCP tools which execute
+      // before the message is created in the database
+      try {
+        const pendingAttachmentsModule = require('~/server/services/pendingAttachments');
+        if (pendingAttachmentsModule && pendingAttachmentsModule.hasPendingAttachments) {
+          const hasPending = pendingAttachmentsModule.hasPendingAttachments(params.messageId);
+          if (hasPending) {
+            const applied = await pendingAttachmentsModule.applyPendingAttachments(
+              mongoose,
+              userId,
+              params.messageId as string,
+            );
+            if (applied > 0) {
+              logger.info(`Applied ${applied} pending attachments to message ${params.messageId}`);
+              // Refresh the message to include the newly added attachments
+              const refreshedMessage = await Message.findOne({ messageId: params.messageId, user: userId });
+              if (refreshedMessage) {
+                return refreshedMessage.toObject();
+              }
+            }
+          }
+        }
+      } catch (pendingError) {
+        // Silently ignore if pendingAttachments module is not available
+        // This can happen in contexts where the module path is different
+        logger.debug('Pending attachments module not available or error:', pendingError);
+      }
+
       return message.toObject();
     } catch (err: unknown) {
       logger.error('Error saving message:', err);


### PR DESCRIPTION
# MCP File Artifacts Integration

## Summary

This PR implements end-to-end MCP (Model Context Protocol) file artifact handling, enabling MCP servers to upload files that persist as message attachments in LibreChat conversations.

**Problem Solved:** MCP tools execute *before* messages exist in MongoDB, making direct attachment updates impossible.

**Solution:** A deferred attachments pattern using an in-memory registry with automatic application after message creation.

### Key Components

| Component | Location | Purpose |
|-----------|----------|----------|
| Service Endpoint | `api/server/routes/serviceFiles.js` (293 lines) | Service-to-service file upload API |
| Pending Registry | `api/server/services/pendingAttachments.js` (173 lines) | Queues attachments during tool execution |
| MCP Handler | `api/server/controllers/callbacks.js` (lines 641-698) | Detects file artifacts, streams SSE, stores pending |
| Post-save Hook | `api/server/controllers/request.js` (line 736) | Applies pending attachments after message save |
| Malformed Parser | `packages/api/src/mcp/MCP.js` (lines 759-810) | Handles non-compliant MCP server responses |
| Type Definitions | `packages/api/src/mcp/types/index.ts` | `FileContent`, `FileArtifact` interfaces |

### Architecture Flow

```
MCP Server → POST /api/service/files → File Storage (db.files)
                                              ↓
MCP Tool Execution → File Artifact → addPendingAttachment(messageId)
                                              ↓
                              SSE Stream → Frontend (real-time preview)
                                              ↓
                              Message Saved to MongoDB
                                              ↓
                              applyPendingAttachments(messageId)
                                              ↓
                              message.attachments[] updated
                                              ↓
                              Frontend displays file (persists on refresh)
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

### Manual Testing
1. Configure an MCP server with file artifact support (e.g., document generator)
2. Set `MCP_SERVICE_TOKEN` in `.env`
3. Execute MCP tool that generates a file
4. Verify:
   - File appears in real-time via SSE
   - File persists after page refresh
   - Download works with authentication

Tests:
- API health check
- File upload to `/api/service/files`
- `db.files` record creation
- Message attachment persistence
- MongoDB verification with `$elemMatch`

### Test Configuration
- **Environment:** Docker Compose (api, mongodb, meilisearch)
- **MCP Server:** Any server returning file artifacts
- **Auth:** `MCP_SERVICE_TOKEN` header + `X-User-Id` for user context

## Technical Details

### Service Endpoint (`/api/service/files`)
- **Auth:** `X-Service-Token` header validated against `process.env.MCP_SERVICE_TOKEN`
- **User Context:** `X-User-Id` header identifies the uploading user
- **Limit:** 100MB max file size
- **Storage:** Local filesystem or S3-compatible (via existing LibreChat storage)

### Pending Attachments Registry
- **TTL:** 5 minutes (auto-cleanup of orphaned entries)
- **Pattern:** `addPendingAttachment(messageId, data)` → message save → `applyPendingAttachments(userId, messageId)`
- **Thread-safe:** Uses `Map` with atomic operations

### Malformed Response Handling
Handles non-compliant MCP servers returning `[json_string, null]` instead of `[content_array, artifacts_object]`:
- Parses JSON strings from multiple locations
- Extracts files from: `result.file`, `result.files`, `structuredContent.files`, top-level `file`/`files`
- Logs extraction for debugging

### SSE Real-time Updates
- Event type: `attachment`
- Streams immediately during tool execution
- Frontend merges SSE data with DB-loaded attachments

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes - I'll create it once we are ready to merge
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted - I'll create it once we are ready to merge

## Files Changed

### New Files
- `api/server/routes/serviceFiles.js` - Service endpoint for MCP file uploads
- `api/server/services/pendingAttachments.js` - Deferred attachment registry
- `full_integration_test.sh` - End-to-end integration test

### Modified Files
- `api/server/index.js` (line 224) - Route registration
- `api/server/controllers/callbacks.js` - MCP file artifact handler
- `api/server/controllers/request.js` - Post-save attachment application
- `packages/api/src/mcp/MCP.js` - Malformed response handling, file artifact processing
- `packages/api/src/mcp/types/index.ts` - TypeScript interfaces
- `packages/api/src/mcp/parsers.ts` - File content parsing
- `packages/data-schemas/src/methods/message.ts` - Post-save hook
- `package.json` - Added `sharp`, updated dependencies