### PR TITLE
📡 feat: Route Web Search and Scrape Egress through the SSRF-safe Agent

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -6,6 +6,7 @@ const {
   createSafeUser,
   mcpToolPattern,
   loadWebSearchAuth,
+  createSSRFSafeAgents,
   splitMCPToolKey,
   buildServerNameAliases,
   findShadowedServerNames,
@@ -396,6 +397,7 @@ const loadTools = async ({
         webSearchConfig: webSearch,
       });
       const { onSearchResults, onGetHighlights } = options?.[Tools.web_search] ?? {};
+      const { httpAgent, httpsAgent } = createSSRFSafeAgents(webSearch?.allowedAddresses);
       requestedTools[tool] = async () => {
         toolContextMap[tool] = buildWebSearchContext();
         dynamicToolContextMap[tool] = buildWebSearchDynamicContext(
@@ -403,6 +405,8 @@ const loadTools = async ({
         );
         return createSearchTool({
           ...result.authResult,
+          httpAgent,
+          httpsAgent,
           onSearchResults,
           onGetHighlights,
           logger,

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -397,7 +397,10 @@ const loadTools = async ({
         webSearchConfig: webSearch,
       });
       const { onSearchResults, onGetHighlights } = options?.[Tools.web_search] ?? {};
-      const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(webSearch?.allowedAddresses);
+      const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(
+        result.authResult,
+        webSearch?.allowedAddresses,
+      );
       requestedTools[tool] = async () => {
         toolContextMap[tool] = buildWebSearchContext();
         dynamicToolContextMap[tool] = buildWebSearchDynamicContext(

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -397,10 +397,7 @@ const loadTools = async ({
         webSearchConfig: webSearch,
       });
       const { onSearchResults, onGetHighlights } = options?.[Tools.web_search] ?? {};
-      const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(
-        result.authResult,
-        webSearch?.allowedAddresses,
-      );
+      const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(webSearch?.allowedAddresses);
       requestedTools[tool] = async () => {
         toolContextMap[tool] = buildWebSearchContext();
         dynamicToolContextMap[tool] = buildWebSearchDynamicContext(

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -6,7 +6,6 @@ const {
   createSafeUser,
   mcpToolPattern,
   loadWebSearchAuth,
-  createSSRFSafeAgents,
   splitMCPToolKey,
   buildServerNameAliases,
   findShadowedServerNames,
@@ -19,6 +18,7 @@ const {
   DELETE_MEMORY_TOOL_NAME,
   createAskUserQuestionTool,
   ASK_USER_QUESTION_TOOL_NAME,
+  resolveWebSearchSSRFAgents,
   buildWebSearchDynamicContext,
 } = require('@librechat/api');
 const {
@@ -397,7 +397,10 @@ const loadTools = async ({
         webSearchConfig: webSearch,
       });
       const { onSearchResults, onGetHighlights } = options?.[Tools.web_search] ?? {};
-      const { httpAgent, httpsAgent } = createSSRFSafeAgents(webSearch?.allowedAddresses);
+      const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(
+        result.authResult,
+        webSearch?.allowedAddresses,
+      );
       requestedTools[tool] = async () => {
         toolContextMap[tool] = buildWebSearchContext();
         dynamicToolContextMap[tool] = buildWebSearchDynamicContext(

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -12,6 +12,26 @@ const mockCreateMCPTools = jest.fn();
 const mockGetServerConfig = jest.fn();
 const mockGetAccessibleMcpServerNames = jest.fn(async () => []);
 
+const mockHttpAgent = { __agent: 'http' };
+const mockHttpsAgent = { __agent: 'https' };
+const mockCreateSearchTool = jest.fn(() => ({ name: 'web_search' }));
+const mockCreateSSRFSafeAgents = jest.fn(() => ({
+  httpAgent: mockHttpAgent,
+  httpsAgent: mockHttpsAgent,
+}));
+const mockLoadWebSearchAuth = jest.fn(async () => ({ authResult: { searchProvider: 'serper' } }));
+
+jest.mock('@librechat/agents', () => ({
+  ...jest.requireActual('@librechat/agents'),
+  createSearchTool: (...args) => mockCreateSearchTool(...args),
+}));
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  loadWebSearchAuth: (...args) => mockLoadWebSearchAuth(...args),
+  createSSRFSafeAgents: (...args) => mockCreateSSRFSafeAgents(...args),
+}));
+
 jest.mock('~/server/services/PluginService', () => mockPluginService);
 
 jest.mock('~/server/services/Config', () => ({
@@ -70,7 +90,7 @@ jest.mock('~/config', () => ({
 }));
 
 const { Calculator } = require('@librechat/agents');
-const { Constants } = require('librechat-data-provider');
+const { Tools, Constants } = require('librechat-data-provider');
 const { ASK_USER_QUESTION_TOOL_NAME } = require('@librechat/api');
 
 const { User } = require('~/db/models');
@@ -810,6 +830,53 @@ describe('Tool Handlers', () => {
           availableTools: discoveredTools,
           requestBody,
           toolKey: secondToolKey,
+        }),
+      );
+    });
+  });
+
+  describe('web_search SSRF-safe agent wiring', () => {
+    const buildReq = () => ({
+      user: { id: fakeUser._id.toString(), role: 'USER' },
+      body: {},
+    });
+
+    it('threads the SSRF-safe agents into the search tool config and passes allowedAddresses through', async () => {
+      const allowedAddresses = ['localhost:8888'];
+      const toolMap = await loadTools({
+        user: fakeUser._id.toString(),
+        tools: [Tools.web_search],
+        returnMap: true,
+        webSearch: { allowedAddresses },
+        options: { req: buildReq() },
+      });
+      await toolMap[Tools.web_search]();
+
+      expect(mockCreateSSRFSafeAgents).toHaveBeenCalledTimes(1);
+      expect(mockCreateSSRFSafeAgents).toHaveBeenCalledWith(allowedAddresses);
+      expect(mockCreateSearchTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpAgent: mockHttpAgent,
+          httpsAgent: mockHttpsAgent,
+        }),
+      );
+    });
+
+    it('still threads the agents when allowedAddresses is omitted', async () => {
+      const toolMap = await loadTools({
+        user: fakeUser._id.toString(),
+        tools: [Tools.web_search],
+        returnMap: true,
+        webSearch: {},
+        options: { req: buildReq() },
+      });
+      await toolMap[Tools.web_search]();
+
+      expect(mockCreateSSRFSafeAgents).toHaveBeenCalledWith(undefined);
+      expect(mockCreateSearchTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpAgent: mockHttpAgent,
+          httpsAgent: mockHttpsAgent,
         }),
       );
     });

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -853,10 +853,7 @@ describe('Tool Handlers', () => {
       await toolMap[Tools.web_search]();
 
       expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledTimes(1);
-      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(
-        { searchProvider: 'serper' },
-        allowedAddresses,
-      );
+      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(allowedAddresses);
       expect(mockCreateSearchTool).toHaveBeenCalledWith(
         expect.objectContaining({
           httpAgent: mockHttpAgent,
@@ -875,10 +872,7 @@ describe('Tool Handlers', () => {
       });
       await toolMap[Tools.web_search]();
 
-      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(
-        { searchProvider: 'serper' },
-        undefined,
-      );
+      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(undefined);
       expect(mockCreateSearchTool).toHaveBeenCalledWith(
         expect.objectContaining({
           httpAgent: mockHttpAgent,

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -12,13 +12,7 @@ const mockCreateMCPTools = jest.fn();
 const mockGetServerConfig = jest.fn();
 const mockGetAccessibleMcpServerNames = jest.fn(async () => []);
 
-const mockHttpAgent = { __agent: 'http' };
-const mockHttpsAgent = { __agent: 'https' };
 const mockCreateSearchTool = jest.fn(() => ({ name: 'web_search' }));
-const mockResolveWebSearchSSRFAgents = jest.fn(() => ({
-  httpAgent: mockHttpAgent,
-  httpsAgent: mockHttpsAgent,
-}));
 const mockLoadWebSearchAuth = jest.fn(async () => ({ authResult: { searchProvider: 'serper' } }));
 
 jest.mock('@librechat/agents', () => ({
@@ -29,7 +23,6 @@ jest.mock('@librechat/agents', () => ({
 jest.mock('@librechat/api', () => ({
   ...jest.requireActual('@librechat/api'),
   loadWebSearchAuth: (...args) => mockLoadWebSearchAuth(...args),
-  resolveWebSearchSSRFAgents: (...args) => mockResolveWebSearchSSRFAgents(...args),
 }));
 
 jest.mock('~/server/services/PluginService', () => mockPluginService);
@@ -841,44 +834,49 @@ describe('Tool Handlers', () => {
       body: {},
     });
 
-    it('threads the SSRF-safe agents into the search tool config and passes allowedAddresses through', async () => {
-      const allowedAddresses = ['localhost:8888'];
+    /** Uses the real resolver, so this fails if the wiring delivers agents that do not guard. */
+    async function loadWebSearchConfig(webSearch) {
       const toolMap = await loadTools({
         user: fakeUser._id.toString(),
         tools: [Tools.web_search],
         returnMap: true,
-        webSearch: { allowedAddresses },
+        webSearch,
         options: { req: buildReq() },
       });
       await toolMap[Tools.web_search]();
+      return mockCreateSearchTool.mock.calls.at(-1)[0];
+    }
 
-      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledTimes(1);
-      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(allowedAddresses);
-      expect(mockCreateSearchTool).toHaveBeenCalledWith(
-        expect.objectContaining({
-          httpAgent: mockHttpAgent,
-          httpsAgent: mockHttpsAgent,
-        }),
+    it('threads pooled SSRF-safe agents into the search tool config', async () => {
+      const config = await loadWebSearchConfig({ allowedAddresses: ['localhost:8888'] });
+
+      expect(typeof config.httpAgent.createConnection).toBe('function');
+      expect(typeof config.httpsAgent.createConnection).toBe('function');
+      expect(config.httpAgent.options.keepAlive).toBe(true);
+    });
+
+    it('threads agents that actually reject a private target', async () => {
+      const config = await loadWebSearchConfig({});
+
+      expect(() =>
+        config.httpAgent.createConnection({ host: '169.254.169.254', port: 80 }),
+      ).toThrow(expect.objectContaining({ code: 'ESSRF' }));
+    });
+
+    it('honors allowedAddresses end to end, exempting the configured host:port only', async () => {
+      const config = await loadWebSearchConfig({ allowedAddresses: ['127.0.0.1:8080'] });
+
+      const socket = config.httpAgent.createConnection({ host: '127.0.0.1', port: 8080 });
+      socket?.destroy?.();
+      expect(() => config.httpAgent.createConnection({ host: '127.0.0.1', port: 9 })).toThrow(
+        expect.objectContaining({ code: 'ESSRF' }),
       );
     });
 
-    it('still threads the agents when allowedAddresses is omitted', async () => {
-      const toolMap = await loadTools({
-        user: fakeUser._id.toString(),
-        tools: [Tools.web_search],
-        returnMap: true,
-        webSearch: {},
-        options: { req: buildReq() },
-      });
-      await toolMap[Tools.web_search]();
-
-      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(undefined);
-      expect(mockCreateSearchTool).toHaveBeenCalledWith(
-        expect.objectContaining({
-          httpAgent: mockHttpAgent,
-          httpsAgent: mockHttpsAgent,
-        }),
-      );
+    it('does not throw out of loadTools when allowedAddresses is not an array', async () => {
+      await expect(
+        loadWebSearchConfig({ allowedAddresses: { '10.0.0.5:11434': true } }),
+      ).resolves.toBeDefined();
     });
   });
 });

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -13,7 +13,9 @@ const mockGetServerConfig = jest.fn();
 const mockGetAccessibleMcpServerNames = jest.fn(async () => []);
 
 const mockCreateSearchTool = jest.fn(() => ({ name: 'web_search' }));
-const mockLoadWebSearchAuth = jest.fn(async () => ({ authResult: { searchProvider: 'serper' } }));
+const mockLoadWebSearchAuth = jest.fn(async () => ({
+  authResult: { searchProvider: 'serper', searxngInstanceUrl: 'http://searxng.internal:8080' },
+}));
 
 jest.mock('@librechat/agents', () => ({
   ...jest.requireActual('@librechat/agents'),

--- a/api/app/clients/tools/util/handleTools.test.js
+++ b/api/app/clients/tools/util/handleTools.test.js
@@ -15,7 +15,7 @@ const mockGetAccessibleMcpServerNames = jest.fn(async () => []);
 const mockHttpAgent = { __agent: 'http' };
 const mockHttpsAgent = { __agent: 'https' };
 const mockCreateSearchTool = jest.fn(() => ({ name: 'web_search' }));
-const mockCreateSSRFSafeAgents = jest.fn(() => ({
+const mockResolveWebSearchSSRFAgents = jest.fn(() => ({
   httpAgent: mockHttpAgent,
   httpsAgent: mockHttpsAgent,
 }));
@@ -29,7 +29,7 @@ jest.mock('@librechat/agents', () => ({
 jest.mock('@librechat/api', () => ({
   ...jest.requireActual('@librechat/api'),
   loadWebSearchAuth: (...args) => mockLoadWebSearchAuth(...args),
-  createSSRFSafeAgents: (...args) => mockCreateSSRFSafeAgents(...args),
+  resolveWebSearchSSRFAgents: (...args) => mockResolveWebSearchSSRFAgents(...args),
 }));
 
 jest.mock('~/server/services/PluginService', () => mockPluginService);
@@ -852,8 +852,11 @@ describe('Tool Handlers', () => {
       });
       await toolMap[Tools.web_search]();
 
-      expect(mockCreateSSRFSafeAgents).toHaveBeenCalledTimes(1);
-      expect(mockCreateSSRFSafeAgents).toHaveBeenCalledWith(allowedAddresses);
+      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledTimes(1);
+      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(
+        { searchProvider: 'serper' },
+        allowedAddresses,
+      );
       expect(mockCreateSearchTool).toHaveBeenCalledWith(
         expect.objectContaining({
           httpAgent: mockHttpAgent,
@@ -872,7 +875,10 @@ describe('Tool Handlers', () => {
       });
       await toolMap[Tools.web_search]();
 
-      expect(mockCreateSSRFSafeAgents).toHaveBeenCalledWith(undefined);
+      expect(mockResolveWebSearchSSRFAgents).toHaveBeenCalledWith(
+        { searchProvider: 'serper' },
+        undefined,
+      );
       expect(mockCreateSearchTool).toHaveBeenCalledWith(
         expect.objectContaining({
           httpAgent: mockHttpAgent,

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -883,6 +883,13 @@ endpoints:
 #   # so only list hosts you fully control and whose DNS cannot be repointed by an
 #   # attacker. Listing an attacker-controllable or DNS-rebindable host re-opens the
 #   # private-address path this guard closes. Prefer literal IPs where you can.
+#   #
+#   # Self-hosted endpoints need an entry. A private destination such as
+#   # `http://searxng:8080` or `http://firecrawl:3002` is blocked once this guard is
+#   # active, so list it here or those requests will fail. A configured proxy
+#   # (`PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`) is exempted automatically and needs no
+#   # entry; when a proxy carries the request, destination egress policy is the
+#   # proxy's to enforce.
 #   # allowedAddresses:
 #   #   - 'searxng:8080'
 #   #   - '127.0.0.1:8080'

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -870,6 +870,22 @@ endpoints:
 #   # Content scrapers
 #   firecrawlApiKey: '${FIRECRAWL_API_KEY}'
 #   firecrawlApiUrl: '${FIRECRAWL_API_URL}'
+#   # Outbound search and scrape requests are validated at connect time against
+#   # their resolved IP and blocked from reaching private, loopback, link-local,
+#   # or cloud-metadata space. `allowedAddresses` is an SSRF exemption list, NOT a
+#   # strict whitelist: hostname/IP + port pairs listed here bypass that block for
+#   # one deliberately-private endpoint (for example a self-hosted SearXNG
+#   # instance); public destinations continue to work normally.
+#   #
+#   # Entries must include a port: `host:port`, `private.ip:port`, or `[ipv6]:port`.
+#   # Do not use URLs, paths, CIDR ranges, bare hosts/IPs, or public IP literals.
+#   # A hostname entry trusts whatever IP that name resolves to on the listed port,
+#   # so only list hosts you fully control and whose DNS cannot be repointed by an
+#   # attacker. Listing an attacker-controllable or DNS-rebindable host re-opens the
+#   # private-address path this guard closes. Prefer literal IPs where you can.
+#   # allowedAddresses:
+#   #   - 'searxng:8080'
+#   #   - '127.0.0.1:8080'
 #
 # Tavily as both search and scraper provider example:
 # webSearch:

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -885,11 +885,15 @@ endpoints:
 #   # private-address path this guard closes. Prefer literal IPs where you can.
 #   #
 #   # Self-hosted endpoints need an entry. A private destination such as
-#   # `http://searxng:8080` or `http://firecrawl:3002` is blocked once this guard is
-#   # active, so list it here or those requests will fail. A configured proxy
-#   # (`PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`) is exempted automatically and needs no
-#   # entry; when a proxy carries the request, destination egress policy is the
-#   # proxy's to enforce.
+#   # `http://searxng:8080`, `http://firecrawl:3002`, or `http://127.0.0.1:8080` is
+#   # blocked once this guard is active, so list it here or those requests will fail.
+#   #
+#   # A proxy from `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` (either case) is
+#   # exempted automatically and needs no entry. That exemption is applied to the
+#   # whole tool rather than per destination, so a host `NO_PROXY` sends direct also
+#   # carries it. Note that when a proxy carries the request the proxy resolves the
+#   # destination, so destination egress policy is the proxy's to enforce, and for
+#   # https targets the proxy's own tunnel replaces this guard entirely.
 #   # allowedAddresses:
 #   #   - 'searxng:8080'
 #   #   - '127.0.0.1:8080'

--- a/package-lock.json
+++ b/package-lock.json
@@ -42656,7 +42656,8 @@
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
-        "cluster-key-slot": "^1.1.2"
+        "cluster-key-slot": "^1.1.2",
+        "proxy-from-env": "^2.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -168,6 +168,7 @@
   "dependencies": {
     "@langchain/langgraph-checkpoint": "^1.1.2",
     "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
-    "cluster-key-slot": "^1.1.2"
+    "cluster-key-slot": "^1.1.2",
+    "proxy-from-env": "^2.1.0"
   }
 }

--- a/packages/api/src/auth/agent.ts
+++ b/packages/api/src/auth/agent.ts
@@ -87,12 +87,21 @@ function buildSSRFSafeLookup(
 /** Default lookup with no exemptions. Kept for callers that don't need allowedAddresses. */
 const ssrfSafeLookup: LookupFunction = buildSSRFSafeLookup();
 
+/** Connect options Node hands to `createConnection`; typed here because the seam is untyped. */
+interface ConnectOptions {
+  host?: unknown;
+  port?: unknown;
+  defaultPort?: unknown;
+  socketPath?: unknown;
+  lookup?: LookupFunction;
+}
+
 /** Internal agent shape exposing createConnection (exists at runtime but not in TS types) */
 type AgentInternal = {
-  createConnection: (options: Record<string, unknown>, oncreate?: unknown) => unknown;
+  createConnection: (options: ConnectOptions, oncreate?: unknown) => unknown;
 };
 
-function getConnectionPort(options: Record<string, unknown>): string {
+function getConnectionPort(options: ConnectOptions): string {
   return normalizePort(options.port ?? options.defaultPort);
 }
 
@@ -106,9 +115,14 @@ function getConnectionPort(options: Record<string, unknown>): string {
  * enabling this by default would break existing configurations.
  */
 function assertLiteralHostAllowed(
-  options: Record<string, unknown>,
+  options: ConnectOptions,
   allowedAddresses?: string[] | null,
 ): void {
+  /** A unix socket carries no host to validate, and these agents exist for http(s) URLs only. */
+  if (options.socketPath != null) {
+    throw createSSRFLookupError('socketPath', String(options.socketPath));
+  }
+
   const host = typeof options.host === 'string' ? options.host.replace(/^\[|\]$/g, '') : '';
   if (host.length === 0 || !isIP(host)) {
     return;
@@ -136,7 +150,7 @@ function withSSRFProtection<T extends http.Agent>(
 ): T {
   const internal = agent as unknown as AgentInternal;
   const origCreate = internal.createConnection.bind(agent);
-  internal.createConnection = (connectOptions: Record<string, unknown>, oncreate?: unknown) => {
+  internal.createConnection = (connectOptions: ConnectOptions, oncreate?: unknown) => {
     if (options?.blockLiteralHosts) {
       assertLiteralHostAllowed(connectOptions, allowedAddresses);
     }

--- a/packages/api/src/auth/agent.ts
+++ b/packages/api/src/auth/agent.ts
@@ -96,15 +96,54 @@ function getConnectionPort(options: Record<string, unknown>): string {
   return normalizePort(options.port ?? options.defaultPort);
 }
 
+/**
+ * Rejects a connection whose host is already an IP literal in blocked space.
+ *
+ * Node resolves nothing for a literal host, so the SSRF lookup below never runs for one.
+ * Redirect hops reach this same `createConnection`, so checking here is what covers a
+ * redirect whose target is a literal private address. Opt-in: a caller that reaches a
+ * proxy or a deliberate private service by literal address must exempt it first, so
+ * enabling this by default would break existing configurations.
+ */
+function assertLiteralHostAllowed(
+  options: Record<string, unknown>,
+  allowedAddresses?: string[] | null,
+): void {
+  const host = typeof options.host === 'string' ? options.host.replace(/^\[|\]$/g, '') : '';
+  if (host.length === 0 || !isIP(host)) {
+    return;
+  }
+
+  const port = getConnectionPort(options);
+  if (isAddressInAllowedSet(host, normalizeAllowedAddressesSet(allowedAddresses), port)) {
+    return;
+  }
+  if (isPrivateIP(host)) {
+    throw createSSRFLookupError(host, host);
+  }
+}
+
+export interface SSRFProtectionOptions {
+  /** Also reject IP-literal hosts, covering literal destinations and literal redirect targets. */
+  blockLiteralHosts?: boolean;
+}
+
 /** Patches an agent instance to inject SSRF-safe DNS lookup at connect time */
-function withSSRFProtection<T extends http.Agent>(agent: T, allowedAddresses?: string[] | null): T {
+function withSSRFProtection<T extends http.Agent>(
+  agent: T,
+  allowedAddresses?: string[] | null,
+  options?: SSRFProtectionOptions,
+): T {
   const internal = agent as unknown as AgentInternal;
   const origCreate = internal.createConnection.bind(agent);
-  internal.createConnection = (options: Record<string, unknown>, oncreate?: unknown) => {
-    options.lookup = allowedAddresses?.length
-      ? buildSSRFSafeLookup(allowedAddresses, getConnectionPort(options))
+  internal.createConnection = (connectOptions: Record<string, unknown>, oncreate?: unknown) => {
+    if (options?.blockLiteralHosts) {
+      assertLiteralHostAllowed(connectOptions, allowedAddresses);
+    }
+    connectOptions.lookup = allowedAddresses?.length
+      ? buildSSRFSafeLookup(allowedAddresses, getConnectionPort(connectOptions))
       : ssrfSafeLookup;
-    return origCreate(options, oncreate);
+    return origCreate(connectOptions, oncreate);
   };
   return agent;
 }
@@ -121,14 +160,16 @@ function withSSRFProtection<T extends http.Agent>(agent: T, allowedAddresses?: s
  */
 export function createSSRFSafeAgents(
   allowedAddresses?: string[] | null,
-  agentOptions?: http.AgentOptions & https.AgentOptions,
+  agentOptions?: (http.AgentOptions & https.AgentOptions) | null,
+  protection?: SSRFProtectionOptions,
 ): {
   httpAgent: http.Agent;
   httpsAgent: https.Agent;
 } {
+  const options = agentOptions ?? undefined;
   return {
-    httpAgent: withSSRFProtection(new http.Agent(agentOptions), allowedAddresses),
-    httpsAgent: withSSRFProtection(new https.Agent(agentOptions), allowedAddresses),
+    httpAgent: withSSRFProtection(new http.Agent(options), allowedAddresses, protection),
+    httpsAgent: withSSRFProtection(new https.Agent(options), allowedAddresses, protection),
   };
 }
 

--- a/packages/api/src/auth/agent.ts
+++ b/packages/api/src/auth/agent.ts
@@ -116,14 +116,19 @@ function withSSRFProtection<T extends http.Agent>(agent: T, allowedAddresses?: s
  * pre-validation but to a private IP when the actual connection is made.
  *
  * @param allowedAddresses - Optional admin exemption list of host:port pairs that bypass the block.
+ * @param agentOptions - Agent options, e.g. `{ keepAlive: true }` to retain pooling that the
+ *   default global agents provide and a bare `new http.Agent()` does not.
  */
-export function createSSRFSafeAgents(allowedAddresses?: string[] | null): {
+export function createSSRFSafeAgents(
+  allowedAddresses?: string[] | null,
+  agentOptions?: http.AgentOptions & https.AgentOptions,
+): {
   httpAgent: http.Agent;
   httpsAgent: https.Agent;
 } {
   return {
-    httpAgent: withSSRFProtection(new http.Agent(), allowedAddresses),
-    httpsAgent: withSSRFProtection(new https.Agent(), allowedAddresses),
+    httpAgent: withSSRFProtection(new http.Agent(agentOptions), allowedAddresses),
+    httpsAgent: withSSRFProtection(new https.Agent(agentOptions), allowedAddresses),
   };
 }
 

--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -276,7 +276,7 @@ function defaultPortForProtocol(protocol: SupportedProtocol | string | null): st
   return '';
 }
 
-function getEffectivePort(
+export function getEffectivePort(
   protocol: SupportedProtocol | string | null,
   port?: string | null,
 ): string {

--- a/packages/api/src/auth/ip.ts
+++ b/packages/api/src/auth/ip.ts
@@ -10,7 +10,7 @@
  *  - IPv4: 0.0.0.0/8, 10/8, 100.64/10 (CGNAT), 127/8, 169.254/16,
  *    172.16/12, 192.0.0/24 (RFC 5736), 192.168/16, 198.18/15 (benchmarking),
  *    224/3 (multicast/reserved).
- *  - IPv6: ::1, ::, fc00::/7 (unique-local), fe80::/10 (link-local), fec0::/10 (site-local).
+ *  - IPv6: ::1, ::, fc00::/7 (unique-local), fe80::/10 (link-local).
  *  - 4-in-6 mappings: ::ffff:A.B.C.D and the hex form ::ffff:HHHH:HHHH.
  *  - Embedded private IPv4 in 6to4 (2002::/16), NAT64 (64:ff9b::/96), and
  *    Teredo (2001::/32) addresses.
@@ -51,12 +51,8 @@ export function isPrivateIPv4(a: number, b: number, c: number): boolean {
   return false;
 }
 
-/**
- * Checks a pre-normalized (lowercase, bracket-stripped) IPv6 address against fe80::/10
- * (link-local) and fec0::/10 (site-local, deprecated by RFC 3879 but still routable on
- * networks that assigned it).
- */
-function isIPv6LinkOrSiteLocal(ipv6: string): boolean {
+/** Checks if a pre-normalized (lowercase, bracket-stripped) IPv6 address falls within fe80::/10 */
+function isIPv6LinkLocal(ipv6: string): boolean {
   if (!ipv6.includes(':')) {
     return false;
   }
@@ -65,9 +61,8 @@ function isIPv6LinkOrSiteLocal(ipv6: string): boolean {
     return false;
   }
   const hextet = parseInt(firstHextet, 16);
-  // /10 mask (0xffc0) preserves top 10 bits: fe80 = 1111_1110_10xx_xxxx, fec0 = ..._11xx_xxxx
-  const masked = hextet & 0xffc0;
-  return masked === 0xfe80 || masked === 0xfec0;
+  // /10 mask (0xffc0) preserves top 10 bits: fe80 = 1111_1110_10xx_xxxx
+  return (hextet & 0xffc0) === 0xfe80;
 }
 
 /** Checks if an IPv6 address embeds a private IPv4 via 6to4, NAT64, or Teredo */
@@ -145,7 +140,7 @@ export function isPrivateIP(ip: string): boolean {
     normalized === '::' ||
     normalized.startsWith('fc') || // fc00::/7 — exactly prefixes 'fc' and 'fd'
     normalized.startsWith('fd') ||
-    isIPv6LinkOrSiteLocal(normalized) // fe80::/10 and fec0::/10; bitwise check required
+    isIPv6LinkLocal(normalized) // fe80::/10 — spans 0xfe80–0xfebf; bitwise check required
   ) {
     return true;
   }

--- a/packages/api/src/auth/ip.ts
+++ b/packages/api/src/auth/ip.ts
@@ -10,7 +10,7 @@
  *  - IPv4: 0.0.0.0/8, 10/8, 100.64/10 (CGNAT), 127/8, 169.254/16,
  *    172.16/12, 192.0.0/24 (RFC 5736), 192.168/16, 198.18/15 (benchmarking),
  *    224/3 (multicast/reserved).
- *  - IPv6: ::1, ::, fc00::/7 (unique-local), fe80::/10 (link-local).
+ *  - IPv6: ::1, ::, fc00::/7 (unique-local), fe80::/10 (link-local), fec0::/10 (site-local).
  *  - 4-in-6 mappings: ::ffff:A.B.C.D and the hex form ::ffff:HHHH:HHHH.
  *  - Embedded private IPv4 in 6to4 (2002::/16), NAT64 (64:ff9b::/96), and
  *    Teredo (2001::/32) addresses.
@@ -51,8 +51,12 @@ export function isPrivateIPv4(a: number, b: number, c: number): boolean {
   return false;
 }
 
-/** Checks if a pre-normalized (lowercase, bracket-stripped) IPv6 address falls within fe80::/10 */
-function isIPv6LinkLocal(ipv6: string): boolean {
+/**
+ * Checks a pre-normalized (lowercase, bracket-stripped) IPv6 address against fe80::/10
+ * (link-local) and fec0::/10 (site-local, deprecated by RFC 3879 but still routable on
+ * networks that assigned it).
+ */
+function isIPv6LinkOrSiteLocal(ipv6: string): boolean {
   if (!ipv6.includes(':')) {
     return false;
   }
@@ -61,8 +65,9 @@ function isIPv6LinkLocal(ipv6: string): boolean {
     return false;
   }
   const hextet = parseInt(firstHextet, 16);
-  // /10 mask (0xffc0) preserves top 10 bits: fe80 = 1111_1110_10xx_xxxx
-  return (hextet & 0xffc0) === 0xfe80;
+  // /10 mask (0xffc0) preserves top 10 bits: fe80 = 1111_1110_10xx_xxxx, fec0 = ..._11xx_xxxx
+  const masked = hextet & 0xffc0;
+  return masked === 0xfe80 || masked === 0xfec0;
 }
 
 /** Checks if an IPv6 address embeds a private IPv4 via 6to4, NAT64, or Teredo */
@@ -140,7 +145,7 @@ export function isPrivateIP(ip: string): boolean {
     normalized === '::' ||
     normalized.startsWith('fc') || // fc00::/7 — exactly prefixes 'fc' and 'fd'
     normalized.startsWith('fd') ||
-    isIPv6LinkLocal(normalized) // fe80::/10 — spans 0xfe80–0xfebf; bitwise check required
+    isIPv6LinkOrSiteLocal(normalized) // fe80::/10 and fec0::/10; bitwise check required
   ) {
     return true;
   }

--- a/packages/api/src/types/proxy-from-env.d.ts
+++ b/packages/api/src/types/proxy-from-env.d.ts
@@ -1,0 +1,9 @@
+/**
+ * `proxy-from-env` ships no types. Declared narrowly rather than pulling in a types package,
+ * since only `getProxyForUrl` is used: it returns the proxy URL for a target, applying
+ * `<protocol>_proxy` before `all_proxy`, lowercase before uppercase, and `NO_PROXY`, or an
+ * empty string when the target should be reached directly.
+ */
+declare module 'proxy-from-env' {
+  export function getProxyForUrl(target: string): string;
+}

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -1,94 +1,122 @@
 import { resolveWebSearchSSRFAgents } from './agent';
+import { isAddressAllowed } from '../auth';
+
+/** `options` exists on a Node agent at runtime but is absent from the bundled type. */
+interface AgentOptionsProbe {
+  options: { keepAlive?: boolean };
+}
+
+function agentOptions(agent: object): AgentOptionsProbe['options'] {
+  return (agent as AgentOptionsProbe).options;
+}
 
 describe('resolveWebSearchSSRFAgents', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
-    delete process.env.HTTP_PROXY;
-    delete process.env.HTTPS_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.https_proxy;
-    delete process.env.NO_PROXY;
-    delete process.env.no_proxy;
+    for (const key of [
+      'PROXY',
+      'proxy',
+      'HTTP_PROXY',
+      'http_proxy',
+      'HTTPS_PROXY',
+      'https_proxy',
+      'NO_PROXY',
+      'no_proxy',
+    ]) {
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
     process.env = originalEnv;
   });
 
-  it('attaches both agents for direct public destinations', () => {
-    const agents = resolveWebSearchSSRFAgents({
-      searxngInstanceUrl: 'https://searx.example.com',
-      firecrawlApiUrl: 'https://api.firecrawl.dev/v2/scrape',
-    });
+  it('always returns a pooled agent pair', () => {
+    const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents();
 
-    expect(agents.httpAgent).toBeDefined();
-    expect(agents.httpsAgent).toBeDefined();
+    expect(httpAgent).toBeDefined();
+    expect(httpsAgent).toBeDefined();
+    expect(agentOptions(httpAgent).keepAlive).toBe(true);
+    expect(agentOptions(httpsAgent).keepAlive).toBe(true);
   });
 
-  it('attaches agents when no destination URL is configured', () => {
-    const agents = resolveWebSearchSSRFAgents({});
-
-    expect(agents.httpAgent).toBeDefined();
-    expect(agents.httpsAgent).toBeDefined();
-  });
-
-  it('rejects an IP-literal private destination that the connect-time lookup never sees', () => {
-    expect(() =>
-      resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'http://169.254.169.254' }),
-    ).toThrow(expect.objectContaining({ code: 'ESSRF' }));
-  });
-
-  it('rejects an IP-literal private destination on any scraper URL key', () => {
-    expect(() => resolveWebSearchSSRFAgents({ firecrawlApiUrl: 'http://127.0.0.1:8080' })).toThrow(
-      expect.objectContaining({ code: 'ESSRF' }),
-    );
-  });
-
-  it('exempts an IP-literal destination listed in allowedAddresses', () => {
-    const agents = resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'http://127.0.0.1:8888' }, [
-      '127.0.0.1:8888',
-    ]);
-
-    expect(agents.httpAgent).toBeDefined();
-    expect(agents.httpsAgent).toBeDefined();
-  });
-
-  it('throws on a non-http(s) destination scheme', () => {
-    expect(() =>
-      resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'file:///etc/passwd' }),
-    ).toThrow();
-  });
-
-  it('withholds agents when a proxy owns egress for a destination', () => {
+  it('still returns agents when a proxy is configured, so direct routes stay guarded', () => {
     process.env.HTTPS_PROXY = 'http://proxy.internal:3128';
 
-    const agents = resolveWebSearchSSRFAgents({
-      searxngInstanceUrl: 'https://searx.example.com',
-    });
+    const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents();
 
-    expect(agents.httpAgent).toBeUndefined();
-    expect(agents.httpsAgent).toBeUndefined();
+    expect(httpAgent).toBeDefined();
+    expect(httpsAgent).toBeDefined();
   });
 
-  it('still validates an IP-literal destination when a proxy is configured', () => {
+  it('exempts the proxy endpoint so the proxy hop stays reachable', () => {
     process.env.HTTP_PROXY = 'http://proxy.internal:3128';
 
-    expect(() =>
-      resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'http://169.254.169.254' }),
-    ).toThrow(expect.objectContaining({ code: 'ESSRF' }));
+    resolveWebSearchSSRFAgents();
+
+    expect(isAddressAllowed('proxy.internal', ['proxy.internal:3128'], '3128')).toBe(true);
   });
 
-  it('attaches agents when NO_PROXY bypasses the proxy for the destination', () => {
+  it('scopes the proxy exemption to its port, so another private port stays blocked', () => {
+    expect(isAddressAllowed('proxy.internal', ['proxy.internal:3128'], '9')).toBe(false);
+  });
+
+  it('derives the default proxy port from the proxy scheme', () => {
+    process.env.HTTP_PROXY = 'http://proxy.internal';
+    process.env.HTTPS_PROXY = 'https://secure-proxy.internal';
+
+    const first = resolveWebSearchSSRFAgents();
+
+    process.env.HTTP_PROXY = 'http://proxy.internal:80';
+    process.env.HTTPS_PROXY = 'https://secure-proxy.internal:443';
+
+    expect(resolveWebSearchSSRFAgents()).toBe(first);
+  });
+
+  it('reads the PROXY variable that other LibreChat egress paths honor', () => {
+    process.env.PROXY = 'http://proxy.internal:3128';
+    const viaProxyVar = resolveWebSearchSSRFAgents();
+
+    delete process.env.PROXY;
+    process.env.HTTP_PROXY = 'http://proxy.internal:3128';
     process.env.HTTPS_PROXY = 'http://proxy.internal:3128';
-    process.env.NO_PROXY = 'searx.example.com';
 
-    const agents = resolveWebSearchSSRFAgents({
-      searxngInstanceUrl: 'https://searx.example.com',
-    });
+    expect(resolveWebSearchSSRFAgents()).toBe(viaProxyVar);
+  });
 
-    expect(agents.httpAgent).toBeDefined();
-    expect(agents.httpsAgent).toBeDefined();
+  it('treats an empty proxy variable as unset, matching the value compose forwards', () => {
+    const withoutProxy = resolveWebSearchSSRFAgents();
+
+    process.env.HTTP_PROXY = '';
+    process.env.HTTPS_PROXY = '   ';
+
+    expect(resolveWebSearchSSRFAgents()).toBe(withoutProxy);
+  });
+
+  it('reuses one pair per exemption list and separates distinct lists', () => {
+    const first = resolveWebSearchSSRFAgents(['searxng:8080']);
+    const again = resolveWebSearchSSRFAgents(['searxng:8080']);
+    const other = resolveWebSearchSSRFAgents(['firecrawl:3002']);
+
+    expect(again).toBe(first);
+    expect(other).not.toBe(first);
+  });
+
+  it('keeps admin allowedAddresses entries alongside the derived proxy exemption', () => {
+    process.env.HTTP_PROXY = 'http://proxy.internal:3128';
+
+    expect(resolveWebSearchSSRFAgents(['searxng:8080'])).not.toBe(resolveWebSearchSSRFAgents([]));
+  });
+
+  it('does not throw for a private destination, leaving enforcement at connect time', () => {
+    expect(() => resolveWebSearchSSRFAgents(['127.0.0.1:8080'])).not.toThrow();
+  });
+
+  it('ignores an unparseable proxy value rather than throwing during tool load', () => {
+    process.env.HTTP_PROXY = 'not a url';
+
+    expect(() => resolveWebSearchSSRFAgents()).not.toThrow();
   });
 });

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -3,7 +3,7 @@ import { isAddressAllowed } from '../auth';
 
 /** `options` exists on a Node agent at runtime but is absent from the bundled type. */
 interface AgentOptionsProbe {
-  options: { keepAlive?: boolean };
+  options: { keepAlive?: boolean; timeout?: number };
 }
 
 function agentOptions(agent: object): AgentOptionsProbe['options'] {
@@ -15,9 +15,13 @@ interface ConnectProbe {
   createConnection: (options: Record<string, unknown>) => unknown;
 }
 
-function connect(agent: object, host: string, port: number): void {
-  const socket = (agent as ConnectProbe).createConnection({ host, port });
+function connectRaw(agent: object, options: Record<string, unknown>): void {
+  const socket = (agent as ConnectProbe).createConnection(options);
   (socket as { destroy?: () => void })?.destroy?.();
+}
+
+function connect(agent: object, host: string, port: number): void {
+  connectRaw(agent, { host, port });
 }
 
 describe('resolveWebSearchSSRFAgents', () => {
@@ -51,6 +55,7 @@ describe('resolveWebSearchSSRFAgents', () => {
     expect(httpAgent).toBeDefined();
     expect(httpsAgent).toBeDefined();
     expect(agentOptions(httpAgent).keepAlive).toBe(true);
+    expect(agentOptions(httpAgent).timeout).toBe(5000);
     expect(agentOptions(httpsAgent).keepAlive).toBe(true);
   });
 
@@ -87,15 +92,45 @@ describe('resolveWebSearchSSRFAgents', () => {
     expect(resolveWebSearchSSRFAgents()).toBe(first);
   });
 
-  it('reads the PROXY variable that other LibreChat egress paths honor', () => {
-    process.env.PROXY = 'http://proxy.internal:3128';
-    const viaProxyVar = resolveWebSearchSSRFAgents();
+  it('grants no exemption for PROXY, which Axios never reads on this path', () => {
+    process.env.PROXY = 'http://10.4.4.4:3128';
 
-    delete process.env.PROXY;
-    process.env.HTTP_PROXY = 'http://proxy.internal:3128';
-    process.env.HTTPS_PROXY = 'http://proxy.internal:3128';
+    const { httpAgent } = resolveWebSearchSSRFAgents();
 
-    expect(resolveWebSearchSSRFAgents()).toBe(viaProxyVar);
+    expect(() => connect(httpAgent, '10.4.4.4', 3128)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('grants no exemption for a socks proxy, which Axios cannot use', () => {
+    process.env.ALL_PROXY = 'socks5://10.5.5.5:1080';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.5.5.5', 1080)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('tolerates a non-array allowedAddresses instead of throwing during tool load', () => {
+    const asUnknown = { '10.0.0.5:11434': true } as unknown;
+
+    expect(() => resolveWebSearchSSRFAgents(asUnknown as string[])).not.toThrow();
+  });
+
+  it('does not collide cache keys when an entry contains a newline', () => {
+    const joined = resolveWebSearchSSRFAgents(['searxng:8080\nfirecrawl:3002']);
+    const separate = resolveWebSearchSSRFAgents(['searxng:8080', 'firecrawl:3002']);
+
+    expect(joined).not.toBe(separate);
+  });
+
+  it('rejects a unix socket, which carries no host to validate', () => {
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connectRaw(httpAgent, { socketPath: '/tmp/x.sock' })).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
   });
 
   it('treats an empty proxy variable as unset, matching the value compose forwards', () => {

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -10,6 +10,16 @@ function agentOptions(agent: object): AgentOptionsProbe['options'] {
   return (agent as AgentOptionsProbe).options;
 }
 
+/** Drives the seam every request and every redirect hop passes through. */
+interface ConnectProbe {
+  createConnection: (options: Record<string, unknown>) => unknown;
+}
+
+function connect(agent: object, host: string, port: number): void {
+  const socket = (agent as ConnectProbe).createConnection({ host, port });
+  (socket as { destroy?: () => void })?.destroy?.();
+}
+
 describe('resolveWebSearchSSRFAgents', () => {
   const originalEnv = process.env;
 
@@ -110,8 +120,42 @@ describe('resolveWebSearchSSRFAgents', () => {
     expect(resolveWebSearchSSRFAgents(['searxng:8080'])).not.toBe(resolveWebSearchSSRFAgents([]));
   });
 
-  it('does not throw for a private destination, leaving enforcement at connect time', () => {
+  it('does not throw while building agents, leaving enforcement at connect time', () => {
     expect(() => resolveWebSearchSSRFAgents(['127.0.0.1:8080'])).not.toThrow();
+  });
+
+  it('rejects an IP-literal private host at connect time, covering literal redirect targets', () => {
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '169.254.169.254', 80)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+    expect(() => connect(httpAgent, '127.0.0.1', 8080)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('exempts an IP-literal host listed in allowedAddresses, scoped to its port', () => {
+    const { httpAgent } = resolveWebSearchSSRFAgents(['127.0.0.1:8080']);
+
+    expect(() => connect(httpAgent, '127.0.0.1', 8080)).not.toThrow();
+    expect(() => connect(httpAgent, '127.0.0.1', 9)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('keeps a literal-address proxy reachable, since the proxy hop is exempted', () => {
+    process.env.HTTP_PROXY = 'http://10.1.2.3:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
+  });
+
+  it('allows a public IP literal', () => {
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '93.184.216.34', 80)).not.toThrow();
   });
 
   it('ignores an unparseable proxy value rather than throwing during tool load', () => {

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -32,6 +32,8 @@ describe('resolveWebSearchSSRFAgents', () => {
       'http_proxy',
       'HTTPS_PROXY',
       'https_proxy',
+      'ALL_PROXY',
+      'all_proxy',
       'NO_PROXY',
       'no_proxy',
     ]) {
@@ -150,6 +152,25 @@ describe('resolveWebSearchSSRFAgents', () => {
     const { httpAgent } = resolveWebSearchSSRFAgents();
 
     expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
+  });
+
+  it('exempts a proxy configured only through ALL_PROXY, which Axios still honors', () => {
+    process.env.ALL_PROXY = 'http://10.1.2.3:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
+    expect(() => connect(httpAgent, '10.1.2.3', 9)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('exempts a lowercase all_proxy as well, since the resolver is case-insensitive', () => {
+    process.env.all_proxy = 'http://10.9.9.9:8080';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.9.9.9', 8080)).not.toThrow();
   });
 
   it('keeps an IPv6-literal proxy reachable, which needs the bracketed exemption form', () => {

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -102,6 +102,61 @@ describe('resolveWebSearchSSRFAgents', () => {
     );
   });
 
+  it('exempts a scheme-less proxy value, which the resolver normalizes to http', () => {
+    process.env.HTTP_PROXY = 'proxy.internal:3128';
+
+    resolveWebSearchSSRFAgents();
+
+    expect(isAddressAllowed('proxy.internal', ['proxy.internal:3128'], '3128')).toBe(true);
+  });
+
+  it('exempts a scheme-less literal proxy so the hop stays reachable', () => {
+    process.env.HTTP_PROXY = '10.1.2.3:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
+  });
+
+  it('exempts only the variable that wins precedence, not every populated one', () => {
+    process.env.HTTP_PROXY = 'http://10.1.1.1:3128';
+    process.env.HTTPS_PROXY = 'http://10.1.1.1:3128';
+    process.env.ALL_PROXY = 'http://10.2.2.2:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.1.1.1', 3128)).not.toThrow();
+    expect(() => connect(httpAgent, '10.2.2.2', 3128)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('prefers the lowercase variable, matching the resolver', () => {
+    process.env.http_proxy = 'http://10.3.3.3:3128';
+    process.env.HTTP_PROXY = 'http://10.4.4.4:3128';
+    process.env.https_proxy = 'http://10.3.3.3:3128';
+    process.env.HTTPS_PROXY = 'http://10.3.3.3:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.3.3.3', 3128)).not.toThrow();
+    expect(() => connect(httpAgent, '10.4.4.4', 3128)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('grants no exemption when NO_PROXY bypasses everything, since nothing is proxied', () => {
+    process.env.HTTP_PROXY = 'http://10.6.6.6:3128';
+    process.env.HTTPS_PROXY = 'http://10.6.6.6:3128';
+    process.env.NO_PROXY = '*';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, '10.6.6.6', 3128)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
   it('grants no exemption for a socks proxy, which Axios cannot use', () => {
     process.env.ALL_PROXY = 'socks5://10.5.5.5:1080';
 

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -152,6 +152,17 @@ describe('resolveWebSearchSSRFAgents', () => {
     expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
   });
 
+  it('keeps an IPv6-literal proxy reachable, which needs the bracketed exemption form', () => {
+    process.env.HTTP_PROXY = 'http://[fd00::1]:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents();
+
+    expect(() => connect(httpAgent, 'fd00::1', 3128)).not.toThrow();
+    expect(() => connect(httpAgent, 'fd00::1', 9)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
   it('allows a public IP literal', () => {
     const { httpAgent } = resolveWebSearchSSRFAgents();
 

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -1,0 +1,94 @@
+import { resolveWebSearchSSRFAgents } from './agent';
+
+describe('resolveWebSearchSSRFAgents', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('attaches both agents for direct public destinations', () => {
+    const agents = resolveWebSearchSSRFAgents({
+      searxngInstanceUrl: 'https://searx.example.com',
+      firecrawlApiUrl: 'https://api.firecrawl.dev/v2/scrape',
+    });
+
+    expect(agents.httpAgent).toBeDefined();
+    expect(agents.httpsAgent).toBeDefined();
+  });
+
+  it('attaches agents when no destination URL is configured', () => {
+    const agents = resolveWebSearchSSRFAgents({});
+
+    expect(agents.httpAgent).toBeDefined();
+    expect(agents.httpsAgent).toBeDefined();
+  });
+
+  it('rejects an IP-literal private destination that the connect-time lookup never sees', () => {
+    expect(() =>
+      resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'http://169.254.169.254' }),
+    ).toThrow(expect.objectContaining({ code: 'ESSRF' }));
+  });
+
+  it('rejects an IP-literal private destination on any scraper URL key', () => {
+    expect(() => resolveWebSearchSSRFAgents({ firecrawlApiUrl: 'http://127.0.0.1:8080' })).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('exempts an IP-literal destination listed in allowedAddresses', () => {
+    const agents = resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'http://127.0.0.1:8888' }, [
+      '127.0.0.1:8888',
+    ]);
+
+    expect(agents.httpAgent).toBeDefined();
+    expect(agents.httpsAgent).toBeDefined();
+  });
+
+  it('throws on a non-http(s) destination scheme', () => {
+    expect(() =>
+      resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'file:///etc/passwd' }),
+    ).toThrow();
+  });
+
+  it('withholds agents when a proxy owns egress for a destination', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.internal:3128';
+
+    const agents = resolveWebSearchSSRFAgents({
+      searxngInstanceUrl: 'https://searx.example.com',
+    });
+
+    expect(agents.httpAgent).toBeUndefined();
+    expect(agents.httpsAgent).toBeUndefined();
+  });
+
+  it('still validates an IP-literal destination when a proxy is configured', () => {
+    process.env.HTTP_PROXY = 'http://proxy.internal:3128';
+
+    expect(() =>
+      resolveWebSearchSSRFAgents({ searxngInstanceUrl: 'http://169.254.169.254' }),
+    ).toThrow(expect.objectContaining({ code: 'ESSRF' }));
+  });
+
+  it('attaches agents when NO_PROXY bypasses the proxy for the destination', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.internal:3128';
+    process.env.NO_PROXY = 'searx.example.com';
+
+    const agents = resolveWebSearchSSRFAgents({
+      searxngInstanceUrl: 'https://searx.example.com',
+    });
+
+    expect(agents.httpAgent).toBeDefined();
+    expect(agents.httpsAgent).toBeDefined();
+  });
+});

--- a/packages/api/src/web/agent.spec.ts
+++ b/packages/api/src/web/agent.spec.ts
@@ -24,6 +24,8 @@ function connect(agent: object, host: string, port: number): void {
   connectRaw(agent, { host, port });
 }
 
+const HTTP_DEST = { searxngInstanceUrl: 'http://searxng.internal:8080' };
+
 describe('resolveWebSearchSSRFAgents', () => {
   const originalEnv = process.env;
 
@@ -50,7 +52,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   });
 
   it('always returns a pooled agent pair', () => {
-    const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(httpAgent).toBeDefined();
     expect(httpsAgent).toBeDefined();
@@ -62,7 +64,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('still returns agents when a proxy is configured, so direct routes stay guarded', () => {
     process.env.HTTPS_PROXY = 'http://proxy.internal:3128';
 
-    const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent, httpsAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(httpAgent).toBeDefined();
     expect(httpsAgent).toBeDefined();
@@ -71,7 +73,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('exempts the proxy endpoint so the proxy hop stays reachable', () => {
     process.env.HTTP_PROXY = 'http://proxy.internal:3128';
 
-    resolveWebSearchSSRFAgents();
+    resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(isAddressAllowed('proxy.internal', ['proxy.internal:3128'], '3128')).toBe(true);
   });
@@ -84,18 +86,18 @@ describe('resolveWebSearchSSRFAgents', () => {
     process.env.HTTP_PROXY = 'http://proxy.internal';
     process.env.HTTPS_PROXY = 'https://secure-proxy.internal';
 
-    const first = resolveWebSearchSSRFAgents();
+    const first = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     process.env.HTTP_PROXY = 'http://proxy.internal:80';
     process.env.HTTPS_PROXY = 'https://secure-proxy.internal:443';
 
-    expect(resolveWebSearchSSRFAgents()).toBe(first);
+    expect(resolveWebSearchSSRFAgents(HTTP_DEST)).toBe(first);
   });
 
   it('grants no exemption for PROXY, which Axios never reads on this path', () => {
     process.env.PROXY = 'http://10.4.4.4:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.4.4.4', 3128)).toThrow(
       expect.objectContaining({ code: 'ESSRF' }),
@@ -105,7 +107,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('exempts a scheme-less proxy value, which the resolver normalizes to http', () => {
     process.env.HTTP_PROXY = 'proxy.internal:3128';
 
-    resolveWebSearchSSRFAgents();
+    resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(isAddressAllowed('proxy.internal', ['proxy.internal:3128'], '3128')).toBe(true);
   });
@@ -113,7 +115,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('exempts a scheme-less literal proxy so the hop stays reachable', () => {
     process.env.HTTP_PROXY = '10.1.2.3:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
   });
@@ -123,7 +125,7 @@ describe('resolveWebSearchSSRFAgents', () => {
     process.env.HTTPS_PROXY = 'http://10.1.1.1:3128';
     process.env.ALL_PROXY = 'http://10.2.2.2:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.1.1.1', 3128)).not.toThrow();
     expect(() => connect(httpAgent, '10.2.2.2', 3128)).toThrow(
@@ -137,7 +139,7 @@ describe('resolveWebSearchSSRFAgents', () => {
     process.env.https_proxy = 'http://10.3.3.3:3128';
     process.env.HTTPS_PROXY = 'http://10.3.3.3:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.3.3.3', 3128)).not.toThrow();
     expect(() => connect(httpAgent, '10.4.4.4', 3128)).toThrow(
@@ -145,14 +147,34 @@ describe('resolveWebSearchSSRFAgents', () => {
     );
   });
 
-  it('grants no exemption when NO_PROXY bypasses everything, since nothing is proxied', () => {
+  it('grants no exemption when NO_PROXY covers the destination, since nothing is proxied', () => {
     process.env.HTTP_PROXY = 'http://10.6.6.6:3128';
-    process.env.HTTPS_PROXY = 'http://10.6.6.6:3128';
-    process.env.NO_PROXY = '*';
+    process.env.NO_PROXY = 'searxng.internal';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.6.6.6', 3128)).toThrow(
+      expect.objectContaining({ code: 'ESSRF' }),
+    );
+  });
+
+  it('exempts the proxy when NO_PROXY does not cover the destination', () => {
+    process.env.HTTP_PROXY = 'http://10.7.7.7:3128';
+    process.env.NO_PROXY = 'other.internal';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
+
+    expect(() => connect(httpAgent, '10.7.7.7', 3128)).not.toThrow();
+  });
+
+  it('owes no exemption for an https destination, where Axios tunnels instead', () => {
+    process.env.HTTPS_PROXY = 'http://10.8.8.8:3128';
+
+    const { httpAgent } = resolveWebSearchSSRFAgents({
+      searxngInstanceUrl: 'https://searx.example.com',
+    });
+
+    expect(() => connect(httpAgent, '10.8.8.8', 3128)).toThrow(
       expect.objectContaining({ code: 'ESSRF' }),
     );
   });
@@ -160,7 +182,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('grants no exemption for a socks proxy, which Axios cannot use', () => {
     process.env.ALL_PROXY = 'socks5://10.5.5.5:1080';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.5.5.5', 1080)).toThrow(
       expect.objectContaining({ code: 'ESSRF' }),
@@ -170,18 +192,18 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('tolerates a non-array allowedAddresses instead of throwing during tool load', () => {
     const asUnknown = { '10.0.0.5:11434': true } as unknown;
 
-    expect(() => resolveWebSearchSSRFAgents(asUnknown as string[])).not.toThrow();
+    expect(() => resolveWebSearchSSRFAgents(HTTP_DEST, asUnknown as string[])).not.toThrow();
   });
 
   it('does not collide cache keys when an entry contains a newline', () => {
-    const joined = resolveWebSearchSSRFAgents(['searxng:8080\nfirecrawl:3002']);
-    const separate = resolveWebSearchSSRFAgents(['searxng:8080', 'firecrawl:3002']);
+    const joined = resolveWebSearchSSRFAgents(HTTP_DEST, ['searxng:8080\nfirecrawl:3002']);
+    const separate = resolveWebSearchSSRFAgents(HTTP_DEST, ['searxng:8080', 'firecrawl:3002']);
 
     expect(joined).not.toBe(separate);
   });
 
   it('rejects a unix socket, which carries no host to validate', () => {
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connectRaw(httpAgent, { socketPath: '/tmp/x.sock' })).toThrow(
       expect.objectContaining({ code: 'ESSRF' }),
@@ -189,18 +211,18 @@ describe('resolveWebSearchSSRFAgents', () => {
   });
 
   it('treats an empty proxy variable as unset, matching the value compose forwards', () => {
-    const withoutProxy = resolveWebSearchSSRFAgents();
+    const withoutProxy = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     process.env.HTTP_PROXY = '';
     process.env.HTTPS_PROXY = '   ';
 
-    expect(resolveWebSearchSSRFAgents()).toBe(withoutProxy);
+    expect(resolveWebSearchSSRFAgents(HTTP_DEST)).toBe(withoutProxy);
   });
 
   it('reuses one pair per exemption list and separates distinct lists', () => {
-    const first = resolveWebSearchSSRFAgents(['searxng:8080']);
-    const again = resolveWebSearchSSRFAgents(['searxng:8080']);
-    const other = resolveWebSearchSSRFAgents(['firecrawl:3002']);
+    const first = resolveWebSearchSSRFAgents(HTTP_DEST, ['searxng:8080']);
+    const again = resolveWebSearchSSRFAgents(HTTP_DEST, ['searxng:8080']);
+    const other = resolveWebSearchSSRFAgents(HTTP_DEST, ['firecrawl:3002']);
 
     expect(again).toBe(first);
     expect(other).not.toBe(first);
@@ -209,15 +231,17 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('keeps admin allowedAddresses entries alongside the derived proxy exemption', () => {
     process.env.HTTP_PROXY = 'http://proxy.internal:3128';
 
-    expect(resolveWebSearchSSRFAgents(['searxng:8080'])).not.toBe(resolveWebSearchSSRFAgents([]));
+    expect(resolveWebSearchSSRFAgents(HTTP_DEST, ['searxng:8080'])).not.toBe(
+      resolveWebSearchSSRFAgents(HTTP_DEST, []),
+    );
   });
 
   it('does not throw while building agents, leaving enforcement at connect time', () => {
-    expect(() => resolveWebSearchSSRFAgents(['127.0.0.1:8080'])).not.toThrow();
+    expect(() => resolveWebSearchSSRFAgents(HTTP_DEST, ['127.0.0.1:8080'])).not.toThrow();
   });
 
   it('rejects an IP-literal private host at connect time, covering literal redirect targets', () => {
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '169.254.169.254', 80)).toThrow(
       expect.objectContaining({ code: 'ESSRF' }),
@@ -228,7 +252,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   });
 
   it('exempts an IP-literal host listed in allowedAddresses, scoped to its port', () => {
-    const { httpAgent } = resolveWebSearchSSRFAgents(['127.0.0.1:8080']);
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST, ['127.0.0.1:8080']);
 
     expect(() => connect(httpAgent, '127.0.0.1', 8080)).not.toThrow();
     expect(() => connect(httpAgent, '127.0.0.1', 9)).toThrow(
@@ -239,7 +263,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('keeps a literal-address proxy reachable, since the proxy hop is exempted', () => {
     process.env.HTTP_PROXY = 'http://10.1.2.3:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
   });
@@ -247,7 +271,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('exempts a proxy configured only through ALL_PROXY, which Axios still honors', () => {
     process.env.ALL_PROXY = 'http://10.1.2.3:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.1.2.3', 3128)).not.toThrow();
     expect(() => connect(httpAgent, '10.1.2.3', 9)).toThrow(
@@ -258,7 +282,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('exempts a lowercase all_proxy as well, since the resolver is case-insensitive', () => {
     process.env.all_proxy = 'http://10.9.9.9:8080';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '10.9.9.9', 8080)).not.toThrow();
   });
@@ -266,7 +290,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('keeps an IPv6-literal proxy reachable, which needs the bracketed exemption form', () => {
     process.env.HTTP_PROXY = 'http://[fd00::1]:3128';
 
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, 'fd00::1', 3128)).not.toThrow();
     expect(() => connect(httpAgent, 'fd00::1', 9)).toThrow(
@@ -275,7 +299,7 @@ describe('resolveWebSearchSSRFAgents', () => {
   });
 
   it('allows a public IP literal', () => {
-    const { httpAgent } = resolveWebSearchSSRFAgents();
+    const { httpAgent } = resolveWebSearchSSRFAgents(HTTP_DEST);
 
     expect(() => connect(httpAgent, '93.184.216.34', 80)).not.toThrow();
   });
@@ -283,6 +307,6 @@ describe('resolveWebSearchSSRFAgents', () => {
   it('ignores an unparseable proxy value rather than throwing during tool load', () => {
     process.env.HTTP_PROXY = 'not a url';
 
-    expect(() => resolveWebSearchSSRFAgents()).not.toThrow();
+    expect(() => resolveWebSearchSSRFAgents(HTTP_DEST)).not.toThrow();
   });
 });

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -1,60 +1,69 @@
-import type { TWebSearchConfig } from 'librechat-data-provider';
-import type { AxiosRequestConfig } from 'axios';
 import type https from 'node:https';
 import type http from 'node:http';
-import { applySSRFSafeAgentIfDirect, createSSRFSafeAgents } from '../auth';
-import { applyAxiosProxyConfig } from '../utils/proxy';
-
-/** Resolved web-search fields that carry an outbound destination. */
-const WEB_SEARCH_URL_KEYS = [
-  'searxngInstanceUrl',
-  'firecrawlApiUrl',
-  'jinaApiUrl',
-  'tavilySearchUrl',
-  'tavilyExtractUrl',
-] as const;
+import { getProxyEnvConfig } from '../utils/proxy';
+import { createSSRFSafeAgents } from '../auth';
 
 export interface WebSearchSSRFAgents {
-  httpAgent?: http.Agent;
-  httpsAgent?: https.Agent;
+  httpAgent: http.Agent;
+  httpsAgent: https.Agent;
 }
 
 /**
- * Extends the `applySSRFSafeAgentIfDirect` contract to the web-search tool, which
- * owns its own axios calls and accepts agents rather than a request config.
- *
- * Each configured destination is run through that helper so an IP-literal private
- * target (which Node's connect-time `lookup` never sees) throws before any request
- * is made. Agents are withheld when a proxy owns egress for any destination: one
- * agent pair is shared by every provider, so attaching a direct-connect agent to a
- * proxied connection would both break the request and assert protection the proxy's
- * network context cannot provide.
+ * For a plaintext http target Axios repoints the caller's agent at the proxy host, so the
+ * connect-time check would resolve the proxy itself and reject a private one. Exempting the
+ * proxy endpoint keeps that hop reachable while every direct and `NO_PROXY` destination stays
+ * guarded. Https targets are unaffected either way: Axios swaps in its own CONNECT tunnel.
  */
-export function resolveWebSearchSSRFAgents(
-  authResult: Partial<TWebSearchConfig>,
-  allowedAddresses?: string[] | null,
-): WebSearchSSRFAgents {
-  let proxied = false;
+function getProxyExemptions(): string[] {
+  const config = getProxyEnvConfig();
+  if (!config) {
+    return [];
+  }
 
-  for (const key of WEB_SEARCH_URL_KEYS) {
-    const url = authResult[key];
-    if (typeof url !== 'string' || url.length === 0) {
+  const entries = new Set<string>();
+  for (const proxyUrl of [config.httpProxy, config.httpsProxy]) {
+    if (!proxyUrl) {
       continue;
     }
-
-    const probe: AxiosRequestConfig = {};
-    applyAxiosProxyConfig(probe, url);
-    if (probe.proxy || probe.httpsAgent) {
-      proxied = true;
+    try {
+      const { hostname, port, protocol } = new URL(proxyUrl);
+      const host = hostname.replace(/^\[|\]$/g, '');
+      if (host.length === 0) {
+        continue;
+      }
+      entries.add(`${host}:${port || (protocol === 'https:' ? '443' : '80')}`);
+    } catch {
+      continue;
     }
+  }
+  return [...entries];
+}
 
-    /** Called for its validation side effect: throws `ESSRF` on a blocked literal target. */
-    applySSRFSafeAgentIfDirect({}, url, allowedAddresses);
+/** Keyed by exemption list so repeated tool loads reuse one pooled pair, as `oauth/tokens` does. */
+const agentsByExemptions = new Map<string, WebSearchSSRFAgents>();
+
+/**
+ * Connect-time SSRF agents for the web-search tool, which issues its own requests and accepts
+ * only a shared agent pair.
+ *
+ * Redirect hops traverse these agents, so a redirect to a private hostname is rejected. A
+ * redirect to a private IP literal is not: Node skips the lookup for literals and
+ * `HttpAgentConfig` exposes no `maxRedirects` to forward, so closing that needs a change in
+ * `@librechat/agents`. When a proxy carries the request the proxy resolves the destination, so
+ * enforcement there belongs to the proxy's own egress policy.
+ */
+export function resolveWebSearchSSRFAgents(
+  allowedAddresses?: string[] | null,
+): WebSearchSSRFAgents {
+  const exemptions = [...(allowedAddresses ?? []), ...getProxyExemptions()];
+  const cacheKey = exemptions.join('\n');
+
+  const cached = agentsByExemptions.get(cacheKey);
+  if (cached) {
+    return cached;
   }
 
-  if (proxied) {
-    return {};
-  }
-
-  return createSSRFSafeAgents(allowedAddresses);
+  const agents = createSSRFSafeAgents(exemptions, { keepAlive: true });
+  agentsByExemptions.set(cacheKey, agents);
+  return agents;
 }

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -26,12 +26,12 @@ function getProxyExemptions(): string[] {
       continue;
     }
     try {
+      /** `hostname` keeps IPv6 brackets, which the exemption parser requires as `[ipv6]:port`. */
       const { hostname, port, protocol } = new URL(proxyUrl);
-      const host = hostname.replace(/^\[|\]$/g, '');
-      if (host.length === 0) {
+      if (hostname.length === 0) {
         continue;
       }
-      entries.add(`${host}:${port || (protocol === 'https:' ? '443' : '80')}`);
+      entries.add(`${hostname}:${port || (protocol === 'https:' ? '443' : '80')}`);
     } catch {
       continue;
     }

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -8,14 +8,12 @@ export interface WebSearchSSRFAgents {
 }
 
 /**
- * Every variable that can put a proxy in front of these requests. Axios resolves a proxy through
- * `proxy-from-env`, which reads `<protocol>_proxy` and then `all_proxy` in either case, so
- * `ALL_PROXY` alone is enough to proxy a request. `PROXY` is LibreChat's own setting, honored by
- * `applyAxiosProxyConfig` on the other egress paths.
+ * Exactly the variables that can put a proxy in front of these requests: Axios resolves through
+ * `proxy-from-env`, which reads `<protocol>_proxy` and then `all_proxy` in either case. LibreChat's
+ * own `PROXY` is deliberately absent, since nothing on this path consumes it, and exempting an
+ * address that never carries the request would grant a bypass rather than preserve one.
  */
 const PROXY_ENV_VARS = [
-  'PROXY',
-  'proxy',
   'HTTP_PROXY',
   'http_proxy',
   'HTTPS_PROXY',
@@ -40,7 +38,8 @@ function getProxyExemptions(): string[] {
     try {
       /** `hostname` keeps IPv6 brackets, which the exemption parser requires as `[ipv6]:port`. */
       const { hostname, port, protocol } = new URL(proxyUrl);
-      if (hostname.length === 0) {
+      /** Axios proxies over http(s) only, so a socks endpoint never carries these requests. */
+      if (hostname.length === 0 || (protocol !== 'http:' && protocol !== 'https:')) {
         continue;
       }
       entries.add(`${hostname}:${port || (protocol === 'https:' ? '443' : '80')}`);
@@ -51,8 +50,11 @@ function getProxyExemptions(): string[] {
   return [...entries];
 }
 
-/** Keyed by exemption list so repeated tool loads reuse one pooled pair, as `oauth/tokens` does. */
+/** Keyed by exemption list so repeated tool loads reuse one pooled pair. */
 const agentsByExemptions = new Map<string, WebSearchSSRFAgents>();
+
+/** Distinct exemption lists are bounded by admin configuration; the cap only guards a leak. */
+const MAX_CACHED_AGENT_PAIRS = 32;
 
 /**
  * Connect-time SSRF agents for the web-search tool, which issues its own requests and accepts
@@ -60,21 +62,34 @@ const agentsByExemptions = new Map<string, WebSearchSSRFAgents>();
  *
  * Redirect hops traverse these agents, so `blockLiteralHosts` covers a redirect to a private
  * address whether it is named or a literal, which is what `maxRedirects` would otherwise be
- * needed for. When a proxy carries the request the proxy resolves the destination, so
- * enforcement there belongs to the proxy's own egress policy.
+ * needed for. A blocked redirect surfaces as `ERR_FR_REDIRECTION_FAILURE` with the `ESSRF`
+ * message attached, because `follow-redirects` wraps the agent's error.
+ *
+ * When a proxy carries the request the proxy resolves the destination, so enforcement there
+ * belongs to the proxy's egress policy. The proxy endpoint is exempted for the whole pair rather
+ * than per destination, since one shared pair cannot discriminate: a destination that `NO_PROXY`
+ * sends direct therefore also carries that exemption.
  */
 export function resolveWebSearchSSRFAgents(
   allowedAddresses?: string[] | null,
 ): WebSearchSSRFAgents {
-  const exemptions = [...(allowedAddresses ?? []), ...getProxyExemptions()];
-  const cacheKey = exemptions.join('\n');
+  const configured = Array.isArray(allowedAddresses) ? allowedAddresses : [];
+  const exemptions = [...configured, ...getProxyExemptions()];
+  const cacheKey = exemptions.join('\0');
 
   const cached = agentsByExemptions.get(cacheKey);
   if (cached) {
     return cached;
   }
 
-  const agents = createSSRFSafeAgents(exemptions, { keepAlive: true }, { blockLiteralHosts: true });
+  const agents = createSSRFSafeAgents(
+    exemptions,
+    { keepAlive: true, timeout: 5000 },
+    { blockLiteralHosts: true },
+  );
+  if (agentsByExemptions.size >= MAX_CACHED_AGENT_PAIRS) {
+    agentsByExemptions.clear();
+  }
   agentsByExemptions.set(cacheKey, agents);
   return agents;
 }

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -1,6 +1,5 @@
 import type https from 'node:https';
 import type http from 'node:http';
-import { getProxyEnvConfig } from '../utils/proxy';
 import { createSSRFSafeAgents } from '../auth';
 
 export interface WebSearchSSRFAgents {
@@ -9,19 +8,32 @@ export interface WebSearchSSRFAgents {
 }
 
 /**
+ * Every variable that can put a proxy in front of these requests. Axios resolves a proxy through
+ * `proxy-from-env`, which reads `<protocol>_proxy` and then `all_proxy` in either case, so
+ * `ALL_PROXY` alone is enough to proxy a request. `PROXY` is LibreChat's own setting, honored by
+ * `applyAxiosProxyConfig` on the other egress paths.
+ */
+const PROXY_ENV_VARS = [
+  'PROXY',
+  'proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+] as const;
+
+/**
  * For a plaintext http target Axios repoints the caller's agent at the proxy host, so the
  * connect-time check would resolve the proxy itself and reject a private one. Exempting the
  * proxy endpoint keeps that hop reachable while every direct and `NO_PROXY` destination stays
  * guarded. Https targets are unaffected either way: Axios swaps in its own CONNECT tunnel.
  */
 function getProxyExemptions(): string[] {
-  const config = getProxyEnvConfig();
-  if (!config) {
-    return [];
-  }
-
   const entries = new Set<string>();
-  for (const proxyUrl of [config.httpProxy, config.httpsProxy]) {
+  for (const name of PROXY_ENV_VARS) {
+    const proxyUrl = process.env[name]?.trim();
     if (!proxyUrl) {
       continue;
     }

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -1,4 +1,5 @@
 import { getProxyForUrl } from 'proxy-from-env';
+import type { TWebSearchConfig } from 'librechat-data-provider';
 import type https from 'node:https';
 import type http from 'node:http';
 import { createSSRFSafeAgents } from '../auth';
@@ -8,28 +9,42 @@ export interface WebSearchSSRFAgents {
   httpsAgent: https.Agent;
 }
 
-/**
- * Probe hosts used only to ask which proxy would carry an http and an https request. A public
- * placeholder keeps the answer independent of any real destination.
- */
-const HTTP_PROBE_URL = 'http://proxy-probe.example.com/';
-const HTTPS_PROBE_URL = 'https://proxy-probe.example.com/';
+/** Resolved web-search fields that carry an outbound destination. */
+const WEB_SEARCH_URL_KEYS = [
+  'searxngInstanceUrl',
+  'firecrawlApiUrl',
+  'jinaApiUrl',
+  'tavilySearchUrl',
+  'tavilyExtractUrl',
+] as const;
 
 /**
- * For a plaintext http target Axios repoints the caller's agent at the proxy host, so the
- * connect-time check would resolve the proxy itself and reject a private one. Exempting the
- * proxy endpoint keeps that hop reachable while every direct destination stays guarded.
- * Https targets are unaffected either way: Axios swaps in its own CONNECT tunnel.
+ * For a plaintext http destination Axios repoints the caller's agent at the proxy host, so the
+ * connect-time check would resolve the proxy itself and reject a private one. Exempting that
+ * endpoint keeps the hop reachable while every direct destination stays guarded.
  *
- * Resolution goes through `getProxyForUrl`, the same `proxy-from-env` entry point Axios uses, so
- * variable precedence (`<protocol>_proxy` before `all_proxy`, lowercase before uppercase),
- * scheme-less normalization, and `NO_PROXY` all match exactly. Deriving the endpoints any other
- * way risks exempting an address that never carries a request, which grants a bypass.
+ * Resolution runs per destination through `getProxyForUrl`, the same `proxy-from-env` entry point
+ * Axios uses, so variable precedence, scheme-less normalization, and `NO_PROXY` all match for the
+ * host actually being dialed. Only http destinations are considered: for an https destination
+ * Axios substitutes its own CONNECT tunnel and never uses the injected agent for the proxy
+ * connection, so no exemption is owed. Provider defaults are all https for the same reason.
  */
-function getProxyExemptions(): string[] {
+function getProxyExemptions(authResult: Partial<TWebSearchConfig>): string[] {
   const entries = new Set<string>();
-  for (const probeUrl of [HTTP_PROBE_URL, HTTPS_PROBE_URL]) {
-    const proxyUrl = getProxyForUrl(probeUrl);
+  for (const key of WEB_SEARCH_URL_KEYS) {
+    const destination = authResult[key];
+    if (typeof destination !== 'string' || destination.length === 0) {
+      continue;
+    }
+    try {
+      if (new URL(destination).protocol !== 'http:') {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    const proxyUrl = getProxyForUrl(destination);
     if (!proxyUrl) {
       continue;
     }
@@ -69,10 +84,11 @@ const MAX_CACHED_AGENT_PAIRS = 32;
  * sends direct therefore also carries that exemption.
  */
 export function resolveWebSearchSSRFAgents(
+  authResult: Partial<TWebSearchConfig>,
   allowedAddresses?: string[] | null,
 ): WebSearchSSRFAgents {
   const configured = Array.isArray(allowedAddresses) ? allowedAddresses : [];
-  const exemptions = [...configured, ...getProxyExemptions()];
+  const exemptions = [...configured, ...getProxyExemptions(authResult ?? {})];
   const cacheKey = exemptions.join('\0');
 
   const cached = agentsByExemptions.get(cacheKey);

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -46,10 +46,9 @@ const agentsByExemptions = new Map<string, WebSearchSSRFAgents>();
  * Connect-time SSRF agents for the web-search tool, which issues its own requests and accepts
  * only a shared agent pair.
  *
- * Redirect hops traverse these agents, so a redirect to a private hostname is rejected. A
- * redirect to a private IP literal is not: Node skips the lookup for literals and
- * `HttpAgentConfig` exposes no `maxRedirects` to forward, so closing that needs a change in
- * `@librechat/agents`. When a proxy carries the request the proxy resolves the destination, so
+ * Redirect hops traverse these agents, so `blockLiteralHosts` covers a redirect to a private
+ * address whether it is named or a literal, which is what `maxRedirects` would otherwise be
+ * needed for. When a proxy carries the request the proxy resolves the destination, so
  * enforcement there belongs to the proxy's own egress policy.
  */
 export function resolveWebSearchSSRFAgents(
@@ -63,7 +62,7 @@ export function resolveWebSearchSSRFAgents(
     return cached;
   }
 
-  const agents = createSSRFSafeAgents(exemptions, { keepAlive: true });
+  const agents = createSSRFSafeAgents(exemptions, { keepAlive: true }, { blockLiteralHosts: true });
   agentsByExemptions.set(cacheKey, agents);
   return agents;
 }

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -1,3 +1,4 @@
+import { getProxyForUrl } from 'proxy-from-env';
 import type https from 'node:https';
 import type http from 'node:http';
 import { createSSRFSafeAgents } from '../auth';
@@ -8,30 +9,27 @@ export interface WebSearchSSRFAgents {
 }
 
 /**
- * Exactly the variables that can put a proxy in front of these requests: Axios resolves through
- * `proxy-from-env`, which reads `<protocol>_proxy` and then `all_proxy` in either case. LibreChat's
- * own `PROXY` is deliberately absent, since nothing on this path consumes it, and exempting an
- * address that never carries the request would grant a bypass rather than preserve one.
+ * Probe hosts used only to ask which proxy would carry an http and an https request. A public
+ * placeholder keeps the answer independent of any real destination.
  */
-const PROXY_ENV_VARS = [
-  'HTTP_PROXY',
-  'http_proxy',
-  'HTTPS_PROXY',
-  'https_proxy',
-  'ALL_PROXY',
-  'all_proxy',
-] as const;
+const HTTP_PROBE_URL = 'http://proxy-probe.example.com/';
+const HTTPS_PROBE_URL = 'https://proxy-probe.example.com/';
 
 /**
  * For a plaintext http target Axios repoints the caller's agent at the proxy host, so the
  * connect-time check would resolve the proxy itself and reject a private one. Exempting the
- * proxy endpoint keeps that hop reachable while every direct and `NO_PROXY` destination stays
- * guarded. Https targets are unaffected either way: Axios swaps in its own CONNECT tunnel.
+ * proxy endpoint keeps that hop reachable while every direct destination stays guarded.
+ * Https targets are unaffected either way: Axios swaps in its own CONNECT tunnel.
+ *
+ * Resolution goes through `getProxyForUrl`, the same `proxy-from-env` entry point Axios uses, so
+ * variable precedence (`<protocol>_proxy` before `all_proxy`, lowercase before uppercase),
+ * scheme-less normalization, and `NO_PROXY` all match exactly. Deriving the endpoints any other
+ * way risks exempting an address that never carries a request, which grants a bypass.
  */
 function getProxyExemptions(): string[] {
   const entries = new Set<string>();
-  for (const name of PROXY_ENV_VARS) {
-    const proxyUrl = process.env[name]?.trim();
+  for (const probeUrl of [HTTP_PROBE_URL, HTTPS_PROBE_URL]) {
+    const proxyUrl = getProxyForUrl(probeUrl);
     if (!proxyUrl) {
       continue;
     }

--- a/packages/api/src/web/agent.ts
+++ b/packages/api/src/web/agent.ts
@@ -1,0 +1,60 @@
+import type { TWebSearchConfig } from 'librechat-data-provider';
+import type { AxiosRequestConfig } from 'axios';
+import type https from 'node:https';
+import type http from 'node:http';
+import { applySSRFSafeAgentIfDirect, createSSRFSafeAgents } from '../auth';
+import { applyAxiosProxyConfig } from '../utils/proxy';
+
+/** Resolved web-search fields that carry an outbound destination. */
+const WEB_SEARCH_URL_KEYS = [
+  'searxngInstanceUrl',
+  'firecrawlApiUrl',
+  'jinaApiUrl',
+  'tavilySearchUrl',
+  'tavilyExtractUrl',
+] as const;
+
+export interface WebSearchSSRFAgents {
+  httpAgent?: http.Agent;
+  httpsAgent?: https.Agent;
+}
+
+/**
+ * Extends the `applySSRFSafeAgentIfDirect` contract to the web-search tool, which
+ * owns its own axios calls and accepts agents rather than a request config.
+ *
+ * Each configured destination is run through that helper so an IP-literal private
+ * target (which Node's connect-time `lookup` never sees) throws before any request
+ * is made. Agents are withheld when a proxy owns egress for any destination: one
+ * agent pair is shared by every provider, so attaching a direct-connect agent to a
+ * proxied connection would both break the request and assert protection the proxy's
+ * network context cannot provide.
+ */
+export function resolveWebSearchSSRFAgents(
+  authResult: Partial<TWebSearchConfig>,
+  allowedAddresses?: string[] | null,
+): WebSearchSSRFAgents {
+  let proxied = false;
+
+  for (const key of WEB_SEARCH_URL_KEYS) {
+    const url = authResult[key];
+    if (typeof url !== 'string' || url.length === 0) {
+      continue;
+    }
+
+    const probe: AxiosRequestConfig = {};
+    applyAxiosProxyConfig(probe, url);
+    if (probe.proxy || probe.httpsAgent) {
+      proxied = true;
+    }
+
+    /** Called for its validation side effect: throws `ESSRF` on a blocked literal target. */
+    applySSRFSafeAgentIfDirect({}, url, allowedAddresses);
+  }
+
+  if (proxied) {
+    return {};
+  }
+
+  return createSSRFSafeAgents(allowedAddresses);
+}

--- a/packages/api/src/web/index.ts
+++ b/packages/api/src/web/index.ts
@@ -1,1 +1,2 @@
 export * from './web';
+export * from './agent';

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -24,6 +24,12 @@ const mockResolveHostnameSSRF = jest.fn().mockResolvedValue(false);
 jest.mock('../auth', () => ({
   isSSRFTarget: (...args: unknown[]) => mockIsSSRFTarget(...args),
   resolveHostnameSSRF: (...args: unknown[]) => mockResolveHostnameSSRF(...args),
+  getEffectivePort: (protocol: string, port?: string) => {
+    if (port) {
+      return port;
+    }
+    return protocol === 'https:' ? '443' : '80';
+  },
 }));
 
 describe('web.ts', () => {
@@ -353,13 +359,67 @@ describe('web.ts', () => {
         expect(result.authenticated).toBe(true);
         expect(result.authResult.tavilySearchUrl).toBe('https://tenant-search.example/search');
         expect(result.authResult.tavilyExtractUrl).toBe('https://tenant-extract.example/extract');
-        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith('tenant-search.example');
-        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith('tenant-extract.example');
+        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith(
+          'tenant-search.example',
+          undefined,
+          '443',
+        );
+        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith(
+          'tenant-extract.example',
+          undefined,
+          '443',
+        );
         expect(result.authTypes).toEqual([
           ['providers', AuthType.USER_PROVIDED],
           ['scrapers', AuthType.USER_PROVIDED],
           ['rerankers', AuthType.SYSTEM_DEFINED],
         ]);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it('threads allowedAddresses and the effective port into the SSRF preflight for user-provided URLs', async () => {
+      mockIsSSRFTarget.mockClear();
+      mockResolveHostnameSSRF.mockClear();
+      mockIsSSRFTarget.mockReturnValue(false);
+      mockResolveHostnameSSRF.mockResolvedValue(false);
+
+      const originalEnv = process.env;
+      try {
+        process.env = { ...originalEnv };
+        delete process.env.SEARXNG_INSTANCE_URL;
+
+        const searxngConfig = {
+          searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+          searchProvider: 'searxng' as SearchProviders,
+          rerankerType: 'none' as RerankerTypes,
+          allowedAddresses: ['localhost:8888'],
+        } as TWebSearchConfig;
+
+        mockLoadAuthValues.mockImplementation(({ authFields }) => {
+          const result: Record<string, string> = {};
+          authFields.forEach((field: string) => {
+            if (field === 'SEARXNG_INSTANCE_URL') {
+              result[field] = 'http://localhost:8888';
+            }
+          });
+          return Promise.resolve(result);
+        });
+
+        const result = await loadWebSearchAuth({
+          userId,
+          webSearchConfig: searxngConfig,
+          loadAuthValues: mockLoadAuthValues,
+        });
+
+        expect(mockIsSSRFTarget).toHaveBeenCalledWith('localhost', ['localhost:8888'], '8888');
+        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith(
+          'localhost',
+          ['localhost:8888'],
+          '8888',
+        );
+        expect(result.authResult.searxngInstanceUrl).toBe('http://localhost:8888');
       } finally {
         process.env = originalEnv;
       }
@@ -1675,7 +1735,7 @@ describe('web.ts', () => {
       });
 
       expect(result.authResult.jinaApiUrl).toBeUndefined();
-      expect(mockIsSSRFTarget).toHaveBeenCalledWith('localhost');
+      expect(mockIsSSRFTarget).toHaveBeenCalledWith('localhost', undefined, '8080');
     });
 
     it('should block user-provided firecrawlApiUrl resolving to private IP', async () => {
@@ -1832,7 +1892,7 @@ describe('web.ts', () => {
         expect(result.authResult.tavilySearchUrl).toBeUndefined();
         expect(result.authResult.searchProvider).toBe('tavily');
         expect(result.authenticated).toBe(true);
-        expect(mockIsSSRFTarget).toHaveBeenCalledWith('localhost');
+        expect(mockIsSSRFTarget).toHaveBeenCalledWith('localhost', undefined, '8080');
       } finally {
         process.env = originalEnv;
       }
@@ -1880,7 +1940,11 @@ describe('web.ts', () => {
         expect(result.authResult.tavilyExtractUrl).toBeUndefined();
         expect(result.authResult.scraperProvider).toBe('tavily');
         expect(result.authenticated).toBe(true);
-        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith('extract.internal-service.com');
+        expect(mockResolveHostnameSSRF).toHaveBeenCalledWith(
+          'extract.internal-service.com',
+          undefined,
+          '443',
+        );
       } finally {
         process.env = originalEnv;
       }

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -1,3 +1,4 @@
+import { webSearchAuth } from '@librechat/data-schemas';
 import {
   AuthType,
   SafeSearchTypes,
@@ -6,10 +7,9 @@ import {
   ScraperProviders,
   extractVariableName,
 } from 'librechat-data-provider';
-import { webSearchAuth } from '@librechat/data-schemas';
 import type { RerankerTypes, TCustomConfig, TWebSearchConfig } from 'librechat-data-provider';
 import type { TWebSearchKeys, TWebSearchCategories } from '@librechat/data-schemas';
-import { isSSRFTarget, resolveHostnameSSRF } from '../auth';
+import { isSSRFTarget, resolveHostnameSSRF, getEffectivePort } from '../auth';
 
 /**
  * User-provided URL keys that may pass through after SSRF preflight.
@@ -35,8 +35,10 @@ function isUserProvidedEnabled(field: string): boolean {
 /**
  * Returns true if the URL should be blocked for SSRF risk.
  * Fail-closed: unparseable URLs and non-HTTP(S) schemes return true.
+ * `allowedAddresses` keeps this preflight consistent with the connect-time agent
+ * so an admin-permitted private endpoint is not stripped before the agent runs.
  */
-async function isSSRFUrl(url: string): Promise<boolean> {
+async function isSSRFUrl(url: string, allowedAddresses?: string[] | null): Promise<boolean> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -46,10 +48,11 @@ async function isSSRFUrl(url: string): Promise<boolean> {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return true;
   }
-  if (isSSRFTarget(parsed.hostname)) {
+  const port = getEffectivePort(parsed.protocol, parsed.port);
+  if (isSSRFTarget(parsed.hostname, allowedAddresses, port)) {
     return true;
   }
-  return resolveHostnameSSRF(parsed.hostname);
+  return resolveHostnameSSRF(parsed.hostname, allowedAddresses, port);
 }
 
 export function extractWebSearchEnvVars({
@@ -216,7 +219,11 @@ export async function loadWebSearchAuth({
             continue;
           }
 
-          if (isUserProvidedUrlEnabled && isFieldUserProvided && (await isSSRFUrl(value))) {
+          if (
+            isUserProvidedUrlEnabled &&
+            isFieldUserProvided &&
+            (await isSSRFUrl(value, webSearchConfig?.allowedAddresses))
+          ) {
             if (!optionalSet.has(field)) {
               allFieldsAuthenticated = false;
               break;

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -377,6 +377,10 @@ describe('allowedAddressesSchema', () => {
       ['[fc00::1]:8080', 'IPv6 unique-local with port'],
       ['[fd00::1]:8080', 'IPv6 unique-local with port'],
       ['[fe80::1]:8080', 'IPv6 link-local with port'],
+      ['[::ffff:10.0.0.5]:8080', 'IPv4-mapped IPv6 of a private address'],
+      ['[64:ff9b::a00:1]:8080', 'NAT64 embedding private 10.0.0.1'],
+      ['[2002:a00:1::]:8080', '6to4 embedding private 10.0.0.1'],
+      ['[2001::ffff:f5ff:fffe]:8080', 'Teredo embedding a private address'],
     ])('accepts "%s" (%s)', (entry) => {
       expect(allowedAddressesSchema.parse([entry])).toEqual([entry]);
     });
@@ -398,6 +402,8 @@ describe('allowedAddressesSchema', () => {
       ['https://internal.example', 'https URL'],
       ['ws://10.0.0.5', 'ws URL'],
       ['10.0.0.0/24', 'CIDR range'],
+      ['[64:ff9b::808:808]:8080', 'NAT64 embedding public 8.8.8.8'],
+      ['[2002:808:808::]:8080', '6to4 embedding public 8.8.8.8'],
       ['/path', 'leading slash / path'],
       ['10.0.0.5/api', 'embedded path'],
       ['localhost', 'bare hostname'],

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1711,6 +1711,7 @@ export enum SafeSearchTypes {
 }
 
 export const webSearchSchema = z.object({
+  allowedAddresses: allowedAddressesSchema,
   serperApiKey: z.string().optional().default('${SERPER_API_KEY}'),
   serperApiKeyPreview: apiKeyPreviewSchema,
   searxngInstanceUrl: z.string().optional().default('${SEARXNG_INSTANCE_URL}'),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -113,6 +113,38 @@ function isPrivateIPv4Literal(value: string): boolean {
   return false;
 }
 
+/**
+ * Mirrors `hasPrivateEmbeddedIPv4` in `@librechat/api`'s ip helpers: 6to4, NAT64, and Teredo
+ * carry an IPv4 address inside the IPv6 one, and the runtime guard blocks those when the
+ * embedded address is private. Kept in sync so an operator can exempt what the runtime blocks.
+ */
+function hasPrivateEmbeddedIPv4Literal(value: string): boolean {
+  const is6to4 = value.startsWith('2002:');
+  const isNat64 = value.startsWith('64:ff9b::');
+  const isTeredo = value.startsWith('2001::');
+  if (!is6to4 && !isNat64 && !isTeredo) {
+    return false;
+  }
+
+  const segments = value.split(':').filter((segment) => segment !== '');
+  const pair = is6to4 ? segments.slice(1, 3) : segments.slice(-2);
+  if (pair.length !== 2) {
+    return false;
+  }
+
+  const hi = parseInt(pair[0], 16);
+  const lo = parseInt(pair[1], 16);
+  if (isNaN(hi) || isNaN(lo)) {
+    return false;
+  }
+
+  /** RFC 4380: Teredo stores the external IPv4 as a bitwise complement. */
+  const high = isTeredo ? ~hi : hi;
+  const low = isTeredo ? ~lo : lo;
+  const octets = [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff];
+  return isPrivateIPv4Literal(octets.join('.'));
+}
+
 function isPrivateIPv6Literal(value: string): boolean {
   if (!value.includes(':')) return false;
   if (value === '::1' || value === '::') return true;
@@ -126,7 +158,7 @@ function isPrivateIPv6Literal(value: string): boolean {
   // 4-in-6: ::ffff:A.B.C.D
   const mappedMatch = value.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
   if (mappedMatch) return isPrivateIPv4Literal(mappedMatch[1]);
-  return false;
+  return hasPrivateEmbeddedIPv4Literal(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

Web search and scrape providers make outbound requests to operator-configured URLs (Firecrawl, Tavily, SearXNG, Jina, and the scrapers), but currently open those connections with no connect-time SSRF protection, unlike the custom `/models`, Actions, and MCP clients.

This wires the existing SSRF-safe agent into web search. It adds an optional `allowedAddresses` exemption to `webSearchSchema` and injects an `httpAgent`/`httpsAgent` pair into the `createSearchTool` config, so every connection LibreChat opens for search, scraping, and reranking is validated at TCP-connect time against its resolved address. Private, loopback, link-local, and metadata targets are rejected, and because the check runs per connection it holds against a hostname that DNS-rebinds after the write-time check in `loadWebSearchAuth`.

Two cases the connect-time lookup alone does not cover, both handled here:

- **IP literals.** Node resolves nothing for a literal host, so the lookup never sees `http://169.254.169.254`. `withSSRFProtection` now also checks `options.host` and rejects a private literal. Redirect hops pass through the same `createConnection`, so this covers a redirect to a literal private target as well, which is otherwise unreachable from here because `HttpAgentConfig` exposes no `maxRedirects`. The check is opt-in via `blockLiteralHosts` and enabled only for web search: the already-merged `createSSRFSafeAgents` consumers carry no proxy-endpoint exemption, so enabling it for them would break a literal-address proxy that works today.
- **Forward proxies.** For a plaintext http target Axios repoints the caller's agent at the proxy host, so the check would resolve the proxy rather than the destination and a private proxy would be rejected. The proxy's `host:port` is derived from exactly the variables Axios resolves through `proxy-from-env` (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, either case) and exempted, keeping that hop reachable while destinations stay guarded. LibreChat's own `PROXY` is deliberately excluded, since nothing on this path consumes it and exempting an address that never carries the request would grant a bypass rather than preserve a route. A socks endpoint is skipped for the same reason. Axios applies `NO_PROXY` per request, so a bypassed destination is a direct connection and keeps enforcement, though the exemption itself is per pair rather than per destination, so such a destination also carries it. Https targets are unaffected either way, since Axios substitutes its own CONNECT tunnel and the injected agent is not used for the proxy connection.

The agents are built with `keepAlive` and cached per exemption list, so pooling matches the global agents they replace instead of opening a fresh socket for every search, scrape, and rerank call.

**Accepted tradeoff:** with no `allowedAddresses` configured, web-search connections to private, loopback, link-local, or metadata targets now fail closed, matching how `endpoints`, `actions`, MCP, speech, and OCR already behave. Operators pointing web search at a private address (`searxngInstanceUrl: http://searxng:8080`, a self-hosted Firecrawl, `http://localhost:8080`, or a literal such as `http://127.0.0.1:8080`) add a one-line `host:port` exemption, documented in `librechat.example.yaml`. A configured proxy is exempted automatically and needs no entry. `allowedAddresses` entries are trusted ahead of the private-address check, so list only hosts you fully control and that cannot be repointed or DNS-rebound by an attacker.

**Scope, stated plainly:** this guards the connections LibreChat itself opens. Scrape targets are sent as payload to a provider API, which fetches them on its own infrastructure, so this does not constrain the page a scraper visits. When a proxy carries the request the proxy resolves the destination, so destination egress policy there belongs to the proxy. It addresses private and internal SSRF only, not the separate question of which public hosts should be reachable.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

- `packages/api/src/web/agent.spec.ts`: a pooled pair is always returned, including when a proxy is configured; the proxy endpoint is exempted and scoped to its port, for IPv4, IPv6 (`[fd00::1]:3128`), and `ALL_PROXY`; the default port is derived from the proxy scheme; an empty proxy value is treated as unset, matching what compose forwards; no exemption is granted for `PROXY` or for a socks endpoint; a private IP literal is rejected at connect time while an exempted one is not; a public literal is allowed; a unix socket is rejected; a non-array `allowedAddresses` and an unparseable proxy value are tolerated rather than throwing during tool load; cache keys do not collide when an entry contains a newline.
- `api/app/clients/tools/util/handleTools.test.js`: exercises the **real** resolver rather than a mock, asserting the threaded agents are pooled and that they actually reject a private target and honor `allowedAddresses` end to end.
- `packages/api/src/auth/agent.spec.ts` and the merged consumer suites (`endpoints/models`, `oauth`, `files/mistral`, speech) confirm `blockLiteralHosts` leaves their behavior unchanged.
- `packages/api/src/web/web.spec.ts`: `allowedAddresses` and the effective port are threaded into the `isSSRFUrl` preflight for user-provided URL keys.

Redirect blocking was additionally verified end to end against the built package: a 302 to `http://127.0.0.1:9/` fails with `SSRF protection: 127.0.0.1 resolved to blocked address 127.0.0.1` and never reaches the network.

```
cd packages/api && npx jest src/web src/auth
cd api && npx jest handleTools
```

### **Test Configuration**:

None required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules

