### PR TITLE
🪢 refactor: Move Agent Execution Seam Before Initialization

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,3 @@
+# Domain language
+
+- **Agent run envelope**: the versioned, JSON-safe request contract created after ingress authentication and protocol validation but before agent, provider, tool, or MCP initialization. It carries only the validated protocol payload and the minimum trusted principal identifiers. The execution host rehydrates all runtime state from those identifiers.

--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -11,6 +11,12 @@ const mockRecordCollectedUsage = jest
   .mockResolvedValue({ input_tokens: 100, output_tokens: 50 });
 const mockGetBalanceConfig = jest.fn().mockReturnValue({ enabled: true });
 const mockGetTransactionsConfig = jest.fn().mockReturnValue({ enabled: true });
+class MockAgentRunEnvelopeError extends TypeError {
+  constructor(message) {
+    super(message);
+    this.name = 'AgentRunEnvelopeError';
+  }
+}
 const mockCreateAgentRunEnvelope = jest.fn(
   ({ protocol, requestId, receivedAt, principal, payload }) => ({
     version: 1,
@@ -102,6 +108,7 @@ jest.mock('@librechat/api', () => ({
   }),
   createChunk: jest.fn().mockReturnValue({}),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  AgentRunEnvelopeError: MockAgentRunEnvelopeError,
   createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),
   scopeSkillIds: jest.fn().mockImplementation((ids) => ids),
   resolveAgentScopedSkillIds: jest
@@ -383,6 +390,20 @@ describe('OpenAIChatCompletionController', () => {
       expect(JSON.stringify(mockCreateAgentRunEnvelope.mock.results[0].value)).not.toContain(
         'secret',
       );
+    });
+
+    it('returns a protocol 400 when the envelope rejects a non-JSON payload', async () => {
+      const message = 'payload.max_tokens must contain only finite numbers';
+      const { createErrorResponse, initializeAgent } = require('@librechat/api');
+      mockCreateAgentRunEnvelope.mockImplementationOnce(() => {
+        throw new MockAgentRunEnvelopeError(message);
+      });
+
+      await OpenAIChatCompletionController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(createErrorResponse).toHaveBeenCalledWith(message, 'invalid_request_error', null);
+      expect(initializeAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -11,6 +11,20 @@ const mockRecordCollectedUsage = jest
   .mockResolvedValue({ input_tokens: 100, output_tokens: 50 });
 const mockGetBalanceConfig = jest.fn().mockReturnValue({ enabled: true });
 const mockGetTransactionsConfig = jest.fn().mockReturnValue({ enabled: true });
+const mockCreateAgentRunEnvelope = jest.fn(
+  ({ protocol, requestId, receivedAt, principal, payload }) => ({
+    version: 1,
+    protocol,
+    requestId,
+    receivedAt,
+    principal: {
+      userId: principal.id,
+      ...(principal.role != null && { role: principal.role }),
+      ...(principal.tenantId != null && { tenantId: principal.tenantId }),
+    },
+    payload: JSON.parse(JSON.stringify(payload)),
+  }),
+);
 const mockBuildSkillPrimedIdsByName = jest.fn((manualSkillPrimes, alwaysApplySkillPrimes) => {
   const primed = {};
   for (const skill of alwaysApplySkillPrimes ?? []) {
@@ -88,6 +102,7 @@ jest.mock('@librechat/api', () => ({
   }),
   createChunk: jest.fn().mockReturnValue({}),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),
   scopeSkillIds: jest.fn().mockImplementation((ids) => ids),
   resolveAgentScopedSkillIds: jest
     .fn()
@@ -328,6 +343,46 @@ describe('OpenAIChatCompletionController', () => {
 
       await OpenAIChatCompletionController(req, res);
       expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('execution envelope', () => {
+    it('creates the portable run input before agent initialization', async () => {
+      req.user = {
+        id: 'user-123',
+        role: 'USER',
+        tenantId: 'tenant-123',
+        federatedTokens: { access_token: 'secret' },
+      };
+      const requestBody = {
+        ...req.body,
+        ephemeralAgent: { skills: true },
+        manualSkills: ['review-code'],
+        timezone: 'America/New_York',
+      };
+      req.body = requestBody;
+      const { validateRequest, initializeAgent } = require('@librechat/api');
+      validateRequest.mockReturnValueOnce({ request: requestBody });
+
+      await OpenAIChatCompletionController(req, res);
+
+      expect(mockCreateAgentRunEnvelope).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocol: 'chat.completions',
+          principal: req.user,
+          payload: requestBody,
+          requestId: expect.any(String),
+          receivedAt: expect.any(Number),
+        }),
+      );
+      expect(mockCreateAgentRunEnvelope.mock.invocationCallOrder[0]).toBeLessThan(
+        initializeAgent.mock.invocationCallOrder[0],
+      );
+      expect(req.body).not.toBe(requestBody);
+      expect(req.body).toEqual(requestBody);
+      expect(JSON.stringify(mockCreateAgentRunEnvelope.mock.results[0].value)).not.toContain(
+        'secret',
+      );
     });
   });
 

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -10,6 +10,20 @@ const mockRecordCollectedUsage = jest
   .mockResolvedValue({ input_tokens: 100, output_tokens: 50 });
 const mockGetBalanceConfig = jest.fn().mockReturnValue({ enabled: true });
 const mockGetTransactionsConfig = jest.fn().mockReturnValue({ enabled: true });
+const mockCreateAgentRunEnvelope = jest.fn(
+  ({ protocol, requestId, receivedAt, principal, payload }) => ({
+    version: 1,
+    protocol,
+    requestId,
+    receivedAt,
+    principal: {
+      userId: principal.id,
+      ...(principal.role != null && { role: principal.role }),
+      ...(principal.tenantId != null && { tenantId: principal.tenantId }),
+    },
+    payload: JSON.parse(JSON.stringify(payload)),
+  }),
+);
 const mockBuildSkillPrimedIdsByName = jest.fn((manualSkillPrimes, alwaysApplySkillPrimes) => {
   const primed = {};
   for (const skill of alwaysApplySkillPrimes ?? []) {
@@ -93,6 +107,7 @@ jest.mock('@librechat/api', () => ({
   }),
   applyContextToAgent: (...args) => mockApplyContextToAgent(...args),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),
   buildAgentScopedContext: (...args) => mockBuildAgentScopedContext(...args),
   buildAgentContextAttachmentsByAgentId: (...args) =>
     mockBuildAgentContextAttachmentsByAgentId(...args),
@@ -317,6 +332,47 @@ describe('createResponse controller', () => {
       end: jest.fn(),
       write: jest.fn(),
     };
+  });
+
+  describe('execution envelope', () => {
+    it('creates the portable run input before agent initialization', async () => {
+      req.user = {
+        id: 'user-123',
+        role: 'USER',
+        tenantId: 'tenant-123',
+        federatedTokens: { access_token: 'secret' },
+      };
+      const requestBody = {
+        ...req.body,
+        ephemeralAgent: { skills: true },
+        manualSkills: ['review-code'],
+        timezone: 'America/New_York',
+        isTemporary: true,
+      };
+      req.body = requestBody;
+      const { validateResponseRequest, initializeAgent } = require('@librechat/api');
+      validateResponseRequest.mockReturnValueOnce({ request: requestBody });
+
+      await createResponse(req, res);
+
+      expect(mockCreateAgentRunEnvelope).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocol: 'responses',
+          principal: req.user,
+          payload: requestBody,
+          requestId: expect.any(String),
+          receivedAt: expect.any(Number),
+        }),
+      );
+      expect(mockCreateAgentRunEnvelope.mock.invocationCallOrder[0]).toBeLessThan(
+        initializeAgent.mock.invocationCallOrder[0],
+      );
+      expect(req.body).not.toBe(requestBody);
+      expect(req.body).toEqual(requestBody);
+      expect(JSON.stringify(mockCreateAgentRunEnvelope.mock.results[0].value)).not.toContain(
+        'secret',
+      );
+    });
   });
 
   describe('conversation ownership validation', () => {

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -10,6 +10,12 @@ const mockRecordCollectedUsage = jest
   .mockResolvedValue({ input_tokens: 100, output_tokens: 50 });
 const mockGetBalanceConfig = jest.fn().mockReturnValue({ enabled: true });
 const mockGetTransactionsConfig = jest.fn().mockReturnValue({ enabled: true });
+class MockAgentRunEnvelopeError extends TypeError {
+  constructor(message) {
+    super(message);
+    this.name = 'AgentRunEnvelopeError';
+  }
+}
 const mockCreateAgentRunEnvelope = jest.fn(
   ({ protocol, requestId, receivedAt, principal, payload }) => ({
     version: 1,
@@ -107,6 +113,7 @@ jest.mock('@librechat/api', () => ({
   }),
   applyContextToAgent: (...args) => mockApplyContextToAgent(...args),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  AgentRunEnvelopeError: MockAgentRunEnvelopeError,
   createAgentRunEnvelope: (...args) => mockCreateAgentRunEnvelope(...args),
   buildAgentScopedContext: (...args) => mockBuildAgentScopedContext(...args),
   buildAgentContextAttachmentsByAgentId: (...args) =>
@@ -372,6 +379,19 @@ describe('createResponse controller', () => {
       expect(JSON.stringify(mockCreateAgentRunEnvelope.mock.results[0].value)).not.toContain(
         'secret',
       );
+    });
+
+    it('returns a protocol 400 when the envelope rejects a non-JSON payload', async () => {
+      const message = 'payload.max_output_tokens must contain only finite numbers';
+      const { sendResponsesErrorResponse, initializeAgent } = require('@librechat/api');
+      mockCreateAgentRunEnvelope.mockImplementationOnce(() => {
+        throw new MockAgentRunEnvelopeError(message);
+      });
+
+      await createResponse(req, res);
+
+      expect(sendResponsesErrorResponse).toHaveBeenCalledWith(res, 400, message, 'invalid_request');
+      expect(initializeAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -13,6 +13,7 @@ const {
   createRun,
   createChunk,
   buildToolSet,
+  createAgentRunEnvelope,
   loadSkillStates,
   sendFinalChunk,
   createSafeUser,
@@ -149,29 +150,20 @@ function sendErrorResponse(res, statusCode, message, type = 'invalid_request_err
 }
 
 /**
- * OpenAI-compatible chat completions controller for agents.
+ * Runs a validated chat-completions envelope in the current process.
+ * Express remains runtime-only state while the envelope is the portable run input.
  *
- * POST /v1/chat/completions
- *
- * Request format:
- * {
- *   "model": "agent_id_here",
- *   "messages": [{"role": "user", "content": "Hello!"}],
- *   "stream": true,
- *   "conversation_id": "optional",
- *   "parent_message_id": "optional"
- * }
+ * @param {import('@librechat/api').ChatCompletionRunEnvelope} envelope
+ * @param {{req: import('express').Request, res: import('express').Response}} runtime
  */
-const OpenAIChatCompletionController = async (req, res) => {
+const executeOpenAIChatCompletion = async (envelope, { req, res }) => {
   const appConfig = req.config;
-  const requestStartTime = Date.now();
-
-  const validation = validateRequest(req.body);
-  if (isChatCompletionValidationFailure(validation)) {
-    return sendErrorResponse(res, 400, validation.error);
-  }
-
-  const request = validation.request;
+  const requestStartTime = envelope.receivedAt;
+  const request = envelope.payload;
+  const { principal } = envelope;
+  // The local executor keeps the current Express-dependent initialization path,
+  // but all request-body reads now observe the detached envelope payload.
+  req.body = request;
   const agentId = request.model;
 
   // Look up the agent
@@ -232,7 +224,7 @@ const OpenAIChatCompletionController = async (req, res) => {
           'invalid_request_error',
         );
       }
-      if (!(await db.getConvo(req.user?.id, request.conversation_id))) {
+      if (!(await db.getConvo(principal.userId, request.conversation_id))) {
         return sendErrorResponse(res, 404, 'Conversation not found', 'invalid_request_error');
       }
     }
@@ -277,12 +269,12 @@ const OpenAIChatCompletionController = async (req, res) => {
 
     const enabledCapabilities = new Set(agentsEConfig?.capabilities);
     const skillsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.skills);
-    const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
+    const ephemeralSkillsToggle = request.ephemeralAgent?.skills === true;
     const accessibleSkillIds = skillsCapabilityEnabled
       ? withDeploymentSkillIds(
           await findAccessibleResources({
-            userId: req.user.id,
-            role: req.user.role,
+            userId: principal.userId,
+            role: principal.role,
             resourceType: ResourceType.SKILL,
             requiredPermissions: PermissionBits.VIEW,
           }),
@@ -290,8 +282,8 @@ const OpenAIChatCompletionController = async (req, res) => {
       : [];
     const editableSkillIds = skillsCapabilityEnabled
       ? await findAccessibleResources({
-          userId: req.user.id,
-          role: req.user.role,
+          userId: principal.userId,
+          role: principal.role,
           resourceType: ResourceType.SKILL,
           requiredPermissions: PermissionBits.EDIT,
         })
@@ -301,13 +293,13 @@ const OpenAIChatCompletionController = async (req, res) => {
       : false;
 
     const { skillStates, defaultActiveOnShare } = await loadSkillStates({
-      userId: req.user.id,
+      userId: principal.userId,
       appConfig,
       getUserById: db.getUserById,
       accessibleSkillIds,
     });
 
-    const manualSkills = extractManualSkills(req.body);
+    const manualSkills = extractManualSkills(request);
 
     const primaryScopedSkillIds = resolveAgentScopedSkillIds({
       agent,
@@ -741,7 +733,7 @@ const OpenAIChatCompletionController = async (req, res) => {
     };
 
     // Create and run the agent
-    const userId = req.user?.id ?? 'api-user';
+    const userId = principal.userId;
 
     // Extract merged userMCPAuthMap (needed for MCP tool connections across
     // the primary and any discovered handoff sub-agents)
@@ -764,7 +756,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         conversationId,
       },
       user: { id: userId },
-      tenantId: req.user?.tenantId,
+      tenantId: principal.tenantId,
       /** Bills subagent child-run model calls (reported outside the
        *  streamEvents loop) into the same collectedUsage array. */
       subagentUsageSink: createSubagentUsageSink(collectedUsage),
@@ -894,6 +886,30 @@ const OpenAIChatCompletionController = async (req, res) => {
       sendErrorResponse(res, statusCode, errorMessage, errorType);
     }
   }
+};
+
+/**
+ * OpenAI-compatible chat completions ingress adapter for agents.
+ * Authentication and remote-agent authorization have already run in route middleware.
+ *
+ * POST /v1/chat/completions
+ */
+const OpenAIChatCompletionController = async (req, res) => {
+  const receivedAt = Date.now();
+  const validation = validateRequest(req.body);
+  if (isChatCompletionValidationFailure(validation)) {
+    return sendErrorResponse(res, 400, validation.error);
+  }
+
+  const envelope = createAgentRunEnvelope({
+    protocol: 'chat.completions',
+    requestId: req.requestId ?? req.id ?? `agent-run-${nanoid()}`,
+    receivedAt,
+    principal: req.user,
+    payload: validation.request,
+  });
+
+  return executeOpenAIChatCompletion(envelope, { req, res });
 };
 
 /**

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -13,6 +13,7 @@ const {
   createRun,
   createChunk,
   buildToolSet,
+  AgentRunEnvelopeError,
   createAgentRunEnvelope,
   loadSkillStates,
   sendFinalChunk,
@@ -901,13 +902,21 @@ const OpenAIChatCompletionController = async (req, res) => {
     return sendErrorResponse(res, 400, validation.error);
   }
 
-  const envelope = createAgentRunEnvelope({
-    protocol: 'chat.completions',
-    requestId: req.requestId ?? req.id ?? `agent-run-${nanoid()}`,
-    receivedAt,
-    principal: req.user,
-    payload: validation.request,
-  });
+  let envelope;
+  try {
+    envelope = createAgentRunEnvelope({
+      protocol: 'chat.completions',
+      requestId: req.requestId ?? req.id ?? `agent-run-${nanoid()}`,
+      receivedAt,
+      principal: req.user,
+      payload: validation.request,
+    });
+  } catch (error) {
+    if (error instanceof AgentRunEnvelopeError) {
+      return sendErrorResponse(res, 400, error.message, 'invalid_request_error');
+    }
+    throw error;
+  }
 
   return executeOpenAIChatCompletion(envelope, { req, res });
 };

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -13,6 +13,7 @@ const {
   createRun,
   applyContextToAgent,
   buildToolSet,
+  createAgentRunEnvelope,
   buildAgentScopedContext,
   buildAgentContextAttachmentsByAgentId,
   createSafeUser,
@@ -284,25 +285,20 @@ function convertMessagesToOutputItems(messages) {
 }
 
 /**
- * Create Response - POST /v1/responses
+ * Runs a validated Responses envelope in the current process.
+ * Express remains runtime-only state while the envelope is the portable run input.
  *
- * Creates a model response following the Open Responses API specification.
- * Supports both streaming and non-streaming responses.
- *
- * @param {import('express').Request} req
- * @param {import('express').Response} res
+ * @param {import('@librechat/api').ResponsesRunEnvelope} envelope
+ * @param {{req: import('express').Request, res: import('express').Response}} runtime
  */
-const createResponse = async (req, res) => {
+const executeResponse = async (envelope, { req, res }) => {
   const appConfig = req.config;
-  const requestStartTime = Date.now();
-
-  // Validate request
-  const validation = validateResponseRequest(req.body);
-  if (isValidationFailure(validation)) {
-    return sendResponsesErrorResponse(res, 400, validation.error);
-  }
-
-  const request = validation.request;
+  const requestStartTime = envelope.receivedAt;
+  const request = envelope.payload;
+  const { principal } = envelope;
+  // The local executor keeps the current Express-dependent initialization path,
+  // but all request-body reads now observe the detached envelope payload.
+  req.body = request;
   const agentId = request.model;
   const isStreaming = request.stream === true;
   const summarizationConfig = appConfig?.summarization;
@@ -348,7 +344,7 @@ const createResponse = async (req, res) => {
           'invalid_request',
         );
       }
-      if (!(await db.getConvo(req.user?.id, request.previous_response_id))) {
+      if (!(await db.getConvo(principal.userId, request.previous_response_id))) {
         return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
       }
     }
@@ -397,12 +393,12 @@ const createResponse = async (req, res) => {
       appConfig?.endpoints?.[EModelEndpoint.agents]?.capabilities,
     );
     const skillsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.skills);
-    const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
+    const ephemeralSkillsToggle = request.ephemeralAgent?.skills === true;
     const accessibleSkillIds = skillsCapabilityEnabled
       ? withDeploymentSkillIds(
           await findAccessibleResources({
-            userId: req.user.id,
-            role: req.user.role,
+            userId: principal.userId,
+            role: principal.role,
             resourceType: ResourceType.SKILL,
             requiredPermissions: PermissionBits.VIEW,
           }),
@@ -410,8 +406,8 @@ const createResponse = async (req, res) => {
       : [];
     const editableSkillIds = skillsCapabilityEnabled
       ? await findAccessibleResources({
-          userId: req.user.id,
-          role: req.user.role,
+          userId: principal.userId,
+          role: principal.role,
           resourceType: ResourceType.SKILL,
           requiredPermissions: PermissionBits.EDIT,
         })
@@ -421,13 +417,13 @@ const createResponse = async (req, res) => {
       : false;
 
     const { skillStates, defaultActiveOnShare } = await loadSkillStates({
-      userId: req.user.id,
+      userId: principal.userId,
       appConfig,
       getUserById: db.getUserById,
       accessibleSkillIds,
     });
 
-    const manualSkills = extractManualSkills(req.body);
+    const manualSkills = extractManualSkills(request);
 
     const primaryScopedSkillIds = resolveAgentScopedSkillIds({
       agent,
@@ -611,7 +607,7 @@ const createResponse = async (req, res) => {
     // Load previous messages if previous_response_id is provided
     let previousMessages = [];
     if (request.previous_response_id) {
-      const userId = req.user?.id ?? 'api-user';
+      const userId = principal.userId;
       previousMessages = await loadPreviousMessages(request.previous_response_id, userId);
     }
 
@@ -777,7 +773,7 @@ const createResponse = async (req, res) => {
       };
 
       // Create and run the agent
-      const userId = req.user?.id ?? 'api-user';
+      const userId = principal.userId;
       const userMCPAuthMap = mergedMCPAuthMap;
 
       const run = await createRun({
@@ -795,7 +791,7 @@ const createResponse = async (req, res) => {
           conversationId,
         },
         user: { id: userId },
-        tenantId: req.user?.tenantId,
+        tenantId: principal.tenantId,
         /** Bills subagent child-run model calls (reported outside the
          *  streamEvents loop) into the same collectedUsage array. */
         subagentUsageSink: createSubagentUsageSink(collectedUsage),
@@ -958,7 +954,7 @@ const createResponse = async (req, res) => {
           : {}),
       };
 
-      const userId = req.user?.id ?? 'api-user';
+      const userId = principal.userId;
       const userMCPAuthMap = mergedMCPAuthMap;
 
       const run = await createRun({
@@ -976,7 +972,7 @@ const createResponse = async (req, res) => {
           conversationId,
         },
         user: { id: userId },
-        tenantId: req.user?.tenantId,
+        tenantId: principal.tenantId,
         /** Bills subagent child-run model calls (reported outside the
          *  streamEvents loop) into the same collectedUsage array. */
         subagentUsageSink: createSubagentUsageSink(collectedUsage),
@@ -1088,6 +1084,33 @@ const createResponse = async (req, res) => {
       sendResponsesErrorResponse(res, statusCode, errorMessage, errorType);
     }
   }
+};
+
+/**
+ * Open Responses ingress adapter for agents.
+ * Authentication and remote-agent authorization have already run in route middleware.
+ *
+ * POST /v1/responses
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const createResponse = async (req, res) => {
+  const receivedAt = Date.now();
+  const validation = validateResponseRequest(req.body);
+  if (isValidationFailure(validation)) {
+    return sendResponsesErrorResponse(res, 400, validation.error);
+  }
+
+  const envelope = createAgentRunEnvelope({
+    protocol: 'responses',
+    requestId: req.requestId ?? req.id ?? `agent-run-${nanoid()}`,
+    receivedAt,
+    principal: req.user,
+    payload: validation.request,
+  });
+
+  return executeResponse(envelope, { req, res });
 };
 
 /**

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -13,6 +13,7 @@ const {
   createRun,
   applyContextToAgent,
   buildToolSet,
+  AgentRunEnvelopeError,
   createAgentRunEnvelope,
   buildAgentScopedContext,
   buildAgentContextAttachmentsByAgentId,
@@ -1102,13 +1103,21 @@ const createResponse = async (req, res) => {
     return sendResponsesErrorResponse(res, 400, validation.error);
   }
 
-  const envelope = createAgentRunEnvelope({
-    protocol: 'responses',
-    requestId: req.requestId ?? req.id ?? `agent-run-${nanoid()}`,
-    receivedAt,
-    principal: req.user,
-    payload: validation.request,
-  });
+  let envelope;
+  try {
+    envelope = createAgentRunEnvelope({
+      protocol: 'responses',
+      requestId: req.requestId ?? req.id ?? `agent-run-${nanoid()}`,
+      receivedAt,
+      principal: req.user,
+      payload: validation.request,
+    });
+  } catch (error) {
+    if (error instanceof AgentRunEnvelopeError) {
+      return sendResponsesErrorResponse(res, 400, error.message, 'invalid_request');
+    }
+    throw error;
+  }
 
   return executeResponse(envelope, { req, res });
 };

--- a/packages/api/src/agents/envelope.spec.ts
+++ b/packages/api/src/agents/envelope.spec.ts
@@ -1,0 +1,144 @@
+import {
+  AGENT_RUN_ENVELOPE_VERSION,
+  AgentRunEnvelopeError,
+  createAgentRunEnvelope,
+} from './envelope';
+
+describe('createAgentRunEnvelope', () => {
+  const createBaseInput = () => ({
+    protocol: 'chat.completions' as const,
+    requestId: 'req-123',
+    receivedAt: 1_725_000_000_000,
+    principal: {
+      id: 'user-123',
+      role: 'USER',
+      tenantId: 'tenant-123',
+      password: 'must-not-cross',
+      federatedTokens: { access_token: 'must-not-cross' },
+    },
+    payload: {
+      model: 'agent-123',
+      messages: [{ role: 'user' as const, content: 'Hello' }],
+      stream: true,
+      ephemeralAgent: { skills: true },
+      manualSkills: ['review-code'],
+      timezone: 'America/New_York',
+    },
+  });
+
+  it('creates a versioned JSON envelope with only the trusted principal projection', () => {
+    const envelope = createAgentRunEnvelope(createBaseInput());
+
+    expect(envelope).toEqual({
+      version: AGENT_RUN_ENVELOPE_VERSION,
+      protocol: 'chat.completions',
+      requestId: 'req-123',
+      receivedAt: 1_725_000_000_000,
+      principal: {
+        userId: 'user-123',
+        role: 'USER',
+        tenantId: 'tenant-123',
+      },
+      payload: {
+        model: 'agent-123',
+        messages: [{ role: 'user', content: 'Hello' }],
+        stream: true,
+        ephemeralAgent: { skills: true },
+        manualSkills: ['review-code'],
+        timezone: 'America/New_York',
+      },
+    });
+    expect(JSON.parse(JSON.stringify(envelope))).toEqual(envelope);
+    expect(JSON.stringify(envelope)).not.toContain('must-not-cross');
+  });
+
+  it('detaches the payload from the Express request body', () => {
+    const input = createBaseInput();
+    const envelope = createAgentRunEnvelope(input);
+    input.payload.messages[0].content = 'Changed after dispatch';
+
+    expect(envelope.payload.messages[0].content).toBe('Hello');
+  });
+
+  it.each([
+    ['function', () => undefined],
+    ['undefined', undefined],
+    ['bigint', BigInt(1)],
+    ['symbol', Symbol('value')],
+    ['non-finite number', Number.NaN],
+    ['class instance', new Date()],
+  ])('rejects a %s in the payload', (_label, value) => {
+    expect(() =>
+      createAgentRunEnvelope({
+        ...createBaseInput(),
+        payload: { ...createBaseInput().payload, unsafe: value },
+      } as unknown as Parameters<typeof createAgentRunEnvelope>[0]),
+    ).toThrow(AgentRunEnvelopeError);
+  });
+
+  it('rejects circular payloads', () => {
+    const payload: Record<string, unknown> = { ...createBaseInput().payload };
+    payload.circular = payload;
+
+    expect(() =>
+      createAgentRunEnvelope({
+        ...createBaseInput(),
+        payload,
+      } as unknown as Parameters<typeof createAgentRunEnvelope>[0]),
+    ).toThrow('payload.circular contains a circular reference');
+  });
+
+  it('rejects sparse arrays and hidden object state', () => {
+    const sparse = Array<string>(1);
+    expect(() =>
+      createAgentRunEnvelope({
+        ...createBaseInput(),
+        payload: { ...createBaseInput().payload, sparse },
+      } as unknown as Parameters<typeof createAgentRunEnvelope>[0]),
+    ).toThrow('payload.sparse contains a sparse array entry at index 0');
+
+    const payload = { ...createBaseInput().payload };
+    Object.defineProperty(payload, 'hidden', { enumerable: false, value: 'state' });
+    expect(() => createAgentRunEnvelope({ ...createBaseInput(), payload })).toThrow(
+      'payload.hidden must be an enumerable property',
+    );
+  });
+
+  it('supports the Responses protocol as a discriminated envelope', () => {
+    const payload = {
+      model: 'agent-123',
+      input: 'Hello',
+      stream: false,
+      isTemporary: true,
+      manualSkills: ['review-code'],
+    };
+    const envelope = createAgentRunEnvelope({
+      protocol: 'responses',
+      requestId: 'req-responses',
+      receivedAt: 1_725_000_000_001,
+      principal: { id: 'user-123' },
+      payload,
+    });
+
+    expect(envelope.protocol).toBe('responses');
+    expect(envelope.payload).toEqual(payload);
+  });
+
+  it('requires an authenticated user id', () => {
+    expect(() =>
+      createAgentRunEnvelope({
+        ...createBaseInput(),
+        principal: undefined,
+      }),
+    ).toThrow('principal.id must be a non-empty string');
+  });
+
+  it('rejects unknown protocol tags at runtime', () => {
+    expect(() =>
+      createAgentRunEnvelope({
+        ...createBaseInput(),
+        protocol: 'assistants',
+      } as unknown as Parameters<typeof createAgentRunEnvelope>[0]),
+    ).toThrow('Unsupported agent run protocol: assistants');
+  });
+});

--- a/packages/api/src/agents/envelope.spec.ts
+++ b/packages/api/src/agents/envelope.spec.ts
@@ -50,6 +50,7 @@ describe('createAgentRunEnvelope', () => {
     });
     expect(JSON.parse(JSON.stringify(envelope))).toEqual(envelope);
     expect(JSON.stringify(envelope)).not.toContain('must-not-cross');
+    expect(envelope.payload.ephemeralAgent?.skills).toBe(true);
   });
 
   it('detaches the payload from the Express request body', () => {
@@ -122,6 +123,7 @@ describe('createAgentRunEnvelope', () => {
 
     expect(envelope.protocol).toBe('responses');
     expect(envelope.payload).toEqual(payload);
+    expect(envelope.payload.isTemporary).toBe(true);
   });
 
   it('requires an authenticated user id', () => {

--- a/packages/api/src/agents/envelope.spec.ts
+++ b/packages/api/src/agents/envelope.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AGENT_RUN_ENVELOPE_MAX_NESTING_DEPTH,
   AGENT_RUN_ENVELOPE_VERSION,
   AgentRunEnvelopeError,
   createAgentRunEnvelope,
@@ -90,6 +91,20 @@ describe('createAgentRunEnvelope', () => {
     ).toThrow('payload.circular contains a circular reference');
   });
 
+  it('rejects payloads that exceed the bounded nesting depth', () => {
+    let nested: unknown = 'value';
+    for (let depth = 0; depth <= AGENT_RUN_ENVELOPE_MAX_NESTING_DEPTH; depth++) {
+      nested = [nested];
+    }
+
+    expect(() =>
+      createAgentRunEnvelope({
+        ...createBaseInput(),
+        payload: { ...createBaseInput().payload, nested },
+      } as unknown as Parameters<typeof createAgentRunEnvelope>[0]),
+    ).toThrow(`exceeds the maximum nesting depth of ${AGENT_RUN_ENVELOPE_MAX_NESTING_DEPTH}`);
+  });
+
   it('rejects sparse arrays and hidden object state', () => {
     const sparse = Array<string>(1);
     expect(() =>
@@ -97,7 +112,7 @@ describe('createAgentRunEnvelope', () => {
         ...createBaseInput(),
         payload: { ...createBaseInput().payload, sparse },
       } as unknown as Parameters<typeof createAgentRunEnvelope>[0]),
-    ).toThrow('payload.sparse contains a sparse array entry at index 0');
+    ).toThrow('payload.sparse contains sparse array entries');
 
     const payload = { ...createBaseInput().payload };
     Object.defineProperty(payload, 'hidden', { enumerable: false, value: 'state' });

--- a/packages/api/src/agents/envelope.spec.ts
+++ b/packages/api/src/agents/envelope.spec.ts
@@ -67,6 +67,7 @@ describe('createAgentRunEnvelope', () => {
     ['bigint', BigInt(1)],
     ['symbol', Symbol('value')],
     ['non-finite number', Number.NaN],
+    ['positive infinity', Number.POSITIVE_INFINITY],
     ['class instance', new Date()],
   ])('rejects a %s in the payload', (_label, value) => {
     expect(() =>

--- a/packages/api/src/agents/envelope.ts
+++ b/packages/api/src/agents/envelope.ts
@@ -1,0 +1,227 @@
+import type { ChatCompletionRequest } from './openai';
+import type { ResponseRequest } from './responses';
+
+export const AGENT_RUN_ENVELOPE_VERSION = 1 as const;
+
+export type AgentRunProtocol = 'chat.completions' | 'responses';
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export interface AgentRunPrincipal {
+  userId: string;
+  role?: string;
+  tenantId?: string;
+}
+
+export interface AgentRunPrincipalInput {
+  id?: string;
+  role?: string;
+  tenantId?: string;
+}
+
+interface AgentRunEnvelopeBase {
+  version: typeof AGENT_RUN_ENVELOPE_VERSION;
+  requestId: string;
+  receivedAt: number;
+  principal: AgentRunPrincipal;
+}
+
+export interface ChatCompletionRunEnvelope extends AgentRunEnvelopeBase {
+  protocol: 'chat.completions';
+  payload: ChatCompletionRequest;
+}
+
+export interface ResponsesRunEnvelope extends AgentRunEnvelopeBase {
+  protocol: 'responses';
+  payload: ResponseRequest;
+}
+
+export type AgentRunEnvelope = ChatCompletionRunEnvelope | ResponsesRunEnvelope;
+
+export type CreateAgentRunEnvelopeInput =
+  | {
+      protocol: 'chat.completions';
+      requestId: string;
+      receivedAt: number;
+      principal: AgentRunPrincipalInput | null | undefined;
+      payload: ChatCompletionRequest;
+    }
+  | {
+      protocol: 'responses';
+      requestId: string;
+      receivedAt: number;
+      principal: AgentRunPrincipalInput | null | undefined;
+      payload: ResponseRequest;
+    };
+
+type CreateChatCompletionRunEnvelopeInput = Extract<
+  CreateAgentRunEnvelopeInput,
+  { protocol: 'chat.completions' }
+>;
+type CreateResponsesRunEnvelopeInput = Extract<
+  CreateAgentRunEnvelopeInput,
+  { protocol: 'responses' }
+>;
+
+export class AgentRunEnvelopeError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentRunEnvelopeError';
+  }
+}
+
+function assertNonEmptyString(value: string | undefined, path: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new AgentRunEnvelopeError(`${path} must be a non-empty string`);
+  }
+  return value;
+}
+
+function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>): JsonValue {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new AgentRunEnvelopeError(`${path} must contain only finite numbers`);
+    }
+    return value;
+  }
+
+  if (typeof value !== 'object') {
+    throw new AgentRunEnvelopeError(`${path} contains a non-JSON ${typeof value} value`);
+  }
+
+  if (ancestors.has(value)) {
+    throw new AgentRunEnvelopeError(`${path} contains a circular reference`);
+  }
+
+  ancestors.add(value);
+
+  try {
+    const symbolKeys = Object.getOwnPropertySymbols(value);
+    if (symbolKeys.length > 0) {
+      throw new AgentRunEnvelopeError(`${path} contains symbol keys`);
+    }
+
+    if (Array.isArray(value)) {
+      const extraKeys = Object.getOwnPropertyNames(value).filter((key) => {
+        if (key === 'length') {
+          return false;
+        }
+        const index = Number(key);
+        return (
+          !Number.isSafeInteger(index) ||
+          index < 0 ||
+          index >= value.length ||
+          String(index) !== key
+        );
+      });
+      if (extraKeys.length > 0) {
+        throw new AgentRunEnvelopeError(`${path} contains non-index array properties`);
+      }
+
+      const cloned: JsonValue[] = [];
+      for (let index = 0; index < value.length; index++) {
+        if (!Object.prototype.hasOwnProperty.call(value, index)) {
+          throw new AgentRunEnvelopeError(
+            `${path} contains a sparse array entry at index ${index}`,
+          );
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (descriptor?.get || descriptor?.set) {
+          throw new AgentRunEnvelopeError(`${path}[${index}] must not be an accessor property`);
+        }
+        cloned.push(cloneJsonValue(value[index], `${path}[${index}]`, ancestors));
+      }
+      return cloned;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      const typeName = value.constructor?.name ?? 'object';
+      throw new AgentRunEnvelopeError(`${path} contains a non-plain ${typeName} value`);
+    }
+
+    const cloned: { [key: string]: JsonValue } = {};
+    for (const key of Object.getOwnPropertyNames(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor?.enumerable !== true) {
+        throw new AgentRunEnvelopeError(`${path}.${key} must be an enumerable property`);
+      }
+      if (descriptor?.get || descriptor?.set) {
+        throw new AgentRunEnvelopeError(`${path}.${key} must not be an accessor property`);
+      }
+      Object.defineProperty(cloned, key, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: cloneJsonValue((value as Record<string, unknown>)[key], `${path}.${key}`, ancestors),
+      });
+    }
+    return cloned;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function createPrincipal(input: AgentRunPrincipalInput | null | undefined): AgentRunPrincipal {
+  const userId = assertNonEmptyString(input?.id, 'principal.id');
+  const principal: AgentRunPrincipal = { userId };
+
+  if (input?.role != null) {
+    principal.role = assertNonEmptyString(input.role, 'principal.role');
+  }
+  if (input?.tenantId != null) {
+    principal.tenantId = assertNonEmptyString(input.tenantId, 'principal.tenantId');
+  }
+
+  return principal;
+}
+
+/**
+ * Creates the versioned, transport-safe request that crosses the agent execution seam.
+ * Runtime objects, provider clients, callbacks, credentials, and Express state belong to
+ * the execution host and must never be added to this envelope.
+ */
+export function createAgentRunEnvelope(
+  input: CreateChatCompletionRunEnvelopeInput,
+): ChatCompletionRunEnvelope;
+export function createAgentRunEnvelope(
+  input: CreateResponsesRunEnvelopeInput,
+): ResponsesRunEnvelope;
+export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): AgentRunEnvelope {
+  const receivedProtocol: string = input.protocol;
+  const requestId = assertNonEmptyString(input.requestId, 'requestId');
+  if (!Number.isSafeInteger(input.receivedAt) || input.receivedAt < 0) {
+    throw new AgentRunEnvelopeError('receivedAt must be a non-negative integer timestamp');
+  }
+
+  const payload = cloneJsonValue(input.payload, 'payload', new WeakSet());
+  const base = {
+    version: AGENT_RUN_ENVELOPE_VERSION,
+    requestId,
+    receivedAt: input.receivedAt,
+    principal: createPrincipal(input.principal),
+  };
+
+  if (input.protocol === 'chat.completions') {
+    return {
+      ...base,
+      protocol: input.protocol,
+      payload: payload as unknown as ChatCompletionRequest,
+    };
+  }
+
+  if (input.protocol === 'responses') {
+    return {
+      ...base,
+      protocol: input.protocol,
+      payload: payload as unknown as ResponseRequest,
+    };
+  }
+
+  throw new AgentRunEnvelopeError(`Unsupported agent run protocol: ${receivedProtocol}`);
+}

--- a/packages/api/src/agents/envelope.ts
+++ b/packages/api/src/agents/envelope.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionRequest } from './openai';
 import type { ResponseRequest } from './responses';
 
 export const AGENT_RUN_ENVELOPE_VERSION = 1 as const;
+export const AGENT_RUN_ENVELOPE_MAX_NESTING_DEPTH = 64;
 
 export type AgentRunProtocol = 'chat.completions' | 'responses';
 
@@ -90,8 +91,19 @@ function assertNonEmptyString(value: string | undefined, path: string): string {
   return value;
 }
 
-function cloneJsonValue<T>(value: T, path: string, ancestors: WeakSet<object>): T;
-function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>): unknown {
+function cloneJsonValue<T>(value: T, path: string, ancestors: WeakSet<object>, depth: number): T;
+function cloneJsonValue(
+  value: unknown,
+  path: string,
+  ancestors: WeakSet<object>,
+  depth: number,
+): unknown {
+  if (depth > AGENT_RUN_ENVELOPE_MAX_NESTING_DEPTH) {
+    throw new AgentRunEnvelopeError(
+      `${path} exceeds the maximum nesting depth of ${AGENT_RUN_ENVELOPE_MAX_NESTING_DEPTH}`,
+    );
+  }
+
   if (value === null || typeof value === 'string' || typeof value === 'boolean') {
     return value;
   }
@@ -120,35 +132,31 @@ function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>
     }
 
     if (Array.isArray(value)) {
-      const extraKeys = Object.getOwnPropertyNames(value).filter((key) => {
+      const cloned: unknown[] = new Array(value.length);
+      let clonedItemCount = 0;
+      for (const key of Object.getOwnPropertyNames(value)) {
         if (key === 'length') {
-          return false;
+          continue;
         }
         const index = Number(key);
-        return (
+        if (
           !Number.isSafeInteger(index) ||
           index < 0 ||
           index >= value.length ||
           String(index) !== key
-        );
-      });
-      if (extraKeys.length > 0) {
-        throw new AgentRunEnvelopeError(`${path} contains non-index array properties`);
-      }
-
-      const cloned: unknown[] = [];
-      for (let index = 0; index < value.length; index++) {
-        if (!Object.prototype.hasOwnProperty.call(value, index)) {
-          throw new AgentRunEnvelopeError(
-            `${path} contains a sparse array entry at index ${index}`,
-          );
+        ) {
+          throw new AgentRunEnvelopeError(`${path} contains non-index array properties`);
         }
-        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
         if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
           throw new AgentRunEnvelopeError(`${path}[${index}] must not be an accessor property`);
         }
         const itemValue: unknown = descriptor.value;
-        cloned.push(cloneJsonValue(itemValue, `${path}[${index}]`, ancestors));
+        cloned[index] = cloneJsonValue(itemValue, `${path}[${index}]`, ancestors, depth + 1);
+        clonedItemCount++;
+      }
+      if (clonedItemCount !== value.length) {
+        throw new AgentRunEnvelopeError(`${path} contains sparse array entries`);
       }
       return cloned;
     }
@@ -173,7 +181,7 @@ function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>
         configurable: true,
         enumerable: true,
         writable: true,
-        value: cloneJsonValue(propertyValue, `${path}.${key}`, ancestors),
+        value: cloneJsonValue(propertyValue, `${path}.${key}`, ancestors, depth + 1),
       });
     }
     return cloned;
@@ -225,7 +233,7 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     return {
       ...base,
       protocol: input.protocol,
-      payload: cloneJsonValue(input.payload, 'payload', new WeakSet()),
+      payload: cloneJsonValue(input.payload, 'payload', new WeakSet(), 0),
     };
   }
 
@@ -233,7 +241,7 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     return {
       ...base,
       protocol: input.protocol,
-      payload: cloneJsonValue(input.payload, 'payload', new WeakSet()),
+      payload: cloneJsonValue(input.payload, 'payload', new WeakSet(), 0),
     };
   }
 

--- a/packages/api/src/agents/envelope.ts
+++ b/packages/api/src/agents/envelope.ts
@@ -1,3 +1,4 @@
+import type { TEphemeralAgent } from 'librechat-data-provider';
 import type { ChatCompletionRequest } from './openai';
 import type { ResponseRequest } from './responses';
 
@@ -20,6 +21,17 @@ export interface AgentRunPrincipalInput {
   tenantId?: string;
 }
 
+/** LibreChat request fields consumed by execution but not declared by the public protocols. */
+export interface AgentRunPayloadExtensions {
+  ephemeralAgent?: TEphemeralAgent | null;
+  manualSkills?: string[];
+  timezone?: string;
+  isTemporary?: boolean;
+}
+
+export type ChatCompletionRunPayload = ChatCompletionRequest & AgentRunPayloadExtensions;
+export type ResponsesRunPayload = ResponseRequest & AgentRunPayloadExtensions;
+
 interface AgentRunEnvelopeBase {
   version: typeof AGENT_RUN_ENVELOPE_VERSION;
   requestId: string;
@@ -29,12 +41,12 @@ interface AgentRunEnvelopeBase {
 
 export interface ChatCompletionRunEnvelope extends AgentRunEnvelopeBase {
   protocol: 'chat.completions';
-  payload: ChatCompletionRequest;
+  payload: ChatCompletionRunPayload;
 }
 
 export interface ResponsesRunEnvelope extends AgentRunEnvelopeBase {
   protocol: 'responses';
-  payload: ResponseRequest;
+  payload: ResponsesRunPayload;
 }
 
 export type AgentRunEnvelope = ChatCompletionRunEnvelope | ResponsesRunEnvelope;
@@ -45,14 +57,14 @@ export type CreateAgentRunEnvelopeInput =
       requestId: string;
       receivedAt: number;
       principal: AgentRunPrincipalInput | null | undefined;
-      payload: ChatCompletionRequest;
+      payload: ChatCompletionRunPayload;
     }
   | {
       protocol: 'responses';
       requestId: string;
       receivedAt: number;
       principal: AgentRunPrincipalInput | null | undefined;
-      payload: ResponseRequest;
+      payload: ResponsesRunPayload;
     };
 
 type CreateChatCompletionRunEnvelopeInput = Extract<
@@ -211,7 +223,7 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     return {
       ...base,
       protocol: input.protocol,
-      payload: payload as unknown as ChatCompletionRequest,
+      payload: payload as unknown as ChatCompletionRunPayload,
     };
   }
 
@@ -219,7 +231,7 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     return {
       ...base,
       protocol: input.protocol,
-      payload: payload as unknown as ResponseRequest,
+      payload: payload as unknown as ResponsesRunPayload,
     };
   }
 

--- a/packages/api/src/agents/envelope.ts
+++ b/packages/api/src/agents/envelope.ts
@@ -143,10 +143,11 @@ function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>
           );
         }
         const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-        if (descriptor?.get || descriptor?.set) {
+        if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
           throw new AgentRunEnvelopeError(`${path}[${index}] must not be an accessor property`);
         }
-        cloned.push(cloneJsonValue(value[index], `${path}[${index}]`, ancestors));
+        const itemValue: unknown = descriptor.value;
+        cloned.push(cloneJsonValue(itemValue, `${path}[${index}]`, ancestors));
       }
       return cloned;
     }
@@ -163,14 +164,15 @@ function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>
       if (descriptor?.enumerable !== true) {
         throw new AgentRunEnvelopeError(`${path}.${key} must be an enumerable property`);
       }
-      if (descriptor?.get || descriptor?.set) {
+      if (!Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
         throw new AgentRunEnvelopeError(`${path}.${key} must not be an accessor property`);
       }
+      const propertyValue: unknown = descriptor.value;
       Object.defineProperty(cloned, key, {
         configurable: true,
         enumerable: true,
         writable: true,
-        value: cloneJsonValue((value as Record<string, unknown>)[key], `${path}.${key}`, ancestors),
+        value: cloneJsonValue(propertyValue, `${path}.${key}`, ancestors),
       });
     }
     return cloned;

--- a/packages/api/src/agents/envelope.ts
+++ b/packages/api/src/agents/envelope.ts
@@ -90,7 +90,8 @@ function assertNonEmptyString(value: string | undefined, path: string): string {
   return value;
 }
 
-function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>): JsonValue {
+function cloneJsonValue<T>(value: T, path: string, ancestors: WeakSet<object>): T;
+function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>): unknown {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') {
     return value;
   }
@@ -135,7 +136,7 @@ function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>
         throw new AgentRunEnvelopeError(`${path} contains non-index array properties`);
       }
 
-      const cloned: JsonValue[] = [];
+      const cloned: unknown[] = [];
       for (let index = 0; index < value.length; index++) {
         if (!Object.prototype.hasOwnProperty.call(value, index)) {
           throw new AgentRunEnvelopeError(
@@ -158,7 +159,7 @@ function cloneJsonValue(value: unknown, path: string, ancestors: WeakSet<object>
       throw new AgentRunEnvelopeError(`${path} contains a non-plain ${typeName} value`);
     }
 
-    const cloned: { [key: string]: JsonValue } = {};
+    const cloned: { [key: string]: unknown } = {};
     for (const key of Object.getOwnPropertyNames(value)) {
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (descriptor?.enumerable !== true) {
@@ -213,7 +214,6 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     throw new AgentRunEnvelopeError('receivedAt must be a non-negative integer timestamp');
   }
 
-  const payload = cloneJsonValue(input.payload, 'payload', new WeakSet());
   const base = {
     version: AGENT_RUN_ENVELOPE_VERSION,
     requestId,
@@ -225,7 +225,7 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     return {
       ...base,
       protocol: input.protocol,
-      payload: payload as unknown as ChatCompletionRunPayload,
+      payload: cloneJsonValue(input.payload, 'payload', new WeakSet()),
     };
   }
 
@@ -233,7 +233,7 @@ export function createAgentRunEnvelope(input: CreateAgentRunEnvelopeInput): Agen
     return {
       ...base,
       protocol: input.protocol,
-      payload: payload as unknown as ResponsesRunPayload,
+      payload: cloneJsonValue(input.payload, 'payload', new WeakSet()),
     };
   }
 

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -9,6 +9,7 @@ export * from './context';
 export * from './conversation';
 export * from './discovery';
 export * from './edges';
+export * from './envelope';
 export * from './handlers';
 export * from './harvest';
 export * from './initialize';


### PR DESCRIPTION
I introduced a versioned, transport-safe Agents API execution envelope and moved both remote API execution seams ahead of agent initialization.

- Add a strict JSON-safe envelope for Chat Completions and Responses payloads.
- Preserve LibreChat request extensions such as `ephemeralAgent`, `manualSkills`, `timezone`, and `isTemporary`.
- Project authenticated users to `userId`, `role`, and `tenantId` without carrying passwords or federated tokens.
- Split both protocol controllers into ingress adapters and in-process executors.
- Route ownership, skill access, billing, and tenant inputs through the envelope principal.
- Keep Express state and ephemeral OIDC credentials local to the current executor.
- Document the agent run envelope domain term.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

I ran the focused envelope and controller suites, TypeScript validation, package build, ESLint, formatting, and JavaScript syntax checks.

### **Test Configuration**:

- Node.js workspace dependencies from the current LibreChat development checkout
- `13` envelope tests
- `28` Chat Completions and Responses controller tests
- `tsc -p packages/api/tsconfig.spec.json --noEmit`
- `npm run build` in `packages/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes