### PR TITLE
🔑 fix: Resolve `{{LIBRECHAT_USER_*}}` Header Placeholders via Agents API

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -508,4 +508,35 @@ describe('OpenAIChatCompletionController', () => {
       });
     });
   });
+
+  describe('user context for header placeholder resolution (issue #14479)', () => {
+    it('forwards the full resolved user (not just the id) to createRun so {{LIBRECHAT_USER_*}} header placeholders resolve', async () => {
+      const { createRun, createSafeUser } = require('@librechat/api');
+      /**
+       * `createSafeUser` projects the allowed user fields (id, email, name,
+       * username, …). Echo those here so we can assert the controller forwards
+       * the full user — header resolution (`resolveConfigHeaders` →
+       * `processUserPlaceholders`) needs email/name/username, not just the id,
+       * to substitute `{{LIBRECHAT_USER_EMAIL}}` and friends. Passing only
+       * `{ id }` leaves those placeholders literal on the Agents API path.
+       */
+      createSafeUser.mockImplementation((u) =>
+        u ? { id: u.id, email: u.email, name: u.name, username: u.username } : {},
+      );
+      req.user = {
+        id: 'user-123',
+        email: 'alice@example.com',
+        name: 'Alice',
+        username: 'alice',
+      };
+
+      await OpenAIChatCompletionController(req, res);
+
+      expect(createRun).toHaveBeenCalledTimes(1);
+      const runArgs = createRun.mock.calls[0][0];
+      expect(runArgs.user).toEqual(
+        expect.objectContaining({ id: 'user-123', email: 'alice@example.com' }),
+      );
+    });
+  });
 });

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -557,6 +557,35 @@ describe('createResponse controller', () => {
         }),
       );
     });
+
+    it('forwards the full resolved user (not just the id) to createRun so {{LIBRECHAT_USER_*}} header placeholders resolve (issue #14479)', async () => {
+      const api = require('@librechat/api');
+      /**
+       * `createSafeUser` projects the allowed user fields (id, email, name,
+       * username, …). Echo those here so we can assert the controller forwards
+       * the full user — header resolution (`resolveConfigHeaders` →
+       * `processUserPlaceholders`) needs email/name/username, not just the id,
+       * to substitute `{{LIBRECHAT_USER_EMAIL}}` and friends. Passing only
+       * `{ id }` left those placeholders literal on the Agents API path.
+       */
+      api.createSafeUser.mockImplementation((u) =>
+        u ? { id: u.id, email: u.email, name: u.name, username: u.username } : {},
+      );
+      req.user = {
+        id: 'user-123',
+        email: 'alice@example.com',
+        name: 'Alice',
+        username: 'alice',
+      };
+
+      await createResponse(req, res);
+
+      expect(api.createRun).toHaveBeenCalledTimes(1);
+      const runArgs = api.createRun.mock.calls[0][0];
+      expect(runArgs.user).toEqual(
+        expect.objectContaining({ id: 'user-123', email: 'alice@example.com' }),
+      );
+    });
   });
 
   describe('token usage recording - streaming', () => {

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -751,7 +751,15 @@ const OpenAIChatCompletionController = async (req, res) => {
         messageId: responseId,
         conversationId,
       },
-      user: { id: userId },
+      /**
+       * Forward the full resolved user (email, name, username, …), not just the
+       * id: `createRun` → `buildAgentInput` → `resolveConfigHeaders` needs those
+       * fields to substitute `{{LIBRECHAT_USER_*}}` custom-header placeholders.
+       * Passing only `{ id }` left them literal on the Agents API path while the
+       * chat UI (which forwards the full user) resolved them (issue #14479). The
+       * `id` fallback (`req.user?.id ?? 'api-user'`) is preserved via `userId`.
+       */
+      user: { ...createSafeUser(req.user), id: userId },
       tenantId: req.user?.tenantId,
       /** Bills subagent child-run model calls (reported outside the
        *  streamEvents loop) into the same collectedUsage array. */

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -786,7 +786,15 @@ const createResponse = async (req, res) => {
           messageId: responseId,
           conversationId,
         },
-        user: { id: userId },
+        /**
+         * Forward the full resolved user (email, name, username, …), not just the
+         * id: `createRun` → `buildAgentInput` → `resolveConfigHeaders` needs those
+         * fields to substitute `{{LIBRECHAT_USER_*}}` custom-header placeholders.
+         * Passing only `{ id }` left them literal on the Agents API path while the
+         * chat UI (which forwards the full user) resolved them (issue #14479). The
+         * `id` fallback (`req.user?.id ?? 'api-user'`) is preserved via `userId`.
+         */
+        user: { ...createSafeUser(req.user), id: userId },
         tenantId: req.user?.tenantId,
         /** Bills subagent child-run model calls (reported outside the
          *  streamEvents loop) into the same collectedUsage array. */
@@ -965,7 +973,15 @@ const createResponse = async (req, res) => {
           messageId: responseId,
           conversationId,
         },
-        user: { id: userId },
+        /**
+         * Forward the full resolved user (email, name, username, …), not just the
+         * id: `createRun` → `buildAgentInput` → `resolveConfigHeaders` needs those
+         * fields to substitute `{{LIBRECHAT_USER_*}}` custom-header placeholders.
+         * Passing only `{ id }` left them literal on the Agents API path while the
+         * chat UI (which forwards the full user) resolved them (issue #14479). The
+         * `id` fallback (`req.user?.id ?? 'api-user'`) is preserved via `userId`.
+         */
+        user: { ...createSafeUser(req.user), id: userId },
         tenantId: req.user?.tenantId,
         /** Bills subagent child-run model calls (reported outside the
          *  streamEvents loop) into the same collectedUsage array. */


### PR DESCRIPTION
## Summary

`{{LIBRECHAT_USER_EMAIL}}` (and the other `{{LIBRECHAT_USER_*}}` custom-header placeholders) resolve correctly when an agent is used in the chat UI, but are sent **literally** when the same agent is invoked through the Agents API — `POST /api/agents/v1/chat/completions` and `/responses`.

Closes #14479

### Root cause

Both Agents API controllers build the run with a *thin* user object:

```js
// api/server/controllers/agents/openai.js  and  responses.js
user: { id: userId },
```

Header placeholder resolution happens at request time in `createRun` → `buildAgentInput` → `resolveConfigHeaders` → `resolveHeaders` → `processUserPlaceholders`. That function substitutes `{{LIBRECHAT_USER_<FIELD>}}` from the passed `user` object and **skips any field that isn't present** (`packages/api/src/utils/env.ts`), so with only `{ id }` the `email`/`name`/`username` placeholders are left literal.

The chat UI path (`AgentClient`) forwards the full user via `createSafeUser(req.user)`, which is exactly why it resolves there and not on the Agents API.

### The fix

Forward the full resolved user to `createRun` on both entry points, while preserving the existing `id` fallback (`req.user?.id ?? 'api-user'`):

```js
user: { ...createSafeUser(req.user), id: userId },
```

`createSafeUser` projects only the allow-listed user fields (and `federatedTokens` for OpenID token placeholders), so this brings the Agents API path to parity with the UI path without exposing anything the UI path doesn't already forward. Minimal, root-cause change — no refactoring of the resolution logic itself.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added regression tests on both Agents API entry points that drive the controller and assert the full user (with `email`) reaches `createRun`, so a `{{LIBRECHAT_USER_*}}` header can resolve. They fail on `main` (only `{ id }` is forwarded) and pass with this change.

- `api/server/controllers/agents/__tests__/openai.spec.js`
- `api/server/controllers/agents/__tests__/responses.unit.spec.js`

```
npx jest server/controllers/agents/__tests__/openai.spec.js \
         server/controllers/agents/__tests__/responses.unit.spec.js
# Test Suites: 2 passed, 2 total
# Tests:       28 passed, 28 total
```

Lint + format clean on the changed files:

```
npx eslint <changed files>      # exit 0
npx prettier --check <changed>  # All matched files use Prettier code style!
```

### **Test Configuration**:
- A custom / OpenAI-compatible endpoint with a header template such as `X-User-Email: {{LIBRECHAT_USER_EMAIL}}`, invoked via the Agents API.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes

---

cc @danny-avila — could you please take a look when you have a chance? 🙏
