### PR TITLE
🧩 fix: Apply Every Entry of Multi-Part Stream Deltas

### DIFF
--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -1197,6 +1197,45 @@ describe('useStepHandler', () => {
       );
     });
 
+    it('applies every entry of a multi-part text delta in order', () => {
+      const responseMessage = createResponseMessage();
+      mockGetMessages.mockReturnValue([responseMessage]);
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
+
+      const runStep = createRunStep();
+      const submission = createSubmission();
+
+      act(() => {
+        result.current.stepHandler({ event: StepEvents.ON_RUN_STEP, data: runStep }, submission);
+      });
+
+      act(() => {
+        result.current.stepHandler(
+          {
+            event: StepEvents.ON_MESSAGE_DELTA,
+            data: {
+              id: 'step-1',
+              delta: {
+                content: [
+                  { type: ContentTypes.TEXT, text: 'Hello ' },
+                  { type: ContentTypes.TEXT, text: 'streaming ' },
+                  { type: ContentTypes.TEXT, text: 'world' },
+                ],
+              },
+            },
+          },
+          submission,
+        );
+      });
+
+      const lastCall = mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 1][0];
+      const responseMsg = lastCall[lastCall.length - 1];
+      expect(responseMsg.content).toContainEqual(
+        expect.objectContaining({ type: ContentTypes.TEXT, text: 'Hello streaming world' }),
+      );
+    });
+
     it('coalesces multiple deltas into a single flush per animation frame', () => {
       const rafQueue: FrameRequestCallback[] = [];
       (window.requestAnimationFrame as jest.Mock).mockImplementation((cb: FrameRequestCallback) => {
@@ -1403,6 +1442,47 @@ describe('useStepHandler', () => {
       const responseMsg = lastCall[lastCall.length - 1];
       expect(responseMsg.content).toContainEqual(
         expect.objectContaining({ type: ContentTypes.THINK, think: 'First thought' }),
+      );
+    });
+
+    it('applies every entry of a multi-part reasoning delta in order', () => {
+      const responseMessage = createResponseMessage();
+      mockGetMessages.mockReturnValue([responseMessage]);
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
+
+      const runStep = createRunStep();
+      const submission = createSubmission();
+
+      act(() => {
+        result.current.stepHandler({ event: StepEvents.ON_RUN_STEP, data: runStep }, submission);
+      });
+
+      act(() => {
+        result.current.stepHandler(
+          {
+            event: StepEvents.ON_REASONING_DELTA,
+            data: {
+              id: 'step-1',
+              delta: {
+                content: [
+                  { type: ContentTypes.THINK, think: 'First reasoning block. ' },
+                  { type: ContentTypes.THINK, think: 'Second reasoning block.' },
+                ],
+              },
+            },
+          },
+          submission,
+        );
+      });
+
+      const lastCall = mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 1][0];
+      const responseMsg = lastCall[lastCall.length - 1];
+      expect(responseMsg.content).toContainEqual(
+        expect.objectContaining({
+          type: ContentTypes.THINK,
+          think: 'First reasoning block. Second reasoning block.',
+        }),
       );
     });
   });

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -894,29 +894,38 @@ export default function useStepHandler({
 
         const response = messageMap.current.get(responseMessageId);
         if (response && messageDelta.delta.content) {
-          const contentPart = Array.isArray(messageDelta.delta.content)
-            ? messageDelta.delta.content[0]
-            : messageDelta.delta.content;
+          /** A delta may carry several parts (e.g. Google server-side tool
+           *  chunks) — every entry must be applied, in order, or streamed
+           *  text is silently dropped. */
+          const contentParts = Array.isArray(messageDelta.delta.content)
+            ? messageDelta.delta.content
+            : [messageDelta.delta.content];
 
-          if (contentPart == null) {
-            return;
+          let updatedResponse = response;
+          let hasUpdate = false;
+          for (const contentPart of contentParts) {
+            if (contentPart == null) {
+              continue;
+            }
+            const currentIndex = calculateContentIndex(
+              runStep.index,
+              initialContent,
+              contentPart.type || '',
+              updatedResponse.content,
+            );
+            updatedResponse = updateContent(
+              updatedResponse,
+              currentIndex,
+              contentPart,
+              false,
+              getStepMetadata(runStep),
+            );
+            hasUpdate = true;
           }
-
-          const currentIndex = calculateContentIndex(
-            runStep.index,
-            initialContent,
-            contentPart.type || '',
-            response.content,
-          );
-          const updatedResponse = updateContent(
-            response,
-            currentIndex,
-            contentPart,
-            false,
-            getStepMetadata(runStep),
-          );
-          messageMap.current.set(responseMessageId, updatedResponse);
-          scheduleCoalescedMessagesFlush(responseMessageId);
+          if (hasUpdate) {
+            messageMap.current.set(responseMessageId, updatedResponse);
+            scheduleCoalescedMessagesFlush(responseMessageId);
+          }
         }
       } else if (stepEvent.event === StepEvents.ON_REASONING_DELTA) {
         const reasoningDelta = stepEvent.data;
@@ -936,29 +945,37 @@ export default function useStepHandler({
 
         const response = messageMap.current.get(responseMessageId);
         if (response && reasoningDelta.delta.content != null) {
-          const contentPart = Array.isArray(reasoningDelta.delta.content)
-            ? reasoningDelta.delta.content[0]
-            : reasoningDelta.delta.content;
+          /** Same multi-part contract as message deltas: Google server-side
+           *  tool chunks emit several think entries in one delta. */
+          const contentParts = Array.isArray(reasoningDelta.delta.content)
+            ? reasoningDelta.delta.content
+            : [reasoningDelta.delta.content];
 
-          if (contentPart == null) {
-            return;
+          let updatedResponse = response;
+          let hasUpdate = false;
+          for (const contentPart of contentParts) {
+            if (contentPart == null) {
+              continue;
+            }
+            const currentIndex = calculateContentIndex(
+              runStep.index,
+              initialContent,
+              contentPart.type || '',
+              updatedResponse.content,
+            );
+            updatedResponse = updateContent(
+              updatedResponse,
+              currentIndex,
+              contentPart,
+              false,
+              getStepMetadata(runStep),
+            );
+            hasUpdate = true;
           }
-
-          const currentIndex = calculateContentIndex(
-            runStep.index,
-            initialContent,
-            contentPart.type || '',
-            response.content,
-          );
-          const updatedResponse = updateContent(
-            response,
-            currentIndex,
-            contentPart,
-            false,
-            getStepMetadata(runStep),
-          );
-          messageMap.current.set(responseMessageId, updatedResponse);
-          scheduleCoalescedMessagesFlush(responseMessageId);
+          if (hasUpdate) {
+            messageMap.current.set(responseMessageId, updatedResponse);
+            scheduleCoalescedMessagesFlush(responseMessageId);
+          }
         }
       } else if (stepEvent.event === StepEvents.ON_RUN_STEP_DELTA) {
         const runStepDelta = stepEvent.data;


### PR DESCRIPTION
## Summary

Fixes a silent data-loss edge found during the reasoning-splitting investigation (#14494): the client's `ON_MESSAGE_DELTA` and `ON_REASONING_DELTA` handlers in `useStepHandler.ts` read only `delta.content[0]`, dropping the remaining entries of any multi-part delta.

This is reachable today: the agents package's Google server-side tool path (`dispatchGoogleServerSideToolStreamContent`) emits several reasoning parts in a single delta event, so Gemini reasoning text could be lost from the live view.

## Changes

- Both delta handlers now iterate every content entry, chaining each through `updateContent` with the per-part content index computed against the progressively updated response — later entries observe earlier state, preserving existing single-entry semantics exactly.
- The cache write + rAF-coalesced flush happen once per delta after all entries apply.
- New unit tests cover multi-part text and reasoning deltas (the existing suite only ever built single-entry arrays).

## Companion

danny-avila/agents#350 applies the identical fix to the SDK's `createContentAggregator` (which had the same `content[0]` truncation at save time — the two sides were consistently wrong together; after both land they're consistently right) and removes the dead legacy `SplitStreamHandler` while at it.

## Validation

- `npx jest src/hooks/SSE/__tests__/useStepHandler.spec.ts`: 69/69 passing (67 existing + 2 new)
- ESLint + Prettier clean