### PR TITLE
🦗 fix: Deliver Abort Acknowledgements on Zero-Subscriber Replicas

### DIFF
--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -505,9 +505,13 @@ export class RedisEventTransport implements IEventTransport {
 
     try {
       const parsed = JSON.parse(message) as PubSubMessage;
+      /** Aborts, preempts, and abort acknowledgements are consumed by
+       *  transport-internal waiters (e.g. pending-ack resolution), not SSE
+       *  subscribers, so they must flow even with zero local subscribers. */
       if (
         streamState.count === 0 &&
         parsed.type !== EventTypes.ABORT &&
+        parsed.type !== EventTypes.ABORT_ACK &&
         parsed.type !== EventTypes.PREEMPT
       ) {
         return;


### PR DESCRIPTION
## Summary

- Extend the zero-subscriber guard from #14557 to also pass `EventTypes.ABORT_ACK`
- Restores the two abort-acknowledgement regression tests from #14558, unblocking `dev` CI

## Problem

#14557 (`de033b7db`) drops incoming pub/sub events on replicas with zero local SSE subscribers, allowlisting only `abort` and `preempt`. But `abort_ack` is also a transport-internal control message: it resolves the pending-ack waiters behind `emitAbortConfirmed`, not an SSE subscriber. A requesting replica frequently has no local subscribers for the stream it is aborting, so its owner acknowledgement was silently dropped and abort confirmations resolved `false` after the timeout.

This semantically conflicted with #14558 (`e7f183851`, merged minutes earlier), whose tests deliver an `abort_ack` to a zero-subscriber replica. Each PR was green against its own base; combined on `dev`, "Tests: @librechat/api (shard 2/4)" fails deterministically for every PR (verified by bisection: suite passes at `e7f183851`, fails at `de033b7db` with no other changes).

Content events (`chunk`/`done`/`error`) are still dropped at zero subscribers — #14557's own regression tests continue to pass unchanged. `ABORT_ACK` is the only ack/control type in `EventTypes` that was missing from the allowlist.

## Tests

- `RedisEventTransport.spec.ts`: 36/36 (the two previously-failing #14558 tests now pass, unmodified)
- Full `src/stream` suite: 22 suites, 632 passed / 40 skipped
- Targeted ESLint: passed