### PR TITLE
HTTP server timeout configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,13 @@
 HOST=localhost
 PORT=3080
 
+# Optional Node.js HTTP server timeouts in milliseconds. When unset, Node.js defaults apply.
+# For an ALB, set the application keep-alive timeout above the ALB idle timeout.
+# HTTP_KEEP_ALIVE_TIMEOUT_MS=70000
+# HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS=5000
+# HTTP_HEADERS_TIMEOUT_MS=80000
+# HTTP_REQUEST_TIMEOUT_MS=300000
+
 MONGO_URI=mongodb://127.0.0.1:27017/LibreChat
 #The maximum number of connections in the connection pool. */
 MONGO_MAX_POOL_SIZE=

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -25,6 +25,7 @@ const {
   loadToolApprovalHooks,
   maybeInjectQueryDevtoolsBootstrap,
   preAuthTenantMiddleware,
+  configureServerTimeouts,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
@@ -468,7 +469,7 @@ if (cluster.isMaster) {
     app.use(ErrorController);
 
     /** Start listening on shared port (cluster will distribute connections) */
-    app.listen(port, host, async (err) => {
+    const server = app.listen(port, host, async (err) => {
       if (err) {
         logger.error(`Worker ${process.pid} failed to start server:`, err);
         process.exit(1);
@@ -496,6 +497,14 @@ if (cluster.isMaster) {
         logger.error(`Worker ${process.pid} post-listen initialization failed:`, initErr);
         process.exit(1);
       }
+    });
+
+    configureServerTimeouts(server);
+    logger.info(`Worker ${process.pid} HTTP server timeout configuration`, {
+      keepAliveTimeout: server.keepAliveTimeout,
+      keepAliveTimeoutBuffer: server.keepAliveTimeoutBuffer,
+      headersTimeout: server.headersTimeout,
+      requestTimeout: server.requestTimeout,
     });
   };
 

--- a/api/server/experimental.spec.js
+++ b/api/server/experimental.spec.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Experimental server configuration', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'experimental.js'), 'utf8');
+
+  it('configures HTTP timeouts for each cluster worker server', () => {
+    const listenIndex = source.indexOf('const server = app.listen');
+    const timeoutConfigIndex = source.indexOf('configureServerTimeouts(server);');
+
+    expect(listenIndex).toBeGreaterThan(-1);
+    expect(timeoutConfigIndex).toBeGreaterThan(-1);
+    expect(listenIndex).toBeLessThan(timeoutConfigIndex);
+  });
+});

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -27,6 +27,7 @@ const {
   loadToolApprovalHooks,
   maybeInjectQueryDevtoolsBootstrap,
   preAuthTenantMiddleware,
+  configureServerTimeouts,
   setupGracefulShutdown,
   updateInterfacePermissions,
 } = require('@librechat/api');
@@ -357,6 +358,14 @@ const startServer = async () => {
       logger.error('Post-listen initialization failed:', initErr);
       process.exit(1);
     }
+  });
+
+  configureServerTimeouts(server);
+  logger.info('HTTP server timeout configuration', {
+    keepAliveTimeout: server.keepAliveTimeout,
+    keepAliveTimeoutBuffer: server.keepAliveTimeoutBuffer,
+    headersTimeout: server.headersTimeout,
+    requestTimeout: server.requestTimeout,
   });
 
   setupGracefulShutdown(server);

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -98,6 +98,18 @@ describe('Startup readiness wiring', () => {
     expect(streamConfigIndex).toBeLessThan(postListenMcpIndex);
   });
 
+  it('configures HTTP timeouts before graceful shutdown handling', () => {
+    const listenIndex = source.indexOf('const server = app.listen');
+    const timeoutConfigIndex = source.indexOf('configureServerTimeouts(server);');
+    const shutdownIndex = source.indexOf('setupGracefulShutdown(server);');
+
+    expect(listenIndex).toBeGreaterThan(-1);
+    expect(timeoutConfigIndex).toBeGreaterThan(-1);
+    expect(shutdownIndex).toBeGreaterThan(-1);
+    expect(listenIndex).toBeLessThan(timeoutConfigIndex);
+    expect(timeoutConfigIndex).toBeLessThan(shutdownIndex);
+  });
+
   it('mounts the chat-start readiness gate before agent routes', () => {
     const readinessGateIndex = source.indexOf(
       "app.use('/api/agents/chat', rejectChatStartsUntilReady);",

--- a/packages/api/src/app/index.ts
+++ b/packages/api/src/app/index.ts
@@ -6,5 +6,6 @@ export * from './cdn';
 export * from './checks';
 export * from './resolve';
 export * from './shutdown';
+export * from './server';
 export { resolveBuildInfo } from './build';
 export type { BuildInfo } from './build';

--- a/packages/api/src/app/server.spec.ts
+++ b/packages/api/src/app/server.spec.ts
@@ -1,0 +1,56 @@
+import { createServer } from 'node:http';
+
+import { configureServerTimeouts } from './server';
+
+describe('configureServerTimeouts', () => {
+  it('preserves Node.js defaults when variables are unset', () => {
+    const server = createServer();
+    const defaults = {
+      keepAliveTimeout: server.keepAliveTimeout,
+      keepAliveTimeoutBuffer: server.keepAliveTimeoutBuffer,
+      headersTimeout: server.headersTimeout,
+      requestTimeout: server.requestTimeout,
+    };
+
+    configureServerTimeouts(server, {});
+
+    expect(server.keepAliveTimeout).toBe(defaults.keepAliveTimeout);
+    expect(server.keepAliveTimeoutBuffer).toBe(defaults.keepAliveTimeoutBuffer);
+    expect(server.headersTimeout).toBe(defaults.headersTimeout);
+    expect(server.requestTimeout).toBe(defaults.requestTimeout);
+  });
+
+  it('applies configured timeout values', () => {
+    const server = createServer();
+
+    configureServerTimeouts(server, {
+      HTTP_KEEP_ALIVE_TIMEOUT_MS: '70000',
+      HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS: '5000',
+      HTTP_HEADERS_TIMEOUT_MS: '80000',
+      HTTP_REQUEST_TIMEOUT_MS: '300000',
+    });
+
+    expect(server.keepAliveTimeout).toBe(70_000);
+    expect(server.keepAliveTimeoutBuffer).toBe(5_000);
+    expect(server.headersTimeout).toBe(80_000);
+    expect(server.requestTimeout).toBe(300_000);
+  });
+
+  it('ignores invalid values and permits zero to disable a timeout', () => {
+    const server = createServer();
+    const defaultKeepAliveTimeout = server.keepAliveTimeout;
+    const defaultHeadersTimeout = server.headersTimeout;
+
+    configureServerTimeouts(server, {
+      HTTP_KEEP_ALIVE_TIMEOUT_MS: '-1',
+      HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS: '0',
+      HTTP_HEADERS_TIMEOUT_MS: 'not-a-number',
+      HTTP_REQUEST_TIMEOUT_MS: '0',
+    });
+
+    expect(server.keepAliveTimeout).toBe(defaultKeepAliveTimeout);
+    expect(server.keepAliveTimeoutBuffer).toBe(0);
+    expect(server.headersTimeout).toBe(defaultHeadersTimeout);
+    expect(server.requestTimeout).toBe(0);
+  });
+});

--- a/packages/api/src/app/server.ts
+++ b/packages/api/src/app/server.ts
@@ -1,12 +1,5 @@
 import type { Server } from 'node:http';
 
-interface HttpServerEnvironment {
-  HTTP_KEEP_ALIVE_TIMEOUT_MS?: string;
-  HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS?: string;
-  HTTP_HEADERS_TIMEOUT_MS?: string;
-  HTTP_REQUEST_TIMEOUT_MS?: string;
-}
-
 const parseTimeout = (value?: string): number | undefined => {
   if (value == null || value.trim() === '') {
     return undefined;
@@ -18,7 +11,7 @@ const parseTimeout = (value?: string): number | undefined => {
 
 export const configureServerTimeouts = (
   server: Server,
-  environment: HttpServerEnvironment = process.env,
+  environment: NodeJS.ProcessEnv = process.env,
 ): void => {
   const keepAliveTimeout = parseTimeout(environment.HTTP_KEEP_ALIVE_TIMEOUT_MS);
   const keepAliveTimeoutBuffer = parseTimeout(environment.HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS);

--- a/packages/api/src/app/server.ts
+++ b/packages/api/src/app/server.ts
@@ -1,0 +1,40 @@
+import type { Server } from 'node:http';
+
+interface HttpServerEnvironment {
+  HTTP_KEEP_ALIVE_TIMEOUT_MS?: string;
+  HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS?: string;
+  HTTP_HEADERS_TIMEOUT_MS?: string;
+  HTTP_REQUEST_TIMEOUT_MS?: string;
+}
+
+const parseTimeout = (value?: string): number | undefined => {
+  if (value == null || value.trim() === '') {
+    return undefined;
+  }
+
+  const timeout = Number(value);
+  return Number.isSafeInteger(timeout) && timeout >= 0 ? timeout : undefined;
+};
+
+export const configureServerTimeouts = (
+  server: Server,
+  environment: HttpServerEnvironment = process.env,
+): void => {
+  const keepAliveTimeout = parseTimeout(environment.HTTP_KEEP_ALIVE_TIMEOUT_MS);
+  const keepAliveTimeoutBuffer = parseTimeout(environment.HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS);
+  const headersTimeout = parseTimeout(environment.HTTP_HEADERS_TIMEOUT_MS);
+  const requestTimeout = parseTimeout(environment.HTTP_REQUEST_TIMEOUT_MS);
+
+  if (keepAliveTimeout != null) {
+    server.keepAliveTimeout = keepAliveTimeout;
+  }
+  if (keepAliveTimeoutBuffer != null) {
+    server.keepAliveTimeoutBuffer = keepAliveTimeoutBuffer;
+  }
+  if (headersTimeout != null) {
+    server.headersTimeout = headersTimeout;
+  }
+  if (requestTimeout != null) {
+    server.requestTimeout = requestTimeout;
+  }
+};


### PR DESCRIPTION
## Summary

Add optional environment variables for configuring the Node.js HTTP server timeouts used by LibreChat:

```env
HTTP_KEEP_ALIVE_TIMEOUT_MS
HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS
HTTP_HEADERS_TIMEOUT_MS
HTTP_REQUEST_TIMEOUT_MS
```

## Motivation

LibreChat is commonly deployed behind reverse proxies, ingress controllers, CDNs, and load balancers. These components maintain their own connection pools and timeout settings, which may differ from Node.js defaults.

In particular, Node.js uses a relatively short default HTTP keep-alive timeout. If an upstream proxy keeps backend connections for longer than the application, the proxy may attempt to reuse a connection while Node.js is closing it. Depending on timing and infrastructure, this can result in intermittent connection resets or proxy-generated `502 Bad Gateway` responses even though the application process remains healthy.

Allowing operators to align application and infrastructure timeouts helps ensure that the proxy closes idle connections before the application does. A common ordering is:

```text
Proxy idle timeout
    < Node keepAliveTimeout
    < keepAliveTimeout + keepAliveTimeoutBuffer
```

The additional settings are useful for deployments with different traffic characteristics:

- `HTTP_KEEP_ALIVE_TIMEOUT_MS` controls how long Node waits for another request after completing the previous response on a persistent connection.
- `HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS` extends Node’s internal socket timeout beyond the advertised keep-alive timeout, reducing reset races at the timeout boundary.
- `HTTP_HEADERS_TIMEOUT_MS` controls how long Node waits to receive complete request headers.
- `HTTP_REQUEST_TIMEOUT_MS` controls how long Node permits receipt of the complete request.

This makes the HTTP server adaptable to different proxies, long-running workloads, security requirements, and organizational infrastructure standards without requiring source-code changes.

## Behavior

Only explicitly configured, non-negative integer values are applied:

```env
HTTP_KEEP_ALIVE_TIMEOUT_MS=70000
HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS=5000
HTTP_HEADERS_TIMEOUT_MS=80000
HTTP_REQUEST_TIMEOUT_MS=300000
```

If no variables are configured, LibreChat continues to use the defaults provided by its current Node.js runtime. This preserves existing behavior and allows future Node.js default changes to remain effective.

Invalid values are ignored, leaving the corresponding runtime default unchanged. A value of `0` is supported where Node.js uses it to disable the associated timeout behavior.

The effective values are logged on startup:

```text
HTTP server timeout configuration
```

This allows operators to confirm that deployment-level environment variables reached the running application.

## Implementation

- Adds a typed HTTP server configuration helper in `packages/api`.
- Applies the configuration immediately after `app.listen()` creates the HTTP server.
- Keeps the legacy JavaScript server integration minimal.
- Documents the optional variables in `.env.example`.

- Adds tests covering:
  - Preservation of Node.js defaults
  - Application of configured values
  - Invalid-value handling
  - Zero-value handling
  - Server startup wiring

## Operational guidance

Values should be selected according to the surrounding infrastructure. For example, when a reverse proxy has an idle timeout of 65 seconds, a possible configuration is:

```env
HTTP_KEEP_ALIVE_TIMEOUT_MS=70000
HTTP_KEEP_ALIVE_TIMEOUT_BUFFER_MS=5000
HTTP_HEADERS_TIMEOUT_MS=80000
```

This example is not intended as a universal default. Operators should account for their proxy configuration, expected request duration, streaming behavior, and security requirements.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Testing has been done in our prod with 15000 users

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

Peter Rothlaender [ginkgo.rothlaender@external.daimlertruck.com](mailto:ginkgo.rothlaender@external.daimlertruck.com) on behalf of Daimler Truck AG.
[Provider & Legal Notice | Daimler Truck](https://www.daimlertruck.com/en/provider-legal-notice)
Copyright (c) {2026} Daimler Truck AG