### PR TITLE
🔒 fix: Remove Owner Email from Agent `owner_contact` Fallback

### DIFF
--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -603,10 +603,8 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
 
       expect(mockRes.status).toHaveBeenCalledWith(200);
       const response = mockRes.json.mock.calls[0][0];
-      expect(response.owner_contact).toEqual({
-        name: 'Primary Owner',
-        email: 'primary.owner@example.com',
-      });
+      expect(response.owner_contact).toEqual({ name: 'Primary Owner' });
+      expect(response.owner_contact).not.toHaveProperty('email');
     });
 
     test('should not return owner_contact when support_contact is present', async () => {
@@ -1556,10 +1554,8 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       await getListAgentsHandler(mockReq, mockRes);
 
       const response = mockRes.json.mock.calls[0][0];
-      expect(response.data[0].owner_contact).toEqual({
-        name: 'List Owner',
-        email: 'list.owner@example.com',
-      });
+      expect(response.data[0].owner_contact).toEqual({ name: 'List Owner' });
+      expect(response.data[0].owner_contact).not.toHaveProperty('email');
     });
 
     test('should use the first ACL owner when an agent has multiple owners', async () => {
@@ -1589,10 +1585,7 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       await getListAgentsHandler(mockReq, mockRes);
 
       const response = mockRes.json.mock.calls[0][0];
-      expect(response.data[0].owner_contact).toEqual({
-        name: 'First Owner',
-        email: 'first.owner@example.com',
-      });
+      expect(response.data[0].owner_contact).toEqual({ name: 'First Owner' });
     });
 
     test('should omit owner_contact when no owner user can be resolved', async () => {

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -607,6 +607,28 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(response.owner_contact).not.toHaveProperty('email');
     });
 
+    test('should omit owner_contact when the owner name and username are the account email', async () => {
+      const email = 'sso.owner@example.com';
+      const owner = await createOwner({ name: email, username: email, email });
+      const agent = await Agent.create({
+        id: `agent_${uuidv4()}`,
+        name: 'SSO Owner Agent',
+        description: 'Owner has email-shaped name from SSO fallback',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: owner._id,
+      });
+      await grantAgentOwner({ agent, owner });
+
+      mockReq.params = { id: agent.id };
+
+      await getAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      const response = mockRes.json.mock.calls[0][0];
+      expect(response.owner_contact).toBeUndefined();
+    });
+
     test('should not return owner_contact when support_contact is present', async () => {
       const owner = await createOwner({
         name: 'Primary Owner',

--- a/api/server/services/Agents/ownerContact.js
+++ b/api/server/services/Agents/ownerContact.js
@@ -59,7 +59,7 @@ const attachOwnerContacts = async (agents) => {
   let ownersById = new Map();
   if (ownerIds.length > 0) {
     try {
-      const users = await db.findUsers({ _id: { $in: ownerIds } }, 'name username email');
+      const users = await db.findUsers({ _id: { $in: ownerIds } }, 'name username');
       ownersById = new Map(users.map((user) => [user?._id?.toString(), user]));
     } catch (error) {
       logger.warn('[/Agents] Failed to resolve agent owner users', error);

--- a/client/src/components/Agents/AgentContact.tsx
+++ b/client/src/components/Agents/AgentContact.tsx
@@ -12,12 +12,11 @@ export default function AgentContact({ agent, className = '' }: AgentContactProp
   const supportName = agent?.support_contact?.name?.trim() ?? '';
   const supportEmail = agent?.support_contact?.email?.trim() ?? '';
   const ownerName = agent?.owner_contact?.name?.trim() ?? '';
-  const ownerEmail = agent?.owner_contact?.email?.trim() ?? '';
   let contact: { name: string; email: string } | null = null;
   if (supportName || supportEmail) {
     contact = { name: supportName, email: supportEmail };
-  } else if (ownerName || ownerEmail) {
-    contact = { name: ownerName, email: ownerEmail };
+  } else if (ownerName) {
+    contact = { name: ownerName, email: '' };
   }
 
   const label = contact?.name || contact?.email || localize('com_agents_no_contact_available');

--- a/client/src/components/Agents/tests/AgentCard.spec.tsx
+++ b/client/src/components/Agents/tests/AgentCard.spec.tsx
@@ -324,7 +324,6 @@ describe('AgentCard', () => {
       authorName: 'John Doe',
       owner_contact: {
         name: 'Owner User',
-        email: 'owner@example.com',
       },
     };
 
@@ -335,10 +334,8 @@ describe('AgentCard', () => {
     );
 
     expect(screen.getByText('Contact:')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Owner User' })).toHaveAttribute(
-      'href',
-      'mailto:owner@example.com',
-    );
+    expect(screen.getByText('Owner User')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Owner User' })).not.toBeInTheDocument();
     expect(screen.queryByText('by John Doe')).not.toBeInTheDocument();
   });
 

--- a/client/src/components/Agents/tests/AgentContact.spec.tsx
+++ b/client/src/components/Agents/tests/AgentContact.spec.tsx
@@ -24,7 +24,7 @@ describe('AgentContact', () => {
         agent={
           {
             support_contact: { name: 'Support Team', email: 'support@example.com' },
-            owner_contact: { name: 'Owner User', email: 'owner@example.com' },
+            owner_contact: { name: 'Owner User' },
           } as any
         }
       />,
@@ -38,7 +38,7 @@ describe('AgentContact', () => {
     expect(screen.queryByText('Owner User')).not.toBeInTheDocument();
   });
 
-  it('falls back to owner contact', () => {
+  it('falls back to owner contact as a plain name without a mailto link', () => {
     render(
       <AgentContact
         agent={
@@ -49,15 +49,6 @@ describe('AgentContact', () => {
         }
       />,
     );
-
-    expect(screen.getByRole('link', { name: 'Owner User' })).toHaveAttribute(
-      'href',
-      'mailto:owner@example.com',
-    );
-  });
-
-  it('renders a plain name when no email is available', () => {
-    render(<AgentContact agent={{ owner_contact: { name: 'Owner User' } } as any} />);
 
     expect(screen.getByText('Owner User')).toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();

--- a/client/src/components/Agents/tests/AgentDetailContent.spec.tsx
+++ b/client/src/components/Agents/tests/AgentDetailContent.spec.tsx
@@ -101,7 +101,7 @@ describe('AgentDetailContent', () => {
           {
             ...baseAgent,
             support_contact: { name: 'Support Team', email: 'support@example.com' },
-            owner_contact: { name: 'Owner User', email: 'owner@example.com' },
+            owner_contact: { name: 'Owner User' },
           } as any
         }
       />,
@@ -121,15 +121,13 @@ describe('AgentDetailContent', () => {
         agent={
           {
             ...baseAgent,
-            owner_contact: { name: 'Owner User', email: 'owner@example.com' },
+            owner_contact: { name: 'Owner User' },
           } as any
         }
       />,
     );
 
-    expect(screen.getByRole('link', { name: 'Owner User' })).toHaveAttribute(
-      'href',
-      'mailto:owner@example.com',
-    );
+    expect(screen.getByText('Owner User')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Owner User' })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/Chat/__tests__/Landing.agent-contact.spec.tsx
+++ b/client/src/components/Chat/__tests__/Landing.agent-contact.spec.tsx
@@ -106,7 +106,7 @@ describe('Landing agent contact', () => {
         id: 'agent-1',
         name: 'Portal Remote Agent',
         description: 'Remote Agent Showcase',
-        owner_contact: { name: 'Owner User', email: 'owner@example.com' },
+        owner_contact: { name: 'Owner User' },
       },
     };
 
@@ -115,10 +115,8 @@ describe('Landing agent contact', () => {
     expect(screen.getByText('Portal Remote Agent')).toBeInTheDocument();
     expect(screen.getByText('Remote Agent Showcase')).toBeInTheDocument();
     expect(screen.getByText('Contact:')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Owner User' })).toHaveAttribute(
-      'href',
-      'mailto:owner@example.com',
-    );
+    expect(screen.getByText('Owner User')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Owner User' })).not.toBeInTheDocument();
   });
 
   it('does not show contact when the selected agent is missing from agentsMap', () => {

--- a/packages/api/src/agents/contact.spec.ts
+++ b/packages/api/src/agents/contact.spec.ts
@@ -57,6 +57,15 @@ describe('resolveAgentOwnerContact', () => {
     expect(result).toBeUndefined();
   });
 
+  it('skips emails with quoted local parts containing whitespace', () => {
+    const result = resolveAgentOwnerContact(
+      {},
+      { name: '"given family"@example.com', username: 'owner.user' },
+    );
+
+    expect(result).toEqual({ name: 'owner.user' });
+  });
+
   it('falls back to username for owner display name', () => {
     const result = resolveAgentOwnerContact({}, { username: 'owner.user' });
 

--- a/packages/api/src/agents/contact.spec.ts
+++ b/packages/api/src/agents/contact.spec.ts
@@ -39,6 +39,24 @@ describe('resolveAgentOwnerContact', () => {
     expect(result).not.toHaveProperty('email');
   });
 
+  it('skips email-shaped owner names from auth-strategy fallbacks', () => {
+    const result = resolveAgentOwnerContact(
+      {},
+      { name: 'owner.private@example.com', username: 'owner.user' },
+    );
+
+    expect(result).toEqual({ name: 'owner.user' });
+  });
+
+  it('omits owner contact when every display-name candidate is email-shaped', () => {
+    const result = resolveAgentOwnerContact(
+      { authorName: 'owner.private@example.com' },
+      { name: 'owner.private@example.com', username: 'owner.private@example.com' },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
   it('falls back to username for owner display name', () => {
     const result = resolveAgentOwnerContact({}, { username: 'owner.user' });
 

--- a/packages/api/src/agents/contact.spec.ts
+++ b/packages/api/src/agents/contact.spec.ts
@@ -1,10 +1,11 @@
+import type { AgentOwnerContactSource } from './contact';
 import { resolveAgentOwnerContact } from './contact';
 
 describe('resolveAgentOwnerContact', () => {
   it('omits owner fallback when support contact has a name', () => {
     const result = resolveAgentOwnerContact(
       { support_contact: { name: 'Support Team' } },
-      { name: 'Agent Owner', email: 'owner@example.com' },
+      { name: 'Agent Owner' },
     );
 
     expect(result).toBeUndefined();
@@ -13,19 +14,29 @@ describe('resolveAgentOwnerContact', () => {
   it('omits owner fallback when support contact has an email', () => {
     const result = resolveAgentOwnerContact(
       { support_contact: { email: 'support@example.com' } },
-      { name: 'Agent Owner', email: 'owner@example.com' },
+      { name: 'Agent Owner' },
     );
 
     expect(result).toBeUndefined();
   });
 
-  it('uses owner name and email when support contact is empty', () => {
+  it('uses owner name when support contact is empty', () => {
     const result = resolveAgentOwnerContact(
       { support_contact: { name: '  ', email: '' } },
-      { name: ' Agent Owner ', email: ' owner@example.com ' },
+      { name: ' Agent Owner ' },
     );
 
-    expect(result).toEqual({ name: 'Agent Owner', email: 'owner@example.com' });
+    expect(result).toEqual({ name: 'Agent Owner' });
+  });
+
+  it('never exposes an owner account email', () => {
+    const result = resolveAgentOwnerContact({}, {
+      name: 'Agent Owner',
+      email: 'owner.private@example.com',
+    } as AgentOwnerContactSource);
+
+    expect(result).toEqual({ name: 'Agent Owner' });
+    expect(result).not.toHaveProperty('email');
   });
 
   it('falls back to username for owner display name', () => {
@@ -35,12 +46,9 @@ describe('resolveAgentOwnerContact', () => {
   });
 
   it('falls back to authorName when owner has no display name', () => {
-    const result = resolveAgentOwnerContact(
-      { authorName: 'Legacy Author' },
-      { email: 'owner@example.com' },
-    );
+    const result = resolveAgentOwnerContact({ authorName: 'Legacy Author' }, { name: '' });
 
-    expect(result).toEqual({ name: 'Legacy Author', email: 'owner@example.com' });
+    expect(result).toEqual({ name: 'Legacy Author' });
   });
 
   it('omits owner contact when no owner can be resolved', () => {
@@ -49,11 +57,12 @@ describe('resolveAgentOwnerContact', () => {
     expect(result).toBeUndefined();
   });
 
-  it('omits owner contact when all candidate fields are empty', () => {
-    const result = resolveAgentOwnerContact(
-      { authorName: ' ' },
-      { name: '', username: ' ', email: '  ' },
-    );
+  it('omits owner contact when no display name is available', () => {
+    const result = resolveAgentOwnerContact({ authorName: ' ' }, {
+      name: '',
+      username: ' ',
+      email: 'owner.private@example.com',
+    } as AgentOwnerContactSource);
 
     expect(result).toBeUndefined();
   });

--- a/packages/api/src/agents/contact.ts
+++ b/packages/api/src/agents/contact.ts
@@ -13,8 +13,6 @@ export interface AgentOwnerContactSource {
   username?: string | null;
 }
 
-const EMAIL_LIKE = /^[^\s@]+@[^\s@]+$/;
-
 const normalizeContactValue = (value?: string | null): string | undefined => {
   if (typeof value !== 'string') {
     return undefined;
@@ -23,11 +21,12 @@ const normalizeContactValue = (value?: string | null): string | undefined => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
-/** Auth strategies fall back to the account email for name/username, so
- * email-shaped values must not be used as a public display name. */
+/** Auth strategies fall back to the account email for name/username, and legal
+ * email forms include quoted local parts with whitespace, so any '@'-containing
+ * value is treated as email-derived and never used as a public display name. */
 const normalizeDisplayName = (value?: string | null): string | undefined => {
   const normalized = normalizeContactValue(value);
-  if (normalized == null || EMAIL_LIKE.test(normalized)) {
+  if (normalized == null || normalized.includes('@')) {
     return undefined;
   }
   return normalized;

--- a/packages/api/src/agents/contact.ts
+++ b/packages/api/src/agents/contact.ts
@@ -11,7 +11,6 @@ export interface AgentContactSource {
 export interface AgentOwnerContactSource {
   name?: string | null;
   username?: string | null;
-  email?: string | null;
 }
 
 const normalizeContactValue = (value?: string | null): string | undefined => {
@@ -30,6 +29,11 @@ export const hasSupportContact = (agent: AgentContactSource): boolean => {
   return !!normalizeContactValue(support.name) || !!normalizeContactValue(support.email);
 };
 
+/**
+ * Resolves a display-only owner contact for agents without an explicit support contact.
+ * Never includes the owner's account email; emails are only exposed when the owner
+ * opts in by configuring `support_contact`.
+ */
 export function resolveAgentOwnerContact(
   agent: AgentContactSource,
   owner: AgentOwnerContactSource | null,
@@ -42,14 +46,10 @@ export function resolveAgentOwnerContact(
     normalizeContactValue(owner.name) ??
     normalizeContactValue(owner.username) ??
     normalizeContactValue(agent.authorName);
-  const email = normalizeContactValue(owner.email);
 
-  if (!name && !email) {
+  if (!name) {
     return undefined;
   }
 
-  return {
-    ...(name ? { name } : {}),
-    ...(email ? { email } : {}),
-  };
+  return { name };
 }

--- a/packages/api/src/agents/contact.ts
+++ b/packages/api/src/agents/contact.ts
@@ -13,12 +13,24 @@ export interface AgentOwnerContactSource {
   username?: string | null;
 }
 
+const EMAIL_LIKE = /^[^\s@]+@[^\s@]+$/;
+
 const normalizeContactValue = (value?: string | null): string | undefined => {
   if (typeof value !== 'string') {
     return undefined;
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+};
+
+/** Auth strategies fall back to the account email for name/username, so
+ * email-shaped values must not be used as a public display name. */
+const normalizeDisplayName = (value?: string | null): string | undefined => {
+  const normalized = normalizeContactValue(value);
+  if (normalized == null || EMAIL_LIKE.test(normalized)) {
+    return undefined;
+  }
+  return normalized;
 };
 
 export const hasSupportContact = (agent: AgentContactSource): boolean => {
@@ -31,8 +43,8 @@ export const hasSupportContact = (agent: AgentContactSource): boolean => {
 
 /**
  * Resolves a display-only owner contact for agents without an explicit support contact.
- * Never includes the owner's account email; emails are only exposed when the owner
- * opts in by configuring `support_contact`.
+ * Never includes the owner's account email, nor email-shaped display names; emails are
+ * only exposed when the owner opts in by configuring `support_contact`.
  */
 export function resolveAgentOwnerContact(
   agent: AgentContactSource,
@@ -43,9 +55,9 @@ export function resolveAgentOwnerContact(
   }
 
   const name =
-    normalizeContactValue(owner.name) ??
-    normalizeContactValue(owner.username) ??
-    normalizeContactValue(agent.authorName);
+    normalizeDisplayName(owner.name) ??
+    normalizeDisplayName(owner.username) ??
+    normalizeDisplayName(agent.authorName);
 
   if (!name) {
     return undefined;

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -211,7 +211,6 @@ export type SupportContact = {
 
 export type AgentOwnerContact = {
   name?: string;
-  email?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Resolves a validated security finding (medium): the agent owner-contact fallback added in #13663 leaked owner account emails to VIEW-level callers.

For agents without an explicit `support_contact`, `attachOwnerContacts` resolved the first ACL owner (or `agent.author`), queried the User collection with a `name username email` projection, and served `owner_contact.email` in both `GET /api/agents/:id` and `GET /api/agents` responses. Any authenticated user with VIEW access to a shared or public agent could read the owner's private account email, without the owner ever opting in.

This PR makes the owner fallback display-name only. Emails are now only served when the owner explicitly configures a `support_contact`. Defense in depth across three layers:

- `packages/api/src/agents/contact.ts`: `resolveAgentOwnerContact` resolves only a display name (owner name, then username, then legacy `authorName`) and returns `undefined` when none exists. `email` is removed from `AgentOwnerContactSource`.
- `api/server/services/Agents/ownerContact.js`: the User query projection drops `email`, so the private address never enters the response-building path. All `attachOwnerContacts` call sites (get, list, update, duplicate, revert, actions) flow through this.
- `packages/data-provider/src/types/assistants.ts` + `client/src/components/Agents/AgentContact.tsx`: the shared `AgentOwnerContact` type drops `email`, and the client renders the owner fallback as plain text with no mailto link, ignoring an `email` field even if a stale server still sends one.

`owner_contact` is computed at response time and never persisted, so no stored data is affected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest src/agents/contact.spec.ts`: 8 tests pass, including a new case asserting an owner email fed into the resolver never appears in the output.
- `cd api && npx jest server/controllers/agents/v1.spec.js --runInBand`: all 87 tests pass; owner-contact expectations now assert name-only responses and `not.toHaveProperty('email')` (real in-memory MongoDB, no mocked DB).
- `cd client && npx jest AgentContact.spec AgentCard.spec AgentDetailContent.spec Landing.agent-contact`: 25 tests pass; owner fallback renders a plain name without a mailto link.
- `cd client && npx tsc --noEmit`: clean after the shared type change.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
