### PR TITLE
fix: restore legacy Code API key header

### DIFF
--- a/packages/api/src/auth/codeapi.spec.ts
+++ b/packages/api/src/auth/codeapi.spec.ts
@@ -19,6 +19,7 @@ const mockGetTenantId = jest.requireMock('@librechat/data-schemas').getTenantId 
 
 const ENV_KEYS = [
   'CODEAPI_AUTH_PROVIDER',
+  'LIBRECHAT_CODE_API_KEY',
   'CODEAPI_JWT_ENABLED',
   'CODEAPI_JWT_PRIVATE_KEY',
   'CODEAPI_JWT_PRIVATE_KEY_BASE64',
@@ -115,6 +116,7 @@ describe('Code API JWT minting', () => {
     process.env.CODEAPI_JWT_MINT_CACHE_SECONDS = '30';
     delete process.env.CODEAPI_JWT_PRIVATE_KEY;
     delete process.env.CODEAPI_JWT_PRIVATE_KEY_BASE64;
+    delete process.env.LIBRECHAT_CODE_API_KEY;
     delete process.env.CODEAPI_JWT_SINGLE_TENANT_ID;
     delete process.env.TENANT_ISOLATION_STRICT;
     delete process.env.OPENID_REUSE_TOKENS;
@@ -273,9 +275,36 @@ describe('Code API JWT minting', () => {
     await expect(getCodeApiAuthHeaders(baseRequest())).resolves.toEqual({
       Authorization: expect.stringMatching(/^Bearer /),
     });
+  });
 
+  it('uses the configured legacy API key when managed JWT auth is disabled', async () => {
+    process.env.CODEAPI_AUTH_PROVIDER = 'legacy-api-key';
+    process.env.LIBRECHAT_CODE_API_KEY = '  sk-local-code-api  ';
+    delete process.env.CODEAPI_JWT_ENABLED;
+
+    await expect(getCodeApiAuthHeaders()).resolves.toEqual({
+      'x-api-key': 'sk-local-code-api',
+    });
+    await expect(getCodeApiAuthHeaders(baseRequest())).resolves.toEqual({
+      'x-api-key': 'sk-local-code-api',
+    });
+  });
+
+  it('returns no legacy auth header when the API key is missing or blank', async () => {
     process.env.CODEAPI_AUTH_PROVIDER = 'legacy-api-key';
     delete process.env.CODEAPI_JWT_ENABLED;
+
     await expect(getCodeApiAuthHeaders(baseRequest())).resolves.toEqual({});
+    process.env.LIBRECHAT_CODE_API_KEY = '   ';
+    await expect(getCodeApiAuthHeaders(baseRequest())).resolves.toEqual({});
+  });
+
+  it('prefers managed JWT auth when both auth modes are configured', async () => {
+    process.env.CODEAPI_AUTH_PROVIDER = 'both';
+    process.env.LIBRECHAT_CODE_API_KEY = 'sk-local-code-api';
+
+    await expect(getCodeApiAuthHeaders(baseRequest())).resolves.toEqual({
+      Authorization: expect.stringMatching(/^Bearer /),
+    });
   });
 });

--- a/packages/api/src/auth/codeapi.ts
+++ b/packages/api/src/auth/codeapi.ts
@@ -372,7 +372,11 @@ export async function mintCodeApiToken(req: ServerRequest): Promise<string> {
 }
 
 export async function getCodeApiAuthHeaders(req?: ServerRequest): Promise<Record<string, string>> {
-  if (!req || !isCodeApiJwtAuthEnabled()) {
+  if (!isCodeApiJwtAuthEnabled()) {
+    const apiKey = process.env.LIBRECHAT_CODE_API_KEY?.trim();
+    return apiKey ? { 'x-api-key': apiKey } : {};
+  }
+  if (!req) {
     return {};
   }
   const token = await mintCodeApiToken(req);


### PR DESCRIPTION
## Summary

- restore `x-api-key` authentication from `LIBRECHAT_CODE_API_KEY` when managed Code API JWT auth is disabled
- keep managed JWT `Authorization: Bearer` authentication as the priority in `librechat-jwt` and `both` modes
- ignore missing or whitespace-only legacy keys
- cover request and no-request legacy call paths with unit tests

## Context

The Code API auth refactor switched execution and file call sites to `getCodeApiAuthHeaders()`. That helper currently returns an empty object whenever JWT auth is disabled, so a configured `LIBRECHAT_CODE_API_KEY` is never forwarded. Self-hosted and subscription Code API deployments then receive unauthenticated `/exec` requests and return 401/403.

This restores backward-compatible legacy API-key authentication without changing managed JWT behavior.

Related: #12889, #13113

## Validation

- `npx jest src/auth/codeapi.spec.ts --runInBand --coverage=false` — 13 passed
- Prettier check — passed
- ESLint on changed files — passed
- `npm run build` in `packages/api` — passed
