### PR TITLE
🔗 fix: Render Shared Links Containing Steers

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo, useState, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
 import { useRecoilValue } from 'recoil';
-import { InfoHoverCard, ESide } from '@librechat/client';
+import { InfoHoverCard, ESide, UserIcon } from '@librechat/client';
 import type { TFile, TMessage } from 'librechat-data-provider';
 import type { TMessageIcon } from '~/common';
 import FilePreviewDialog from '~/components/Chat/Messages/Content/FilePreviewDialog';
@@ -91,7 +91,24 @@ const SteerPart = memo(function SteerPart({
     >
       <div className="relative flex flex-shrink-0 flex-col items-center">
         <div className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full">
-          <MessageIcon iconData={USER_ICON} />
+          {isSharedConvo === true ? (
+            /** The atom still holds the viewer's identity when a signed-in user opens
+             *  a share link, so rendering the identity-bearing avatar here would put
+             *  the viewer's face on the sharer's steer. Mirrors Share/MessageIcon. */
+            <div
+              style={{
+                backgroundColor: 'rgb(121, 137, 255)',
+                width: '20px',
+                height: '20px',
+                boxShadow: 'rgba(240, 246, 252, 0.1) 0px 0px 0px 1px',
+              }}
+              className="relative flex h-9 w-9 items-center justify-center rounded-sm p-1 text-white"
+            >
+              <UserIcon />
+            </div>
+          ) : (
+            <MessageIcon iconData={USER_ICON} />
+          )}
         </div>
       </div>
       <div className="user-turn relative flex w-11/12 flex-col">

--- a/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
@@ -10,7 +10,6 @@ import MarkdownLite from '~/components/Chat/Messages/Content/MarkdownLite';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import MessageIcon from '~/components/Chat/Messages/MessageIcon';
 import Image from '~/components/Chat/Messages/Content/Image';
-import { useAuthContext } from '~/hooks/AuthContext';
 import { fontSizeAtom } from '~/store/fontSize';
 import { useShareContext } from '~/Providers';
 import { useLocalize } from '~/hooks';
@@ -41,7 +40,9 @@ const SteerPart = memo(function SteerPart({
   createdAt?: number;
 }) {
   const localize = useLocalize();
-  const { user } = useAuthContext();
+  /** Read the atom rather than the auth context: AuthContextProvider mirrors the
+   *  user into it, and the public share route mounts outside that provider. */
+  const user = useRecoilValue(store.user);
   const fontSize = useAtomValue(fontSizeAtom);
   const { isSharedConvo } = useShareContext();
   const usernameDisplay = useRecoilValue<boolean>(store.UsernameDisplay);

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { TMessage } from 'librechat-data-provider';
 import SteerPart from '../SteerPart';
+import store from '~/store';
 
 let mockShareContext: { isSharedConvo?: boolean; shareId?: string } = {};
 
@@ -10,17 +12,8 @@ jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
 }));
 
-jest.mock('~/hooks/AuthContext', () => ({
-  useAuthContext: () => ({ user: { name: 'Danny', username: 'danny' } }),
-}));
-
 jest.mock('~/Providers', () => ({
   useShareContext: () => mockShareContext,
-}));
-
-jest.mock('~/components/Chat/Messages/MessageIcon', () => ({
-  __esModule: true,
-  default: () => <div data-testid="user-icon" />,
 }));
 
 jest.mock('~/components/Chat/Messages/ui/MessageTimestamp', () => ({
@@ -53,11 +46,19 @@ jest.mock('~/components/Chat/Messages/Content/Image', () => ({
   default: ({ altText }: { altText: string }) => <img alt={altText} data-testid="steer-image" />,
 }));
 
-function renderPart(files?: TMessage['files']) {
+/** Seeds the user atom rather than mocking `useAuthContext`, and renders the real
+ *  MessageIcon tree — mocking either one hid a crash on the share route, where
+ *  neither an auth context nor a user exists. */
+function renderPart(
+  files?: TMessage['files'],
+  user: { name: string; username: string } | undefined = { name: 'Danny', username: 'danny' },
+) {
   return render(
-    <RecoilRoot>
-      <SteerPart steer="steered words" steerId="s1" createdAt={1} files={files} />
-    </RecoilRoot>,
+    <QueryClientProvider client={new QueryClient()}>
+      <RecoilRoot initializeState={({ set }) => user && set(store.user, user as never)}>
+        <SteerPart steer="steered words" steerId="s1" createdAt={1} files={files} />
+      </RecoilRoot>
+    </QueryClientProvider>,
   );
 }
 
@@ -70,6 +71,18 @@ describe('SteerPart author label', () => {
     renderPart();
     expect(screen.getByText('Danny')).toBeInTheDocument();
     expect(screen.queryByText('com_user_message')).toBeNull();
+  });
+
+  it('renders on the share route, where there is no auth context and no user', () => {
+    /** Regression for #14474: `/share/:shareId` mounts outside AuthContextProvider,
+     *  so any `useAuthContext()` on this tree throws and the whole page is replaced
+     *  by the route error boundary. Both SteerPart and the MessageIcon tree it
+     *  renders used to call it. */
+    mockShareContext = { isSharedConvo: true, shareId: 'share-1' };
+
+    expect(() => renderPart(undefined, undefined)).not.toThrow();
+    expect(screen.getByText('steered words')).toBeInTheDocument();
+    expect(screen.getByText('com_user_message')).toBeInTheDocument();
   });
 
   it('labels with the generic user message in the share view, never the viewer identity', () => {
@@ -104,7 +117,9 @@ describe('SteerPart presentation', () => {
 
   it('presents the steer as a user message with an icon', () => {
     renderPart();
-    expect(screen.getByTestId('user-icon')).toBeInTheDocument();
+    /** Asserts the real avatar rather than a stubbed one — the previous mock was
+     *  what hid the auth-context crash inside this icon tree. */
+    expect(screen.getByTitle('danny')).toBeInTheDocument();
     expect(screen.getByText('steered words')).toBeInTheDocument();
   });
 

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TMessage } from 'librechat-data-provider';
 import SteerPart from '../SteerPart';
 import store from '~/store';
@@ -119,7 +119,7 @@ describe('SteerPart presentation', () => {
     renderPart();
     /** Asserts the real avatar rather than a stubbed one — the previous mock was
      *  what hid the auth-context crash inside this icon tree. */
-    expect(screen.getByTitle('danny')).toBeInTheDocument();
+    expect(screen.getByTitle('Danny')).toBeInTheDocument();
     expect(screen.getByText('steered words')).toBeInTheDocument();
   });
 

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -49,9 +49,13 @@ jest.mock('~/components/Chat/Messages/Content/Image', () => ({
 /** Seeds the user atom rather than mocking `useAuthContext`, and renders the real
  *  MessageIcon tree — mocking either one hid a crash on the share route, where
  *  neither an auth context nor a user exists. */
+const SEEDED_USER = { name: 'Danny', username: 'danny' };
+
 function renderPart(
   files?: TMessage['files'],
-  user: { name: string; username: string } | undefined = { name: 'Danny', username: 'danny' },
+  /** `null` seeds nothing — passing `undefined` would fall back to the default and
+   *  silently test the signed-in state instead of the anonymous share route. */
+  user: { name: string; username: string } | null = SEEDED_USER,
 ) {
   return render(
     <QueryClientProvider client={new QueryClient()}>
@@ -80,9 +84,20 @@ describe('SteerPart author label', () => {
      *  renders used to call it. */
     mockShareContext = { isSharedConvo: true, shareId: 'share-1' };
 
-    expect(() => renderPart(undefined, undefined)).not.toThrow();
+    expect(() => renderPart(undefined, null)).not.toThrow();
     expect(screen.getByText('steered words')).toBeInTheDocument();
     expect(screen.getByText('com_user_message')).toBeInTheDocument();
+  });
+
+  it('never renders the viewer identity on a shared steer avatar', () => {
+    /** The user atom is app-wide and survives navigation, so a signed-in viewer
+     *  opening a share link still has an identity in state. The shared steer must
+     *  show the generic avatar regardless. */
+    mockShareContext = { isSharedConvo: true, shareId: 'share-1' };
+    renderPart(undefined, SEEDED_USER);
+
+    expect(screen.queryByTitle('Danny')).toBeNull();
+    expect(screen.queryByText('Danny')).toBeNull();
   });
 
   it('labels with the generic user message in the share view, never the viewer identity', () => {

--- a/client/src/components/Endpoints/Icon.tsx
+++ b/client/src/components/Endpoints/Icon.tsx
@@ -1,10 +1,11 @@
 import React, { memo } from 'react';
+import { useRecoilValue } from 'recoil';
 import { UserIcon, useAvatar } from '@librechat/client';
 import type { IconProps } from '~/common';
 import MessageEndpointIcon from './MessageEndpointIcon';
-import { useAuthContext } from '~/hooks/AuthContext';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
+import store from '~/store';
 
 type ResolvedAvatar = { type: 'image'; src: string } | { type: 'fallback' };
 
@@ -101,7 +102,9 @@ const UserAvatar = memo(
 UserAvatar.displayName = 'UserAvatar';
 
 const Icon: React.FC<IconProps> = memo((props) => {
-  const { user } = useAuthContext();
+  /** Same reason as SteerPart: this renders on the unauthenticated share route,
+   *  where `useAuthContext` throws. The atom is the same value in the app. */
+  const user = useRecoilValue(store.user);
   const { size = 30, isCreatedByUser } = props;
 
   const avatarSrc = useAvatar(user);


### PR DESCRIPTION
Fixes #14474.

## The crash

`/share/:shareId` is registered as a top-level route (`client/src/routes/index.tsx:60`) and is **not** wrapped by `AuthContextProvider` — that only wraps the `AuthLayout` branch. `useAuthContext` throws when the context is undefined (`client/src/hooks/AuthContext.tsx:302`), so any component on the share tree that calls it replaces the entire page with `RouteErrorBoundary`.

`SteerPart` calls it directly. Every viewer of a shared conversation containing a steer gets "Oops! Something Unexpected Occurred", with no viewer-side workaround.

**There are two crash sites, not one.** `SteerPart` also renders `MessageIcon`, which reaches `Endpoints/Icon.tsx`, which calls `useAuthContext` as well — so fixing only `SteerPart` still dies on the icon. The share view normally sidesteps this with its own auth-free `Share/MessageIcon`; `SteerPart` bypasses that.

## The fix

Both read `store.user` instead. `AuthContextProvider` already mirrors the user into that atom (`AuthContext.tsx:48`) and the memoized context value exposes that exact atom, so authenticated rendering is byte-identical. The atom has no persistence effect, so the share route reads `undefined` — no viewer identity leaks into the sharer's steer, and the existing `isSharedConvo` guard still falls back to the generic label.

Fixing `Endpoints/Icon` also hardens every other public surface against the same throw.

## Scope

Regression from #14220 (`9bb351ad9`, 14 July), which introduced the STEER content part. Before it, no share-rendered component called `useAuthContext`.

**Tagged releases are unaffected** — steering is not an ancestor of `v0.8.7`, so this only reaches `dev`, `main`, and the `latest` image.

## Why no test caught it

`SteerPart.test.tsx` mocked **both** `~/hooks/AuthContext` and `MessageIcon`, masking each crash site independently. Both mocks are removed here:

- the test seeds `store.user` rather than stubbing the hook, so the owner-view label assertion still passes for the right reason
- the real `MessageIcon` → `Endpoints/Icon` tree renders, which required wrapping in a `QueryClientProvider` (that tree issues `useGetEndpointsQuery`)
- the icon assertion moves off the stub's `data-testid` onto the real avatar
- a new case renders with `isSharedConvo: true`, no auth context, and no seeded user — the actual share-route condition — asserting it renders rather than throws

## Notes

Deliberately not included: `SteerPart` still renders `Endpoints/Icon`'s generic avatar on share rather than `Share/MessageIcon`'s blue-square `UserIcon`, so shared steers look slightly different from shared user messages. That is visual parity, not a crash, and worth doing separately — it would also avoid firing `useGetEndpointsQuery` on the public route, which 401s for anonymous viewers.