### PR TITLE
fix(ocr): correct MIME type regex for .doc files in defaultOCRMimeTypes

### DIFF
--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -170,6 +170,18 @@ describe('defaultOCRMimeTypes', () => {
   ])('matches ODF type for OCR: %s', (mimeType) => {
     expect(checkOCRType(mimeType)).toBe(true);
   });
+
+  it('matches application/msword (.doc) for OCR', () => {
+    expect(checkOCRType('application/msword')).toBe(true);
+  });
+
+  it('matches application/vnd.ms-powerpoint (.ppt) for OCR', () => {
+    expect(checkOCRType('application/vnd.ms-powerpoint')).toBe(true);
+  });
+
+  it('does not match the non-existent application/vnd.ms-word type', () => {
+    expect(checkOCRType('application/vnd.ms-word')).toBe(false);
+  });
 });
 
 describe('supportedMimeTypes', () => {

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -205,7 +205,7 @@ export const defaultOCRMimeTypes = [
   excelMimeTypes,
   /^application\/pdf$/,
   /^application\/vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation)$/,
-  /^application\/vnd\.ms-(word|powerpoint)$/,
+  /^application\/(msword|vnd\.ms-powerpoint)$/,
   /^application\/epub\+zip$/,
   /^application\/vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)$/,
 ];


### PR DESCRIPTION
## Problem

`defaultOCRMimeTypes` in `packages/data-provider/src/file-config.ts` contained the regex:

```ts
/^application\/vnd\.ms-(word|powerpoint)$/
```

The `word` branch of that regex matches `application/vnd.ms-word`, which is not a real MIME type. The actual MIME type for legacy `.doc` files is `application/msword` (no `vnd` prefix), so `.doc` uploads were silently excluded from OCR processing despite the project correctly mapping `application/msword` everywhere else in the codebase (see `inferMimeType`, `mimeTypeToExtension`, and `baseFileConfig.checkType` - all of which handle `application/msword` correctly).

`application/vnd.ms-powerpoint` for `.ppt` files was already correct and is preserved by this change.

## Fix

Changed the regex to:

```ts
/^application\/(msword|vnd\.ms-powerpoint)$/
```

This matches `application/msword` for `.doc` files and `application/vnd.ms-powerpoint` for `.ppt` files, consistent with the rest of the codebase.

## Tests

Added three regression tests to the `defaultOCRMimeTypes` describe block:

- `application/msword` is accepted (was previously rejected)
- `application/vnd.ms-powerpoint` is still accepted
- `application/vnd.ms-word` is rejected (the non-existent type the old regex matched)

Fixes #14413