### PR TITLE
🔗 fix: Prevent duplicate share rows from clobbering pending role edits (dedupe adds by stable id)

### DIFF
--- a/client/src/components/Sharing/GenericGrantAccessDialog.tsx
+++ b/client/src/components/Sharing/GenericGrantAccessDialog.tsx
@@ -26,7 +26,7 @@ import UnifiedPeopleSearch from './PeoplePicker/UnifiedPeopleSearch';
 import PeoplePickerAdminSettings from './PeoplePickerAdminSettings';
 import PublicSharingToggle from './PublicSharingToggle';
 import { SelectedPrincipalsList } from './PeoplePicker';
-import { computeShareChanges } from './shareChanges';
+import { computeShareChanges, dedupeNewShares } from './shareChanges';
 import { cn } from '~/utils';
 
 export default function GenericGrantAccessDialog({
@@ -110,10 +110,10 @@ export default function GenericGrantAccessDialog({
 
   // Handler for adding users from search (immediate add to unified list)
   const handleAddFromSearch = (newShares: TPrincipal[]) => {
-    const sharesToAdd = newShares.filter(
-      (newShare) =>
-        !allShares.some((existing) => existing.idOnTheSource === newShare.idOnTheSource),
-    );
+    const sharesToAdd = dedupeNewShares(allShares, newShares);
+    if (!sharesToAdd.length) {
+      return;
+    }
 
     const sharesWithDefaults = sharesToAdd.map((share) => ({
       ...share,

--- a/client/src/components/Sharing/__tests__/shareChanges.spec.ts
+++ b/client/src/components/Sharing/__tests__/shareChanges.spec.ts
@@ -1,6 +1,6 @@
 import { AccessRoleIds, PrincipalType } from 'librechat-data-provider';
 import type { TPrincipal } from 'librechat-data-provider';
-import { computeShareChanges, principalKey } from '../shareChanges';
+import { computeShareChanges, dedupeNewShares, principalKey } from '../shareChanges';
 
 const principal = (over: Partial<TPrincipal>): TPrincipal => ({
   type: PrincipalType.USER,
@@ -63,5 +63,52 @@ describe('computeShareChanges', () => {
     const { removed } = computeShareChanges(currentShares, allShares);
     expect(removed.some((p) => p.idOnTheSource === 'group-oid')).toBe(true);
     expect(principalKey(currentShares[0])).toBe(`${PrincipalType.GROUP}-group-oid`);
+  });
+});
+
+describe('dedupeNewShares', () => {
+  it('filters out an already-listed principal even when idOnTheSource differs (oid vs local id)', () => {
+    // Loaded ACL row carries the external oid; the picker returns the local `_id`.
+    const existing = [principal({ id: 'u1', idOnTheSource: 'entra-oid-abc' })];
+    const incoming = [principal({ id: 'u1', idOnTheSource: 'u1' })];
+
+    expect(dedupeNewShares(existing, incoming)).toEqual([]);
+  });
+
+  it('keeps genuinely new principals', () => {
+    const existing = [principal({ id: 'u1', idOnTheSource: 'entra-oid-abc' })];
+    const incoming = [principal({ id: 'u2', idOnTheSource: 'u2' })];
+
+    expect(dedupeNewShares(existing, incoming)).toHaveLength(1);
+    expect(dedupeNewShares(existing, incoming)[0].id).toBe('u2');
+  });
+
+  it('prevents a re-added picker row from clobbering a pending role edit', () => {
+    // Persisted: Entra-linked user shared as viewer, ACL row keyed by external oid.
+    const currentShares = [
+      principal({
+        id: 'u1',
+        idOnTheSource: 'entra-oid-abc',
+        accessRoleId: AccessRoleIds.AGENT_VIEWER,
+      }),
+    ];
+    // Working list: the admin promoted the row to editor...
+    const workingRow = principal({
+      id: 'u1',
+      idOnTheSource: 'entra-oid-abc',
+      accessRoleId: AccessRoleIds.AGENT_EDITOR,
+    });
+    // ...then re-added the same user from the picker (local `_id`, default role).
+    const pickerResult = principal({
+      id: 'u1',
+      idOnTheSource: 'u1',
+      accessRoleId: AccessRoleIds.AGENT_VIEWER,
+    });
+
+    const allShares = [workingRow, ...dedupeNewShares([workingRow], [pickerResult])];
+    const { updated, removed } = computeShareChanges(currentShares, allShares);
+
+    expect(removed).toHaveLength(0);
+    expect(updated.map((p) => p.accessRoleId)).toEqual([AccessRoleIds.AGENT_EDITOR]);
   });
 });

--- a/client/src/components/Sharing/shareChanges.ts
+++ b/client/src/components/Sharing/shareChanges.ts
@@ -16,6 +16,23 @@ export const principalKey = (share: TPrincipal): string =>
   `${share.type}-${share.id ?? share.idOnTheSource}`;
 
 /**
+ * Filter people-picker results down to principals not already present in the working
+ * list, keyed by the same stable identity `computeShareChanges` diffs on.
+ *
+ * Comparing raw `idOnTheSource` here is not enough: loaded ACL rows carry the external
+ * oid for OpenID/Entra-linked users while search results carry the local `_id`, so the
+ * same principal would be appended twice — and the duplicate (collapsing to the same
+ * key in the diff) would silently shadow a pending role edit.
+ */
+export function dedupeNewShares(
+  existingShares: TPrincipal[],
+  newShares: TPrincipal[],
+): TPrincipal[] {
+  const existingKeys = new Set(existingShares.map(principalKey));
+  return newShares.filter((share) => !existingKeys.has(principalKey(share)));
+}
+
+/**
  * Diff the currently-persisted shares (`currentShares`) against the working list
  * (`allShares`) to derive which principals to grant/update and which to revoke.
  */

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -1096,6 +1096,7 @@ export function createUserGroupMethods(
               username: userWithId.username,
               avatar: userWithId.avatar,
               provider: userWithId.provider,
+              idOnTheSource: userWithId.idOnTheSource,
             } as TUser);
           }),
         ),


### PR DESCRIPTION
## Summary

Closes #14654. Follow-up to #14316 / #14317 — fixes, at the source, the residual corner case the de-dup comment in `shareChanges.ts` anticipated (*"possible while the add/dedupe path still keys on idOnTheSource"*).

For OpenID/Entra-linked users, loaded ACL rows carry the external oid as `idOnTheSource` (`PermissionsController.js`), while people-picker results carry the local `_id` — `searchPrincipals` selects `idOnTheSource` from Mongo but dropped it in the object literal passed to `transformUserToTPrincipalSearchResult`. Because `handleAddFromSearch` deduped adds by raw `idOnTheSource`, re-adding an already-listed user appended a duplicate row for the same principal, and the stable-id Map de-dup in `computeShareChanges` (last entry wins) let the appended default-role row silently shadow a pending role edit: the dialog sent `{"updated":[],"removed":[]}` and still showed the success toast. Full analysis and a standalone repro in #14654.

Two changes, each sufficient to stop the silent drop; together they remove both sides of the mismatch:

1. **`client/src/components/Sharing/shareChanges.ts` / `GenericGrantAccessDialog.tsx`** — new `dedupeNewShares` helper keyed by the same `principalKey` the diff uses; `handleAddFromSearch` now uses it and returns early when nothing new was added (so a fully-deduped add no longer marks the dialog dirty).
2. **`packages/data-schemas/src/methods/userGroup.ts`** — pass the already-selected `idOnTheSource` through the user-search transform, so picker results match ACL rows. This also fixes the `excludeIds` filter in `UnifiedPeopleSearch`, which compares `idOnTheSource` and previously failed to hide already-shared IdP-linked users from search results.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added three regression tests to `client/src/components/Sharing/__tests__/shareChanges.spec.ts` (style-matched to the existing suite): `dedupeNewShares` filters an already-listed principal whose `idOnTheSource` differs (oid vs local id), keeps genuinely new principals, and the end-to-end case — a re-added picker row no longer clobbers a pending role edit.
- `cd client && npx jest shareChanges` → 6/6 pass (3 existing + 3 new).
- `cd packages/data-schemas && npx jest userGroup` → 167/167 pass across 3 suites (covers the `searchPrincipals` change against real in-memory MongoDB).
- ESLint clean on all four changed files.
- The standalone repro from #14654 (run against the real `computeShareChanges`) returns `{updated:[], removed:[]}` before this change and `updated=[editor row]` after.

### **Test Configuration**:

Node v25 (repo toolchain), `npm ci` + `npm run build:data-provider` at repo root.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
