### PR TITLE
feat: support per-user (templated) Bedrock bearer token for gateway auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -344,8 +344,13 @@ ANTHROPIC_API_KEY=user_provided
 # BEDROCK_AWS_SECRET_ACCESS_KEY=someSecretAccessKey
 # BEDROCK_AWS_SESSION_TOKEN=someSessionToken
 
-# Bedrock API key
+# Bedrock API key (sent as `Authorization: Bearer …` via the httpBearerAuth scheme)
 # BEDROCK_AWS_BEARER_TOKEN=yourBedrockApiKey
+
+# The bearer token also supports LibreChat placeholder templates, resolved per request.
+# Combine with BEDROCK_REVERSE_PROXY to forward a per-user identity token (e.g. the OIDC
+# ID token) to an AI gateway that authenticates the caller instead of AWS SigV4:
+# BEDROCK_AWS_BEARER_TOKEN={{LIBRECHAT_OPENID_ID_TOKEN}}
 
 # Note: This example list is not meant to be exhaustive. If omitted, all known, supported model IDs will be included for you.
 # BEDROCK_AWS_MODELS=anthropic.claude-fable-5,anthropic.claude-opus-4-8,anthropic.claude-opus-4-7,anthropic.claude-sonnet-5,anthropic.claude-sonnet-4-6,anthropic.claude-opus-4-6-v1,anthropic.claude-3-5-sonnet-20240620-v1:0,meta.llama3-1-8b-instruct-v1:0

--- a/.env.example
+++ b/.env.example
@@ -493,8 +493,13 @@ ANTHROPIC_API_KEY=user_provided
 # BEDROCK_AWS_SECRET_ACCESS_KEY=someSecretAccessKey
 # BEDROCK_AWS_SESSION_TOKEN=someSessionToken
 
-# Bedrock API key
+# Bedrock API key (sent as `Authorization: Bearer …` via the httpBearerAuth scheme)
 # BEDROCK_AWS_BEARER_TOKEN=yourBedrockApiKey
+
+# The bearer token also supports LibreChat placeholder templates, resolved per request.
+# Combine with BEDROCK_REVERSE_PROXY to forward a per-user identity token (e.g. the OIDC
+# ID token) to an AI gateway that authenticates the caller instead of AWS SigV4:
+# BEDROCK_AWS_BEARER_TOKEN={{LIBRECHAT_OPENID_ID_TOKEN}}
 
 # Note: This example list is not meant to be exhaustive. If omitted, all known, supported model IDs will be included for you.
 # Claude 4+ models cannot be invoked on-demand by their bare `anthropic.` foundation-model ID; Bedrock requires a

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -32,6 +32,7 @@ jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
 }));
 
 jest.mock('~/utils', () => ({
+  ...jest.requireActual('~/utils'),
   checkUserKeyExpiry: jest.fn(),
 }));
 
@@ -43,7 +44,7 @@ const createMockParams = (
   overrides: Partial<{
     config: Record<string, unknown>;
     body: Record<string, unknown>;
-    user: { id: string };
+    user: Record<string, unknown>;
     model_parameters: Record<string, unknown>;
     env: Record<string, string | undefined>;
   }> = {},
@@ -441,6 +442,52 @@ describe('initializeBedrock', () => {
 
       expect(result.llmConfig).toHaveProperty('endpointHost', 'reverse-proxy.example.com');
       expect(result.llmConfig).not.toHaveProperty('client');
+    });
+  });
+
+  describe('Dynamic Bearer Token', () => {
+    const createOpenIDUser = (idToken: string) => ({
+      id: 'test-user-id',
+      provider: 'openid',
+      openidId: 'oidc-subject',
+      openidTokens: {
+        access_token: 'access-token-abc',
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+
+    it('should resolve {{LIBRECHAT_OPENID_ID_TOKEN}} into the client bearer token', async () => {
+      const idToken = 'header.e30.signature';
+      process.env.BEDROCK_AWS_BEARER_TOKEN = '{{LIBRECHAT_OPENID_ID_TOKEN}}';
+      process.env.BEDROCK_REVERSE_PROXY = 'gateway.example.com';
+      const params = createMockParams({ user: createOpenIDUser(idToken) });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.client).toHaveProperty('token', { token: idToken });
+      expect(result.llmConfig.client).toHaveProperty('authSchemePreference', ['httpBearerAuth']);
+      expect(result.llmConfig.client).toHaveProperty('endpoint', 'https://gateway.example.com');
+      expect(result.llmConfig).not.toHaveProperty('credentials');
+    });
+
+    it('should resolve user field placeholders in the bearer token', async () => {
+      process.env.BEDROCK_AWS_BEARER_TOKEN = 'tenant-{{LIBRECHAT_USER_ID}}';
+      const params = createMockParams({ user: { id: 'user-123' } });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.client).toHaveProperty('token', { token: 'tenant-user-123' });
+      expect(result.llmConfig.client).toHaveProperty('authSchemePreference', ['httpBearerAuth']);
+    });
+
+    it('should pass a static bearer token through unchanged when no placeholder is present', async () => {
+      process.env.BEDROCK_AWS_BEARER_TOKEN = 'static-bedrock-api-key';
+      const params = createMockParams({ user: createOpenIDUser('header.e30.signature') });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.client).toHaveProperty('token', { token: 'static-bedrock-api-key' });
     });
   });
 

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -32,6 +32,7 @@ jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
 }));
 
 jest.mock('~/utils', () => ({
+  ...jest.requireActual('~/utils'),
   checkUserKeyExpiry: jest.fn(),
 }));
 
@@ -43,7 +44,7 @@ const createMockParams = (
   overrides: Partial<{
     config: Record<string, unknown>;
     body: Record<string, unknown>;
-    user: { id: string };
+    user: Record<string, unknown>;
     model_parameters: Record<string, unknown>;
     env: Record<string, string | undefined>;
   }> = {},
@@ -441,6 +442,66 @@ describe('initializeBedrock', () => {
 
       expect(result.llmConfig).toHaveProperty('endpointHost', 'reverse-proxy.example.com');
       expect(result.llmConfig).not.toHaveProperty('client');
+    });
+  });
+
+  describe('Dynamic Bearer Token', () => {
+    /** `exp` is required for the ID token to pass the OpenID freshness check */
+    const createIdToken = (exp: number = Math.floor(Date.now() / 1000) + 3600) =>
+      `header.${Buffer.from(JSON.stringify({ sub: 'oidc-subject', exp })).toString(
+        'base64url',
+      )}.signature`;
+
+    const createOpenIDUser = (idToken: string) => ({
+      id: 'test-user-id',
+      provider: 'openid',
+      openidId: 'oidc-subject',
+      openidTokens: {
+        access_token: 'access-token-abc',
+        id_token: idToken,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+
+    it('should resolve {{LIBRECHAT_OPENID_ID_TOKEN}} into the client bearer token', async () => {
+      const idToken = createIdToken();
+      process.env.BEDROCK_AWS_BEARER_TOKEN = '{{LIBRECHAT_OPENID_ID_TOKEN}}';
+      process.env.BEDROCK_REVERSE_PROXY = 'gateway.example.com';
+      const params = createMockParams({ user: createOpenIDUser(idToken) });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.client).toHaveProperty('token', { token: idToken });
+      expect(result.llmConfig.client).toHaveProperty('authSchemePreference', ['httpBearerAuth']);
+      expect(result.llmConfig.client).toHaveProperty('endpoint', 'https://gateway.example.com');
+      expect(result.llmConfig).not.toHaveProperty('credentials');
+    });
+
+    it('should resolve user field placeholders in the bearer token', async () => {
+      process.env.BEDROCK_AWS_BEARER_TOKEN = 'tenant-{{LIBRECHAT_USER_ID}}';
+      const params = createMockParams({ user: { id: 'user-123' } });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.client).toHaveProperty('token', { token: 'tenant-user-123' });
+      expect(result.llmConfig.client).toHaveProperty('authSchemePreference', ['httpBearerAuth']);
+    });
+
+    it('should pass a static bearer token through unchanged when no placeholder is present', async () => {
+      process.env.BEDROCK_AWS_BEARER_TOKEN = 'static-bedrock-api-key';
+      const params = createMockParams({ user: createOpenIDUser(createIdToken()) });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.client).toHaveProperty('token', { token: 'static-bedrock-api-key' });
+    });
+
+    it('should require re-authentication rather than forward an expired ID token', async () => {
+      process.env.BEDROCK_AWS_BEARER_TOKEN = '{{LIBRECHAT_OPENID_ID_TOKEN}}';
+      const expired = createIdToken(Math.floor(Date.now() / 1000) - 3600);
+      const params = createMockParams({ user: createOpenIDUser(expired) });
+
+      await expect(initializeBedrock(params)).rejects.toThrow(/re-authentication is required/);
     });
   });
 

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -18,7 +18,7 @@ import type {
   InferenceProfileConfig,
 } from '~/types';
 import { getHttpsProxyAgent } from '~/utils/proxy';
-import { checkUserKeyExpiry } from '~/utils';
+import { checkUserKeyExpiry, resolveHeaders } from '~/utils';
 
 const BEDROCK_CREDENTIALS_ERROR = 'Bedrock credentials not provided. Please provide them again.';
 
@@ -36,6 +36,26 @@ function getBedrockProxyTarget(region?: string, reverseProxy?: string): string |
   if (!trimmedRegion) return undefined;
 
   return `https://bedrock-runtime.${trimmedRegion}.amazonaws.com`;
+}
+
+/**
+ * Resolves LibreChat placeholder templates (e.g. `{{LIBRECHAT_OPENID_ID_TOKEN}}`,
+ * `{{LIBRECHAT_USER_ID}}`) in a statically-configured Bedrock bearer token at
+ * request time, forwarding a per-user identity token as the outbound
+ * `Authorization: Bearer …` credential. This is useful when Bedrock traffic is
+ * routed through an AI gateway / `BEDROCK_REVERSE_PROXY` that authenticates the
+ * caller itself (via `httpBearerAuth`) rather than AWS SigV4. Tokens without a
+ * placeholder are returned unchanged, so static Bedrock API keys are unaffected.
+ */
+function resolveBearerToken(
+  token: string,
+  user: BaseInitializeParams['req']['user'],
+  body: BaseInitializeParams['req']['body'],
+): string {
+  if (!token.includes('{{')) {
+    return token;
+  }
+  return resolveHeaders({ headers: { token }, user, body }).token;
 }
 
 function isParsedBedrockUserCredentials(value: unknown): value is ParsedBedrockUserCredentials {
@@ -95,6 +115,10 @@ function getUserCredentialValue(
  * Reverse Proxy Support:
  * - When BEDROCK_REVERSE_PROXY is set, routes Bedrock API calls through a custom endpoint
  * - Works with or without the PROXY setting
+ * - A BEDROCK_AWS_BEARER_TOKEN containing LibreChat placeholder templates (e.g.
+ *   `{{LIBRECHAT_OPENID_ID_TOKEN}}`) is resolved per request, forwarding a per-user
+ *   identity token as the `Authorization: Bearer …` credential so an AI gateway can
+ *   authenticate each caller instead of AWS SigV4
  *
  * Without Proxy:
  * - Credentials and endpoint configuration are passed separately to ChatBedrockConverse,
@@ -203,7 +227,7 @@ export async function initializeBedrock({
       checkUserKeyExpiry(expiresAt, EModelEndpoint.bedrock);
     }
   } else if (staticBearerToken) {
-    bearerToken = staticBearerToken;
+    bearerToken = resolveBearerToken(staticBearerToken, req.user, req.body);
   } else if (hasAccessKey !== hasSecretKey) {
     throw new Error(
       'Both BEDROCK_AWS_ACCESS_KEY_ID and BEDROCK_AWS_SECRET_ACCESS_KEY must be provided together.',

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -15,11 +15,12 @@ import type {
   BedrockCredentials,
   GuardrailConfiguration,
   InferenceProfileConfig,
+  EndpointRuntimeContext,
   ProviderInitializeParams,
 } from '~/types';
+import { checkUserKeyExpiry, resolveHeaders } from '~/utils';
 import { getHttpsProxyAgent } from '~/utils/proxy';
 import { resolveEndpointRuntime } from '~/types';
-import { checkUserKeyExpiry } from '~/utils';
 
 const BEDROCK_CREDENTIALS_ERROR = 'Bedrock credentials not provided. Please provide them again.';
 
@@ -37,6 +38,26 @@ function getBedrockProxyTarget(region?: string, reverseProxy?: string): string |
   if (!trimmedRegion) return undefined;
 
   return `https://bedrock-runtime.${trimmedRegion}.amazonaws.com`;
+}
+
+/**
+ * Resolves LibreChat placeholder templates (e.g. `{{LIBRECHAT_OPENID_ID_TOKEN}}`,
+ * `{{LIBRECHAT_USER_ID}}`) in a statically-configured Bedrock bearer token at
+ * request time, forwarding a per-user identity token as the outbound
+ * `Authorization: Bearer …` credential. This is useful when Bedrock traffic is
+ * routed through an AI gateway / `BEDROCK_REVERSE_PROXY` that authenticates the
+ * caller itself (via `httpBearerAuth`) rather than AWS SigV4. Tokens without a
+ * placeholder are returned unchanged, so static Bedrock API keys are unaffected.
+ */
+function resolveBearerToken(
+  token: string,
+  user: EndpointRuntimeContext['user'],
+  body: EndpointRuntimeContext['requestBody'],
+): string {
+  if (!token.includes('{{')) {
+    return token;
+  }
+  return resolveHeaders({ headers: { token }, user, body }).token;
 }
 
 function isParsedBedrockUserCredentials(value: unknown): value is ParsedBedrockUserCredentials {
@@ -96,6 +117,10 @@ function getUserCredentialValue(
  * Reverse Proxy Support:
  * - When BEDROCK_REVERSE_PROXY is set, routes Bedrock API calls through a custom endpoint
  * - Works with or without the PROXY setting
+ * - A BEDROCK_AWS_BEARER_TOKEN containing LibreChat placeholder templates (e.g.
+ *   `{{LIBRECHAT_OPENID_ID_TOKEN}}`) is resolved per request, forwarding a per-user
+ *   identity token as the `Authorization: Bearer …` credential so an AI gateway can
+ *   authenticate each caller instead of AWS SigV4
  *
  * Without Proxy:
  * - Credentials and endpoint configuration are passed separately to ChatBedrockConverse,
@@ -202,7 +227,7 @@ export async function initializeBedrock(
       checkUserKeyExpiry(expiresAt, EModelEndpoint.bedrock);
     }
   } else if (staticBearerToken) {
-    bearerToken = staticBearerToken;
+    bearerToken = resolveBearerToken(staticBearerToken, user, requestBody);
   } else if (hasAccessKey !== hasSecretKey) {
     throw new Error(
       'Both BEDROCK_AWS_ACCESS_KEY_ID and BEDROCK_AWS_SECRET_ACCESS_KEY must be provided together.',


### PR DESCRIPTION

## Summary

When AWS Bedrock is routed through an AI gateway / reverse proxy (`BEDROCK_REVERSE_PROXY`), the gateway — not AWS SigV4 — authenticates the caller. Today the only way to authenticate is a **single static** `BEDROCK_AWS_BEARER_TOKEN` shared by every user, so per-user identity/governance is lost.

This PR lets `BEDROCK_AWS_BEARER_TOKEN` contain the same LibreChat placeholder templates already supported for endpoint headers (e.g. `{{LIBRECHAT_OPENID_ID_TOKEN}}`, `{{LIBRECHAT_USER_ID}}`). The token is resolved **per request** against the authenticated user and forwarded via the AWS SDK's native `httpBearerAuth` scheme as `Authorization: Bearer <resolved token>`.

**Why not custom headers (like #13742)?** Unlike the OpenAI/Anthropic/Google clients, Bedrock's `Authorization` header is generated by the AWS SDK (SigV4 or `httpBearerAuth`), not passed through from config. A custom config header cannot override it. Resolving the value the SDK actually sends — the bearer token — is the clean, SDK-idiomatic way to forward a per-user credential, and it deliberately does **not** conflict with #13742's rule that custom headers never touch provider-managed auth.

**Behavior / compatibility**
- Resolution only runs when the token contains a `{{ … }}` placeholder; static Bedrock API keys are returned byte-for-byte unchanged (no behavior change for existing users).
- Reuses the existing `resolveHeaders` placeholder machinery (env → customUserVars → user/OpenID → body ordering preserved) and the existing bearer-token / `httpBearerAuth` code path.
- No new config keys, no schema changes, no new dependencies.

**Example configuration**

```bash
# Forward each user's OIDC ID token to a Bedrock-compatible gateway that authenticates the caller
BEDROCK_AWS_BEARER_TOKEN={{LIBRECHAT_OPENID_ID_TOKEN}}
BEDROCK_REVERSE_PROXY=your-bedrock-gateway.example.com
```

This produces a per-request `Authorization: Bearer <user OIDC id token>` to the gateway, with no AWS SigV4 signing. File uploads (Converse `document`/`image` blocks) and token counts (Converse `usage`) are unaffected.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Unit tests were added to `packages/api/src/endpoints/bedrock/initialize.spec.ts` covering:
1. `{{LIBRECHAT_OPENID_ID_TOKEN}}` resolves to the user's OIDC ID token and is set as the client bearer token (`token`, `authSchemePreference: ['httpBearerAuth']`, reverse-proxy `endpoint`), with no AWS credentials.
2. User-field placeholders (e.g. `{{LIBRECHAT_USER_ID}}`) resolve in the bearer token.
3. A static token with no placeholder is passed through unchanged (backward compatibility).

Run:

```bash
cd packages/api && npx jest src/endpoints/bedrock/initialize.spec.ts
```

Result: **61/61 passing** (3 new + all existing). ESLint clean on the changed files.

### **Test Configuration**:

- Node.js per project requirements; `npm ci` at the repo root, then `npm run build:data-provider` before running the api workspace tests.
- No external services required — OIDC token info is supplied via the mocked request user in tests.

## Files Changed

- `packages/api/src/endpoints/bedrock/initialize.ts` — add `resolveBearerToken` helper (guarded on `{{`, reuses `resolveHeaders`) and apply it in the static-bearer branch; extend the module JSDoc.
- `packages/api/src/endpoints/bedrock/initialize.spec.ts` — new "Dynamic Bearer Token" test suite; switch the `~/utils` mock to `...jest.requireActual('~/utils')` (matching the Google/Anthropic specs) so the real resolver is exercised.
- `.env.example` — document the templating capability under `BEDROCK_AWS_BEARER_TOKEN`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes (`.env.example`; user-docs PR to follow if requested)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules — N/A
- [ ] A pull request for updating the documentation has been submitted — pending maintainer preference
