### PR TITLE
fix: unbreak client build by excluding oversized http-client chunk from precache

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -113,6 +113,9 @@ export default defineConfig(({ command }) => ({
           'assets/rum.*.js',
           'assets/locale-*.js',
           'assets/query-devtools*.js',
+          /** Lazily loaded and far above the precache size limit; fetched on demand
+           * instead, which also keeps the service worker install payload small. */
+          'assets/http-client.*.js',
         ],
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         /** LibreChat mutates index.html per request for subpath and language support. */


### PR DESCRIPTION
## Summary

`npm run build:client` currently fails on `dev`. The `http-client` chunk is 6.99 MB, above the configured precache ceiling of 4 MiB (`maximumFileSizeToCacheInBytes: 4 * 1024 * 1024`, `client/vite.config.ts:117`), and `vite-plugin-pwa` raises that as a build error rather than a warning. The "2 MiB" figure in the error text below is workbox's boilerplate reference to its own default, not the limit in effect here.

```
error during build:
Error:
  Configure "workbox.maximumFileSizeToCacheInBytes" to change the limit: the default value is 2 MiB.
  Assets exceeding the limit:
  - assets/http-client.BBJd4Mom.js is 6.99 MB, and won't be precached.
  code: 'PLUGIN_ERROR',
  plugin: 'vite-plugin-pwa:build',
  hook: 'closeBundle'
```

Reproduce from a clean checkout of `dev` (verified at `664290c65`, with `client/dist` removed and no `.env` present):

```bash
npm ci
npm run build:packages
npm run build:client   # exits 1
```

This adds `assets/http-client.*.js` to `globIgnores`, the same treatment `assets/rum.*.js` and `assets/query-devtools*.js` already get. The chunk is lazily loaded, so fetching it on demand also keeps the service worker install payload small.

## Why CI is green today

Two independent layers hide this:

1. **E2E workflow** caches `client/dist` under `build-client-app-e2e-*` and guards the build with `if: steps.cache-client-app.outputs.cache-hit != 'true'`. In the most recent green run the cache was restored and the `Build client app` step reports `skipped`, so the build never executed.
2. **Docker image build** runs `npm run frontend;` (`Dockerfile:58`) terminated by a semicolon rather than `&&`, followed by `npm prune --production;` and `npm cache clean --force`. A `RUN` layer exits with the status of its last command, so a failed frontend build still yields a successful image, with an incomplete `client/dist` since `post-build.cjs` is `&&`-chained after `vite build`.

Both are worth addressing separately, since together they mean a broken client build can reach `dev` unnoticed.

## Follow-up worth considering (deliberately not in this PR)

The underlying cause is the chunk predicate in `client/vite.config.ts`:

```js
if (
  normalizedId.includes('axios') ||
  normalizedId.includes('ky') ||
  normalizedId.includes('fetch')
) {
  return 'http-client';
}
```

`includes('ky')` and `includes('fetch')` are substring matches against the full module id, so unrelated modules whose paths happen to contain those sequences get pulled in. The result is a 6.99 MB chunk, roughly 3.6x the next largest (`mermaid`, 1.94 MB). Narrowing those matches would shrink the chunk rather than exempt it, but that changes chunk splitting for every consumer and deserves its own review. This PR restores a working build without altering what ships.

## Testing

- `npm run build:client` exits 1 on `dev` at `664290c65` and exits 0 on this branch.
- Confirmed the 6.7 MB `http-client.*.js` is absent from the generated `sw.js` precache manifest, while the small `http-client.*.css` entry is retained.
