### PR TITLE
🏔️ feat: Support OpenAI Models on Amazon Bedrock via bedrock-mantle (Responses API)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2855,6 +2855,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws/bedrock-token-generator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws/bedrock-token-generator/-/bedrock-token-generator-1.1.0.tgz",
+      "integrity": "sha512-i+DkWnfdA4j4sffy9dI4k3OGoOWqN8CTGdtO4IZ3c0kpKYFr6KyqzqLQmoRNrF3ACFcWj6u+J6cbBQ97j9wx5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-providers": "^3.525.0",
+        "@aws-sdk/util-format-url": ">=3.525.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/hash-node": ">=2.1.3",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": ">=3.2.1",
+        "@smithy/signature-v4": ">=2.1.3",
+        "@smithy/types": ">=2.11.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
@@ -42643,6 +42663,7 @@
       "version": "1.7.34",
       "license": "ISC",
       "dependencies": {
+        "@aws/bedrock-token-generator": "^1.1.0",
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0"
       },
@@ -45688,28 +45709,6 @@
         "vue-tsc": {
           "optional": true
         }
-      }
-    },
-    "packages/data-schemas/node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
-      "peer": true,
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "packages/data-schemas/node_modules/winston-daily-rotate-file": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -159,6 +159,7 @@
     "zod": "^3.22.4"
   },
   "dependencies": {
+    "@aws/bedrock-token-generator": "^1.1.0",
     "@langchain/langgraph-checkpoint": "^1.1.2",
     "@langchain/langgraph-checkpoint-mongodb": "^1.4.0"
   }

--- a/packages/api/src/endpoints/bedrock/index.ts
+++ b/packages/api/src/endpoints/bedrock/index.ts
@@ -1,1 +1,2 @@
 export * from './initialize';
+export * from './mantle';

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -32,6 +32,7 @@ jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
 }));
 
 jest.mock('~/utils', () => ({
+  ...jest.requireActual('~/utils'),
   checkUserKeyExpiry: jest.fn(),
 }));
 

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -10,6 +10,7 @@ import {
   removeNullishValues,
 } from 'librechat-data-provider';
 import type { BedrockRuntimeClientConfig } from '@aws-sdk/client-bedrock-runtime';
+import type { BedrockConverseInput } from 'librechat-data-provider';
 import type {
   BaseInitializeParams,
   InitializeResultBase,
@@ -220,7 +221,7 @@ export async function initializeBedrock({
   const model = model_parameters?.model as string | undefined;
   if (isBedrockMantleModel(model)) {
     return initializeBedrockMantle({
-      model_parameters,
+      model_parameters: model_parameters as Partial<BedrockConverseInput> | undefined,
       credentials,
       bearerToken,
       profile: BEDROCK_AWS_PROFILE,

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -17,6 +17,7 @@ import type {
   GuardrailConfiguration,
   InferenceProfileConfig,
 } from '~/types';
+import { isBedrockMantleModel, initializeBedrockMantle } from './mantle';
 import { getHttpsProxyAgent } from '~/utils/proxy';
 import { checkUserKeyExpiry } from '~/utils';
 
@@ -216,8 +217,20 @@ export async function initializeBedrock({
     };
   }
 
+  const model = model_parameters?.model as string | undefined;
+  if (isBedrockMantleModel(model)) {
+    return initializeBedrockMantle({
+      model_parameters,
+      credentials,
+      bearerToken,
+      profile: BEDROCK_AWS_PROFILE,
+      defaultRegion: BEDROCK_AWS_DEFAULT_REGION,
+      userId: req.user?.id,
+    });
+  }
+
   const requestOptions: Record<string, unknown> = {
-    model: model_parameters?.model as string | undefined,
+    model,
     region: BEDROCK_AWS_DEFAULT_REGION,
   };
 
@@ -249,7 +262,6 @@ export async function initializeBedrock({
     };
   }
 
-  const model = model_parameters?.model as string | undefined;
   if (model && bedrockConfig?.inferenceProfiles?.[model]) {
     const applicationInferenceProfile = extractEnvVariable(bedrockConfig.inferenceProfiles[model]);
     llmConfig.applicationInferenceProfile = applicationInferenceProfile;

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -226,6 +226,7 @@ export async function initializeBedrock({
       bearerToken,
       profile: BEDROCK_AWS_PROFILE,
       defaultRegion: BEDROCK_AWS_DEFAULT_REGION,
+      reverseProxy: BEDROCK_REVERSE_PROXY,
       userId: req.user?.id,
     });
   }

--- a/packages/api/src/endpoints/bedrock/mantle.spec.ts
+++ b/packages/api/src/endpoints/bedrock/mantle.spec.ts
@@ -88,6 +88,15 @@ describe('getBedrockMantleBaseURL', () => {
       'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
     );
   });
+
+  it('should replace the AWS host with a configured reverse proxy', () => {
+    expect(getBedrockMantleBaseURL('us-east-2', 'bedrock-gateway.internal')).toBe(
+      'https://bedrock-gateway.internal/openai/v1',
+    );
+    expect(getBedrockMantleBaseURL('us-east-2', '  ')).toBe(
+      'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+    );
+  });
 });
 
 describe('initializeBedrock mantle routing', () => {
@@ -99,6 +108,7 @@ describe('initializeBedrock mantle routing', () => {
     delete process.env.BEDROCK_AWS_BEARER_TOKEN;
     delete process.env.BEDROCK_AWS_PROFILE;
     delete process.env.BEDROCK_AWS_SESSION_TOKEN;
+    delete process.env.BEDROCK_REVERSE_PROXY;
     delete process.env.PROXY;
     process.env.BEDROCK_AWS_ACCESS_KEY_ID = 'test-access-key';
     process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = 'test-secret-key';
@@ -167,6 +177,14 @@ describe('initializeBedrock mantle routing', () => {
     expect(result.configOptions?.baseURL).toBe(
       'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
     );
+  });
+
+  it('should route mantle traffic through BEDROCK_REVERSE_PROXY when configured', async () => {
+    process.env.BEDROCK_REVERSE_PROXY = 'bedrock-gateway.internal';
+    const params = createMockParams();
+    const result = await initializeBedrock(params);
+
+    expect(result.configOptions?.baseURL).toBe('https://bedrock-gateway.internal/openai/v1');
   });
 
   it('should throw when no region is available', async () => {

--- a/packages/api/src/endpoints/bedrock/mantle.spec.ts
+++ b/packages/api/src/endpoints/bedrock/mantle.spec.ts
@@ -1,7 +1,7 @@
 import { Providers } from '@librechat/agents';
 import { getToken } from '@aws/bedrock-token-generator';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { EModelEndpoint } from 'librechat-data-provider';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import type { BaseInitializeParams } from '~/types';
 import { isBedrockMantleModel, getBedrockMantleBaseURL } from './mantle';
 import { initializeBedrock } from './initialize';

--- a/packages/api/src/endpoints/bedrock/mantle.spec.ts
+++ b/packages/api/src/endpoints/bedrock/mantle.spec.ts
@@ -1,0 +1,275 @@
+import { Providers } from '@librechat/agents';
+import { getToken } from '@aws/bedrock-token-generator';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { BaseInitializeParams } from '~/types';
+import { isBedrockMantleModel, getBedrockMantleBaseURL } from './mantle';
+import { initializeBedrock } from './initialize';
+
+jest.mock('@aws/bedrock-token-generator', () => ({
+  getToken: jest.fn().mockResolvedValue('generated-short-term-token'),
+}));
+
+jest.mock('@aws-sdk/credential-providers', () => ({
+  fromNodeProviderChain: jest.fn().mockImplementation((config) => {
+    const provider = jest.fn();
+    return Object.assign(provider, { config });
+  }),
+}));
+
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn().mockImplementation((config) => ({
+    ...config,
+    _isBedrockClient: true,
+  })),
+}));
+
+jest.mock('~/utils', () => ({
+  ...jest.requireActual('~/utils'),
+  checkUserKeyExpiry: jest.fn(),
+}));
+
+const mockedGetToken = jest.mocked(getToken);
+const mockedFromNodeProviderChain = jest.mocked(fromNodeProviderChain);
+
+const createMockParams = (
+  overrides: Partial<{
+    body: Record<string, unknown>;
+    model_parameters: Record<string, unknown>;
+    userKey: string;
+  }> = {},
+): BaseInitializeParams => {
+  const mockDb = {
+    getUserKey: jest.fn().mockResolvedValue(
+      overrides.userKey ??
+        JSON.stringify({
+          accessKeyId: 'user-access-key',
+          secretAccessKey: 'user-secret-key',
+        }),
+    ),
+  };
+
+  return {
+    req: {
+      config: {},
+      body: overrides.body ?? {},
+      user: { id: 'test-user-id' },
+    },
+    endpoint: EModelEndpoint.bedrock,
+    model_parameters: overrides.model_parameters ?? { model: 'openai.gpt-5.5' },
+    db: mockDb,
+  } as unknown as BaseInitializeParams;
+};
+
+describe('isBedrockMantleModel', () => {
+  it('should match OpenAI models that require bedrock-mantle', () => {
+    expect(isBedrockMantleModel('openai.gpt-5.5')).toBe(true);
+    expect(isBedrockMantleModel('openai.gpt-5.4')).toBe(true);
+    expect(isBedrockMantleModel('openai.gpt-5.4-codex')).toBe(true);
+  });
+
+  it('should not match Converse-compatible gpt-oss models', () => {
+    expect(isBedrockMantleModel('openai.gpt-oss-20b')).toBe(false);
+    expect(isBedrockMantleModel('openai.gpt-oss-120b-1:0')).toBe(false);
+  });
+
+  it('should not match other providers or empty values', () => {
+    expect(isBedrockMantleModel('anthropic.claude-sonnet-4-5')).toBe(false);
+    expect(isBedrockMantleModel('us.anthropic.claude-opus-5')).toBe(false);
+    expect(isBedrockMantleModel('meta.llama3-70b-instruct-v1:0')).toBe(false);
+    expect(isBedrockMantleModel('')).toBe(false);
+    expect(isBedrockMantleModel(undefined)).toBe(false);
+  });
+});
+
+describe('getBedrockMantleBaseURL', () => {
+  it('should build the in-region mantle endpoint URL', () => {
+    expect(getBedrockMantleBaseURL('us-east-2')).toBe(
+      'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+    );
+  });
+});
+
+describe('initializeBedrock mantle routing', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.BEDROCK_AWS_BEARER_TOKEN;
+    delete process.env.BEDROCK_AWS_PROFILE;
+    delete process.env.BEDROCK_AWS_SESSION_TOKEN;
+    delete process.env.PROXY;
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = 'test-access-key';
+    process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = 'test-secret-key';
+    process.env.BEDROCK_AWS_DEFAULT_REGION = 'us-east-1';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should route mantle models to the OpenAI-compatible provider', async () => {
+    const params = createMockParams();
+    const result = await initializeBedrock(params);
+
+    expect(result.provider).toBe(Providers.OPENAI);
+    const llmConfig = result.llmConfig as Record<string, unknown>;
+    expect(llmConfig.model).toBe('openai.gpt-5.5');
+    expect(llmConfig.useResponsesApi).toBe(true);
+    expect(llmConfig.apiKey).toBe('generated-short-term-token');
+    expect(result.configOptions?.baseURL).toBe(
+      'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+    );
+  });
+
+  it('should mint a short-term token from static credentials', async () => {
+    const params = createMockParams();
+    await initializeBedrock(params);
+
+    expect(mockedGetToken).toHaveBeenCalledTimes(1);
+    expect(mockedGetToken).toHaveBeenCalledWith({
+      credentials: {
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret-key',
+      },
+      region: 'us-east-1',
+    });
+  });
+
+  it('should use a static bearer token without minting one', async () => {
+    process.env.BEDROCK_AWS_BEARER_TOKEN = 'static-api-key';
+    const params = createMockParams();
+    const result = await initializeBedrock(params);
+
+    expect(mockedGetToken).not.toHaveBeenCalled();
+    expect((result.llmConfig as Record<string, unknown>).apiKey).toBe('static-api-key');
+  });
+
+  it('should use a user-provided bearer token without minting one', async () => {
+    process.env.BEDROCK_AWS_BEARER_TOKEN = 'user_provided';
+    const params = createMockParams({
+      userKey: JSON.stringify({ bearerToken: 'user-api-key' }),
+    });
+    const result = await initializeBedrock(params);
+
+    expect(mockedGetToken).not.toHaveBeenCalled();
+    expect((result.llmConfig as Record<string, unknown>).apiKey).toBe('user-api-key');
+  });
+
+  it('should prefer the request region over the default region', async () => {
+    const params = createMockParams({
+      model_parameters: { model: 'openai.gpt-5.5', region: 'us-east-2' },
+    });
+    const result = await initializeBedrock(params);
+
+    expect(mockedGetToken).toHaveBeenCalledWith(expect.objectContaining({ region: 'us-east-2' }));
+    expect(result.configOptions?.baseURL).toBe(
+      'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+    );
+  });
+
+  it('should throw when no region is available', async () => {
+    delete process.env.BEDROCK_AWS_DEFAULT_REGION;
+    const params = createMockParams();
+
+    await expect(initializeBedrock(params)).rejects.toThrow(/region is required/i);
+  });
+
+  it('should reject regions that could break out of the mantle URL', async () => {
+    const params = createMockParams({
+      model_parameters: { model: 'openai.gpt-5.5', region: 'us-east-1.evil.com/openai/v1?' },
+    });
+
+    await expect(initializeBedrock(params)).rejects.toThrow(/invalid aws region/i);
+    expect(mockedGetToken).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to the default credential chain when no static credentials exist', async () => {
+    delete process.env.BEDROCK_AWS_ACCESS_KEY_ID;
+    delete process.env.BEDROCK_AWS_SECRET_ACCESS_KEY;
+    process.env.BEDROCK_AWS_PROFILE = 'bedrock-profile';
+    const params = createMockParams();
+    await initializeBedrock(params);
+
+    expect(mockedFromNodeProviderChain).toHaveBeenCalledWith({ profile: 'bedrock-profile' });
+    expect(mockedGetToken).toHaveBeenCalledWith(
+      expect.objectContaining({ credentials: expect.any(Function) }),
+    );
+  });
+
+  it('should include session tokens when minting a short-term token', async () => {
+    process.env.BEDROCK_AWS_SESSION_TOKEN = 'test-session-token';
+    const params = createMockParams();
+    await initializeBedrock(params);
+
+    expect(mockedGetToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: {
+          accessKeyId: 'test-access-key',
+          secretAccessKey: 'test-secret-key',
+          sessionToken: 'test-session-token',
+        },
+      }),
+    );
+  });
+
+  it('should only forward OpenAI-compatible model parameters', async () => {
+    const params = createMockParams({
+      model_parameters: {
+        model: 'openai.gpt-5.5',
+        temperature: 0.5,
+        topP: 0.9,
+        maxTokens: 2048,
+        region: 'us-east-1',
+        thinking: true,
+        thinkingBudget: 2000,
+        promptCache: true,
+        topK: 40,
+        additionalModelRequestFields: { foo: 'bar' },
+      },
+    });
+    const result = await initializeBedrock(params);
+
+    const llmConfig = result.llmConfig as Record<string, unknown>;
+    const modelKwargs = llmConfig.modelKwargs as Record<string, unknown> | undefined;
+    expect(llmConfig.temperature).toBe(0.5);
+    expect(llmConfig.topP).toBe(0.9);
+    expect(modelKwargs?.max_output_tokens).toBe(2048);
+    expect(llmConfig.user).toBe('test-user-id');
+    expect(llmConfig).not.toHaveProperty('region');
+    expect(llmConfig).not.toHaveProperty('thinking');
+    expect(llmConfig).not.toHaveProperty('thinkingBudget');
+    expect(llmConfig).not.toHaveProperty('promptCache');
+    expect(llmConfig).not.toHaveProperty('topK');
+    expect(llmConfig).not.toHaveProperty('additionalModelRequestFields');
+  });
+
+  it('should shape reasoning_effort for the Responses API', async () => {
+    const params = createMockParams({
+      model_parameters: { model: 'openai.gpt-5.5', reasoning_effort: 'high' },
+    });
+    const result = await initializeBedrock(params);
+
+    const llmConfig = result.llmConfig as Record<string, unknown>;
+    const modelKwargs = llmConfig.modelKwargs as Record<string, unknown> | undefined;
+    expect(modelKwargs?.reasoning).toEqual({ effort: 'high' });
+    expect(llmConfig).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('should keep Converse-compatible models on the default Bedrock path', async () => {
+    const params = createMockParams({
+      model_parameters: { model: 'openai.gpt-oss-120b' },
+    });
+    const result = await initializeBedrock(params);
+
+    expect(result.provider).toBeUndefined();
+    expect(mockedGetToken).not.toHaveBeenCalled();
+    const llmConfig = result.llmConfig as Record<string, unknown>;
+    expect(llmConfig.model).toBe('openai.gpt-oss-120b');
+    expect(llmConfig.credentials).toEqual({
+      accessKeyId: 'test-access-key',
+      secretAccessKey: 'test-secret-key',
+    });
+  });
+});

--- a/packages/api/src/endpoints/bedrock/mantle.ts
+++ b/packages/api/src/endpoints/bedrock/mantle.ts
@@ -2,6 +2,7 @@ import { Providers } from '@librechat/agents';
 import { getToken } from '@aws/bedrock-token-generator';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types';
+import type { BedrockConverseInput } from 'librechat-data-provider';
 import type { BedrockCredentials, InitializeResultBase } from '~/types';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
 
@@ -38,17 +39,17 @@ export function getBedrockMantleBaseURL(region: string): string {
  * `additionalModelRequestFields`, etc.) are intentionally excluded so they
  * never leak into the Responses API request body.
  */
-const mantleModelOptionKeys = [
+const mantleModelOptionKeys: readonly (keyof BedrockConverseInput)[] = [
   'model',
   'maxTokens',
   'temperature',
   'topP',
   'stop',
   'reasoning_effort',
-] as const;
+];
 
 export interface BedrockMantleParams {
-  model_parameters?: Record<string, unknown>;
+  model_parameters?: Partial<BedrockConverseInput>;
   /** Static or user-provided AWS credentials resolved by `initializeBedrock` */
   credentials?: BedrockCredentials;
   /** Pre-issued Bedrock API key (long-term key or user-provided bearer token) */
@@ -118,7 +119,10 @@ export async function initializeBedrockMantle({
   /** `useResponsesApi` is part of the model options so reasoning params are
    *  shaped for the Responses API — `bedrock-mantle` does not serve these
    *  models over Chat Completions. */
-  const modelOptions: Record<string, unknown> = { user: userId, useResponsesApi: true };
+  const modelOptions: Record<string, unknown> = { useResponsesApi: true };
+  if (userId) {
+    modelOptions.user = userId;
+  }
   for (const key of mantleModelOptionKeys) {
     const value = model_parameters?.[key];
     if (value != null) {

--- a/packages/api/src/endpoints/bedrock/mantle.ts
+++ b/packages/api/src/endpoints/bedrock/mantle.ts
@@ -27,10 +27,15 @@ export function isBedrockMantleModel(model?: string): boolean {
 
 /**
  * In-Region `bedrock-mantle` endpoint URL serving the OpenAI-compatible API.
+ * When `BEDROCK_REVERSE_PROXY` is configured, it replaces the AWS host — same
+ * as the Converse path — so gateway-only deployments keep working and the
+ * bearer token never bypasses the gateway; the `/openai/v1` path is preserved.
  * @see https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
  */
-export function getBedrockMantleBaseURL(region: string): string {
-  return `https://bedrock-mantle.${region}.api.aws/openai/v1`;
+export function getBedrockMantleBaseURL(region: string, reverseProxy?: string): string {
+  const trimmedReverseProxy = reverseProxy?.trim();
+  const host = trimmedReverseProxy || `bedrock-mantle.${region}.api.aws`;
+  return `https://${host}/openai/v1`;
 }
 
 /**
@@ -58,6 +63,8 @@ export interface BedrockMantleParams {
   profile?: string;
   /** Fallback region (`BEDROCK_AWS_DEFAULT_REGION`) when the request has none */
   defaultRegion?: string;
+  /** Reverse-proxy host (`BEDROCK_REVERSE_PROXY`) replacing the AWS endpoint */
+  reverseProxy?: string;
   userId?: string;
 }
 
@@ -95,6 +102,7 @@ export async function initializeBedrockMantle({
   bearerToken,
   profile,
   defaultRegion,
+  reverseProxy,
   userId,
 }: BedrockMantleParams): Promise<InitializeResultBase> {
   const requestRegion =
@@ -131,7 +139,7 @@ export async function initializeBedrockMantle({
   }
 
   const options = getOpenAIConfig(apiKey, {
-    reverseProxyUrl: getBedrockMantleBaseURL(region),
+    reverseProxyUrl: getBedrockMantleBaseURL(region, reverseProxy),
     modelOptions,
     proxy: process.env.PROXY ?? undefined,
     streaming: true,

--- a/packages/api/src/endpoints/bedrock/mantle.ts
+++ b/packages/api/src/endpoints/bedrock/mantle.ts
@@ -1,0 +1,140 @@
+import { Providers } from '@librechat/agents';
+import { getToken } from '@aws/bedrock-token-generator';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types';
+import type { BedrockCredentials, InitializeResultBase } from '~/types';
+import { getOpenAIConfig } from '~/endpoints/openai/config';
+
+const mantleModelPattern = /^openai\.(?!gpt-oss)/;
+
+/** AWS region names are lowercase alphanumerics and hyphens (e.g. `us-east-2`).
+ *  The request-supplied region is interpolated into the credential-bearing
+ *  `baseURL` host, so anything else must be rejected to prevent URL breakout. */
+const awsRegionPattern = /^[a-z0-9-]+$/;
+
+/**
+ * OpenAI models on Amazon Bedrock (GPT-5.5, Codex, etc.) are served exclusively
+ * through the `bedrock-mantle` endpoint's OpenAI-compatible Responses API — they
+ * support neither the Converse nor the Invoke API, so they cannot go through
+ * `ChatBedrockConverse`. The exception is the open-weight `openai.gpt-oss-*`
+ * family, which is Converse-compatible and stays on the default Bedrock path.
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
+ */
+export function isBedrockMantleModel(model?: string): boolean {
+  return model != null && mantleModelPattern.test(model);
+}
+
+/**
+ * In-Region `bedrock-mantle` endpoint URL serving the OpenAI-compatible API.
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html
+ */
+export function getBedrockMantleBaseURL(region: string): string {
+  return `https://bedrock-mantle.${region}.api.aws/openai/v1`;
+}
+
+/**
+ * Model options that translate directly to the OpenAI-compatible API. Bedrock
+ * Converse-specific parameters (`thinking`, `promptCache`, `topK`,
+ * `additionalModelRequestFields`, etc.) are intentionally excluded so they
+ * never leak into the Responses API request body.
+ */
+const mantleModelOptionKeys = [
+  'model',
+  'maxTokens',
+  'temperature',
+  'topP',
+  'stop',
+  'reasoning_effort',
+] as const;
+
+export interface BedrockMantleParams {
+  model_parameters?: Record<string, unknown>;
+  /** Static or user-provided AWS credentials resolved by `initializeBedrock` */
+  credentials?: BedrockCredentials;
+  /** Pre-issued Bedrock API key (long-term key or user-provided bearer token) */
+  bearerToken?: string;
+  /** AWS profile name (`BEDROCK_AWS_PROFILE`) for the default credential chain */
+  profile?: string;
+  /** Fallback region (`BEDROCK_AWS_DEFAULT_REGION`) when the request has none */
+  defaultRegion?: string;
+  userId?: string;
+}
+
+function resolveTokenCredentials({
+  credentials,
+  profile,
+}: Pick<BedrockMantleParams, 'credentials' | 'profile'>):
+  | AwsCredentialIdentity
+  | AwsCredentialIdentityProvider {
+  if (credentials?.accessKeyId && credentials?.secretAccessKey) {
+    return credentials as AwsCredentialIdentity;
+  }
+  return fromNodeProviderChain(profile ? { profile } : undefined);
+}
+
+/**
+ * Initializes an OpenAI-compatible client configuration for OpenAI models on
+ * Amazon Bedrock (`bedrock-mantle`).
+ *
+ * Authentication uses a Bedrock API key sent as a plain bearer token — no
+ * SigV4 signing of individual requests is involved. When no static key
+ * (`BEDROCK_AWS_BEARER_TOKEN` or a user-provided one) is available, a
+ * short-term key is minted from the resolved AWS credentials via the official
+ * `@aws/bedrock-token-generator`, which AWS recommends over long-term keys for
+ * production. Minting is a local SigV4 presign (no network call), and a fresh
+ * token per initialization keeps it within both the 12h token cap and the
+ * credentials' own expiry.
+ *
+ * The Responses API is forced on: `bedrock-mantle` does not serve these models
+ * over Chat Completions.
+ */
+export async function initializeBedrockMantle({
+  model_parameters,
+  credentials,
+  bearerToken,
+  profile,
+  defaultRegion,
+  userId,
+}: BedrockMantleParams): Promise<InitializeResultBase> {
+  const requestRegion =
+    typeof model_parameters?.region === 'string' ? model_parameters.region.trim() : undefined;
+  const region = (requestRegion !== '' ? requestRegion : undefined) ?? defaultRegion;
+  if (!region) {
+    throw new Error(
+      'An AWS region is required for OpenAI models on Bedrock (bedrock-mantle). Set BEDROCK_AWS_DEFAULT_REGION or select a region.',
+    );
+  }
+  if (!awsRegionPattern.test(region)) {
+    throw new Error('Invalid AWS region for OpenAI models on Bedrock (bedrock-mantle).');
+  }
+
+  const apiKey =
+    bearerToken ??
+    (await getToken({
+      credentials: resolveTokenCredentials({ credentials, profile }),
+      region,
+    }));
+
+  /** `useResponsesApi` is part of the model options so reasoning params are
+   *  shaped for the Responses API — `bedrock-mantle` does not serve these
+   *  models over Chat Completions. */
+  const modelOptions: Record<string, unknown> = { user: userId, useResponsesApi: true };
+  for (const key of mantleModelOptionKeys) {
+    const value = model_parameters?.[key];
+    if (value != null) {
+      modelOptions[key] = value;
+    }
+  }
+
+  const options = getOpenAIConfig(apiKey, {
+    reverseProxyUrl: getBedrockMantleBaseURL(region),
+    modelOptions,
+    proxy: process.env.PROXY ?? undefined,
+    streaming: true,
+  });
+
+  return {
+    ...options,
+    provider: Providers.OPENAI,
+  };
+}

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -358,6 +358,9 @@ const amazonModels = {
 const openAIBedrockModels = {
   'openai.gpt-oss-20b': 128000,
   'openai.gpt-oss-120b': 128000,
+  /** bedrock-mantle models: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html */
+  'openai.gpt-5': 272000,
+  'openai.gpt-5.5': 272000,
 };
 
 const bedrockModels = {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2167,6 +2167,8 @@ export const bedrockModels = [
   'global.anthropic.claude-sonnet-4-5-20250929-v1:0',
   'global.anthropic.claude-haiku-4-5-20251001-v1:0',
   'us.anthropic.claude-opus-4-1-20250805-v1:0',
+  /** Served via the `bedrock-mantle` OpenAI-compatible Responses API */
+  'openai.gpt-5.5',
   // 'cohere.command-text-v14', // no conversation history
   // 'cohere.command-light-text-v14', // no conversation history
   'cohere.command-r-v1:0',

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -1120,6 +1120,40 @@ const bedrockZAICol2: SettingsConfiguration = [
   librechat.fileTokenLimit,
 ];
 
+/** OpenAI models on Bedrock go through the `bedrock-mantle` Responses API, so
+ *  Converse-only controls (prompt caching, thinking) are omitted. */
+const bedrockOpenAI: SettingsConfiguration = [
+  librechat.modelLabel,
+  librechat.promptPrefix,
+  librechat.maxContextTokens,
+  bedrock.maxTokens,
+  meta.temperature,
+  meta.topP,
+  baseDefinitions.stop,
+  librechat.resendFiles,
+  bedrock.region,
+  bedrock.reasoning_effort,
+  librechat.fileTokenLimit,
+];
+
+const bedrockOpenAICol1: SettingsConfiguration = [
+  baseDefinitions.model as SettingDefinition,
+  librechat.modelLabel,
+  librechat.promptPrefix,
+  baseDefinitions.stop,
+];
+
+const bedrockOpenAICol2: SettingsConfiguration = [
+  librechat.maxContextTokens,
+  bedrock.maxTokens,
+  meta.temperature,
+  meta.topP,
+  librechat.resendFiles,
+  bedrock.region,
+  bedrock.reasoning_effort,
+  librechat.fileTokenLimit,
+];
+
 const bedrockMoonshot: SettingsConfiguration = [
   librechat.modelLabel,
   bedrock.system,
@@ -1171,7 +1205,7 @@ export const paramSettings: Record<string, SettingsConfiguration | undefined> = 
   [`${EModelEndpoint.bedrock}-${BedrockProviders.DeepSeek}`]: bedrockGeneral,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: bedrockMoonshot,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.MoonshotAI}`]: bedrockMoonshot,
-  [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockGeneral,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockOpenAI,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockZAI,
   [EModelEndpoint.google]: googleConfig,
 };
@@ -1229,7 +1263,10 @@ export const presetSettings: Record<
     col1: bedrockMoonshotCol1,
     col2: bedrockMoonshotCol2,
   },
-  [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockGeneralColumns,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: {
+    col1: bedrockOpenAICol1,
+    col2: bedrockOpenAICol2,
+  },
   [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: {
     col1: bedrockZAICol1,
     col2: bedrockZAICol2,


### PR DESCRIPTION
# Summary

Closes #14635

Adds support for OpenAI models hosted on Amazon Bedrock (GPT-5.5, Codex, etc.) to the built-in Bedrock endpoint. AWS serves these models exclusively through the **`bedrock-mantle`** endpoint's OpenAI-compatible **Responses API** — they support neither the Converse nor the Invoke API ([GPT-5.5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html)), so they cannot go through `ChatBedrockConverse`, and adding e.g. `openai.gpt-5.5` to `BEDROCK_AWS_MODELS` fails at the AWS API level today.

With this change, `openai.gpt-5.5` is part of the default Bedrock model list and works out of the box; curated setups just add the model ID:

```bash
BEDROCK_AWS_MODELS=anthropic.claude-sonnet-4-5,openai.gpt-5.5
```

## How it works

- **Routing** (`packages/api/src/endpoints/bedrock/initialize.ts`): after the existing credential resolution, model IDs matching `openai.*` — except the Converse-compatible `openai.gpt-oss*` family — are dispatched to the new mantle initializer instead of the Converse path.
- **OpenAI-compatible client** (`packages/api/src/endpoints/bedrock/mantle.ts`): reuses `getOpenAIConfig()` with `baseURL: https://bedrock-mantle.{region}.api.aws/openai/v1` and returns `provider: Providers.OPENAI`, so the agent layer runs these models through the existing OpenAI client. `useResponsesApi` is forced on (mantle does not serve these models over Chat Completions), which also shapes `reasoning_effort` and `max_output_tokens` correctly.
- **Authentication**: `bedrock-mantle` accepts [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) as plain `Authorization: Bearer` headers — no per-request SigV4. The bearer token is resolved in order:
  1. `BEDROCK_AWS_BEARER_TOKEN` (or a user-provided bearer token), reusing the existing Bedrock API key support, or
  2. a **short-term API key minted from the already-configured AWS credentials** (env access keys, user-provided keys, `BEDROCK_AWS_PROFILE`, or the default provider chain) via AWS's official [`@aws/bedrock-token-generator`](https://github.com/aws/aws-bedrock-token-generator-js). Minting is a local SigV4 presign (no network round-trip) and happens per initialization, staying within the 12h token cap and the credentials' own expiry — this follows AWS's recommendation of short-term keys over long-term ones for production.
- **Parameter hygiene**: only OpenAI-compatible model options (`model`, `maxTokens`, `temperature`, `topP`, `stop`, `reasoning_effort`) are forwarded; Converse-specific parameters (`thinking`, `promptCache`, `topK`, `additionalModelRequestFields`, …) never leak into the Responses API request body.
- **Region safety**: the request-supplied `region` is interpolated into the credential-bearing base URL, so it is validated against a strict `[a-z0-9-]` pattern before any token is minted — a malformed region cannot redirect the bearer token off `*.api.aws`.
- **Context windows** (`packages/api/src/utils/tokens.ts`): `openai.gpt-5` / `openai.gpt-5.5` → 272K, per the model card.
- **Defaults & UI**: `openai.gpt-5.5` is added to the default `bedrockModels` list (`packages/data-provider/src/config.ts`) so `validateModel` accepts it without extra config, and `bedrock-openai` gets a dedicated parameter panel (`packages/data-provider/src/parameterSettings.ts`) with `maxTokens` / `reasoning_effort` and without the Converse-only prompt-cache controls.

## What stays the same

- `openai.gpt-oss-*` models keep using the Converse path (they support it and gain nothing from mantle).
- All other Bedrock providers/models are untouched — the mantle branch returns before any Converse-specific config is built.
- No config schema changes; region resolution honors the request's `region` parameter with `BEDROCK_AWS_DEFAULT_REGION` as fallback (mantle models are currently us-east-1/us-east-2 only on the AWS side).

## Testing

- New `mantle.spec.ts` (14 tests): routing, bearer-token precedence (static / user-provided / minted), region resolution, the no-region error and region-injection rejection, credential-chain fallback with `BEDROCK_AWS_PROFILE`, session-token passthrough, parameter allowlisting (Converse-only params don't leak), Responses-API reasoning shape, and gpt-oss staying on Converse.
- Existing `initialize.spec.ts` still passes; its `~/utils` mock now spreads `jest.requireActual` (same pattern as `openai/initialize.spec.ts`) because the new import chain reaches modules that use `isEnabled`.
- `packages/data-provider`: full suite passes (28 suites / 1465 tests).
- `npx tsc --noEmit`, ESLint, and `npm run build` pass for both touched workspaces.

## Notes for reviewers

- The one new dependency, `@aws/bedrock-token-generator`, is AWS-official, tiny (SigV4 presign only), and reuses `@aws-sdk`/`@smithy` packages already in the tree.
- `BEDROCK_REVERSE_PROXY` is honored for mantle traffic with the same host-replacement semantics as the Converse path (the `/openai/v1` path is preserved), so gateway-only deployments keep working and the bearer token never bypasses the gateway. The standard `PROXY` env var is honored via `getOpenAIConfig`.
- Follow-ups that could build on this: per-model routing overrides in `endpoints.bedrock` config, and Bedrock-specific pricing entries once published (token pricing currently falls back to the `gpt-5.5` substring match).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
