### PR TITLE
🎯 fix: Exact Ask-Question Attribution via Interrupt tool_call_id

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2078,7 +2078,11 @@ class AgentClient extends BaseClient {
     // and the streamed args were dropped (name-less chunks) — without this the
     // unfinished turn saves an empty ask part the record card can't render.
     if (interrupt.payload?.type === 'ask_user_question' && Array.isArray(this.contentParts)) {
-      const stamped = attachAskUserQuestionArgs(this.contentParts, interrupt.payload.question);
+      const stamped = attachAskUserQuestionArgs(
+        this.contentParts,
+        interrupt.payload.question,
+        interrupt.payload.tool_call_id,
+      );
       if (stamped !== this.contentParts) {
         this.contentParts.length = 0;
         this.contentParts.push(...stamped);

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -773,6 +773,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
         seedContent,
         pendingAction.payload.question,
         req.body.answer,
+        pendingAction.payload.tool_call_id,
       );
     }
     if (client.contentParts) {

--- a/client/src/utils/approval.spec.ts
+++ b/client/src/utils/approval.spec.ts
@@ -374,6 +374,31 @@ describe('resolveAskUserQuestionPart', () => {
     expect(getSubmittedAskAnswer('unknown')).toBeUndefined();
     expect(getSubmittedAskAnswer(undefined)).toBeUndefined();
   });
+
+  it('stamps the exact tool_call when the payload carried tool_call_id (multi-ask turn)', () => {
+    const askToolCallPart = (id: string) =>
+      ({
+        type: 'tool_call',
+        tool_call: { id, name: 'ask_user_question', args: '', type: 'tool_call' },
+      }) as unknown as TMessageContentParts;
+    const base = msg({ content: [askToolCallPart('tc_a'), askToolCallPart('tc_b')] });
+    const withCard = applyPendingAction(
+      base,
+      askAction({
+        actionId: 'a-multi-ask',
+        payload: {
+          type: 'ask_user_question',
+          question: { question: 'Which region?' },
+          tool_call_id: 'tc_a',
+        },
+      }),
+    );
+    const resolved = resolveAskUserQuestionPart(withCard, 'a-multi-ask', 'us-east');
+    const content = resolved.content as Array<{ tool_call?: Record<string, unknown> }>;
+    // Without the id, the newest-unanswered fallback would stamp tc_b.
+    expect(content[0]?.tool_call?.output).toBe('us-east');
+    expect(content[1]?.tool_call?.output).toBeUndefined();
+  });
 });
 
 describe('splitOtherOption', () => {

--- a/client/src/utils/approval.ts
+++ b/client/src/utils/approval.ts
@@ -23,6 +23,10 @@ export interface AskUserQuestionPart {
   [ASK_USER_QUESTION]: {
     actionId: string;
     question: Agents.AskUserQuestionRequest;
+    /** The ask tool call that raised the pause (present from
+     *  `@librechat/agents` > 3.3.8) — lets the answer stamp target the exact
+     *  tool-call part in multi-ask turns. */
+    tool_call_id?: string;
   };
 }
 
@@ -171,7 +175,11 @@ function applyAskUserQuestion(
   const content = Array.isArray(message.content) ? message.content : [];
   const askPart = {
     type: ASK_USER_QUESTION,
-    [ASK_USER_QUESTION]: { actionId, question: payload.question },
+    [ASK_USER_QUESTION]: {
+      actionId,
+      question: payload.question,
+      ...(payload.tool_call_id != null && { tool_call_id: payload.tool_call_id }),
+    },
   } as unknown as TMessageContentParts;
 
   const existingIdx = content.findIndex(
@@ -325,6 +333,10 @@ export function resolveAskUserQuestionPart(
     return message;
   }
   answeredAskActionIds.add(actionId);
+  /** Exact-attribution target when the payload carried the interrupting call's
+   *  id — several ask cards in one turn each resolve their own part. Absent
+   *  (older server/SDK), the newest-unanswered fallback below applies. */
+  const targetToolCallId = syntheticPart[ASK_USER_QUESTION].tool_call_id;
 
   let patched = false;
   const nextContent: TMessageContentParts[] = [];
@@ -340,10 +352,13 @@ export function resolveAskUserQuestionPart(
   for (let i = nextContent.length - 1; i >= 0; i--) {
     const part = nextContent[i] as { type?: string; tool_call?: Agents.ToolCall } | undefined;
     const toolCall = part?.tool_call;
+    if (part?.type !== ContentTypes.TOOL_CALL || toolCall?.name !== ASK_USER_QUESTION) {
+      continue;
+    }
     if (
-      part?.type !== ContentTypes.TOOL_CALL ||
-      toolCall?.name !== ASK_USER_QUESTION ||
-      (typeof toolCall.output === 'string' && toolCall.output.length > 0)
+      targetToolCallId != null
+        ? toolCall.id !== targetToolCallId
+        : typeof toolCall.output === 'string' && toolCall.output.length > 0
     ) {
       continue;
     }

--- a/packages/api/src/agents/hitl/askUserQuestionTool.ts
+++ b/packages/api/src/agents/hitl/askUserQuestionTool.ts
@@ -201,12 +201,25 @@ export const AskUserQuestionToolDefinition: AskUserQuestionToolDefinitionShape =
  * from the top on the resume pass, and sibling tools in the same batch re-execute —
  * which is why the description forbids parallel calls.
  */
+/**
+ * `askUserQuestion` with the optional attribution argument shipped in
+ * `@librechat/agents` > 3.3.8 (interrupt payload gains `tool_call_id`, letting
+ * the host stamp the question/answer onto the exact tool-call part in
+ * multi-ask turns). The pinned release still types the single-arg form; the
+ * extra argument is ignored at runtime by older versions. Drop this alias once
+ * the dependency pin includes the two-arg signature.
+ */
+const askUserQuestionWithId = askUserQuestion as (
+  question: AskUserQuestionToolInput,
+  options?: { toolCallId?: string },
+) => ReturnType<typeof askUserQuestion>;
+
 export function createAskUserQuestionTool(
   validationErrorsByToolCallId?: Map<string, ToolInputValidationError>,
 ): DynamicStructuredTool<typeof askUserQuestionToolSchema> {
   const askTool = tool(
-    async (input: AskUserQuestionToolInput) => {
-      const { answer } = askUserQuestion(input);
+    async (input: AskUserQuestionToolInput, config?: { toolCall?: { id?: string } }) => {
+      const { answer } = askUserQuestionWithId(input, { toolCallId: config?.toolCall?.id });
       return answer;
     },
     {

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -437,6 +437,32 @@ describe('attachAskUserQuestionAnswer', () => {
     const content = [{ type: 'text' } as never, askPart('done')];
     expect(attachAskUserQuestionAnswer(content as never, question as never, 'x')).toBe(content);
   });
+
+  it('targets the payload tool_call_id exactly when provided (multi-ask turn)', () => {
+    const first = {
+      type: 'tool_call',
+      tool_call: { id: 'tc_a', name: 'ask_user_question', args: '' },
+    };
+    const second = {
+      type: 'tool_call',
+      tool_call: { id: 'tc_b', name: 'ask_user_question', args: '' },
+    };
+    const next = attachAskUserQuestionAnswer(
+      [first, second] as never,
+      question as never,
+      'the answer',
+      'tc_a',
+    );
+    expect((next[0] as { tool_call: { output?: string } }).tool_call.output).toBe('the answer');
+    expect((next[1] as { tool_call: { output?: string } }).tool_call.output).toBeUndefined();
+  });
+
+  it('returns the input untouched when the payload tool_call_id matches no part', () => {
+    const content = [askPart()];
+    expect(
+      attachAskUserQuestionAnswer(content as never, question as never, 'x', 'tc_missing'),
+    ).toBe(content);
+  });
 });
 
 describe('attachAskUserQuestionArgs (pause-time stamp)', () => {
@@ -461,5 +487,17 @@ describe('attachAskUserQuestionArgs (pause-time stamp)', () => {
       { type: 'tool_call', tool_call: { name: 'ask_user_question', args: '', output: 'done' } },
     ];
     expect(attachAskUserQuestionArgs(answered as never, question as never)).toBe(answered);
+  });
+
+  it('targets the payload tool_call_id exactly when provided (multi-ask turn)', () => {
+    const content = [
+      { type: 'tool_call', tool_call: { id: 'tc_a', name: 'ask_user_question', args: '' } },
+      { type: 'tool_call', tool_call: { id: 'tc_b', name: 'ask_user_question', args: '' } },
+    ];
+    const next = attachAskUserQuestionArgs(content as never, question as never, 'tc_a');
+    expect(JSON.parse((next[0] as { tool_call: { args: string } }).tool_call.args)).toEqual(
+      question,
+    );
+    expect((next[1] as { tool_call: { args: string } }).tool_call.args).toBe('');
   });
 });

--- a/packages/api/src/agents/hitl/resume.ts
+++ b/packages/api/src/agents/hitl/resume.ts
@@ -301,6 +301,36 @@ export function createContentIndexOffsetHandlers(
 }
 
 /**
+ * Locate the ask part a stamp should target. With a `toolCallId` (the SDK
+ * surfaces the interrupting call's id on the payload from `@librechat/agents`
+ * > 3.3.8) the match is exact — several ask parts in one turn each get their
+ * own question/answer. Without one, fall back to the newest ask part that
+ * passes `isStampable` (a re-pause targets the newest question; earlier ones
+ * already carry their answers).
+ */
+function findAskPartIndex<
+  TPart extends { type?: string; tool_call?: { id?: string; name?: string } },
+>(content: TPart[], toolCallId: string | undefined, isStampable: (part: TPart) => boolean): number {
+  for (let i = content.length - 1; i >= 0; i--) {
+    const part = content[i];
+    const toolCall = part?.tool_call;
+    if (part?.type !== 'tool_call' || toolCall?.name !== ASK_USER_QUESTION_TOOL_NAME) {
+      continue;
+    }
+    if (toolCallId != null && toolCallId.length > 0) {
+      if (toolCall.id === toolCallId) {
+        return i;
+      }
+      continue;
+    }
+    if (isStampable(part)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * Stamp the answered question onto the paused `ask_user_question` tool-call part
  * before the resume run seeds it back into the content pipeline.
  *
@@ -312,36 +342,38 @@ export function createContentIndexOffsetHandlers(
  * The authoritative data exists anyway: the pendingAction payload carries the full
  * question, and the resume request carries the user's answer.
  *
- * Patches the LAST unanswered ask part (a re-pause targets the newest question;
- * earlier ones already carry their answers). Pure — returns the input array when
- * nothing matched.
+ * Targets the payload's `tool_call_id` part when present (exact attribution for
+ * multi-ask turns), else the LAST unanswered ask part. Pure — returns the input
+ * array when nothing matched.
  */
 export function attachAskUserQuestionAnswer<
-  TPart extends { type?: string; tool_call?: { name?: string; output?: unknown } },
->(content: TPart[], question: Agents.AskUserQuestionRequest, answer: string): TPart[] {
-  for (let i = content.length - 1; i >= 0; i--) {
-    const part = content[i];
-    const toolCall = part?.tool_call;
-    if (
-      part?.type !== 'tool_call' ||
-      toolCall?.name !== ASK_USER_QUESTION_TOOL_NAME ||
-      (typeof toolCall.output === 'string' && toolCall.output.length > 0)
-    ) {
-      continue;
-    }
-    const next = [...content];
-    next[i] = {
-      ...part,
-      tool_call: {
-        ...toolCall,
-        args: JSON.stringify(question),
-        output: answer,
-        progress: 1,
-      },
-    };
-    return next;
+  TPart extends { type?: string; tool_call?: { id?: string; name?: string; output?: unknown } },
+>(
+  content: TPart[],
+  question: Agents.AskUserQuestionRequest,
+  answer: string,
+  toolCallId?: string,
+): TPart[] {
+  const index = findAskPartIndex(
+    content,
+    toolCallId,
+    (part) => !(typeof part.tool_call?.output === 'string' && part.tool_call.output.length > 0),
+  );
+  if (index < 0) {
+    return content;
   }
-  return content;
+  const part = content[index];
+  const next = [...content];
+  next[index] = {
+    ...part,
+    tool_call: {
+      ...part.tool_call,
+      args: JSON.stringify(question),
+      output: answer,
+      progress: 1,
+    },
+  };
+  return next;
 }
 
 /**
@@ -351,33 +383,29 @@ export function attachAskUserQuestionAnswer<
  * reaches the answer-resume stamp, and the streamed args were dropped by the
  * aggregator (name-less chunks), so without this the persisted unfinished turn
  * carries an empty ask part the record card can't render a question from.
- * Targets the newest ask part with empty args and no output. Pure.
+ * Targets the payload's `tool_call_id` part when present, else the newest ask
+ * part with empty args and no output. Pure.
  */
 export function attachAskUserQuestionArgs<
   TPart extends {
     type?: string;
-    tool_call?: { name?: string; args?: unknown; output?: unknown };
+    tool_call?: { id?: string; name?: string; args?: unknown; output?: unknown };
   },
->(content: TPart[], question: Agents.AskUserQuestionRequest): TPart[] {
-  for (let i = content.length - 1; i >= 0; i--) {
-    const part = content[i];
-    const toolCall = part?.tool_call;
+>(content: TPart[], question: Agents.AskUserQuestionRequest, toolCallId?: string): TPart[] {
+  const index = findAskPartIndex(content, toolCallId, (part) => {
+    const toolCall = part.tool_call;
     const hasArgs =
       (typeof toolCall?.args === 'string' && toolCall.args.trim().length > 0) ||
       (toolCall?.args != null &&
         typeof toolCall.args === 'object' &&
         Object.keys(toolCall.args as object).length > 0);
-    if (
-      part?.type !== 'tool_call' ||
-      toolCall?.name !== ASK_USER_QUESTION_TOOL_NAME ||
-      hasArgs ||
-      (typeof toolCall.output === 'string' && toolCall.output.length > 0)
-    ) {
-      continue;
-    }
-    const next = [...content];
-    next[i] = { ...part, tool_call: { ...toolCall, args: JSON.stringify(question) } };
-    return next;
+    return !hasArgs && !(typeof toolCall?.output === 'string' && toolCall.output.length > 0);
+  });
+  if (index < 0) {
+    return content;
   }
-  return content;
+  const part = content[index];
+  const next = [...content];
+  next[index] = { ...part, tool_call: { ...part.tool_call, args: JSON.stringify(question) } };
+  return next;
 }

--- a/packages/data-provider/src/types/agents.ts
+++ b/packages/data-provider/src/types/agents.ts
@@ -381,6 +381,13 @@ export namespace Agents {
   export interface AskUserQuestionInterruptPayload {
     type: 'ask_user_question';
     question: AskUserQuestionRequest;
+    /**
+     * The ask tool call that raised this interrupt (mirrors the SDK field,
+     * present from `@librechat/agents` > 3.3.8). Lets the question/answer
+     * stamps target the exact tool-call part instead of guessing by
+     * position when a model emits several ask calls in one turn.
+     */
+    tool_call_id?: string;
   }
 
   /**


### PR DESCRIPTION
## Summary

Companion to danny-avila/agents#366. Together they fix the production failure where a model emitted two parallel `ask_user_question` calls (one with malformed streamed args), the popover rendered the wrong/junk question, and answering resumed into an Anthropic 400 (`INVALID_TOOL_RESULTS`, dangling `tool_use`).

The dangling-result fix itself lives in the agents SDK (synthesized error ToolMessages for `invalid_tool_calls`). This PR fixes the attribution half on the LibreChat side:

- The ask pause/answer stamps — pause-time args stamp (`attachAskUserQuestionArgs`), resume-time answer stamp (`attachAskUserQuestionAnswer`), and the client mirror (`resolveAskUserQuestionPart`) — targeted the newest unanswered ask part **by position**. With several ask calls in one turn, the question and answer land on the wrong card.
- `@librechat/agents` > 3.3.8 surfaces the interrupting call's `tool_call_id` on the ask interrupt payload. All three stamps now target that id exactly when present, with the positional fallback preserved for older payloads.
- The tool body passes `config.toolCall.id` (stamped by LangChain) through to `askUserQuestion` via a typed alias that is a runtime no-op on the pinned SDK and activates on the next dependency bump; the alias comment marks it for removal then.
- `Agents.AskUserQuestionInterruptPayload` gains the optional `tool_call_id` (mirrors the SDK), which rides the pendingAction verbatim through `buildPendingAction`/`toClientPendingAction`.

## Behavior

- Single ask call (the normal case): unchanged — fallback path is byte-for-byte the old logic.
- Multi-ask turn on the new SDK: each question/answer stamps its own card; questions resolve serially (answer one, the run re-pauses with the next), verified end-to-end at the SDK level.

## Tests

- `packages/api` `resume.spec.ts`: id-targeted stamping (multi-ask), unknown-id no-op, existing positional cases untouched (31 passing).
- `client` `approval.spec.ts`: client mirror stamps the exact `tool_call` when the payload carries the id (43 passing).
- `api` `askUserQuestion.e2e.spec.js` + `resume.spec.js` against rebuilt dists (64 passing).
- eslint clean, `client` tsc clean, `packages/api` build clean.