### PR TITLE
⏱️ fix: Compile admin file-config MIME patterns on a linear-time engine (ReDoS)

### DIFF
--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -49,6 +49,12 @@ const staticCache = require('./utils/staticCache');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
 const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
+const { RE2JS } = require('re2js');
+const { setFileConfigRegexCompiler } = require('librechat-data-provider');
+
+/** Compile admin-configured file-config MIME patterns with a linear-time engine so a
+ *  catastrophic-backtracking pattern cannot ReDoS the event loop when tested on upload. */
+setFileConfigRegexCompiler((pattern) => RE2JS.compile(pattern));
 
 /** Reject messageFilter PII patterns the RE2 runtime engine cannot compile, at config load. */
 configureMessageFilterRegexValidator();

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -25,6 +25,7 @@ const {
   preAuthTenantMiddleware,
   configureServerTimeouts,
   configureMessageFilterRegexValidator,
+  configureFileConfigRegexEngine,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
@@ -49,12 +50,9 @@ const staticCache = require('./utils/staticCache');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
 const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
-const { RE2JS } = require('re2js');
-const { setFileConfigRegexCompiler } = require('librechat-data-provider');
 
-/** Compile admin-configured file-config MIME patterns with a linear-time engine so a
- *  catastrophic-backtracking pattern cannot ReDoS the event loop when tested on upload. */
-setFileConfigRegexCompiler((pattern) => RE2JS.compile(pattern));
+/** Route admin file-config MIME patterns through a linear-time engine (ReDoS-safe) on upload. */
+configureFileConfigRegexEngine();
 
 /** Reject messageFilter PII patterns the RE2 runtime engine cannot compile, at config load. */
 configureMessageFilterRegexValidator();

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -33,6 +33,7 @@ const {
   setupGracefulShutdown,
   updateInterfacePermissions,
   configureMessageFilterRegexValidator,
+  configureFileConfigRegexEngine,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
 const {
@@ -44,7 +45,6 @@ const {
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
 const { capabilityContextMiddleware } = require('./middleware/roles/capabilities');
 const createValidateImageRequest = require('./middleware/validateImageRequest');
-const { setFileConfigRegexCompiler } = require('librechat-data-provider');
 const { initializeGitHubSkillSync } = require('./services/Skills/sync');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
 const { startExpiredFileSweep } = require('./services/Files/process');
@@ -57,11 +57,9 @@ const { getAppConfig } = require('./services/Config');
 const staticCache = require('./utils/staticCache');
 const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
-const { RE2JS } = require('re2js');
 
-/** Compile admin-configured file-config MIME patterns with a linear-time engine so a
- *  catastrophic-backtracking pattern cannot ReDoS the event loop when tested on upload. */
-setFileConfigRegexCompiler((pattern) => RE2JS.compile(pattern));
+/** Route admin file-config MIME patterns through a linear-time engine (ReDoS-safe) on upload. */
+configureFileConfigRegexEngine();
 
 /** Reject messageFilter PII patterns the RE2 runtime engine cannot compile, at config load. */
 configureMessageFilterRegexValidator();

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -44,9 +44,10 @@ const {
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
 const { capabilityContextMiddleware } = require('./middleware/roles/capabilities');
 const createValidateImageRequest = require('./middleware/validateImageRequest');
-const { startExpiredFileSweep } = require('./services/Files/process');
+const { setFileConfigRegexCompiler } = require('librechat-data-provider');
 const { initializeGitHubSkillSync } = require('./services/Skills/sync');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
+const { startExpiredFileSweep } = require('./services/Files/process');
 const { checkMigrations } = require('./services/start/migration');
 const optionalJwtAuth = require('./middleware/optionalJwtAuth');
 const initializeMCPs = require('./services/initializeMCPs');
@@ -56,6 +57,11 @@ const { getAppConfig } = require('./services/Config');
 const staticCache = require('./utils/staticCache');
 const noIndex = require('./middleware/noIndex');
 const routes = require('./routes');
+const { RE2JS } = require('re2js');
+
+/** Compile admin-configured file-config MIME patterns with a linear-time engine so a
+ *  catastrophic-backtracking pattern cannot ReDoS the event loop when tested on upload. */
+setFileConfigRegexCompiler((pattern) => RE2JS.compile(pattern));
 
 /** Reject messageFilter PII patterns the RE2 runtime engine cannot compile, at config load. */
 configureMessageFilterRegexValidator();

--- a/client/src/utils/files.ts
+++ b/client/src/utils/files.ts
@@ -21,7 +21,7 @@ import {
   isDocumentSupportedProvider,
   fileConfig as defaultFileConfig,
 } from 'librechat-data-provider';
-import type { TFile, EndpointFileConfig, FileConfig } from 'librechat-data-provider';
+import type { TFile, EndpointFileConfig, FileConfig, RegexLike } from 'librechat-data-provider';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ExtendedFile } from '~/common';
 
@@ -336,7 +336,7 @@ export type UploadOptionContext = {
   fileSearchAllowedByAgent: boolean;
   codeAllowedByAgent: boolean;
   fileConfig: FileConfig | null;
-  endpointSupportedMimeTypes?: RegExp[];
+  endpointSupportedMimeTypes?: RegexLike[];
 };
 
 const isProviderAttachType = (type: string, ctx: UploadOptionContext): boolean => {

--- a/packages/api/src/files/fileConfigRegex.spec.ts
+++ b/packages/api/src/files/fileConfigRegex.spec.ts
@@ -1,0 +1,19 @@
+import { RE2JS } from 're2js';
+import { convertStringsToRegex, setFileConfigRegexCompiler } from 'librechat-data-provider';
+
+describe('file-config MIME patterns on a linear-time engine (ReDoS-safe)', () => {
+  afterAll(() => {
+    setFileConfigRegexCompiler((pattern) => new RegExp(pattern));
+  });
+
+  it('evaluates a catastrophic admin MIME pattern in bounded time', () => {
+    setFileConfigRegexCompiler((pattern) => RE2JS.compile(pattern));
+    const [matcher] = convertStringsToRegex(['(a+)+$']);
+    const adversarial = 'a'.repeat(60) + '!';
+    const start = process.hrtime.bigint();
+    const matched = matcher.test(adversarial);
+    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+    expect(matched).toBe(false);
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+});

--- a/packages/api/src/files/filter.ts
+++ b/packages/api/src/files/filter.ts
@@ -6,7 +6,7 @@ import type { ServerRequest } from '~/types';
 /**
  * Checks if a MIME type is supported by the endpoint configuration
  * @param mimeType - The MIME type to check
- * @param supportedMimeTypes - Array of RegExp patterns to match against
+ * @param supportedMimeTypes - Array of compiled matchers (RegexLike) to test against
  * @returns True if the MIME type matches any pattern
  */
 function isMimeTypeSupported(mimeType: string, supportedMimeTypes?: RegexLike[]): boolean {

--- a/packages/api/src/files/filter.ts
+++ b/packages/api/src/files/filter.ts
@@ -1,5 +1,6 @@
 import { getEndpointFileConfig, mergeFileConfig, fileConfig } from 'librechat-data-provider';
 import type { IMongoFile } from '@librechat/data-schemas';
+import type { RegexLike } from 'librechat-data-provider';
 import type { ServerRequest } from '~/types';
 
 /**
@@ -8,7 +9,7 @@ import type { ServerRequest } from '~/types';
  * @param supportedMimeTypes - Array of RegExp patterns to match against
  * @returns True if the MIME type matches any pattern
  */
-function isMimeTypeSupported(mimeType: string, supportedMimeTypes?: RegExp[]): boolean {
+function isMimeTypeSupported(mimeType: string, supportedMimeTypes?: RegexLike[]): boolean {
   if (!supportedMimeTypes || supportedMimeTypes.length === 0) {
     return true;
   }

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -9,6 +9,7 @@ export * from './mistral/crud';
 export * from './ocr';
 export * from './parse';
 export * from './rag';
+export * from './regexEngine';
 export * from './retention';
 export * from './sse';
 export * from './sweep';

--- a/packages/api/src/files/regexEngine.ts
+++ b/packages/api/src/files/regexEngine.ts
@@ -1,0 +1,12 @@
+import { RE2JS } from 're2js';
+import { setFileConfigRegexCompiler } from 'librechat-data-provider';
+
+/**
+ * Route admin-configured file-config MIME patterns through a linear-time engine (RE2) on the
+ * server so a catastrophic-backtracking pattern cannot ReDoS the event loop when tested against
+ * an uploaded file's Content-Type. Call once at server startup, before any upload is handled.
+ * Browser builds keep the native compiler, so no regex engine is added to the client bundle.
+ */
+export function configureFileConfigRegexEngine(): void {
+  setFileConfigRegexCompiler((pattern) => RE2JS.compile(pattern));
+}

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -8,6 +8,7 @@ import {
   isAnthropicDocumentType,
   isPermissiveMimeConfig,
   convertStringsToRegex,
+  setFileConfigRegexCompiler,
   documentParserMimeTypes,
   getEndpointFileConfig,
   applicationMimeTypes,
@@ -1612,5 +1613,28 @@ describe('getConfiguredMimeAccept', () => {
     );
     expect(accept.has('.epub')).toBe(true);
     expect(accept.has('.parquet')).toBe(true);
+  });
+});
+
+describe('setFileConfigRegexCompiler (MIME pattern compiler seam)', () => {
+  afterEach(() => {
+    setFileConfigRegexCompiler((pattern) => new RegExp(pattern));
+  });
+
+  it('defaults to a native RegExp compiler', () => {
+    const [regex] = convertStringsToRegex(['^text/']);
+    expect(regex.test('text/csv')).toBe(true);
+    expect(regex.test('image/png')).toBe(false);
+  });
+
+  it('routes patterns through an injected compiler', () => {
+    const seen: string[] = [];
+    setFileConfigRegexCompiler((pattern) => {
+      seen.push(pattern);
+      return { test: () => false };
+    });
+    const compiled = convertStringsToRegex(['application/pdf', 'text/*']);
+    expect(seen).toEqual(['application/pdf', 'text/*']);
+    expect(compiled.every((matcher) => matcher.test('anything') === false)).toBe(true);
   });
 });

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -1637,4 +1637,14 @@ describe('setFileConfigRegexCompiler (MIME pattern compiler seam)', () => {
     expect(seen).toEqual(['application/pdf', 'text/*']);
     expect(compiled.every((matcher) => matcher.test('anything') === false)).toBe(true);
   });
+
+  it('returns a single reject-all matcher when every pattern fails to compile', () => {
+    setFileConfigRegexCompiler(() => {
+      throw new Error('unsupported pattern');
+    });
+    const compiled = convertStringsToRegex(['application/pdf', 'text/*']);
+    expect(compiled).toHaveLength(1);
+    expect(compiled[0].test('application/pdf')).toBe(false);
+    expect(compiled[0].test('anything')).toBe(false);
+  });
 });

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -557,15 +557,24 @@ export const setFileConfigRegexCompiler = (compile: (pattern: string) => RegexLi
 };
 
 /** Helper function to safely convert string patterns to matcher objects */
-export const convertStringsToRegex = (patterns: string[]): RegexLike[] =>
-  patterns.reduce((acc: RegexLike[], pattern) => {
+export const convertStringsToRegex = (patterns: string[]): RegexLike[] => {
+  const compiled = patterns.reduce((acc: RegexLike[], pattern) => {
     try {
       acc.push(compileMimeRegex(pattern));
     } catch (error) {
       console.error(`Invalid regex pattern "${pattern}" skipped.`, error);
     }
     return acc;
-  }, []);
+  }, [] as RegexLike[]);
+  // Surface the dangerous case: every configured pattern was dropped, so the allowlist is now
+  // empty and this file type gate will reject all files rather than silently degrading unnoticed.
+  if (patterns.length > 0 && compiled.length === 0) {
+    console.error(
+      `All ${patterns.length} MIME type pattern(s) were invalid and skipped; the resulting allowlist is empty and will reject every file.`,
+    );
+  }
+  return compiled;
+};
 
 /** Detects whether the given MIME type patterns accept all file types (e.g., `.*` or `.+`). */
 export const isPermissiveMimeConfig = (types?: RegexLike[]): boolean => {

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -556,6 +556,10 @@ export const setFileConfigRegexCompiler = (compile: (pattern: string) => RegexLi
   compileMimeRegex = compile;
 };
 
+/** Returned when every configured pattern fails to compile, so consumers that read an empty
+ *  allowlist as "no restriction" fail closed instead of allowing every file. */
+const rejectAllMimeMatcher: RegexLike = { test: () => false };
+
 /** Helper function to safely convert string patterns to matcher objects */
 export const convertStringsToRegex = (patterns: string[]): RegexLike[] => {
   const compiled = patterns.reduce((acc: RegexLike[], pattern) => {
@@ -566,12 +570,13 @@ export const convertStringsToRegex = (patterns: string[]): RegexLike[] => {
     }
     return acc;
   }, [] as RegexLike[]);
-  // Surface the dangerous case: every configured pattern was dropped, so the allowlist is now
-  // empty and this file type gate will reject all files rather than silently degrading unnoticed.
+  // Every configured pattern was dropped. Return an explicit reject-all matcher so consumers that
+  // read an empty allowlist as "no restriction" fail closed instead of allowing every file.
   if (patterns.length > 0 && compiled.length === 0) {
     console.error(
-      `All ${patterns.length} MIME type pattern(s) were invalid and skipped; the resulting allowlist is empty and will reject every file.`,
+      `All ${patterns.length} MIME type pattern(s) were invalid and skipped; the resulting allowlist rejects every file.`,
     );
+    return [rejectAllMimeMatcher];
   }
   return compiled;
 };

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { EndpointFileConfig, FileConfig } from './types/files';
+import type { EndpointFileConfig, FileConfig, RegexLike } from './types/files';
 import { EModelEndpoint, isAgentsEndpoint, isDocumentSupportedProvider } from './schemas';
 import { normalizeEndpointName } from './utils';
 
@@ -490,7 +490,7 @@ export const fileConfig = {
   stt: {
     supportedMimeTypes: defaultSTTMimeTypes,
   },
-  checkType: function (fileType: string, supportedTypes: RegExp[] = supportedMimeTypes) {
+  checkType: function (fileType: string, supportedTypes: RegexLike[] = supportedMimeTypes) {
     return supportedTypes.some((regex) => regex.test(fileType));
   },
 };
@@ -543,12 +543,24 @@ export const fileConfigSchema = z.object({
 
 export type TFileConfig = z.infer<typeof fileConfigSchema>;
 
-/** Helper function to safely convert string patterns to RegExp objects */
-export const convertStringsToRegex = (patterns: string[]): RegExp[] =>
-  patterns.reduce((acc: RegExp[], pattern) => {
+/**
+ * Compiler for admin-supplied MIME patterns. Defaults to native `RegExp`, which browser
+ * builds keep so no extra dependency is bundled. The server swaps in a linear-time engine
+ * via `setFileConfigRegexCompiler` so an admin-authored catastrophic-backtracking pattern
+ * cannot ReDoS the shared event loop when tested against an uploaded file's MIME type.
+ */
+let compileMimeRegex: (pattern: string) => RegexLike = (pattern) => new RegExp(pattern);
+
+/** Override the MIME-pattern compiler; the server injects a linear-time engine at startup. */
+export const setFileConfigRegexCompiler = (compile: (pattern: string) => RegexLike): void => {
+  compileMimeRegex = compile;
+};
+
+/** Helper function to safely convert string patterns to matcher objects */
+export const convertStringsToRegex = (patterns: string[]): RegexLike[] =>
+  patterns.reduce((acc: RegexLike[], pattern) => {
     try {
-      const regex = new RegExp(pattern);
-      acc.push(regex);
+      acc.push(compileMimeRegex(pattern));
     } catch (error) {
       console.error(`Invalid regex pattern "${pattern}" skipped.`, error);
     }
@@ -556,7 +568,7 @@ export const convertStringsToRegex = (patterns: string[]): RegExp[] =>
   }, []);
 
 /** Detects whether the given MIME type patterns accept all file types (e.g., `.*` or `.+`). */
-export const isPermissiveMimeConfig = (types?: RegExp[]): boolean => {
+export const isPermissiveMimeConfig = (types?: RegexLike[]): boolean => {
   if (!types || types.length === 0) {
     return false;
   }
@@ -714,7 +726,7 @@ const isRepresentable = (mimeType: string): boolean =>
  * picker never hides a file the path would have accepted.
  */
 const buildMimeAccept = (
-  types: RegExp[],
+  types: RegexLike[],
   { categories, documentMimeTypes }: MimeUploadCapability,
 ): string | undefined => {
   const permittedSet = new Set<MimeUploadCategory>(categories);
@@ -792,7 +804,7 @@ const buildMimeAccept = (
  * `supportedMimeTypes` on upload.
  */
 export const getConfiguredMimeAccept = (
-  types: RegExp[] | undefined,
+  types: RegexLike[] | undefined,
   capability: MimeUploadCapability,
 ): string | undefined => {
   /** Referential identity with the built-in list signals an unconfigured endpoint (keep provider filter). */

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -39,12 +39,15 @@ export enum FileContext {
   bytes = 'bytes',
 }
 
+/** Structural type for a compiled matcher: a native `RegExp` or a linear-time engine both satisfy it. Only `test` is ever called on `supportedMimeTypes`. */
+export type RegexLike = { test(input: string): boolean };
+
 export type EndpointFileConfig = {
   disabled?: boolean;
   fileLimit?: number;
   fileSizeLimit?: number;
   totalSizeLimit?: number;
-  supportedMimeTypes?: RegExp[];
+  supportedMimeTypes?: RegexLike[];
 };
 
 export type FileConfig = {
@@ -64,15 +67,15 @@ export type FileConfig = {
     quality?: number;
   };
   ocr?: {
-    supportedMimeTypes?: RegExp[];
+    supportedMimeTypes?: RegexLike[];
   };
   text?: {
-    supportedMimeTypes?: RegExp[];
+    supportedMimeTypes?: RegexLike[];
   };
   stt?: {
-    supportedMimeTypes?: RegExp[];
+    supportedMimeTypes?: RegexLike[];
   };
-  checkType?: (fileType: string, supportedTypes: RegExp[]) => boolean;
+  checkType?: (fileType: string, supportedTypes: RegexLike[]) => boolean;
 };
 
 export type FileConfigInput = {
@@ -99,7 +102,7 @@ export type FileConfigInput = {
   stt?: {
     supportedMimeTypes?: string[];
   };
-  checkType?: (fileType: string, supportedTypes: RegExp[]) => boolean;
+  checkType?: (fileType: string, supportedTypes: RegexLike[]) => boolean;
 };
 
 export type TFile = {


### PR DESCRIPTION
## Summary

Stacked on #14554, which adds the `re2js` dependency this reuses. Same class of fix as that PR, in a different spot.

`convertStringsToRegex` compiles admin-configured `fileConfig` `supportedMimeTypes` with native `RegExp`, and `checkType` runs those patterns against an uploaded file's `Content-Type` on the server event loop, so a catastrophic-backtracking pattern in `supportedMimeTypes` could ReDoS the whole process on upload.

The MIME-pattern compiler is now swappable. It defaults to native `RegExp`, which browser builds keep so no regex engine is added to the client bundle, and the server injects the linear-time engine (RE2JS) once at startup. Only `test` is ever called on these matchers, so the shared type widens to a structural `RegexLike` with no behavior change for valid patterns. The browser stays on native because a client-side stall would only affect that one user's tab.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`file-config.spec.ts` gains seam coverage (compiler defaults to native; an injected compiler is used). `packages/api` adds `fileConfigRegex.spec.ts` proving a catastrophic admin MIME pattern evaluates in bounded time under the linear engine. Full suites pass (data-provider 172, `@librechat/api` middleware/files specs green); `tsc --noEmit` clean on both packages.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
