### PR TITLE
🎯 feat: Render Tool Intent as the Live Tool-Call Label

### DIFF
--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -223,7 +223,7 @@ const Part = memo(function Part({
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}
               toolName={toolCall.name}
-              args={typeof toolCall.args === 'string' ? toolCall.args : ''}
+              args={toolCall.args ?? ''}
               output={toolCall.output ?? ''}
               attachments={attachments}
               hideAttachments={hideAttachments}

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -332,6 +332,7 @@ const Part = memo(function Part({
             <RetrievalCall
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}
+              args={toolCall.args}
               output={toolCall.output ?? undefined}
               attachments={attachments}
               onExpand={onToolExpand}

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -318,6 +318,7 @@ const Part = memo(function Part({
         } else if (toolCall.name === Tools.web_search) {
           return (
             <WebSearch
+              args={toolCall.args}
               output={toolCall.output ?? ''}
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}

--- a/client/src/components/Chat/Messages/Content/Parts/BashCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/BashCall.tsx
@@ -12,6 +12,7 @@ import useToolCallState from './useToolCallState';
 import useLazyHighlight from './useLazyHighlight';
 import { ERROR_PATTERNS } from './ExecuteCode';
 import { AttachmentGroup } from './Attachment';
+import { useToolCallIntent } from './intent';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -75,7 +76,15 @@ export default function BashCall({
     timerRef.current = setTimeout(() => setIsCopied(false), 3000);
   }, [command]);
 
+  /** The model-authored `intent` streams as the FIRST args key, so it is the
+   *  live label from the earliest delta — before the command exists and while
+   *  it runs. It persists as the settled label too (completion is a UI state,
+   *  not a tense change); the generic texts are the no-intent fallback. */
+  const intent = useToolCallIntent(args);
   const inProgressText = (() => {
+    if (intent != null) {
+      return intent;
+    }
     if (isWritingCommand) {
       return localize('com_ui_writing_command');
     }
@@ -95,7 +104,7 @@ export default function BashCall({
           finishedText={
             cancelled
               ? localize('com_ui_cancelled')
-              : (backgroundFinishedText ?? localize('com_ui_command_finished'))
+              : (backgroundFinishedText ?? intent ?? localize('com_ui_command_finished'))
           }
           errorSuffix={
             (hasError && !cancelled) || backgroundFailed

--- a/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
@@ -9,6 +9,7 @@ import useLazyHighlight from './useLazyHighlight';
 import useToolCallState from './useToolCallState';
 import CodeWindowHeader from './CodeWindowHeader';
 import { AttachmentGroup } from './Attachment';
+import { useToolCallIntent } from './intent';
 import { useLocalize } from '~/hooks';
 import Stdout from './Stdout';
 import { cn } from '~/utils';
@@ -74,6 +75,9 @@ export default function ExecuteCode({
 }) {
   const localize = useLocalize();
   const { lang = 'py', code } = useParseArgs(args) ?? ({} as ParsedArgs);
+  /** Model-authored live label, streamed as the first args key; persists as
+   *  the settled label (completion is a UI state, not a tense change). */
+  const intent = useToolCallIntent(args);
   const sandboxStarting = useRecoilValue(sandboxStartingByToolCallId(toolCallId ?? ''));
 
   const { showCode, toggleCode, expandStyle, expandRef, progress, cancelled, hasError, hasOutput } =
@@ -106,12 +110,13 @@ export default function ExecuteCode({
           progress={progress}
           onClick={toggleCode}
           inProgressText={
-            sandboxStarting ? localize('com_ui_sandbox_starting') : localize('com_ui_analyzing')
+            intent ??
+            (sandboxStarting ? localize('com_ui_sandbox_starting') : localize('com_ui_analyzing'))
           }
           finishedText={
             cancelled
               ? localize('com_ui_cancelled')
-              : (backgroundFinishedText ?? localize('com_ui_analyzing_finished'))
+              : (backgroundFinishedText ?? intent ?? localize('com_ui_analyzing_finished'))
           }
           errorSuffix={
             (hasError && !cancelled) || backgroundFailed

--- a/client/src/components/Chat/Messages/Content/Parts/FileAuthoringCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/FileAuthoringCall.tsx
@@ -8,6 +8,7 @@ import useLazyHighlight from './useLazyHighlight';
 import CodeWindowHeader from './CodeWindowHeader';
 import { AttachmentGroup } from './Attachment';
 import { langFromPath } from './ReadFileCall';
+import { useToolCallIntent } from './intent';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -128,6 +129,7 @@ export default function FileAuthoringCall({
    *  `Created`/`Updated`, so key the finished label off it for truthfulness. */
   const overwrote = isCreate && output.startsWith('Updated ');
   const filePath = useMemo(() => parseJsonField(args, 'file_path'), [args]);
+  const intent = useToolCallIntent(args);
   const authoredContent = useMemo(() => parseJsonField(args, 'content'), [args]);
   const editArgsPreview = useMemo(() => buildEditArgsPreview(args), [args]);
   const fileName = filePath.split('/').pop() || filePath;
@@ -162,11 +164,16 @@ export default function FileAuthoringCall({
         <ProgressText
           progress={progress}
           onClick={toggleCode}
-          inProgressText={localize(isCreate ? 'com_ui_creating_file' : 'com_ui_editing_file', {
-            0: fileName,
-          })}
+          inProgressText={
+            intent ??
+            localize(isCreate ? 'com_ui_creating_file' : 'com_ui_editing_file', {
+              0: fileName,
+            })
+          }
           finishedText={
-            cancelled ? localize('com_ui_cancelled') : localize(finishedKey, { 0: fileName })
+            cancelled
+              ? localize('com_ui_cancelled')
+              : (intent ?? localize(finishedKey, { 0: fileName }))
           }
           errorSuffix={hasError && !cancelled ? localize('com_ui_tool_failed') : undefined}
           icon={

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { AGENT_STYLE_TOOLS } from '.';
 import { PixelCard } from '@librechat/client';
 import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
 import { ToolIcon, isError } from '~/components/Chat/Messages/Content/ToolOutput';
 import Image from '~/components/Chat/Messages/Content/Image';
 import { useProgress, useLocalize } from '~/hooks';
+import { useToolCallIntent } from '../intent';
 import ProgressText from './ProgressText';
-import { AGENT_STYLE_TOOLS } from '.';
 import { scaleImage } from '~/utils';
 
 function computeCancelled(
@@ -42,6 +43,9 @@ export default function OpenAIImageGen({
   hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
+  /** Model-authored live label (injected when the tool is opted into
+   *  describe_intent); wins over the phase texts. */
+  const intent = useToolCallIntent(_args);
   const isAgentStyle = toolName != null && AGENT_STYLE_TOOLS.has(toolName);
   const [agentProgress, setAgentProgress] = useState(initialProgress);
   const legacyProgress = useProgress(isAgentStyle ? 1 : initialProgress);
@@ -226,7 +230,7 @@ export default function OpenAIImageGen({
       </span>
       <div className="relative my-1 flex h-5 shrink-0 items-center gap-2">
         <ToolIcon type="image_gen" isAnimating={isInProgress} />
-        <ProgressText progress={progress} error={cancelled} toolName={toolName} />
+        <ProgressText progress={progress} error={cancelled} toolName={toolName} intent={intent} />
       </div>
       {isAgentStyle && !hideAttachments && (
         <div className="relative mb-2 flex w-full justify-start">

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -225,7 +225,7 @@ export default function OpenAIImageGen({
           if (cancelled) {
             return localize('com_ui_cancelled');
           }
-          return localize('com_ui_image_created');
+          return intent ?? localize('com_ui_image_created');
         })()}
       </span>
       <div className="relative my-1 flex h-5 shrink-0 items-center gap-2">

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/ProgressText.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/ProgressText.tsx
@@ -6,16 +6,22 @@ export default function ProgressText({
   progress,
   error,
   toolName = '',
+  intent,
 }: {
   progress: number;
   error?: boolean;
   toolName?: string;
+  /** Model-authored label; wins over the phase texts (error state excepted). */
+  intent?: string;
 }) {
   const localize = useLocalize();
 
   const getText = () => {
     if (error) {
       return localize('com_ui_image_gen_failed');
+    }
+    if (intent != null) {
+      return intent;
     }
 
     if (toolName === 'image_edit_oai') {

--- a/client/src/components/Chat/Messages/Content/Parts/ReadFileCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ReadFileCall.tsx
@@ -7,6 +7,7 @@ import useLazyHighlight from './useLazyHighlight';
 import CodeWindowHeader from './CodeWindowHeader';
 import { AttachmentGroup } from './Attachment';
 import parseJsonField from './parseJsonField';
+import { useToolCallIntent } from './intent';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -80,6 +81,7 @@ export default function ReadFileCall({
 }) {
   const localize = useLocalize();
   const filePath = useMemo(() => parseJsonField(args, 'file_path'), [args]);
+  const intent = useToolCallIntent(args);
   const fileName = filePath.split('/').pop() || filePath;
   const lang = useMemo(() => langFromPath(filePath), [filePath]);
 
@@ -94,9 +96,11 @@ export default function ReadFileCall({
         <ProgressText
           progress={progress}
           onClick={toggleCode}
-          inProgressText={localize('com_ui_reading_file', { 0: fileName })}
+          inProgressText={intent ?? localize('com_ui_reading_file', { 0: fileName })}
           finishedText={
-            cancelled ? localize('com_ui_cancelled') : localize('com_ui_read_file', { 0: fileName })
+            cancelled
+              ? localize('com_ui_cancelled')
+              : (intent ?? localize('com_ui_read_file', { 0: fileName }))
           }
           errorSuffix={hasError && !cancelled ? localize('com_ui_tool_failed') : undefined}
           icon={

--- a/client/src/components/Chat/Messages/Content/Parts/SkillCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SkillCall.tsx
@@ -5,6 +5,7 @@ import ProgressText from '~/components/Chat/Messages/Content/ProgressText';
 import useToolCallState from './useToolCallState';
 import { AttachmentGroup } from './Attachment';
 import parseJsonField from './parseJsonField';
+import { useToolCallIntent } from './intent';
 import { useLocalize } from '~/hooks';
 import Stdout from './Stdout';
 import { cn } from '~/utils';
@@ -28,6 +29,7 @@ export default function SkillCall({
 }) {
   const localize = useLocalize();
   const skillName = useMemo(() => parseJsonField(args, 'skillName'), [args]);
+  const intent = useToolCallIntent(args);
 
   const { showCode, toggleCode, expandStyle, expandRef, progress, cancelled, hasError, hasOutput } =
     useToolCallState(initialProgress, isSubmitting, output, !!skillName, onExpand);
@@ -38,11 +40,11 @@ export default function SkillCall({
         <ProgressText
           progress={progress}
           onClick={toggleCode}
-          inProgressText={localize('com_ui_skill_running', { 0: skillName })}
+          inProgressText={intent ?? localize('com_ui_skill_running', { 0: skillName })}
           finishedText={
             cancelled
               ? localize('com_ui_cancelled')
-              : localize('com_ui_skill_finished', { 0: skillName })
+              : (intent ?? localize('com_ui_skill_finished', { 0: skillName }))
           }
           errorSuffix={hasError && !cancelled ? localize('com_ui_tool_failed') : undefined}
           icon={

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -18,6 +18,7 @@ import { subagentProgressByToolCallId } from '~/store';
 import { useAgentsMapContext } from '~/Providers';
 import { useMCPServerNames } from '~/hooks/MCP';
 import { AttachmentGroup } from './Attachment';
+import { useToolCallIntent } from './intent';
 import { useLocalize } from '~/hooks';
 import Reasoning from './Reasoning';
 import Text from './Text';
@@ -252,9 +253,13 @@ export default function SubagentCall({
   /** Base verb-only label ("Running agent" / "Ran agent"). The agent name
    *  is rendered separately as a muted sub-label so "agent" stays a
    *  constant visual anchor regardless of name length. */
+  /** Model-authored live label (subagent carries `intent` natively); wins
+   *  over the generic verb, never over error/cancellation framing. */
+  const intent = useToolCallIntent(args);
   const getHeaderText = () => {
     if (hasError) return localize('com_ui_subagent_errored');
     if (cancelled) return localize('com_ui_subagent_cancelled');
+    if (intent != null) return intent;
     if (running) return localize('com_ui_subagent_running');
     return localize('com_ui_subagent_complete');
   };

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
@@ -193,6 +193,12 @@ describe('BashCall intent label', () => {
     renderBashCall('{"intent":"Checking caf\\u00e9 menu da');
     expect(screen.getByTestId('progress-text')).toHaveTextContent('Checking café menu da');
   });
+
+  it('keeps a terminal lone high surrogate once the value is settled (matches JSON.parse)', () => {
+    renderBashCall('{"intent":"odd \\ud83d","command":"sleep 10"}');
+    const text = screen.getByTestId('progress-text').textContent ?? '';
+    expect(text).toBe('odd \ud83d');
+  });
 });
 
 describe('BashCall backgrounded calls', () => {

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
@@ -181,6 +181,14 @@ describe('BashCall intent label', () => {
     expect(text.endsWith('…')).toBe(true);
   });
 
+  it('never splits a surrogate pair at the truncation boundary', () => {
+    const straddling = `${'x'.repeat(254)}😀 and more text to exceed the bound`;
+    renderBashCall({ intent: straddling, command: 'sleep 10' });
+    const text = screen.getByTestId('progress-text').textContent ?? '';
+    expect(text.endsWith('x…')).toBe(true);
+    expect(text).not.toContain('�');
+  });
+
   it('decodes unicode escapes in a streaming intent (no literal \\uXXXX flash)', () => {
     renderBashCall('{"intent":"Checking caf\\u00e9 menu da');
     expect(screen.getByTestId('progress-text')).toHaveTextContent('Checking café menu da');

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
@@ -122,6 +122,46 @@ describe('BashCall status text', () => {
   );
 });
 
+describe('BashCall intent label', () => {
+  it('shows a streaming intent before any other arg exists (first key, partial JSON)', () => {
+    renderBashCall('{"intent":"Checking the countdown ta');
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Checking the countdown ta');
+    expect(screen.queryByText('Writing command')).not.toBeInTheDocument();
+  });
+
+  it('keeps the intent as the in-progress label once the command has streamed', () => {
+    renderBashCall('{"intent":"Waiting for the task to settle","command":"sleep 8; echo waited"}');
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Waiting for the task to settle');
+    expect(screen.queryByText('Running command')).not.toBeInTheDocument();
+    expect(screen.getByText(/sleep 8/)).toBeInTheDocument();
+  });
+
+  it('keeps the intent as the settled label (completion is a UI state, not a tense change)', () => {
+    render(
+      <RecoilRoot>
+        <BashCall
+          initialProgress={1}
+          isSubmitting={false}
+          args={'{"intent":"Waiting for the task to settle","command":"sleep 8"}'}
+          output="waited"
+        />
+      </RecoilRoot>,
+    );
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Waiting for the task to settle');
+    expect(screen.queryByText('Finished running')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the generic labels when no intent is present', () => {
+    renderBashCall({ command: 'sleep 10' });
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');
+  });
+
+  it('ignores a non-string intent arg (a business param, not the label contract)', () => {
+    renderBashCall({ intent: { nested: true }, command: 'sleep 10' });
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');
+  });
+});
+
 describe('BashCall backgrounded calls', () => {
   const HANDLE_OUTPUT = JSON.stringify({
     background_task_id: 'task-1',

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
@@ -160,6 +160,25 @@ describe('BashCall intent label', () => {
     renderBashCall({ intent: { nested: true }, command: 'sleep 10' });
     expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');
   });
+
+  it('ignores an intent that is not the FIRST args key (label contract is first-position)', () => {
+    renderBashCall('{"command":"sleep 10","intent":"billing_inquiry"}');
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');
+    expect(screen.queryByText('billing_inquiry')).not.toBeInTheDocument();
+  });
+
+  it('bounds a runaway intent to a single 256-char line', () => {
+    const runaway = `Checking ${'a very long clause '.repeat(30)}end`;
+    renderBashCall({ intent: runaway, command: 'sleep 10' });
+    const text = screen.getByTestId('progress-text').textContent ?? '';
+    expect(text.length).toBeLessThanOrEqual(256);
+    expect(text.endsWith('…')).toBe(true);
+  });
+
+  it('decodes unicode escapes in a streaming intent (no literal \\uXXXX flash)', () => {
+    renderBashCall('{"intent":"Checking caf\\u00e9 menu da');
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Checking café menu da');
+  });
 });
 
 describe('BashCall backgrounded calls', () => {

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/BashCall.test.tsx
@@ -161,6 +161,12 @@ describe('BashCall intent label', () => {
     expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');
   });
 
+  it('ignores a non-string intent in complete SERIALIZED args (no String() coercion)', () => {
+    renderBashCall('{"intent":{"topic":"billing"},"command":"sleep 10"}');
+    expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');
+    expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+  });
+
   it('ignores an intent that is not the FIRST args key (label contract is first-position)', () => {
     renderBashCall('{"command":"sleep 10","intent":"billing_inquiry"}');
     expect(screen.getByTestId('progress-text')).toHaveTextContent('Running command');

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/parseJsonField.test.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/parseJsonField.test.ts
@@ -123,6 +123,19 @@ describe('parseJsonField', () => {
       expect(parseJsonField(partial, 'intent')).toBe('Searching ');
     });
 
+    it.each(['\\', '\\u', '\\uD', '\\uDE0'])(
+      'holds the high surrogate while the low escape is still streaming: "\\ud83d%s"',
+      (lowPrefix) => {
+        const partial = `{"intent":"Searching \\ud83d${lowPrefix}`;
+        expect(parseJsonField(partial, 'intent')).toBe('Searching ');
+      },
+    );
+
+    it('emits a lone high surrogate when followed by ordinary text (matches JSON.parse)', () => {
+      const partial = '{"intent":"odd \\ud83d tail","incomplete":';
+      expect(parseJsonField(partial, 'intent')).toBe('odd \ud83d tail');
+    });
+
     it('keeps a malformed \\u (bad hex mid-string) literal rather than corrupting the tail', () => {
       const partial = '{"command":"regex \\uZZZZ tail","incomplete":';
       expect(parseJsonField(partial, 'command')).toBe('regex \\uZZZZ tail');

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/parseJsonField.test.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/parseJsonField.test.ts
@@ -98,9 +98,34 @@ describe('parseJsonField', () => {
       expect(parseJsonField(partial, 'file_path')).toBe('C:\\note');
     });
 
-    it('preserves unknown escape sequences', () => {
-      const partial = '{"command":"tab\\there","incomplete":';
-      expect(parseJsonField(partial, 'command')).toBe('tab\\there');
+    it('decodes the full JSON escape set (matches the settled JSON.parse rendering)', () => {
+      const partial = '{"command":"tab\\there\\rreturn\\bback\\fform\\/slash","incomplete":';
+      expect(parseJsonField(partial, 'command')).toBe('tab\there\rreturn\bback\fform/slash');
+    });
+
+    it('preserves genuinely unknown escape sequences', () => {
+      const partial = '{"command":"odd\\qescape","incomplete":';
+      expect(parseJsonField(partial, 'command')).toBe('odd\\qescape');
+    });
+
+    it('decodes \\uXXXX escapes mid-stream, including surrogate pairs', () => {
+      const partial = '{"intent":"Checking caf\\u00e9 menu \\ud83d\\ude00 da';
+      expect(parseJsonField(partial, 'intent')).toBe('Checking café menu 😀 da');
+    });
+
+    it('drops an incomplete \\uXX escape at the stream edge instead of showing it literally', () => {
+      const partial = '{"intent":"Checking caf\\u00e';
+      expect(parseJsonField(partial, 'intent')).toBe('Checking caf');
+    });
+
+    it('holds back the high half of a split surrogate pair at the stream edge', () => {
+      const partial = '{"intent":"Searching \\ud83d';
+      expect(parseJsonField(partial, 'intent')).toBe('Searching ');
+    });
+
+    it('keeps a malformed \\u (bad hex mid-string) literal rather than corrupting the tail', () => {
+      const partial = '{"command":"regex \\uZZZZ tail","incomplete":';
+      expect(parseJsonField(partial, 'command')).toBe('regex \\uZZZZ tail');
     });
   });
 

--- a/client/src/components/Chat/Messages/Content/Parts/intent.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/intent.ts
@@ -2,6 +2,40 @@ import { useMemo } from 'react';
 import parseJsonField from './parseJsonField';
 
 /**
+ * Single-line clamp mirroring the SDK's outcome-label bound
+ * (`MAX_OUTCOME_CHARS` in `@librechat/agents`): the label is one progress
+ * line in UI chrome rendered with `whitespace-nowrap`, so a verbose or
+ * malformed model response must not extend across adjacent controls.
+ */
+const MAX_INTENT_CHARS = 256;
+
+function boundIntentLabel(label: string): string | undefined {
+  const singleLine = label.replace(/\s+/g, ' ').trim();
+  if (singleLine === '') {
+    return undefined;
+  }
+  if (singleLine.length <= MAX_INTENT_CHARS) {
+    return singleLine;
+  }
+  return `${singleLine.slice(0, MAX_INTENT_CHARS - 1)}…`;
+}
+
+/**
+ * Whether the args carry `intent` as their FIRST key. The label contract
+ * demands first position ("ALWAYS write this field FIRST" — that ordering is
+ * the entire streaming mechanism), so requiring it here is what separates
+ * the injected label from a tool's own business parameter that merely
+ * shares the name (e.g. a CRM tool's `{"q":"acme","intent":"billing"}`),
+ * which serializes wherever the model put it.
+ */
+function isIntentFirstKey(args: string | Record<string, unknown>): boolean {
+  if (typeof args === 'object') {
+    return Object.keys(args)[0] === 'intent';
+  }
+  return /^\s*\{\s*"intent"\s*:/.test(args);
+}
+
+/**
  * The model-authored `intent` label for a tool call: one sentence, injected
  * as the FIRST property of the tool's schema (SDK-native or host-injected),
  * so it is the first key providers stream in the args. `parseJsonField`'s
@@ -16,12 +50,13 @@ import parseJsonField from './parseJsonField';
  */
 export function useToolCallIntent(args?: string | Record<string, unknown>): string | undefined {
   return useMemo(() => {
-    if (typeof args === 'object' && args !== null) {
-      const value = args.intent;
-      const trimmed = typeof value === 'string' ? value.trim() : '';
-      return trimmed === '' ? undefined : trimmed;
+    if (args == null || !isIntentFirstKey(args)) {
+      return undefined;
     }
-    const intent = parseJsonField(args, 'intent').trim();
-    return intent === '' ? undefined : intent;
+    if (typeof args === 'object') {
+      const value = args.intent;
+      return typeof value === 'string' ? boundIntentLabel(value) : undefined;
+    }
+    return boundIntentLabel(parseJsonField(args, 'intent'));
   }, [args]);
 }

--- a/client/src/components/Chat/Messages/Content/Parts/intent.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/intent.ts
@@ -27,7 +27,7 @@ const INTENT_SCAN_CHARS = 2048;
  * first-key `intent` (`{"intent":{...}}`) never matches the opening quote,
  * so schema-invalid calls keep their generic label without any JSON.parse.
  */
-const INTENT_PREFIX_REGEX = /^\s*\{\s*"intent"\s*:\s*"((?:[^"\\]|\\.)*)(?:"|\\?$)/;
+const INTENT_PREFIX_REGEX = /^\s*\{\s*"intent"\s*:\s*"((?:[^"\\]|\\.)*)(")?/;
 
 function boundIntentLabel(label: string): string | undefined {
   const singleLine = label.replace(/\s+/g, ' ').trim();
@@ -80,6 +80,9 @@ export function useToolCallIntent(args?: string | Record<string, unknown>): stri
     if (!match) {
       return undefined;
     }
-    return boundIntentLabel(unescapeJsonString(match[1]));
+    /** A captured closing quote means the value is settled: decode it
+     *  without the stream-edge hold-backs, so a value genuinely ending in
+     *  a lone high surrogate matches its JSON.parse rendering. */
+    return boundIntentLabel(unescapeJsonString(match[1], match[2] !== '"'));
   }, [args]);
 }

--- a/client/src/components/Chat/Messages/Content/Parts/intent.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/intent.ts
@@ -57,6 +57,19 @@ export function useToolCallIntent(args?: string | Record<string, unknown>): stri
       const value = args.intent;
       return typeof value === 'string' ? boundIntentLabel(value) : undefined;
     }
-    return boundIntentLabel(parseJsonField(args, 'intent'));
+    try {
+      /** Complete serialized args need the same non-string guard as object
+       *  args — `parseJsonField` would coerce `{"intent":{...}}` into
+       *  "[object Object]" via String(). */
+      const parsed = JSON.parse(args) as unknown;
+      if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const value = (parsed as Record<string, unknown>).intent;
+        return typeof value === 'string' ? boundIntentLabel(value) : undefined;
+      }
+      return undefined;
+    } catch {
+      /** Partial stream: the regex fallback only matches string values. */
+      return boundIntentLabel(parseJsonField(args, 'intent'));
+    }
   }, [args]);
 }

--- a/client/src/components/Chat/Messages/Content/Parts/intent.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/intent.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import parseJsonField from './parseJsonField';
+import { unescapeJsonString } from './parseJsonField';
 
 /**
  * Single-line clamp mirroring the SDK's outcome-label bound
@@ -9,6 +9,26 @@ import parseJsonField from './parseJsonField';
  */
 const MAX_INTENT_CHARS = 256;
 
+/**
+ * Head window scanned for the label. The gate + a full 256-char label (with
+ * escapes) fit comfortably; bounding the scan keeps per-delta work constant
+ * even when a tool streams megabytes of `code`/`content` after the intent.
+ */
+const INTENT_SCAN_CHARS = 2048;
+
+/**
+ * Anchored prefix extractor: the label contract puts `intent` FIRST
+ * ("ALWAYS write this field FIRST" — that ordering is the entire streaming
+ * mechanism), so a single anchored match both gates out a tool's own
+ * business parameter that merely shares the name (e.g. a CRM's
+ * `{"q":"acme","intent":"billing"}`, which serializes wherever the model
+ * put it) and captures the string value, complete or still streaming
+ * (tolerating a missing closing quote and a dangling escape). A non-string
+ * first-key `intent` (`{"intent":{...}}`) never matches the opening quote,
+ * so schema-invalid calls keep their generic label without any JSON.parse.
+ */
+const INTENT_PREFIX_REGEX = /^\s*\{\s*"intent"\s*:\s*"((?:[^"\\]|\\.)*)(?:"|\\?$)/;
+
 function boundIntentLabel(label: string): string | undefined {
   const singleLine = label.replace(/\s+/g, ' ').trim();
   if (singleLine === '') {
@@ -17,32 +37,28 @@ function boundIntentLabel(label: string): string | undefined {
   if (singleLine.length <= MAX_INTENT_CHARS) {
     return singleLine;
   }
-  return `${singleLine.slice(0, MAX_INTENT_CHARS - 1)}…`;
-}
-
-/**
- * Whether the args carry `intent` as their FIRST key. The label contract
- * demands first position ("ALWAYS write this field FIRST" — that ordering is
- * the entire streaming mechanism), so requiring it here is what separates
- * the injected label from a tool's own business parameter that merely
- * shares the name (e.g. a CRM tool's `{"q":"acme","intent":"billing"}`),
- * which serializes wherever the model put it.
- */
-function isIntentFirstKey(args: string | Record<string, unknown>): boolean {
-  if (typeof args === 'object') {
-    return Object.keys(args)[0] === 'intent';
+  let head = singleLine.slice(0, MAX_INTENT_CHARS - 1);
+  const lastCode = head.charCodeAt(head.length - 1);
+  /** Never split a surrogate pair at the cut — a lone high surrogate
+   *  renders as a replacement glyph before the ellipsis. */
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    head = head.slice(0, -1);
   }
-  return /^\s*\{\s*"intent"\s*:/.test(args);
+  return `${head}…`;
 }
 
 /**
  * The model-authored `intent` label for a tool call: one sentence, injected
  * as the FIRST property of the tool's schema (SDK-native or host-injected),
- * so it is the first key providers stream in the args. `parseJsonField`'s
- * partial-JSON fallback reads it from the streaming args string as it is
- * typed, before the rest of the args exist — which is what lets a card show
- * it as the call's live status label. Returns undefined until any non-empty
+ * so it is the first key providers stream in the args — which is what lets
+ * a card show it as the call's live status label from the earliest delta,
+ * before the rest of the args exist. Returns undefined until any non-empty
  * text has streamed, so callers can fall back to their generic label.
+ *
+ * Extraction never parses the args buffer: one anchored regex over a
+ * bounded head window does the gating and the capture, so per-delta cost
+ * stays constant while a large `code`/`content` argument streams behind
+ * the label.
  *
  * The label persists unchanged when the call settles: completion is a UI
  * state (the shimmer stopping), not a tense change (see `applyOutcome` in
@@ -50,26 +66,20 @@ function isIntentFirstKey(args: string | Record<string, unknown>): boolean {
  */
 export function useToolCallIntent(args?: string | Record<string, unknown>): string | undefined {
   return useMemo(() => {
-    if (args == null || !isIntentFirstKey(args)) {
+    if (args == null) {
       return undefined;
     }
     if (typeof args === 'object') {
+      if (Object.keys(args)[0] !== 'intent') {
+        return undefined;
+      }
       const value = args.intent;
       return typeof value === 'string' ? boundIntentLabel(value) : undefined;
     }
-    try {
-      /** Complete serialized args need the same non-string guard as object
-       *  args — `parseJsonField` would coerce `{"intent":{...}}` into
-       *  "[object Object]" via String(). */
-      const parsed = JSON.parse(args) as unknown;
-      if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        const value = (parsed as Record<string, unknown>).intent;
-        return typeof value === 'string' ? boundIntentLabel(value) : undefined;
-      }
+    const match = INTENT_PREFIX_REGEX.exec(args.slice(0, INTENT_SCAN_CHARS));
+    if (!match) {
       return undefined;
-    } catch {
-      /** Partial stream: the regex fallback only matches string values. */
-      return boundIntentLabel(parseJsonField(args, 'intent'));
     }
+    return boundIntentLabel(unescapeJsonString(match[1]));
   }, [args]);
 }

--- a/client/src/components/Chat/Messages/Content/Parts/intent.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/intent.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import parseJsonField from './parseJsonField';
+
+/**
+ * The model-authored `intent` label for a tool call: one sentence, injected
+ * as the FIRST property of the tool's schema (SDK-native or host-injected),
+ * so it is the first key providers stream in the args. `parseJsonField`'s
+ * partial-JSON fallback reads it from the streaming args string as it is
+ * typed, before the rest of the args exist — which is what lets a card show
+ * it as the call's live status label. Returns undefined until any non-empty
+ * text has streamed, so callers can fall back to their generic label.
+ *
+ * The label persists unchanged when the call settles: completion is a UI
+ * state (the shimmer stopping), not a tense change (see `applyOutcome` in
+ * `@librechat/agents` for why there is deliberately no rewrite).
+ */
+export function useToolCallIntent(args?: string | Record<string, unknown>): string | undefined {
+  return useMemo(() => {
+    if (typeof args === 'object' && args !== null) {
+      const value = args.intent;
+      const trimmed = typeof value === 'string' ? value.trim() : '';
+      return trimmed === '' ? undefined : trimmed;
+    }
+    const intent = parseJsonField(args, 'intent').trim();
+    return intent === '' ? undefined : intent;
+  }, [args]);
+}

--- a/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
@@ -21,16 +21,59 @@ function fieldRegex(field: string, flags?: string): RegExp {
   return new RegExp(`"${escaped}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)(?:"|\\\\?$)`, flags);
 }
 
+const SIMPLE_ESCAPES: Record<string, string> = {
+  n: '\n',
+  t: '\t',
+  r: '\r',
+  b: '\b',
+  f: '\f',
+  '"': '"',
+  '\\': '\\',
+  '/': '/',
+};
+
+/**
+ * Decodes the full JSON string escape set so a partially streamed value
+ * renders exactly as its settled `JSON.parse` form will — without this,
+ * `café` displays literally mid-stream and then snaps to `café` once
+ * the object becomes valid JSON. Stream-boundary incompletions (a dangling
+ * `\`, a partial `\uXX`, or the high half of a split surrogate pair) are
+ * dropped rather than shown, since the next delta completes them; unknown
+ * escapes elsewhere are preserved literally.
+ */
 function unescapeJsonString(value: string): string {
-  return value.replace(/\\(.)/g, (_, c: string) => {
-    if (c === 'n') {
-      return '\n';
+  let out = '';
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch !== '\\') {
+      out += ch;
+      continue;
     }
-    if (c === '"' || c === '\\') {
-      return c;
+    const next = value[i + 1];
+    if (next === undefined) {
+      break;
     }
-    return `\\${c}`;
-  });
+    i++;
+    if (next !== 'u') {
+      out += SIMPLE_ESCAPES[next] ?? `\\${next}`;
+      continue;
+    }
+    const hex = value.slice(i + 1, i + 5);
+    if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+      if (i + 5 > value.length) {
+        return out;
+      }
+      out += '\\u';
+      continue;
+    }
+    i += 4;
+    const code = parseInt(hex, 16);
+    if (code >= 0xd800 && code <= 0xdbff && i + 1 >= value.length) {
+      return out;
+    }
+    out += String.fromCharCode(code);
+  }
+  return out;
 }
 
 /** Extracts a string field from tool call args, handling object, JSON string, and partial-JSON fallback. */

--- a/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
@@ -68,8 +68,16 @@ function unescapeJsonString(value: string): string {
     }
     i += 4;
     const code = parseInt(hex, 16);
-    if (code >= 0xd800 && code <= 0xdbff && i + 1 >= value.length) {
-      return out;
+    if (code >= 0xd800 && code <= 0xdbff) {
+      /** Hold back a high surrogate while its low half could still be
+       *  streaming in — the remainder being any proper prefix of `\uXXXX`
+       *  (including the empty string). A complete following escape decodes
+       *  on the next iteration and composes the pair; anything else means
+       *  the lone surrogate is real data (matches `JSON.parse`). */
+      const rest = value.slice(i + 1);
+      if (/^(?:\\(?:u[0-9a-fA-F]{0,3})?)?$/.test(rest)) {
+        return out;
+      }
     }
     out += String.fromCharCode(code);
   }

--- a/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
@@ -41,7 +41,7 @@ const SIMPLE_ESCAPES: Record<string, string> = {
  * dropped rather than shown, since the next delta completes them; unknown
  * escapes elsewhere are preserved literally.
  */
-function unescapeJsonString(value: string): string {
+export function unescapeJsonString(value: string): string {
   let out = '';
   for (let i = 0; i < value.length; i++) {
     const ch = value[i];

--- a/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/parseJsonField.ts
@@ -39,9 +39,12 @@ const SIMPLE_ESCAPES: Record<string, string> = {
  * the object becomes valid JSON. Stream-boundary incompletions (a dangling
  * `\`, a partial `\uXX`, or the high half of a split surrogate pair) are
  * dropped rather than shown, since the next delta completes them; unknown
- * escapes elsewhere are preserved literally.
+ * escapes elsewhere are preserved literally. Callers that KNOW the value is
+ * settled (its closing quote was present) pass `streaming: false` so a value
+ * genuinely ending in a lone high surrogate keeps its final code unit,
+ * matching `JSON.parse`.
  */
-export function unescapeJsonString(value: string): string {
+export function unescapeJsonString(value: string, streaming = true): string {
   let out = '';
   for (let i = 0; i < value.length; i++) {
     const ch = value[i];
@@ -60,7 +63,7 @@ export function unescapeJsonString(value: string): string {
     }
     const hex = value.slice(i + 1, i + 5);
     if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
-      if (i + 5 > value.length) {
+      if (streaming && i + 5 > value.length) {
         return out;
       }
       out += '\\u';
@@ -68,7 +71,7 @@ export function unescapeJsonString(value: string): string {
     }
     i += 4;
     const code = parseInt(hex, 16);
-    if (code >= 0xd800 && code <= 0xdbff) {
+    if (streaming && code >= 0xd800 && code <= 0xdbff) {
       /** Hold back a high surrogate while its low half could still be
        *  streaming in — the remainder being any proper prefix of `\uXXXX`
        *  (including the empty string). A complete following escape decodes

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -8,6 +8,7 @@ import { useLocalize, useProgress, useExpandCollapse } from '~/hooks';
 import { ToolIcon, OutputRenderer, isError } from './ToolOutput';
 import FilePreviewDialog from './FilePreviewDialog';
 import { sortPagesByRelevance, cn } from '~/utils';
+import { useToolCallIntent } from './Parts/intent';
 import { useGetFiles } from '~/data-provider';
 import ProgressText from './ProgressText';
 import store from '~/store';
@@ -324,18 +325,24 @@ function FileHeader({
 export default function RetrievalCall({
   initialProgress = 0.1,
   isSubmitting,
+  args,
   output,
   attachments,
   onExpand,
 }: {
   initialProgress: number;
   isSubmitting: boolean;
+  args?: string | Record<string, unknown>;
   output?: string;
   attachments?: TAttachment[];
   onExpand?: () => void;
 }) {
   const progress = useProgress(initialProgress);
   const localize = useLocalize();
+  /** Model-authored live label (injected when file_search is opted into
+   *  describe_intent); persists as the settled label. The sr-only live
+   *  region below deliberately keeps its stable generic value. */
+  const intent = useToolCallIntent(args);
 
   const errorState = typeof output === 'string' && isError(output);
   const cancelled = !isSubmitting && initialProgress < 1 && !errorState;
@@ -429,8 +436,8 @@ export default function RetrievalCall({
         <ProgressText
           progress={progress}
           onClick={hasOutput ? handleToggleOutput : undefined}
-          inProgressText={localize('com_ui_searching_files')}
-          finishedText={localize('com_ui_retrieved_files')}
+          inProgressText={intent ?? localize('com_ui_searching_files')}
+          finishedText={intent ?? localize('com_ui_retrieved_files')}
           errorSuffix={errorState && !cancelled ? localize('com_ui_tool_failed') : undefined}
           icon={
             <ToolIcon type="file_search" isAnimating={progress < 1 && !cancelled && !errorState} />

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -429,7 +429,7 @@ export default function RetrievalCall({
           if (cancelled) {
             return localize('com_ui_cancelled');
           }
-          return localize('com_ui_retrieved_files');
+          return intent ?? localize('com_ui_retrieved_files');
         })()}
       </span>
       <div className="relative my-1 flex h-5 shrink-0 items-center gap-2.5">

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -13,6 +13,7 @@ import type { TAttachment } from 'librechat-data-provider';
 import { useLocalize, useProgress, useExpandCollapse } from '~/hooks';
 import { ToolIcon, getToolIconType, isError } from './ToolOutput';
 import { useMCPIconMap, useMCPServerNames } from '~/hooks/MCP';
+import { useToolCallIntent } from './Parts/intent';
 import { AttachmentGroup } from './Parts';
 import ToolCallInfo from './ToolCallInfo';
 import ProgressText from './ProgressText';
@@ -187,9 +188,17 @@ export default function ToolCall({
     return undefined;
   }, [isMCPToolCall, mcpServerName, domain, localize]);
 
+  /** Model-authored live label, streamed as the first args key (injected by
+   *  the `tool_intents` capability); persists as the settled label —
+   *  completion is a UI state, not a tense change. */
+  const intent = useToolCallIntent(_args);
+
   const getFinishedText = () => {
     if (cancelled) {
       return localize('com_ui_cancelled');
+    }
+    if (intent != null) {
+      return intent;
     }
     if (isMCPToolCall === true) {
       return localize('com_assistants_completed_function', { 0: function_name });
@@ -209,9 +218,12 @@ export default function ToolCall({
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {(() => {
           if (progress < 1 && !showCancelled) {
-            return function_name
-              ? localize('com_assistants_running_var', { 0: function_name })
-              : localize('com_assistants_running_action');
+            return (
+              intent ??
+              (function_name
+                ? localize('com_assistants_running_var', { 0: function_name })
+                : localize('com_assistants_running_action'))
+            );
           }
           return getFinishedText();
         })()}
@@ -225,9 +237,10 @@ export default function ToolCall({
           progress={progress}
           onClick={handleToggleInfo}
           inProgressText={
-            function_name
+            intent ??
+            (function_name
               ? localize('com_assistants_running_var', { 0: function_name })
-              : localize('com_assistants_running_action')
+              : localize('com_assistants_running_action'))
           }
           authText={
             !showCancelled && authDomain.length > 0 ? localize('com_ui_requires_auth') : undefined

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -215,15 +215,16 @@ export default function ToolCall({
 
   return (
     <>
+      {/* The live region gets a STABLE in-progress value: the streaming
+          intent grows on every delta, and an atomic polite region would
+          re-announce the whole sentence each time. The settled intent is
+          announced once via getFinishedText. */}
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {(() => {
           if (progress < 1 && !showCancelled) {
-            return (
-              intent ??
-              (function_name
-                ? localize('com_assistants_running_var', { 0: function_name })
-                : localize('com_assistants_running_action'))
-            );
+            return function_name
+              ? localize('com_assistants_running_var', { 0: function_name })
+              : localize('com_assistants_running_action');
           }
           return getFinishedText();
         })()}

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -6,6 +6,7 @@ import type { TAttachment, ValidSource, SearchResultData } from 'librechat-data-
 import { FaviconImage, getCleanDomain } from '~/components/Web/SourceHovercard';
 import { StackedFavicons } from '~/components/Web/Sources';
 import { useLocalize, useExpandCollapse } from '~/hooks';
+import { useToolCallIntent } from './Parts/intent';
 import { useSearchContext } from '~/Providers';
 import cn from '~/utils/cn';
 import store from '~/store';
@@ -80,18 +81,23 @@ export default function WebSearch({
   initialProgress: progress = 0.1,
   isSubmitting,
   isLast,
+  args,
   output,
   attachments,
   onExpand,
 }: {
   isLast?: boolean;
   isSubmitting: boolean;
+  args?: string | Record<string, unknown>;
   output?: string | null;
   initialProgress: number;
   attachments?: TAttachment[];
   onExpand?: () => void;
 }) {
   const localize = useLocalize();
+  /** Model-authored live label (web_search carries `intent` natively);
+   *  persists as the settled label like the other tool cards. */
+  const intent = useToolCallIntent(args);
   const { searchResults } = useSearchContext();
   const error = typeof output === 'string' && output.toLowerCase().includes('error processing');
 
@@ -157,6 +163,9 @@ export default function WebSearch({
 
   const showSources = streamingSources.length > 0;
   const progressText = useMemo(() => {
+    if (intent != null) {
+      return intent;
+    }
     let text: ProgressKeys =
       ownTurn !== '0' ? 'com_ui_web_searching_again' : 'com_ui_web_searching';
     if (showSources) {
@@ -166,7 +175,7 @@ export default function WebSearch({
       text = 'com_ui_web_search_reading';
     }
     return localize(text);
-  }, [ownTurn, localize, showSources, finalizing]);
+  }, [intent, ownTurn, localize, showSources, finalizing]);
 
   const autoExpand = useRecoilValue(store.autoExpandTools);
   const sourceCount = allSources.length;
@@ -195,7 +204,7 @@ export default function WebSearch({
 
   if (complete) {
     const hasSourceData = sourceCount > 0;
-    const completedText = localize('com_ui_web_searched');
+    const completedText = intent ?? localize('com_ui_web_searched');
 
     return (
       <div className="mb-2">

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -162,10 +162,10 @@ export default function WebSearch({
   }, [searchResults, complete, finalizing, ownTurn]);
 
   const showSources = streamingSources.length > 0;
-  const progressText = useMemo(() => {
-    if (intent != null) {
-      return intent;
-    }
+  /** Stable phase text: the live region must not re-announce the growing
+   *  intent on every delta, so it always gets this value while streaming;
+   *  the settled intent is announced once via the completed branch. */
+  const genericProgressText = useMemo(() => {
     let text: ProgressKeys =
       ownTurn !== '0' ? 'com_ui_web_searching_again' : 'com_ui_web_searching';
     if (showSources) {
@@ -175,7 +175,8 @@ export default function WebSearch({
       text = 'com_ui_web_search_reading';
     }
     return localize(text);
-  }, [intent, ownTurn, localize, showSources, finalizing]);
+  }, [ownTurn, localize, showSources, finalizing]);
+  const progressText = intent ?? genericProgressText;
 
   const autoExpand = useRecoilValue(store.autoExpandTools);
   const sourceCount = allSources.length;
@@ -280,7 +281,7 @@ export default function WebSearch({
   return (
     <div className="my-1 flex items-center gap-2.5">
       <span className="sr-only" aria-live="polite" aria-atomic="true">
-        {progressText}
+        {genericProgressText}
       </span>
       {showSources && <StackedFavicons sources={streamingSources} start={-5} />}
       <Globe className="size-4 shrink-0 text-text-secondary" aria-hidden="true" />

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -111,8 +111,12 @@ export default function WebSearch({
   const effectiveProgress = hasResults && !isSubmitting ? 1 : progress;
   const cancelled = (!isSubmitting && effectiveProgress < 1) || error === true;
 
-  const complete = !isLast && effectiveProgress === 1;
   const finalizing = isSubmitting && isLast && effectiveProgress === 1;
+  /** A search that is the message's FINAL part stays "finalizing" only while
+   *  the submission is live — afterwards it must settle like any other call,
+   *  or the completed label (and its settled intent announcement) never
+   *  renders and the card shimmers forever. */
+  const complete = effectiveProgress === 1 && !finalizing && (!isLast || !isSubmitting);
 
   const ownTurn = useMemo((): string => {
     if (!attachments) {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
@@ -133,7 +133,10 @@ describe('ToolCall', () => {
       expect(
         screen.getAllByText(/Searching for OAuth handling in the callbac/).length,
       ).toBeGreaterThan(0);
-      expect(screen.queryByText('Running testFunction')).not.toBeInTheDocument();
+      /** The aria-live region keeps its STABLE generic value while the intent
+       *  streams — an atomic polite region would otherwise re-announce the
+       *  whole growing sentence on every delta. */
+      expect(screen.getByText('Running testFunction')).toBeInTheDocument();
     });
 
     it('keeps the intent as the settled label instead of the generic completion text', () => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
@@ -119,6 +119,37 @@ describe('ToolCall', () => {
     jest.clearAllMocks();
   });
 
+  describe('intent label', () => {
+    it('renders a streaming intent as the live label before args are complete', () => {
+      renderWithRecoil(
+        <ToolCall
+          {...mockProps}
+          args={'{"intent":"Searching for OAuth handling in the callbac'}
+          output={null}
+          initialProgress={0.5}
+          isSubmitting={true}
+        />,
+      );
+      expect(
+        screen.getAllByText(/Searching for OAuth handling in the callbac/).length,
+      ).toBeGreaterThan(0);
+      expect(screen.queryByText('Running testFunction')).not.toBeInTheDocument();
+    });
+
+    it('keeps the intent as the settled label instead of the generic completion text', () => {
+      renderWithRecoil(
+        <ToolCall {...mockProps} args={'{"intent":"Looking up the customer record","q":"acme"}'} />,
+      );
+      expect(screen.getAllByText('Looking up the customer record').length).toBeGreaterThan(0);
+      expect(screen.queryByText('Completed testFunction')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the generic labels when args carry no intent', () => {
+      renderWithRecoil(<ToolCall {...mockProps} />);
+      expect(screen.getAllByText('Completed testFunction').length).toBeGreaterThan(0);
+    });
+  });
+
   describe('attachments prop passing', () => {
     it('should pass attachments to ToolCallInfo when provided', () => {
       const attachments = [


### PR DESCRIPTION
## Summary

The `tool_intents` capability injects a model-authored `intent` sentence as the FIRST key of a tool call's args, and the SDK's coding tools (`bash_tool`, `execute_code`, `read_file`, `skill`, ...) carry it natively — but no client component ever read it. Cards kept showing their generic labels ("Running command") while the intent streamed by unused, which is exactly the reported symptom: the model confirms writing an intent, the card never shows it.

## What changed

- **`useToolCallIntent`** ([Parts/intent.ts](client/src/components/Chat/Messages/Content/Parts/intent.ts)): extracts the intent from streaming args via `parseJsonField`'s partial-JSON fallback. Because the property is the first key, the label renders from the earliest delta — before any other arg exists — and updates live as the sentence streams.
- **When present, the intent is the label**: it replaces the generic in-progress text even after args finish streaming and the tool is executing, and it persists as the settled label — completion is a UI state (the shimmer stopping), not a tense change, matching the SDK's `applyOutcome` design. Cancelled, error, and background-dispatch states keep their existing precedence.
- **Wired into every ProgressText card that can carry an intent**: `BashCall`, `ExecuteCode`, the generic `ToolCall` (MCP, actions, plugin tools — including its `sr-only` live region), `ReadFileCall`, `SkillCall`, and `FileAuthoringCall`.
- Non-string `intent` args (a tool's own business param, not the label contract) are ignored. Escaped occurrences of `"intent"` inside string values (e.g. code bodies) cannot false-match the extractor, since JSON escaping means a real top-level key is the only unescaped occurrence.

## Out of scope

- `SubagentCall` keeps its deliberate verb+name header with the live activity ticker; folding intent into that layout is a design follow-up.
- Settled `outcome`/`outcome_patch` labels (tool-authored rewrites) need the outcome field plumbed to the client first; the intent persisting unchanged is the designed fallback.

## Testing

8 new cases across the `BashCall` and `ToolCall` suites: streaming intent before any other arg (partial JSON), intent winning over "Running command" while executing, intent persisting as the settled label, generic fallback with no intent, and the non-string business-param guard. All 58 tests in the touched suites pass; client tsc and eslint clean.