### PR TITLE
fix: resolve MCP tool-name delimiter collision at invocation time

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -6,6 +6,7 @@ const {
   createSafeUser,
   mcpToolPattern,
   loadWebSearchAuth,
+  splitMCPToolKey,
   buildInlineMemoryTool,
   getCodeApiAuthHeaders,
   buildImageToolContext,
@@ -396,7 +397,7 @@ const loadTools = async ({
         continue;
       }
 
-      const [toolName, serverName] = tool.split(Constants.mcp_delimiter);
+      const [toolName, serverName] = splitMCPToolKey(tool);
       if (toolName === Constants.mcp_server) {
         /** Placeholder used for UI purposes */
         continue;

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -354,6 +354,51 @@ describe('Tool Handlers', () => {
       );
     });
 
+    it('resolves an MCP tool whose raw name itself contains the delimiter substring', async () => {
+      // Regression test for https://github.com/danny-avila/LibreChat/issues/14440:
+      // gateways that prefix aggregated tool names by server (e.g. LiteLLM's
+      // MCP proxy) can produce a raw tool name that already contains "_mcp_"
+      // (e.g. GitLab's own "get_mcp_server_version" tool becomes
+      // "gitlab-get_mcp_server_version" once gateway-prefixed). Once
+      // LibreChat appends its own server suffix, the combined key has the
+      // delimiter twice - a naive split used to silently derive the wrong
+      // server name ("server_version" instead of "gitlab") and drop the tool.
+      const serverName = 'gitlab';
+      const rawToolName = 'gitlab-get_mcp_server_version';
+      const toolKey = `${rawToolName}${Constants.mcp_delimiter}${serverName}`;
+      const serverConfig = {
+        type: 'streamable-http',
+        url: 'https://litellm.example.com/gitlab/mcp',
+        source: 'yaml',
+      };
+
+      mockGetServerConfig.mockResolvedValue(serverConfig);
+      mockCreateMCPTool.mockResolvedValue({ name: 'loaded-mcp-tool' });
+
+      const result = await loadTools({
+        user: fakeUser._id.toString(),
+        tools: [toolKey],
+        options: {
+          req: {
+            user: { id: fakeUser._id.toString(), role: 'USER' },
+          },
+        },
+      });
+
+      expect(result.loadedTools).toEqual([{ name: 'loaded-mcp-tool' }]);
+      expect(mockGetServerConfig).toHaveBeenCalledWith(
+        serverName,
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockCreateMCPTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolKey,
+          config: serverConfig,
+        }),
+      );
+    });
+
     it('uses run-scoped MCP tool definitions before cache lookup', async () => {
       const serverName = 'body-scoped';
       const toolKey = `search${Constants.mcp_delimiter}${serverName}`;

--- a/api/server/controllers/agents/filterAuthorizedTools.spec.js
+++ b/api/server/controllers/agents/filterAuthorizedTools.spec.js
@@ -342,23 +342,58 @@ describe('MCP Tool Authorization', () => {
       expect(result).toEqual(['web_search']);
     });
 
-    test('should not preserve malformed existing tools when registry is unavailable', async () => {
+    test('should not preserve a tool key with no delimiter at all when registry is unavailable', async () => {
+      // A key that isn't a real MCP tool key (no delimiter, so it has no
+      // resolvable server) is rejected regardless of the existing-tools
+      // fallback - unlike a key with multiple delimiters, which does have a
+      // resolvable server (the segment after the last delimiter) and is
+      // covered separately below.
       getMCPServersRegistry.mockImplementation(() => {
         throw new Error('MCPServersRegistry has not been initialized.');
       });
 
-      const malformedTool = `a${d}b${d}c`;
+      // Deliberately not named anything containing "_mcp_" - that would
+      // ironically make it an MCP tool key itself, exactly the class of
+      // naming collision this whole regression is about. (Confirmed
+      // programmatically, not just by eye - it's an easy mistake to repeat.)
+      const noDelimiterTool = 'regular_web_tool';
       const result = await filterAuthorizedTools({
-        tools: [malformedTool, `legit${d}serverA`, 'web_search'],
+        tools: [noDelimiterTool, `legit${d}serverA`, 'web_search'],
         userId,
         user: testUser,
         availableTools,
-        existingTools: [malformedTool, `legit${d}serverA`],
+        existingTools: [noDelimiterTool, `legit${d}serverA`],
       });
 
       expect(result).toContain(`legit${d}serverA`);
       expect(result).toContain('web_search');
-      expect(result).not.toContain(malformedTool);
+      expect(result).not.toContain(noDelimiterTool);
+    });
+
+    test('should preserve an existing MCP tool key with multiple delimiters when registry is unavailable', async () => {
+      // Regression test for https://github.com/danny-avila/LibreChat/issues/14440:
+      // a tool key with more than one delimiter occurrence is not inherently
+      // malformed - it just means the raw tool-name half (everything before
+      // the *last* delimiter) itself contains the delimiter substring, which
+      // legitimately happens with some upstream MCP tool names. The
+      // registry-unavailable fallback should treat it like any other
+      // previously-persisted tool, not single it out as broken.
+      getMCPServersRegistry.mockImplementation(() => {
+        throw new Error('MCPServersRegistry has not been initialized.');
+      });
+
+      const multiDelimiterTool = `a${d}b${d}c`;
+      const result = await filterAuthorizedTools({
+        tools: [multiDelimiterTool, `legit${d}serverA`, 'web_search'],
+        userId,
+        user: testUser,
+        availableTools,
+        existingTools: [multiDelimiterTool, `legit${d}serverA`],
+      });
+
+      expect(result).toContain(multiDelimiterTool);
+      expect(result).toContain(`legit${d}serverA`);
+      expect(result).toContain('web_search');
     });
 
     test('should gate app-level MCP tools present in the global tool cache', async () => {
@@ -398,12 +433,29 @@ describe('MCP Tool Authorization', () => {
       expect(mockGetAllServerConfigs).not.toHaveBeenCalled();
     });
 
-    test('should reject malformed MCP tool keys with multiple delimiters', async () => {
+    test('should resolve MCP tool keys with multiple delimiters using the last segment as the server name', async () => {
+      // Regression test for https://github.com/danny-avila/LibreChat/issues/14440.
+      // A tool key with more than one delimiter occurrence is not inherently
+      // malformed - it means the raw tool-name half (the part before the
+      // *last* delimiter, which is always the segment LibreChat itself
+      // appends) legitimately contains the delimiter substring. Previously
+      // any key with >2 segments was rejected outright; now the server name
+      // is always the last segment, matching how the key is actually built.
+      //
+      // `multiSegmentTool` below has an unrelated string ("victimServer")
+      // embedded in its raw-tool-name half purely to prove there's no way to
+      // spoof a *different* server via that embedded text - only the real
+      // last segment ("authorizedServer") is ever consulted for
+      // authorization, so this does not grant access to anything the user
+      // isn't already allowed to use.
+      const multiSegmentTool = `attack${d}victimServer${d}authorizedServer`;
+      const unauthorizedMultiSegmentTool = `a${d}b${d}c${d}forbiddenServer`;
+
       const result = await filterAuthorizedTools({
         tools: [
-          `attack${d}victimServer${d}authorizedServer`,
+          multiSegmentTool,
           `legit${d}authorizedServer`,
-          `a${d}b${d}c${d}d`,
+          unauthorizedMultiSegmentTool,
           'web_search',
         ],
         userId,
@@ -411,9 +463,14 @@ describe('MCP Tool Authorization', () => {
         availableTools,
       });
 
-      expect(result).toEqual([`legit${d}authorizedServer`, 'web_search']);
-      expect(result).not.toContainEqual(expect.stringContaining('victimServer'));
-      expect(result).not.toContainEqual(expect.stringContaining(`a${d}b`));
+      expect(result).toContain(multiSegmentTool);
+      expect(result).toContain(`legit${d}authorizedServer`);
+      expect(result).toContain('web_search');
+      // The unrelated embedded text does not let the key resolve to a
+      // different, unauthorized server: only the true last segment
+      // ("forbiddenServer", not in the mocked server configs) is checked,
+      // and it's correctly rejected.
+      expect(result).not.toContain(unauthorizedMultiSegmentTool);
     });
   });
 

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -4,6 +4,7 @@ const { nanoid } = require('nanoid');
 const { logger } = require('@librechat/data-schemas');
 const {
   refreshS3Url,
+  splitMCPToolKey,
   agentCreateSchema,
   agentUpdateSchema,
   refreshListAvatars,
@@ -262,8 +263,8 @@ const filterAuthorizedTools = async ({
       }
     }
 
-    const parts = tool.split(Constants.mcp_delimiter);
-    if (parts.length !== 2) {
+    const [, serverName] = splitMCPToolKey(tool);
+    if (!serverName) {
       logger.warn(
         `[filterAuthorizedTools] Rejected malformed MCP tool key "${tool}" for user ${userId}`,
       );
@@ -275,8 +276,7 @@ const filterAuthorizedTools = async ({
       continue;
     }
 
-    const [, serverName] = parts;
-    if (!serverName || !Object.hasOwn(mcpServerConfigs, serverName)) {
+    if (!Object.hasOwn(mcpServerConfigs, serverName)) {
       logger.warn(
         `[filterAuthorizedTools] Rejected MCP tool "${tool}" — server "${serverName}" not accessible to user ${userId}`,
       );

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -10,6 +10,7 @@ const {
   checkAccess,
   isUserSourced,
   MCPErrorCodes,
+  splitMCPToolKey,
   redactServerSecrets,
   redactAllServerSecrets,
   isMCPDomainNotAllowedError,
@@ -177,7 +178,7 @@ const getMCPTools = async (req, res) => {
               continue;
             }
 
-            const toolName = toolKey.split(Constants.mcp_delimiter)[0];
+            const [toolName] = splitMCPToolKey(toolKey);
             server.tools.push({
               name: toolName,
               pluginKey: toolKey,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -6,6 +6,7 @@ const {
   PENDING_STALE_MS,
   MCPOAuthHandler,
   isMCPDomainAllowed,
+  splitMCPToolKey,
   normalizeServerName,
   normalizeJsonSchema,
   GenerationJobManager,
@@ -638,7 +639,7 @@ async function createMCPTool({
   onAvailableTools,
   streamId = null,
 }) {
-  const [toolName, serverName] = toolKey.split(Constants.mcp_delimiter);
+  const [toolName, serverName] = splitMCPToolKey(toolKey);
 
   const serverConfig =
     config ?? (await getMCPServersRegistry().getServerConfig(serverName, user?.id, configServers));

--- a/client/src/hooks/MCP/__tests__/useVisibleTools.test.ts
+++ b/client/src/hooks/MCP/__tests__/useVisibleTools.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { Constants } from 'librechat-data-provider';
+import type { TPlugin } from 'librechat-data-provider';
+import type { MCPServerInfo } from '~/common';
+import { useVisibleTools } from '../useVisibleTools';
+
+const d = Constants.mcp_delimiter;
+
+describe('useVisibleTools', () => {
+  const regularTools: TPlugin[] = [{ name: 'Web Search', pluginKey: 'web_search' }] as TPlugin[];
+  const mcpServersMap = new Map<string, MCPServerInfo>([
+    ['gitlab', {} as MCPServerInfo],
+    ['myserver', {} as MCPServerInfo],
+  ]);
+
+  it('resolves a normal single-delimiter MCP tool id to its server name', () => {
+    const { result } = renderHook(() =>
+      useVisibleTools([`search${d}myserver`], regularTools, mcpServersMap),
+    );
+    expect(result.current.mcpServerNames).toEqual(['myserver']);
+    expect(result.current.toolIds).toEqual([]);
+  });
+
+  it('resolves an MCP tool id whose raw tool name itself contains the delimiter substring', () => {
+    // Regression test for https://github.com/danny-avila/LibreChat/issues/14440:
+    // a raw MCP tool name that already contains "_mcp_" (e.g. one exposed
+    // through a gateway that prefixes tool names by server) must still
+    // resolve to the real server name - the *last* segment, not
+    // `.split(delimiter)[1]`, which would grab the wrong (middle) segment
+    // once there's more than one occurrence.
+    const toolId = `gitlab-get${d}server_version${d}gitlab`;
+    const { result } = renderHook(() => useVisibleTools([toolId], regularTools, mcpServersMap));
+    expect(result.current.mcpServerNames).toEqual(['gitlab']);
+  });
+
+  it('keeps regular (non-MCP) tools separate from MCP server names', () => {
+    const { result } = renderHook(() =>
+      useVisibleTools(['web_search'], regularTools, mcpServersMap),
+    );
+    expect(result.current.toolIds).toEqual(['web_search']);
+    expect(result.current.mcpServerNames).toEqual([]);
+  });
+});

--- a/client/src/hooks/MCP/useVisibleTools.ts
+++ b/client/src/hooks/MCP/useVisibleTools.ts
@@ -29,7 +29,14 @@ export function useVisibleTools(
     for (const toolId of selectedToolIds ?? []) {
       // MCP tools/servers
       if (toolId.includes(Constants.mcp_delimiter)) {
-        const serverName = toolId.split(Constants.mcp_delimiter)[1];
+        // Split on the *last* occurrence, not `.split()[1]` - the raw tool
+        // name half (everything before the server-name suffix LibreChat
+        // appends) can itself legitimately contain the delimiter substring
+        // (e.g. a tool literally named `get_mcp_server_version`, or one
+        // already prefixed by an upstream gateway), which would otherwise
+        // shift the server name to the wrong index.
+        const delimiterIndex = toolId.lastIndexOf(Constants.mcp_delimiter);
+        const serverName = toolId.slice(delimiterIndex + Constants.mcp_delimiter.length);
         if (serverName) {
           mcpServers.add(serverName);
         }

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import type { ParsedServerConfig } from '~/mcp/types';
 import {
   buildOAuthToolCallName,
   normalizeServerName,
+  splitMCPToolKey,
   redactAllServerSecrets,
   redactServerSecrets,
   requiresUserScopedConnection,
@@ -42,6 +43,35 @@ describe('normalizeServerName', () => {
     const result = normalizeServerName('!server-name!');
     expect(result).toBe('server-name');
     expect(result).toMatch(/^[a-zA-Z0-9_.-]+$/);
+  });
+});
+
+describe('splitMCPToolKey', () => {
+  it('should return the tool name unchanged with an undefined server name when there is no delimiter', () => {
+    expect(splitMCPToolKey('plainToolName')).toEqual(['plainToolName', undefined]);
+  });
+
+  it('should split a normal single-occurrence key the same way String.split would', () => {
+    expect(splitMCPToolKey('search_mcp_myserver')).toEqual(['search', 'myserver']);
+  });
+
+  it('should resolve a raw tool name that itself contains the delimiter substring by using the last occurrence', () => {
+    // Regression test: a tool whose own (possibly gateway-prefixed) name
+    // already contains "_mcp_" - e.g. LiteLLM's MCP gateway prefixes
+    // aggregated tool names with "{server}-", so GitLab's own
+    // "get_mcp_server_version" tool becomes "gitlab-get_mcp_server_version"
+    // before LibreChat appends its own "_mcp_gitlab" suffix. A naive
+    // `.split(delimiter)` produces 3 segments here and silently drops the
+    // 3rd, yielding a bogus server name ("server_version" instead of
+    // "gitlab"). See https://github.com/danny-avila/LibreChat/issues/14440
+    expect(splitMCPToolKey('gitlab-get_mcp_server_version_mcp_gitlab')).toEqual([
+      'gitlab-get_mcp_server_version',
+      'gitlab',
+    ]);
+  });
+
+  it('should handle a raw tool name with multiple delimiter occurrences by always taking the last segment as the server name', () => {
+    expect(splitMCPToolKey('a_mcp_b_mcp_c_mcp_server')).toEqual(['a_mcp_b_mcp_c', 'server']);
   });
 });
 

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -362,6 +362,33 @@ export function normalizeServerName(serverName: string): string {
 }
 
 /**
+ * Splits a combined MCP tool key (`${rawToolName}${mcp_delimiter}${serverName}`)
+ * back into its two parts.
+ *
+ * Uses the *last* occurrence of the delimiter, not a plain `.split()`. The
+ * server-name half is always `normalizeServerName`'s output appended once by
+ * LibreChat itself; the raw tool-name half comes from the upstream MCP
+ * server and is untrusted - it can legitimately contain the delimiter
+ * substring itself (e.g. a tool literally named `get_mcp_server_version`,
+ * or one whose name was already prefixed by a gateway sitting in front of
+ * the MCP server, such as `gitlab-get_mcp_server_version`). A naive
+ * `toolKey.split(Constants.mcp_delimiter)` then produces more than two
+ * segments, and destructuring `[toolName, serverName]` silently keeps only
+ * the first two - yielding a `serverName` that doesn't match any configured
+ * server, so the tool resolves to nothing instead of erroring.
+ *
+ * `lastIndexOf` matches `.split()`'s result whenever the delimiter occurs
+ * exactly once, so this is a drop-in replacement for the normal case.
+ */
+export function splitMCPToolKey(toolKey: string): [string, string | undefined] {
+  const idx = toolKey.lastIndexOf(Constants.mcp_delimiter);
+  if (idx === -1) {
+    return [toolKey, undefined];
+  }
+  return [toolKey.slice(0, idx), toolKey.slice(idx + Constants.mcp_delimiter.length)];
+}
+
+/**
  * Builds the synthetic tool-call name used during MCP OAuth flows.
  * Format: `oauth<mcp_delimiter><normalizedServerName>`
  *


### PR DESCRIPTION
## Summary

Fixes #14440.

MCP tool keys are identified internally as `${rawToolName}${mcp_delimiter}${serverName}` (delimiter `_mcp_`). Several call sites parsed this back apart with a naive `toolKey.split(Constants.mcp_delimiter)`, assuming the delimiter occurs exactly once:

- `api/app/clients/tools/util/handleTools.js`
- `api/server/services/MCP.js` (`createMCPTool`)
- `api/server/controllers/mcp.js`
- `api/server/controllers/agents/v1.js` (`filterAuthorizedTools`)
- `client/src/hooks/MCP/useVisibleTools.ts`

When the *raw* upstream tool name itself contains the delimiter substring, the combined key has the delimiter more than once. This isn't exotic — it happens whenever a tool is exposed through a gateway that prefixes aggregated tool names by server (several MCP gateway/proxy implementations do this, e.g. `{server}-{tool}`), and the underlying tool's own name happens to contain `_mcp_` (as, ironically, `get_mcp_server_version` does). `.split()` then produces more than two segments, and destructuring `[toolName, serverName]` silently keeps only the first two, yielding a bogus server name that matches no configured server.

Tool *listing* still worked, because discovery goes through a different code path (the `mcp_all`/whole-server placeholder expansion) that builds keys directly rather than re-splitting an already-combined string. But actual tool *invocation* — reachable since #11588's event-driven lazy tool loading re-parses the model's own already-fully-qualified `tc.name` back through this same split logic — failed with `Tool {name} not found`, and `filterAuthorizedTools` rejected such keys outright as malformed before they ever got that far via the agent-tools path.

## Fix

Add `splitMCPToolKey` (`packages/api/src/mcp/utils.ts`, alongside `normalizeServerName`), which splits on the **last** occurrence of the delimiter instead of the first:

```ts
export function splitMCPToolKey(toolKey: string): [string, string | undefined] {
  const idx = toolKey.lastIndexOf(Constants.mcp_delimiter);
  if (idx === -1) {
    return [toolKey, undefined];
  }
  return [toolKey.slice(0, idx), toolKey.slice(idx + Constants.mcp_delimiter.length)];
}
```

This is safe because the server-name half is always LibreChat's own `normalizeServerName` output, appended once — it can't itself contain `_mcp_` given how server names are chosen in practice — while the raw tool-name half comes from the upstream MCP server and is untrusted. Taking the tail gives the identical result to today's `.split()` whenever the delimiter occurs exactly once (the normal case), and correctly resolves the collision case.

Updated all five call sites above to use it (four already had `@librechat/api` imports; the client hook gets an equivalent inline fix since it depends on `librechat-data-provider`, not `@librechat/api`).

Two other MCP-tool-authorization tests explicitly asserted the *old* behavior of rejecting any multi-delimiter key outright (`filterAuthorizedTools.spec.js`) — one of them (`should reject malformed MCP tool keys with multiple delimiters`) was deliberately named to probe a spoofing concern (crafting a key with an unrelated server name embedded earlier in the string). I kept that scenario but updated the assertion to what I believe is the correct invariant: only the **true last segment** is ever consulted for authorization (proven by including a case where the last segment is *not* authorized, and confirming it's still correctly rejected), so embedding arbitrary text earlier in the key does not let it resolve to a different server than the one actually checked — server-scoped authorization is unaffected. I'd appreciate a maintainer's judgment on whether that test's original intent needs anything further, since I don't have full context on why it was written that way.

## Test plan

- [x] Added a `splitMCPToolKey` unit test covering: no delimiter, single delimiter (normal case), multiple delimiters (collision case)
- [x] Added a regression test to `handleTools.test.js` reproducing the collision with a `gitlab-get_mcp_server_version_mcp_gitlab`-style key
- [x] Updated the two `filterAuthorizedTools.spec.js` tests whose assertions encoded the old (buggy) reject-on-collision behavior, and added one confirming multi-segment keys still can't be used to spoof a different, unauthorized server
- [x] Added a `useVisibleTools` test covering the same collision case on the client side
- [x] `npm run test:api`, `npm run test:packages:api`, and `npm run test:client` all pass (one unrelated, pre-existing flaky test in `auth.cloudfront.test.js` — confirmed passing in isolation, a `socket hang up` timing flake unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)