### PR TITLE
🧪 test: Reasoning-Stream Render Perf Benchmark via react-scan

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -31,8 +31,11 @@ const NODE_POLYFILL_SHIMS: Record<string, string> = {
 
 // https://vitejs.dev/config/
 const backendPort = (process.env.BACKEND_PORT && Number(process.env.BACKEND_PORT)) || 3080;
-const backendURL = process.env.HOST
-  ? `http://${process.env.HOST}:${backendPort}`
+/** IPv6 hosts arrive unbracketed (valid for the listen address) but must be
+ *  bracketed inside a URL, or the proxy target parses as host `:` port soup. */
+const backendHost = process.env.HOST?.includes(':') ? `[${process.env.HOST}]` : process.env.HOST;
+const backendURL = backendHost
+  ? `http://${backendHost}:${backendPort}`
   : `http://localhost:${backendPort}`;
 const buildSourceMap = process.env.NODE_ENV === 'development';
 const QUERY_DEVTOOLS_CHUNK_MODULES = [

--- a/e2e/benchmarks-reasoning/README.md
+++ b/e2e/benchmarks-reasoning/README.md
@@ -22,14 +22,16 @@ injected into the page:
 
 ## Run
 
-react-scan is not a repo dependency; provide the bundle path:
+react-scan is not a repo dependency; provide the bundle path. The recorded
+baselines and thresholds were measured with react-scan 0.5.7 — instrumentation
+overhead and `onRender` semantics are version-dependent, so keep it pinned:
 
 ```bash
-npm i --no-save react-scan
+npm i --no-save react-scan@0.5.7
 npx playwright test --config=e2e/playwright.config.reasoning-perf.ts
 ```
 
 or point `REACT_SCAN_PATH` at an existing
-`react-scan/dist/auto.global.js`.
+`react-scan@0.5.7/dist/auto.global.js`.
 
 Requires a built client (`client/dist`) like the other mock e2e configs.

--- a/e2e/benchmarks-reasoning/README.md
+++ b/e2e/benchmarks-reasoning/README.md
@@ -1,0 +1,35 @@
+# Reasoning-Stream Perf Benchmark (react-scan)
+
+Verifies that streaming one long, **unsplit** reasoning block (plus long markdown
+text) through the real mock-model agents pipeline stays render-bounded — i.e.
+the legacy content-part splitting (`SplitStreamHandler` / `blockThreshold`,
+removed in #10533) is not needed for rendering performance.
+
+What it measures, via [react-scan](https://github.com/aidenybai/react-scan)
+injected into the page:
+
+- Per-component render counts and render time while a ~18k-char `<think>` block
+  and ~6k-char markdown reply stream token by token.
+- That the whole reasoning section lands in **one** think part (a single
+  "Thoughts" toggle) — no re-splitting anywhere in the pipeline.
+- rAF coalescing: the think box re-renders far fewer times than there are
+  streamed chunks.
+- Markdown block memoization: `MarkdownBlock` renders stay ~O(tokens + blocks),
+  not O(tokens × blocks).
+- Main-thread health: long-task totals bounded relative to stream wall time.
+- Typing latency after the long transcript: transcript components must not
+  re-render per keystroke.
+
+## Run
+
+react-scan is not a repo dependency; provide the bundle path:
+
+```bash
+npm i --no-save react-scan
+npx playwright test --config=e2e/playwright.config.reasoning-perf.ts
+```
+
+or point `REACT_SCAN_PATH` at an existing
+`react-scan/dist/auto.global.js`.
+
+Requires a built client (`client/dist`) like the other mock e2e configs.

--- a/e2e/benchmarks-reasoning/payload.ts
+++ b/e2e/benchmarks-reasoning/payload.ts
@@ -1,0 +1,57 @@
+/**
+ * Deterministic long-form reply payload for the reasoning-stream perf benchmark.
+ *
+ * The reasoning section intentionally far exceeds the legacy 4500-char
+ * `blockThreshold` the old SplitStreamHandler used, so streaming it as ONE
+ * contiguous think part exercises exactly the case the legacy splitting
+ * existed to protect against.
+ */
+const SENTENCE =
+  'The quarterly analytics review shows sustained growth across every referral channel, with notable spikes on launch days. ';
+
+export const THINK_TARGET_CHARS = 18000;
+export const TEXT_TARGET_CHARS = 6000;
+export const END_MARKER = 'END-OF-BENCH-STREAM';
+
+export function buildThinkSection(): string {
+  let think = '';
+  let i = 0;
+  while (think.length < THINK_TARGET_CHARS) {
+    i += 1;
+    think += `Step ${i}: ${SENTENCE}`;
+    if (i % 6 === 0) {
+      think += '\n\n';
+    }
+  }
+  return think;
+}
+
+export function buildTextSection(): string {
+  const codeBlock =
+    '```ts\nexport function estimate(total: number, rate: number): number {\n  return Math.round(total * rate);\n}\n```\n\n';
+  const table =
+    '| Month | Visitors | Growth |\n| --- | --- | --- |\n| Jan | 120000 | 4% |\n| Feb | 135500 | 12% |\n| Mar | 151200 | 11% |\n\n';
+  let text = '# Milestone Report\n\n';
+  let j = 0;
+  while (text.length < TEXT_TARGET_CHARS) {
+    j += 1;
+    text += `## Section ${j}\n\n${SENTENCE}${SENTENCE}\n\n- Point one for section ${j}\n- Point two for section ${j}\n\n`;
+    if (j % 3 === 0) {
+      text += codeBlock;
+    }
+    if (j % 4 === 0) {
+      text += table;
+    }
+  }
+  text += `\n\n${END_MARKER}\n`;
+  return text;
+}
+
+export function buildReasoningPayload(): string {
+  return `<think>${buildThinkSection()}</think>\n\n${buildTextSection()}`;
+}
+
+/** Mirrors the mock FakeChatModel's default whitespace split strategy. */
+export function countModelChunks(text: string): number {
+  return text.split(/(?<=\s+)|(?=\s+)/).length;
+}

--- a/e2e/benchmarks-reasoning/payload.ts
+++ b/e2e/benchmarks-reasoning/payload.ts
@@ -6,7 +6,7 @@
  * contiguous think part exercises exactly the case the legacy splitting
  * existed to protect against.
  */
-const SENTENCE =
+export const SENTENCE =
   'The quarterly analytics review shows sustained growth across every referral channel, with notable spikes on launch days. ';
 
 export const THINK_TARGET_CHARS = 18000;

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -17,6 +17,17 @@ type PerfSnapshot = {
   longTasks: number[];
 };
 
+type PerfGlobal = PerfSnapshot & {
+  drain(): void;
+  reset(): void;
+};
+
+declare global {
+  interface Window {
+    __PERF__: PerfGlobal;
+  }
+}
+
 /**
  * The react-scan bundle is injected from disk so the repo does not need it as
  * a dependency; point REACT_SCAN_PATH at `react-scan/dist/auto.global.js`.
@@ -33,18 +44,29 @@ const TALLY_SETUP = `(() => {
   const perf = {
     renders: Object.create(null),
     longTasks: [],
+    observer: null,
+    drain() {
+      if (!this.observer) {
+        return;
+      }
+      for (const entry of this.observer.takeRecords()) {
+        this.longTasks.push(entry.duration);
+      }
+    },
     reset() {
+      this.drain();
       this.renders = Object.create(null);
       this.longTasks = [];
     },
   };
   window.__PERF__ = perf;
   try {
-    new PerformanceObserver((list) => {
+    perf.observer = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
         perf.longTasks.push(entry.duration);
       }
-    }).observe({ type: 'longtask', buffered: true });
+    });
+    perf.observer.observe({ type: 'longtask', buffered: true });
   } catch (_error) {
     /* longtask unsupported: totals stay empty */
   }
@@ -102,14 +124,14 @@ const TALLY_SETUP = `(() => {
 
 async function snapshotPerf(page: Page): Promise<PerfSnapshot> {
   return page.evaluate(() => {
-    const perf = (window as unknown as { __PERF__: PerfSnapshot }).__PERF__;
-    return { renders: perf.renders, longTasks: perf.longTasks.slice() };
+    window.__PERF__.drain();
+    return { renders: window.__PERF__.renders, longTasks: window.__PERF__.longTasks.slice() };
   });
 }
 
 async function resetPerf(page: Page): Promise<void> {
   await page.evaluate(() => {
-    (window as unknown as { __PERF__: { reset(): void } }).__PERF__.reset();
+    window.__PERF__.reset();
   });
 }
 
@@ -155,6 +177,7 @@ test.describe('reasoning stream perf (react-scan)', () => {
     const textSection = buildTextSection();
     const thinkChunks = countModelChunks(thinkSection);
     const textChunks = countModelChunks(textSection);
+    const sectionCount = (textSection.match(/## Section /g) ?? []).length;
 
     await page.addInitScript({ content: fs.readFileSync(resolveReactScanPath(), 'utf8') });
     await page.addInitScript({ content: TALLY_SETUP });
@@ -163,9 +186,11 @@ test.describe('reasoning stream perf (react-scan)', () => {
     await page.goto(NEW_CHAT_PATH, { timeout: 180_000 });
     await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
 
-    const streamStart = Date.now();
     await sendMessage(page, 'Stream the long reasoning benchmark reply.');
+    /** Clock and tally start together so wall time covers exactly the
+     *  measured interval — request-setup time is excluded from both. */
     await resetPerf(page);
+    const streamStart = Date.now();
 
     await expect(messagesView(page).getByText(END_MARKER)).toBeVisible({
       timeout: 4 * 60 * 1000,
@@ -195,6 +220,22 @@ test.describe('reasoning stream perf (react-scan)', () => {
     const renderedThink = (await thinkGroup.locator('p').first().textContent()) ?? '';
     const normalize = (value: string) => value.replace(/\s+/g, ' ').trim();
     expect(normalize(renderedThink)).toBe(normalize(thinkSection));
+
+    /**
+     * The markdown body must also arrive whole — END_MARKER only proves the
+     * suffix rendered. Every generated section heading must be present, along
+     * with the exact table count and the generated code block, so the
+     * measured render work covers the full payload.
+     */
+    expect(sectionCount).toBeGreaterThan(0);
+    for (let section = 1; section <= sectionCount; section += 1) {
+      await expect(
+        messagesView(page).getByRole('heading', { name: `Section ${section}`, exact: true }),
+      ).toBeVisible();
+    }
+    await expect(messagesView(page).getByRole('listitem')).toHaveCount(sectionCount * 2);
+    await expect(messagesView(page).getByRole('table')).toHaveCount(Math.floor(sectionCount / 4));
+    await expect(messagesView(page).getByText('export function estimate').first()).toBeVisible();
 
     await resetPerf(page);
     const input = page.getByRole('textbox', { name: 'Message input' });
@@ -242,9 +283,10 @@ test.describe('reasoning stream perf (react-scan)', () => {
      * rAF coalescing must keep per-token work bounded: cache flushes happen at
      * most once per animation frame, so render counts scale with elapsed
      * frames, never with chunk count. The bound is derived from wall time
-     * (60fps + 50% headroom), which keeps it meaningful regardless of how many
-     * chunks streamed before `resetPerf` — without coalescing, renders track
-     * chunks (~5k in ~13s) and blow far past it (measured baseline: 122).
+     * (60fps + 50% headroom) — without coalescing, renders track chunks
+     * (~5k in ~13s) and blow far past it (measured baseline: 122). The floor
+     * guards against the instrumentation (or the component name) silently
+     * disappearing, which would zero the count and void the upper bound.
      */
     const framesUpperBound = Math.ceil((streamMs / 1000) * 90);
     const thinkingContentRenders = streaming.renders['ThinkingContent']?.count ?? 0;
@@ -254,18 +296,23 @@ test.describe('reasoning stream perf (react-scan)', () => {
     /**
      * Markdown must not re-render every block on every token — total
      * MarkdownBlock renders stay in the order of frames + blocks (measured
-     * baseline: 153), far below blocks × tokens (~100k).
+     * baseline: 153), far below blocks × tokens (~100k). Same floor rationale
+     * as above: zero means the guard lost its subject, not that it passed.
      */
     const markdownBlockRenders = streaming.renders['MarkdownBlock']?.count ?? 0;
+    expect(markdownBlockRenders).toBeGreaterThan(10);
     expect(markdownBlockRenders).toBeLessThan(framesUpperBound);
 
     /**
      * The main thread must stay responsive while the huge block streams:
-     * no single stall past 250ms, and no more than 10% of the stream's wall
-     * time spent in long tasks (measured baseline: one 96ms task in 13.4s).
+     * no single stall past 250ms, no more than 10% of the stream's wall time
+     * in long tasks (measured baseline: one 51-96ms task), and — because
+     * sustained sub-50ms work never surfaces as a long task — cumulative
+     * render time capped as well (measured baseline: ~4-7% of wall time).
      */
     expect(worstLongTask).toBeLessThan(250);
     expect(longTaskTotal).toBeLessThan(streamMs * 0.1);
+    expect(streamTotals.time).toBeLessThan(streamMs * 0.25);
 
     /**
      * Typing after the long transcript must not re-render the transcript:

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -21,8 +21,9 @@ type RenderTally = Record<string, { count: number; time: number }>;
 type PerfSnapshot = {
   renders: RenderTally;
   longTasks: number[];
-  /** Milliseconds between the last reset and this snapshot, measured on the
-   *  page's own clock so it covers exactly the tallied interval. */
+  /** Milliseconds between the first render after the last reset (fallback:
+   *  the reset itself) and this snapshot, measured on the page's own clock so
+   *  it covers exactly the tallied interval without idle request setup. */
   elapsedMs: number;
 };
 
@@ -30,6 +31,7 @@ type PerfGlobal = {
   renders: RenderTally;
   longTasks: number[];
   startedAt: number;
+  firstRenderAt: number | null;
   drain(): void;
   reset(): void;
 };
@@ -58,6 +60,7 @@ const TALLY_SETUP = `(() => {
     longTasks: [],
     observer: null,
     startedAt: performance.now(),
+    firstRenderAt: null,
     drain() {
       if (!this.observer) {
         return;
@@ -71,6 +74,7 @@ const TALLY_SETUP = `(() => {
       this.renders = Object.create(null);
       this.longTasks = [];
       this.startedAt = performance.now();
+      this.firstRenderAt = null;
     },
   };
   window.__PERF__ = perf;
@@ -113,6 +117,9 @@ const TALLY_SETUP = `(() => {
       trackUnnecessaryRenders: false,
       dangerouslyForceRunInProduction: true,
       onRender: (fiber, renders) => {
+        if (perf.firstRenderAt == null) {
+          perf.firstRenderAt = performance.now();
+        }
         for (const render of renders) {
           const name = render.componentName || nameOf(fiber) || 'anonymous';
           let slot = perf.renders[name];
@@ -142,7 +149,7 @@ async function snapshotPerf(page: Page): Promise<PerfSnapshot> {
     return {
       renders: window.__PERF__.renders,
       longTasks: window.__PERF__.longTasks.slice(),
-      elapsedMs: performance.now() - window.__PERF__.startedAt,
+      elapsedMs: performance.now() - (window.__PERF__.firstRenderAt ?? window.__PERF__.startedAt),
     };
   });
 }
@@ -199,6 +206,13 @@ test.describe('reasoning stream perf (react-scan)', () => {
 
     await page.addInitScript({ content: fs.readFileSync(resolveReactScanPath(), 'utf8') });
     await page.addInitScript({ content: TALLY_SETUP });
+    /** Stream with the reasoning box EXPANDED — the heavier layout path a
+     *  user gets with "Show Thinking" enabled — so the measured interval
+     *  covers live paragraph layout inside the box, not just the collapsed
+     *  header. */
+    await page.addInitScript(() => {
+      localStorage.setItem('showThinking', 'true');
+    });
 
     /** First load through the vite dev server transforms the module graph. */
     await page.goto(NEW_CHAT_PATH, { timeout: 180_000 });
@@ -206,10 +220,10 @@ test.describe('reasoning stream perf (react-scan)', () => {
 
     /** Reset BEFORE the send: with a 1ms chunk delay the earliest deltas can
      *  render between the response headers resolving and any later
-     *  evaluation, and a post-send reset would erase them. The composer's own
-     *  submit renders are a negligible constant. The reset stamps the start
-     *  time on the page's own clock; the matching end time is read inside the
-     *  snapshot evaluation, so wall time covers exactly the tallied interval. */
+     *  evaluation, and a post-send reset would erase them. The clock starts
+     *  at the FIRST RENDER after the reset (stamped inside onRender, read in
+     *  the snapshot evaluation), so idle request-setup time between the reset
+     *  and the submit/stream renders never pads the wall-time denominators. */
     await resetPerf(page);
     await sendMessage(page, 'Stream the long reasoning benchmark reply.');
 
@@ -240,8 +254,8 @@ test.describe('reasoning stream perf (react-scan)', () => {
      * renders whitespace-pre-wrap, so they are user-visible content). The
      * only transforms the UI applies are inline-tag stripping and edge
      * trimming, so the comparison is exact after trimming the source edges.
+     * The box is already expanded via the seeded showThinking preference.
      */
-    await thoughtToggles.click();
     const thinkGroup = messagesView(page).getByRole('group', {
       name: /^(Thoughts|Thinking)$/,
     });
@@ -381,5 +395,18 @@ test.describe('reasoning stream perf (react-scan)', () => {
       const renders = typing.renders[component]?.count ?? 0;
       expect(renders, `${component} re-rendered while typing`).toBeLessThanOrEqual(2);
     }
+
+    /**
+     * Quiet transcript components alone don't prove keystrokes feel fast —
+     * slow input handlers or layout can lag without re-rendering any named
+     * component. Bound the typing phase's own long tasks and cumulative
+     * render time (measured baseline: no long tasks, ~3% render time).
+     */
+    const typingWorstLongTask = typing.longTasks.reduce(
+      (max, duration) => Math.max(max, duration),
+      0,
+    );
+    expect(typingWorstLongTask).toBeLessThan(150);
+    expect(typingTotals.time).toBeLessThan(typing.elapsedMs * 0.25);
   });
 });

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -204,12 +204,14 @@ test.describe('reasoning stream perf (react-scan)', () => {
     await page.goto(NEW_CHAT_PATH, { timeout: 180_000 });
     await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
 
-    await sendMessage(page, 'Stream the long reasoning benchmark reply.');
-    /** The tally reset stamps the start time on the page's own clock; the
-     *  matching end time is read inside the snapshot evaluation, so wall time
-     *  covers exactly the tallied interval — request setup excluded, work
-     *  between marker paint and snapshot included. */
+    /** Reset BEFORE the send: with a 1ms chunk delay the earliest deltas can
+     *  render between the response headers resolving and any later
+     *  evaluation, and a post-send reset would erase them. The composer's own
+     *  submit renders are a negligible constant. The reset stamps the start
+     *  time on the page's own clock; the matching end time is read inside the
+     *  snapshot evaluation, so wall time covers exactly the tallied interval. */
     await resetPerf(page);
+    await sendMessage(page, 'Stream the long reasoning benchmark reply.');
 
     await expect(messagesView(page).getByText(END_MARKER)).toBeVisible({
       timeout: 4 * 60 * 1000,
@@ -277,10 +279,13 @@ test.describe('reasoning stream perf (react-scan)', () => {
         messagesView(page).getByRole('cell', { name: cellValue, exact: true }),
       ).toHaveCount(tableCount);
     }
-    await expect(messagesView(page).getByText('export function estimate').first()).toBeVisible();
-    await expect(
-      messagesView(page).getByText('return Math.round(total * rate);').first(),
-    ).toBeVisible();
+    const codeBlockCount = Math.floor(sectionCount / 3);
+    expect(codeBlockCount).toBeGreaterThan(0);
+    for (const codeLine of ['export function estimate', 'return Math.round(total * rate);']) {
+      await expect(messagesView(page).locator('code', { hasText: codeLine })).toHaveCount(
+        codeBlockCount,
+      );
+    }
 
     await resetPerf(page);
     const input = page.getByRole('textbox', { name: 'Message input' });

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -21,9 +21,11 @@ type RenderTally = Record<string, { count: number; time: number }>;
 type PerfSnapshot = {
   renders: RenderTally;
   longTasks: number[];
-  /** Milliseconds between the first render after the last reset (fallback:
-   *  the reset itself) and this snapshot, measured on the page's own clock so
-   *  it covers exactly the tallied interval without idle request setup. */
+  /** Milliseconds between the phase's anchor render and this snapshot, on
+   *  the page's own clock: the first ThinkingContent render (assistant
+   *  content = stream start) when one occurred, else the first render after
+   *  the reset (typing phase), else the reset itself. Idle request-setup
+   *  time before the assistant renders never pads the interval. */
   elapsedMs: number;
 };
 
@@ -32,6 +34,7 @@ type PerfGlobal = {
   longTasks: number[];
   startedAt: number;
   firstRenderAt: number | null;
+  firstStreamRenderAt: number | null;
   drain(): void;
   reset(): void;
 };
@@ -61,6 +64,7 @@ const TALLY_SETUP = `(() => {
     observer: null,
     startedAt: performance.now(),
     firstRenderAt: null,
+    firstStreamRenderAt: null,
     drain() {
       if (!this.observer) {
         return;
@@ -75,6 +79,7 @@ const TALLY_SETUP = `(() => {
       this.longTasks = [];
       this.startedAt = performance.now();
       this.firstRenderAt = null;
+      this.firstStreamRenderAt = null;
     },
   };
   window.__PERF__ = perf;
@@ -122,6 +127,9 @@ const TALLY_SETUP = `(() => {
         }
         for (const render of renders) {
           const name = render.componentName || nameOf(fiber) || 'anonymous';
+          if (perf.firstStreamRenderAt == null && name === 'ThinkingContent') {
+            perf.firstStreamRenderAt = performance.now();
+          }
           let slot = perf.renders[name];
           if (!slot) {
             slot = { count: 0, time: 0 };
@@ -149,7 +157,11 @@ async function snapshotPerf(page: Page): Promise<PerfSnapshot> {
     return {
       renders: window.__PERF__.renders,
       longTasks: window.__PERF__.longTasks.slice(),
-      elapsedMs: performance.now() - (window.__PERF__.firstRenderAt ?? window.__PERF__.startedAt),
+      elapsedMs:
+        performance.now() -
+        (window.__PERF__.firstStreamRenderAt ??
+          window.__PERF__.firstRenderAt ??
+          window.__PERF__.startedAt),
     };
   });
 }
@@ -220,10 +232,12 @@ test.describe('reasoning stream perf (react-scan)', () => {
 
     /** Reset BEFORE the send: with a 1ms chunk delay the earliest deltas can
      *  render between the response headers resolving and any later
-     *  evaluation, and a post-send reset would erase them. The clock starts
-     *  at the FIRST RENDER after the reset (stamped inside onRender, read in
-     *  the snapshot evaluation), so idle request-setup time between the reset
-     *  and the submit/stream renders never pads the wall-time denominators. */
+     *  evaluation, and a post-send reset would erase them. The clock anchors
+     *  to the first ThinkingContent render — the payload always opens with
+     *  reasoning, so that is the first assistant-content paint — keeping
+     *  composer renders and idle request setup out of the denominators (the
+     *  few pre-stream composer renders stay in the tally, which only makes
+     *  the bounds stricter). */
     await resetPerf(page);
     await sendMessage(page, 'Stream the long reasoning benchmark reply.');
 
@@ -356,6 +370,9 @@ test.describe('reasoning stream perf (react-scan)', () => {
     const thinkingContentRenders = streaming.renders['ThinkingContent']?.count ?? 0;
     expect(thinkingContentRenders).toBeGreaterThan(10);
     expect(thinkingContentRenders).toBeLessThan(framesUpperBound);
+    /** Rate-independent companion bound: even on a slow stream (where the
+     *  frame bound balloons), one-render-per-chunk behavior must still fail. */
+    expect(thinkingContentRenders).toBeLessThan(thinkChunks / 4);
 
     /**
      * Markdown must not re-render every block on every token — total
@@ -366,6 +383,7 @@ test.describe('reasoning stream perf (react-scan)', () => {
     const markdownBlockRenders = streaming.renders['MarkdownBlock']?.count ?? 0;
     expect(markdownBlockRenders).toBeGreaterThan(10);
     expect(markdownBlockRenders).toBeLessThan(framesUpperBound);
+    expect(markdownBlockRenders).toBeLessThan(textChunks / 4);
 
     /**
      * The main thread must stay responsive while the huge block streams:
@@ -406,7 +424,11 @@ test.describe('reasoning stream perf (react-scan)', () => {
       (max, duration) => Math.max(max, duration),
       0,
     );
+    const typingLongTaskTotal = typing.longTasks.reduce((sum, duration) => sum + duration, 0);
     expect(typingWorstLongTask).toBeLessThan(150);
+    /** Absolute cumulative budget — repeated sub-threshold stalls both evade
+     *  a worst-case check and inflate elapsedMs, so no ratio is used here. */
+    expect(typingLongTaskTotal).toBeLessThan(300);
     expect(typingTotals.time).toBeLessThan(typing.elapsedMs * 0.25);
   });
 });

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -1,0 +1,266 @@
+import fs from 'node:fs';
+import { expect, test } from '@playwright/test';
+import type { Page, TestInfo } from '@playwright/test';
+import {
+  MOCK_ENDPOINTS,
+  NEW_CHAT_PATH,
+  messagesView,
+  selectMockEndpoint,
+  sendMessage,
+} from '../specs/mock/helpers';
+import { buildTextSection, buildThinkSection, countModelChunks, END_MARKER } from './payload';
+
+type RenderTally = Record<string, { count: number; time: number }>;
+
+type PerfSnapshot = {
+  renders: RenderTally;
+  longTasks: number[];
+};
+
+/**
+ * The react-scan bundle is injected from disk so the repo does not need it as
+ * a dependency; point REACT_SCAN_PATH at `react-scan/dist/auto.global.js`.
+ */
+function resolveReactScanPath(): string {
+  const fromEnv = process.env.REACT_SCAN_PATH;
+  if (fromEnv && fs.existsSync(fromEnv)) {
+    return fromEnv;
+  }
+  return require.resolve('react-scan/dist/auto.global.js');
+}
+
+const TALLY_SETUP = `(() => {
+  const perf = {
+    renders: Object.create(null),
+    longTasks: [],
+    reset() {
+      this.renders = Object.create(null);
+      this.longTasks = [];
+    },
+  };
+  window.__PERF__ = perf;
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        perf.longTasks.push(entry.duration);
+      }
+    }).observe({ type: 'longtask', buffered: true });
+  } catch (_error) {
+    /* longtask unsupported: totals stay empty */
+  }
+  const nameOf = (fiber) => {
+    let type = fiber && fiber.type;
+    for (let depth = 0; depth < 4 && type; depth += 1) {
+      if (typeof type === 'function') {
+        return type.displayName || type.name || null;
+      }
+      if (typeof type === 'object') {
+        if (type.displayName) {
+          return type.displayName;
+        }
+        type = type.type || type.render;
+        continue;
+      }
+      return String(type);
+    }
+    return null;
+  };
+  const configure = () => {
+    if (typeof window.reactScan !== 'function') {
+      return false;
+    }
+    window.reactScan({
+      enabled: true,
+      log: false,
+      showToolbar: false,
+      animationSpeed: 'off',
+      trackUnnecessaryRenders: false,
+      dangerouslyForceRunInProduction: true,
+      onRender: (fiber, renders) => {
+        for (const render of renders) {
+          const name = render.componentName || nameOf(fiber) || 'anonymous';
+          let slot = perf.renders[name];
+          if (!slot) {
+            slot = { count: 0, time: 0 };
+            perf.renders[name] = slot;
+          }
+          slot.count += render.count || 1;
+          slot.time += render.time || 0;
+        }
+      },
+    });
+    return true;
+  };
+  if (!configure()) {
+    const timer = setInterval(() => {
+      if (configure()) {
+        clearInterval(timer);
+      }
+    }, 50);
+  }
+})();`;
+
+async function snapshotPerf(page: Page): Promise<PerfSnapshot> {
+  return page.evaluate(() => {
+    const perf = (window as unknown as { __PERF__: PerfSnapshot }).__PERF__;
+    return { renders: perf.renders, longTasks: perf.longTasks.slice() };
+  });
+}
+
+async function resetPerf(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __PERF__: { reset(): void } }).__PERF__.reset();
+  });
+}
+
+function totals(snapshot: PerfSnapshot): { renders: number; time: number } {
+  let renders = 0;
+  let time = 0;
+  for (const slot of Object.values(snapshot.renders)) {
+    renders += slot.count;
+    time += slot.time;
+  }
+  return { renders, time };
+}
+
+function topComponents(snapshot: PerfSnapshot, limit: number): string[] {
+  return Object.entries(snapshot.renders)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, limit)
+    .map(
+      ([name, slot]) =>
+        `${name.padEnd(28)} renders=${String(slot.count).padStart(6)} time=${slot.time.toFixed(1)}ms`,
+    );
+}
+
+async function attachSnapshot(
+  testInfo: TestInfo,
+  name: string,
+  snapshot: PerfSnapshot,
+  extra: Record<string, number>,
+): Promise<void> {
+  await testInfo.attach(name, {
+    body: JSON.stringify({ ...extra, ...snapshot }, null, 2),
+    contentType: 'application/json',
+  });
+}
+
+test.describe('reasoning stream perf (react-scan)', () => {
+  test('one long unsplit reasoning + markdown reply stays render-bounded', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(6 * 60 * 1000);
+
+    const thinkSection = buildThinkSection();
+    const textSection = buildTextSection();
+    const thinkChunks = countModelChunks(thinkSection);
+    const textChunks = countModelChunks(textSection);
+
+    await page.addInitScript({ content: fs.readFileSync(resolveReactScanPath(), 'utf8') });
+    await page.addInitScript({ content: TALLY_SETUP });
+
+    /** First load through the vite dev server transforms the module graph. */
+    await page.goto(NEW_CHAT_PATH, { timeout: 180_000 });
+    await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+
+    const streamStart = Date.now();
+    await sendMessage(page, 'Stream the long reasoning benchmark reply.');
+    await resetPerf(page);
+
+    await expect(messagesView(page).getByText(END_MARKER)).toBeVisible({
+      timeout: 4 * 60 * 1000,
+    });
+    const streamMs = Date.now() - streamStart;
+    const streaming = await snapshotPerf(page);
+
+    /**
+     * The whole reasoning section must land in ONE think part — a single
+     * Thoughts toggle. More than one means something re-split the reasoning.
+     */
+    const thoughtToggles = messagesView(page).getByRole('button', {
+      name: /^(Thoughts|Thinking)$/,
+    });
+    await expect(thoughtToggles).toHaveCount(1);
+
+    await resetPerf(page);
+    const input = page.getByRole('textbox', { name: 'Message input' });
+    await input.click();
+    await input.pressSequentially('typing latency probe after long transcript', { delay: 25 });
+    const typing = await snapshotPerf(page);
+
+    const streamTotals = totals(streaming);
+    const typingTotals = totals(typing);
+    const longTaskTotal = streaming.longTasks.reduce((sum, duration) => sum + duration, 0);
+    const worstLongTask = streaming.longTasks.reduce((max, duration) => Math.max(max, duration), 0);
+
+    console.log(`\n=== Streaming phase (${streamMs}ms wall) ===`);
+    console.log(`model chunks: think=${thinkChunks} text=${textChunks}`);
+    console.log(
+      `total renders=${streamTotals.renders} render-time=${streamTotals.time.toFixed(0)}ms ` +
+        `longtask-total=${longTaskTotal.toFixed(0)}ms worst-longtask=${worstLongTask.toFixed(0)}ms`,
+    );
+    for (const line of topComponents(streaming, 15)) {
+      console.log(`  ${line}`);
+    }
+    console.log('key components:');
+    for (const component of ['ThinkingContent', 'MarkdownBlock', 'MarkdownBlocks', 'TextPart']) {
+      const slot = streaming.renders[component];
+      console.log(
+        `  ${component.padEnd(20)} renders=${slot?.count ?? 0} time=${(slot?.time ?? 0).toFixed(1)}ms`,
+      );
+    }
+    console.log('=== Typing phase (40 keys) ===');
+    console.log(
+      `total renders=${typingTotals.renders} render-time=${typingTotals.time.toFixed(0)}ms`,
+    );
+    for (const line of topComponents(typing, 10)) {
+      console.log(`  ${line}`);
+    }
+
+    await attachSnapshot(testInfo, 'streaming-renders.json', streaming, {
+      streamMs,
+      thinkChunks,
+      textChunks,
+    });
+    await attachSnapshot(testInfo, 'typing-renders.json', typing, {});
+
+    /**
+     * rAF coalescing must keep per-token work bounded: the think box may
+     * re-render at most once per animation frame, so its render count has to
+     * stay well below one render per streamed chunk.
+     */
+    const thinkingContentRenders = streaming.renders['ThinkingContent']?.count ?? 0;
+    expect(thinkingContentRenders).toBeGreaterThan(10);
+    expect(thinkingContentRenders).toBeLessThan(thinkChunks);
+
+    /**
+     * Markdown must not re-render every block on every token — total
+     * MarkdownBlock renders stay in the order of frames + blocks, far below
+     * blocks × tokens.
+     */
+    const markdownBlockRenders = streaming.renders['MarkdownBlock']?.count ?? 0;
+    expect(markdownBlockRenders).toBeLessThan(textChunks * 3);
+
+    /** The main thread must not seize up while the huge block streams. */
+    expect(worstLongTask).toBeLessThan(1000);
+    expect(longTaskTotal).toBeLessThan(streamMs * 0.5);
+
+    /**
+     * Typing after the long transcript must not re-render the transcript:
+     * message-content components stay quiet while the composer updates.
+     */
+    const transcriptComponents = [
+      'MarkdownBlock',
+      'MarkdownBlocks',
+      'Markdown',
+      'ThinkingContent',
+      'TextPart',
+      'Part',
+      'MessageContent',
+    ];
+    for (const component of transcriptComponents) {
+      const renders = typing.renders[component]?.count ?? 0;
+      expect(renders, `${component} re-rendered while typing`).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -8,16 +8,28 @@ import {
   selectMockEndpoint,
   sendMessage,
 } from '../specs/mock/helpers';
-import { buildTextSection, buildThinkSection, countModelChunks, END_MARKER } from './payload';
+import {
+  buildTextSection,
+  buildThinkSection,
+  countModelChunks,
+  END_MARKER,
+  SENTENCE,
+} from './payload';
 
 type RenderTally = Record<string, { count: number; time: number }>;
 
 type PerfSnapshot = {
   renders: RenderTally;
   longTasks: number[];
+  /** Milliseconds between the last reset and this snapshot, measured on the
+   *  page's own clock so it covers exactly the tallied interval. */
+  elapsedMs: number;
 };
 
-type PerfGlobal = PerfSnapshot & {
+type PerfGlobal = {
+  renders: RenderTally;
+  longTasks: number[];
+  startedAt: number;
   drain(): void;
   reset(): void;
 };
@@ -45,6 +57,7 @@ const TALLY_SETUP = `(() => {
     renders: Object.create(null),
     longTasks: [],
     observer: null,
+    startedAt: performance.now(),
     drain() {
       if (!this.observer) {
         return;
@@ -57,6 +70,7 @@ const TALLY_SETUP = `(() => {
       this.drain();
       this.renders = Object.create(null);
       this.longTasks = [];
+      this.startedAt = performance.now();
     },
   };
   window.__PERF__ = perf;
@@ -125,7 +139,11 @@ const TALLY_SETUP = `(() => {
 async function snapshotPerf(page: Page): Promise<PerfSnapshot> {
   return page.evaluate(() => {
     window.__PERF__.drain();
-    return { renders: window.__PERF__.renders, longTasks: window.__PERF__.longTasks.slice() };
+    return {
+      renders: window.__PERF__.renders,
+      longTasks: window.__PERF__.longTasks.slice(),
+      elapsedMs: performance.now() - window.__PERF__.startedAt,
+    };
   });
 }
 
@@ -187,16 +205,23 @@ test.describe('reasoning stream perf (react-scan)', () => {
     await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
 
     await sendMessage(page, 'Stream the long reasoning benchmark reply.');
-    /** Clock and tally start together so wall time covers exactly the
-     *  measured interval — request-setup time is excluded from both. */
+    /** The tally reset stamps the start time on the page's own clock; the
+     *  matching end time is read inside the snapshot evaluation, so wall time
+     *  covers exactly the tallied interval — request setup excluded, work
+     *  between marker paint and snapshot included. */
     await resetPerf(page);
-    const streamStart = Date.now();
 
     await expect(messagesView(page).getByText(END_MARKER)).toBeVisible({
       timeout: 4 * 60 * 1000,
     });
-    const streamMs = Date.now() - streamStart;
+    /** The marker only proves the final text delta painted — generation
+     *  finalization (usage chunk, terminal events, save-time re-render) is
+     *  part of the measured stream, so wait for it to finish first. */
+    await expect(page.getByRole('button', { name: 'Stop generating' })).toBeHidden({
+      timeout: 30_000,
+    });
     const streaming = await snapshotPerf(page);
+    const streamMs = Math.ceil(streaming.elapsedMs);
 
     /**
      * The whole reasoning section must land in ONE think part — a single
@@ -209,33 +234,53 @@ test.describe('reasoning stream perf (react-scan)', () => {
 
     /**
      * One nonempty toggle is not enough — the ENTIRE reasoning section must
-     * survive the pipeline. Expand the toggle and compare the rendered think
-     * text against the source payload (whitespace-normalized; the UI strips
-     * the inline think tags and trims).
+     * survive the pipeline, internal paragraph breaks included (the box
+     * renders whitespace-pre-wrap, so they are user-visible content). The
+     * only transforms the UI applies are inline-tag stripping and edge
+     * trimming, so the comparison is exact after trimming the source edges.
      */
     await thoughtToggles.click();
     const thinkGroup = messagesView(page).getByRole('group', {
       name: /^(Thoughts|Thinking)$/,
     });
     const renderedThink = (await thinkGroup.locator('p').first().textContent()) ?? '';
-    const normalize = (value: string) => value.replace(/\s+/g, ' ').trim();
-    expect(normalize(renderedThink)).toBe(normalize(thinkSection));
+    expect(renderedThink).toBe(thinkSection.trim());
 
     /**
      * The markdown body must also arrive whole — END_MARKER only proves the
-     * suffix rendered. Every generated section heading must be present, along
-     * with the exact table count and the generated code block, so the
-     * measured render work covers the full payload.
+     * suffix rendered. Structure alone is not enough either: verify the prose
+     * itself — every section's heading, doubled-sentence paragraph, and both
+     * list items, plus the exact table count with cell values and the code
+     * block's lines — so the measured render work covers the full payload.
      */
     expect(sectionCount).toBeGreaterThan(0);
+    const doubledSentence = `${SENTENCE}${SENTENCE}`.trim();
+    await expect(messagesView(page).getByText(doubledSentence, { exact: true })).toHaveCount(
+      sectionCount,
+    );
     for (let section = 1; section <= sectionCount; section += 1) {
       await expect(
         messagesView(page).getByRole('heading', { name: `Section ${section}`, exact: true }),
       ).toBeVisible();
+      await expect(
+        messagesView(page).getByText(`Point one for section ${section}`, { exact: true }),
+      ).toBeVisible();
+      await expect(
+        messagesView(page).getByText(`Point two for section ${section}`, { exact: true }),
+      ).toBeVisible();
     }
     await expect(messagesView(page).getByRole('listitem')).toHaveCount(sectionCount * 2);
-    await expect(messagesView(page).getByRole('table')).toHaveCount(Math.floor(sectionCount / 4));
+    const tableCount = Math.floor(sectionCount / 4);
+    await expect(messagesView(page).getByRole('table')).toHaveCount(tableCount);
+    for (const cellValue of ['120000', '135500', '151200']) {
+      await expect(
+        messagesView(page).getByRole('cell', { name: cellValue, exact: true }),
+      ).toHaveCount(tableCount);
+    }
     await expect(messagesView(page).getByText('export function estimate').first()).toBeVisible();
+    await expect(
+      messagesView(page).getByText('return Math.round(total * rate);').first(),
+    ).toBeVisible();
 
     await resetPerf(page);
     const input = page.getByRole('textbox', { name: 'Message input' });

--- a/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
+++ b/e2e/benchmarks-reasoning/reasoning-stream.perf.spec.ts
@@ -182,6 +182,20 @@ test.describe('reasoning stream perf (react-scan)', () => {
     });
     await expect(thoughtToggles).toHaveCount(1);
 
+    /**
+     * One nonempty toggle is not enough — the ENTIRE reasoning section must
+     * survive the pipeline. Expand the toggle and compare the rendered think
+     * text against the source payload (whitespace-normalized; the UI strips
+     * the inline think tags and trims).
+     */
+    await thoughtToggles.click();
+    const thinkGroup = messagesView(page).getByRole('group', {
+      name: /^(Thoughts|Thinking)$/,
+    });
+    const renderedThink = (await thinkGroup.locator('p').first().textContent()) ?? '';
+    const normalize = (value: string) => value.replace(/\s+/g, ' ').trim();
+    expect(normalize(renderedThink)).toBe(normalize(thinkSection));
+
     await resetPerf(page);
     const input = page.getByRole('textbox', { name: 'Message input' });
     await input.click();
@@ -225,25 +239,33 @@ test.describe('reasoning stream perf (react-scan)', () => {
     await attachSnapshot(testInfo, 'typing-renders.json', typing, {});
 
     /**
-     * rAF coalescing must keep per-token work bounded: the think box may
-     * re-render at most once per animation frame, so its render count has to
-     * stay well below one render per streamed chunk.
+     * rAF coalescing must keep per-token work bounded: cache flushes happen at
+     * most once per animation frame, so render counts scale with elapsed
+     * frames, never with chunk count. The bound is derived from wall time
+     * (60fps + 50% headroom), which keeps it meaningful regardless of how many
+     * chunks streamed before `resetPerf` — without coalescing, renders track
+     * chunks (~5k in ~13s) and blow far past it (measured baseline: 122).
      */
+    const framesUpperBound = Math.ceil((streamMs / 1000) * 90);
     const thinkingContentRenders = streaming.renders['ThinkingContent']?.count ?? 0;
     expect(thinkingContentRenders).toBeGreaterThan(10);
-    expect(thinkingContentRenders).toBeLessThan(thinkChunks);
+    expect(thinkingContentRenders).toBeLessThan(framesUpperBound);
 
     /**
      * Markdown must not re-render every block on every token — total
-     * MarkdownBlock renders stay in the order of frames + blocks, far below
-     * blocks × tokens.
+     * MarkdownBlock renders stay in the order of frames + blocks (measured
+     * baseline: 153), far below blocks × tokens (~100k).
      */
     const markdownBlockRenders = streaming.renders['MarkdownBlock']?.count ?? 0;
-    expect(markdownBlockRenders).toBeLessThan(textChunks * 3);
+    expect(markdownBlockRenders).toBeLessThan(framesUpperBound);
 
-    /** The main thread must not seize up while the huge block streams. */
-    expect(worstLongTask).toBeLessThan(1000);
-    expect(longTaskTotal).toBeLessThan(streamMs * 0.5);
+    /**
+     * The main thread must stay responsive while the huge block streams:
+     * no single stall past 250ms, and no more than 10% of the stream's wall
+     * time spent in long tasks (measured baseline: one 96ms task in 13.4s).
+     */
+    expect(worstLongTask).toBeLessThan(250);
+    expect(longTaskTotal).toBeLessThan(streamMs * 0.1);
 
     /**
      * Typing after the long transcript must not re-render the transcript:

--- a/e2e/playwright.config.mock.ts
+++ b/e2e/playwright.config.mock.ts
@@ -26,6 +26,11 @@ const vanillaOverrides = {
   ALLOW_SOCIAL_LOGIN: 'false',
   ALLOW_SOCIAL_REGISTRATION: 'false',
   STREAM_KEEP_COMPLETED_JOBS: 'true',
+  /** A local `.env` may enable balance enforcement, which `neutralizeCredentialEnv`
+   *  does not blank (not credential-shaped); the fresh e2e user has no balance
+   *  record, so every streaming spec would be refused with a token_balance
+   *  violation before the mock model runs. */
+  CHECK_BALANCE: 'false',
 };
 
 const baseEnv = {

--- a/e2e/playwright.config.reasoning-perf.ts
+++ b/e2e/playwright.config.reasoning-perf.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 import path from 'node:path';
 import mockConfig from './playwright.config.mock';
 import { buildReasoningPayload } from './benchmarks-reasoning/payload';
-import { getE2EBaseURL } from './setup/env';
+import { getE2EServerAddress } from './setup/env';
 
 /**
  * Reasoning-stream perf benchmark config.
@@ -22,7 +22,7 @@ process.env.MOCK_LLM_CHUNK_DELAY_MS ??= '1';
 
 const rootPath = path.resolve(__dirname, '..');
 const DEV_SERVER_URL = 'http://localhost:3090';
-const backendPort = new URL(getE2EBaseURL()).port || '3080';
+const backendPort = getE2EServerAddress().port;
 
 const appServer = Array.isArray(mockConfig.webServer)
   ? mockConfig.webServer[0]

--- a/e2e/playwright.config.reasoning-perf.ts
+++ b/e2e/playwright.config.reasoning-perf.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 import path from 'node:path';
 import mockConfig from './playwright.config.mock';
 import { buildReasoningPayload } from './benchmarks-reasoning/payload';
+import { getE2EBaseURL } from './setup/env';
 
 /**
  * Reasoning-stream perf benchmark config.
@@ -21,6 +22,7 @@ process.env.MOCK_LLM_CHUNK_DELAY_MS ??= '1';
 
 const rootPath = path.resolve(__dirname, '..');
 const DEV_SERVER_URL = 'http://localhost:3090';
+const backendPort = new URL(getE2EBaseURL()).port || '3080';
 
 const appServer = Array.isArray(mockConfig.webServer)
   ? mockConfig.webServer[0]
@@ -42,9 +44,10 @@ export default defineConfig({
     {
       command: 'npm run frontend:dev',
       cwd: rootPath,
-      /** The mock env exports PORT for the backend (3080); vite reads PORT for
-       *  its own listen port, so pin the dev server back to 3090. */
-      env: { ...process.env, PORT: '3090', HOST: 'localhost' },
+      /** The mock env exports PORT for the backend; vite reads PORT for its
+       *  own listen port, so pin the dev server back to 3090 and point its
+       *  /api proxy at whichever port the app server actually uses. */
+      env: { ...process.env, PORT: '3090', HOST: 'localhost', BACKEND_PORT: backendPort },
       url: DEV_SERVER_URL,
       stdout: 'pipe',
       timeout: 180_000,

--- a/e2e/playwright.config.reasoning-perf.ts
+++ b/e2e/playwright.config.reasoning-perf.ts
@@ -21,8 +21,9 @@ process.env.MOCK_LLM_REPLY = buildReasoningPayload();
 process.env.MOCK_LLM_CHUNK_DELAY_MS ??= '1';
 
 const rootPath = path.resolve(__dirname, '..');
-const DEV_SERVER_URL = 'http://localhost:3090';
-const backendPort = getE2EServerAddress().port;
+const { host: backendHost, port: backendPort } = getE2EServerAddress();
+const devHost = backendHost.includes(':') ? `[${backendHost}]` : backendHost;
+const DEV_SERVER_URL = `http://${devHost}:3090`;
 
 const appServer = Array.isArray(mockConfig.webServer)
   ? mockConfig.webServer[0]
@@ -46,8 +47,9 @@ export default defineConfig({
       cwd: rootPath,
       /** The mock env exports PORT for the backend; vite reads PORT for its
        *  own listen port, so pin the dev server back to 3090 and point its
-       *  /api proxy at whichever port the app server actually uses. */
-      env: { ...process.env, PORT: '3090', HOST: 'localhost', BACKEND_PORT: backendPort },
+       *  /api proxy (HOST + BACKEND_PORT in client/vite.config.ts) at the
+       *  host/port the app server actually binds per the E2E base URL. */
+      env: { ...process.env, PORT: '3090', HOST: backendHost, BACKEND_PORT: backendPort },
       url: DEV_SERVER_URL,
       stdout: 'pipe',
       timeout: 180_000,

--- a/e2e/playwright.config.reasoning-perf.ts
+++ b/e2e/playwright.config.reasoning-perf.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from '@playwright/test';
+import path from 'node:path';
+import mockConfig from './playwright.config.mock';
+import { buildReasoningPayload } from './benchmarks-reasoning/payload';
+
+/**
+ * Reasoning-stream perf benchmark config.
+ *
+ * Streams one long `<think>…</think>` + markdown reply through the real
+ * mock-model agents pipeline so react-scan can verify that rendering a single
+ * large, unsplit reasoning part (plus long markdown text) stays
+ * render-bounded — confirming the legacy content-part splitting is not needed.
+ *
+ * Tests run against the vite dev server (port 3090, proxying /api to the mock
+ * backend on 3080): the dev build keeps component names, which react-scan
+ * needs for per-component tallies — the production minifier (oxc) strips
+ * `displayName` assignments.
+ */
+process.env.MOCK_LLM_REPLY = buildReasoningPayload();
+process.env.MOCK_LLM_CHUNK_DELAY_MS ??= '1';
+
+const rootPath = path.resolve(__dirname, '..');
+const DEV_SERVER_URL = 'http://localhost:3090';
+
+const appServer = Array.isArray(mockConfig.webServer)
+  ? mockConfig.webServer[0]
+  : mockConfig.webServer;
+
+export default defineConfig({
+  ...mockConfig,
+  testDir: 'benchmarks-reasoning',
+  outputDir: 'benchmarks-reasoning/.test-results',
+  timeout: 10 * 60 * 1000,
+  retries: 0,
+  reporter: [['line']],
+  use: {
+    ...mockConfig.use,
+    baseURL: DEV_SERVER_URL,
+  },
+  webServer: [
+    ...(appServer ? [appServer] : []),
+    {
+      command: 'npm run frontend:dev',
+      cwd: rootPath,
+      /** The mock env exports PORT for the backend (3080); vite reads PORT for
+       *  its own listen port, so pin the dev server back to 3090. */
+      env: { ...process.env, PORT: '3090', HOST: 'localhost' },
+      url: DEV_SERVER_URL,
+      stdout: 'pipe',
+      timeout: 180_000,
+      reuseExistingServer: false,
+    },
+  ],
+});

--- a/e2e/playwright.config.reasoning-perf.ts
+++ b/e2e/playwright.config.reasoning-perf.ts
@@ -18,7 +18,10 @@ import { getE2EServerAddress } from './setup/env';
  * `displayName` assignments.
  */
 process.env.MOCK_LLM_REPLY = buildReasoningPayload();
-process.env.MOCK_LLM_CHUNK_DELAY_MS ??= '1';
+/** Pinned, not defaulted: the render-count thresholds are calibrated against
+ *  this delivery rate, and a slower stream would loosen the frame-derived
+ *  bounds. */
+process.env.MOCK_LLM_CHUNK_DELAY_MS = '1';
 
 const rootPath = path.resolve(__dirname, '..');
 const { host: backendHost, port: backendPort } = getE2EServerAddress();


### PR DESCRIPTION
## Summary

Adds a Playwright benchmark that proves the legacy reasoning/text content-part splitting (`SplitStreamHandler` / `blockThreshold: 4500`, removed in #10533) is **not needed** for rendering performance, so reasoning can stream as one contiguous block without the bad UX of split "Thoughts" sections.

The spec streams one long, unsplit `<think>` block (**18k chars — 4× the legacy split threshold**) plus **6k chars of markdown** (headings, lists, code fences, tables) through the real mock-model agents pipeline, with [react-scan](https://github.com/aidenybai/react-scan) injected to tally per-component renders, and asserts:

- **Single think part end-to-end**: the whole reasoning section renders as exactly one "Thoughts" toggle — nothing re-splits it anywhere in the pipeline.
- **rAF coalescing works**: the think box renders ~1× per 43 streamed chunks (122 renders / 5,290 think chunks), far below one render per token.
- **Markdown block memoization works**: `MarkdownBlock` totals stay O(blocks + flushes) — 153 renders for 2,092 text chunks — not O(blocks × tokens) (~100k+).
- **Main thread stays healthy**: one 96ms long task across the entire 13.4s stream; 885ms total render time (~6.6% of one core).
- **Typing latency**: after the long transcript, 40 keystrokes leave transcript components at ≤2 renders — only composer-local components re-render.

## Measured (vite dev server, dev React, react-scan instrumented)

| Metric (13.4s stream, 5,290 think + 2,092 text chunks) | Result |
|---|---|
| `ThinkingContent` renders | 122 |
| `MarkdownBlock` renders | 153 |
| Total render time, whole app | 885ms |
| Long tasks (≥50ms) | 1 × 96ms |
| Thoughts toggles | exactly 1 |
| Typing (40 keys) transcript renders | ≤2 per component |

## Details

- Runs against the vite dev server (`PORT` pinned back to 3090 — the mock env exports `PORT=3080` for the backend and vite would otherwise hijack it). Prod builds don't work for naming: the oxc minifier strips `displayName` assignments, which react-scan needs.
- react-scan is **not** added as a repo dependency: `npm i --no-save react-scan` or point `REACT_SCAN_PATH` at its `auto.global.js`.
- Run with:
  ```bash
  npx playwright test --config=e2e/playwright.config.reasoning-perf.ts
  ```

## Fix: mock e2e stack vs local `.env`

A developer `.env` with `CHECK_BALANCE=true` leaks through `neutralizeCredentialEnv` (not credential-shaped), and the fresh e2e user has no balance record — so **every streaming mock spec fails** locally with a `token_balance` violation before the mock model runs. `vanillaOverrides` now pins `CHECK_BALANCE: 'false'`.

## Context

Investigated after reasoning appeared "split" in a deployment screenshot: the two Thoughts sections around a tool call are by-design interleaved reasoning (one reasoning part per model invocation), and mid-word paragraph seams (e.g. `ChatGPT.` / `com.`) arrive inside the provider's own summarized-thinking stream — verified that neither LibreChat nor `@librechat/agents` splits a continuous reasoning phase or inserts separators anywhere. This benchmark locks in that the no-splitting pipeline stays performant.