### PR TITLE
feat: respond to notifications/tools/list_changed

### DIFF
--- a/api/server/services/Config/mcp.js
+++ b/api/server/services/Config/mcp.js
@@ -1,16 +1,22 @@
 const { createMCPToolCacheService, MCPServersRegistry } = require('@librechat/api');
 const { getCachedTools, setCachedTools } = require('./getCachedTools');
 
-const { mergeAppTools, cacheMCPServerTools, updateMCPServerTools, getMCPServerTools } =
-  createMCPToolCacheService({
-    getCachedTools,
-    setCachedTools,
-    getServerConfig: (serverName, userId) =>
-      MCPServersRegistry.getInstance().getServerConfig(serverName, userId),
-  });
+const {
+  mergeAppTools,
+  replaceAppServerTools,
+  cacheMCPServerTools,
+  updateMCPServerTools,
+  getMCPServerTools,
+} = createMCPToolCacheService({
+  getCachedTools,
+  setCachedTools,
+  getServerConfig: (serverName, userId) =>
+    MCPServersRegistry.getInstance().getServerConfig(serverName, userId),
+});
 
 module.exports = {
   mergeAppTools,
+  replaceAppServerTools,
   getMCPServerTools,
   cacheMCPServerTools,
   updateMCPServerTools,

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -1,7 +1,9 @@
 const mongoose = require('mongoose');
 const { logger } = require('@librechat/data-schemas');
+const { setMCPToolsChangedHandler } = require('@librechat/api');
 const { mergeAppTools, getAppConfig } = require('./Config');
-const { createMCPServersRegistry, createMCPManager } = require('~/config');
+const { replaceAppServerTools, cacheMCPServerTools } = require('./Config/mcp');
+const { createMCPServersRegistry, createMCPManager, getMCPManager } = require('~/config');
 
 /**
  * Resolves the current request's effective MCP allowlists from the merged (tenant-scoped)
@@ -16,6 +18,35 @@ async function resolveMCPAllowlists(ctx) {
     allowedDomains: appConfig?.mcpSettings?.allowedDomains,
     allowedAddresses: appConfig?.mcpSettings?.allowedAddresses,
   };
+}
+
+/**
+ * Refreshes one server's tools after it reported `notifications/tools/list_changed`.
+ *
+ * A server that builds tools at runtime is the case this exists for: without it the tool list
+ * stayed frozen at connection time and only a restart picked up the change (#7117). The list is
+ * re-fetched from the live connection and written over that server's cache entry, so tools that
+ * disappeared stop being advertised too.
+ */
+async function refreshChangedServerTools({ serverName, userId }) {
+  const mcpManager = getMCPManager();
+  const serverTools = await mcpManager.getServerToolFunctions(userId ?? '', serverName);
+  if (!serverTools) {
+    logger.debug(
+      `[MCP][${serverName}] Tool list changed but no connection answered; leaving the cache alone`,
+    );
+    return;
+  }
+
+  const toolCount = Object.keys(serverTools).length;
+  if (userId) {
+    await cacheMCPServerTools({ userId, serverName, serverTools });
+  } else {
+    await replaceAppServerTools({ serverName, serverTools });
+  }
+  logger.info(
+    `[MCP][${serverName}] Tool list changed; refreshed ${toolCount} ${toolCount === 1 ? 'tool' : 'tools'}${userId ? ` for user ${userId}` : ''}`,
+  );
 }
 
 /**
@@ -39,6 +70,7 @@ async function initializeMCPs() {
 
   try {
     const mcpManager = await createMCPManager(mcpServers || {});
+    setMCPToolsChangedHandler(refreshChangedServerTools);
 
     if (mcpServers && Object.keys(mcpServers).length > 0) {
       const mcpTools = (await mcpManager.getAppToolFunctions()) || {};
@@ -58,3 +90,4 @@ async function initializeMCPs() {
 }
 
 module.exports = initializeMCPs;
+module.exports.refreshChangedServerTools = refreshChangedServerTools;

--- a/api/server/services/initializeMCPs.spec.js
+++ b/api/server/services/initializeMCPs.spec.js
@@ -45,12 +45,36 @@ const mockMCPManagerInstance = {
   getAppToolFunctions: jest.fn(),
 };
 
+const mockGetMCPManager = jest.fn();
+
 jest.mock('~/config', () => ({
   get createMCPServersRegistry() {
     return mockCreateMCPServersRegistry;
   },
   get createMCPManager() {
     return mockCreateMCPManager;
+  },
+  get getMCPManager() {
+    return mockGetMCPManager;
+  },
+}));
+
+const mockSetMCPToolsChangedHandler = jest.fn();
+const mockReplaceAppServerTools = jest.fn();
+const mockCacheMCPServerTools = jest.fn();
+
+jest.mock('@librechat/api', () => ({
+  get setMCPToolsChangedHandler() {
+    return mockSetMCPToolsChangedHandler;
+  },
+}));
+
+jest.mock('./Config/mcp', () => ({
+  get replaceAppServerTools() {
+    return mockReplaceAppServerTools;
+  },
+  get cacheMCPServerTools() {
+    return mockCacheMCPServerTools;
   },
 }));
 
@@ -313,5 +337,72 @@ describe('initializeMCPs', () => {
       // Verify manager was created with empty config (not null/undefined)
       expect(mockCreateMCPManager).toHaveBeenCalledWith({});
     });
+  });
+});
+
+describe('refreshChangedServerTools', () => {
+  const { refreshChangedServerTools } = require('./initializeMCPs');
+  const serverTools = { [`tool${'_mcp_'}dynamic`]: { type: 'function' } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('writes to the user cache when the change came from a user connection', async () => {
+    mockGetMCPManager.mockReturnValue({
+      getServerToolFunctions: jest.fn().mockResolvedValue(serverTools),
+    });
+
+    await refreshChangedServerTools({ serverName: 'dynamic', userId: 'user-1' });
+
+    expect(mockCacheMCPServerTools).toHaveBeenCalledWith({
+      userId: 'user-1',
+      serverName: 'dynamic',
+      serverTools,
+    });
+    expect(mockReplaceAppServerTools).not.toHaveBeenCalled();
+  });
+
+  it('replaces the app-level entry when there is no user scope', async () => {
+    mockGetMCPManager.mockReturnValue({
+      getServerToolFunctions: jest.fn().mockResolvedValue(serverTools),
+    });
+
+    await refreshChangedServerTools({ serverName: 'dynamic' });
+
+    expect(mockReplaceAppServerTools).toHaveBeenCalledWith({ serverName: 'dynamic', serverTools });
+    expect(mockCacheMCPServerTools).not.toHaveBeenCalled();
+  });
+
+  it('leaves the cache alone when no connection answers', async () => {
+    mockGetMCPManager.mockReturnValue({
+      getServerToolFunctions: jest.fn().mockResolvedValue(null),
+    });
+
+    await refreshChangedServerTools({ serverName: 'dynamic', userId: 'user-1' });
+
+    expect(mockCacheMCPServerTools).not.toHaveBeenCalled();
+    expect(mockReplaceAppServerTools).not.toHaveBeenCalled();
+  });
+
+  it('applies an empty tool set, so removals take effect', async () => {
+    mockGetMCPManager.mockReturnValue({
+      getServerToolFunctions: jest.fn().mockResolvedValue({}),
+    });
+
+    await refreshChangedServerTools({ serverName: 'dynamic' });
+
+    expect(mockReplaceAppServerTools).toHaveBeenCalledWith({
+      serverName: 'dynamic',
+      serverTools: {},
+    });
+  });
+
+  it('is registered as the tools-changed handler during initialization', async () => {
+    mockGetAppConfig.mockResolvedValue({ mcpConfig: null, mcpSettings: {} });
+
+    await initializeMCPs();
+
+    expect(mockSetMCPToolsChangedHandler).toHaveBeenCalledWith(refreshChangedServerTools);
   });
 });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -13,6 +13,7 @@ export * from './mcp/mcpConfig';
 export * from './mcp/registry/MCPServersRegistry';
 export * from './mcp/MCPManager';
 export * from './mcp/connection';
+export * from './mcp/toolsChanged';
 export * from './mcp/oauth';
 export * from './mcp/auth';
 export * from './mcp/zod';

--- a/packages/api/src/mcp/ConnectionsRepository.ts
+++ b/packages/api/src/mcp/ConnectionsRepository.ts
@@ -3,6 +3,7 @@ import type * as t from './types';
 import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import { isUserSourced, requiresUserScopedConnection } from './utils';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
+import { notifyMCPToolsChanged } from './toolsChanged';
 import { MCPConnection } from './connection';
 
 const CONNECT_CONCURRENCY = 3;
@@ -91,6 +92,12 @@ export class ConnectionsRepository {
       },
       this.oauthOpts,
     );
+
+    /* Both scopes get the same treatment: this repository is per-owner, so ownerId already says
+     * whose tool cache a change belongs to (undefined = the app-level, shared one). */
+    connection.on('toolsChanged', () => {
+      void notifyMCPToolsChanged({ serverName, userId: this.ownerId });
+    });
 
     this.connections.set(serverName, connection);
     return connection;

--- a/packages/api/src/mcp/__tests__/ConnectionsRepository.test.ts
+++ b/packages/api/src/mcp/__tests__/ConnectionsRepository.test.ts
@@ -76,6 +76,8 @@ describe('ConnectionsRepository', () => {
       disconnect: jest.fn().mockResolvedValue(undefined),
       createdAt: Date.now(),
       isStale: jest.fn().mockReturnValue(false),
+      /* A real connection is an EventEmitter and the repository subscribes to it. */
+      on: jest.fn(),
     } as unknown as jest.Mocked<MCPConnection>;
 
     (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(mockConnection);

--- a/packages/api/src/mcp/__tests__/toolListChanged.integration.test.ts
+++ b/packages/api/src/mcp/__tests__/toolListChanged.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration test for `notifications/tools/list_changed` (#7117).
+ *
+ * Real MCP server, real transport, real MCPConnection: a server that registers a tool after the
+ * connection is up must make the client re-fetch, which is what kept dynamic tools invisible until
+ * a restart. Only the app-layer cache write is stubbed, since that is the boundary the connection
+ * layer deliberately does not reach across.
+ */
+import { z } from 'zod';
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Server } from 'node:http';
+import { setMCPToolsChangedHandler, notifyMCPToolsChanged } from '../toolsChanged';
+import { MCPConnection } from '../connection';
+
+jest.setTimeout(30000);
+
+/**
+ * Waits for a condition instead of sleeping a fixed amount: the notification travels over a real
+ * socket, so a fixed wait is a flake under parallel test load.
+ */
+async function waitFor(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for the notification to arrive');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+interface RunningServer {
+  url: string;
+  addTool: (name: string) => void;
+  close: () => Promise<void>;
+}
+
+async function startDynamicToolServer(): Promise<RunningServer> {
+  const mcpServer = new McpServer(
+    { name: 'dynamic-tool-server', version: '1.0.0' },
+    { capabilities: { tools: { listChanged: true } } },
+  );
+
+  mcpServer.registerTool(
+    'initial_tool',
+    { description: 'Present from the start', inputSchema: { value: z.string() } },
+    async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+  );
+
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+  await mcpServer.connect(transport);
+
+  const app = express();
+  app.use(express.json());
+  app.all('/mcp', (req, res) => {
+    void transport.handleRequest(req, res, req.body);
+  });
+
+  const httpServer: Server = await new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve(server));
+  });
+  const { port } = httpServer.address() as { port: number };
+
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    /* registerTool on a connected server emits notifications/tools/list_changed by itself - the
+     * same thing a server building tools at runtime does. */
+    addTool: (name: string) =>
+      mcpServer.registerTool(
+        name,
+        { description: `Added at runtime: ${name}`, inputSchema: { value: z.string() } },
+        async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      ),
+    close: async () => {
+      await mcpServer.close();
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+describe('tools/list_changed', () => {
+  let server: RunningServer;
+  let connection: MCPConnection;
+
+  afterEach(async () => {
+    setMCPToolsChangedHandler(null);
+    await connection?.disconnect();
+    await server?.close();
+  });
+
+  it('re-fetches the tool list when the server adds a tool after connecting', async () => {
+    server = await startDynamicToolServer();
+    connection = new MCPConnection({
+      serverName: 'dynamic',
+      serverConfig: { type: 'streamable-http', url: server.url },
+    });
+
+    const changes: string[] = [];
+    connection.on('toolsChanged', () => {
+      changes.push('toolsChanged');
+    });
+
+    await connection.connect();
+    const before = await connection.fetchTools();
+    expect(before.map((tool) => tool.name)).toEqual(['initial_tool']);
+
+    server.addTool('added_later');
+    await waitFor(() => changes.length === 1);
+
+    expect(changes).toEqual(['toolsChanged']);
+    const after = await connection.fetchTools();
+    expect(after.map((tool) => tool.name).sort()).toEqual(['added_later', 'initial_tool']);
+  });
+
+  it('routes the change to the registered handler with the server name', async () => {
+    server = await startDynamicToolServer();
+    connection = new MCPConnection({
+      serverName: 'dynamic',
+      serverConfig: { type: 'streamable-http', url: server.url },
+    });
+
+    const refreshed: Array<{ serverName: string; userId?: string }> = [];
+    setMCPToolsChangedHandler((event) => {
+      refreshed.push(event);
+    });
+    /* The repository wires this when it creates a connection; the connection itself only emits. */
+    connection.on('toolsChanged', () => {
+      void notifyMCPToolsChanged({ serverName: 'dynamic', userId: 'user-42' });
+    });
+
+    await connection.connect();
+    /* One round-trip first: notifications only reach a client whose stream is up, and a real client
+     * lists tools right after connecting anyway. */
+    await connection.fetchTools();
+    server.addTool('second_tool');
+    await waitFor(() => refreshed.length === 1);
+
+    expect(refreshed).toEqual([{ serverName: 'dynamic', userId: 'user-42' }]);
+  });
+
+  it('emits once per change, so several additions are each picked up', async () => {
+    server = await startDynamicToolServer();
+    connection = new MCPConnection({
+      serverName: 'dynamic',
+      serverConfig: { type: 'streamable-http', url: server.url },
+    });
+
+    let changes = 0;
+    connection.on('toolsChanged', () => {
+      changes++;
+    });
+
+    await connection.connect();
+    await connection.fetchTools();
+    server.addTool('one');
+    server.addTool('two');
+    await waitFor(() => changes === 2);
+
+    expect(changes).toBe(2);
+    const tools = await connection.fetchTools();
+    expect(tools).toHaveLength(3);
+  });
+});

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -5,12 +5,15 @@ import { fetch as undiciFetch, Agent, ProxyAgent } from 'undici';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js';
-import { ResourceListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
   StdioClientTransport,
   getDefaultEnvironment,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  ResourceListChangedNotificationSchema,
+  ToolListChangedNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import type {
   RequestInit as UndiciRequestInit,
   RequestInfo as UndiciRequestInfo,
@@ -1773,6 +1776,7 @@ export class MCPConnection extends EventEmitter {
     });
 
     this.subscribeToResources();
+    this.subscribeToToolListChanges();
   }
 
   private async handleReconnection(): Promise<void> {
@@ -1851,6 +1855,20 @@ export class MCPConnection extends EventEmitter {
   private subscribeToResources(): void {
     this.client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
       this.emit('resourcesChanged');
+    });
+  }
+
+  /**
+   * A server that builds tools at runtime tells us so instead of us polling for it.
+   *
+   * The spec's list-changed flow is: the server notifies, the client asks for the list again. Until
+   * this was handled the tool list stayed at whatever it was when the connection came up, so a
+   * server that adds a tool mid-session was invisible until a restart (#7117).
+   */
+  private subscribeToToolListChanges(): void {
+    this.client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+      logger.debug(`${this.getLogPrefix()} Server reported a changed tool list`);
+      this.emit('toolsChanged');
     });
   }
 

--- a/packages/api/src/mcp/tools.spec.ts
+++ b/packages/api/src/mcp/tools.spec.ts
@@ -25,6 +25,67 @@ function createMockDeps(overrides: Partial<MCPToolCacheDeps> = {}): MCPToolCache
 }
 
 describe('createMCPToolCacheService', () => {
+  describe('replaceAppServerTools', () => {
+    const toolName = (name: string, server: string) => `${name}${Constants.mcp_delimiter}${server}`;
+
+    it('drops tools the server no longer reports and keeps other servers untouched', async () => {
+      const cached: LCAvailableTools = {
+        [toolName('gone', 'dynamic')]: { type: 'function', function: { name: 'gone' } },
+        [toolName('stays', 'dynamic')]: { type: 'function', function: { name: 'stays' } },
+        [toolName('other', 'unrelated')]: { type: 'function', function: { name: 'other' } },
+      } as unknown as LCAvailableTools;
+      const deps = createMockDeps({ getCachedTools: jest.fn().mockResolvedValue(cached) });
+      const service = createMCPToolCacheService(deps);
+
+      const serverTools = {
+        [toolName('stays', 'dynamic')]: { type: 'function', function: { name: 'stays' } },
+        [toolName('added', 'dynamic')]: { type: 'function', function: { name: 'added' } },
+      } as unknown as LCAvailableTools;
+
+      await service.replaceAppServerTools({ serverName: 'dynamic', serverTools });
+
+      expect(deps.setCachedTools).toHaveBeenCalledWith({
+        [toolName('other', 'unrelated')]: cached[toolName('other', 'unrelated')],
+        ...serverTools,
+      });
+    });
+
+    it('clears a server that now reports no tools at all', async () => {
+      const cached = {
+        [toolName('gone', 'dynamic')]: { type: 'function', function: { name: 'gone' } },
+      } as unknown as LCAvailableTools;
+      const deps = createMockDeps({ getCachedTools: jest.fn().mockResolvedValue(cached) });
+      const service = createMCPToolCacheService(deps);
+
+      await service.replaceAppServerTools({ serverName: 'dynamic', serverTools: {} });
+
+      expect(deps.setCachedTools).toHaveBeenCalledWith({});
+    });
+
+    it('starts from an empty cache without failing', async () => {
+      const deps = createMockDeps();
+      const service = createMCPToolCacheService(deps);
+      const serverTools = {
+        [toolName('first', 'dynamic')]: { type: 'function', function: { name: 'first' } },
+      } as unknown as LCAvailableTools;
+
+      await service.replaceAppServerTools({ serverName: 'dynamic', serverTools });
+
+      expect(deps.setCachedTools).toHaveBeenCalledWith(serverTools);
+    });
+
+    it('propagates a cache write failure', async () => {
+      const deps = createMockDeps({
+        setCachedTools: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      const service = createMCPToolCacheService(deps);
+
+      await expect(
+        service.replaceAppServerTools({ serverName: 'dynamic', serverTools: {} }),
+      ).rejects.toThrow('Redis down');
+    });
+  });
+
   describe('updateMCPServerTools', () => {
     it('returns empty object for null tools', async () => {
       const deps = createMockDeps();

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -30,6 +30,10 @@ export interface MCPToolCacheService {
     serverConfig?: ParsedServerConfig;
   }) => Promise<LCAvailableTools>;
   mergeAppTools: (appTools: LCAvailableTools) => Promise<void>;
+  replaceAppServerTools: (params: {
+    serverName: string;
+    serverTools: LCAvailableTools;
+  }) => Promise<void>;
   cacheMCPServerTools: (params: {
     userId: string;
     serverName: string;
@@ -138,6 +142,37 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheS
     }
   }
 
+  /**
+   * Swaps one server's app-level tools for the set it reports now.
+   *
+   * Unlike mergeAppTools this also drops what disappeared: a server that removes a tool at runtime
+   * would otherwise keep it advertised forever, since merging can only ever add. Only entries
+   * belonging to `serverName` are touched, so other servers' tools survive untouched.
+   */
+  async function replaceAppServerTools(params: {
+    serverName: string;
+    serverTools: LCAvailableTools;
+  }): Promise<void> {
+    const { serverName, serverTools } = params;
+    try {
+      const cachedTools = (await getCachedTools()) ?? {};
+      const suffix = `${Constants.mcp_delimiter}${serverName}`;
+      const kept: LCAvailableTools = {};
+      for (const [name, tool] of Object.entries(cachedTools)) {
+        if (!name.endsWith(suffix)) {
+          kept[name] = tool;
+        }
+      }
+      await setCachedTools({ ...kept, ...serverTools });
+      logger.debug(
+        `[MCP Cache] Replaced app-level tools for ${serverName} with ${Object.keys(serverTools).length} tool(s)`,
+      );
+    } catch (error) {
+      logger.error(`[MCP Cache] Failed to replace app-level tools for ${serverName}:`, error);
+      throw error;
+    }
+  }
+
   async function cacheMCPServerTools(params: {
     userId: string;
     serverName: string;
@@ -180,5 +215,11 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps): MCPToolCacheS
     }
   }
 
-  return { updateMCPServerTools, mergeAppTools, cacheMCPServerTools, getMCPServerTools };
+  return {
+    updateMCPServerTools,
+    mergeAppTools,
+    replaceAppServerTools,
+    cacheMCPServerTools,
+    getMCPServerTools,
+  };
 }

--- a/packages/api/src/mcp/toolsChanged.spec.ts
+++ b/packages/api/src/mcp/toolsChanged.spec.ts
@@ -1,0 +1,60 @@
+import {
+  setMCPToolsChangedHandler,
+  hasMCPToolsChangedHandler,
+  notifyMCPToolsChanged,
+} from './toolsChanged';
+
+describe('MCP tools-changed dispatch', () => {
+  afterEach(() => {
+    setMCPToolsChangedHandler(null);
+  });
+
+  it('reports whether a handler is registered', () => {
+    expect(hasMCPToolsChangedHandler()).toBe(false);
+    setMCPToolsChangedHandler(jest.fn());
+    expect(hasMCPToolsChangedHandler()).toBe(true);
+    setMCPToolsChangedHandler(null);
+    expect(hasMCPToolsChangedHandler()).toBe(false);
+  });
+
+  it('passes the server and user scope to the handler', async () => {
+    const handler = jest.fn();
+    setMCPToolsChangedHandler(handler);
+
+    await notifyMCPToolsChanged({ serverName: 'dynamic', userId: 'user-1' });
+    await notifyMCPToolsChanged({ serverName: 'dynamic' });
+
+    expect(handler).toHaveBeenNthCalledWith(1, { serverName: 'dynamic', userId: 'user-1' });
+    expect(handler).toHaveBeenNthCalledWith(2, { serverName: 'dynamic' });
+  });
+
+  it('awaits an async handler before returning', async () => {
+    let finished = false;
+    setMCPToolsChangedHandler(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      finished = true;
+    });
+
+    await notifyMCPToolsChanged({ serverName: 'dynamic' });
+
+    expect(finished).toBe(true);
+  });
+
+  it('swallows handler errors - a notification has nowhere to report them', async () => {
+    setMCPToolsChangedHandler(() => {
+      throw new Error('cache unavailable');
+    });
+
+    await expect(notifyMCPToolsChanged({ serverName: 'dynamic' })).resolves.toBeUndefined();
+  });
+
+  it('swallows async handler rejections as well', async () => {
+    setMCPToolsChangedHandler(() => Promise.reject(new Error('redis down')));
+
+    await expect(notifyMCPToolsChanged({ serverName: 'dynamic' })).resolves.toBeUndefined();
+  });
+
+  it('does nothing when no handler is registered', async () => {
+    await expect(notifyMCPToolsChanged({ serverName: 'dynamic' })).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/mcp/toolsChanged.ts
+++ b/packages/api/src/mcp/toolsChanged.ts
@@ -1,0 +1,48 @@
+import { logger } from '@librechat/data-schemas';
+
+/**
+ * Which server changed, and whose tool cache it affects. No `userId` means an app-level
+ * connection, shared by everyone.
+ */
+export interface MCPToolsChangedEvent {
+  serverName: string;
+  userId?: string;
+}
+
+export type MCPToolsChangedHandler = (event: MCPToolsChangedEvent) => Promise<void> | void;
+
+let handler: MCPToolsChangedHandler | null = null;
+
+/**
+ * Registers what to do when a server reports a changed tool list.
+ *
+ * The connection layer knows *that* the list changed; only the app layer owns the tool caches and
+ * can refresh them, so the reaction is injected rather than reached for across that boundary.
+ * Pass null to unregister (tests, shutdown).
+ */
+export function setMCPToolsChangedHandler(fn: MCPToolsChangedHandler | null): void {
+  handler = fn;
+}
+
+/** Whether a handler is registered - lets callers skip work nobody would consume. */
+export function hasMCPToolsChangedHandler(): boolean {
+  return handler != null;
+}
+
+/**
+ * Dispatches a tool-list change. Never throws: this runs from a notification handler, where an
+ * error has nowhere to go and must not take the connection down with it.
+ */
+export async function notifyMCPToolsChanged(event: MCPToolsChangedEvent): Promise<void> {
+  if (!handler) {
+    logger.debug(
+      `[MCP][${event.serverName}] Tool list changed but no handler is registered; tools stay as they were`,
+    );
+    return;
+  }
+  try {
+    await handler(event);
+  } catch (error) {
+    logger.error(`[MCP][${event.serverName}] Failed to refresh tools after list_changed:`, error);
+  }
+}


### PR DESCRIPTION
Fixes #7117

## Summary

A server that builds tools at runtime announces it with `notifications/tools/list_changed`, and [the spec's flow](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#list-changed-notification) is that the client then asks for the list again. No handler was registered for it, so the tool list stayed at whatever it was when the connection came up - the reporter's instrument server could add a tool but LibreChat only saw it after a restart.

The SDK does support this now (`ToolListChangedNotificationSchema`), so the concern raised in the issue thread - that this had to wait for typescript-sdk#239 - no longer applies.

## Changes

- `MCPConnection` emits `toolsChanged` on the notification, mirroring the existing `resourcesChanged` subscription.
- `ConnectionsRepository` wires that event to a handler the app layer registers (`setMCPToolsChangedHandler`). The connection layer knows *that* the list changed; only the app layer owns the tool caches, so the reaction is injected rather than reached for across that boundary. The repository is per-owner, so its `ownerId` already distinguishes an app-level connection from a user's - no separate wiring for the two.
- The refresh re-fetches from the live connection and **replaces** that server's cache entry instead of merging into it. `mergeAppTools` can only ever add, so a tool the server dropped would stay advertised forever; `replaceAppServerTools` drops keys ending in that server's delimiter suffix and leaves other servers untouched. User-scoped changes go through the existing `cacheMCPServerTools`.
- Dispatch never throws: it runs from a notification handler, where an error has nowhere to go and must not take the connection down.

Nothing changes for servers that never send the notification.

## Tests

- **Integration** (`toolListChanged.integration.test.ts`): a real `McpServer` over a real `StreamableHTTPServerTransport` and a real `MCPConnection`. Registering a tool after connect fires the event, a re-fetch sees the new tool, and two additions fire twice. Ran 12x consecutively without a flake.
- **Dispatch unit tests**: scope passed through, async handlers awaited, sync and async handler errors swallowed, no-op without a handler.
- **`replaceAppServerTools`**: drops what disappeared, keeps other servers' tools, an empty set clears the server, write failures propagate.
- **App-layer branching**: user scope vs app scope, no cache write when no connection answers, empty tool set applied so removals take effect, and the handler is registered during initialization.

Local: `packages/api` 113/113 on the touched suites, `api` 20/20 on `initializeMCPs.spec.js` (the pre-existing tests in that file still pass), tsc and eslint clean.

## Note

`resourcesChanged` is emitted today but nothing subscribes to it, so `notifications/resources/list_changed` currently has no effect either. Left alone here to keep this change to one concern.