### PR TITLE
📧 fix: Add .msg (application/vnd.ms-outlook) Support to File Upload

### DIFF
--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -83,6 +83,25 @@ describe('inferMimeType', () => {
     expect(baseFileConfig.checkType(normalized)).toBe(true);
   });
 
+  it('should infer application/vnd.ms-outlook from extension when browser type is empty', () => {
+    expect(inferMimeType('email.msg', '')).toBe('application/vnd.ms-outlook');
+  });
+
+  it('should pass through application/vnd.ms-outlook when browser reports it', () => {
+    expect(inferMimeType('email.msg', 'application/vnd.ms-outlook')).toBe(
+      'application/vnd.ms-outlook',
+    );
+  });
+
+  it('should normalize application/x-msg to application/vnd.ms-outlook', () => {
+    expect(inferMimeType('email.msg', 'application/x-msg')).toBe('application/vnd.ms-outlook');
+  });
+
+  it('should produce a type accepted by checkType for .msg files', () => {
+    const normalized = inferMimeType('test.msg', '');
+    expect(baseFileConfig.checkType(normalized)).toBe(true);
+  });
+
   it('infers Office MIME types from extension when the browser reports none', () => {
     expect(inferMimeType('legacy.doc', '')).toBe('application/msword');
     expect(inferMimeType('report.docx', '')).toBe(
@@ -188,6 +207,10 @@ describe('supportedMimeTypes', () => {
   it('message/rfc822 (.eml) flows through supportedMimeTypes', () => {
     expect(checkSupported('message/rfc822')).toBe(true);
   });
+
+  it('application/vnd.ms-outlook (.msg) flows through supportedMimeTypes', () => {
+    expect(checkSupported('application/vnd.ms-outlook')).toBe(true);
+  });
 });
 
 describe('documentParserMimeTypes', () => {
@@ -213,6 +236,8 @@ describe('documentParserMimeTypes', () => {
     'application/vnd.oasis.opendocument.graphics',
     'text/plain',
     'image/png',
+    // .msg is accepted for upload but, like .eml, is not routed to the document parser
+    'application/vnd.ms-outlook',
   ])('does not match OCR-only or unsupported type: %s', (mimeType) => {
     expect(check(mimeType)).toBe(false);
   });

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -70,6 +70,7 @@ export const fullMimeTypesList = [
   'image/svg',
   'image/svg+xml',
   'message/rfc822',
+  'application/vnd.ms-outlook',
   // Video formats
   'video/mp4',
   'video/avi',
@@ -234,6 +235,8 @@ export const supportedMimeTypes = [
   /^image\/(svg|svg\+xml)$/,
   /** .eml email files */
   /^message\/rfc822$/,
+  /** .msg Outlook email files */
+  /^application\/vnd\.ms-outlook$/,
 ];
 
 export const codeInterpreterMimeTypes = [
@@ -291,6 +294,7 @@ export const codeTypeMapping: { [key: string]: string } = {
   cljc: 'text/plain', // .cljc - Clojure common source
   elm: 'text/plain', // .elm - Elm source
   eml: 'message/rfc822', // .eml - Email message (RFC 822)
+  msg: 'application/vnd.ms-outlook', // .msg - Outlook email message
   erl: 'text/plain', // .erl - Erlang source
   hrl: 'text/plain', // .hrl - Erlang header
   ex: 'text/plain', // .ex - Elixir source
@@ -385,6 +389,8 @@ export const mimeTypeAliases: Readonly<Record<string, string>> = {
   'application/x-zip-compressed': 'application/zip',
   'text/x-python-script': 'text/x-python',
   'text/x-markdown': 'text/markdown',
+  // Some clients (e.g. Windows with Outlook installed) report .msg as x-msg
+  'application/x-msg': 'application/vnd.ms-outlook',
 };
 
 /**
@@ -651,6 +657,7 @@ const documentMimeExtensions: ReadonlyArray<readonly [string, readonly string[]]
   ['text/html', ['.html', '.htm']],
   ['text/calendar', ['.ics']],
   ['message/rfc822', ['.eml']],
+  ['application/vnd.ms-outlook', ['.msg']],
 ];
 
 const documentMimeSet = new Set(documentMimeExtensions.map(([mimeType]) => mimeType));


### PR DESCRIPTION
## Summary

Fixes #14404 — uploading an Outlook `.msg` file fails with **"Unable to determine file type"**, even when `application/vnd.ms-outlook` is allowed in `librechat.yaml`.

**Root cause:** Browsers report an empty `File.type` for `.msg` (uncommon extension), so `inferMimeType()` has nothing to pass through and falls back to `codeTypeMapping` — which has no `msg` entry, returning `''`. `validateFiles()` then bails on the empty type **before** `supportedMimeTypes` is ever evaluated, so the YAML allow-list never gets a chance to run. This is the same class of bug fixed for `.eml` in #13989 (reported in #13988).

**Why YAML config alone doesn't fix this:** allow-listing `application/vnd.ms-outlook` only helps once a type is *detected*. The extension→MIME fallback in `codeTypeMapping` is the only path when the browser reports an empty type, and it had no `.msg` entry.

**Changes** (`packages/data-provider/src/file-config.ts`):
- Add `msg: 'application/vnd.ms-outlook'` to `codeTypeMapping` (extension → MIME fallback)
- Add `/^application\/vnd\.ms-outlook$/` to `supportedMimeTypes` (accept the type once detected)
- Add `'application/vnd.ms-outlook'` to `fullMimeTypesList` and `['application/vnd.ms-outlook', ['.msg']]` to `documentMimeExtensions`
- Normalize `application/x-msg` → `application/vnd.ms-outlook` via `mimeTypeAliases` (some Windows/Outlook clients report the `x-msg` variant)
- Add unit tests mirroring the `.eml` coverage

Scope matches #13989: this enables the **upload** of `.msg` (as with `.eml`, the type is not routed through `documentParserMimeTypes`). Server-side content extraction/OCR for `.msg` is out of scope.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Start LibreChat with any endpoint that supports file uploads.
2. Upload a `.msg` file — it should be accepted rather than rejected with "Unable to determine file type".
3. Works in browsers that report an empty type for `.msg` (extension fallback resolves it) and in clients that report `application/vnd.ms-outlook` or `application/x-msg` (passed through / normalized).

### **Test Configuration**:

- `packages/data-provider` unit tests: **25 suites / 1362 tests pass** (`npx jest --ci` in `packages/data-provider/`).
- `file-config.spec.ts`: **153 tests pass**, including 5 new `.msg` cases (empty-type inference, pass-through, `x-msg` normalization, `checkType`, and `supportedMimeTypes` flow).
- `npx tsc --noEmit`, `npx eslint`, and `npx prettier --check` on the changed files: all clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
