### PR TITLE
🧹 fix: Clean Up MCP OAuth State Mappings on Uninstall + Reject Superseded Callbacks

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -457,7 +457,11 @@ const clearStoredMCPOAuthState = async (userId, serverName) => {
         }) === index,
     );
     const results = await Promise.allSettled(
-      flowDeletes.map(([flowId, type]) => flowManager.deleteFlow(flowId, type)),
+      flowDeletes.map(([flowId, type]) =>
+        type === 'mcp_oauth'
+          ? MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)
+          : flowManager.deleteFlow(flowId, type),
+      ),
     );
     for (const result of results) {
       if (result.status === 'rejected') {

--- a/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
+++ b/api/server/controllers/__tests__/UserController.mcpOAuth.spec.js
@@ -31,6 +31,7 @@ jest.mock('@librechat/api', () => ({
       const flowId = `${userId}:${serverName}`;
       return tenantId ? `tenant:${encodeURIComponent(tenantId)}:${flowId}` : flowId;
     }),
+    deleteFlowAndStateMapping: jest.fn().mockResolvedValue(undefined),
     revokeOAuthToken: jest.fn(),
   },
   MCPTokenStorage: {
@@ -182,7 +183,10 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
       deleteToken: expect.any(Function),
     });
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(MCPOAuthHandler.revokeOAuthToken).not.toHaveBeenCalled();
     expect(mcpManager.disconnectUserConnection).toHaveBeenCalledWith('user-1', 'test-server');
   });
@@ -198,7 +202,10 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(logger.warn).toHaveBeenCalledWith(
       '[clearStoredMCPOAuthState] Failed to delete MCP OAuth tokens for test-server:',
       cleanupError,
@@ -210,16 +217,18 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
     const getTokensFlowError = new Error('get tokens flow cache down');
     const oauthFlowError = new Error('oauth flow cache down');
     MCPTokenStorage.getClientInfoAndMetadata.mockResolvedValue(null);
-    flowManager.deleteFlow
-      .mockRejectedValueOnce(getTokensFlowError)
-      .mockRejectedValueOnce(oauthFlowError);
+    flowManager.deleteFlow.mockRejectedValueOnce(getTokensFlowError);
+    MCPOAuthHandler.deleteFlowAndStateMapping.mockRejectedValueOnce(oauthFlowError);
 
     const res = createResponse();
     await updateUserPluginsController(createRequest(), res);
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(logger.warn).toHaveBeenCalledWith(
       '[clearStoredMCPOAuthState] Failed to clear MCP OAuth flow state for test-server:',
       getTokensFlowError,
@@ -248,7 +257,10 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
       deleteToken: expect.any(Function),
     });
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(MCPTokenStorage.getTokens).not.toHaveBeenCalled();
     expect(MCPOAuthHandler.revokeOAuthToken).not.toHaveBeenCalled();
   });
@@ -266,12 +278,15 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
       'tenant:tenant-a:user-1:test-server',
       'mcp_get_tokens',
     );
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith(
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
       'tenant:tenant-a:user-1:test-server',
-      'mcp_oauth',
+      flowManager,
     );
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
   });
 
   it('clears stored OAuth token state when server config is missing', async () => {
@@ -288,7 +303,10 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
       deleteToken: expect.any(Function),
     });
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(MCPTokenStorage.getClientInfoAndMetadata).not.toHaveBeenCalled();
     expect(MCPOAuthHandler.revokeOAuthToken).not.toHaveBeenCalled();
   });
@@ -307,7 +325,10 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
       deleteToken: expect.any(Function),
     });
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(MCPTokenStorage.getClientInfoAndMetadata).not.toHaveBeenCalled();
     expect(MCPOAuthHandler.revokeOAuthToken).not.toHaveBeenCalled();
   });
@@ -339,7 +360,10 @@ describe('updateUserPluginsController MCP OAuth cleanup', () => {
       deleteToken: expect.any(Function),
     });
     expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_get_tokens');
-    expect(flowManager.deleteFlow).toHaveBeenCalledWith('user-1:test-server', 'mcp_oauth');
+    expect(MCPOAuthHandler.deleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'user-1:test-server',
+      flowManager,
+    );
     expect(MCPOAuthHandler.revokeOAuthToken).not.toHaveBeenCalled();
   });
 

--- a/api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js
+++ b/api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js
@@ -7,6 +7,7 @@ const mockGetOAuthServers = jest.fn();
 const mockGetAllowedDomains = jest.fn();
 const mockGetAllowedAddresses = jest.fn();
 const mockDeleteFlow = jest.fn();
+const mockDeleteFlowAndStateMapping = jest.fn();
 const mockGetLogStores = jest.fn();
 const mockFindToken = jest.fn();
 const mockDeleteTokens = jest.fn();
@@ -25,6 +26,7 @@ jest.mock('@librechat/api', () => {
   return {
     MCPOAuthHandler: {
       revokeOAuthToken: (...args) => mockRevokeOAuthToken(...args),
+      deleteFlowAndStateMapping: (...args) => mockDeleteFlowAndStateMapping(...args),
       generateFlowId: (userId, serverName, tenantId) => {
         const flowId = `${userId}:${serverName}`;
         return tenantId ? `tenant:${encodeURIComponent(tenantId)}:${flowId}` : flowId;
@@ -170,6 +172,7 @@ describe('maybeUninstallOAuthMCP', () => {
     expect(mockGetTokens).not.toHaveBeenCalled();
     expect(mockDeleteUserTokens).not.toHaveBeenCalled();
     expect(mockDeleteFlow).not.toHaveBeenCalled();
+    expect(mockDeleteFlowAndStateMapping).not.toHaveBeenCalled();
   });
 
   test('clears stored state when the MCP server is not an OAuth server', async () => {
@@ -182,7 +185,8 @@ describe('maybeUninstallOAuthMCP', () => {
     expect(mockGetTokens).not.toHaveBeenCalled();
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
     expect(mockDeleteUserTokens.mock.calls[0][0]).toMatchObject({ userId, serverName });
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
   });
 
   test('clears stored state when client info is missing', async () => {
@@ -194,7 +198,8 @@ describe('maybeUninstallOAuthMCP', () => {
     expect(mockGetTokens).not.toHaveBeenCalled();
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
     expect(mockDeleteUserTokens.mock.calls[0][0]).toMatchObject({ userId, serverName });
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
   });
 
   test('clears stored state when client info cannot be loaded', async () => {
@@ -208,7 +213,8 @@ describe('maybeUninstallOAuthMCP', () => {
     expect(mockGetTokens).not.toHaveBeenCalled();
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
     expect(mockDeleteUserTokens.mock.calls[0][0]).toMatchObject({ userId, serverName });
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       `[maybeUninstallOAuthMCP] Unable to load OAuth client metadata for ${serverName}; clearing local MCP OAuth state only.`,
       expect.any(Error),
@@ -222,11 +228,15 @@ describe('maybeUninstallOAuthMCP', () => {
 
     await maybeUninstallOAuthMCP(userId, pluginKey, appConfig);
 
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(4);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
     expect(mockDeleteFlow).toHaveBeenCalledWith('tenant:tenant-a:user-123:acme', 'mcp_get_tokens');
-    expect(mockDeleteFlow).toHaveBeenCalledWith('tenant:tenant-a:user-123:acme', 'mcp_oauth');
     expect(mockDeleteFlow).toHaveBeenCalledWith('user-123:acme', 'mcp_get_tokens');
-    expect(mockDeleteFlow).toHaveBeenCalledWith('user-123:acme', 'mcp_oauth');
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledWith(
+      'tenant:tenant-a:user-123:acme',
+      expect.anything(),
+    );
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledWith('user-123:acme', expect.anything());
   });
 
   test('revokes both tokens and runs cleanup on happy path', async () => {
@@ -250,9 +260,10 @@ describe('maybeUninstallOAuthMCP', () => {
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
     expect(mockDeleteUserTokens.mock.calls[0][0]).toMatchObject({ userId, serverName });
 
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
     expect(mockDeleteFlow.mock.calls[0][1]).toBe('mcp_get_tokens');
-    expect(mockDeleteFlow.mock.calls[1][1]).toBe('mcp_oauth');
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledWith('user-123:acme', expect.anything());
   });
 
   test('skips revocation but still runs cleanup when token retrieval fails', async () => {
@@ -265,7 +276,8 @@ describe('maybeUninstallOAuthMCP', () => {
 
     expect(mockRevokeOAuthToken).not.toHaveBeenCalled();
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       `[maybeUninstallOAuthMCP] Unable to load OAuth tokens for ${serverName}; clearing local token state.`,
       expect.any(Error),
@@ -282,7 +294,8 @@ describe('maybeUninstallOAuthMCP', () => {
 
     expect(mockRevokeOAuthToken).not.toHaveBeenCalled();
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       `[maybeUninstallOAuthMCP] Unable to load OAuth tokens for ${serverName}; clearing local token state.`,
       expect.any(Error),
@@ -301,7 +314,8 @@ describe('maybeUninstallOAuthMCP', () => {
     expect(mockRevokeOAuthToken).toHaveBeenCalledTimes(1);
     expect(mockRevokeOAuthToken.mock.calls[0][2]).toBe('access');
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
   });
 
   test('still runs cleanup even when both revocation calls fail', async () => {
@@ -318,7 +332,8 @@ describe('maybeUninstallOAuthMCP', () => {
 
     expect(mockRevokeOAuthToken).toHaveBeenCalledTimes(2);
     expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
-    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlowAndStateMapping).toHaveBeenCalledTimes(1);
     expect(mockLoggerError).toHaveBeenCalled();
   });
 });

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -560,6 +560,7 @@ describe('MCP Routes', () => {
         getLogStores.mockReturnValueOnce({});
         require('~/config').getFlowStateManager.mockReturnValueOnce(mockFlowManager);
         MCPOAuthHandler.resolveStateToFlowId.mockResolvedValueOnce(flowId);
+        MCPOAuthHandler.getFlowState.mockResolvedValueOnce({ state: flowId });
 
         const csrfToken = generateTestCsrfToken(flowId);
         const response = await request(app)
@@ -589,6 +590,7 @@ describe('MCP Routes', () => {
         getLogStores.mockReturnValueOnce({});
         require('~/config').getFlowStateManager.mockReturnValueOnce(mockFlowManager);
         MCPOAuthHandler.resolveStateToFlowId.mockResolvedValueOnce(flowId);
+        MCPOAuthHandler.getFlowState.mockResolvedValueOnce({ state: flowId });
 
         const sessionToken = generateTestCsrfToken('test-user-id');
         const response = await request(app)
@@ -607,6 +609,33 @@ describe('MCP Routes', () => {
           'mcp_oauth',
           'invalid_client',
         );
+      });
+
+      it('should NOT fail the flow when the error callback carries a superseded state', async () => {
+        const flowId = 'test-user-id:test-server';
+        const mockFlowManager = {
+          failFlow: jest.fn(),
+        };
+
+        getLogStores.mockReturnValueOnce({});
+        require('~/config').getFlowStateManager.mockReturnValueOnce(mockFlowManager);
+        /** Orphaned mapping resolves the superseded state to the current flow */
+        MCPOAuthHandler.resolveStateToFlowId.mockResolvedValueOnce(flowId);
+        MCPOAuthHandler.getFlowState.mockResolvedValueOnce({ state: 'current-attempt-state' });
+
+        const csrfToken = generateTestCsrfToken(flowId);
+        const response = await request(app)
+          .get('/api/mcp/test-server/oauth/callback')
+          .set('Cookie', [`oauth_csrf=${csrfToken}`])
+          .query({
+            error: 'access_denied',
+            state: 'superseded-attempt-state',
+          });
+        const basePath = getBasePath();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe(`${basePath}/oauth/error?error=access_denied`);
+        expect(mockFlowManager.failFlow).not.toHaveBeenCalled();
       });
 
       it('should NOT fail the flow when OAuth error is received without cookies (DoS prevention)', async () => {

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -719,6 +719,115 @@ describe('MCP Routes', () => {
       expect(response.headers.location).toBe(`${basePath}/oauth/error?error=invalid_state`);
     });
 
+    it('should redirect to error page when the state cannot be resolved to a flow ID', async () => {
+      MCPOAuthHandler.resolveStateToFlowId.mockResolvedValueOnce(null);
+
+      const response = await request(app)
+        .get('/api/mcp/test-server/oauth/callback')
+        .query({ code: 'test-auth-code', state: 'orphaned-state-value' });
+      const basePath = getBasePath();
+
+      expect(response.status).toBe(302);
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=invalid_state`);
+      expect(MCPOAuthHandler.completeOAuthFlow).not.toHaveBeenCalled();
+    });
+
+    it('should reject a stale-state callback without consuming the current flow', async () => {
+      const flowId = 'test-user-id:test-server';
+      const mockFlowManager = {
+        getFlowState: jest.fn().mockResolvedValue({
+          status: 'PENDING',
+          createdAt: Date.now(),
+        }),
+        completeFlow: jest.fn().mockResolvedValue(true),
+        deleteFlow: jest.fn().mockResolvedValue(true),
+      };
+
+      getLogStores.mockReturnValue({});
+      require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
+      /** Orphaned mapping from a superseded attempt resolves the old state to the live flow id */
+      MCPOAuthHandler.resolveStateToFlowId.mockResolvedValueOnce(flowId);
+      MCPOAuthHandler.getFlowState.mockResolvedValue({
+        state: 'current-attempt-state',
+        serverName: 'test-server',
+        userId: 'test-user-id',
+        metadata: {},
+        clientInfo: {},
+        codeVerifier: 'current-verifier',
+      });
+
+      const csrfToken = generateTestCsrfToken(flowId);
+      const response = await request(app)
+        .get('/api/mcp/test-server/oauth/callback')
+        .set('Cookie', [`oauth_csrf=${csrfToken}`])
+        .query({ code: 'stale-auth-code', state: 'superseded-attempt-state' });
+      const basePath = getBasePath();
+
+      expect(response.status).toBe(302);
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=invalid_state`);
+      expect(MCPOAuthHandler.completeOAuthFlow).not.toHaveBeenCalled();
+      expect(MCPTokenStorage.storeTokens).not.toHaveBeenCalled();
+      expect(mockFlowManager.completeFlow).not.toHaveBeenCalled();
+    });
+
+    it('should let the current tab complete after a stale callback burned the CSRF cookie', async () => {
+      const flowId = 'test-user-id:test-server';
+      const mockFlowManager = {
+        getFlowState: jest.fn().mockResolvedValue({
+          status: 'PENDING',
+          createdAt: Date.now(),
+        }),
+        completeFlow: jest.fn().mockResolvedValue(true),
+        deleteFlow: jest.fn().mockResolvedValue(true),
+      };
+
+      getLogStores.mockReturnValue({});
+      require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
+      MCPOAuthHandler.getFlowState.mockResolvedValue({
+        state: flowId,
+        serverName: 'test-server',
+        userId: 'test-user-id',
+        metadata: {},
+        clientInfo: {},
+        codeVerifier: 'current-verifier',
+      });
+      MCPOAuthHandler.completeOAuthFlow.mockResolvedValue({ access_token: 'test-token' });
+      MCPTokenStorage.storeTokens.mockResolvedValue();
+      mockRegistryInstance.getServerConfig.mockResolvedValue({});
+
+      const mockMcpManager = {
+        getUserConnection: jest.fn().mockResolvedValue({
+          fetchTools: jest.fn().mockResolvedValue([]),
+        }),
+      };
+      require('~/config').getMCPManager.mockReturnValue(mockMcpManager);
+      require('~/config').getOAuthReconnectionManager.mockReturnValue({
+        clearReconnection: jest.fn(),
+      });
+      require('~/server/services/Config/mcp').updateMCPServerTools.mockResolvedValue();
+
+      MCPOAuthHandler.resolveStateToFlowId.mockResolvedValueOnce(flowId);
+      const csrfToken = generateTestCsrfToken(flowId);
+      const staleResponse = await request(app)
+        .get('/api/mcp/test-server/oauth/callback')
+        .set('Cookie', [`oauth_csrf=${csrfToken}`])
+        .query({ code: 'stale-auth-code', state: 'superseded-attempt-state' });
+
+      const basePath = getBasePath();
+      expect(staleResponse.status).toBe(302);
+      expect(staleResponse.headers.location).toBe(`${basePath}/oauth/error?error=invalid_state`);
+      expect(MCPOAuthHandler.completeOAuthFlow).not.toHaveBeenCalled();
+
+      /** The stale callback consumed the CSRF cookie; the current tab recovers via the fresh PENDING flow */
+      const legitResponse = await request(app)
+        .get('/api/mcp/test-server/oauth/callback')
+        .query({ code: 'current-auth-code', state: flowId });
+
+      expect(legitResponse.status).toBe(302);
+      expect(legitResponse.headers.location).toContain(`${basePath}/oauth/success`);
+      expect(MCPOAuthHandler.completeOAuthFlow).toHaveBeenCalledTimes(1);
+    });
+
     describe('CSRF fallback via active PENDING flow', () => {
       it('should proceed when a fresh PENDING flow exists and no cookies are present', async () => {
         const flowId = 'test-user-id:test-server';
@@ -731,6 +840,7 @@ describe('MCP Routes', () => {
           deleteFlow: jest.fn().mockResolvedValue(true),
         };
         const mockFlowState = {
+          state: 'test-user-id:test-server',
           serverName: 'test-server',
           userId: 'test-user-id',
           metadata: {},
@@ -778,6 +888,7 @@ describe('MCP Routes', () => {
           deleteFlow: jest.fn().mockResolvedValue(true),
         };
         const mockFlowState = {
+          state: 'test-user-id:test-server',
           serverName: 'test-server',
           userId: 'test-user-id',
           metadata: {},
@@ -841,6 +952,7 @@ describe('MCP Routes', () => {
           deleteFlow: jest.fn().mockResolvedValue(true),
         };
         const mockFlowState = {
+          state: 'test-user-id:test-server',
           serverName: 'test-server',
           userId: 'test-user-id',
           metadata: {},
@@ -908,6 +1020,7 @@ describe('MCP Routes', () => {
           deleteFlow: jest.fn().mockResolvedValue(true),
         };
         const mockFlowState = {
+          state: 'test-user-id:test-server',
           serverName: 'test-server',
           userId: 'test-user-id',
           metadata: {},
@@ -1030,6 +1143,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { toolFlowId: 'tool-flow-123' },
@@ -1120,6 +1234,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: {
@@ -1194,6 +1309,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: {},
@@ -1254,6 +1370,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { toolFlowId: 'tool-flow-123' },
@@ -1304,6 +1421,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { toolFlowId: 'tool-flow-123' },
@@ -1379,6 +1497,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'system',
         metadata: { toolFlowId: 'tool-flow-123' },
@@ -1422,6 +1541,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { toolFlowId: 'tool-flow-123' },
@@ -1474,6 +1594,7 @@ describe('MCP Routes', () => {
         deleteFlow: jest.fn().mockResolvedValue(true),
       };
       const mockFlowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { toolFlowId: 'tool-flow-123' },
@@ -1526,6 +1647,7 @@ describe('MCP Routes', () => {
         client_secret: 'client_secret',
       };
       const flowState = {
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { toolFlowId: 'tool-flow-123', serverUrl: 'http://example.com' },
@@ -1601,6 +1723,7 @@ describe('MCP Routes', () => {
       });
 
       MCPOAuthHandler.getFlowState.mockResolvedValue({
+        state: 'test-user-id:test-server',
         status: 'COMPLETED',
         serverName: 'test-server',
         userId: 'test-user-id',
@@ -2465,6 +2588,7 @@ describe('MCP Routes', () => {
       };
       MCPOAuthHandler.getFlowState = jest.fn().mockResolvedValue({
         id: 'test-user-id:test-server',
+        state: 'test-user-id:test-server',
         userId: 'test-user-id',
         metadata: {
           serverUrl: 'https://example.com',
@@ -2527,6 +2651,7 @@ describe('MCP Routes', () => {
       };
       require('~/config').getFlowStateManager.mockReturnValue(mockFlowManager);
       MCPOAuthHandler.getFlowState.mockResolvedValue({
+        state: 'test-user-id:test-server',
         serverName: 'test-server',
         userId: 'test-user-id',
         metadata: { serverUrl: 'https://example.com', oauth: {} },
@@ -2583,6 +2708,7 @@ describe('MCP Routes', () => {
 
       MCPOAuthHandler.resolveStateToFlowId.mockResolvedValue(flowId);
       MCPOAuthHandler.getFlowState.mockResolvedValue({
+        state: flowId,
         serverName: 'test-server',
         userId: 'user123',
         tenantId: 'tenant-abc',

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -335,6 +335,17 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
       return res.redirect(`${basePath}/oauth/error?error=invalid_state`);
     }
 
+    /**
+     * Flow ids are deterministic (userId:serverName), so a stale state mapping
+     * can resolve to a newer flow for the same server. The stored state is the
+     * only per-attempt nonce; a mismatch means this callback belongs to a
+     * superseded authorization attempt and must not consume the current flow.
+     */
+    if (flowState.state !== state) {
+      logger.error('[MCP OAuth] State mismatch for flow', { flowId, serverName });
+      return res.redirect(`${basePath}/oauth/error?error=invalid_state`);
+    }
+
     logger.debug('[MCP OAuth] Flow state details', {
       serverName: flowState.serverName,
       userId: flowState.userId,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -255,11 +255,21 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
               const hasCsrf = validateOAuthCsrf(req, res, flowId, OAUTH_CSRF_COOKIE_PATH);
               const hasSession = !hasCsrf && validateOAuthSession(req, parsed.userId);
               if (hasCsrf || hasSession) {
-                await flowManager.failFlow(flowId, 'mcp_oauth', String(oauthError));
-                logger.debug('[MCP OAuth] Marked flow as FAILED with OAuth error', {
-                  flowId,
-                  error: oauthError,
-                });
+                /** A stale mapping can resolve a superseded attempt's state to the
+                 *  current flow (deterministic flow ids); only fail the flow this
+                 *  error callback actually belongs to */
+                const flowMeta = await MCPOAuthHandler.getFlowState(flowId, flowManager);
+                if (flowMeta?.state === state) {
+                  await flowManager.failFlow(flowId, 'mcp_oauth', String(oauthError));
+                  logger.debug('[MCP OAuth] Marked flow as FAILED with OAuth error', {
+                    flowId,
+                    error: oauthError,
+                  });
+                } else {
+                  logger.warn('[MCP OAuth] Skipping failFlow for superseded OAuth error callback', {
+                    flowId,
+                  });
+                }
               }
             }
           }

--- a/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
@@ -663,6 +663,26 @@ describe('MCP OAuth Race Condition Fixes', () => {
       expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeTruthy();
     });
 
+    it('still deletes the flow and rejects when the metadata read hits a storage error', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'user1:test-server';
+      const state = 'unreadable-state-pqr678';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { state });
+      await MCPOAuthHandler.storeStateMapping(state, flowId, flowManager);
+
+      jest
+        .spyOn(flowManager, 'getFlowState')
+        .mockRejectedValueOnce(new Error('read connection lost'));
+
+      await expect(MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)).rejects.toThrow(
+        'Failed to fully delete OAuth flow',
+      );
+
+      /** The callback-capable flow must not survive token deletion */
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeFalsy();
+    });
+
     it('still deletes the flow when metadata carries no state', async () => {
       const flowManager = createFlowManager();
       const flowId = 'user1:stateless-server';

--- a/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
@@ -594,7 +594,7 @@ describe('MCP OAuth Race Condition Fixes', () => {
       expect(await MCPOAuthHandler.resolveStateToFlowId(otherState, flowManager)).toBe(otherFlowId);
     });
 
-    it('deletes the state mapping before the flow', async () => {
+    it('deletes the flow before the state mapping', async () => {
       const flowManager = createFlowManager();
       const flowId = 'user1:test-server';
       const state = 'ordered-state-ghi789';
@@ -611,10 +611,10 @@ describe('MCP OAuth Race Condition Fixes', () => {
 
       await MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager);
 
-      expect(calls).toEqual([`mcp_oauth_state:${state}`, `mcp_oauth:${flowId}`]);
+      expect(calls).toEqual([`mcp_oauth:${flowId}`, `mcp_oauth_state:${state}`]);
     });
 
-    it('leaves the flow in place when the mapping delete hits a storage error', async () => {
+    it('still deletes the flow and rejects when the mapping delete hits a storage error', async () => {
       const flowManager = createFlowManager();
       const flowId = 'user1:test-server';
       const state = 'failing-state-jkl012';
@@ -631,13 +631,14 @@ describe('MCP OAuth Race Condition Fixes', () => {
       });
 
       await expect(MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)).rejects.toThrow(
-        'Failed to delete OAuth state mapping',
+        'Failed to fully delete OAuth flow',
       );
 
-      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeTruthy();
+      /** The callback-capable flow must not survive token deletion */
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeFalsy();
     });
 
-    it('restores the mapping when the flow delete hits a storage error', async () => {
+    it('still deletes the mapping and rejects when the flow delete hits a storage error', async () => {
       const flowManager = createFlowManager();
       const flowId = 'user1:test-server';
       const state = 'restore-state-mno345';
@@ -654,10 +655,11 @@ describe('MCP OAuth Race Condition Fixes', () => {
       });
 
       await expect(MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)).rejects.toThrow(
-        'Failed to delete OAuth flow',
+        'Failed to fully delete OAuth flow',
       );
 
-      expect(await MCPOAuthHandler.resolveStateToFlowId(state, flowManager)).toBe(flowId);
+      /** The surviving flow must not stay callback-capable: its state no longer resolves */
+      expect(await MCPOAuthHandler.resolveStateToFlowId(state, flowManager)).toBeNull();
       expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeTruthy();
     });
 

--- a/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
@@ -614,6 +614,29 @@ describe('MCP OAuth Race Condition Fixes', () => {
       expect(calls).toEqual([`mcp_oauth_state:${state}`, `mcp_oauth:${flowId}`]);
     });
 
+    it('leaves the flow in place when the mapping delete hits a storage error', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'user1:test-server';
+      const state = 'failing-state-jkl012';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { state });
+      await MCPOAuthHandler.storeStateMapping(state, flowId, flowManager);
+
+      const realDeleteFlow = flowManager.deleteFlow.bind(flowManager);
+      jest.spyOn(flowManager, 'deleteFlow').mockImplementation(async (id, type) => {
+        if (type === 'mcp_oauth_state') {
+          return false;
+        }
+        return realDeleteFlow(id, type);
+      });
+
+      await expect(MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)).rejects.toThrow(
+        'Failed to delete OAuth state mapping',
+      );
+
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeTruthy();
+    });
+
     it('still deletes the flow when metadata carries no state', async () => {
       const flowManager = createFlowManager();
       const flowId = 'user1:stateless-server';

--- a/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
@@ -542,6 +542,90 @@ describe('MCP OAuth Race Condition Fixes', () => {
     });
   });
 
+  describe('deleteFlowAndStateMapping (uninstall teardown)', () => {
+    const createFlowManager = () => {
+      const store = new MockKeyv();
+      return new FlowStateManager<MCPOAuthTokens | null>(store as unknown as Keyv, {
+        ttl: 30000,
+        ci: true,
+      });
+    };
+
+    it('deletes both the flow and its state mapping', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'user1:test-server';
+      const state = 'random-state-abc123';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { state });
+      await MCPOAuthHandler.storeStateMapping(state, flowId, flowManager);
+
+      await MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager);
+
+      expect(await MCPOAuthHandler.resolveStateToFlowId(state, flowManager)).toBeNull();
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeFalsy();
+    });
+
+    it('handles tenant-prefixed flow ids', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'tenant:acme:user1:test-server';
+      const state = 'tenant-state-xyz789';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { state });
+      await MCPOAuthHandler.storeStateMapping(state, flowId, flowManager);
+
+      await MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager);
+
+      expect(await MCPOAuthHandler.resolveStateToFlowId(state, flowManager)).toBeNull();
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeFalsy();
+    });
+
+    it('is a no-op when the flow is absent and leaves unrelated mappings intact', async () => {
+      const flowManager = createFlowManager();
+      const otherFlowId = 'user2:other-server';
+      const otherState = 'other-state-def456';
+
+      await flowManager.initFlow(otherFlowId, 'mcp_oauth', { state: otherState });
+      await MCPOAuthHandler.storeStateMapping(otherState, otherFlowId, flowManager);
+
+      await expect(
+        MCPOAuthHandler.deleteFlowAndStateMapping('user1:missing-server', flowManager),
+      ).resolves.toBeUndefined();
+
+      expect(await MCPOAuthHandler.resolveStateToFlowId(otherState, flowManager)).toBe(otherFlowId);
+    });
+
+    it('deletes the state mapping before the flow', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'user1:test-server';
+      const state = 'ordered-state-ghi789';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { state });
+      await MCPOAuthHandler.storeStateMapping(state, flowId, flowManager);
+
+      const calls: string[] = [];
+      const deleteFlowSpy = jest.spyOn(flowManager, 'deleteFlow');
+      deleteFlowSpy.mockImplementation(async (id, type) => {
+        calls.push(`${type}:${id}`);
+        return true;
+      });
+
+      await MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager);
+
+      expect(calls).toEqual([`mcp_oauth_state:${state}`, `mcp_oauth:${flowId}`]);
+    });
+
+    it('still deletes the flow when metadata carries no state', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'user1:stateless-server';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { serverName: 'stateless-server' });
+
+      await MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager);
+
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeFalsy();
+    });
+  });
+
   describe('Fix 4: ReauthenticationRequiredError for no-refresh-token', () => {
     it('should throw ReauthenticationRequiredError when access token expired and no refresh token', async () => {
       const expiredDate = new Date(Date.now() - 60000);

--- a/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthRaceCondition.test.ts
@@ -637,6 +637,30 @@ describe('MCP OAuth Race Condition Fixes', () => {
       expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeTruthy();
     });
 
+    it('restores the mapping when the flow delete hits a storage error', async () => {
+      const flowManager = createFlowManager();
+      const flowId = 'user1:test-server';
+      const state = 'restore-state-mno345';
+
+      await flowManager.initFlow(flowId, 'mcp_oauth', { state });
+      await MCPOAuthHandler.storeStateMapping(state, flowId, flowManager);
+
+      const realDeleteFlow = flowManager.deleteFlow.bind(flowManager);
+      jest.spyOn(flowManager, 'deleteFlow').mockImplementation(async (id, type) => {
+        if (type === 'mcp_oauth') {
+          return false;
+        }
+        return realDeleteFlow(id, type);
+      });
+
+      await expect(MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)).rejects.toThrow(
+        'Failed to delete OAuth flow',
+      );
+
+      expect(await MCPOAuthHandler.resolveStateToFlowId(state, flowManager)).toBe(flowId);
+      expect(await flowManager.getFlowState(flowId, 'mcp_oauth')).toBeTruthy();
+    });
+
     it('still deletes the flow when metadata carries no state', async () => {
       const flowManager = createFlowManager();
       const flowId = 'user1:stateless-server';

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1307,6 +1307,10 @@ export class MCPOAuthHandler {
    * next replacement retries both deletes, whereas deleting the flow past a
    * failed mapping delete would orphan the mapping, and its state would
    * resolve against the next flow created under the same deterministic flowId.
+   * The inverse partial failure is compensated too: when the flow delete
+   * fails, the mapping is restored so the surviving flow's stored
+   * authorization URL remains resolvable instead of dead-ending every
+   * callback in invalid_state until the flow goes stale.
    */
   static async deleteFlowAndStateMapping(
     flowId: string,
@@ -1314,15 +1318,26 @@ export class MCPOAuthHandler {
   ): Promise<void> {
     const flowState = await flowManager.getFlowState(flowId, this.FLOW_TYPE);
     const metadata = flowState?.metadata as MCPOAuthFlowMetadata | undefined;
-    if (typeof metadata?.state === 'string') {
-      const mappingDeleted = await this.deleteStateMapping(metadata.state, flowManager);
+    const state = typeof metadata?.state === 'string' ? metadata.state : null;
+
+    if (state) {
+      const mappingDeleted = await this.deleteStateMapping(state, flowManager);
       if (!mappingDeleted) {
         throw new Error(
           `Failed to delete OAuth state mapping for flow ${flowId}; leaving the flow in place`,
         );
       }
     }
-    await flowManager.deleteFlow(flowId, this.FLOW_TYPE);
+
+    const flowDeleted = await flowManager.deleteFlow(flowId, this.FLOW_TYPE);
+    if (!flowDeleted) {
+      if (state) {
+        await this.storeStateMapping(state, flowId, flowManager);
+      }
+      throw new Error(
+        `Failed to delete OAuth flow ${flowId}; restored its state mapping so the surviving flow stays resolvable`,
+      );
+    }
   }
 
   /**

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1315,16 +1315,24 @@ export class MCPOAuthHandler {
     flowId: string,
     flowManager: FlowStateManager<MCPOAuthTokens | null>,
   ): Promise<void> {
-    const flowState = await flowManager.getFlowState(flowId, this.FLOW_TYPE);
-    const metadata = flowState?.metadata as MCPOAuthFlowMetadata | undefined;
-    const state = typeof metadata?.state === 'string' ? metadata.state : null;
+    /** A failed metadata read must not abort teardown: the flow is deleted
+     *  blindly and the unidentifiable mapping is left to the callback gates */
+    let state: string | null = null;
+    let metadataReadFailed = false;
+    try {
+      const flowState = await flowManager.getFlowState(flowId, this.FLOW_TYPE);
+      const metadata = flowState?.metadata as MCPOAuthFlowMetadata | undefined;
+      state = typeof metadata?.state === 'string' ? metadata.state : null;
+    } catch {
+      metadataReadFailed = true;
+    }
 
     const flowDeleted = await flowManager.deleteFlow(flowId, this.FLOW_TYPE);
     const mappingDeleted = state ? await this.deleteStateMapping(state, flowManager) : true;
 
-    if (!flowDeleted || !mappingDeleted) {
+    if (metadataReadFailed || !flowDeleted || !mappingDeleted) {
       throw new Error(
-        `Failed to fully delete OAuth flow ${flowId} (flow deleted: ${flowDeleted}, state mapping deleted: ${mappingDeleted})`,
+        `Failed to fully delete OAuth flow ${flowId} (metadata read ok: ${!metadataReadFailed}, flow deleted: ${flowDeleted}, state mapping deleted: ${mappingDeleted})`,
       );
     }
   }

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1290,21 +1290,23 @@ export class MCPOAuthHandler {
   /**
    * Deletes an orphaned state mapping when a flow is replaced.
    * Prevents old authorization URLs from resolving after a flow restart.
+   * Returns `false` when the underlying store rejected the delete.
    */
   static async deleteStateMapping(
     state: string,
     flowManager: FlowStateManager<MCPOAuthTokens | null>,
-  ): Promise<void> {
-    await flowManager.deleteFlow(state, this.STATE_MAP_TYPE);
+  ): Promise<boolean> {
+    return flowManager.deleteFlow(state, this.STATE_MAP_TYPE);
   }
 
   /**
    * Deletes an OAuth flow together with its state mapping, for teardown paths
    * that don't already hold the flow (e.g. server uninstall). The mapping is
-   * deleted first on purpose: a crash between the two deletes then leaves an
-   * unresolvable flow that fails closed and expires, whereas flow-first would
-   * orphan the mapping, and its state would resolve against the next flow
-   * created under the same deterministic flowId.
+   * deleted first on purpose, and the flow is left in place when the mapping
+   * delete hits a storage error: an unresolvable flow fails closed and the
+   * next replacement retries both deletes, whereas deleting the flow past a
+   * failed mapping delete would orphan the mapping, and its state would
+   * resolve against the next flow created under the same deterministic flowId.
    */
   static async deleteFlowAndStateMapping(
     flowId: string,
@@ -1313,7 +1315,12 @@ export class MCPOAuthHandler {
     const flowState = await flowManager.getFlowState(flowId, this.FLOW_TYPE);
     const metadata = flowState?.metadata as MCPOAuthFlowMetadata | undefined;
     if (typeof metadata?.state === 'string') {
-      await this.deleteStateMapping(metadata.state, flowManager);
+      const mappingDeleted = await this.deleteStateMapping(metadata.state, flowManager);
+      if (!mappingDeleted) {
+        throw new Error(
+          `Failed to delete OAuth state mapping for flow ${flowId}; leaving the flow in place`,
+        );
+      }
     }
     await flowManager.deleteFlow(flowId, this.FLOW_TYPE);
   }

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1299,6 +1299,26 @@ export class MCPOAuthHandler {
   }
 
   /**
+   * Deletes an OAuth flow together with its state mapping, for teardown paths
+   * that don't already hold the flow (e.g. server uninstall). The mapping is
+   * deleted first on purpose: a crash between the two deletes then leaves an
+   * unresolvable flow that fails closed and expires, whereas flow-first would
+   * orphan the mapping, and its state would resolve against the next flow
+   * created under the same deterministic flowId.
+   */
+  static async deleteFlowAndStateMapping(
+    flowId: string,
+    flowManager: FlowStateManager<MCPOAuthTokens | null>,
+  ): Promise<void> {
+    const flowState = await flowManager.getFlowState(flowId, this.FLOW_TYPE);
+    const metadata = flowState?.metadata as MCPOAuthFlowMetadata | undefined;
+    if (typeof metadata?.state === 'string') {
+      await this.deleteStateMapping(metadata.state, flowManager);
+    }
+    await flowManager.deleteFlow(flowId, this.FLOW_TYPE);
+  }
+
+  /**
    * Gets the default redirect URI for a server
    */
   private static getDefaultRedirectUri(serverName?: string): string {

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1301,16 +1301,15 @@ export class MCPOAuthHandler {
 
   /**
    * Deletes an OAuth flow together with its state mapping, for teardown paths
-   * that don't already hold the flow (e.g. server uninstall). The mapping is
-   * deleted first on purpose, and the flow is left in place when the mapping
-   * delete hits a storage error: an unresolvable flow fails closed and the
-   * next replacement retries both deletes, whereas deleting the flow past a
-   * failed mapping delete would orphan the mapping, and its state would
-   * resolve against the next flow created under the same deterministic flowId.
-   * The inverse partial failure is compensated too: when the flow delete
-   * fails, the mapping is restored so the surviving flow's stored
-   * authorization URL remains resolvable instead of dead-ending every
-   * callback in invalid_state until the flow goes stale.
+   * that don't already hold the flow (e.g. server uninstall). The flow is
+   * deleted first on purpose: it is what makes a provider callback
+   * completable, and teardown runs after the server's tokens were removed, so
+   * a surviving callback-capable flow could recreate credentials the user
+   * just revoked. A failure between the two deletes leaves at worst an
+   * orphaned mapping, which the callback's stored-state equality gates reduce
+   * to a clean invalid_state. Both deletes are attempted regardless of the
+   * other's outcome; any reported storage failure is surfaced as a rejection
+   * for the caller's best-effort logging.
    */
   static async deleteFlowAndStateMapping(
     flowId: string,
@@ -1320,22 +1319,12 @@ export class MCPOAuthHandler {
     const metadata = flowState?.metadata as MCPOAuthFlowMetadata | undefined;
     const state = typeof metadata?.state === 'string' ? metadata.state : null;
 
-    if (state) {
-      const mappingDeleted = await this.deleteStateMapping(state, flowManager);
-      if (!mappingDeleted) {
-        throw new Error(
-          `Failed to delete OAuth state mapping for flow ${flowId}; leaving the flow in place`,
-        );
-      }
-    }
-
     const flowDeleted = await flowManager.deleteFlow(flowId, this.FLOW_TYPE);
-    if (!flowDeleted) {
-      if (state) {
-        await this.storeStateMapping(state, flowId, flowManager);
-      }
+    const mappingDeleted = state ? await this.deleteStateMapping(state, flowManager) : true;
+
+    if (!flowDeleted || !mappingDeleted) {
       throw new Error(
-        `Failed to delete OAuth flow ${flowId}; restored its state mapping so the surviving flow stays resolvable`,
+        `Failed to fully delete OAuth flow ${flowId} (flow deleted: ${flowDeleted}, state mapping deleted: ${mappingDeleted})`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Fixes #14534.

Disconnecting an OAuth MCP server (`maybeUninstallOAuthMCP` → `clearStoredMCPOAuthState`) deleted the `mcp_oauth` flow states but never the `mcp_oauth_state:{state}` cache mappings, which then survived for the full flow TTL (~15 min). The mapping is keyed by the opaque state string, and there is no reverse index, so the uninstall path could only find it by reading the flow's stored `metadata.state` before deletion — which it never did.

The reported symptom (`invalid_state` / "Could not resolve state to flow ID" on reconnect) is the benign variant. The worse one: flow ids are deterministic (`{userId}:{serverName}`) and the CSRF cookie token is `HMAC(flowId)`, so after uninstall → reconnect, a stale browser tab's callback resolves its orphaned state to the **new live flow**, passes CSRF, consumes the new flow's one-shot CSRF cookie, and drives `completeOAuthFlow` into a PKCE mismatch — sabotaging the legitimate authorization attempt in the other tab.

## Changes

**1. `MCPOAuthHandler.deleteFlowAndStateMapping(flowId, flowManager)`** (packages/api): reads the flow's stored `state`, deletes the state mapping, then deletes the flow. Mapping-before-flow ordering is deliberate: a crash between the two deletes leaves an unresolvable flow that fails closed and expires, whereas flow-first would recreate exactly this orphan bug. The four existing inline copies of this idiom already hold the flow in hand or carry extra guards (tenant/COMPLETED-only), so they are intentionally not converted here.

**2. Uninstall integration**: `clearStoredMCPOAuthState` routes its `mcp_oauth` deletions (both tenant-scoped and legacy flow ids, which can hold different states) through the helper. `mcp_get_tokens` deletion and the best-effort `allSettled` + warn semantics are unchanged.

**3. Callback state-equality check**: the callback now rejects when the resolved flow's stored `state` differs from the incoming `state` query param. Since the flow id is deterministic and the CSRF token derives from it, the per-attempt state nonce is the only control that distinguishes a superseded attempt from the current one — this also covers any mapping leak from paths this PR doesn't touch. Verified compatible with authorization-URL reuse (same stored URL ⇒ same state) and the COMPLETED idempotency re-redirect (duplicate callbacks carry the current state).

**Considered and deferred** (interacts with the idempotency design; tracked separately): deleting the mapping after successful token exchange would break the deliberate duplicate-callback re-redirect to `/oauth/success`; reordering the flow read ahead of CSRF validation to avoid the cookie burn adds review risk for no user-visible gain, since the rejected stale callback leaves the flow PENDING and the legitimate tab recovers via the `oauth_session` cookie or the fresh-PENDING fallback (regression-tested).

## Testing

- **`packages/api`**: new `deleteFlowAndStateMapping` suite over a real `FlowStateManager` + MockKeyv (5 tests: both keys deleted, tenant-prefixed ids, no-op on missing flow with unrelated mappings intact, mapping-before-flow ordering, stateless flow still deleted). `MCPOAuthRaceCondition` 21 passed; `MCPConnectionFactory` 60 passed; `tsc` clean.
- **`api`**: 145 passed across the three touched suites. New regressions: unresolved state → `invalid_state` (previously uncovered branch), stale-state callback rejected without consuming the current flow (`completeOAuthFlow`/`storeTokens`/`completeFlow` all uncalled), and the two-step poisoning scenario — stale callback burns the CSRF cookie yet the current tab still completes via the fresh-PENDING fallback. Existing idempotency and URL-reuse tests pass with the equality check in place.
- ESLint clean on all touched files.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)