### PR TITLE
🌊 feat: Wire Adaptive Stream Smoothing Across Google, Bedrock, and Zero-Disable Semantics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1001,6 +1001,10 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Redis CPU at high token rates) at the cost of up to one window of added delivery
 # latency. Enable only after EVERY replica runs a build with batch-frame support;
 # older subscribers drop coalesced frames. Values are capped at 1000.
+# Keep the window <= the stream-smoothing cadence (`streamRate`, default 25ms):
+# each smoothing tick emits its pieces in one burst, so a tick-sized window
+# captures exactly one batch per tick; a larger window re-batches the paced
+# deltas and quantizes the smoothed cadence at delivery.
 # STREAM_DELTA_COALESCE_MS=25
 
 # Single Redis instance

--- a/.env.example
+++ b/.env.example
@@ -1004,7 +1004,9 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Keep the window <= the stream-smoothing cadence (`streamRate`, default 25ms):
 # each smoothing tick emits its pieces in one burst, so a tick-sized window
 # captures exactly one batch per tick; a larger window re-batches the paced
-# deltas and quantizes the smoothed cadence at delivery.
+# deltas and quantizes the smoothed cadence at delivery. With smoothing
+# disabled (`streamRate: 0`) there is no cadence to preserve — the window is
+# then purely the Redis-cost vs delivery-latency tradeoff described above.
 # STREAM_DELTA_COALESCE_MS=25
 
 # Single Redis instance

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -461,7 +461,8 @@ endpoints:
   # Anthropic endpoint configuration with Vertex AI support
   # Use this to run Anthropic Claude models through Google Cloud Vertex AI
   # anthropic:
-  #   # (optional) Stream rate limiting in milliseconds
+  #   # (optional) Override the adaptive stream-smoothing cadence in milliseconds.
+  #   # All endpoints smooth at 25ms by default; set 0 to disable smoothing.
   #   streamRate: 20
   #   # (optional) Title model for conversation titles
   #   titleModel: claude-3.5-haiku  # Use the visible model name (key from models config)

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -462,7 +462,8 @@ endpoints:
   # Use this to run Anthropic Claude models through Google Cloud Vertex AI
   # anthropic:
   #   # (optional) Override the adaptive stream-smoothing cadence in milliseconds.
-  #   # All endpoints smooth at 25ms by default; set 0 to disable smoothing.
+  #   # Agents SDK-backed providers smooth at 25ms by default; set 0 to disable
+  #   # smoothing. (Legacy Assistants/Ollama paths sleep this long per chunk instead.)
   #   streamRate: 20
   #   # (optional) Title model for conversation titles
   #   titleModel: claude-3.5-haiku  # Use the visible model name (key from models config)

--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -85,11 +85,11 @@ export async function initializeAnthropic({
 
   const result = getLLMConfig(credentials, clientOptions);
 
-  if (anthropicConfig?.streamRate) {
+  if (anthropicConfig?.streamRate != null) {
     (result.llmConfig as Record<string, unknown>)._lc_stream_delay = anthropicConfig.streamRate;
   }
 
-  if (allConfig?.streamRate) {
+  if (allConfig?.streamRate != null) {
     (result.llmConfig as Record<string, unknown>)._lc_stream_delay = allConfig.streamRate;
   }
 

--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -86,11 +86,11 @@ export async function initializeAnthropic({
   const result = getLLMConfig(credentials, clientOptions);
 
   if (anthropicConfig?.streamRate != null) {
-    (result.llmConfig as Record<string, unknown>)._lc_stream_delay = anthropicConfig.streamRate;
+    result.llmConfig._lc_stream_delay = anthropicConfig.streamRate;
   }
 
   if (allConfig?.streamRate != null) {
-    (result.llmConfig as Record<string, unknown>)._lc_stream_delay = allConfig.streamRate;
+    result.llmConfig._lc_stream_delay = allConfig.streamRate;
   }
 
   return result;

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -1106,3 +1106,44 @@ describe('initializeBedrock', () => {
     });
   });
 });
+
+describe('initializeBedrock streamRate resolution', () => {
+  beforeEach(() => {
+    process.env.BEDROCK_AWS_ACCESS_KEY_ID = 'test-access-key';
+    process.env.BEDROCK_AWS_SECRET_ACCESS_KEY = 'test-secret-key';
+    process.env.BEDROCK_AWS_DEFAULT_REGION = 'us-east-1';
+  });
+
+  async function delayFor(config: Record<string, unknown>): Promise<unknown> {
+    const result = await initializeBedrock(createMockParams({ config }));
+    return (result.llmConfig as Record<string, unknown>)._lc_stream_delay;
+  }
+
+  it('wires `endpoints.bedrock.streamRate` into llmConfig._lc_stream_delay', async () => {
+    await expect(
+      delayFor({ endpoints: { [EModelEndpoint.bedrock]: { streamRate: 25 } } }),
+    ).resolves.toBe(25);
+  });
+
+  it('preserves the endpoint streamRate when `endpoints.all` exists without one', async () => {
+    await expect(
+      delayFor({
+        endpoints: { [EModelEndpoint.bedrock]: { streamRate: 25 }, all: { activityLabel: true } },
+      }),
+    ).resolves.toBe(25);
+  });
+
+  it('lets `endpoints.all.streamRate` (including 0) override the endpoint value', async () => {
+    await expect(
+      delayFor({
+        endpoints: { [EModelEndpoint.bedrock]: { streamRate: 25 }, all: { streamRate: 0 } },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it('leaves the delay unset when neither level configures a streamRate', async () => {
+    await expect(
+      delayFor({ endpoints: { all: { activityLabel: true } } }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -330,7 +330,7 @@ export async function initializeBedrock({
       ? appConfig.endpoints.all.streamRate
       : (bedrockConfig?.streamRate as number | undefined);
   if (streamRate != null) {
-    (llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
+    llmConfig._lc_stream_delay = streamRate;
   }
 
   return {

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -325,6 +325,14 @@ export async function initializeBedrock({
     }
   }
 
+  const streamRate =
+    appConfig?.endpoints?.all?.streamRate != null
+      ? appConfig.endpoints.all.streamRate
+      : (bedrockConfig?.streamRate as number | undefined);
+  if (streamRate != null) {
+    (llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
+  }
+
   return {
     llmConfig,
     configOptions,

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -346,7 +346,7 @@ export async function initializeCustom({
 
   const streamRate = clientOptions.streamRate as number | undefined;
   if (streamRate != null) {
-    (options.llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;
+    options.llmConfig._lc_stream_delay = streamRate;
   }
 
   return options;

--- a/packages/api/src/endpoints/google/initialize.spec.ts
+++ b/packages/api/src/endpoints/google/initialize.spec.ts
@@ -165,3 +165,60 @@ describe('initializeGoogle', () => {
     });
   });
 });
+
+describe('initializeGoogle streamRate resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GOOGLE_KEY = 'test-api-key';
+  });
+
+  async function initWithConfig(
+    endpointsConfig: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const req = createReq();
+    (req as unknown as { config: Record<string, unknown> }).config = {
+      endpoints: endpointsConfig,
+    };
+    const result = await initializeGoogle({
+      req,
+      endpoint: EModelEndpoint.google,
+      model_parameters: { model: 'gemini-2.5-flash' },
+      db: createDb(),
+    });
+    return result.llmConfig as Record<string, unknown>;
+  }
+
+  it('wires the endpoint streamRate into llmConfig._lc_stream_delay', async () => {
+    const llmConfig = await initWithConfig({ [EModelEndpoint.google]: { streamRate: 25 } });
+    expect(llmConfig._lc_stream_delay).toBe(25);
+  });
+
+  it('preserves the endpoint streamRate when `endpoints.all` exists without one', async () => {
+    const llmConfig = await initWithConfig({
+      [EModelEndpoint.google]: { streamRate: 25 },
+      all: { activityLabel: true },
+    });
+    expect(llmConfig._lc_stream_delay).toBe(25);
+  });
+
+  it('lets `endpoints.all.streamRate` override the endpoint value', async () => {
+    const llmConfig = await initWithConfig({
+      [EModelEndpoint.google]: { streamRate: 25 },
+      all: { streamRate: 10 },
+    });
+    expect(llmConfig._lc_stream_delay).toBe(10);
+  });
+
+  it('lets `endpoints.all.streamRate: 0` disable smoothing explicitly', async () => {
+    const llmConfig = await initWithConfig({
+      [EModelEndpoint.google]: { streamRate: 25 },
+      all: { streamRate: 0 },
+    });
+    expect(llmConfig._lc_stream_delay).toBe(0);
+  });
+
+  it('leaves the delay unset when neither level configures a streamRate', async () => {
+    const llmConfig = await initWithConfig({ all: { activityLabel: true } });
+    expect(llmConfig._lc_stream_delay).toBeUndefined();
+  });
+});

--- a/packages/api/src/endpoints/google/initialize.ts
+++ b/packages/api/src/endpoints/google/initialize.ts
@@ -84,7 +84,7 @@ export async function initializeGoogle({
     clientOptions.titleModel = googleConfig.titleModel;
   }
 
-  if (allConfig) {
+  if (allConfig?.streamRate != null) {
     clientOptions.streamRate = allConfig.streamRate;
   }
 
@@ -124,5 +124,11 @@ export async function initializeGoogle({
     ...clientOptions,
   };
 
-  return getGoogleConfig(credentials, clientOptions);
+  const result = getGoogleConfig(credentials, clientOptions);
+
+  if (clientOptions.streamRate != null) {
+    (result.llmConfig as Record<string, unknown>)._lc_stream_delay = clientOptions.streamRate;
+  }
+
+  return result;
 }

--- a/packages/api/src/endpoints/google/initialize.ts
+++ b/packages/api/src/endpoints/google/initialize.ts
@@ -127,7 +127,7 @@ export async function initializeGoogle({
   const result = getGoogleConfig(credentials, clientOptions);
 
   if (clientOptions.streamRate != null) {
-    (result.llmConfig as Record<string, unknown>)._lc_stream_delay = clientOptions.streamRate;
+    result.llmConfig._lc_stream_delay = clientOptions.streamRate;
   }
 
   return result;

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -194,21 +194,19 @@ export async function initializeOpenAI({
     (options as InitializeResultBase).useLegacyContent = true;
   }
 
-  const azureRate = modelName?.includes('gpt-4') ? 30 : 17;
-
   let streamRate: number | undefined;
 
   if (isAzureOpenAI && azureConfig) {
-    streamRate = azureConfig.streamRate ?? azureRate;
+    streamRate = azureConfig.streamRate;
   } else if (!isAzureOpenAI && openAIConfig) {
     streamRate = openAIConfig.streamRate;
   }
 
-  if (allConfig?.streamRate) {
+  if (allConfig?.streamRate != null) {
     streamRate = allConfig.streamRate;
   }
 
-  if (streamRate) {
+  if (streamRate != null) {
     options.llmConfig._lc_stream_delay = streamRate;
   }
 

--- a/packages/api/src/utils/generators.ts
+++ b/packages/api/src/utils/generators.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
+import { GraphEvents } from '@librechat/agents';
 import { logger } from '@librechat/data-schemas';
-import { GraphEvents, sleep } from '@librechat/agents';
 import type { Response as ServerResponse } from 'express';
 import type { Agent as HttpsAgent } from 'node:https';
 import type { Agent as HttpAgent } from 'node:http';
@@ -89,13 +89,5 @@ export function createStreamEventHandlers(res: ServerResponse): {
         sendEvent(res, event);
       }
     },
-  };
-}
-
-export function createHandleLLMNewToken(streamRate: number) {
-  return async function (): Promise<void> {
-    if (streamRate) {
-      await sleep(streamRate);
-    }
   };
 }

--- a/packages/api/src/utils/generators.ts
+++ b/packages/api/src/utils/generators.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
-import { GraphEvents } from '@librechat/agents';
 import { logger } from '@librechat/data-schemas';
+import { GraphEvents, sleep } from '@librechat/agents';
 import type { Response as ServerResponse } from 'express';
 import type { Agent as HttpsAgent } from 'node:https';
 import type { Agent as HttpAgent } from 'node:http';
@@ -89,5 +89,21 @@ export function createStreamEventHandlers(res: ServerResponse): {
         sendEvent(res, event);
       }
     },
+  };
+}
+
+/**
+ * @deprecated No longer used internally: stream pacing lives in
+ * `@librechat/agents` (adaptive smoothing via `_lc_stream_delay` /
+ * `streamRate`), and LangChain runs callback handlers in the background, so
+ * a sleep here never paced token delivery. Kept as a compatibility shim for
+ * external `@librechat/api` consumers; removal is reserved for a major
+ * release.
+ */
+export function createHandleLLMNewToken(streamRate: number) {
+  return async function (): Promise<void> {
+    if (streamRate) {
+      await sleep(streamRate);
+    }
   };
 }

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -592,9 +592,11 @@ export const defaultAssistantsVersion = {
 
 export const baseEndpointSchema = z.object({
   /**
-   * Milliseconds between visible streamed chunks. The agents SDK smooths
-   * adaptively at 25ms by default; set to override the cadence, 0 to disable
-   * smoothing entirely.
+   * Milliseconds between visible streamed chunks. Agents SDK-backed
+   * providers (openAI, custom, anthropic, google, bedrock, agents) smooth
+   * adaptively at 25ms by default; set to override the cadence, 0 to
+   * disable smoothing. Legacy Assistants and Ollama paths instead sleep
+   * this long per provider chunk (default 1ms), with no adaptive smoothing.
    */
   streamRate: z.number().min(0).optional(),
   baseURL: z.string().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -591,7 +591,12 @@ export const defaultAssistantsVersion = {
 };
 
 export const baseEndpointSchema = z.object({
-  streamRate: z.number().optional(),
+  /**
+   * Milliseconds between visible streamed chunks. The agents SDK smooths
+   * adaptively at 25ms by default; set to override the cadence, 0 to disable
+   * smoothing entirely.
+   */
+  streamRate: z.number().min(0).optional(),
   baseURL: z.string().optional(),
   /**
    * Custom request headers forwarded to the provider on every request. Values


### PR DESCRIPTION
## Summary

Completes the LibreChat side of adaptive stream smoothing (danny-avila/agents#389, shipped in `@librechat/agents` 3.4.0, already bumped in #14647). The SDK now smooths every provider at an adaptive 25ms cadence by default, with `_lc_stream_delay: 0` as the explicit disable — this PR makes LibreChat's `streamRate` config actually reach the SDK everywhere, with zero-preserving semantics.

### What was broken

| Path | Before |
|---|---|
| **Google/Vertex** | `streamRate` read from config, then **silently dropped** — `getGoogleConfig` never consumed it, and any `endpoints.all` block clobbered it with `undefined` first (same bug class as #14645). A no-op end to end. |
| **Bedrock** | No `streamRate` handling **at all** — schema-valid config, silently ignored. |
| **Anthropic / OpenAI** | Truthy guards, so `streamRate: 0` (now meaningful as "disable smoothing") was indistinguishable from unset. |
| **Azure** | Hardcoded 30/17ms fallback from the pre-adaptive era, silently overriding the SDK's better default. |

### Changes

- **google/initialize.ts**: nullish `endpoints.all` guard + wire `clientOptions.streamRate` → `llmConfig._lc_stream_delay` after `getGoogleConfig` (which stays untouched for its other callers)
- **bedrock/initialize.ts**: resolve endpoint-level then `endpoints.all` `streamRate` (nullish precedence) → `llmConfig._lc_stream_delay`
- **anthropic/openai/initialize.ts**: truthy → nullish guards; remove the azure `gpt-4 ? 30 : 17` fallback (release-notes item: azure deployments that relied on it now get the SDK's adaptive 25ms)
- **utils/generators.ts**: delete `createHandleLLMNewToken` — zero call sites since #6886, and LangChain backgrounds callback handlers so its sleep never paced anything
- **data-provider/config.ts**: `streamRate` gains `.min(0)` + JSDoc (ms between chunks; SDK default 25; 0 disables)
- **Docs**: `librechat.example.yaml` streamRate comment reflects adaptive-default semantics; `.env.example` documents pairing `STREAM_DELTA_COALESCE_MS` with the smoothing tick (window ≤ tick, one batch frame per tick burst — see #14614)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

New resolution-matrix specs mirroring `custom/streamrate.spec.ts`:
- `google/initialize.spec.ts` +5: endpoint wiring, all-block preservation (regression), all-override, all-`0` explicit disable, unset
- `bedrock/initialize.spec.ts` +4: same matrix

```bash
cd packages/api && npx jest src/endpoints/ src/utils/
```
54 suites / 1,579 tests pass. `data-provider` config spec 132/132; data-provider builds clean; no new TS/ESLint diagnostics in touched files.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules (agents 3.4.0)