### PR TITLE
📦 chore: Bump @librechat/agents to v3.3.5

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.4",
+    "@librechat/agents": "^3.3.5",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.4",
+        "@librechat/agents": "^3.3.5",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10615,9 +10615,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.4.tgz",
-      "integrity": "sha512-ip6aKxlyDGXlBgOpztPz4g3dts2LIuksSWFJ2va015OFpQCeXwujscQ0X2z6Fw001mmx8s0255BS1E1MsfSUbw==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.5.tgz",
+      "integrity": "sha512-0mdLZmPpD15eV/4UlyUxIgDT7qA1q+hIGNFPh/imqYQk7s5IVn7+CuaDkd11JA5F/RW9K0pXQYFK03A0qVVj1w==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42535,7 +42535,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.4",
+        "@librechat/agents": "^3.3.5",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -108,7 +108,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.4",
+    "@librechat/agents": "^3.3.5",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Pure SDK bump — `^3.3.4` → `^3.3.5` in `api/package.json` + `packages/api/package.json` plus the lockfile. No code changes.

## What v3.3.5 brings

- **danny-avila/agents#335** — 🔪 Cooperative mid-generation stream preemption: the SDK seam for interrupt & steer (`RunConfig.preemption`, `PreemptBoundary` hook, provider-safe seal gate, halt semantics). **Fully opt-in** — nothing in LibreChat activates until the upcoming steering server PR configures it.
- **danny-avila/agents#346** — 🧵 Predecessor-prefill handoff cue for bare direct-edge multi-agent successors on Claude (fixes danny-avila/agents#345 — empty/continuation-voiced successor turns).
- danny-avila/agents#343, #337, #348, #350 — jest/ESM mapping for mistralai, Keenable scraper, Langfuse trace normalization, delta content-part fixes.

## Behavior notes for review

The only shared-path changes affecting existing LibreChat traffic (no preemption configured) are: the vendored Bedrock converter now merges **all** consecutive user-role messages (previously only toolResult pairs — Converse's documented contract; live-verified both shapes against claude-sonnet-4-5), and the multi-agent handoff cue above. Both are live-verified; the SDK's seal paths were additionally verified end-to-end on 8 providers.

Merging this first keeps the steering server PR's diff purely feature code.