### PR TITLE
🧬 fix: Resolve URL-Named Model Spec to Its Full Preset on Cold Load

### DIFF
--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -166,10 +166,6 @@ export default function ChatRoute() {
     }
 
     const getNewConvoPreset = () => {
-      const result = getDefaultModelSpec(startupConfig, endpointsQuery.data);
-      const spec = result?.default ?? result?.last ?? result?.softDefault;
-      const specPreset = spec ? getModelSpecPreset(spec) : undefined;
-
       const queryParams: Record<string, string> = {};
       searchParams.forEach((value, key) => {
         if (key !== 'prompt' && key !== 'q' && key !== 'submit' && key !== 'projectId') {
@@ -177,6 +173,19 @@ export default function ChatRoute() {
         }
       });
       const querySettings = processValidSettings(queryParams);
+
+      /** A spec named in the URL is an explicit selection: it must resolve to its own
+       * full preset, or stale last-selection state (endpoint/agent) fills the gaps. */
+      const urlSpec = querySettings.spec
+        ? startupConfig?.modelSpecs?.list?.find((spec) => spec.name === querySettings.spec)
+        : undefined;
+      if (querySettings.spec != null && !urlSpec) {
+        delete querySettings.spec;
+      }
+
+      const result = urlSpec ? undefined : getDefaultModelSpec(startupConfig, endpointsQuery.data);
+      const spec = urlSpec ?? result?.default ?? result?.last ?? result?.softDefault;
+      const specPreset = spec ? getModelSpecPreset(spec) : undefined;
 
       if (Object.keys(querySettings).length > 0) {
         return mergeQuerySettingsWithSpec(specPreset, querySettings);

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -175,13 +175,12 @@ export default function ChatRoute() {
       const querySettings = processValidSettings(queryParams);
 
       /** A spec named in the URL is an explicit selection: it must resolve to its own
-       * full preset, or stale last-selection state (endpoint/agent) fills the gaps. */
+       * full preset, or stale last-selection state (endpoint/agent) fills the gaps.
+       * Names absent from the client config (e.g. `showInMenu: false`) stay in the
+       * query settings untouched, since they remain resolvable server-side by name. */
       const urlSpec = querySettings.spec
         ? startupConfig?.modelSpecs?.list?.find((spec) => spec.name === querySettings.spec)
         : undefined;
-      if (querySettings.spec != null && !urlSpec) {
-        delete querySettings.spec;
-      }
 
       const result = urlSpec ? undefined : getDefaultModelSpec(startupConfig, endpointsQuery.data);
       const spec = urlSpec ?? result?.default ?? result?.last ?? result?.softDefault;

--- a/e2e/specs/mock/soft-default.spec.ts
+++ b/e2e/specs/mock/soft-default.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { TStartupConfig } from 'librechat-data-provider';
 import type { Page } from '@playwright/test';
+import { getPrimaryE2EUser } from '../../setup/users.mock';
 import {
   NEW_CHAT_PATH,
   getAccessToken,
@@ -12,6 +13,9 @@ import {
 
 /** Label of the `softDefault: true` spec in e2e/config/librechat.e2e.yaml. */
 const SOFT_DEFAULT_LABEL = 'E2E Soft Default';
+
+/** Name (URL identity) of the `softDefault: true` spec in e2e/config/librechat.e2e.yaml. */
+const SOFT_DEFAULT_NAME = 'e2e-soft-default';
 
 /** Ephemeral endpoint from e2e/config/librechat.e2e.yaml with no mirroring spec. */
 const EPHEMERAL_ENDPOINT = { label: 'Mock Provider C', model: 'mock-model-c' };
@@ -32,7 +36,7 @@ type AgentResponse = {
   name?: string | null;
 };
 
-async function createAgent(page: Page, name: string): Promise<AgentResponse> {
+async function createAgent(page: Page, name: string, description?: string): Promise<AgentResponse> {
   const token = await getAccessToken(page);
   return requestJson<AgentResponse>(page, {
     path: '/api/agents',
@@ -40,6 +44,7 @@ async function createAgent(page: Page, name: string): Promise<AgentResponse> {
     method: 'POST',
     body: {
       name,
+      ...(description ? { description } : {}),
       provider: 'Mock Provider A',
       model: 'mock-model-a',
       model_parameters: {},
@@ -225,5 +230,46 @@ test.describe('soft default model spec', () => {
     await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
     await expect(modelTrigger(page)).toContainText(SOFT_DEFAULT_LABEL, { timeout: 15000 });
     await expect(modelTrigger(page)).not.toHaveText('Select a model');
+  });
+
+  // Regression: two tabs share localStorage — one on the soft default spec, one on a
+  // configured agent. Refreshing the agent tab stamps the agent as the last setup; a
+  // cold load of `/c/new?spec=<name>` then carried only the spec NAME while the
+  // endpoint and agent_id resurfaced from storage, rendering a chimera (spec chip over
+  // an agent landing/composer). A spec named in the URL must resolve to its full preset.
+  test('a spec named in the URL wins over a previously selected agent on a cold load', async ({
+    page,
+  }) => {
+    test.setTimeout(120000);
+    await startFresh(page);
+    await expect(modelTrigger(page)).toContainText(SOFT_DEFAULT_LABEL, { timeout: 15000 });
+
+    const agentName = uniqueName('E2E URL Spec Agent');
+    const agentDescription = 'Powered by E2E Mock';
+    await createAgent(page, agentName, agentDescription);
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+    await selectAgent(page, agentName);
+
+    // Mirrors refreshing the agent tab: the restored selection is re-stamped as the
+    // last conversation setup.
+    await page.reload({ timeout: 10000 });
+    await expect(modelTrigger(page)).toContainText(agentName, { timeout: 15000 });
+
+    await page.goto(`${NEW_CHAT_PATH}?spec=${SOFT_DEFAULT_NAME}`, { timeout: 10000 });
+    await expect(modelTrigger(page)).toContainText(SOFT_DEFAULT_LABEL, { timeout: 15000 });
+
+    const main = page.getByRole('main');
+    const composer = page.getByRole('textbox', { name: 'Message input' });
+    const user = getPrimaryE2EUser();
+    await expect(composer).toHaveAttribute('placeholder', /Mock Provider A/, { timeout: 15000 });
+    await expect(main).toContainText(user.name, { timeout: 15000 });
+    await expect(main).not.toContainText(agentName);
+    await expect(main).not.toContainText(agentDescription);
+
+    // The mixed state used to be written back to localStorage; a follow-up cold load
+    // of a plain New Chat must stay on the spec, not resurrect the agent.
+    await page.goto(NEW_CHAT_PATH, { timeout: 10000 });
+    await expect(modelTrigger(page)).toContainText(SOFT_DEFAULT_LABEL, { timeout: 15000 });
+    await expect(main).not.toContainText(agentName);
   });
 });


### PR DESCRIPTION
## Summary

Fixes a visual chimera on cold loads of `c/new?spec=<name>`: the header chip shows the URL-named spec while the landing and composer render a previously selected agent.

**Repro** (two tabs share localStorage):
1. Tab A sits on a softDefault model spec; Tab B on a configured agent.
2. Refresh Tab B — the agent selection is re-stamped as `lastConversationSetup_0` and `agent_id__0`.
3. Cold-load `c/new?spec=<spec name>` in Tab A.
4. The chip shows the spec, but the landing shows the agent entity and the composer targets the agent.

## Root cause

On a cold load, `ChatRoute.getNewConvoPreset` merged the raw `spec` query param over whatever `getDefaultModelSpec` resolved. When the stored last setup names a concrete agent, `getDefaultModelSpec` yields to that selection and returns `undefined`, so the new-convo preset carried only the spec **name** with no endpoint or model. `switchToConversation` then filled the endpoint from localStorage (`agents`) and `useSelectorEffects` filled `agent_id` from storage, producing a conversation that is half spec, half stale agent. The mixed state was then written back to `lastConversationSetup_0`, poisoning subsequent loads.

The SPA path (`useQueryParams.newQueryConvo`) already resolves a URL spec to its full preset, but it never corrects the cold path: `areSettingsApplied` skips the `spec` key, so spec-only query settings always read as applied.

## Fix

In `ChatRoute.getNewConvoPreset`, a spec named in the URL is treated as an explicit selection: it resolves to its own full preset (same semantics as `newQueryConvo`) instead of merging the bare name over the default-spec resolution. An unknown spec name is dropped, matching `newQueryConvo`'s ignore behavior.

## Regression test

`e2e/specs/mock/soft-default.spec.ts` — "a spec named in the URL wins over a previously selected agent on a cold load": selects an agent, reloads (stamping storage), cold-loads `c/new?spec=e2e-soft-default`, and asserts the trigger shows the spec, the composer targets the spec's endpoint, the landing keeps the personalized greeting with no agent name/description, and a follow-up cold `c/new` stays on the spec (guards the poisoned-storage variant).

Verified manually against the mock harness: pre-fix reproduces the exact chimera (spec chip + agent landing/composer, mixed `lastConversationSetup_0`); post-fix the conversation is the spec's full preset with no agent residue. Full `soft-default.spec.ts` suite passes (8/8).
