### PR TITLE
chore: add helmet for baseline HTTP security headers

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -84,6 +84,7 @@
     "form-data": "^4.0.4",
     "get-stream": "^6.0.1",
     "handlebars": "^4.7.9",
+    "helmet": "^8.3.0",
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.3.2",
     "js-yaml": "^4.2.0",

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..') });
 const cors = require('cors');
 const axios = require('axios');
+const helmet = require('helmet');
 const express = require('express');
 const passport = require('passport');
 const compression = require('compression');
@@ -118,6 +119,17 @@ const startServer = async () => {
 
   app.disable('x-powered-by');
   app.set('trust proxy', trusted_proxy);
+  app.use(
+    helmet({
+      // The SPA shell (client/index.html) ships inline <script> for theme
+      // detection and RUM stale-asset recovery, served as a static file
+      // with no per-request nonce injection. A default CSP would block
+      // those and break first paint. Left off until nonce-based script
+      // tagging lands; the other helmet headers (HSTS, X-Frame-Options,
+      // X-Content-Type-Options, COOP, CORP, etc.) don't depend on it.
+      contentSecurityPolicy: false,
+    }),
+  );
 
   if (isEnabled(process.env.TENANT_ISOLATION_STRICT)) {
     logger.warn(

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "form-data": "^4.0.4",
         "get-stream": "^6.0.1",
         "handlebars": "^4.7.9",
+        "helmet": "^8.3.0",
         "https-proxy-agent": "^7.0.6",
         "ioredis": "^5.3.2",
         "js-yaml": "^4.2.0",
@@ -27724,6 +27725,18 @@
       "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.1.14.tgz",
       "integrity": "sha512-CxJE27BF6JcQvrL1giK478iSZr7EJNTnAN2Th1rAJiN1BSMYZxDLm4PL/p/ha3aSqVHvCo+YNk++5tIj0JVxLQ==",
       "license": "LGPL-3.0"
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
     },
     "node_modules/highlight.js": {
       "version": "11.8.0",


### PR DESCRIPTION
## Summary
- Adds `helmet()` to every route (registered before route handlers, so health checks get the headers too), enabling HSTS, `X-Frame-Options`, `X-Content-Type-Options`, COOP/CORP, and helmet's other non-CSP defaults.
- `contentSecurityPolicy` is explicitly set to `false`.

Closes #14438

## Related to #7110
#7110 asked for CSP specifically, after a pentest flagged the app's lack of security headers as exposing it to XSS and clickjacking. `rubentalstra` addressed it via #7377 — helmet with a hardcoded, enforced CSP (hand-rolled `directives` for `scriptSrc`, `frameSrc`, etc., allow-listing Cloudflare Turnstile and Sandpack/CodeSandbox via `SANDPACK_BUNDLER_URL`/`SANDPACK_STATIC_BUNDLER_URL`). It was reverted the next day in #7419 ("Temporarily Remove CSP until Configurable") because the hardcoded allow-list didn't account for every deployment's optional features, so CSP started blocking things depending on what a given instance had enabled. Since that code never separated "safe headers" from "CSP directives," removing CSP meant removing the entire `helmet()` call, and it was never reintroduced. #7110 has stayed open since.

This PR only adds the CSP-independent headers and passes `contentSecurityPolicy: false` explicitly — there's no directive allow-list to go stale against Turnstile, Sandpack, or any other configurable embed, so it can't regress the same way. It does **not** close #7110: the CSP/XSS half of that ask is still unaddressed and would need per-deployment configurability to be safe, which is a separate, larger change. This PR only covers clickjacking/MIME-sniffing/cross-origin isolation, which don't need that configurability.

## Verification
Running this change on a live deployment; response headers confirmed on `/health`:

```
strict-transport-security: max-age=31536000; includeSubDomains
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
cross-origin-opener-policy: same-origin
cross-origin-resource-policy: same-origin
x-dns-prefetch-control: off
x-download-options: noopen
x-permitted-cross-domain-policies: none
x-xss-protection: 0
```

Not independently verified on this deployment (no Sandpack/Turnstile configured there): interaction with `SANDPACK_BUNDLER_URL`/Turnstile setups on other instances. Since CSP is off, there's no directive to interact with those features in the first place.
