### PR TITLE
🗺️ chore: Bump PostCSS to 8.5.18 to Patch Source Map Traversal

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -159,7 +159,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "jest-file-loader": "^1.0.3",
     "jest-junit": "^17.0.0",
-    "postcss": "^8.4.31",
+    "postcss": "^8.5.18",
     "postcss-preset-env": "^11.2.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,7 +1050,7 @@
         "jest-environment-jsdom": "^30.2.0",
         "jest-file-loader": "^1.0.3",
         "jest-junit": "^17.0.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.18",
         "postcss-preset-env": "^11.2.0",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.9.3",
@@ -33812,9 +33812,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -35244,9 +35244,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -35263,7 +35263,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "elliptic": "^6.6.1",
     "form-data": "^4.0.6",
     "langsmith": "^0.6.0",
-    "postcss": "^8.5.13",
+    "postcss": "^8.5.18",
     "tslib": "^2.8.1",
     "fast-xml-parser": "5.7.2",
     "serialize-javascript": "7.0.5",


### PR DESCRIPTION
## Summary

I raised the `postcss` floor from 8.5.13 to 8.5.18 to close [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), the one high-severity finding `npm audit` reported on this repo. It is a path traversal in previous source map auto-loading (CVSS 7.5, CWE-22): PostCSS parses `/*# sourceMappingURL=... */` comments by default and loads the referenced file, so a traversal sequence reads arbitrary `.map` files outside the intended directory. The affected range is `<=8.5.17`, patched in 8.5.18.

- Raised the `postcss` entry in the root `overrides` block, which is what governs the single resolved copy across the whole workspace tree, and raised the `client` devDependency floor to match.
- Aligned both declarations at `^8.5.18`, the patched boundary, which resolves to 8.5.23.
- Confirmed the tree still collapses to exactly one `postcss` copy after the bump, so the override is doing its job and no transitive copy lingers on a vulnerable version.
- Verified `npm audit` drops from 9 vulnerabilities (6 low, 2 moderate, 1 high) to 8 (6 low, 2 moderate), clearing the only high.

I reproduced the vulnerability rather than trusting the advisory. Processing CSS whose `sourceMappingURL` points at `../../secret/private.css.map` loads that out-of-tree file on 8.5.13 and returns its contents as the previous map; on 8.5.23 nothing is loaded.

| | 8.5.13 | 8.5.23 |
| --- | --- | --- |
| Out-of-tree `.map` loaded via `../../` | yes, 106 bytes | no |

Worth noting this is not reachable in production. PostCSS is build-time only here: it appears in `client/postcss.config.cjs` behind `postcss-import`, `postcss-preset-env`, `tailwindcss`, and `autoprefixer`, and there is no runtime `postcss` import anywhere in `api`, `client/src`, or `packages/*/src`. The pipeline only ever processes first-party stylesheets, never attacker-supplied CSS. So this clears a real audit high and removes the footgun without closing a live hole.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

PostCSS sits directly in the CSS build pipeline, so the meaningful risk is a broken or silently degraded stylesheet rather than anything at runtime. I verified the emitted CSS rather than just that the command exited zero.

- Ran the full `npm run frontend` build (data-provider, data-schemas, api, client-package, then the client Vite build). It completes successfully.
- Confirmed the CSS output is intact and the plugin chain still ran: 243 KB main bundle plus a 28 KB KaTeX bundle, 2820 Tailwind custom properties, 33 media queries, and 86 autoprefixer vendor prefixes.
- Reproduced the CVE with the before/after control described above.
- Confirmed a single `postcss` copy resolves in `node_modules` at 8.5.23.

To reproduce:

```bash
npm install
npm run frontend
npm audit
```

### **Test Configuration**:

- Node.js v24.16.0, macOS
- postcss resolves to 8.5.23 via the root `overrides` entry
- Client toolchain unchanged: `postcss-preset-env` 11.2.0, `tailwindcss` 3.4.1, Vite 8

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
