### PR TITLE
✨ feat+lil bug: Broaden RAG /text routing + fix legacy .doc OCR MIME

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -17,6 +17,7 @@ const {
   isAssistantsEndpoint,
   getEndpointFileConfig,
   documentParserMimeTypes,
+  ragTextMimeTypes,
   isPermissiveMimeConfig,
 } = require('librechat-data-provider');
 const { logger, runAsSystem } = require('@librechat/data-schemas');
@@ -803,6 +804,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     const isDocumentParserEligible = documentParserMimeTypes.some((regex) =>
       regex.test(file.mimetype),
     );
+    const isRagTextEligible = ragTextMimeTypes.some((regex) => regex.test(file.mimetype));
 
     /**
      * When an admin narrows `fileConfig.text.supportedMimeTypes` to a non-permissive allowlist that
@@ -810,10 +812,13 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
      * RAG `/text` instead of the built-in document parser. The permissive default catch-all is
      * excluded via `isPermissiveMimeConfig`, so RAG deployments that never customized text handling
      * keep the built-in parser introduced in #11900.
+     *
+     * Eligibility uses `ragTextMimeTypes` (not `documentParserMimeTypes`) since RAG `/text` does its
+     * own extraction; on RAG failure the catch below still falls back to the built-in parser.
      */
     const shouldUseConfiguredText =
       !!process.env.RAG_API_URL &&
-      isDocumentParserEligible &&
+      isRagTextEligible &&
       !isPermissiveMimeConfig(fileConfig.text?.supportedMimeTypes) &&
       fileConfig.checkType(file.mimetype, fileConfig.text?.supportedMimeTypes || []);
 

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -433,6 +433,26 @@ describe('processAgentFileUpload', () => {
       expect(getStrategyFunctions).not.toHaveBeenCalledWith(FileSources.document_parser);
     });
 
+    test('routes a non-parser OCR type (pptx) to RAG /text when admin narrows text config', async () => {
+      // pptx isn't in documentParserMimeTypes but is in ragTextMimeTypes → should route to RAG /text.
+      process.env.RAG_API_URL = 'http://rag-api.test';
+      const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+      const PPTX_TEXT_REGEX = [
+        /^application\/vnd\.openxmlformats-officedocument\.presentationml\.presentation$/,
+      ];
+      mergeFileConfig.mockReturnValue(makeFileConfig({ textSupportedMimeTypes: PPTX_TEXT_REGEX }));
+      const { parseText } = require('@librechat/api');
+      parseText.mockResolvedValueOnce({ text: 'rag extracted pptx', bytes: 18 });
+      const req = makeReq({ mimetype: PPTX_MIME, ocrConfig: null });
+
+      await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+      expect(parseText).toHaveBeenCalledWith(
+        expect.objectContaining({ allowNativeFallback: false }),
+      );
+      expect(getStrategyFunctions).not.toHaveBeenCalledWith(FileSources.document_parser);
+    });
+
     test('keeps the built-in document parser when text config is the permissive default', async () => {
       process.env.RAG_API_URL = 'http://rag-api.test';
       mergeFileConfig.mockReturnValue(

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -84,18 +84,22 @@ jest.mock('@librechat/api', () => {
       if (ocrConfigured && checkType(mimeType, fileConfig.ocr?.supportedMimeTypes ?? [])) {
         return UPLOAD_EXTRACTED_TEXT_PLANS.configuredOCR;
       }
-      const isDocumentParserEligible = actualDataProvider.documentParserMimeTypes.some((pattern) =>
+      const isRagTextEligible = actualDataProvider.ragTextMimeTypes.some((pattern) =>
         pattern.test(mimeType),
       );
-      if (!isDocumentParserEligible) {
-        return null;
-      }
       if (
+        isRagTextEligible &&
         ragConfigured &&
         !actualDataProvider.isPermissiveMimeConfig(fileConfig.text?.supportedMimeTypes) &&
         checkType(mimeType, fileConfig.text?.supportedMimeTypes ?? [])
       ) {
         return UPLOAD_EXTRACTED_TEXT_PLANS.configuredRAG;
+      }
+      const isDocumentParserEligible = actualDataProvider.documentParserMimeTypes.some((pattern) =>
+        pattern.test(mimeType),
+      );
+      if (!isDocumentParserEligible) {
+        return null;
       }
       return UPLOAD_EXTRACTED_TEXT_PLANS.documentParser;
     },
@@ -799,6 +803,26 @@ describe('processAgentFileUpload', () => {
       const { parseText } = require('@librechat/api');
       parseText.mockResolvedValueOnce({ text: 'rag extracted', bytes: 13 });
       const req = makeReq({ mimetype: DOCX_MIME, ocrConfig: null });
+
+      await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
+
+      expect(parseText).toHaveBeenCalledWith(
+        expect.objectContaining({ allowNativeFallback: false }),
+      );
+      expect(getStrategyFunctions).not.toHaveBeenCalledWith(FileSources.document_parser);
+    });
+
+    test('routes a non-parser OCR type (pptx) to RAG /text when admin narrows text config', async () => {
+      // pptx isn't in documentParserMimeTypes but is in ragTextMimeTypes → should route to RAG /text.
+      process.env.RAG_API_URL = 'http://rag-api.test';
+      const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+      const PPTX_TEXT_REGEX = [
+        /^application\/vnd\.openxmlformats-officedocument\.presentationml\.presentation$/,
+      ];
+      mergeFileConfig.mockReturnValue(makeFileConfig({ textSupportedMimeTypes: PPTX_TEXT_REGEX }));
+      const { parseText } = require('@librechat/api');
+      parseText.mockResolvedValueOnce({ text: 'rag extracted pptx', bytes: 18 });
+      const req = makeReq({ mimetype: PPTX_MIME, ocrConfig: null });
 
       await processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() });
 

--- a/packages/api/src/protection/files.ts
+++ b/packages/api/src/protection/files.ts
@@ -6,6 +6,7 @@ import {
   hasActivePiiPatterns,
   isAssistantsEndpoint,
   isPermissiveMimeConfig,
+  ragTextMimeTypes,
 } from 'librechat-data-provider';
 import type { FileConfig, FileFilterField, FiltersConfig } from 'librechat-data-provider';
 import {
@@ -324,19 +325,23 @@ export function getUploadExtractedTextPlan(
   ) {
     return UPLOAD_EXTRACTED_TEXT_PLANS.configuredOCR;
   }
-  const isDocumentParserEligible = documentParserMimeTypes.some((mimePattern) =>
+  const isRagTextEligible = ragTextMimeTypes.some((mimePattern) =>
     mimePattern.test(input.mimeType),
   );
-  if (!isDocumentParserEligible) {
-    return null;
-  }
   if (
     checkType != null &&
+    isRagTextEligible &&
     input.ragConfigured &&
     !isPermissiveMimeConfig(input.fileConfig.text?.supportedMimeTypes) &&
     checkType(input.mimeType, input.fileConfig.text?.supportedMimeTypes ?? [])
   ) {
     return UPLOAD_EXTRACTED_TEXT_PLANS.configuredRAG;
+  }
+  const isDocumentParserEligible = documentParserMimeTypes.some((mimePattern) =>
+    mimePattern.test(input.mimeType),
+  );
+  if (!isDocumentParserEligible) {
+    return null;
   }
   return UPLOAD_EXTRACTED_TEXT_PLANS.documentParser;
 }

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -7,6 +7,7 @@ import {
   isPermissiveMimeConfig,
   convertStringsToRegex,
   documentParserMimeTypes,
+  ragTextMimeTypes,
   getEndpointFileConfig,
   applicationMimeTypes,
   defaultOCRMimeTypes,
@@ -170,6 +171,54 @@ describe('defaultOCRMimeTypes', () => {
   ])('matches ODF type for OCR: %s', (mimeType) => {
     expect(checkOCRType(mimeType)).toBe(true);
   });
+
+  it.each([
+    'application/msword', // legacy .doc
+    'application/vnd.ms-powerpoint', // legacy .ppt
+  ])('matches legacy Office type for OCR: %s', (mimeType) => {
+    expect(checkOCRType(mimeType)).toBe(true);
+  });
+});
+
+describe('ragTextMimeTypes', () => {
+  const check = (mimeType: string): boolean =>
+    ragTextMimeTypes.some((regex) => regex.test(mimeType));
+
+  it.each([
+    'application/pdf',
+    'application/msword',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.oasis.opendocument.text',
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/vnd.oasis.opendocument.presentation',
+    'application/vnd.oasis.opendocument.graphics',
+  ])('is eligible to route to RAG /text: %s', (mimeType) => {
+    expect(check(mimeType)).toBe(true);
+  });
+
+  it('is a superset of documentParserMimeTypes for the shared document set', () => {
+    for (const mimeType of [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel',
+      'application/vnd.oasis.opendocument.spreadsheet',
+      'application/vnd.oasis.opendocument.text',
+    ]) {
+      expect(documentParserMimeTypes.some((regex) => regex.test(mimeType))).toBe(true);
+      expect(check(mimeType)).toBe(true);
+    }
+  });
+
+  it.each(['image/png', 'image/jpeg', 'application/epub+zip'])(
+    'excludes non-document / image type: %s',
+    (mimeType) => {
+      expect(check(mimeType)).toBe(false);
+    },
+  );
 });
 
 describe('supportedMimeTypes', () => {

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -11,6 +11,7 @@ import {
   convertStringsToRegex,
   setFileConfigRegexCompiler,
   documentParserMimeTypes,
+  ragTextMimeTypes,
   getEndpointFileConfig,
   applicationMimeTypes,
   defaultOCRMimeTypes,
@@ -151,6 +152,7 @@ describe('applicationMimeTypes', () => {
     'application/json',
     'application/csv',
     'application/msword',
+    'application/vnd.ms-powerpoint',
     'application/xml',
     'application/zip',
     'application/x-zip-compressed',
@@ -201,6 +203,54 @@ describe('defaultOCRMimeTypes', () => {
   ])('matches configured OCR type: %s', (mimeType) => {
     expect(checkOCRType(mimeType)).toBe(true);
   });
+
+  it.each([
+    'application/msword', // legacy .doc
+    'application/vnd.ms-powerpoint', // legacy .ppt
+  ])('matches legacy Office type for OCR: %s', (mimeType) => {
+    expect(checkOCRType(mimeType)).toBe(true);
+  });
+});
+
+describe('ragTextMimeTypes', () => {
+  const check = (mimeType: string): boolean =>
+    ragTextMimeTypes.some((regex) => regex.test(mimeType));
+
+  it.each([
+    'application/pdf',
+    'application/msword',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.oasis.opendocument.text',
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/vnd.oasis.opendocument.presentation',
+    'application/vnd.oasis.opendocument.graphics',
+  ])('is eligible to route to RAG /text: %s', (mimeType) => {
+    expect(check(mimeType)).toBe(true);
+  });
+
+  it('is a superset of documentParserMimeTypes for the shared document set', () => {
+    for (const mimeType of [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel',
+      'application/vnd.oasis.opendocument.spreadsheet',
+      'application/vnd.oasis.opendocument.text',
+    ]) {
+      expect(documentParserMimeTypes.some((regex) => regex.test(mimeType))).toBe(true);
+      expect(check(mimeType)).toBe(true);
+    }
+  });
+
+  it.each(['image/png', 'image/jpeg', 'application/epub+zip'])(
+    'excludes non-document / image type: %s',
+    (mimeType) => {
+      expect(check(mimeType)).toBe(false);
+    },
+  );
 });
 
 describe('supportedMimeTypes', () => {

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -205,8 +205,19 @@ export const defaultOCRMimeTypes = [
   excelMimeTypes,
   /^application\/pdf$/,
   /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
-  /^application\/vnd\.ms-(word|powerpoint)$/,
+  // application/msword is the real legacy .doc MIME; vnd.ms-word is non-standard (never matches).
+  /^application\/(msword|vnd\.ms-(word|powerpoint))$/,
   /^application\/epub\+zip$/,
+  /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
+];
+
+/** MIME types eligible to route to a configured RAG `/text` endpoint: superset of `documentParserMimeTypes` (OCR-document set minus images and EPUB). */
+export const ragTextMimeTypes = [
+  /^application\/pdf$/,
+  /^application\/msword$/,
+  /^application\/vnd\.ms-powerpoint$/,
+  excelMimeTypes,
+  /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
   /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
 ];
 

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -220,7 +220,7 @@ export const textMimeTypes =
   /^(text\/(x-c|x-csharp|tab-separated-values|x-c\+\+|x-h|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|vtt|javascript|csv|xml|calendar))$/;
 
 export const applicationMimeTypes =
-  /^(application\/(epub\+zip|csv|json|msword|pdf|x-tar|x-sh|x-zip-compressed|typescript|sql|yaml|x-parquet|vnd\.apache\.parquet|vnd\.coffeescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.(presentation|template)|spreadsheetml\.sheet)|vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)|xml|zip))$/;
+  /^(application\/(epub\+zip|csv|json|msword|pdf|x-tar|x-sh|x-zip-compressed|typescript|sql|yaml|x-parquet|vnd\.apache\.parquet|vnd\.coffeescript|vnd\.ms-powerpoint|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.(presentation|template)|spreadsheetml\.sheet)|vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)|xml|zip))$/;
 
 export const imageMimeTypes = /^image\/(jpeg|gif|png|webp|heic|heif)$/;
 
@@ -235,8 +235,19 @@ export const defaultOCRMimeTypes = [
   /^application\/pdf$/,
   /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
   /^application\/vnd\.openxmlformats-officedocument\.presentationml\.template$/,
-  /^application\/vnd\.ms-(word|powerpoint)$/,
+  // application/msword is the real legacy .doc MIME; vnd.ms-word is non-standard (never matches).
+  /^application\/(msword|vnd\.ms-(word|powerpoint))$/,
   /^application\/epub\+zip$/,
+  /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
+];
+
+/** MIME types eligible to route to a configured RAG `/text` endpoint: superset of `documentParserMimeTypes` (OCR-document set minus images and EPUB). */
+export const ragTextMimeTypes = [
+  /^application\/pdf$/,
+  /^application\/msword$/,
+  /^application\/vnd\.ms-powerpoint$/,
+  excelMimeTypes,
+  /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
   /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
 ];
 


### PR DESCRIPTION
## Summary

Two related fixes to document handling on agent "Upload as Text".

**1. Bug fix — legacy `.doc` excluded from OCR (Related to #14413).**
`defaultOCRMimeTypes` matched `application/vnd.ms-word`, which is not a real MIME type — the actual legacy Word MIME is `application/msword`, as this file's own `bedrockDocumentFormats`, `mimeTypesMap`, and `inferMimeType('legacy.doc')` all use. So legacy `.doc` uploads never matched the OCR mimetype set and were silently excluded from OCR (they fell through to the built-in document parser, which can't handle legacy `.doc`). `.ppt` (`application/vnd.ms-powerpoint`) already matched and is unchanged.

**2. Feature — broaden RAG `/text` routing eligibility.**
`shouldUseConfiguredText` gated eligibility on `documentParserMimeTypes` (the built-in-parser subset). But routing to a configured RAG `/text` endpoint means RAG performs the extraction/OCR — so an admin who narrows `fileConfig.text.supportedMimeTypes` to include e.g. `pptx` / legacy office / OpenDocument clearly intends those for RAG, yet today they fall through to the default path instead. This adds a `ragTextMimeTypes` export (the OCR-document set minus images and EPUB) and uses it for the gate's eligibility.

Safety is preserved: the gate still requires `RAG_API_URL` and a non-permissive `text.supportedMimeTypes` (opt-in). On RAG failure, the existing `parseText({ allowNativeFallback: false })` + `resolveDocumentText()` path still applies — it falls back to the built-in document parser where one exists, else fails with a clear error, and never decodes raw bytes as text. `shouldUseDocumentParser` continues to key off `documentParserMimeTypes`, so the built-in-parser path is unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- `packages/data-provider` `file-config` tests: **165 passed** — adds `ragTextMimeTypes` coverage (incl. superset-of-`documentParserMimeTypes` assertion and image/EPUB exclusion) and a `defaultOCRMimeTypes` regression for `application/msword` / `application/vnd.ms-powerpoint`.
- `api` `process.spec.js`: **57 passed** — adds a case asserting a non-parser OCR type (`pptx`) routes to RAG `/text` with `allowNativeFallback: false` when the admin narrows text config.
- Builds (`data-provider`, `data-schemas`, `@librechat/api`); ESLint; Prettier

### Test Configuration:

Node v24.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
