### PR TITLE
fix(files): add legacy application/msword to defaultOCRMimeTypes (fixes #14413)

### DIFF
--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -163,6 +163,7 @@ describe('defaultOCRMimeTypes', () => {
     defaultOCRMimeTypes.some((regex) => regex.test(mimeType));
 
   it.each([
+    'application/msword',
     'application/vnd.oasis.opendocument.text',
     'application/vnd.oasis.opendocument.spreadsheet',
     'application/vnd.oasis.opendocument.presentation',

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -206,6 +206,7 @@ export const defaultOCRMimeTypes = [
   /^application\/pdf$/,
   /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
   /^application\/vnd\.ms-(word|powerpoint)$/,
+  /^application\/msword$/,
   /^application\/epub\+zip$/,
   /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
 ];


### PR DESCRIPTION
## Summary
Fixes #14413.

## Changes
- Add `/^application\/msword$/` regex to `defaultOCRMimeTypes` in `packages/data-provider/src/file-config.ts`.
- Add `application/msword` test case to `packages/data-provider/src/file-config.spec.ts`.