### PR TITLE
fix(mcp): sanitize $schema keyword in tool inputSchema to prevent MongoDB storage failure (#14323)

### DIFF
--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -43,6 +43,15 @@ export interface MCPToolCacheService {
   ) => Promise<LCAvailableTools | null>;
 }
 
+export function sanitizeInputSchema(schema?: JsonSchemaType): JsonSchemaType {
+  if (!schema || typeof schema !== 'object') {
+    return (schema ?? { type: 'object', properties: {} }) as JsonSchemaType;
+  }
+  const sanitized = { ...schema };
+  delete (sanitized as Record<string, unknown>)['$schema'];
+  return sanitized as JsonSchemaType;
+}
+
 export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheService {
   const { getCachedTools, setCachedTools, getServerConfig } = deps;
 
@@ -95,7 +104,7 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheS
           ['function']: {
             name,
             description: tool.description ?? '',
-            parameters: tool.inputSchema ?? ({ type: 'object', properties: {} } as JsonSchemaType),
+            parameters: sanitizeInputSchema(tool.inputSchema),
           },
         };
         serverTools[name] = entry;


### PR DESCRIPTION
### Summary
Fixes #14323.

### Description
When an MCP server exposes a tool whose `inputSchema` includes a standard `$schema` keyword (e.g. declaring JSON Schema draft version), LibreChat fails to persist tool definitions to MongoDB because MongoDB rejects field names prefixed with `$` as reserved query/update operators.

This PR adds `sanitizeInputSchema()` in `packages/api/src/mcp/tools.ts` to strip top-level `$schema` property before saving MCP tool definitions to MongoDB storage/cache.

### Testing
- Tested `sanitizeInputSchema` with tool definitions containing `$schema: "http://json-schema.org/draft-07/schema#"`.
- Verified `$schema` property is stripped while leaving `type`, `properties`, and all valid schema definitions intact.
