### PR TITLE
🔐 fix: Preserve structured JWT auth context

### DIFF
--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -23,6 +23,7 @@ const {
   loadToolApprovalHooks,
   maybeInjectQueryDevtoolsBootstrap,
   preAuthTenantMiddleware,
+  requestContextMiddleware,
   configureServerTimeouts,
   configureMessageFilterRegexValidator,
 } = require('@librechat/api');
@@ -358,6 +359,7 @@ if (cluster.isMaster) {
     app.get('/health', (_req, res) => res.status(200).send('OK'));
 
     /** Middleware */
+    app.use(requestContextMiddleware);
     app.use(noIndex);
     app.use(express.json({ limit: '3mb' }));
     app.use(express.urlencoded({ extended: true, limit: '3mb' }));

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -28,6 +28,7 @@ const {
   loadToolApprovalHooks,
   maybeInjectQueryDevtoolsBootstrap,
   preAuthTenantMiddleware,
+  requestContextMiddleware,
   registerShutdownTask,
   configureServerTimeouts,
   setupGracefulShutdown,
@@ -204,6 +205,7 @@ const startServer = async () => {
   });
 
   /* Middleware */
+  app.use(requestContextMiddleware);
   app.use('/api/agents/chat', agentStartupIngressMiddleware);
   app.use(metricsMiddleware);
   app.use(noIndex);

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -120,12 +120,43 @@ jest.mock('@librechat/api', () => {
   const getAuthFailureErrorName = (err, info) =>
     normalizeAuthLogValue(getAuthFailureField(info, 'name')) ??
     normalizeAuthLogValue(getAuthFailureField(err, 'name'));
+  const getAuthFailureReasonCategory = (err, info) => {
+    const reason = getAuthFailureReason(err, info).toLowerCase();
+    const errorName = getAuthFailureErrorName(err, info)?.toLowerCase();
+    if (reason.includes('expired') || errorName === 'tokenexpirederror') {
+      return 'expired_jwt';
+    }
+    if (reason.includes('user-id mismatch') || reason.includes('principal mismatch')) {
+      return 'principal_mismatch';
+    }
+    if (
+      errorName === 'jsonwebtokenerror' ||
+      reason.includes('jwt malformed') ||
+      reason.includes('invalid signature') ||
+      reason.includes('invalid algorithm') ||
+      reason.includes('invalid token') ||
+      reason.includes('invalid key')
+    ) {
+      return 'malformed_jwt';
+    }
+    if (reason === 'unauthorized' || reason.includes('no auth token')) {
+      return 'missing_or_unrecognized_token';
+    }
+    return 'authentication_error';
+  };
   const getSafeTokenProvider = (tokenProvider) => {
     const normalized = normalizeAuthLogValue(tokenProvider);
     if (!normalized) {
       return undefined;
     }
     return normalized === 'openid' || normalized === 'librechat' ? normalized : 'other';
+  };
+  const getSafeTokenSource = (tokenSource) => {
+    const normalized = normalizeAuthLogValue(tokenSource);
+    if (!normalized) {
+      return undefined;
+    }
+    return ['bearer', 'none'].includes(normalized) ? normalized : 'other';
   };
   const normalizeRoutePath = (path) => {
     if (typeof path === 'string') {
@@ -195,11 +226,11 @@ jest.mock('@librechat/api', () => {
       method: normalizeAuthLogValue(req.method),
       path: getRequestPath(req),
       token_provider: getSafeTokenProvider(authState.tokenProvider),
+      token_source: getSafeTokenSource(authState.tokenSource),
       openid_reuse_enabled: authState.openidReuseEnabled,
       openid_jwt_available: authState.openidJwtAvailable,
       has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
     });
-  const formatAuthLogMessage = (message, context) => `${message} ${JSON.stringify(context)}`;
   const normalizeContextValue = (value) => {
     const trimmed = value?.trim?.();
     return trimmed || undefined;
@@ -216,8 +247,8 @@ jest.mock('@librechat/api', () => {
     recordRumProxyRequest: jest.fn(),
     getAuthFailureReason,
     getAuthFailureErrorName,
+    getAuthFailureReasonCategory,
     buildSafeAuthLogContext,
-    formatAuthLogMessage,
     maybeRefreshCloudFrontAuthCookiesMiddleware: jest.fn((req, res, next) => next()),
     tenantContextMiddleware: (req, res, next) => {
       const context = {
@@ -371,15 +402,17 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(getTenantId()).toBeUndefined();
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] Authentication failed after all strategies'),
       expect.objectContaining({
+        message: '[requireJwtAuth] Authentication failed after all strategies',
+        event_name: 'jwt_auth_rejected',
         primary_strategy: 'jwt',
         fallback_attempted: false,
         fallback_succeeded: false,
         attempted_strategies: ['jwt'],
         final_strategy: 'jwt',
-        reason: 'Unauthorized',
-        status: 401,
+        reason_category: 'missing_or_unrecognized_token',
+        recovery_classification: 'terminal_rejection',
+        response_status: 401,
       }),
     );
     expect(logger.warn).not.toHaveBeenCalled();
@@ -393,6 +426,7 @@ describe('requireJwtAuth tenant context chaining', () => {
       method: 'GET',
       path: '/api/messages',
       headers: {
+        authorization: 'Bearer valid-openid-token',
         cookie: `token_provider=openid; openid_user_id=${signedOpenIdUserCookie('user-jwt')}`,
       },
       _mockStrategies: {
@@ -413,40 +447,40 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(req.authStrategy).toBe('jwt');
     expect(res.status).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
+        message: '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+        event_name: 'jwt_auth_fallback_attempt',
         request_id: 'req-expired-success',
         method: 'GET',
         path: '/api/messages',
         token_provider: 'openid',
+        token_source: 'bearer',
         openid_reuse_enabled: true,
         openid_jwt_available: true,
         has_openid_reuse_user_id: true,
         primary_strategy: 'openidJwt',
         fallback_strategy: 'jwt',
         fallback_attempted: true,
-        reason: 'jwt expired',
-        error_name: 'TokenExpiredError',
-        status: 401,
+        reason_category: 'expired_jwt',
+        recovery_classification: 'fallback_attempted',
+        strategy_status: 401,
       }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure'),
       expect.objectContaining({
+        message: '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
+        event_name: 'jwt_auth_recovered',
         request_id: 'req-expired-success',
         auth_strategy: 'jwt',
         primary_strategy: 'openidJwt',
         fallback_strategy: 'jwt',
         fallback_attempted: true,
         fallback_succeeded: true,
-        primary_failure_reason: 'jwt expired',
-        reason: 'jwt expired',
-        error_name: 'TokenExpiredError',
+        primary_failure_reason_category: 'expired_jwt',
+        recovery_classification: 'fallback_succeeded',
       }),
     );
-    expect(logger.debug.mock.calls[0][0]).toContain('"reason":"jwt expired"');
-    expect(logger.debug.mock.calls[0][0]).toContain('"fallback_attempted":true');
-    expect(logger.debug.mock.calls[1][0]).toContain('"fallback_succeeded":true');
+    expect(JSON.stringify(logger.debug.mock.calls)).not.toContain('jwt expired');
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
@@ -491,20 +525,20 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(req.authStrategy).toBe('jwt');
     expect(res.status).not.toHaveBeenCalled();
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
+        message: '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
         request_id: 'req-malformed-info',
         fallback_attempted: true,
-        reason: 'Unauthorized',
-        status: 401,
+        reason_category: 'missing_or_unrecognized_token',
+        strategy_status: 401,
       }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure'),
       expect.objectContaining({
+        message: '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
         request_id: 'req-malformed-info',
         fallback_succeeded: true,
-        primary_failure_reason: 'Unauthorized',
+        primary_failure_reason_category: 'missing_or_unrecognized_token',
       }),
     );
   });
@@ -540,20 +574,21 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
+        message: '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
+        event_name: 'jwt_auth_fallback_attempt',
         request_id: 'req-expired-fail',
         method: 'POST',
         path: '/api/ask',
         fallback_attempted: true,
-        reason: 'jwt expired',
-        error_name: 'TokenExpiredError',
-        status: 401,
+        reason_category: 'expired_jwt',
+        strategy_status: 401,
       }),
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] Authentication failed after all strategies'),
       expect.objectContaining({
+        message: '[requireJwtAuth] Authentication failed after all strategies',
+        event_name: 'jwt_auth_rejected',
         request_id: 'req-expired-fail',
         method: 'POST',
         path: '/api/ask',
@@ -564,24 +599,23 @@ describe('requireJwtAuth tenant context chaining', () => {
         fallback_strategy: 'jwt',
         fallback_attempted: true,
         fallback_succeeded: false,
-        // The real openidJwt failure is surfaced alongside the fallback's reason so a
-        // reused-token failure is not misattributed to the `jwt` fallback's error (#14311).
-        primary_failure_reason: 'jwt expired',
-        primary_failure_error_name: 'TokenExpiredError',
-        reason: 'invalid signature',
-        error_name: 'JsonWebTokenError',
-        status: 401,
+        primary_failure_reason_category: 'expired_jwt',
+        reason_category: 'malformed_jwt',
+        recovery_classification: 'terminal_rejection',
+        response_status: 401,
       }),
     );
-    expect(logger.warn.mock.calls[0][0]).toContain('"reason":"invalid signature"');
-    expect(logger.warn.mock.calls[0][0]).toContain('"primary_failure_reason":"jwt expired"');
-    expect(logger.warn.mock.calls[0][0]).toContain('"path":"/api/ask"');
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('invalid signature');
   });
 
-  it('does not fall back to OpenID JWT for bearer-only reuse requests', () => {
+  it('attributes malformed bearer rejections as structured 401s without an OpenID fallback', () => {
     isEnabled.mockReturnValue(true);
     mockRegisteredStrategies.add('openidJwt');
     const req = mockReq(undefined, {
+      id: 'malformed-bearer-401',
+      method: 'GET',
+      originalUrl: '/api/banner?access_token=not-logged',
+      headers: { authorization: 'Bearer malformed-token' },
       _mockStrategies: {
         jwt: { user: false, info: { message: 'invalid signature' }, status: 401 },
         openidJwt: { user: { tenantId: 'tenant-openid', role: 'user' } },
@@ -601,6 +635,20 @@ describe('requireJwtAuth tenant context chaining', () => {
       { session: false },
       expect.any(Function),
     );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'jwt_auth_rejected',
+        request_id: 'malformed-bearer-401',
+        method: 'GET',
+        path: '/api/banner',
+        token_source: 'bearer',
+        reason_category: 'malformed_jwt',
+        recovery_classification: 'terminal_rejection',
+        response_status: 401,
+      }),
+    );
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('malformed-token');
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('invalid signature');
   });
 
   it('uses OpenID JWT before LibreChat JWT when the OpenID cookie is present', async () => {
@@ -658,25 +706,24 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).toHaveBeenCalled();
     expect(req.authStrategy).toBe('jwt');
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
+        message: '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
         request_id: 'req-mismatch-success',
         primary_strategy: 'openidJwt',
         fallback_strategy: 'jwt',
         fallback_attempted: true,
-        reason: 'openid user-id mismatch',
-        status: 401,
+        reason_category: 'principal_mismatch',
+        strategy_status: 401,
       }),
     );
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure'),
       expect.objectContaining({
+        message: '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure',
         request_id: 'req-mismatch-success',
         auth_strategy: 'jwt',
         fallback_attempted: true,
         fallback_succeeded: true,
-        primary_failure_reason: 'openid user-id mismatch',
-        reason: 'openid user-id mismatch',
+        primary_failure_reason_category: 'principal_mismatch',
       }),
     );
     expect(logger.warn).not.toHaveBeenCalled();
@@ -705,24 +752,25 @@ describe('requireJwtAuth tenant context chaining', () => {
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(401);
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] OpenID JWT auth failed; trying fallback'),
       expect.objectContaining({
+        message: '[requireJwtAuth] OpenID JWT auth failed; trying fallback',
         request_id: 'req-mismatch-fail',
         fallback_attempted: true,
-        reason: 'openid user-id mismatch',
-        status: 401,
+        reason_category: 'principal_mismatch',
+        strategy_status: 401,
       }),
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[requireJwtAuth] Authentication failed after all strategies'),
       expect.objectContaining({
+        message: '[requireJwtAuth] Authentication failed after all strategies',
         request_id: 'req-mismatch-fail',
         attempted_strategies: ['openidJwt', 'jwt'],
         final_strategy: 'jwt',
         fallback_attempted: true,
         fallback_succeeded: false,
-        reason: 'Unauthorized',
-        status: 401,
+        primary_failure_reason_category: 'principal_mismatch',
+        reason_category: 'missing_or_unrecognized_token',
+        response_status: 401,
       }),
     );
   });

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -5,10 +5,8 @@ const { logger } = require('@librechat/data-schemas');
 const {
   isEnabled,
   tenantContextMiddleware,
-  getAuthFailureReason,
-  getAuthFailureErrorName,
+  getAuthFailureReasonCategory,
   buildSafeAuthLogContext,
-  formatAuthLogMessage,
   maybeRefreshCloudFrontAuthCookiesMiddleware,
   recordRumProxyRequest,
 } = require('@librechat/api');
@@ -36,6 +34,12 @@ const getAuthenticatedUserId = (user) => user?.id?.toString?.() ?? user?._id?.to
 const refreshCloudFrontCookies =
   maybeRefreshCloudFrontAuthCookiesMiddleware ?? ((_req, _res, next) => next());
 
+const getAuthTokenSource = (req) => {
+  const authorization = req.headers.authorization;
+  const value = Array.isArray(authorization) ? authorization[0] : authorization;
+  return typeof value === 'string' && /^Bearer\s+/i.test(value) ? 'bearer' : 'none';
+};
+
 const getAuthStrategies = (req) => {
   const cookieHeader = req.headers.cookie;
   const parsedCookies = cookieHeader ? cookies.parse(cookieHeader) : {};
@@ -48,6 +52,7 @@ const getAuthStrategies = (req) => {
 
   return {
     tokenProvider,
+    tokenSource: getAuthTokenSource(req),
     openidReuseEnabled,
     openidJwtAvailable,
     openIdReuseUserId,
@@ -84,57 +89,61 @@ const isOpenIdReuseUser = (strategy, user, openIdReuseUserId) =>
  * for downstream Mongoose tenant isolation and structured logging.
  */
 const requireJwtAuth = (req, res, next) => {
-  const { tokenProvider, openidReuseEnabled, openidJwtAvailable, openIdReuseUserId, strategies } =
-    getAuthStrategies(req);
+  const {
+    tokenProvider,
+    tokenSource,
+    openidReuseEnabled,
+    openidJwtAvailable,
+    openIdReuseUserId,
+    strategies,
+  } = getAuthStrategies(req);
   const authLogState = {
     tokenProvider,
+    tokenSource,
     openidReuseEnabled,
     openidJwtAvailable,
     hasOpenIdReuseUserId: openIdReuseUserId != null,
   };
-  let primaryFailureReason;
-  let primaryFailureErrorName;
+  let primaryFailureReasonCategory;
   let fallbackAttempted = false;
 
-  const logOpenIdFallbackAttempt = ({ fallbackStrategy, reason, errorName, status }) => {
-    primaryFailureReason = reason;
-    primaryFailureErrorName = errorName;
+  const logOpenIdFallbackAttempt = ({ fallbackStrategy, reasonCategory, status }) => {
+    primaryFailureReasonCategory = reasonCategory;
     fallbackAttempted = true;
     const message = '[requireJwtAuth] OpenID JWT auth failed; trying fallback';
     const context = buildSafeAuthLogContext(req, authLogState, {
+      event_name: 'jwt_auth_fallback_attempt',
       primary_strategy: 'openidJwt',
       fallback_strategy: fallbackStrategy,
       fallback_attempted: true,
-      reason,
-      error_name: errorName,
-      status,
+      reason_category: reasonCategory,
+      recovery_classification: 'fallback_attempted',
+      strategy_status: status,
     });
-    logger.debug(formatAuthLogMessage(message, context), context);
+    logger.debug({ message, ...context });
   };
 
   const logAuthenticationFailure = ({ strategy, info, status, err }) => {
     const message = '[requireJwtAuth] Authentication failed after all strategies';
+    const reasonCategory = getAuthFailureReasonCategory(err, info);
     const context = buildSafeAuthLogContext(req, authLogState, {
+      event_name: 'jwt_auth_rejected',
       primary_strategy: strategies[0],
       fallback_strategy: strategies[1],
       fallback_attempted: fallbackAttempted,
       fallback_succeeded: false,
       attempted_strategies: strategies,
       final_strategy: strategy,
-      // Surface the primary (openidJwt) failure alongside the final strategy's reason so a
-      // reused-token failure is not misattributed to the HS256 `jwt` fallback's "invalid
-      // algorithm" error, which is the fallback rejecting an RS256 provider token, not the
-      // real reason openidJwt did not authenticate.
       ...(fallbackAttempted && {
-        primary_failure_reason: primaryFailureReason,
-        primary_failure_error_name: primaryFailureErrorName,
+        primary_failure_reason_category: primaryFailureReasonCategory,
       }),
-      reason: getAuthFailureReason(err, info),
-      error_name: getAuthFailureErrorName(err, info),
-      status: status || 401,
+      reason_category: reasonCategory,
+      recovery_classification: 'terminal_rejection',
+      response_status: status || 401,
     });
-    const log = fallbackAttempted ? logger.warn : logger.debug;
-    log.call(logger, formatAuthLogMessage(message, context), context);
+    const log =
+      fallbackAttempted || reasonCategory === 'malformed_jwt' ? logger.warn : logger.debug;
+    log.call(logger, { message, ...context });
   };
 
   const logFallbackSuccess = (strategy) => {
@@ -143,16 +152,16 @@ const requireJwtAuth = (req, res, next) => {
     }
     const message = '[requireJwtAuth] JWT fallback succeeded after OpenID JWT failure';
     const context = buildSafeAuthLogContext(req, authLogState, {
+      event_name: 'jwt_auth_recovered',
       auth_strategy: 'jwt',
       primary_strategy: 'openidJwt',
       fallback_strategy: 'jwt',
       fallback_attempted: true,
       fallback_succeeded: true,
-      primary_failure_reason: primaryFailureReason,
-      reason: primaryFailureReason,
-      error_name: primaryFailureErrorName,
+      primary_failure_reason_category: primaryFailureReasonCategory,
+      recovery_classification: 'fallback_succeeded',
     });
-    logger.debug(formatAuthLogMessage(message, context), context);
+    logger.debug({ message, ...context });
   };
 
   const authenticateWithStrategy = (index) => {
@@ -165,8 +174,7 @@ const requireJwtAuth = (req, res, next) => {
         if (index + 1 < strategies.length) {
           logOpenIdFallbackAttempt({
             fallbackStrategy: strategies[index + 1],
-            reason: getAuthFailureReason(err, info),
-            errorName: getAuthFailureErrorName(err, info),
+            reasonCategory: getAuthFailureReasonCategory(err, info),
             status: status || 401,
           });
           return authenticateWithStrategy(index + 1);
@@ -180,7 +188,7 @@ const requireJwtAuth = (req, res, next) => {
         if (index + 1 < strategies.length) {
           logOpenIdFallbackAttempt({
             fallbackStrategy: strategies[index + 1],
-            reason: 'openid user-id mismatch',
+            reasonCategory: 'principal_mismatch',
             status: 401,
           });
           return authenticateWithStrategy(index + 1);

--- a/packages/api/src/middleware/__tests__/tenant.spec.ts
+++ b/packages/api/src/middleware/__tests__/tenant.spec.ts
@@ -3,6 +3,8 @@ import {
   getTenantId,
   getUserId,
   getRequestId,
+  getRequestMethod,
+  getRequestPath,
   SYSTEM_TENANT_ID,
   logger,
 } from '@librechat/data-schemas';
@@ -12,6 +14,7 @@ import type { ServerRequest } from '~/types/http';
 // excluded from the public barrel export (index.ts).
 import {
   tenantContextMiddleware,
+  requestContextMiddleware,
   restoreTenantContextFromReq,
   resolveRequestTenantId,
   _resetTenantMiddlewareStrictCache,
@@ -75,6 +78,82 @@ function runMiddlewareContext(
     tenantContextMiddleware(req, res, next);
   });
 }
+
+function runRequestContext(req: ServerRequest): Promise<{
+  tenantId?: string;
+  userId?: string;
+  requestId?: string;
+  method?: string;
+  path?: string;
+}> {
+  return new Promise((resolve) => {
+    requestContextMiddleware(req, mockRes(), async () => {
+      await new Promise((nextTick) => setImmediate(nextTick));
+      resolve({
+        tenantId: getTenantId(),
+        userId: getUserId(),
+        requestId: getRequestId(),
+        method: getRequestMethod(),
+        path: getRequestPath(),
+      });
+    });
+  });
+}
+
+describe('requestContextMiddleware', () => {
+  it('generates a safe request ID when no trusted correlation ID is available', async () => {
+    const req = {
+      headers: {
+        'x-request-id': `${'a'.repeat(24)}.${'b'.repeat(24)}.${'c'.repeat(24)}`,
+      },
+      method: 'GET',
+      originalUrl: '/api/banner',
+    } as unknown as ServerRequest & { requestId?: string };
+
+    const context = await runRequestContext(req);
+
+    expect(context.requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(req.requestId).toBe(context.requestId);
+  });
+
+  it('keeps malformed-auth and parallel page requests independently attributable', async () => {
+    const malformedAuthRequest = {
+      headers: {
+        authorization: 'Bearer malformed-token',
+        'x-request-id': 'auth-401-request',
+      },
+      method: 'GET',
+      originalUrl: '/api/auth/me?access_token=not-logged',
+    } as unknown as ServerRequest;
+    const pageRequest = {
+      headers: { 'x-request-id': 'page-request' },
+      method: 'GET',
+      originalUrl: '/api/banner?access_token=not-logged',
+    } as unknown as ServerRequest;
+
+    const [authContext, pageContext] = await Promise.all([
+      runRequestContext(malformedAuthRequest),
+      runRequestContext(pageRequest),
+    ]);
+
+    expect(authContext).toEqual({
+      tenantId: undefined,
+      userId: undefined,
+      requestId: 'auth-401-request',
+      method: 'GET',
+      path: '/api/auth',
+    });
+    expect(pageContext).toEqual({
+      tenantId: undefined,
+      userId: undefined,
+      requestId: 'page-request',
+      method: 'GET',
+      path: '/api/banner',
+    });
+  });
+});
 
 describe('tenantContextMiddleware', () => {
   afterEach(() => {

--- a/packages/api/src/middleware/__tests__/tenant.spec.ts
+++ b/packages/api/src/middleware/__tests__/tenant.spec.ts
@@ -118,6 +118,26 @@ describe('requestContextMiddleware', () => {
     expect(req.requestId).toBe(context.requestId);
   });
 
+  it('does not trust tenant or user identity before authentication', async () => {
+    const req = {
+      headers: { 'x-request-id': 'pre-auth-request' },
+      method: 'GET',
+      originalUrl: '/api/auth/me',
+      tenantId: 'untrusted-tenant',
+      user: { id: 'untrusted-user', tenantId: 'untrusted-tenant' },
+    } as unknown as ServerRequest;
+
+    const context = await runRequestContext(req);
+
+    expect(context).toEqual({
+      tenantId: undefined,
+      userId: undefined,
+      requestId: 'pre-auth-request',
+      method: 'GET',
+      path: '/api/auth',
+    });
+  });
+
   it('keeps malformed-auth and parallel page requests independently attributable', async () => {
     const malformedAuthRequest = {
       headers: {

--- a/packages/api/src/middleware/auth.spec.ts
+++ b/packages/api/src/middleware/auth.spec.ts
@@ -1,8 +1,10 @@
 import {
   buildSafeAuthLogContext,
-  formatAuthLogMessage,
+  buildSafeRequestLogContext,
+  buildTenantIsolationErrorLogContext,
   getAuthFailureErrorName,
   getAuthFailureReason,
+  getAuthFailureReasonCategory,
 } from './auth';
 import type { AuthLogRequest, AuthLogState } from './auth';
 
@@ -19,6 +21,7 @@ function createRequest(overrides: Partial<AuthLogRequest> = {}): AuthLogRequest 
 function createAuthState(overrides: Partial<AuthLogState> = {}): AuthLogState {
   return {
     tokenProvider: 'openid',
+    tokenSource: 'bearer',
     openidReuseEnabled: true,
     openidJwtAvailable: true,
     hasOpenIdReuseUserId: true,
@@ -36,12 +39,13 @@ describe('auth middleware logging helpers', () => {
       }),
       createAuthState(),
       {
+        event_name: 'jwt_auth_rejected',
         attempted_strategies: ['openidJwt', 'jwt'],
         fallback_attempted: true,
         fallback_succeeded: false,
-        reason: 'jwt expired',
-        error_name: 'TokenExpiredError',
-        status: 401,
+        reason_category: 'expired_jwt',
+        recovery_classification: 'terminal_rejection',
+        response_status: 401,
       },
     );
 
@@ -50,15 +54,17 @@ describe('auth middleware logging helpers', () => {
       method: 'GET',
       path: '/api/ask',
       token_provider: 'openid',
+      token_source: 'bearer',
       openid_reuse_enabled: true,
       openid_jwt_available: true,
       has_openid_reuse_user_id: true,
       attempted_strategies: ['openidJwt', 'jwt'],
       fallback_attempted: true,
       fallback_succeeded: false,
-      reason: 'jwt expired',
-      error_name: 'TokenExpiredError',
-      status: 401,
+      event_name: 'jwt_auth_rejected',
+      reason_category: 'expired_jwt',
+      recovery_classification: 'terminal_rejection',
+      response_status: 401,
     });
     expect(JSON.stringify(log)).not.toContain('secret-token');
   });
@@ -72,6 +78,7 @@ describe('auth middleware logging helpers', () => {
       }),
       createAuthState({
         tokenProvider: null,
+        tokenSource: null,
         openidReuseEnabled: false,
         openidJwtAvailable: false,
         hasOpenIdReuseUserId: false,
@@ -88,6 +95,21 @@ describe('auth middleware logging helpers', () => {
     });
   });
 
+  it('drops JWT-shaped and oversized request IDs supplied through headers', () => {
+    const jwtShapedRequestId = `${'a'.repeat(24)}.${'b'.repeat(24)}.${'c'.repeat(24)}`;
+    const log = buildSafeAuthLogContext(
+      createRequest({ headers: { 'x-request-id': jwtShapedRequestId } }),
+      createAuthState(),
+    );
+    const oversizedLog = buildSafeAuthLogContext(
+      createRequest({ headers: { 'x-request-id': 'a'.repeat(129) } }),
+      createAuthState(),
+    );
+
+    expect(log.request_id).toBeUndefined();
+    expect(oversizedLog.request_id).toBeUndefined();
+  });
+
   it('buckets unknown token providers to keep auth logs low-cardinality', () => {
     const log = buildSafeAuthLogContext(
       createRequest(),
@@ -97,6 +119,15 @@ describe('auth middleware logging helpers', () => {
     );
 
     expect(log.token_provider).toBe('other');
+  });
+
+  it('buckets unknown token sources to keep auth logs low-cardinality', () => {
+    const log = buildSafeAuthLogContext(
+      createRequest(),
+      createAuthState({ tokenSource: 'attacker-controlled-source' }),
+    );
+
+    expect(log.token_source).toBe('other');
   });
 
   it('prefers route buckets over concrete dynamic request paths', () => {
@@ -128,13 +159,13 @@ describe('auth middleware logging helpers', () => {
     expect(log.path).toBe('/api/share/link/:conversationId');
   });
 
-  it('drops unsupported extra values and keeps safe arrays primitive', () => {
+  it('drops unsupported and sensitive extra values while keeping allowed fields', () => {
     const log = buildSafeAuthLogContext(createRequest({ id: 'request-id' }), createAuthState(), {
       attempted_strategies: ['openidJwt', '', { strategy: 'jwt' }, 'jwt'],
       fallback_attempted: true,
       path: { unsafe: true },
       request_id: { unsafe: true },
-      status: Number.NaN,
+      response_status: Number.NaN,
       unsafe_object: { token: 'secret-token' },
       reason: '  jwt expired  ',
     });
@@ -144,29 +175,49 @@ describe('auth middleware logging helpers', () => {
       method: 'GET',
       path: '/api/messages',
       token_provider: 'openid',
+      token_source: 'bearer',
       openid_reuse_enabled: true,
       openid_jwt_available: true,
       has_openid_reuse_user_id: true,
       attempted_strategies: ['openidJwt', 'jwt'],
       fallback_attempted: true,
-      reason: 'jwt expired',
     });
     expect(JSON.stringify(log)).not.toContain('secret-token');
   });
 
-  it('formats auth log messages with serialized safe context for stdout collectors', () => {
-    const log = buildSafeAuthLogContext(createRequest({ id: 'request-id' }), createAuthState(), {
-      fallback_attempted: true,
-      reason: 'jwt expired',
-      error_name: 'TokenExpiredError',
-      status: 401,
-    });
-
-    expect(
-      formatAuthLogMessage('[requireJwtAuth] OpenID JWT auth failed; trying fallback', log),
-    ).toBe(
-      '[requireJwtAuth] OpenID JWT auth failed; trying fallback {"fallback_attempted":true,"reason":"jwt expired","error_name":"TokenExpiredError","status":401,"request_id":"request-id","method":"GET","path":"/api/messages","token_provider":"openid","openid_reuse_enabled":true,"openid_jwt_available":true,"has_openid_reuse_user_id":true}',
+  it('builds request context without raw query strings', () => {
+    const context = buildSafeRequestLogContext(
+      createRequest({
+        id: 'request-id',
+        path: undefined,
+        originalUrl: '/api/convos/conversation-123?access_token=secret-token',
+      }),
     );
+
+    expect(context).toEqual({ request_id: 'request-id', method: 'GET', path: '/api/convos' });
+    expect(JSON.stringify(context)).not.toContain('secret-token');
+  });
+
+  it('builds a safe, joinable context for tenant-isolation errors', () => {
+    const context = buildTenantIsolationErrorLogContext(
+      createRequest({
+        id: 'request-id',
+        path: undefined,
+        originalUrl: '/api/banner?access_token=secret-token',
+      }),
+      new Error('[TenantIsolation] Query attempted without tenant context in strict mode'),
+    );
+
+    expect(context).toEqual({
+      event_name: 'tenant_isolation_error',
+      error_category: 'tenant_isolation',
+      error_signature: 'missing_query_context',
+      response_status: 500,
+      request_id: 'request-id',
+      method: 'GET',
+      path: '/api/banner',
+    });
+    expect(JSON.stringify(context)).not.toContain('secret-token');
   });
 
   it('prefers Passport info fields for auth failure reason and error name', () => {
@@ -175,6 +226,7 @@ describe('auth middleware logging helpers', () => {
 
     expect(getAuthFailureReason(err, info)).toBe('jwt expired');
     expect(getAuthFailureErrorName(err, info)).toBe('TokenExpiredError');
+    expect(getAuthFailureReasonCategory(err, info)).toBe('expired_jwt');
   });
 
   it('falls back to Error fields when Passport info is absent', () => {
@@ -182,6 +234,7 @@ describe('auth middleware logging helpers', () => {
 
     expect(getAuthFailureReason(err, undefined)).toBe('invalid signature');
     expect(getAuthFailureErrorName(err, undefined)).toBe('JsonWebTokenError');
+    expect(getAuthFailureReasonCategory(err, undefined)).toBe('malformed_jwt');
   });
 
   it('does not throw when Passport failure objects expose throwing getters', () => {
@@ -202,5 +255,6 @@ describe('auth middleware logging helpers', () => {
 
     expect(getAuthFailureReason(err, info)).toBe('invalid signature');
     expect(getAuthFailureErrorName(err, info)).toBe('JsonWebTokenError');
+    expect(getAuthFailureReasonCategory(err, info)).toBe('malformed_jwt');
   });
 });

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -7,6 +7,24 @@ type AuthLogValue = string | number | boolean | readonly string[];
 type AuthLogHeaderValue = string | string[] | undefined;
 type AuthRoutePath = string | RegExp | readonly (string | RegExp)[];
 
+const JWT_SHAPED_VALUE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const MAX_REQUEST_ID_LENGTH = 128;
+const AUTH_LOG_EXTRA_KEYS = new Set([
+  'event_name',
+  'auth_strategy',
+  'primary_strategy',
+  'fallback_strategy',
+  'fallback_attempted',
+  'fallback_succeeded',
+  'attempted_strategies',
+  'final_strategy',
+  'primary_failure_reason_category',
+  'reason_category',
+  'recovery_classification',
+  'response_status',
+  'strategy_status',
+]);
+
 export type AuthLogRequest = {
   headers?: Record<string, AuthLogHeaderValue>;
   method?: string;
@@ -23,12 +41,26 @@ export type AuthLogRequest = {
 
 export type AuthLogState = {
   tokenProvider?: string | null;
+  tokenSource?: string | null;
   openidReuseEnabled: boolean;
   openidJwtAvailable: boolean;
   hasOpenIdReuseUserId: boolean;
 };
 
-export type AuthLogContext = Record<string, AuthLogValue>;
+export type RequestLogContext = {
+  request_id?: string;
+  method?: string;
+  path?: string;
+};
+
+export type AuthLogContext = RequestLogContext & Record<string, AuthLogValue>;
+
+export type AuthFailureReasonCategory =
+  | 'expired_jwt'
+  | 'malformed_jwt'
+  | 'principal_mismatch'
+  | 'missing_or_unrecognized_token'
+  | 'authentication_error';
 
 function normalizeAuthLogValue(value: unknown): string | undefined {
   if (value == null) {
@@ -85,12 +117,22 @@ function normalizeAuthLogContextValue(value: unknown): AuthLogValue | undefined 
 }
 
 function getRequestId(req: AuthLogRequest): string | undefined {
-  return (
+  const requestId =
     normalizeAuthLogValue(req.requestId) ??
     normalizeAuthLogValue(req.id) ??
     normalizeAuthLogValue(req.headers?.['x-request-id']) ??
-    normalizeAuthLogValue(req.headers?.['x-correlation-id'])
-  );
+    normalizeAuthLogValue(req.headers?.['x-correlation-id']);
+
+  if (
+    !requestId ||
+    requestId.length > MAX_REQUEST_ID_LENGTH ||
+    JWT_SHAPED_VALUE.test(requestId) ||
+    !/^[A-Za-z0-9_.:-]+$/.test(requestId)
+  ) {
+    return undefined;
+  }
+
+  return requestId;
 }
 
 function normalizeRoutePath(path: AuthRoutePath | undefined): string | undefined {
@@ -138,7 +180,7 @@ function bucketConcretePath(path: string | undefined): string | undefined {
 }
 
 function getRequestPath(req: AuthLogRequest): string | undefined {
-  const baseUrl = normalizeAuthLogValue(req.baseUrl);
+  const baseUrl = bucketConcretePath(normalizeAuthLogValue(req.baseUrl));
   const routePath = normalizeRoutePath(req.route?.path);
   if (routePath) {
     return joinRoutePath(baseUrl, routePath);
@@ -149,6 +191,18 @@ function getRequestPath(req: AuthLogRequest): string | undefined {
 
   const path = normalizeAuthLogValue(req.path) ?? normalizeAuthLogValue(req.originalUrl ?? req.url);
   return bucketConcretePath(path);
+}
+
+export function buildSafeRequestLogContext(req: AuthLogRequest): RequestLogContext {
+  const requestId = getRequestId(req);
+  const method = normalizeAuthLogValue(req.method);
+  const path = getRequestPath(req);
+
+  return {
+    ...(requestId && { request_id: requestId }),
+    ...(method && { method }),
+    ...(path && { path }),
+  };
 }
 
 function getAuthFailureField(source: unknown, field: keyof AuthFailureLike): unknown {
@@ -179,6 +233,10 @@ function compactAuthLogContext(log: Record<string, unknown>): AuthLogContext {
   return compacted as AuthLogContext;
 }
 
+function selectAuthLogExtra(extra: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(extra).filter(([key]) => AUTH_LOG_EXTRA_KEYS.has(key)));
+}
+
 export function getAuthFailureReason(
   err: unknown,
   info: unknown,
@@ -198,6 +256,39 @@ export function getAuthFailureErrorName(err: unknown, info: unknown): string | u
   );
 }
 
+export function getAuthFailureReasonCategory(
+  err: unknown,
+  info: unknown,
+): AuthFailureReasonCategory {
+  const reason = getAuthFailureReason(err, info).toLowerCase();
+  const errorName = getAuthFailureErrorName(err, info)?.toLowerCase();
+
+  if (reason.includes('expired') || errorName === 'tokenexpirederror') {
+    return 'expired_jwt';
+  }
+
+  if (reason.includes('user-id mismatch') || reason.includes('principal mismatch')) {
+    return 'principal_mismatch';
+  }
+
+  if (
+    errorName === 'jsonwebtokenerror' ||
+    reason.includes('jwt malformed') ||
+    reason.includes('invalid signature') ||
+    reason.includes('invalid algorithm') ||
+    reason.includes('invalid token') ||
+    reason.includes('invalid key')
+  ) {
+    return 'malformed_jwt';
+  }
+
+  if (reason === 'unauthorized' || reason.includes('no auth token')) {
+    return 'missing_or_unrecognized_token';
+  }
+
+  return 'authentication_error';
+}
+
 function getSafeTokenProvider(tokenProvider: unknown): string | undefined {
   const normalized = normalizeAuthLogValue(tokenProvider);
   if (!normalized) {
@@ -206,23 +297,80 @@ function getSafeTokenProvider(tokenProvider: unknown): string | undefined {
   return normalized === 'openid' || normalized === 'librechat' ? normalized : 'other';
 }
 
+function getSafeTokenSource(tokenSource: unknown): string | undefined {
+  const normalized = normalizeAuthLogValue(tokenSource);
+  if (!normalized) {
+    return undefined;
+  }
+
+  return ['bearer', 'none'].includes(normalized) ? normalized : 'other';
+}
+
 export function buildSafeAuthLogContext(
   req: AuthLogRequest,
   authState: AuthLogState,
   extra: Record<string, unknown> = {},
 ): AuthLogContext {
-  return compactAuthLogContext({
-    ...extra,
-    request_id: getRequestId(req),
-    method: normalizeAuthLogValue(req.method),
-    path: getRequestPath(req),
-    token_provider: getSafeTokenProvider(authState.tokenProvider),
-    openid_reuse_enabled: authState.openidReuseEnabled,
-    openid_jwt_available: authState.openidJwtAvailable,
-    has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
-  });
+  return {
+    ...compactAuthLogContext({
+      ...selectAuthLogExtra(extra),
+      token_provider: getSafeTokenProvider(authState.tokenProvider),
+      token_source: getSafeTokenSource(authState.tokenSource),
+      openid_reuse_enabled: authState.openidReuseEnabled,
+      openid_jwt_available: authState.openidJwtAvailable,
+      has_openid_reuse_user_id: authState.hasOpenIdReuseUserId,
+    }),
+    ...buildSafeRequestLogContext(req),
+  };
 }
 
+/**
+ * @deprecated Pass `{ message, ...context }` to the logger so structured fields
+ * survive JSON message truncation. Retained for package API compatibility only.
+ */
 export function formatAuthLogMessage(message: string, context: AuthLogContext): string {
   return `${message} ${JSON.stringify(context)}`;
+}
+
+function getTenantIsolationSignature(message: string): string {
+  if (message.includes('Query attempted without tenant context')) {
+    return 'missing_query_context';
+  }
+  if (message.includes('Aggregate attempted without tenant context')) {
+    return 'missing_aggregate_context';
+  }
+  if (message.includes('Save attempted without tenant context')) {
+    return 'missing_save_context';
+  }
+  if (message.includes('insertMany attempted without tenant context')) {
+    return 'missing_insert_many_context';
+  }
+  if (message.includes('Cross-tenant')) {
+    return 'cross_tenant_mutation';
+  }
+  if (message.includes('does not match current tenant context')) {
+    return 'tenant_mismatch';
+  }
+  if (message.includes('Modifying tenantId via replacement')) {
+    return 'replacement_tenant_mutation';
+  }
+  return 'tenant_isolation_error';
+}
+
+export function buildTenantIsolationErrorLogContext(
+  req: AuthLogRequest,
+  err: unknown,
+): AuthLogContext | undefined {
+  const message = normalizeAuthLogValue(getAuthFailureField(err, 'message'));
+  if (!message?.startsWith('[TenantIsolation]')) {
+    return undefined;
+  }
+
+  return {
+    event_name: 'tenant_isolation_error',
+    error_category: 'tenant_isolation',
+    error_signature: getTenantIsolationSignature(message),
+    response_status: 500,
+    ...buildSafeRequestLogContext(req),
+  };
 }

--- a/packages/api/src/middleware/error.spec.ts
+++ b/packages/api/src/middleware/error.spec.ts
@@ -231,6 +231,32 @@ describe('ErrorController', () => {
       expect(mockRes.send).toHaveBeenCalledWith('An unknown error occurred.');
       expect(logger.error).toHaveBeenCalledWith('ErrorController => error', genericError);
     });
+
+    it('emits a structured, joinable event for tenant-isolation errors', () => {
+      mockReq = {
+        id: 'request-123',
+        method: 'GET',
+        originalUrl: '/api/banner?access_token=secret-token',
+      } as Request;
+      const tenantError = new Error(
+        '[TenantIsolation] Query attempted without tenant context in strict mode',
+      );
+
+      ErrorController(tenantError, mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(logger.error).toHaveBeenCalledWith({
+        message: 'Tenant-isolation request failed',
+        event_name: 'tenant_isolation_error',
+        error_category: 'tenant_isolation',
+        error_signature: 'missing_query_context',
+        response_status: 500,
+        request_id: 'request-123',
+        method: 'GET',
+        path: '/api/banner',
+      });
+      expect(JSON.stringify((logger.error as jest.Mock).mock.calls)).not.toContain('secret-token');
+    });
   });
 
   describe('Catch block handling', () => {

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -2,6 +2,7 @@ import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { NextFunction, Request, Response } from 'express';
 import type { MongoServerError, ValidationError, CustomError } from '~/types';
+import { buildTenantIsolationErrorLogContext } from './auth';
 
 const handleDuplicateKeyError = (err: MongoServerError, res: Response) => {
   logger.warn('Duplicate key error: ' + (err.errmsg || err.message));
@@ -74,7 +75,15 @@ export const ErrorController = (
       return res.status(error.statusCode).send(error.body);
     }
 
-    logger.error('ErrorController => error', err);
+    const tenantIsolationContext = buildTenantIsolationErrorLogContext(req, err);
+    if (tenantIsolationContext) {
+      logger.error({
+        message: 'Tenant-isolation request failed',
+        ...tenantIsolationContext,
+      });
+    } else {
+      logger.error('ErrorController => error', err);
+    }
     return res.status(500).send('An unknown error occurred.');
   } catch (processingError) {
     logger.error('ErrorController => processing error', processingError);

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -8,6 +8,7 @@ export * from './json';
 export * from './capabilities';
 export * from './auth';
 export {
+  requestContextMiddleware,
   tenantContextMiddleware,
   restoreTenantContextFromReq,
   resolveRequestTenantId,

--- a/packages/api/src/middleware/preAuthTenant.ts
+++ b/packages/api/src/middleware/preAuthTenant.ts
@@ -35,7 +35,7 @@ const VALID_TENANT_ID = /^[-a-zA-Z0-9_.]+$/;
 
 export function preAuthTenantMiddleware(req: Request, res: Response, next: NextFunction): void {
   const raw = req.headers['x-tenant-id'];
-  const requestContext = buildTenantContext({ headers: req.headers });
+  const requestContext = buildTenantContext(req);
 
   if (!raw || typeof raw !== 'string') {
     runWithTenantContext(requestContext, next);
@@ -72,5 +72,5 @@ export function preAuthTenantMiddleware(req: Request, res: Response, next: NextF
     return;
   }
 
-  runWithTenantContext(buildTenantContext({ headers: req.headers }, tenantId), next);
+  runWithTenantContext(buildTenantContext(req, tenantId), next);
 }

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -88,7 +88,12 @@ export function requestContextMiddleware(
   next: NextFunction,
 ): void {
   const request = req as ServerRequest & { requestId?: string };
-  const context = buildTenantContext(request);
+  const requestLogContext = buildSafeRequestLogContext(request);
+  const context: TenantContext = {
+    requestId: requestLogContext.request_id,
+    requestMethod: requestLogContext.method,
+    requestPath: requestLogContext.path,
+  };
   if (!context.requestId) {
     context.requestId = randomUUID();
     request.requestId = context.requestId;

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from 'crypto';
 import { unlink } from 'fs/promises';
 import { isMainThread } from 'worker_threads';
 import { tenantStorage, logger, SYSTEM_TENANT_ID } from '@librechat/data-schemas';
 import type { TenantContext } from '@librechat/data-schemas';
 import type { Response, NextFunction } from 'express';
 import type { ServerRequest } from '~/types/http';
+import { buildSafeRequestLogContext } from './auth';
 
 type ContextUser = {
   tenantId?: string;
@@ -17,9 +19,16 @@ type ContextRequest = {
   user?: ContextUser;
   id?: string;
   requestId?: string;
+  method?: string;
+  path?: string;
+  originalUrl?: string;
+  url?: string;
+  baseUrl?: string;
+  route?: {
+    path?: string | RegExp | readonly (string | RegExp)[];
+  };
 };
 
-const REQUEST_ID_HEADERS = ['x-request-id', 'x-correlation-id'] as const;
 const SYSTEM_TENANT_REJECTION_MESSAGE = 'System tenant is not allowed for request-scoped routes';
 
 let _checkedThread = false;
@@ -40,41 +49,51 @@ function normalizeContextValue(value?: string): string | undefined {
   return trimmed || undefined;
 }
 
-function getHeaderValue(value: string | string[] | undefined): string | undefined {
-  return normalizeContextValue(Array.isArray(value) ? value[0] : value);
-}
-
-function getRequestId(req: ContextRequest): string | undefined {
-  const requestId = normalizeContextValue(req.requestId) ?? normalizeContextValue(req.id);
-  if (requestId) {
-    return requestId;
-  }
-  for (const header of REQUEST_ID_HEADERS) {
-    const value = getHeaderValue(req.headers[header]);
-    if (value) {
-      return value;
-    }
-  }
-  return undefined;
-}
-
 function getUserId(user: ContextUser): string | undefined {
   return normalizeContextValue(user?.id) ?? normalizeContextValue(user?._id?.toString());
 }
 
 function hasTenantContext(context: TenantContext): boolean {
-  return Boolean(context.tenantId || context.userId || context.requestId);
+  return Boolean(
+    context.tenantId ||
+      context.userId ||
+      context.requestId ||
+      context.requestMethod ||
+      context.requestPath,
+  );
 }
 
 export function buildTenantContext(
   req: ContextRequest,
   tenantId: string | undefined = req.tenantId ?? req.user?.tenantId,
 ): TenantContext {
+  const requestContext = buildSafeRequestLogContext(req);
+
   return {
     tenantId: normalizeContextValue(tenantId),
     userId: getUserId(req.user ?? null),
-    requestId: getRequestId(req),
+    requestId: requestContext.request_id,
+    requestMethod: requestContext.method,
+    requestPath: requestContext.path,
   };
+}
+
+/**
+ * Establishes safe, request-level correlation before authentication. It carries
+ * no tenant or user identity, so strict tenant isolation remains fail-closed.
+ */
+export function requestContextMiddleware(
+  req: ServerRequest,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const request = req as ServerRequest & { requestId?: string };
+  const context = buildTenantContext(request);
+  if (!context.requestId) {
+    context.requestId = randomUUID();
+    request.requestId = context.requestId;
+  }
+  runWithTenantContext(context, next);
 }
 
 export function runWithTenantContext(context: TenantContext, next: NextFunction): void {

--- a/packages/data-schemas/src/config/parsers.spec.ts
+++ b/packages/data-schemas/src/config/parsers.spec.ts
@@ -1,5 +1,5 @@
 import winston from 'winston';
-import { debugTraverse, redactFormat, redactMessage } from './parsers';
+import { debugTraverse, jsonTruncateFormat, redactFormat, redactMessage } from './parsers';
 
 const SPLAT_SYMBOL = Symbol.for('splat');
 const MESSAGE_SYMBOL = Symbol.for('message');
@@ -318,5 +318,40 @@ describe('debugTraverse request context', () => {
     expect(out).not.toContain('__SYSTEM__');
     expect(out).not.toMatch(/tenantId:/);
     expect(out).toContain('userId');
+  });
+});
+
+describe('jsonTruncateFormat structured events', () => {
+  it('preserves short auth correlation fields when the human-readable message is truncated', () => {
+    const format = jsonTruncateFormat();
+    const info = {
+      level: 'warn',
+      message: `JWT auth rejected: ${'x'.repeat(300)}`,
+      event_name: 'jwt_auth_rejected',
+      request_id: 'request-123',
+      method: 'GET',
+      path: '/api/messages',
+      token_source: 'bearer',
+      reason_category: 'malformed_jwt',
+      recovery_classification: 'terminal_rejection',
+      response_status: 401,
+    };
+
+    const output = format.transform(
+      info as unknown as import('winston').Logform.TransformableInfo,
+      format.options,
+    ) as Record<string, unknown>;
+
+    expect(output.message).toBe(`${info.message.slice(0, 255)}...`);
+    expect(output).toMatchObject({
+      event_name: 'jwt_auth_rejected',
+      request_id: 'request-123',
+      method: 'GET',
+      path: '/api/messages',
+      token_source: 'bearer',
+      reason_category: 'malformed_jwt',
+      recovery_classification: 'terminal_rejection',
+      response_status: 401,
+    });
   });
 });

--- a/packages/data-schemas/src/config/requestLogContext.spec.ts
+++ b/packages/data-schemas/src/config/requestLogContext.spec.ts
@@ -1,0 +1,55 @@
+import { tenantStorage } from './tenantContext';
+import { attachRequestContext } from './requestLogContext';
+
+describe('attachRequestContext', () => {
+  const context = {
+    tenantId: 'tenant-123',
+    userId: 'user-123',
+    requestId: 'request-123',
+    requestMethod: 'POST',
+    requestPath: '/api/example',
+  };
+
+  it.each(['jwt_auth_rejected', 'jwt_auth_recovered', 'tenant_isolation_error'])(
+    'omits identity fields from %s while preserving request correlation',
+    (eventName) =>
+      tenantStorage.run(context, () => {
+        const info = {
+          level: 'warn',
+          message: 'event',
+          event_name: eventName,
+          tenantId: 'explicit-tenant',
+          tenant_id: 'explicit-tenant',
+          userId: 'explicit-user',
+          user_id: 'explicit-user',
+        };
+
+        const result = attachRequestContext(info);
+
+        expect(result).not.toHaveProperty('tenantId');
+        expect(result).not.toHaveProperty('tenant_id');
+        expect(result).not.toHaveProperty('userId');
+        expect(result).not.toHaveProperty('user_id');
+        expect(result).toMatchObject({
+          requestId: 'request-123',
+          request_id: 'request-123',
+          method: 'POST',
+          path: '/api/example',
+        });
+      }),
+  );
+
+  it('retains identity context on ordinary application logs', () =>
+    tenantStorage.run(context, () => {
+      const result = attachRequestContext({ level: 'info', message: 'event' });
+
+      expect(result).toMatchObject({
+        tenantId: 'tenant-123',
+        userId: 'user-123',
+        requestId: 'request-123',
+        request_id: 'request-123',
+        method: 'POST',
+        path: '/api/example',
+      });
+    }));
+});

--- a/packages/data-schemas/src/config/requestLogContext.ts
+++ b/packages/data-schemas/src/config/requestLogContext.ts
@@ -1,0 +1,62 @@
+import type winston from 'winston';
+import {
+  getTenantId,
+  getUserId,
+  getRequestId,
+  getRequestMethod,
+  getRequestPath,
+  SYSTEM_TENANT_ID,
+} from './tenantContext';
+
+export const LOG_CONTEXT_KEYS = [
+  'tenantId',
+  'userId',
+  'requestId',
+  'request_id',
+  'method',
+  'path',
+] as const;
+
+const IDENTITY_CONTEXT_KEYS = ['tenantId', 'tenant_id', 'userId', 'user_id'] as const;
+
+function isIdentityFreeEvent(eventName: unknown): boolean {
+  return (
+    typeof eventName === 'string' &&
+    (eventName.startsWith('jwt_auth_') || eventName === 'tenant_isolation_error')
+  );
+}
+
+function getLogTenantId(): string | undefined {
+  const tenantId = getTenantId();
+  return tenantId === SYSTEM_TENANT_ID ? undefined : tenantId;
+}
+
+/**
+ * Adds request-scoped context to a log record. Authentication and tenant-isolation
+ * events intentionally omit identity fields while retaining request correlation.
+ */
+export function attachRequestContext(
+  info: winston.Logform.TransformableInfo,
+): winston.Logform.TransformableInfo {
+  const omitIdentity = isIdentityFreeEvent(info.event_name);
+  if (omitIdentity) {
+    IDENTITY_CONTEXT_KEYS.forEach((key) => delete info[key]);
+  } else if (info.tenantId === SYSTEM_TENANT_ID) {
+    delete info.tenantId;
+  }
+
+  const context = {
+    tenantId: omitIdentity ? undefined : getLogTenantId(),
+    userId: omitIdentity ? undefined : getUserId(),
+    requestId: getRequestId(),
+    request_id: getRequestId(),
+    method: getRequestMethod(),
+    path: getRequestPath(),
+  };
+  LOG_CONTEXT_KEYS.forEach((key) => {
+    if (context[key] && info[key] == null) {
+      info[key] = context[key];
+    }
+  });
+  return info;
+}

--- a/packages/data-schemas/src/config/tenantContext.ts
+++ b/packages/data-schemas/src/config/tenantContext.ts
@@ -4,6 +4,8 @@ export interface TenantContext {
   tenantId?: string;
   userId?: string;
   requestId?: string;
+  requestMethod?: string;
+  requestPath?: string;
 }
 
 /** Sentinel value for deliberate cross-tenant system operations */
@@ -32,13 +34,26 @@ export function getRequestId(): string | undefined {
   return tenantStorage.getStore()?.requestId;
 }
 
+/** Returns the safe request method from async context, or undefined if none is set */
+export function getRequestMethod(): string | undefined {
+  return tenantStorage.getStore()?.requestMethod;
+}
+
+/** Returns the safe request path from async context, or undefined if none is set */
+export function getRequestPath(): string | undefined {
+  return tenantStorage.getStore()?.requestPath;
+}
+
 /**
  * Runs a function in an explicit cross-tenant system context (bypasses tenant filtering).
  * The callback MUST be async — sync callbacks returning Mongoose thenables will lose context.
  */
 export function runAsSystem<T>(fn: () => Promise<T>): Promise<T> {
-  const { requestId, userId } = tenantStorage.getStore() ?? {};
-  return tenantStorage.run({ tenantId: SYSTEM_TENANT_ID, requestId, userId }, fn);
+  const { requestId, userId, requestMethod, requestPath } = tenantStorage.getStore() ?? {};
+  return tenantStorage.run(
+    { tenantId: SYSTEM_TENANT_ID, requestId, userId, requestMethod, requestPath },
+    fn,
+  );
 }
 
 /**

--- a/packages/data-schemas/src/config/winston.ts
+++ b/packages/data-schemas/src/config/winston.ts
@@ -7,7 +7,14 @@ import {
   jsonTruncateFormat,
   stripHeavyErrorFields,
 } from './parsers';
-import { getTenantId, getUserId, getRequestId, SYSTEM_TENANT_ID } from './tenantContext';
+import {
+  getTenantId,
+  getUserId,
+  getRequestId,
+  getRequestMethod,
+  getRequestPath,
+  SYSTEM_TENANT_ID,
+} from './tenantContext';
 import { getLogDirectory } from './utils';
 
 const { NODE_ENV, DEBUG_LOGGING, CONSOLE_JSON, DEBUG_CONSOLE, LOG_TO_FILE } = process.env;
@@ -31,7 +38,14 @@ const levels: winston.config.AbstractConfigSetLevels = {
   silly: 7,
 };
 
-const LOG_CONTEXT_KEYS = ['tenantId', 'userId', 'requestId'] as const;
+const LOG_CONTEXT_KEYS = [
+  'tenantId',
+  'userId',
+  'requestId',
+  'request_id',
+  'method',
+  'path',
+] as const;
 
 function getLogTenantId(): string | undefined {
   const tenantId = getTenantId();
@@ -46,6 +60,9 @@ const requestContextFormat = winston.format((info: winston.Logform.Transformable
     tenantId: getLogTenantId(),
     userId: getUserId(),
     requestId: getRequestId(),
+    request_id: getRequestId(),
+    method: getRequestMethod(),
+    path: getRequestPath(),
   };
   LOG_CONTEXT_KEYS.forEach((key) => {
     if (context[key] && info[key] == null) {

--- a/packages/data-schemas/src/config/winston.ts
+++ b/packages/data-schemas/src/config/winston.ts
@@ -7,14 +7,8 @@ import {
   jsonTruncateFormat,
   stripHeavyErrorFields,
 } from './parsers';
-import {
-  getTenantId,
-  getUserId,
-  getRequestId,
-  getRequestMethod,
-  getRequestPath,
-  SYSTEM_TENANT_ID,
-} from './tenantContext';
+import { SYSTEM_TENANT_ID } from './tenantContext';
+import { attachRequestContext, LOG_CONTEXT_KEYS } from './requestLogContext';
 import { getLogDirectory } from './utils';
 
 const { NODE_ENV, DEBUG_LOGGING, CONSOLE_JSON, DEBUG_CONSOLE, LOG_TO_FILE } = process.env;
@@ -38,39 +32,7 @@ const levels: winston.config.AbstractConfigSetLevels = {
   silly: 7,
 };
 
-const LOG_CONTEXT_KEYS = [
-  'tenantId',
-  'userId',
-  'requestId',
-  'request_id',
-  'method',
-  'path',
-] as const;
-
-function getLogTenantId(): string | undefined {
-  const tenantId = getTenantId();
-  return tenantId === SYSTEM_TENANT_ID ? undefined : tenantId;
-}
-
-const requestContextFormat = winston.format((info: winston.Logform.TransformableInfo) => {
-  if (info.tenantId === SYSTEM_TENANT_ID) {
-    delete info.tenantId;
-  }
-  const context = {
-    tenantId: getLogTenantId(),
-    userId: getUserId(),
-    requestId: getRequestId(),
-    request_id: getRequestId(),
-    method: getRequestMethod(),
-    path: getRequestPath(),
-  };
-  LOG_CONTEXT_KEYS.forEach((key) => {
-    if (context[key] && info[key] == null) {
-      info[key] = context[key];
-    }
-  });
-  return info;
-});
+const requestContextFormat = winston.format(attachRequestContext);
 
 function formatRequestContext(info: winston.Logform.TransformableInfo): string {
   const context: Partial<Record<(typeof LOG_CONTEXT_KEYS)[number], string>> = {};

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -50,6 +50,8 @@ export {
   getTenantId,
   getUserId,
   getRequestId,
+  getRequestMethod,
+  getRequestPath,
   runAsSystem,
   scopedCacheKey,
   SYSTEM_TENANT_ID,


### PR DESCRIPTION
## Summary

- emit compact, structured JWT authentication events with request ID, route, token source, reason category, recovery classification, and response status
- establish safe request correlation context before authentication so tenant-isolation errors retain the same request ID and route
- emit a dedicated structured tenant-isolation 500 event and preserve correlation fields through Winston message truncation
- reject JWT-shaped or oversized correlation IDs and avoid logging raw JWTs, cookies, headers, user IDs, tenant IDs, or verification messages

## Why

Authentication correlation fields were appended to human-readable log messages. Production JSON logging truncates strings at 255 characters, making request-level attribution unreliable during correlated tenant-isolation error bursts.

Moving the correlation contract into top-level fields keeps authentication outcomes and tenant-isolation failures joinable without depending on a truncated message tail.

## Validation

- `packages/api`: 51 focused middleware tests passed
- `packages/data-schemas`: 34 focused logging/context tests passed
- `api`: 24 `requireJwtAuth` tests passed
- ESLint passed for all changed files
- `@librechat/data-schemas` and `@librechat/api` builds passed

## Follow-up validation

After deployment to dev/staging, send a malformed bearer request alongside normal page requests and join `jwt_auth_rejected` and `tenant_isolation_error` events by `request_id`. This will establish whether observed 401/500 bursts share a request or are only temporally correlated.