### PR TITLE
fix(speech): connect conversation mode, skip silent recordings

### DIFF
--- a/client/src/components/Chat/Input/AudioRecorder.tsx
+++ b/client/src/components/Chat/Input/AudioRecorder.tsx
@@ -1,22 +1,31 @@
-import { memo, useCallback, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { MicOff } from 'lucide-react';
+import { useRecoilValue } from 'recoil';
 import { useToastContext, TooltipAnchor, ListeningIcon, Spinner } from '@librechat/client';
 import { useLocalize, useSpeechToText, useGetAudioSettings } from '~/hooks';
 import { globalAudioId, type TAskFunction } from '~/common';
 import { useChatFormContext } from '~/Providers';
 import { cn } from '~/utils';
+import store from '~/store';
 
 const isExternalSTT = (speechToTextEndpoint: string) => speechToTextEndpoint === 'external';
+
+/** Pause between the assistant finishing and the microphone re-arming in
+ * conversation mode. Long enough for playback to settle and for the user to
+ * register that it is their turn; short enough not to feel broken. */
+const REARM_DELAY_MS = 2000;
 export default memo(function AudioRecorder({
   disabled,
   ask,
   methods,
   isSubmitting,
+  index = 0,
 }: {
   disabled: boolean;
   ask: TAskFunction;
   methods: ReturnType<typeof useChatFormContext>;
   isSubmitting: boolean;
+  index?: number;
 }) {
   const { setValue, reset, getValues } = methods;
   const localize = useLocalize();
@@ -26,6 +35,24 @@ export default memo(function AudioRecorder({
   const existingTextRef = useRef<string>('');
   const isSubmittingRef = useRef(isSubmitting);
   isSubmittingRef.current = isSubmitting;
+
+  /** Conversation mode: re-arm the microphone once the assistant stops speaking.
+   *
+   * Only when the turn was started by voice - typing a message and then
+   * listening to the reply should not silently switch the microphone on. */
+  const conversationMode = useRecoilValue(store.conversationMode);
+  const isPlaying = useRecoilValue(store.globalAudioPlayingFamily(index));
+  const textToSpeech = useRecoilValue(store.textToSpeech);
+  const automaticPlayback = useRecoilValue(store.automaticPlayback);
+  const voiceTurnRef = useRef(false);
+  const wasPlayingRef = useRef(false);
+  const wasSubmittingRef = useRef(false);
+
+  /** Whether the assistant is going to speak this reply. Determines WHICH
+   * event ends the assistant's turn: playback finishing, or generation
+   * finishing. Without automatic playback there is no audio to wait for, so
+   * waiting for it would mean never re-arming at all. */
+  const willSpeak = textToSpeech && automaticPlayback;
 
   const onTranscriptionComplete = useCallback(
     (text: string) => {
@@ -51,6 +78,9 @@ export default memo(function AudioRecorder({
         if (submitted === false) {
           return;
         }
+        /** This turn began with speech, so conversation mode may re-arm the
+         * microphone when the reply finishes playing. */
+        voiceTurnRef.current = true;
         reset({ text: '' });
         existingTextRef.current = '';
       }
@@ -79,6 +109,61 @@ export default memo(function AudioRecorder({
     setText,
     onTranscriptionComplete,
   );
+
+  /** Re-arm the microphone when the assistant finishes speaking.
+   *
+   * Gated on all three of:
+   *   - the Conversation mode toggle being on (Settings -> Speech)
+   *   - the turn having been started by voice, not typed
+   *   - playback having actually transitioned from playing to stopped
+   *
+   * The transition matters: this atom is false before playback begins as well
+   * as after it ends, so acting on the value alone would start recording the
+   * moment the component mounts. */
+  useEffect(() => {
+    const stoppedPlaying = wasPlayingRef.current && !isPlaying;
+    const stoppedGenerating = wasSubmittingRef.current && !isSubmitting;
+    wasPlayingRef.current = isPlaying;
+    wasSubmittingRef.current = isSubmitting;
+
+    /** The assistant's turn ends when it stops SPEAKING if it speaks, and when
+     * it stops WRITING if it does not. Supporting only the first means voice
+     * input with a text-only reply never re-arms - a perfectly reasonable way
+     * to use this, and quieter than being spoken to. */
+    const turnEnded = willSpeak ? stoppedPlaying : stoppedGenerating;
+
+    if (!conversationMode || !turnEnded) {
+      return;
+    }
+    if (!voiceTurnRef.current) {
+      return;
+    }
+    voiceTurnRef.current = false;
+
+    /** Wait before listening again. After speech this stops the microphone
+     * catching the tail of the assistant's own audio and the room's reverb,
+     * which gets transcribed as something the user never said. After a written
+     * reply there is no audio to avoid, but the pause still gives the user a
+     * moment to read before being listened to. */
+    const timer = setTimeout(() => {
+      if (disabled || isSubmittingRef.current || isListening === true) {
+        return;
+      }
+      existingTextRef.current = getValues('text') || '';
+      startRecording();
+    }, REARM_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [
+    isPlaying,
+    isSubmitting,
+    willSpeak,
+    conversationMode,
+    disabled,
+    isListening,
+    startRecording,
+    getValues,
+  ]);
 
   const handleStartRecording = async () => {
     existingTextRef.current = getValues('text') || '';

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -659,6 +659,7 @@ const ChatForm = memo(function ChatForm({
                     ask={submitMessage}
                     disabled={disableInputs || isNotAppendable}
                     isSubmitting={isSubmitting}
+                    index={index}
                   />
                 )}
                 <div className={`${isRTL ? 'ml-2' : 'mr-2'}`}>

--- a/client/src/hooks/Input/useSpeechToTextExternal.ts
+++ b/client/src/hooks/Input/useSpeechToTextExternal.ts
@@ -5,6 +5,16 @@ import { useSpeechToTextMutation } from '~/data-provider';
 import useGetAudioSettings from './useGetAudioSettings';
 import store from '~/store';
 
+/** How long to wait for the user to START speaking before giving up. Generous:
+ * in conversation mode the microphone opens by itself and the user may still
+ * be thinking. Closing early here looks like the microphone is broken. */
+const INITIAL_SILENCE_MS = 15000;
+
+/** How long a pause must last, once speech has begun, before the utterance is
+ * treated as finished. Felt on every single turn, so it stays short - but not
+ * so short that a breath mid-sentence submits half a thought. */
+const TRAILING_SILENCE_MS = 3000;
+
 const useSpeechToTextExternal = (
   setText: (text: string) => void,
   onTranscriptionComplete: (text: string) => void,
@@ -18,6 +28,11 @@ const useSpeechToTextExternal = (
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
 
   const audioChunksRef = useRef<Blob[]>([]);
+  /** Whether any sound crossed minDecibels during this recording, and whether
+   * the silence monitor ran at all. Together they let handleStop discard a
+   * recording that captured nothing but room tone. */
+  const soundDetectedRef = useRef(false);
+  const silenceMonitorRanRef = useRef(false);
   const [permission, setPermission] = useState(false);
   const [isListening, setIsListening] = useState(false);
   const [isRequestBeingMade, setIsRequestBeingMade] = useState(false);
@@ -110,6 +125,23 @@ const useSpeechToTextExternal = (
   };
 
   const handleStop = () => {
+    /** Discard a recording in which no sound ever crossed the threshold.
+     *
+     * Silence is not harmless: Whisper hallucinates confident phrases from
+     * near-silent audio - "Thank you." is the classic one - so submitting it
+     * produces a real-looking message the user never said. With conversation
+     * mode on, that reply is spoken aloud, the microphone re-arms, and it
+     * loops indefinitely.
+     *
+     * Applied only when the silence monitor actually ran (autoTranscribeAudio).
+     * A manual stop has no sound history to judge by, and pressing stop is
+     * explicit intent to submit whatever was captured. */
+    if (silenceMonitorRanRef.current && !soundDetectedRef.current) {
+      audioChunksRef.current = [];
+      cleanup();
+      return;
+    }
+
     if (audioChunksRef.current.length > 0) {
       const audioBlob = new Blob(audioChunksRef.current, { type: audioMimeType });
       const fileExtension = getFileExtension(audioMimeType);
@@ -139,6 +171,8 @@ const useSpeechToTextExternal = (
     const bufferLength = analyser.frequencyBinCount;
     const domainData = new Uint8Array(bufferLength);
     let lastSoundTime = Date.now();
+    silenceMonitorRanRef.current = true;
+    soundDetectedRef.current = false;
 
     const detectSound = () => {
       analyser.getByteFrequencyData(domainData);
@@ -146,12 +180,26 @@ const useSpeechToTextExternal = (
 
       if (isSoundDetected) {
         lastSoundTime = Date.now();
+        soundDetectedRef.current = true;
       }
 
+      /** Two different questions, two different timeouts.
+       *
+       * Before any speech: "is the user going to say anything?" - which needs
+       * to be patient, especially in conversation mode where the microphone
+       * opened on its own and the user is still deciding what to say.
+       *
+       * After speech has started: "has the user finished?" - which should be
+       * short, because that delay is felt on every single utterance.
+       *
+       * A single threshold cannot serve both. Using the trailing value for
+       * both is what made the microphone close before the user began. */
       const timeSinceLastSound = Date.now() - lastSoundTime;
-      const isOverSilenceThreshold = timeSinceLastSound > 3000;
+      const threshold = soundDetectedRef.current
+        ? TRAILING_SILENCE_MS
+        : INITIAL_SILENCE_MS;
 
-      if (isOverSilenceThreshold) {
+      if (timeSinceLastSound > threshold) {
         stopRecording();
         return;
       }
@@ -175,6 +223,10 @@ const useSpeechToTextExternal = (
     if (audioStream.current) {
       try {
         audioChunksRef.current = [];
+        /** Reset per recording. monitorSilence sets these when it runs; leaving
+         * them stale would let one recording's result decide the next one. */
+        soundDetectedRef.current = false;
+        silenceMonitorRanRef.current = false;
         const bestMimeType = getBestSupportedMimeType();
         setAudioMimeType(bestMimeType);
 


### PR DESCRIPTION
Fixes #14543

Completes hands-free voice conversation. The groundwork was already there —
`conversationMode` and its UI, the silence monitor, `globalAudioPlayingFamily`
tracking playback for both TTS engines. This connects them and closes three
gaps.

Based on v0.8.7. Typechecks clean, builds clean. No new dependencies, no new
Recoil atoms, no server changes.

### 1. Re-arm the mic when the assistant's turn ends

`AudioRecorder` now starts recording again, gated on three conditions:

- `conversationMode` is on
- **the turn began with speech** — set only in `onTranscriptionComplete`, so
  typing a message and hearing the reply never opens the mic unexpectedly
- playback transitioned **playing → stopped**

The edge matters: `globalAudioPlayingFamily` is `false` both before playback
starts and after it ends, so watching the value would record on mount.

Hooked there rather than in the TTS hooks because both engines already drive it,
so one hook point covers both. `index` is threaded from `ChatForm` (which
already has it); optional with a default of `0` to keep existing call sites
valid — happy to make it required.

### 2. Skip recordings with no speech

`handleStop` submits whenever there's ≥1 chunk, and silence produces chunks, so
"The audio was too short" is rarely reached. `monitorSilence` already computes
`isSoundDetected` against `minDecibels`; this carries it through so `handleStop`
can skip a recording where sound never crossed the threshold.

Narrow by design: only when the silence monitor ran (`autoTranscribeAudio`). A
manual stop has no sound history, and pressing stop is intent to submit.

Useful independently of conversation mode, for anyone using auto-transcribe.

### 3. Separate start/end silence thresholds

One 3 s value served both "will the user start?" (wants patience) and "has the
user finished?" (felt every turn, wants to be short). Split into
`INITIAL_SILENCE_MS = 15000` and `TRAILING_SILENCE_MS = 3000`.

### Plus

**Written replies end the turn too.** With TTS or automatic playback off there's
no audio event, so the trigger switches:

```
willSpeak = textToSpeech && automaticPlayback
  willSpeak  -> re-arm when PLAYBACK ends
  !willSpeak -> re-arm when GENERATION ends
```

**A 2 s pause before re-arming** (`REARM_DELAY_MS`), so the mic doesn't catch
the tail of the assistant's own audio.

### Questions

- **Constants or settings?** The three timings are module constants; they'd sit
  naturally in Settings → Speech beside `autoSendText`. Glad to move them, just
  didn't want to add settings UI unprompted.
- **Browser STT** doesn't need changes 2 and 3 (Web Speech API does its own
  endpoint detection). Change 1 covers both engines.
- **Scope** — change 2 stands alone if you'd rather take it separately.

### Testing

Against an OpenAI-compatible speech backend:

- conversation mode off → unchanged, mic never self-arms
- typed message + spoken reply → mic does **not** arm
- spoken message → reply plays → 2 s → mic re-arms
- playback off → reply written → 2 s → mic re-arms
- mic open, no speech → closes after 15 s, submits nothing
- speaking then pausing → submits ~3 s after the last word
- previously a quiet room produced `"Thank you."` and looped; now nothing

Reproduces on device speakers, not headphones — playback has to reach the mic.

```
AudioRecorder.tsx            +87 -1
ChatForm.tsx                  +1
useSpeechToTextExternal.ts   +56 -3
```

Happy to rework any of this.
