### PR TITLE
🧠 fix: Return 400 for Invalid Memory Keys

### DIFF
--- a/api/server/routes/__tests__/memories.spec.js
+++ b/api/server/routes/__tests__/memories.spec.js
@@ -104,6 +104,23 @@ describe('memories routes', () => {
       expect(createMemory).not.toHaveBeenCalled();
     });
 
+    it('trims the new key before validating and renaming', async () => {
+      const { deleteMemory } = require('~/models');
+      getUserMemories
+        .mockResolvedValueOnce([{ key: 'my_key', value: 'old value', tokenCount: 5 }])
+        .mockResolvedValueOnce([{ key: 'new_key', value: 'updated value', tokenCount: 5 }]);
+      createMemory.mockResolvedValue({ ok: true });
+      deleteMemory.mockResolvedValue({ ok: true });
+
+      const response = await request(app)
+        .patch('/api/memories/my_key')
+        .send({ key: '  new_key  ', value: 'updated value' });
+
+      expect(response.status).toBe(200);
+      expect(createMemory).toHaveBeenCalledWith(expect.objectContaining({ key: 'new_key' }));
+      expect(deleteMemory).toHaveBeenCalledWith(expect.objectContaining({ key: 'my_key' }));
+    });
+
     it('updates the value when the key is unchanged', async () => {
       getUserMemories
         .mockResolvedValueOnce([{ key: 'my_key', value: 'old value', tokenCount: 5 }])

--- a/api/server/routes/__tests__/memories.spec.js
+++ b/api/server/routes/__tests__/memories.spec.js
@@ -104,6 +104,17 @@ describe('memories routes', () => {
       expect(createMemory).not.toHaveBeenCalled();
     });
 
+    it('returns 400 when the key is not a string', async () => {
+      const response = await request(app)
+        .patch('/api/memories/my_key')
+        .send({ key: 123, value: 'updated value' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Key must be a string.');
+      expect(setMemory).not.toHaveBeenCalled();
+      expect(createMemory).not.toHaveBeenCalled();
+    });
+
     it('trims the new key before validating and renaming', async () => {
       const { deleteMemory } = require('~/models');
       getUserMemories

--- a/api/server/routes/__tests__/memories.spec.js
+++ b/api/server/routes/__tests__/memories.spec.js
@@ -1,0 +1,124 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  Tokenizer: {
+    getTokenCount: jest.fn().mockReturnValue(5),
+  },
+  generateCheckAccess: jest.fn(() => (req, res, next) => next()),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  ...jest.requireActual('librechat-data-provider'),
+}));
+
+jest.mock('~/models', () => ({
+  getAllUserMemories: jest.fn(),
+  getUserMemories: jest.fn(),
+  toggleUserMemories: jest.fn(),
+  getRoleByName: jest.fn(),
+  createMemory: jest.fn(),
+  deleteMemory: jest.fn(),
+  setMemory: jest.fn(),
+  getAgents: jest.fn(),
+}));
+
+jest.mock('~/server/services/PermissionService', () => ({
+  findAccessibleResources: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('~/server/middleware', () => ({
+  requireJwtAuth: (req, res, next) => next(),
+  configMiddleware: (req, res, next) => next(),
+}));
+
+const { createMemory, getUserMemories, setMemory } = require('~/models');
+
+describe('memories routes', () => {
+  let app;
+
+  beforeAll(() => {
+    const memoriesRouter = require('../memories');
+
+    app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      req.user = { id: 'user-1', role: 'USER' };
+      next();
+    });
+    app.use('/api/memories', memoriesRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /', () => {
+    it('returns 400 when the key contains invalid characters', async () => {
+      const response = await request(app)
+        .post('/api/memories')
+        .send({ key: 'My Key!', value: 'some value' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('lowercase letters and underscores');
+      expect(createMemory).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the key contains uppercase letters', async () => {
+      const response = await request(app)
+        .post('/api/memories')
+        .send({ key: 'myKey', value: 'some value' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('lowercase letters and underscores');
+      expect(createMemory).not.toHaveBeenCalled();
+    });
+
+    it('creates a memory when the key is valid', async () => {
+      getUserMemories
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ key: 'my_key', value: 'some value', tokenCount: 5 }]);
+      createMemory.mockResolvedValue({ ok: true });
+
+      const response = await request(app)
+        .post('/api/memories')
+        .send({ key: 'my_key', value: 'some value' });
+
+      expect(response.status).toBe(201);
+      expect(response.body.created).toBe(true);
+      expect(createMemory).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1', key: 'my_key' }),
+      );
+    });
+  });
+
+  describe('PATCH /:key', () => {
+    it('returns 400 when renaming to a key with invalid characters', async () => {
+      const response = await request(app)
+        .patch('/api/memories/my_key')
+        .send({ key: 'New Key', value: 'updated value' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('lowercase letters and underscores');
+      expect(createMemory).not.toHaveBeenCalled();
+    });
+
+    it('updates the value when the key is unchanged', async () => {
+      getUserMemories
+        .mockResolvedValueOnce([{ key: 'my_key', value: 'old value', tokenCount: 5 }])
+        .mockResolvedValueOnce([{ key: 'my_key', value: 'updated value', tokenCount: 5 }]);
+      setMemory.mockResolvedValue({ ok: true });
+
+      const response = await request(app)
+        .patch('/api/memories/my_key')
+        .send({ value: 'updated value' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.updated).toBe(true);
+      expect(setMemory).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-1', key: 'my_key' }),
+      );
+    });
+  });
+});

--- a/api/server/routes/__tests__/memories.spec.js
+++ b/api/server/routes/__tests__/memories.spec.js
@@ -115,6 +115,19 @@ describe('memories routes', () => {
       expect(createMemory).not.toHaveBeenCalled();
     });
 
+    it('rejects a whitespace-only rename instead of updating the existing memory', async () => {
+      getUserMemories.mockResolvedValue([{ key: 'my_key', value: 'old value', tokenCount: 5 }]);
+      setMemory.mockResolvedValue({ ok: true });
+
+      const response = await request(app)
+        .patch('/api/memories/my_key')
+        .send({ key: ' \t\n ', value: 'updated value' });
+
+      expect(response.status).toBe(400);
+      expect(setMemory).not.toHaveBeenCalled();
+      expect(createMemory).not.toHaveBeenCalled();
+    });
+
     it('trims the new key before validating and renaming', async () => {
       const { deleteMemory } = require('~/models');
       getUserMemories

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -55,6 +55,10 @@ router.use(requireJwtAuth);
 const getAgentIdParam = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
 
+/** Mirrors the MemoryEntry schema's key validator so invalid keys are
+ *  rejected with a 400 instead of surfacing as a Mongoose validation 500 */
+const MEMORY_KEY_REGEX = /^[a-z_]+$/;
+
 /** Resolves agent display names for agent-partitioned memories, restricted
  *  to agents the requester can VIEW — `agentId` is caller-supplied on write,
  *  so an unrestricted lookup would leak private agents' names. */
@@ -139,6 +143,12 @@ router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async 
 
   if (typeof value !== 'string' || value.trim() === '') {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
+  }
+
+  if (!MEMORY_KEY_REGEX.test(key.trim())) {
+    return res.status(400).json({
+      error: 'Key must only contain lowercase letters and underscores.',
+    });
   }
 
   const appConfig = req.config;
@@ -249,6 +259,13 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
   }
 
   const newKey = bodyKey || urlKey;
+
+  if (newKey !== urlKey && !MEMORY_KEY_REGEX.test(newKey)) {
+    return res.status(400).json({
+      error: 'Key must only contain lowercase letters and underscores.',
+    });
+  }
+
   const appConfig = req.config;
   const memoryConfig = appConfig?.memory;
   const charLimit = memoryConfig?.charLimit || 10000;

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -258,7 +258,8 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
   }
 
-  const newKey = bodyKey || urlKey;
+  /** Trim to match POST's key normalization; blank/whitespace-only falls back to urlKey */
+  const newKey = typeof bodyKey === 'string' && bodyKey.trim() !== '' ? bodyKey.trim() : urlKey;
 
   if (newKey !== urlKey && !MEMORY_KEY_REGEX.test(newKey)) {
     return res.status(400).json({

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -258,6 +258,10 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
   }
 
+  if (bodyKey !== undefined && typeof bodyKey !== 'string') {
+    return res.status(400).json({ error: 'Key must be a string.' });
+  }
+
   /** Trim to match POST's key normalization; blank/whitespace-only falls back to urlKey */
   const newKey = typeof bodyKey === 'string' && bodyKey.trim() !== '' ? bodyKey.trim() : urlKey;
 

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -326,8 +326,7 @@ router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
     return res.status(400).json({ error: 'Key must be a string.' });
   }
 
-  /** Trim to match POST's key normalization; blank/whitespace-only falls back to urlKey */
-  const newKey = typeof bodyKey === 'string' && bodyKey.trim() !== '' ? bodyKey.trim() : urlKey;
+  const newKey = bodyKey === undefined ? urlKey : bodyKey.trim();
 
   if (newKey !== urlKey && !isValidMemoryKey(newKey)) {
     return res.status(400).json({

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { isValidMemoryKey } = require('@librechat/data-schemas');
 const {
   Tokenizer,
   generateCheckAccess,
@@ -101,10 +102,6 @@ const updateMemoryMiddleware = [
   configMiddleware,
 ];
 
-/** Mirrors the MemoryEntry schema's key validator so invalid keys are
- *  rejected with a 400 instead of surfacing as a Mongoose validation 500 */
-const MEMORY_KEY_REGEX = /^[a-z_]+$/;
-
 /** Resolves agent display names for agent-partitioned memories, restricted
  *  to agents the requester can VIEW — `agentId` is caller-supplied on write,
  *  so an unrestricted lookup would leak private agents' names. */
@@ -192,7 +189,7 @@ router.post('/', createMemoryMiddleware, async (req, res) => {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
   }
 
-  if (!MEMORY_KEY_REGEX.test(key.trim())) {
+  if (!isValidMemoryKey(key.trim())) {
     return res.status(400).json({
       error: 'Key must only contain lowercase letters and underscores.',
     });
@@ -332,7 +329,7 @@ router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
   /** Trim to match POST's key normalization; blank/whitespace-only falls back to urlKey */
   const newKey = typeof bodyKey === 'string' && bodyKey.trim() !== '' ? bodyKey.trim() : urlKey;
 
-  if (newKey !== urlKey && !MEMORY_KEY_REGEX.test(newKey)) {
+  if (newKey !== urlKey && !isValidMemoryKey(newKey)) {
     return res.status(400).json({
       error: 'Key must only contain lowercase letters and underscores.',
     });

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -101,6 +101,10 @@ const updateMemoryMiddleware = [
   configMiddleware,
 ];
 
+/** Mirrors the MemoryEntry schema's key validator so invalid keys are
+ *  rejected with a 400 instead of surfacing as a Mongoose validation 500 */
+const MEMORY_KEY_REGEX = /^[a-z_]+$/;
+
 /** Resolves agent display names for agent-partitioned memories, restricted
  *  to agents the requester can VIEW — `agentId` is caller-supplied on write,
  *  so an unrestricted lookup would leak private agents' names. */
@@ -186,6 +190,12 @@ router.post('/', createMemoryMiddleware, async (req, res) => {
 
   if (typeof value !== 'string' || value.trim() === '') {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
+  }
+
+  if (!MEMORY_KEY_REGEX.test(key.trim())) {
+    return res.status(400).json({
+      error: 'Key must only contain lowercase letters and underscores.',
+    });
   }
 
   const appConfig = req.config;
@@ -316,6 +326,13 @@ router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
   }
 
   const newKey = bodyKey || urlKey;
+
+  if (newKey !== urlKey && !MEMORY_KEY_REGEX.test(newKey)) {
+    return res.status(400).json({
+      error: 'Key must only contain lowercase letters and underscores.',
+    });
+  }
+
   const appConfig = req.config;
   const memoryConfig = appConfig?.memory;
   const charLimit = memoryConfig?.charLimit || 10000;

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -325,7 +325,8 @@ router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
   }
 
-  const newKey = bodyKey || urlKey;
+  /** Trim to match POST's key normalization; blank/whitespace-only falls back to urlKey */
+  const newKey = typeof bodyKey === 'string' && bodyKey.trim() !== '' ? bodyKey.trim() : urlKey;
 
   if (newKey !== urlKey && !MEMORY_KEY_REGEX.test(newKey)) {
     return res.status(400).json({

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -325,6 +325,10 @@ router.patch('/:key', updateMemoryMiddleware, async (req, res) => {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
   }
 
+  if (bodyKey !== undefined && typeof bodyKey !== 'string') {
+    return res.status(400).json({ error: 'Key must be a string.' });
+  }
+
   /** Trim to match POST's key normalization; blank/whitespace-only falls back to urlKey */
   const newKey = typeof bodyKey === 'string' && bodyKey.trim() !== '' ? bodyKey.trim() : urlKey;
 

--- a/api/server/routes/memories.test.js
+++ b/api/server/routes/memories.test.js
@@ -55,19 +55,6 @@ jest.mock('@librechat/api', () => ({
   contentFilterBlockResponse: jest.fn(),
 }));
 
-jest.mock('librechat-data-provider', () => ({
-  PermissionTypes: { MEMORIES: 'MEMORIES' },
-  Permissions: {
-    USE: 'USE',
-    READ: 'READ',
-    CREATE: 'CREATE',
-    UPDATE: 'UPDATE',
-    OPT_OUT: 'OPT_OUT',
-  },
-  ResourceType: { AGENT: 'agent' },
-  PermissionBits: { VIEW: 1 },
-}));
-
 jest.mock('~/server/services/PermissionService', () => ({
   checkPermission: (...args) => mockCheckPermission(...args),
   findAccessibleResources: jest.fn().mockResolvedValue([]),

--- a/packages/api/src/memory/handlers.ts
+++ b/packages/api/src/memory/handlers.ts
@@ -1,5 +1,7 @@
-import { hasActivePiiPatterns, type FiltersConfig } from 'librechat-data-provider';
+import { isValidMemoryKey } from '@librechat/data-schemas';
+import { hasActivePiiPatterns } from 'librechat-data-provider';
 import type { MemoryMethods } from '@librechat/data-schemas';
+import type { FiltersConfig } from 'librechat-data-provider';
 import type { Request, Response } from 'express';
 import type { MemoryContentInput } from '../protection/adapters/submissions';
 import type { ProjectedStoredMemory } from './protection';
@@ -90,7 +92,7 @@ export function createMemoryManagementHandlers(deps: MemoryManagementHandlersDep
         error: `Key exceeds maximum length of 1000 characters. Current length: ${key.length} characters.`,
       });
     }
-    if (key != null && !/^[a-z_]+$/.test(key)) {
+    if (key != null && !isValidMemoryKey(key)) {
       return res
         .status(400)
         .json({ error: 'Key must only contain lowercase letters and underscores.' });

--- a/packages/data-schemas/src/schema/index.ts
+++ b/packages/data-schemas/src/schema/index.ts
@@ -29,7 +29,7 @@ export { default as tokenSchema } from './token';
 export { default as toolCallSchema } from './toolCall';
 export { default as transactionSchema } from './transaction';
 export { default as userSchema } from './user';
-export { default as memorySchema } from './memory';
+export { default as memorySchema, isValidMemoryKey } from './memory';
 export { default as toolFavoriteSchema } from './favorite';
 export { default as groupSchema } from './group';
 export { default as systemGrantSchema } from './systemGrant';

--- a/packages/data-schemas/src/schema/memory.ts
+++ b/packages/data-schemas/src/schema/memory.ts
@@ -1,6 +1,12 @@
 import { Schema } from 'mongoose';
 import type { IMemoryEntry } from '~/types/memory';
 
+const MEMORY_KEY_REGEX = /^[a-z_]+$/;
+
+export function isValidMemoryKey(key: string): boolean {
+  return MEMORY_KEY_REGEX.test(key);
+}
+
 const MemoryEntrySchema: Schema<IMemoryEntry> = new Schema({
   userId: {
     type: Schema.Types.ObjectId,
@@ -12,7 +18,7 @@ const MemoryEntrySchema: Schema<IMemoryEntry> = new Schema({
     type: String,
     required: true,
     validate: {
-      validator: (v: string) => /^[a-z_]+$/.test(v),
+      validator: isValidMemoryKey,
       message: 'Key must only contain lowercase letters and underscores',
     },
   },


### PR DESCRIPTION
## Summary

Fixes #14617

`POST /api/memories` returned **HTTP 500** when the memory `key` failed the `MemoryEntry` schema's format rule (`/^[a-z_]+$/` — lowercase letters and underscores only): the route never pre-validated the key, so `createMemory` threw the Mongoose `ValidationError`, which fell into the generic `catch` and surfaced as a 500. The same happened on `PATCH /api/memories/:key` when renaming a memory to an invalid key.

This PR pre-validates the key format in the route and returns **400** with the rule spelled out, consistent with the route's other input validations (empty key/value, key length, charLimit, tokenLimit — all 400):

- `POST /` — reject invalid `key` with 400 before any DB work.
- `PATCH /:key` — reject an invalid rename target (`newKey !== urlKey`) with 400 before the create/delete sequence.

The 400 error message intentionally keeps the schema's phrasing (`Key must only contain lowercase letters and underscores.`) so the existing client-side mapping in `MemoryCreateDialog.tsx` / `MemoryEditDialog` (which matches on `'lowercase letters and underscores'`) continues to localize the toast (`com_ui_memory_key_validation`) with no client changes needed.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `api/server/routes/__tests__/memories.spec.js` (the route previously had no spec) covering:

- `POST /` with a key containing spaces/punctuation → 400, `createMemory` not called
- `POST /` with a key containing uppercase letters → 400, `createMemory` not called
- `POST /` with a valid key → 201, memory created
- `PATCH /:key` renaming to an invalid key → 400, `createMemory` not called
- `PATCH /:key` value-only update (key unchanged) → 200, `setMemory` called

Run with:

```bash
cd api && npx jest server/routes/__tests__/memories.spec.js
```

All 5 tests pass. Manual repro: `curl -X POST http://localhost:3080/api/memories -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"key": "My Key", "value": "test"}'` now returns 400 (was 500).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
