### PR TITLE
fix(files): add legacy application/msword to defaultOCRMimeTypes (fixes #14413)

### DIFF
--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -167,7 +167,8 @@ describe('defaultOCRMimeTypes', () => {
     'application/vnd.oasis.opendocument.spreadsheet',
     'application/vnd.oasis.opendocument.presentation',
     'application/vnd.oasis.opendocument.graphics',
-  ])('matches ODF type for OCR: %s', (mimeType) => {
+    'application/msword',
+  ])('matches OCR type: %s', (mimeType) => {
     expect(checkOCRType(mimeType)).toBe(true);
   });
 });

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -206,6 +206,7 @@ export const defaultOCRMimeTypes = [
   /^application\/pdf$/,
   /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
   /^application\/vnd\.ms-(word|powerpoint)$/,
+  /^application\/msword$/,
   /^application\/epub\+zip$/,
   /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
 ];


### PR DESCRIPTION
## Summary
Fixes #14413.

## Changes
- Add `/^application\/msword$/` regex to `defaultOCRMimeTypes` in `packages/data-provider/src/file-config.ts`
- Update test suite in `file-config.spec.ts` to verify `application/msword` matches OCR types