### PR TITLE
fix: render MCP tool results that only return structuredContent

### DIFF
--- a/packages/api/src/mcp/__tests__/structuredContent.test.ts
+++ b/packages/api/src/mcp/__tests__/structuredContent.test.ts
@@ -1,0 +1,54 @@
+import { formatToolContent } from '../parsers';
+import type * as t from '../types';
+
+/**
+ * Tools that declare an `outputSchema` may return their payload in
+ * `structuredContent` (MCP spec revision 2025-06-18). The spec says servers
+ * SHOULD also mirror it into a text content block, but that is a SHOULD —
+ * a server may legitimately send `structuredContent` with no `content`.
+ *
+ * The SDK's CallToolResult schema defaults a missing `content` to `[]`, so
+ * without a fallback such a result is indistinguishable from an empty one.
+ */
+const structuredOnlyResult = {
+  content: [],
+  structuredContent: {
+    items: [{ id: 'item-1', name: 'Example', permissionLevel: 'create' }],
+  },
+  isError: false,
+} as unknown as t.MCPToolCallResponse;
+
+describe('structuredContent fallback', () => {
+  it('renders structuredContent when content is empty', () => {
+    const [text] = formatToolContent(structuredOnlyResult, 'anthropic' as t.Provider);
+    expect(text).toContain('item-1');
+    expect(text).not.toBe('(No response)');
+  });
+
+  it('still returns (No response) when there is genuinely nothing', () => {
+    const [text] = formatToolContent(
+      { content: [] } as t.MCPToolCallResponse,
+      'anthropic' as t.Provider,
+    );
+    expect(text).toBe('(No response)');
+  });
+
+  it('ignores empty structuredContent objects', () => {
+    const [text] = formatToolContent(
+      { content: [], structuredContent: {} } as unknown as t.MCPToolCallResponse,
+      'anthropic' as t.Provider,
+    );
+    expect(text).toBe('(No response)');
+  });
+
+  it('prefers text content when both are present, leaving existing servers unaffected', () => {
+    const [text] = formatToolContent(
+      {
+        content: [{ type: 'text', text: 'hello' }],
+        structuredContent: { a: 1 },
+      } as unknown as t.MCPToolCallResponse,
+      'anthropic' as t.Provider,
+    );
+    expect(text).toBe('hello');
+  });
+});

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -94,10 +94,34 @@ function isImageContent(item: t.ToolContentPart): item is t.ImageContent {
   return item.type === 'image';
 }
 
+/**
+ * Renders `structuredContent` (MCP spec revision 2025-06-18) as pretty JSON.
+ *
+ * Tools that declare an `outputSchema` may return their payload solely in
+ * `structuredContent`. The spec says servers SHOULD also mirror it into a text
+ * content block, but that is a SHOULD, and some servers omit it — in at least
+ * one case only after a protocol version newer than 2024-11-05 is negotiated.
+ * Since the SDK defaults a missing `content` to `[]`, such a result is
+ * otherwise indistinguishable from an empty response and the payload is
+ * silently dropped.
+ *
+ * @returns the serialized structured content, or undefined if there is none.
+ */
+function stringifyStructuredContent(result: t.MCPToolCallResponse): string | undefined {
+  const structured = result?.structuredContent;
+  if (structured == null || typeof structured !== 'object') {
+    return undefined;
+  }
+  if (Object.keys(structured).length === 0) {
+    return undefined;
+  }
+  return JSON.stringify(structured, null, 2);
+}
+
 function parseAsString(result: t.MCPToolCallResponse): string {
   const content = result?.content ?? [];
   if (!content.length) {
-    return '(No response)';
+    return stringifyStructuredContent(result) ?? '(No response)';
   }
 
   const text = content
@@ -148,7 +172,7 @@ export function formatToolContent(
 
   const content = result?.content ?? [];
   if (!content.length) {
-    return ['(No response)', undefined];
+    return [stringifyStructuredContent(result) ?? '(No response)', undefined];
   }
 
   const imageUrls: t.FormattedContent[] = [];
@@ -250,5 +274,10 @@ UI Resource Markers Available:
     };
   }
 
-  return [currentTextBlock || (artifacts !== undefined ? '' : '(No response)'), artifacts];
+  return [
+    currentTextBlock ||
+      stringifyStructuredContent(result) ||
+      (artifacts !== undefined ? '' : '(No response)'),
+    artifacts,
+  ];
 }

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -71,6 +71,14 @@ export type MCPToolCallResponse =
   | {
       _meta?: Record<string, unknown>;
       content?: Array<ToolContentPart>;
+      /**
+       * Structured tool output, added in MCP spec revision 2025-06-18 for tools
+       * that declare an `outputSchema`. Servers SHOULD also mirror this into a
+       * text content block for backwards compatibility, but that is a SHOULD —
+       * some servers send `structuredContent` with an empty `content` array.
+       * Without this, such results are indistinguishable from an empty response.
+       */
+      structuredContent?: Record<string, unknown>;
       isError?: boolean;
     };
 


### PR DESCRIPTION
## Summary

MCP spec revision [2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) added `structuredContent` for tools that declare an `outputSchema`. The spec says servers **SHOULD** also mirror the payload into a text content block — but that's a SHOULD, and some servers omit it, returning `structuredContent` with no `content`.

The SDK's `CallToolResult` schema defaults a missing `content` to `[]`, so such a result is indistinguishable from an empty one. `formatToolContent` returns `(No response)` and the payload is **silently discarded**, despite being present on the object.

To be clear on scope: this isn't about *consuming* structured output for rich rendering (the original ask in #8450) — it's about not throwing away data we already hold.

## Why this can't be left to the server

LibreChat never sets `protocolVersion`. The SDK hardcodes `LATEST_PROTOCOL_VERSION` into the initialize request (`client/index.js:296`), which on the pinned `1.29.0` is `2025-11-25`. It isn't a client option and no configuration changes it — so **every** LibreChat connection negotiates the newest protocol, under which `structuredContent`-only responses are entirely legal.

This matters because Airtable's official hosted MCP server ([docs](https://support.airtable.com/docs/using-the-airtable-mcp-server)) varies its response shape by negotiated version:

| `MCP-Protocol-Version` | `content` blocks | `structuredContent` |
|---|---|---|
| `2024-11-05` | 1 (text w/ JSON) | yes |
| `2025-03-26` | **0** | yes |
| `2025-06-18` | **0** | yes |
| `2025-11-25` | **0** | yes |

The server has a mode that works, and LibreChat cannot reach it. There is no operator-side workaround — not a config change, not a server setting. The only place this is fixable is the client.

## What a user sees

| Tool | Has `outputSchema` | Result |
|---|---|---|
| `ping` | no → text block | ✅ `pong` |
| `list_bases` | yes → structured | ❌ `(No response)` |
| `search_bases` | yes → structured | ❌ `(No response)` |

Every data-returning tool fails while `ping` works, which presents as an auth or permissions fault and is very hard to diagnose. Captured live from the SDK:

```json
{"content":[],"structuredContent":{"bases":[...]},"isError":false}
```

Also reported against Splunk's MCP server in #8450.

## Change

Falls back to serialising `structuredContent` at the three points where `(No response)` is produced, and adds the field to `MCPToolCallResponse`.

The fallback **only** applies when no text content was produced, so behaviour for servers that do return content blocks is unchanged.

## Testing

- 4 new tests in `packages/api/src/mcp/__tests__/structuredContent.test.ts`: structured-only results, genuinely-empty results, empty `structuredContent` objects, and text-content precedence
- All 50 existing `parsers.test.ts` tests pass
- Verified end-to-end in a local LibreChat against the live Airtable MCP server — `list_bases` now renders the base list instead of `(No response)`

Refs the request in discussion #8450 (originally #8447). Happy to adjust the approach — e.g. behind a config flag, or gated on `isError === false`.
