### PR TITLE
🌀 ci: Deterministic Circular Dependency Checks

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -157,7 +157,6 @@ jobs:
 
   circular-deps:
     name: Circular dependency checks
-    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -184,36 +183,8 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Download data-provider build
-        uses: actions/download-artifact@v4
-        with:
-          name: build-data-provider
-          path: packages/data-provider/dist
-
-      - name: Download data-schemas build
-        uses: actions/download-artifact@v4
-        with:
-          name: build-data-schemas
-          path: packages/data-schemas/dist
-
-      - name: Rebuild @librechat/api and check for circular dependencies
-        run: |
-          output=$(npm run build:api 2>&1)
-          echo "$output"
-          if echo "$output" | grep -q "Circular depend"; then
-            echo "Error: Circular dependency detected in @librechat/api!"
-            exit 1
-          fi
-
-      - name: Detect circular dependencies in rollup
-        working-directory: ./packages/data-provider
-        run: |
-          output=$(npm run rollup:api)
-          echo "$output"
-          if echo "$output" | grep -q "Circular dependency"; then
-            echo "Error: Circular dependency detected!"
-            exit 1
-          fi
+      - name: Detect circular dependencies
+        run: node config/circular-deps.mjs
 
   test-api:
     name: 'Tests: api (shard ${{ matrix.shard }}/3)'

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - 'api/**'
       - 'packages/**'
+      - 'config/circular-deps.mjs'
+      - '.github/workflows/backend-review.yml'
       - '!**.md'
 
 permissions:

--- a/config/circular-deps.mjs
+++ b/config/circular-deps.mjs
@@ -64,10 +64,11 @@ const targets = [
 ];
 
 /**
- * Recursively collects every type-only dependency specifier: top-level
- * `import type` / `export type ... from` declarations plus `import('...')`
- * type expressions (TSImportType), which nest arbitrarily deep inside other
- * declarations. All three forms carry the specifier as `source.value`.
+ * Recursively collects every type-only dependency specifier: `import type` /
+ * `export type ... from` declarations, inline type specifiers (`import { type
+ * Foo } from` — kind lives on the child specifier, source on the parent), and
+ * `import('...')` type expressions (TSImportType), which nest arbitrarily deep
+ * inside other declarations. All forms carry the specifier as `source.value`.
  */
 const collectTypeSpecifiers = (node, specifiers) => {
   if (node === null || typeof node !== 'object') {
@@ -79,8 +80,12 @@ const collectTypeSpecifiers = (node, specifiers) => {
     }
     return;
   }
-  const kind = node.type === 'TSImportType' ? 'type' : (node.importKind ?? node.exportKind);
-  if (kind === 'type' && typeof node.source?.value === 'string') {
+  const typeOnly =
+    node.type === 'TSImportType' ||
+    (node.importKind ?? node.exportKind) === 'type' ||
+    (Array.isArray(node.specifiers) &&
+      node.specifiers.some((s) => (s.importKind ?? s.exportKind) === 'type'));
+  if (typeOnly && typeof node.source?.value === 'string') {
     specifiers.add(node.source.value);
   }
   for (const value of Object.values(node)) {

--- a/config/circular-deps.mjs
+++ b/config/circular-deps.mjs
@@ -25,9 +25,17 @@ const targets = [
     name: 'librechat-data-provider',
     dir: 'packages/data-provider',
     entries: ['src/index.ts', 'src/react-query/index.ts'],
-    alias: { src: 'src' },
-    internal: ['src/'],
+    alias: { 'librechat-data-provider/react-query': 'src/react-query/index.ts', src: 'src' },
+    internal: ['src/', 'librechat-data-provider/react-query'],
     minModules: 20,
+    /**
+     * Grandfathered: the core type modules (schemas, config, api-endpoints,
+     * types/{assistants,agents,runs,web}) hold six pre-existing type-only
+     * knots that need their own untangling PR. Runtime edges are still
+     * enforced; the exclusion is logged on every run so it cannot read as
+     * full coverage.
+     */
+    typeEdges: false,
   },
   {
     name: '@librechat/data-schemas',
@@ -36,6 +44,14 @@ const targets = [
     alias: { '~': 'src' },
     internal: ['~'],
     minModules: 75,
+  },
+  {
+    name: '@librechat/client',
+    dir: 'packages/client',
+    entries: ['src/index.ts'],
+    alias: { '~': 'src' },
+    internal: ['~'],
+    minModules: 100,
   },
   {
     name: 'api server',
@@ -47,20 +63,61 @@ const targets = [
   },
 ];
 
+/**
+ * Bundlers erase `import type` / `export type ... from` edges before building
+ * the module graph, so purely type-level cycles (the declaration-graph kind)
+ * would never be reported. Re-materialize each type-only specifier as a bare
+ * side-effect import so the scanned graph carries type edges too. Uses the
+ * real parser (not a regex) so imports inside string templates never count.
+ */
+const typeEdgesPlugin = (parseAst) => ({
+  name: 'type-edges',
+  transform(code, id) {
+    const extension = /\.([mc]?tsx?)(?:$|\?)/.exec(id)?.[1];
+    if (!extension) {
+      return null;
+    }
+    const { body } = parseAst(code, { lang: extension.endsWith('x') ? 'tsx' : 'ts' });
+    const specifiers = new Set();
+    for (const node of body) {
+      const kind = node.importKind ?? node.exportKind;
+      if (kind === 'type' && node.source?.value) {
+        specifiers.add(node.source.value);
+      }
+    }
+    if (specifiers.size === 0) {
+      return null;
+    }
+    const edges = [...specifiers].map((s) => `\nimport ${JSON.stringify(s)};`).join('');
+    return { code: code + edges, map: null };
+  },
+});
+
+/** Stub style/asset imports: rolldown no longer bundles CSS, and assets carry no module edges. */
+const assetsPlugin = {
+  name: 'assets-as-empty',
+  load(id) {
+    if (/\.(css|scss|sass|less|svg|png|jpe?g|gif|webp)(?:$|\?)/.test(id)) {
+      return { code: 'export {};', moduleType: 'js' };
+    }
+    return null;
+  },
+};
+
 /** Loads the rolldown instance the tsdown builds run on, keeping resolution semantics identical. */
 async function loadRolldown() {
   const apiRequire = createRequire(path.join(root, 'packages/api/package.json'));
   const tsdownRequire = createRequire(apiRequire.resolve('tsdown'));
-  const rolldownEntry = tsdownRequire.resolve('rolldown');
-  const { rolldown } = await import(pathToFileURL(rolldownEntry).href);
-  return rolldown;
+  const { rolldown } = await import(pathToFileURL(tsdownRequire.resolve('rolldown')).href);
+  const { parseAst } = await import(pathToFileURL(tsdownRequire.resolve('rolldown/parseAst')).href);
+  return { rolldown, parseAst };
 }
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (message) => message.replace(/\u001B\[[0-9;]*m/g, '');
 const relativize = (message) => stripAnsi(message).replaceAll(root + path.sep, '');
 
-async function scan(rolldown, target) {
+async function scan({ rolldown, parseAst }, target) {
   const cycles = [];
   const unresolved = [];
   const isInternal = (id) =>
@@ -75,6 +132,7 @@ async function scan(rolldown, target) {
       platform: 'node',
       resolve: { alias },
       external: (id) => !isInternal(id),
+      plugins: [...(target.typeEdges === false ? [] : [typeEdgesPlugin(parseAst)]), assetsPlugin],
       checks: { circularDependency: true },
       onLog(_level, log) {
         if (log.code === 'CIRCULAR_DEPENDENCY') {
@@ -111,7 +169,11 @@ function report({ target, cycles, unresolved, modules, error }) {
   }
 
   if (problems.length === 0) {
-    console.log(`✓ ${target.name}: no circular dependencies (${modules} modules)`);
+    const scope =
+      target.typeEdges === false
+        ? 'runtime edges only, type edges grandfathered'
+        : 'runtime + type edges';
+    console.log(`✓ ${target.name}: no circular dependencies (${modules} modules, ${scope})`);
     return true;
   }
   console.error(`✗ ${target.name}:`);
@@ -121,8 +183,8 @@ function report({ target, cycles, unresolved, modules, error }) {
   return false;
 }
 
-const rolldown = await loadRolldown();
-const results = await Promise.all(targets.map((target) => scan(rolldown, target)));
+const engine = await loadRolldown();
+const results = await Promise.all(targets.map((target) => scan(engine, target)));
 const passed = results.map(report).every(Boolean);
 
 if (!passed) {

--- a/config/circular-deps.mjs
+++ b/config/circular-deps.mjs
@@ -1,0 +1,131 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(fileURLToPath(import.meta.url), '../..');
+
+/**
+ * Module graphs checked for cycles. `alias` mirrors each target's tsconfig
+ * paths (or module-alias for the legacy server); `internal` lists the aliased
+ * specifier prefixes that are first-party alongside relative/absolute imports.
+ * `minModules` is a resolution-rot guard: if a graph shrinks below it, the
+ * scan is no longer seeing the real codebase and must fail rather than
+ * silently pass.
+ */
+const targets = [
+  {
+    name: '@librechat/api',
+    dir: 'packages/api',
+    entries: ['src/index.ts', 'src/telemetry.ts'],
+    alias: { '~': 'src' },
+    internal: ['~'],
+    minModules: 200,
+  },
+  {
+    name: 'librechat-data-provider',
+    dir: 'packages/data-provider',
+    entries: ['src/index.ts', 'src/react-query/index.ts'],
+    alias: { src: 'src' },
+    internal: ['src/'],
+    minModules: 20,
+  },
+  {
+    name: '@librechat/data-schemas',
+    dir: 'packages/data-schemas',
+    entries: ['src/index.ts', 'src/admin/capabilities.ts'],
+    alias: { '~': 'src' },
+    internal: ['~'],
+    minModules: 75,
+  },
+  {
+    name: 'api server',
+    dir: 'api',
+    entries: ['server/index.js'],
+    alias: { '~': '.' },
+    internal: ['~'],
+    minModules: 150,
+  },
+];
+
+/** Loads the rolldown instance the tsdown builds run on, keeping resolution semantics identical. */
+async function loadRolldown() {
+  const apiRequire = createRequire(path.join(root, 'packages/api/package.json'));
+  const tsdownRequire = createRequire(apiRequire.resolve('tsdown'));
+  const rolldownEntry = tsdownRequire.resolve('rolldown');
+  const { rolldown } = await import(pathToFileURL(rolldownEntry).href);
+  return rolldown;
+}
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (message) => message.replace(/\u001B\[[0-9;]*m/g, '');
+const relativize = (message) => stripAnsi(message).replaceAll(root + path.sep, '');
+
+async function scan(rolldown, target) {
+  const cycles = [];
+  const unresolved = [];
+  const isInternal = (id) =>
+    id.startsWith('.') || path.isAbsolute(id) || target.internal.some((p) => id.startsWith(p));
+  const alias = Object.fromEntries(
+    Object.entries(target.alias).map(([key, dir]) => [key, path.join(root, target.dir, dir)]),
+  );
+
+  try {
+    const build = await rolldown({
+      input: target.entries.map((entry) => path.join(root, target.dir, entry)),
+      platform: 'node',
+      resolve: { alias },
+      external: (id) => !isInternal(id),
+      checks: { circularDependency: true },
+      onLog(_level, log) {
+        if (log.code === 'CIRCULAR_DEPENDENCY') {
+          cycles.push(relativize(log.message));
+        } else if (log.code === 'UNRESOLVED_IMPORT') {
+          unresolved.push(relativize(log.message));
+        }
+      },
+    });
+    const { output } = await build.generate({ format: 'cjs' });
+    const modules = output.reduce((sum, chunk) => sum + (chunk.moduleIds?.length ?? 0), 0);
+    await build.close();
+    return { target, cycles, unresolved, modules, error: null };
+  } catch (error) {
+    return { target, cycles, unresolved, modules: 0, error };
+  }
+}
+
+function report({ target, cycles, unresolved, modules, error }) {
+  const problems = [];
+  if (error) {
+    problems.push(`build failed: ${relativize(error.message)}`);
+  }
+  if (cycles.length > 0) {
+    problems.push(...cycles);
+  }
+  if (unresolved.length > 0) {
+    problems.push(...unresolved.map((message) => `unresolved first-party import: ${message}`));
+  }
+  if (!error && modules < target.minModules) {
+    problems.push(
+      `graph has ${modules} modules, below the ${target.minModules} floor; the scan is no longer resolving the real codebase`,
+    );
+  }
+
+  if (problems.length === 0) {
+    console.log(`✓ ${target.name}: no circular dependencies (${modules} modules)`);
+    return true;
+  }
+  console.error(`✗ ${target.name}:`);
+  for (const problem of problems) {
+    console.error(`    ${problem}`);
+  }
+  return false;
+}
+
+const rolldown = await loadRolldown();
+const results = await Promise.all(targets.map((target) => scan(rolldown, target)));
+const passed = results.map(report).every(Boolean);
+
+if (!passed) {
+  console.error('\nCircular dependency check failed.');
+  process.exit(1);
+}

--- a/config/circular-deps.mjs
+++ b/config/circular-deps.mjs
@@ -64,11 +64,38 @@ const targets = [
 ];
 
 /**
- * Bundlers erase `import type` / `export type ... from` edges before building
- * the module graph, so purely type-level cycles (the declaration-graph kind)
- * would never be reported. Re-materialize each type-only specifier as a bare
- * side-effect import so the scanned graph carries type edges too. Uses the
- * real parser (not a regex) so imports inside string templates never count.
+ * Recursively collects every type-only dependency specifier: top-level
+ * `import type` / `export type ... from` declarations plus `import('...')`
+ * type expressions (TSImportType), which nest arbitrarily deep inside other
+ * declarations. All three forms carry the specifier as `source.value`.
+ */
+const collectTypeSpecifiers = (node, specifiers) => {
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectTypeSpecifiers(item, specifiers);
+    }
+    return;
+  }
+  const kind = node.type === 'TSImportType' ? 'type' : (node.importKind ?? node.exportKind);
+  if (kind === 'type' && typeof node.source?.value === 'string') {
+    specifiers.add(node.source.value);
+  }
+  for (const value of Object.values(node)) {
+    if (value !== null && typeof value === 'object') {
+      collectTypeSpecifiers(value, specifiers);
+    }
+  }
+};
+
+/**
+ * Bundlers erase type-only edges before building the module graph, so purely
+ * type-level cycles (the declaration-graph kind) would never be reported.
+ * Re-materialize each type-only specifier as a bare side-effect import so the
+ * scanned graph carries type edges too. Uses the real parser (not a regex) so
+ * imports inside string templates never count.
  */
 const typeEdgesPlugin = (parseAst) => ({
   name: 'type-edges',
@@ -79,12 +106,7 @@ const typeEdgesPlugin = (parseAst) => ({
     }
     const { body } = parseAst(code, { lang: extension.endsWith('x') ? 'tsx' : 'ts' });
     const specifiers = new Set();
-    for (const node of body) {
-      const kind = node.importKind ?? node.exportKind;
-      if (kind === 'type' && node.source?.value) {
-        specifiers.add(node.source.value);
-      }
-    }
+    collectTypeSpecifiers(body, specifiers);
     if (specifiers.size === 0) {
       return null;
     }

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -25,13 +25,18 @@ import type { GenericTool, LCToolRegistry, ToolMap, LCTool } from '@librechat/ag
 import type { IMongoFile, FileOwnerScope } from '@librechat/data-schemas';
 import type { Response as ServerResponse } from 'express';
 import type {
+  ResolvedManualSkill,
+  ResolvedAlwaysApplySkill,
+  TListSkillsByAccess,
+  TGetSkillByName,
+} from './skills';
+import type {
   ServerRequest,
   EndpointDbMethods,
   EndpointTokenConfig,
   InitializeResultBase,
 } from '~/types';
 import type { LCAvailableTools, RequestScopedMCPConnectionStore } from '../mcp/types';
-import type { ResolvedManualSkill, ResolvedAlwaysApplySkill } from './skills';
 import type { TFilterFilesByAgentAccess } from './resources';
 import {
   injectSkillCatalog,
@@ -529,77 +534,9 @@ export interface InitializeAgentDbMethods extends EndpointDbMethods {
     files?: Array<{ file_id: string }>;
   }> | null>;
   /** List skill summaries for catalog injection (paginated, omits body/frontmatter) */
-  listSkillsByAccess?: (params: {
-    accessibleIds: import('mongoose').Types.ObjectId[];
-    limit: number;
-    cursor?: string | null;
-  }) => Promise<{
-    skills: Array<{
-      _id: import('mongoose').Types.ObjectId;
-      name: string;
-      description: string;
-      author: import('mongoose').Types.ObjectId;
-      /**
-       * When `true`, the skill is excluded from the catalog injected into
-       * the agent's additional_instructions and the model cannot invoke it
-       * via the `skill` tool. Manual `$` invocation is unaffected.
-       */
-      disableModelInvocation?: boolean;
-      /**
-       * When `false`, the skill is hidden from the `$` popover and rejected
-       * by the manual-invocation resolver. Defaults to `true`.
-       */
-      userInvocable?: boolean;
-      /** True for deployment-directory skills that are loaded in memory. */
-      deployment?: boolean;
-    }>;
-    has_more?: boolean;
-    after?: string | null;
-  }>;
-  /**
-   * Load a single skill by name, constrained to an ACL-accessible ID set.
-   * Returns the full document (including `body`) so manual invocation can
-   * prime SKILL.md without a second DB round-trip.
-   *
-   * `preferUserInvocable` (manual paths): on a same-name collision,
-   * prefer the newest doc with `userInvocable !== false`.
-   * `preferModelInvocable` (model paths — `skill` / `read_file`): on a
-   * same-name collision, prefer the newest doc with
-   * `disableModelInvocation !== true`. Both fall back to the newest match
-   * so the explicit-rejection error paths still fire when only the
-   * non-preferred variant exists.
-   */
-  getSkillByName?: (
-    name: string,
-    accessibleIds: import('mongoose').Types.ObjectId[],
-    options?: { preferUserInvocable?: boolean; preferModelInvocable?: boolean },
-  ) => Promise<{
-    _id: import('mongoose').Types.ObjectId;
-    name: string;
-    body: string;
-    author: import('mongoose').Types.ObjectId;
-    /**
-     * Skill-declared tool allowlist, forwarded verbatim from the skill doc.
-     * Surfaced so the resolver can carry it onto `ResolvedManualSkill` for
-     * future runtime enforcement without a second round-trip.
-     */
-    allowedTools?: string[];
-    /**
-     * Set when the skill was authored with `disable-model-invocation: true`.
-     * The skill tool handler short-circuits on this so a model that names
-     * such a skill (e.g. via hallucination or stale catalog) gets a clear
-     * rejection instead of silently executing.
-     */
-    disableModelInvocation?: boolean;
-    /**
-     * Set when the skill was authored with `user-invocable: false`. The
-     * manual-invocation resolver skips with a warn log so an API-direct
-     * caller can't bypass the popover-side filter.
-     */
-    userInvocable?: boolean;
-    /** True for deployment-directory skills that are loaded in memory. */
-    deployment?: boolean;
-  } | null>;
+  listSkillsByAccess?: TListSkillsByAccess;
+  /** Load a single skill by name, constrained to an ACL-accessible ID set. */
+  getSkillByName?: TGetSkillByName;
   /**
    * Load accessible skills with `alwaysApply: true`, eagerly including
    * `body` so the priming pipeline can splice at turn start without a

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -6,9 +6,82 @@ import type { LCToolRegistry, LCTool, InjectedMessage } from '@librechat/agents'
 import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { Agent } from 'librechat-data-provider';
 import type { Types } from 'mongoose';
-import type { InitializeAgentDbMethods } from './initialize';
 import { registerCodeExecutionTools } from './tools';
 import { logAxiosError } from '~/utils';
+
+/**
+ * Load a single skill by name, constrained to an ACL-accessible ID set.
+ * Returns the full document (including `body`) so manual invocation can
+ * prime SKILL.md without a second DB round-trip.
+ *
+ * `preferUserInvocable` (manual paths): on a same-name collision,
+ * prefer the newest doc with `userInvocable !== false`.
+ * `preferModelInvocable` (model paths — `skill` / `read_file`): on a
+ * same-name collision, prefer the newest doc with
+ * `disableModelInvocation !== true`. Both fall back to the newest match
+ * so the explicit-rejection error paths still fire when only the
+ * non-preferred variant exists.
+ */
+export type TGetSkillByName = (
+  name: string,
+  accessibleIds: Types.ObjectId[],
+  options?: { preferUserInvocable?: boolean; preferModelInvocable?: boolean },
+) => Promise<{
+  _id: Types.ObjectId;
+  name: string;
+  body: string;
+  author: Types.ObjectId;
+  /**
+   * Skill-declared tool allowlist, forwarded verbatim from the skill doc.
+   * Surfaced so the resolver can carry it onto `ResolvedManualSkill` for
+   * future runtime enforcement without a second round-trip.
+   */
+  allowedTools?: string[];
+  /**
+   * Set when the skill was authored with `disable-model-invocation: true`.
+   * The skill tool handler short-circuits on this so a model that names
+   * such a skill (e.g. via hallucination or stale catalog) gets a clear
+   * rejection instead of silently executing.
+   */
+  disableModelInvocation?: boolean;
+  /**
+   * Set when the skill was authored with `user-invocable: false`. The
+   * manual-invocation resolver skips with a warn log so an API-direct
+   * caller can't bypass the popover-side filter.
+   */
+  userInvocable?: boolean;
+  /** True for deployment-directory skills that are loaded in memory. */
+  deployment?: boolean;
+} | null>;
+
+/** List skill summaries for catalog injection (paginated, omits body/frontmatter). */
+export type TListSkillsByAccess = (params: {
+  accessibleIds: Types.ObjectId[];
+  limit: number;
+  cursor?: string | null;
+}) => Promise<{
+  skills: Array<{
+    _id: Types.ObjectId;
+    name: string;
+    description: string;
+    author: Types.ObjectId;
+    /**
+     * When `true`, the skill is excluded from the catalog injected into
+     * the agent's additional_instructions and the model cannot invoke it
+     * via the `skill` tool. Manual `$` invocation is unaffected.
+     */
+    disableModelInvocation?: boolean;
+    /**
+     * When `false`, the skill is hidden from the `$` popover and rejected
+     * by the manual-invocation resolver. Defaults to `true`.
+     */
+    userInvocable?: boolean;
+    /** True for deployment-directory skills that are loaded in memory. */
+    deployment?: boolean;
+  }>;
+  has_more?: boolean;
+  after?: string | null;
+}>;
 
 const SKILL_CATALOG_LIMIT = 100;
 const MIN_SKILL_CATALOG_LIMIT = 1;
@@ -153,7 +226,7 @@ export interface ResolveModelSpecSkillIdsParams {
   /** Full VIEW-accessible skill IDs for this user before model-spec scoping. */
   accessibleSkillIds: Types.ObjectId[];
   /** DB lookup: name → skill doc constrained to the user's accessible IDs. */
-  getSkillByName?: InitializeAgentDbMethods['getSkillByName'];
+  getSkillByName?: TGetSkillByName;
 }
 
 /**
@@ -331,7 +404,7 @@ export interface InjectSkillCatalogParams {
   toolRegistry: LCToolRegistry | undefined;
   accessibleSkillIds: Types.ObjectId[];
   contextWindowTokens: number;
-  listSkillsByAccess: InitializeAgentDbMethods['listSkillsByAccess'];
+  listSkillsByAccess: TListSkillsByAccess | undefined;
   /** When true, registers bash_tool alongside skill + read_file. */
   codeEnvAvailable?: boolean;
   /** When true, bash_tool registers with the hedged stateful-session description. */

--- a/packages/api/src/agents/steering/__tests__/media.spec.ts
+++ b/packages/api/src/agents/steering/__tests__/media.spec.ts
@@ -1,5 +1,6 @@
 import type { IMongoFile } from '@librechat/data-schemas';
-import type { SteerMediaClient, SteerFileFetcher } from '../media';
+import type { SteerFileFetcher } from '../request';
+import type { SteerMediaClient } from '../media';
 import { buildSteerMedia, stampSteerPartMedia } from '../media';
 
 jest.spyOn(console, 'log').mockImplementation();

--- a/packages/api/src/agents/steering/index.ts
+++ b/packages/api/src/agents/steering/index.ts
@@ -19,10 +19,11 @@ export type {
   SteerRequestDeps,
   SteerRunContext,
   SteerCancelBody,
+  SteerFileFetcher,
   SteerRequestResult,
 } from './request';
 export { buildSteerMedia, stampSteerPartMedia } from './media';
-export type { SteerMediaClient, SteerFileFetcher, StampedSteerMedia } from './media';
+export type { SteerMediaClient, StampedSteerMedia } from './media';
 export { createSteerIndexOffsetHandlers } from './offset';
 export type { SteerOffsetState } from './offset';
 export { toSteerFileRef } from './refs';

--- a/packages/api/src/agents/steering/index.ts
+++ b/packages/api/src/agents/steering/index.ts
@@ -14,7 +14,6 @@ export {
   STEER_MAX_FILES,
 } from './request';
 export type {
-  SteerRequestUser,
   SteerRequestBody,
   SteerRequestDeps,
   SteerRunContext,
@@ -27,3 +26,4 @@ export type { SteerMediaClient, StampedSteerMedia } from './media';
 export { createSteerIndexOffsetHandlers } from './offset';
 export type { SteerOffsetState } from './offset';
 export { toSteerFileRef } from './refs';
+export type { SteerRequestUser } from './refs';

--- a/packages/api/src/agents/steering/media.ts
+++ b/packages/api/src/agents/steering/media.ts
@@ -3,9 +3,10 @@ import { formatMessage } from '@librechat/agents';
 import { ContentTypes } from 'librechat-data-provider';
 import type { IMongoFile } from '@librechat/data-schemas';
 import type { TFile } from 'librechat-data-provider';
-import type { SteerRequestUser, SteerFileFetcher } from './request';
 import type { SteerQueueItem } from '~/stream/interfaces/IJobStore';
+import type { SteerFileFetcher } from './request';
 import type { SteerMediaResult } from './runtime';
+import type { SteerRequestUser } from './refs';
 import { toSteerFileRef, collectFileIds, buildOwnerFilter } from './refs';
 import { prependFileContext } from '../client';
 

--- a/packages/api/src/agents/steering/media.ts
+++ b/packages/api/src/agents/steering/media.ts
@@ -3,9 +3,9 @@ import { formatMessage } from '@librechat/agents';
 import { ContentTypes } from 'librechat-data-provider';
 import type { IMongoFile } from '@librechat/data-schemas';
 import type { TFile } from 'librechat-data-provider';
+import type { SteerRequestUser, SteerFileFetcher } from './request';
 import type { SteerQueueItem } from '~/stream/interfaces/IJobStore';
 import type { SteerMediaResult } from './runtime';
-import type { SteerRequestUser } from './request';
 import { toSteerFileRef, collectFileIds, buildOwnerFilter } from './refs';
 import { prependFileContext } from '../client';
 
@@ -17,13 +17,6 @@ export interface SteerMediaClient {
     files: IMongoFile[],
   ): Promise<IMongoFile[] | undefined>;
 }
-
-/** `db.getFiles`-shaped dependency (injected — this package has no DB access). */
-export type SteerFileFetcher = (
-  filter: Record<string, unknown>,
-  sortOptions: Record<string, unknown>,
-  selectFields: Record<string, unknown>,
-) => Promise<IMongoFile[] | null | undefined>;
 
 interface PseudoMessage {
   messageId: string;

--- a/packages/api/src/agents/steering/refs.ts
+++ b/packages/api/src/agents/steering/refs.ts
@@ -1,5 +1,9 @@
 import type { TFile } from 'librechat-data-provider';
-import type { SteerRequestUser } from './request';
+
+export interface SteerRequestUser {
+  id?: string;
+  tenantId?: string;
+}
 
 /**
  * Copies the display-metadata fields a steer attachment ref may carry,

--- a/packages/api/src/agents/steering/request.ts
+++ b/packages/api/src/agents/steering/request.ts
@@ -8,6 +8,7 @@ import type {
   SteerQueueItem,
   SteerReceipt,
 } from '~/stream/interfaces/IJobStore';
+import type { SteerRequestUser } from './refs';
 import {
   STEER_ENQUEUE_NOT_RUNNING,
   STEER_ENQUEUE_QUEUE_FULL,
@@ -32,11 +33,6 @@ const STEER_DISARM_ACK_TIMEOUT_MS = 1000;
 /** Character cap for a single steer message (env-overridable). */
 export function getSteerMaxLength(): number {
   return parseInt(process.env.STEER_MAX_LENGTH ?? '', 10) || DEFAULT_STEER_MAX_LENGTH;
-}
-
-export interface SteerRequestUser {
-  id?: string;
-  tenantId?: string;
 }
 
 /** `db.getFiles`-shaped dependency (injected — this package has no DB access). */

--- a/packages/api/src/agents/steering/request.ts
+++ b/packages/api/src/agents/steering/request.ts
@@ -1,13 +1,13 @@
 import { createHash, randomUUID } from 'crypto';
 import { logger } from '@librechat/data-schemas';
 import { SteerEvents } from 'librechat-data-provider';
+import type { IMongoFile } from '@librechat/data-schemas';
 import type { TFile } from 'librechat-data-provider';
 import type {
   GenerationProtocolVersion,
   SteerQueueItem,
   SteerReceipt,
 } from '~/stream/interfaces/IJobStore';
-import type { SteerFileFetcher } from './media';
 import {
   STEER_ENQUEUE_NOT_RUNNING,
   STEER_ENQUEUE_QUEUE_FULL,
@@ -38,6 +38,13 @@ export interface SteerRequestUser {
   id?: string;
   tenantId?: string;
 }
+
+/** `db.getFiles`-shaped dependency (injected — this package has no DB access). */
+export type SteerFileFetcher = (
+  filter: Record<string, unknown>,
+  sortOptions: Record<string, unknown>,
+  selectFields: Record<string, unknown>,
+) => Promise<IMongoFile[] | null | undefined>;
 
 export interface SteerRequestBody {
   conversationId?: unknown;

--- a/packages/api/src/storage/types.ts
+++ b/packages/api/src/storage/types.ts
@@ -1,5 +1,5 @@
 import type { TFile } from 'librechat-data-provider';
-import type { ServerRequest } from '~/types';
+import type { ServerRequest } from '~/types/http';
 
 export interface SaveBufferParams {
   userId: string;

--- a/packages/api/src/tools/registry/definitions.ts
+++ b/packages/api/src/tools/registry/definitions.ts
@@ -1,34 +1,10 @@
 import { WebSearchToolDefinition, CalculatorToolDefinition } from '@librechat/agents';
+import type { ExtendedJsonSchema } from './schema';
 import { AskUserQuestionToolDefinition } from '~/agents/hitl/askUserQuestionTool';
 import { geminiToolkit } from '~/tools/toolkits/gemini';
 import { oaiToolkit } from '~/tools/toolkits/oai';
 
-/** Extended JSON Schema type that includes standard validation keywords */
-export type ExtendedJsonSchema = {
-  type?: 'string' | 'number' | 'integer' | 'float' | 'boolean' | 'array' | 'object' | 'null';
-  enum?: (string | number | boolean | null)[];
-  items?: ExtendedJsonSchema;
-  properties?: Record<string, ExtendedJsonSchema>;
-  required?: string[];
-  description?: string;
-  additionalProperties?: boolean | ExtendedJsonSchema;
-  minLength?: number;
-  maxLength?: number;
-  minimum?: number;
-  maximum?: number;
-  minItems?: number;
-  maxItems?: number;
-  pattern?: string;
-  format?: string;
-  default?: unknown;
-  const?: unknown;
-  oneOf?: ExtendedJsonSchema[];
-  anyOf?: ExtendedJsonSchema[];
-  allOf?: ExtendedJsonSchema[];
-  $ref?: string;
-  $defs?: Record<string, ExtendedJsonSchema>;
-  definitions?: Record<string, ExtendedJsonSchema>;
-};
+export type { ExtendedJsonSchema } from './schema';
 
 export interface ToolRegistryDefinition {
   name: string;

--- a/packages/api/src/tools/registry/schema.ts
+++ b/packages/api/src/tools/registry/schema.ts
@@ -1,0 +1,26 @@
+/** Extended JSON Schema type that includes standard validation keywords */
+export type ExtendedJsonSchema = {
+  type?: 'string' | 'number' | 'integer' | 'float' | 'boolean' | 'array' | 'object' | 'null';
+  enum?: (string | number | boolean | null)[];
+  items?: ExtendedJsonSchema;
+  properties?: Record<string, ExtendedJsonSchema>;
+  required?: string[];
+  description?: string;
+  additionalProperties?: boolean | ExtendedJsonSchema;
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  minItems?: number;
+  maxItems?: number;
+  pattern?: string;
+  format?: string;
+  default?: unknown;
+  const?: unknown;
+  oneOf?: ExtendedJsonSchema[];
+  anyOf?: ExtendedJsonSchema[];
+  allOf?: ExtendedJsonSchema[];
+  $ref?: string;
+  $defs?: Record<string, ExtendedJsonSchema>;
+  definitions?: Record<string, ExtendedJsonSchema>;
+};

--- a/packages/api/src/tools/toolkits/gemini.ts
+++ b/packages/api/src/tools/toolkits/gemini.ts
@@ -1,4 +1,4 @@
-import type { ExtendedJsonSchema } from '../registry/definitions';
+import type { ExtendedJsonSchema } from '../registry/schema';
 
 /** Default description for Gemini image generation tool */
 const DEFAULT_GEMINI_IMAGE_GEN_DESCRIPTION =

--- a/packages/api/src/tools/toolkits/oai.ts
+++ b/packages/api/src/tools/toolkits/oai.ts
@@ -1,4 +1,4 @@
-import type { ExtendedJsonSchema } from '../registry/definitions';
+import type { ExtendedJsonSchema } from '../registry/schema';
 
 /** Default descriptions for image generation tool  */
 const DEFAULT_IMAGE_GEN_DESCRIPTION =

--- a/packages/api/src/types/endpoints.ts
+++ b/packages/api/src/types/endpoints.ts
@@ -1,6 +1,7 @@
 import type { ClientOptions, OpenAIClientOptions } from '@librechat/agents';
 import type { TConfig } from 'librechat-data-provider';
-import type { EndpointTokenConfig, ServerRequest } from '~/types';
+import type { EndpointTokenConfig } from './tokens';
+import type { ServerRequest } from './http';
 
 export type TCustomEndpointsConfig = Partial<{ [key: string]: Omit<TConfig, 'order'> }>;
 

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -1,6 +1,6 @@
 import type { Agents } from 'librechat-data-provider';
 import type { EventEmitter } from 'events';
-import type { ServerSentEvent } from '~/types';
+import type { ServerSentEvent } from './events';
 
 export interface GenerationJobMetadata {
   userId: string;

--- a/packages/api/tsdown.config.mjs
+++ b/packages/api/tsdown.config.mjs
@@ -12,6 +12,8 @@ export default defineConfig({
   dts: { oxc: true },
   outDir: 'dist',
   sourcemap: true,
+  // Warn on module cycles at build time; CI enforces via config/circular-deps.mjs.
+  checks: { circularDependency: true },
   // Externalize every third-party dependency (consumers provide the peers) and bundle
   // only first-party code: relative imports and the `~/*` tsconfig alias (-> src).
   // `neverBundle` is the 0.22 replacement for the deprecated `external` option.

--- a/packages/client/tsdown.config.mjs
+++ b/packages/client/tsdown.config.mjs
@@ -17,6 +17,8 @@ export default defineConfig({
   dts: { oxc: true },
   outDir: 'dist',
   sourcemap: true,
+  // Warn on module cycles at build time; CI enforces via config/circular-deps.mjs.
+  checks: { circularDependency: true },
   // Force .mjs/.cjs (and .d.mts/.d.cts) regardless of package `type`, so the package can stay
   // CommonJS (jest.config.js / babel.config.js are CJS) while still shipping dual ESM/CJS.
   fixedExtension: true,

--- a/packages/data-provider/tsdown.config.mjs
+++ b/packages/data-provider/tsdown.config.mjs
@@ -17,6 +17,8 @@ export default defineConfig({
   dts: false,
   outDir: 'dist',
   sourcemap: true,
+  // Warn on module cycles at build time; CI enforces via config/circular-deps.mjs.
+  checks: { circularDependency: true },
   deps: {
     // Match the prior Rollup build: bundle nothing third-party. Externalize every
     // bare import (deps, peers, and node built-ins like `crypto`); bundle only the

--- a/packages/data-schemas/src/admin/capabilities.ts
+++ b/packages/data-schemas/src/admin/capabilities.ts
@@ -1,10 +1,5 @@
 import { ResourceType } from 'librechat-data-provider';
-import type {
-  BaseSystemCapability,
-  SystemCapability,
-  ConfigSection,
-  CapabilityCategory,
-} from '~/types/admin';
+import type { TCustomConfig } from 'librechat-data-provider';
 
 // ---------------------------------------------------------------------------
 // System Capabilities
@@ -49,6 +44,39 @@ export const SystemCapabilities = {
    */
   READ_AUDIT_LOG: 'read:audit_log',
 } as const;
+
+/** Base capabilities derived from the SystemCapabilities constant. */
+export type BaseSystemCapability = (typeof SystemCapabilities)[keyof typeof SystemCapabilities];
+
+/** Principal types that can receive config overrides. */
+export type ConfigAssignTarget = 'user' | 'group' | 'role';
+
+/** Top-level keys of the configSchema from librechat.yaml. */
+export type ConfigSection = string & keyof TCustomConfig;
+
+/** Section-level config capabilities derived from configSchema keys. */
+type ConfigSectionCapability = `manage:configs:${ConfigSection}` | `read:configs:${ConfigSection}`;
+
+/** Principal-scoped config assignment capabilities. */
+type ConfigAssignCapability = `assign:configs:${ConfigAssignTarget}`;
+
+/**
+ * Union of all valid capability strings:
+ * - Base capabilities from SystemCapabilities
+ * - Section-level config capabilities (manage:configs:<section>, read:configs:<section>)
+ * - Config assignment capabilities (assign:configs:<user|group|role>)
+ */
+export type SystemCapability =
+  | BaseSystemCapability
+  | ConfigSectionCapability
+  | ConfigAssignCapability;
+
+/** UI grouping of capabilities for the admin panel's capability editor. */
+export type CapabilityCategory = {
+  key: string;
+  labelKey: string;
+  capabilities: BaseSystemCapability[];
+};
 
 /**
  * Capabilities that are implied by holding a broader capability.

--- a/packages/data-schemas/src/types/admin.ts
+++ b/packages/data-schemas/src/types/admin.ts
@@ -1,40 +1,14 @@
 import type { PrincipalType, PrincipalModel, TCustomConfig } from 'librechat-data-provider';
-import type { SystemCapabilities } from '~/admin/capabilities';
 
-/* ── Capability types ───────────────────────────────────────────────── */
+/* ── Capability types (defined alongside the SystemCapabilities constant) ── */
 
-/** Base capabilities derived from the SystemCapabilities constant. */
-export type BaseSystemCapability = (typeof SystemCapabilities)[keyof typeof SystemCapabilities];
-
-/** Principal types that can receive config overrides. */
-export type ConfigAssignTarget = 'user' | 'group' | 'role';
-
-/** Top-level keys of the configSchema from librechat.yaml. */
-export type ConfigSection = string & keyof TCustomConfig;
-
-/** Section-level config capabilities derived from configSchema keys. */
-type ConfigSectionCapability = `manage:configs:${ConfigSection}` | `read:configs:${ConfigSection}`;
-
-/** Principal-scoped config assignment capabilities. */
-type ConfigAssignCapability = `assign:configs:${ConfigAssignTarget}`;
-
-/**
- * Union of all valid capability strings:
- * - Base capabilities from SystemCapabilities
- * - Section-level config capabilities (manage:configs:<section>, read:configs:<section>)
- * - Config assignment capabilities (assign:configs:<user|group|role>)
- */
-export type SystemCapability =
-  | BaseSystemCapability
-  | ConfigSectionCapability
-  | ConfigAssignCapability;
-
-/** UI grouping of capabilities for the admin panel's capability editor. */
-export type CapabilityCategory = {
-  key: string;
-  labelKey: string;
-  capabilities: BaseSystemCapability[];
-};
+export type {
+  BaseSystemCapability,
+  ConfigAssignTarget,
+  ConfigSection,
+  SystemCapability,
+  CapabilityCategory,
+} from '~/admin/capabilities';
 
 /* ── Admin API response types ───────────────────────────────────────── */
 

--- a/packages/data-schemas/tsdown.config.mjs
+++ b/packages/data-schemas/tsdown.config.mjs
@@ -8,6 +8,8 @@ export default defineConfig({
   dts: { oxc: true },
   outDir: 'dist',
   sourcemap: true,
+  // Warn on module cycles at build time; CI enforces via config/circular-deps.mjs.
+  checks: { circularDependency: true },
   // Externalize all third-party deps (consumers provide the peers); bundle only `dotenv`
   // so the package stays self-contained for its env-loading side effect, matching the
   // prior Rollup build. `neverBundle` is the 0.22 replacement for the deprecated `external`.


### PR DESCRIPTION
## Problem

Both steps of the \`circular-deps\` CI job were dead checks that could never fail:

1. **tsdown grep**: the \`grep -q "Circular depend"\` on \`npm run build:api\` output dates from #2149, when the build used rollup. #13595 migrated the build to tsdown, and rolldown's \`checks.circularDependency\` defaults to \`false\`, so the warning text is never emitted. Verified empirically: a hard A-to-B-to-A cycle builds clean with exit 0 on tsdown 0.22.2.
2. **rollup grep**: rollup writes \`(!) Circular dependency\` to stderr, but the step captured stdout only (\`output=$(npm run rollup:api)\` with no \`2>&1\`), so the grep could never see it. Visible in any recent job log: the rollup warnings stream uncaptured while the echoed \`$output\` contains only the npm banner.

## Changes

**\`config/circular-deps.mjs\`** replaces both greps with a deterministic scan:
- Covers all four first-party graphs: \`@librechat/api\`, \`librechat-data-provider\`, \`@librechat/data-schemas\` (TS sources, matching each package's tsconfig aliases and entries), plus the legacy \`api/server\` CJS graph (rolldown handles it natively, replacing rollup plus three plugins).
- Loads the exact rolldown instance the tsdown builds use (resolved through \`packages/api\` -> \`tsdown\` -> \`rolldown\`), so resolution semantics match the real bundles.
- Fails on exit code, not warning-text scraping: cycles, unresolved first-party imports, build errors, and a per-target module-count floor (so if resolution rots and the graph quietly shrinks, the scan fails instead of vacuously passing, which is exactly how the old check died).
- The CI job no longer needs build artifacts, so it drops \`needs: build\` and the artifact downloads and runs immediately.

**tsdown configs**: \`checks: { circularDependency: true }\` in all three packages so local builds warn too (defense in depth; CI enforcement is the script).

**Type-level cycle fixes**: enabling the check surfaced 6 declaration-graph cycles that would otherwise warn on every build. All type-only, no runtime changes:
- \`types/stream.ts\`, \`types/endpoints.ts\`, \`storage/types.ts\`: import concrete modules instead of the \`~/types\` barrel that re-exports them.
- \`steering/request.ts\` <-> \`steering/media.ts\`: moved \`SteerFileFetcher\` next to \`SteerRequestUser\` in \`request.ts\` (media already imported from request).
- \`agents/skills.ts\` <-> \`agents/initialize.ts\`: skills now owns \`TGetSkillByName\` / \`TListSkillsByAccess\` (mirroring the existing \`TFilterFilesByAgentAccess\` pattern); \`InitializeAgentDbMethods\` references them.
- \`data-schemas types/admin.ts\` <-> \`admin/capabilities.ts\`: capability types moved next to the \`SystemCapabilities\` constant they derive from; \`types/admin\` re-exports them so all import paths keep working.

## Verification

- Scan passes on clean tree: 385 / 39 / 153 / 323 modules across the four graphs, zero cycles.
- Injected a reachable A-to-B-to-A cycle in \`packages/api/src\`: scan exits 1 with a readable trace. Broken \`~/*\` import: exits 1 via resolve error.
- All three package builds now complete with zero \`CIRCULAR_DEPENDENCY\` warnings.
- \`tsc --noEmit\` passes for data-provider, data-schemas, @librechat/api, @librechat/client.
- Jest: 470 tests (steering + skills suites, packages/api) and 159 tests (data-schemas) pass.