### PR TITLE
fix: include agent-level File Context for subagent invocations

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -955,6 +955,21 @@ const initializeClient = async ({
 
   await resolveSubagentTrees([primaryConfig, ...agentConfigs.values()]);
 
+  /** Snapshot pure-subagent configs BEFORE they are pruned from
+   *  `agentConfigs`. Their `agentContextAttachments` (resolved from
+   *  the agent's `tool_resources.file_search.file_ids` during
+   *  `initializeAgent`) must reach `buildAgentContextAttachmentsByAgentId`
+   *  so the subagent's file context is available when the child graph
+   *  builds its context window. Without this, a pure subagent spawns with
+   *  its Agent-Builder-attached files silently absent. */
+  const pureSubagentConfigs = [];
+  for (const id of pureSubagentIds) {
+    const config = agentConfigs.get(id);
+    if (config) {
+      pureSubagentConfigs.push(config);
+    }
+  }
+
   /** Drop pure-subagent entries now that every reachable config has
    *  had its subagents resolved. They stay in `agentToolContexts` so
    *  their tools still execute with the right scoping. */
@@ -980,6 +995,7 @@ const initializeClient = async ({
   const agentContextAttachmentsByAgentId = buildAgentContextAttachmentsByAgentId([
     primaryConfig,
     ...agentConfigs.values(),
+    ...pureSubagentConfigs,
   ]);
 
   let endpointConfig = appConfig.endpoints?.[primaryConfig.endpoint];

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1250,7 +1250,23 @@ export async function createRun({
 
     const systemContent = [toolInstructions, agent.instructions ?? ''].join('\n').trim();
 
-    const additionalInstructions = [dynamicToolInstructions, agent.additional_instructions ?? '']
+    /** Extract file context text from agent-level File Context attachments
+     *  (tool_resources.file_search.file_ids resolved during initializeAgent).
+     *  For subagents, this is the primary path through which their
+     *  Agent-Builder-attached files reach the child graph — the
+     *  `applyContextToAgent` loop in the host only covers primary + handoff
+     *  agents, not pure subagents pruned from `agentConfigs`. */
+    const agentContextText = (agent.agentContextAttachments ?? [])
+      .filter((file) => file?.text)
+      .map((file) => `# "${file.filename}"\n${file.text}`)
+      .join('\n\n');
+
+    const additionalInstructions = [
+      dynamicToolInstructions,
+      agent.additional_instructions ?? '',
+      agentContextText,
+    ]
+      .filter(Boolean)
       .join('\n')
       .trim();
 


### PR DESCRIPTION
## Summary

When an agent has File Context (files attached via Agent Builder) and is spawned as a subagent, the attached files are silently omitted. The same agent references its File Context correctly when run as a standalone/primary agent, but NOT when invoked as a subagent.

### Root Cause

Two gaps in the subagent initialization pipeline:

1. **initialize.js**: Pure subagent configs (agents referenced only via subagents.agent_ids, not as handoff targets) were pruned from agentConfigs before buildAgentContextAttachmentsByAgentId was called. This meant the attachments map never included pure subagents.

2. **run.ts - buildAgentInput**: The applyContextToAgent loop only covers primary + handoff agents. Pure subagents were never processed. buildAgentInput did not extract file context from agentContextAttachments itself.

### Changes

1. **initialize.js**: Snapshot pure subagent configs before pruning and include them in buildAgentContextAttachmentsByAgentId.

2. **run.ts**: In buildAgentInput, extract file context text from agent.agentContextAttachments and append it to additional_instructions.

Closes #14663