### PR TITLE
🧪 ci: Settle to Render-Idle Before ConversationsSection Memo Baselines

### DIFF
--- a/client/src/components/UnifiedSidebar/__tests__/ConversationsSection.spec.tsx
+++ b/client/src/components/UnifiedSidebar/__tests__/ConversationsSection.spec.tsx
@@ -110,6 +110,31 @@ function TickController() {
 
 const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+const renderCount = () =>
+  mockUseFavorites.mock.calls.length +
+  mockUseGetConversationTags.mock.calls.length +
+  mockUseTitleGeneration.mock.calls.length;
+
+/**
+ * Yield a full event-loop turn inside act. The lazy BookmarkNav's Suspense commit
+ * lands during waitFor's polling, outside act, so its follow-up work sits in the real
+ * scheduler as a macrotask that a microtask-only `await act(async () => {})` misses.
+ */
+const flushEventLoopTurn = () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+/** Flush event-loop turns until two consecutive turns add no renders (bounded). */
+const settleRenders = async () => {
+  let stableTurns = 0;
+  for (let turn = 0; turn < 20 && stableTurns < 2; turn++) {
+    const before = renderCount();
+    await flushEventLoopTurn();
+    stableTurns = renderCount() === before ? stableTurns + 1 : 0;
+  }
+};
+
 const renderSection = () =>
   render(
     <QueryClientProvider client={createQueryClient()}>
@@ -144,11 +169,10 @@ describe('ConversationsSection streaming re-renders', () => {
     // data hook firing is the deterministic signal that the chunk resolved).
     await waitFor(() => expect(mockUseGetConversationTags).toHaveBeenCalled());
 
-    // waitFor resolves as soon as the hook has fired once, but the Suspense
-    // resolution commit can still have a trailing render pass pending on slow
-    // runners (Windows CI shards). Flush it before capturing baselines so the
-    // first stream tick doesn't carry it and inflate the children's counts.
-    await act(async () => {});
+    // waitFor resolves once the hook first fires, but on loaded Windows shards the
+    // Suspense resolution can leave a trailing pass pending in the real scheduler,
+    // which the first stream tick's act would flush into the children's counts.
+    await settleRenders();
 
     expect(mockUseFavorites.mock.calls.length).toBeGreaterThan(0);
     expect(mockUseGetConversationTags.mock.calls.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

De-flakes `ConversationsSection streaming re-renders › does not re-render FavoritesList or BookmarkNav when the section re-renders mid-stream`, which failed twice in a row on "Tests: Windows (shard 1/4)" for run 30720231275 (PR #14588's merge ref, attempts 1 and 2) while the identical dev base passed. Both failures have the same signature: the BookmarkNav counter came back `Expected: 1, Received: 2` at the final assertion.

## Root cause

`BookmarkNav` is lazy-loaded behind `Suspense`. Its resolution commit happens during `waitFor`'s polling, **outside any act scope**, so React schedules the follow-up render work through the real scheduler as a macrotask rather than the act queue. The empty `await act(async () => {})` added in #14071 only drains microtasks and the act queue; it never yields an event-loop turn, so on slow Windows shards (both failing runs logged ~1 GB heap next to the FAIL line) that scheduler task can still be pending when the baselines are captured.

Everything between baseline capture and the assertions is synchronous, so the pending work cannot fire on its own — instead the first stream tick's `act` flushes pending root work wholesale, and the leftover BookmarkNav pass rides along with the tick, inflating the count by exactly one. That also explains why the failure is always +1 and always the tag counter.

## Fix

Replace the single blind flush with a bounded settle loop: flush full event-loop turns inside `act` (`await new Promise((resolve) => setTimeout(resolve, 0))`) until two consecutive turns add no renders across all three hook counters, then capture baselines. Yielding a real turn lets the scheduler's macrotask run inside the act scope, so its React work is flushed before the baselines are read.

The assertion intent is unchanged and still strict: after the section re-renders five times mid-stream, the memoized children must have recorded **zero** additional renders (`toBe(baseline)`).

## Testing

Verified via CI on this PR (the flake only reproduces under loaded Windows runners; the failing runs' logs were pulled from both attempts of run 30720231275 to confirm an identical signature).