### PR TITLE
🧭 fix: Drop v6-Only MemoryRouter future Prop from Skill Markdown Spec

### DIFF
--- a/client/src/components/Skills/display/__tests__/SkillMarkdownRenderer.spec.tsx
+++ b/client/src/components/Skills/display/__tests__/SkillMarkdownRenderer.spec.tsx
@@ -11,10 +11,7 @@ function LocationProbe() {
 
 function renderMarkdown(content: string, currentFilePath = 'SKILL.md') {
   return render(
-    <MemoryRouter
-      initialEntries={['/skills/skill-id']}
-      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-    >
+    <MemoryRouter initialEntries={['/skills/skill-id']}>
       <SkillMarkdownRenderer
         content={content}
         skillId="skill-id"


### PR DESCRIPTION
## Summary

The client TypeScript check is red on every open PR's merge ref: #14586 added `SkillMarkdownRenderer.spec.tsx` with the react-router v6 `future` opt-in flags on `MemoryRouter`, and #14582 (merged just before it) upgraded react-router-dom to v7.18.2, whose `MemoryRouterProps` no longer accepts `future` (those behaviors are v7 defaults). The two PRs each passed CI against their own pre-merge bases, so the break only shows up on merge refs.

Removing the prop compiles under both v6 and v7 typings, and all 9 spec tests pass unchanged.

Observed failing on the PR 14587 merge ref: `TypeScript type checks (client)` with TS2322 at `SkillMarkdownRenderer.spec.tsx(16,7)`.