### PR TITLE
fix(cli): generate invite link when email service is disabled (#14433)

### DIFF
--- a/config/invite-user.js
+++ b/config/invite-user.js
@@ -21,12 +21,6 @@ const connect = require('./connect');
     console.purple('--------------------------');
   }
 
-  // Check if email service is enabled
-  if (!checkEmailConfig()) {
-    console.red('Error: Email service is not enabled!');
-    silentExit(1);
-  }
-
   // Get the email of the user to be invited
   let email = '';
   if (process.argv.length >= 3) {
@@ -54,6 +48,7 @@ const connect = require('./connect');
   const appName = process.env.APP_TITLE || 'LibreChat';
 
   if (!checkEmailConfig()) {
+    console.orange('Note: Email service is not enabled, invitation email will not be sent.');
     console.green('Send this link to the user:', inviteLink);
     silentExit(0);
   }


### PR DESCRIPTION
## Summary
Fixes #14433.

## Description
When running `npm run invite-user <email>` without SMTP configured (`checkEmailConfig()` returning `false`), the script previously failed early with `Error: Email service is not enabled!`.

However, lines 57-59 already had logic intended to handle disabled email service by printing the invite registration URL directly:
```js
if (!checkEmailConfig()) {
  console.green('Send this link to the user:', inviteLink);
  silentExit(0);
}
```

The early exit check at lines 25-28 prevented this logic from ever being reached. Removing the duplicate early check allows the CLI to generate the invite token and present the registration link to the administrator even when email service is disabled.

## Changes
- Removed premature `checkEmailConfig()` exit check prior to email prompt & token creation in `config/invite-user.js`.
- Added an informative note (`Note: Email service is not enabled, invitation email will not be sent.`) before displaying the generated invite link.