### PR TITLE
🍃 chore: Bump Mongoose to 8.24.1 to Patch Prototype Pollution

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -102,7 +102,7 @@
     "mime": "^3.0.0",
     "module-alias": "^2.2.3",
     "mongodb": "^6.14.2",
-    "mongoose": "^8.23.1",
+    "mongoose": "^8.24.1",
     "multer": "^2.2.0",
     "nanoid": "^3.3.7",
     "node-fetch": "^2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "mime": "^3.0.0",
         "module-alias": "^2.2.3",
         "mongodb": "^6.14.2",
-        "mongoose": "^8.23.1",
+        "mongoose": "^8.24.1",
         "multer": "^2.2.0",
         "nanoid": "^3.3.7",
         "node-fetch": "^2.7.0",
@@ -33704,9 +33704,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.1.tgz",
-      "integrity": "sha512-gHSPD8qEwRmiXapK17hEnFWZdcFENMegHTcw5XIIg2+7R8eXQvdwSiMpD/A2oG8tKzFLLHyRXd8/eaDPAVwZgQ==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -43738,7 +43738,7 @@
         "mathjs": "^15.2.0",
         "memorystore": "^1.6.7",
         "mongodb": "^6.14.2",
-        "mongoose": "^8.23.1",
+        "mongoose": "^8.24.1",
         "nanoid": "^3.3.7",
         "node-fetch": "2.7.0",
         "pdfjs-dist": "^5.4.624",
@@ -46124,7 +46124,7 @@
         "librechat-data-provider": "*",
         "lodash": "^4.17.23",
         "meilisearch": "^0.38.0",
-        "mongoose": "^8.23.1",
+        "mongoose": "^8.24.1",
         "nanoid": "^3.3.7",
         "winston": "^3.17.0",
         "winston-daily-rotate-file": "^5.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -155,7 +155,7 @@
     "mathjs": "^15.2.0",
     "memorystore": "^1.6.7",
     "mongodb": "^6.14.2",
-    "mongoose": "^8.23.1",
+    "mongoose": "^8.24.1",
     "nanoid": "^3.3.7",
     "node-fetch": "2.7.0",
     "pdfjs-dist": "^5.4.624",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -80,7 +80,7 @@
     "librechat-data-provider": "*",
     "lodash": "^4.17.23",
     "meilisearch": "^0.38.0",
-    "mongoose": "^8.23.1",
+    "mongoose": "^8.24.1",
     "nanoid": "^3.3.7",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0"


### PR DESCRIPTION
## Summary

I bumped `mongoose` from 8.23.1 to 8.24.1 across the three workspaces that declare it. This is a security patch rather than routine maintenance: 8.23.1 is affected by [GHSA-664h-wqgq-64gw](https://github.com/advisories/GHSA-664h-wqgq-64gw), a moderate-severity prototype pollution (CVSS 6.5, CWE-1321) in update casting via a `__proto__`-prefixed dotted path in `Schema._getSchema`. The affected range is `>=8.0.0 <8.24.1`, and `npm audit` flags it on the current lockfile.

- Updated the `mongoose` range to `^8.24.1` in `api/package.json`, `packages/api/package.json`, and `packages/data-schemas/package.json`, and refreshed `package-lock.json`.
- Confirmed the vulnerability is real and the patch works, rather than relying on the advisory alone. On 8.23.1, casting `{ $set: { '__proto__.x': ... } }` sets `$fullPath` on `Object.prototype`; on 8.24.1 it does not.
- Verified `npm audit` drops `mongoose` from its findings, taking moderate advisories from 3 to 2.
- Scoped the blast radius: the range spans only 8.24.0 and 8.24.1, carries no breaking changes, and resolves to identical transitive dependencies (`mongodb ~6.20.0`, `bson ^6.10.4`), so there is no driver bump involved.

Worth noting that this repo is not exploitable through the advisory's vector. The attack requires a user-controlled object reaching an update operation, and no update call here takes a raw `req.body`. The one route that forwards a body, `updateConversationTag`, destructures and rebuilds an allowlisted `updateData`, and `skillStates` is validated and pruned to known skill ids before it is written under a fixed key. This bump therefore clears a real audit finding and removes the footgun, but does not close a live hole.

I also checked the four behavior fixes in 8.24.1 against actual usage. None of them apply: there are no maps of subdocuments (both `type: Map` fields are `of: Boolean` and `of: Mixed`), no `.watch()` change streams, no document `.clone()`, and no document-array reorder-then-save.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The meaningful risk in this bump is the `types:` changes present in both releases affecting the TypeScript build, so I targeted verification there rather than at runtime.

- Typechecked `packages/data-schemas` and `packages/api` with `tsc --noEmit`. Both are clean.
- Built both packages successfully, including the mongoose-typed `.d.ts` emit from `data-schemas`.
- Ran the full `packages/data-schemas` suite: 53/53 suites, 1865/1865 tests passing against real `mongodb-memory-server` instances.
- Ran the full `packages/api` suite: 280/280 suites, 7326 passing, 10 skipped.
- Reproduced the CVE with a before/after control to prove the fix, as described above.

To reproduce:

```bash
npm install && npm run build
cd packages/data-schemas && npx jest --ci
cd ../api && npx jest --ci --testPathIgnorePatterns="\.*integration\.|\.*helper\.|__tests__/helpers/|\.*manual\.spec\."
```

One note for anyone re-running this in a fresh worktree: build the workspace packages first. Without a built `data-provider` and `data-schemas` dist, jest reports large numbers of failed suites with `Cannot find module '@librechat/data-schemas'` while every test that actually runs passes. That signature is stale dist, not a regression from this bump.

### **Test Configuration**:

- Node.js v24.16.0, macOS
- mongoose 8.24.1, mongodb driver 6.20.0 (unchanged)
- `mongodb-memory-server` for the data-schemas suite

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
