### PR TITLE
fix: Prevent silent-refresh network errors from forcing logout

### DIFF
--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -236,7 +236,13 @@ const AuthContextProvider = ({
       setUser(userQuery.data);
     } else if (userQuery.isError) {
       doSetError((userQuery.error as Error).message);
-      navigate(buildLoginRedirectUrl(), { replace: true });
+      /** Same reasoning as the silentRefresh onError handler above: a missing
+       * status means this never reached the server, so don't force a logout
+       * redirect for what may just be a transient connection failure. */
+      const status = getResponseStatus(userQuery.error);
+      if (status === 401 || status === 403) {
+        navigate(buildLoginRedirectUrl(), { replace: true });
+      }
     }
     if (error != null && error && isAuthenticated) {
       doSetError(undefined);

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -27,7 +27,7 @@ import {
   useRefreshTokenMutation,
 } from '~/data-provider';
 import { TAuthConfig, TUserContext, TAuthContext, TResError } from '~/common';
-import { SESSION_KEY, isSafeRedirect, getPostLoginRedirect } from '~/utils';
+import { SESSION_KEY, isSafeRedirect, getResponseStatus, getPostLoginRedirect } from '~/utils';
 import useTimeout from './useTimeout';
 import store from '~/store';
 
@@ -215,7 +215,14 @@ const AuthContextProvider = ({
         if (authConfig?.test === true) {
           return;
         }
-        navigate(buildLoginRedirectUrl());
+        /** A missing status means the request never reached the server (network
+         * error, backend restart/restart window, etc.) — the existing refresh
+         * token may still be valid, so don't force a logout redirect for that.
+         * Only redirect on an actual auth failure from the server. */
+        const status = getResponseStatus(error);
+        if (status === 401 || status === 403) {
+          navigate(buildLoginRedirectUrl());
+        }
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are stable at mount; adding refreshToken causes infinite re-fire


### PR DESCRIPTION
## Summary

`AuthContext.tsx` has two places that force a redirect to `/login` on *any* error from an auth-related request — including network-level failures with no HTTP response at all (e.g. the backend being briefly unreachable during a restart/deploy). Neither distinguishes "the server rejected this token" from "this request never reached the server."

1. `silentRefresh`'s `onError` (fires once on mount, i.e. every page load/reload)
2. `userQuery`'s `isError` branch (`GET /api/user`, enabled whenever a token exists from a prior session)

Concretely: if a user reloads or opens the app in the exact window where the API is momentarily unreachable, either of these can force them to `/login` even though their refresh token was never actually rejected by the server and the session is otherwise completely valid. It's indistinguishable, from the user's perspective, from a real logout — but nothing about their auth state actually changed.

This is a real papercut for any self-hosted deployment where the API container gets restarted periodically (config changes, updates, etc.) — every restart has a chance of bouncing whoever happens to reload the page during that window straight to the login screen.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## The fix

Use the existing `getResponseStatus(error)` helper (`client/src/utils/errors.ts`) — already used elsewhere in the codebase for exactly this distinction (e.g. `request.ts`'s own axios interceptor already special-cases `!error.response` for network errors) — to only redirect on an actual `401`/`403` response from the server in both places. A missing status (network error, no response) now leaves the existing session alone instead of discarding it.

```diff
-        navigate(buildLoginRedirectUrl());
+        const status = getResponseStatus(error);
+        if (status === 401 || status === 403) {
+          navigate(buildLoginRedirectUrl());
+        }
```
(same shape applied to both call sites)

## Testing

Reproduced on a local deployment: restarted the `api` container while the client had an open tab, timed a page reload to land during the container's restart window, and observed the forced redirect to `/login` despite the refresh token still being valid. After the fix, the same reload-during-restart sequence no longer redirects; a genuine expired/invalid refresh token (tested by manually invalidating the session) still correctly redirects to `/login`.

Note: while diagnosing this on my own deployment, the specific case I kept reproducing turned out to have a second, unrelated root cause (`Secure`-flagged cookies over a non-HTTPS LAN deployment — fixed via `SESSION_COOKIE_SECURE=false`), so this frontend fix wasn't the thing that resolved *my* particular case end-to-end. It's still a genuine gap independent of that: any deployment with a real network blip during the refresh/user-check window will hit this, HTTPS or not.

### **Test Configuration**:
- LibreChat built from `main` (`21dc4a2`)
- Self-hosted docker-compose deployment, LDAP authentication
- Reproduced with a real API container restart (`docker compose restart api`), not simulated

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.