### PR TITLE
🔑 fix: Scope RAG API Tokens and Agent Knowledge-File Deletion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -613,6 +613,21 @@ TTS_API_KEY=
 # EMBEDDINGS_PROVIDER=openai
 # EMBEDDINGS_MODEL=text-embedding-3-small
 
+# Dedicated signing key for tokens sent to the RAG API. It must differ from
+# JWT_SECRET: sharing the key would make every RAG token a valid application
+# session token and vice versa. At least 32 characters for HMAC algorithms.
+# Set the same value on the RAG API. While it is unset, LibreChat keeps minting
+# the pre-scopes token shape, so an older RAG API deployment keeps working.
+# RAG_JWT_SECRET=
+# RAG_JWT_PRIVATE_KEY=
+# RAG_JWT_ALGORITHM=HS256
+# RAG_JWT_ISSUER=librechat
+# RAG_JWT_AUDIENCE=rag_api
+
+# Set to false once RAG_JWT_SECRET is configured on both sides. LibreChat then
+# refuses to mint a token at all rather than falling back to JWT_SECRET.
+# RAG_AUTH_ACCEPT_LEGACY=true
+
 # Stream upload responses with heartbeats during long-running file processing.
 # FILE_UPLOAD_SSE_ENABLED=false
 

--- a/.env.example
+++ b/.env.example
@@ -627,6 +627,13 @@ TTS_API_KEY=
 # RAG_JWT_ALGORITHM=HS256
 # RAG_JWT_ISSUER=librechat
 # RAG_JWT_AUDIENCE=rag_api
+# Key id stamped into every token header, so the RAG API can trust more than one
+# key at a time and a rotation does not need both sides restarted together:
+# publish the new key there, then move this side onto it.
+# RAG_JWT_KID=lc-rag-2026-08
+# Token lifetime in seconds. 300 is both the default and the maximum, so this
+# can only shorten it.
+# RAG_JWT_TTL_SECONDS=300
 
 # Set to false once RAG_JWT_SECRET is configured on both sides. LibreChat then
 # refuses to mint a token at all rather than falling back to JWT_SECRET.

--- a/.env.example
+++ b/.env.example
@@ -619,7 +619,11 @@ TTS_API_KEY=
 # Set the same value on the RAG API. While it is unset, LibreChat keeps minting
 # the pre-scopes token shape, so an older RAG API deployment keeps working.
 # RAG_JWT_SECRET=
+# RAG_JWT_PRIVATE_KEY is read instead of RAG_JWT_SECRET for the asymmetric
+# algorithms. A PEM flattened to one line with literal \n escapes is accepted.
 # RAG_JWT_PRIVATE_KEY=
+# Supported: HS256 HS384 HS512 RS256 RS384 RS512 PS256 PS384 PS512 ES256 ES384
+# ES512. Matched case-insensitively.
 # RAG_JWT_ALGORITHM=HS256
 # RAG_JWT_ISSUER=librechat
 # RAG_JWT_AUDIENCE=rag_api

--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -24,21 +24,27 @@ function createContextHandlers(req, userMessageContent) {
    * under, so both the token and the request have to name that entity. Message
    * attachments carry none, and stay scoped to the user alone.
    *
+   * The two branches reach different planes of the RAG service and so mint
+   * different scopes: reading a file's stored context needs document access and
+   * no inference, while a retrieval query embeds the user's message and needs
+   * exactly the reverse.
+   *
    * @param {MongoFile & { entity_id?: string }} file
    */
   const query = async (file) => {
     const entity_id = file.entity_id;
-    const jwtToken = generateShortLivedToken({
-      userId: req.user.id,
-      tenantId: req.user.tenantId,
-      entityIds: entity_id ? [entity_id] : [],
-      scopes: [RagScopes.embed],
-    });
+    const mintToken = (scope) =>
+      generateShortLivedToken({
+        userId: req.user.id,
+        tenantId: req.user.tenantId,
+        entityIds: entity_id ? [entity_id] : [],
+        scopes: [scope],
+      });
 
     if (useFullContext) {
       return axios.get(`${process.env.RAG_API_URL}/documents/${file.file_id}/context`, {
         headers: {
-          Authorization: `Bearer ${jwtToken}`,
+          Authorization: `Bearer ${mintToken(RagScopes.documents)}`,
         },
         params: entity_id ? { entity_id } : undefined,
       });
@@ -54,7 +60,7 @@ function createContextHandlers(req, userMessageContent) {
       },
       {
         headers: {
-          Authorization: `Bearer ${jwtToken}`,
+          Authorization: `Bearer ${mintToken(RagScopes.embed)}`,
           'Content-Type': 'application/json',
         },
       },

--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { isEnabled, generateShortLivedToken, logAxiosError } = require('@librechat/api');
+const { RagScopes, isEnabled, logAxiosError, generateShortLivedToken } = require('@librechat/api');
 
 const footer = `Use the context as your learned knowledge to better answer the user.
 
@@ -17,15 +17,30 @@ function createContextHandlers(req, userMessageContent) {
   const queryPromises = [];
   const processedFiles = [];
   const processedIds = new Set();
-  const jwtToken = generateShortLivedToken(req.user.id);
   const useFullContext = isEnabled(process.env.RAG_USE_FULL_CONTEXT);
 
+  /**
+   * Chunks of a knowledge-base file are owned by the agent it was embedded
+   * under, so both the token and the request have to name that entity. Message
+   * attachments carry none, and stay scoped to the user alone.
+   *
+   * @param {MongoFile & { entity_id?: string }} file
+   */
   const query = async (file) => {
+    const entity_id = file.entity_id;
+    const jwtToken = generateShortLivedToken({
+      userId: req.user.id,
+      tenantId: req.user.tenantId,
+      entityIds: entity_id ? [entity_id] : [],
+      scopes: [RagScopes.embed],
+    });
+
     if (useFullContext) {
       return axios.get(`${process.env.RAG_API_URL}/documents/${file.file_id}/context`, {
         headers: {
           Authorization: `Bearer ${jwtToken}`,
         },
+        params: entity_id ? { entity_id } : undefined,
       });
     }
 
@@ -35,6 +50,7 @@ function createContextHandlers(req, userMessageContent) {
         file_id: file.file_id,
         query: userMessageContent,
         k: 4,
+        ...(entity_id ? { entity_id } : {}),
       },
       {
         headers: {

--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -1,5 +1,11 @@
 const axios = require('axios');
-const { RagScopes, isEnabled, logAxiosError, generateShortLivedToken } = require('@librechat/api');
+const {
+  RagScopes,
+  isEnabled,
+  logAxiosError,
+  generateShortLivedToken,
+  getRecordedEmbeddingEntityId,
+} = require('@librechat/api');
 
 const footer = `Use the context as your learned knowledge to better answer the user.
 
@@ -22,17 +28,19 @@ function createContextHandlers(req, userMessageContent) {
   /**
    * Chunks of a knowledge-base file are owned by the agent it was embedded
    * under, so both the token and the request have to name that entity. Message
-   * attachments carry none, and stay scoped to the user alone.
+   * attachments carry none, and stay scoped to the user alone. The file record
+   * says which of the two it was; a file that predates that record has nothing
+   * to name and stays user-scoped, exactly as it always has.
    *
    * The two branches reach different planes of the RAG service and so mint
    * different scopes: reading a file's stored context needs document access and
    * no inference, while a retrieval query embeds the user's message and needs
    * exactly the reverse.
    *
-   * @param {MongoFile & { entity_id?: string }} file
+   * @param {MongoFile} file
    */
   const query = async (file) => {
-    const entity_id = file.entity_id;
+    const entity_id = getRecordedEmbeddingEntityId(file);
     const mintToken = (scope) =>
       generateShortLivedToken({
         userId: req.user.id,

--- a/api/app/clients/prompts/createContextHandlers.spec.js
+++ b/api/app/clients/prompts/createContextHandlers.spec.js
@@ -1,0 +1,112 @@
+const axios = require('axios');
+
+jest.mock('axios');
+
+jest.mock('@librechat/api', () => ({
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  isEnabled: jest.fn(() => false),
+  logAxiosError: jest.fn(),
+  generateShortLivedToken: jest.fn(() => 'mock-jwt-token'),
+}));
+
+const createContextHandlers = require('./createContextHandlers');
+const { isEnabled, generateShortLivedToken } = require('@librechat/api');
+
+describe('createContextHandlers', () => {
+  const ORIGINAL_RAG_API_URL = process.env.RAG_API_URL;
+
+  const req = { user: { id: 'user-1', tenantId: 'tenant-a' } };
+
+  const embeddedFile = (file_id, extra = {}) => ({
+    file_id,
+    filename: `${file_id}.pdf`,
+    type: 'application/pdf',
+    embedded: true,
+    ...extra,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isEnabled.mockReturnValue(false);
+    generateShortLivedToken.mockReturnValue('mock-jwt-token');
+    axios.post.mockResolvedValue({ data: [] });
+    axios.get.mockResolvedValue({ data: '' });
+    process.env.RAG_API_URL = 'http://rag-api.test';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_RAG_API_URL === undefined) {
+      delete process.env.RAG_API_URL;
+    } else {
+      process.env.RAG_API_URL = ORIGINAL_RAG_API_URL;
+    }
+  });
+
+  describe('semantic search', () => {
+    it('names the owning agent on the query and in the token', async () => {
+      const handlers = createContextHandlers(req, 'what does it say?');
+      await handlers.processFile(embeddedFile('kb-1', { entity_id: 'agent_123' }));
+      await handlers.createContext();
+
+      const [, body] = axios.post.mock.calls[0];
+      expect(body).toMatchObject({ file_id: 'kb-1', entity_id: 'agent_123' });
+      expect(generateShortLivedToken).toHaveBeenCalledWith({
+        userId: 'user-1',
+        tenantId: 'tenant-a',
+        entityIds: ['agent_123'],
+        scopes: ['rag:embed'],
+      });
+    });
+
+    it('keeps a message attachment scoped to the user alone', async () => {
+      const handlers = createContextHandlers(req, 'what does it say?');
+      await handlers.processFile(embeddedFile('attachment-1'));
+      await handlers.createContext();
+
+      const [, body] = axios.post.mock.calls[0];
+      expect(body).not.toHaveProperty('entity_id');
+      expect(generateShortLivedToken).toHaveBeenCalledWith({
+        userId: 'user-1',
+        tenantId: 'tenant-a',
+        entityIds: [],
+        scopes: ['rag:embed'],
+      });
+    });
+  });
+
+  describe('full-context reads', () => {
+    beforeEach(() => {
+      isEnabled.mockReturnValue(true);
+    });
+
+    it('names the owning agent on the document context request', async () => {
+      const handlers = createContextHandlers(req, 'what does it say?');
+      await handlers.processFile(embeddedFile('kb-1', { entity_id: 'agent_123' }));
+      await handlers.createContext();
+
+      const [url, config] = axios.get.mock.calls[0];
+      expect(url).toBe('http://rag-api.test/documents/kb-1/context');
+      expect(config.params).toEqual({ entity_id: 'agent_123' });
+      expect(generateShortLivedToken).toHaveBeenCalledWith({
+        userId: 'user-1',
+        tenantId: 'tenant-a',
+        entityIds: ['agent_123'],
+        scopes: ['rag:embed'],
+      });
+    });
+
+    it('sends no entity for a file with no agent context', async () => {
+      const handlers = createContextHandlers(req, 'what does it say?');
+      await handlers.processFile(embeddedFile('attachment-1'));
+      await handlers.createContext();
+
+      const [, config] = axios.get.mock.calls[0];
+      expect(config.params).toBeUndefined();
+    });
+  });
+
+  it('returns nothing when the RAG API is not configured', () => {
+    delete process.env.RAG_API_URL;
+    expect(createContextHandlers(req, 'query')).toBeUndefined();
+  });
+});

--- a/api/app/clients/prompts/createContextHandlers.spec.js
+++ b/api/app/clients/prompts/createContextHandlers.spec.js
@@ -7,6 +7,10 @@ jest.mock('@librechat/api', () => ({
   isEnabled: jest.fn(() => false),
   logAxiosError: jest.fn(),
   generateShortLivedToken: jest.fn(() => 'mock-jwt-token'),
+  getRecordedEmbeddingEntityId: (file) =>
+    file.embedding_entity_id != null && file.embedding_entity_id !== '__NONE__'
+      ? file.embedding_entity_id
+      : undefined,
 }));
 
 const createContextHandlers = require('./createContextHandlers');
@@ -45,7 +49,7 @@ describe('createContextHandlers', () => {
   describe('semantic search', () => {
     it('names the owning agent on the query and in the token', async () => {
       const handlers = createContextHandlers(req, 'what does it say?');
-      await handlers.processFile(embeddedFile('kb-1', { entity_id: 'agent_123' }));
+      await handlers.processFile(embeddedFile('kb-1', { embedding_entity_id: 'agent_123' }));
       await handlers.createContext();
 
       const [, body] = axios.post.mock.calls[0];
@@ -81,7 +85,7 @@ describe('createContextHandlers', () => {
 
     it('names the owning agent on the document context request', async () => {
       const handlers = createContextHandlers(req, 'what does it say?');
-      await handlers.processFile(embeddedFile('kb-1', { entity_id: 'agent_123' }));
+      await handlers.processFile(embeddedFile('kb-1', { embedding_entity_id: 'agent_123' }));
       await handlers.createContext();
 
       const [url, config] = axios.get.mock.calls[0];
@@ -131,6 +135,16 @@ describe('createContextHandlers', () => {
       ['rag:documents'],
       ['rag:embed'],
     ]);
+  });
+
+  it('keeps a file recorded as user-scoped unscoped', async () => {
+    const handlers = createContextHandlers(req, 'what does it say?');
+    await handlers.processFile(embeddedFile('attachment-1', { embedding_entity_id: '__NONE__' }));
+    await handlers.createContext();
+
+    const [, body] = axios.post.mock.calls[0];
+    expect(body).not.toHaveProperty('entity_id');
+    expect(generateShortLivedToken.mock.calls[0][0].entityIds).toEqual([]);
   });
 
   it('returns nothing when the RAG API is not configured', () => {

--- a/api/app/clients/prompts/createContextHandlers.spec.js
+++ b/api/app/clients/prompts/createContextHandlers.spec.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 jest.mock('axios');
 
 jest.mock('@librechat/api', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
   isEnabled: jest.fn(() => false),
   logAxiosError: jest.fn(),
   generateShortLivedToken: jest.fn(() => 'mock-jwt-token'),
@@ -91,7 +91,7 @@ describe('createContextHandlers', () => {
         userId: 'user-1',
         tenantId: 'tenant-a',
         entityIds: ['agent_123'],
-        scopes: ['rag:embed'],
+        scopes: ['rag:documents'],
       });
     });
 
@@ -103,6 +103,34 @@ describe('createContextHandlers', () => {
       const [, config] = axios.get.mock.calls[0];
       expect(config.params).toBeUndefined();
     });
+
+    it('buys no inference for a read that only returns stored text', async () => {
+      const handlers = createContextHandlers(req, 'what does it say?');
+      await handlers.processFile(embeddedFile('attachment-1'));
+      await handlers.createContext();
+
+      const { scopes } = generateShortLivedToken.mock.calls[0][0];
+      expect(scopes).toEqual(['rag:documents']);
+      expect(scopes).not.toContain('rag:embed');
+      expect(scopes).not.toContain('rag:rerank');
+    });
+  });
+
+  it('mints the plane each branch reaches, not one token covering both', async () => {
+    isEnabled.mockReturnValue(true);
+    const fullContext = createContextHandlers(req, 'what does it say?');
+    await fullContext.processFile(embeddedFile('kb-1'));
+    await fullContext.createContext();
+
+    isEnabled.mockReturnValue(false);
+    const semanticSearch = createContextHandlers(req, 'what does it say?');
+    await semanticSearch.processFile(embeddedFile('kb-1'));
+    await semanticSearch.createContext();
+
+    expect(generateShortLivedToken.mock.calls.map(([{ scopes }]) => scopes)).toEqual([
+      ['rag:documents'],
+      ['rag:embed'],
+    ]);
   });
 
   it('returns nothing when the RAG API is not configured', () => {

--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -1,7 +1,13 @@
 const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
 const { tool } = require('@librechat/agents/langchain/tools');
-const { RagScopes, logAxiosError, generateShortLivedToken } = require('@librechat/api');
+const {
+  RagScopes,
+  logAxiosError,
+  generateShortLivedToken,
+  hasRecordedEmbeddingEntity,
+  getRecordedEmbeddingEntityId,
+} = require('@librechat/api');
 const { Tools, EToolResources } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { getFiles } = require('~/models');
@@ -57,6 +63,21 @@ const primeFiles = async (options) => {
 
   let toolContext = `- Note: Semantic search is available through the ${Tools.file_search} tool but no files are currently loaded. Request the user to upload documents to search through.`;
 
+  /**
+   * Whether this agent's id is the one the file's chunks were written under.
+   * Being listed in its knowledge base does not settle that — an already-owned
+   * file id can be added to any agent's `tool_resources`, and a message
+   * attachment is embedded with no entity — so the recorded value decides
+   * wherever there is one. Files predating that record fall back to the
+   * association, which is all they ever had.
+   *
+   * @param {MongoFile} file
+   */
+  const isEmbeddedUnderAgent = (file) =>
+    hasRecordedEmbeddingEntity(file)
+      ? getRecordedEmbeddingEntityId(file) === agentId
+      : agentResourceIds.has(file.file_id);
+
   const files = [];
   for (let i = 0; i < dbFiles.length; i++) {
     const file = dbFiles[i];
@@ -72,7 +93,7 @@ const primeFiles = async (options) => {
     files.push({
       file_id: file.file_id,
       filename: file.filename,
-      fromAgent: agentResourceIds.has(file.file_id),
+      fromAgent: isEmbeddedUnderAgent(file),
     });
   }
 

--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
 const { tool } = require('@librechat/agents/langchain/tools');
-const { generateShortLivedToken, logAxiosError } = require('@librechat/api');
+const { RagScopes, logAxiosError, generateShortLivedToken } = require('@librechat/api');
 const { Tools, EToolResources } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { getFiles } = require('~/models');
@@ -85,16 +85,37 @@ const primeFiles = async (options) => {
  * @param {string} options.userId
  * @param {Array<{ file_id: string; filename: string; fromAgent?: boolean }>} options.files
  * @param {string} [options.entity_id]
+ * @param {string} [options.tenantId]
  * @param {boolean} [options.fileCitations=false] - Whether to include citation instructions
  * @returns
  */
-const createFileSearchTool = async ({ userId, files, entity_id, fileCitations = false }) => {
+const createFileSearchTool = async ({
+  userId,
+  files,
+  entity_id,
+  tenantId,
+  fileCitations = false,
+}) => {
   return tool(
     async ({ query }) => {
       if (files.length === 0) {
         return ['No files to search. Instruct the user to add files for the search.', undefined];
       }
-      const jwtToken = generateShortLivedToken(userId);
+      /** Only knowledge-base files are owned by the agent; the token names the
+       * entity only when at least one of them is in play. */
+      const searchesAgentFiles = entity_id != null && files.some((file) => file.fromAgent === true);
+      let jwtToken;
+      try {
+        jwtToken = generateShortLivedToken({
+          userId,
+          tenantId,
+          entityIds: searchesAgentFiles ? [entity_id] : [],
+          scopes: [RagScopes.embed],
+        });
+      } catch (error) {
+        logger.error(`[${Tools.file_search}] Unable to mint a RAG API token`, error);
+        return ['There was an error authenticating the file search request.', undefined];
+      }
       if (!jwtToken) {
         return ['There was an error authenticating the file search request.', undefined];
       }

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -385,6 +385,7 @@ const loadTools = async ({
           userId: user,
           files,
           entity_id: agent?.id,
+          tenantId: options.req?.user?.tenantId,
           fileCitations,
         });
       };

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -121,7 +121,7 @@ async function getAzureURL({ fileName, basePath = defaultBasePath, userId, conta
  * @param {MongoFile} params.file - The file object.
  */
 async function deleteFileFromAzure(req, file) {
-  await deleteRagFile({ userId: req.user.id, file });
+  await deleteRagFile({ userId: req.user.id, file, tenantId: req.user.tenantId });
 
   try {
     const containerClient = await getAzureContainerClient(AZURE_CONTAINER_NAME);

--- a/api/server/services/Files/Firebase/crud.js
+++ b/api/server/services/Files/Firebase/crud.js
@@ -185,7 +185,7 @@ function extractFirebaseFilePath(urlString) {
  *          Throws an error if there is an issue with deletion.
  */
 const deleteFirebaseFile = async (req, file) => {
-  await deleteRagFile({ userId: req.user.id, file });
+  await deleteRagFile({ userId: req.user.id, file, tenantId: req.user.tenantId });
 
   const fileName = extractFirebaseFilePath(file.filepath);
   if (!fileName.includes(req.user.id)) {

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -234,7 +234,7 @@ const deleteLocalFile = async (req, file) => {
   /** Filepath stripped of query parameters (e.g., ?manual=true) */
   const cleanFilepath = file.filepath.split('?')[0];
 
-  await deleteRagFile({ userId: req.user.id, file });
+  await deleteRagFile({ userId: req.user.id, file, tenantId: req.user.tenantId });
 
   if (cleanFilepath.startsWith(`/uploads/${req.user.id}`)) {
     const userUploadDir = path.join(uploads, req.user.id);

--- a/api/server/services/Files/VectorDB/crud.js
+++ b/api/server/services/Files/VectorDB/crud.js
@@ -29,7 +29,7 @@ const deleteVectors = async (req, file) => {
       userId: req.user.id,
       tenantId: req.user.tenantId,
       entityIds: file.entity_id ? [file.entity_id] : [],
-      scopes: [RagScopes.embed],
+      scopes: [RagScopes.documents],
     });
 
     return await axios.delete(`${process.env.RAG_API_URL}/documents`, {

--- a/api/server/services/Files/VectorDB/crud.js
+++ b/api/server/services/Files/VectorDB/crud.js
@@ -3,15 +3,18 @@ const axios = require('axios');
 const FormData = require('form-data');
 const { logger } = require('@librechat/data-schemas');
 const { FileSources } = require('librechat-data-provider');
-const { logAxiosError, generateShortLivedToken } = require('@librechat/api');
+const { RagScopes, logAxiosError, generateShortLivedToken } = require('@librechat/api');
 
 /**
  * Deletes a file from the vector database. This function takes a file object, constructs the full path, and
  * verifies the path's validity before deleting the file. If the path is invalid, an error is thrown.
  *
  * @param {ServerRequest} req - The request object from Express.
- * @param {MongoFile} file - The file object to be deleted. It should have a `filepath` property that is
- *                           a string representing the path of the file relative to the publicPath.
+ * @param {MongoFile & { entity_id?: string }} file - The file object to be deleted. It should have a
+ *                           `filepath` property that is a string representing the path of the file
+ *                           relative to the publicPath. `entity_id` names the agent whose knowledge
+ *                           base holds the file, when its chunks are owned by that agent rather than
+ *                           by the user.
  *
  * @returns {Promise<void>}
  *          A promise that resolves when the file has been successfully deleted, or throws an error if the
@@ -22,7 +25,12 @@ const deleteVectors = async (req, file) => {
     return;
   }
   try {
-    const jwtToken = generateShortLivedToken(req.user.id);
+    const jwtToken = generateShortLivedToken({
+      userId: req.user.id,
+      tenantId: req.user.tenantId,
+      entityIds: file.entity_id ? [file.entity_id] : [],
+      scopes: [RagScopes.embed],
+    });
 
     return await axios.delete(`${process.env.RAG_API_URL}/documents`, {
       headers: {
@@ -30,6 +38,7 @@ const deleteVectors = async (req, file) => {
         'Content-Type': 'application/json',
         accept: 'application/json',
       },
+      params: file.entity_id ? { entity_id: file.entity_id } : undefined,
       data: [file.file_id],
     });
   } catch (error) {
@@ -70,7 +79,12 @@ async function uploadVectors({ req, file, file_id, entity_id, storageMetadata })
   }
 
   try {
-    const jwtToken = generateShortLivedToken(req.user.id);
+    const jwtToken = generateShortLivedToken({
+      userId: req.user.id,
+      tenantId: req.user.tenantId,
+      entityIds: entity_id ? [entity_id] : [],
+      scopes: [RagScopes.embed],
+    });
     const formData = new FormData();
     formData.append('file_id', file_id);
     formData.append('file', fs.createReadStream(file.path));

--- a/api/server/services/Files/VectorDB/crud.js
+++ b/api/server/services/Files/VectorDB/crud.js
@@ -17,8 +17,11 @@ const { RagScopes, logAxiosError, generateShortLivedToken } = require('@librecha
  *                           by the user.
  *
  * @returns {Promise<void>}
- *          A promise that resolves when the file has been successfully deleted, or throws an error if the
- *          file path is invalid or if there is an error in deletion.
+ *          A promise that resolves only once the chunks are gone — a 404 counts, since the file
+ *          the caller is about to forget about is already absent. Every other failure throws,
+ *          including one raised before the request is even sent (an unmintable token), so the
+ *          caller keeps the file's metadata instead of reporting a delete that left its chunks
+ *          behind with nothing left to reference them.
  */
 const deleteVectors = async (req, file) => {
   if (!file.embedded || !process.env.RAG_API_URL) {
@@ -46,14 +49,11 @@ const deleteVectors = async (req, file) => {
       error,
       message: 'Error deleting vectors',
     });
-    if (
-      error.response &&
-      error.response.status !== 404 &&
-      (error.response.status < 200 || error.response.status >= 300)
-    ) {
-      logger.warn('Error deleting vectors, file will not be deleted');
-      throw new Error(error.message || 'An error occurred during file deletion.');
+    if (error.response?.status === 404) {
+      return;
     }
+    logger.warn('Error deleting vectors, file will not be deleted');
+    throw new Error(error.message || 'An error occurred during file deletion.');
   }
 };
 

--- a/api/server/services/Files/process.integration.spec.js
+++ b/api/server/services/Files/process.integration.spec.js
@@ -33,6 +33,7 @@ jest.mock('@librechat/api', () => ({
   sanitizeFilename: jest.fn((n) => n),
   parseText: jest.fn().mockResolvedValue({ text: '', bytes: 0 }),
   processAudioFile: jest.fn(),
+  resolveEmbeddingEntityIds: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('~/server/controllers/assistants/v2', () => ({

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -19,13 +19,14 @@ const {
   documentParserMimeTypes,
   isPermissiveMimeConfig,
 } = require('librechat-data-provider');
-const { logger, runAsSystem } = require('@librechat/data-schemas');
+const { logger, runAsSystem, NO_EMBEDDING_ENTITY } = require('@librechat/data-schemas');
 const {
   sanitizeFilename,
   parseText,
   processAudioFile,
   sendUploadSuccess,
   getStorageMetadata,
+  resolveEmbeddingEntityIds,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
 } = require('@librechat/api');
@@ -154,30 +155,15 @@ function enqueueDeleteOperation({
  *
  * Knowledge-base files are embedded under the agent's id rather than the
  * uploader's, so a delete that names only the user matches nothing and leaves
- * the chunks behind. One lookup covers the whole batch.
+ * the chunks behind. The entity is read from what the upload recorded; only
+ * files predating that record need the agent lookup, and one call covers them
+ * all.
  *
  * @param {MongoFile[]} files - The files being deleted.
  * @returns {Promise<Record<string, string>>} File id to owning entity id.
  */
-async function resolveVectorEntityIds(files) {
-  const embeddedFileIds = [];
-  for (const file of files) {
-    if (file.embedded === true && file.file_id) {
-      embeddedFileIds.push(file.file_id);
-    }
-  }
-
-  if (embeddedFileIds.length === 0) {
-    return {};
-  }
-
-  try {
-    return await db.getAgentIdsByFileIds({ file_ids: embeddedFileIds });
-  } catch (error) {
-    logger.error('Error resolving knowledge-base owners before vector deletion', error);
-    return {};
-  }
-}
+const resolveVectorEntityIds = (files) =>
+  resolveEmbeddingEntityIds({ files, lookupLegacyEntityIds: db.getAgentIdsByFileIds });
 
 const getDeleteMethod = ({ source, deletionMethods }) => {
   if (deletionMethods[source]) {
@@ -1061,6 +1047,10 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       metadata: fileInfoMetadata,
       type: file.mimetype,
       embedded,
+      /* Stamped from the value the vectors were actually written under, so a
+       * later delete or query names the same entity instead of inferring one
+       * from whichever agent happens to reference the file by then. */
+      embedding_entity_id: embedded ? (entity_id ?? NO_EMBEDDING_ENTITY) : undefined,
       source,
       height,
       width,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -148,6 +148,37 @@ function enqueueDeleteOperation({
   }
 }
 
+/**
+ * Resolves, for the embedded files in a delete batch, the entity their vector
+ * chunks are stored under.
+ *
+ * Knowledge-base files are embedded under the agent's id rather than the
+ * uploader's, so a delete that names only the user matches nothing and leaves
+ * the chunks behind. One lookup covers the whole batch.
+ *
+ * @param {MongoFile[]} files - The files being deleted.
+ * @returns {Promise<Record<string, string>>} File id to owning entity id.
+ */
+async function resolveVectorEntityIds(files) {
+  const embeddedFileIds = [];
+  for (const file of files) {
+    if (file.embedded === true && file.file_id) {
+      embeddedFileIds.push(file.file_id);
+    }
+  }
+
+  if (embeddedFileIds.length === 0) {
+    return {};
+  }
+
+  try {
+    return await db.getAgentIdsByFileIds({ file_ids: embeddedFileIds });
+  } catch (error) {
+    logger.error('Error resolving knowledge-base owners before vector deletion', error);
+    return {};
+  }
+}
+
 const getDeleteMethod = ({ source, deletionMethods }) => {
   if (deletionMethods[source]) {
     return deletionMethods[source];
@@ -242,6 +273,8 @@ const processDeleteRequest = async ({ req, files }) => {
 
   const agentFiles = [];
 
+  const entityIdByFileId = await resolveVectorEntityIds(files);
+
   for (const file of files) {
     const source = file.source ?? FileSources.local;
     if (req.body.agent_id && req.body.tool_resource) {
@@ -277,9 +310,10 @@ const processDeleteRequest = async ({ req, files }) => {
     }
 
     const deleteFile = getDeleteMethod({ source, deletionMethods });
+    const entity_id = entityIdByFileId[file.file_id];
     enqueueDeleteOperation({
       req,
-      file,
+      file: entity_id ? { ...file, entity_id } : file,
       deleteFile: createDeleteFileWithSecondaryStorage({ source, deleteFile, deletionMethods }),
       promises,
       resolvedFileIds,

--- a/api/server/services/Files/process.ragEntity.spec.js
+++ b/api/server/services/Files/process.ragEntity.spec.js
@@ -238,6 +238,65 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
     expect(paramsByFileId.get(ownFileId)).toBeUndefined();
   });
 
+  describe('a vector delete that never happened is never reported as done', () => {
+    const runDelete = async (fileId) => {
+      const userId = new mongoose.Types.ObjectId();
+      const file = await seedFile(fileId, userId);
+      const result = await processDeleteRequest({
+        req: buildReq([file.toObject()], { id: userId.toString() }),
+        files: [file.toObject()],
+      });
+      return { result, record: await File.findOne({ file_id: fileId }) };
+    };
+
+    test('keeps the file record when the RAG token cannot be minted', async () => {
+      generateShortLivedToken.mockImplementation(() => {
+        throw new Error('RAG_AUTH_ACCEPT_LEGACY=false requires RAG_JWT_SECRET');
+      });
+
+      const { result, record } = await runDelete('file_mint_failure');
+
+      expect(axios.delete).not.toHaveBeenCalled();
+      expect(result.deletedFileIds).not.toContain('file_mint_failure');
+      expect(result.failedFileIds).toContain('file_mint_failure');
+      expect(record).not.toBeNull();
+    });
+
+    test('keeps the file record when the RAG API rejects the delete', async () => {
+      const error = new Error('Internal Server Error');
+      error.response = { status: 500 };
+      axios.delete.mockRejectedValue(error);
+
+      const { result, record } = await runDelete('file_rag_rejected');
+
+      expect(result.deletedFileIds).not.toContain('file_rag_rejected');
+      expect(result.failedFileIds).toContain('file_rag_rejected');
+      expect(record).not.toBeNull();
+    });
+
+    test('keeps the file record when the RAG API is unreachable', async () => {
+      axios.delete.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:8000'));
+
+      const { result, record } = await runDelete('file_rag_unreachable');
+
+      expect(result.deletedFileIds).not.toContain('file_rag_unreachable');
+      expect(result.failedFileIds).toContain('file_rag_unreachable');
+      expect(record).not.toBeNull();
+    });
+
+    test('removes the file record once the RAG API has forgotten the chunks', async () => {
+      const error = new Error('Not Found');
+      error.response = { status: 404 };
+      axios.delete.mockRejectedValue(error);
+
+      const { result, record } = await runDelete('file_rag_absent');
+
+      expect(result.deletedFileIds).toContain('file_rag_absent');
+      expect(result.failedFileIds).not.toContain('file_rag_absent');
+      expect(record).toBeNull();
+    });
+  });
+
   test('deletes the file record even when the entity lookup fails', async () => {
     const userId = new mongoose.Types.ObjectId();
     const fileId = 'file_lookup_failure';

--- a/api/server/services/Files/process.ragEntity.spec.js
+++ b/api/server/services/Files/process.ragEntity.spec.js
@@ -13,7 +13,12 @@ const axios = require('axios');
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const { FileSources } = require('librechat-data-provider');
-const { agentSchema, fileSchema, createMethods } = require('@librechat/data-schemas');
+const {
+  agentSchema,
+  fileSchema,
+  createMethods,
+  NO_EMBEDDING_ENTITY,
+} = require('@librechat/data-schemas');
 
 jest.mock('axios');
 
@@ -25,17 +30,11 @@ jest.mock('@librechat/data-schemas', () => {
   };
 });
 
-jest.mock('@librechat/agents', () => ({
-  EnvVar: { CODE_API_KEY: 'CODE_API_KEY' },
-}));
-
+/* Everything except the token mint stays real: the entity resolution under
+ * test is the whole point of this file, so only the signing key is stubbed. */
 jest.mock('@librechat/api', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
+  ...jest.requireActual('@librechat/api'),
   generateShortLivedToken: jest.fn(() => 'mock-jwt-token'),
-  logAxiosError: jest.fn(),
-  sanitizeFilename: jest.fn((n) => n),
-  parseText: jest.fn().mockResolvedValue({ text: '', bytes: 0 }),
-  processAudioFile: jest.fn(),
 }));
 
 jest.mock('~/server/controllers/assistants/v2', () => ({
@@ -123,7 +122,9 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
     await File.deleteMany({});
   });
 
-  const seedFile = async (file_id, userId, source = FileSources.vectordb) =>
+  /** Seeds a file record. Omitting `embedding_entity_id` produces a legacy
+   * record — one written before uploads recorded where the chunks went. */
+  const seedFile = async (file_id, userId, { source = FileSources.vectordb, ...rest } = {}) =>
     File.create({
       file_id,
       user: userId,
@@ -134,11 +135,12 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
       bytes: 1,
       embedded: true,
       source,
+      ...rest,
     });
 
-  const seedAgent = async (authorId, file_ids) =>
+  const seedAgent = async (authorId, file_ids, id) =>
     Agent.create({
-      id: `agent_${Math.random().toString(36).slice(2, 10)}`,
+      id: id ?? `agent_${Math.random().toString(36).slice(2, 10)}`,
       name: 'Knowledge Agent',
       provider: 'test',
       model: 'test-model',
@@ -157,8 +159,8 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
   test('names the owning agent on the vector delete and in the token', async () => {
     const userId = new mongoose.Types.ObjectId();
     const fileId = 'file_kb_1';
-    const file = await seedFile(fileId, userId);
     const agent = await seedAgent(userId, [fileId]);
+    const file = await seedFile(fileId, userId, { embedding_entity_id: agent.id });
 
     await processDeleteRequest({
       req: buildReq([file.toObject()], { id: userId.toString(), tenantId: 'tenant-a' }),
@@ -181,7 +183,9 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
   test('leaves a user-owned file scoped to the user alone', async () => {
     const userId = new mongoose.Types.ObjectId();
     const fileId = 'file_attachment_1';
-    const file = await seedFile(fileId, userId);
+    const file = await seedFile(fileId, userId, {
+      embedding_entity_id: NO_EMBEDDING_ENTITY,
+    });
 
     await processDeleteRequest({
       req: buildReq([file.toObject()], { id: userId.toString() }),
@@ -201,8 +205,11 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
   test('scopes the secondary vector delete when the file lives in another store', async () => {
     const userId = new mongoose.Types.ObjectId();
     const fileId = 'file_kb_local';
-    const file = await seedFile(fileId, userId, FileSources.local);
     const agent = await seedAgent(userId, [fileId]);
+    const file = await seedFile(fileId, userId, {
+      source: FileSources.local,
+      embedding_entity_id: agent.id,
+    });
 
     await processDeleteRequest({
       req: buildReq([file.toObject()], { id: userId.toString() }),
@@ -222,9 +229,11 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
     const userId = new mongoose.Types.ObjectId();
     const kbFileId = 'file_kb_mixed';
     const ownFileId = 'file_own_mixed';
-    const kbFile = await seedFile(kbFileId, userId);
-    const ownFile = await seedFile(ownFileId, userId);
     const agent = await seedAgent(userId, [kbFileId]);
+    const kbFile = await seedFile(kbFileId, userId, { embedding_entity_id: agent.id });
+    const ownFile = await seedFile(ownFileId, userId, {
+      embedding_entity_id: NO_EMBEDDING_ENTITY,
+    });
 
     await processDeleteRequest({
       req: buildReq([kbFile.toObject(), ownFile.toObject()], { id: userId.toString() }),
@@ -294,6 +303,112 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
       expect(result.deletedFileIds).toContain('file_rag_absent');
       expect(result.failedFileIds).not.toContain('file_rag_absent');
       expect(record).toBeNull();
+    });
+  });
+
+  /**
+   * The entity comes from what the upload recorded, never from whichever agent
+   * happens to list the file at delete time. Those two disagree routinely: an
+   * agent can be given a file id it never embedded, and can drop one it did.
+   */
+  describe('the recorded entity outranks the current association', () => {
+    const deleteAndReadEntity = async (file, userId) => {
+      await processDeleteRequest({
+        req: buildReq([file.toObject()], { id: userId.toString() }),
+        files: [file.toObject()],
+      });
+      const [, config] = deleteCall();
+      return {
+        param: config.params?.entity_id,
+        claimed: generateShortLivedToken.mock.calls[0][0].entityIds,
+      };
+    };
+
+    test('a message attachment later referenced by an agent stays user-scoped', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const fileId = 'file_attachment_adopted';
+      const file = await seedFile(fileId, userId, {
+        embedding_entity_id: NO_EMBEDDING_ENTITY,
+      });
+      await seedAgent(userId, [fileId]);
+
+      const { param, claimed } = await deleteAndReadEntity(file, userId);
+
+      expect(param).toBeUndefined();
+      expect(claimed).toEqual([]);
+    });
+
+    test('a file listed by several agents keeps the one that embedded it', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const fileId = 'file_kb_shared';
+      const owner = await seedAgent(userId, [fileId], 'agent_zzz_owner');
+      await seedAgent(userId, [fileId], 'agent_aaa_borrower');
+      const file = await seedFile(fileId, userId, { embedding_entity_id: owner.id });
+
+      const { param, claimed } = await deleteAndReadEntity(file, userId);
+
+      expect(param).toBe(owner.id);
+      expect(claimed).toEqual([owner.id]);
+    });
+
+    test('a file detached from its agent still names that agent', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const fileId = 'file_kb_detached';
+      const agent = await seedAgent(userId, []);
+      const file = await seedFile(fileId, userId, { embedding_entity_id: agent.id });
+
+      const { param, claimed } = await deleteAndReadEntity(file, userId);
+
+      expect(param).toBe(agent.id);
+      expect(claimed).toEqual([agent.id]);
+    });
+  });
+
+  /* Records written before uploads stamped the entity have nothing to read
+   * back, so they alone still infer it from the agents that hold them. */
+  describe('files predating the recorded entity', () => {
+    test('infer the entity from the agent that holds them', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const fileId = 'file_legacy_held';
+      const agent = await seedAgent(userId, [fileId]);
+      const file = await seedFile(fileId, userId);
+
+      await processDeleteRequest({
+        req: buildReq([file.toObject()], { id: userId.toString() }),
+        files: [file.toObject()],
+      });
+
+      expect(deleteCall()[1].params).toEqual({ entity_id: agent.id });
+      expect(await File.findOne({ file_id: fileId })).toBeNull();
+    });
+
+    test('are deleted user-scoped when no agent holds them', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const fileId = 'file_legacy_unheld';
+      const file = await seedFile(fileId, userId);
+
+      await processDeleteRequest({
+        req: buildReq([file.toObject()], { id: userId.toString() }),
+        files: [file.toObject()],
+      });
+
+      expect(deleteCall()[1].params).toBeUndefined();
+      expect(await File.findOne({ file_id: fileId })).toBeNull();
+    });
+
+    test('resolve to the same agent every time when several hold them', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const fileId = 'file_legacy_shared';
+      await seedAgent(userId, [fileId], 'agent_zzz');
+      await seedAgent(userId, [fileId], 'agent_aaa');
+      const file = await seedFile(fileId, userId);
+
+      await processDeleteRequest({
+        req: buildReq([file.toObject()], { id: userId.toString() }),
+        files: [file.toObject()],
+      });
+
+      expect(deleteCall()[1].params).toEqual({ entity_id: 'agent_aaa' });
     });
   });
 

--- a/api/server/services/Files/process.ragEntity.spec.js
+++ b/api/server/services/Files/process.ragEntity.spec.js
@@ -30,7 +30,7 @@ jest.mock('@librechat/agents', () => ({
 }));
 
 jest.mock('@librechat/api', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
   generateShortLivedToken: jest.fn(() => 'mock-jwt-token'),
   logAxiosError: jest.fn(),
   sanitizeFilename: jest.fn((n) => n),
@@ -174,7 +174,7 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
       userId: userId.toString(),
       tenantId: 'tenant-a',
       entityIds: [agent.id],
-      scopes: ['rag:embed'],
+      scopes: ['rag:documents'],
     });
   });
 
@@ -194,7 +194,7 @@ describe('processDeleteRequest — agent knowledge-base scoping', () => {
       userId: userId.toString(),
       tenantId: undefined,
       entityIds: [],
-      scopes: ['rag:embed'],
+      scopes: ['rag:documents'],
     });
   });
 

--- a/api/server/services/Files/process.ragEntity.spec.js
+++ b/api/server/services/Files/process.ragEntity.spec.js
@@ -1,0 +1,260 @@
+/**
+ * Agent knowledge-base files are embedded in the vector store under the
+ * agent's id, not the uploader's. A delete that names only the user matches
+ * nothing, so the chunks survive the file record — silently, because the RAG
+ * API answers `404` and the caller treats that as "already gone".
+ *
+ * These tests run the real delete service against an in-memory Mongo so the
+ * entity resolution, the token claims and the outgoing request are all
+ * exercised together.
+ */
+
+const axios = require('axios');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { FileSources } = require('librechat-data-provider');
+const { agentSchema, fileSchema, createMethods } = require('@librechat/data-schemas');
+
+jest.mock('axios');
+
+jest.mock('@librechat/data-schemas', () => {
+  const actual = jest.requireActual('@librechat/data-schemas');
+  return {
+    ...actual,
+    logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
+  };
+});
+
+jest.mock('@librechat/agents', () => ({
+  EnvVar: { CODE_API_KEY: 'CODE_API_KEY' },
+}));
+
+jest.mock('@librechat/api', () => ({
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  generateShortLivedToken: jest.fn(() => 'mock-jwt-token'),
+  logAxiosError: jest.fn(),
+  sanitizeFilename: jest.fn((n) => n),
+  parseText: jest.fn().mockResolvedValue({ text: '', bytes: 0 }),
+  processAudioFile: jest.fn(),
+}));
+
+jest.mock('~/server/controllers/assistants/v2', () => ({
+  addResourceFileId: jest.fn(),
+  deleteResourceFileId: jest.fn(),
+}));
+
+jest.mock('~/server/controllers/assistants/helpers', () => ({
+  getOpenAIClient: jest.fn(),
+}));
+
+jest.mock('~/server/services/Tools/credentials', () => ({
+  loadAuthValues: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/Audio/STTService', () => ({
+  STTService: { getInstance: jest.fn() },
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  checkCapability: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('~/cache', () => ({
+  getLogStores: jest.fn(() => ({ get: jest.fn(), set: jest.fn(), delete: jest.fn() })),
+}));
+
+const mockPrimaryDeleteFile = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('~/server/services/Files/strategies', () => {
+  const { FileSources } = require('librechat-data-provider');
+  return {
+    getStrategyFunctions: jest.fn((source) => {
+      if (source === FileSources.vectordb) {
+        const { deleteVectors } = require('~/server/services/Files/VectorDB/crud');
+        return { deleteFile: deleteVectors };
+      }
+      return { deleteFile: mockPrimaryDeleteFile };
+    }),
+  };
+});
+
+jest.mock('~/models', () => {
+  const mongoose = require('mongoose');
+  const { createMethods } = require('@librechat/data-schemas');
+  return createMethods(mongoose, {
+    removeAllPermissions: jest.fn().mockResolvedValue(undefined),
+  });
+});
+
+require('module-alias/register');
+const { processDeleteRequest } = require('./process');
+const { generateShortLivedToken } = require('@librechat/api');
+
+describe('processDeleteRequest — agent knowledge-base scoping', () => {
+  let mongoServer;
+  let Agent;
+  let File;
+  const ORIGINAL_RAG_API_URL = process.env.RAG_API_URL;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    Agent = mongoose.models.Agent || mongoose.model('Agent', agentSchema);
+    File = mongoose.models.File || mongoose.model('File', fileSchema);
+    createMethods(mongoose, { removeAllPermissions: jest.fn() });
+  }, 30000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+    if (ORIGINAL_RAG_API_URL === undefined) {
+      delete process.env.RAG_API_URL;
+    } else {
+      process.env.RAG_API_URL = ORIGINAL_RAG_API_URL;
+    }
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    generateShortLivedToken.mockReturnValue('mock-jwt-token');
+    axios.delete.mockResolvedValue({ status: 200 });
+    process.env.RAG_API_URL = 'http://rag-api.test';
+    await Agent.deleteMany({});
+    await File.deleteMany({});
+  });
+
+  const seedFile = async (file_id, userId, source = FileSources.vectordb) =>
+    File.create({
+      file_id,
+      user: userId,
+      filename: `${file_id}.pdf`,
+      filepath: `/tmp/${file_id}`,
+      object: 'file',
+      type: 'application/pdf',
+      bytes: 1,
+      embedded: true,
+      source,
+    });
+
+  const seedAgent = async (authorId, file_ids) =>
+    Agent.create({
+      id: `agent_${Math.random().toString(36).slice(2, 10)}`,
+      name: 'Knowledge Agent',
+      provider: 'test',
+      model: 'test-model',
+      author: authorId,
+      tool_resources: { file_search: { file_ids } },
+    });
+
+  const buildReq = (fileDocs, user) => ({
+    user,
+    body: { files: fileDocs },
+    config: { fileStrategy: 'local', fileConfig: {}, endpoints: {} },
+  });
+
+  const deleteCall = () => axios.delete.mock.calls[0];
+
+  test('names the owning agent on the vector delete and in the token', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const fileId = 'file_kb_1';
+    const file = await seedFile(fileId, userId);
+    const agent = await seedAgent(userId, [fileId]);
+
+    await processDeleteRequest({
+      req: buildReq([file.toObject()], { id: userId.toString(), tenantId: 'tenant-a' }),
+      files: [file.toObject()],
+    });
+
+    const [url, config] = deleteCall();
+    expect(url).toBe('http://rag-api.test/documents');
+    expect(config.params).toEqual({ entity_id: agent.id });
+    expect(config.data).toEqual([fileId]);
+
+    expect(generateShortLivedToken).toHaveBeenCalledWith({
+      userId: userId.toString(),
+      tenantId: 'tenant-a',
+      entityIds: [agent.id],
+      scopes: ['rag:embed'],
+    });
+  });
+
+  test('leaves a user-owned file scoped to the user alone', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const fileId = 'file_attachment_1';
+    const file = await seedFile(fileId, userId);
+
+    await processDeleteRequest({
+      req: buildReq([file.toObject()], { id: userId.toString() }),
+      files: [file.toObject()],
+    });
+
+    const [, config] = deleteCall();
+    expect(config.params).toBeUndefined();
+    expect(generateShortLivedToken).toHaveBeenCalledWith({
+      userId: userId.toString(),
+      tenantId: undefined,
+      entityIds: [],
+      scopes: ['rag:embed'],
+    });
+  });
+
+  test('scopes the secondary vector delete when the file lives in another store', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const fileId = 'file_kb_local';
+    const file = await seedFile(fileId, userId, FileSources.local);
+    const agent = await seedAgent(userId, [fileId]);
+
+    await processDeleteRequest({
+      req: buildReq([file.toObject()], { id: userId.toString() }),
+      files: [file.toObject()],
+    });
+
+    expect(mockPrimaryDeleteFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ entity_id: agent.id }),
+      undefined,
+    );
+    const [, config] = deleteCall();
+    expect(config.params).toEqual({ entity_id: agent.id });
+  });
+
+  test('resolves each file to its own agent in a mixed batch', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const kbFileId = 'file_kb_mixed';
+    const ownFileId = 'file_own_mixed';
+    const kbFile = await seedFile(kbFileId, userId);
+    const ownFile = await seedFile(ownFileId, userId);
+    const agent = await seedAgent(userId, [kbFileId]);
+
+    await processDeleteRequest({
+      req: buildReq([kbFile.toObject(), ownFile.toObject()], { id: userId.toString() }),
+      files: [kbFile.toObject(), ownFile.toObject()],
+    });
+
+    const paramsByFileId = new Map(
+      axios.delete.mock.calls.map(([, config]) => [config.data[0], config.params]),
+    );
+    expect(paramsByFileId.get(kbFileId)).toEqual({ entity_id: agent.id });
+    expect(paramsByFileId.get(ownFileId)).toBeUndefined();
+  });
+
+  test('deletes the file record even when the entity lookup fails', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const fileId = 'file_lookup_failure';
+    const file = await seedFile(fileId, userId);
+
+    const db = require('~/models');
+    const original = db.getAgentIdsByFileIds;
+    db.getAgentIdsByFileIds = jest.fn().mockRejectedValue(new Error('lookup failed'));
+
+    try {
+      await processDeleteRequest({
+        req: buildReq([file.toObject()], { id: userId.toString() }),
+        files: [file.toObject()],
+      });
+      expect(await File.findOne({ file_id: fileId })).toBeNull();
+    } finally {
+      db.getAgentIdsByFileIds = original;
+    }
+  });
+});

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -4,6 +4,7 @@ jest.mock('@librechat/data-schemas', () => ({
   logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn(), info: jest.fn() },
   runAsSystem: jest.fn((fn) => fn()),
   createTempChatExpirationDate: jest.fn(() => new Date('2030-01-01T00:00:00.000Z')),
+  NO_EMBEDDING_ENTITY: '__NONE__',
 }));
 
 jest.mock('@librechat/agents', () => ({
@@ -64,6 +65,9 @@ jest.mock('@librechat/api', () => {
     }),
     sweepExpiredFiles: jest.fn().mockResolvedValue({ scanned: 0, deleted: 0, failed: 0 }),
     startExpiredFileSweep: jest.fn().mockReturnValue('sweep-interval'),
+    /* Resolution is covered for real in process.ragEntity.spec.js and
+     * packages/api/src/files/embedding.spec.ts; this suite is about upload. */
+    resolveEmbeddingEntityIds: jest.fn().mockResolvedValue({}),
   };
 });
 
@@ -87,6 +91,7 @@ jest.mock('~/server/services/Tools/credentials', () => ({
 }));
 
 jest.mock('~/models', () => ({
+  getAgentIdsByFileIds: jest.fn().mockResolvedValue({}),
   createFile: jest.fn().mockResolvedValue({ file_id: 'created-file-id' }),
   updateFileUsage: jest.fn(),
   deleteFiles: jest.fn(),
@@ -138,6 +143,7 @@ const {
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
 } = require('@librechat/api');
+const { NO_EMBEDDING_ENTITY } = require('@librechat/data-schemas');
 const {
   EToolResources,
   FileSources,
@@ -720,6 +726,52 @@ describe('processAgentFileUpload', () => {
           tool_resource: EToolResources.file_search,
         }),
       );
+    });
+  });
+
+  /* The entity the chunks were written under is only knowable here. Once the
+   * upload returns, the file's agent associations can change freely, so a
+   * later delete that reads them back can name an agent whose namespace never
+   * held the chunks — and a delete that misses leaves them orphaned. */
+  describe('embedding entity persistence', () => {
+    const uploadForSearch = async (metadata) => {
+      setupStoredFileUpload();
+      await processAgentFileUpload({
+        req: makeReq({ mimetype: 'text/plain', ocrConfig: null }),
+        res: mockRes,
+        metadata: { ...makeMetadata(), tool_resource: EToolResources.file_search, ...metadata },
+      });
+      return db.createFile.mock.calls[0][0];
+    };
+
+    test('records the agent a knowledge-base file was embedded under', async () => {
+      const persisted = await uploadForSearch({ agent_id: 'agent-abc' });
+
+      expect(uploadVectors).toHaveBeenCalledWith(
+        expect.objectContaining({ entity_id: 'agent-abc' }),
+      );
+      expect(persisted.embedding_entity_id).toBe('agent-abc');
+    });
+
+    test('records an explicit none for a user-scoped message attachment', async () => {
+      const persisted = await uploadForSearch({ message_file: true });
+
+      expect(uploadVectors).toHaveBeenCalledWith(expect.objectContaining({ entity_id: undefined }));
+      expect(persisted.embedding_entity_id).toBe(NO_EMBEDDING_ENTITY);
+      expect(persisted.context).toBe(FileContext.message_attachment);
+    });
+
+    test('records nothing when the file never made it into the vector store', async () => {
+      uploadVectors.mockResolvedValueOnce({
+        bytes: 42,
+        filename: 'upload.bin',
+        filepath: 'vectordb',
+        embedded: false,
+      });
+
+      const persisted = await uploadForSearch({ agent_id: 'agent-abc' });
+
+      expect(persisted).not.toHaveProperty('embedding_entity_id');
     });
   });
 

--- a/api/strategies/jwtStrategy.js
+++ b/api/strategies/jwtStrategy.js
@@ -1,3 +1,4 @@
+const { isRagAudience } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { SystemRoles } = require('librechat-data-provider');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
@@ -12,6 +13,13 @@ const jwtLogin = () =>
     },
     async (payload, done) => {
       try {
+        /** Tokens minted for the RAG service are signed with a separate key and
+         * are never application session tokens; refuse them by audience too so
+         * a shared-secret misconfiguration cannot turn one into the other. */
+        if (isRagAudience(payload?.aud)) {
+          logger.warn('[jwtLogin] JwtStrategy => refused a token minted for the RAG service');
+          return done(null, false);
+        }
         const user = await getUserById(payload?.id, '-password -__v -totpSecret -backupCodes');
         if (user) {
           user.id = user._id.toString();

--- a/api/strategies/jwtStrategy.spec.js
+++ b/api/strategies/jwtStrategy.spec.js
@@ -72,4 +72,50 @@ describe('jwtStrategy', () => {
 
     expect(user).toBe(false);
   });
+
+  describe('RAG service tokens', () => {
+    const originalAudience = process.env.RAG_JWT_AUDIENCE;
+
+    afterEach(() => {
+      if (originalAudience === undefined) {
+        delete process.env.RAG_JWT_AUDIENCE;
+      } else {
+        process.env.RAG_JWT_AUDIENCE = originalAudience;
+      }
+    });
+
+    it('refuses a token minted for the RAG service without looking up a user', async () => {
+      const { user } = await invokeVerify({ id: 'user-1', sub: 'user-1', aud: 'rag_api' });
+
+      expect(user).toBe(false);
+      expect(getUserById).not.toHaveBeenCalled();
+    });
+
+    it('refuses a RAG token whose audience is a list', async () => {
+      const { user } = await invokeVerify({ id: 'user-1', aud: ['other', 'rag_api'] });
+
+      expect(user).toBe(false);
+      expect(getUserById).not.toHaveBeenCalled();
+    });
+
+    it('refuses a token carrying a configured RAG audience', async () => {
+      process.env.RAG_JWT_AUDIENCE = 'rag-eu';
+
+      const { user } = await invokeVerify({ id: 'user-1', aud: 'rag-eu' });
+
+      expect(user).toBe(false);
+      expect(getUserById).not.toHaveBeenCalled();
+    });
+
+    it('still accepts an application session token', async () => {
+      getUserById.mockResolvedValue({
+        _id: { toString: () => 'user-1' },
+        role: SystemRoles.USER,
+      });
+
+      const { user } = await invokeVerify({ id: 'user-1' });
+
+      expect(user.id).toBe('user-1');
+    });
+  });
 });

--- a/api/test/app/clients/tools/util/fileSearch.test.js
+++ b/api/test/app/clients/tools/util/fileSearch.test.js
@@ -3,7 +3,7 @@ const { ResourceType } = require('librechat-data-provider');
 
 jest.mock('axios');
 jest.mock('@librechat/api', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
   generateShortLivedToken: jest.fn(),
   logAxiosError: jest.fn(),
 }));

--- a/api/test/app/clients/tools/util/fileSearch.test.js
+++ b/api/test/app/clients/tools/util/fileSearch.test.js
@@ -3,6 +3,7 @@ const { ResourceType } = require('librechat-data-provider');
 
 jest.mock('axios');
 jest.mock('@librechat/api', () => ({
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
   generateShortLivedToken: jest.fn(),
   logAxiosError: jest.fn(),
 }));
@@ -314,5 +315,64 @@ describe('entity_id scoping by file origin', () => {
     });
     await tool.func({ query: 'q' });
     expect(bodiesSent()[0].entity_id).toBeUndefined();
+  });
+
+  it('names the agent in the token when a knowledge-base file is searched', async () => {
+    const tool = await createFileSearchTool({
+      userId: 'user1',
+      entity_id: 'agent_123',
+      tenantId: 'tenant-a',
+      files: [{ file_id: 'kb-1', filename: 'kb.pdf', fromAgent: true }],
+    });
+    await tool.func({ query: 'q' });
+
+    expect(generateShortLivedToken).toHaveBeenCalledWith({
+      userId: 'user1',
+      tenantId: 'tenant-a',
+      entityIds: ['agent_123'],
+      scopes: ['rag:embed'],
+    });
+  });
+
+  it('omits the entity from the token when only user attachments are searched', async () => {
+    const tool = await createFileSearchTool({
+      userId: 'user1',
+      entity_id: 'agent_123',
+      files: [{ file_id: 'user-1', filename: 'attachment.txt', fromAgent: false }],
+    });
+    await tool.func({ query: 'q' });
+
+    expect(generateShortLivedToken).toHaveBeenCalledWith({
+      userId: 'user1',
+      tenantId: undefined,
+      entityIds: [],
+      scopes: ['rag:embed'],
+    });
+  });
+
+  it('never requests the rerank scope for a search', async () => {
+    const tool = await createFileSearchTool({
+      userId: 'user1',
+      files: [{ file_id: 'f1', filename: 'a.txt' }],
+    });
+    await tool.func({ query: 'q' });
+
+    const { scopes } = generateShortLivedToken.mock.calls[0][0];
+    expect(scopes).not.toContain('rag:rerank');
+  });
+
+  it('reports an authentication error instead of querying when minting fails', async () => {
+    generateShortLivedToken.mockImplementationOnce(() => {
+      throw new Error('RAG_AUTH_ACCEPT_LEGACY=false requires RAG_JWT_SECRET');
+    });
+    const tool = await createFileSearchTool({
+      userId: 'user1',
+      files: [{ file_id: 'f1', filename: 'a.txt' }],
+    });
+
+    const [message] = await tool.func({ query: 'q' });
+
+    expect(message).toBe('There was an error authenticating the file search request.');
+    expect(axios.post).not.toHaveBeenCalled();
   });
 });

--- a/api/test/app/clients/tools/util/fileSearch.test.js
+++ b/api/test/app/clients/tools/util/fileSearch.test.js
@@ -2,11 +2,21 @@ const axios = require('axios');
 const { ResourceType } = require('librechat-data-provider');
 
 jest.mock('axios');
-jest.mock('@librechat/api', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
-  generateShortLivedToken: jest.fn(),
-  logAxiosError: jest.fn(),
-}));
+jest.mock('@librechat/api', () => {
+  const NO_EMBEDDING_ENTITY = '__NONE__';
+  const hasRecordedEmbeddingEntity = (file) =>
+    file.embedding_entity_id != null && file.embedding_entity_id !== '';
+  return {
+    RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
+    generateShortLivedToken: jest.fn(),
+    logAxiosError: jest.fn(),
+    hasRecordedEmbeddingEntity,
+    getRecordedEmbeddingEntityId: (file) =>
+      hasRecordedEmbeddingEntity(file) && file.embedding_entity_id !== NO_EMBEDDING_ENTITY
+        ? file.embedding_entity_id
+        : undefined,
+  };
+});
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -47,6 +57,57 @@ describe('fileSearch.js - agent file authorization', () => {
       role: 'USER',
       agentId: 'agent-123',
       resourceType: ResourceType.REMOTE_AGENT,
+    });
+  });
+
+  /* A query scoped to an agent that never embedded the file finds nothing, so
+   * the entity recorded at upload decides — not the agent's current listing. */
+  describe("which files count as the agent's own", () => {
+    const primeFor = async (file) => {
+      const { getFiles } = require('~/models');
+      getFiles.mockResolvedValueOnce([file]);
+      const { files } = await primeFiles({
+        req: { user: { id: 'user-1', role: 'USER' } },
+        agentId: 'agent-123',
+        tool_resources: { file_search: { file_ids: [file.file_id] } },
+      });
+      return files[0];
+    };
+
+    it('excludes a message attachment the agent merely references', async () => {
+      const primed = await primeFor({
+        file_id: 'attached',
+        filename: 'attached.pdf',
+        embedding_entity_id: '__NONE__',
+      });
+
+      expect(primed.fromAgent).toBe(false);
+    });
+
+    it('excludes a file embedded under a different agent', async () => {
+      const primed = await primeFor({
+        file_id: 'borrowed',
+        filename: 'borrowed.pdf',
+        embedding_entity_id: 'agent-999',
+      });
+
+      expect(primed.fromAgent).toBe(false);
+    });
+
+    it('includes a file embedded under this agent', async () => {
+      const primed = await primeFor({
+        file_id: 'own',
+        filename: 'own.pdf',
+        embedding_entity_id: 'agent-123',
+      });
+
+      expect(primed.fromAgent).toBe(true);
+    });
+
+    it('falls back to the association for a file predating the record', async () => {
+      const primed = await primeFor({ file_id: 'legacy', filename: 'legacy.pdf' });
+
+      expect(primed.fromAgent).toBe(true);
     });
   });
 });

--- a/packages/api/src/auth/codeapi.ts
+++ b/packages/api/src/auth/codeapi.ts
@@ -2,6 +2,7 @@ import { getTenantId } from '@librechat/data-schemas';
 import { createHash, createPrivateKey, randomUUID, sign as cryptoSign } from 'crypto';
 import type { KeyObject, JsonWebKey } from 'crypto';
 import type { ServerRequest } from '~/types';
+import { normalizePem } from '~/crypto/keys';
 import { isEnabled } from '~/utils';
 
 type CodeApiJwtAlg = 'EdDSA' | 'RS256';
@@ -75,10 +76,6 @@ let tokenCacheLastPrunedAt = 0;
 
 function base64Url(value: Buffer | string): string {
   return Buffer.from(value).toString('base64url');
-}
-
-function normalizePem(value: string): string {
-  return value.replace(/\\n/g, '\n').trim();
 }
 
 function getPrivateKeyRaw(): string {

--- a/packages/api/src/auth/codeapi.ts
+++ b/packages/api/src/auth/codeapi.ts
@@ -2,6 +2,7 @@ import { getTenantId } from '@librechat/data-schemas';
 import { createHash, createPrivateKey, randomUUID, sign as cryptoSign } from 'crypto';
 import type { KeyObject, JsonWebKey } from 'crypto';
 import type { ServerRequest } from '~/types';
+import { createTokenMintCache } from '~/crypto/cache';
 import { normalizePem } from '~/crypto/keys';
 import { isEnabled } from '~/utils';
 
@@ -53,12 +54,6 @@ interface SigningConfig {
   rawKey: string;
 }
 
-interface CachedToken {
-  token: string;
-  expiresAt: number;
-  cachedUntil: number;
-}
-
 const DEFAULT_ISSUER = 'librechat';
 const DEFAULT_AUDIENCE = 'codeapi';
 const DEFAULT_KID = 'lc-codeapi-2026-05';
@@ -67,12 +62,9 @@ const DEFAULT_TTL_SECONDS = 300;
 const DEFAULT_CACHE_SECONDS = 30;
 const MAX_TTL_SECONDS = 300;
 const MAX_CACHE_SECONDS = 30;
-const TOKEN_REUSE_SAFETY_WINDOW_SECONDS = 30;
-const TOKEN_CACHE_PRUNE_INTERVAL_SECONDS = 30;
 
 let signingConfigCache: SigningConfig | null = null;
-const tokenCache = new Map<string, CachedToken>();
-let tokenCacheLastPrunedAt = 0;
+const tokenCache = createTokenMintCache();
 
 function base64Url(value: Buffer | string): string {
   return Buffer.from(value).toString('base64url');
@@ -160,7 +152,6 @@ function getSigningConfig(): SigningConfig {
     key: createSigningKey(rawKey),
   };
   tokenCache.clear();
-  tokenCacheLastPrunedAt = 0;
   return signingConfigCache;
 }
 
@@ -305,8 +296,12 @@ function signJwt(config: SigningConfig, claims: CodeApiClaims): string {
   return `${signingInput}.${base64Url(signature)}`;
 }
 
+/**
+ * Structured rather than delimiter-joined so that a value containing the
+ * separator cannot make two different claim sets share a cache entry.
+ */
 function cacheKey(config: SigningConfig, claims: CodeApiClaims): string {
-  return [
+  return JSON.stringify([
     config.alg,
     config.kid,
     claims.sub,
@@ -318,23 +313,7 @@ function cacheKey(config: SigningConfig, claims: CodeApiClaims): string {
     claims.chc_user_id ?? '',
     claims.plan_id ?? '',
     claims.auth_context_hash,
-  ].join(':');
-}
-
-function pruneTokenCache(now: number): void {
-  if (tokenCache.size === 0) {
-    return;
-  }
-  if (now - tokenCacheLastPrunedAt < TOKEN_CACHE_PRUNE_INTERVAL_SECONDS) {
-    return;
-  }
-
-  tokenCacheLastPrunedAt = now;
-  for (const [key, cached] of tokenCache) {
-    if (cached.cachedUntil <= now || cached.expiresAt <= now + TOKEN_REUSE_SAFETY_WINDOW_SECONDS) {
-      tokenCache.delete(key);
-    }
-  }
+  ]);
 }
 
 export async function mintCodeApiToken(req: ServerRequest): Promise<string> {
@@ -344,27 +323,15 @@ export async function mintCodeApiToken(req: ServerRequest): Promise<string> {
 
   const config = getSigningConfig();
   const now = Math.floor(Date.now() / 1000);
-  pruneTokenCache(now);
   const claims = buildClaims(req, config, now);
   const key = cacheKey(config, claims);
-  const cached = tokenCache.get(key);
-  if (
-    cached &&
-    cached.cachedUntil > now &&
-    cached.expiresAt > now + TOKEN_REUSE_SAFETY_WINDOW_SECONDS
-  ) {
-    return cached.token;
+  const cached = tokenCache.get(key, now);
+  if (cached) {
+    return cached;
   }
 
   const token = signJwt(config, claims);
-  tokenCache.set(key, {
-    token,
-    expiresAt: claims.exp,
-    cachedUntil: Math.min(
-      now + config.cacheSeconds,
-      claims.exp - TOKEN_REUSE_SAFETY_WINDOW_SECONDS,
-    ),
-  });
+  tokenCache.set(key, token, claims.exp, now, config.cacheSeconds);
   return token;
 }
 

--- a/packages/api/src/crypto/cache.ts
+++ b/packages/api/src/crypto/cache.ts
@@ -1,0 +1,87 @@
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+  cachedUntil: number;
+}
+
+export interface TokenMintCache {
+  /** A cached token for `key`, or `null` when nothing reusable is held. */
+  get(key: string, now: number): string | null;
+  /**
+   * Records `token`, reusable until `cacheSeconds` elapse or the safety margin
+   * before its expiry begins, whichever comes first. The window is passed per
+   * call because a deployment may reconfigure it without restarting.
+   */
+  set(key: string, token: string, expiresAt: number, now: number, cacheSeconds: number): void;
+  /** Drops every entry. Call whenever the signing material changes. */
+  clear(): void;
+}
+
+/**
+ * Reuse window for a minted token, and the margin kept clear of its expiry.
+ * A token is only ever served while it has more than the margin left, so a
+ * consumer that receives it always has time to spend it before it expires.
+ */
+export const TOKEN_MINT_CACHE_SECONDS = 30;
+export const TOKEN_REUSE_SAFETY_WINDOW_SECONDS = 30;
+const PRUNE_INTERVAL_SECONDS = 30;
+
+/**
+ * Caches short-lived service tokens keyed on the exact claim set they carry.
+ *
+ * Asymmetric signing is expensive enough to matter on request paths that mint
+ * per file, so a token is reused for a bounded window rather than re-signed for
+ * every call. Reuse means the `jti` is shared across that window too: it stays
+ * a replay handle for the receiving service, but it does not make each call
+ * individually identifiable.
+ *
+ * Entries are pruned lazily, at most once per interval, so a cache that is hit
+ * steadily never walks itself on the hot path.
+ */
+export const createTokenMintCache = (): TokenMintCache => {
+  const entries = new Map<string, CachedToken>();
+  let lastPrunedAt = 0;
+
+  const prune = (now: number): void => {
+    if (entries.size === 0 || now - lastPrunedAt < PRUNE_INTERVAL_SECONDS) {
+      return;
+    }
+    lastPrunedAt = now;
+    for (const [key, cached] of entries) {
+      if (
+        cached.cachedUntil <= now ||
+        cached.expiresAt <= now + TOKEN_REUSE_SAFETY_WINDOW_SECONDS
+      ) {
+        entries.delete(key);
+      }
+    }
+  };
+
+  return {
+    get(key, now) {
+      prune(now);
+      const cached = entries.get(key);
+      if (!cached) {
+        return null;
+      }
+      if (
+        cached.cachedUntil <= now ||
+        cached.expiresAt <= now + TOKEN_REUSE_SAFETY_WINDOW_SECONDS
+      ) {
+        return null;
+      }
+      return cached.token;
+    },
+    set(key, token, expiresAt, now, cacheSeconds) {
+      entries.set(key, {
+        token,
+        expiresAt,
+        cachedUntil: Math.min(now + cacheSeconds, expiresAt - TOKEN_REUSE_SAFETY_WINDOW_SECONDS),
+      });
+    },
+    clear() {
+      entries.clear();
+      lastPrunedAt = 0;
+    },
+  };
+};

--- a/packages/api/src/crypto/index.ts
+++ b/packages/api/src/crypto/index.ts
@@ -9,3 +9,4 @@ export {
   getRandomValues,
 } from '@librechat/data-schemas';
 export * from './jwt';
+export * from './keys';

--- a/packages/api/src/crypto/index.ts
+++ b/packages/api/src/crypto/index.ts
@@ -8,5 +8,6 @@ export {
   hashBackupCode,
   getRandomValues,
 } from '@librechat/data-schemas';
+export * from './cache';
 export * from './jwt';
 export * from './keys';

--- a/packages/api/src/crypto/jwt.spec.ts
+++ b/packages/api/src/crypto/jwt.spec.ts
@@ -109,6 +109,24 @@ describe('generateShortLivedToken', () => {
       ).toThrow(/At least one scope is required/);
     });
 
+    it('mints the document scope without any inference scope alongside it', () => {
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: ['agent_abc'],
+        scopes: [RagScopes.documents],
+      });
+
+      const claims = decodeWithRagKey(token);
+      expect(claims.scopes).toEqual(['rag:documents']);
+      expect(claims.entities).toEqual(['agent_abc']);
+    });
+
+    it('keeps the document and inference scopes distinct', () => {
+      expect(RagScopes.documents).not.toBe(RagScopes.embed);
+      expect(RagScopes.documents).not.toBe(RagScopes.rerank);
+      expect(new Set(Object.values(RagScopes)).size).toBe(Object.values(RagScopes).length);
+    });
+
     it('refuses to mint a token for the system tenant', () => {
       expect(() =>
         generateShortLivedToken({

--- a/packages/api/src/crypto/jwt.spec.ts
+++ b/packages/api/src/crypto/jwt.spec.ts
@@ -1,0 +1,295 @@
+import jwt from 'jsonwebtoken';
+import type { JwtPayload } from 'jsonwebtoken';
+import { RagScopes, isRagAudience, getRagAudience, generateShortLivedToken } from './jwt';
+
+const RAG_SECRET = 'rag-secret-that-is-long-enough-for-hs256';
+const APP_SECRET = 'app-secret-that-is-long-enough-for-hs256';
+
+const decodeWithRagKey = (token: string): JwtPayload =>
+  jwt.verify(token, RAG_SECRET, {
+    audience: 'rag_api',
+    issuer: 'librechat',
+  }) as JwtPayload;
+
+describe('generateShortLivedToken', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.RAG_JWT_SECRET;
+    delete process.env.RAG_JWT_PRIVATE_KEY;
+    delete process.env.RAG_JWT_ALGORITHM;
+    delete process.env.RAG_JWT_ISSUER;
+    delete process.env.RAG_JWT_AUDIENCE;
+    delete process.env.RAG_AUTH_ACCEPT_LEGACY;
+    process.env.JWT_SECRET = APP_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('strict claim set', () => {
+    beforeEach(() => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+    });
+
+    it('mints issuer, audience, subject, expiry, tenant, scopes and entities', () => {
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        tenantId: 'tenant-a',
+        entityIds: ['agent_abc'],
+        scopes: [RagScopes.embed],
+      });
+
+      const claims = decodeWithRagKey(token);
+      expect(claims.iss).toBe('librechat');
+      expect(claims.aud).toBe('rag_api');
+      expect(claims.sub).toBe('user-1');
+      expect(claims.tenant).toBe('tenant-a');
+      expect(claims.scopes).toEqual(['rag:embed']);
+      expect(claims.entities).toEqual(['agent_abc']);
+      expect(typeof claims.exp).toBe('number');
+    });
+
+    it('omits the entities claim when the call has no entity context', () => {
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      const claims = decodeWithRagKey(token);
+      expect(claims).not.toHaveProperty('entities');
+      expect(claims).not.toHaveProperty('id');
+    });
+
+    it('falls back to the base tenant when the user carries none', () => {
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      expect(decodeWithRagKey(token).tenant).toBe('__BASE__');
+    });
+
+    it('drops empty entity ids and de-duplicates scopes', () => {
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: ['agent_abc', undefined, null, '', 'agent_abc'],
+        scopes: [RagScopes.embed, RagScopes.embed],
+      });
+
+      const claims = decodeWithRagKey(token);
+      expect(claims.entities).toEqual(['agent_abc']);
+      expect(claims.scopes).toEqual(['rag:embed']);
+    });
+
+    it('honours a configured issuer and audience', () => {
+      process.env.RAG_JWT_ISSUER = 'librechat-eu';
+      process.env.RAG_JWT_AUDIENCE = 'rag-eu';
+
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.rerank],
+      });
+
+      const claims = jwt.verify(token, RAG_SECRET, {
+        audience: 'rag-eu',
+        issuer: 'librechat-eu',
+      }) as JwtPayload;
+      expect(claims.scopes).toEqual(['rag:rerank']);
+    });
+
+    it('refuses to mint a token with no scopes', () => {
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [] }),
+      ).toThrow(/At least one scope is required/);
+    });
+
+    it('refuses to mint a token for the system tenant', () => {
+      expect(() =>
+        generateShortLivedToken({
+          userId: 'user-1',
+          tenantId: '__SYSTEM__',
+          entityIds: [],
+          scopes: [RagScopes.embed],
+        }),
+      ).toThrow(/system tenant/);
+    });
+
+    it('refuses to mint a token with no subject', () => {
+      expect(() =>
+        generateShortLivedToken({ userId: '', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/user id is required/);
+    });
+  });
+
+  describe('key separation', () => {
+    it('signs with the dedicated key, not the application secret', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      expect(() => jwt.verify(token, APP_SECRET, { audience: 'rag_api' })).toThrow(
+        jwt.JsonWebTokenError,
+      );
+      expect(() => decodeWithRagKey(token)).not.toThrow();
+    });
+
+    it('an application session token does not verify against the RAG key', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      const sessionToken = jwt.sign({ id: 'user-1' }, APP_SECRET, { expiresIn: '5m' });
+
+      expect(() => jwt.verify(sessionToken, RAG_SECRET)).toThrow(jwt.JsonWebTokenError);
+    });
+
+    it('refuses a RAG secret identical to the application secret', () => {
+      process.env.RAG_JWT_SECRET = APP_SECRET;
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/must differ from JWT_SECRET/);
+    });
+
+    it('refuses a RAG secret shorter than the HMAC minimum', () => {
+      process.env.RAG_JWT_SECRET = 'too-short';
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/at least 32 characters/);
+    });
+  });
+
+  describe('fail-closed configuration', () => {
+    it('mints the legacy shape while legacy tokens are still accepted', () => {
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      const claims = jwt.verify(token, APP_SECRET) as JwtPayload;
+      expect(claims.id).toBe('user-1');
+      expect(claims).not.toHaveProperty('aud');
+      expect(claims).not.toHaveProperty('scopes');
+    });
+
+    it('throws when RAG_JWT_SECRET is unset and legacy tokens are refused', () => {
+      process.env.RAG_AUTH_ACCEPT_LEGACY = 'false';
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/RAG_AUTH_ACCEPT_LEGACY=false requires RAG_JWT_SECRET/);
+    });
+
+    it('throws rather than signing with JWT_SECRET when an asymmetric algorithm has no key', () => {
+      process.env.RAG_JWT_ALGORITHM = 'RS256';
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/requires RAG_JWT_PRIVATE_KEY/);
+    });
+
+    it('throws on an unsupported algorithm', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      process.env.RAG_JWT_ALGORITHM = 'none';
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/is not supported/);
+    });
+
+    it('throws when no signing key is configured at all', () => {
+      delete process.env.JWT_SECRET;
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/refusing to mint an unsigned token/);
+    });
+
+    it('throws when the configured issuer is blank', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      process.env.RAG_JWT_ISSUER = '  ';
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/RAG_JWT_ISSUER must not be empty/);
+    });
+
+    it('throws when the configured audience is blank', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      process.env.RAG_JWT_AUDIENCE = '';
+
+      expect(() =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
+      ).toThrow(/RAG_JWT_AUDIENCE must not be empty/);
+    });
+
+    it.each([
+      ['true', true],
+      ['1', true],
+      ['yes', true],
+      ['on', true],
+      ['false', false],
+      ['0', false],
+      ['no', false],
+    ])('reads RAG_AUTH_ACCEPT_LEGACY=%s the same way the service does', (value, accepted) => {
+      process.env.RAG_AUTH_ACCEPT_LEGACY = value;
+
+      const mint = () =>
+        generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] });
+
+      if (accepted) {
+        expect(mint).not.toThrow();
+      } else {
+        expect(mint).toThrow(/requires RAG_JWT_SECRET/);
+      }
+    });
+  });
+});
+
+describe('isRagAudience', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.RAG_JWT_AUDIENCE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('recognises the default audience', () => {
+    expect(isRagAudience('rag_api')).toBe(true);
+  });
+
+  it('recognises a configured audience', () => {
+    process.env.RAG_JWT_AUDIENCE = 'rag-eu';
+    expect(isRagAudience('rag-eu')).toBe(true);
+    expect(isRagAudience('rag_api')).toBe(false);
+  });
+
+  it('recognises the audience inside a list', () => {
+    expect(isRagAudience(['other', 'rag_api'])).toBe(true);
+  });
+
+  it('ignores tokens with no audience', () => {
+    expect(isRagAudience(undefined)).toBe(false);
+    expect(isRagAudience(null)).toBe(false);
+    expect(isRagAudience([])).toBe(false);
+  });
+
+  it('keeps the default audience when configuration is blank', () => {
+    process.env.RAG_JWT_AUDIENCE = '   ';
+    expect(getRagAudience()).toBe('rag_api');
+    expect(isRagAudience('rag_api')).toBe(true);
+  });
+});

--- a/packages/api/src/crypto/jwt.spec.ts
+++ b/packages/api/src/crypto/jwt.spec.ts
@@ -70,6 +70,8 @@ describe('generateShortLivedToken', () => {
     delete process.env.RAG_JWT_ALGORITHM;
     delete process.env.RAG_JWT_ISSUER;
     delete process.env.RAG_JWT_AUDIENCE;
+    delete process.env.RAG_JWT_KID;
+    delete process.env.RAG_JWT_TTL_SECONDS;
     delete process.env.RAG_AUTH_ACCEPT_LEGACY;
     process.env.JWT_SECRET = APP_SECRET;
   });
@@ -293,6 +295,173 @@ describe('generateShortLivedToken', () => {
       process.env.RAG_JWT_ALGORITHM = 'Ed25519';
 
       expect(mint).toThrow(/RAG_JWT_ALGORITHM 'Ed25519' is not supported/);
+    });
+  });
+
+  describe('key id', () => {
+    const mint = (userId: string) =>
+      generateShortLivedToken({
+        userId,
+        tenantId: 'tenant-a',
+        entityIds: [],
+        scopes: [RagScopes.documents],
+      });
+
+    it('stamps a default key id so the service can hold more than one key', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+
+      const header = jwt.decode(mint('kid-user-1'), { complete: true })?.header;
+      expect(header?.kid).toBe('lc-rag-2026-08');
+    });
+
+    it('uses a configured key id', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      process.env.RAG_JWT_KID = 'rag-2027-01';
+
+      expect(jwt.decode(mint('kid-user-2'), { complete: true })?.header.kid).toBe('rag-2027-01');
+    });
+
+    it('falls back to the default rather than emitting a blank key id', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      process.env.RAG_JWT_KID = '   ';
+
+      expect(jwt.decode(mint('kid-user-3'), { complete: true })?.header.kid).toBe('lc-rag-2026-08');
+    });
+
+    it('stamps the key id for asymmetric algorithms too', () => {
+      process.env.RAG_JWT_ALGORITHM = 'ES256';
+      process.env.RAG_JWT_PRIVATE_KEY = keyPairFor('ES256').privateKey;
+
+      expect(jwt.decode(mint('kid-user-4'), { complete: true })?.header.kid).toBe('lc-rag-2026-08');
+    });
+  });
+
+  describe('replay and validity claims', () => {
+    const mint = (userId: string, scope: string = RagScopes.documents) =>
+      generateShortLivedToken({
+        userId,
+        tenantId: 'tenant-a',
+        entityIds: [],
+        scopes: [scope as (typeof RagScopes)[keyof typeof RagScopes]],
+      });
+
+    beforeEach(() => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+    });
+
+    it('carries a token id the service can use as a replay handle', () => {
+      const claims = decodeWithRagKey(mint('jti-user-1'));
+      expect(typeof claims.jti).toBe('string');
+      expect(claims.jti).not.toBe('');
+    });
+
+    it('gives distinct claim sets distinct token ids', () => {
+      const first = decodeWithRagKey(mint('jti-user-2', RagScopes.documents));
+      const second = decodeWithRagKey(mint('jti-user-2', RagScopes.embed));
+      expect(first.jti).not.toBe(second.jti);
+    });
+
+    it('is valid from the moment it is issued', () => {
+      const claims = decodeWithRagKey(mint('nbf-user-1'));
+      expect(claims.nbf).toBe(claims.iat);
+    });
+
+    it('expires five minutes after issue by default', () => {
+      const claims = decodeWithRagKey(mint('ttl-user-1'));
+      expect(claims.exp! - claims.iat!).toBe(300);
+    });
+
+    it('honours a shorter configured lifetime', () => {
+      process.env.RAG_JWT_TTL_SECONDS = '60';
+
+      const claims = decodeWithRagKey(mint('ttl-user-2'));
+      expect(claims.exp! - claims.iat!).toBe(60);
+    });
+
+    it('refuses to be configured beyond the maximum lifetime', () => {
+      process.env.RAG_JWT_TTL_SECONDS = '86400';
+
+      const claims = decodeWithRagKey(mint('ttl-user-3'));
+      expect(claims.exp! - claims.iat!).toBe(300);
+    });
+
+    it('ignores a lifetime that is not a positive number', () => {
+      process.env.RAG_JWT_TTL_SECONDS = 'soon';
+
+      const claims = decodeWithRagKey(mint('ttl-user-4'));
+      expect(claims.exp! - claims.iat!).toBe(300);
+    });
+  });
+
+  describe('mint caching', () => {
+    const mint = (overrides: {
+      userId?: string;
+      tenantId?: string;
+      entityIds?: string[];
+      scopes?: Array<(typeof RagScopes)[keyof typeof RagScopes]>;
+    }) =>
+      generateShortLivedToken({
+        userId: 'cache-user',
+        tenantId: 'tenant-a',
+        entityIds: [],
+        scopes: [RagScopes.documents],
+        ...overrides,
+      });
+
+    let now: jest.SpyInstance<number, []>;
+
+    beforeEach(() => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      now = jest.spyOn(Date, 'now').mockReturnValue(1_778_250_000_000);
+    });
+
+    afterEach(() => {
+      now.mockRestore();
+    });
+
+    it('reuses a token rather than re-signing for an identical call', () => {
+      const first = mint({ userId: 'cache-identical' });
+      expect(mint({ userId: 'cache-identical' })).toBe(first);
+    });
+
+    it('re-signs once the reuse window has passed', () => {
+      const first = mint({ userId: 'cache-window' });
+      now.mockReturnValue(1_778_250_031_000);
+      expect(mint({ userId: 'cache-window' })).not.toBe(first);
+    });
+
+    it.each([
+      ['user', { userId: 'cache-other-user' }],
+      ['tenant', { tenantId: 'tenant-b' }],
+      ['scope', { scopes: [RagScopes.embed] }],
+      ['entity', { entityIds: ['agent_abc'] }],
+    ])('never reuses a token across a different %s', (_label, overrides) => {
+      const base = mint({ userId: 'cache-distinct' });
+      const other = mint({ userId: 'cache-distinct', ...overrides });
+      expect(other).not.toBe(base);
+    });
+
+    /**
+     * The reused token carries its original `jti`, so the id identifies a token
+     * rather than an individual call for as long as it is reused. A fresh mint
+     * after the window gets a fresh id.
+     */
+    it('shares one token id for the reuse window and takes a new one after it', () => {
+      const cached = decodeWithRagKey(mint({ userId: 'cache-jti' }));
+      const reused = decodeWithRagKey(mint({ userId: 'cache-jti' }));
+      expect(reused.jti).toBe(cached.jti);
+
+      now.mockReturnValue(1_778_250_031_000);
+      expect(decodeWithRagKey(mint({ userId: 'cache-jti' })).jti).not.toBe(cached.jti);
+    });
+
+    it('discards cached tokens when the signing key is rotated', () => {
+      const first = mint({ userId: 'cache-rotation' });
+      process.env.RAG_JWT_SECRET = `${RAG_SECRET}-rotated`;
+
+      const afterRotation = mint({ userId: 'cache-rotation' });
+      expect(afterRotation).not.toBe(first);
+      expect(() => decodeWithRagKey(afterRotation)).toThrow();
     });
   });
 

--- a/packages/api/src/crypto/jwt.spec.ts
+++ b/packages/api/src/crypto/jwt.spec.ts
@@ -1,6 +1,13 @@
 import jwt from 'jsonwebtoken';
-import type { JwtPayload } from 'jsonwebtoken';
-import { RagScopes, isRagAudience, getRagAudience, generateShortLivedToken } from './jwt';
+import { generateKeyPairSync } from 'crypto';
+import type { Algorithm, JwtPayload } from 'jsonwebtoken';
+import {
+  RagScopes,
+  isRagAudience,
+  getRagAudience,
+  supportedRagAlgorithms,
+  generateShortLivedToken,
+} from './jwt';
 
 const RAG_SECRET = 'rag-secret-that-is-long-enough-for-hs256';
 const APP_SECRET = 'app-secret-that-is-long-enough-for-hs256';
@@ -10,6 +17,48 @@ const decodeWithRagKey = (token: string): JwtPayload =>
     audience: 'rag_api',
     issuer: 'librechat',
   }) as JwtPayload;
+
+const EC_CURVES: Record<string, string> = {
+  ES256: 'prime256v1',
+  ES384: 'secp384r1',
+  ES512: 'secp521r1',
+};
+
+interface KeyPair {
+  privateKey: string;
+  publicKey: string;
+}
+
+const keyPairCache = new Map<string, KeyPair>();
+
+/**
+ * A real key of the type the algorithm demands, so the round trip below
+ * exercises the signer instead of a stub. An algorithm with no known key type
+ * throws rather than being skipped: that is what keeps an unusable entry from
+ * sitting in the supported set unexercised.
+ */
+const keyPairFor = (algorithm: Algorithm): KeyPair => {
+  const cached = keyPairCache.get(algorithm);
+  if (cached) {
+    return cached;
+  }
+
+  const publicKeyEncoding = { type: 'spki', format: 'pem' } as const;
+  const privateKeyEncoding = { type: 'pkcs8', format: 'pem' } as const;
+
+  const curve = EC_CURVES[algorithm];
+  const isRsa = algorithm.startsWith('RS') || algorithm.startsWith('PS');
+  if (!curve && !isRsa) {
+    throw new Error(`No key type is known for algorithm '${algorithm}'`);
+  }
+
+  const pair = curve
+    ? generateKeyPairSync('ec', { namedCurve: curve, publicKeyEncoding, privateKeyEncoding })
+    : generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding, privateKeyEncoding });
+
+  keyPairCache.set(algorithm, pair);
+  return pair;
+};
 
 describe('generateShortLivedToken', () => {
   const originalEnv = process.env;
@@ -182,6 +231,129 @@ describe('generateShortLivedToken', () => {
       expect(() =>
         generateShortLivedToken({ userId: 'user-1', entityIds: [], scopes: [RagScopes.embed] }),
       ).toThrow(/at least 32 characters/);
+    });
+  });
+
+  describe('algorithm support', () => {
+    const mint = () =>
+      generateShortLivedToken({
+        userId: 'user-1',
+        tenantId: 'tenant-a',
+        entityIds: ['agent_abc'],
+        scopes: [RagScopes.documents],
+      });
+
+    it.each(supportedRagAlgorithms())(
+      'signs and verifies end to end with %s',
+      (algorithm: Algorithm) => {
+        process.env.RAG_JWT_ALGORITHM = algorithm;
+
+        let verificationKey = RAG_SECRET;
+        if (algorithm.startsWith('HS')) {
+          process.env.RAG_JWT_SECRET = RAG_SECRET;
+        } else {
+          const { privateKey, publicKey } = keyPairFor(algorithm);
+          process.env.RAG_JWT_PRIVATE_KEY = privateKey;
+          verificationKey = publicKey;
+        }
+
+        const token = mint();
+        const header = jwt.decode(token, { complete: true })?.header;
+        expect(header?.alg).toBe(algorithm);
+
+        const claims = jwt.verify(token, verificationKey, {
+          algorithms: [algorithm],
+          audience: 'rag_api',
+          issuer: 'librechat',
+        }) as JwtPayload;
+        expect(claims.sub).toBe('user-1');
+        expect(claims.scopes).toEqual(['rag:documents']);
+      },
+    );
+
+    it('does not offer EdDSA, which the pinned jsonwebtoken cannot sign', () => {
+      expect(supportedRagAlgorithms()).not.toContain('EdDSA');
+
+      process.env.RAG_JWT_ALGORITHM = 'EdDSA';
+      process.env.RAG_JWT_PRIVATE_KEY = keyPairFor('RS256').privateKey;
+
+      expect(mint).toThrow(/RAG_JWT_ALGORITHM 'EdDSA' is not supported/);
+    });
+
+    it('resolves a supported algorithm whatever case it is configured in', () => {
+      process.env.RAG_JWT_ALGORITHM = 'hs384';
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+
+      const token = mint();
+      expect(jwt.decode(token, { complete: true })?.header.alg).toBe('HS384');
+    });
+
+    it('reports an unsupported algorithm exactly as it was configured', () => {
+      process.env.RAG_JWT_SECRET = RAG_SECRET;
+      process.env.RAG_JWT_ALGORITHM = 'Ed25519';
+
+      expect(mint).toThrow(/RAG_JWT_ALGORITHM 'Ed25519' is not supported/);
+    });
+  });
+
+  describe('private key normalization', () => {
+    it('accepts an RSA key supplied as one line with literal \\n escapes', () => {
+      const { privateKey, publicKey } = keyPairFor('RS256');
+      process.env.RAG_JWT_ALGORITHM = 'RS256';
+      process.env.RAG_JWT_PRIVATE_KEY = privateKey.replace(/\n/g, '\\n');
+
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      const claims = jwt.verify(token, publicKey, {
+        algorithms: ['RS256'],
+        audience: 'rag_api',
+        issuer: 'librechat',
+      }) as JwtPayload;
+      expect(claims.sub).toBe('user-1');
+    });
+
+    it('accepts an EC key supplied as one line with literal \\n escapes', () => {
+      const { privateKey, publicKey } = keyPairFor('ES256');
+      process.env.RAG_JWT_ALGORITHM = 'ES256';
+      process.env.RAG_JWT_PRIVATE_KEY = privateKey.replace(/\n/g, '\\n');
+
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      expect(
+        (
+          jwt.verify(token, publicKey, {
+            algorithms: ['ES256'],
+            audience: 'rag_api',
+            issuer: 'librechat',
+          }) as JwtPayload
+        ).sub,
+      ).toBe('user-1');
+    });
+
+    it('leaves an HMAC secret containing escape sequences byte for byte', () => {
+      const secret = 'rag-secret-with-\\n-escape-and-enough-length';
+      process.env.RAG_JWT_SECRET = secret;
+
+      const token = generateShortLivedToken({
+        userId: 'user-1',
+        entityIds: [],
+        scopes: [RagScopes.embed],
+      });
+
+      expect(() =>
+        jwt.verify(token, secret, { audience: 'rag_api', issuer: 'librechat' }),
+      ).not.toThrow();
+      expect(() =>
+        jwt.verify(token, secret.replace(/\\n/g, '\n'), { audience: 'rag_api' }),
+      ).toThrow(jwt.JsonWebTokenError);
     });
   });
 

--- a/packages/api/src/crypto/jwt.ts
+++ b/packages/api/src/crypto/jwt.ts
@@ -1,14 +1,225 @@
 import jwt from 'jsonwebtoken';
+import { SYSTEM_TENANT_ID } from '@librechat/data-schemas';
+import type { Algorithm } from 'jsonwebtoken';
 
 /**
- * Generate a short-lived JWT token
- * @param {String} userId - The ID of the user
- * @param {String} [expireIn='5m'] - The expiration time for the token (default is 5 minutes)
- * @returns {String} - The generated JWT token
+ * Scopes the RAG service recognises. `rag:embed` guards its embeddings
+ * endpoint, `rag:rerank` its rerank endpoint. A strict token carrying no scope
+ * at all is refused, so every call path names the scopes it actually uses
+ * instead of receiving a blanket grant.
  */
-export const generateShortLivedToken = (userId: string, expireIn: string = '5m'): string => {
-  return jwt.sign({ id: userId }, process.env.JWT_SECRET!, {
+export const RagScopes = {
+  embed: 'rag:embed',
+  rerank: 'rag:rerank',
+} as const;
+
+export type RagScope = (typeof RagScopes)[keyof typeof RagScopes];
+
+/** Tenant recorded for deployments that never adopted tenants. */
+export const BASE_TENANT_ID = '__BASE__';
+
+export interface RagTokenParams {
+  /** Token subject — the acting user's id. */
+  userId: string;
+  /** Scopes this call needs. */
+  scopes: RagScope[];
+  /**
+   * Entity (agent) ids whose documents this call may reach. Pass an empty
+   * array when the call has no entity context: that is a statement about the
+   * call, not a default, and it keeps the token scoped to the user's own
+   * documents.
+   */
+  entityIds: Array<string | null | undefined>;
+  /** Tenant the call acts within. Falls back to the base tenant. */
+  tenantId?: string | null;
+  expireIn?: string;
+}
+
+interface RagSigningConfig {
+  key: string;
+  algorithm: Algorithm;
+  issuer: string;
+  audience: string;
+}
+
+const DEFAULT_ISSUER = 'librechat';
+const DEFAULT_AUDIENCE = 'rag_api';
+const DEFAULT_EXPIRY = '5m';
+const MIN_HMAC_SECRET_LENGTH = 32;
+
+const TRUTHY_VALUES: ReadonlySet<string> = new Set(['true', '1', 'yes', 'on', 'y']);
+
+const HMAC_ALGORITHMS: ReadonlySet<string> = new Set(['HS256', 'HS384', 'HS512']);
+const ASYMMETRIC_ALGORITHMS: ReadonlySet<string> = new Set([
+  'RS256',
+  'RS384',
+  'RS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'EdDSA',
+]);
+
+/**
+ * Mirrors the RAG service's own `RAG_AUTH_ACCEPT_LEGACY` parsing so both sides
+ * of the migration read the flag identically.
+ */
+const acceptsLegacyTokens = (): boolean =>
+  TRUTHY_VALUES.has((process.env.RAG_AUTH_ACCEPT_LEGACY ?? 'true').trim().toLowerCase());
+
+const configuredIssuer = (): string => (process.env.RAG_JWT_ISSUER ?? DEFAULT_ISSUER).trim();
+
+const configuredAudience = (): string => (process.env.RAG_JWT_AUDIENCE ?? DEFAULT_AUDIENCE).trim();
+
+/**
+ * The audience RAG tokens carry. Blank configuration falls back to the default
+ * so the audience rejection in the application's own JWT strategy can never be
+ * silently disabled by an empty environment variable.
+ */
+export const getRagAudience = (): string => configuredAudience() || DEFAULT_AUDIENCE;
+
+/**
+ * Whether a decoded token's `aud` claim marks it as minted for the RAG service.
+ * Such a token is never a valid application session token, even if it somehow
+ * verifies — the two are signed with separate keys precisely so that neither
+ * can stand in for the other.
+ */
+export const isRagAudience = (audience?: string | string[] | null): boolean => {
+  if (audience == null) {
+    return false;
+  }
+  const ragAudience = getRagAudience();
+  if (Array.isArray(audience)) {
+    return audience.some((entry) => entry === ragAudience);
+  }
+  return audience === ragAudience;
+};
+
+/**
+ * Resolves the dedicated signing configuration, or `null` when the deployment
+ * has not adopted one yet and legacy tokens are still accepted.
+ *
+ * Every failure mode throws rather than degrading to `JWT_SECRET`: sharing that
+ * key would make every RAG token a full application session token and vice
+ * versa, which is the whole reason the dedicated key exists.
+ */
+function resolveSigningConfig(): RagSigningConfig | null {
+  const algorithm = (process.env.RAG_JWT_ALGORITHM ?? 'HS256').trim().toUpperCase() as Algorithm;
+  const isHmac = HMAC_ALGORITHMS.has(algorithm);
+
+  if (!isHmac && !ASYMMETRIC_ALGORITHMS.has(algorithm)) {
+    throw new Error(`[generateShortLivedToken] RAG_JWT_ALGORITHM '${algorithm}' is not supported`);
+  }
+
+  const keyVariable = isHmac ? 'RAG_JWT_SECRET' : 'RAG_JWT_PRIVATE_KEY';
+  const key = isHmac ? process.env.RAG_JWT_SECRET : process.env.RAG_JWT_PRIVATE_KEY;
+
+  if (!key) {
+    if (!acceptsLegacyTokens()) {
+      throw new Error(
+        `[generateShortLivedToken] RAG_AUTH_ACCEPT_LEGACY=false requires ${keyVariable}`,
+      );
+    }
+    if (!isHmac) {
+      throw new Error(
+        `[generateShortLivedToken] RAG_JWT_ALGORITHM '${algorithm}' requires ${keyVariable}`,
+      );
+    }
+    return null;
+  }
+
+  if (isHmac) {
+    if (key === process.env.JWT_SECRET) {
+      throw new Error(
+        '[generateShortLivedToken] RAG_JWT_SECRET must differ from JWT_SECRET: sharing the key makes every RAG token a full application session token and vice versa',
+      );
+    }
+    if (key.length < MIN_HMAC_SECRET_LENGTH) {
+      throw new Error(
+        `[generateShortLivedToken] RAG_JWT_SECRET must be at least ${MIN_HMAC_SECRET_LENGTH} characters for ${algorithm}`,
+      );
+    }
+  }
+
+  const issuer = configuredIssuer();
+  if (!issuer) {
+    throw new Error('[generateShortLivedToken] RAG_JWT_ISSUER must not be empty');
+  }
+
+  const audience = configuredAudience();
+  if (!audience) {
+    throw new Error('[generateShortLivedToken] RAG_JWT_AUDIENCE must not be empty');
+  }
+
+  return { key, algorithm, issuer, audience };
+}
+
+function signLegacyToken(userId: string, expireIn: string): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error(
+      '[generateShortLivedToken] Neither RAG_JWT_SECRET nor JWT_SECRET is set; refusing to mint an unsigned token',
+    );
+  }
+  return jwt.sign({ id: userId }, secret, { expiresIn: expireIn, algorithm: 'HS256' });
+}
+
+const uniqueValues = (values: Array<string | null | undefined>): string[] => {
+  const collected = new Set<string>();
+  for (const value of values) {
+    if (value) {
+      collected.add(value);
+    }
+  }
+  return [...collected];
+};
+
+/**
+ * Mints a short-lived bearer token for the RAG service.
+ *
+ * With a dedicated signing key configured the token carries the strict claim
+ * set — issuer, audience, subject, expiry, tenant, scopes and the entity ids
+ * the call may act for. Without one it keeps minting the `{ id }` shape older
+ * RAG deployments accept, so an upgrade can be staged: point both sides at the
+ * dedicated key first, then stop accepting the legacy shape.
+ */
+export const generateShortLivedToken = ({
+  userId,
+  scopes,
+  entityIds,
+  tenantId,
+  expireIn = DEFAULT_EXPIRY,
+}: RagTokenParams): string => {
+  if (!userId) {
+    throw new Error('[generateShortLivedToken] A user id is required');
+  }
+
+  const config = resolveSigningConfig();
+  if (!config) {
+    return signLegacyToken(userId, expireIn);
+  }
+
+  const grantedScopes = uniqueValues(scopes);
+  if (grantedScopes.length === 0) {
+    throw new Error('[generateShortLivedToken] At least one scope is required');
+  }
+
+  const tenant = tenantId?.trim() || BASE_TENANT_ID;
+  if (tenant === SYSTEM_TENANT_ID) {
+    throw new Error('[generateShortLivedToken] The system tenant may not call the RAG service');
+  }
+
+  const entities = uniqueValues(entityIds);
+  const payload =
+    entities.length > 0
+      ? { tenant, scopes: grantedScopes, entities }
+      : { tenant, scopes: grantedScopes };
+
+  return jwt.sign(payload, config.key, {
+    algorithm: config.algorithm,
     expiresIn: expireIn,
-    algorithm: 'HS256',
+    issuer: config.issuer,
+    audience: config.audience,
+    subject: userId,
   });
 };

--- a/packages/api/src/crypto/jwt.ts
+++ b/packages/api/src/crypto/jwt.ts
@@ -1,6 +1,8 @@
 import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
 import { SYSTEM_TENANT_ID } from '@librechat/data-schemas';
 import type { Algorithm } from 'jsonwebtoken';
+import { createTokenMintCache, TOKEN_MINT_CACHE_SECONDS } from '~/crypto/cache';
 import { normalizePem } from '~/crypto/keys';
 
 /**
@@ -39,7 +41,6 @@ export interface RagTokenParams {
   entityIds: Array<string | null | undefined>;
   /** Tenant the call acts within. Falls back to the base tenant. */
   tenantId?: string | null;
-  expireIn?: string;
 }
 
 interface RagSigningConfig {
@@ -47,11 +48,32 @@ interface RagSigningConfig {
   algorithm: Algorithm;
   issuer: string;
   audience: string;
+  kid: string;
+  ttlSeconds: number;
+}
+
+/**
+ * The claims this side authors. `entities` is omitted rather than sent empty:
+ * absent means the call carries no entity context and stays scoped to the
+ * user's own documents, which is a narrower statement than an empty list.
+ */
+interface RagPayload {
+  tenant: string;
+  scopes: string[];
+  entities?: string[];
 }
 
 const DEFAULT_ISSUER = 'librechat';
 const DEFAULT_AUDIENCE = 'rag_api';
-const DEFAULT_EXPIRY = '5m';
+const DEFAULT_KID = 'lc-rag-2026-08';
+const DEFAULT_TTL_SECONDS = 300;
+/**
+ * Ceiling on a minted token's lifetime. `RAG_JWT_TTL_SECONDS` can only lower
+ * it: the lifetime is a property of the deployment rather than of the caller,
+ * so no call path can widen its own token past what the operator allows.
+ */
+const MAX_TTL_SECONDS = 300;
+const LEGACY_EXPIRY = '5m';
 const MIN_HMAC_SECRET_LENGTH = 32;
 
 const TRUTHY_VALUES: ReadonlySet<string> = new Set(['true', '1', 'yes', 'on', 'y']);
@@ -103,6 +125,22 @@ const configuredIssuer = (): string => (process.env.RAG_JWT_ISSUER ?? DEFAULT_IS
 const configuredAudience = (): string => (process.env.RAG_JWT_AUDIENCE ?? DEFAULT_AUDIENCE).trim();
 
 /**
+ * Key id stamped into every token header so the RAG service can hold more than
+ * one trusted key at a time. Rotation is then additive on the verifying side —
+ * publish the new key alongside the old, move the minter, retire the old one —
+ * instead of a synchronised restart of both services.
+ */
+const configuredKid = (): string => (process.env.RAG_JWT_KID ?? '').trim() || DEFAULT_KID;
+
+const parseCappedSeconds = (value: string | undefined, fallback: number, max: number): number => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.floor(parsed), max);
+};
+
+/**
  * The audience RAG tokens carry. Blank configuration falls back to the default
  * so the audience rejection in the application's own JWT strategy can never be
  * silently disabled by an empty environment variable.
@@ -134,7 +172,7 @@ export const isRagAudience = (audience?: string | string[] | null): boolean => {
  * key would make every RAG token a full application session token and vice
  * versa, which is the whole reason the dedicated key exists.
  */
-function resolveSigningConfig(): RagSigningConfig | null {
+function buildSigningConfig(): RagSigningConfig | null {
   const configured = (process.env.RAG_JWT_ALGORITHM ?? 'HS256').trim();
   const algorithm = ALGORITHMS_BY_UPPERCASE.get(configured.toUpperCase());
 
@@ -191,17 +229,72 @@ function resolveSigningConfig(): RagSigningConfig | null {
     throw new Error('[generateShortLivedToken] RAG_JWT_AUDIENCE must not be empty');
   }
 
-  return { key: signingKey, algorithm, issuer, audience };
+  return {
+    key: signingKey,
+    algorithm,
+    issuer,
+    audience,
+    kid: configuredKid(),
+    ttlSeconds: parseCappedSeconds(
+      process.env.RAG_JWT_TTL_SECONDS,
+      DEFAULT_TTL_SECONDS,
+      MAX_TTL_SECONDS,
+    ),
+  };
 }
 
-function signLegacyToken(userId: string, expireIn: string): string {
+/**
+ * The environment values the signing configuration is derived from. Comparing
+ * this against the cached copy is what makes rebuilding cheap while still
+ * reacting to a rotated key or a changed algorithm within the process.
+ */
+const signingConfigFingerprint = (): string =>
+  JSON.stringify([
+    process.env.RAG_JWT_ALGORITHM,
+    process.env.RAG_JWT_SECRET,
+    process.env.RAG_JWT_PRIVATE_KEY,
+    process.env.RAG_JWT_ISSUER,
+    process.env.RAG_JWT_AUDIENCE,
+    process.env.RAG_JWT_KID,
+    process.env.RAG_JWT_TTL_SECONDS,
+    process.env.RAG_AUTH_ACCEPT_LEGACY,
+    process.env.JWT_SECRET,
+  ]);
+
+let cachedFingerprint: string | null = null;
+let cachedSigningConfig: RagSigningConfig | null = null;
+const tokenCache = createTokenMintCache();
+
+/**
+ * Resolves the dedicated signing configuration, or `null` when the deployment
+ * has not adopted one yet and legacy tokens are still accepted.
+ *
+ * The result is memoised against the environment it came from, so validation
+ * runs once per configuration rather than once per mint. Any change invalidates
+ * the minted-token cache as well — a token signed with a retired key must never
+ * outlive the key itself.
+ */
+function resolveSigningConfig(): RagSigningConfig | null {
+  const fingerprint = signingConfigFingerprint();
+  if (fingerprint === cachedFingerprint) {
+    return cachedSigningConfig;
+  }
+
+  const config = buildSigningConfig();
+  cachedFingerprint = fingerprint;
+  cachedSigningConfig = config;
+  tokenCache.clear();
+  return config;
+}
+
+function signLegacyToken(userId: string): string {
   const secret = process.env.JWT_SECRET;
   if (!secret) {
     throw new Error(
       '[generateShortLivedToken] Neither RAG_JWT_SECRET nor JWT_SECRET is set; refusing to mint an unsigned token',
     );
   }
-  return jwt.sign({ id: userId }, secret, { expiresIn: expireIn, algorithm: 'HS256' });
+  return jwt.sign({ id: userId }, secret, { expiresIn: LEGACY_EXPIRY, algorithm: 'HS256' });
 }
 
 const uniqueValues = (values: Array<string | null | undefined>): string[] => {
@@ -215,20 +308,42 @@ const uniqueValues = (values: Array<string | null | undefined>): string[] => {
 };
 
 /**
+ * Identifies a token by everything that distinguishes what it may do, so a
+ * cached token is only ever handed back to a call that would have minted the
+ * same claims. The signing material is deliberately absent: a change there
+ * empties the cache outright rather than partitioning it.
+ */
+const mintCacheKey = (config: RagSigningConfig, subject: string, payload: RagPayload): string =>
+  JSON.stringify([
+    config.algorithm,
+    config.kid,
+    config.issuer,
+    config.audience,
+    subject,
+    payload.tenant,
+    payload.scopes,
+    payload.entities ?? [],
+  ]);
+
+/**
  * Mints a short-lived bearer token for the RAG service.
  *
  * With a dedicated signing key configured the token carries the strict claim
- * set — issuer, audience, subject, expiry, tenant, scopes and the entity ids
- * the call may act for. Without one it keeps minting the `{ id }` shape older
- * RAG deployments accept, so an upgrade can be staged: point both sides at the
- * dedicated key first, then stop accepting the legacy shape.
+ * set — issuer, audience, subject, expiry, key id, token id, tenant, scopes and
+ * the entity ids the call may act for. Without one it keeps minting the
+ * `{ id }` shape older RAG deployments accept, so an upgrade can be staged:
+ * point both sides at the dedicated key first, then stop accepting the legacy
+ * shape.
+ *
+ * Tokens are reused for a bounded window. Paths that mint per file — reading
+ * attachment context, deleting a file's chunks — would otherwise pay for a
+ * signature per file, which is far from free under the RSA and PSS algorithms.
  */
 export const generateShortLivedToken = ({
   userId,
   scopes,
   entityIds,
   tenantId,
-  expireIn = DEFAULT_EXPIRY,
 }: RagTokenParams): string => {
   if (!userId) {
     throw new Error('[generateShortLivedToken] A user id is required');
@@ -236,7 +351,7 @@ export const generateShortLivedToken = ({
 
   const config = resolveSigningConfig();
   if (!config) {
-    return signLegacyToken(userId, expireIn);
+    return signLegacyToken(userId);
   }
 
   const grantedScopes = uniqueValues(scopes);
@@ -250,16 +365,32 @@ export const generateShortLivedToken = ({
   }
 
   const entities = uniqueValues(entityIds);
-  const payload =
+  const payload: RagPayload =
     entities.length > 0
       ? { tenant, scopes: grantedScopes, entities }
       : { tenant, scopes: grantedScopes };
 
+  const now = Math.floor(Date.now() / 1000);
+  const cacheKey = mintCacheKey(config, userId, payload);
+  const cached = tokenCache.get(cacheKey, now);
+  if (cached) {
+    return cached;
+  }
+
+  const token = signRagToken(config, userId, payload);
+  tokenCache.set(cacheKey, token, now + config.ttlSeconds, now, TOKEN_MINT_CACHE_SECONDS);
+  return token;
+};
+
+function signRagToken(config: RagSigningConfig, subject: string, payload: RagPayload): string {
   return jwt.sign(payload, config.key, {
     algorithm: config.algorithm,
-    expiresIn: expireIn,
+    expiresIn: config.ttlSeconds,
     issuer: config.issuer,
     audience: config.audience,
-    subject: userId,
+    subject,
+    keyid: config.kid,
+    jwtid: randomUUID(),
+    notBefore: 0,
   });
-};
+}

--- a/packages/api/src/crypto/jwt.ts
+++ b/packages/api/src/crypto/jwt.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import { SYSTEM_TENANT_ID } from '@librechat/data-schemas';
 import type { Algorithm } from 'jsonwebtoken';
+import { normalizePem } from '~/crypto/keys';
 
 /**
  * Scopes the RAG service recognises, one per capability. `rag:embed` guards its
@@ -55,16 +56,40 @@ const MIN_HMAC_SECRET_LENGTH = 32;
 
 const TRUTHY_VALUES: ReadonlySet<string> = new Set(['true', '1', 'yes', 'on', 'y']);
 
-const HMAC_ALGORITHMS: ReadonlySet<string> = new Set(['HS256', 'HS384', 'HS512']);
-const ASYMMETRIC_ALGORITHMS: ReadonlySet<string> = new Set([
+/**
+ * Every algorithm the pinned `jsonwebtoken` can both sign and verify. `EdDSA`
+ * is deliberately absent: the pinned `jws`/`jwa` implementation has no Ed25519
+ * signer, so offering it would accept a configuration that then throws on the
+ * first mint. `jwt.spec.ts` signs and verifies a real key of the matching type
+ * for every entry below, so nothing can be listed here without being exercised.
+ */
+const HMAC_ALGORITHMS: ReadonlySet<Algorithm> = new Set<Algorithm>(['HS256', 'HS384', 'HS512']);
+const ASYMMETRIC_ALGORITHMS: ReadonlySet<Algorithm> = new Set<Algorithm>([
   'RS256',
   'RS384',
   'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
   'ES256',
   'ES384',
   'ES512',
-  'EdDSA',
 ]);
+
+/**
+ * Case-insensitive lookup from configured value to the exact spelling
+ * `jsonwebtoken` expects. Matching on an upper-cased copy rather than
+ * upper-casing the value itself keeps mixed-case algorithm names (the JOSE
+ * registry has them) resolvable instead of silently unmatchable.
+ */
+const ALGORITHMS_BY_UPPERCASE: ReadonlyMap<string, Algorithm> = new Map(
+  [...HMAC_ALGORITHMS, ...ASYMMETRIC_ALGORITHMS].map((algorithm) => [
+    algorithm.toUpperCase(),
+    algorithm,
+  ]),
+);
+
+export const supportedRagAlgorithms = (): Algorithm[] => [...ALGORITHMS_BY_UPPERCASE.values()];
 
 /**
  * Mirrors the RAG service's own `RAG_AUTH_ACCEPT_LEGACY` parsing so both sides
@@ -110,13 +135,14 @@ export const isRagAudience = (audience?: string | string[] | null): boolean => {
  * versa, which is the whole reason the dedicated key exists.
  */
 function resolveSigningConfig(): RagSigningConfig | null {
-  const algorithm = (process.env.RAG_JWT_ALGORITHM ?? 'HS256').trim().toUpperCase() as Algorithm;
-  const isHmac = HMAC_ALGORITHMS.has(algorithm);
+  const configured = (process.env.RAG_JWT_ALGORITHM ?? 'HS256').trim();
+  const algorithm = ALGORITHMS_BY_UPPERCASE.get(configured.toUpperCase());
 
-  if (!isHmac && !ASYMMETRIC_ALGORITHMS.has(algorithm)) {
-    throw new Error(`[generateShortLivedToken] RAG_JWT_ALGORITHM '${algorithm}' is not supported`);
+  if (!algorithm) {
+    throw new Error(`[generateShortLivedToken] RAG_JWT_ALGORITHM '${configured}' is not supported`);
   }
 
+  const isHmac = HMAC_ALGORITHMS.has(algorithm);
   const keyVariable = isHmac ? 'RAG_JWT_SECRET' : 'RAG_JWT_PRIVATE_KEY';
   const key = isHmac ? process.env.RAG_JWT_SECRET : process.env.RAG_JWT_PRIVATE_KEY;
 
@@ -147,6 +173,14 @@ function resolveSigningConfig(): RagSigningConfig | null {
     }
   }
 
+  /**
+   * An HMAC secret is opaque bytes and has to reach the signer exactly as the
+   * RAG service reads it; a PEM is structured text that environments routinely
+   * flatten to one line with literal `\n` escapes, which Node's key parser
+   * rejects.
+   */
+  const signingKey = isHmac ? key : normalizePem(key);
+
   const issuer = configuredIssuer();
   if (!issuer) {
     throw new Error('[generateShortLivedToken] RAG_JWT_ISSUER must not be empty');
@@ -157,7 +191,7 @@ function resolveSigningConfig(): RagSigningConfig | null {
     throw new Error('[generateShortLivedToken] RAG_JWT_AUDIENCE must not be empty');
   }
 
-  return { key, algorithm, issuer, audience };
+  return { key: signingKey, algorithm, issuer, audience };
 }
 
 function signLegacyToken(userId: string, expireIn: string): string {

--- a/packages/api/src/crypto/jwt.ts
+++ b/packages/api/src/crypto/jwt.ts
@@ -3,14 +3,20 @@ import { SYSTEM_TENANT_ID } from '@librechat/data-schemas';
 import type { Algorithm } from 'jsonwebtoken';
 
 /**
- * Scopes the RAG service recognises. `rag:embed` guards its embeddings
- * endpoint, `rag:rerank` its rerank endpoint. A strict token carrying no scope
- * at all is refused, so every call path names the scopes it actually uses
+ * Scopes the RAG service recognises, one per capability. `rag:embed` guards its
+ * embeddings endpoint and `rag:rerank` its rerank endpoint; both spend
+ * inference budget. `rag:documents` guards the stored-chunk routes — reading a
+ * file's context, listing ids, deleting a file — and buys no inference at all.
+ *
+ * Neither plane substitutes for the other, so a token minted to delete a file
+ * cannot be replayed against an embedding provider. A strict token carrying no
+ * scope at all is refused, so every call path names the scopes it actually uses
  * instead of receiving a blanket grant.
  */
 export const RagScopes = {
   embed: 'rag:embed',
   rerank: 'rag:rerank',
+  documents: 'rag:documents',
 } as const;
 
 export type RagScope = (typeof RagScopes)[keyof typeof RagScopes];

--- a/packages/api/src/crypto/keys.ts
+++ b/packages/api/src/crypto/keys.ts
@@ -1,0 +1,9 @@
+/**
+ * Restores a PEM that was supplied as a single-line environment value.
+ *
+ * Secret stores, CI variables and container runtimes routinely flatten a
+ * private key into one line with literal `\n` escapes. Node's key parser
+ * rejects that form outright, so every consumer of an inline PEM has to undo
+ * it before handing the value to a signer.
+ */
+export const normalizePem = (value: string): string => value.replace(/\\n/g, '\n').trim();

--- a/packages/api/src/files/embedding.spec.ts
+++ b/packages/api/src/files/embedding.spec.ts
@@ -1,0 +1,102 @@
+import { NO_EMBEDDING_ENTITY } from '@librechat/data-schemas';
+import type { EmbeddedFileRef, LegacyEntityLookup } from './embedding';
+import {
+  resolveEmbeddingEntityIds,
+  hasRecordedEmbeddingEntity,
+  getRecordedEmbeddingEntityId,
+} from './embedding';
+
+const embedded = (file_id: string, embedding_entity_id?: string): EmbeddedFileRef => ({
+  file_id,
+  embedded: true,
+  ...(embedding_entity_id === undefined ? {} : { embedding_entity_id }),
+});
+
+describe('getRecordedEmbeddingEntityId', () => {
+  it('returns the agent a knowledge-base file was embedded under', () => {
+    expect(getRecordedEmbeddingEntityId(embedded('f1', 'agent_abc'))).toBe('agent_abc');
+  });
+
+  it('reads a recorded none as user-scoped rather than unknown', () => {
+    const file = embedded('f1', NO_EMBEDDING_ENTITY);
+    expect(hasRecordedEmbeddingEntity(file)).toBe(true);
+    expect(getRecordedEmbeddingEntityId(file)).toBeUndefined();
+  });
+
+  it('reports a file predating the record as having nothing recorded', () => {
+    expect(hasRecordedEmbeddingEntity(embedded('f1'))).toBe(false);
+    expect(hasRecordedEmbeddingEntity(embedded('f1', ''))).toBe(false);
+  });
+});
+
+describe('resolveEmbeddingEntityIds', () => {
+  const neverCalled: LegacyEntityLookup = jest.fn(() => {
+    throw new Error('the legacy lookup must not run for files that recorded their entity');
+  });
+
+  it('uses the recorded agent and never consults the associations', async () => {
+    const resolved = await resolveEmbeddingEntityIds({
+      files: [embedded('f1', 'agent_abc')],
+      lookupLegacyEntityIds: neverCalled,
+    });
+
+    expect(resolved).toEqual({ f1: 'agent_abc' });
+  });
+
+  it('keeps a recorded user-scoped file unscoped even when an agent claims it', async () => {
+    const lookup = jest.fn().mockResolvedValue({ f1: 'agent_adopter' });
+
+    const resolved = await resolveEmbeddingEntityIds({
+      files: [embedded('f1', NO_EMBEDDING_ENTITY)],
+      lookupLegacyEntityIds: lookup,
+    });
+
+    expect(resolved).toEqual({});
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('ignores files that were never embedded', async () => {
+    const resolved = await resolveEmbeddingEntityIds({
+      files: [{ file_id: 'f1', embedded: false, embedding_entity_id: 'agent_abc' }],
+      lookupLegacyEntityIds: neverCalled,
+    });
+
+    expect(resolved).toEqual({});
+  });
+
+  it('asks the legacy lookup only about files with nothing recorded', async () => {
+    const lookup = jest.fn().mockResolvedValue({ legacy: 'agent_legacy' });
+
+    const resolved = await resolveEmbeddingEntityIds({
+      files: [
+        embedded('recorded', 'agent_recorded'),
+        embedded('userScoped', NO_EMBEDDING_ENTITY),
+        embedded('legacy'),
+      ],
+      lookupLegacyEntityIds: lookup,
+    });
+
+    expect(lookup).toHaveBeenCalledWith({ file_ids: ['legacy'] });
+    expect(resolved).toEqual({ recorded: 'agent_recorded', legacy: 'agent_legacy' });
+  });
+
+  it('skips the lookup entirely when every file recorded its entity', async () => {
+    const lookup = jest.fn().mockResolvedValue({});
+
+    await resolveEmbeddingEntityIds({
+      files: [embedded('f1', 'agent_abc'), embedded('f2', NO_EMBEDDING_ENTITY)],
+      lookupLegacyEntityIds: lookup,
+    });
+
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('leaves legacy files user-scoped rather than blocking the delete when the lookup fails', async () => {
+    const resolved = await resolveEmbeddingEntityIds({
+      files: [embedded('recorded', 'agent_recorded'), embedded('legacy')],
+      lookupLegacyEntityIds: jest.fn().mockRejectedValue(new Error('mongo down')),
+    });
+
+    expect(resolved).toEqual({ recorded: 'agent_recorded' });
+  });
+});

--- a/packages/api/src/files/embedding.ts
+++ b/packages/api/src/files/embedding.ts
@@ -1,0 +1,94 @@
+import { logger, NO_EMBEDDING_ENTITY } from '@librechat/data-schemas';
+
+/** The subset of a file record needed to work out where its chunks live. */
+export interface EmbeddedFileRef {
+  file_id: string;
+  embedded?: boolean;
+  embedding_entity_id?: string;
+}
+
+/** Looks up, for files with no recorded entity, the agents that reference them. */
+export type LegacyEntityLookup = (params: {
+  file_ids: string[];
+}) => Promise<Record<string, string>>;
+
+/**
+ * Whether the file carries the entity its vectors were written under. False for
+ * records that predate the field — their scope has to be inferred instead.
+ */
+export const hasRecordedEmbeddingEntity = (file: EmbeddedFileRef): boolean =>
+  file.embedding_entity_id != null && file.embedding_entity_id !== '';
+
+/**
+ * The entity to name when reaching the file's chunks, or `undefined` when they
+ * are the user's own. A recorded `NO_EMBEDDING_ENTITY` is a positive statement
+ * that the upload was user-scoped, not an absence of information.
+ */
+export const getRecordedEmbeddingEntityId = (file: EmbeddedFileRef): string | undefined => {
+  if (!hasRecordedEmbeddingEntity(file) || file.embedding_entity_id === NO_EMBEDDING_ENTITY) {
+    return undefined;
+  }
+  return file.embedding_entity_id;
+};
+
+/**
+ * Maps each embedded file in a batch to the entity that owns its chunks.
+ *
+ * The recorded value decides, because it is the only thing that reflects what
+ * was actually sent to the RAG service at embed time. An agent's current
+ * `file_search` association proves nothing about that: an already-owned file id
+ * can be added to any agent's `tool_resources` afterwards, and a message
+ * attachment is embedded with no entity at all — scoping either one to an agent
+ * sends the delete looking in a namespace that never held the chunks.
+ *
+ * Files written before the field existed have nothing recorded, so they alone
+ * fall back to the association lookup. It is a guess, but a strictly better one
+ * than naming no entity at all, which is what those files got previously. A
+ * failed lookup leaves them user-scoped rather than blocking the delete, so a
+ * legacy file is never left undeletable.
+ */
+export async function resolveEmbeddingEntityIds({
+  files,
+  lookupLegacyEntityIds,
+}: {
+  files: EmbeddedFileRef[];
+  lookupLegacyEntityIds: LegacyEntityLookup;
+}): Promise<Record<string, string>> {
+  const entityIdByFileId: Record<string, string> = {};
+  const legacyFileIds: string[] = [];
+
+  for (const file of files) {
+    if (file.embedded !== true || !file.file_id) {
+      continue;
+    }
+    if (!hasRecordedEmbeddingEntity(file)) {
+      legacyFileIds.push(file.file_id);
+      continue;
+    }
+    const entityId = getRecordedEmbeddingEntityId(file);
+    if (entityId) {
+      entityIdByFileId[file.file_id] = entityId;
+    }
+  }
+
+  if (legacyFileIds.length === 0) {
+    return entityIdByFileId;
+  }
+
+  try {
+    const inferred = await lookupLegacyEntityIds({ file_ids: legacyFileIds });
+    for (const fileId of legacyFileIds) {
+      const entityId = inferred[fileId];
+      if (entityId) {
+        entityIdByFileId[fileId] = entityId;
+      }
+    }
+  } catch (error) {
+    logger.error(
+      '[resolveEmbeddingEntityIds] Could not infer the owner of files predating embedding_entity_id; treating them as user-scoped',
+      error,
+    );
+  }
+
+  return entityIdByFileId;
+}

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -3,6 +3,7 @@ export * from './audio';
 export * from './code';
 export * from './context';
 export * from './documents/crud';
+export * from './embedding';
 export * from './encode';
 export * from './filter';
 export * from './mistral/crud';

--- a/packages/api/src/files/rag.spec.ts
+++ b/packages/api/src/files/rag.spec.ts
@@ -48,9 +48,8 @@ describe('deleteRagFile', () => {
       const file = { file_id: 'file-123', embedded: true };
       mockedAxios.delete.mockResolvedValueOnce({ status: 200 });
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).resolves.toBeUndefined();
 
-      expect(result).toBe(true);
       expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith({
         userId: 'user123',
         tenantId: undefined,
@@ -75,9 +74,10 @@ describe('deleteRagFile', () => {
       const file = { file_id: 'file-123', embedded: true, entity_id: 'agent_abc' };
       mockedAxios.delete.mockResolvedValueOnce({ status: 200 });
 
-      const result = await deleteRagFile({ userId: 'user123', file, tenantId: 'tenant-1' });
+      await expect(
+        deleteRagFile({ userId: 'user123', file, tenantId: 'tenant-1' }),
+      ).resolves.toBeUndefined();
 
-      expect(result).toBe(true);
       expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith({
         userId: 'user123',
         tenantId: 'tenant-1',
@@ -90,15 +90,16 @@ describe('deleteRagFile', () => {
       );
     });
 
-    it('returns false without calling the RAG API when the token cannot be minted', async () => {
+    it('throws without calling the RAG API when the token cannot be minted', async () => {
       const file = { file_id: 'file-123', embedded: true };
       mockedGenerateShortLivedToken.mockImplementationOnce(() => {
         throw new Error('RAG_AUTH_ACCEPT_LEGACY=false requires RAG_JWT_SECRET');
       });
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).rejects.toThrow(
+        /Unable to mint a RAG API token/,
+      );
 
-      expect(result).toBe(false);
       expect(mockedAxios.delete).not.toHaveBeenCalled();
       expect(mockedLogger.error).toHaveBeenCalledWith(
         '[deleteRagFile] Unable to mint a RAG API token:',
@@ -106,43 +107,49 @@ describe('deleteRagFile', () => {
       );
     });
 
-    it('should return true and log warning when document is not found (404)', async () => {
+    it('treats a 404 as already deleted and resolves', async () => {
       const file = { file_id: 'file-not-found', embedded: true };
       const error = new Error('Not Found') as Error & { response?: { status?: number } };
       error.response = { status: 404 };
       mockedAxios.delete.mockRejectedValueOnce(error);
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).resolves.toBeUndefined();
 
-      expect(result).toBe(true);
       expect(mockedLogger.warn).toHaveBeenCalledWith(
         '[deleteRagFile] Document file-not-found not found in RAG API, may have been deleted already',
       );
     });
 
-    it('should return false and log error on other errors', async () => {
+    it('throws so the caller keeps the metadata when the RAG API rejects the delete', async () => {
       const file = { file_id: 'file-error', embedded: true };
       const error = new Error('Server Error') as Error & { response?: { status?: number } };
       error.response = { status: 500 };
       mockedAxios.delete.mockRejectedValueOnce(error);
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).rejects.toThrow(/Server Error/);
 
-      expect(result).toBe(false);
       expect(mockedLogger.error).toHaveBeenCalledWith(
         '[deleteRagFile] Error deleting document from RAG API:',
         'Server Error',
       );
     });
+
+    it('throws when the RAG API is unreachable and no response ever arrives', async () => {
+      const file = { file_id: 'file-error', embedded: true };
+      mockedAxios.delete.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+
+      await expect(deleteRagFile({ userId: 'user123', file })).rejects.toThrow(
+        /connect ECONNREFUSED/,
+      );
+    });
   });
 
   describe('when file is not embedded', () => {
-    it('should skip RAG deletion and return true', async () => {
+    it('should skip RAG deletion', async () => {
       const file = { file_id: 'file-123', embedded: false };
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).resolves.toBeUndefined();
 
-      expect(result).toBe(true);
       expect(mockedAxios.delete).not.toHaveBeenCalled();
       expect(mockedGenerateShortLivedToken).not.toHaveBeenCalled();
     });
@@ -150,43 +157,38 @@ describe('deleteRagFile', () => {
     it('should skip RAG deletion when embedded is undefined', async () => {
       const file = { file_id: 'file-123' };
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).resolves.toBeUndefined();
 
-      expect(result).toBe(true);
       expect(mockedAxios.delete).not.toHaveBeenCalled();
     });
   });
 
   describe('when RAG_API_URL is not configured', () => {
-    it('should skip RAG deletion and return true', async () => {
+    it('should skip RAG deletion', async () => {
       delete process.env.RAG_API_URL;
       const file = { file_id: 'file-123', embedded: true };
 
-      const result = await deleteRagFile({ userId: 'user123', file });
+      await expect(deleteRagFile({ userId: 'user123', file })).resolves.toBeUndefined();
 
-      expect(result).toBe(true);
       expect(mockedAxios.delete).not.toHaveBeenCalled();
     });
   });
 
   describe('userId handling', () => {
-    it('should return false when no userId is provided', async () => {
+    it('throws when no userId is provided', async () => {
       const file = { file_id: 'file-123', embedded: true };
 
-      const result = await deleteRagFile({ userId: '', file });
+      await expect(deleteRagFile({ userId: '', file })).rejects.toThrow(/No user ID provided/);
 
-      expect(result).toBe(false);
-      expect(mockedLogger.error).toHaveBeenCalledWith('[deleteRagFile] No user ID provided');
       expect(mockedAxios.delete).not.toHaveBeenCalled();
     });
 
-    it('should return false when userId is undefined', async () => {
+    it('throws when userId is undefined', async () => {
       const file = { file_id: 'file-123', embedded: true };
 
-      const result = await deleteRagFile({ userId: undefined as unknown as string, file });
-
-      expect(result).toBe(false);
-      expect(mockedLogger.error).toHaveBeenCalledWith('[deleteRagFile] No user ID provided');
+      await expect(deleteRagFile({ userId: undefined as unknown as string, file })).rejects.toThrow(
+        /No user ID provided/,
+      );
     });
   });
 });

--- a/packages/api/src/files/rag.spec.ts
+++ b/packages/api/src/files/rag.spec.ts
@@ -7,6 +7,7 @@ jest.mock('@librechat/data-schemas', () => ({
 }));
 
 jest.mock('~/crypto/jwt', () => ({
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
   generateShortLivedToken: jest.fn().mockReturnValue('mock-jwt-token'),
 }));
 
@@ -50,17 +51,58 @@ describe('deleteRagFile', () => {
       const result = await deleteRagFile({ userId: 'user123', file });
 
       expect(result).toBe(true);
-      expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith('user123');
+      expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith({
+        userId: 'user123',
+        tenantId: undefined,
+        entityIds: [],
+        scopes: ['rag:embed'],
+      });
       expect(mockedAxios.delete).toHaveBeenCalledWith('http://localhost:8000/documents', {
         headers: {
           Authorization: 'Bearer mock-jwt-token',
           'Content-Type': 'application/json',
           accept: 'application/json',
         },
+        params: undefined,
         data: ['file-123'],
       });
       expect(mockedLogger.debug).toHaveBeenCalledWith(
         '[deleteRagFile] Successfully deleted document file-123 from RAG API',
+      );
+    });
+
+    it('scopes the delete to the agent when the file belongs to a knowledge base', async () => {
+      const file = { file_id: 'file-123', embedded: true, entity_id: 'agent_abc' };
+      mockedAxios.delete.mockResolvedValueOnce({ status: 200 });
+
+      const result = await deleteRagFile({ userId: 'user123', file, tenantId: 'tenant-1' });
+
+      expect(result).toBe(true);
+      expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith({
+        userId: 'user123',
+        tenantId: 'tenant-1',
+        entityIds: ['agent_abc'],
+        scopes: ['rag:embed'],
+      });
+      expect(mockedAxios.delete).toHaveBeenCalledWith(
+        'http://localhost:8000/documents',
+        expect.objectContaining({ params: { entity_id: 'agent_abc' }, data: ['file-123'] }),
+      );
+    });
+
+    it('returns false without calling the RAG API when the token cannot be minted', async () => {
+      const file = { file_id: 'file-123', embedded: true };
+      mockedGenerateShortLivedToken.mockImplementationOnce(() => {
+        throw new Error('RAG_AUTH_ACCEPT_LEGACY=false requires RAG_JWT_SECRET');
+      });
+
+      const result = await deleteRagFile({ userId: 'user123', file });
+
+      expect(result).toBe(false);
+      expect(mockedAxios.delete).not.toHaveBeenCalled();
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        '[deleteRagFile] Unable to mint a RAG API token:',
+        'RAG_AUTH_ACCEPT_LEGACY=false requires RAG_JWT_SECRET',
       );
     });
 

--- a/packages/api/src/files/rag.spec.ts
+++ b/packages/api/src/files/rag.spec.ts
@@ -7,7 +7,7 @@ jest.mock('@librechat/data-schemas', () => ({
 }));
 
 jest.mock('~/crypto/jwt', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
   generateShortLivedToken: jest.fn().mockReturnValue('mock-jwt-token'),
 }));
 
@@ -55,7 +55,7 @@ describe('deleteRagFile', () => {
         userId: 'user123',
         tenantId: undefined,
         entityIds: [],
-        scopes: ['rag:embed'],
+        scopes: ['rag:documents'],
       });
       expect(mockedAxios.delete).toHaveBeenCalledWith('http://localhost:8000/documents', {
         headers: {
@@ -82,7 +82,7 @@ describe('deleteRagFile', () => {
         userId: 'user123',
         tenantId: 'tenant-1',
         entityIds: ['agent_abc'],
-        scopes: ['rag:embed'],
+        scopes: ['rag:documents'],
       });
       expect(mockedAxios.delete).toHaveBeenCalledWith(
         'http://localhost:8000/documents',

--- a/packages/api/src/files/rag.ts
+++ b/packages/api/src/files/rag.ts
@@ -25,24 +25,29 @@ interface DeleteRagFileParams {
  * This is a shared utility function used by all file storage strategies
  * (S3, Azure, Firebase, Local) to delete RAG embeddings when a file is deleted.
  *
+ * Resolves only when the chunks are gone — including the case where the RAG
+ * API has never heard of them. Anything that leaves them in place throws, so
+ * the caller's own failure handling runs and the file's metadata survives for
+ * a retry. A swallowed failure here would report the file as deleted while its
+ * chunks stayed behind, unreferenced and unreachable by any later delete.
+ *
  * @param params - The parameters object.
  * @param params.userId - The user ID for authentication.
  * @param params.file - The file object. Must have `embedded` and `file_id` properties.
  * @param params.tenantId - The tenant the file belongs to.
- * @returns Returns true if deletion was successful or skipped, false if there was an error.
+ * @throws When the chunks could not be confirmed deleted.
  */
 export async function deleteRagFile({
   userId,
   file,
   tenantId,
-}: DeleteRagFileParams): Promise<boolean> {
+}: DeleteRagFileParams): Promise<void> {
   if (!file.embedded || !process.env.RAG_API_URL) {
-    return true;
+    return;
   }
 
   if (!userId) {
-    logger.error('[deleteRagFile] No user ID provided');
-    return false;
+    throw new Error('[deleteRagFile] No user ID provided');
   }
 
   const entityIds = file.entity_id ? [file.entity_id] : [];
@@ -56,8 +61,9 @@ export async function deleteRagFile({
       scopes: [RagScopes.documents],
     });
   } catch (error) {
-    logger.error('[deleteRagFile] Unable to mint a RAG API token:', (error as Error).message);
-    return false;
+    const message = (error as Error).message;
+    logger.error('[deleteRagFile] Unable to mint a RAG API token:', message);
+    throw new Error(`[deleteRagFile] Unable to mint a RAG API token: ${message}`);
   }
 
   try {
@@ -71,17 +77,17 @@ export async function deleteRagFile({
       data: [file.file_id],
     });
     logger.debug(`[deleteRagFile] Successfully deleted document ${file.file_id} from RAG API`);
-    return true;
   } catch (error) {
     const axiosError = error as { response?: { status?: number }; message?: string };
     if (axiosError.response?.status === 404) {
       logger.warn(
         `[deleteRagFile] Document ${file.file_id} not found in RAG API, may have been deleted already`,
       );
-      return true;
-    } else {
-      logger.error('[deleteRagFile] Error deleting document from RAG API:', axiosError.message);
-      return false;
+      return;
     }
+    logger.error('[deleteRagFile] Error deleting document from RAG API:', axiosError.message);
+    throw new Error(
+      `[deleteRagFile] Error deleting document ${file.file_id} from RAG API: ${axiosError.message}`,
+    );
   }
 }

--- a/packages/api/src/files/rag.ts
+++ b/packages/api/src/files/rag.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { logger } from '@librechat/data-schemas';
-import { generateShortLivedToken } from '~/crypto/jwt';
+import { RagScopes, generateShortLivedToken } from '~/crypto/jwt';
 
 interface DeleteRagFileParams {
   /** The user ID. Required for authentication. If not provided, the function returns false and logs an error. */
@@ -9,7 +9,15 @@ interface DeleteRagFileParams {
   file: {
     file_id: string;
     embedded?: boolean;
+    /**
+     * The entity (agent) whose knowledge base the file was embedded under, when
+     * it was not embedded under the user. Its chunks are owned by that entity,
+     * so a delete that names only the user matches nothing.
+     */
+    entity_id?: string;
   };
+  /** The tenant the file belongs to. */
+  tenantId?: string | null;
 }
 
 /**
@@ -20,9 +28,14 @@ interface DeleteRagFileParams {
  * @param params - The parameters object.
  * @param params.userId - The user ID for authentication.
  * @param params.file - The file object. Must have `embedded` and `file_id` properties.
+ * @param params.tenantId - The tenant the file belongs to.
  * @returns Returns true if deletion was successful or skipped, false if there was an error.
  */
-export async function deleteRagFile({ userId, file }: DeleteRagFileParams): Promise<boolean> {
+export async function deleteRagFile({
+  userId,
+  file,
+  tenantId,
+}: DeleteRagFileParams): Promise<boolean> {
   if (!file.embedded || !process.env.RAG_API_URL) {
     return true;
   }
@@ -32,7 +45,20 @@ export async function deleteRagFile({ userId, file }: DeleteRagFileParams): Prom
     return false;
   }
 
-  const jwtToken = generateShortLivedToken(userId);
+  const entityIds = file.entity_id ? [file.entity_id] : [];
+
+  let jwtToken: string;
+  try {
+    jwtToken = generateShortLivedToken({
+      userId,
+      tenantId,
+      entityIds,
+      scopes: [RagScopes.embed],
+    });
+  } catch (error) {
+    logger.error('[deleteRagFile] Unable to mint a RAG API token:', (error as Error).message);
+    return false;
+  }
 
   try {
     await axios.delete(`${process.env.RAG_API_URL}/documents`, {
@@ -41,6 +67,7 @@ export async function deleteRagFile({ userId, file }: DeleteRagFileParams): Prom
         'Content-Type': 'application/json',
         accept: 'application/json',
       },
+      params: file.entity_id ? { entity_id: file.entity_id } : undefined,
       data: [file.file_id],
     });
     logger.debug(`[deleteRagFile] Successfully deleted document ${file.file_id} from RAG API`);

--- a/packages/api/src/files/rag.ts
+++ b/packages/api/src/files/rag.ts
@@ -53,7 +53,7 @@ export async function deleteRagFile({
       userId,
       tenantId,
       entityIds,
-      scopes: [RagScopes.embed],
+      scopes: [RagScopes.documents],
     });
   } catch (error) {
     logger.error('[deleteRagFile] Unable to mint a RAG API token:', (error as Error).message);

--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -15,7 +15,7 @@ jest.mock('fs', () => ({
 }));
 
 jest.mock('../crypto/jwt', () => ({
-  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank', documents: 'rag:documents' },
   generateShortLivedToken: jest.fn(),
 }));
 
@@ -370,7 +370,7 @@ describe('text', () => {
       );
     });
 
-    it('requests only the embed scope and no entity for text extraction', async () => {
+    it('requests only the document scope and no entity for text extraction', async () => {
       process.env.RAG_API_URL = 'http://rag-api.test';
 
       mockedAxios.get.mockResolvedValue({ status: 200, statusText: 'OK' });
@@ -386,7 +386,7 @@ describe('text', () => {
         userId: 'user123',
         tenantId: undefined,
         entityIds: [],
-        scopes: ['rag:embed'],
+        scopes: ['rag:documents'],
       });
     });
 

--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -15,6 +15,7 @@ jest.mock('fs', () => ({
 }));
 
 jest.mock('../crypto/jwt', () => ({
+  RagScopes: { embed: 'rag:embed', rerank: 'rag:rerank' },
   generateShortLivedToken: jest.fn(),
 }));
 
@@ -367,6 +368,26 @@ describe('text', () => {
         expect.any(Object),
         expect.objectContaining({ timeout: 300000 }),
       );
+    });
+
+    it('requests only the embed scope and no entity for text extraction', async () => {
+      process.env.RAG_API_URL = 'http://rag-api.test';
+
+      mockedAxios.get.mockResolvedValue({ status: 200, statusText: 'OK' });
+      mockedAxios.post.mockResolvedValue({ data: { text: 'plain text content' } });
+
+      await parseText({
+        req: mockReq,
+        file: mockFile,
+        file_id: mockFileId,
+      });
+
+      expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith({
+        userId: 'user123',
+        tenantId: undefined,
+        entityIds: [],
+        scopes: ['rag:embed'],
+      });
     });
 
     describe('allowNativeFallback: false', () => {

--- a/packages/api/src/files/text.ts
+++ b/packages/api/src/files/text.ts
@@ -100,12 +100,14 @@ export async function parseText({
 
   try {
     /** Text extraction never reaches a knowledge base, so the token carries no
-     * entity — the upload is stored under the user alone. */
+     * entity — the upload is stored under the user alone. Nor does it embed
+     * anything: the file is parsed to text and handed back, so the token buys
+     * document access and no inference. */
     const jwtToken = generateShortLivedToken({
       userId,
       entityIds: [],
       tenantId: req.user?.tenantId,
-      scopes: [RagScopes.embed],
+      scopes: [RagScopes.documents],
     });
     const formData = new FormData();
     formData.append('file_id', file_id);

--- a/packages/api/src/files/text.ts
+++ b/packages/api/src/files/text.ts
@@ -4,8 +4,8 @@ import { createReadStream } from 'fs';
 import { logger } from '@librechat/data-schemas';
 import { FileSources } from 'librechat-data-provider';
 import type { ServerRequest } from '~/types';
+import { RagScopes, generateShortLivedToken } from '~/crypto/jwt';
 import { logAxiosError, readFileAsString } from '~/utils';
-import { generateShortLivedToken } from '~/crypto/jwt';
 
 const MARKDOWN_MIME_TYPES = new Set([
   'text/markdown',
@@ -99,7 +99,14 @@ export async function parseText({
   }
 
   try {
-    const jwtToken = generateShortLivedToken(userId);
+    /** Text extraction never reaches a knowledge base, so the token carries no
+     * entity — the upload is stored under the user alone. */
+    const jwtToken = generateShortLivedToken({
+      userId,
+      entityIds: [],
+      tenantId: req.user?.tenantId,
+      scopes: [RagScopes.embed],
+    });
     const formData = new FormData();
     formData.append('file_id', file_id);
     formData.append('file', createReadStream(file.path));

--- a/packages/api/src/storage/s3/__tests__/crud.test.ts
+++ b/packages/api/src/storage/s3/__tests__/crud.test.ts
@@ -857,7 +857,11 @@ describe('S3 CRUD', () => {
       const { deleteFileFromS3 } = await import('../crud');
       await deleteFileFromS3(mockReq, mockFile);
 
-      expect(deleteRagFile).toHaveBeenCalledWith({ userId: 'user123', file: mockFile });
+      expect(deleteRagFile).toHaveBeenCalledWith({
+        userId: 'user123',
+        file: mockFile,
+        tenantId: null,
+      });
       expect(s3Mock.commandCalls(HeadObjectCommand)).toHaveLength(1);
       expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1);
     });
@@ -875,7 +879,11 @@ describe('S3 CRUD', () => {
       const { deleteFileFromS3 } = await import('../crud');
       await deleteFileFromS3(requesterReq, mockFile);
 
-      expect(deleteRagFile).toHaveBeenCalledWith({ userId: 'user123', file: mockFile });
+      expect(deleteRagFile).toHaveBeenCalledWith({
+        userId: 'user123',
+        file: mockFile,
+        tenantId: null,
+      });
       expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(1);
     });
 
@@ -895,7 +903,11 @@ describe('S3 CRUD', () => {
       expect(s3Mock.commandCalls(DeleteObjectCommand)[0].args[0].input.Key).toBe(
         'r/us-east-2/t/tenantA/images/user123/file.jpg',
       );
-      expect(deleteRagFile).toHaveBeenCalledWith({ userId: 'user123', file: mockFile });
+      expect(deleteRagFile).toHaveBeenCalledWith({
+        userId: 'user123',
+        file: mockFile,
+        tenantId: 'tenantA',
+      });
     });
 
     it('prefers storageKey when deleting legacy filepath records', async () => {
@@ -930,7 +942,11 @@ describe('S3 CRUD', () => {
       await deleteFileFromS3(mockReq, mockFile);
 
       expect(logger.warn).toHaveBeenCalled();
-      expect(deleteRagFile).toHaveBeenCalledWith({ userId: 'user123', file: mockFile });
+      expect(deleteRagFile).toHaveBeenCalledWith({
+        userId: 'user123',
+        file: mockFile,
+        tenantId: null,
+      });
       expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
     });
 
@@ -972,7 +988,11 @@ describe('S3 CRUD', () => {
 
       const { deleteFileFromS3 } = await import('../crud');
       await expect(deleteFileFromS3(mockReq, mockFile)).resolves.toBeUndefined();
-      expect(deleteRagFile).toHaveBeenCalledWith({ userId: 'user123', file: mockFile });
+      expect(deleteRagFile).toHaveBeenCalledWith({
+        userId: 'user123',
+        file: mockFile,
+        tenantId: null,
+      });
     });
 
     it('rejects tenant-prefixed keys when the file record lacks tenantId', async () => {

--- a/packages/api/src/storage/s3/__tests__/crud.test.ts
+++ b/packages/api/src/storage/s3/__tests__/crud.test.ts
@@ -995,6 +995,67 @@ describe('S3 CRUD', () => {
       });
     });
 
+    /**
+     * A RAG cleanup that failed leaves the chunks in place. Reporting the
+     * delete as done would strip the file's metadata and leave nothing able to
+     * reference them again, so every path through this function has to surface
+     * the failure rather than absorb it into its own error handling.
+     */
+    describe('RAG cleanup failures', () => {
+      const ragFailure = () => new Error('[deleteRagFile] Unable to mint a RAG API token: no key');
+
+      it('surfaces the failure after the object was deleted', async () => {
+        const mockFile = {
+          filepath: 'https://bucket.s3.amazonaws.com/images/user123/file.jpg',
+          file_id: 'file123',
+          user: 'user123',
+        } as TFile;
+
+        s3Mock.on(HeadObjectCommand).resolvesOnce({});
+        (deleteRagFile as jest.Mock).mockRejectedValueOnce(ragFailure());
+
+        const { deleteFileFromS3 } = await import('../crud');
+        await expect(deleteFileFromS3(mockReq, mockFile)).rejects.toThrow(
+          /Unable to mint a RAG API token/,
+        );
+      });
+
+      it('surfaces the failure when the object was already missing', async () => {
+        const mockFile = {
+          filepath: 'https://bucket.s3.amazonaws.com/images/user123/nonexistent.jpg',
+          file_id: 'file123',
+          user: 'user123',
+        } as TFile;
+
+        s3Mock.on(HeadObjectCommand).rejects({ name: 'NotFound' });
+        (deleteRagFile as jest.Mock).mockRejectedValueOnce(ragFailure());
+
+        const { deleteFileFromS3 } = await import('../crud');
+        await expect(deleteFileFromS3(mockReq, mockFile)).rejects.toThrow(
+          /Unable to mint a RAG API token/,
+        );
+      });
+
+      it('surfaces the failure on the NoSuchKey path', async () => {
+        const mockFile = {
+          filepath: 'https://bucket.s3.amazonaws.com/images/user123/file.jpg',
+          file_id: 'file123',
+          user: 'user123',
+        } as TFile;
+
+        s3Mock.on(HeadObjectCommand).resolvesOnce({});
+        s3Mock
+          .on(DeleteObjectCommand)
+          .rejects(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' }));
+        (deleteRagFile as jest.Mock).mockRejectedValueOnce(ragFailure());
+
+        const { deleteFileFromS3 } = await import('../crud');
+        await expect(deleteFileFromS3(mockReq, mockFile)).rejects.toThrow(
+          /Unable to mint a RAG API token/,
+        );
+      });
+    });
+
     it('rejects tenant-prefixed keys when the file record lacks tenantId', async () => {
       const mockFile = {
         filepath: 'https://bucket.s3.amazonaws.com/t/tenantA/images/user123/file.jpg',

--- a/packages/api/src/storage/s3/crud.ts
+++ b/packages/api/src/storage/s3/crud.ts
@@ -761,21 +761,21 @@ export async function deleteFileFromS3(req: ServerRequest, file: TFile): Promise
     } catch (headErr) {
       if ((headErr as { name?: string }).name === 'NotFound') {
         logger.warn(`[deleteFileFromS3] File does not exist: ${key}`);
-        await deleteRagFile({ userId: ownerId, file });
+        await deleteRagFile({ userId: ownerId, file, tenantId: fileTenantId });
         return;
       }
       throw headErr;
     }
 
     await s3.send(new DeleteObjectCommand(params));
-    await deleteRagFile({ userId: ownerId, file });
+    await deleteRagFile({ userId: ownerId, file, tenantId: fileTenantId });
     logger.debug('[deleteFileFromS3] S3 File deletion completed');
   } catch (error) {
     logger.error(`[deleteFileFromS3] Error deleting file from S3: ${(error as Error).message}`);
     logger.error((error as Error).stack);
 
     if ((error as { name?: string }).name === 'NoSuchKey') {
-      await deleteRagFile({ userId: ownerId, file });
+      await deleteRagFile({ userId: ownerId, file, tenantId: fileTenantId });
       return;
     }
     throw error;

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -56,6 +56,7 @@ let revertAgentVersion: AgentMethods['revertAgentVersion'];
 let addAgentResourceFile: AgentMethods['addAgentResourceFile'];
 let removeAgentResourceFiles: AgentMethods['removeAgentResourceFiles'];
 let removeAgentResourceFilesFromAllAgents: AgentMethods['removeAgentResourceFilesFromAllAgents'];
+let getAgentIdsByFileIds: AgentMethods['getAgentIdsByFileIds'];
 let getListAgentsByAccess: AgentMethods['getListAgentsByAccess'];
 let generateActionMetadataHash: AgentMethods['generateActionMetadataHash'];
 
@@ -103,6 +104,7 @@ beforeAll(async () => {
   addAgentResourceFile = methods.addAgentResourceFile;
   removeAgentResourceFiles = methods.removeAgentResourceFiles;
   removeAgentResourceFilesFromAllAgents = methods.removeAgentResourceFilesFromAllAgents;
+  getAgentIdsByFileIds = methods.getAgentIdsByFileIds;
   getListAgentsByAccess = methods.getListAgentsByAccess;
   generateActionMetadataHash = methods.generateActionMetadataHash;
 
@@ -3221,6 +3223,83 @@ describe('Agent Methods', () => {
         const result = await removeAgentResourceFilesFromAllAgents({ file_ids: [fileId] });
         expect(result.matchedCount).toBe(0);
         expect(result.modifiedCount).toBe(0);
+      });
+    });
+
+    describe('getAgentIdsByFileIds', () => {
+      beforeEach(async () => {
+        await Agent.deleteMany({});
+      });
+
+      test('maps a knowledge-base file to the agent that holds it', async () => {
+        const fileId = `file_${uuidv4()}`;
+        const agent = await createBasicAgent();
+
+        await addAgentResourceFile({
+          agent_id: agent.id,
+          tool_resource: EToolResources.file_search,
+          file_id: fileId,
+        });
+
+        expect(await getAgentIdsByFileIds({ file_ids: [fileId] })).toEqual({
+          [fileId]: agent.id,
+        });
+      });
+
+      test('returns nothing for files no agent holds', async () => {
+        const agent = await createBasicAgent();
+        await addAgentResourceFile({
+          agent_id: agent.id,
+          tool_resource: EToolResources.file_search,
+          file_id: `file_${uuidv4()}`,
+        });
+
+        expect(await getAgentIdsByFileIds({ file_ids: [`file_${uuidv4()}`] })).toEqual({});
+      });
+
+      test('ignores files held only by other tool resources', async () => {
+        const codeFileId = `file_${uuidv4()}`;
+        const agent = await createBasicAgent();
+
+        await addAgentResourceFile({
+          agent_id: agent.id,
+          tool_resource: EToolResources.execute_code,
+          file_id: codeFileId,
+        });
+
+        expect(await getAgentIdsByFileIds({ file_ids: [codeFileId] })).toEqual({});
+      });
+
+      test('resolves each file in a batch independently', async () => {
+        const firstFileId = `file_${uuidv4()}`;
+        const secondFileId = `file_${uuidv4()}`;
+        const unheldFileId = `file_${uuidv4()}`;
+        const firstAgent = await createBasicAgent();
+        const secondAgent = await createBasicAgent();
+
+        await addAgentResourceFile({
+          agent_id: firstAgent.id,
+          tool_resource: EToolResources.file_search,
+          file_id: firstFileId,
+        });
+        await addAgentResourceFile({
+          agent_id: secondAgent.id,
+          tool_resource: EToolResources.file_search,
+          file_id: secondFileId,
+        });
+
+        expect(
+          await getAgentIdsByFileIds({
+            file_ids: [firstFileId, secondFileId, unheldFileId],
+          }),
+        ).toEqual({
+          [firstFileId]: firstAgent.id,
+          [secondFileId]: secondAgent.id,
+        });
+      });
+
+      test('queries nothing for an empty batch', async () => {
+        expect(await getAgentIdsByFileIds({ file_ids: [] })).toEqual({});
       });
     });
 

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -3301,6 +3301,33 @@ describe('Agent Methods', () => {
       test('queries nothing for an empty batch', async () => {
         expect(await getAgentIdsByFileIds({ file_ids: [] })).toEqual({});
       });
+
+      /* Only records written before uploads stamped `embedding_entity_id` reach
+       * this lookup, and a file several agents list is genuinely ambiguous. The
+       * answer at least has to be the same one twice, so a second delete
+       * attempt reaches the same place as the first. */
+      test('picks the same agent every time when several hold the file', async () => {
+        const fileId = `file_${uuidv4()}`;
+        const agents = await Promise.all([
+          createBasicAgent(),
+          createBasicAgent(),
+          createBasicAgent(),
+        ]);
+        for (const agent of agents) {
+          await addAgentResourceFile({
+            agent_id: agent.id,
+            tool_resource: EToolResources.file_search,
+            file_id: fileId,
+          });
+        }
+
+        const lowestId = agents.map((agent) => agent.id).sort()[0];
+        const first = await getAgentIdsByFileIds({ file_ids: [fileId] });
+        const second = await getAgentIdsByFileIds({ file_ids: [fileId] });
+
+        expect(first).toEqual({ [fileId]: lowestId });
+        expect(second).toEqual(first);
+      });
     });
 
     test('should handle updateAgent with complex nested updates', async () => {

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -861,12 +861,22 @@ export function createAgentMethods(
   }
 
   /**
-   * Maps file ids to the agent whose `file_search` knowledge base holds them.
+   * LEGACY FALLBACK ONLY — do not call this to decide where a file's chunks
+   * live. Uploads record that on the file itself (`embedding_entity_id`), and
+   * that recorded value is the only one that reflects what was sent to the RAG
+   * service at embed time.
    *
-   * Knowledge-base files are embedded in the vector store under the agent's id
-   * rather than the uploader's, so reading or deleting their chunks has to name
-   * that entity. The agent document is the only durable record of which entity
-   * a given file was embedded under.
+   * A `file_search` association is not evidence of it: the agent create and
+   * update APIs accept file ids the user already owns, and a message attachment
+   * is embedded with no entity at all, so a file can end up listed by an agent
+   * that never embedded it. This exists solely for records written before
+   * `embedding_entity_id` did, where nothing better survives; for those, an
+   * associated agent is a better guess than naming no entity, which is what
+   * they got before.
+   *
+   * A file listed by several agents is genuinely ambiguous. The lowest id wins
+   * so a repeated delete behaves the same way twice rather than depending on
+   * the order Mongo happened to return.
    */
   async function getAgentIdsByFileIds({
     file_ids,
@@ -889,7 +899,11 @@ export function createAgentMethods(
     for (const agent of agents) {
       const knowledgeFileIds = agent.tool_resources?.[EToolResources.file_search]?.file_ids ?? [];
       for (const fileId of knowledgeFileIds) {
-        if (requested.has(fileId) && entityByFileId[fileId] == null) {
+        if (!requested.has(fileId)) {
+          continue;
+        }
+        const current = entityByFileId[fileId];
+        if (current == null || agent.id < current) {
           entityByFileId[fileId] = agent.id;
         }
       }

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -450,6 +450,7 @@ export function createAgentMethods(
   }: {
     file_ids: string[];
   }) => Promise<{ matchedCount: number; modifiedCount: number }>;
+  getAgentIdsByFileIds: ({ file_ids }: { file_ids: string[] }) => Promise<Record<string, string>>;
 } {
   const { removeAllPermissions, getActions, getSoleOwnedResourceIds, isExternalSkillId } = deps;
 
@@ -860,6 +861,43 @@ export function createAgentMethods(
   }
 
   /**
+   * Maps file ids to the agent whose `file_search` knowledge base holds them.
+   *
+   * Knowledge-base files are embedded in the vector store under the agent's id
+   * rather than the uploader's, so reading or deleting their chunks has to name
+   * that entity. The agent document is the only durable record of which entity
+   * a given file was embedded under.
+   */
+  async function getAgentIdsByFileIds({
+    file_ids,
+  }: {
+    file_ids: string[];
+  }): Promise<Record<string, string>> {
+    if (!file_ids || file_ids.length === 0) {
+      return {};
+    }
+
+    const Agent = mongoose.models.Agent as Model<IAgent>;
+    const fileIdsPath = `tool_resources.${EToolResources.file_search}.file_ids`;
+    const agents = await Agent.find(
+      { [fileIdsPath]: { $in: file_ids } },
+      { id: 1, [fileIdsPath]: 1 },
+    ).lean<Array<Pick<IAgent, 'id' | 'tool_resources'>>>();
+
+    const requested = new Set(file_ids);
+    const entityByFileId: Record<string, string> = {};
+    for (const agent of agents) {
+      const knowledgeFileIds = agent.tool_resources?.[EToolResources.file_search]?.file_ids ?? [];
+      for (const fileId of knowledgeFileIds) {
+        if (requested.has(fileId) && entityByFileId[fileId] == null) {
+          entityByFileId[fileId] = agent.id;
+        }
+      }
+    }
+    return entityByFileId;
+  }
+
+  /**
    * Deletes an agent based on the provided search parameter.
    */
   async function deleteAgent(searchParameter: FilterQuery<IAgent>): Promise<IAgent | null> {
@@ -1183,6 +1221,7 @@ export function createAgentMethods(
     addAgentResourceFile,
     getListAgentsByAccess,
     removeAgentResourceFiles,
+    getAgentIdsByFileIds,
     generateActionMetadataHash,
     removeAgentFromUserFavorites,
     removeAgentResourceFilesFromAllAgents,

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -2,6 +2,14 @@ import mongoose, { Schema } from 'mongoose';
 import { FileContext, FileSources } from 'librechat-data-provider';
 import type { IMongoFile } from '~/types';
 
+/**
+ * Recorded in `embedding_entity_id` when a file's vectors were written with no
+ * entity — owned by the uploading user alone. Storing it explicitly is what
+ * separates a deliberately user-scoped embedding from a record that predates
+ * the field, whose scope can only be guessed at.
+ */
+export const NO_EMBEDDING_ENTITY = '__NONE__';
+
 const file: Schema<IMongoFile> = new Schema(
   {
     user: {
@@ -52,6 +60,17 @@ const file: Schema<IMongoFile> = new Schema(
     },
     embedded: {
       type: Boolean,
+    },
+    embedding_entity_id: {
+      /* The entity the file's chunks were written under, stamped at embed
+       * time from the same value sent to the RAG API — the agent id for a
+       * knowledge-base upload, `NO_EMBEDDING_ENTITY` for a user-scoped one.
+       * Deleting or querying those chunks has to name the same entity, and an
+       * agent's *current* file_search association does not prove it: an
+       * existing file id can be added to any agent's tool_resources long after
+       * it was embedded. Absent on records written before this field existed
+       * and on files that were never embedded. */
+      type: String,
     },
     type: {
       type: String,

--- a/packages/data-schemas/src/schema/index.ts
+++ b/packages/data-schemas/src/schema/index.ts
@@ -10,7 +10,7 @@ export { default as categoriesSchema } from './categories';
 export { default as chatProjectSchema } from './chatProject';
 export { default as conversationTagSchema } from './conversationTag';
 export { default as convoSchema } from './convo';
-export { default as fileSchema } from './file';
+export { default as fileSchema, NO_EMBEDDING_ENTITY } from './file';
 export { default as keySchema } from './key';
 export { default as messageSchema } from './message';
 export { default as pluginAuthSchema } from './pluginAuth';

--- a/packages/data-schemas/src/types/file.ts
+++ b/packages/data-schemas/src/types/file.ts
@@ -55,6 +55,14 @@ export interface IMongoFile extends Omit<Document, 'model'> {
   storageRegion?: string;
   object: 'file';
   embedded?: boolean;
+  /**
+   * The entity the file's vector chunks were written under, recorded at embed
+   * time rather than inferred later: the agent id for a knowledge-base upload,
+   * `NO_EMBEDDING_ENTITY` for one scoped to the uploading user alone. Absent on
+   * records written before the field existed and on files that were never
+   * embedded.
+   */
+  embedding_entity_id?: string;
   type: string;
   context?: string;
   usage: number;


### PR DESCRIPTION
## Summary

Two related changes to how LibreChat talks to the RAG API.

**1. Agent knowledge files are deleted with the wrong owner.** Files uploaded to an agent's `file_search` resource are embedded in the vector store under the *agent's* id (`entity_id`), not the uploader's — that is what `uploadVectors` already sends, and what the file-search `/query` path already accounts for. The delete path did not: it sent a plain user token with no `entity_id`, so the delete predicate matched no rows and the chunks outlived the file record. It failed silently, because the API answers `404` and the caller reads that as "already gone".

**2. RAG tokens and application session tokens are the same tokens.** `generateShortLivedToken` signed with the application's `JWT_SECRET`, so every token minted for the RAG API was simultaneously a valid full-API LibreChat session token, and every LibreChat session token was accepted by the RAG API. A token leaked from either side reached both.

## What changed

### Entity scoping on the document routes

Uploads record the entity their vectors were written under. `processAgentFileUpload` stamps `embedding_entity_id` on the file record from the same value it hands `uploadVectors`: the agent id for a knowledge-base upload, an explicit `NO_EMBEDDING_ENTITY` sentinel for one scoped to the uploading user. `processDeleteRequest`, `createContextHandlers` and `fileSearch` all read that value back, so the delete names the same entity on both the token's `entities` claim and the request's `entity_id` parameter.

An agent's *current* `file_search` association is deliberately not used for this. The two disagree routinely — the agent create and update APIs accept file ids the user already owns, so an agent can list a file it never embedded, and a message attachment is embedded with no entity at all. Scoping such a file's delete to that agent sends it looking in a namespace that never held the chunks, and the metadata is removed regardless.

`getAgentIdsByFileIds` (new in `data-schemas`) remains only as the fallback for records written before the field existed, commented as such at its definition. Those files stay deletable: an associated agent is a better guess than no entity — which is all they had previously — and a file no agent holds, or a lookup that fails, falls back to user scope rather than blocking the delete. Where several agents hold one, the lowest id wins so a retry lands in the same place instead of following Mongo's return order.

The new field is additive and unindexed. Nothing backfills it, and nothing needs to: an absent value is exactly what marks a record as predating it.

`createContextHandlers` does the same for `GET /documents/{id}/context` (`RAG_USE_FULL_CONTEXT`) and its `/query` calls. `GET /documents?ids=` and `GET /ids` have no callers in this repository.

### Token claim set and key separation

With `RAG_JWT_SECRET` configured, tokens carry issuer, audience, subject, expiry, tenant, scopes and permitted entity ids, signed with that key alone. `jwtStrategy` additionally refuses any token bearing the RAG audience, so a misconfiguration cannot let one stand in for the other.

Each call path names the scopes it uses rather than receiving a blanket grant. All six minting paths were migrated: file search, context handlers, vector upload, vector delete, RAG delete, text extraction. None requests `rag:rerank`.

### Document-plane calls carry no inference capability

The RAG API's document routes — deleting a file's vectors, reading a file's stored context, extracting text from an upload — call no inference provider. But the only scopes available were `rag:embed` and `rag:rerank`, and a strict token carrying no scope at all is refused, so those calls asked for `rag:embed` purely to satisfy the requirement. A leaked or stolen delete token therefore also carried the ability to spend embedding budget.

`RagScopes.documents` (`rag:documents`) names that plane, matching the scope the service now requires on those routes. Each site mints only what it reaches:

| Call site | Endpoint | Scope |
| --- | --- | --- |
| `VectorDB/crud.js` `deleteVectors` | `DELETE /documents` | `rag:documents` |
| `files/rag.ts` `deleteRagFile` | `DELETE /documents` | `rag:documents` |
| `createContextHandlers` (`RAG_USE_FULL_CONTEXT`) | `GET /documents/{id}/context` | `rag:documents` |
| `files/text.ts` `parseText` | `POST /text` | `rag:documents` |
| `createContextHandlers` (retrieval) | `POST /query` | `rag:embed` |
| `fileSearch.js` | `POST /query` | `rag:embed` |
| `VectorDB/crud.js` `uploadVectors` | `POST /embed` | `rag:embed` |

`createContextHandlers` reaches a different plane on each of its two branches, so it mints per branch rather than one token covering both: the full-context read fetches stored text and needs no inference, while a retrieval query embeds the user's message and needs exactly the reverse.

Misconfiguration fails closed rather than degrading to `JWT_SECRET`:

| Condition | Result |
| --- | --- |
| `RAG_JWT_SECRET` equals `JWT_SECRET` | refuses to mint |
| HMAC secret under 32 characters | refuses to mint |
| blank issuer or audience | refuses to mint |
| asymmetric algorithm with no private key | refuses to mint |
| `RAG_AUTH_ACCEPT_LEGACY=false` with no key | refuses to mint |
| neither `RAG_JWT_SECRET` nor `JWT_SECRET` set | refuses to mint |

`RAG_AUTH_ACCEPT_LEGACY` is read with exactly the parsing the service uses, so both sides agree on what the flag says.

`RAG_JWT_ALGORITHM` accepts `HS256`/`HS384`/`HS512`, `RS256`/`RS384`/`RS512`, `PS256`/`PS384`/`PS512` and `ES256`/`ES384`/`ES512`, matched case-insensitively against the exact spelling `jsonwebtoken` expects. `EdDSA` is not offered: the pinned `jws`/`jwa` implementation has no Ed25519 signer, so accepting it would take a configuration the signer then throws on. Every listed algorithm is signed and verified end to end in the spec with a freshly generated key of the matching type, so an unusable entry cannot sit in the list unexercised.

`RAG_JWT_PRIVATE_KEY` is normalized through the same helper the Code API key path uses, so a PEM flattened to one line with literal `\n` escapes — the usual shape out of a secret store — parses rather than failing every strict RAG call. HMAC secrets are passed through byte for byte, since they have to match what the service reads.

## Deploy order

The two sides are decoupled by `RAG_JWT_SECRET` being unset: until it is set, LibreChat keeps minting the pre-scopes `{ id }` shape, so a deployment running an older RAG API is unaffected by this PR.

1. **Ship the RAG API upgrade** with `RAG_JWT_SECRET` set to a fresh value (≥32 characters, different from `JWT_SECRET`) and `RAG_AUTH_ACCEPT_LEGACY=true` (the default). It now accepts both shapes; LibreChat is still sending the old one.
2. **Ship LibreChat** with the same `RAG_JWT_SECRET`. It starts minting the full claim set with entity scoping. The RAG API validates it on the strict path.
3. **Flip `RAG_AUTH_ACCEPT_LEGACY=false`** on both sides once no caller mints the old shape. On the service side this stops grandfathering scopes and entity claims; on the LibreChat side it turns a missing `RAG_JWT_SECRET` into a startup-visible refusal rather than a silent fallback.

Rolling back step 2 while step 3 has been applied will break RAG calls, so flip the flag last.

### Ordering for `rag:documents`

The `rag:documents` scope is defined and enforced by the RAG API (`danny-avila/rag_api#318`), and this PR is the minting half. The coupling between the two is asymmetric, so the order matters:

- **This PR first, then the service — safe.** A service build that does not yet enforce `rag:documents` never inspects the scope on those routes, so a token carrying it is simply accepted. The unknown scope is inert.
- **The service first, then this PR — breaks.** A build that requires `rag:documents` refuses a token still carrying only `rag:embed`, so every document read and delete returns `403` until this side catches up.

Ship this side first, or ship both together. Either way this lands inside step 2 above: with `RAG_JWT_SECRET` unset LibreChat mints the legacy `{ id }` shape and no scope is sent at all.

New environment variables, all optional and documented in `.env.example`: `RAG_JWT_SECRET`, `RAG_JWT_PRIVATE_KEY`, `RAG_JWT_ALGORITHM`, `RAG_JWT_ISSUER`, `RAG_JWT_AUDIENCE`, `RAG_AUTH_ACCEPT_LEGACY`. No defaults are baked in for any secret.

## Tests

- `packages/api/src/crypto/jwt.spec.ts` — the strict claim set, tenant fallback, entity/scope de-duplication, key separation in both directions (a RAG token does not verify with `JWT_SECRET`; a session token does not verify with `RAG_JWT_SECRET`, which is what makes the service's `/v1` reject it), and each fail-closed condition above.
- `api/strategies/jwtStrategy.spec.js` — RAG-audience tokens are refused before any user lookup, including a list-valued `aud` and a configured audience; session tokens still pass.
- `api/server/services/Files/process.ragEntity.spec.js` — the delete path end to end against an in-memory Mongo with real entity resolution: the owning agent appears on the request and in the token, a user-owned file stays user-scoped, the secondary vector delete is scoped when the file lives in another store, and a mixed batch resolves each file independently. Then the cases where the recorded entity and the current association disagree — a message attachment an agent later references, a file listed by several agents, a file detached from its agent after upload — and the legacy paths for records with nothing recorded, including two agents holding one file resolving the same way twice.
- The same file also pins that a delete which left the chunks in place is never reported as done: an unmintable token, a rejected request and an unreachable service each keep the file record, while a `404` removes it.
- `api/server/services/Files/process.spec.js` — the upload stamps the agent id, stamps the explicit none for a message attachment, and stamps nothing when the file never reached the vector store.
- `packages/api/src/files/embedding.spec.ts` — the resolver in isolation: the recorded value wins, a recorded none is read as user-scoped rather than unknown, the legacy lookup is asked only about files with nothing recorded and skipped entirely otherwise, and a failed lookup leaves those files user-scoped instead of blocking.
- `packages/data-schemas/src/methods/agent.spec.ts` — `getAgentIdsByFileIds` against real documents, including other tool resources, batch resolution, and the same answer twice when several agents hold one file.
- `api/app/clients/prompts/createContextHandlers.spec.js` — entity propagation on `/query` and `GET /documents/{id}/context`.
- `api/test/app/clients/tools/util/fileSearch.test.js` — token entities follow `fromAgent`, `fromAgent` itself follows the recorded entity rather than the agent's listing, no path requests `rag:rerank`, and a mint failure reports an auth error instead of querying.
- `packages/api/src/files/rag.spec.ts`, `text.spec.ts` — per-path scope minimization (`rag:documents` alone for the delete and the text extraction), and that `deleteRagFile` resolves only once the chunks are gone: a `404` counts, an unmintable token, a rejected request and an unreachable service all throw. `packages/api/src/storage/s3/__tests__/crud.test.ts` covers the three S3 call sites surfacing that failure instead of absorbing it.
- `packages/api/src/crypto/jwt.spec.ts` also signs and verifies every supported algorithm with a real key, refuses `EdDSA` naming it as configured, resolves a supported algorithm in any case, and accepts RSA and EC keys supplied with literal `\n` escapes while leaving an HMAC secret containing them untouched.
- `api/app/clients/prompts/createContextHandlers.spec.js` also pins that the two branches mint different planes, in order, and that the full-context read carries neither inference scope. Reverting the per-branch minting fails those assertions.

`packages/api` and `packages/data-schemas` suites pass; the `api` workspace suites for files, strategies, prompts and controllers pass. The pre-existing `packages/api` failures are environmental (Redis, LibreOffice, the secrets integration spec) and fail identically on the base branch.


