### PR TITLE
fix(cli): generate invite link when email service is disabled (fixes #14433)

### DIFF
--- a/config/invite-user.js
+++ b/config/invite-user.js
@@ -21,12 +21,6 @@ const connect = require('./connect');
     console.purple('--------------------------');
   }
 
-  // Check if email service is enabled
-  if (!checkEmailConfig()) {
-    console.red('Error: Email service is not enabled!');
-    silentExit(1);
-  }
-
   // Get the email of the user to be invited
   let email = '';
   if (process.argv.length >= 3) {
@@ -54,6 +48,7 @@ const connect = require('./connect');
   const appName = process.env.APP_TITLE || 'LibreChat';
 
   if (!checkEmailConfig()) {
+    console.orange('Note: Email service is not enabled, invitation email will not be sent.');
     console.green('Send this link to the user:', inviteLink);
     silentExit(0);
   }


### PR DESCRIPTION
## Summary
Fixes #14433.

## Changes
- Remove early `checkEmailConfig()` abort check at line 25 of `config/invite-user.js`.
- Allow the CLI script to prompt for user email, check for existing accounts, generate an invite token, and output the invite URL even when email service is not configured.
- Output an orange note (`Note: Email service is not enabled, invitation email will not be sent.`) alongside the generated invite link.