### PR TITLE
✨ feat: interface.i18nOverrides — per-locale UI string overrides via config

### DIFF
--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -12,6 +12,7 @@ import type { TStartupConfig, TUser } from 'librechat-data-provider';
 import { useMCPToolsQuery, useMCPServersQuery } from '~/data-provider';
 import { cleanupTimestampedStorage } from '~/utils/timestamps';
 import useSpeechSettingsInit from './useSpeechSettingsInit';
+import { applyI18nOverrides } from '~/locales/i18n';
 import { useHasAccess } from '~/hooks';
 import store from '~/store';
 
@@ -55,6 +56,11 @@ export default function useAppStartup({
     }
     document.title = appTitle;
     localStorage.setItem(LocalStorageKeys.APP_TITLE, appTitle);
+  }, [startupConfig]);
+
+  /** Apply per-deployment UI string overrides (interface.i18nOverrides) */
+  useEffect(() => {
+    applyI18nOverrides(startupConfig?.interface?.i18nOverrides);
   }, [startupConfig]);
 
   /** Set the default spec's preset as default */

--- a/client/src/locales/i18n.ts
+++ b/client/src/locales/i18n.ts
@@ -221,6 +221,48 @@ export function detectInitialLanguage() {
   return normalizeLocale(cookieLang || storedLang || getNavigatorLanguage());
 }
 
+/**
+ * Per-locale UI string overrides from the server config (interface.i18nOverrides).
+ * Kept module-level so they can be re-applied whenever a locale bundle (re)loads —
+ * `ensureLocale` adds bundles with overwrite=true, which would otherwise clobber an
+ * override the first time a non-English locale is loaded after startup.
+ */
+let configuredOverrides: Partial<Record<SupportedLocale, TranslationResource>> = {};
+
+function applyOverrideFor(locale: SupportedLocale) {
+  const overrides = configuredOverrides[locale];
+  if (overrides && Object.keys(overrides).length > 0) {
+    i18n.addResourceBundle(locale, defaultNS, overrides, true, true);
+  }
+}
+
+/**
+ * Merge UI string overrides on top of the bundled translations. Safe to call
+ * repeatedly (e.g. once the per-user startup config resolves). react-i18next binds
+ * `languageChanged`/`loaded` but not `added`, so nudge a re-render with the current
+ * language after applying.
+ */
+export function applyI18nOverrides(overrides?: Record<string, Record<string, string>>): void {
+  configuredOverrides = {};
+  if (overrides) {
+    for (const [locale, map] of Object.entries(overrides)) {
+      if (map && typeof map === 'object') {
+        configuredOverrides[normalizeLocale(locale)] = map;
+      }
+    }
+  }
+  let applied = false;
+  for (const locale of Object.keys(configuredOverrides) as SupportedLocale[]) {
+    if (i18n.hasResourceBundle(locale, defaultNS)) {
+      applyOverrideFor(locale);
+      applied = true;
+    }
+  }
+  if (applied) {
+    void i18n.changeLanguage(i18n.language);
+  }
+}
+
 export async function ensureLocale(locale?: string | null): Promise<SupportedLocale> {
   const normalized = normalizeLocale(locale);
 
@@ -242,6 +284,9 @@ export async function ensureLocale(locale?: string | null): Promise<SupportedLoc
     loadingLocales[normalized] = loader()
       .then((module) => {
         i18n.addResourceBundle(normalized, defaultNS, module.default, true, true);
+        // Re-apply any configured overrides for this locale — the bundle we just
+        // added with overwrite=true would otherwise clobber them.
+        applyOverrideFor(normalized);
         loadedLocales.add(normalized);
         return normalized;
       })

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -95,6 +95,14 @@ cache: true
 # Custom interface configuration
 interface:
   customWelcome: 'Welcome to LibreChat! Enjoy your experience.'
+  # Per-locale UI string overrides, merged over the bundled translations on the
+  # client. Relabel any UI string by its i18n key without forking the client.
+  # Shape: { <locale>: { <translationKey>: <value> } }. Because `interface` resolves
+  # per principal, a role/group/user config override can carry its own overrides.
+  # i18nOverrides:
+  #   en:
+  #     com_nav_setting_mcp: 'Connectors'
+  #     com_ui_filter_mcp_servers: 'Search connectors'
   # Enable/disable file search as a chatarea selection (default: true)
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1293,6 +1293,14 @@ export const interfaceSchema = z
       .optional(),
     termsOfService: termsOfServiceSchema.optional(),
     customWelcome: z.string().optional(),
+    /**
+     * Per-locale UI string overrides, merged over the bundled i18n resources on
+     * the client: `{ [locale]: { [translationKey]: value } }`. Lets a deployment
+     * relabel any UI string (e.g. rename "MCP Settings" to "Connectors") without
+     * forking the client. Because `interface` resolves per principal, a role/group/
+     * user config override can carry its own overrides for white-labeled tenants.
+     */
+    i18nOverrides: z.record(z.string(), z.record(z.string(), z.string())).optional(),
     mcpServers: mcpServersSchema.optional(),
     modelSelect: z.boolean().optional(),
     parameters: z.boolean().optional(),

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -38,6 +38,7 @@ export async function loadDefaultInterface({
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    i18nOverrides: interfaceConfig?.i18nOverrides,
     autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
     buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo,
     contextUsage: interfaceConfig?.contextUsage ?? defaults.contextUsage,


### PR DESCRIPTION
## Summary

Adds an optional `interface.i18nOverrides` config field that lets a deployment relabel **any** UI string by its i18n key — e.g. rename *"MCP Settings"* to *"Connectors"* — **without forking the client**. Today the only way to change baked-in UI text is to patch the compiled bundle; this makes it a config line.

```yaml
interface:
  i18nOverrides:
    en:
      com_nav_setting_mcp: 'Connectors'
      com_ui_filter_mcp_servers: 'Search connectors'
```

## Why

White-labeling / rebranding is a common enterprise ask, and there's currently no supported way to override individual UI strings. This rides entirely on machinery that already exists (i18next resource bundles + the `interface` config), is fully opt-in, and is a no-op when unset.

Nicely, because `interface` already resolves **per principal**, a role/group/user config override can carry its own `i18nOverrides` — so different tenants can see different labels.

## Changes

- **data-provider**: `interfaceSchema` gains optional `i18nOverrides` (`{ [locale]: { [translationKey]: value } }`).
- **data-schemas**: `loadDefaultInterface` passes it through to the resolved `interfaceConfig` (already sent to the client in the authenticated startup config).
- **client (i18n)**: `applyI18nOverrides()` merges the overrides onto the bundled resources (`addResourceBundle`, overwrite) and **re-applies after a locale (re)loads**, so a lazily-loaded non-English locale doesn't clobber the overrides. `useAppStartup` applies them when the startup config resolves; a `changeLanguage(current)` nudge triggers the re-render (react-i18next binds `languageChanged`/`loaded`, not `added`).
- **docs**: example in `librechat.example.yaml`.

## Notes

Opened as a draft — happy to add tests and align with contribution guidelines; wanted to get the design in front of maintainers first. No behavior change when `i18nOverrides` is absent.