### PR TITLE
📦 chore: bump `@librechat/agents` to v3.3.11

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.10",
+    "@librechat/agents": "^3.3.11",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.10",
+        "@librechat/agents": "^3.3.11",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10615,9 +10615,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.10.tgz",
-      "integrity": "sha512-oiu1RPPKAcBNaRtYHiZVEjaPLyTaavJn1gm6/K62YkBQZ0ROUCp32zbbVajevUZT9GM6+9SB2FfaEzp5ApAb+A==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.3.11.tgz",
+      "integrity": "sha512-rCCUQbi6b2HcUfq11a/1FXR9JveCmV/30HH64TkVyVHoUkL7QlSd99rddaYRjnAcsGlWb1zY+0oHEO1jQ3m93A==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42539,7 +42539,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.3.10",
+        "@librechat/agents": "^3.3.11",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -108,7 +108,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.3.10",
+    "@librechat/agents": "^3.3.11",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

- bump `@librechat/agents` from `^3.3.10` to `^3.3.11`
- consume the interrupted OpenAI Responses replay fix from danny-avila/agents#376
- preserve the existing workspace and peer-dependency ranges while refreshing the lockfile to the published artifact

## Validation

- `corepack npm ls @librechat/agents` (both consumers resolve `3.3.11`)
- `corepack npm run build:data-provider --silent`
- `corepack npm run build:data-schemas --silent`
- `corepack npm run build --workspace=packages/api --silent`
- Agents-focused `packages/api` Jest suite: 60 passed, 1 skipped; 1,572 tests passed, 4 skipped
- `git diff --check`
