### PR TITLE
feat: bill MCP tool provider costs against the user balance

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -16,7 +16,9 @@ const {
 } = require('@librechat/agents');
 const {
   sendEvent,
+  getBalanceConfig,
   computeUsageCostUSD,
+  getTransactionsConfig,
   GenerationJobManager,
   writeAttachmentEvent,
   createToolExecuteHandler,
@@ -26,6 +28,54 @@ const {
   shouldSignalSandboxStart,
   getToolInputValidationDetails,
 } = require('@librechat/api');
+
+/** LibreChat convention: 1,000,000 token credits = 1 USD. */
+const CREDITS_PER_USD = 1_000_000;
+
+/**
+ * Bills a provider cost an MCP tool reported for itself (result `_meta.cost`) against the
+ * user's balance, so spend that happens outside the LLM - image generation, transcription,
+ * a paid search API - is accounted for like token spend instead of being invisible.
+ *
+ * Recorded through `spendTokens` with a 1 credit-per-token rate, so the USD figure maps
+ * straight onto credits and shows up in `transactions` with the tool as the model label.
+ * No-ops unless the deployment has balance or transactions enabled, and ignores a missing
+ * or non-positive amount.
+ */
+async function recordToolCost({ req, cost, toolName, metadata }) {
+  const userId = req?.user?.id;
+  const usd = Number(cost?.usd);
+  if (!userId || !Number.isFinite(usd) || usd <= 0) {
+    return null;
+  }
+  const appConfig = req?.config;
+  const balance = getBalanceConfig(appConfig);
+  const transactions = getTransactionsConfig(appConfig);
+  if (!balance?.enabled && transactions?.enabled === false) {
+    return null;
+  }
+  const model = cost.model || toolName;
+  const credits = Math.round(usd * CREDITS_PER_USD);
+  /* Lazy require: pulling ~/models at module load creates a circular dependency
+   * (models/index.js) that breaks this module's consumers. */
+  const { spendTokens } = require('~/models');
+  await spendTokens(
+    {
+      user: userId,
+      model,
+      conversationId: metadata?.thread_id,
+      messageId: metadata?.run_id,
+      context: 'mcp_tool',
+      balance,
+      transactions,
+      endpointTokenConfig: { [model]: { prompt: 1, completion: 1 } },
+    },
+    { completionTokens: credits },
+  );
+  logger.debug('[recordToolCost] Billed MCP tool cost', { userId, model, usd, credits });
+  return null;
+}
+
 const { processFileCitations } = require('~/server/services/Files/Citations');
 const { processCodeOutput, runPreviewFinalize } = require('~/server/services/Files/Code/process');
 const { saveBase64Image } = require('~/server/services/Files/process');
@@ -740,6 +790,20 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null, jo
       return;
     }
 
+    if (output.artifact.cost) {
+      artifactPromises.push(
+        recordToolCost({
+          req,
+          cost: output.artifact.cost,
+          toolName: output.name,
+          metadata,
+        }).catch((error) => {
+          logger.error('[recordToolCost] Error billing MCP tool cost:', error);
+          return null;
+        }),
+      );
+    }
+
     if (output.artifact[Tools.file_search]) {
       artifactPromises.push(
         (async () => {
@@ -1078,6 +1142,20 @@ function createResponsesToolEndCallback({ req, res, tracker, artifactPromises })
 
     if (!output.artifact) {
       return;
+    }
+
+    if (output.artifact.cost) {
+      artifactPromises.push(
+        recordToolCost({
+          req,
+          cost: output.artifact.cost,
+          toolName: output.name,
+          metadata,
+        }).catch((error) => {
+          logger.error('[recordToolCost] Error billing MCP tool cost:', error);
+          return null;
+        }),
+      );
     }
 
     if (output.artifact[Tools.file_search]) {

--- a/packages/api/src/mcp/__tests__/parsers.test.ts
+++ b/packages/api/src/mcp/__tests__/parsers.test.ts
@@ -1,5 +1,5 @@
-import { formatToolContent } from '../parsers';
 import type * as t from '../types';
+import { formatToolContent } from '../parsers';
 
 describe('formatToolContent', () => {
   describe('unrecognized providers', () => {
@@ -502,6 +502,43 @@ describe('formatToolContent', () => {
       const [content, artifacts] = formatToolContent(result, 'google');
       expect(content).toBe('Response with metadata');
       expect(artifacts).toBeUndefined();
+    });
+  });
+
+  describe('tool cost from _meta', () => {
+    it('attaches a reported cost to the artifacts', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [{ type: 'image', data: 'AAAA', mimeType: 'image/png' }],
+        _meta: {
+          cost: { usd: 0.0387, model: 'google/gemini-2.5-flash-image', provider: 'openrouter' },
+        },
+      };
+      const [, artifacts] = formatToolContent(result, 'openai');
+      expect(artifacts?.cost).toEqual({
+        usd: 0.0387,
+        model: 'google/gemini-2.5-flash-image',
+        provider: 'openrouter',
+      });
+    });
+
+    it('attaches cost even when there is no image artifact', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [{ type: 'text', text: 'done' }],
+        _meta: { cost: { usd: 0.02 } },
+      };
+      const [, artifacts] = formatToolContent(result, 'openai');
+      expect(artifacts?.cost).toEqual({ usd: 0.02, model: undefined, provider: undefined });
+    });
+
+    it('ignores a non-positive or malformed cost', () => {
+      for (const badCost of [{ usd: 0 }, { usd: -1 }, { usd: 'x' }, {}, null]) {
+        const result: t.MCPToolCallResponse = {
+          content: [{ type: 'text', text: 'done' }],
+          _meta: { cost: badCost },
+        };
+        const [, artifacts] = formatToolContent(result, 'openai');
+        expect(artifacts?.cost).toBeUndefined();
+      }
     });
   });
 });

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -250,5 +250,32 @@ UI Resource Markers Available:
     };
   }
 
+  const cost = parseToolCost(result?._meta);
+  if (cost) {
+    artifacts = { ...artifacts, cost };
+  }
+
   return [currentTextBlock || (artifacts !== undefined ? '' : '(No response)'), artifacts];
+}
+
+/**
+ * Reads a provider cost reported by the MCP server under the result's `_meta.cost`.
+ * Anything missing, non-numeric or non-positive is ignored, so a server that reports
+ * nothing (or reports garbage) behaves exactly as before.
+ */
+function parseToolCost(meta: Record<string, unknown> | undefined): t.ToolCost | undefined {
+  const raw = meta?.cost;
+  if (raw == null || typeof raw !== 'object') {
+    return undefined;
+  }
+  const candidate = raw as { usd?: unknown; model?: unknown; provider?: unknown };
+  const usd = typeof candidate.usd === 'number' ? candidate.usd : Number(candidate.usd);
+  if (!Number.isFinite(usd) || usd <= 0) {
+    return undefined;
+  }
+  return {
+    usd,
+    model: typeof candidate.model === 'string' ? candidate.model : undefined,
+    provider: typeof candidate.provider === 'string' ? candidate.provider : undefined,
+  };
 }

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -125,6 +125,19 @@ export type FileSearchSource = {
   [key: string]: unknown;
 };
 
+/**
+ * Provider cost of a single tool call, reported by the MCP server under the result's
+ * `_meta.cost`. Only the server knows its own pricing (and per-call variation such as
+ * image size or the model it picked), so the figure is supplied rather than derived.
+ */
+export type ToolCost = {
+  /** Cost in USD for this call. */
+  usd: number;
+  /** What produced it, used as the billing model label; falls back to the tool name. */
+  model?: string;
+  provider?: string;
+};
+
 export type Artifacts =
   | {
       content?: FormattedContent[];
@@ -139,6 +152,7 @@ export type Artifacts =
       files?: Array<{ id: string; name: string }>;
       session_id?: string;
       file_ids?: string[];
+      cost?: ToolCost;
     }
   | undefined;
 


### PR DESCRIPTION
Closes #14489

## Problem

MCP tools that spend real money on the operator's behalf — image generation, transcription, a paid search API — are invisible to the balance system. Only LLM tokens create `transactions` rows, so with `balance.enabled: true` a user whose balance is exhausted is blocked from chatting yet can keep generating images through an MCP tool at full cost.

For a self-hosted deployment running per-user budgets, that is the one hole in the accounting.

## Approach

Let a server report what its call cost, using the `_meta` field the MCP spec already provides:

```json
{
  "content": [{ "type": "image", "data": "...", "mimeType": "image/png" }],
  "_meta": {
    "cost": { "usd": 0.04, "model": "flux-1.1-pro", "provider": "replicate" }
  }
}
```

1. `formatToolContent` parses `_meta.cost` onto the artifact (new `ToolCost` type).
2. The tool-end callback converts USD to credits with the existing `1,000,000 credits = 1 USD` convention and calls `spendTokens`, so the charge lands in `transactions` and decrements the balance like any token spend — with `cost.model` (or the tool name) as the model label.

## Properties

- **Opt-in and backwards compatible.** A server that reports nothing behaves exactly as today. A missing, malformed or non-positive amount is ignored.
- **Respects both switches.** No-ops unless `balance.enabled` or `transactions.enabled` is on, so a deployment that only tracks spend still gets the rows.
- **Never breaks a tool call.** Billing runs in the artifact-promise set and its failures are caught and logged.

## Why the server reports the price

Only the server knows its own pricing, and its per-call variation: image size, audio duration, or which model it picked at runtime. A pricing table in `librechat.yaml` could express none of that and would need maintaining against every upstream price change.

The trade-off is that a deployment trusts the cost its configured MCP servers report — which it already does, since those servers execute tool calls on its behalf.

## Tests

3 cases on the parsing: a full cost attached to artifacts, a cost with no image artifact, and malformed/non-positive input ignored. The `api/server/controllers/agents` suite passes (458), tsc and eslint clean.

Running in production against our own MCP image-generation server, which reports the OpenRouter cost of each generation.