### PR TITLE
enhancement:prevent-model-switch

### DIFF
--- a/api/server/middleware/__tests__/convoAccess.spec.js
+++ b/api/server/middleware/__tests__/convoAccess.spec.js
@@ -1,0 +1,182 @@
+const validateConvoAccess = require('../validate/convoAccess');
+const { ViolationTypes } = require('librechat-data-provider');
+
+jest.mock('@librechat/api', () => ({
+  isEnabled: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('~/server/middleware/denyRequest', () => jest.fn());
+
+jest.mock('~/cache', () => ({
+  logViolation: jest.fn(),
+  getLogStores: jest.fn().mockReturnValue({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(true),
+  }),
+}));
+
+jest.mock('~/models', () => ({
+  searchConversation: jest.fn(),
+}));
+
+const { searchConversation } = require('~/models');
+const denyRequest = require('~/server/middleware/denyRequest');
+
+describe('validateConvoAccess', () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = {
+      user: { id: 'user_123' },
+      body: { conversationId: 'convo_123' },
+      config: {
+        interfaceConfig: {
+          agents: {
+            preventSwitching: false,
+          },
+        },
+      },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  it('allows access for new conversations immediately', async () => {
+    req.body.conversationId = 'new';
+    await validateConvoAccess(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(searchConversation).not.toHaveBeenCalled();
+  });
+
+  it('allows access if user owns the conversation', async () => {
+    searchConversation.mockResolvedValue({
+      conversationId: 'convo_123',
+      user: 'user_123',
+      agent_id: 'agent_abc',
+    });
+
+    await validateConvoAccess(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(denyRequest).not.toHaveBeenCalled();
+  });
+
+  it('denies access if user does not own the conversation', async () => {
+    searchConversation.mockResolvedValue({
+      conversationId: 'convo_123',
+      user: 'user_456',
+      agent_id: 'agent_abc',
+    });
+
+    await validateConvoAccess(req, res, next);
+
+    expect(denyRequest).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  describe('preventSwitching setting tests', () => {
+    beforeEach(() => {
+      req.config.interfaceConfig.agents.preventSwitching = true;
+    });
+
+    it('blocks switching from custom Agent A to custom Agent B', async () => {
+      searchConversation.mockResolvedValue({
+        conversationId: 'convo_123',
+        user: 'user_123',
+        agent_id: 'agent_abc',
+      });
+      req.body.agent_id = 'agent_xyz';
+      req.body.endpoint = 'agents';
+
+      await validateConvoAccess(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'Agent Switching Prohibited',
+        }),
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('blocks switching from custom Agent A to no agent (ephemeral/standard)', async () => {
+      searchConversation.mockResolvedValue({
+        conversationId: 'convo_123',
+        user: 'user_123',
+        agent_id: 'agent_abc',
+      });
+      req.body.agent_id = 'ephemeral';
+      req.body.endpoint = 'openAI';
+
+      await validateConvoAccess(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('blocks switching from no agent (ephemeral/standard) to custom Agent A', async () => {
+      searchConversation.mockResolvedValue({
+        conversationId: 'convo_123',
+        user: 'user_123',
+        agent_id: 'ephemeral',
+      });
+      req.body.agent_id = 'agent_abc';
+      req.body.endpoint = 'agents';
+
+      await validateConvoAccess(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('allows changing models within non-agent endpoints (ephemeral to ephemeral)', async () => {
+      searchConversation.mockResolvedValue({
+        conversationId: 'convo_123',
+        user: 'user_123',
+        agent_id: 'ephemeral',
+        endpoint: 'openAI',
+      });
+      req.body.agent_id = undefined;
+      req.body.endpoint = 'openAI';
+
+      await validateConvoAccess(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('allows accessing same agent when preventSwitching is true', async () => {
+      searchConversation.mockResolvedValue({
+        conversationId: 'convo_123',
+        user: 'user_123',
+        agent_id: 'agent_abc',
+      });
+      req.body.agent_id = 'agent_abc';
+      req.body.endpoint = 'agents';
+
+      await validateConvoAccess(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('does not block archive/pin/update requests (where agent_id & endpoint are undefined)', async () => {
+      searchConversation.mockResolvedValue({
+        conversationId: 'convo_123',
+        user: 'user_123',
+        agent_id: 'agent_abc',
+      });
+      // No agent_id or endpoint in body (typical of title updates, archiving, pinning)
+      req.body = { conversationId: 'convo_123' };
+
+      await validateConvoAccess(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/server/middleware/validate/convoAccess.js
+++ b/api/server/middleware/validate/convoAccess.js
@@ -1,5 +1,5 @@
 const { isEnabled } = require('@librechat/api');
-const { Constants, ViolationTypes, Time } = require('librechat-data-provider');
+const { Constants, ViolationTypes, Time, isEphemeralAgentId } = require('librechat-data-provider');
 const denyRequest = require('~/server/middleware/denyRequest');
 const { logViolation, getLogStores } = require('~/cache');
 const { searchConversation } = require('~/models');
@@ -67,6 +67,26 @@ const validateConvoAccess = async (req, res, next) => {
         await logViolation(req, res, type, errorMessage, score);
       }
       return await denyRequest(req, res, errorMessage);
+    }
+
+    const preventSwitching = req.config?.interfaceConfig?.agents?.preventSwitching === true;
+    if (preventSwitching && req.body && (req.body.agent_id !== undefined || req.body.endpoint !== undefined)) {
+      const getCleanAgentId = (id) => {
+        if (!id || isEphemeralAgentId(id)) {
+          return '';
+        }
+        return id;
+      };
+
+      const currentAgent = getCleanAgentId(conversation.agent_id);
+      const targetAgent = getCleanAgentId(req.body.agent_id);
+
+      if (currentAgent !== targetAgent) {
+        return res.status(400).json({
+          error: 'Agent Switching Prohibited',
+          message: 'Switching agents during an existing chat is not allowed due to compliance policy.',
+        });
+      }
     }
 
     if (cache) {

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { TooltipAnchor } from '@librechat/client';
-import { getConfigDefaults } from 'librechat-data-provider';
+import { getConfigDefaults, isEphemeralAgentId } from 'librechat-data-provider';
 import type { ModelSelectorProps } from '~/common';
 import {
   renderModelSpecs,
@@ -10,7 +10,8 @@ import {
 } from './components';
 import { ModelSelectorProvider, useModelSelectorContext } from './ModelSelectorContext';
 import { useShortcutAriaKey, useShortcutHint } from '~/hooks/useKeyboardShortcuts';
-import { ModelSelectorChatProvider } from './ModelSelectorChatContext';
+import { useGetStartupConfig } from '~/data-provider';
+import { ModelSelectorChatProvider, useModelSelectorChatContext } from './ModelSelectorChatContext';
 import { getSelectedIcon, getDisplayValue } from './utils';
 import { CustomMenu as Menu } from './CustomMenu';
 import DialogManager from './DialogManager';
@@ -22,6 +23,18 @@ function ModelSelectorContent() {
   const localize = useLocalize();
   const modelSelectorHint = useShortcutHint('openModelSelector', localize('com_ui_select_model'));
   const modelSelectorAriaKey = useShortcutAriaKey('openModelSelector');
+
+  const { data: startupConfig } = useGetStartupConfig();
+  const { getConversation } = useModelSelectorChatContext();
+  const conversation = getConversation();
+  const isExisting = !!(conversation?.conversationId && conversation?.conversationId !== 'new');
+  const preventSwitching = startupConfig?.interface?.agents?.preventSwitching === true;
+  const hasAgent = conversation && conversation.agent_id && !isEphemeralAgentId(conversation.agent_id);
+  const isLocked = preventSwitching && isExisting && hasAgent;
+
+  const tooltipDescription = isLocked
+    ? localize('com_ui_agent_switch_restricted') || 'Switching agents during a chat is disabled.'
+    : modelSelectorHint;
 
   const {
     // LibreChat
@@ -67,12 +80,13 @@ function ModelSelectorContent() {
   const trigger = (
     <TooltipAnchor
       aria-label={localize('com_ui_select_model')}
-      description={modelSelectorHint}
+      description={tooltipDescription}
       render={
         <button
           data-testid="model-selector-button"
           aria-keyshortcuts={modelSelectorAriaKey}
-          className="my-1 flex h-9 w-full max-w-[70vw] items-center justify-center gap-2 rounded-xl border border-border-light bg-presentation px-3 py-2 text-sm text-text-primary hover:bg-surface-active-alt"
+          disabled={isLocked}
+          className="my-1 flex h-9 w-full max-w-[70vw] items-center justify-center gap-2 rounded-xl border border-border-light bg-presentation px-3 py-2 text-sm text-text-primary hover:bg-surface-active-alt disabled:opacity-50 disabled:cursor-not-allowed"
           aria-label={localize('com_ui_select_model')}
         >
           {selectedIcon && React.isValidElement(selectedIcon) && (

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useMemo, useCallback } from 'react';
 import debounce from 'lodash/debounce';
-import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint, isEphemeralAgentId } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { Endpoint, SelectedValues } from '~/common';
 import {
@@ -62,8 +62,19 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
     useModelSelectorChatContext();
   const localize = useLocalize();
   const { announcePolite } = useLiveAnnouncer();
+  const conversation = getConversation();
+  const isExisting = !!(conversation?.conversationId && conversation?.conversationId !== 'new');
+  const preventSwitching = startupConfig?.interface?.agents?.preventSwitching === true;
+  const isAgentDisabled = useMemo(() => {
+    const hasAgent = conversation && conversation.agent_id && !isEphemeralAgentId(conversation.agent_id);
+    return preventSwitching && isExisting && !hasAgent;
+  }, [conversation, preventSwitching, isExisting]);
+
   const modelSpecs = useMemo(() => {
-    const specs = startupConfig?.modelSpecs?.list ?? [];
+    let specs = startupConfig?.modelSpecs?.list ?? [];
+    if (isAgentDisabled) {
+      specs = specs.filter((spec) => spec.preset?.endpoint !== EModelEndpoint.agents);
+    }
     if (!agentsMap) {
       return specs;
     }
@@ -79,7 +90,7 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
       /** Keep non-agent modelSpecs */
       return true;
     });
-  }, [startupConfig, agentsMap]);
+  }, [startupConfig, agentsMap, isAgentDisabled]);
 
   const permissionLevel = useAgentDefaultPermissionLevel();
   const { data: agents = null } = useListAgentsQuery(
@@ -89,12 +100,19 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
     },
   );
 
-  const { mappedEndpoints, endpointRequiresUserKey } = useEndpoints({
+  const { mappedEndpoints: allMappedEndpoints, endpointRequiresUserKey } = useEndpoints({
     agents,
     assistantsMap,
     startupConfig,
     endpointsConfig,
   });
+
+  const mappedEndpoints = useMemo(() => {
+    if (isAgentDisabled) {
+      return allMappedEndpoints.filter((ep) => ep.value !== EModelEndpoint.agents);
+    }
+    return allMappedEndpoints;
+  }, [allMappedEndpoints, isAgentDisabled]);
 
   const getModelDisplayName = useCallback(
     (endpoint: Endpoint, model: string): string => {

--- a/client/src/hooks/Input/useMentions.ts
+++ b/client/src/hooks/Input/useMentions.ts
@@ -8,6 +8,7 @@ import {
   PermissionTypes,
   isAgentsEndpoint,
   getConfigDefaults,
+  isEphemeralAgentId,
   isAssistantsEndpoint,
 } from 'librechat-data-provider';
 import type { TAssistantsMap, TEndpointsConfig } from 'librechat-data-provider';
@@ -23,6 +24,8 @@ import { useAgentsMapContext } from '~/Providers/AgentsMapContext';
 import { mapEndpoints, getPresetTitle } from '~/utils';
 import { EndpointIcon } from '~/components/Endpoints';
 import useHasAccess from '~/hooks/Roles/useHasAccess';
+import { useRecoilValue } from 'recoil';
+import store from '~/store';
 import { filterMentionEndpoints } from './mentions';
 
 const defaultInterface = getConfigDefaults().interface;
@@ -83,6 +86,19 @@ export default function useMentions({
     () => startupConfig?.interface ?? defaultInterface,
     [startupConfig?.interface],
   );
+  const conversation = useRecoilValue(store.conversationByIndex(0));
+  const isExisting = !!(conversation?.conversationId && conversation?.conversationId !== 'new');
+  const preventSwitching = interfaceConfig?.agents?.preventSwitching === true;
+  const isAgentDisabled = useMemo(() => {
+    const hasAgent = conversation && conversation.agent_id && !isEphemeralAgentId(conversation.agent_id);
+    return preventSwitching && isExisting && !hasAgent;
+  }, [conversation, preventSwitching, isExisting]);
+
+  const isLocked = useMemo(() => {
+    const hasAgent = conversation && conversation.agent_id && !isEphemeralAgentId(conversation.agent_id);
+    return preventSwitching && isExisting && hasAgent;
+  }, [conversation, preventSwitching, isExisting]);
+
   const includedEndpoints = useMemo(
     () => new Set(startupConfig?.modelSpecs?.addedEndpoints ?? []),
     [startupConfig?.modelSpecs?.addedEndpoints],
@@ -99,6 +115,7 @@ export default function useMentions({
   );
   const validEndpointSet = useMemo(() => new Set(validEndpoints), [validEndpoints]);
   const agentQueryEnabled =
+    !isAgentDisabled &&
     hasAgentAccess &&
     interfaceConfig.modelSelect === true &&
     (includedEndpoints.size === 0 || includedEndpoints.has(EModelEndpoint.agents));
@@ -152,7 +169,10 @@ export default function useMentions({
   );
 
   const modelSpecs = useMemo(() => {
-    const specs = startupConfig?.modelSpecs?.list ?? [];
+    let specs = startupConfig?.modelSpecs?.list ?? [];
+    if (isAgentDisabled) {
+      specs = specs.filter((spec) => spec.preset?.endpoint !== EModelEndpoint.agents);
+    }
     if (!agentsMap) {
       return specs;
     }
@@ -168,9 +188,12 @@ export default function useMentions({
       /** Keep non-agent modelSpecs */
       return true;
     });
-  }, [startupConfig, agentsMap]);
+  }, [startupConfig, agentsMap, isAgentDisabled]);
 
   const options: MentionOption[] = useMemo(() => {
+    if (isLocked) {
+      return [];
+    }
     const modelOptions = validEndpoints.flatMap((endpoint) => {
       if (isAssistantsEndpoint(endpoint) || isAgentsEndpoint(endpoint)) {
         return [];
@@ -270,6 +293,7 @@ export default function useMentions({
     includeAssistants,
     interfaceConfig.presets,
     interfaceConfig.modelSelect,
+    isLocked,
   ]);
 
   const isLoading =

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -852,6 +852,7 @@
   "com_ui_api_keys_empty_text": "API keys let external applications run your agents through the OpenAI-compatible API. Create a key to get started.",
   "com_ui_api_keys_empty_title": "Connect your agents to external apps",
   "com_ui_api_keys_load_error": "Failed to load API keys",
+  "com_ui_agent_switch_restricted": "Switching agents during a chat is disabled.",
   "com_ui_approval_error": "Something went wrong submitting your decision. Please try again.",
   "com_ui_approval_expired": "This request expired or was already handled.",
   "com_ui_approve": "Approve",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1319,6 +1319,7 @@ export const interfaceSchema = z
           create: z.boolean().optional(),
           share: z.boolean().optional(),
           public: z.boolean().optional(),
+          preventSwitching: z.boolean().optional(),
         }),
       ])
       .optional(),
@@ -1404,6 +1405,7 @@ export const interfaceSchema = z
       create: true,
       share: false,
       public: false,
+      preventSwitching: false,
     },
     temporaryChat: true,
     autoSubmitFromUrl: true,


### PR DESCRIPTION
# Summary

Adds a new `preventSwitching` option under `interface.agents` (default: `false`).

When enabled, users cannot switch agents or models after a conversation has started, helping prevent compliance bypasses.

### Changes

* Added `preventSwitching` to the configuration schema, defaults, and `librechat.example.yaml`.
* Blocked agent/model switching in `validateConvoAccess` for active conversations.
* Added unit tests for the new validation.
* Updated the frontend to disable or hide switching options and added a tooltip explaining the restriction.
* Added the `com_ui_agent_switch_restricted` localization key.

Related issue: **#<issue-number>**

## Change Type

* [x] New feature (non-breaking change which adds functionality)

## Testing

* Enabled `interface.agents.preventSwitching`.
* Verified agent/model switching is blocked after a conversation starts.
* Confirmed backend returns **400 Bad Request** for restricted switches.
* Ran unit tests successfully.

## Checklist

* [x] Self-reviewed my code
* [x] Added/updated tests
* [x] Local unit tests pass
