### PR TITLE
♿ fix: Restore WCAG AA Contrast for Text Tokens & Hide Edit Action While Streaming

### DIFF
--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -96,8 +96,9 @@ const HoverButton = memo(
       'hover:text-text-primary hover:bg-surface-hover',
       'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
       !isLast &&
+        isVisible &&
         'group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:hover)]:opacity-0',
-      !isVisible && 'opacity-0',
+      !isVisible && 'pointer-events-none opacity-0',
       'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',
       isActive && isVisible && 'active text-text-primary bg-surface-hover',
       className,

--- a/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { RecoilRoot, type MutableSnapshot } from 'recoil';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { RecoilRoot, type MutableSnapshot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EModelEndpoint, type TConversation, type TMessage } from 'librechat-data-provider';
 import HoverButtons from '~/components/Chat/Messages/HoverButtons';

--- a/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { RecoilRoot, type MutableSnapshot } from 'recoil';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EModelEndpoint, type TConversation, type TMessage } from 'librechat-data-provider';
+import HoverButtons from '~/components/Chat/Messages/HoverButtons';
+import store from '~/store';
+
+const conversation = {
+  conversationId: 'convo-1',
+  endpoint: EModelEndpoint.agents,
+  title: 'Test',
+} as TConversation;
+
+const userMessage = {
+  messageId: 'user-1',
+  conversationId: 'convo-1',
+  parentMessageId: null,
+  isCreatedByUser: true,
+  text: 'tell me a long story',
+} as TMessage;
+
+function renderHoverButtons(isSubmitting: boolean) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const initializeState = ({ set }: MutableSnapshot) => set(store.textToSpeech, false);
+
+  const { container } = render(
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot initializeState={initializeState}>
+        <MemoryRouter>
+          <HoverButtons
+            index={0}
+            isLast={false}
+            isEditing={false}
+            message={userMessage}
+            conversation={conversation}
+            isSubmitting={isSubmitting}
+            enterEdit={jest.fn()}
+            regenerate={jest.fn()}
+            handleContinue={jest.fn()}
+            copyToClipboard={jest.fn()}
+            latestMessageId="assistant-1"
+          />
+        </MemoryRouter>
+      </RecoilRoot>
+    </QueryClientProvider>,
+  );
+
+  const editButton = container.querySelector<HTMLButtonElement>(`#edit-${userMessage.messageId}`);
+  if (!editButton) {
+    throw new Error('edit button not rendered');
+  }
+  return editButton;
+}
+
+describe('HoverButtons edit affordance', () => {
+  it('stays hidden on row hover while a generation is in flight', () => {
+    const editButton = renderHoverButtons(true);
+
+    expect(editButton).toBeDisabled();
+    expect(editButton).toHaveClass('opacity-0', 'pointer-events-none');
+    expect(editButton.className).not.toMatch(/group-hover:opacity-100/);
+    expect(editButton.className).not.toMatch(/group-focus-within:opacity-100/);
+  });
+
+  it('reveals on row hover once the generation settles', () => {
+    const editButton = renderHoverButtons(false);
+
+    expect(editButton).toBeEnabled();
+    expect(editButton).toHaveClass('group-hover:opacity-100');
+    expect(editButton).not.toHaveClass('pointer-events-none', 'opacity-0');
+  });
+});

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -151,7 +151,7 @@ html {
   --text-secondary: var(--gray-600);
   --text-secondary-alt: var(--gray-500);
   --text-tertiary: var(--gray-500);
-  --text-warning: var(--amber-500);
+  --text-warning: var(--amber-700);
   --text-destructive: var(--red-600);
   --link: var(--blue-600);
   --link-hover: var(--blue-700);
@@ -190,7 +190,7 @@ html {
   --border-xheavy: var(--gray-500);
   --border-xheavy-alpha: 1;
   --border-destructive: var(--red-600);
-  --status-success: var(--green-600);
+  --status-success: var(--green-700);
   --status-success-subtle: var(--green-50);
   --status-success-border: var(--green-300);
   --status-success-strong: 2 133 94;
@@ -198,11 +198,11 @@ html {
   --status-info-subtle: var(--blue-50);
   --status-info-border: var(--blue-300);
   --status-info-strong: var(--gray-500);
-  --status-warning: var(--amber-600);
+  --status-warning: var(--amber-700);
   --status-warning-subtle: var(--amber-50);
   --status-warning-border: var(--amber-300);
   --status-warning-strong: 199 82 9;
-  --status-error: var(--red-600);
+  --status-error: var(--red-700);
   --status-error-subtle: var(--red-50);
   --status-error-border: var(--red-300);
   --status-error-strong: 224 47 31;
@@ -226,7 +226,7 @@ html {
   --text-primary: var(--gray-100);
   --text-secondary: var(--gray-300);
   --text-secondary-alt: var(--gray-400);
-  --text-tertiary: var(--gray-500);
+  --text-tertiary: var(--gray-400);
   --text-warning: var(--amber-500);
   --text-destructive: var(--status-error);
   --link: var(--blue-400);

--- a/packages/client/src/theme/semanticTokens.spec.ts
+++ b/packages/client/src/theme/semanticTokens.spec.ts
@@ -1,5 +1,8 @@
 import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
+import type { IThemeRGB } from './types';
+import { defaultTheme } from './themes/default';
+import { darkTheme } from './themes/dark';
 
 const sharedComponents = [
   'AnimatedSearchInput.tsx',
@@ -24,5 +27,92 @@ describe('shared component color guardrail', () => {
       expect(source).not.toMatch(directPalette);
       expect(source).not.toMatch(hexColor);
     });
+  });
+});
+
+type Rgb = [number, number, number];
+
+/** Surfaces that carry body copy; `surface-tertiary` is chip/input fill, added per-group below. */
+const canvasSurfaces: Array<keyof IThemeRGB> = [
+  'rgb-surface-primary',
+  'rgb-surface-primary-alt',
+  'rgb-surface-secondary',
+  'rgb-surface-dialog',
+  'rgb-surface-chat',
+  'rgb-presentation',
+];
+
+const neutralTextTokens: Array<keyof IThemeRGB> = [
+  'rgb-text-primary',
+  'rgb-text-secondary',
+  'rgb-text-secondary-alt',
+  'rgb-text-tertiary',
+];
+
+const statusTextTokens: Array<keyof IThemeRGB> = ['rgb-text-warning', 'rgb-text-destructive'];
+
+/** How Alert/Badge/Tag/Chip paint every status variant: `text-status-x` on `bg-status-x-subtle`. */
+const statusHues = ['success', 'info', 'warning', 'error', 'neutral'] as const;
+
+const WCAG_AA_NORMAL = 4.5;
+
+function toRgb(theme: IThemeRGB, token: keyof IThemeRGB): Rgb {
+  const parts = theme[token]?.trim().split(/\s+/).map(Number);
+  if (parts?.length !== 3 || parts.some(Number.isNaN)) {
+    throw new Error(`theme token "${token}" is not an "R G B" triplet`);
+  }
+  return [parts[0], parts[1], parts[2]];
+}
+
+function channel(value: number): number {
+  const c = value / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function luminance([r, g, b]: Rgb): number {
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [lighter, darker] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function belowAA(
+  theme: IThemeRGB,
+  textTokens: Array<keyof IThemeRGB>,
+  surfaces: Array<keyof IThemeRGB>,
+): string[] {
+  return textTokens.flatMap((text) =>
+    surfaces.flatMap((surface) => {
+      const ratio = contrast(toRgb(theme, text), toRgb(theme, surface));
+      return ratio < WCAG_AA_NORMAL ? [`${text} on ${surface}: ${ratio.toFixed(2)}:1`] : [];
+    }),
+  );
+}
+
+describe.each([
+  ['default', defaultTheme],
+  ['dark', darkTheme],
+])('%s theme text contrast', (_name, theme: IThemeRGB) => {
+  it('keeps neutral text at WCAG AA on every surface it renders on', () => {
+    expect(belowAA(theme, neutralTextTokens, [...canvasSurfaces, 'rgb-surface-tertiary'])).toEqual(
+      [],
+    );
+  });
+
+  it('keeps warning and destructive text at WCAG AA on canvas surfaces', () => {
+    expect(belowAA(theme, statusTextTokens, canvasSurfaces)).toEqual([]);
+  });
+
+  it('keeps every status hue at WCAG AA against its own subtle fill', () => {
+    const failures = statusHues.flatMap((hue) =>
+      belowAA(
+        theme,
+        [`rgb-status-${hue}` as keyof IThemeRGB],
+        [`rgb-status-${hue}-subtle` as keyof IThemeRGB],
+      ),
+    );
+    expect(failures).toEqual([]);
   });
 });

--- a/packages/client/src/theme/themes/dark.ts
+++ b/packages/client/src/theme/themes/dark.ts
@@ -9,7 +9,7 @@ export const darkTheme: IThemeRGB = {
   'rgb-text-primary': '236 236 236', // #ececec (gray-100)
   'rgb-text-secondary': '205 205 205', // #cdcdcd (gray-300)
   'rgb-text-secondary-alt': '153 150 150', // #999696 (gray-400)
-  'rgb-text-tertiary': '89 89 89', // #595959 (gray-500)
+  'rgb-text-tertiary': '153 150 150', // #999696 (gray-400)
   'rgb-text-warning': '245 158 11', // #f59e0b (amber-500)
   'rgb-text-destructive': '252 165 165', // #fca5a5 (red-300, matches status-error)
 

--- a/packages/client/src/theme/themes/default.ts
+++ b/packages/client/src/theme/themes/default.ts
@@ -10,7 +10,7 @@ export const defaultTheme: IThemeRGB = {
   'rgb-text-secondary': '66 66 66', // #424242 (gray-600)
   'rgb-text-secondary-alt': '89 89 89', // #595959 (gray-500)
   'rgb-text-tertiary': '89 89 89', // #595959 (gray-500)
-  'rgb-text-warning': '245 158 11', // #f59e0b (amber-500)
+  'rgb-text-warning': '180 83 9', // #b45309 (amber-700)
   'rgb-text-destructive': '220 38 38', // #dc2626 (red-600)
 
   // Link and accent colors
@@ -63,7 +63,7 @@ export const defaultTheme: IThemeRGB = {
   'rgb-border-destructive': '220 38 38', // #dc2626 (red-600)
 
   // Status colors
-  'rgb-status-success': '5 150 105', // #059669 (green-600)
+  'rgb-status-success': '4 120 87', // #047857 (green-700)
   'rgb-status-success-subtle': '236 253 245', // #ecfdf5 (green-50)
   'rgb-status-success-border': '110 231 183', // #6ee7b7 (green-300)
   'rgb-status-success-strong': '2 133 94', // #02855e
@@ -71,11 +71,11 @@ export const defaultTheme: IThemeRGB = {
   'rgb-status-info-subtle': '239 246 255', // #eff6ff (blue-50)
   'rgb-status-info-border': '147 197 253', // #93c5fd (blue-300)
   'rgb-status-info-strong': '89 89 89', // #595959 (gray-500)
-  'rgb-status-warning': '217 119 6', // #d97706 (amber-600)
+  'rgb-status-warning': '180 83 9', // #b45309 (amber-700)
   'rgb-status-warning-subtle': '255 251 235', // #fffbeb (amber-50)
   'rgb-status-warning-border': '252 211 77', // #fcd34d (amber-300)
   'rgb-status-warning-strong': '199 82 9', // #c75209
-  'rgb-status-error': '220 38 38', // #dc2626 (red-600)
+  'rgb-status-error': '185 28 28', // #b91c1c (red-700)
   'rgb-status-error-subtle': '254 242 242', // #fef2f2 (red-50)
   'rgb-status-error-border': '252 165 165', // #fca5a5 (red-300)
   'rgb-status-error-strong': '224 47 31', // #e02f1f

--- a/packages/client/src/theme/utils/applyTheme.spec.ts
+++ b/packages/client/src/theme/utils/applyTheme.spec.ts
@@ -72,7 +72,9 @@ describe('applyTheme', () => {
   it('ships status tokens in the bundled themes', () => {
     applyTheme(defaultTheme);
 
-    expect(document.documentElement.style.getPropertyValue('--status-error')).toBe('220 38 38');
+    expect(document.documentElement.style.getPropertyValue('--status-error')).toBe(
+      defaultTheme['rgb-status-error'],
+    );
     expect(document.documentElement.style.getPropertyValue('--surface-overlay')).toBe('89 89 89');
   });
 });


### PR DESCRIPTION
## Summary

Two reported regressions, plus the sibling failures found while tracing the root cause. All four are the same underlying bug: **a semantic token that was never tuned per theme**.

### 1. Composer placeholder unreadable in dark mode

#13879 moved the composer from `dark:placeholder-white/60` to the semantic `placeholder:text-text-tertiary`. But `--text-tertiary` was `var(--gray-500)` in *both* themes, and `#595959` is a *dark* gray — so dark mode inherited a foreground darker than most of its own surfaces.

| Composer placeholder on `surface-chat` (dark) | Ratio |
|---|---|
| Before #13879 (`placeholder-white/60`) | 5.90:1 |
| After #13879 (`text-tertiary`) | **1.91:1** |
| This PR | 4.56:1 ✅ |

Fixed at the **token**, not the call site: `text-text-tertiary` has 99 usages and was failing at **1.91–2.77:1 on every dark surface**. The `.gizmo` dark theme already uses a light gray (`#999999`) for the same token, so only the default dark theme carried the inverted value.

### 2. Edit pencil appears on hover mid-generation

`hideEditButton` already covers `isSubmitting`, and the button correctly received `isVisible={false}` → `opacity-0`. But `group-hover:opacity-100` has specificity (0,2,0) and outranks bare `opacity-0` (0,1,0) — so hovering the row revealed a **disabled** pencil.

The hover-reveal classes are now gated on `isVisible`, with `pointer-events-none` so the hidden button is fully inert. Both render paths (`ContentRender`, `MessageRender`) share this component. `Fork` and `Feedback` use the same class block but have no hidden state, so they were unaffected.

### 3. `--text-warning` in light mode — 2.15:1

Same shape: `amber-500` in both themes, never tuned for light. 13 usages, all real warning copy (`ToolApproval`, `AskUserQuestion`, `DeleteAccount`, API key warnings). Now `amber-700` → **5.02:1**.

### 4. Status hues on their own subtle fill (light) — Alert / Badge / Tag / Chip

`text-status-x` on `bg-status-x-subtle` is exactly how all four shared primitives paint every status variant:

| Light hue | Before | After |
|---|---|---|
| success | 3.58:1 | **5.21:1** |
| warning | 3.07:1 | **4.84:1** |
| error | 4.41:1 | **5.91:1** |
| info | 4.75:1 | unchanged |
| neutral | 8.51:1 | unchanged |

Bumped to the 700 ramp. Solid `bg-status-*` is only used for small dots/indicators — nothing renders text on it — so darkening the light foregrounds is safe. Dark mode already measured 8–10:1 and is untouched.

## Not changed

- `text-destructive` (4.09:1) and `text-warning` (4.25:1) on `bg-surface-tertiary` in light — no component pairs them today.
- The `status-*-strong` + `text-on-status` tokens added in #14670 all pass (4.53–10.05, clearly hand-tuned).

## Notes

Both token sources of truth (`client/src/style.css` and `packages/client/src/theme/themes/*.ts`) were updated and verified in sync across all 67 tokens — nothing had enforced that before.

## Test plan

- New `HoverButtons.spec.tsx` covers both hover states (hidden while streaming, revealed once settled).
- `semanticTokens.spec.ts` gains a contrast guardrail: text tokens × surfaces, and each status hue against its subtle fill. Verified it **fails** on the original values:
  ```
  - Array []
  + Array [
  +   "rgb-text-tertiary on rgb-surface-primary: 2.77:1",
  +   "rgb-text-tertiary on rgb-surface-secondary: 2.30:1",
  ```
- `applyTheme.spec.ts` pinned `--status-error` to a literal hex; it now derives the expectation from the theme object, so retuning a hue no longer breaks an unrelated plumbing test.
- Green: **175** tests in `packages/client`, **2056** across `client/src/components/Chat|MCP|utils`, eslint clean, `tsc --noEmit` clean.