### PR TITLE
feat: allow MCP customUserVars to be declared optional

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -270,15 +270,19 @@ const getMCPTools = async (req, res) => {
 
         // Set authentication config once for the server
         if (serverConfig?.customUserVars) {
-          const customVarKeys = Object.keys(serverConfig.customUserVars);
-          if (customVarKeys.length > 0) {
-            server.authConfig = Object.entries(serverConfig.customUserVars).map(([key, value]) => ({
+          const customVars = Object.entries(serverConfig.customUserVars);
+          if (customVars.length > 0) {
+            server.authConfig = customVars.map(([key, value]) => ({
               authField: key,
               label: value.title || key,
               description: value.description || '',
               sensitive: value.sensitive,
+              optional: value.optional,
             }));
-            server.authenticated = false;
+            /* Optional vars override a default the deployment provides, so a server that declares
+             * only those is already usable - marking it unauthenticated would show it as needing
+             * setup when nothing is missing. */
+            server.authenticated = !customVars.some(([, value]) => value?.optional !== true);
           }
         }
 

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -18,6 +18,8 @@ export interface ConfigFieldDetail {
   description: string;
   /** Whether the field holds a secret and should be masked (defaults to masked when omitted). */
   sensitive?: boolean;
+  /** Whether the value overrides a working default and may be left blank. */
+  optional?: boolean;
 }
 
 export type CodeBarProps = {

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -15,6 +15,8 @@ export interface CustomUserVarConfig {
   description?: string;
   /** Whether the field holds a secret and should be masked (defaults to masked when omitted). */
   sensitive?: boolean;
+  /** Whether the value overrides a working default and may be left blank. */
+  optional?: boolean;
 }
 
 interface CustomUserVarsSectionProps {
@@ -53,7 +55,13 @@ function AuthField({ name, config, hasValue, control, errors, autoFocus }: AuthF
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <Label htmlFor={name} className="text-sm font-medium">
-          {config.title} <span className="sr-only">({statusText})</span>
+          {config.title}
+          {config.optional === true && (
+            <span className="ml-1 font-normal text-text-secondary">
+              {localize('com_ui_optional')}
+            </span>
+          )}
+          <span className="sr-only">({statusText})</span>
         </Label>
         <div aria-hidden="true">
           {hasValue ? (

--- a/client/src/components/MCP/__tests__/CustomUserVarsSection.test.tsx
+++ b/client/src/components/MCP/__tests__/CustomUserVarsSection.test.tsx
@@ -32,6 +32,27 @@ describe('CustomUserVarsSection', () => {
     expect(input).toHaveAttribute('data-1p-ignore', 'true');
   });
 
+  it('marks optional variables in the label and leaves required ones unmarked', () => {
+    render(
+      <CustomUserVarsSection
+        serverName="test-server"
+        fields={{
+          api_key: { title: 'My API Key', description: 'Your API key' },
+          own_token: {
+            title: 'Own Token',
+            description: 'Overrides the shared account',
+            optional: true,
+          },
+        }}
+        onSave={jest.fn()}
+        onRevoke={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Own Token').textContent).toContain('com_ui_optional');
+    expect(screen.getByText('My API Key').textContent).not.toContain('com_ui_optional');
+  });
+
   it('renders non-sensitive fields as unmasked text while keeping secrets masked', () => {
     render(
       <CustomUserVarsSection

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -692,6 +692,7 @@ export function useMCPServerManager({
                   label: config.title,
                   description: config.description,
                   sensitive: config.sensitive,
+                  optional: config.optional,
                 }))
               : []),
           authenticated: serverData?.authenticated ?? false,
@@ -743,6 +744,7 @@ export function useMCPServerManager({
           title: field.label || field.authField,
           description: field.description,
           sensitive: field.sensitive,
+          optional: field.optional,
         };
       });
     }

--- a/packages/api/src/mcp/__tests__/customUserVars.integration.test.ts
+++ b/packages/api/src/mcp/__tests__/customUserVars.integration.test.ts
@@ -71,4 +71,83 @@ describe('processMCPEnv — customUserVars placeholder resolution', () => {
 
     expect((result as t.StreamableHTTPOptions).url).toContain('{{MY_CUSTOM_KEY}}');
   });
+  describe('optional vars the user has not set', () => {
+    const withOptionalPat = () =>
+      ({
+        type: 'streamable-http',
+        url: 'https://my-mcp.server.com/mcp',
+        headers: {
+          'X-User-Email': '{{LIBRECHAT_USER_EMAIL}}',
+          'X-User-Github-Pat': '{{GITHUB_PAT}}',
+        },
+        customUserVars: {
+          GITHUB_PAT: { title: 'GitHub Token', description: 'own account', optional: true },
+        },
+      }) as unknown as t.MCPOptions;
+
+    it('omits a header made solely of an unset optional placeholder', () => {
+      const result = processMCPEnv({ options: withOptionalPat(), user: mockUser });
+      const headers = (result as t.StreamableHTTPOptions).headers ?? {};
+
+      expect(headers).not.toHaveProperty('X-User-Github-Pat');
+      expect(headers['X-User-Email']).toBe('test@example.com');
+    });
+
+    it('sends the value once the user sets it', () => {
+      const result = processMCPEnv({
+        options: withOptionalPat(),
+        user: mockUser,
+        customUserVars: { GITHUB_PAT: 'ghp_realtoken' },
+      });
+
+      expect((result as t.StreamableHTTPOptions).headers?.['X-User-Github-Pat']).toBe(
+        'ghp_realtoken',
+      );
+    });
+
+    it('treats a blank value as unset rather than as an empty credential', () => {
+      const result = processMCPEnv({
+        options: withOptionalPat(),
+        user: mockUser,
+        customUserVars: { GITHUB_PAT: '   ' },
+      });
+
+      expect((result as t.StreamableHTTPOptions).headers).not.toHaveProperty('X-User-Github-Pat');
+    });
+
+    it('clears the placeholder but keeps a header that carries other content', () => {
+      const options = {
+        type: 'streamable-http',
+        url: 'https://my-mcp.server.com/mcp?pat={{GITHUB_PAT}}',
+        headers: { 'X-Combined': 'user={{LIBRECHAT_USER_EMAIL}};pat={{GITHUB_PAT}}' },
+        customUserVars: {
+          GITHUB_PAT: { title: 'GitHub Token', description: 'own account', optional: true },
+        },
+      } as unknown as t.MCPOptions;
+
+      const result = processMCPEnv({ options, user: mockUser });
+
+      expect((result as t.StreamableHTTPOptions).url).toBe('https://my-mcp.server.com/mcp?pat=');
+      expect((result as t.StreamableHTTPOptions).headers?.['X-Combined']).toBe(
+        'user=test@example.com;pat=',
+      );
+    });
+
+    it('leaves a required var untouched, so its absence stays visible', () => {
+      const options = {
+        type: 'streamable-http',
+        url: 'https://my-mcp.server.com/mcp',
+        headers: { Authorization: 'Bearer {{REQUIRED_TOKEN}}' },
+        customUserVars: {
+          REQUIRED_TOKEN: { title: 'Token', description: 'required' },
+        },
+      } as unknown as t.MCPOptions;
+
+      const result = processMCPEnv({ options, user: mockUser });
+
+      expect((result as t.StreamableHTTPOptions).headers?.['Authorization']).toBe(
+        'Bearer {{REQUIRED_TOKEN}}',
+      );
+    });
+  });
 });

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -1051,4 +1051,40 @@ describe('getMissingCustomUserVars', () => {
       getMissingCustomUserVars(config, { THINGY_TOKEN: 'abc123', UNRELATED: 'value' }),
     ).toEqual([]);
   });
+
+  describe('optional variables', () => {
+    const mixedConfig: Pick<ParsedServerConfig, 'customUserVars'> = {
+      customUserVars: {
+        THINGY_TOKEN: { title: 'Token', description: 'required token' },
+        THINGY_OVERRIDE: { title: 'Override', description: 'own account', optional: true },
+      },
+    };
+
+    it('never reports a variable marked optional, whatever the user provided', () => {
+      expect(getMissingCustomUserVars(mixedConfig, undefined)).toEqual(['THINGY_TOKEN']);
+      expect(getMissingCustomUserVars(mixedConfig, { THINGY_OVERRIDE: '' })).toEqual([
+        'THINGY_TOKEN',
+      ]);
+      expect(getMissingCustomUserVars(mixedConfig, { THINGY_TOKEN: 'abc123' })).toEqual([]);
+    });
+
+    it('keeps a server with only optional variables ungated', () => {
+      const config: Pick<ParsedServerConfig, 'customUserVars'> = {
+        customUserVars: {
+          THINGY_OVERRIDE: { title: 'Override', description: 'own account', optional: true },
+        },
+      };
+      expect(hasCustomUserVars(config)).toBe(true);
+      expect(getMissingCustomUserVars(config, undefined)).toEqual([]);
+    });
+
+    it('still gates when optional is explicitly false', () => {
+      const config: Pick<ParsedServerConfig, 'customUserVars'> = {
+        customUserVars: {
+          THINGY_TOKEN: { title: 'Token', description: 'required token', optional: false },
+        },
+      };
+      expect(getMissingCustomUserVars(config, undefined)).toEqual(['THINGY_TOKEN']);
+    });
+  });
 });

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -410,14 +410,17 @@ export function canUseAppConnection(config: UserScopedConnectionConfig): boolean
 }
 
 /**
- * Returns the names of `customUserVars` declared on the server config for which
- * the user has not supplied a non-blank value (unset, empty, or whitespace-only
- * values count as missing, since they still fail auth). An empty array means
- * every declared variable is satisfied (or the server declares none).
+ * Returns the names of *required* `customUserVars` declared on the server config for which
+ * the user has not supplied a non-blank value (unset, empty, or whitespace-only values
+ * count as missing, since they still fail auth). An empty array means every required
+ * variable is satisfied (or the server declares none).
  *
- * Used to gate tool exposure: a server that requires user-provided credentials
- * should not surface its tools to the model until those values are set,
- * otherwise every tool call fails authentication. See issue #10969.
+ * Used to gate tool exposure: a server that requires user-provided credentials should not
+ * surface its tools to the model until those values are set, otherwise every tool call
+ * fails authentication. See issue #10969.
+ *
+ * Variables marked `optional` are excluded: they override a default the deployment already
+ * provides, so leaving one unset must not take the server's tools away.
  */
 export function getMissingCustomUserVars(
   config: Pick<ParsedServerConfig, 'customUserVars'>,
@@ -426,7 +429,11 @@ export function getMissingCustomUserVars(
   if (!hasCustomUserVars(config)) {
     return [];
   }
-  return Object.keys(config.customUserVars ?? {}).filter((key) => {
+  const declared = config.customUserVars ?? {};
+  return Object.keys(declared).filter((key) => {
+    if (declared[key]?.optional === true) {
+      return false;
+    }
     const value = providedVars?.[key];
     return value == null || (typeof value === 'string' && value.trim() === '');
   });

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -258,6 +258,37 @@ function processBodyPlaceholders(value: string, body: RequestBody): string {
   return value;
 }
 
+function customUserVarPlaceholder(varName: string): RegExp {
+  const escaped = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\{\\{${escaped}\\}\\}`, 'g');
+}
+
+/**
+ * Names of `optional` customUserVars the user has not supplied a usable value for.
+ *
+ * Unlike required vars - whose absence hides the server's tools - these leave the server running
+ * on the deployment's own default, so their placeholders have to resolve to nothing.
+ */
+function unsetOptionalVars(
+  declared: MCPOptions['customUserVars'],
+  provided?: Record<string, string>,
+): string[] {
+  if (!declared) {
+    return [];
+  }
+  return Object.keys(declared).filter((key) => {
+    if (declared[key]?.optional !== true) {
+      return false;
+    }
+    const value = provided?.[key];
+    return typeof value !== 'string' || value.trim() === '';
+  });
+}
+
+function referencesAnyVar(value: string, varNames: string[]): boolean {
+  return varNames.some((varName) => customUserVarPlaceholder(varName).test(value));
+}
+
 /**
  * Processes a single string value by replacing various types of placeholders
  *
@@ -266,6 +297,7 @@ function processBodyPlaceholders(value: string, body: RequestBody): string {
  * @param user - Optional user object for replacing user field placeholders
  * @param body - Optional request body object for replacing body field placeholders
  * @param isHeader - Whether this value will be used in an HTTP header (enables encoding)
+ * @param clearVars - Names of declared vars whose placeholders resolve to an empty string
  * @returns The processed string with all placeholders replaced
  */
 function processSingleValue({
@@ -275,6 +307,7 @@ function processSingleValue({
   body = undefined,
   isHeader = false,
   dbSourced = false,
+  clearVars,
 }: {
   originalValue: string;
   customUserVars?: Record<string, string>;
@@ -283,6 +316,7 @@ function processSingleValue({
   isHeader?: boolean;
   /** When true, only resolve customUserVars — skip env vars, user/OpenID/body placeholders */
   dbSourced?: boolean;
+  clearVars?: string[];
 }): string {
   // Type guard: ensure we're working with a string
   if (typeof originalValue !== 'string') {
@@ -305,9 +339,17 @@ function processSingleValue({
   /** Runs for both dbSourced and non-dbSourced — it is the only resolution DB-stored servers get */
   if (customUserVars) {
     for (const [varName, varVal] of Object.entries(customUserVars)) {
-      const escapedVarName = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const placeholderRegex = new RegExp(`\\{\\{${escapedVarName}\\}\\}`, 'g');
-      value = value.replace(placeholderRegex, varVal);
+      value = value.replace(customUserVarPlaceholder(varName), varVal);
+    }
+  }
+
+  /**
+   * An optional var the user never set has no value to substitute. Clearing it keeps the literal
+   * `{{VAR}}` from reaching the server as if it were the credential.
+   */
+  if (clearVars) {
+    for (const varName of clearVars) {
+      value = value.replace(customUserVarPlaceholder(varName), '');
     }
   }
 
@@ -376,6 +418,7 @@ export function processMCPEnv(params: {
   const dbSourced = params.dbSourced ?? !!options.dbId;
 
   const newObj: MCPOptions = structuredClone(options);
+  const clearVars = unsetOptionalVars(newObj.customUserVars, customUserVars);
 
   // Apply admin-provided API key to headers at runtime
   // Note: User-provided keys use {{MCP_API_KEY}} placeholder in headers,
@@ -416,6 +459,7 @@ export function processMCPEnv(params: {
         user,
         body,
         dbSourced,
+        clearVars,
         originalValue,
         customUserVars,
       });
@@ -427,7 +471,7 @@ export function processMCPEnv(params: {
     const processedArgs: string[] = [];
     for (const originalValue of newObj.args) {
       processedArgs.push(
-        processSingleValue({ originalValue, customUserVars, user, body, dbSourced }),
+        processSingleValue({ originalValue, customUserVars, user, body, dbSourced, clearVars }),
       );
     }
     newObj.args = processedArgs;
@@ -438,14 +482,24 @@ export function processMCPEnv(params: {
   if ('headers' in newObj && newObj.headers) {
     const processedHeaders: Record<string, string> = {};
     for (const [key, originalValue] of Object.entries(newObj.headers)) {
-      processedHeaders[key] = processSingleValue({
+      const processed = processSingleValue({
         user,
         body,
         dbSourced,
+        clearVars,
         originalValue,
         customUserVars,
         isHeader: true, // Important: Enable header encoding
       });
+      /**
+       * A header whose whole value came from an unset optional var carries no credential at all.
+       * Omitting it lets the server apply its own default, where sending it empty would instead
+       * read as a deliberate empty credential.
+       */
+      if (processed.trim() === '' && referencesAnyVar(originalValue, clearVars)) {
+        continue;
+      }
+      processedHeaders[key] = processed;
     }
     newObj.headers = processedHeaders;
   }
@@ -454,14 +508,19 @@ export function processMCPEnv(params: {
   if ('oauth_headers' in newObj && newObj.oauth_headers) {
     const processedOAuthHeaders: Record<string, string> = {};
     for (const [key, originalValue] of Object.entries(newObj.oauth_headers)) {
-      processedOAuthHeaders[key] = processSingleValue({
+      const processed = processSingleValue({
         user,
         body,
         dbSourced,
+        clearVars,
         originalValue,
         customUserVars,
         isHeader: true,
       });
+      if (processed.trim() === '' && referencesAnyVar(originalValue, clearVars)) {
+        continue;
+      }
+      processedOAuthHeaders[key] = processed;
     }
     newObj.oauth_headers = processedOAuthHeaders;
   }
@@ -472,6 +531,7 @@ export function processMCPEnv(params: {
       user,
       body,
       dbSourced,
+      clearVars,
       customUserVars,
       originalValue: newObj.url,
     });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1689,6 +1689,9 @@ export type TStartupConfig = {
         {
           title: string;
           description: string;
+          sensitive?: boolean;
+          /** Override rather than requirement - tools stay available while it is unset. */
+          optional?: boolean;
         }
       >;
       chatMenu?: boolean;

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -225,6 +225,14 @@ const BaseOptionsSchema = z.object({
          * values (e.g. username, project key, base URL) to render as plain text.
          */
         sensitive: z.boolean().optional(),
+        /**
+         * When true the variable is an override rather than a requirement: the server keeps
+         * exposing its tools while it is unset, using whatever default the deployment
+         * configured. Use it for "shared admin credential by default, user may substitute
+         * their own"; leave it off for values without which the server cannot work at all,
+         * so its tools stay hidden until they are supplied.
+         */
+        optional: z.boolean().optional(),
       }),
     )
     .optional(),


### PR DESCRIPTION
Fixes #14512

## Summary

A `customUserVar` is always a requirement today: while one is unset, `getMissingCustomUserVars` reports it and `ToolService` hides **every** tool of that server (#10969). That is right when the value is the only credential the server has. It leaves the opposite case unexpressible - the deployment already provides a credential and a user may substitute their own.

Our case: an MCP server running a per-user Linux workspace where git and `gh` act as a shared machine account. A user should be able to store their own GitHub token to work on their own repos. Declaring `GITHUB_PAT` there makes the workspace vanish for everyone who has not set one; not declaring it means the override cannot exist.

`optional` already exists on plugin `authConfig` and is honoured by `PluginAuthForm`, so this gives MCP servers a notion the codebase already has.

## Changes

- `optional?: boolean` on the `customUserVars` entry schema, carried through to the client-facing server payload type.
- `getMissingCustomUserVars` skips optional vars, so tool gating is unaffected by them.
- An unset optional placeholder resolves to empty instead of being passed on as the literal `{{VAR}}`, and a header whose whole value came from one is omitted - the server sees no credential rather than an empty one. Required vars keep the current behaviour untouched.
- `getMCPTools` carries `optional` into its `authConfig` so the config dialog can label the field, and no longer sets `authenticated: false` for a server whose vars are *all* optional - that made such a server show as `needs_setup` in the agent tool catalog although nothing is missing. A single required var still marks it unauthenticated, so existing configs are unaffected.
- The config dialog marks optional fields with the existing `com_ui_optional` label.

Default behaviour is unchanged: without `optional`, or with `optional: false`, everything gates exactly as before.

## Tests

`packages/api`:
- gating - optional vars never reported, a server with only optional vars stays ungated, `optional: false` still gates;
- placeholder resolution - header omitted when unset, sent once set, blank treated as unset, a partially-optional value cleared in place, required vars left literal.

`client`: optional fields labelled, required ones not.

Local: the api mcp+env suites pass (207 tests), client suite 3/3, tsc and eslint clean on the changed files. The `*cache_integration*` suites need a Redis cluster that is not available locally.

Verified end to end in a running stack (LibreChat + an MCP server that declares one optional var):

| check | result |
|---|---|
| tools with the var unset | 25 exposed, server `authenticated: true` |
| a second server whose var is required | 0 tools, `authenticated: false` |
| `authConfig` reaching the client | includes `optional: true` |
| value saved through the UI's endpoint | `authValueFlags: {VAR: true}`, connection re-established |
| header at the MCP server | value present, and absent entirely while unset |