### PR TITLE
📦 chore: bump `@librechat/agents` to v3.3.9

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.8",
+    "@librechat/agents": "^3.3.9",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.8",
+        "@librechat/agents": "^3.3.9",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10247,13 +10247,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.7.tgz",
-      "integrity": "sha512-2tcyf3QGC7v89kqSxMCtRvzg/3L/4yHtOaWC49A8KieCciWJs7LGaxHoPB6QRxXyUgyR+Zg9Q1ss/XJIE+JuSQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
+      "integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.25",
+        "@langchain/langgraph-sdk": "~1.9.26",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -10340,9 +10340,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.25",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.25.tgz",
-      "integrity": "sha512-mRKW8zyQUaHox+HirRFMRrPqOvNbQI3xeXDt6kkk4PbBg77V92bsO1WzUVNrmJ81zCkvxyOrWSK8D6ioCj0a8A==",
+      "version": "1.9.28",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
+      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
       "license": "MIT",
       "dependencies": {
         "@langchain/protocol": "^0.0.18",
@@ -10373,9 +10373,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -10615,9 +10615,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.8.tgz",
-      "integrity": "sha512-SpEKK4JsInpIggQNdiTzm+4VgBJRYVasDlJixsP7M+ahK48VzYvLIfkMPITKk2WZJ65RGkJqVnz6RmRLHIQhTA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.9.tgz",
+      "integrity": "sha512-4PJZR/jV8iS2PpLQZHxVw/PeNrkNBKgRaM1sKRhiV/72iofu4Ofm1wdaVZh0wlJ29mxkMyXxJGzsog+GflYsOA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -10630,17 +10630,17 @@
         "@langchain/google-gauth": "2.2.0",
         "@langchain/google-genai": "2.2.0",
         "@langchain/google-vertexai": "2.2.0",
-        "@langchain/langgraph": "^1.4.6",
+        "@langchain/langgraph": "1.4.8",
         "@langchain/mistralai": "^1.2.0",
         "@langchain/openai": "1.5.5",
         "@langchain/textsplitters": "^1.0.1",
         "@langchain/xai": "^1.4.3",
+        "@langfuse/core": "^5.4.1",
         "@langfuse/langchain": "^5.4.1",
         "@langfuse/otel": "^5.4.1",
         "@langfuse/tracing": "^5.4.1",
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/sdk-node": "^0.220.0",
-        "@scarf/scarf": "^1.4.0",
         "@types/diff": "^7.0.2",
         "ai-tokenizer": "^1.0.6",
         "axios": "^1.18.1",
@@ -10652,6 +10652,7 @@
         "nanoid": "^3.3.7",
         "okapibm25": "^1.4.1",
         "openai": "^6.46.0",
+        "reo-census": "^1.2.9",
         "uuid": "^11.1.1"
       },
       "engines": {
@@ -17788,13 +17789,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@sentry/core": {
       "version": "8.55.2",
@@ -37835,6 +37829,16 @@
       "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==",
       "dev": true
     },
+    "node_modules/reo-census": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/reo-census/-/reo-census-1.2.9.tgz",
+      "integrity": "sha512-QPnAyRk6gUK9h2XJy9yTXiA91+LEHahmzbRdfb6DigAoe1S/nKg2LXc+/m3//HGyMPAkCFVz/FJJ8YrKm5IrXw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -42535,7 +42539,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.8",
+        "@librechat/agents": "^3.3.9",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -108,7 +108,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.8",
+    "@librechat/agents": "^3.3.9",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Bumps [`@librechat/agents`](https://github.com/danny-avila/agents) to [v3.3.9](https://github.com/danny-avila/agents/pull/365) — a patch release carrying the Langfuse trace-quality/isolation fixes and the tool-call robustness follow-ups:

### Langfuse

- [🧭 fix: Detach Langfuse Roots From Foreign Ambient Spans + Trace-Shaping Docs](https://github.com/danny-avila/agents/pull/361) — trace input/output restored, agent/title trace separation, deterministic ids honored, ephemeral agent-id span rename, destination-aware managed-span parenting
- [🔭 fix: Keep Generation-Root Observation Input in Langfuse Traces](https://github.com/danny-avila/agents/pull/362)
- [🏷️ feat: Reference-Material Framing for the Activity-Label Prompt](https://github.com/danny-avila/agents/pull/363)
- [🔒 fix: Stamp Langfuse Runtime Scopes With Run Identity](https://github.com/danny-avila/agents/pull/364) — fixes cross-tenant span routing under concurrent runs on LangChain's shared background callback queue; replace-mode foreign-scope rejection covering config, seed, tool-output policy, and propagated identity; per-agent overlay scoping

### Tool-call robustness

- [🛡️ fix: Synthesize Tool Results for Invalid Tool Calls (+ ask tool_call_id attribution)](https://github.com/danny-avila/agents/pull/366)
- [🔁 fix: Verify Eager Prestart Args Against Canonical Accumulation + Divergence Circuit Breaker](https://github.com/danny-avila/agents/pull/368)
- [🩹 fix: Keep Truncated Tool-Call Inputs JSON Objects on Anthropic Replay](https://github.com/danny-avila/agents/pull/369)
- [🩹 fix: Coerce Non-Object toolUse Inputs in the Bedrock Converse Formatter](https://github.com/danny-avila/agents/pull/370)

### Dependencies & chores

- [📦 chore: Bump `@langchain/langgraph` to 1.4.8](https://github.com/danny-avila/agents/pull/367)
- [🧪 chore: SDK-Side Activity-Label Prose Eval Harness](https://github.com/danny-avila/agents/pull/360)
- [📡 chore: Replace Scarf With Reo Install Analytics](https://github.com/danny-avila/agents/pull/359)

Verified upstream: full suite green, `langfuse-routing` integration suite fully green, and live end-to-end verification against Langfuse cloud (concurrent-run isolation, identity separation, deterministic trace ids).