### PR TITLE
feat: scope memory to chat projects

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -419,6 +419,7 @@ const loadTools = async ({
           req: options.req,
           agent,
           userId: user,
+          chatProjectId: options.req?.body?.endpointOption?.chatProjectId || undefined,
           memoryMethods: { setMemory, deleteMemory, getFormattedMemories },
           getRoleByName,
         });

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -384,6 +384,15 @@ class AgentClient extends BaseClient {
   setOptions(_options) {}
 
   /**
+   * Chat project partition for this run; `undefined` outside a project, so
+   * memory reads and writes fall back to the shared personal pool.
+   * @returns {string | undefined}
+   */
+  get memoryChatProjectId() {
+    return this.options.chatProjectId || undefined;
+  }
+
+  /**
    * Resolve provider + client options for the
    * tool-batch summary model. Same resolution path as titleConvo minus the
    * title-specific branches. Model precedence: the endpoint's
@@ -1346,6 +1355,7 @@ class AgentClient extends BaseClient {
           req: this.options.req,
           userId: this.options.req.user.id + '',
           agentId: agentPartition,
+          chatProjectId: this.memoryChatProjectId,
           getFormattedMemories: db.getFormattedMemories,
         });
       } catch (error) {
@@ -1489,6 +1499,7 @@ class AgentClient extends BaseClient {
           req: this.options.req,
           userId,
           agentId: memoryAgentId,
+          chatProjectId: this.memoryChatProjectId,
           getFormattedMemories: db.getFormattedMemories,
         });
         return { withKeys, withoutKeys };
@@ -1597,6 +1608,7 @@ class AgentClient extends BaseClient {
     const [withoutKeys, processMemory] = await createMemoryProcessor({
       userId,
       agentId: memoryAgentId,
+      chatProjectId: this.memoryChatProjectId,
       config,
       messageId,
       streamId,
@@ -1618,6 +1630,7 @@ class AgentClient extends BaseClient {
         req: this.options.req,
         userId,
         agentId: memoryAgentId,
+        chatProjectId: this.memoryChatProjectId,
         getFormattedMemories: db.getFormattedMemories,
       }));
     } catch (error) {

--- a/api/server/routes/memories.js
+++ b/api/server/routes/memories.js
@@ -16,6 +16,7 @@ const {
   deleteMemory,
   setMemory,
   getAgents,
+  getChatProject,
 } = require('~/models');
 const { requireJwtAuth, configMiddleware } = require('~/server/middleware');
 
@@ -51,8 +52,8 @@ const checkMemoryOptOut = generateCheckAccess({
 
 router.use(requireJwtAuth);
 
-/** Normalizes the optional agent partition param; undefined = shared personal pool */
-const getAgentIdParam = (value) =>
+/** Normalizes an optional partition param; undefined = shared personal pool */
+const getPartitionParam = (value) =>
   typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
 
 /** Resolves agent display names for agent-partitioned memories, restricted
@@ -82,6 +83,29 @@ const withAgentNames = async (memories, user) => {
   }
 };
 
+/** Resolves project display names for project-partitioned memories. Each lookup
+ *  is scoped to the requester, so a `chatProjectId` they do not own resolves to
+ *  nothing rather than leaking another user's project name. */
+const withProjectNames = async (memories, user) => {
+  const projectIds = [...new Set(memories.map((m) => m.chatProjectId).filter(Boolean))];
+  if (projectIds.length === 0) {
+    return memories;
+  }
+  try {
+    const projects = await Promise.all(projectIds.map((id) => getChatProject(user.id, id)));
+    const namesById = new Map(
+      projects.filter(Boolean).map((project) => [project._id.toString(), project.name]),
+    );
+    return memories.map((memory) =>
+      memory.chatProjectId
+        ? { ...memory, chatProjectName: namesById.get(memory.chatProjectId) ?? undefined }
+        : memory,
+    );
+  } catch (_error) {
+    return memories;
+  }
+};
+
 /**
  * GET /memories
  * Returns all memories for the authenticated user, sorted by updated_at (newest first).
@@ -91,14 +115,15 @@ router.get('/', checkMemoryRead, configMiddleware, async (req, res) => {
   try {
     const memories = await getAllUserMemories(req.user.id);
 
-    const sortedMemories = (await withAgentNames(memories, req.user)).sort(
+    const named = await withProjectNames(await withAgentNames(memories, req.user), req.user);
+    const sortedMemories = named.sort(
       (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
     );
 
     /** Usage totals reflect the shared personal pool only — `tokenLimit`
      *  applies per partition, matching the inline tools' enforcement. */
     const totalTokens = memories.reduce((sum, memory) => {
-      return sum + (memory.agentId ? 0 : memory.tokenCount || 0);
+      return sum + (memory.agentId || memory.chatProjectId ? 0 : memory.tokenCount || 0);
     }, 0);
 
     const appConfig = req.config;
@@ -131,7 +156,8 @@ router.get('/', checkMemoryRead, configMiddleware, async (req, res) => {
  */
 router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async (req, res) => {
   const { key, value } = req.body;
-  const agentId = getAgentIdParam(req.body.agentId);
+  const agentId = getPartitionParam(req.body.agentId);
+  const chatProjectId = getPartitionParam(req.body.chatProjectId);
 
   if (typeof key !== 'string' || key.trim() === '') {
     return res.status(400).json({ error: 'Key is required and must be a non-empty string.' });
@@ -160,7 +186,7 @@ router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async 
   try {
     const tokenCount = Tokenizer.getTokenCount(value, 'o200k_base');
 
-    const memories = await getUserMemories({ userId: req.user.id, agentId });
+    const memories = await getUserMemories({ userId: req.user.id, agentId, chatProjectId });
 
     const appConfig = req.config;
     const memoryConfig = appConfig?.memory;
@@ -184,13 +210,14 @@ router.post('/', memoryPayloadLimit, checkMemoryCreate, configMiddleware, async 
       value: value.trim(),
       tokenCount,
       agentId,
+      chatProjectId,
     });
 
     if (!result.ok) {
       return res.status(500).json({ error: 'Failed to create memory.' });
     }
 
-    const updatedMemories = await getUserMemories({ userId: req.user.id, agentId });
+    const updatedMemories = await getUserMemories({ userId: req.user.id, agentId, chatProjectId });
     const newMemory = updatedMemories.find((m) => m.key === key.trim());
 
     res.status(201).json({ created: true, memory: newMemory });
@@ -242,7 +269,8 @@ router.patch('/preferences', checkMemoryOptOut, async (req, res) => {
 router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, async (req, res) => {
   const { key: urlKey } = req.params;
   const { key: bodyKey, value } = req.body || {};
-  const agentId = getAgentIdParam(req.query.agentId);
+  const agentId = getPartitionParam(req.query.agentId);
+  const chatProjectId = getPartitionParam(req.query.chatProjectId);
 
   if (typeof value !== 'string' || value.trim() === '') {
     return res.status(400).json({ error: 'Value is required and must be a non-empty string.' });
@@ -268,7 +296,7 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
   try {
     const tokenCount = Tokenizer.getTokenCount(value, 'o200k_base');
 
-    const memories = await getUserMemories({ userId: req.user.id, agentId });
+    const memories = await getUserMemories({ userId: req.user.id, agentId, chatProjectId });
     const existingMemory = memories.find((m) => m.key === urlKey);
 
     if (!existingMemory) {
@@ -287,13 +315,19 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
         value,
         tokenCount,
         agentId,
+        chatProjectId,
       });
 
       if (!createResult.ok) {
         return res.status(500).json({ error: 'Failed to create new memory.' });
       }
 
-      const deleteResult = await deleteMemory({ userId: req.user.id, key: urlKey, agentId });
+      const deleteResult = await deleteMemory({
+        userId: req.user.id,
+        key: urlKey,
+        agentId,
+        chatProjectId,
+      });
       if (!deleteResult.ok) {
         return res.status(500).json({ error: 'Failed to delete old memory.' });
       }
@@ -304,6 +338,7 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
         value,
         tokenCount,
         agentId,
+        chatProjectId,
       });
 
       if (!result.ok) {
@@ -311,7 +346,7 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
       }
     }
 
-    const updatedMemories = await getUserMemories({ userId: req.user.id, agentId });
+    const updatedMemories = await getUserMemories({ userId: req.user.id, agentId, chatProjectId });
     const updatedMemory = updatedMemories.find((m) => m.key === newKey);
 
     res.json({ updated: true, memory: updatedMemory });
@@ -327,10 +362,11 @@ router.patch('/:key', memoryPayloadLimit, checkMemoryUpdate, configMiddleware, a
  */
 router.delete('/:key', checkMemoryDelete, async (req, res) => {
   const { key } = req.params;
-  const agentId = getAgentIdParam(req.query.agentId);
+  const agentId = getPartitionParam(req.query.agentId);
+  const chatProjectId = getPartitionParam(req.query.chatProjectId);
 
   try {
-    const result = await deleteMemory({ userId: req.user.id, key, agentId });
+    const result = await deleteMemory({ userId: req.user.id, key, agentId, chatProjectId });
 
     if (!result.ok) {
       return res.status(404).json({ error: 'Memory not found.' });

--- a/api/server/routes/projects.js
+++ b/api/server/routes/projects.js
@@ -11,6 +11,7 @@ const handlers = createProjectHandlers({
   updateChatProject: db.updateChatProject,
   deleteChatProject: db.deleteChatProject,
   assignConversationToProject: db.assignConversationToProject,
+  deleteProjectMemories: db.deleteProjectMemories,
 });
 
 router.use(requireJwtAuth);

--- a/client/src/components/SidePanel/Memories/MemoryCard.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryCard.tsx
@@ -38,6 +38,14 @@ export default function MemoryCard({ memory, hasUpdateAccess }: MemoryCardProps)
             {memory.agentName ?? memory.agentId}
           </span>
         )}
+        {memory.chatProjectId != null && (
+          <span
+            className="shrink-0 truncate rounded-full border border-border-light px-2 py-0.5 text-xs text-text-secondary"
+            title={localize('com_ui_memory_project_badge')}
+          >
+            {memory.chatProjectName ?? memory.chatProjectId}
+          </span>
+        )}
         {memory.tokenCount !== undefined && (
           <span className="shrink-0 text-xs text-text-secondary">
             {memory.tokenCount}{' '}

--- a/client/src/components/SidePanel/Memories/MemoryCardActions.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryCardActions.tsx
@@ -40,7 +40,7 @@ export default function MemoryCardActions({ memory }: MemoryCardActionsProps) {
 
   const confirmDelete = () => {
     deleteMemory(
-      { key: memory.key, agentId: memory.agentId },
+      { key: memory.key, agentId: memory.agentId, chatProjectId: memory.chatProjectId },
       {
         onSuccess: () => {
           showToast({ message: localize('com_ui_deleted'), status: 'success' });

--- a/client/src/components/SidePanel/Memories/MemoryEditDialog.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryEditDialog.tsx
@@ -118,6 +118,7 @@ export default function MemoryEditDialog({
       key: key.trim(),
       value: value.trim(),
       agentId: memory.agentId,
+      chatProjectId: memory.chatProjectId,
       ...(originalKey !== key.trim() && { originalKey }),
     });
   };

--- a/client/src/data-provider/Memories/queries.ts
+++ b/client/src/data-provider/Memories/queries.ts
@@ -19,11 +19,12 @@ export const useMemoriesQuery = (
   });
 };
 
-export type DeleteMemoryParams = { key: string; agentId?: string };
+export type DeleteMemoryParams = { key: string; agentId?: string; chatProjectId?: string };
 export const useDeleteMemoryMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    ({ key, agentId }: DeleteMemoryParams) => dataService.deleteMemory(key, agentId),
+    ({ key, agentId, chatProjectId }: DeleteMemoryParams) =>
+      dataService.deleteMemory(key, agentId, chatProjectId),
     {
       onSuccess: () => {
         queryClient.invalidateQueries([QueryKeys.memories]);
@@ -37,14 +38,15 @@ export type UpdateMemoryParams = {
   value: string;
   originalKey?: string;
   agentId?: string;
+  chatProjectId?: string;
 };
 export const useUpdateMemoryMutation = (
   options?: UseMutationOptions<TUserMemory, Error, UpdateMemoryParams>,
 ) => {
   const queryClient = useQueryClient();
   return useMutation(
-    ({ key, value, originalKey, agentId }: UpdateMemoryParams) =>
-      dataService.updateMemory(key, value, originalKey, agentId),
+    ({ key, value, originalKey, agentId, chatProjectId }: UpdateMemoryParams) =>
+      dataService.updateMemory(key, value, originalKey, agentId, chatProjectId),
     {
       ...options,
       onSuccess: (...params) => {
@@ -83,7 +85,12 @@ export const useUpdateMemoryPreferencesMutation = (
   );
 };
 
-export type CreateMemoryParams = { key: string; value: string; agentId?: string };
+export type CreateMemoryParams = {
+  key: string;
+  value: string;
+  agentId?: string;
+  chatProjectId?: string;
+};
 export type CreateMemoryResponse = { created: boolean; memory: TUserMemory };
 
 export const useCreateMemoryMutation = (
@@ -91,8 +98,8 @@ export const useCreateMemoryMutation = (
 ) => {
   const queryClient = useQueryClient();
   return useMutation<CreateMemoryResponse, Error, CreateMemoryParams>(
-    ({ key, value, agentId }: CreateMemoryParams) =>
-      dataService.createMemory({ key, value, agentId }),
+    ({ key, value, agentId, chatProjectId }: CreateMemoryParams) =>
+      dataService.createMemory({ key, value, agentId, chatProjectId }),
     {
       ...options,
       onSuccess: (data, variables, context) => {
@@ -102,7 +109,8 @@ export const useCreateMemoryMutation = (
           const newMemories = [...oldData.memories, data.memory];
           /** Usage totals track the shared personal pool only */
           const totalTokens = newMemories.reduce(
-            (sum, memory) => sum + (memory.agentId ? 0 : memory.tokenCount || 0),
+            (sum, memory) =>
+              sum + (memory.agentId || memory.chatProjectId ? 0 : memory.tokenCount || 0),
             0,
           );
           const tokenLimit = oldData.tokenLimit;

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1453,6 +1453,7 @@
   "com_ui_memory_key_exists": "A memory with this key already exists. Please use a different key.",
   "com_ui_memory_key_hint": "Use lowercase letters and underscores only",
   "com_ui_memory_key_validation": "Memory key must only contain lowercase letters and underscores.",
+  "com_ui_memory_project_badge": "Project-scoped memory",
   "com_ui_memory_storage_full": "Memory Storage Full",
   "com_ui_memory_updated": "Updated saved memory",
   "com_ui_memory_updated_items": "Updated Memories",

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -120,6 +120,7 @@ type MemoryArtifactRecord = Record<Tools.memory, MemoryArtifact>;
 export const createMemoryTool = ({
   userId,
   agentId,
+  chatProjectId,
   setMemory,
   validKeys,
   charLimit,
@@ -130,6 +131,8 @@ export const createMemoryTool = ({
   userId: string | ObjectId;
   /** Agent partition to write to; omit for the shared personal pool */
   agentId?: string;
+  /** Chat project partition to write to; omit when not inside a project */
+  chatProjectId?: string;
   setMemory: MemoryMethods['setMemory'];
   validKeys?: string[];
   charLimit?: number;
@@ -226,10 +229,18 @@ export const createMemoryTool = ({
               tokenCount,
               type: 'update',
               ...(agentId ? { agentId } : {}),
+              ...(chatProjectId ? { chatProjectId } : {}),
             },
           };
 
-          const result = await setMemory({ userId, key, value, tokenCount, agentId });
+          const result = await setMemory({
+            userId,
+            key,
+            value,
+            tokenCount,
+            agentId,
+            chatProjectId,
+          });
           if (result.ok) {
             if (tokenLimit) {
               currentTotalTokens = newTotalTokens;
@@ -281,6 +292,7 @@ export const createMemoryTool = ({
 export const createDeleteMemoryTool = ({
   userId,
   agentId,
+  chatProjectId,
   deleteMemory,
   validKeys,
   onWrite,
@@ -288,6 +300,8 @@ export const createDeleteMemoryTool = ({
   userId: string | ObjectId;
   /** Agent partition to delete from; omit for the shared personal pool */
   agentId?: string;
+  /** Chat project partition to delete from; omit when not inside a project */
+  chatProjectId?: string;
   deleteMemory: MemoryMethods['deleteMemory'];
   validKeys?: string[];
   onWrite?: () => void;
@@ -309,10 +323,11 @@ export const createDeleteMemoryTool = ({
             key,
             type: 'delete',
             ...(agentId ? { agentId } : {}),
+            ...(chatProjectId ? { chatProjectId } : {}),
           },
         };
 
-        const result = await deleteMemory({ userId, key, agentId });
+        const result = await deleteMemory({ userId, key, agentId, chatProjectId });
         if (result.ok) {
           onWrite?.();
           logger.debug(`Memory deleted for key "${key}" for user "${userId}"`);
@@ -496,16 +511,24 @@ export function agentHasInlineMemoryTools(agent: InlineMemoryAgent): boolean {
  */
 const requestMemoriesCache = new WeakMap<object, Map<string, Promise<FormattedMemoriesResult>>>();
 
+/** Cache key for a partition; both dimensions participate, so an agent's
+ *  memories inside a project never alias the project's own. */
+const requestPartitionKey = (agentId?: string, chatProjectId?: string): string =>
+  `${agentId ?? ''}:${chatProjectId ?? ''}`;
+
 export function getRequestMemories({
   req,
   userId,
   agentId,
+  chatProjectId,
   getFormattedMemories,
 }: {
   req: object;
   userId: string | ObjectId;
   /** Agent partition; omit for the shared personal pool */
   agentId?: string;
+  /** Chat project partition; omit when not inside a project */
+  chatProjectId?: string;
   getFormattedMemories: MemoryMethods['getFormattedMemories'];
 }): Promise<FormattedMemoriesResult> {
   let partitions = requestMemoriesCache.get(req);
@@ -513,10 +536,10 @@ export function getRequestMemories({
     partitions = new Map();
     requestMemoriesCache.set(req, partitions);
   }
-  const partitionKey = agentId ?? '';
+  const partitionKey = requestPartitionKey(agentId, chatProjectId);
   let cached = partitions.get(partitionKey);
   if (!cached) {
-    cached = getFormattedMemories({ userId, agentId });
+    cached = getFormattedMemories({ userId, agentId, chatProjectId });
     partitions.set(partitionKey, cached);
   }
   return cached;
@@ -528,8 +551,12 @@ export function getRequestMemories({
  * writes call this on success so a later tool round in the same response is
  * seeded with the post-write usage total instead of a stale pre-write one.
  */
-export function invalidateRequestMemories(req: object, agentId?: string): void {
-  requestMemoriesCache.get(req)?.delete(agentId ?? '');
+export function invalidateRequestMemories(
+  req: object,
+  agentId?: string,
+  chatProjectId?: string,
+): void {
+  requestMemoriesCache.get(req)?.delete(requestPartitionKey(agentId, chatProjectId));
 }
 
 /**
@@ -585,6 +612,7 @@ export async function buildInlineMemoryTool({
   req,
   agent,
   userId,
+  chatProjectId,
   memoryMethods,
   getRoleByName,
 }: {
@@ -592,6 +620,8 @@ export async function buildInlineMemoryTool({
   req: ServerRequest;
   agent: InlineMemoryAgent;
   userId: string | ObjectId;
+  /** Chat project partition; omit when not inside a project */
+  chatProjectId?: string;
   memoryMethods: Pick<MemoryMethods, 'setMemory' | 'deleteMemory' | 'getFormattedMemories'>;
   getRoleByName: GetRoleByName;
 }): Promise<DynamicStructuredTool | null> {
@@ -615,9 +645,10 @@ export async function buildInlineMemoryTool({
     return createDeleteMemoryTool({
       userId,
       agentId: memoryAgentId,
+      chatProjectId,
       deleteMemory: memoryMethods.deleteMemory,
       validKeys,
-      onWrite: () => invalidateRequestMemories(req, memoryAgentId),
+      onWrite: () => invalidateRequestMemories(req, memoryAgentId, chatProjectId),
     });
   }
 
@@ -639,6 +670,7 @@ export async function buildInlineMemoryTool({
         req,
         userId,
         agentId: memoryAgentId,
+        chatProjectId,
         getFormattedMemories: memoryMethods.getFormattedMemories,
       });
       totalTokens = formatted?.totalTokens ?? 0;
@@ -653,12 +685,13 @@ export async function buildInlineMemoryTool({
   return createMemoryTool({
     userId,
     agentId: memoryAgentId,
+    chatProjectId,
     setMemory: memoryMethods.setMemory,
     validKeys,
     charLimit,
     tokenLimit,
     totalTokens,
-    onWrite: () => invalidateRequestMemories(req, memoryAgentId),
+    onWrite: () => invalidateRequestMemories(req, memoryAgentId, chatProjectId),
   });
 }
 
@@ -690,6 +723,7 @@ export async function processMemory({
   res,
   userId,
   agentId,
+  chatProjectId,
   setMemory,
   deleteMemory,
   messages,
@@ -711,6 +745,8 @@ export async function processMemory({
   userId: string | ObjectId;
   /** Agent partition; omit for the shared personal pool */
   agentId?: string;
+  /** Chat project partition; omit when not inside a project */
+  chatProjectId?: string;
   memory: string;
   messageId: string;
   conversationId: string;
@@ -728,6 +764,7 @@ export async function processMemory({
     const memoryTool = createMemoryTool({
       userId,
       agentId,
+      chatProjectId,
       tokenLimit,
       setMemory,
       validKeys,
@@ -736,6 +773,7 @@ export async function processMemory({
     const deleteMemoryTool = createDeleteMemoryTool({
       userId,
       agentId,
+      chatProjectId,
       validKeys,
       deleteMemory,
     });
@@ -932,6 +970,7 @@ export async function createMemoryProcessor({
   messageId,
   memoryMethods,
   conversationId,
+  chatProjectId,
   config = {},
   streamId = null,
   jobCreatedAt,
@@ -943,6 +982,8 @@ export async function createMemoryProcessor({
   userId: string | ObjectId;
   /** Agent partition; omit for the shared personal pool */
   agentId?: string;
+  /** Chat project partition; omit when not inside a project */
+  chatProjectId?: string;
   memoryMethods: RequiredMemoryMethods;
   config?: MemoryConfig;
   streamId?: string | null;
@@ -955,6 +996,7 @@ export async function createMemoryProcessor({
   const { withKeys, withoutKeys, totalTokens } = await memoryMethods.getFormattedMemories({
     userId,
     agentId,
+    chatProjectId,
   });
 
   return [
@@ -965,6 +1007,7 @@ export async function createMemoryProcessor({
           res,
           userId,
           agentId,
+          chatProjectId,
           messages,
           validKeys,
           llmConfig,

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -514,7 +514,7 @@ const requestMemoriesCache = new WeakMap<object, Map<string, Promise<FormattedMe
 /** Cache key for a partition; both dimensions participate, so an agent's
  *  memories inside a project never alias the project's own. */
 const requestPartitionKey = (agentId?: string, chatProjectId?: string): string =>
-  `${agentId ?? ''}:${chatProjectId ?? ''}`;
+  `${encodeURIComponent(agentId ?? '')}:${encodeURIComponent(chatProjectId ?? '')}`;
 
 export function getRequestMemories({
   req,

--- a/packages/api/src/projects/handlers.spec.ts
+++ b/packages/api/src/projects/handlers.spec.ts
@@ -1,0 +1,71 @@
+import { createProjectHandlers } from './handlers';
+import type { Response } from 'express';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const projectId = '507f1f77bcf86cd799439011';
+const userId = 'user-1';
+
+const buildResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res as unknown as Response & { status: jest.Mock; json: jest.Mock };
+};
+
+const buildDeps = (overrides: Partial<Parameters<typeof createProjectHandlers>[0]> = {}) =>
+  ({
+    listChatProjects: jest.fn(),
+    createChatProject: jest.fn(),
+    getChatProject: jest.fn(),
+    updateChatProject: jest.fn(),
+    deleteChatProject: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    assignConversationToProject: jest.fn(),
+    deleteProjectMemories: jest.fn().mockResolvedValue(0),
+    ...overrides,
+  }) as unknown as Parameters<typeof createProjectHandlers>[0];
+
+describe('deleteProject memory cascade', () => {
+  it('deletes the project partition after the project itself', async () => {
+    const deps = buildDeps();
+    const handlers = createProjectHandlers(deps);
+    const res = buildResponse();
+
+    await handlers.deleteProject({ user: { id: userId }, params: { projectId } } as never, res);
+
+    expect(deps.deleteProjectMemories).toHaveBeenCalledWith({
+      userId,
+      chatProjectId: projectId,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('does not cascade when no project was deleted', async () => {
+    const deps = buildDeps({
+      deleteChatProject: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+    } as never);
+    const handlers = createProjectHandlers(deps);
+    const res = buildResponse();
+
+    await handlers.deleteProject({ user: { id: userId }, params: { projectId } } as never, res);
+
+    expect(deps.deleteProjectMemories).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('still reports success when the cascade fails', async () => {
+    const deps = buildDeps({
+      deleteProjectMemories: jest.fn().mockRejectedValue(new Error('mongo down')),
+    } as never);
+    const handlers = createProjectHandlers(deps);
+    const res = buildResponse();
+
+    await handlers.deleteProject({ user: { id: userId }, params: { projectId } } as never, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/packages/api/src/projects/handlers.ts
+++ b/packages/api/src/projects/handlers.ts
@@ -1,6 +1,7 @@
 import { isValidObjectIdString, logger } from '@librechat/data-schemas';
 
 import type {
+  MemoryMethods,
   ChatProjectMethods,
   ChatProjectSortBy,
   ChatProjectSortDirection,
@@ -33,7 +34,8 @@ type ProjectHandlerDependencies = Pick<
   | 'updateChatProject'
   | 'deleteChatProject'
   | 'assignConversationToProject'
->;
+> &
+  Pick<MemoryMethods, 'deleteProjectMemories'>;
 
 const getUserId = (req: ProjectRequest): string => req.user?.id ?? req.user?._id?.toString() ?? '';
 
@@ -208,9 +210,15 @@ export function createProjectHandlers(deps: ProjectHandlerDependencies): {
     }
 
     try {
-      const result = await deps.deleteChatProject(getUserId(req), projectId);
+      const userId = getUserId(req);
+      const result = await deps.deleteChatProject(userId, projectId);
       if (!result.deletedCount) {
         return res.status(404).json({ error: PROJECT_NOT_FOUND });
+      }
+      try {
+        await deps.deleteProjectMemories({ userId, chatProjectId: projectId });
+      } catch (error) {
+        logger.error('[projects] Error deleting project memories', error);
       }
       return res.status(200).json(result);
     } catch (error) {

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -496,8 +496,17 @@ export const verifyTwoFactorTemp = () => `${BASE_URL}/api/auth/2fa/verify-temp`;
 
 /* Memories */
 export const memories = () => `${BASE_URL}/api/memories`;
-export const memory = (key: string, agentId?: string) =>
-  `${memories()}/${encodeURIComponent(key)}${agentId ? `?agentId=${encodeURIComponent(agentId)}` : ''}`;
+export const memory = (key: string, agentId?: string, chatProjectId?: string) => {
+  const params = new URLSearchParams();
+  if (agentId) {
+    params.set('agentId', agentId);
+  }
+  if (chatProjectId) {
+    params.set('chatProjectId', chatProjectId);
+  }
+  const query = params.toString();
+  return `${memories()}/${encodeURIComponent(key)}${query ? `?${query}` : ''}`;
+};
 export const memoryPreferences = () => `${memories()}/preferences`;
 
 export const searchPrincipals = (params: q.PrincipalSearchParams) => {

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -1344,8 +1344,12 @@ export const getMemories = (): Promise<q.MemoriesResponse> => {
   return request.get(endpoints.memories());
 };
 
-export const deleteMemory = (key: string, agentId?: string): Promise<void> => {
-  return request.delete(endpoints.memory(key, agentId));
+export const deleteMemory = (
+  key: string,
+  agentId?: string,
+  chatProjectId?: string,
+): Promise<void> => {
+  return request.delete(endpoints.memory(key, agentId, chatProjectId));
 };
 
 export const updateMemory = (
@@ -1353,8 +1357,12 @@ export const updateMemory = (
   value: string,
   originalKey?: string,
   agentId?: string,
+  chatProjectId?: string,
 ): Promise<q.TUserMemory> => {
-  return request.patch(endpoints.memory(originalKey || key, agentId), { key, value });
+  return request.patch(endpoints.memory(originalKey || key, agentId, chatProjectId), {
+    key,
+    value,
+  });
 };
 
 export const updateMemoryPreferences = (preferences: {
@@ -1367,6 +1375,7 @@ export const createMemory = (data: {
   key: string;
   value: string;
   agentId?: string;
+  chatProjectId?: string;
 }): Promise<{ created: boolean; memory: q.TUserMemory }> => {
   return request.post(endpoints.memories(), data);
 };

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -874,6 +874,8 @@ export type MemoryArtifact = {
   type: 'update' | 'delete' | 'error';
   /** Agent partition the write targeted; absent = shared personal pool */
   agentId?: string;
+  /** Chat project partition the write targeted; absent = not project-scoped */
+  chatProjectId?: string;
 };
 
 export type UIResource = {

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -154,6 +154,10 @@ export type TUserMemory = {
   agentId?: string;
   /** Display name of the partition's agent, resolved server-side when available */
   agentName?: string;
+  /** Chat project partition this memory belongs to; absent = not project-scoped */
+  chatProjectId?: string;
+  /** Display name of the partition's project, resolved server-side when available */
+  chatProjectName?: string;
 };
 
 export type MemoriesResponse = {

--- a/packages/data-schemas/src/methods/memory.spec.ts
+++ b/packages/data-schemas/src/methods/memory.spec.ts
@@ -19,6 +19,8 @@ const userId = new mongoose.Types.ObjectId();
 const otherUserId = new mongoose.Types.ObjectId();
 const agentId = 'agent_partition_a';
 const otherAgentId = 'agent_partition_b';
+const chatProjectId = 'project_partition_a';
+const otherChatProjectId = 'project_partition_b';
 
 beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create();
@@ -151,6 +153,128 @@ describe('memory partitions', () => {
 
     const deleted = await methods.deleteAllUserMemories(userId);
     expect(deleted).toBe(2);
+    expect(await MemoryEntry.countDocuments({ userId: otherUserId })).toBe(1);
+  });
+});
+
+describe('chat project partitions', () => {
+  it('keeps a project partition out of the shared personal pool', async () => {
+    await methods.setMemory({ userId, key: 'context', value: 'personal', tokenCount: 1 });
+    await methods.setMemory({
+      userId,
+      key: 'context',
+      value: 'project',
+      tokenCount: 2,
+      chatProjectId,
+    });
+
+    expect((await methods.getUserMemories({ userId })).map((m) => m.value)).toEqual(['personal']);
+    expect((await methods.getUserMemories({ userId, chatProjectId })).map((m) => m.value)).toEqual([
+      'project',
+    ]);
+  });
+
+  it('isolates one project from another', async () => {
+    await methods.setMemory({ userId, key: 'goal', value: 'project a', chatProjectId });
+    await methods.setMemory({
+      userId,
+      key: 'goal',
+      value: 'project b',
+      chatProjectId: otherChatProjectId,
+    });
+
+    expect((await methods.getUserMemories({ userId, chatProjectId })).map((m) => m.value)).toEqual([
+      'project a',
+    ]);
+    expect(
+      (await methods.getUserMemories({ userId, chatProjectId: otherChatProjectId })).map(
+        (m) => m.value,
+      ),
+    ).toEqual(['project b']);
+  });
+
+  it('composes with the agent partition instead of overriding it', async () => {
+    await methods.setMemory({ userId, key: 'context', value: 'project only', chatProjectId });
+    await methods.setMemory({
+      userId,
+      key: 'context',
+      value: 'agent in project',
+      agentId,
+      chatProjectId,
+    });
+
+    expect((await methods.getUserMemories({ userId, chatProjectId })).map((m) => m.value)).toEqual([
+      'project only',
+    ]);
+    expect(
+      (await methods.getUserMemories({ userId, agentId, chatProjectId })).map((m) => m.value),
+    ).toEqual(['agent in project']);
+    expect(await methods.getUserMemories({ userId, agentId })).toHaveLength(0);
+  });
+
+  it('treats entries without a chatProjectId field as the personal pool', async () => {
+    await MemoryEntry.collection.insertOne({
+      userId,
+      key: 'legacy',
+      value: 'pre-partition entry',
+      tokenCount: 4,
+      updated_at: new Date(),
+    });
+
+    expect((await methods.getUserMemories({ userId })).map((m) => m.key)).toEqual(['legacy']);
+    expect(await methods.getUserMemories({ userId, chatProjectId })).toHaveLength(0);
+  });
+
+  it('scopes formatted memories and their totals to the project', async () => {
+    await methods.setMemory({ userId, key: 'one', value: 'personal one', tokenCount: 5 });
+    await methods.setMemory({
+      userId,
+      key: 'two',
+      value: 'project two',
+      tokenCount: 7,
+      chatProjectId,
+    });
+
+    const personal = await methods.getFormattedMemories({ userId });
+    expect(personal.totalTokens).toBe(5);
+    expect(personal.withoutKeys).not.toContain('project two');
+
+    const project = await methods.getFormattedMemories({ userId, chatProjectId });
+    expect(project.totalTokens).toBe(7);
+    expect(project.withKeys).toContain('"key": "two"');
+    expect(project.withKeys).not.toContain('personal one');
+  });
+
+  it('deletes only the targeted project, for the targeted user', async () => {
+    await methods.setMemory({ userId, key: 'one', value: 'personal', tokenCount: 1 });
+    await methods.setMemory({ userId, key: 'two', value: 'project a', chatProjectId });
+    await methods.setMemory({
+      userId,
+      key: 'three',
+      value: 'agent in project a',
+      agentId,
+      chatProjectId,
+    });
+    await methods.setMemory({
+      userId,
+      key: 'four',
+      value: 'project b',
+      chatProjectId: otherChatProjectId,
+    });
+    await methods.setMemory({
+      userId: otherUserId,
+      key: 'five',
+      value: 'other user',
+      chatProjectId,
+    });
+
+    const deleted = await methods.deleteProjectMemories({ userId, chatProjectId });
+
+    expect(deleted).toBe(2);
+    expect(await methods.getUserMemories({ userId })).toHaveLength(1);
+    expect(
+      await methods.getUserMemories({ userId, chatProjectId: otherChatProjectId }),
+    ).toHaveLength(1);
     expect(await MemoryEntry.countDocuments({ userId: otherUserId })).toBe(1);
   });
 });

--- a/packages/data-schemas/src/methods/memory.ts
+++ b/packages/data-schemas/src/methods/memory.ts
@@ -9,34 +9,32 @@ const formatDate = (date: Date): string => {
   return date.toISOString().split('T')[0];
 };
 
-/** Partition filter: `agentId: null` matches both null and missing fields,
+/** Partition filter: a `null` match covers both null and missing fields,
  *  so pre-partition entries remain part of the shared personal pool. */
-const partitionFilter = (agentId?: string) => ({ agentId: agentId ?? null });
+const partitionFilter = ({ agentId, chatProjectId }: t.MemoryPartition) => ({
+  agentId: agentId ?? null,
+  chatProjectId: chatProjectId ?? null,
+});
+
+/** Partition fields to persist; absent dimensions are left off the document
+ *  rather than stored as null, matching how entries looked before partitions. */
+const partitionFields = ({ agentId, chatProjectId }: t.MemoryPartition) => ({
+  ...(agentId ? { agentId } : {}),
+  ...(chatProjectId ? { chatProjectId } : {}),
+});
 
 // Factory function that takes mongoose instance and returns the methods
 export function createMemoryMethods(mongoose: typeof import('mongoose')): {
-  setMemory: ({
-    userId,
-    key,
-    value,
-    tokenCount,
-    agentId,
-  }: t.SetMemoryParams) => Promise<t.MemoryResult>;
-  createMemory: ({
-    userId,
-    key,
-    value,
-    tokenCount,
-    agentId,
-  }: t.SetMemoryParams) => Promise<t.MemoryResult>;
-  deleteMemory: ({ userId, key, agentId }: t.DeleteMemoryParams) => Promise<t.MemoryResult>;
+  setMemory: (params: t.SetMemoryParams) => Promise<t.MemoryResult>;
+  createMemory: (params: t.SetMemoryParams) => Promise<t.MemoryResult>;
+  deleteMemory: (params: t.DeleteMemoryParams) => Promise<t.MemoryResult>;
   getAllUserMemories: (userId: string | Types.ObjectId) => Promise<t.IMemoryEntryLean[]>;
-  getUserMemories: ({ userId, agentId }: t.GetUserMemoriesParams) => Promise<t.IMemoryEntryLean[]>;
-  getFormattedMemories: ({
-    userId,
-    agentId,
-  }: t.GetFormattedMemoriesParams) => Promise<t.FormattedMemoriesResult>;
+  getUserMemories: (params: t.GetUserMemoriesParams) => Promise<t.IMemoryEntryLean[]>;
+  getFormattedMemories: (
+    params: t.GetFormattedMemoriesParams,
+  ) => Promise<t.FormattedMemoriesResult>;
   deleteAllUserMemories: (userId: string | Types.ObjectId) => Promise<number>;
+  deleteProjectMemories: (params: t.DeleteProjectMemoriesParams) => Promise<number>;
 } {
   /**
    * Creates a new memory entry for a user
@@ -48,17 +46,19 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
     value,
     tokenCount = 0,
     agentId,
+    chatProjectId,
   }: t.SetMemoryParams): Promise<t.MemoryResult> {
     try {
       if (key?.toLowerCase() === 'nothing') {
         return { ok: false };
       }
 
+      const partition = { agentId, chatProjectId };
       const MemoryEntry = mongoose.models.MemoryEntry;
       const existingMemory = await MemoryEntry.findOne({
         userId,
         key,
-        ...partitionFilter(agentId),
+        ...partitionFilter(partition),
       });
       if (existingMemory) {
         throw new Error('Memory with this key already exists');
@@ -69,7 +69,7 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
         key,
         value,
         tokenCount,
-        ...(agentId ? { agentId } : {}),
+        ...partitionFields(partition),
         updated_at: new Date(),
       });
 
@@ -90,19 +90,21 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
     value,
     tokenCount = 0,
     agentId,
+    chatProjectId,
   }: t.SetMemoryParams): Promise<t.MemoryResult> {
     try {
       if (key?.toLowerCase() === 'nothing') {
         return { ok: false };
       }
 
+      const partition = { agentId, chatProjectId };
       const MemoryEntry = mongoose.models.MemoryEntry;
       await MemoryEntry.findOneAndUpdate(
-        { userId, key, ...partitionFilter(agentId) },
+        { userId, key, ...partitionFilter(partition) },
         {
           value,
           tokenCount,
-          ...(agentId ? { agentId } : {}),
+          ...partitionFields(partition),
           updated_at: new Date(),
         },
         {
@@ -126,13 +128,14 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
     userId,
     key,
     agentId,
+    chatProjectId,
   }: t.DeleteMemoryParams): Promise<t.MemoryResult> {
     try {
       const MemoryEntry = mongoose.models.MemoryEntry;
       const result = await MemoryEntry.findOneAndDelete({
         userId,
         key,
-        ...partitionFilter(agentId),
+        ...partitionFilter({ agentId, chatProjectId }),
       });
       return { ok: !!result };
     } catch (error) {
@@ -160,17 +163,18 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
 
   /**
    * Gets a user's memory entries for a single partition
-   * (the shared personal pool when `agentId` is omitted)
+   * (the shared personal pool when no partition is given)
    */
   async function getUserMemories({
     userId,
     agentId,
+    chatProjectId,
   }: t.GetUserMemoriesParams): Promise<t.IMemoryEntryLean[]> {
     try {
       const MemoryEntry = mongoose.models.MemoryEntry;
       return (await MemoryEntry.find({
         userId,
-        ...partitionFilter(agentId),
+        ...partitionFilter({ agentId, chatProjectId }),
       }).lean()) as t.IMemoryEntryLean[];
     } catch (error) {
       throw new Error(
@@ -185,9 +189,10 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
   async function getFormattedMemories({
     userId,
     agentId,
+    chatProjectId,
   }: t.GetFormattedMemoriesParams): Promise<t.FormattedMemoriesResult> {
     try {
-      const memories = await getUserMemories({ userId, agentId });
+      const memories = await getUserMemories({ userId, agentId, chatProjectId });
 
       if (!memories || memories.length === 0) {
         return { withKeys: '', withoutKeys: '', totalTokens: 0 };
@@ -238,6 +243,25 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
     }
   }
 
+  /**
+   * Deletes every memory entry in a project's partition, for cascading a
+   * project deletion.
+   */
+  async function deleteProjectMemories({
+    userId,
+    chatProjectId,
+  }: t.DeleteProjectMemoriesParams): Promise<number> {
+    try {
+      const MemoryEntry = mongoose.models.MemoryEntry;
+      const result = await MemoryEntry.deleteMany({ userId, chatProjectId });
+      return result.deletedCount;
+    } catch (error) {
+      throw new Error(
+        `Failed to delete project memories: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
   return {
     setMemory,
     createMemory,
@@ -246,6 +270,7 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
     getUserMemories,
     getFormattedMemories,
     deleteAllUserMemories,
+    deleteProjectMemories,
   };
 }
 

--- a/packages/data-schemas/src/schema/memory.ts
+++ b/packages/data-schemas/src/schema/memory.ts
@@ -25,6 +25,11 @@ const MemoryEntrySchema: Schema<IMemoryEntry> = new Schema({
     type: String,
     default: undefined,
   },
+  /** Chat project partition; null/absent = not scoped to a project */
+  chatProjectId: {
+    type: String,
+    default: undefined,
+  },
   tokenCount: {
     type: Number,
     default: 0,
@@ -40,5 +45,6 @@ const MemoryEntrySchema: Schema<IMemoryEntry> = new Schema({
 });
 
 MemoryEntrySchema.index({ userId: 1, agentId: 1, key: 1 });
+MemoryEntrySchema.index({ userId: 1, chatProjectId: 1, key: 1 });
 
 export default MemoryEntrySchema;

--- a/packages/data-schemas/src/types/memory.ts
+++ b/packages/data-schemas/src/types/memory.ts
@@ -1,52 +1,61 @@
 import type { Types, Document } from 'mongoose';
 
+/**
+ * Partition an entry belongs to. Omitting every field addresses the shared
+ * personal pool; the fields are independent, so a project's memories stay
+ * separate from an agent's.
+ */
+export interface MemoryPartition {
+  /** Agent partition; omit for the shared personal pool */
+  agentId?: string;
+  /** Chat project partition; omit for memories not scoped to a project */
+  chatProjectId?: string;
+}
+
 // Base memory interfaces
-export interface IMemoryEntry extends Document {
+export interface IMemoryEntry extends Document, MemoryPartition {
   userId: Types.ObjectId;
   key: string;
   value: string;
-  /** Agent partition; null/absent = shared personal pool */
-  agentId?: string;
   tokenCount?: number;
   updated_at?: Date;
   tenantId?: string;
 }
 
-export interface IMemoryEntryLean {
+export interface IMemoryEntryLean extends MemoryPartition {
   _id: Types.ObjectId;
   userId: Types.ObjectId;
   key: string;
   value: string;
-  agentId?: string;
   tokenCount?: number;
   updated_at?: Date;
   __v?: number;
 }
 
 // Method parameter interfaces
-export interface SetMemoryParams {
+export interface SetMemoryParams extends MemoryPartition {
   userId: string | Types.ObjectId;
   key: string;
   value: string;
   tokenCount?: number;
-  /** Agent partition; omit for the shared personal pool */
-  agentId?: string;
 }
 
-export interface DeleteMemoryParams {
+export interface DeleteMemoryParams extends MemoryPartition {
   userId: string | Types.ObjectId;
   key: string;
-  agentId?: string;
 }
 
-export interface GetUserMemoriesParams {
+export interface GetUserMemoriesParams extends MemoryPartition {
   userId: string | Types.ObjectId;
-  agentId?: string;
 }
 
-export interface GetFormattedMemoriesParams {
+export interface GetFormattedMemoriesParams extends MemoryPartition {
   userId: string | Types.ObjectId;
-  agentId?: string;
+}
+
+export interface DeleteProjectMemoriesParams {
+  userId: string | Types.ObjectId;
+  chatProjectId: string;
 }
 
 // Result interfaces


### PR DESCRIPTION
## Summary

Memories inside a chat project are stored in that project's own partition instead of the
shared personal pool. Addresses the "Project memory" item of #13495.

Instead of a new collection, routes and side panel, this reuses the partition mechanism
already built for `agentId`:

- `MemoryEntry` gains an optional `chatProjectId`, filtered through the same
  `partitionFilter`. The two dimensions are independent, so an agent with
  `memory_scope: agent` used inside a project gets its own per-project pool.
- `chatProjectId` is threaded through `createMemoryProcessor`, `processMemory`, the inline
  memory tools and `getRequestMemories`, mirroring `agentId`. `AgentClient` takes it from the
  `chatProjectId` the request already carries — no new request plumbing.
- `GET /api/memories` annotates project entries with the project name, ownership-checked like
  `withAgentNames`. Personal usage totals exclude partitioned entries.
- Deleting a project cascades to its memories; a cascade failure is logged, not fatal.

Project memories show up in the existing Memories panel with a project badge.

**Backwards compatible.** Entries without a `chatProjectId` still match the personal pool, so
existing memories are unaffected. No migration. One index added; the existing one is untouched.

Two things worth flagging: `withProjectNames` does one lookup per project because
`ChatProjectMethods` has no bulk equivalent (happy to add one), and there is no dedicated
project-memory UI — entries are managed through the existing panel.

I raised this on #13495 first and haven't had a response; happy to move it to a discussion or
adjust the approach.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `packages/data-schemas/src/methods/memory.spec.ts` — 6 new cases: isolation from the personal
  pool, isolation between projects, composition with the agent partition, legacy entries
  staying personal, project-scoped formatting/totals, and scoped cascade deletion. The 8
  existing agent-partition cases pass unchanged.
- `packages/api/src/projects/handlers.spec.ts` — new: cascade arguments, no cascade when
  nothing was deleted, cascade failure still returns success.
- Manual: created memories in two projects and outside any project, confirmed in MongoDB that
  the same key can exist in a project and in the personal pool as separate documents, that a
  project chat sees only its own, and that deleting a project removes only its entries.

### Test Configuration:

- `npm run build` — 5/5 successful. `npm run test:api` — 3486 passed; 4 unrelated suites fail
  locally with module-resolution errors on Node 22 instead of the required Node 24, identically
  with and without this change. ESLint clean.
- No new configuration: project memory rides on the existing `memory:` block.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted — docs live in the
      separate `librechat.ai` repo; happy to open one once the approach is agreed.