### PR TITLE
🔗 feat: Admin Panel Link in Settings for Admins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ DOMAIN_CLIENT=http://localhost:3080
 DOMAIN_SERVER=http://localhost:3080
 
 # External admin panel base URL used for admin OAuth/SSO redirects.
+# When set, admins also get an Admin Panel link in Settings > General.
 # Required when the admin panel is hosted separately from LibreChat.
 # May include a path. Do not include a trailing slash.
 # Example: https://admin.example.com/admin

--- a/api/server/routes/__tests__/config.spec.js
+++ b/api/server/routes/__tests__/config.spec.js
@@ -103,6 +103,7 @@ afterEach(() => {
   delete process.env.SAML_CERT;
   delete process.env.SAML_SESSION_SECRET;
   delete process.env.ALLOW_ACCOUNT_DELETION;
+  delete process.env.ADMIN_PANEL_URL;
   delete process.env.ANALYTICS_GTM_ID;
   delete process.env.CUSTOM_FOOTER;
   delete process.env.HELP_AND_FAQ_URL;
@@ -179,6 +180,7 @@ describe('GET /api/config', () => {
       process.env.ANALYTICS_GTM_ID = 'GTM-XYZ';
       process.env.CUSTOM_FOOTER = 'internal footer text';
       process.env.HELP_AND_FAQ_URL = 'https://internal.example.com/faq';
+      process.env.ADMIN_PANEL_URL = 'https://admin.example.com';
       mockGetAppConfig.mockResolvedValue(baseAppConfig);
       const app = createApp(null);
 
@@ -193,6 +195,7 @@ describe('GET /api/config', () => {
       expect(response.body).not.toHaveProperty('openidReuseTokens');
       expect(response.body).not.toHaveProperty('allowAccountDeletion');
       expect(response.body).not.toHaveProperty('customFooter');
+      expect(response.body).not.toHaveProperty('adminPanelURL');
     });
 
     it('should not include share-only fields when share context is requested', async () => {
@@ -625,6 +628,40 @@ describe('GET /api/config', () => {
 
       expect(response.body.allowAccountDeletion).toBe(true);
       expect(mockHasCapability).not.toHaveBeenCalled();
+    });
+
+    it('should include adminPanelURL for users with ACCESS_ADMIN capability', async () => {
+      process.env.ADMIN_PANEL_URL = 'https://admin.example.com';
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      mockHasCapability.mockResolvedValue(true);
+      const app = createApp(mockUser);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body.adminPanelURL).toBe('https://admin.example.com');
+      expect(mockHasCapability).toHaveBeenCalled();
+    });
+
+    it('should omit adminPanelURL for authenticated users without ACCESS_ADMIN', async () => {
+      process.env.ADMIN_PANEL_URL = 'https://admin.example.com';
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      mockHasCapability.mockResolvedValue(false);
+      const app = createApp(mockUser);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body).not.toHaveProperty('adminPanelURL');
+      expect(mockHasCapability).toHaveBeenCalled();
+    });
+
+    it('should omit adminPanelURL when ADMIN_PANEL_URL is not set', async () => {
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      mockHasCapability.mockResolvedValue(true);
+      const app = createApp(mockUser);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body).not.toHaveProperty('adminPanelURL');
     });
 
     it('should return 500 when getAppConfig throws', async () => {

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -319,15 +319,19 @@ router.get('/', async function (req, res) {
       payload.buildInfo = buildInfo;
     }
 
-    if (!payload.allowAccountDeletion) {
+    const adminPanelURL = process.env.ADMIN_PANEL_URL;
+    if (adminPanelURL || !payload.allowAccountDeletion) {
       try {
         const userId = req.user.id ?? req.user._id?.toString();
         if (userId) {
-          const canDelete = await hasCapability(
+          const hasAdminAccess = await hasCapability(
             { id: userId, role: req.user.role ?? '', tenantId: req.user.tenantId },
             SystemCapabilities.ACCESS_ADMIN,
           );
-          if (canDelete) {
+          if (hasAdminAccess && adminPanelURL) {
+            payload.adminPanelURL = adminPanelURL;
+          }
+          if (hasAdminAccess && !payload.allowAccountDeletion) {
             payload.allowAccountDeletion = true;
           }
         }

--- a/client/src/components/Nav/Settings/__tests__/Sidebar.spec.tsx
+++ b/client/src/components/Nav/Settings/__tests__/Sidebar.spec.tsx
@@ -19,6 +19,7 @@ const ctx: SettingsContextValue = {
   aboutEnabled: false,
   engineTTS: 'browser',
   langfuseConnectionAccess: false,
+  adminPanelURL: '',
 };
 
 function setup(extra: Partial<SettingsContextValue> = {}, query = '') {

--- a/client/src/components/Nav/Settings/__tests__/registry.spec.ts
+++ b/client/src/components/Nav/Settings/__tests__/registry.spec.ts
@@ -21,6 +21,7 @@ const settingsContext: SettingsContextValue = {
   aboutEnabled: false,
   engineTTS: 'browser',
   langfuseConnectionAccess: false,
+  adminPanelURL: '',
 };
 
 describe('settings registry', () => {

--- a/client/src/components/Nav/Settings/context.tsx
+++ b/client/src/components/Nav/Settings/context.tsx
@@ -28,6 +28,7 @@ export function useSettingsContext(): SettingsContextValue {
 
   const balanceEnabled = startupConfig?.balance?.enabled === true;
   const langfuseConnectionAccess = startupConfig?.langfuseConnectionAccess === true;
+  const adminPanelURL = startupConfig?.adminPanelURL ?? '';
   const isLocalProvider = user?.provider === 'local';
   const twoFactorEnabled = user?.twoFactorEnabled === true;
   const allowAccountDeletion = startupConfig?.allowAccountDeletion !== false;
@@ -53,6 +54,7 @@ export function useSettingsContext(): SettingsContextValue {
       aboutEnabled,
       engineTTS,
       langfuseConnectionAccess,
+      adminPanelURL,
     }),
     [
       balanceEnabled,
@@ -68,6 +70,7 @@ export function useSettingsContext(): SettingsContextValue {
       aboutEnabled,
       engineTTS,
       langfuseConnectionAccess,
+      adminPanelURL,
     ],
   );
 }

--- a/client/src/components/Nav/Settings/registry.tsx
+++ b/client/src/components/Nav/Settings/registry.tsx
@@ -33,6 +33,7 @@ import { DeleteCache } from '../SettingsTabs/Data/DeleteCache';
 import { RevokeKeys } from '../SettingsTabs/Data/RevokeKeys';
 import { ClearChats } from '../SettingsTabs/Data/ClearChats';
 import { TokenCredits, AutoRefill } from './BillingControls';
+import AdminPanel from '../SettingsTabs/General/AdminPanel';
 import SharedLinks from '../SettingsTabs/Data/SharedLinks';
 import { showThinkingAtom } from '~/store/showThinking';
 import ProviderKeys from '../SettingsTabs/ProviderKeys';
@@ -124,6 +125,16 @@ export const registry: SettingEntry[] = [
       localizationKey: 'com_nav_keep_screen_awake',
       switchId: 'keepScreenAwake',
     }),
+  },
+  // General · Admin
+  {
+    id: 'adminPanel',
+    tab: GENERAL,
+    section: 'admin',
+    labelKey: 'com_ui_admin_panel',
+    keywords: ['admin', 'panel', 'dashboard'],
+    Component: AdminPanel,
+    show: (ctx) => ctx.adminPanelURL !== '',
   },
 
   // Chat · Sending

--- a/client/src/components/Nav/Settings/types.ts
+++ b/client/src/components/Nav/Settings/types.ts
@@ -18,6 +18,7 @@ export type SectionId =
   | 'appearance'
   | 'layout'
   | 'accessibility'
+  | 'admin'
   | 'sending'
   | 'commands'
   | 'messages'
@@ -49,6 +50,7 @@ export interface SettingsContextValue {
   aboutEnabled: boolean;
   engineTTS: string;
   langfuseConnectionAccess: boolean;
+  adminPanelURL: string;
 }
 
 export interface SettingEntry {
@@ -96,6 +98,7 @@ export const TABS: TabMeta[] = [
       { id: 'appearance', labelKey: 'com_ui_settings_section_appearance' },
       { id: 'layout', labelKey: 'com_ui_settings_section_layout' },
       { id: 'accessibility', labelKey: 'com_ui_settings_section_accessibility' },
+      { id: 'admin', labelKey: 'com_ui_settings_section_admin' },
     ],
   },
   {

--- a/client/src/components/Nav/SettingsTabs/General/AdminPanel.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/AdminPanel.tsx
@@ -1,0 +1,26 @@
+import { ExternalLink } from 'lucide-react';
+import { Label, Button } from '@librechat/client';
+import { useGetStartupConfig } from '~/data-provider';
+import { useLocalize } from '~/hooks';
+
+export default function AdminPanel() {
+  const localize = useLocalize();
+  const { data: startupConfig } = useGetStartupConfig();
+  const adminPanelURL = startupConfig?.adminPanelURL ?? '';
+
+  if (!adminPanelURL) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <Label id="admin-panel-label">{localize('com_ui_admin_panel')}</Label>
+      <Button asChild variant="outline" aria-labelledby="admin-panel-label">
+        <a href={adminPanelURL} target="_blank" rel="noopener noreferrer">
+          {localize('com_ui_open_var', { 0: localize('com_ui_admin_panel') })}
+          <ExternalLink className="size-4" aria-hidden="true" />
+        </a>
+      </Button>
+    </div>
+  );
+}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1774,6 +1774,7 @@
   "com_ui_settings_results_aria": "Search results",
   "com_ui_settings_search_placeholder": "Search settings",
   "com_ui_settings_section_accessibility": "Accessibility",
+  "com_ui_settings_section_admin": "Admin",
   "com_ui_settings_section_api_keys": "API keys",
   "com_ui_settings_section_appearance": "Appearance",
   "com_ui_settings_section_billing": "Billing",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1590,6 +1590,8 @@ export type TStartupConfig = {
   emailEnabled: boolean;
   showBirthdayIcon: boolean;
   helpAndFaqURL: string;
+  /** Admin panel link, only present for users with admin access */
+  adminPanelURL?: string;
   customFooter?: string;
   modelSpecs?: TSpecsConfig;
   modelDescriptions?: Record<string, Record<string, string>>;


### PR DESCRIPTION
## Summary

When `ADMIN_PANEL_URL` is configured, users with the `access:admin` capability now see an Admin section in Settings > General with an external link that opens the admin panel in a new tab.

The URL is exposed through the authenticated startup config payload and is omitted server-side for unauthenticated requests and for users without admin access, so non-admins never receive it. The capability check is folded into the existing `ACCESS_ADMIN` block used by `allowAccountDeletion`, and capability results are cached per request, so no additional database reads are introduced.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

New coverage in `api/server/routes/__tests__/config.spec.js`: `adminPanelURL` included for admins, omitted for non-admins, omitted when the env var is unset, and stripped from unauthenticated responses. The settings registry spec validates the new row, section, and translation key.

Verified end-to-end locally: with `ADMIN_PANEL_URL` set, an admin sees the Admin section with the link in Settings > General and it opens the panel in a new tab; the section auto-hides when the variable is unset or the user lacks admin access.

## Before
<img width="1200" height="897" alt="admin-panel-link-before" src="https://github.com/user-attachments/assets/b92bb795-4285-420f-85b6-734bc112ca54" />

## After
<img width="1200" height="897" alt="admin-panel-link-after" src="https://github.com/user-attachments/assets/5a447cfd-8d85-408c-a4e9-3407716e3a69" />

### **Test Configuration**:

`ADMIN_PANEL_URL` set in `.env`, one user with the ADMIN role and one regular user, verified `/api/config` payloads and the settings modal for both.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
