### PR TITLE
feat(agents): restore provider reasoning across runs

### DIFF
--- a/api/server/controllers/agents/__tests__/reasoningReplay.integration.spec.js
+++ b/api/server/controllers/agents/__tests__/reasoningReplay.integration.spec.js
@@ -1,0 +1,383 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { ChatGenerationChunk } = require('@langchain/core/outputs');
+const { AIMessageChunk, HumanMessage } = require('@langchain/core/messages');
+const { createModels, createMethods } = require('@librechat/data-schemas');
+const {
+  Run,
+  Providers,
+  GraphEvents,
+  FakeChatModel,
+  createContentAggregator,
+  formatAgentMessages,
+} = require('@librechat/agents');
+
+const USER_ID = new mongoose.Types.ObjectId().toString();
+const TOKEN_COUNT = 777;
+
+const fixtures = {
+  anthropic: {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-sonnet-5',
+    secret: 'anthropic-signed-thinking',
+    chunks: [
+      new AIMessageChunk({
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'Anthropic summary.',
+            signature: 'anthropic-signed-thinking',
+          },
+        ],
+      }),
+      new AIMessageChunk({ content: 'Anthropic answer.' }),
+    ],
+  },
+  bedrock: {
+    provider: Providers.BEDROCK,
+    model: 'global.anthropic.claude-sonnet-5-v1:0',
+    secret: 'bedrock-signed-thinking',
+    chunks: [
+      new AIMessageChunk({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: {
+              text: 'Bedrock summary.',
+              signature: 'bedrock-signed-thinking',
+            },
+          },
+        ],
+      }),
+      new AIMessageChunk({ content: 'Bedrock answer.' }),
+    ],
+  },
+  openai: {
+    provider: Providers.OPENAI,
+    model: 'gpt-5.6-terra',
+    useResponsesApi: true,
+    secret: 'openai-encrypted-reasoning',
+    chunks: [
+      new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          reasoning: { summary: [{ text: 'OpenAI summary.' }] },
+        },
+      }),
+      new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          openai_responses_reasoning_replay: [
+            {
+              type: 'reasoning',
+              id: 'rs_openai',
+              status: 'completed',
+              summary: [{ type: 'summary_text', text: 'OpenAI summary.' }],
+              encrypted_content: 'openai-encrypted-reasoning',
+            },
+          ],
+        },
+      }),
+      new AIMessageChunk({ content: 'OpenAI answer.' }),
+    ],
+  },
+  azure: {
+    provider: Providers.AZURE,
+    model: 'gpt-5.6-terra',
+    useResponsesApi: true,
+    secret: 'azure-encrypted-reasoning',
+    chunks: [
+      new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          reasoning: { summary: [{ text: 'Azure summary.' }] },
+        },
+      }),
+      new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          openai_responses_reasoning_replay: [
+            {
+              type: 'reasoning',
+              id: 'rs_azure',
+              status: 'completed',
+              summary: [{ type: 'summary_text', text: 'Azure summary.' }],
+              encrypted_content: 'azure-encrypted-reasoning',
+            },
+          ],
+        },
+      }),
+      new AIMessageChunk({ content: 'Azure answer.' }),
+    ],
+  },
+};
+
+const withinProviderSwitches = [
+  {
+    name: 'anthropic',
+    kind: 'model',
+    target: { provider: Providers.ANTHROPIC, model: 'claude-opus-5' },
+  },
+  {
+    name: 'bedrock',
+    kind: 'model',
+    target: {
+      provider: Providers.BEDROCK,
+      model: 'global.anthropic.claude-opus-5-v1:0',
+    },
+  },
+  {
+    name: 'openai',
+    kind: 'model',
+    target: { provider: Providers.OPENAI, model: 'gpt-5.5', useResponsesApi: true },
+  },
+  {
+    name: 'azure',
+    kind: 'model',
+    target: { provider: Providers.AZURE, model: 'gpt-5.5', useResponsesApi: true },
+  },
+  {
+    name: 'openai',
+    kind: 'Responses-to-Chat API',
+    target: { provider: Providers.OPENAI, model: 'gpt-5.6-terra', useResponsesApi: false },
+  },
+  {
+    name: 'azure',
+    kind: 'Responses-to-Chat API',
+    target: { provider: Providers.AZURE, model: 'gpt-5.6-terra', useResponsesApi: false },
+  },
+];
+
+const crossProviderSwitches = Object.entries(fixtures).flatMap(([name, fixture]) =>
+  Object.entries(fixtures)
+    .filter(([, target]) => target.provider !== fixture.provider)
+    .map(([targetName, target]) => ({
+      name,
+      kind: `provider (${name} to ${targetName})`,
+      target,
+    })),
+);
+
+class ProviderResponseModel extends FakeChatModel {
+  constructor(chunks) {
+    super({ responses: [''] });
+    this.chunks = chunks;
+  }
+
+  async *_streamResponseChunks(_messages, _options, runManager) {
+    for (const chunk of this.chunks) {
+      const text = typeof chunk.content === 'string' ? chunk.content : '';
+      yield new ChatGenerationChunk({ text, message: chunk });
+      void runManager?.handleLLMNewToken(text);
+    }
+  }
+}
+
+function createAggregationHandlers(aggregateContent) {
+  return Object.fromEntries(
+    [GraphEvents.ON_RUN_STEP, GraphEvents.ON_MESSAGE_DELTA, GraphEvents.ON_REASONING_DELTA].map(
+      (event) => [
+        event,
+        {
+          handle: (receivedEvent, data) => aggregateContent({ event: receivedEvent, data }),
+        },
+      ],
+    ),
+  );
+}
+
+function containsSecret(value, secret) {
+  return JSON.stringify(value).includes(secret);
+}
+
+describe('reasoning replay across the MongoDB boundary', () => {
+  jest.setTimeout(60000);
+
+  let mongoServer;
+  let methods;
+  let modelNames;
+  let mixedConversationId;
+  const persisted = {};
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    const models = createModels(mongoose);
+    modelNames = Object.keys(models);
+    Object.assign(mongoose.models, models);
+    methods = createMethods(mongoose);
+
+    for (const [name, fixture] of Object.entries(fixtures)) {
+      persisted[name] = await capturePersistAndReload(name, fixture);
+    }
+    mixedConversationId = await persistMixedProviderConversation();
+  });
+
+  afterAll(async () => {
+    for (const collection of Object.values(mongoose.connection.collections)) {
+      await collection.deleteMany({});
+    }
+    for (const modelName of modelNames ?? []) {
+      delete mongoose.models[modelName];
+    }
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoServer?.stop();
+  });
+
+  async function capturePersistAndReload(name, fixture) {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create({
+      runId: `reasoning-replay-${name}`,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: fixture.provider,
+          model: fixture.model,
+          streamUsage: false,
+          ...(fixture.useResponsesApi != null && {
+            useResponsesApi: fixture.useResponsesApi,
+          }),
+        },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createAggregationHandlers(aggregateContent),
+    });
+
+    run.Graph.overrideModel = new ProviderResponseModel(fixture.chunks);
+    await run.processStream(
+      { messages: [new HumanMessage(`mock ${name} request`)] },
+      {
+        configurable: { thread_id: `reasoning-replay-${name}` },
+        streamMode: 'values',
+        version: 'v2',
+      },
+    );
+
+    expect(containsSecret(contentParts, fixture.secret)).toBe(true);
+
+    const conversationId = uuidv4();
+    const messageId = uuidv4();
+    await methods.saveMessage(
+      { userId: USER_ID },
+      {
+        messageId,
+        conversationId,
+        parentMessageId: uuidv4(),
+        isCreatedByUser: false,
+        sender: 'Agent',
+        endpoint: 'agents',
+        model: 'mock-agent',
+        text: '',
+        content: contentParts,
+        tokenCount: TOKEN_COUNT,
+      },
+    );
+
+    const messages = await methods.getMessages({ user: USER_ID, conversationId });
+    expect(messages).toHaveLength(1);
+    expect(containsSecret(messages[0].content, fixture.secret)).toBe(true);
+    return { conversationId, messageId, content: messages[0].content };
+  }
+
+  async function reloadPayload(name) {
+    const { conversationId } = persisted[name];
+    const messages = await methods.getMessages({ user: USER_ID, conversationId });
+    return messages.map((message) => ({
+      role: message.isCreatedByUser ? 'user' : 'assistant',
+      messageId: message.messageId,
+      text: message.text,
+      content: message.content,
+    }));
+  }
+
+  async function persistMixedProviderConversation() {
+    const conversationId = uuidv4();
+    let parentMessageId = uuidv4();
+    for (const [index, [name, fixture]] of Object.entries(fixtures).entries()) {
+      const messageId = uuidv4();
+      await methods.saveMessage(
+        { userId: USER_ID },
+        {
+          messageId,
+          conversationId,
+          parentMessageId,
+          isCreatedByUser: false,
+          sender: 'Agent',
+          endpoint: fixture.provider,
+          model: fixture.model,
+          text: '',
+          content: persisted[name].content,
+          tokenCount: TOKEN_COUNT,
+          createdAt: new Date(Date.now() + index * 1000),
+        },
+      );
+      parentMessageId = messageId;
+    }
+    return conversationId;
+  }
+
+  function format(payload, target) {
+    return formatAgentMessages(payload, { 0: TOKEN_COUNT }, undefined, undefined, target);
+  }
+
+  test.each(Object.entries(fixtures))(
+    'replays %s reasoning after persistence for the same endpoint and model',
+    async (name, fixture) => {
+      const payload = await reloadPayload(name);
+      const result = format(payload, fixture);
+
+      expect(containsSecret(result.messages, fixture.secret)).toBe(true);
+      expect(result.indexTokenCountMap).toEqual({ 0: TOKEN_COUNT });
+    },
+  );
+
+  test.each([...withinProviderSwitches, ...crossProviderSwitches])(
+    'strips $name replay on a $kind switch and restores it when switching back',
+    async ({ name, target }) => {
+      const fixture = fixtures[name];
+      const switchedPayload = await reloadPayload(name);
+      const switched = format(switchedPayload, target);
+
+      expect(containsSecret(switched.messages, fixture.secret)).toBe(false);
+      expect(switched.indexTokenCountMap).toEqual({});
+
+      const restoredPayload = await reloadPayload(name);
+      const restored = format(restoredPayload, fixture);
+      expect(containsSecret(restored.messages, fixture.secret)).toBe(true);
+      expect(restored.indexTokenCountMap).toEqual({ 0: TOKEN_COUNT });
+
+      const storedAgain = await reloadPayload(name);
+      expect(containsSecret(storedAgain, fixture.secret)).toBe(true);
+    },
+  );
+
+  test('selects only compatible replay from a mixed-provider conversation reloaded from MongoDB', async () => {
+    const mixedMessages = await methods.getMessages({
+      user: USER_ID,
+      conversationId: mixedConversationId,
+    });
+    expect(mixedMessages).toHaveLength(Object.keys(fixtures).length);
+    const payload = mixedMessages.map((message) => ({
+      role: 'assistant',
+      messageId: message.messageId,
+      text: message.text,
+      content: message.content,
+    }));
+    const tokenMap = {};
+    for (const index of payload.keys()) {
+      tokenMap[index] = TOKEN_COUNT;
+    }
+
+    for (const [activeName, activeFixture] of Object.entries(fixtures)) {
+      const result = formatAgentMessages(payload, tokenMap, undefined, undefined, activeFixture);
+      for (const [name, fixture] of Object.entries(fixtures)) {
+        expect(containsSecret(result.messages, fixture.secret)).toBe(name === activeName);
+      }
+      expect(Object.values(result.indexTokenCountMap)).toEqual([TOKEN_COUNT]);
+    }
+  });
+});

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -315,6 +315,28 @@ describe('createResponse controller', () => {
     };
   });
 
+  it('passes the initialized provider, model, and API mode when formatting history', async () => {
+    const { formatAgentMessages } = require('@librechat/agents');
+    const { initializeAgent } = require('@librechat/api');
+    initializeAgent.mockResolvedValueOnce({
+      id: 'agent-123',
+      provider: 'openAI',
+      model: 'gpt-5.6-terra',
+      model_parameters: { useResponsesApi: true },
+      toolRegistry: {},
+      edges: [],
+      agentContextAttachments: [],
+    });
+
+    await createResponse(req, res);
+
+    expect(formatAgentMessages.mock.calls[0][4]).toEqual({
+      provider: 'openAI',
+      model: 'gpt-5.6-terra',
+      useResponsesApi: true,
+    });
+  });
+
   describe('conversation ownership validation', () => {
     it('should skip ownership check when previous_response_id is not provided', async () => {
       const { getConvo } = require('~/models');

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1658,15 +1658,13 @@ class AgentClient extends BaseClient {
         manualSkillPrimes,
         alwaysApplySkillPrimes,
       });
-      const formatOptions =
-        needsReasoningContentFormat || freshSkillPrimeNames.size > 0
-          ? {
-              ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
-              ...(freshSkillPrimeNames.size > 0
-                ? { skipSkillBodyNames: freshSkillPrimeNames }
-                : {}),
-            }
-          : undefined;
+      const formatOptions = {
+        provider: this.options.agent.provider,
+        model: this.options.agent.model_parameters?.model,
+        useResponsesApi: this.options.agent.model_parameters?.useResponsesApi === true,
+        ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
+        ...(freshSkillPrimeNames.size > 0 ? { skipSkillBodyNames: freshSkillPrimeNames } : {}),
+      };
       let {
         messages: initialMessages,
         indexTokenCountMap,

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -168,6 +168,11 @@ describe('AgentClient - startup telemetry', () => {
     expect(startupTelemetry.mark.mock.calls.map(([milestone]) => milestone)).toEqual([
       'run_input_prepared',
     ]);
+    expect(mockFormatAgentMessages.mock.calls[0][4]).toEqual({
+      provider: EModelEndpoint.openAI,
+      model: 'gpt-4',
+      useResponsesApi: false,
+    });
     expect(processStream).not.toHaveBeenCalled();
 
     runCreation.resolve(run);

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -629,7 +629,11 @@ const createResponse = async (req, res) => {
     const allMessages = [...previousMessages, ...inputMessages];
 
     const toolSet = buildToolSet(primaryConfig);
-    const formatted = formatAgentMessages(allMessages, {}, toolSet);
+    const formatted = formatAgentMessages(allMessages, {}, toolSet, undefined, {
+      provider: primaryConfig.provider,
+      model: primaryConfig.model || agent.model_parameters?.model,
+      useResponsesApi: primaryConfig.model_parameters?.useResponsesApi === true,
+    });
     const formattedMessages = formatted.messages;
     const initialSummary = formatted.summary;
     let indexTokenCountMap = formatted.indexTokenCountMap;

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1207,6 +1207,58 @@ async function callAndCaptureRunConfig({
   return createMock.mock.calls[0][0] as Record<string, unknown>;
 }
 
+function getPrimaryLLMConfig(runConfig: Record<string, unknown>): Record<string, unknown> {
+  const graphConfig = runConfig.graphConfig as { agents: Array<{ clientOptions: unknown }> };
+  return graphConfig.agents[0].clientOptions as Record<string, unknown>;
+}
+
+describe('OpenAI Responses prompt cache key', () => {
+  it.each(['openAI', 'azureOpenAI'])(
+    'defaults %s Responses requests to the stable agent id',
+    async (provider) => {
+      const runConfig = await callAndCaptureRunConfig({
+        overrides: {
+          provider,
+          endpoint: provider,
+          model_parameters: { model: 'gpt-5.6-terra', useResponsesApi: true },
+        },
+      });
+
+      expect(getPrimaryLLMConfig(runConfig).promptCacheKey).toBe('agent_1');
+    },
+  );
+
+  it('preserves an explicit prompt cache key', async () => {
+    const runConfig = await callAndCaptureRunConfig({
+      overrides: {
+        model_parameters: {
+          model: 'gpt-5.6-terra',
+          useResponsesApi: true,
+          promptCacheKey: 'conversation-specific-key',
+        },
+      },
+    });
+
+    expect(getPrimaryLLMConfig(runConfig).promptCacheKey).toBe('conversation-specific-key');
+  });
+
+  it.each([
+    ['OpenAI Chat Completions', 'openAI', { model: 'gpt-5.6-terra' }],
+    ['Anthropic Messages', 'anthropic', { model: 'claude-sonnet-5' }],
+    ['Bedrock', 'bedrock', { model: 'global.anthropic.claude-sonnet-5-v1:0' }],
+  ])('does not add a key for %s', async (_name, provider, modelParameters) => {
+    const runConfig = await callAndCaptureRunConfig({
+      overrides: {
+        provider,
+        endpoint: provider,
+        model_parameters: modelParameters,
+      },
+    });
+
+    expect(getPrimaryLLMConfig(runConfig).promptCacheKey).toBeUndefined();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Suite: Langfuse run config
 // ---------------------------------------------------------------------------

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1170,6 +1170,15 @@ export async function createRun({
       },
       modelParameters,
     ) as t.RunLLMConfig;
+    if (
+      (provider === Providers.OPENAI || provider === Providers.AZURE) &&
+      (llmConfig as OpenAIClientOptions).useResponsesApi === true &&
+      typeof agent.id === 'string' &&
+      agent.id !== '' &&
+      (llmConfig as OpenAIClientOptions).promptCacheKey == null
+    ) {
+      (llmConfig as OpenAIClientOptions).promptCacheKey = agent.id;
+    }
 
     const joinInstructionMap = (map?: Record<string, unknown>) =>
       Object.values(map ?? {})


### PR DESCRIPTION
## Summary

Restore provider-native reasoning from persisted agent messages and pass provider, model, and API context so replay is accepted only for compatible runs. Add a stable cache-routing key for OpenAI/Azure Responses.

Cache reads and writes will increase because more prior reasoning is retained in the prompt. In exchange, generated output tokens and the number of turns needed to finish a task may decrease: later turns can reuse prior knowledge and decisions instead of exploring them again. The measurements below come from a local toy conversation. They demonstrate persistence and cache reuse, but we still need measurements from representative real workloads to quantify the effect on quality, task length, latency, and total cost.

Depends on [danny-avila/agents#371](https://github.com/danny-avila/agents/pull/371).

## Cache and cost impact

Reasoning replay preserves more context, so higher cache writes and reads are expected. A reasoning block is new suffix content when it first enters the next request: it is written once, then becomes a cache read on later turns.

Five-turn advancing local validation used independently keyed replay and stripped-control conversations with identical prompts and visible history:

| Provider/API | Cache writes: stripped → replay | Cache reads: stripped → replay |
|---|---:|---:|
| OpenAI Responses, GPT-5.6 Terra | 3,127 → 4,241 (**+1,114**) | 11,750 → 13,654 (**+1,904**) |
| Bedrock Mantle Responses, GPT-5.6 Terra | 3,131 → 4,192 (**+1,061**) | 11,761 → 13,585 (**+1,824**) |
| Anthropic Messages, Claude Sonnet 5 | 5,853 → 8,686 (**+2,833**) | 22,182 → 27,164 (**+4,982**) |
| Bedrock Converse, Claude Sonnet 5 | 5,832 → 8,831 (**+2,999**) | 22,282 → 27,544 (**+5,262**) |

The Bedrock Sonnet 5 run also measured billable output and total cost at the current promotional rates:

| Conversation length | Total cost: stripped → replay | Output tokens: stripped → replay |
|---|---:|---:|
| Five turns | $0.08356 → $0.08428 (**+0.9%**) | 5,576 → 4,343 (**-1,233**) |
| Six turns, after MongoDB/process boundary | $0.09733 → $0.09248 (**-5.0%**) | 6,791 → 4,490 (**-2,301**) |

In this toy example, the reduction in generated output more than offset the additional cached-input cost after six turns. Output is model-dependent, so this is not evidence of a general saving; representative real workloads must determine whether shorter outputs and tasks consistently compensate for the larger cached prompt.

The boundary run loaded five signed reasoning blocks from MongoDB in a second LibreChat process. Its next cache-read increase exactly matched the prior **+2,999** replay-write delta, confirming that persisted reasoning was reused after restart.

Pricing calculation: $2/M uncached input, $4/M one-hour cache writes, $0.20/M cache reads, and $10/M output under [Claude Sonnet 5 promotional pricing](https://aws.amazon.com/bedrock/pricing/) through August 31, 2026. Billable output includes the model's full thinking tokens, not only the visible summary.

## Change Type

- [x] New feature

## Testing

- 106 controller tests passed.
- 121 package tests passed.
- 23 MongoDB replay and provider/model switching integration cases passed.
- 6 reusable cache-harness tests passed.
- Five advancing live turns passed across OpenAI direct, Bedrock Mantle/OpenAI, Anthropic direct, and Bedrock Claude.
- A sixth Bedrock Claude turn passed through a second LibreChat process with retained MongoDB.
