### PR TITLE
🏷️ fix: Skip Title Generation for Preempt-Incomplete Turns

### DIFF
--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -3091,4 +3091,112 @@ describe('ResumableAgentController resume metadata', () => {
     expect(mockGenerationJobManager.createJob).not.toHaveBeenCalled();
     expect(mockGenerationJobManager.releaseGeneration).not.toHaveBeenCalled();
   });
+
+  describe('preempt-incomplete title gating', () => {
+    const { Constants } = require('librechat-data-provider');
+    const { resolveTitleTiming } = require('@librechat/api');
+
+    /** An empty preempt boundary ends the turn truncated — the response is
+     *  persisted `unfinished`, so it must follow the abort title contract. */
+    const preemptIncompleteRun = {
+      getPreemptStats: () => ({ emptyBoundaries: 1 }),
+      getHaltReason: () => 'preempt_incomplete',
+    };
+
+    const runFirstTurn = async ({ run } = {}) => {
+      let signalFinished;
+      const finished = new Promise((resolve) => {
+        signalFinished = resolve;
+      });
+      mockGenerationJobManager.finishTerminalJob.mockImplementation(async () => signalFinished());
+
+      let titleSignal;
+      const addTitle = jest.fn(async (_req, options) => {
+        titleSignal = options?.signal;
+      });
+
+      const client = {
+        options: {},
+        savedMessageIds: new Set(),
+        skipSaveUserMessage: false,
+        ...(run && { run }),
+        sendMessage: jest.fn(async (_text, options) => {
+          const userMessage = {
+            messageId: 'user-msg',
+            parentMessageId: Constants.NO_PARENT,
+            conversationId: options.conversationId,
+            text: 'First message',
+          };
+          options.onStart(userMessage, 'response-msg');
+          return {
+            messageId: 'response-msg',
+            parentMessageId: 'user-msg',
+            conversationId: options.conversationId,
+            content: [{ type: 'text', text: 'Truncated answer' }],
+            databasePromise: Promise.resolve({
+              conversation: { conversationId: options.conversationId, title: null },
+            }),
+          };
+        }),
+      };
+      const req = {
+        user: { id: 'user-123' },
+        body: {
+          text: 'First message',
+          messageId: 'user-msg',
+          parentMessageId: Constants.NO_PARENT,
+          conversationId: 'new',
+          endpointOption: { endpoint: 'agents', modelOptions: { model: 'gpt-4.1' } },
+        },
+        config: {},
+      };
+
+      await AgentController(
+        req,
+        createResumableResponse(),
+        jest.fn(),
+        jest.fn().mockResolvedValue({ client }),
+        addTitle,
+      );
+      await finished;
+      await nextTick();
+      await nextTick();
+
+      return { addTitle, getTitleSignal: () => titleSignal };
+    };
+
+    it('skips deferred title generation when an empty preempt boundary truncates the first turn', async () => {
+      resolveTitleTiming.mockReturnValueOnce('final');
+
+      const { addTitle } = await runFirstTurn({ run: preemptIncompleteRun });
+
+      expect(addTitle).not.toHaveBeenCalled();
+    });
+
+    it('still generates a deferred title for a completed first turn', async () => {
+      resolveTitleTiming.mockReturnValueOnce('final');
+
+      const { addTitle } = await runFirstTurn();
+
+      expect(addTitle).toHaveBeenCalledTimes(1);
+      expect(addTitle).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ response: expect.anything() }),
+      );
+    });
+
+    it('cancels an in-flight immediate title when the turn ends preempt-incomplete', async () => {
+      const { addTitle, getTitleSignal } = await runFirstTurn({ run: preemptIncompleteRun });
+
+      expect(addTitle).toHaveBeenCalledTimes(1);
+      expect(getTitleSignal().aborted).toBe(true);
+    });
+
+    it('lets an immediate title proceed for a completed first turn', async () => {
+      const { addTitle, getTitleSignal } = await runFirstTurn();
+
+      expect(addTitle).toHaveBeenCalledTimes(1);
+      expect(getTitleSignal().aborted).toBe(false);
+    });
+  });
 });

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1562,7 +1562,11 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         }
 
         const shouldGenerateTitle =
-          addTitle && parentMessageId === Constants.NO_PARENT && isNewConvo && !terminalWasAborted;
+          addTitle &&
+          parentMessageId === Constants.NO_PARENT &&
+          isNewConvo &&
+          !terminalWasAborted &&
+          !preemptIncomplete;
 
         // Save user message BEFORE sending final event to avoid race condition
         // where client refetch happens before database is updated
@@ -1616,10 +1620,11 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           );
         }
 
-        // If the user stopped this turn, cancel the title BEFORE unblocking its
-        // persistence wait — otherwise resolving `convoReady` lets the title task
-        // resume and save before the later abort runs.
-        if (terminalWasAborted) {
+        // If the user stopped this turn — or an empty preempt boundary truncated
+        // it, which persists under the same honest `unfinished` contract — cancel
+        // the title BEFORE unblocking its persistence wait; otherwise resolving
+        // `convoReady` lets the title task resume and save before the later abort runs.
+        if (terminalWasAborted || preemptIncomplete) {
           titleAbortController.abort();
         } else {
           job.abortController.signal.removeEventListener('abort', abortTitleOnJobAbort);


### PR DESCRIPTION
## Summary

- Exclude `preemptIncomplete` turns from `shouldGenerateTitle` (deferred/final title timing)
- Cancel the in-flight immediate title when a turn ends preempt-incomplete, matching the user-abort contract
- Add red-green regression coverage for both title timings, with completed-turn controls

## Problem

A preempt boundary with nothing to inject ends the turn genuinely truncated, and the terminal region already persists and emits it under the abort contract (`responseIsUnfinished = terminalWasAborted || preemptIncomplete`). But the two title gates only checked `terminalWasAborted`:

- `shouldGenerateTitle` still allowed the deferred (`final` timing) title to run — generated from the truncated response
- the pre-`resolveConvoReady` cancellation only aborted the immediate title for user stops, so an in-flight immediate title was allowed to persist

So a new conversation whose first turn ends preempt-incomplete gets titled from a truncated answer, while an aborted first turn (same `unfinished` persistence contract) does not. Surfaced by a Cursor Bugbot report on a downstream fork's sync of this code.

## Fix

Treat `preemptIncomplete` exactly like `terminalWasAborted` at both gates. `preemptIncomplete` is always assigned before the terminal region (`claimBeforeResponsePersistence` runs via BaseClient's pre-persistence hook or the explicit fallback call), so both gates see the settled value.

## Tests

- 4 new tests in `request.resumeMetadata.spec.js` (preempt-incomplete skips deferred title / cancels immediate title via its abort signal; completed-turn controls for both timings)
- Red-check: with the `request.js` fix reverted, exactly the 2 preempt tests fail and both controls pass
- `request.resumeMetadata.spec.js`: 82 passed; neighboring controller suites (`request.partialDisconnect`, `resume`, `jobReplacement`): 195 passed total
- Targeted ESLint: passed