### PR TITLE
🕶 feat: Generalize Admin Config Secret Redaction

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -3,7 +3,12 @@ const fs = require('fs').promises;
 const FormData = require('form-data');
 const { Readable } = require('stream');
 const { logger } = require('@librechat/data-schemas');
-const { genAzureEndpoint, logAxiosError, applyAxiosProxyConfig } = require('@librechat/api');
+const {
+  genAzureEndpoint,
+  logAxiosError,
+  applyAxiosProxyConfig,
+  resolveConfigSecret,
+} = require('@librechat/api');
 const { extractEnvVariable, STTProviders } = require('librechat-data-provider');
 const { getAppConfig } = require('~/server/services/Config');
 
@@ -195,7 +200,7 @@ class STTService {
    */
   openAIProvider(sttSchema, audioReadStream, audioFile, language) {
     const url = sttSchema?.url || 'https://api.openai.com/v1/audio/transcriptions';
-    const apiKey = extractEnvVariable(sttSchema.apiKey) || '';
+    const apiKey = resolveConfigSecret(sttSchema.apiKey) || '';
 
     const data = {
       file: audioReadStream,
@@ -231,7 +236,7 @@ class STTService {
       azureOpenAIApiDeploymentName: extractEnvVariable(sttSchema?.deploymentName),
     })}/audio/transcriptions?api-version=${extractEnvVariable(sttSchema?.apiVersion)}`;
 
-    const apiKey = sttSchema.apiKey ? extractEnvVariable(sttSchema.apiKey) : '';
+    const apiKey = sttSchema.apiKey ? resolveConfigSecret(sttSchema.apiKey) || '' : '';
 
     if (audioBuffer.byteLength > 25 * 1024 * 1024) {
       throw new Error('The audio file size exceeds the limit of 25MB');

--- a/api/server/services/Files/Audio/TTSService.js
+++ b/api/server/services/Files/Audio/TTSService.js
@@ -125,9 +125,10 @@ class TTSService {
       backend: ttsSchema?.backend,
     };
 
+    const apiKey = resolveConfigSecret(ttsSchema?.apiKey) || '';
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${resolveConfigSecret(ttsSchema?.apiKey)}`,
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     };
 
     return [url, data, headers];
@@ -200,9 +201,10 @@ class TTSService {
       pronunciation_dictionary_locators: ttsSchema?.pronunciation_dictionary_locators,
     };
 
+    const apiKey = resolveConfigSecret(ttsSchema?.apiKey) || '';
     const headers = {
       'Content-Type': 'application/json',
-      'xi-api-key': resolveConfigSecret(ttsSchema?.apiKey),
+      ...(apiKey && { 'xi-api-key': apiKey }),
       Accept: 'audio/mpeg',
     };
 
@@ -235,14 +237,11 @@ class TTSService {
       backend: ttsSchema?.backend,
     };
 
+    const apiKey = resolveConfigSecret(ttsSchema?.apiKey) || '';
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${resolveConfigSecret(ttsSchema?.apiKey)}`,
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
     };
-
-    if (resolveConfigSecret(ttsSchema.apiKey) === '') {
-      delete headers.Authorization;
-    }
 
     return [url, data, headers];
   }
@@ -497,4 +496,5 @@ module.exports = {
   textToSpeech,
   streamAudio,
   getProvider,
+  TTSService,
 };

--- a/api/server/services/Files/Audio/TTSService.js
+++ b/api/server/services/Files/Audio/TTSService.js
@@ -1,6 +1,11 @@
 const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
-const { genAzureEndpoint, logAxiosError, applyAxiosProxyConfig } = require('@librechat/api');
+const {
+  genAzureEndpoint,
+  logAxiosError,
+  applyAxiosProxyConfig,
+  resolveConfigSecret,
+} = require('@librechat/api');
 const { extractEnvVariable, TTSProviders } = require('librechat-data-provider');
 const { getRandomVoiceId, createChunkProcessor, splitTextIntoChunks } = require('./streamAudio');
 const { getAppConfig } = require('~/server/services/Config');
@@ -122,7 +127,7 @@ class TTSService {
 
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${extractEnvVariable(ttsSchema?.apiKey)}`,
+      Authorization: `Bearer ${resolveConfigSecret(ttsSchema?.apiKey)}`,
     };
 
     return [url, data, headers];
@@ -159,7 +164,7 @@ class TTSService {
 
     const headers = {
       'Content-Type': 'application/json',
-      'api-key': ttsSchema.apiKey ? extractEnvVariable(ttsSchema.apiKey) : '',
+      'api-key': ttsSchema.apiKey ? resolveConfigSecret(ttsSchema.apiKey) || '' : '',
     };
 
     return [url, data, headers];
@@ -197,7 +202,7 @@ class TTSService {
 
     const headers = {
       'Content-Type': 'application/json',
-      'xi-api-key': extractEnvVariable(ttsSchema?.apiKey),
+      'xi-api-key': resolveConfigSecret(ttsSchema?.apiKey),
       Accept: 'audio/mpeg',
     };
 
@@ -232,10 +237,10 @@ class TTSService {
 
     const headers = {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${extractEnvVariable(ttsSchema?.apiKey)}`,
+      Authorization: `Bearer ${resolveConfigSecret(ttsSchema?.apiKey)}`,
     };
 
-    if (extractEnvVariable(ttsSchema.apiKey) === '') {
+    if (resolveConfigSecret(ttsSchema.apiKey) === '') {
       delete headers.Authorization;
     }
 

--- a/api/server/services/Files/Audio/TTSService.spec.js
+++ b/api/server/services/Files/Audio/TTSService.spec.js
@@ -1,0 +1,72 @@
+jest.mock('axios');
+jest.mock('@librechat/data-schemas', () => ({ logger: { warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@librechat/api', () => ({
+  genAzureEndpoint: jest.fn(),
+  logAxiosError: jest.fn(),
+  applyAxiosProxyConfig: jest.fn(),
+  resolveConfigSecret: jest.fn(),
+}));
+jest.mock('librechat-data-provider', () => ({
+  extractEnvVariable: jest.fn((value) => value),
+  TTSProviders: {
+    OPENAI: 'openai',
+    AZURE_OPENAI: 'azureOpenAI',
+    ELEVENLABS: 'elevenlabs',
+    LOCALAI: 'localai',
+  },
+}));
+jest.mock('./streamAudio', () => ({
+  getRandomVoiceId: jest.fn(),
+  createChunkProcessor: jest.fn(),
+  splitTextIntoChunks: jest.fn(),
+}));
+jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
+
+const { resolveConfigSecret } = require('@librechat/api');
+const { TTSService } = require('./TTSService');
+
+describe('TTSService provider header construction with an undecryptable apiKey', () => {
+  let service;
+
+  beforeEach(() => {
+    service = new TTSService();
+    resolveConfigSecret.mockReset();
+  });
+
+  it('omits the Authorization header for openAIProvider instead of sending "Bearer undefined"', () => {
+    resolveConfigSecret.mockReturnValue(undefined);
+    const [, , headers] = service.openAIProvider(
+      { apiKey: 'v3:corrupted', voices: [] },
+      'hi',
+      'alloy',
+    );
+    expect(headers).not.toHaveProperty('Authorization');
+  });
+
+  it('sets the Authorization header normally when the key resolves', () => {
+    resolveConfigSecret.mockReturnValue('sk-real-key');
+    const [, , headers] = service.openAIProvider({ apiKey: 'v3:ok', voices: [] }, 'hi', 'alloy');
+    expect(headers.Authorization).toBe('Bearer sk-real-key');
+  });
+
+  it('omits the xi-api-key header for elevenLabsProvider instead of sending "undefined"', () => {
+    resolveConfigSecret.mockReturnValue(undefined);
+    const [, , headers] = service.elevenLabsProvider(
+      { apiKey: 'v3:corrupted', voices: ['ALL'] },
+      'hi',
+      'voice1',
+      false,
+    );
+    expect(headers).not.toHaveProperty('xi-api-key');
+  });
+
+  it('omits the Authorization header for localAIProvider instead of sending "Bearer undefined"', () => {
+    resolveConfigSecret.mockReturnValue(undefined);
+    const [, , headers] = service.localAIProvider(
+      { apiKey: 'v3:corrupted', voices: [] },
+      'hi',
+      'voice1',
+    );
+    expect(headers).not.toHaveProperty('Authorization');
+  });
+});

--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -93,7 +93,7 @@ describe('createAdminConfigHandlers', () => {
               langfuse: {
                 publicKey: 'pk-lf-1',
                 secretKey: 'v3:encrypted',
-                displaySecretKey: 'sk-lf-...cret',
+                secretKeyPreview: 'sk-lf-...cret',
               },
             },
           },
@@ -110,7 +110,7 @@ describe('createAdminConfigHandlers', () => {
       }>;
       expect(configs[0].overrides.langfuse).toEqual({
         publicKey: 'pk-lf-1',
-        displaySecretKey: 'sk-lf-...cret',
+        secretKeyPreview: 'sk-lf-...cret',
       });
     });
   });
@@ -486,13 +486,13 @@ describe('createAdminConfigHandlers', () => {
       const savedOverrides = deps.upsertConfig.mock.calls[0][3];
       expect(savedOverrides.langfuse.secretKey).toMatch(/^v3:/);
       expect(savedOverrides.langfuse.secretKey).not.toBe('sk-lf-secret');
-      expect(savedOverrides.langfuse.displaySecretKey).toBe('sk-lf-...cret');
+      expect(savedOverrides.langfuse.secretKeyPreview).toBe('sk-lf-...cret');
       const responseConfig = res.body!.config as {
         overrides: { langfuse: Record<string, string> };
       };
       expect(responseConfig.overrides.langfuse).toEqual({
         publicKey: 'pk-lf-1',
-        displaySecretKey: savedOverrides.langfuse.displaySecretKey,
+        secretKeyPreview: savedOverrides.langfuse.secretKeyPreview,
       });
     });
 
@@ -504,7 +504,7 @@ describe('createAdminConfigHandlers', () => {
           langfuse: {
             publicKey: 'pk-old',
             secretKey: 'v3:test:sk-old',
-            displaySecretKey: 'sk-old...-old',
+            secretKeyPreview: 'sk-old...-old',
           },
         },
       };
@@ -537,7 +537,7 @@ describe('createAdminConfigHandlers', () => {
         publicKey: 'pk-new',
         destination: 'eu',
         secretKey: 'v3:test:sk-old',
-        displaySecretKey: 'sk-old...-old',
+        secretKeyPreview: 'sk-old...-old',
       });
       const responseConfig = res.body!.config as {
         overrides: { langfuse: Record<string, string> };
@@ -545,7 +545,7 @@ describe('createAdminConfigHandlers', () => {
       expect(responseConfig.overrides.langfuse).toEqual({
         publicKey: 'pk-new',
         destination: 'eu',
-        displaySecretKey: 'sk-old...-old',
+        secretKeyPreview: 'sk-old...-old',
       });
     });
 
@@ -556,7 +556,7 @@ describe('createAdminConfigHandlers', () => {
           overrides: {
             langfuse: {
               secretKey: 'v3:test:sk-old',
-              displaySecretKey: 'sk-old...-old',
+              secretKeyPreview: 'sk-old...-old',
             },
           },
         }),
@@ -586,7 +586,7 @@ describe('createAdminConfigHandlers', () => {
       expect(savedOverrides.langfuse).toEqual({
         publicKey: 'pk-new',
         secretKey: '',
-        displaySecretKey: '',
+        secretKeyPreview: '',
       });
     });
 
@@ -624,7 +624,7 @@ describe('createAdminConfigHandlers', () => {
         body: {
           overrides: {
             'langfuse.secretKey': 'sk-lf-secret',
-            'langfuse.displaySecretKey': 'spoofed',
+            'langfuse.secretKeyPreview': 'spoofed',
             langfuse: { publicKey: 'pk-lf-1' },
           },
         },
@@ -636,7 +636,7 @@ describe('createAdminConfigHandlers', () => {
       expect(res.statusCode).toBe(201);
       const savedOverrides = deps.upsertConfig.mock.calls[0][3];
       expect(savedOverrides).not.toHaveProperty('langfuse.secretKey');
-      expect(savedOverrides).not.toHaveProperty('langfuse.displaySecretKey');
+      expect(savedOverrides).not.toHaveProperty('langfuse.secretKeyPreview');
       expect(savedOverrides.langfuse).toEqual({ publicKey: 'pk-lf-1' });
       const responseConfig = res.body!.config as {
         overrides: { langfuse: Record<string, string> };
@@ -837,7 +837,7 @@ describe('createAdminConfigHandlers', () => {
       expect(deps.unsetConfigField).toHaveBeenCalledWith(
         'role',
         'admin',
-        'langfuse.displaySecretKey',
+        'langfuse.secretKeyPreview',
       );
     });
 
@@ -845,7 +845,7 @@ describe('createAdminConfigHandlers', () => {
       const { handlers, deps } = createHandlers();
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
-        query: { fieldPath: 'langfuse.displaySecretKey' },
+        query: { fieldPath: 'langfuse.secretKeyPreview' },
       });
       const res = mockRes();
 
@@ -947,7 +947,7 @@ describe('createAdminConfigHandlers', () => {
         'role',
         'admin',
         expect.anything(),
-        'langfuse.displaySecretKey',
+        'langfuse.secretKeyPreview',
         10,
       );
     });
@@ -956,7 +956,7 @@ describe('createAdminConfigHandlers', () => {
       const { handlers, deps } = createHandlers();
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
-        body: { fieldPath: 'langfuse.displaySecretKey' },
+        body: { fieldPath: 'langfuse.secretKeyPreview' },
       });
       const res = mockRes();
 
@@ -1054,7 +1054,7 @@ describe('createAdminConfigHandlers', () => {
       expect(patchedFields['interface.modelSelect']).toBe(false);
     });
 
-    it('clears stale Langfuse display secret keys when clearing a secret', async () => {
+    it('clears stale Langfuse secret previews when clearing a secret', async () => {
       const { handlers, deps } = createHandlers();
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
@@ -1069,7 +1069,7 @@ describe('createAdminConfigHandlers', () => {
       expect(res.statusCode).toBe(200);
       const patchedFields = deps.patchConfigFields.mock.calls[0][3];
       expect(patchedFields['langfuse.secretKey']).toBe('');
-      expect(patchedFields['langfuse.displaySecretKey']).toBe('');
+      expect(patchedFields['langfuse.secretKeyPreview']).toBe('');
     });
 
     it('encrypts Langfuse secret keys inside object-valued patch entries', async () => {
@@ -1096,7 +1096,7 @@ describe('createAdminConfigHandlers', () => {
       const patchedFields = deps.patchConfigFields.mock.calls[0][3];
       expect(patchedFields.langfuse.secretKey).toMatch(/^v3:/);
       expect(patchedFields.langfuse.secretKey).not.toBe('sk-lf-secret');
-      expect(patchedFields.langfuse.displaySecretKey).toBe('sk-lf-...cret');
+      expect(patchedFields.langfuse.secretKeyPreview).toBe('sk-lf-...cret');
     });
 
     it('preserves existing encrypted Langfuse secrets on object-valued patch entries when omitted', async () => {
@@ -1108,7 +1108,7 @@ describe('createAdminConfigHandlers', () => {
             langfuse: {
               publicKey: 'pk-old',
               secretKey: 'v3:test:sk-old',
-              displaySecretKey: 'sk-old...-old',
+              secretKeyPreview: 'sk-old...-old',
             },
           },
         }),
@@ -1138,7 +1138,7 @@ describe('createAdminConfigHandlers', () => {
         publicKey: 'pk-new',
         destination: 'eu',
         secretKey: 'v3:test:sk-old',
-        displaySecretKey: 'sk-old...-old',
+        secretKeyPreview: 'sk-old...-old',
       });
       expect(deps.findConfigByPrincipal).toHaveBeenCalled();
     });
@@ -1151,7 +1151,7 @@ describe('createAdminConfigHandlers', () => {
           overrides: {
             langfuse: {
               secretKey: 'v3:test:sk-old',
-              displaySecretKey: 'sk-old...-old',
+              secretKeyPreview: 'sk-old...-old',
             },
           },
         }),
@@ -1179,7 +1179,7 @@ describe('createAdminConfigHandlers', () => {
       expect(patchedFields.langfuse).toEqual({
         publicKey: 'pk-new',
         secretKey: '',
-        displaySecretKey: '',
+        secretKeyPreview: '',
       });
     });
 
@@ -1219,7 +1219,7 @@ describe('createAdminConfigHandlers', () => {
       expect(res.statusCode).toBe(200);
       const patchedFields = deps.patchConfigFields.mock.calls[0][3];
       expect(patchedFields['langfuse.secretKey']).toBe('');
-      expect(patchedFields['langfuse.displaySecretKey']).toBe('');
+      expect(patchedFields['langfuse.secretKeyPreview']).toBe('');
     });
 
     it('rejects direct display secret key patch entries', async () => {
@@ -1227,7 +1227,7 @@ describe('createAdminConfigHandlers', () => {
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
         body: {
-          entries: [{ fieldPath: 'langfuse.displaySecretKey', value: 'spoofed' }],
+          entries: [{ fieldPath: 'langfuse.secretKeyPreview', value: 'spoofed' }],
         },
       });
       const res = mockRes();
@@ -1270,12 +1270,12 @@ describe('createAdminConfigHandlers', () => {
       expect(deps.patchConfigFields).not.toHaveBeenCalled();
     });
 
-    it('rejects patch entries below protected Langfuse displaySecretKey paths', async () => {
+    it('rejects patch entries below protected Langfuse secretKeyPreview paths', async () => {
       const { handlers, deps } = createHandlers();
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
         body: {
-          entries: [{ fieldPath: 'langfuse.displaySecretKey.hidden', value: 'spoofed' }],
+          entries: [{ fieldPath: 'langfuse.secretKeyPreview.hidden', value: 'spoofed' }],
         },
       });
       const res = mockRes();
@@ -2294,13 +2294,13 @@ describe('createAdminConfigHandlers', () => {
           langfuse: {
             publicKey: 'pk-lf-1',
             secretKey: 'sk-lf-secret',
-            displaySecretKey: 'sk-lf-...cret',
+            secretKeyPreview: 'sk-lf-...cret',
           },
           config: {
             langfuse: {
               publicKey: 'pk-lf-1',
               secretKey: 'sk-lf-raw-secret',
-              displaySecretKey: 'sk-lf-...cret',
+              secretKeyPreview: 'sk-lf-...cret',
             },
           },
         }),
@@ -2317,11 +2317,11 @@ describe('createAdminConfigHandlers', () => {
       };
       expect(responseConfig.langfuse).toEqual({
         publicKey: 'pk-lf-1',
-        displaySecretKey: 'sk-lf-...cret',
+        secretKeyPreview: 'sk-lf-...cret',
       });
       expect(responseConfig.config.langfuse).toEqual({
         publicKey: 'pk-lf-1',
-        displaySecretKey: 'sk-lf-...cret',
+        secretKeyPreview: 'sk-lf-...cret',
       });
     });
 

--- a/packages/api/src/admin/config.spec.ts
+++ b/packages/api/src/admin/config.spec.ts
@@ -43,6 +43,13 @@ describe('isValidFieldPath', () => {
     expect(isValidFieldPath('prototypeChain')).toBe(true);
     expect(isValidFieldPath('a.myConstructor')).toBe(true);
   });
+
+  it('rejects MongoDB operator segments', () => {
+    expect(isValidFieldPath('webSearch.$[].serperApiKey')).toBe(false);
+    expect(isValidFieldPath('speech.tts.$.apiKey')).toBe(false);
+    expect(isValidFieldPath('a.$set')).toBe(false);
+    expect(isValidFieldPath('$')).toBe(false);
+  });
 });
 
 describe('getTopLevelSection', () => {

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -36,6 +36,7 @@ export function isValidFieldPath(path: string): boolean {
     !path.startsWith('.') &&
     !path.endsWith('.') &&
     !path.includes('..') &&
+    !path.includes('$') &&
     !UNSAFE_SEGMENTS.test(path)
   );
 }

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -17,6 +17,7 @@ import {
   encryptConfigSecrets,
   getConfigSecretMutationPaths,
   getConfigSecretInputError,
+  getConfigSecretSections,
   isConfigSecretAncestorPath,
   isConfigSecretDescendantPath,
   preserveConfigSecrets,
@@ -319,7 +320,7 @@ function redactAppConfigForResponse(appConfig: AppConfig): AppConfig {
   return safeConfig;
 }
 
-function isObjectValuedLangfusePatch(fieldPath: string, value: unknown): boolean {
+function isObjectValuedSecretAncestorPatch(fieldPath: string, value: unknown): boolean {
   return (
     isConfigSecretAncestorPath(fieldPath) &&
     value != null &&
@@ -334,7 +335,7 @@ function preservePatchedConfigSecretFields(
 ): Record<string, unknown> {
   const result = { ...fields };
   for (const [fieldPath, value] of Object.entries(result)) {
-    if (isObjectValuedLangfusePatch(fieldPath, value)) {
+    if (isObjectValuedSecretAncestorPatch(fieldPath, value)) {
       result[fieldPath] = preserveConfigSecrets(value, existingOverrides, fieldPath);
     }
   }
@@ -595,18 +596,22 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
         ? { expectEmpty: false }
         : { expectEmpty: true, preservePriority: true };
 
-      const langfuseInputError = getConfigSecretInputError(
-        'langfuse',
-        (filteredOverrides as Record<string, unknown>).langfuse,
-      );
-      if (langfuseInputError) {
-        return res.status(400).json({ error: langfuseInputError });
+      for (const section of getConfigSecretSections()) {
+        const secretInputError = getConfigSecretInputError(
+          section,
+          (filteredOverrides as Record<string, unknown>)[section],
+        );
+        if (secretInputError) {
+          return res.status(400).json({ error: secretInputError });
+        }
       }
 
       const encryptedOverrides = encryptConfigSecrets(filteredOverrides);
-      const existingForSecrets = isObjectValuedLangfusePatch(
-        'langfuse',
-        (filteredOverrides as Record<string, unknown>).langfuse,
+      const existingForSecrets = getConfigSecretSections().some((section) =>
+        isObjectValuedSecretAncestorPatch(
+          section,
+          (filteredOverrides as Record<string, unknown>)[section],
+        ),
       )
         ? await findConfigByPrincipal(principalType, principalId, { includeInactive: true })
         : null;
@@ -754,11 +759,11 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps): {
       }
       const requestedPriority = hasBroadManage ? priority : undefined;
 
-      const hasObjectValuedLangfusePatch = Object.entries(fields).some(([fieldPath, value]) =>
-        isObjectValuedLangfusePatch(fieldPath, value),
+      const hasObjectValuedSecretPatch = Object.entries(fields).some(([fieldPath, value]) =>
+        isObjectValuedSecretAncestorPatch(fieldPath, value),
       );
       const existing =
-        requestedPriority == null || hasObjectValuedLangfusePatch
+        requestedPriority == null || hasObjectValuedSecretPatch
           ? await findConfigByPrincipal(principalType, principalId, { includeInactive: true })
           : null;
       const encryptedFields = encryptConfigSecretFields(fields);

--- a/packages/api/src/admin/index.ts
+++ b/packages/api/src/admin/index.ts
@@ -5,6 +5,7 @@ export { createAdminRolesHandlers } from './roles';
 export { createAdminSkillsSyncAccess, createAdminSkillsSyncHandlers } from './skills';
 export { createAdminUsersHandlers } from './users';
 export { createAdminAuditLogHandlers } from './auditLog';
+export { resolveConfigSecret } from './secrets';
 export type { AdminConfigDeps } from './config';
 export type { AdminGrantsDeps, GrantPrincipalType } from './grants';
 export type { AdminGroupsDeps } from './groups';

--- a/packages/api/src/admin/secrets.integration.spec.ts
+++ b/packages/api/src/admin/secrets.integration.spec.ts
@@ -13,13 +13,13 @@ type AdminConfigHandlers = ReturnType<typeof import('./config').createAdminConfi
 let mongoServer: MongoMemoryServer;
 let handlers: AdminConfigHandlers;
 let decryptV3: DataSchemas['decryptV3'];
-let getDisplaySecretKey: typeof import('./secrets').getDisplaySecretKey;
+let getSecretPreview: typeof import('./secrets').getSecretPreview;
 
 interface SecretFieldCase {
   /** Dot-path of the secret field */
   path: string;
-  /** Dot-path of the non-secret masked display companion for `path` */
-  displayPath: string;
+  /** Dot-path of the non-secret masked preview companion for `path` */
+  previewPath: string;
   /** Section object containing the secret plus a non-secret sibling */
   section: string;
   object: Record<string, unknown>;
@@ -33,7 +33,7 @@ const SECRET = 'sk-super-secret-literal';
 const SECRET_FIELD_CASES: SecretFieldCase[] = [
   {
     path: 'langfuse.secretKey',
-    displayPath: 'langfuse.displaySecretKey',
+    previewPath: 'langfuse.secretKeyPreview',
     section: 'langfuse',
     object: { publicKey: 'pk-lf-1', secretKey: SECRET },
     siblingPath: 'langfuse.publicKey',
@@ -41,7 +41,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'ocr.apiKey',
-    displayPath: 'ocr.displayApiKey',
+    previewPath: 'ocr.apiKeyPreview',
     section: 'ocr',
     object: { apiKey: SECRET, mistralModel: 'mistral-ocr-latest' },
     siblingPath: 'ocr.mistralModel',
@@ -49,7 +49,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.openai.apiKey',
-    displayPath: 'speech.tts.openai.displayApiKey',
+    previewPath: 'speech.tts.openai.apiKeyPreview',
     section: 'speech',
     object: { tts: { openai: { apiKey: SECRET, model: 'tts-1', voices: ['alloy'] } } },
     siblingPath: 'speech.tts.openai.model',
@@ -57,7 +57,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.azureOpenAI.apiKey',
-    displayPath: 'speech.tts.azureOpenAI.displayApiKey',
+    previewPath: 'speech.tts.azureOpenAI.apiKeyPreview',
     section: 'speech',
     object: { tts: { azureOpenAI: { apiKey: SECRET, instanceName: 'inst' } } },
     siblingPath: 'speech.tts.azureOpenAI.instanceName',
@@ -65,7 +65,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.elevenlabs.apiKey',
-    displayPath: 'speech.tts.elevenlabs.displayApiKey',
+    previewPath: 'speech.tts.elevenlabs.apiKeyPreview',
     section: 'speech',
     object: { tts: { elevenlabs: { apiKey: SECRET, model: 'eleven_multilingual_v2' } } },
     siblingPath: 'speech.tts.elevenlabs.model',
@@ -73,7 +73,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.localai.apiKey',
-    displayPath: 'speech.tts.localai.displayApiKey',
+    previewPath: 'speech.tts.localai.apiKeyPreview',
     section: 'speech',
     object: { tts: { localai: { apiKey: SECRET, url: 'http://localai:8080' } } },
     siblingPath: 'speech.tts.localai.url',
@@ -81,7 +81,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.stt.openai.apiKey',
-    displayPath: 'speech.stt.openai.displayApiKey',
+    previewPath: 'speech.stt.openai.apiKeyPreview',
     section: 'speech',
     object: { stt: { openai: { apiKey: SECRET, model: 'whisper-1' } } },
     siblingPath: 'speech.stt.openai.model',
@@ -89,7 +89,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.stt.azureOpenAI.apiKey',
-    displayPath: 'speech.stt.azureOpenAI.displayApiKey',
+    previewPath: 'speech.stt.azureOpenAI.apiKeyPreview',
     section: 'speech',
     object: { stt: { azureOpenAI: { apiKey: SECRET, instanceName: 'inst' } } },
     siblingPath: 'speech.stt.azureOpenAI.instanceName',
@@ -97,7 +97,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.serperApiKey',
-    displayPath: 'webSearch.displaySerperApiKey',
+    previewPath: 'webSearch.serperApiKeyPreview',
     section: 'webSearch',
     object: { serperApiKey: SECRET, searchProvider: 'serper' },
     siblingPath: 'webSearch.searchProvider',
@@ -105,7 +105,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.searxngApiKey',
-    displayPath: 'webSearch.displaySearxngApiKey',
+    previewPath: 'webSearch.searxngApiKeyPreview',
     section: 'webSearch',
     object: { searxngApiKey: SECRET, searxngInstanceUrl: 'https://searx.example.com' },
     siblingPath: 'webSearch.searxngInstanceUrl',
@@ -113,7 +113,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.firecrawlApiKey',
-    displayPath: 'webSearch.displayFirecrawlApiKey',
+    previewPath: 'webSearch.firecrawlApiKeyPreview',
     section: 'webSearch',
     object: { firecrawlApiKey: SECRET, firecrawlApiUrl: 'https://api.firecrawl.dev' },
     siblingPath: 'webSearch.firecrawlApiUrl',
@@ -121,7 +121,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.tavilyApiKey',
-    displayPath: 'webSearch.displayTavilyApiKey',
+    previewPath: 'webSearch.tavilyApiKeyPreview',
     section: 'webSearch',
     object: { tavilyApiKey: SECRET, scraperTimeout: 7500 },
     siblingPath: 'webSearch.scraperTimeout',
@@ -129,7 +129,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.jinaApiKey',
-    displayPath: 'webSearch.displayJinaApiKey',
+    previewPath: 'webSearch.jinaApiKeyPreview',
     section: 'webSearch',
     object: { jinaApiKey: SECRET, jinaApiUrl: 'https://r.jina.ai' },
     siblingPath: 'webSearch.jinaApiUrl',
@@ -137,7 +137,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.cohereApiKey',
-    displayPath: 'webSearch.displayCohereApiKey',
+    previewPath: 'webSearch.cohereApiKeyPreview',
     section: 'webSearch',
     object: { cohereApiKey: SECRET, rerankerType: 'cohere' },
     siblingPath: 'webSearch.rerankerType',
@@ -145,7 +145,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'endpoints.assistants.apiKey',
-    displayPath: 'endpoints.assistants.displayApiKey',
+    previewPath: 'endpoints.assistants.apiKeyPreview',
     section: 'endpoints',
     object: { assistants: { apiKey: SECRET, disableBuilder: true } },
     siblingPath: 'endpoints.assistants.disableBuilder',
@@ -153,7 +153,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'endpoints.azureAssistants.apiKey',
-    displayPath: 'endpoints.azureAssistants.displayApiKey',
+    previewPath: 'endpoints.azureAssistants.apiKeyPreview',
     section: 'endpoints',
     object: { azureAssistants: { apiKey: SECRET, disableBuilder: true } },
     siblingPath: 'endpoints.azureAssistants.disableBuilder',
@@ -236,7 +236,7 @@ beforeAll(async () => {
   jest.spyOn(dataSchemas.logger, 'debug').mockReturnValue(dataSchemas.logger);
 
   const { createAdminConfigHandlers } = await import('./config');
-  ({ getDisplaySecretKey } = await import('./secrets'));
+  ({ getSecretPreview } = await import('./secrets'));
 
   mongoServer = await MongoMemoryServer.create();
   await mongoose.connect(mongoServer.getUri());
@@ -266,8 +266,8 @@ afterAll(async () => {
 describe('config secret registry — real handlers against a real Config collection', () => {
   describe.each(SECRET_FIELD_CASES)(
     '$path',
-    ({ path, displayPath, section, object, siblingPath, siblingValue }) => {
-      it('encrypts dotted patch writes at rest, sets the masked display companion, and redacts the secret from the response', async () => {
+    ({ path, previewPath, section, object, siblingPath, siblingValue }) => {
+      it('encrypts dotted patch writes at rest, sets the masked preview companion, and redacts the secret from the response', async () => {
         const principalId = nextPrincipalId();
         const res = mockRes();
         await handlers.patchConfigField(
@@ -285,15 +285,15 @@ describe('config secret registry — real handlers against a real Config collect
         expect(typeof stored).toBe('string');
         expect(stored).toMatch(/^v3:/);
         expect(decryptV3(stored as string)).toBe(SECRET);
-        expect(getAtPath(overrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+        expect(getAtPath(overrides, previewPath)).toBe(getSecretPreview(SECRET));
 
         const responseOverrides = (res.body!.config as { overrides: Record<string, unknown> })
           .overrides;
         expect(getAtPath(responseOverrides, path)).toBeUndefined();
-        expect(getAtPath(responseOverrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+        expect(getAtPath(responseOverrides, previewPath)).toBe(getSecretPreview(SECRET));
       });
 
-      it('encrypts object-valued upsert writes at rest, sets the masked display companion, and redacts reads', async () => {
+      it('encrypts object-valued upsert writes at rest, sets the masked preview companion, and redacts reads', async () => {
         const principalId = nextPrincipalId();
         const upsertRes = mockRes();
         await handlers.upsertConfigOverrides(
@@ -308,7 +308,7 @@ describe('config secret registry — real handlers against a real Config collect
 
         const overrides = await readRawOverrides(principalId);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
-        expect(getAtPath(overrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+        expect(getAtPath(overrides, previewPath)).toBe(getSecretPreview(SECRET));
 
         const getRes = mockRes();
         await handlers.getConfig(
@@ -321,7 +321,7 @@ describe('config secret registry — real handlers against a real Config collect
         const getOverrides = (getRes.body!.config as { overrides: Record<string, unknown> })
           .overrides;
         expect(getAtPath(getOverrides, path)).toBeUndefined();
-        expect(getAtPath(getOverrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+        expect(getAtPath(getOverrides, previewPath)).toBe(getSecretPreview(SECRET));
 
         const listRes = mockRes();
         await handlers.listConfigs(mockReq(), listRes);
@@ -330,7 +330,7 @@ describe('config secret registry — real handlers against a real Config collect
         expect(JSON.stringify(listRes.body)).not.toContain('v3:');
       });
 
-      it('preserves the stored secret and its display companion across an unrelated dotted patch', async () => {
+      it('preserves the stored secret and its preview companion across an unrelated dotted patch', async () => {
         const principalId = nextPrincipalId();
         await handlers.patchConfigField(
           mockReq({
@@ -341,8 +341,8 @@ describe('config secret registry — real handlers against a real Config collect
         );
         const rawBefore = await readRawOverrides(principalId);
         const before = getAtPath(rawBefore, path);
-        const displayBefore = getAtPath(rawBefore, displayPath);
-        expect(displayBefore).toBe(getDisplaySecretKey(SECRET));
+        const displayBefore = getAtPath(rawBefore, previewPath);
+        expect(displayBefore).toBe(getSecretPreview(SECRET));
 
         await handlers.patchConfigField(
           mockReq({
@@ -355,11 +355,11 @@ describe('config secret registry — real handlers against a real Config collect
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBe(before);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
-        expect(getAtPath(overrides, displayPath)).toBe(displayBefore);
+        expect(getAtPath(overrides, previewPath)).toBe(displayBefore);
         expect(getAtPath(overrides, siblingPath)).toEqual(siblingValue);
       });
 
-      it('round-trips a redacted read (including the visible display companion) back through a full upsert without clobbering the secret', async () => {
+      it('round-trips a redacted read (including the visible preview companion) back through a full upsert without clobbering the secret', async () => {
         const principalId = nextPrincipalId();
         await handlers.upsertConfigOverrides(
           mockReq({
@@ -370,7 +370,7 @@ describe('config secret registry — real handlers against a real Config collect
         );
         const rawBefore = await readRawOverrides(principalId);
         const before = getAtPath(rawBefore, path);
-        const displayBefore = getAtPath(rawBefore, displayPath);
+        const displayBefore = getAtPath(rawBefore, previewPath);
 
         const getRes = mockRes();
         await handlers.getConfig(
@@ -380,7 +380,7 @@ describe('config secret registry — real handlers against a real Config collect
         const redactedOverrides = (getRes.body!.config as { overrides: Record<string, unknown> })
           .overrides;
         expect(getAtPath(redactedOverrides, path)).toBeUndefined();
-        expect(getAtPath(redactedOverrides, displayPath)).toBe(displayBefore);
+        expect(getAtPath(redactedOverrides, previewPath)).toBe(displayBefore);
 
         const clientEdited = JSON.parse(JSON.stringify(redactedOverrides)) as Record<
           string,
@@ -400,10 +400,10 @@ describe('config secret registry — real handlers against a real Config collect
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBe(before);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
-        expect(getAtPath(overrides, displayPath)).toBe(displayBefore);
+        expect(getAtPath(overrides, previewPath)).toBe(displayBefore);
       });
 
-      it('clears the secret and its display companion when explicitly set to an empty value', async () => {
+      it('clears the secret and its preview companion when explicitly set to an empty value', async () => {
         const principalId = nextPrincipalId();
         await handlers.patchConfigField(
           mockReq({
@@ -421,7 +421,7 @@ describe('config secret registry — real handlers against a real Config collect
         );
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBe('');
-        expect(getAtPath(overrides, displayPath)).toBe('');
+        expect(getAtPath(overrides, previewPath)).toBe('');
       });
 
       it('rejects encrypted value submissions', async () => {
@@ -436,7 +436,7 @@ describe('config secret registry — real handlers against a real Config collect
         expect(res.statusCode).toBe(400);
       });
 
-      it('rejects a direct dotted-patch write to the display companion path itself', async () => {
+      it('rejects a direct dotted-patch write to the preview companion path itself', async () => {
         const principalId = nextPrincipalId();
         await handlers.patchConfigField(
           mockReq({
@@ -450,7 +450,7 @@ describe('config secret registry — real handlers against a real Config collect
         await handlers.patchConfigField(
           mockReq({
             params: { principalType: 'role', principalId },
-            body: { entries: [{ fieldPath: displayPath, value: 'attacker-supplied-display' }] },
+            body: { entries: [{ fieldPath: previewPath, value: 'attacker-supplied-display' }] },
           }),
           res,
         );
@@ -458,7 +458,7 @@ describe('config secret registry — real handlers against a real Config collect
 
         const overrides = await readRawOverrides(principalId);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
-        expect(getAtPath(overrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+        expect(getAtPath(overrides, previewPath)).toBe(getSecretPreview(SECRET));
       });
 
       it('never persists a client-supplied display value as the real secret via an object-valued upsert', async () => {
@@ -470,9 +470,9 @@ describe('config secret registry — real handlers against a real Config collect
           cursor = cursor[objectPathSegments[i]] as Record<string, unknown>;
         }
         const secretKey = objectPathSegments[objectPathSegments.length - 1];
-        const displayKey = displayPath.split('.').slice(-1)[0];
+        const previewKey = previewPath.split('.').slice(-1)[0];
         delete cursor[secretKey];
-        cursor[displayKey] = 'v3:attacker-supplied-looks-encrypted';
+        cursor[previewKey] = 'v3:attacker-supplied-looks-encrypted';
 
         const res = mockRes();
         await handlers.upsertConfigOverrides(
@@ -486,7 +486,7 @@ describe('config secret registry — real handlers against a real Config collect
 
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBeUndefined();
-        expect(getAtPath(overrides, displayPath)).toBeUndefined();
+        expect(getAtPath(overrides, previewPath)).toBeUndefined();
       });
     },
   );
@@ -535,12 +535,12 @@ describe('config secret registry — real handlers against a real Config collect
       const overrides = (getRes.body!.config as { overrides: Record<string, unknown> }).overrides;
       expect(getAtPath(overrides, 'speech.tts.openai.model')).toBe('tts-1');
       expect(getAtPath(overrides, 'webSearch.searchProvider')).toBe('serper');
-      // Documents written before this field existed have no display companion at all.
+      // Documents written before this field existed have no preview companion at all.
       // Redaction must not fabricate one — it only ever copies forward a companion
       // that a prior encrypt actually wrote.
-      expect(getAtPath(overrides, 'speech.tts.openai.displayApiKey')).toBeUndefined();
-      expect(getAtPath(overrides, 'ocr.displayApiKey')).toBeUndefined();
-      expect(getAtPath(overrides, 'webSearch.displaySerperApiKey')).toBeUndefined();
+      expect(getAtPath(overrides, 'speech.tts.openai.apiKeyPreview')).toBeUndefined();
+      expect(getAtPath(overrides, 'ocr.apiKeyPreview')).toBeUndefined();
+      expect(getAtPath(overrides, 'webSearch.serperApiKeyPreview')).toBeUndefined();
 
       const listRes = mockRes();
       await handlers.listConfigs(mockReq(), listRes);
@@ -553,12 +553,12 @@ describe('config secret registry — real handlers against a real Config collect
       const appConfig = {
         speech: {
           tts: {
-            openai: { apiKey: SECRET, displayApiKey: getDisplaySecretKey(SECRET), model: 'tts-1' },
+            openai: { apiKey: SECRET, apiKeyPreview: getSecretPreview(SECRET), model: 'tts-1' },
           },
         },
         ocr: { apiKey: '${OCR_API_KEY}' },
         webSearch: { serperApiKey: SECRET, searchProvider: 'serper' },
-        langfuse: { publicKey: 'pk-lf-1', secretKey: 'v3:stored', displaySecretKey: 'sk-...ret' },
+        langfuse: { publicKey: 'pk-lf-1', secretKey: 'v3:stored', secretKeyPreview: 'sk-...ret' },
         paths: { uploads: '/tmp' },
         config: {
           speech: { tts: { openai: { apiKey: SECRET, model: 'tts-1' } } },
@@ -590,10 +590,8 @@ describe('config secret registry — real handlers against a real Config collect
       expect(getAtPath(config, 'ocr.apiKey')).toBe('${OCR_API_KEY}');
       expect(getAtPath(config, 'speech.tts.openai.model')).toBe('tts-1');
       expect(getAtPath(config, 'speech.tts.openai.apiKey')).toBeUndefined();
-      expect(getAtPath(config, 'speech.tts.openai.displayApiKey')).toBe(
-        getDisplaySecretKey(SECRET),
-      );
-      expect(getAtPath(config, 'langfuse.displaySecretKey')).toBe('sk-...ret');
+      expect(getAtPath(config, 'speech.tts.openai.apiKeyPreview')).toBe(getSecretPreview(SECRET));
+      expect(getAtPath(config, 'langfuse.secretKeyPreview')).toBe('sk-...ret');
       expect(getAtPath(config, 'config.speech.tts.openai.apiKey')).toBeUndefined();
     });
   });

--- a/packages/api/src/admin/secrets.integration.spec.ts
+++ b/packages/api/src/admin/secrets.integration.spec.ts
@@ -13,10 +13,13 @@ type AdminConfigHandlers = ReturnType<typeof import('./config').createAdminConfi
 let mongoServer: MongoMemoryServer;
 let handlers: AdminConfigHandlers;
 let decryptV3: DataSchemas['decryptV3'];
+let getDisplaySecretKey: typeof import('./secrets').getDisplaySecretKey;
 
 interface SecretFieldCase {
   /** Dot-path of the secret field */
   path: string;
+  /** Dot-path of the non-secret masked display companion for `path` */
+  displayPath: string;
   /** Section object containing the secret plus a non-secret sibling */
   section: string;
   object: Record<string, unknown>;
@@ -30,6 +33,7 @@ const SECRET = 'sk-super-secret-literal';
 const SECRET_FIELD_CASES: SecretFieldCase[] = [
   {
     path: 'langfuse.secretKey',
+    displayPath: 'langfuse.displaySecretKey',
     section: 'langfuse',
     object: { publicKey: 'pk-lf-1', secretKey: SECRET },
     siblingPath: 'langfuse.publicKey',
@@ -37,6 +41,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'ocr.apiKey',
+    displayPath: 'ocr.displayApiKey',
     section: 'ocr',
     object: { apiKey: SECRET, mistralModel: 'mistral-ocr-latest' },
     siblingPath: 'ocr.mistralModel',
@@ -44,6 +49,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.openai.apiKey',
+    displayPath: 'speech.tts.openai.displayApiKey',
     section: 'speech',
     object: { tts: { openai: { apiKey: SECRET, model: 'tts-1', voices: ['alloy'] } } },
     siblingPath: 'speech.tts.openai.model',
@@ -51,6 +57,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.azureOpenAI.apiKey',
+    displayPath: 'speech.tts.azureOpenAI.displayApiKey',
     section: 'speech',
     object: { tts: { azureOpenAI: { apiKey: SECRET, instanceName: 'inst' } } },
     siblingPath: 'speech.tts.azureOpenAI.instanceName',
@@ -58,6 +65,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.elevenlabs.apiKey',
+    displayPath: 'speech.tts.elevenlabs.displayApiKey',
     section: 'speech',
     object: { tts: { elevenlabs: { apiKey: SECRET, model: 'eleven_multilingual_v2' } } },
     siblingPath: 'speech.tts.elevenlabs.model',
@@ -65,6 +73,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.tts.localai.apiKey',
+    displayPath: 'speech.tts.localai.displayApiKey',
     section: 'speech',
     object: { tts: { localai: { apiKey: SECRET, url: 'http://localai:8080' } } },
     siblingPath: 'speech.tts.localai.url',
@@ -72,6 +81,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.stt.openai.apiKey',
+    displayPath: 'speech.stt.openai.displayApiKey',
     section: 'speech',
     object: { stt: { openai: { apiKey: SECRET, model: 'whisper-1' } } },
     siblingPath: 'speech.stt.openai.model',
@@ -79,6 +89,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'speech.stt.azureOpenAI.apiKey',
+    displayPath: 'speech.stt.azureOpenAI.displayApiKey',
     section: 'speech',
     object: { stt: { azureOpenAI: { apiKey: SECRET, instanceName: 'inst' } } },
     siblingPath: 'speech.stt.azureOpenAI.instanceName',
@@ -86,6 +97,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.serperApiKey',
+    displayPath: 'webSearch.displaySerperApiKey',
     section: 'webSearch',
     object: { serperApiKey: SECRET, searchProvider: 'serper' },
     siblingPath: 'webSearch.searchProvider',
@@ -93,6 +105,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.searxngApiKey',
+    displayPath: 'webSearch.displaySearxngApiKey',
     section: 'webSearch',
     object: { searxngApiKey: SECRET, searxngInstanceUrl: 'https://searx.example.com' },
     siblingPath: 'webSearch.searxngInstanceUrl',
@@ -100,6 +113,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.firecrawlApiKey',
+    displayPath: 'webSearch.displayFirecrawlApiKey',
     section: 'webSearch',
     object: { firecrawlApiKey: SECRET, firecrawlApiUrl: 'https://api.firecrawl.dev' },
     siblingPath: 'webSearch.firecrawlApiUrl',
@@ -107,6 +121,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.tavilyApiKey',
+    displayPath: 'webSearch.displayTavilyApiKey',
     section: 'webSearch',
     object: { tavilyApiKey: SECRET, scraperTimeout: 7500 },
     siblingPath: 'webSearch.scraperTimeout',
@@ -114,6 +129,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.jinaApiKey',
+    displayPath: 'webSearch.displayJinaApiKey',
     section: 'webSearch',
     object: { jinaApiKey: SECRET, jinaApiUrl: 'https://r.jina.ai' },
     siblingPath: 'webSearch.jinaApiUrl',
@@ -121,6 +137,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'webSearch.cohereApiKey',
+    displayPath: 'webSearch.displayCohereApiKey',
     section: 'webSearch',
     object: { cohereApiKey: SECRET, rerankerType: 'cohere' },
     siblingPath: 'webSearch.rerankerType',
@@ -128,6 +145,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'endpoints.assistants.apiKey',
+    displayPath: 'endpoints.assistants.displayApiKey',
     section: 'endpoints',
     object: { assistants: { apiKey: SECRET, disableBuilder: true } },
     siblingPath: 'endpoints.assistants.disableBuilder',
@@ -135,6 +153,7 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
   },
   {
     path: 'endpoints.azureAssistants.apiKey',
+    displayPath: 'endpoints.azureAssistants.displayApiKey',
     section: 'endpoints',
     object: { azureAssistants: { apiKey: SECRET, disableBuilder: true } },
     siblingPath: 'endpoints.azureAssistants.disableBuilder',
@@ -217,6 +236,7 @@ beforeAll(async () => {
   jest.spyOn(dataSchemas.logger, 'debug').mockReturnValue(dataSchemas.logger);
 
   const { createAdminConfigHandlers } = await import('./config');
+  ({ getDisplaySecretKey } = await import('./secrets'));
 
   mongoServer = await MongoMemoryServer.create();
   await mongoose.connect(mongoServer.getUri());
@@ -246,8 +266,8 @@ afterAll(async () => {
 describe('config secret registry — real handlers against a real Config collection', () => {
   describe.each(SECRET_FIELD_CASES)(
     '$path',
-    ({ path, section, object, siblingPath, siblingValue }) => {
-      it('encrypts dotted patch writes at rest and redacts them from the response', async () => {
+    ({ path, displayPath, section, object, siblingPath, siblingValue }) => {
+      it('encrypts dotted patch writes at rest, sets the masked display companion, and redacts the secret from the response', async () => {
         const principalId = nextPrincipalId();
         const res = mockRes();
         await handlers.patchConfigField(
@@ -265,9 +285,15 @@ describe('config secret registry — real handlers against a real Config collect
         expect(typeof stored).toBe('string');
         expect(stored).toMatch(/^v3:/);
         expect(decryptV3(stored as string)).toBe(SECRET);
+        expect(getAtPath(overrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+
+        const responseOverrides = (res.body!.config as { overrides: Record<string, unknown> })
+          .overrides;
+        expect(getAtPath(responseOverrides, path)).toBeUndefined();
+        expect(getAtPath(responseOverrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
       });
 
-      it('encrypts object-valued upsert writes at rest and redacts reads', async () => {
+      it('encrypts object-valued upsert writes at rest, sets the masked display companion, and redacts reads', async () => {
         const principalId = nextPrincipalId();
         const upsertRes = mockRes();
         await handlers.upsertConfigOverrides(
@@ -282,6 +308,7 @@ describe('config secret registry — real handlers against a real Config collect
 
         const overrides = await readRawOverrides(principalId);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+        expect(getAtPath(overrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
 
         const getRes = mockRes();
         await handlers.getConfig(
@@ -291,6 +318,10 @@ describe('config secret registry — real handlers against a real Config collect
         expect(getRes.statusCode).toBe(200);
         expect(JSON.stringify(getRes.body)).not.toContain(SECRET);
         expect(JSON.stringify(getRes.body)).not.toContain('v3:');
+        const getOverrides = (getRes.body!.config as { overrides: Record<string, unknown> })
+          .overrides;
+        expect(getAtPath(getOverrides, path)).toBeUndefined();
+        expect(getAtPath(getOverrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
 
         const listRes = mockRes();
         await handlers.listConfigs(mockReq(), listRes);
@@ -299,7 +330,7 @@ describe('config secret registry — real handlers against a real Config collect
         expect(JSON.stringify(listRes.body)).not.toContain('v3:');
       });
 
-      it('preserves the stored secret across an unrelated dotted patch', async () => {
+      it('preserves the stored secret and its display companion across an unrelated dotted patch', async () => {
         const principalId = nextPrincipalId();
         await handlers.patchConfigField(
           mockReq({
@@ -308,7 +339,10 @@ describe('config secret registry — real handlers against a real Config collect
           }),
           mockRes(),
         );
-        const before = getAtPath(await readRawOverrides(principalId), path);
+        const rawBefore = await readRawOverrides(principalId);
+        const before = getAtPath(rawBefore, path);
+        const displayBefore = getAtPath(rawBefore, displayPath);
+        expect(displayBefore).toBe(getDisplaySecretKey(SECRET));
 
         await handlers.patchConfigField(
           mockReq({
@@ -321,10 +355,11 @@ describe('config secret registry — real handlers against a real Config collect
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBe(before);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+        expect(getAtPath(overrides, displayPath)).toBe(displayBefore);
         expect(getAtPath(overrides, siblingPath)).toEqual(siblingValue);
       });
 
-      it('round-trips a redacted read back through a full upsert without clobbering the secret', async () => {
+      it('round-trips a redacted read (including the visible display companion) back through a full upsert without clobbering the secret', async () => {
         const principalId = nextPrincipalId();
         await handlers.upsertConfigOverrides(
           mockReq({
@@ -333,7 +368,9 @@ describe('config secret registry — real handlers against a real Config collect
           }),
           mockRes(),
         );
-        const before = getAtPath(await readRawOverrides(principalId), path);
+        const rawBefore = await readRawOverrides(principalId);
+        const before = getAtPath(rawBefore, path);
+        const displayBefore = getAtPath(rawBefore, displayPath);
 
         const getRes = mockRes();
         await handlers.getConfig(
@@ -343,6 +380,7 @@ describe('config secret registry — real handlers against a real Config collect
         const redactedOverrides = (getRes.body!.config as { overrides: Record<string, unknown> })
           .overrides;
         expect(getAtPath(redactedOverrides, path)).toBeUndefined();
+        expect(getAtPath(redactedOverrides, displayPath)).toBe(displayBefore);
 
         const clientEdited = JSON.parse(JSON.stringify(redactedOverrides)) as Record<
           string,
@@ -362,9 +400,10 @@ describe('config secret registry — real handlers against a real Config collect
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBe(before);
         expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+        expect(getAtPath(overrides, displayPath)).toBe(displayBefore);
       });
 
-      it('clears the secret when explicitly set to an empty value', async () => {
+      it('clears the secret and its display companion when explicitly set to an empty value', async () => {
         const principalId = nextPrincipalId();
         await handlers.patchConfigField(
           mockReq({
@@ -382,6 +421,7 @@ describe('config secret registry — real handlers against a real Config collect
         );
         const overrides = await readRawOverrides(principalId);
         expect(getAtPath(overrides, path)).toBe('');
+        expect(getAtPath(overrides, displayPath)).toBe('');
       });
 
       it('rejects encrypted value submissions', async () => {
@@ -394,6 +434,59 @@ describe('config secret registry — real handlers against a real Config collect
           res,
         );
         expect(res.statusCode).toBe(400);
+      });
+
+      it('rejects a direct dotted-patch write to the display companion path itself', async () => {
+        const principalId = nextPrincipalId();
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: path, value: SECRET }] },
+          }),
+          mockRes(),
+        );
+
+        const res = mockRes();
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: displayPath, value: 'attacker-supplied-display' }] },
+          }),
+          res,
+        );
+        expect(res.statusCode).toBe(400);
+
+        const overrides = await readRawOverrides(principalId);
+        expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+        expect(getAtPath(overrides, displayPath)).toBe(getDisplaySecretKey(SECRET));
+      });
+
+      it('never persists a client-supplied display value as the real secret via an object-valued upsert', async () => {
+        const principalId = nextPrincipalId();
+        const spoofedObject = JSON.parse(JSON.stringify(object)) as Record<string, unknown>;
+        const objectPathSegments = path.slice(section.length + 1).split('.');
+        let cursor = spoofedObject;
+        for (let i = 0; i < objectPathSegments.length - 1; i++) {
+          cursor = cursor[objectPathSegments[i]] as Record<string, unknown>;
+        }
+        const secretKey = objectPathSegments[objectPathSegments.length - 1];
+        const displayKey = displayPath.split('.').slice(-1)[0];
+        delete cursor[secretKey];
+        cursor[displayKey] = 'v3:attacker-supplied-looks-encrypted';
+
+        const res = mockRes();
+        await handlers.upsertConfigOverrides(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { overrides: { [section]: spoofedObject } },
+          }),
+          res,
+        );
+        expect(res.statusCode).toBe(201);
+
+        const overrides = await readRawOverrides(principalId);
+        expect(getAtPath(overrides, path)).toBeUndefined();
+        expect(getAtPath(overrides, displayPath)).toBeUndefined();
       });
     },
   );
@@ -442,6 +535,12 @@ describe('config secret registry — real handlers against a real Config collect
       const overrides = (getRes.body!.config as { overrides: Record<string, unknown> }).overrides;
       expect(getAtPath(overrides, 'speech.tts.openai.model')).toBe('tts-1');
       expect(getAtPath(overrides, 'webSearch.searchProvider')).toBe('serper');
+      // Documents written before this field existed have no display companion at all.
+      // Redaction must not fabricate one — it only ever copies forward a companion
+      // that a prior encrypt actually wrote.
+      expect(getAtPath(overrides, 'speech.tts.openai.displayApiKey')).toBeUndefined();
+      expect(getAtPath(overrides, 'ocr.displayApiKey')).toBeUndefined();
+      expect(getAtPath(overrides, 'webSearch.displaySerperApiKey')).toBeUndefined();
 
       const listRes = mockRes();
       await handlers.listConfigs(mockReq(), listRes);
@@ -452,7 +551,11 @@ describe('config secret registry — real handlers against a real Config collect
   describe('getBaseConfig', () => {
     it('redacts literal secrets sourced from the resolved AppConfig (e.g. YAML literals)', async () => {
       const appConfig = {
-        speech: { tts: { openai: { apiKey: SECRET, model: 'tts-1' } } },
+        speech: {
+          tts: {
+            openai: { apiKey: SECRET, displayApiKey: getDisplaySecretKey(SECRET), model: 'tts-1' },
+          },
+        },
         ocr: { apiKey: '${OCR_API_KEY}' },
         webSearch: { serperApiKey: SECRET, searchProvider: 'serper' },
         langfuse: { publicKey: 'pk-lf-1', secretKey: 'v3:stored', displaySecretKey: 'sk-...ret' },
@@ -486,6 +589,10 @@ describe('config secret registry — real handlers against a real Config collect
       const config = res.body!.config as Record<string, unknown>;
       expect(getAtPath(config, 'ocr.apiKey')).toBe('${OCR_API_KEY}');
       expect(getAtPath(config, 'speech.tts.openai.model')).toBe('tts-1');
+      expect(getAtPath(config, 'speech.tts.openai.apiKey')).toBeUndefined();
+      expect(getAtPath(config, 'speech.tts.openai.displayApiKey')).toBe(
+        getDisplaySecretKey(SECRET),
+      );
       expect(getAtPath(config, 'langfuse.displaySecretKey')).toBe('sk-...ret');
       expect(getAtPath(config, 'config.speech.tts.openai.apiKey')).toBeUndefined();
     });

--- a/packages/api/src/admin/secrets.integration.spec.ts
+++ b/packages/api/src/admin/secrets.integration.spec.ts
@@ -1,0 +1,493 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types/http';
+
+process.env.CREDS_KEY =
+  process.env.CREDS_KEY ?? '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+process.env.CREDS_IV = process.env.CREDS_IV ?? '0123456789abcdef0123456789abcdef';
+
+type DataSchemas = typeof import('@librechat/data-schemas');
+type AdminConfigHandlers = ReturnType<typeof import('./config').createAdminConfigHandlers>;
+
+let mongoServer: MongoMemoryServer;
+let handlers: AdminConfigHandlers;
+let decryptV3: DataSchemas['decryptV3'];
+
+interface SecretFieldCase {
+  /** Dot-path of the secret field */
+  path: string;
+  /** Section object containing the secret plus a non-secret sibling */
+  section: string;
+  object: Record<string, unknown>;
+  /** Dot-path of a non-secret sibling used for unrelated writes */
+  siblingPath: string;
+  siblingValue: unknown;
+}
+
+const SECRET = 'sk-super-secret-literal';
+
+const SECRET_FIELD_CASES: SecretFieldCase[] = [
+  {
+    path: 'langfuse.secretKey',
+    section: 'langfuse',
+    object: { publicKey: 'pk-lf-1', secretKey: SECRET },
+    siblingPath: 'langfuse.publicKey',
+    siblingValue: 'pk-lf-2',
+  },
+  {
+    path: 'ocr.apiKey',
+    section: 'ocr',
+    object: { apiKey: SECRET, mistralModel: 'mistral-ocr-latest' },
+    siblingPath: 'ocr.mistralModel',
+    siblingValue: 'mistral-ocr-next',
+  },
+  {
+    path: 'speech.tts.openai.apiKey',
+    section: 'speech',
+    object: { tts: { openai: { apiKey: SECRET, model: 'tts-1', voices: ['alloy'] } } },
+    siblingPath: 'speech.tts.openai.model',
+    siblingValue: 'tts-2',
+  },
+  {
+    path: 'speech.tts.azureOpenAI.apiKey',
+    section: 'speech',
+    object: { tts: { azureOpenAI: { apiKey: SECRET, instanceName: 'inst' } } },
+    siblingPath: 'speech.tts.azureOpenAI.instanceName',
+    siblingValue: 'inst-2',
+  },
+  {
+    path: 'speech.tts.elevenlabs.apiKey',
+    section: 'speech',
+    object: { tts: { elevenlabs: { apiKey: SECRET, model: 'eleven_multilingual_v2' } } },
+    siblingPath: 'speech.tts.elevenlabs.model',
+    siblingValue: 'eleven_turbo_v2',
+  },
+  {
+    path: 'speech.tts.localai.apiKey',
+    section: 'speech',
+    object: { tts: { localai: { apiKey: SECRET, url: 'http://localai:8080' } } },
+    siblingPath: 'speech.tts.localai.url',
+    siblingValue: 'http://localai:8081',
+  },
+  {
+    path: 'speech.stt.openai.apiKey',
+    section: 'speech',
+    object: { stt: { openai: { apiKey: SECRET, model: 'whisper-1' } } },
+    siblingPath: 'speech.stt.openai.model',
+    siblingValue: 'whisper-2',
+  },
+  {
+    path: 'speech.stt.azureOpenAI.apiKey',
+    section: 'speech',
+    object: { stt: { azureOpenAI: { apiKey: SECRET, instanceName: 'inst' } } },
+    siblingPath: 'speech.stt.azureOpenAI.instanceName',
+    siblingValue: 'inst-2',
+  },
+  {
+    path: 'webSearch.serperApiKey',
+    section: 'webSearch',
+    object: { serperApiKey: SECRET, searchProvider: 'serper' },
+    siblingPath: 'webSearch.searchProvider',
+    siblingValue: 'serper',
+  },
+  {
+    path: 'webSearch.searxngApiKey',
+    section: 'webSearch',
+    object: { searxngApiKey: SECRET, searxngInstanceUrl: 'https://searx.example.com' },
+    siblingPath: 'webSearch.searxngInstanceUrl',
+    siblingValue: 'https://searx2.example.com',
+  },
+  {
+    path: 'webSearch.firecrawlApiKey',
+    section: 'webSearch',
+    object: { firecrawlApiKey: SECRET, firecrawlApiUrl: 'https://api.firecrawl.dev' },
+    siblingPath: 'webSearch.firecrawlApiUrl',
+    siblingValue: 'https://api2.firecrawl.dev',
+  },
+  {
+    path: 'webSearch.tavilyApiKey',
+    section: 'webSearch',
+    object: { tavilyApiKey: SECRET, scraperTimeout: 7500 },
+    siblingPath: 'webSearch.scraperTimeout',
+    siblingValue: 8000,
+  },
+  {
+    path: 'webSearch.jinaApiKey',
+    section: 'webSearch',
+    object: { jinaApiKey: SECRET, jinaApiUrl: 'https://r.jina.ai' },
+    siblingPath: 'webSearch.jinaApiUrl',
+    siblingValue: 'https://r2.jina.ai',
+  },
+  {
+    path: 'webSearch.cohereApiKey',
+    section: 'webSearch',
+    object: { cohereApiKey: SECRET, rerankerType: 'cohere' },
+    siblingPath: 'webSearch.rerankerType',
+    siblingValue: 'cohere',
+  },
+  {
+    path: 'endpoints.assistants.apiKey',
+    section: 'endpoints',
+    object: { assistants: { apiKey: SECRET, disableBuilder: true } },
+    siblingPath: 'endpoints.assistants.disableBuilder',
+    siblingValue: false,
+  },
+  {
+    path: 'endpoints.azureAssistants.apiKey',
+    section: 'endpoints',
+    object: { azureAssistants: { apiKey: SECRET, disableBuilder: true } },
+    siblingPath: 'endpoints.azureAssistants.disableBuilder',
+    siblingValue: false,
+  },
+];
+
+/** Fields whose values conventionally hold `${ENV_VAR}` placeholder references. */
+const PLACEHOLDER_CASES = [
+  { path: 'ocr.apiKey', placeholder: '${OCR_API_KEY}' },
+  { path: 'speech.tts.openai.apiKey', placeholder: '${TTS_API_KEY}' },
+  { path: 'webSearch.serperApiKey', placeholder: '${SERPER_API_KEY}' },
+  { path: 'endpoints.assistants.apiKey', placeholder: '${ASSISTANTS_API_KEY}' },
+];
+
+function mockReq(overrides: Record<string, unknown> = {}): ServerRequest {
+  return {
+    user: { id: 'u1', role: 'ADMIN', _id: { toString: () => 'u1' } },
+    params: {},
+    body: {},
+    query: {},
+    ...overrides,
+  } as Partial<ServerRequest> as ServerRequest;
+}
+
+interface MockRes {
+  statusCode: number;
+  body: undefined | { config?: Record<string, unknown>; error?: string; [key: string]: unknown };
+  status: jest.Mock;
+  json: jest.Mock;
+}
+
+function mockRes(): Response & MockRes {
+  const res: MockRes = {
+    statusCode: 200,
+    body: undefined,
+    status: jest.fn((code: number) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn((data: MockRes['body']) => {
+      res.body = data;
+      return res;
+    }),
+  };
+  return res as Partial<Response> as Response & MockRes;
+}
+
+function getAtPath(root: unknown, path: string): unknown {
+  let cursor: unknown = root;
+  for (const segment of path.split('.')) {
+    if (cursor == null || typeof cursor !== 'object') {
+      return undefined;
+    }
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+}
+
+async function readRawOverrides(principalId: string): Promise<Record<string, unknown>> {
+  const doc = await mongoose.models.Config.findOne({ principalId });
+  expect(doc).not.toBeNull();
+  expect(doc!.$isNew).toBe(false);
+  return (doc!.toObject() as { overrides: Record<string, unknown> }).overrides;
+}
+
+let principalCounter = 0;
+function nextPrincipalId(): string {
+  principalCounter += 1;
+  return `admin-${principalCounter}`;
+}
+
+beforeAll(async () => {
+  jest.resetModules();
+  const dataSchemas = await import('@librechat/data-schemas');
+  ({ decryptV3 } = dataSchemas);
+  jest.spyOn(dataSchemas.logger, 'error').mockReturnValue(dataSchemas.logger);
+  jest.spyOn(dataSchemas.logger, 'warn').mockReturnValue(dataSchemas.logger);
+  jest.spyOn(dataSchemas.logger, 'info').mockReturnValue(dataSchemas.logger);
+  jest.spyOn(dataSchemas.logger, 'debug').mockReturnValue(dataSchemas.logger);
+
+  const { createAdminConfigHandlers } = await import('./config');
+
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  dataSchemas.createModels(mongoose);
+  const methods = dataSchemas.createMethods(mongoose);
+
+  handlers = createAdminConfigHandlers({
+    listAllConfigs: methods.listAllConfigs,
+    findConfigByPrincipal: methods.findConfigByPrincipal,
+    upsertConfig: methods.upsertConfig,
+    patchConfigFields: methods.patchConfigFields,
+    tombstoneConfigField: methods.tombstoneConfigField,
+    unsetConfigField: methods.unsetConfigField,
+    deleteConfig: methods.deleteConfig,
+    toggleConfigActive: methods.toggleConfigActive,
+    hasConfigCapability: async () => true,
+    hasAnyConfigReadAccess: async () => true,
+    hasCapability: async () => true,
+  });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('config secret registry — real handlers against a real Config collection', () => {
+  describe.each(SECRET_FIELD_CASES)(
+    '$path',
+    ({ path, section, object, siblingPath, siblingValue }) => {
+      it('encrypts dotted patch writes at rest and redacts them from the response', async () => {
+        const principalId = nextPrincipalId();
+        const res = mockRes();
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: path, value: SECRET }] },
+          }),
+          res,
+        );
+        expect(res.statusCode).toBe(200);
+        expect(JSON.stringify(res.body)).not.toContain(SECRET);
+
+        const overrides = await readRawOverrides(principalId);
+        const stored = getAtPath(overrides, path);
+        expect(typeof stored).toBe('string');
+        expect(stored).toMatch(/^v3:/);
+        expect(decryptV3(stored as string)).toBe(SECRET);
+      });
+
+      it('encrypts object-valued upsert writes at rest and redacts reads', async () => {
+        const principalId = nextPrincipalId();
+        const upsertRes = mockRes();
+        await handlers.upsertConfigOverrides(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { overrides: { [section]: object } },
+          }),
+          upsertRes,
+        );
+        expect(upsertRes.statusCode).toBe(201);
+        expect(JSON.stringify(upsertRes.body)).not.toContain(SECRET);
+
+        const overrides = await readRawOverrides(principalId);
+        expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+
+        const getRes = mockRes();
+        await handlers.getConfig(
+          mockReq({ params: { principalType: 'role', principalId } }),
+          getRes,
+        );
+        expect(getRes.statusCode).toBe(200);
+        expect(JSON.stringify(getRes.body)).not.toContain(SECRET);
+        expect(JSON.stringify(getRes.body)).not.toContain('v3:');
+
+        const listRes = mockRes();
+        await handlers.listConfigs(mockReq(), listRes);
+        expect(listRes.statusCode).toBe(200);
+        expect(JSON.stringify(listRes.body)).not.toContain(SECRET);
+        expect(JSON.stringify(listRes.body)).not.toContain('v3:');
+      });
+
+      it('preserves the stored secret across an unrelated dotted patch', async () => {
+        const principalId = nextPrincipalId();
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: path, value: SECRET }] },
+          }),
+          mockRes(),
+        );
+        const before = getAtPath(await readRawOverrides(principalId), path);
+
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: siblingPath, value: siblingValue }] },
+          }),
+          mockRes(),
+        );
+
+        const overrides = await readRawOverrides(principalId);
+        expect(getAtPath(overrides, path)).toBe(before);
+        expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+        expect(getAtPath(overrides, siblingPath)).toEqual(siblingValue);
+      });
+
+      it('round-trips a redacted read back through a full upsert without clobbering the secret', async () => {
+        const principalId = nextPrincipalId();
+        await handlers.upsertConfigOverrides(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { overrides: { [section]: object } },
+          }),
+          mockRes(),
+        );
+        const before = getAtPath(await readRawOverrides(principalId), path);
+
+        const getRes = mockRes();
+        await handlers.getConfig(
+          mockReq({ params: { principalType: 'role', principalId } }),
+          getRes,
+        );
+        const redactedOverrides = (getRes.body!.config as { overrides: Record<string, unknown> })
+          .overrides;
+        expect(getAtPath(redactedOverrides, path)).toBeUndefined();
+
+        const clientEdited = JSON.parse(JSON.stringify(redactedOverrides)) as Record<
+          string,
+          unknown
+        >;
+        const upsertRes = mockRes();
+        await handlers.upsertConfigOverrides(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { overrides: clientEdited },
+          }),
+          upsertRes,
+        );
+        expect(upsertRes.statusCode).toBe(200);
+        expect(JSON.stringify(upsertRes.body)).not.toContain(SECRET);
+
+        const overrides = await readRawOverrides(principalId);
+        expect(getAtPath(overrides, path)).toBe(before);
+        expect(decryptV3(getAtPath(overrides, path) as string)).toBe(SECRET);
+      });
+
+      it('clears the secret when explicitly set to an empty value', async () => {
+        const principalId = nextPrincipalId();
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: path, value: SECRET }] },
+          }),
+          mockRes(),
+        );
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId },
+            body: { entries: [{ fieldPath: path, value: '' }] },
+          }),
+          mockRes(),
+        );
+        const overrides = await readRawOverrides(principalId);
+        expect(getAtPath(overrides, path)).toBe('');
+      });
+
+      it('rejects encrypted value submissions', async () => {
+        const res = mockRes();
+        await handlers.patchConfigField(
+          mockReq({
+            params: { principalType: 'role', principalId: nextPrincipalId() },
+            body: { entries: [{ fieldPath: path, value: 'v3:attacker-controlled' }] },
+          }),
+          res,
+        );
+        expect(res.statusCode).toBe(400);
+      });
+    },
+  );
+
+  describe.each(PLACEHOLDER_CASES)('$path env placeholder', ({ path, placeholder }) => {
+    it('stores and returns `${ENV_VAR}` references without encryption or redaction', async () => {
+      const principalId = nextPrincipalId();
+      await handlers.patchConfigField(
+        mockReq({
+          params: { principalType: 'role', principalId },
+          body: { entries: [{ fieldPath: path, value: placeholder }] },
+        }),
+        mockRes(),
+      );
+
+      const overrides = await readRawOverrides(principalId);
+      expect(getAtPath(overrides, path)).toBe(placeholder);
+
+      const getRes = mockRes();
+      await handlers.getConfig(mockReq({ params: { principalType: 'role', principalId } }), getRes);
+      const responseOverrides = (getRes.body!.config as { overrides: Record<string, unknown> })
+        .overrides;
+      expect(getAtPath(responseOverrides, path)).toBe(placeholder);
+    });
+  });
+
+  describe('legacy plaintext literals stored before encryption existed', () => {
+    it('never returns a plaintext literal stored directly on the config document', async () => {
+      const principalId = nextPrincipalId();
+      await mongoose.models.Config.create({
+        principalType: 'role',
+        principalId,
+        principalModel: 'Role',
+        priority: 10,
+        overrides: {
+          speech: { tts: { openai: { apiKey: SECRET, model: 'tts-1' } } },
+          ocr: { apiKey: SECRET },
+          webSearch: { serperApiKey: SECRET, searchProvider: 'serper' },
+        },
+      });
+
+      const getRes = mockRes();
+      await handlers.getConfig(mockReq({ params: { principalType: 'role', principalId } }), getRes);
+      expect(getRes.statusCode).toBe(200);
+      expect(JSON.stringify(getRes.body)).not.toContain(SECRET);
+      const overrides = (getRes.body!.config as { overrides: Record<string, unknown> }).overrides;
+      expect(getAtPath(overrides, 'speech.tts.openai.model')).toBe('tts-1');
+      expect(getAtPath(overrides, 'webSearch.searchProvider')).toBe('serper');
+
+      const listRes = mockRes();
+      await handlers.listConfigs(mockReq(), listRes);
+      expect(JSON.stringify(listRes.body)).not.toContain(SECRET);
+    });
+  });
+
+  describe('getBaseConfig', () => {
+    it('redacts literal secrets sourced from the resolved AppConfig (e.g. YAML literals)', async () => {
+      const appConfig = {
+        speech: { tts: { openai: { apiKey: SECRET, model: 'tts-1' } } },
+        ocr: { apiKey: '${OCR_API_KEY}' },
+        webSearch: { serperApiKey: SECRET, searchProvider: 'serper' },
+        langfuse: { publicKey: 'pk-lf-1', secretKey: 'v3:stored', displaySecretKey: 'sk-...ret' },
+        paths: { uploads: '/tmp' },
+        config: {
+          speech: { tts: { openai: { apiKey: SECRET, model: 'tts-1' } } },
+        },
+      };
+      const { createAdminConfigHandlers } = await import('./config');
+      const baseHandlers = createAdminConfigHandlers({
+        listAllConfigs: async () => [],
+        findConfigByPrincipal: async () => null,
+        upsertConfig: async () => null,
+        patchConfigFields: async () => null,
+        tombstoneConfigField: async () => null,
+        unsetConfigField: async () => null,
+        deleteConfig: async () => null,
+        toggleConfigActive: async () => null,
+        hasConfigCapability: async () => true,
+        hasAnyConfigReadAccess: async () => true,
+        hasCapability: async () => true,
+        getAppConfig: async () => appConfig as never,
+      });
+
+      const res = mockRes();
+      await baseHandlers.getBaseConfig(mockReq(), res);
+      expect(res.statusCode).toBe(200);
+      const payload = JSON.stringify(res.body);
+      expect(payload).not.toContain(SECRET);
+      expect(payload).not.toContain('v3:stored');
+      const config = res.body!.config as Record<string, unknown>;
+      expect(getAtPath(config, 'ocr.apiKey')).toBe('${OCR_API_KEY}');
+      expect(getAtPath(config, 'speech.tts.openai.model')).toBe('tts-1');
+      expect(getAtPath(config, 'langfuse.displaySecretKey')).toBe('sk-...ret');
+      expect(getAtPath(config, 'config.speech.tts.openai.apiKey')).toBeUndefined();
+    });
+  });
+});

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -6,6 +6,7 @@ process.env.CREDS_KEY =
 let decryptConfigSecret: typeof import('./secrets').decryptConfigSecret;
 let encryptConfigSecretFields: typeof import('./secrets').encryptConfigSecretFields;
 let encryptConfigSecrets: typeof import('./secrets').encryptConfigSecrets;
+let getDisplaySecretKey: typeof import('./secrets').getDisplaySecretKey;
 let getConfigSecretInputError: typeof import('./secrets').getConfigSecretInputError;
 let getConfigSecretMutationPaths: typeof import('./secrets').getConfigSecretMutationPaths;
 let getConfigSecretSections: typeof import('./secrets').getConfigSecretSections;
@@ -21,6 +22,7 @@ beforeAll(async () => {
     decryptConfigSecret,
     encryptConfigSecretFields,
     encryptConfigSecrets,
+    getDisplaySecretKey,
     getConfigSecretInputError,
     getConfigSecretMutationPaths,
     getConfigSecretSections,
@@ -274,7 +276,7 @@ describe('Config secret registry fields', () => {
     expect(decryptV3(out.langfuse.secretKey)).toBe('${LANGFUSE_SECRET_KEY}');
   });
 
-  it('encrypts dotted patch writes without creating display companions', () => {
+  it('encrypts dotted patch writes and sets a masked display companion for every field', () => {
     const out = encryptConfigSecretFields({
       'speech.tts.openai.apiKey': 'sk-tts',
       'webSearch.serperApiKey': '${SERPER_API_KEY}',
@@ -282,22 +284,28 @@ describe('Config secret registry fields', () => {
     });
 
     expect(decryptV3(out['speech.tts.openai.apiKey'] as string)).toBe('sk-tts');
+    expect(out['speech.tts.openai.displayApiKey']).toBe(getDisplaySecretKey('sk-tts'));
     expect(out['webSearch.serperApiKey']).toBe('${SERPER_API_KEY}');
+    expect(out['webSearch.displaySerperApiKey']).toBeUndefined();
     expect(out['ocr.apiKey']).toBe('');
+    expect(out['ocr.displayApiKey']).toBe('');
     expect(Object.keys(out).sort()).toEqual([
       'ocr.apiKey',
+      'ocr.displayApiKey',
       'speech.tts.openai.apiKey',
+      'speech.tts.openai.displayApiKey',
       'webSearch.serperApiKey',
     ]);
   });
 
-  it('encrypts secrets nested inside object-valued ancestor patch entries', () => {
+  it('encrypts secrets nested inside object-valued ancestor patch entries and sets their display companion', () => {
     type SpeechPatch = { tts: { openai: Record<string, string> } };
     const sectionPatch = encryptConfigSecretFields({
       speech: { tts: { openai: { apiKey: 'sk-tts', model: 'tts-1' } } },
     });
     const speech = sectionPatch.speech as SpeechPatch;
     expect(decryptV3(speech.tts.openai.apiKey)).toBe('sk-tts');
+    expect(speech.tts.openai.displayApiKey).toBe(getDisplaySecretKey('sk-tts'));
     expect(speech.tts.openai.model).toBe('tts-1');
 
     const midPatch = encryptConfigSecretFields({
@@ -305,59 +313,88 @@ describe('Config secret registry fields', () => {
     });
     const tts = midPatch['speech.tts'] as SpeechPatch['tts'];
     expect(decryptV3(tts.openai.apiKey)).toBe('sk-tts');
+    expect(tts.openai.displayApiKey).toBe(getDisplaySecretKey('sk-tts'));
 
     const leafParentPatch = encryptConfigSecretFields({
       'speech.tts.openai': { apiKey: 'sk-tts', model: 'tts-1' },
     });
     const openai = leafParentPatch['speech.tts.openai'] as Record<string, string>;
     expect(decryptV3(openai.apiKey)).toBe('sk-tts');
+    expect(openai.displayApiKey).toBe(getDisplaySecretKey('sk-tts'));
   });
 
-  it('strips dotted registry-related keys from whole-override writes', () => {
+  it('strips dotted registry-related keys, including display companions, from whole-override writes', () => {
     const out = encryptConfigSecrets({
       'speech.tts.openai.apiKey': 'sk-smuggled',
+      'speech.tts.openai.displayApiKey': 'sk-spoofed...display',
       'ocr.apiKey': 'sk-smuggled',
       'webSearch.serperApiKey.nested': 'sk-smuggled',
       'speech.tts': { openai: { apiKey: 'sk-smuggled' } },
-      ocr: { apiKey: 'sk-legit' },
+      ocr: { apiKey: 'sk-legit' } as Record<string, string>,
     });
 
     expect(out).not.toHaveProperty(['speech.tts.openai.apiKey']);
+    expect(out).not.toHaveProperty(['speech.tts.openai.displayApiKey']);
     expect(out).not.toHaveProperty(['ocr.apiKey']);
     expect(out).not.toHaveProperty(['webSearch.serperApiKey.nested']);
     expect(out).not.toHaveProperty(['speech.tts']);
     expect(decryptV3(out.ocr.apiKey)).toBe('sk-legit');
+    expect(out.ocr.displayApiKey).toBe(getDisplaySecretKey('sk-legit'));
   });
 
-  it('redacts literal and encrypted values but keeps env placeholders and siblings', () => {
+  it('redacts secrets but keeps display companions, env placeholders, and siblings visible on read', () => {
     const redacted = redactConfigSecrets({
       speech: {
-        tts: { openai: { apiKey: 'sk-literal', model: 'tts-1' } },
-        stt: { openai: { apiKey: 'v3:abc:def', model: 'whisper-1' } },
+        tts: {
+          openai: {
+            apiKey: 'sk-literal',
+            displayApiKey: getDisplaySecretKey('sk-literal'),
+            model: 'tts-1',
+          },
+        },
+        stt: {
+          openai: { apiKey: 'v3:abc:def', displayApiKey: 'sk-old...-old', model: 'whisper-1' },
+        },
       },
       ocr: { apiKey: '${OCR_API_KEY}', mistralModel: 'mistral-ocr-latest' },
-      webSearch: { serperApiKey: 'sk-literal', searchProvider: 'serper' },
+      webSearch: {
+        serperApiKey: 'sk-literal',
+        displaySerperApiKey: 'sk-lite...eral',
+        searchProvider: 'serper',
+      },
     });
 
-    expect(redacted.speech.tts.openai).toEqual({ model: 'tts-1' });
-    expect(redacted.speech.stt.openai).toEqual({ model: 'whisper-1' });
+    expect(redacted.speech.tts.openai).toEqual({
+      displayApiKey: getDisplaySecretKey('sk-literal'),
+      model: 'tts-1',
+    });
+    expect(redacted.speech.stt.openai).toEqual({
+      displayApiKey: 'sk-old...-old',
+      model: 'whisper-1',
+    });
     expect(redacted.ocr).toEqual({
       apiKey: '${OCR_API_KEY}',
       mistralModel: 'mistral-ocr-latest',
     });
-    expect(redacted.webSearch).toEqual({ searchProvider: 'serper' });
+    expect(redacted.webSearch).toEqual({
+      displaySerperApiKey: 'sk-lite...eral',
+      searchProvider: 'serper',
+    });
   });
 
-  it('preserves omitted encrypted secrets on nested object writes', () => {
+  it('preserves omitted encrypted secrets and their display companion on nested object writes', () => {
     const existing = encryptConfigSecrets({
-      speech: { tts: { openai: { apiKey: 'sk-old', model: 'tts-1' } } },
+      speech: { tts: { openai: { apiKey: 'sk-old', model: 'tts-1' } as Record<string, string> } },
     });
+    const existingDisplay = existing.speech.tts.openai.displayApiKey;
+    expect(existingDisplay).toBe(getDisplaySecretKey('sk-old'));
 
     const next = preserveConfigSecrets(
       { speech: { tts: { openai: { model: 'tts-2' } as Record<string, string> } } },
       existing,
     );
     expect(decryptV3(next.speech.tts.openai.apiKey)).toBe('sk-old');
+    expect(next.speech.tts.openai.displayApiKey).toBe(existingDisplay);
     expect(next.speech.tts.openai.model).toBe('tts-2');
 
     const providerRemoved = preserveConfigSecrets({ speech: { tts: {} } }, existing);
@@ -369,16 +406,20 @@ describe('Config secret registry fields', () => {
       'speech.tts',
     );
     expect(decryptV3(ancestorPatch.openai.apiKey)).toBe('sk-old');
+    expect(ancestorPatch.openai.displayApiKey).toBe(existingDisplay);
   });
 
-  it('does not preserve explicitly cleared or plaintext existing secrets', () => {
+  it('does not preserve explicitly cleared or plaintext existing secrets, and clears the display companion too', () => {
     const cleared = encryptConfigSecrets({
-      speech: { tts: { openai: { apiKey: '' } } },
+      speech: { tts: { openai: { apiKey: '' } as Record<string, string> } },
     });
+    expect(cleared.speech.tts.openai.displayApiKey).toBe('');
     const existing = encryptConfigSecrets({
-      speech: { tts: { openai: { apiKey: 'sk-old' } } },
+      speech: { tts: { openai: { apiKey: 'sk-old' } as Record<string, string> } },
     });
-    expect(preserveConfigSecrets(cleared, existing).speech.tts.openai.apiKey).toBe('');
+    const preservedAfterClear = preserveConfigSecrets(cleared, existing);
+    expect(preservedAfterClear.speech.tts.openai.apiKey).toBe('');
+    expect(preservedAfterClear.speech.tts.openai.displayApiKey).toBe('');
 
     const fromPlaintext = preserveConfigSecrets(
       { ocr: { mistralModel: 'm' } },
@@ -401,13 +442,21 @@ describe('Config secret registry fields', () => {
     expect(resolveConfigSecret('v3:not-valid-ciphertext')).toBeUndefined();
   });
 
-  it('reports mutation paths and ancestor/descendant checks for registry fields', () => {
+  it('reports mutation paths (including the display companion) and ancestor/descendant checks for registry fields', () => {
     expect(getConfigSecretMutationPaths('speech.tts.openai.apiKey')).toEqual([
       'speech.tts.openai.apiKey',
+      'speech.tts.openai.displayApiKey',
+    ]);
+    expect(getConfigSecretMutationPaths('webSearch.serperApiKey')).toEqual([
+      'webSearch.serperApiKey',
+      'webSearch.displaySerperApiKey',
     ]);
     expect(getConfigSecretMutationPaths('langfuse.secretKey')).toEqual([
       'langfuse.secretKey',
       'langfuse.displaySecretKey',
+    ]);
+    expect(getConfigSecretMutationPaths('speech.tts.openai.displayApiKey')).toEqual([
+      'speech.tts.openai.displayApiKey',
     ]);
 
     for (const path of ['speech', 'speech.tts', 'speech.tts.openai', 'ocr', 'webSearch']) {
@@ -418,6 +467,7 @@ describe('Config secret registry fields', () => {
 
     expect(isConfigSecretDescendantPath('speech.tts.openai.apiKey.hidden')).toBe(true);
     expect(isConfigSecretDescendantPath('webSearch.serperApiKey.hidden')).toBe(true);
+    expect(isConfigSecretDescendantPath('speech.tts.openai.displayApiKey.hidden')).toBe(true);
     expect(isConfigSecretDescendantPath('speech.tts.openai.model')).toBe(false);
   });
 
@@ -433,5 +483,53 @@ describe('Config secret registry fields', () => {
     );
     expect(getConfigSecretInputError('speech.tts.openai.apiKey', 'sk-legit')).toBeNull();
     expect(getConfigSecretInputError('ocr.apiKey', '${OCR_API_KEY}')).toBeNull();
+  });
+
+  describe('display companion fields are write-side read-only for every registered field', () => {
+    it.each([
+      'ocr.displayApiKey',
+      'speech.tts.openai.displayApiKey',
+      'speech.stt.azureOpenAI.displayApiKey',
+      'webSearch.displaySerperApiKey',
+      'webSearch.displayCohereApiKey',
+      'endpoints.assistants.displayApiKey',
+      'endpoints.azureAssistants.displayApiKey',
+      'langfuse.displaySecretKey',
+    ])('rejects a direct dotted-patch write to %s', (displayPath) => {
+      expect(getConfigSecretInputError(displayPath, 'attacker-supplied-display-value')).toContain(
+        'Cannot write protected display secret path',
+      );
+    });
+
+    it('drops a client-supplied display value when the ancestor object omits the real secret, never storing it', () => {
+      const out = encryptConfigSecretFields({
+        speech: { tts: { openai: { model: 'tts-1', displayApiKey: 'attacker-injected-display' } } },
+      });
+      const openai = (out.speech as { tts: { openai: Record<string, unknown> } }).tts.openai;
+      expect(openai).not.toHaveProperty('displayApiKey');
+      expect(openai.model).toBe('tts-1');
+    });
+
+    it('overwrites a client-supplied display value with the server-computed one when a real secret is also present, never persisting the attacker value', () => {
+      const out = encryptConfigSecretFields({
+        webSearch: {
+          serperApiKey: 'sk-real-secret',
+          displaySerperApiKey: 'v3:looks-encrypted-but-is-attacker-input',
+        },
+      });
+      const webSearch = out.webSearch as Record<string, string>;
+      expect(decryptV3(webSearch.serperApiKey)).toBe('sk-real-secret');
+      expect(webSearch.displaySerperApiKey).toBe(getDisplaySecretKey('sk-real-secret'));
+      expect(webSearch.displaySerperApiKey).not.toBe('v3:looks-encrypted-but-is-attacker-input');
+    });
+
+    it('never encrypts or stores a display-path value submitted without its real secret, even if it looks like a secret literal', () => {
+      const out = encryptConfigSecrets({
+        ocr: { displayApiKey: 'this-should-never-be-treated-as-a-secret', mistralModel: 'x' },
+      });
+      expect(out.ocr).not.toHaveProperty('displayApiKey');
+      expect(out.ocr).not.toHaveProperty('apiKey');
+      expect(out.ocr.mistralModel).toBe('x');
+    });
   });
 });

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -381,6 +381,24 @@ describe('Config secret registry fields', () => {
     expect(out.ocr.displayApiKey).toBe(getDisplaySecretKey('sk-legit'));
   });
 
+  it('strips a nested array smuggled at any depth along a secret ancestor path, not just the top level', () => {
+    const encrypted = encryptConfigSecrets({
+      speech: { tts: { openai: [{ apiKey: 'sk-smuggled-via-array' }] } },
+    });
+    const speechOut = encrypted.speech as { tts: Record<string, unknown> };
+    expect(speechOut.tts).not.toHaveProperty('openai');
+    expect(JSON.stringify(encrypted)).not.toContain('sk-smuggled-via-array');
+
+    const readBack = redactConfigSecrets(
+      structuredClone({
+        speech: { tts: { openai: [{ apiKey: 'sk-smuggled-via-array' }] } },
+      }),
+    );
+    const speechRead = readBack.speech as { tts: Record<string, unknown> };
+    expect(speechRead.tts).not.toHaveProperty('openai');
+    expect(JSON.stringify(readBack)).not.toContain('sk-smuggled-via-array');
+  });
+
   it('redacts secrets but keeps display companions, env placeholders, and siblings visible on read', () => {
     const redacted = redactConfigSecrets({
       speech: {

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -553,7 +553,8 @@ describe('Config secret registry fields', () => {
     expect(resolveConfigSecret('sk-plain-literal')).toBe('sk-plain-literal');
     expect(resolveConfigSecret('')).toBe('');
     expect(resolveConfigSecret(undefined)).toBeUndefined();
-    expect(resolveConfigSecret('v3:not-valid-ciphertext')).toBeUndefined();
+    expect(resolveConfigSecret('v3:not-valid-ciphertext')).toBe('v3:not-valid-ciphertext');
+    expect(resolveConfigSecret('v3:provider-literal-token')).toBe('v3:provider-literal-token');
   });
 
   it('reports mutation paths (including the preview companion) and ancestor/descendant checks for registry fields', () => {

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -6,7 +6,7 @@ process.env.CREDS_KEY =
 let decryptConfigSecret: typeof import('./secrets').decryptConfigSecret;
 let encryptConfigSecretFields: typeof import('./secrets').encryptConfigSecretFields;
 let encryptConfigSecrets: typeof import('./secrets').encryptConfigSecrets;
-let getDisplaySecretKey: typeof import('./secrets').getDisplaySecretKey;
+let getSecretPreview: typeof import('./secrets').getSecretPreview;
 let getConfigSecretInputError: typeof import('./secrets').getConfigSecretInputError;
 let getConfigSecretMutationPaths: typeof import('./secrets').getConfigSecretMutationPaths;
 let getConfigSecretSections: typeof import('./secrets').getConfigSecretSections;
@@ -22,7 +22,7 @@ beforeAll(async () => {
     decryptConfigSecret,
     encryptConfigSecretFields,
     encryptConfigSecrets,
-    getDisplaySecretKey,
+    getSecretPreview,
     getConfigSecretInputError,
     getConfigSecretMutationPaths,
     getConfigSecretSections,
@@ -44,49 +44,49 @@ describe('Langfuse config secrets', () => {
 
     expect(out['langfuse.secretKey']).toMatch(/^v3:/);
     expect(decryptV3(out['langfuse.secretKey'] as string)).toBe('sk-lf-secret');
-    expect(out['langfuse.displaySecretKey']).toBe('sk-lf-...cret');
+    expect(out['langfuse.secretKeyPreview']).toBe('sk-lf-...cret');
     expect(out['langfuse.publicKey']).toBe('pk-lf-1');
   });
 
-  it('encrypts object writes and removes client-supplied display secret keys', () => {
+  it('encrypts object writes and removes client-supplied secret previews', () => {
     const out = encryptConfigSecrets({
       langfuse: {
         publicKey: 'pk-lf-1',
         secretKey: 'sk-lf-secret',
-        displaySecretKey: 'spoofed',
+        secretKeyPreview: 'spoofed',
       },
     });
 
     expect(out.langfuse.secretKey).toMatch(/^v3:/);
     expect(decryptV3(out.langfuse.secretKey)).toBe('sk-lf-secret');
-    expect(out.langfuse.displaySecretKey).toBe('sk-lf-...cret');
+    expect(out.langfuse.secretKeyPreview).toBe('sk-lf-...cret');
     expect(out.langfuse.publicKey).toBe('pk-lf-1');
   });
 
   it('clears empty or non-string secret values', () => {
     expect(encryptConfigSecretFields({ 'langfuse.secretKey': '' })).toEqual({
       'langfuse.secretKey': '',
-      'langfuse.displaySecretKey': '',
+      'langfuse.secretKeyPreview': '',
     });
 
     expect(
       encryptConfigSecrets({
         langfuse: {
           secretKey: null,
-          displaySecretKey: 'spoofed',
+          secretKeyPreview: 'spoofed',
         },
       }),
     ).toEqual({
       langfuse: {
         secretKey: '',
-        displaySecretKey: '',
+        secretKeyPreview: '',
       },
     });
   });
 
   it('rejects protected display-key writes and encrypted secret submissions', () => {
-    expect(getConfigSecretInputError('langfuse.displaySecretKey', 'spoofed')).toContain(
-      'protected display secret path',
+    expect(getConfigSecretInputError('langfuse.secretKeyPreview', 'spoofed')).toContain(
+      'protected secret preview path',
     );
     expect(getConfigSecretInputError('langfuse.secretKey', 'v3:attacker-controlled')).toContain(
       'Encrypted config secret values',
@@ -126,7 +126,7 @@ describe('Langfuse config secrets', () => {
     const existingLangfuse = existing.langfuse as Record<string, string>;
 
     expect(decryptV3(preservedLangfuse.secretKey)).toBe('sk-old');
-    expect(preservedLangfuse.displaySecretKey).toBe(existingLangfuse.displaySecretKey);
+    expect(preservedLangfuse.secretKeyPreview).toBe(existingLangfuse.secretKeyPreview);
     expect(preserved.langfuse.publicKey).toBe('pk-new');
   });
 
@@ -146,7 +146,7 @@ describe('Langfuse config secrets', () => {
     const preservedLangfuse = fromPlaintext.langfuse as Record<string, string>;
     expect(preservedLangfuse.publicKey).toBe('pk-new');
     expect(decryptV3(preservedLangfuse.secretKey)).toBe('sk-plain-existing');
-    expect(preservedLangfuse.displaySecretKey).toBe(getDisplaySecretKey('sk-plain-existing'));
+    expect(preservedLangfuse.secretKeyPreview).toBe(getSecretPreview('sk-plain-existing'));
 
     const existing = encryptConfigSecrets({
       langfuse: {
@@ -161,7 +161,7 @@ describe('Langfuse config secrets', () => {
     expect(preserveConfigSecrets(cleared, existing)).toEqual({
       langfuse: {
         secretKey: '',
-        displaySecretKey: '',
+        secretKeyPreview: '',
       },
     });
   });
@@ -179,31 +179,61 @@ describe('Langfuse config secrets', () => {
     const existingLangfuse = existing.langfuse as Record<string, string>;
 
     expect(decryptV3(preservedLangfuse.secretKey)).toBe('sk-old');
-    expect(preservedLangfuse.displaySecretKey).toBe(existingLangfuse.displaySecretKey);
+    expect(preservedLangfuse.secretKeyPreview).toBe(existingLangfuse.secretKeyPreview);
     expect(preserved.publicKey).toBe('pk-new');
   });
 
-  it('redacts secret values while preserving display secret keys', () => {
+  it('redacts secret values while preserving secret previews', () => {
     const redacted = redactConfigSecrets({
       'langfuse.secretKey': 'literal',
-      'langfuse.displaySecretKey': 'literal-display',
+      'langfuse.secretKeyPreview': 'literal-display',
       langfuse: {
         enabled: true,
         destination: 'eu',
         publicKey: 'pk-lf-1',
         secretKey: 'v3:abc:def',
-        displaySecretKey: 'sk-lf-...cret',
+        secretKeyPreview: 'sk-lf-...cret',
       },
     });
 
     expect(redacted['langfuse.secretKey']).toBeUndefined();
-    expect(redacted['langfuse.displaySecretKey']).toBeUndefined();
+    expect(redacted['langfuse.secretKeyPreview']).toBeUndefined();
     expect(redacted.langfuse).toEqual({
       enabled: true,
       destination: 'eu',
       publicKey: 'pk-lf-1',
-      displaySecretKey: 'sk-lf-...cret',
+      secretKeyPreview: 'sk-lf-...cret',
     });
+  });
+
+  it('strips legacy displaySecretKey companions and migrates them on preserve', () => {
+    const redacted = redactConfigSecrets({
+      langfuse: { publicKey: 'pk-lf-1', secretKey: 'v3:abc:def', displaySecretKey: 'sk-lf-...old' },
+    });
+    expect(redacted.langfuse).toEqual({ publicKey: 'pk-lf-1' });
+
+    const encrypted = encryptConfigSecrets({
+      langfuse: { secretKey: 'sk-lf-new-secret', displaySecretKey: 'sk-lf-...old' },
+    }).langfuse as Record<string, string>;
+    expect(encrypted.displaySecretKey).toBeUndefined();
+    expect(encrypted.secretKeyPreview).toBe('sk-lf-...cret');
+
+    const existing = {
+      langfuse: {
+        secretKey: encryptConfigSecrets({ langfuse: { secretKey: 'sk-lf-old-secret' } }).langfuse
+          .secretKey,
+        displaySecretKey: 'sk-lf-...cret',
+      },
+    };
+    const preserved = preserveConfigSecrets({ langfuse: { publicKey: 'pk-new' } }, existing);
+    const preservedLangfuse = preserved.langfuse as Record<string, string>;
+    expect(decryptV3(preservedLangfuse.secretKey)).toBe('sk-lf-old-secret');
+    expect(preservedLangfuse.secretKeyPreview).toBe('sk-lf-...cret');
+    expect(preservedLangfuse.displaySecretKey).toBeUndefined();
+
+    expect(getConfigSecretInputError('langfuse.displaySecretKey', 'spoofed')).toContain(
+      'protected secret preview path',
+    );
   });
 });
 
@@ -282,42 +312,42 @@ describe('Config secret registry fields', () => {
   it('clears a stale display mask when a literal secret is rotated to an env placeholder', () => {
     const dottedOut = encryptConfigSecretFields({ 'ocr.apiKey': '${OCR_API_KEY}' });
     expect(dottedOut['ocr.apiKey']).toBe('${OCR_API_KEY}');
-    expect(dottedOut['ocr.displayApiKey']).toBe('');
+    expect(dottedOut['ocr.apiKeyPreview']).toBe('');
 
     const objectOut = encryptConfigSecrets({
-      ocr: { apiKey: '${OCR_API_KEY}', displayApiKey: 'sk-sta...LE00' },
+      ocr: { apiKey: '${OCR_API_KEY}', apiKeyPreview: 'sk-sta...LE00' },
     });
     expect(objectOut.ocr.apiKey).toBe('${OCR_API_KEY}');
-    expect(objectOut.ocr.displayApiKey).toBe('');
+    expect(objectOut.ocr.apiKeyPreview).toBe('');
   });
 
   it('never persists a client-supplied display mask alongside an env placeholder secret', () => {
     const out = encryptConfigSecrets({
-      ocr: { apiKey: '${OCR_API_KEY}', displayApiKey: 'sk-atk...ACK' },
+      ocr: { apiKey: '${OCR_API_KEY}', apiKeyPreview: 'sk-atk...ACK' },
     });
     expect(out.ocr.apiKey).toBe('${OCR_API_KEY}');
-    expect(out.ocr.displayApiKey).toBe('');
+    expect(out.ocr.apiKeyPreview).toBe('');
   });
 
   it('trims whitespace from a literal secret before encrypting and masking', () => {
     const out = encryptConfigSecretFields({ 'ocr.apiKey': '  sk-padded-secret  ' });
     expect(decryptV3(out['ocr.apiKey'] as string)).toBe('sk-padded-secret');
-    expect(out['ocr.displayApiKey']).toBe(getDisplaySecretKey('sk-padded-secret'));
+    expect(out['ocr.apiKeyPreview']).toBe(getSecretPreview('sk-padded-secret'));
   });
 
   it('treats a whitespace-only literal secret as empty and clears it', () => {
     const out = encryptConfigSecretFields({ 'ocr.apiKey': '   ' });
     expect(out['ocr.apiKey']).toBe('');
-    expect(out['ocr.displayApiKey']).toBe('');
+    expect(out['ocr.apiKeyPreview']).toBe('');
   });
 
-  it('masks short credentials fully instead of disclosing them via the display companion', () => {
-    expect(getDisplaySecretKey('short12')).toBe('*******');
-    expect(getDisplaySecretKey('0123456789')).toBe('**********');
-    expect(getDisplaySecretKey('sk-longer-secret-value')).toBe('sk-lon...alue');
+  it('masks short credentials fully instead of disclosing them via the preview companion', () => {
+    expect(getSecretPreview('short12')).toBe('*******');
+    expect(getSecretPreview('0123456789')).toBe('**********');
+    expect(getSecretPreview('sk-longer-secret-value')).toBe('sk-lon...alue');
   });
 
-  it('encrypts dotted patch writes and sets a masked display companion for every field', () => {
+  it('encrypts dotted patch writes and sets a masked preview companion for every field', () => {
     const out = encryptConfigSecretFields({
       'speech.tts.openai.apiKey': 'sk-tts',
       'webSearch.serperApiKey': '${SERPER_API_KEY}',
@@ -325,29 +355,29 @@ describe('Config secret registry fields', () => {
     });
 
     expect(decryptV3(out['speech.tts.openai.apiKey'] as string)).toBe('sk-tts');
-    expect(out['speech.tts.openai.displayApiKey']).toBe(getDisplaySecretKey('sk-tts'));
+    expect(out['speech.tts.openai.apiKeyPreview']).toBe(getSecretPreview('sk-tts'));
     expect(out['webSearch.serperApiKey']).toBe('${SERPER_API_KEY}');
-    expect(out['webSearch.displaySerperApiKey']).toBe('');
+    expect(out['webSearch.serperApiKeyPreview']).toBe('');
     expect(out['ocr.apiKey']).toBe('');
-    expect(out['ocr.displayApiKey']).toBe('');
+    expect(out['ocr.apiKeyPreview']).toBe('');
     expect(Object.keys(out).sort()).toEqual([
       'ocr.apiKey',
-      'ocr.displayApiKey',
+      'ocr.apiKeyPreview',
       'speech.tts.openai.apiKey',
-      'speech.tts.openai.displayApiKey',
-      'webSearch.displaySerperApiKey',
+      'speech.tts.openai.apiKeyPreview',
       'webSearch.serperApiKey',
+      'webSearch.serperApiKeyPreview',
     ]);
   });
 
-  it('encrypts secrets nested inside object-valued ancestor patch entries and sets their display companion', () => {
+  it('encrypts secrets nested inside object-valued ancestor patch entries and sets their preview companion', () => {
     type SpeechPatch = { tts: { openai: Record<string, string> } };
     const sectionPatch = encryptConfigSecretFields({
       speech: { tts: { openai: { apiKey: 'sk-tts', model: 'tts-1' } } },
     });
     const speech = sectionPatch.speech as SpeechPatch;
     expect(decryptV3(speech.tts.openai.apiKey)).toBe('sk-tts');
-    expect(speech.tts.openai.displayApiKey).toBe(getDisplaySecretKey('sk-tts'));
+    expect(speech.tts.openai.apiKeyPreview).toBe(getSecretPreview('sk-tts'));
     expect(speech.tts.openai.model).toBe('tts-1');
 
     const midPatch = encryptConfigSecretFields({
@@ -355,20 +385,20 @@ describe('Config secret registry fields', () => {
     });
     const tts = midPatch['speech.tts'] as SpeechPatch['tts'];
     expect(decryptV3(tts.openai.apiKey)).toBe('sk-tts');
-    expect(tts.openai.displayApiKey).toBe(getDisplaySecretKey('sk-tts'));
+    expect(tts.openai.apiKeyPreview).toBe(getSecretPreview('sk-tts'));
 
     const leafParentPatch = encryptConfigSecretFields({
       'speech.tts.openai': { apiKey: 'sk-tts', model: 'tts-1' },
     });
     const openai = leafParentPatch['speech.tts.openai'] as Record<string, string>;
     expect(decryptV3(openai.apiKey)).toBe('sk-tts');
-    expect(openai.displayApiKey).toBe(getDisplaySecretKey('sk-tts'));
+    expect(openai.apiKeyPreview).toBe(getSecretPreview('sk-tts'));
   });
 
-  it('strips dotted registry-related keys, including display companions, from whole-override writes', () => {
+  it('strips dotted registry-related keys, including preview companions, from whole-override writes', () => {
     const out = encryptConfigSecrets({
       'speech.tts.openai.apiKey': 'sk-smuggled',
-      'speech.tts.openai.displayApiKey': 'sk-spoofed...display',
+      'speech.tts.openai.apiKeyPreview': 'sk-spoofed...display',
       'ocr.apiKey': 'sk-smuggled',
       'webSearch.serperApiKey.nested': 'sk-smuggled',
       'speech.tts': { openai: { apiKey: 'sk-smuggled' } },
@@ -376,12 +406,12 @@ describe('Config secret registry fields', () => {
     });
 
     expect(out).not.toHaveProperty(['speech.tts.openai.apiKey']);
-    expect(out).not.toHaveProperty(['speech.tts.openai.displayApiKey']);
+    expect(out).not.toHaveProperty(['speech.tts.openai.apiKeyPreview']);
     expect(out).not.toHaveProperty(['ocr.apiKey']);
     expect(out).not.toHaveProperty(['webSearch.serperApiKey.nested']);
     expect(out).not.toHaveProperty(['speech.tts']);
     expect(decryptV3(out.ocr.apiKey)).toBe('sk-legit');
-    expect(out.ocr.displayApiKey).toBe(getDisplaySecretKey('sk-legit'));
+    expect(out.ocr.apiKeyPreview).toBe(getSecretPreview('sk-legit'));
   });
 
   it('strips a nested array smuggled at any depth along a secret ancestor path, not just the top level', () => {
@@ -402,34 +432,34 @@ describe('Config secret registry fields', () => {
     expect(JSON.stringify(readBack)).not.toContain('sk-smuggled-via-array');
   });
 
-  it('redacts secrets but keeps display companions, env placeholders, and siblings visible on read', () => {
+  it('redacts secrets but keeps preview companions, env placeholders, and siblings visible on read', () => {
     const redacted = redactConfigSecrets({
       speech: {
         tts: {
           openai: {
             apiKey: 'sk-literal',
-            displayApiKey: getDisplaySecretKey('sk-literal'),
+            apiKeyPreview: getSecretPreview('sk-literal'),
             model: 'tts-1',
           },
         },
         stt: {
-          openai: { apiKey: 'v3:abc:def', displayApiKey: 'sk-old...-old', model: 'whisper-1' },
+          openai: { apiKey: 'v3:abc:def', apiKeyPreview: 'sk-old...-old', model: 'whisper-1' },
         },
       },
       ocr: { apiKey: '${OCR_API_KEY}', mistralModel: 'mistral-ocr-latest' },
       webSearch: {
         serperApiKey: 'sk-literal',
-        displaySerperApiKey: 'sk-lite...eral',
+        serperApiKeyPreview: 'sk-lite...eral',
         searchProvider: 'serper',
       },
     });
 
     expect(redacted.speech.tts.openai).toEqual({
-      displayApiKey: getDisplaySecretKey('sk-literal'),
+      apiKeyPreview: getSecretPreview('sk-literal'),
       model: 'tts-1',
     });
     expect(redacted.speech.stt.openai).toEqual({
-      displayApiKey: 'sk-old...-old',
+      apiKeyPreview: 'sk-old...-old',
       model: 'whisper-1',
     });
     expect(redacted.ocr).toEqual({
@@ -437,24 +467,24 @@ describe('Config secret registry fields', () => {
       mistralModel: 'mistral-ocr-latest',
     });
     expect(redacted.webSearch).toEqual({
-      displaySerperApiKey: 'sk-lite...eral',
+      serperApiKeyPreview: 'sk-lite...eral',
       searchProvider: 'serper',
     });
   });
 
-  it('preserves omitted encrypted secrets and their display companion on nested object writes', () => {
+  it('preserves omitted encrypted secrets and their preview companion on nested object writes', () => {
     const existing = encryptConfigSecrets({
       speech: { tts: { openai: { apiKey: 'sk-old', model: 'tts-1' } as Record<string, string> } },
     });
-    const existingDisplay = existing.speech.tts.openai.displayApiKey;
-    expect(existingDisplay).toBe(getDisplaySecretKey('sk-old'));
+    const existingDisplay = existing.speech.tts.openai.apiKeyPreview;
+    expect(existingDisplay).toBe(getSecretPreview('sk-old'));
 
     const next = preserveConfigSecrets(
       { speech: { tts: { openai: { model: 'tts-2' } as Record<string, string> } } },
       existing,
     );
     expect(decryptV3(next.speech.tts.openai.apiKey)).toBe('sk-old');
-    expect(next.speech.tts.openai.displayApiKey).toBe(existingDisplay);
+    expect(next.speech.tts.openai.apiKeyPreview).toBe(existingDisplay);
     expect(next.speech.tts.openai.model).toBe('tts-2');
 
     const providerRemoved = preserveConfigSecrets({ speech: { tts: {} } }, existing);
@@ -466,20 +496,20 @@ describe('Config secret registry fields', () => {
       'speech.tts',
     );
     expect(decryptV3(ancestorPatch.openai.apiKey)).toBe('sk-old');
-    expect(ancestorPatch.openai.displayApiKey).toBe(existingDisplay);
+    expect(ancestorPatch.openai.apiKeyPreview).toBe(existingDisplay);
   });
 
-  it('does not preserve explicitly cleared secrets, and clears the display companion too', () => {
+  it('does not preserve explicitly cleared secrets, and clears the preview companion too', () => {
     const cleared = encryptConfigSecrets({
       speech: { tts: { openai: { apiKey: '' } as Record<string, string> } },
     });
-    expect(cleared.speech.tts.openai.displayApiKey).toBe('');
+    expect(cleared.speech.tts.openai.apiKeyPreview).toBe('');
     const existing = encryptConfigSecrets({
       speech: { tts: { openai: { apiKey: 'sk-old' } as Record<string, string> } },
     });
     const preservedAfterClear = preserveConfigSecrets(cleared, existing);
     expect(preservedAfterClear.speech.tts.openai.apiKey).toBe('');
-    expect(preservedAfterClear.speech.tts.openai.displayApiKey).toBe('');
+    expect(preservedAfterClear.speech.tts.openai.apiKeyPreview).toBe('');
   });
 
   it('migrates a legacy plaintext existing secret on an omitted allow-placeholder field too', () => {
@@ -490,7 +520,7 @@ describe('Config secret registry fields', () => {
     const ocr = fromPlaintext.ocr as Record<string, string>;
     expect(ocr.mistralModel).toBe('m');
     expect(decryptV3(ocr.apiKey)).toBe('sk-plain-existing');
-    expect(ocr.displayApiKey).toBe(getDisplaySecretKey('sk-plain-existing'));
+    expect(ocr.apiKeyPreview).toBe(getSecretPreview('sk-plain-existing'));
   });
 
   it('preserves an existing env placeholder secret verbatim without encrypting it', () => {
@@ -500,7 +530,7 @@ describe('Config secret registry fields', () => {
     );
     const ocr = fromPlaceholder.ocr as Record<string, string>;
     expect(ocr.apiKey).toBe('${OCR_API_KEY}');
-    expect(ocr.displayApiKey).toBeUndefined();
+    expect(ocr.apiKeyPreview).toBeUndefined();
   });
 
   it('resolveConfigSecret decrypts, resolves env references, and passes literals through', () => {
@@ -517,21 +547,21 @@ describe('Config secret registry fields', () => {
     expect(resolveConfigSecret('v3:not-valid-ciphertext')).toBeUndefined();
   });
 
-  it('reports mutation paths (including the display companion) and ancestor/descendant checks for registry fields', () => {
+  it('reports mutation paths (including the preview companion) and ancestor/descendant checks for registry fields', () => {
     expect(getConfigSecretMutationPaths('speech.tts.openai.apiKey')).toEqual([
       'speech.tts.openai.apiKey',
-      'speech.tts.openai.displayApiKey',
+      'speech.tts.openai.apiKeyPreview',
     ]);
     expect(getConfigSecretMutationPaths('webSearch.serperApiKey')).toEqual([
       'webSearch.serperApiKey',
-      'webSearch.displaySerperApiKey',
+      'webSearch.serperApiKeyPreview',
     ]);
     expect(getConfigSecretMutationPaths('langfuse.secretKey')).toEqual([
       'langfuse.secretKey',
-      'langfuse.displaySecretKey',
+      'langfuse.secretKeyPreview',
     ]);
-    expect(getConfigSecretMutationPaths('speech.tts.openai.displayApiKey')).toEqual([
-      'speech.tts.openai.displayApiKey',
+    expect(getConfigSecretMutationPaths('speech.tts.openai.apiKeyPreview')).toEqual([
+      'speech.tts.openai.apiKeyPreview',
     ]);
 
     for (const path of ['speech', 'speech.tts', 'speech.tts.openai', 'ocr', 'webSearch']) {
@@ -542,7 +572,7 @@ describe('Config secret registry fields', () => {
 
     expect(isConfigSecretDescendantPath('speech.tts.openai.apiKey.hidden')).toBe(true);
     expect(isConfigSecretDescendantPath('webSearch.serperApiKey.hidden')).toBe(true);
-    expect(isConfigSecretDescendantPath('speech.tts.openai.displayApiKey.hidden')).toBe(true);
+    expect(isConfigSecretDescendantPath('speech.tts.openai.apiKeyPreview.hidden')).toBe(true);
     expect(isConfigSecretDescendantPath('speech.tts.openai.model')).toBe(false);
   });
 
@@ -560,28 +590,28 @@ describe('Config secret registry fields', () => {
     expect(getConfigSecretInputError('ocr.apiKey', '${OCR_API_KEY}')).toBeNull();
   });
 
-  describe('display companion fields are write-side read-only for every registered field', () => {
+  describe('preview companion fields are write-side read-only for every registered field', () => {
     it.each([
-      'ocr.displayApiKey',
-      'speech.tts.openai.displayApiKey',
-      'speech.stt.azureOpenAI.displayApiKey',
-      'webSearch.displaySerperApiKey',
-      'webSearch.displayCohereApiKey',
-      'endpoints.assistants.displayApiKey',
-      'endpoints.azureAssistants.displayApiKey',
-      'langfuse.displaySecretKey',
-    ])('rejects a direct dotted-patch write to %s', (displayPath) => {
-      expect(getConfigSecretInputError(displayPath, 'attacker-supplied-display-value')).toContain(
-        'Cannot write protected display secret path',
+      'ocr.apiKeyPreview',
+      'speech.tts.openai.apiKeyPreview',
+      'speech.stt.azureOpenAI.apiKeyPreview',
+      'webSearch.serperApiKeyPreview',
+      'webSearch.cohereApiKeyPreview',
+      'endpoints.assistants.apiKeyPreview',
+      'endpoints.azureAssistants.apiKeyPreview',
+      'langfuse.secretKeyPreview',
+    ])('rejects a direct dotted-patch write to %s', (previewPath) => {
+      expect(getConfigSecretInputError(previewPath, 'attacker-supplied-display-value')).toContain(
+        'Cannot write protected secret preview path',
       );
     });
 
     it('drops a client-supplied display value when the ancestor object omits the real secret, never storing it', () => {
       const out = encryptConfigSecretFields({
-        speech: { tts: { openai: { model: 'tts-1', displayApiKey: 'attacker-injected-display' } } },
+        speech: { tts: { openai: { model: 'tts-1', apiKeyPreview: 'attacker-injected-display' } } },
       });
       const openai = (out.speech as { tts: { openai: Record<string, unknown> } }).tts.openai;
-      expect(openai).not.toHaveProperty('displayApiKey');
+      expect(openai).not.toHaveProperty('apiKeyPreview');
       expect(openai.model).toBe('tts-1');
     });
 
@@ -589,20 +619,20 @@ describe('Config secret registry fields', () => {
       const out = encryptConfigSecretFields({
         webSearch: {
           serperApiKey: 'sk-real-secret',
-          displaySerperApiKey: 'v3:looks-encrypted-but-is-attacker-input',
+          serperApiKeyPreview: 'v3:looks-encrypted-but-is-attacker-input',
         },
       });
       const webSearch = out.webSearch as Record<string, string>;
       expect(decryptV3(webSearch.serperApiKey)).toBe('sk-real-secret');
-      expect(webSearch.displaySerperApiKey).toBe(getDisplaySecretKey('sk-real-secret'));
-      expect(webSearch.displaySerperApiKey).not.toBe('v3:looks-encrypted-but-is-attacker-input');
+      expect(webSearch.serperApiKeyPreview).toBe(getSecretPreview('sk-real-secret'));
+      expect(webSearch.serperApiKeyPreview).not.toBe('v3:looks-encrypted-but-is-attacker-input');
     });
 
     it('never encrypts or stores a display-path value submitted without its real secret, even if it looks like a secret literal', () => {
       const out = encryptConfigSecrets({
-        ocr: { displayApiKey: 'this-should-never-be-treated-as-a-secret', mistralModel: 'x' },
+        ocr: { apiKeyPreview: 'this-should-never-be-treated-as-a-secret', mistralModel: 'x' },
       });
-      expect(out.ocr).not.toHaveProperty('displayApiKey');
+      expect(out.ocr).not.toHaveProperty('apiKeyPreview');
       expect(out.ocr).not.toHaveProperty('apiKey');
       expect(out.ocr.mistralModel).toBe('x');
     });

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -210,7 +210,16 @@ describe('Langfuse config secrets', () => {
     const redacted = redactConfigSecrets({
       langfuse: { publicKey: 'pk-lf-1', secretKey: 'v3:abc:def', displaySecretKey: 'sk-lf-...old' },
     });
-    expect(redacted.langfuse).toEqual({ publicKey: 'pk-lf-1' });
+    expect(redacted.langfuse).toEqual({ publicKey: 'pk-lf-1', secretKeyPreview: 'sk-lf-...old' });
+
+    const alreadyMigrated = redactConfigSecrets({
+      langfuse: {
+        secretKey: 'v3:abc:def',
+        secretKeyPreview: 'sk-lf-...new',
+        displaySecretKey: 'sk-lf-...old',
+      },
+    });
+    expect(alreadyMigrated.langfuse).toEqual({ secretKeyPreview: 'sk-lf-...new' });
 
     const encrypted = encryptConfigSecrets({
       langfuse: { secretKey: 'sk-lf-new-secret', displaySecretKey: 'sk-lf-...old' },

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -7,8 +7,13 @@ let decryptConfigSecret: typeof import('./secrets').decryptConfigSecret;
 let encryptConfigSecretFields: typeof import('./secrets').encryptConfigSecretFields;
 let encryptConfigSecrets: typeof import('./secrets').encryptConfigSecrets;
 let getConfigSecretInputError: typeof import('./secrets').getConfigSecretInputError;
+let getConfigSecretMutationPaths: typeof import('./secrets').getConfigSecretMutationPaths;
+let getConfigSecretSections: typeof import('./secrets').getConfigSecretSections;
+let isConfigSecretAncestorPath: typeof import('./secrets').isConfigSecretAncestorPath;
+let isConfigSecretDescendantPath: typeof import('./secrets').isConfigSecretDescendantPath;
 let preserveConfigSecrets: typeof import('./secrets').preserveConfigSecrets;
 let redactConfigSecrets: typeof import('./secrets').redactConfigSecrets;
+let resolveConfigSecret: typeof import('./secrets').resolveConfigSecret;
 let decryptV3: typeof import('@librechat/data-schemas').decryptV3;
 
 beforeAll(async () => {
@@ -17,8 +22,13 @@ beforeAll(async () => {
     encryptConfigSecretFields,
     encryptConfigSecrets,
     getConfigSecretInputError,
+    getConfigSecretMutationPaths,
+    getConfigSecretSections,
+    isConfigSecretAncestorPath,
+    isConfigSecretDescendantPath,
     preserveConfigSecrets,
     redactConfigSecrets,
+    resolveConfigSecret,
   } = await import('./secrets'));
   ({ decryptV3 } = await import('@librechat/data-schemas'));
 });
@@ -189,5 +199,239 @@ describe('Langfuse config secrets', () => {
       publicKey: 'pk-lf-1',
       displaySecretKey: 'sk-lf-...cret',
     });
+  });
+});
+
+describe('Config secret registry fields', () => {
+  it('exposes the registered top-level sections', () => {
+    expect([...getConfigSecretSections()].sort()).toEqual([
+      'endpoints',
+      'langfuse',
+      'ocr',
+      'speech',
+      'webSearch',
+    ]);
+  });
+
+  it('encrypts assistants endpoint keys but leaves unrelated endpoints untouched', () => {
+    const out = encryptConfigSecrets({
+      endpoints: {
+        assistants: { apiKey: 'sk-assist', disableBuilder: true },
+        azureAssistants: { apiKey: '${AZURE_ASSISTANTS_API_KEY}' },
+        custom: [{ name: 'my-endpoint', apiKey: '${MY_KEY}', baseURL: 'https://x' }],
+      },
+    });
+    const endpoints = out.endpoints as {
+      assistants: Record<string, unknown>;
+      azureAssistants: Record<string, unknown>;
+      custom: Array<Record<string, unknown>>;
+    };
+    expect(decryptV3(endpoints.assistants.apiKey as string)).toBe('sk-assist');
+    expect(endpoints.assistants.disableBuilder).toBe(true);
+    expect(endpoints.azureAssistants.apiKey).toBe('${AZURE_ASSISTANTS_API_KEY}');
+    expect(endpoints.custom[0]).toEqual({
+      name: 'my-endpoint',
+      apiKey: '${MY_KEY}',
+      baseURL: 'https://x',
+    });
+  });
+
+  it('encrypts speech, ocr, and webSearch literals on object writes', () => {
+    const out = encryptConfigSecrets({
+      speech: {
+        tts: { openai: { apiKey: 'sk-tts', model: 'tts-1' } },
+        stt: { azureOpenAI: { apiKey: 'sk-stt', instanceName: 'inst' } },
+      },
+      ocr: { apiKey: 'sk-ocr', mistralModel: 'mistral-ocr-latest' },
+      webSearch: { serperApiKey: 'sk-serper', searchProvider: 'serper' },
+    });
+
+    expect(decryptV3(out.speech.tts.openai.apiKey)).toBe('sk-tts');
+    expect(out.speech.tts.openai.model).toBe('tts-1');
+    expect(decryptV3(out.speech.stt.azureOpenAI.apiKey)).toBe('sk-stt');
+    expect(out.speech.stt.azureOpenAI.instanceName).toBe('inst');
+    expect(decryptV3(out.ocr.apiKey)).toBe('sk-ocr');
+    expect(out.ocr.mistralModel).toBe('mistral-ocr-latest');
+    expect(decryptV3(out.webSearch.serperApiKey)).toBe('sk-serper');
+    expect(out.webSearch.searchProvider).toBe('serper');
+  });
+
+  it('keeps env placeholder references as plain strings for fields that allow them', () => {
+    const out = encryptConfigSecrets({
+      speech: { tts: { openai: { apiKey: '${TTS_API_KEY}' } } },
+      ocr: { apiKey: '${OCR_API_KEY}' },
+      webSearch: { serperApiKey: '${SERPER_API_KEY}' },
+    });
+
+    expect(out.speech.tts.openai.apiKey).toBe('${TTS_API_KEY}');
+    expect(out.ocr.apiKey).toBe('${OCR_API_KEY}');
+    expect(out.webSearch.serperApiKey).toBe('${SERPER_API_KEY}');
+  });
+
+  it('still encrypts placeholder-shaped Langfuse secrets (no placeholder exemption)', () => {
+    const out = encryptConfigSecrets({ langfuse: { secretKey: '${LANGFUSE_SECRET_KEY}' } });
+    expect(out.langfuse.secretKey).toMatch(/^v3:/);
+    expect(decryptV3(out.langfuse.secretKey)).toBe('${LANGFUSE_SECRET_KEY}');
+  });
+
+  it('encrypts dotted patch writes without creating display companions', () => {
+    const out = encryptConfigSecretFields({
+      'speech.tts.openai.apiKey': 'sk-tts',
+      'webSearch.serperApiKey': '${SERPER_API_KEY}',
+      'ocr.apiKey': '',
+    });
+
+    expect(decryptV3(out['speech.tts.openai.apiKey'] as string)).toBe('sk-tts');
+    expect(out['webSearch.serperApiKey']).toBe('${SERPER_API_KEY}');
+    expect(out['ocr.apiKey']).toBe('');
+    expect(Object.keys(out).sort()).toEqual([
+      'ocr.apiKey',
+      'speech.tts.openai.apiKey',
+      'webSearch.serperApiKey',
+    ]);
+  });
+
+  it('encrypts secrets nested inside object-valued ancestor patch entries', () => {
+    type SpeechPatch = { tts: { openai: Record<string, string> } };
+    const sectionPatch = encryptConfigSecretFields({
+      speech: { tts: { openai: { apiKey: 'sk-tts', model: 'tts-1' } } },
+    });
+    const speech = sectionPatch.speech as SpeechPatch;
+    expect(decryptV3(speech.tts.openai.apiKey)).toBe('sk-tts');
+    expect(speech.tts.openai.model).toBe('tts-1');
+
+    const midPatch = encryptConfigSecretFields({
+      'speech.tts': { openai: { apiKey: 'sk-tts' } },
+    });
+    const tts = midPatch['speech.tts'] as SpeechPatch['tts'];
+    expect(decryptV3(tts.openai.apiKey)).toBe('sk-tts');
+
+    const leafParentPatch = encryptConfigSecretFields({
+      'speech.tts.openai': { apiKey: 'sk-tts', model: 'tts-1' },
+    });
+    const openai = leafParentPatch['speech.tts.openai'] as Record<string, string>;
+    expect(decryptV3(openai.apiKey)).toBe('sk-tts');
+  });
+
+  it('strips dotted registry-related keys from whole-override writes', () => {
+    const out = encryptConfigSecrets({
+      'speech.tts.openai.apiKey': 'sk-smuggled',
+      'ocr.apiKey': 'sk-smuggled',
+      'webSearch.serperApiKey.nested': 'sk-smuggled',
+      'speech.tts': { openai: { apiKey: 'sk-smuggled' } },
+      ocr: { apiKey: 'sk-legit' },
+    });
+
+    expect(out).not.toHaveProperty(['speech.tts.openai.apiKey']);
+    expect(out).not.toHaveProperty(['ocr.apiKey']);
+    expect(out).not.toHaveProperty(['webSearch.serperApiKey.nested']);
+    expect(out).not.toHaveProperty(['speech.tts']);
+    expect(decryptV3(out.ocr.apiKey)).toBe('sk-legit');
+  });
+
+  it('redacts literal and encrypted values but keeps env placeholders and siblings', () => {
+    const redacted = redactConfigSecrets({
+      speech: {
+        tts: { openai: { apiKey: 'sk-literal', model: 'tts-1' } },
+        stt: { openai: { apiKey: 'v3:abc:def', model: 'whisper-1' } },
+      },
+      ocr: { apiKey: '${OCR_API_KEY}', mistralModel: 'mistral-ocr-latest' },
+      webSearch: { serperApiKey: 'sk-literal', searchProvider: 'serper' },
+    });
+
+    expect(redacted.speech.tts.openai).toEqual({ model: 'tts-1' });
+    expect(redacted.speech.stt.openai).toEqual({ model: 'whisper-1' });
+    expect(redacted.ocr).toEqual({
+      apiKey: '${OCR_API_KEY}',
+      mistralModel: 'mistral-ocr-latest',
+    });
+    expect(redacted.webSearch).toEqual({ searchProvider: 'serper' });
+  });
+
+  it('preserves omitted encrypted secrets on nested object writes', () => {
+    const existing = encryptConfigSecrets({
+      speech: { tts: { openai: { apiKey: 'sk-old', model: 'tts-1' } } },
+    });
+
+    const next = preserveConfigSecrets(
+      { speech: { tts: { openai: { model: 'tts-2' } as Record<string, string> } } },
+      existing,
+    );
+    expect(decryptV3(next.speech.tts.openai.apiKey)).toBe('sk-old');
+    expect(next.speech.tts.openai.model).toBe('tts-2');
+
+    const providerRemoved = preserveConfigSecrets({ speech: { tts: {} } }, existing);
+    expect(providerRemoved.speech.tts).toEqual({});
+
+    const ancestorPatch = preserveConfigSecrets(
+      { openai: { model: 'tts-2' } as Record<string, string> },
+      existing,
+      'speech.tts',
+    );
+    expect(decryptV3(ancestorPatch.openai.apiKey)).toBe('sk-old');
+  });
+
+  it('does not preserve explicitly cleared or plaintext existing secrets', () => {
+    const cleared = encryptConfigSecrets({
+      speech: { tts: { openai: { apiKey: '' } } },
+    });
+    const existing = encryptConfigSecrets({
+      speech: { tts: { openai: { apiKey: 'sk-old' } } },
+    });
+    expect(preserveConfigSecrets(cleared, existing).speech.tts.openai.apiKey).toBe('');
+
+    const fromPlaintext = preserveConfigSecrets(
+      { ocr: { mistralModel: 'm' } },
+      { ocr: { apiKey: 'sk-plain-existing' } },
+    );
+    expect(fromPlaintext.ocr).toEqual({ mistralModel: 'm' });
+  });
+
+  it('resolveConfigSecret decrypts, resolves env references, and passes literals through', () => {
+    const encrypted = encryptConfigSecrets({ ocr: { apiKey: 'sk-ocr' } }).ocr.apiKey;
+    expect(resolveConfigSecret(encrypted)).toBe('sk-ocr');
+
+    process.env.SECRETS_SPEC_TEST_KEY = 'sk-from-env';
+    expect(resolveConfigSecret('${SECRETS_SPEC_TEST_KEY}')).toBe('sk-from-env');
+    delete process.env.SECRETS_SPEC_TEST_KEY;
+
+    expect(resolveConfigSecret('sk-plain-literal')).toBe('sk-plain-literal');
+    expect(resolveConfigSecret('')).toBe('');
+    expect(resolveConfigSecret(undefined)).toBeUndefined();
+    expect(resolveConfigSecret('v3:not-valid-ciphertext')).toBeUndefined();
+  });
+
+  it('reports mutation paths and ancestor/descendant checks for registry fields', () => {
+    expect(getConfigSecretMutationPaths('speech.tts.openai.apiKey')).toEqual([
+      'speech.tts.openai.apiKey',
+    ]);
+    expect(getConfigSecretMutationPaths('langfuse.secretKey')).toEqual([
+      'langfuse.secretKey',
+      'langfuse.displaySecretKey',
+    ]);
+
+    for (const path of ['speech', 'speech.tts', 'speech.tts.openai', 'ocr', 'webSearch']) {
+      expect(isConfigSecretAncestorPath(path)).toBe(true);
+    }
+    expect(isConfigSecretAncestorPath('speech.tts.openai.apiKey')).toBe(false);
+    expect(isConfigSecretAncestorPath('interface')).toBe(false);
+
+    expect(isConfigSecretDescendantPath('speech.tts.openai.apiKey.hidden')).toBe(true);
+    expect(isConfigSecretDescendantPath('webSearch.serperApiKey.hidden')).toBe(true);
+    expect(isConfigSecretDescendantPath('speech.tts.openai.model')).toBe(false);
+  });
+
+  it('rejects encrypted submissions at registry paths and inside ancestor objects', () => {
+    expect(getConfigSecretInputError('webSearch.serperApiKey', 'v3:attacker')).toContain(
+      'Encrypted config secret values',
+    );
+    expect(
+      getConfigSecretInputError('speech', { tts: { openai: { apiKey: 'v3:attacker' } } }),
+    ).toContain('Encrypted config secret values');
+    expect(getConfigSecretInputError('speech.tts.openai', { apiKey: 'v3:attacker' })).toContain(
+      'Encrypted config secret values',
+    );
+    expect(getConfigSecretInputError('speech.tts.openai.apiKey', 'sk-legit')).toBeNull();
+    expect(getConfigSecretInputError('ocr.apiKey', '${OCR_API_KEY}')).toBeNull();
   });
 });

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -130,7 +130,7 @@ describe('Langfuse config secrets', () => {
     expect(preserved.langfuse.publicKey).toBe('pk-new');
   });
 
-  it('does not preserve plaintext existing secrets or explicitly cleared secrets', () => {
+  it('migrates a legacy plaintext existing secret by encrypting it, and drops explicitly cleared secrets', () => {
     const next = encryptConfigSecrets({
       langfuse: {
         publicKey: 'pk-new',
@@ -143,7 +143,10 @@ describe('Langfuse config secrets', () => {
         secretKey: 'sk-plain-existing',
       },
     });
-    expect(fromPlaintext.langfuse).toEqual({ publicKey: 'pk-new' });
+    const preservedLangfuse = fromPlaintext.langfuse as Record<string, string>;
+    expect(preservedLangfuse.publicKey).toBe('pk-new');
+    expect(decryptV3(preservedLangfuse.secretKey)).toBe('sk-plain-existing');
+    expect(preservedLangfuse.displaySecretKey).toBe(getDisplaySecretKey('sk-plain-existing'));
 
     const existing = encryptConfigSecrets({
       langfuse: {
@@ -466,7 +469,7 @@ describe('Config secret registry fields', () => {
     expect(ancestorPatch.openai.displayApiKey).toBe(existingDisplay);
   });
 
-  it('does not preserve explicitly cleared or plaintext existing secrets, and clears the display companion too', () => {
+  it('does not preserve explicitly cleared secrets, and clears the display companion too', () => {
     const cleared = encryptConfigSecrets({
       speech: { tts: { openai: { apiKey: '' } as Record<string, string> } },
     });
@@ -477,12 +480,27 @@ describe('Config secret registry fields', () => {
     const preservedAfterClear = preserveConfigSecrets(cleared, existing);
     expect(preservedAfterClear.speech.tts.openai.apiKey).toBe('');
     expect(preservedAfterClear.speech.tts.openai.displayApiKey).toBe('');
+  });
 
+  it('migrates a legacy plaintext existing secret on an omitted allow-placeholder field too', () => {
     const fromPlaintext = preserveConfigSecrets(
       { ocr: { mistralModel: 'm' } },
       { ocr: { apiKey: 'sk-plain-existing' } },
     );
-    expect(fromPlaintext.ocr).toEqual({ mistralModel: 'm' });
+    const ocr = fromPlaintext.ocr as Record<string, string>;
+    expect(ocr.mistralModel).toBe('m');
+    expect(decryptV3(ocr.apiKey)).toBe('sk-plain-existing');
+    expect(ocr.displayApiKey).toBe(getDisplaySecretKey('sk-plain-existing'));
+  });
+
+  it('preserves an existing env placeholder secret verbatim without encrypting it', () => {
+    const fromPlaceholder = preserveConfigSecrets(
+      { ocr: { mistralModel: 'm' } },
+      { ocr: { apiKey: '${OCR_API_KEY}' } },
+    );
+    const ocr = fromPlaceholder.ocr as Record<string, string>;
+    expect(ocr.apiKey).toBe('${OCR_API_KEY}');
+    expect(ocr.displayApiKey).toBeUndefined();
   });
 
   it('resolveConfigSecret decrypts, resolves env references, and passes literals through', () => {

--- a/packages/api/src/admin/secrets.spec.ts
+++ b/packages/api/src/admin/secrets.spec.ts
@@ -276,6 +276,44 @@ describe('Config secret registry fields', () => {
     expect(decryptV3(out.langfuse.secretKey)).toBe('${LANGFUSE_SECRET_KEY}');
   });
 
+  it('clears a stale display mask when a literal secret is rotated to an env placeholder', () => {
+    const dottedOut = encryptConfigSecretFields({ 'ocr.apiKey': '${OCR_API_KEY}' });
+    expect(dottedOut['ocr.apiKey']).toBe('${OCR_API_KEY}');
+    expect(dottedOut['ocr.displayApiKey']).toBe('');
+
+    const objectOut = encryptConfigSecrets({
+      ocr: { apiKey: '${OCR_API_KEY}', displayApiKey: 'sk-sta...LE00' },
+    });
+    expect(objectOut.ocr.apiKey).toBe('${OCR_API_KEY}');
+    expect(objectOut.ocr.displayApiKey).toBe('');
+  });
+
+  it('never persists a client-supplied display mask alongside an env placeholder secret', () => {
+    const out = encryptConfigSecrets({
+      ocr: { apiKey: '${OCR_API_KEY}', displayApiKey: 'sk-atk...ACK' },
+    });
+    expect(out.ocr.apiKey).toBe('${OCR_API_KEY}');
+    expect(out.ocr.displayApiKey).toBe('');
+  });
+
+  it('trims whitespace from a literal secret before encrypting and masking', () => {
+    const out = encryptConfigSecretFields({ 'ocr.apiKey': '  sk-padded-secret  ' });
+    expect(decryptV3(out['ocr.apiKey'] as string)).toBe('sk-padded-secret');
+    expect(out['ocr.displayApiKey']).toBe(getDisplaySecretKey('sk-padded-secret'));
+  });
+
+  it('treats a whitespace-only literal secret as empty and clears it', () => {
+    const out = encryptConfigSecretFields({ 'ocr.apiKey': '   ' });
+    expect(out['ocr.apiKey']).toBe('');
+    expect(out['ocr.displayApiKey']).toBe('');
+  });
+
+  it('masks short credentials fully instead of disclosing them via the display companion', () => {
+    expect(getDisplaySecretKey('short12')).toBe('*******');
+    expect(getDisplaySecretKey('0123456789')).toBe('**********');
+    expect(getDisplaySecretKey('sk-longer-secret-value')).toBe('sk-lon...alue');
+  });
+
   it('encrypts dotted patch writes and sets a masked display companion for every field', () => {
     const out = encryptConfigSecretFields({
       'speech.tts.openai.apiKey': 'sk-tts',
@@ -286,7 +324,7 @@ describe('Config secret registry fields', () => {
     expect(decryptV3(out['speech.tts.openai.apiKey'] as string)).toBe('sk-tts');
     expect(out['speech.tts.openai.displayApiKey']).toBe(getDisplaySecretKey('sk-tts'));
     expect(out['webSearch.serperApiKey']).toBe('${SERPER_API_KEY}');
-    expect(out['webSearch.displaySerperApiKey']).toBeUndefined();
+    expect(out['webSearch.displaySerperApiKey']).toBe('');
     expect(out['ocr.apiKey']).toBe('');
     expect(out['ocr.displayApiKey']).toBe('');
     expect(Object.keys(out).sort()).toEqual([
@@ -294,6 +332,7 @@ describe('Config secret registry fields', () => {
       'ocr.displayApiKey',
       'speech.tts.openai.apiKey',
       'speech.tts.openai.displayApiKey',
+      'webSearch.displaySerperApiKey',
       'webSearch.serperApiKey',
     ]);
   });

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -454,18 +454,26 @@ export function preserveConfigSecrets<T>(next: T, existing?: unknown, basePath =
     }
 
     const existingSection = walkToParent(existing, field.path.split('.'));
-    if (!existingSection || !isEncryptedConfigSecret(existingSection[key])) {
+    if (!existingSection) {
       continue;
     }
     const existingSecret = normalizeSecretString(existingSection[key]);
     if (!existingSecret) {
       continue;
     }
-    section[key] = existingSecret;
+    const isAlreadyEncrypted = isEncryptedConfigSecret(existingSecret);
+    const isPlaceholder = field.allowEnvPlaceholder && isEnvPlaceholder(existingSecret);
+    // A legacy plaintext secret stored before this field was registered has
+    // no ciphertext to preserve verbatim — encrypt it now instead of
+    // silently dropping it the first time an unrelated field is edited.
+    section[key] = isAlreadyEncrypted || isPlaceholder ? existingSecret : encryptV3(existingSecret);
     if (field.displayPath) {
       const displayKey = lastSegment(field.displayPath);
-      if (typeof existingSection[displayKey] === 'string') {
-        section[displayKey] = existingSection[displayKey];
+      const existingDisplay = existingSection[displayKey];
+      if (typeof existingDisplay === 'string') {
+        section[displayKey] = existingDisplay;
+      } else if (!isAlreadyEncrypted && !isPlaceholder) {
+        section[displayKey] = getDisplaySecretKey(existingSecret);
       }
     }
   }

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -113,6 +113,9 @@ const SECRET_SECTIONS: readonly string[] = [
 ];
 
 export function getDisplaySecretKey(secret: string): string {
+  if (secret.length <= 10) {
+    return '*'.repeat(secret.length);
+  }
   return secret.slice(0, 6) + '...' + secret.slice(-4);
 }
 
@@ -262,8 +265,16 @@ function writeSecretIntoSection(section: Record<string, unknown>, field: ConfigS
     return;
   }
 
-  const value = section[key];
-  if (typeof value !== 'string' || value.length === 0 || value.startsWith(ENCRYPTED_PREFIX)) {
+  const rawValue = section[key];
+  if (typeof rawValue !== 'string' || rawValue.startsWith(ENCRYPTED_PREFIX)) {
+    section[key] = '';
+    if (displayKey) {
+      section[displayKey] = '';
+    }
+    return;
+  }
+  const value = normalizeSecretString(rawValue);
+  if (!value) {
     section[key] = '';
     if (displayKey) {
       section[displayKey] = '';
@@ -271,6 +282,10 @@ function writeSecretIntoSection(section: Record<string, unknown>, field: ConfigS
     return;
   }
   if (field.allowEnvPlaceholder && isEnvPlaceholder(value)) {
+    section[key] = value;
+    if (displayKey) {
+      section[displayKey] = '';
+    }
     return;
   }
 
@@ -281,8 +296,16 @@ function writeSecretIntoSection(section: Record<string, unknown>, field: ConfigS
 }
 
 function writeDottedSecret(result: Record<string, unknown>, field: ConfigSecretField): void {
-  const value = result[field.path];
-  if (typeof value !== 'string' || value.length === 0 || value.startsWith(ENCRYPTED_PREFIX)) {
+  const rawValue = result[field.path];
+  if (typeof rawValue !== 'string' || rawValue.startsWith(ENCRYPTED_PREFIX)) {
+    result[field.path] = '';
+    if (field.displayPath) {
+      result[field.displayPath] = '';
+    }
+    return;
+  }
+  const value = normalizeSecretString(rawValue);
+  if (!value) {
     result[field.path] = '';
     if (field.displayPath) {
       result[field.displayPath] = '';
@@ -290,6 +313,10 @@ function writeDottedSecret(result: Record<string, unknown>, field: ConfigSecretF
     return;
   }
   if (field.allowEnvPlaceholder && isEnvPlaceholder(value)) {
+    result[field.path] = value;
+    if (field.displayPath) {
+      result[field.displayPath] = '';
+    }
     return;
   }
   result[field.path] = encryptV3(value);

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -168,6 +168,33 @@ function walkToParent(root: unknown, segments: string[]): Record<string, unknown
   return cursor;
 }
 
+/**
+ * Deletes any array value found along a registered secret's ancestor chain
+ * (relative to `basePath`), at any depth, not just the top level. `walkToParent`
+ * silently stops and returns null at an array, which would otherwise let a
+ * secret smuggled inside an unexpected array-of-objects shape (e.g.
+ * `speech.tts.openai` submitted as an array) bypass both encryption and
+ * redaction entirely instead of being stripped like a top-level array is.
+ */
+function pruneSecretAncestorArrays(root: Record<string, unknown>, basePath: string): void {
+  for (const field of CONFIG_SECRET_FIELDS) {
+    const segments = relativeSegments(field.path, basePath);
+    if (!segments) {
+      continue;
+    }
+    let cursor: Record<string, unknown> | null = root;
+    for (let i = 0; cursor != null && i < segments.length - 1; i++) {
+      const value = cursor[segments[i]];
+      if (Array.isArray(value)) {
+        delete cursor[segments[i]];
+        cursor = null;
+        continue;
+      }
+      cursor = getPlainRecord(value);
+    }
+  }
+}
+
 /** True when a dotted key equals, contains, or is contained by a registered secret or display path. */
 function isConfigSecretRelatedPath(fieldPath: string): boolean {
   if (SECRET_FIELDS_BY_PATH.has(fieldPath) || DISPLAY_PATHS.has(fieldPath)) {
@@ -380,6 +407,7 @@ export function encryptConfigSecrets<T>(root: T, basePath = ''): T {
       }
     }
   }
+  pruneSecretAncestorArrays(rootRecord, basePath);
 
   for (const field of CONFIG_SECRET_FIELDS) {
     const segments = relativeSegments(field.path, basePath);
@@ -463,6 +491,7 @@ export function redactConfigSecrets<T>(root: T): T {
       delete rootRecord[key];
     }
   }
+  pruneSecretAncestorArrays(rootRecord, '');
 
   for (const field of CONFIG_SECRET_FIELDS) {
     const segments = field.path.split('.');

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -128,7 +128,7 @@ function normalizeSecretString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
 }
 
-function isEncryptedConfigSecret(value: unknown): boolean {
+export function isEncryptedConfigSecret(value: unknown): boolean {
   return typeof value === 'string' && value.trim().startsWith(ENCRYPTED_PREFIX);
 }
 

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -246,6 +246,24 @@ function deleteLegacyPreviewKey(section: Record<string, unknown>, field: ConfigS
 }
 
 /**
+ * Translates a legacy preview companion to its `<field>Preview` name in place,
+ * so reads of not-yet-migrated documents still indicate a configured secret.
+ * The stored document migrates for real on its next write.
+ */
+function migrateLegacyPreviewKey(section: Record<string, unknown>, field: ConfigSecretField): void {
+  const legacyPath = LEGACY_PREVIEW_PATHS.get(field.path);
+  if (!legacyPath) {
+    return;
+  }
+  const legacyValue = section[lastSegment(legacyPath)];
+  const previewKey = lastSegment(field.previewPath);
+  if (typeof legacyValue === 'string' && section[previewKey] === undefined) {
+    section[previewKey] = legacyValue;
+  }
+  delete section[lastSegment(legacyPath)];
+}
+
+/**
  * Encrypts a secret value in place within its parent record. Empty and
  * non-string values reset the secret (and preview companion). Env placeholder
  * values are kept as plain references for fields that allow them.
@@ -478,7 +496,7 @@ export function redactConfigSecrets<T>(root: T): T {
     if (!section) {
       continue;
     }
-    deleteLegacyPreviewKey(section, field);
+    migrateLegacyPreviewKey(section, field);
     const key = segments[segments.length - 1];
     if (!(key in section)) {
       continue;

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -4,102 +4,63 @@ import { envVarRegex, extractEnvVariable } from 'librechat-data-provider';
 
 const ENCRYPTED_PREFIX = 'v3:';
 
-interface ConfigSecretField {
+interface ConfigSecretFieldInput {
   /** Dot-path of the secret value within config overrides */
   path: string;
-  /** Non-secret display companion, written on encrypt and preserved by redaction. Must be a sibling of `path`. */
-  displayPath?: string;
   /** When true, `${ENV_VAR}` placeholder values are stored and returned as plain references instead of being encrypted */
   allowEnvPlaceholder?: boolean;
+}
+
+interface ConfigSecretField extends ConfigSecretFieldInput {
+  /** Non-secret masked-preview companion, always the sibling `<field>Preview`. Written on encrypt, preserved by redaction. */
+  previewPath: string;
 }
 
 /**
  * Registry of config fields that hold secret values. Writes through the admin
  * config API encrypt these at rest, reads redact them, and omitting them on a
- * subsequent write preserves the stored encrypted value.
+ * subsequent write preserves the stored encrypted value. Each secret's
+ * masked-preview companion is derived as `<path>Preview` — recognizing a new
+ * sensitive field is a one-line path addition (plus the `<field>Preview`
+ * companion in the config schema).
  */
-const CONFIG_SECRET_FIELDS: readonly ConfigSecretField[] = [
-  { path: 'langfuse.secretKey', displayPath: 'langfuse.displaySecretKey' },
-  { path: 'ocr.apiKey', displayPath: 'ocr.displayApiKey', allowEnvPlaceholder: true },
-  {
-    path: 'speech.tts.openai.apiKey',
-    displayPath: 'speech.tts.openai.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'speech.tts.azureOpenAI.apiKey',
-    displayPath: 'speech.tts.azureOpenAI.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'speech.tts.elevenlabs.apiKey',
-    displayPath: 'speech.tts.elevenlabs.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'speech.tts.localai.apiKey',
-    displayPath: 'speech.tts.localai.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'speech.stt.openai.apiKey',
-    displayPath: 'speech.stt.openai.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'speech.stt.azureOpenAI.apiKey',
-    displayPath: 'speech.stt.azureOpenAI.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'webSearch.serperApiKey',
-    displayPath: 'webSearch.displaySerperApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'webSearch.searxngApiKey',
-    displayPath: 'webSearch.displaySearxngApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'webSearch.firecrawlApiKey',
-    displayPath: 'webSearch.displayFirecrawlApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'webSearch.tavilyApiKey',
-    displayPath: 'webSearch.displayTavilyApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'webSearch.jinaApiKey',
-    displayPath: 'webSearch.displayJinaApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'webSearch.cohereApiKey',
-    displayPath: 'webSearch.displayCohereApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'endpoints.assistants.apiKey',
-    displayPath: 'endpoints.assistants.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-  {
-    path: 'endpoints.azureAssistants.apiKey',
-    displayPath: 'endpoints.azureAssistants.displayApiKey',
-    allowEnvPlaceholder: true,
-  },
-];
+const CONFIG_SECRET_FIELDS: readonly ConfigSecretField[] = (
+  [
+    { path: 'langfuse.secretKey' },
+    { path: 'ocr.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.tts.openai.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.tts.azureOpenAI.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.tts.elevenlabs.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.tts.localai.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.stt.openai.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.stt.azureOpenAI.apiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.serperApiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.searxngApiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.firecrawlApiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.tavilyApiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.jinaApiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.cohereApiKey', allowEnvPlaceholder: true },
+    { path: 'endpoints.assistants.apiKey', allowEnvPlaceholder: true },
+    { path: 'endpoints.azureAssistants.apiKey', allowEnvPlaceholder: true },
+  ] satisfies ConfigSecretFieldInput[]
+).map((field) => ({ ...field, previewPath: `${field.path}Preview` }));
+
+/**
+ * Preview companions written under earlier naming conventions. Stripped from
+ * writes and reads so stored documents self-clean; never written.
+ */
+const LEGACY_PREVIEW_PATHS: ReadonlyMap<string, string> = new Map([
+  ['langfuse.secretKey', 'langfuse.displaySecretKey'],
+]);
 
 const SECRET_FIELDS_BY_PATH = new Map<string, ConfigSecretField>(
   CONFIG_SECRET_FIELDS.map((field) => [field.path, field]),
 );
 
-const DISPLAY_PATHS = new Set<string>(
-  CONFIG_SECRET_FIELDS.flatMap((field) => (field.displayPath ? [field.displayPath] : [])),
-);
+const PREVIEW_PATHS = new Set<string>([
+  ...CONFIG_SECRET_FIELDS.map((field) => field.previewPath),
+  ...LEGACY_PREVIEW_PATHS.values(),
+]);
 
 const ANCESTOR_PATHS = new Set<string>(
   CONFIG_SECRET_FIELDS.flatMap((field) => {
@@ -112,7 +73,7 @@ const SECRET_SECTIONS: readonly string[] = [
   ...new Set(CONFIG_SECRET_FIELDS.map((field) => field.path.split('.')[0])),
 ];
 
-export function getDisplaySecretKey(secret: string): string {
+export function getSecretPreview(secret: string): string {
   if (secret.length <= 10) {
     return '*'.repeat(secret.length);
   }
@@ -195,9 +156,9 @@ function pruneSecretAncestorArrays(root: Record<string, unknown>, basePath: stri
   }
 }
 
-/** True when a dotted key equals, contains, or is contained by a registered secret or display path. */
+/** True when a dotted key equals, contains, or is contained by a registered secret or preview path. */
 function isConfigSecretRelatedPath(fieldPath: string): boolean {
-  if (SECRET_FIELDS_BY_PATH.has(fieldPath) || DISPLAY_PATHS.has(fieldPath)) {
+  if (SECRET_FIELDS_BY_PATH.has(fieldPath) || PREVIEW_PATHS.has(fieldPath)) {
     return true;
   }
   return ANCESTOR_PATHS.has(fieldPath) || isConfigSecretDescendantPath(fieldPath);
@@ -232,8 +193,8 @@ export function resolveConfigSecret(value?: string): string | undefined {
 
 export function getConfigSecretMutationPaths(fieldPath: string): string[] {
   const field = SECRET_FIELDS_BY_PATH.get(fieldPath);
-  if (field?.displayPath) {
-    return [field.path, field.displayPath];
+  if (field?.previewPath) {
+    return [field.path, field.previewPath];
   }
   return [fieldPath];
 }
@@ -243,7 +204,7 @@ export function isConfigSecretDescendantPath(fieldPath: string): boolean {
     if (fieldPath.startsWith(`${field.path}.`)) {
       return true;
     }
-    if (field.displayPath && fieldPath.startsWith(`${field.displayPath}.`)) {
+    if (field.previewPath && fieldPath.startsWith(`${field.previewPath}.`)) {
       return true;
     }
   }
@@ -255,8 +216,8 @@ export function isConfigSecretAncestorPath(fieldPath: string): boolean {
 }
 
 export function getConfigSecretInputError(fieldPath: string, value: unknown): string | null {
-  if (DISPLAY_PATHS.has(fieldPath)) {
-    return `Cannot write protected display secret path: ${fieldPath}`;
+  if (PREVIEW_PATHS.has(fieldPath)) {
+    return `Cannot write protected secret preview path: ${fieldPath}`;
   }
   if (SECRET_FIELDS_BY_PATH.has(fieldPath) && isEncryptedConfigSecret(value)) {
     return `Encrypted config secret values cannot be submitted: ${fieldPath}`;
@@ -277,17 +238,25 @@ export function getConfigSecretInputError(fieldPath: string, value: unknown): st
   return null;
 }
 
+function deleteLegacyPreviewKey(section: Record<string, unknown>, field: ConfigSecretField): void {
+  const legacyPath = LEGACY_PREVIEW_PATHS.get(field.path);
+  if (legacyPath) {
+    delete section[lastSegment(legacyPath)];
+  }
+}
+
 /**
  * Encrypts a secret value in place within its parent record. Empty and
- * non-string values reset the secret (and display companion). Env placeholder
+ * non-string values reset the secret (and preview companion). Env placeholder
  * values are kept as plain references for fields that allow them.
  */
 function writeSecretIntoSection(section: Record<string, unknown>, field: ConfigSecretField): void {
   const key = lastSegment(field.path);
-  const displayKey = field.displayPath ? lastSegment(field.displayPath) : undefined;
+  const previewKey = field.previewPath ? lastSegment(field.previewPath) : undefined;
+  deleteLegacyPreviewKey(section, field);
   if (!(key in section)) {
-    if (displayKey) {
-      delete section[displayKey];
+    if (previewKey) {
+      delete section[previewKey];
     }
     return;
   }
@@ -295,30 +264,30 @@ function writeSecretIntoSection(section: Record<string, unknown>, field: ConfigS
   const rawValue = section[key];
   if (typeof rawValue !== 'string' || rawValue.startsWith(ENCRYPTED_PREFIX)) {
     section[key] = '';
-    if (displayKey) {
-      section[displayKey] = '';
+    if (previewKey) {
+      section[previewKey] = '';
     }
     return;
   }
   const value = normalizeSecretString(rawValue);
   if (!value) {
     section[key] = '';
-    if (displayKey) {
-      section[displayKey] = '';
+    if (previewKey) {
+      section[previewKey] = '';
     }
     return;
   }
   if (field.allowEnvPlaceholder && isEnvPlaceholder(value)) {
     section[key] = value;
-    if (displayKey) {
-      section[displayKey] = '';
+    if (previewKey) {
+      section[previewKey] = '';
     }
     return;
   }
 
   section[key] = encryptV3(value);
-  if (displayKey) {
-    section[displayKey] = getDisplaySecretKey(value);
+  if (previewKey) {
+    section[previewKey] = getSecretPreview(value);
   }
 }
 
@@ -326,36 +295,36 @@ function writeDottedSecret(result: Record<string, unknown>, field: ConfigSecretF
   const rawValue = result[field.path];
   if (typeof rawValue !== 'string' || rawValue.startsWith(ENCRYPTED_PREFIX)) {
     result[field.path] = '';
-    if (field.displayPath) {
-      result[field.displayPath] = '';
+    if (field.previewPath) {
+      result[field.previewPath] = '';
     }
     return;
   }
   const value = normalizeSecretString(rawValue);
   if (!value) {
     result[field.path] = '';
-    if (field.displayPath) {
-      result[field.displayPath] = '';
+    if (field.previewPath) {
+      result[field.previewPath] = '';
     }
     return;
   }
   if (field.allowEnvPlaceholder && isEnvPlaceholder(value)) {
     result[field.path] = value;
-    if (field.displayPath) {
-      result[field.displayPath] = '';
+    if (field.previewPath) {
+      result[field.previewPath] = '';
     }
     return;
   }
   result[field.path] = encryptV3(value);
-  if (field.displayPath) {
-    result[field.displayPath] = getDisplaySecretKey(value);
+  if (field.previewPath) {
+    result[field.previewPath] = getSecretPreview(value);
   }
 }
 
 /**
- * Returns a new field map with registered secret entries encrypted (and display
+ * Returns a new field map with registered secret entries encrypted (and preview
  * companions set where configured). Empty values reset the secret and its
- * display companion. Handles both dotted secret paths and object-valued
+ * preview companion. Handles both dotted secret paths and object-valued
  * ancestor entries.
  */
 export function encryptConfigSecretFields(
@@ -375,8 +344,8 @@ export function encryptConfigSecretFields(
   }
 
   for (const field of CONFIG_SECRET_FIELDS) {
-    if (field.displayPath && !(field.path in result) && field.displayPath in result) {
-      delete result[field.displayPath];
+    if (field.previewPath && !(field.path in result) && field.previewPath in result) {
+      delete result[field.previewPath];
     }
     if (field.path in result) {
       writeDottedSecret(result, field);
@@ -388,7 +357,7 @@ export function encryptConfigSecretFields(
 
 /**
  * Returns a cloned config object with registered secret values encrypted
- * before writes. Empty secrets reset their display companions. `basePath`
+ * before writes. Empty secrets reset their preview companions. `basePath`
  * locates `root` within the config tree ('' for whole-overrides writes).
  */
 export function encryptConfigSecrets<T>(root: T, basePath = ''): T {
@@ -467,13 +436,15 @@ export function preserveConfigSecrets<T>(next: T, existing?: unknown, basePath =
     // no ciphertext to preserve verbatim — encrypt it now instead of
     // silently dropping it the first time an unrelated field is edited.
     section[key] = isAlreadyEncrypted || isPlaceholder ? existingSecret : encryptV3(existingSecret);
-    if (field.displayPath) {
-      const displayKey = lastSegment(field.displayPath);
-      const existingDisplay = existingSection[displayKey];
-      if (typeof existingDisplay === 'string') {
-        section[displayKey] = existingDisplay;
+    if (field.previewPath) {
+      const previewKey = lastSegment(field.previewPath);
+      const legacyPath = LEGACY_PREVIEW_PATHS.get(field.path);
+      const legacyPreview = legacyPath ? existingSection[lastSegment(legacyPath)] : undefined;
+      const existingPreview = existingSection[previewKey] ?? legacyPreview;
+      if (typeof existingPreview === 'string') {
+        section[previewKey] = existingPreview;
       } else if (!isAlreadyEncrypted && !isPlaceholder) {
-        section[displayKey] = getDisplaySecretKey(existingSecret);
+        section[previewKey] = getSecretPreview(existingSecret);
       }
     }
   }
@@ -482,7 +453,7 @@ export function preserveConfigSecrets<T>(next: T, existing?: unknown, basePath =
 
 /**
  * Deletes registered secret values from `root` in place so admin reads never
- * return them (encrypted or plaintext). Display companions and plain
+ * return them (encrypted or plaintext). Preview companions and plain
  * `${ENV_VAR}` references (for fields that allow them) are preserved.
  * The caller passes a cloned object.
  */
@@ -507,6 +478,7 @@ export function redactConfigSecrets<T>(root: T): T {
     if (!section) {
       continue;
     }
+    deleteLegacyPreviewKey(section, field);
     const key = segments[segments.length - 1];
     if (!(key in section)) {
       continue;

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -1,15 +1,68 @@
 import isPlainObject from 'lodash/isPlainObject';
 import { encryptV3, decryptV3, logger } from '@librechat/data-schemas';
+import { envVarRegex, extractEnvVariable } from 'librechat-data-provider';
 
-const LANGFUSE_SECTION = 'langfuse';
-const LANGFUSE_SECRET_KEY = 'secretKey';
-const LANGFUSE_DISPLAY_SECRET_KEY = 'displaySecretKey';
-const LANGFUSE_SECRET_PATH = `${LANGFUSE_SECTION}.${LANGFUSE_SECRET_KEY}`;
-const LANGFUSE_DISPLAY_SECRET_PATH = `${LANGFUSE_SECTION}.${LANGFUSE_DISPLAY_SECRET_KEY}`;
 const ENCRYPTED_PREFIX = 'v3:';
+
+interface ConfigSecretField {
+  /** Dot-path of the secret value within config overrides */
+  path: string;
+  /** Non-secret display companion, written on encrypt and preserved by redaction. Must be a sibling of `path`. */
+  displayPath?: string;
+  /** When true, `${ENV_VAR}` placeholder values are stored and returned as plain references instead of being encrypted */
+  allowEnvPlaceholder?: boolean;
+}
+
+/**
+ * Registry of config fields that hold secret values. Writes through the admin
+ * config API encrypt these at rest, reads redact them, and omitting them on a
+ * subsequent write preserves the stored encrypted value.
+ */
+const CONFIG_SECRET_FIELDS: readonly ConfigSecretField[] = [
+  { path: 'langfuse.secretKey', displayPath: 'langfuse.displaySecretKey' },
+  { path: 'ocr.apiKey', allowEnvPlaceholder: true },
+  { path: 'speech.tts.openai.apiKey', allowEnvPlaceholder: true },
+  { path: 'speech.tts.azureOpenAI.apiKey', allowEnvPlaceholder: true },
+  { path: 'speech.tts.elevenlabs.apiKey', allowEnvPlaceholder: true },
+  { path: 'speech.tts.localai.apiKey', allowEnvPlaceholder: true },
+  { path: 'speech.stt.openai.apiKey', allowEnvPlaceholder: true },
+  { path: 'speech.stt.azureOpenAI.apiKey', allowEnvPlaceholder: true },
+  { path: 'webSearch.serperApiKey', allowEnvPlaceholder: true },
+  { path: 'webSearch.searxngApiKey', allowEnvPlaceholder: true },
+  { path: 'webSearch.firecrawlApiKey', allowEnvPlaceholder: true },
+  { path: 'webSearch.tavilyApiKey', allowEnvPlaceholder: true },
+  { path: 'webSearch.jinaApiKey', allowEnvPlaceholder: true },
+  { path: 'webSearch.cohereApiKey', allowEnvPlaceholder: true },
+  { path: 'endpoints.assistants.apiKey', allowEnvPlaceholder: true },
+  { path: 'endpoints.azureAssistants.apiKey', allowEnvPlaceholder: true },
+];
+
+const SECRET_FIELDS_BY_PATH = new Map<string, ConfigSecretField>(
+  CONFIG_SECRET_FIELDS.map((field) => [field.path, field]),
+);
+
+const DISPLAY_PATHS = new Set<string>(
+  CONFIG_SECRET_FIELDS.flatMap((field) => (field.displayPath ? [field.displayPath] : [])),
+);
+
+const ANCESTOR_PATHS = new Set<string>(
+  CONFIG_SECRET_FIELDS.flatMap((field) => {
+    const segments = field.path.split('.');
+    return segments.slice(0, -1).map((_, index) => segments.slice(0, index + 1).join('.'));
+  }),
+);
+
+const SECRET_SECTIONS: readonly string[] = [
+  ...new Set(CONFIG_SECRET_FIELDS.map((field) => field.path.split('.')[0])),
+];
 
 export function getDisplaySecretKey(secret: string): string {
   return secret.slice(0, 6) + '...' + secret.slice(-4);
+}
+
+/** Top-level config sections containing registered secret fields. */
+export function getConfigSecretSections(): readonly string[] {
+  return SECRET_SECTIONS;
 }
 
 function normalizeSecretString(value: unknown): string | undefined {
@@ -20,19 +73,48 @@ function isEncryptedConfigSecret(value: unknown): boolean {
   return typeof value === 'string' && value.trim().startsWith(ENCRYPTED_PREFIX);
 }
 
+function isEnvPlaceholder(value: string): boolean {
+  return envVarRegex.test(value.trim());
+}
+
 function getPlainRecord(value: unknown): Record<string, unknown> | null {
   return isPlainObject(value) ? (value as Record<string, unknown>) : null;
 }
 
-function getLangfuseSection(root: unknown, basePath = ''): Record<string, unknown> | null {
-  const rootRecord = getPlainRecord(root);
-  if (!rootRecord) {
+function lastSegment(path: string): string {
+  return path.split('.').slice(-1)[0];
+}
+
+/**
+ * Returns the segments of `path` relative to `basePath`, or null when
+ * `basePath` is not an ancestor of `path`. An empty `basePath` yields the
+ * full segment list.
+ */
+function relativeSegments(path: string, basePath: string): string[] | null {
+  if (basePath === '') {
+    return path.split('.');
+  }
+  if (!path.startsWith(`${basePath}.`)) {
     return null;
   }
-  if (basePath === LANGFUSE_SECTION) {
-    return rootRecord;
+  return path.slice(basePath.length + 1).split('.');
+}
+
+/** Walks `root` along all but the last segment, returning the parent record of the final key. */
+function walkToParent(root: unknown, segments: string[]): Record<string, unknown> | null {
+  let cursor = getPlainRecord(root);
+  for (let i = 0; cursor != null && i < segments.length - 1; i++) {
+    cursor = getPlainRecord(cursor[segments[i]]);
   }
-  return getPlainRecord(rootRecord[LANGFUSE_SECTION]);
+  return cursor;
+}
+
+/** True when a dotted key equals, contains, or is contained by a registered secret or display path. */
+function isConfigSecretRelatedPath(fieldPath: string): boolean {
+  if (SECRET_FIELDS_BY_PATH.has(fieldPath) || DISPLAY_PATHS.has(fieldPath)) {
+    return true;
+  }
+  return ANCESTOR_PATHS.has(fieldPath) || isConfigSecretDescendantPath(fieldPath);
 }
 
 export function decryptConfigSecret(value: unknown): string | undefined {
@@ -48,93 +130,146 @@ export function decryptConfigSecret(value: unknown): string | undefined {
   }
 }
 
+/**
+ * Resolves a config credential for runtime use: decrypts encrypted values and
+ * resolves `${ENV_VAR}` placeholders, passing plain literals through unchanged.
+ */
+export function resolveConfigSecret(value?: string): string | undefined {
+  if (value == null || value === '') {
+    return value;
+  }
+  if (isEncryptedConfigSecret(value)) {
+    return decryptConfigSecret(value);
+  }
+  return extractEnvVariable(value);
+}
+
 export function getConfigSecretMutationPaths(fieldPath: string): string[] {
-  if (fieldPath === LANGFUSE_SECRET_PATH) {
-    return [LANGFUSE_SECRET_PATH, LANGFUSE_DISPLAY_SECRET_PATH];
+  const field = SECRET_FIELDS_BY_PATH.get(fieldPath);
+  if (field?.displayPath) {
+    return [field.path, field.displayPath];
   }
   return [fieldPath];
 }
 
 export function isConfigSecretDescendantPath(fieldPath: string): boolean {
-  return (
-    fieldPath.startsWith(`${LANGFUSE_SECRET_PATH}.`) ||
-    fieldPath.startsWith(`${LANGFUSE_DISPLAY_SECRET_PATH}.`)
-  );
-}
-
-export function isConfigSecretAncestorPath(fieldPath: string): boolean {
-  return fieldPath === LANGFUSE_SECTION;
-}
-
-export function getConfigSecretInputError(fieldPath: string, value: unknown): string | null {
-  if (fieldPath === LANGFUSE_DISPLAY_SECRET_PATH) {
-    return `Cannot write protected display secret path: ${fieldPath}`;
-  }
-  if (fieldPath === LANGFUSE_SECRET_PATH && isEncryptedConfigSecret(value)) {
-    return `Encrypted config secret values cannot be submitted: ${fieldPath}`;
-  }
-  const langfuseInput = fieldPath === LANGFUSE_SECTION ? getPlainRecord(value) : null;
-  if (langfuseInput && isEncryptedConfigSecret(langfuseInput[LANGFUSE_SECRET_KEY])) {
-    return `Encrypted config secret values cannot be submitted: ${LANGFUSE_SECRET_PATH}`;
-  }
-  return null;
-}
-
-function removeLangfuseArraySection(root: Record<string, unknown>): boolean {
-  if (Array.isArray(root[LANGFUSE_SECTION])) {
-    delete root[LANGFUSE_SECTION];
-    return true;
+  for (const field of CONFIG_SECRET_FIELDS) {
+    if (fieldPath.startsWith(`${field.path}.`)) {
+      return true;
+    }
+    if (field.displayPath && fieldPath.startsWith(`${field.displayPath}.`)) {
+      return true;
+    }
   }
   return false;
 }
 
-function applyLangfuseSecretWrite(section: Record<string, unknown>): void {
-  if (!(LANGFUSE_SECRET_KEY in section)) {
-    delete section[LANGFUSE_DISPLAY_SECRET_KEY];
-    return;
-  }
+export function isConfigSecretAncestorPath(fieldPath: string): boolean {
+  return ANCESTOR_PATHS.has(fieldPath);
+}
 
-  const value = section[LANGFUSE_SECRET_KEY];
-  if (typeof value !== 'string' || value.length === 0 || value.startsWith(ENCRYPTED_PREFIX)) {
-    section[LANGFUSE_SECRET_KEY] = '';
-    section[LANGFUSE_DISPLAY_SECRET_KEY] = '';
-    return;
+export function getConfigSecretInputError(fieldPath: string, value: unknown): string | null {
+  if (DISPLAY_PATHS.has(fieldPath)) {
+    return `Cannot write protected display secret path: ${fieldPath}`;
   }
-
-  section[LANGFUSE_SECRET_KEY] = encryptV3(value);
-  section[LANGFUSE_DISPLAY_SECRET_KEY] = getDisplaySecretKey(value);
+  if (SECRET_FIELDS_BY_PATH.has(fieldPath) && isEncryptedConfigSecret(value)) {
+    return `Encrypted config secret values cannot be submitted: ${fieldPath}`;
+  }
+  if (!isConfigSecretAncestorPath(fieldPath)) {
+    return null;
+  }
+  for (const field of CONFIG_SECRET_FIELDS) {
+    const segments = relativeSegments(field.path, fieldPath);
+    if (!segments) {
+      continue;
+    }
+    const parent = walkToParent(value, segments);
+    if (parent && isEncryptedConfigSecret(parent[segments[segments.length - 1]])) {
+      return `Encrypted config secret values cannot be submitted: ${field.path}`;
+    }
+  }
+  return null;
 }
 
 /**
- * Returns a new field map with Langfuse secret entries encrypted and their
- * displaySecretKey companion set. Empty values reset the secret and displaySecretKey.
+ * Encrypts a secret value in place within its parent record. Empty and
+ * non-string values reset the secret (and display companion). Env placeholder
+ * values are kept as plain references for fields that allow them.
+ */
+function writeSecretIntoSection(section: Record<string, unknown>, field: ConfigSecretField): void {
+  const key = lastSegment(field.path);
+  const displayKey = field.displayPath ? lastSegment(field.displayPath) : undefined;
+  if (!(key in section)) {
+    if (displayKey) {
+      delete section[displayKey];
+    }
+    return;
+  }
+
+  const value = section[key];
+  if (typeof value !== 'string' || value.length === 0 || value.startsWith(ENCRYPTED_PREFIX)) {
+    section[key] = '';
+    if (displayKey) {
+      section[displayKey] = '';
+    }
+    return;
+  }
+  if (field.allowEnvPlaceholder && isEnvPlaceholder(value)) {
+    return;
+  }
+
+  section[key] = encryptV3(value);
+  if (displayKey) {
+    section[displayKey] = getDisplaySecretKey(value);
+  }
+}
+
+function writeDottedSecret(result: Record<string, unknown>, field: ConfigSecretField): void {
+  const value = result[field.path];
+  if (typeof value !== 'string' || value.length === 0 || value.startsWith(ENCRYPTED_PREFIX)) {
+    result[field.path] = '';
+    if (field.displayPath) {
+      result[field.displayPath] = '';
+    }
+    return;
+  }
+  if (field.allowEnvPlaceholder && isEnvPlaceholder(value)) {
+    return;
+  }
+  result[field.path] = encryptV3(value);
+  if (field.displayPath) {
+    result[field.displayPath] = getDisplaySecretKey(value);
+  }
+}
+
+/**
+ * Returns a new field map with registered secret entries encrypted (and display
+ * companions set where configured). Empty values reset the secret and its
+ * display companion. Handles both dotted secret paths and object-valued
+ * ancestor entries.
  */
 export function encryptConfigSecretFields(
   fields: Record<string, unknown>,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { ...fields };
 
-  if (Array.isArray(result[LANGFUSE_SECTION])) {
-    delete result[LANGFUSE_SECTION];
-  } else {
-    const section = getPlainRecord(result[LANGFUSE_SECTION]);
-    if (section) {
-      result[LANGFUSE_SECTION] = encryptConfigSecrets(section, LANGFUSE_SECTION);
+  for (const key of Object.keys(result)) {
+    if (!isConfigSecretAncestorPath(key)) {
+      continue;
+    }
+    if (Array.isArray(result[key])) {
+      delete result[key];
+    } else if (isPlainObject(result[key])) {
+      result[key] = encryptConfigSecrets(result[key], key);
     }
   }
 
-  if (!(LANGFUSE_SECRET_PATH in result) && LANGFUSE_DISPLAY_SECRET_PATH in result) {
-    delete result[LANGFUSE_DISPLAY_SECRET_PATH];
-  }
-
-  if (LANGFUSE_SECRET_PATH in result) {
-    const value = result[LANGFUSE_SECRET_PATH];
-    if (typeof value !== 'string' || value.length === 0 || value.startsWith(ENCRYPTED_PREFIX)) {
-      result[LANGFUSE_SECRET_PATH] = '';
-      result[LANGFUSE_DISPLAY_SECRET_PATH] = '';
-    } else {
-      result[LANGFUSE_SECRET_PATH] = encryptV3(value);
-      result[LANGFUSE_DISPLAY_SECRET_PATH] = getDisplaySecretKey(value);
+  for (const field of CONFIG_SECRET_FIELDS) {
+    if (field.displayPath && !(field.path in result) && field.displayPath in result) {
+      delete result[field.displayPath];
+    }
+    if (field.path in result) {
+      writeDottedSecret(result, field);
     }
   }
 
@@ -142,8 +277,9 @@ export function encryptConfigSecretFields(
 }
 
 /**
- * Returns a cloned config override object with Langfuse secret values encrypted
- * before full-document writes. Empty secrets reset their displaySecretKey.
+ * Returns a cloned config object with registered secret values encrypted
+ * before writes. Empty secrets reset their display companions. `basePath`
+ * locates `root` within the config tree ('' for whole-overrides writes).
  */
 export function encryptConfigSecrets<T>(root: T, basePath = ''): T {
   if (root == null || typeof root !== 'object') {
@@ -151,23 +287,35 @@ export function encryptConfigSecrets<T>(root: T, basePath = ''): T {
   }
 
   const result = structuredClone(root);
+  const rootRecord = result as Record<string, unknown>;
   if (basePath === '') {
-    delete (result as Record<string, unknown>)[LANGFUSE_SECRET_PATH];
-    delete (result as Record<string, unknown>)[LANGFUSE_DISPLAY_SECRET_PATH];
-    removeLangfuseArraySection(result as Record<string, unknown>);
+    for (const key of Object.keys(rootRecord)) {
+      if (key.includes('.') && isConfigSecretRelatedPath(key)) {
+        delete rootRecord[key];
+      } else if (isConfigSecretAncestorPath(key) && Array.isArray(rootRecord[key])) {
+        delete rootRecord[key];
+      }
+    }
   }
 
-  const section = getLangfuseSection(result, basePath);
-  if (section) {
-    applyLangfuseSecretWrite(section);
+  for (const field of CONFIG_SECRET_FIELDS) {
+    const segments = relativeSegments(field.path, basePath);
+    if (!segments) {
+      continue;
+    }
+    const section = walkToParent(result, segments);
+    if (section) {
+      writeSecretIntoSection(section, field);
+    }
   }
   return result;
 }
 
 /**
- * Preserves an existing encrypted Langfuse secret when a whole Langfuse object is
- * replaced without a secret value. This lets redacted admin reads round-trip
- * safely: omitting a secret keeps it, while setting it to an empty value clears it.
+ * Preserves existing encrypted secrets when an object write omits them. This
+ * lets redacted admin reads round-trip safely: omitting a secret keeps it,
+ * while setting it to an empty value clears it. `basePath` locates `next`
+ * within the config tree; `existing` is always the full overrides object.
  */
 export function preserveConfigSecrets<T>(next: T, existing?: unknown, basePath = ''): T {
   if (
@@ -180,31 +328,43 @@ export function preserveConfigSecrets<T>(next: T, existing?: unknown, basePath =
   }
 
   const result = structuredClone(next);
-  const section = getLangfuseSection(result, basePath);
-  const existingSection = getLangfuseSection(existing);
-  if (
-    !section ||
-    !existingSection ||
-    LANGFUSE_SECRET_KEY in section ||
-    !isEncryptedConfigSecret(existingSection[LANGFUSE_SECRET_KEY])
-  ) {
-    return result;
-  }
+  for (const field of CONFIG_SECRET_FIELDS) {
+    const segments = relativeSegments(field.path, basePath);
+    if (!segments) {
+      continue;
+    }
+    const section = walkToParent(result, segments);
+    if (!section) {
+      continue;
+    }
+    const key = segments[segments.length - 1];
+    if (key in section) {
+      continue;
+    }
 
-  const existingSecret = normalizeSecretString(existingSection[LANGFUSE_SECRET_KEY]);
-  if (!existingSecret) {
-    return result;
-  }
-  section[LANGFUSE_SECRET_KEY] = existingSecret;
-  if (typeof existingSection[LANGFUSE_DISPLAY_SECRET_KEY] === 'string') {
-    section[LANGFUSE_DISPLAY_SECRET_KEY] = existingSection[LANGFUSE_DISPLAY_SECRET_KEY];
+    const existingSection = walkToParent(existing, field.path.split('.'));
+    if (!existingSection || !isEncryptedConfigSecret(existingSection[key])) {
+      continue;
+    }
+    const existingSecret = normalizeSecretString(existingSection[key]);
+    if (!existingSecret) {
+      continue;
+    }
+    section[key] = existingSecret;
+    if (field.displayPath) {
+      const displayKey = lastSegment(field.displayPath);
+      if (typeof existingSection[displayKey] === 'string') {
+        section[displayKey] = existingSection[displayKey];
+      }
+    }
   }
   return result;
 }
 
 /**
- * Deletes Langfuse secret fields from `root` in place so admin reads never
- * return secret values (encrypted or otherwise). Display companions are preserved.
+ * Deletes registered secret values from `root` in place so admin reads never
+ * return them (encrypted or plaintext). Display companions and plain
+ * `${ENV_VAR}` references (for fields that allow them) are preserved.
  * The caller passes a cloned object.
  */
 export function redactConfigSecrets<T>(root: T): T {
@@ -212,15 +372,30 @@ export function redactConfigSecrets<T>(root: T): T {
   if (!rootRecord) {
     return root;
   }
-  delete rootRecord[LANGFUSE_SECRET_PATH];
-  delete rootRecord[LANGFUSE_DISPLAY_SECRET_PATH];
-  if (Array.isArray(rootRecord[LANGFUSE_SECTION])) {
-    delete rootRecord[LANGFUSE_SECTION];
-    return root;
+
+  for (const key of Object.keys(rootRecord)) {
+    if (key.includes('.') && isConfigSecretRelatedPath(key)) {
+      delete rootRecord[key];
+    } else if (isConfigSecretAncestorPath(key) && Array.isArray(rootRecord[key])) {
+      delete rootRecord[key];
+    }
   }
-  const section = getPlainRecord(rootRecord[LANGFUSE_SECTION]);
-  if (section) {
-    delete section[LANGFUSE_SECRET_KEY];
+
+  for (const field of CONFIG_SECRET_FIELDS) {
+    const segments = field.path.split('.');
+    const section = walkToParent(rootRecord, segments);
+    if (!section) {
+      continue;
+    }
+    const key = segments[segments.length - 1];
+    if (!(key in section)) {
+      continue;
+    }
+    const value = section[key];
+    if (field.allowEnvPlaceholder && typeof value === 'string' && isEnvPlaceholder(value)) {
+      continue;
+    }
+    delete section[key];
   }
   return root;
 }

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -3,6 +3,7 @@ import { encryptV3, decryptV3, logger } from '@librechat/data-schemas';
 import { envVarRegex, extractEnvVariable } from 'librechat-data-provider';
 
 const ENCRYPTED_PREFIX = 'v3:';
+const ENCRYPTED_PAYLOAD_REGEX = /^v3:[0-9a-f]{32}:[0-9a-f]+$/;
 
 interface ConfigSecretFieldInput {
   /** Dot-path of the secret value within config overrides */
@@ -181,11 +182,22 @@ export function decryptConfigSecret(value: unknown): string | undefined {
  * Resolves a config credential for runtime use: decrypts encrypted values and
  * resolves `${ENV_VAR}` placeholders, passing plain literals through unchanged.
  */
+/**
+ * Whether a value has the exact shape `encryptV3` produces
+ * (`v3:<32-hex-iv>:<hex-ciphertext>`). Runtime resolution uses this strict
+ * check so a legitimate literal credential that merely starts with `v3:`
+ * (e.g. from a YAML config never touched by the admin write path) resolves
+ * as a literal instead of failing decryption.
+ */
+export function isEncryptedSecretPayload(value: string): boolean {
+  return ENCRYPTED_PAYLOAD_REGEX.test(value.trim());
+}
+
 export function resolveConfigSecret(value?: string): string | undefined {
   if (value == null || value === '') {
     return value;
   }
-  if (isEncryptedConfigSecret(value)) {
+  if (isEncryptedSecretPayload(value)) {
     return decryptConfigSecret(value);
   }
   return extractEnvVariable(value);

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -20,21 +20,77 @@ interface ConfigSecretField {
  */
 const CONFIG_SECRET_FIELDS: readonly ConfigSecretField[] = [
   { path: 'langfuse.secretKey', displayPath: 'langfuse.displaySecretKey' },
-  { path: 'ocr.apiKey', allowEnvPlaceholder: true },
-  { path: 'speech.tts.openai.apiKey', allowEnvPlaceholder: true },
-  { path: 'speech.tts.azureOpenAI.apiKey', allowEnvPlaceholder: true },
-  { path: 'speech.tts.elevenlabs.apiKey', allowEnvPlaceholder: true },
-  { path: 'speech.tts.localai.apiKey', allowEnvPlaceholder: true },
-  { path: 'speech.stt.openai.apiKey', allowEnvPlaceholder: true },
-  { path: 'speech.stt.azureOpenAI.apiKey', allowEnvPlaceholder: true },
-  { path: 'webSearch.serperApiKey', allowEnvPlaceholder: true },
-  { path: 'webSearch.searxngApiKey', allowEnvPlaceholder: true },
-  { path: 'webSearch.firecrawlApiKey', allowEnvPlaceholder: true },
-  { path: 'webSearch.tavilyApiKey', allowEnvPlaceholder: true },
-  { path: 'webSearch.jinaApiKey', allowEnvPlaceholder: true },
-  { path: 'webSearch.cohereApiKey', allowEnvPlaceholder: true },
-  { path: 'endpoints.assistants.apiKey', allowEnvPlaceholder: true },
-  { path: 'endpoints.azureAssistants.apiKey', allowEnvPlaceholder: true },
+  { path: 'ocr.apiKey', displayPath: 'ocr.displayApiKey', allowEnvPlaceholder: true },
+  {
+    path: 'speech.tts.openai.apiKey',
+    displayPath: 'speech.tts.openai.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'speech.tts.azureOpenAI.apiKey',
+    displayPath: 'speech.tts.azureOpenAI.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'speech.tts.elevenlabs.apiKey',
+    displayPath: 'speech.tts.elevenlabs.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'speech.tts.localai.apiKey',
+    displayPath: 'speech.tts.localai.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'speech.stt.openai.apiKey',
+    displayPath: 'speech.stt.openai.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'speech.stt.azureOpenAI.apiKey',
+    displayPath: 'speech.stt.azureOpenAI.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'webSearch.serperApiKey',
+    displayPath: 'webSearch.displaySerperApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'webSearch.searxngApiKey',
+    displayPath: 'webSearch.displaySearxngApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'webSearch.firecrawlApiKey',
+    displayPath: 'webSearch.displayFirecrawlApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'webSearch.tavilyApiKey',
+    displayPath: 'webSearch.displayTavilyApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'webSearch.jinaApiKey',
+    displayPath: 'webSearch.displayJinaApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'webSearch.cohereApiKey',
+    displayPath: 'webSearch.displayCohereApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'endpoints.assistants.apiKey',
+    displayPath: 'endpoints.assistants.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
+  {
+    path: 'endpoints.azureAssistants.apiKey',
+    displayPath: 'endpoints.azureAssistants.displayApiKey',
+    allowEnvPlaceholder: true,
+  },
 ];
 
 const SECRET_FIELDS_BY_PATH = new Map<string, ConfigSecretField>(

--- a/packages/api/src/files/mistral/crud.spec.ts
+++ b/packages/api/src/files/mistral/crud.spec.ts
@@ -42,7 +42,7 @@ jest.mock('@librechat/data-schemas', () => ({
 
 jest.mock('~/admin/secrets', () => ({
   decryptConfigSecret: jest.fn(),
-  isEncryptedConfigSecret: jest.fn(),
+  isEncryptedSecretPayload: jest.fn(),
 }));
 
 jest.mock('~/utils/axios', () => ({
@@ -65,7 +65,7 @@ import type {
   OCRResult,
 } from '~/types';
 import { logger as mockLogger } from '@librechat/data-schemas';
-import { decryptConfigSecret, isEncryptedConfigSecret } from '~/admin/secrets';
+import { decryptConfigSecret, isEncryptedSecretPayload } from '~/admin/secrets';
 import { readFileAsBuffer } from '~/utils/files';
 import {
   uploadDocumentToMistral,
@@ -1082,7 +1082,7 @@ describe('MistralOCR Service', () => {
     it('should fail closed to env-var loading instead of sending a corrupted ciphertext as the apiKey', async () => {
       // Simulates a stored v3 ciphertext that fails to decrypt (e.g. corrupted at rest).
       const corruptedCiphertext = 'v3:corrupted-ciphertext';
-      (isEncryptedConfigSecret as jest.Mock).mockReturnValueOnce(true);
+      (isEncryptedSecretPayload as jest.Mock).mockReturnValueOnce(true);
       (decryptConfigSecret as jest.Mock).mockReturnValueOnce(undefined);
 
       mockLoadAuthValues.mockResolvedValue({ OCR_API_KEY: 'env-fallback-key' });

--- a/packages/api/src/files/mistral/crud.spec.ts
+++ b/packages/api/src/files/mistral/crud.spec.ts
@@ -40,6 +40,11 @@ jest.mock('@librechat/data-schemas', () => ({
   },
 }));
 
+jest.mock('~/admin/secrets', () => ({
+  decryptConfigSecret: jest.fn(),
+  isEncryptedConfigSecret: jest.fn(),
+}));
+
 jest.mock('~/utils/axios', () => ({
   createAxiosInstance: () => jest.requireMock('axios'),
   logAxiosError: jest.fn(({ message }) => message || 'Error'),
@@ -60,6 +65,7 @@ import type {
   OCRResult,
 } from '~/types';
 import { logger as mockLogger } from '@librechat/data-schemas';
+import { decryptConfigSecret, isEncryptedConfigSecret } from '~/admin/secrets';
 import { readFileAsBuffer } from '~/utils/files';
 import {
   uploadDocumentToMistral,
@@ -1071,6 +1077,100 @@ describe('MistralOCR Service', () => {
 
       // Verify loadAuthValues was never called since we used direct values
       expect(mockLoadAuthValues).not.toHaveBeenCalled();
+    });
+
+    it('should fail closed to env-var loading instead of sending a corrupted ciphertext as the apiKey', async () => {
+      // Simulates a stored v3 ciphertext that fails to decrypt (e.g. corrupted at rest).
+      const corruptedCiphertext = 'v3:corrupted-ciphertext';
+      (isEncryptedConfigSecret as jest.Mock).mockReturnValueOnce(true);
+      (decryptConfigSecret as jest.Mock).mockReturnValueOnce(undefined);
+
+      mockLoadAuthValues.mockResolvedValue({ OCR_API_KEY: 'env-fallback-key' });
+
+      mockAxios.post!.mockClear();
+      mockAxios.get!.mockClear();
+
+      mockAxios.post!.mockImplementationOnce(() =>
+        Promise.resolve({
+          data: {
+            id: 'file-456',
+            object: 'file',
+            bytes: 1024,
+            created_at: Date.now(),
+            filename: 'corrupted-key.pdf',
+            purpose: 'ocr',
+          } as MistralFileUploadResponse,
+        }),
+      );
+      mockAxios.get!.mockImplementationOnce(() =>
+        Promise.resolve({
+          data: {
+            url: 'https://signed-url.com',
+            expires_at: Date.now() + 86400000,
+          } as MistralSignedUrlResponse,
+        }),
+      );
+      mockAxios.post!.mockImplementationOnce(() =>
+        Promise.resolve({
+          data: {
+            model: 'mistral-ocr-latest',
+            pages: [
+              {
+                index: 0,
+                markdown: 'Processed with the env-fallback key',
+                images: [],
+                dimensions: { dpi: 300, height: 1100, width: 850 },
+              },
+            ],
+            document_annotation: '',
+            usage_info: { pages_processed: 1, doc_size_bytes: 1024 },
+          },
+        }),
+      );
+
+      const req = {
+        user: { id: 'user123' },
+        config: {
+          ocr: {
+            apiKey: corruptedCiphertext,
+            baseURL: 'https://api.mistral.ai/v1',
+            mistralModel: 'mistral-ocr-latest',
+          },
+        },
+      } as unknown as ServerRequest;
+
+      const file = {
+        path: '/tmp/upload/file.pdf',
+        originalname: 'corrupted-key.pdf',
+        mimetype: 'application/pdf',
+      } as Express.Multer.File;
+
+      await uploadMistralOCR({ req, file, loadAuthValues: mockLoadAuthValues });
+
+      // The corrupted ciphertext must never be sent as the credential.
+      expect(mockAxios.post).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: expect.stringContaining(corruptedCiphertext),
+          }),
+        }),
+      );
+
+      // Treated as empty, so it fails over to loading OCR_API_KEY from the environment.
+      expect(mockLoadAuthValues).toHaveBeenCalledWith(
+        expect.objectContaining({ authFields: expect.arrayContaining(['OCR_API_KEY']) }),
+      );
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer env-fallback-key',
+          }),
+        }),
+      );
     });
 
     it('should handle empty configuration values and use defaults', async () => {

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -20,8 +20,8 @@ import type {
   OCRResult,
   OCRImage,
 } from '~/types';
+import { decryptConfigSecret, isEncryptedConfigSecret } from '~/admin/secrets';
 import { logAxiosError, createAxiosInstance } from '~/utils/axios';
-import { decryptConfigSecret } from '~/admin/secrets';
 import { applyAxiosProxyConfig } from '~/utils/proxy';
 import { readFileAsBuffer } from '~/utils/files';
 import { loadServiceKey } from '~/utils/key';
@@ -258,7 +258,9 @@ async function loadAuthConfig(context: OCRContext): Promise<AuthConfig> {
   const appConfig = context.req.config;
   const ocrConfig = appConfig?.ocr;
   const rawApiKeyConfig = ocrConfig?.apiKey || '';
-  const apiKeyConfig = decryptConfigSecret(rawApiKeyConfig) ?? rawApiKeyConfig;
+  const apiKeyConfig = isEncryptedConfigSecret(rawApiKeyConfig)
+    ? (decryptConfigSecret(rawApiKeyConfig) ?? '')
+    : rawApiKeyConfig;
   const baseURLConfig = ocrConfig?.baseURL || '';
 
   if (!needsEnvLoad(apiKeyConfig) && !needsEnvLoad(baseURLConfig)) {

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -21,6 +21,7 @@ import type {
   OCRImage,
 } from '~/types';
 import { logAxiosError, createAxiosInstance } from '~/utils/axios';
+import { decryptConfigSecret } from '~/admin/secrets';
 import { applyAxiosProxyConfig } from '~/utils/proxy';
 import { readFileAsBuffer } from '~/utils/files';
 import { loadServiceKey } from '~/utils/key';
@@ -256,7 +257,8 @@ async function resolveConfigValue(
 async function loadAuthConfig(context: OCRContext): Promise<AuthConfig> {
   const appConfig = context.req.config;
   const ocrConfig = appConfig?.ocr;
-  const apiKeyConfig = ocrConfig?.apiKey || '';
+  const rawApiKeyConfig = ocrConfig?.apiKey || '';
+  const apiKeyConfig = decryptConfigSecret(rawApiKeyConfig) ?? rawApiKeyConfig;
   const baseURLConfig = ocrConfig?.baseURL || '';
 
   if (!needsEnvLoad(apiKeyConfig) && !needsEnvLoad(baseURLConfig)) {

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -20,7 +20,7 @@ import type {
   OCRResult,
   OCRImage,
 } from '~/types';
-import { decryptConfigSecret, isEncryptedConfigSecret } from '~/admin/secrets';
+import { decryptConfigSecret, isEncryptedSecretPayload } from '~/admin/secrets';
 import { logAxiosError, createAxiosInstance } from '~/utils/axios';
 import { applyAxiosProxyConfig } from '~/utils/proxy';
 import { readFileAsBuffer } from '~/utils/files';
@@ -258,7 +258,7 @@ async function loadAuthConfig(context: OCRContext): Promise<AuthConfig> {
   const appConfig = context.req.config;
   const ocrConfig = appConfig?.ocr;
   const rawApiKeyConfig = ocrConfig?.apiKey || '';
-  const apiKeyConfig = isEncryptedConfigSecret(rawApiKeyConfig)
+  const apiKeyConfig = isEncryptedSecretPayload(rawApiKeyConfig)
     ? (decryptConfigSecret(rawApiKeyConfig) ?? '')
     : rawApiKeyConfig;
   const baseURLConfig = ocrConfig?.baseURL || '';

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -666,11 +666,11 @@ export const assistantEndpointSchema = baseEndpointSchema.merge(
       ]),
     /* general */
     apiKey: z.string().optional(),
-    /** Non-secret display value of the API key, stored at write time so admin
+    /** Masked preview of the API key, stored at write time so admin
      * reads can show which key is configured without returning the secret.
      * Shared by both `endpoints.assistants` and `endpoints.azureAssistants`,
      * which both use this schema. */
-    displayApiKey: z.string().optional(),
+    apiKeyPreview: z.string().optional(),
     models: z
       .object({
         default: z.array(modelItemSchema).min(1),
@@ -1101,14 +1101,14 @@ export const anthropicEndpointSchema = baseEndpointSchema.merge(
 
 export type TAnthropicEndpoint = z.infer<typeof anthropicEndpointSchema>;
 
-/** Non-secret display value of the API key, stored at write time so admin
+/** Masked preview of the API key, stored at write time so admin
  * reads can show which key is configured without returning the secret. */
-const displayApiKeySchema = z.string().optional();
+const apiKeyPreviewSchema = z.string().optional();
 
 const ttsOpenaiSchema = z.object({
   url: z.string().optional(),
   apiKey: z.string(),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   model: z.string(),
   voices: z.array(z.string()),
 });
@@ -1116,7 +1116,7 @@ const ttsOpenaiSchema = z.object({
 const ttsAzureOpenAISchema = z.object({
   instanceName: z.string(),
   apiKey: z.string(),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   deploymentName: z.string(),
   apiVersion: z.string(),
   model: z.string(),
@@ -1127,7 +1127,7 @@ const ttsElevenLabsSchema = z.object({
   url: z.string().optional(),
   websocketUrl: z.string().optional(),
   apiKey: z.string(),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   model: z.string(),
   voices: z.array(z.string()),
   voice_settings: z
@@ -1144,7 +1144,7 @@ const ttsElevenLabsSchema = z.object({
 const ttsLocalaiSchema = z.object({
   url: z.string(),
   apiKey: z.string().optional(),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   voices: z.array(z.string()),
   backend: z.string(),
 });
@@ -1159,14 +1159,14 @@ const ttsSchema = z.object({
 const sttOpenaiSchema = z.object({
   url: z.string().optional(),
   apiKey: z.string(),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   model: z.string(),
 });
 
 const sttAzureOpenAISchema = z.object({
   instanceName: z.string(),
   apiKey: z.string(),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   deploymentName: z.string(),
   apiVersion: z.string(),
 });
@@ -1649,23 +1649,23 @@ export enum SafeSearchTypes {
 
 export const webSearchSchema = z.object({
   serperApiKey: z.string().optional().default('${SERPER_API_KEY}'),
-  displaySerperApiKey: displayApiKeySchema,
+  serperApiKeyPreview: apiKeyPreviewSchema,
   searxngInstanceUrl: z.string().optional().default('${SEARXNG_INSTANCE_URL}'),
   searxngApiKey: z.string().optional().default('${SEARXNG_API_KEY}'),
-  displaySearxngApiKey: displayApiKeySchema,
+  searxngApiKeyPreview: apiKeyPreviewSchema,
   firecrawlApiKey: z.string().optional().default('${FIRECRAWL_API_KEY}'),
-  displayFirecrawlApiKey: displayApiKeySchema,
+  firecrawlApiKeyPreview: apiKeyPreviewSchema,
   firecrawlApiUrl: z.string().optional().default('${FIRECRAWL_API_URL}'),
   firecrawlVersion: z.string().optional().default('${FIRECRAWL_VERSION}'),
   tavilyApiKey: z.string().optional().default('${TAVILY_API_KEY}'),
-  displayTavilyApiKey: displayApiKeySchema,
+  tavilyApiKeyPreview: apiKeyPreviewSchema,
   tavilySearchUrl: z.string().optional().default('${TAVILY_SEARCH_URL}'),
   tavilyExtractUrl: z.string().optional().default('${TAVILY_EXTRACT_URL}'),
   jinaApiKey: z.string().optional().default('${JINA_API_KEY}'),
-  displayJinaApiKey: displayApiKeySchema,
+  jinaApiKeyPreview: apiKeyPreviewSchema,
   jinaApiUrl: z.string().optional().default('${JINA_API_URL}'),
   cohereApiKey: z.string().optional().default('${COHERE_API_KEY}'),
-  displayCohereApiKey: displayApiKeySchema,
+  cohereApiKeyPreview: apiKeyPreviewSchema,
   searchProvider: z.nativeEnum(SearchProviders).optional(),
   scraperProvider: z.nativeEnum(ScraperProviders).optional(),
   rerankerType: z.nativeEnum(RerankerTypes).optional(),
@@ -1738,7 +1738,7 @@ export type TWebSearchConfig = DeepPartial<z.infer<typeof webSearchSchema>>;
 export const ocrSchema = z.object({
   mistralModel: z.string().optional(),
   apiKey: z.string().optional().default('${OCR_API_KEY}'),
-  displayApiKey: displayApiKeySchema,
+  apiKeyPreview: apiKeyPreviewSchema,
   baseURL: z.string().optional().default('${OCR_BASEURL}'),
   strategy: z.nativeEnum(OCRStrategy).default(OCRStrategy.MISTRAL_OCR),
 });
@@ -1867,9 +1867,9 @@ export const langfuseConfigSchema = z.object({
   enabled: z.boolean().optional(),
   publicKey: z.string().optional(),
   secretKey: z.string().optional(),
-  /** Non-secret display value of the secret key, stored at write time so
+  /** Masked preview of the secret key, stored at write time so
    * admin reads can show which secret key is configured without returning the secret. */
-  displaySecretKey: z.string().optional(),
+  secretKeyPreview: z.string().optional(),
   /** Routing key for one of the deployment-configured tenant Langfuse destinations. */
   destination: z.string().optional(),
   fanout: z

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -666,6 +666,11 @@ export const assistantEndpointSchema = baseEndpointSchema.merge(
       ]),
     /* general */
     apiKey: z.string().optional(),
+    /** Non-secret display value of the API key, stored at write time so admin
+     * reads can show which key is configured without returning the secret.
+     * Shared by both `endpoints.assistants` and `endpoints.azureAssistants`,
+     * which both use this schema. */
+    displayApiKey: z.string().optional(),
     models: z
       .object({
         default: z.array(modelItemSchema).min(1),
@@ -1096,9 +1101,14 @@ export const anthropicEndpointSchema = baseEndpointSchema.merge(
 
 export type TAnthropicEndpoint = z.infer<typeof anthropicEndpointSchema>;
 
+/** Non-secret display value of the API key, stored at write time so admin
+ * reads can show which key is configured without returning the secret. */
+const displayApiKeySchema = z.string().optional();
+
 const ttsOpenaiSchema = z.object({
   url: z.string().optional(),
   apiKey: z.string(),
+  displayApiKey: displayApiKeySchema,
   model: z.string(),
   voices: z.array(z.string()),
 });
@@ -1106,6 +1116,7 @@ const ttsOpenaiSchema = z.object({
 const ttsAzureOpenAISchema = z.object({
   instanceName: z.string(),
   apiKey: z.string(),
+  displayApiKey: displayApiKeySchema,
   deploymentName: z.string(),
   apiVersion: z.string(),
   model: z.string(),
@@ -1116,6 +1127,7 @@ const ttsElevenLabsSchema = z.object({
   url: z.string().optional(),
   websocketUrl: z.string().optional(),
   apiKey: z.string(),
+  displayApiKey: displayApiKeySchema,
   model: z.string(),
   voices: z.array(z.string()),
   voice_settings: z
@@ -1132,6 +1144,7 @@ const ttsElevenLabsSchema = z.object({
 const ttsLocalaiSchema = z.object({
   url: z.string(),
   apiKey: z.string().optional(),
+  displayApiKey: displayApiKeySchema,
   voices: z.array(z.string()),
   backend: z.string(),
 });
@@ -1146,12 +1159,14 @@ const ttsSchema = z.object({
 const sttOpenaiSchema = z.object({
   url: z.string().optional(),
   apiKey: z.string(),
+  displayApiKey: displayApiKeySchema,
   model: z.string(),
 });
 
 const sttAzureOpenAISchema = z.object({
   instanceName: z.string(),
   apiKey: z.string(),
+  displayApiKey: displayApiKeySchema,
   deploymentName: z.string(),
   apiVersion: z.string(),
 });
@@ -1634,17 +1649,23 @@ export enum SafeSearchTypes {
 
 export const webSearchSchema = z.object({
   serperApiKey: z.string().optional().default('${SERPER_API_KEY}'),
+  displaySerperApiKey: displayApiKeySchema,
   searxngInstanceUrl: z.string().optional().default('${SEARXNG_INSTANCE_URL}'),
   searxngApiKey: z.string().optional().default('${SEARXNG_API_KEY}'),
+  displaySearxngApiKey: displayApiKeySchema,
   firecrawlApiKey: z.string().optional().default('${FIRECRAWL_API_KEY}'),
+  displayFirecrawlApiKey: displayApiKeySchema,
   firecrawlApiUrl: z.string().optional().default('${FIRECRAWL_API_URL}'),
   firecrawlVersion: z.string().optional().default('${FIRECRAWL_VERSION}'),
   tavilyApiKey: z.string().optional().default('${TAVILY_API_KEY}'),
+  displayTavilyApiKey: displayApiKeySchema,
   tavilySearchUrl: z.string().optional().default('${TAVILY_SEARCH_URL}'),
   tavilyExtractUrl: z.string().optional().default('${TAVILY_EXTRACT_URL}'),
   jinaApiKey: z.string().optional().default('${JINA_API_KEY}'),
+  displayJinaApiKey: displayApiKeySchema,
   jinaApiUrl: z.string().optional().default('${JINA_API_URL}'),
   cohereApiKey: z.string().optional().default('${COHERE_API_KEY}'),
+  displayCohereApiKey: displayApiKeySchema,
   searchProvider: z.nativeEnum(SearchProviders).optional(),
   scraperProvider: z.nativeEnum(ScraperProviders).optional(),
   rerankerType: z.nativeEnum(RerankerTypes).optional(),
@@ -1717,6 +1738,7 @@ export type TWebSearchConfig = DeepPartial<z.infer<typeof webSearchSchema>>;
 export const ocrSchema = z.object({
   mistralModel: z.string().optional(),
   apiKey: z.string().optional().default('${OCR_API_KEY}'),
+  displayApiKey: displayApiKeySchema,
   baseURL: z.string().optional().default('${OCR_BASEURL}'),
   strategy: z.nativeEnum(OCRStrategy).default(OCRStrategy.MISTRAL_OCR),
 });


### PR DESCRIPTION
## Summary

`packages/api/src/admin/secrets.ts` was introduced by the already-merged Encrypted Langfuse Fanout Config feature (#14107) and was hardcoded to exactly one field, `langfuse.secretKey`: encrypt-at-rest on write, redact on read, preserve-on-omit. 

Every other credential-shaped field in the admin-editable config schema had no such protection. Because `BASE_ONLY_CONFIG_SECTIONS` is empty, the whole `TCustomConfig` document is admin-writable and readable through the admin config API, so any operator who stored a literal (non-`${ENV_VAR}`) key on the base config document got that plaintext value back verbatim in the API response to any admin holding `read:configs:<section>`.

This PR replaces the single hardcoded field with a registry (`CONFIG_SECRET_FIELDS`) and generalizes every function in the module (`encryptConfigSecretFields`, `encryptConfigSecrets`, `getConfigSecretMutationPaths`, `getConfigSecretInputError`, `isConfigSecretAncestorPath`, `isConfigSecretDescendantPath`, `preserveConfigSecrets`, `redactConfigSecrets`, plus a new `getConfigSecretSections` and a runtime `resolveConfigSecret`) to operate over arbitrary dot-paths at any depth. `langfuse.secretKey` semantics are preserved byte-for-byte (display companion, always-encrypt, array-section stripping); its existing tests stay green.

Two behaviors distinguish the new fields from langfuse:
- **Env-placeholder exemption.** Fields conventionally set to `${ENV_VAR}` references keep those references stored and returned as plain, visible values (an env-var name is not a secret, and admins need to see which var is wired). A literal value in the same field is always encrypted. `langfuse.secretKey` keeps its original no-exemption behavior.
- **Runtime decryption at the consumer.** Stored values become `v3:` ciphertext, so the consumers that read them from the merged app config must decrypt. `resolveConfigSecret` (decrypt, else resolve `${ENV_VAR}`, else pass through) is wired into the speech STT/TTS services; the Mistral OCR auth loader uses `decryptConfigSecret`. webSearch and the assistants endpoints need no runtime change (see scout table).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue) — closes a plaintext-secret exposure on admin config reads
- [x] New feature (non-breaking change which adds functionality) — encryption-at-rest for the newly-registered fields

## Scout list — every credential-shaped field in the config schema

Paths are in `packages/data-provider/src/config.ts` / `mcp.ts`. "Registered" = added to `CONFIG_SECRET_FIELDS`.

### Registered (encrypt-at-rest + redact-on-read)

| Dot-path | Schema | Env-placeholder exempt | Runtime decrypt wired | Why sensitive |
|---|---|---|---|---|
| `langfuse.secretKey` | `z.string().optional()` | no (unchanged) | already existed (`langfuse/utils.ts`) | Langfuse private key; the pre-existing registered field |
| `ocr.apiKey` | `z.string().optional().default('${OCR_API_KEY}')` | yes | `files/mistral/crud.ts` `loadAuthConfig` | Mistral OCR key |
| `speech.tts.openai.apiKey` | `z.string()` | yes | `STTService`/`TTSService` via `resolveConfigSecret` | OpenAI TTS key |
| `speech.tts.azureOpenAI.apiKey` | `z.string()` | yes | TTSService | Azure OpenAI TTS key |
| `speech.tts.elevenlabs.apiKey` | `z.string()` | yes | TTSService | ElevenLabs key |
| `speech.tts.localai.apiKey` | `z.string().optional()` | yes | TTSService | LocalAI key |
| `speech.stt.openai.apiKey` | `z.string()` | yes | STTService | OpenAI STT key |
| `speech.stt.azureOpenAI.apiKey` | `z.string()` | yes | STTService | Azure OpenAI STT key |
| `webSearch.serperApiKey` | `z.string().optional().default('${SERPER_API_KEY}')` | yes | none needed¹ | Serper key |
| `webSearch.searxngApiKey` | `...default('${SEARXNG_API_KEY}')` | yes | none needed¹ | SearXNG key |
| `webSearch.firecrawlApiKey` | `...default('${FIRECRAWL_API_KEY}')` | yes | none needed¹ | Firecrawl key |
| `webSearch.tavilyApiKey` | `...default('${TAVILY_API_KEY}')` | yes | none needed¹ | Tavily key |
| `webSearch.jinaApiKey` | `...default('${JINA_API_KEY}')` | yes | none needed¹ | Jina key |
| `webSearch.cohereApiKey` | `...default('${COHERE_API_KEY}')` | yes | none needed¹ | Cohere reranker key |
| `endpoints.assistants.apiKey` | `z.string().optional()` | yes | none needed² | Assistants provider key |
| `endpoints.azureAssistants.apiKey` | `z.string().optional()` | yes | none needed² | Azure Assistants provider key |

¹ `webSearch` credentials are resolved by `packages/api/src/web/web.ts` `loadWebSearchAuth`, which only ever collects `${VAR}` references (`extractWebSearchEnvVars` skips any non-placeholder string). A literal webSearch key never reached the runtime auth path pre-PR, so encrypting the literal at rest changes nothing at runtime — the protection is purely the at-rest/redaction fix. Documented so a reviewer knows this is deliberate, not a forgotten decrypt. These six fields also don't get a `display<Field>` companion (unlike every other registered field) — narrower public schema surface for a section where the masked-display UX has less payoff, given the point above.

² `endpoints.assistants.apiKey` / `endpoints.azureAssistants.apiKey` are never read from the merged app config at runtime — `api/server/services/Endpoints/{assistants,azureAssistants}/initialize.js` source the key from `process.env.ASSISTANTS_API_KEY` / `AZURE_ASSISTANTS_API_KEY` via `EndpointService.js`. The config-schema field is a config-document field only, so registering it gives at-rest + redaction protection with no runtime decrypt.

### Considered sensitive-looking but deliberately NOT registered

| Path | Reason excluded |
|---|---|
| `mcpServers.<name>.apiKey.key`, `.oauth.client_secret` | The primary admin write path is the MCP registry (`ServerConfigsDB`), which already encrypts these with `encryptV2`. A `v3:` value written through the generic config API could not be decrypted by MCP runtime, so registering here would break MCP. Residual: the generic config API still round-trips these two in plaintext (secondary write path) — a known scoped gap, not closed here to avoid the v2/v3 scheme conflict. |
| `mcpServers.<name>.headers`, `.oauth_headers`, `.env` | `z.record(z.string(), z.string())` maps of mixed-sensitivity values (some entries are auth tokens, some are not). Redacting the whole record would blank non-secret entries; per-entry classification is out of scope for a dot-path registry. |
| `endpoints.custom[].apiKey`, `endpoints.azureOpenAI.groups[].apiKey` | Array-of-objects. Preserve-on-omit has no stable identity for a dot-path registry, and azure group keys are resolved in `packages/data-provider/src/azure.ts`, shared with the frontend bundle, which cannot import the backend decrypt. |
| `endpoints.*.headers` / `additionalHeaders` | Same mixed-sensitivity record rationale as MCP headers. |
| `turnstile.siteKey` | Public Cloudflare site key, designed for browser exposure. The Turnstile secret is env-only (`TURNSTILE_SECRET`), not in this schema. |
| `langfuse.publicKey`, `langfuse.displaySecretKey` | Public identifier and the deliberately-non-secret masked display value. |
| `skillSync.github.sources[].token` | Schema refinement forces a `${VAR}` reference and rejects literals, so a literal secret cannot be stored. |
| `agents.remoteApi.auth.apiKey` | Not a key — an `{ enabled: boolean }` toggle. |
| `anthropic.vertex.serviceKeyFile` | A filesystem path, not the secret value. |

## Testing

### Automated

- `packages/api/src/admin/secrets.spec.ts` — unit coverage for every registry function over the new fields; the original langfuse cases are unchanged and green.
- `packages/api/src/admin/secrets.integration.spec.ts` (new) — drives the **real** `createAdminConfigHandlers` against a real `mongodb-memory-server` Config collection with real `createModels`/`createMethods` (hydrated Mongoose documents, not mocks). For all 16 registered fields it asserts, per field: dotted-patch write is encrypted at rest and redacted from the response; object-valued upsert is encrypted at rest and redacted from `getConfig`/`listConfigs`; an unrelated write preserves the stored ciphertext; a redacted read round-tripped back through a full upsert does not clobber the secret; explicit-empty clears it; `v3:` submissions are rejected. Plus env-placeholder pass-through, legacy-plaintext redaction, and `getBaseConfig` YAML-literal redaction.
- Every regression test was proven to catch the regression: reverting `secrets.ts` to the origin/main single-field version makes the new-field cases fail (e.g. the `endpoints.assistants.apiKey` cases: 5 fail), restoring makes them pass.
- `packages/api`: `admin` + `langfuse` + `files/mistral` suites — 670/670 pass. Speech services (`api` workspace, `STTService.spec.js`) — 29/29 pass. `tsc --noEmit` clean; `eslint` clean; `prettier --check` clean. Full `packages/api` suite: 7929 pass; the 202 failures are entirely pre-existing Redis/stream `*_integration.spec.ts` suites (no local Redis), none in changed areas.

### Live verification (real backend + real MongoDB)

Isolated instance: ephemeral MongoDB on `:27057`, backend on `:3092`, so it doesn't collide with other local dev. This PR's scope is the API contract only — `packages/api/src/admin/*` — verified directly against real requests/responses and the real Mongo document, independent of any particular UI:

- **Before (origin/main):** a literal `ocr.apiKey` and `webSearch.serperApiKey` written through the config API come back verbatim, in plaintext, in the read response. Confirmed at rest in Mongo (`overrides.ocr.apiKey: "sk-mistral-LEAKED-..."`) and in the API response body. The vulnerability is real, not theoretical.
- **After (patched):** the same fields at rest in Mongo are now `v3:...` ciphertext. The redacted field itself is fully absent from the read response — no plaintext, no ciphertext. Every registered field except the six `webSearch` keys (see footnote ¹ above) also gets a masked-display companion (`display<Field>`, e.g. `ocr.displayApiKey: "sk-mis...4321"`) alongside it in the same response. A consumer that renders that companion can show "configured, hidden" instead of a state indistinguishable from never-configured; a consumer that doesn't know about it just doesn't render it, which is exactly the byte-for-byte-preserved behavior `langfuse.secretKey` already had before this PR — this isn't new API surface for most fields, it's the existing convention extended.
- **Feature still usable:** the runtime `resolveConfigSecret` (the exact helper wired into speech; `decryptConfigSecret` for OCR) was run against the actual ciphertext stored in Mongo and recovered the exact secret that was written (`sk-mistral-PATCHED-...`, `sk-serper-PATCHED-...`); `${ENV_VAR}` references still resolve. The encryption round-trip is genuinely usable by the backend, not just accepted at write time.

**Companion PR — a real consumer:** https://github.com/ClickHouse/librechat-admin-panel/pull/99 builds and ships the masked-display UI that consumes the `display<Field>` companions added here (disabled input showing the mask, explicit Replace/Reset, and a payload-safety guarantee that the masked string can never round-trip as a real secret). That PR has the full before/after UI screenshots and component/integration tests for the rendering side; this PR's tests cover the API contract those screenshots are built on.

### Test Configuration

- Local MongoDB, `packages/api` + `packages/data-schemas` rebuilt (`npm run build`) so the legacy `api/` workspace picks up the compiled `dist/`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code (plus an adversarial subagent review pass)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes


