### PR TITLE
🌊 fix: Preserve Custom Endpoint `streamRate` When `endpoints.all` Is Defined

### DIFF
--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -115,7 +115,7 @@ function buildCustomOptions(
   }
 
   const allConfig = appConfig?.endpoints?.all;
-  if (allConfig?.streamRate) {
+  if (allConfig?.streamRate != null) {
     customOptions.streamRate = allConfig.streamRate;
   }
 
@@ -345,7 +345,7 @@ export async function initializeCustom({
   }
 
   const streamRate = clientOptions.streamRate as number | undefined;
-  if (streamRate) {
+  if (streamRate != null) {
     (options.llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
   }
 

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -115,7 +115,7 @@ function buildCustomOptions(
   }
 
   const allConfig = appConfig?.endpoints?.all;
-  if (allConfig) {
+  if (allConfig?.streamRate) {
     customOptions.streamRate = allConfig.streamRate;
   }
 

--- a/packages/api/src/endpoints/custom/streamrate.spec.ts
+++ b/packages/api/src/endpoints/custom/streamrate.spec.ts
@@ -89,4 +89,16 @@ describe('custom endpoint streamRate resolution', () => {
     const options = await initializeCustom(makeParams({ allBlock: { activityLabel: true } }));
     expect(streamDelayOf(options)).toBeUndefined();
   });
+
+  it('lets `endpoints.all.streamRate: 0` override an endpoint streamRate (explicit disable)', async () => {
+    const options = await initializeCustom(
+      makeParams({ endpointStreamRate: 25, allBlock: { streamRate: 0 } }),
+    );
+    expect(streamDelayOf(options)).toBe(0);
+  });
+
+  it('passes an explicit endpoint `streamRate: 0` through to the llmConfig', async () => {
+    const options = await initializeCustom(makeParams({ endpointStreamRate: 0 }));
+    expect(streamDelayOf(options)).toBe(0);
+  });
 });

--- a/packages/api/src/endpoints/custom/streamrate.spec.ts
+++ b/packages/api/src/endpoints/custom/streamrate.spec.ts
@@ -1,0 +1,92 @@
+import type { BaseInitializeParams } from '~/types';
+
+jest.mock('~/auth', () => ({
+  validateEndpointURL: jest.fn(),
+  createSSRFSafeUndiciConnect: jest.fn(() => ({ lookup: jest.fn() })),
+}));
+
+const mockGetOpenAIConfig = jest.fn((..._args: unknown[]) => ({
+  llmConfig: { model: 'claude-haiku-4-5' } as Record<string, unknown>,
+  configOptions: {},
+}));
+jest.mock('~/endpoints/openai/config', () => ({
+  getOpenAIConfig: (...args: unknown[]) => mockGetOpenAIConfig(...args),
+}));
+
+jest.mock('~/endpoints/models', () => ({ fetchModels: jest.fn() }));
+jest.mock('~/cache', () => ({
+  standardCache: jest.fn(() => ({ get: jest.fn().mockResolvedValue(null) })),
+  tokenConfigCache: jest.fn(() => ({ get: jest.fn().mockResolvedValue(null) })),
+}));
+jest.mock('~/utils', () => ({
+  isUserProvided: (val: string) => val === 'user_provided',
+  checkUserKeyExpiry: jest.fn(),
+}));
+
+const mockGetCustomEndpointConfig = jest.fn();
+jest.mock('~/app/config', () => ({
+  getCustomEndpointConfig: (...args: unknown[]) => mockGetCustomEndpointConfig(...args),
+}));
+
+import { initializeCustom } from './initialize';
+
+function makeParams({
+  allBlock,
+  endpointStreamRate,
+}: {
+  allBlock?: Record<string, unknown>;
+  endpointStreamRate?: number;
+} = {}): BaseInitializeParams {
+  mockGetCustomEndpointConfig.mockReturnValue({
+    apiKey: 'test-key',
+    baseURL: 'https://gateway.example.com/v1',
+    models: { default: ['claude-haiku-4-5'], fetch: false },
+    streamRate: endpointStreamRate,
+  });
+
+  return {
+    req: {
+      user: { id: 'user-1' },
+      body: {},
+      config: allBlock ? { endpoints: { all: allBlock } } : {},
+    } as unknown as BaseInitializeParams['req'],
+    endpoint: 'ClickHouse',
+    model_parameters: { model: 'claude-haiku-4-5' },
+    db: { getUserKeyValues: jest.fn() } as unknown as BaseInitializeParams['db'],
+  };
+}
+
+function streamDelayOf(options: { llmConfig: unknown }): unknown {
+  return (options.llmConfig as Record<string, unknown>)._lc_stream_delay;
+}
+
+describe('custom endpoint streamRate resolution', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('applies the endpoint streamRate when no `endpoints.all` block is present', async () => {
+    const options = await initializeCustom(makeParams({ endpointStreamRate: 25 }));
+    expect(streamDelayOf(options)).toBe(25);
+  });
+
+  it('preserves the endpoint streamRate when `endpoints.all` exists without its own streamRate', async () => {
+    const options = await initializeCustom(
+      makeParams({
+        endpointStreamRate: 25,
+        allBlock: { activityLabel: true, activityModel: 'gpt-5.6-luna' },
+      }),
+    );
+    expect(streamDelayOf(options)).toBe(25);
+  });
+
+  it('lets `endpoints.all.streamRate` override the endpoint streamRate', async () => {
+    const options = await initializeCustom(
+      makeParams({ endpointStreamRate: 25, allBlock: { streamRate: 10 } }),
+    );
+    expect(streamDelayOf(options)).toBe(10);
+  });
+
+  it('leaves the stream delay unset when neither level configures a streamRate', async () => {
+    const options = await initializeCustom(makeParams({ allBlock: { activityLabel: true } }));
+    expect(streamDelayOf(options)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`streamRate` was silently ignored for **every custom endpoint** whenever an `endpoints.all` block was present in `librechat.yaml`, even when that block had nothing to do with streaming.

`buildCustomOptions` assigned `allConfig.streamRate` unconditionally:

```js
const allConfig = appConfig?.endpoints?.all;
if (allConfig) {
  customOptions.streamRate = allConfig.streamRate;  // undefined when `all` defines no streamRate
}
```

Any `endpoints.all` block makes `allConfig` truthy, so a config like this one — `all` present purely for activity labels — overwrote the per-endpoint `streamRate` with `undefined`:

```yaml
endpoints:
  all:
    activityLabel: true
    activityModel: "gpt-5.6-luna"
  custom:
    - name: "ClickHouse"
      streamRate: 25   # silently discarded
```

That value is read back further down to set `_lc_stream_delay` on the llmConfig:

```js
const streamRate = clientOptions.streamRate as number | undefined;
if (streamRate) {
  (options.llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
}
```

Since it had already been clobbered, `_lc_stream_delay` was never set and stream smoothing never engaged — responses render as raw provider chunks. This is most visible on OpenAI-compatible gateways that emit large deltas, where the difference between smoothed and unsmoothed output is stark.

The equivalent OpenAI path already guards correctly ([`openai/initialize.ts`](https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/endpoints/openai/initialize.ts)):

```js
if (allConfig?.streamRate) {
  streamRate = allConfig.streamRate;
}
```

This change applies the same guard to the custom path, so `endpoints.all.streamRate` still overrides when set, and is ignored when absent.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `packages/api/src/endpoints/custom/streamrate.spec.ts` covering the resolution matrix:

| endpoint `streamRate` | `endpoints.all` | expected `_lc_stream_delay` |
|---|---|---|
| 25 | absent | 25 |
| 25 | present, no `streamRate` | 25 (regression case) |
| 25 | `streamRate: 10` | 10 (override still works) |
| unset | present, no `streamRate` | unset |

The second row fails on `main` (receives `undefined`) and passes with this change.

```bash
cd packages/api && npx jest src/endpoints/custom/
```

`Test Suites: 3 passed, Tests: 38 passed`. No new TypeScript or ESLint diagnostics.

### **Test Configuration**:

Reproduces with any custom endpoint whose config declares `streamRate` while `endpoints.all` exists without one.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes