### PR TITLE
fix: prevent session context leakage by clearing Ollama KV cache on flush

### DIFF
--- a/config/flush-cache.js
+++ b/config/flush-cache.js
@@ -277,6 +277,49 @@ async function flushFileCache(dryRun = false, verbose = false) {
   return true;
 }
 
+async function flushOllamaCache(dryRun = false, verbose = false) {
+  const ollamaHost = process.env.OLLAMA_HOST || 'http://localhost:11434';
+  const clearUrl = `${ollamaHost.replace(/\/+$/, '')}/api/clear`;
+
+  if (dryRun) {
+    console.log('🔍 [DRY RUN] Would clear Ollama model KV cache');
+    console.log(`   Endpoint: ${clearUrl}`);
+    return true;
+  }
+
+  try {
+    if (verbose) {
+      console.log(`🔍 Clearing Ollama model KV cache at ${clearUrl}`);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    const response = await fetch(clearUrl, {
+      method: 'POST',
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error(`Ollama /api/clear returned ${response.status} ${response.statusText}`);
+    }
+
+    console.log('✅ Ollama model KV cache cleared successfully');
+    return true;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.warn('⚠️  Ollama /api/clear request timed out — model KV cache may not have been cleared');
+    } else if (error.cause?.code === 'ECONNREFUSED' || error.cause?.code === 'ENOTFOUND') {
+      console.warn('⚠️  Ollama server is not reachable — skipping model KV cache clear');
+    } else {
+      console.warn(`⚠️  Failed to clear Ollama model KV cache: ${error.message}`);
+    }
+    // Never fail the whole flush just because Ollama clear didn't work
+    return true;
+  }
+}
+
 async function restartRecommendation() {
   console.log('\n💡 RECOMMENDATION:');
   console.log('   For complete cache clearing, especially for in-memory caches,');
@@ -317,6 +360,9 @@ async function main() {
 
   // Always check file cache
   success = (await flushFileCache(dryRun, verbose)) && success;
+
+  // Clear Ollama model KV cache to prevent context leakage between sessions
+  success = (await flushOllamaCache(dryRun, verbose)) && success;
 
   console.log('\n' + '='.repeat(50));
 


### PR DESCRIPTION
## Summary

LibreChat currently does not clear the Ollama model's server-side KV cache when flushing the application cache, leading to context bleeding between separate chat sessions. A user reported receiving responses containing context from a previous BAML test run after starting a new chat (issue #14669).

This fix extends the cache flushing script (`config/flush-cache.js`) to also send a request to Ollama's `/api/clear` endpoint (if configured), ensuring the model's context cache is emptied alongside application caches.

## Changes

- Add `flushOllamaCache()` function that sends a POST to Ollama's `/api/clear` endpoint
- Detect Ollama host from `OLLAMA_HOST` environment variable (defaults to `http://localhost:11434`)
- Add proper error handling: timeouts and connection failures log warnings but never block the flush
- Integrate the model cache clearing step after existing cache flushing operations

## Validation

- Dry-run mode (`--dry-run`) shows the endpoint that would be called without making the request
- Verbose mode (`--verbose`) logs the exact endpoint being contacted
- If Ollama is unreachable, a warning is logged and the flush continues normally
- If Ollama is not in use (default state for most deployments), the `/api/clear` call simply fails gracefully

## Risks

- If the Ollama server is down or unreachable, a warning is logged but the flush continues — model cache clearing is best-effort
- Clearing the model KV cache is a global operation affecting all active model contexts, which is expected during a cache flush

Closes #14669