### PR TITLE
🪪 fix: Strip Unresolved Header Placeholders at Final Resolution

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -3232,11 +3232,13 @@ class AgentClient extends BaseClient {
 
     /** Resolve request-based headers across provider-specific header locations:
      *  OpenAI `configuration.defaultHeaders`, Anthropic `clientOptions.defaultHeaders`
-     *  (preserved above), and Google `customHeaders`.
+     *  (preserved above), and Google `customHeaders`. Uses the `req` captured at
+     *  entry — `disposeClient` nulls `this.options.req` and can race this async
+     *  title flow, which would blank the user context mid-generation.
      */
     resolveConfigHeaders({
       llmConfig: clientOptions,
-      user: createSafeUser(this.options.req?.user),
+      user: createSafeUser(req?.user),
       body: {
         messageId: this.responseMessageId,
         conversationId: this.conversationId,

--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -117,6 +117,7 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
         'OpenAI-Beta': `assistants=${version}`,
       },
       user: req.user,
+      stripUnresolved: true,
     });
     opts.model = azureOptions.azureOpenAIApiDeploymentName;
 

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -539,6 +539,7 @@ function resolveSummarizationProvider(
             headers: customEndpointConfig.headers as Record<string, string>,
             user: createSafeUser(headerContext.user),
             body: headerContext.requestBody,
+            stripUnresolved: true,
           })
         : undefined;
     /**

--- a/packages/api/src/endpoints/google/initialize.ts
+++ b/packages/api/src/endpoints/google/initialize.ts
@@ -100,7 +100,12 @@ export async function initializeGoogle({
    */
   const mergedHeaders = mergeHeaders(allConfig?.headers, googleConfig?.headers);
   const headers = mergedHeaders
-    ? resolveHeaders({ headers: mergedHeaders, user: req.user, body: req.body })
+    ? resolveHeaders({
+        headers: mergedHeaders,
+        user: req.user,
+        body: req.body,
+        stripUnresolved: true,
+      })
     : undefined;
 
   clientOptions = {

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -199,6 +199,7 @@ describe('fetchModels', () => {
     expect(resolveHeaders).toHaveBeenCalledWith({
       headers: customHeaders,
       user: userObject,
+      stripUnresolved: true,
     });
     expect(mockedAxios.get).toHaveBeenCalledWith(
       expect.stringContaining('https://api.test.com/models'),
@@ -658,6 +659,7 @@ describe('fetchModels with Ollama specific logic', () => {
     expect(resolveHeaders).toHaveBeenCalledWith({
       headers: customHeaders,
       user: userObject,
+      stripUnresolved: true,
     });
     expect(mockedAxios.get).toHaveBeenCalledWith('https://api.ollama.test.com/api/tags', {
       headers: customHeaders,

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -97,6 +97,7 @@ async function fetchOllamaModels(
   const resolvedHeaders = resolveHeaders({
     headers: options.headers ?? undefined,
     user: options.user,
+    stripUnresolved: true,
   });
 
   const requestOptions: AxiosRequestConfig & {
@@ -240,6 +241,7 @@ export async function fetchModels({
     const resolvedHeaders = resolveHeaders({
       headers: headers ?? undefined,
       user: userObject,
+      stripUnresolved: true,
     });
 
     const options: AxiosRequestConfig & {

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -2189,3 +2189,107 @@ describe('createSafeUser', () => {
     expect(createSafeUser(user).id).toBeUndefined();
   });
 });
+
+describe('resolveHeaders stripUnresolved', () => {
+  const templateHeaders = {
+    'X-OpenID-Id': '{{LIBRECHAT_USER_OPENIDID}}',
+    'X-User-Id': '{{LIBRECHAT_USER_ID}}',
+    'Content-Type': 'application/json',
+  };
+
+  it('strips user placeholders when user context is missing entirely', () => {
+    const result = resolveHeaders({ headers: { ...templateHeaders }, stripUnresolved: true });
+
+    expect(result).toEqual({
+      'X-OpenID-Id': '',
+      'X-User-Id': '',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('strips user placeholders when the safe user is an empty object (issue #14580)', () => {
+    const result = resolveHeaders({
+      headers: { ...templateHeaders },
+      user: createSafeUser(undefined),
+      stripUnresolved: true,
+    });
+
+    expect(result).toEqual({
+      'X-OpenID-Id': '',
+      'X-User-Id': '',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('strips placeholders for fields the user lacks while substituting present fields', () => {
+    const localUser = createSafeUser({ id: 'user-123', email: 'me@example.com' } as IUser);
+
+    const result = resolveHeaders({
+      headers: { ...templateHeaders, 'X-Email': '{{LIBRECHAT_USER_EMAIL}}' },
+      user: localUser,
+      stripUnresolved: true,
+    });
+
+    expect(result).toEqual({
+      'X-OpenID-Id': '',
+      'X-User-Id': 'user-123',
+      'X-Email': 'me@example.com',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('strips only the placeholder within a composite header value', () => {
+    const result = resolveHeaders({
+      headers: { Authorization: 'Bearer {{LIBRECHAT_USER_OPENIDID}}' },
+      stripUnresolved: true,
+    });
+
+    expect(result.Authorization).toBe('Bearer ');
+  });
+
+  it('strips body placeholders when no body context is available', () => {
+    const result = resolveHeaders({
+      headers: { 'X-Convo': '{{LIBRECHAT_BODY_CONVERSATIONID}}' },
+      user: { id: 'user-123' },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Convo']).toBe('');
+  });
+
+  it('strips OpenID token placeholders when no valid token is available', () => {
+    const result = resolveHeaders({
+      headers: {
+        'X-Access': '{{LIBRECHAT_OPENID_ACCESS_TOKEN}}',
+        'X-Token': '{{LIBRECHAT_OPENID_TOKEN}}',
+      },
+      user: { id: 'user-123' },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Access']).toBe('');
+    expect(result['X-Token']).toBe('');
+  });
+
+  it('leaves unknown and non-resolvable placeholders untouched', () => {
+    const result = resolveHeaders({
+      headers: {
+        'X-Typo': '{{LIBRECHAT_USER_NONEXISTENT}}',
+        'X-Graph': '{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}',
+        'X-Custom': '{{MY_CUSTOM_VAR}}',
+      },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Typo']).toBe('{{LIBRECHAT_USER_NONEXISTENT}}');
+    expect(result['X-Graph']).toBe('{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}');
+    expect(result['X-Custom']).toBe('{{MY_CUSTOM_VAR}}');
+  });
+
+  it('preserves unresolved placeholders by default (staged flows resolve later)', () => {
+    const result = resolveHeaders({ headers: { ...templateHeaders } });
+
+    expect(result['X-OpenID-Id']).toBe('{{LIBRECHAT_USER_OPENIDID}}');
+    expect(result['X-User-Id']).toBe('{{LIBRECHAT_USER_ID}}');
+  });
+});

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -2,7 +2,12 @@ import { extractEnvVariable } from 'librechat-data-provider';
 import type { MCPOptions } from 'librechat-data-provider';
 import type { IUser } from '@librechat/data-schemas';
 import type { RequestBody } from '~/types';
-import { extractOpenIDTokenInfo, processOpenIDPlaceholders, isOpenIDTokenValid } from './oidc';
+import {
+  OPENID_TOKEN_FIELDS,
+  isOpenIDTokenValid,
+  extractOpenIDTokenInfo,
+  processOpenIDPlaceholders,
+} from './oidc';
 
 /**
  * List of allowed user fields that can be used in MCP environment variables.
@@ -123,6 +128,36 @@ export function createSafeUser(
  * These are common fields from the request body that are safe to expose in headers.
  */
 const ALLOWED_BODY_FIELDS = ['conversationId', 'parentMessageId', 'messageId'] as const;
+
+/**
+ * Matches every placeholder this module knows how to resolve: the enumerated
+ * `{{LIBRECHAT_USER_*}}`, `{{LIBRECHAT_BODY_*}}`, and `{{LIBRECHAT_OPENID_*}}`
+ * names. Deliberately excludes unknown names (a typo'd placeholder staying
+ * literal is diagnosable) and `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}`, which is
+ * resolved asynchronously via the OBO flow outside this pipeline.
+ */
+const RESOLVABLE_PLACEHOLDER_PATTERN = new RegExp(
+  [
+    `LIBRECHAT_USER_(?:${ALLOWED_USER_FIELDS.map((field) => field.toUpperCase()).join('|')})`,
+    `LIBRECHAT_BODY_(?:${ALLOWED_BODY_FIELDS.map((field) => field.toUpperCase()).join('|')})`,
+    `LIBRECHAT_OPENID_(?:${OPENID_TOKEN_FIELDS.join('|')}|TOKEN)`,
+  ]
+    .map((names) => `\\{\\{(?:${names})\\}\\}`)
+    .join('|'),
+  'g',
+);
+
+/**
+ * Replaces resolvable-but-unresolved placeholders with an empty string so
+ * LibreChat's internal template syntax is never sent upstream as if it were
+ * real user data (e.g. a gateway trusting a literal
+ * `{{LIBRECHAT_USER_OPENIDID}}` as an account identity would pool unrelated
+ * users under that one string). Only for final resolution passes — staged
+ * flows that resolve again later with more context must not strip.
+ */
+function stripUnresolvedPlaceholders(value: string): string {
+  return value.replace(RESOLVABLE_PLACEHOLDER_PATTERN, '');
+}
 
 /**
  * Processes a string value to replace user field placeholders.
@@ -520,6 +555,10 @@ export function resolveNestedObject<T = unknown>(options?: {
  * @param options.user - Optional user object for replacing user field placeholders (can be partial with just id)
  * @param options.body - Optional request body object for replacing body field placeholders
  * @param options.customUserVars - Optional custom user variables to replace placeholders
+ * @param options.stripUnresolved - When true (final resolution passes only), replaces any
+ *   remaining resolvable placeholders with an empty string so internal template syntax is
+ *   never forwarded upstream. Leave unset for staged flows whose values are resolved again
+ *   later with more context.
  * @returns The processed headers with all placeholders replaced
  */
 export function resolveHeaders(options?: {
@@ -527,21 +566,23 @@ export function resolveHeaders(options?: {
   user?: Partial<IUser> | { id: string };
   body?: RequestBody;
   customUserVars?: Record<string, string>;
+  stripUnresolved?: boolean;
 }): Record<string, string> {
-  const { headers, user, body, customUserVars } = options ?? {};
+  const { headers, user, body, customUserVars, stripUnresolved = false } = options ?? {};
   const inputHeaders = headers ?? {};
 
   const resolvedHeaders: Record<string, string> = { ...inputHeaders };
 
   if (inputHeaders && typeof inputHeaders === 'object' && !Array.isArray(inputHeaders)) {
     Object.keys(inputHeaders).forEach((key) => {
-      resolvedHeaders[key] = processSingleValue({
+      const processed = processSingleValue({
         originalValue: inputHeaders[key],
         customUserVars,
         user: user as IUser,
         body,
         isHeader: true, // Important: Enable header encoding
       });
+      resolvedHeaders[key] = stripUnresolved ? stripUnresolvedPlaceholders(processed) : processed;
     });
   }
 

--- a/packages/api/src/utils/headers.spec.ts
+++ b/packages/api/src/utils/headers.spec.ts
@@ -152,4 +152,36 @@ describe('resolveConfigHeaders', () => {
     expect(() => resolveConfigHeaders({ llmConfig, user, body })).not.toThrow();
     expect(llmConfig.configuration).toEqual({});
   });
+
+  it('never forwards unresolved user placeholders when user context is missing (issue #14580)', () => {
+    const llmConfig = {
+      configuration: {
+        defaultHeaders: {
+          'X-LibreChat-User': '{{LIBRECHAT_USER_OPENIDID}}',
+          'X-Conversation-Id': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+        },
+      },
+    } as unknown as RunLLMConfig;
+
+    // The empty safe user produced by createSafeUser(undefined) — e.g. a disposed
+    // req racing async title generation — must not leak literal template text.
+    resolveConfigHeaders({ llmConfig, user: {} as { id: string }, body });
+
+    expect(llmConfig.configuration?.defaultHeaders).toEqual({
+      'X-LibreChat-User': '',
+      'X-Conversation-Id': 'convo-abc',
+    });
+  });
+
+  it('strips placeholders for fields the resolved user lacks', () => {
+    const llmConfig = {
+      configuration: {
+        defaultHeaders: { 'X-LibreChat-User': '{{LIBRECHAT_USER_OPENIDID}}' },
+      },
+    } as unknown as RunLLMConfig;
+
+    resolveConfigHeaders({ llmConfig, user, body });
+
+    expect(llmConfig.configuration?.defaultHeaders).toEqual({ 'X-LibreChat-User': '' });
+  });
 });

--- a/packages/api/src/utils/headers.ts
+++ b/packages/api/src/utils/headers.ts
@@ -89,6 +89,11 @@ const resolvedHeaderMaps = new WeakSet<object>();
  * Resolution runs at request time so request-body placeholders (e.g.
  * `{{LIBRECHAT_BODY_CONVERSATIONID}}`) resolve against the live request. It is a
  * no-op for header values without placeholders, and idempotent under config reuse.
+ *
+ * This is the last resolution pass before the outbound provider request, so any
+ * placeholder still unresolved here (missing user context, a user without the
+ * configured field) is stripped rather than forwarded as literal template text
+ * the upstream could mistake for real user data.
  */
 export function resolveConfigHeaders({
   llmConfig,
@@ -113,7 +118,7 @@ export function resolveConfigHeaders({
     if (resolvedHeaderMaps.has(headers)) {
       return headers;
     }
-    const resolved = resolveHeaders({ headers, user, body, customUserVars });
+    const resolved = resolveHeaders({ headers, user, body, customUserVars, stripUnresolved: true });
     resolvedHeaderMaps.add(resolved);
     return resolved;
   };

--- a/packages/api/src/utils/oidc.ts
+++ b/packages/api/src/utils/oidc.ts
@@ -18,7 +18,7 @@ function isFederatedTokens(obj: unknown): obj is OIDCTokens {
   return 'access_token' in obj || 'id_token' in obj || 'expires_at' in obj;
 }
 
-const OPENID_TOKEN_FIELDS = [
+export const OPENID_TOKEN_FIELDS = [
   'ACCESS_TOKEN',
   'ID_TOKEN',
   'USER_ID',


### PR DESCRIPTION
## Summary

Fixes #14580

`titleConvo` could forward a custom endpoint header containing the literal, unsubstituted `{{LIBRECHAT_USER_OPENIDID}}` template to the upstream provider. A downstream gateway using that header as an account identity then pools unrelated requests under one literal-string identity.

Root cause, exactly as traced in the issue: `createSafeUser` returns a truthy `{}` when its input is falsy, which bypasses the `!user` guard in `processUserPlaceholders`, and the per-field `field in user` check then skips every substitution, leaving the raw template in the header. For custom endpoints, the request-time `resolveConfigHeaders` call is the only resolution pass, so nothing downstream catches it. The likely trigger for a falsy user mid-title is `disposeClient`, which nulls `client.options.req` and can race the async title flow. The same leak also occurs without any race whenever the resolved user simply lacks the configured field (e.g. `{{LIBRECHAT_USER_OPENIDID}}` with a local-auth user).

## Changes

- `resolveHeaders` accepts an opt-in `stripUnresolved` flag: after normal resolution, any remaining resolvable placeholder (enumerated `LIBRECHAT_USER_*`, `LIBRECHAT_BODY_*`, `LIBRECHAT_OPENID_*` names) is replaced with an empty string, matching how present-but-null fields already resolve. This implements option 3 from the issue: internal template syntax is never sent upstream as if it were data.
- The flag is enabled at every final resolution boundary: `resolveConfigHeaders` (main agent runs, titles, memory, activity labels, tool-batch summaries), both model-fetch paths, Google init, summarization client overrides, and azureAssistants init.
- The flag is deliberately NOT set on the staged Azure/OpenAI init pass, whose output is resolved again at request time with body context. Unknown placeholder names (typos) stay literal for diagnosability, and `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` is untouched since it resolves asynchronously via the OBO flow.
- `titleConvo` now resolves headers from the `req` captured at method entry instead of re-reading `this.options.req`, closing the disposal race for the title path specifically.

Default `resolveHeaders` behavior is unchanged, so multi-pass flows (`processMCPEnv` startup vs. connection-time resolution) keep their semantics.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New `resolveHeaders` tests cover: missing user, the exact `createSafeUser(undefined)` empty-object case from the issue, user lacking the configured field, composite values (`Bearer {{...}}`), body/OpenID placeholders without context, typo'd and Graph placeholders staying literal, and default (non-stripping) behavior.
- New `resolveConfigHeaders` tests reproduce the titleConvo scenario end to end.
- `cd packages/api && npx jest src/utils src/endpoints src/agents` passes; `cd api && npx jest server/services/Endpoints/agents/title.test.js server/controllers/agents/client.test.js` passes (106 tests).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes