### PR TITLE
🎲 test: Replace Microtask Timing Assumptions in Client Specs

### DIFF
--- a/client/src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx
+++ b/client/src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { FileConfigInput } from 'librechat-data-provider';
 import type { ReactNode } from 'react';
 import UploadSkillDialog from '../UploadSkillDialog';
@@ -70,14 +70,12 @@ jest.mock('~/utils', () => ({
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
 }));
 
-function findFileInput(container: HTMLElement): Promise<HTMLInputElement> {
-  return waitFor(() => {
-    const input = container.querySelector('input[type="file"]');
-    if (!(input instanceof HTMLInputElement)) {
-      throw new Error('Upload input was not rendered');
-    }
-    return input;
-  });
+function getFileInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector('input[type="file"]');
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('Upload input was not rendered');
+  }
+  return input;
 }
 
 describe('UploadSkillDialog', () => {
@@ -108,13 +106,13 @@ describe('UploadSkillDialog', () => {
     expect(screen.getByText('File size must not exceed 1.06 MB')).toBeInTheDocument();
   });
 
-  it('rejects files above the configured skill import limit before upload', async () => {
+  it('rejects files above the configured skill import limit before upload', () => {
     const { container } = render(<UploadSkillDialog isOpen={true} setIsOpen={mockSetIsOpen} />);
     const file = new File([new Uint8Array(1024 * 1024 + 1)], 'too-large.skill', {
       type: 'application/zip',
     });
 
-    fireEvent.change(await findFileInput(container), {
+    fireEvent.change(getFileInput(container), {
       target: {
         files: [file],
       },
@@ -127,14 +125,14 @@ describe('UploadSkillDialog', () => {
     });
   });
 
-  it('uploads files exactly at the configured skill import limit', async () => {
+  it('uploads files exactly at the configured skill import limit', () => {
     const appendSpy = jest.spyOn(FormData.prototype, 'append');
     const { container } = render(<UploadSkillDialog isOpen={true} setIsOpen={mockSetIsOpen} />);
     const file = new File([new Uint8Array(1024 * 1024)], 'exact-limit.skill', {
       type: 'application/zip',
     });
 
-    fireEvent.change(await findFileInput(container), {
+    fireEvent.change(getFileInput(container), {
       target: {
         files: [file],
       },
@@ -146,14 +144,14 @@ describe('UploadSkillDialog', () => {
     appendSpy.mockRestore();
   });
 
-  it('uploads files under the configured skill import limit', async () => {
+  it('uploads files under the configured skill import limit', () => {
     const appendSpy = jest.spyOn(FormData.prototype, 'append');
     const { container } = render(<UploadSkillDialog isOpen={true} setIsOpen={mockSetIsOpen} />);
     const file = new File([new Uint8Array(1024)], 'small.skill', {
       type: 'application/zip',
     });
 
-    fireEvent.change(await findFileInput(container), {
+    fireEvent.change(getFileInput(container), {
       target: {
         files: [file],
       },

--- a/client/src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx
+++ b/client/src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx
@@ -70,13 +70,14 @@ jest.mock('~/utils', () => ({
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
 }));
 
-async function findFileInput(container: HTMLElement): Promise<HTMLInputElement> {
-  let input: Element | null = null;
-  await waitFor(() => {
-    input = container.querySelector('input[type="file"]');
-    expect(input).toBeInstanceOf(HTMLInputElement);
+function findFileInput(container: HTMLElement): Promise<HTMLInputElement> {
+  return waitFor(() => {
+    const input = container.querySelector('input[type="file"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Upload input was not rendered');
+    }
+    return input;
   });
-  return input as unknown as HTMLInputElement;
 }
 
 describe('UploadSkillDialog', () => {

--- a/client/src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx
+++ b/client/src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { FileConfigInput } from 'librechat-data-provider';
+import type { ReactNode } from 'react';
 import UploadSkillDialog from '../UploadSkillDialog';
 
 const mockMutate = jest.fn();
@@ -70,12 +70,13 @@ jest.mock('~/utils', () => ({
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
 }));
 
-function getFileInput(container: HTMLElement): HTMLInputElement {
-  const input = container.querySelector('input[type="file"]');
-  if (!(input instanceof HTMLInputElement)) {
-    throw new Error('Upload input was not rendered');
-  }
-  return input;
+async function findFileInput(container: HTMLElement): Promise<HTMLInputElement> {
+  let input: Element | null = null;
+  await waitFor(() => {
+    input = container.querySelector('input[type="file"]');
+    expect(input).toBeInstanceOf(HTMLInputElement);
+  });
+  return input as unknown as HTMLInputElement;
 }
 
 describe('UploadSkillDialog', () => {
@@ -106,13 +107,13 @@ describe('UploadSkillDialog', () => {
     expect(screen.getByText('File size must not exceed 1.06 MB')).toBeInTheDocument();
   });
 
-  it('rejects files above the configured skill import limit before upload', () => {
+  it('rejects files above the configured skill import limit before upload', async () => {
     const { container } = render(<UploadSkillDialog isOpen={true} setIsOpen={mockSetIsOpen} />);
     const file = new File([new Uint8Array(1024 * 1024 + 1)], 'too-large.skill', {
       type: 'application/zip',
     });
 
-    fireEvent.change(getFileInput(container), {
+    fireEvent.change(await findFileInput(container), {
       target: {
         files: [file],
       },
@@ -125,14 +126,14 @@ describe('UploadSkillDialog', () => {
     });
   });
 
-  it('uploads files exactly at the configured skill import limit', () => {
+  it('uploads files exactly at the configured skill import limit', async () => {
     const appendSpy = jest.spyOn(FormData.prototype, 'append');
     const { container } = render(<UploadSkillDialog isOpen={true} setIsOpen={mockSetIsOpen} />);
     const file = new File([new Uint8Array(1024 * 1024)], 'exact-limit.skill', {
       type: 'application/zip',
     });
 
-    fireEvent.change(getFileInput(container), {
+    fireEvent.change(await findFileInput(container), {
       target: {
         files: [file],
       },
@@ -144,14 +145,14 @@ describe('UploadSkillDialog', () => {
     appendSpy.mockRestore();
   });
 
-  it('uploads files under the configured skill import limit', () => {
+  it('uploads files under the configured skill import limit', async () => {
     const appendSpy = jest.spyOn(FormData.prototype, 'append');
     const { container } = render(<UploadSkillDialog isOpen={true} setIsOpen={mockSetIsOpen} />);
     const file = new File([new Uint8Array(1024)], 'small.skill', {
       type: 'application/zip',
     });
 
-    fireEvent.change(getFileInput(container), {
+    fireEvent.change(await findFileInput(container), {
       target: {
         files: [file],
       },

--- a/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
+++ b/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
@@ -14,8 +14,25 @@ function Probe() {
 /** MutationObserver delivery can slip well past a microtask on a loaded machine. */
 const OBSERVER_WAIT = { timeout: 4000 };
 
+/** One test chains two OBSERVER_WAITs, whose budget exceeds Jest's 5s default. */
+jest.setTimeout(20_000);
+
 const getProbe = (container: HTMLElement) =>
   container.querySelector('[data-testid="probe"]') as HTMLDivElement;
+
+/**
+ * Resolves once the browser has delivered an attribute mutation on `element`. The hook
+ * registers its observer at mount, so it is earlier in delivery order than this one and
+ * has already run its callback by the time this resolves.
+ */
+const nextAttributeMutation = (element: HTMLElement): Promise<void> =>
+  new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(element, { attributes: true });
+  });
 
 describe('useIsActiveItem', () => {
   it('starts with isActive=false when data-active-item is absent', () => {
@@ -54,21 +71,13 @@ describe('useIsActiveItem', () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);
 
-    act(() => {
+    const delivered = nextAttributeMutation(probe);
+    await act(async () => {
       probe.setAttribute('data-something-else', 'x');
+      await delivered;
     });
-    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('false'), OBSERVER_WAIT);
 
-    /** A later observed mutation proves the observer ran without the unrelated one flipping it. */
-    act(() => {
-      probe.setAttribute('data-active-item', '');
-    });
-    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
-
-    act(() => {
-      probe.removeAttribute('data-active-item');
-    });
-    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('false'), OBSERVER_WAIT);
+    expect(probe.getAttribute('data-active')).toBe('false');
   });
 
   it('disconnects the MutationObserver on unmount', async () => {

--- a/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
+++ b/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
@@ -11,7 +11,10 @@ function Probe() {
   return <div ref={ref} data-testid="probe" data-active={isActive ? 'true' : 'false'} />;
 }
 
-/** MutationObserver delivery can slip well past a microtask on a loaded machine. */
+/**
+ * Observer delivery lands on the next microtask in this environment; the wait exists so the
+ * test does not depend on that scheduling detail, with budget to ride out a stalled host.
+ */
 const OBSERVER_WAIT = { timeout: 4000 };
 
 /** One test chains two OBSERVER_WAITs, whose budget exceeds Jest's 5s default. */
@@ -21,9 +24,10 @@ const getProbe = (container: HTMLElement) =>
   container.querySelector('[data-testid="probe"]') as HTMLDivElement;
 
 /**
- * Resolves once the browser has delivered an attribute mutation on `element`. The hook
- * registers its observer at mount, so it is earlier in delivery order than this one and
- * has already run its callback by the time this resolves.
+ * Resolves once an attribute mutation on `element` has been delivered to observers. The
+ * hook's observer filters on `data-active-item`, so it is never notified of the unrelated
+ * mutation; this unfiltered observer proves delivery happened before the test asserts
+ * that the hook did not react.
  */
 const nextAttributeMutation = (element: HTMLElement): Promise<void> =>
   new Promise((resolve) => {
@@ -48,7 +52,6 @@ describe('useIsActiveItem', () => {
       probe.setAttribute('data-active-item', '');
     });
 
-    // MutationObserver delivery is not guaranteed within a single microtask
     await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
   });
 

--- a/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
+++ b/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @happy-dom/jest-environment
  */
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
 import useIsActiveItem from '../useIsActiveItem';
 
@@ -10,6 +10,9 @@ function Probe() {
   const { ref, isActive } = useIsActiveItem<HTMLDivElement>();
   return <div ref={ref} data-testid="probe" data-active={isActive ? 'true' : 'false'} />;
 }
+
+/** MutationObserver delivery can slip well past a microtask on a loaded machine. */
+const OBSERVER_WAIT = { timeout: 4000 };
 
 const getProbe = (container: HTMLElement) =>
   container.querySelector('[data-testid="probe"]') as HTMLDivElement;
@@ -24,42 +27,48 @@ describe('useIsActiveItem', () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);
 
-    await act(async () => {
+    act(() => {
       probe.setAttribute('data-active-item', '');
-      // Allow the MutationObserver microtask to run
-      await Promise.resolve();
     });
 
-    expect(probe.getAttribute('data-active')).toBe('true');
+    // MutationObserver delivery is not guaranteed within a single microtask
+    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
   });
 
   it('flips isActive back to false when data-active-item is removed', async () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);
 
-    await act(async () => {
+    act(() => {
       probe.setAttribute('data-active-item', '');
-      await Promise.resolve();
     });
-    expect(probe.getAttribute('data-active')).toBe('true');
+    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
 
-    await act(async () => {
+    act(() => {
       probe.removeAttribute('data-active-item');
-      await Promise.resolve();
     });
-    expect(probe.getAttribute('data-active')).toBe('false');
+    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('false'), OBSERVER_WAIT);
   });
 
   it('ignores unrelated attribute mutations', async () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);
 
-    await act(async () => {
+    act(() => {
       probe.setAttribute('data-something-else', 'x');
-      await Promise.resolve();
     });
+    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('false'), OBSERVER_WAIT);
 
-    expect(probe.getAttribute('data-active')).toBe('false');
+    /** A later observed mutation proves the observer ran without the unrelated one flipping it. */
+    act(() => {
+      probe.setAttribute('data-active-item', '');
+    });
+    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
+
+    act(() => {
+      probe.removeAttribute('data-active-item');
+    });
+    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('false'), OBSERVER_WAIT);
   });
 
   it('disconnects the MutationObserver on unmount', async () => {


### PR DESCRIPTION
## Summary

Two client specs asserted that asynchronous work had settled after a fixed tick, and both failed intermittently on a heavily loaded host. Review traced the two files to different root causes, so they are handled differently.

`useIsActiveItem.spec.tsx`: the original single-microtask wait was actually deterministic in this environment. happy-dom queues the observer-delivery microtask synchronously at mutation time, before `await Promise.resolve()` schedules its continuation, and load cannot reorder enqueued microtasks, so the intermittent failures were wall-clock test timeouts rather than delivery slipping past the wait. The spec now uses polling waits so it no longer depends on that scheduling detail, raises the per-wait and per-test budgets to survive a stalled host, and synchronizes the unrelated-mutation case on a second unfiltered observer that proves the mutation was delivered at all. The hook's own observer is excluded from that mutation by its `attributeFilter`, which is what makes the case safe to assert.

`UploadSkillDialog.spec.tsx`: an earlier revision wrapped the file-input lookup in `waitFor`, but that diagnosis did not survive review. The dialog renders the input synchronously and unconditionally, so the lookup cannot race and the wait was inert. It has been reverted; only a type-import ordering fix remains in that file.

To be clear about scope: on a heavily loaded host these specs can still time out, along with unrelated ones, because the machine is the bottleneck rather than the test code. The value here is removing incorrect timing assumptions, not a guarantee against starvation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran both specs together after the latest revision; both suites pass (10 tests total). Earlier revisions were additionally run ten consecutive times in isolation and six times with the full client suite on a 16-core host.

### **Test Configuration**:

`cd client && npx jest src/hooks/__tests__/useIsActiveItem.spec.tsx src/components/Skills/dialogs/__tests__/UploadSkillDialog.spec.tsx`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
