### PR TITLE
📦 chore: bump `@librechat/agents` to v3.3.8

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.7",
+    "@librechat/agents": "^3.3.8",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.7",
+        "@librechat/agents": "^3.3.8",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10615,9 +10615,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.7.tgz",
-      "integrity": "sha512-lWX2Om+iME32QQy1kZKx52SE3edECp8Wgvvi4OJ7qdmsDSJPJOZBqKuSS8XNxAyGaqeo664H5JlgHWsa+I9CSw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.8.tgz",
+      "integrity": "sha512-SpEKK4JsInpIggQNdiTzm+4VgBJRYVasDlJixsP7M+ahK48VzYvLIfkMPITKk2WZJ65RGkJqVnz6RmRLHIQhTA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42535,7 +42535,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.7",
+        "@librechat/agents": "^3.3.8",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -108,7 +108,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.7",
+    "@librechat/agents": "^3.3.8",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

Bumps `@librechat/agents` from v3.3.7 to v3.3.8, which **activates activity-label continuity end to end**.

The host side already landed with the activity-groups feature (#14391): a per-run accumulator that records committed header text by content index, reads it at request-build time (not claim time — a batch claims its slot while the previous batch's fill is still in flight, which is exactly the rapid-consecutive case where continuity matters), threads it through `GenerateLabelPayload.previousLabels`, seeds it from resumed content on HITL resume, and passes it across the SDK bridge. But the SDK had no field to receive it, so the traced generation path silently dropped the context and only the direct fallback rendered it.

v3.3.8 carries danny-avila/agents#356, which adds `previousLabels` to `RunActivityLabelOptions` and renders it as the label prompt's first section.

## Why it matters

Each label call sees only its own batch, its reasoning excerpts, and the assistant's last ~200 characters — no conversation history and no user messages by design. It had no way to know a header already existed above it, and two existing decisions compounded the problem: reasoning collection stops at the previous label part (correct, or another batch's reasoning bleeds in) while intent keeps scanning past labels, so consecutive batches with no interleaved narration received identical framing context and zero memory.

In a real 9-batch run that produced two pairs of near-duplicate headers out of nine lines — a setup batch and its payoff each announcing the same finding, and two consecutive network probes both reporting "blocked". Against the feature's own bar (*do the headers alone reconstruct the run when the cards are collapsed?*), roughly 44% of the lines repeated their neighbour.

Worse than repetition: blind labels asserted conclusions their tools had not established. A batch that merely *wrote* a marker file was labeled `Confirmed /tmp/persist-probe.txt persists across calls` — before anything had tested persistence. With continuity context the same batch pair resolves honestly:

```
Wrote marker file to /tmp/persist-probe.txt
Confirmed marker file persists across tool calls
```

## Safety properties inherited from #356

Previous labels are the one prompt input that **re-enters on every later batch**, so a single malformed label would persistently steer the rest of the run rather than affecting one request. v3.3.8 therefore:

- collapses whitespace per label — prompt sections are blank-line delimited, so an embedded newline could otherwise forge an apparent `Tool calls:` or `Label:` section, whether from plain model noncompliance or from injection surfacing through a tool result;
- clips each label at 200 characters, matching how `lastAssistantText` and reasoning excerpts are already bounded (array-length capping alone never bounded prompt *size*, so a few oversized headers could exceed the fast model's window and starve the run of labels);
- caps the window at 3, which is measured rather than assumed: an unbounded-history variant scored no better on the eval corpus — restatement was already fully eliminated at 3, being inherently a recency problem — while prompt growth is linear and unbounded (+82 input tokens by batch 9, extrapolating to roughly +250 on a ~550-token prompt at the `activityMaxPerRun` default of 20).

## Also included between v3.3.7 and v3.3.8

danny-avila/agents#354 — anchors summary coverage to a source message id. Worth naming explicitly, since a version bump quietly ships everything between the two tags.

## Test plan

Verified in an isolated worktree against the **installed** 3.3.8, not just the source:

- `packages/api` — 73 `activityLabels` tests pass; `tsc --noEmit` clean.
- `api` — 218 agents-controller tests pass (1 skipped).
- Rendered a prompt through the published build to confirm the shipped behavior: 3-entry cap honored, a 400-char label clipped at 200 with an ellipsis, and an injected `Tool calls:` section flattened to inert text with exactly one real section surviving.
- Lockfile shows no transitive churn — 3.3.8's dependency tree is identical to 3.3.7's, so the upgrade risk is limited to the two PRs above.
