### PR TITLE
⚓ fix: Bind Action Servers to Metadata Ports

### DIFF
--- a/packages/data-provider/specs/actions.spec.ts
+++ b/packages/data-provider/specs/actions.spec.ts
@@ -1936,6 +1936,21 @@ describe('SSRF Protection', () => {
       expect(result.message).toContain('Port mismatch');
     });
 
+    it('rejects a different port when metadata has trailing whitespace', () => {
+      const result = validateActionDomain(
+        'https://example.com:8443 ',
+        'https://example.com:9443/api',
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Port mismatch');
+    });
+
+    it('rejects reserved port zero', () => {
+      const result = validateActionDomain('https://example.com:0', 'https://example.com:0/api');
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Invalid port');
+    });
+
     it('rejects a same-IPv4 OpenAPI server on a different metadata port', () => {
       const result = validateActionDomain('http://127.0.0.1:38079', 'http://127.0.0.1:38080/api');
       expect(result.isValid).toBe(false);

--- a/packages/data-provider/specs/actions.spec.ts
+++ b/packages/data-provider/specs/actions.spec.ts
@@ -1921,10 +1921,52 @@ describe('SSRF Protection', () => {
       expect(result.message).toContain('Failed to validate domain');
     });
 
-    it('validates with port numbers', () => {
+    it('preserves custom ports when the client domain omits a port', () => {
       const result = validateActionDomain('example.com', 'https://example.com:8443/api');
       expect(result.isValid).toBe(true);
       expect(result.normalizedSpecDomain).toBe('https://example.com');
+    });
+
+    it('rejects a same-host OpenAPI server on a different metadata port', () => {
+      const result = validateActionDomain(
+        'https://example.com:8443',
+        'https://example.com:9443/api',
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Port mismatch');
+    });
+
+    it('rejects a same-IPv4 OpenAPI server on a different metadata port', () => {
+      const result = validateActionDomain('http://127.0.0.1:38079', 'http://127.0.0.1:38080/api');
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Port mismatch');
+    });
+
+    it('rejects a same-IPv6 OpenAPI server on a different metadata port', () => {
+      const result = validateActionDomain('http://[::1]:8080', 'http://[::1]:8081/api');
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Port mismatch');
+    });
+
+    it('validates matching custom ports for IPv6 domains', () => {
+      const result = validateActionDomain('http://[::1]:8080', 'http://[::1]:8080/api');
+      expect(result.isValid).toBe(true);
+    });
+
+    it('matches an explicit HTTPS default port to an omitted server port', () => {
+      const result = validateActionDomain('https://example.com:443', 'https://example.com/api');
+      expect(result.isValid).toBe(true);
+    });
+
+    it('matches an explicit HTTP default port to an omitted server port', () => {
+      const result = validateActionDomain('http://example.com:80', 'http://example.com/api');
+      expect(result.isValid).toBe(true);
+    });
+
+    it('rejects an omitted server port when metadata specifies a custom port', () => {
+      const result = validateActionDomain('https://example.com:8443', 'https://example.com/api');
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Port mismatch');
     });
 
     it('detects port-based SSRF attempt', () => {
@@ -2503,9 +2545,8 @@ describe('SSRF Protection', () => {
 
     it('handles client domain with port and no protocol', () => {
       const result = validateActionDomain('example.com:443', 'https://example.com:443/api');
-      // Port is included in hostname comparison, causing mismatch
-      expect(result.isValid).toBe(false);
-      expect(result.normalizedClientDomain).toBe('https://example.com:443');
+      expect(result.isValid).toBe(true);
+      expect(result.normalizedClientDomain).toBe('https://example.com');
       expect(result.normalizedSpecDomain).toBe('https://example.com');
     });
 

--- a/packages/data-provider/specs/actions.spec.ts
+++ b/packages/data-provider/specs/actions.spec.ts
@@ -1945,6 +1945,19 @@ describe('SSRF Protection', () => {
       expect(result.message).toContain('Port mismatch');
     });
 
+    it.each([
+      ['an ASCII newline', '\n/path'],
+      ['an ASCII tab', '\t/path'],
+      ['a backslash', '\\path'],
+    ])('rejects a different port when metadata contains %s', (_description, suffix) => {
+      const result = validateActionDomain(
+        `https://example.com:8443${suffix}`,
+        'https://example.com:9443/api',
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('Port mismatch');
+    });
+
     it('rejects reserved port zero', () => {
       const result = validateActionDomain('https://example.com:0', 'https://example.com:0/api');
       expect(result.isValid).toBe(false);

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -3,10 +3,10 @@ import { URL } from 'url';
 import _axios from 'axios';
 import crypto from 'crypto';
 import { load } from 'js-yaml';
+import type { OpenAPIV3 } from 'openapi-types';
 import type { ActionMetadata, ActionMetadataRuntime } from './types/agents';
 import type { FunctionTool, Schema, Reference } from './types/assistants';
 import { AuthTypeEnum, AuthorizationTypeEnum } from './types/agents';
-import type { OpenAPIV3 } from 'openapi-types';
 import { Tools } from './types/assistants';
 
 export type ParametersSchema = {

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -637,9 +637,10 @@ export type DomainValidationResult = {
 };
 
 function getExplicitPort(value: string): string | null {
-  const protocolSeparatorIndex = value.indexOf('://');
+  const normalizedValue = value.trim();
+  const protocolSeparatorIndex = normalizedValue.indexOf('://');
   const authorityStart = protocolSeparatorIndex === -1 ? 0 : protocolSeparatorIndex + 3;
-  const authority = value.slice(authorityStart).split(/[/?#]/, 1)[0];
+  const authority = normalizedValue.slice(authorityStart).split(/[/?#]/, 1)[0];
   const host = authority.slice(authority.lastIndexOf('@') + 1);
   const portMatch = host.startsWith('[')
     ? host.match(/^\[[^\]]+\]:(\d+)$/)
@@ -650,7 +651,7 @@ function getExplicitPort(value: string): string | null {
   }
 
   const port = Number(portMatch[1]);
-  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(`Invalid port in domain: ${value}`);
   }
 

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -639,23 +639,36 @@ export type DomainValidationResult = {
 function getExplicitPort(value: string): string | null {
   const normalizedValue = value.trim();
   const protocolSeparatorIndex = normalizedValue.indexOf('://');
-  const authorityStart = protocolSeparatorIndex === -1 ? 0 : protocolSeparatorIndex + 3;
-  const authority = normalizedValue.slice(authorityStart).split(/[/?#]/, 1)[0];
-  const host = authority.slice(authority.lastIndexOf('@') + 1);
-  const portMatch = host.startsWith('[')
-    ? host.match(/^\[[^\]]+\]:(\d+)$/)
-    : host.match(/^[^:]+:(\d+)$/);
+  const hasProtocol = protocolSeparatorIndex !== -1;
+  const authorityAndPath = hasProtocol
+    ? normalizedValue.slice(protocolSeparatorIndex + 3)
+    : normalizedValue;
 
-  if (!portMatch) {
+  let port: string;
+  try {
+    const parsedUrl = new URL(hasProtocol ? normalizedValue : `https://${normalizedValue}`);
+    port = parsedUrl.port;
+
+    // WHATWG URL parsing removes explicit default ports, so parse the same authority with
+    // the alternate HTTP scheme to distinguish an explicit port from an omitted one.
+    if (!port && (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:')) {
+      const alternateProtocol = parsedUrl.protocol === 'http:' ? 'https:' : 'http:';
+      port = new URL(`${alternateProtocol}//${authorityAndPath}`).port;
+    }
+  } catch {
     return null;
   }
 
-  const port = Number(portMatch[1]);
-  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  if (!port) {
+    return null;
+  }
+
+  const parsedPort = Number(port);
+  if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
     throw new Error(`Invalid port in domain: ${value}`);
   }
 
-  return String(port);
+  return String(parsedPort);
 }
 
 function getDefaultActionPort(protocol: string): string {

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -636,6 +636,31 @@ export type DomainValidationResult = {
   normalizedClientDomain?: string;
 };
 
+function getExplicitPort(value: string): string | null {
+  const protocolSeparatorIndex = value.indexOf('://');
+  const authorityStart = protocolSeparatorIndex === -1 ? 0 : protocolSeparatorIndex + 3;
+  const authority = value.slice(authorityStart).split(/[/?#]/, 1)[0];
+  const host = authority.slice(authority.lastIndexOf('@') + 1);
+  const portMatch = host.startsWith('[')
+    ? host.match(/^\[[^\]]+\]:(\d+)$/)
+    : host.match(/^[^:]+:(\d+)$/);
+
+  if (!portMatch) {
+    return null;
+  }
+
+  const port = Number(portMatch[1]);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid port in domain: ${value}`);
+  }
+
+  return String(port);
+}
+
+function getDefaultActionPort(protocol: string): string {
+  return protocol === 'https:' ? '443' : '80';
+}
+
 /**
  * Validates client domain matches OpenAPI spec server URL domain (SSRF prevention).
  * @param clientProvidedDomain - Domain from client (with/without protocol)
@@ -669,6 +694,7 @@ export function validateActionDomain(
     /** Extract hostname from client domain if it's a full URL */
     let clientHostname = clientProvidedDomain;
     let clientHasProtocol = false;
+    const clientExplicitPort = getExplicitPort(clientProvidedDomain);
 
     // Check for any protocol in the client domain
     if (clientProvidedDomain.includes('://')) {
@@ -689,6 +715,9 @@ export function validateActionDomain(
         // If parsing fails, treat as hostname
         clientHasProtocol = false;
       }
+    } else if (clientExplicitPort !== null) {
+      const clientUrl = new URL(`https://${clientProvidedDomain}`);
+      clientHostname = clientUrl.hostname;
     }
 
     /** Normalize IPv6 addresses by removing brackets for comparison */
@@ -718,20 +747,33 @@ export function validateActionDomain(
       }
     }
 
-    if (
+    const domainMatches =
       normalizedSpecDomain === normalizedClientDomain ||
-      (!clientHasProtocol && isIPAddress && normalizedClientHostname === normalizedSpecHostname)
-    ) {
+      (!clientHasProtocol && isIPAddress && normalizedClientHostname === normalizedSpecHostname);
+
+    if (!domainMatches) {
       return {
-        isValid: true,
+        isValid: false,
+        message: `Domain mismatch: Client provided '${clientProvidedDomain}', but spec uses '${specHostname}'`,
         normalizedSpecDomain,
         normalizedClientDomain,
       };
     }
 
+    if (clientExplicitPort !== null) {
+      const specEffectivePort = specUrl.port || getDefaultActionPort(specUrl.protocol);
+      if (clientExplicitPort !== specEffectivePort) {
+        return {
+          isValid: false,
+          message: `Port mismatch: Client provided '${clientProvidedDomain}', but spec uses effective port '${specEffectivePort}'`,
+          normalizedSpecDomain,
+          normalizedClientDomain,
+        };
+      }
+    }
+
     return {
-      isValid: false,
-      message: `Domain mismatch: Client provided '${clientProvidedDomain}', but spec uses '${specHostname}'`,
+      isValid: true,
       normalizedSpecDomain,
       normalizedClientDomain,
     };


### PR DESCRIPTION
## Summary

I fixed Action server validation so an explicit port in persisted Action metadata constrains the raw OpenAPI server URL to the same effective port.

- Compare explicit metadata ports with the effective port used by the parsed OpenAPI server URL.
- Normalize omitted HTTP and HTTPS ports to 80 and 443 while retaining explicit custom-port restrictions.
- Preserve the existing behavior for Action domains that intentionally omit a port.
- Add regression coverage for hostnames, IPv4, IPv6, custom ports, and default-port equivalence.

Private security tracking: GHSA-596c-824c-267q.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/data-provider && npx jest specs/actions.spec.ts --runInBand` — 195 tests passed.
- `npx eslint packages/data-provider/src/actions.ts packages/data-provider/specs/actions.spec.ts` — passed.
- `git diff --check` — passed.
- `cd packages/data-provider && npm run build` — the CJS/ESM bundles completed; the final package-wide TypeScript check remains blocked by the pre-existing `src/request.ts:14` TS2322 error in unchanged code.

### **Test Configuration**:

- Node.js v24.16.0
- npm 11.13.0
- macOS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes