### PR TITLE
⚙️ ci: Bump GitHub Actions to Node.js 24 Runtimes

### DIFF
--- a/.github/playwright.yml
+++ b/.github/playwright.yml
@@ -36,8 +36,8 @@
 #       PLAYWRIGHT_BROWSERS_PATH: 0 # Places binaries to node_modules/@playwright/test
 #       TITLE_CONVO: false
 #     steps:
-#       - uses: actions/checkout@v4
-#       - uses: actions/setup-node@v4
+#       - uses: actions/checkout@v5
+#       - uses: actions/setup-node@v5
 #         with:
 #           node-version: 24.16.0
 #           cache: 'npm'
@@ -64,7 +64,7 @@
 #         run: npm run e2e:ci
 
 #       - name: Upload playwright report
-#         uses: actions/upload-artifact@v3
+#         uses: actions/upload-artifact@v6
 #         if: always()
 #         with:
 #           name: playwright-report

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -24,8 +24,8 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_workflow == 'true')
     
     steps:
-      - uses: actions/checkout@v4
-      - uses: dequelabs/axe-linter-action@v1
+      - uses: actions/checkout@v5
+      - uses: dequelabs/axe-linter-action@v2
         with:
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agents-integration-tests.yml
+++ b/.github/workflows/agents-integration-tests.yml
@@ -28,16 +28,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -53,7 +53,7 @@ jobs:
 
       - name: Restore data-provider build cache
         id: cache-data-provider
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-provider/dist
           key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Restore data-schemas build cache
         id: cache-data-schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-schemas/dist
           key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Restore api build cache
         id: cache-api
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/api/dist
           key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/tsdown.config.mjs', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json') }}

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -46,7 +46,7 @@ jobs:
 
       - name: Restore data-provider build cache
         id: cache-data-provider
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-provider/dist
           key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Restore data-schemas build cache
         id: cache-data-schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-schemas/dist
           key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Restore api build cache
         id: cache-api
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/api/dist
           key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/tsdown.config.mjs', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json') }}
@@ -78,21 +78,21 @@ jobs:
         run: npm run build:api
 
       - name: Upload data-provider build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-data-provider
           path: packages/data-provider/dist
           retention-days: 2
 
       - name: Upload data-schemas build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-data-schemas
           path: packages/data-schemas/dist
           retention-days: 2
 
       - name: Upload api build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-api
           path: packages/api/dist
@@ -104,16 +104,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -128,19 +128,19 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download data-schemas build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-schemas
           path: packages/data-schemas/dist
 
       - name: Download api build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-api
           path: packages/api/dist
@@ -162,16 +162,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -207,16 +207,16 @@ jobs:
       BAN_DURATION: ${{ secrets.BAN_DURATION }}
       BAN_INTERVAL: ${{ secrets.BAN_INTERVAL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -231,19 +231,19 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download data-schemas build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-schemas
           path: packages/data-schemas/dist
 
       - name: Download api build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-api
           path: packages/api/dist
@@ -265,16 +265,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -289,7 +289,7 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
@@ -303,16 +303,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -327,13 +327,13 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download data-schemas build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-schemas
           path: packages/data-schemas/dist
@@ -355,16 +355,16 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -379,19 +379,19 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download data-schemas build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-schemas
           path: packages/data-schemas/dist
 
       - name: Download api build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-api
           path: packages/api/dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,15 +15,15 @@ jobs:
     steps:
       # checkout the repo
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Login via Azure CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: 'Build GitHub Runner container image'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -32,7 +32,7 @@ jobs:
           docker build --build-arg RUNNER_VERSION=${{ env.RUNNER_VERSION }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/pwd9000-github-runner-lin:${{ env.RUNNER_VERSION }} .
 
       - name: 'Push container image to ACR'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/cache-integration-tests.yml
+++ b/.github/workflows/cache-integration-tests.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -75,7 +75,7 @@ jobs:
 
       - name: Restore data-provider build cache
         id: cache-data-provider
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-provider/dist
           key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Restore data-schemas build cache
         id: cache-data-schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-schemas/dist
           key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: Restore api build cache
         id: cache-api
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/api/dist
           key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/tsdown.config.mjs', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json') }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -22,10 +22,10 @@ jobs:
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload package
         if: steps.check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: librechat-client-package
           path: npm-package/*.tgz
@@ -75,7 +75,7 @@ jobs:
       id-token: write  # Required for OIDC trusted publishing
     steps:
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
           registry-url: 'https://registry.npmjs.org'
@@ -84,7 +84,7 @@ jobs:
         run: npm install -g npm@11.14.1 --ignore-scripts
 
       - name: Download package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: librechat-client-package
           path: npm-package

--- a/.github/workflows/config-review.yml
+++ b/.github/workflows/config-review.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -46,7 +46,7 @@ jobs:
 
       - name: Restore data-provider build cache
         id: cache-data-provider
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-provider/dist
           key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Restore data-schemas build cache
         id: cache-data-schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-schemas/dist
           key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Restore api build cache
         id: cache-api
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/api/dist
           key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/tsdown.config.mjs', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json') }}

--- a/.github/workflows/data-provider.yml
+++ b/.github/workflows/data-provider.yml
@@ -20,8 +20,8 @@ jobs:
   pack:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
       - run: cd packages/data-provider && npm ci
@@ -32,7 +32,7 @@ jobs:
           cd packages/data-provider
           npm pack --pack-destination "$GITHUB_WORKSPACE/npm-package"
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: librechat-data-provider-package
           path: npm-package/*.tgz
@@ -48,7 +48,7 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC trusted publishing
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
           registry-url: 'https://registry.npmjs.org'
@@ -57,7 +57,7 @@ jobs:
         run: npm install -g npm@11.14.1 --ignore-scripts
 
       - name: Download package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: librechat-data-provider-package
           path: npm-package

--- a/.github/workflows/data-schemas.yml
+++ b/.github/workflows/data-schemas.yml
@@ -22,10 +22,10 @@ jobs:
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload package
         if: steps.check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: librechat-data-schemas-package
           path: npm-package/*.tgz
@@ -75,7 +75,7 @@ jobs:
       id-token: write  # Required for OIDC trusted publishing
     steps:
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
           registry-url: 'https://registry.npmjs.org'
@@ -84,7 +84,7 @@ jobs:
         run: npm install -g npm@11.14.1 --ignore-scripts
 
       - name: Download package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: librechat-data-schemas-package
           path: npm-package

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,7 +19,7 @@ jobs:
        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'dev'))
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       # checkout the repo
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 'Login via Azure CLI'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/dev-branch-images.yml
+++ b/.github/workflows/dev-branch-images.yml
@@ -40,19 +40,19 @@ jobs:
     steps:
       # Check out the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up QEMU
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
 
       # Login to Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
 
       # Build and push Docker images for each target
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -36,19 +36,19 @@ jobs:
     steps:
       # Check out the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up QEMU
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
 
       # Login to Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
 
       # Build and push Docker images for each target
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/dev-staging-images.yml
+++ b/.github/workflows/dev-staging-images.yml
@@ -23,19 +23,19 @@ jobs:
     steps:
       # Check out the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up QEMU
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       # Login to Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
 
       # Build and push Docker images for each target
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build client package target
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.multi
@@ -51,16 +51,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Build the real production image (final `api-build` stage), which installs
       # with `npm ci --omit=dev` — the same prune that, in prod, exposed runtime
       # dependencies the tsdown bundle externalizes but were never declared.
       - name: Build production image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.multi

--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -24,12 +24,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
           cache: npm

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -45,7 +45,7 @@ jobs:
 
       - name: Restore data-provider build cache
         id: cache-data-provider
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-provider/dist
           key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Restore client-package build cache
         id: cache-client-package
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/client/dist
           key: build-client-package-${{ runner.os }}-${{ hashFiles('packages/client/src/**', 'packages/client/tsconfig*.json', 'packages/client/tsdown.config.mjs', 'packages/client/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -66,14 +66,14 @@ jobs:
         run: npm run build:client-package
 
       - name: Upload data-provider build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-data-provider
           path: packages/data-provider/dist
           retention-days: 2
 
       - name: Upload client-package build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-client-package
           path: packages/client/dist
@@ -85,16 +85,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -108,13 +108,13 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download client-package build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-client-package
           path: packages/client/dist
@@ -129,16 +129,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -152,7 +152,7 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
@@ -171,16 +171,16 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -194,13 +194,13 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download client-package build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-client-package
           path: packages/client/dist
@@ -219,16 +219,16 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -242,13 +242,13 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download client-package build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-client-package
           path: packages/client/dist
@@ -263,16 +263,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -286,13 +286,13 @@ jobs:
         run: npm ci
 
       - name: Download data-provider build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-data-provider
           path: packages/data-provider/dist
 
       - name: Download client-package build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-client-package
           path: packages/client/dist

--- a/.github/workflows/generate_embeddings.yml
+++ b/.github/workflows/generate_embeddings.yml
@@ -14,7 +14,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: supabase/embeddings-generator@v0.0.5
         with:
           supabase-url: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/gitnexus-cleanup-pr.yml
+++ b/.github/workflows/gitnexus-cleanup-pr.yml
@@ -34,7 +34,7 @@ jobs:
       # sessions on a busy repo.
       - name: Check for index artifact
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data } = await github.rest.actions.listArtifactsForRepo({

--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -104,7 +104,7 @@ jobs:
       image_tag: ${{ steps.tag.outputs.value }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -127,11 +127,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: steps.changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
 
       - name: Build and push image
         if: steps.changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .do/gitnexus
           file: .do/gitnexus/Dockerfile
@@ -162,7 +162,7 @@ jobs:
       pull-requests: write # post deploy-complete comments on PR command dispatches
     steps:
       - name: Checkout deploy config
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: .do/gitnexus
           fetch-depth: 1
@@ -181,7 +181,7 @@ jobs:
       # artifact name directly avoids the whole mess.
       - name: Resolve indexes to serve
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const serve = []; // [{ name, artifactName, runId }]
@@ -505,7 +505,7 @@ jobs:
       # PR that asked for a fresh index gets a reply.
       - name: Comment on PR — deploy complete
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MATRIX: ${{ steps.resolve.outputs.matrix }}
           TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -138,7 +138,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
@@ -170,7 +170,7 @@ jobs:
           test -x "$RUNNER_TEMP/gitnexus-cli/node_modules/.bin/gitnexus"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # When the /gitnexus command dispatches us with a pr_ref, it's
           # a refs/pull/<N>/head ref that GitHub mirrors into the base
@@ -186,7 +186,7 @@ jobs:
       # across runs so warm runs never touch HF at all.
       - name: Cache HuggingFace embedding model
         if: steps.flags.outputs.enable_embeddings == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/hf-cache
           key: hf-model-snowflake-arctic-embed-xs-v1
@@ -234,7 +234,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload GitNexus index
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           # Artifact naming order of precedence:
           #   1. /gitnexus command dispatch: inputs.pr_number -> pr-<N>
@@ -270,7 +270,7 @@ jobs:
       # a PR number can still opt into a deploy by setting deploy_after=true.
       - name: Trigger deploy workflow after non-PR dispatches
         if: inputs.deploy_after && inputs.pr_number == '' && needs.index.result == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.info('deploy_after=true; dispatching gitnexus-deploy.yml manually.');
@@ -289,7 +289,7 @@ jobs:
       # inputs.pr_number is set and reports the index job result.
       - name: Comment on PR — index complete
         if: inputs.pr_number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EMBEDDINGS_INPUT: ${{ inputs.embeddings }}
           INDEX_RESULT: ${{ needs.index.result }}

--- a/.github/workflows/gitnexus-pr-command.yml
+++ b/.github/workflows/gitnexus-pr-command.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Parse command and resolve PR head ref
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.comment.body.trim();
@@ -93,7 +93,7 @@ jobs:
             );
 
       - name: Dispatch gitnexus-index workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           EMBEDDINGS: ${{ steps.parse.outputs.embeddings }}
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
@@ -130,7 +130,7 @@ jobs:
             });
 
       - name: React to the comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/helmcharts.yml
+++ b/.github/workflows/helmcharts.yml
@@ -48,7 +48,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       
@@ -73,7 +73,7 @@ jobs:
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/i18n-unused-keys.yml
+++ b/.github/workflows/i18n-unused-keys.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Find unused i18next keys
         id: find-unused

--- a/.github/workflows/langfuse-fanout.yml
+++ b/.github/workflows/langfuse-fanout.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: otel/langfuse-fanout/go.mod
           cache-dependency-path: otel/langfuse-fanout/go.sum

--- a/.github/workflows/locize-i18n-sync.yml
+++ b/.github/workflows/locize-i18n-sync.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Set Up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
@@ -53,7 +53,7 @@ jobs:
     steps:
       # 1. Check out the repository.
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
       # workflow does not depend on the global GITHUB_TOKEN PR-creation setting.
       - name: Create Pull Request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.LOCIZE_PR_TOKEN }}
           add-paths: |

--- a/.github/workflows/main-image-workflow.yml
+++ b/.github/workflows/main-image-workflow.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -46,15 +46,15 @@ jobs:
 
       # Set up QEMU
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       # Login to Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
 
       # Build and push Docker images for each target
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -55,16 +55,16 @@ jobs:
       E2E_STREAM_STORE: ${{ matrix.stream_store }}
       REDIS_URI: redis://127.0.0.1:6379
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
 
       - name: Restore node_modules cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -82,7 +82,7 @@ jobs:
 
       - name: Restore data-provider build cache
         id: cache-data-provider
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-provider/dist
           key: build-data-provider-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Restore data-schemas build cache
         id: cache-data-schemas
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/data-schemas/dist
           key: build-data-schemas-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -104,7 +104,7 @@ jobs:
 
       - name: Restore api build cache
         id: cache-api
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/api/dist
           key: build-api-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/tsdown.config.mjs', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/tsdown.config.mjs', 'packages/data-schemas/package.json') }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Restore client-package build cache
         id: cache-client-package
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/client/dist
           key: build-client-package-${{ runner.os }}-${{ hashFiles('package-lock.json', 'packages/client/src/**', 'packages/client/tsconfig*.json', 'packages/client/tsdown.config.mjs', 'packages/client/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Restore client app build cache
         id: cache-client-app
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: client/dist
           key: build-client-app-e2e-${{ runner.os }}-${{ hashFiles('package-lock.json', 'client/src/**', 'client/public/**', 'client/scripts/post-build.cjs', 'client/index.html', 'client/package.json', 'client/vite.config.*', 'client/tsconfig*.json', 'client/tailwind.config.*', 'client/postcss.config.*', 'packages/client/src/**', 'packages/client/tsconfig*.json', 'packages/client/tsdown.config.mjs', 'packages/client/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/tsdown.config.mjs', 'packages/data-provider/package.json') }}
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload Playwright HTML report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report-${{ matrix.stream_store }}-${{ matrix.shard }}
           path: e2e/playwright-report/**
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload traces & screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-test-results-${{ matrix.stream_store }}-${{ matrix.shard }}
           path: e2e/specs/.test-results/**

--- a/.github/workflows/tag-images.yml
+++ b/.github/workflows/tag-images.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Check out the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate release tag
         id: release-tag
@@ -48,15 +48,15 @@ jobs:
 
       # Set up QEMU
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
 
       # Login to Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
 
       # Build and push Docker images for each target
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/unused-packages.yml
+++ b/.github/workflows/unused-packages.yml
@@ -19,10 +19,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 24.16.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.16.0'
           cache: 'npm'

--- a/packages/api/src/cluster/LeaderElection.ts
+++ b/packages/api/src/cluster/LeaderElection.ts
@@ -1,7 +1,7 @@
 import { logger } from '@librechat/data-schemas';
-import { observeRedisOperation, RedisUseCases } from '~/cache/redisTelemetry';
+import { instrumentIORedisClient, RedisUseCases } from '~/cache/redisTelemetry';
 import { cacheConfig as cache } from '~/cache/cacheConfig';
-import { keyvRedisClient } from '~/cache/redisClients';
+import { ioredisClient } from '~/cache/redisClients';
 import { clusterConfig as cluster } from './config';
 
 /**
@@ -19,10 +19,18 @@ import { clusterConfig as cluster } from './config';
  * - If leader crashes, the lease eventually expires, and the key disappears
  * - On shutdown, leader deletes its key to allow immediate re-election
  * - Followers check for leadership and attempt to claim it when the key is empty
+ *
+ * Uses ioredis (not @keyv/redis) for all lock operations. ioredis applies REDIS_KEY_PREFIX via
+ * keyPrefix and correctly retries MOVED/ASK redirects on Redis Cluster for SET NX and Lua EVAL.
+ * @keyv/redis EVAL has been observed to surface unhandled MOVED errors on cluster, leaving the
+ * leadership key stuck after resign().
  */
 export class LeaderElection {
-  // We can't use Keyv namespace here because we need direct Redis access for atomic operations
-  static readonly LEADER_KEY: string = `${cache.REDIS_KEY_PREFIX}${cache.GLOBAL_PREFIX_SEPARATOR}LeadingServerUUID`;
+  /**
+   * Logical leadership key. ioredis prepends REDIS_KEY_PREFIX via its keyPrefix option,
+   * so the on-wire key is `{REDIS_KEY_PREFIX}::LeadingServerUUID`.
+   */
+  static readonly LEADER_KEY: string = 'LeadingServerUUID';
   private static _instance = new LeaderElection();
 
   readonly UUID: string = crypto.randomUUID();
@@ -36,6 +44,13 @@ export class LeaderElection {
     process.on('SIGTERM', () => this.resign());
     process.on('SIGINT', () => this.resign());
     LeaderElection._instance = this;
+  }
+
+  private static redis() {
+    if (!ioredisClient) {
+      throw new Error('Redis client is not initialized');
+    }
+    return instrumentIORedisClient(ioredisClient, RedisUseCases.LEADER_ELECTION);
   }
 
   /**
@@ -80,12 +95,7 @@ export class LeaderElection {
         end
       `;
 
-      await observeRedisOperation('keyv', RedisUseCases.LEADER_ELECTION, 'eval', () =>
-        keyvRedisClient!.eval(script, {
-          keys: [LeaderElection.LEADER_KEY],
-          arguments: [this.UUID],
-        }),
-      );
+      await LeaderElection.redis().eval(script, 1, LeaderElection.LEADER_KEY, this.UUID);
     } catch (error) {
       logger.error('Failed to release leadership lock:', error);
     }
@@ -98,9 +108,7 @@ export class LeaderElection {
    */
   public static async getLeaderUUID(): Promise<string | null> {
     if (!cache.USE_REDIS) return null;
-    return await observeRedisOperation('keyv', RedisUseCases.LEADER_ELECTION, 'get', () =>
-      keyvRedisClient!.get(LeaderElection.LEADER_KEY),
-    );
+    return await LeaderElection.redis().get(LeaderElection.LEADER_KEY);
   }
 
   /**
@@ -120,11 +128,12 @@ export class LeaderElection {
    */
   private async electSelf(): Promise<boolean> {
     try {
-      const result = await observeRedisOperation('keyv', RedisUseCases.LEADER_ELECTION, 'set', () =>
-        keyvRedisClient!.set(LeaderElection.LEADER_KEY, this.UUID, {
-          NX: true,
-          EX: cluster.LEADER_LEASE_DURATION,
-        }),
+      const result = await LeaderElection.redis().set(
+        LeaderElection.LEADER_KEY,
+        this.UUID,
+        'EX',
+        cluster.LEADER_LEASE_DURATION,
+        'NX',
       );
 
       if (result !== 'OK') return false;
@@ -159,15 +168,12 @@ export class LeaderElection {
         end
       `;
 
-      const result = await observeRedisOperation(
-        'keyv',
-        RedisUseCases.LEADER_ELECTION,
-        'eval',
-        () =>
-          keyvRedisClient!.eval(script, {
-            keys: [LeaderElection.LEADER_KEY],
-            arguments: [this.UUID, cluster.LEADER_LEASE_DURATION.toString()],
-          }),
+      const result = await LeaderElection.redis().eval(
+        script,
+        1,
+        LeaderElection.LEADER_KEY,
+        this.UUID,
+        cluster.LEADER_LEASE_DURATION.toString(),
       );
 
       if (result === 0) {

--- a/packages/api/src/cluster/__tests__/LeaderElection.cache_integration.spec.ts
+++ b/packages/api/src/cluster/__tests__/LeaderElection.cache_integration.spec.ts
@@ -6,6 +6,13 @@ describe('LeaderElection with Redis', () => {
   let keyvRedisClient: Awaited<typeof import('~/cache/redisClients')>['keyvRedisClient'];
   let ioredisClient: Awaited<typeof import('~/cache/redisClients')>['ioredisClient'];
 
+  const clearLeaderKey = async () => {
+    // LeaderElection uses ioredis (keyPrefix applied). Match that client for cleanup.
+    if (ioredisClient) {
+      await ioredisClient.del(LeaderElection.LEADER_KEY);
+    }
+  };
+
   beforeAll(async () => {
     // Set up environment variables for Redis
     process.env.USE_REDIS = 'true';
@@ -20,22 +27,42 @@ describe('LeaderElection with Redis', () => {
     keyvRedisClient = redisClients.keyvRedisClient;
     ioredisClient = redisClients.ioredisClient;
 
-    // Ensure Redis is connected
+    // Ensure Redis is connected (both clients; LeaderElection uses ioredis)
+    if (!ioredisClient) {
+      throw new Error('ioredis client is not initialized');
+    }
     if (!keyvRedisClient) {
       throw new Error('Redis client is not initialized');
     }
 
     // Wait for connection and topology discovery to complete
     await redisClients.keyvRedisClientReady;
+    const redis = ioredisClient;
+    if (redis.status !== 'ready') {
+      await new Promise<void>((resolve, reject) => {
+        const onReady = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: Error) => {
+          cleanup();
+          reject(err);
+        };
+        const cleanup = () => {
+          redis.off('ready', onReady);
+          redis.off('error', onError);
+        };
+        redis.once('ready', onReady);
+        redis.once('error', onError);
+      });
+    }
 
     // Increase max listeners to handle many instances in tests
     process.setMaxListeners(200);
   });
 
   beforeEach(async () => {
-    if (keyvRedisClient) {
-      await keyvRedisClient.del(LeaderElection.LEADER_KEY);
-    }
+    await clearLeaderKey();
     new LeaderElection().clearRefreshTimer();
   });
 
@@ -44,9 +71,7 @@ describe('LeaderElection with Redis', () => {
       await Promise.all(instances.map((instance) => instance.resign()));
     } finally {
       instances = [];
-      if (keyvRedisClient) {
-        await keyvRedisClient.del(LeaderElection.LEADER_KEY);
-      }
+      await clearLeaderKey();
     }
   });
 


### PR DESCRIPTION
## Summary

- Bumps first-party and Docker-related GitHub Actions across workflows to majors that declare the Node.js 24 runtime, clearing the runner deprecation annotations for Node 20 actions.
- Covers the original smoke-job warnings (`actions/checkout`, `docker/setup-buildx-action`, `docker/build-push-action`) and the rest of CI so the same noise does not keep firing elsewhere.
- Leaves third-party pins that still have no Node 24 release (`azure/aci-deploy`, `supabase/embeddings-generator`).

### Pin map

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `actions/github-script` | v7 | v8 |
| `actions/setup-go` | v5 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/build-push-action` | v5 | v7 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `azure/login` | v2 | v3 |
| `azure/setup-helm` | v4 | v5 |
| `peter-evans/create-pull-request` | v7 | v8 |
| `dequelabs/axe-linter-action` | v1 | v2 |

`checkout` is intentionally on **v5** (not v7) so `workflow_run` jobs avoid v7’s stricter fork-PR checkout defaults. Artifact majors use the first Node 24 pair (`upload@v6` / `download@v7`) to keep default zipped artifacts.

## Test plan

- [ ] Confirm Docker Build Smoke Tests run without Node 20 deprecation annotations
- [ ] Spot-check backend/frontend review workflows still pass artifact handoff (upload v6 → download v7)
- [ ] Spot-check a Docker image workflow (buildx + login + build-push) on next image build
- [ ] Confirm residual third-party actions (`aci-deploy`, embeddings-generator) are accepted until upstream ships Node 24