### PR TITLE
🚏 fix: Localized Guidance for Model-Not-Found Errors

### DIFF
--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -6,6 +6,7 @@ import { useLocalize } from '~/hooks';
 import CodeBlock from './CodeBlock';
 
 const localizedErrorPrefix = 'com_error';
+const langChainModelNotFoundUrl = /langchain\.com\/.*\/MODEL_NOT_FOUND(?:\/|\b)/i;
 
 type TConcurrent = {
   limit: number;
@@ -134,6 +135,10 @@ const Error = ({ text }: { text: string }) => {
   const jsonString = extractJson(text);
   const errorMessage = text.length > 512 && !jsonString ? text.slice(0, 512) + '...' : text;
   const defaultResponse = `Something went wrong. Here's the specific error message we encountered: ${errorMessage}`;
+
+  if (langChainModelNotFoundUrl.test(text)) {
+    return localize('com_error_model_not_found');
+  }
 
   if (!isJson(jsonString)) {
     return defaultResponse;

--- a/client/src/components/Messages/Content/__tests__/Error.spec.tsx
+++ b/client/src/components/Messages/Content/__tests__/Error.spec.tsx
@@ -30,6 +30,15 @@ describe('Error — typed provider errors', () => {
     expect(catalog.com_error_google_video_unprocessable).toMatch(/too long/i);
   });
 
+  it('replaces LangChain model-not-found attribution with localized guidance', () => {
+    const raw =
+      'An error occurred while processing the request: 404 404 page not found Troubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/MODEL_NOT_FOUND/';
+    render(<Error text={raw} />);
+
+    expect(screen.getByText(catalog.com_error_model_not_found)).toBeInTheDocument();
+    expect(screen.queryByText(/langchain\.com/i)).not.toBeInTheDocument();
+  });
+
   it('falls back to the raw provider text for an unmapped error', () => {
     const raw =
       '[GoogleGenerativeAI Error]: [400 Bad Request] Request contains an invalid argument';

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -392,6 +392,7 @@
   "com_error_invalid_base_url": "The base URL you provided targets a restricted address. Please use a valid external URL and try again.",
   "com_error_invalid_user_key": "Invalid key provided. Please provide a valid key and try again.",
   "com_error_missing_model": "No model selected for {{0}}. Please select a model and try again.",
+  "com_error_model_not_found": "The selected model is unavailable from this provider. Select a different model or ask an administrator to verify the provider configuration.",
   "com_error_models_not_loaded": "Models configuration could not be loaded. Please refresh the page and try again.",
   "com_error_moderation": "It appears that the content submitted has been flagged by our moderation system for not aligning with our community guidelines. We're unable to proceed with this specific topic. If you have any other questions or topics you'd like to explore, please edit your message, or create a new conversation.",
   "com_error_no_base_url": "No base URL found. Please provide one and try again.",


### PR DESCRIPTION
## Summary

I replaced LangChain's raw `MODEL_NOT_FOUND` diagnostic in chat error cards with localized guidance that tells users how to recover.

- Detect the LangChain `MODEL_NOT_FOUND` troubleshooting URL before the generic raw-error fallback.
- Render provider-neutral guidance to select another model or verify the provider configuration.
- Preserve unmapped provider errors and server-side diagnostics unchanged.
- Cover the reported error payload with a regression test.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run build:data-provider`
- `npm run build:client-package`
- `cd client && npm run test:ci -- Error.spec.tsx --runInBand`
- `npx eslint client/src/components/Messages/Content/Error.tsx client/src/components/Messages/Content/__tests__/Error.spec.tsx`
- `npx prettier --check client/src/components/Messages/Content/Error.tsx client/src/components/Messages/Content/__tests__/Error.spec.tsx client/src/locales/en/translation.json`

### **Test Configuration**:

- Node.js v24.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes