### PR TITLE
fix(client): use boolean for Monaco hover option

### DIFF
--- a/client/src/components/Artifacts/ArtifactCodeEditor.tsx
+++ b/client/src/components/Artifacts/ArtifactCodeEditor.tsx
@@ -422,7 +422,7 @@ export const ArtifactCodeEditor = function ArtifactCodeEditor({
       quickSuggestions: !readOnly,
       suggestOnTriggerCharacters: !readOnly,
       parameterHints: { enabled: !readOnly },
-      hover: { enabled: readOnly ? 'off' : 'on' },
+      hover: { enabled: !readOnly },
       matchBrackets: readOnly ? 'never' : 'always',
     }),
     [readOnly],


### PR DESCRIPTION
## What this fixes

The artifact editor configures Monaco's `hover.enabled` option with the strings `'off'` and `'on'`. The current Monaco API defines this option as a boolean, so the frontend TypeScript check fails with:

```text
Type 'string' is not assignable to type 'boolean | undefined'.
```

Both strings are also truthy at runtime, so they do not reliably express the intended disabled state.

## Change

Use `!readOnly` for `hover.enabled`. This matches Monaco's API and preserves the intended behavior: hover is enabled while editing and disabled in read-only mode.

## Scope

One option value in `ArtifactCodeEditor.tsx`; no dependency, API, or persistence changes.

## Validation

- frontend TypeScript check passed after rebuilding the current data-provider package
- 8 focused `ArtifactCodeEditor` tests passed
- focused ESLint and Prettier checks passed
