### PR TITLE
fix: reuse cached OBO token after upstream token expiration

### DIFF
--- a/api/server/services/OboTokenService.js
+++ b/api/server/services/OboTokenService.js
@@ -117,28 +117,25 @@ async function performOboExchange({ user, accessToken, scopes, config, tokensCac
  * after a cache miss does not produce N parallel requests to the IdP.
  *
  * @param {Object} user - User object with OpenID information
- * @param {string} accessToken - Federated access token used as OBO assertion
+ * @param {string | undefined} accessToken - Federated access token used as OBO assertion
  * @param {string} scopes - Scopes to request for the downstream service
  * @param {boolean} [fromCache=true] - When true, read from cache and join any
  *   in-flight exchange. When false, bypass both and force a fresh exchange.
+ * @param {boolean} [cacheOnly=false] - When true, return only a cached or
+ *   in-flight token and do not start a new exchange.
  * @returns {Promise<Object>} Token response with access_token and expires_in
  */
-async function exchangeOboToken(user, accessToken, scopes, fromCache = true) {
+async function exchangeOboToken(user, accessToken, scopes, fromCache = true, cacheOnly = false) {
   if (!user.openidId) {
     throw new Error('User must be authenticated via OpenID to perform OBO token exchange');
-  }
-
-  if (!accessToken) {
-    throw new Error('Access token is required for OBO exchange');
   }
 
   if (!scopes) {
     throw new Error('Scopes are required for OBO exchange');
   }
 
-  const config = getOpenIdConfig();
-  if (!config) {
-    throw new Error('OpenID configuration not available');
+  if (cacheOnly && !fromCache) {
+    throw new Error('cacheOnly requires fromCache to be enabled');
   }
 
   const cacheKey = `${user.openidId}:${scopes}`;
@@ -156,6 +153,19 @@ async function exchangeOboToken(user, accessToken, scopes, fromCache = true) {
       logger.debug(`[OboTokenService] Joining in-flight OBO exchange for user: ${user.openidId}`);
       return inFlight;
     }
+  }
+
+  if (cacheOnly) {
+    return null;
+  }
+
+  if (!accessToken) {
+    throw new Error('Access token is required for OBO exchange');
+  }
+
+  const config = getOpenIdConfig();
+  if (!config) {
+    throw new Error('OpenID configuration not available');
   }
 
   logger.debug(

--- a/api/server/services/OboTokenService.spec.js
+++ b/api/server/services/OboTokenService.spec.js
@@ -118,6 +118,44 @@ describe('OboTokenService', () => {
 
       expect(mockTokensCache.get).toHaveBeenCalledWith('oidc-sub-123:api://scope');
     });
+
+    it('should return cached token in cacheOnly mode without requiring an access token', async () => {
+      const cachedToken = {
+        access_token: 'cached-obo-token',
+        token_type: 'Bearer',
+        expires_in: 1800,
+        scope: 'api://scope',
+      };
+
+      mockTokensCache.get.mockResolvedValue(cachedToken);
+
+      const result = await exchangeOboToken(mockUser, undefined, 'api://scope', true, true);
+
+      expect(result).toBe(cachedToken);
+      expect(mockTokensCache.get).toHaveBeenCalledWith('oidc-sub-123:api://scope');
+      expect(client.genericGrantRequest).not.toHaveBeenCalled();
+      expect(getOpenIdConfig).not.toHaveBeenCalled();
+    });
+
+    it('should return null on a cache miss in cacheOnly mode without starting an exchange', async () => {
+      mockTokensCache.get.mockResolvedValue(null);
+
+      const result = await exchangeOboToken(mockUser, undefined, 'api://scope', true, true);
+
+      expect(result).toBeNull();
+      expect(mockTokensCache.get).toHaveBeenCalledWith('oidc-sub-123:api://scope');
+      expect(client.genericGrantRequest).not.toHaveBeenCalled();
+      expect(getOpenIdConfig).not.toHaveBeenCalled();
+    });
+
+    it('should reject cacheOnly mode when fromCache is false', async () => {
+      await expect(
+        exchangeOboToken(mockUser, undefined, 'api://scope', false, true),
+      ).rejects.toThrow('cacheOnly requires fromCache to be enabled');
+
+      expect(mockTokensCache.get).not.toHaveBeenCalled();
+      expect(client.genericGrantRequest).not.toHaveBeenCalled();
+    });
   });
 
   describe('OBO token exchange', () => {

--- a/packages/api/src/mcp/oauth/obo.spec.ts
+++ b/packages/api/src/mcp/oauth/obo.spec.ts
@@ -35,18 +35,38 @@ describe('resolveOboToken', () => {
     },
   };
 
-  const oboConfig = { scopes: 'api://mcp-server-id/Mcp.Tools.ReadWrite' };
+  const oboConfig = {
+    scopes: 'api://mcp-server-id/Mcp.Tools.ReadWrite',
+  };
 
-  const mockResolver: OboTokenResolver = jest.fn().mockResolvedValue({
-    access_token: 'exchanged-mcp-token',
-    expires_in: 3600,
-  });
+  let mockResolver: jest.MockedFunction<OboTokenResolver>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockResolver = jest.fn();
+  });
+
+  it('should reuse a cached OBO token without requiring a valid upstream token', async () => {
+    mockResolver.mockResolvedValueOnce({
+      access_token: 'cached-mcp-token',
+      expires_in: 1800,
+    });
+
+    const result = await resolveOboToken(mockUser as IUser, oboConfig, mockResolver);
+
+    expect(mockResolver).toHaveBeenCalledTimes(1);
+    expect(mockResolver).toHaveBeenCalledWith(mockUser, undefined, oboConfig.scopes, true, true);
+
+    expect(mockExtractOpenIDTokenInfo).not.toHaveBeenCalled();
+    expect(mockIsOpenIDTokenValid).not.toHaveBeenCalled();
+
+    expect(result.access_token).toBe('cached-mcp-token');
+    expect(result.token_type).toBe('Bearer');
+    expect(result.expires_at).toBe(result.obtained_at + 1800 * 1000);
   });
 
   it('should throw when user has no valid OpenID token info', async () => {
+    mockResolver.mockResolvedValueOnce(null);
     mockExtractOpenIDTokenInfo.mockReturnValue(null);
 
     await expect(resolveOboToken(mockUser as IUser, oboConfig, mockResolver)).rejects.toMatchObject(
@@ -55,11 +75,16 @@ describe('resolveOboToken', () => {
         retryable: false,
       },
     );
-    expect(mockResolver).not.toHaveBeenCalled();
+
+    expect(mockResolver).toHaveBeenCalledTimes(1);
+    expect(mockResolver).toHaveBeenCalledWith(mockUser, undefined, oboConfig.scopes, true, true);
   });
 
   it('should throw when OpenID token is not valid (expired)', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'some-token' });
+    mockResolver.mockResolvedValueOnce(null);
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'some-token',
+    });
     mockIsOpenIDTokenValid.mockReturnValue(false);
 
     await expect(resolveOboToken(mockUser as IUser, oboConfig, mockResolver)).rejects.toMatchObject(
@@ -68,11 +93,15 @@ describe('resolveOboToken', () => {
         retryable: false,
       },
     );
-    expect(mockResolver).not.toHaveBeenCalled();
+
+    expect(mockResolver).toHaveBeenCalledTimes(1);
   });
 
   it('should throw when access token is missing from token info', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ userId: 'user-123' });
+    mockResolver.mockResolvedValueOnce(null);
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      userId: 'user-123',
+    });
     mockIsOpenIDTokenValid.mockReturnValue(true);
 
     await expect(resolveOboToken(mockUser as IUser, oboConfig, mockResolver)).rejects.toMatchObject(
@@ -81,51 +110,82 @@ describe('resolveOboToken', () => {
         retryable: false,
       },
     );
-    expect(mockResolver).not.toHaveBeenCalled();
+
+    expect(mockResolver).toHaveBeenCalledTimes(1);
   });
 
   it('should call the resolver with correct arguments and return MCPOAuthTokens', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
+    mockResolver.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      access_token: 'exchanged-mcp-token',
+      expires_in: 3600,
+    });
+
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
+    });
     mockIsOpenIDTokenValid.mockReturnValue(true);
 
     const beforeCall = Date.now();
+
     const result = await resolveOboToken(mockUser as IUser, oboConfig, mockResolver);
+
     const afterCall = Date.now();
 
-    expect(mockResolver).toHaveBeenCalledWith(
+    expect(mockResolver).toHaveBeenCalledTimes(2);
+
+    expect(mockResolver).toHaveBeenNthCalledWith(
+      1,
       mockUser,
-      'federated-access-token',
-      'api://mcp-server-id/Mcp.Tools.ReadWrite',
+      undefined,
+      oboConfig.scopes,
+      true,
       true,
     );
 
-    expect(result).not.toBeNull();
-    expect(result!.access_token).toBe('exchanged-mcp-token');
-    expect(result!.token_type).toBe('Bearer');
-    expect(result!.obtained_at).toBeGreaterThanOrEqual(beforeCall);
-    expect(result!.obtained_at).toBeLessThanOrEqual(afterCall);
-    expect(result!.expires_at).toBe(result!.obtained_at + 3600 * 1000);
+    expect(mockResolver).toHaveBeenNthCalledWith(
+      2,
+      mockUser,
+      'federated-access-token',
+      oboConfig.scopes,
+      true,
+    );
+
+    expect(result.access_token).toBe('exchanged-mcp-token');
+    expect(result.token_type).toBe('Bearer');
+    expect(result.obtained_at).toBeGreaterThanOrEqual(beforeCall);
+    expect(result.obtained_at).toBeLessThanOrEqual(afterCall);
+    expect(result.expires_at).toBe(result.obtained_at + 3600 * 1000);
   });
 
   it('should default expires_in to 3600 when not provided by resolver', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
-    mockIsOpenIDTokenValid.mockReturnValue(true);
+    const resolverNoExpiry: OboTokenResolver = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        access_token: 'exchanged-token',
+      });
 
-    const resolverNoExpiry: OboTokenResolver = jest.fn().mockResolvedValue({
-      access_token: 'exchanged-token',
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
     });
+    mockIsOpenIDTokenValid.mockReturnValue(true);
 
     const result = await resolveOboToken(mockUser as IUser, oboConfig, resolverNoExpiry);
 
-    expect(result).not.toBeNull();
-    expect(result!.expires_at).toBe(result!.obtained_at + 3600 * 1000);
+    expect(result.expires_at).toBe(result.obtained_at + 3600 * 1000);
   });
 
   it('should throw when resolver returns no access_token', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
+    const emptyResolver: OboTokenResolver = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({} as { access_token: string });
+
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
+    });
     mockIsOpenIDTokenValid.mockReturnValue(true);
 
-    const emptyResolver: OboTokenResolver = jest.fn().mockResolvedValue({});
     await expect(
       resolveOboToken(mockUser as IUser, oboConfig, emptyResolver),
     ).rejects.toMatchObject({
@@ -135,12 +195,19 @@ describe('resolveOboToken', () => {
   });
 
   it('should throw a retryable error when resolver reports a transient failure', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
-    mockIsOpenIDTokenValid.mockReturnValue(true);
-
     const failingResolver: OboTokenResolver = jest
       .fn()
-      .mockRejectedValue(Object.assign(new Error('temporary timeout'), { retryable: true }));
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(
+        Object.assign(new Error('temporary timeout'), {
+          retryable: true,
+        }),
+      );
+
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
+    });
+    mockIsOpenIDTokenValid.mockReturnValue(true);
 
     await expect(
       resolveOboToken(mockUser as IUser, oboConfig, failingResolver),
@@ -152,12 +219,15 @@ describe('resolveOboToken', () => {
   });
 
   it('should throw a non-retryable error when resolver reports a permanent failure', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
-    mockIsOpenIDTokenValid.mockReturnValue(true);
-
     const failingResolver: OboTokenResolver = jest
       .fn()
-      .mockRejectedValue(new Error('invalid_grant: assertion invalid'));
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error('invalid_grant: assertion invalid'));
+
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
+    });
+    mockIsOpenIDTokenValid.mockReturnValue(true);
 
     await expect(
       resolveOboToken(mockUser as IUser, oboConfig, failingResolver),
@@ -169,13 +239,33 @@ describe('resolveOboToken', () => {
   });
 
   it('should use the correct scopes from oboConfig', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
+    mockResolver.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      access_token: 'exchanged-mcp-token',
+      expires_in: 3600,
+    });
+
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
+    });
     mockIsOpenIDTokenValid.mockReturnValue(true);
 
-    const customConfig = { scopes: 'api://other-app/Custom.Scope' };
+    const customConfig = {
+      scopes: 'api://other-app/Custom.Scope',
+    };
+
     await resolveOboToken(mockUser as IUser, customConfig, mockResolver);
 
-    expect(mockResolver).toHaveBeenCalledWith(
+    expect(mockResolver).toHaveBeenNthCalledWith(
+      1,
+      mockUser,
+      undefined,
+      'api://other-app/Custom.Scope',
+      true,
+      true,
+    );
+
+    expect(mockResolver).toHaveBeenNthCalledWith(
+      2,
       mockUser,
       'federated-access-token',
       'api://other-app/Custom.Scope',
@@ -184,18 +274,22 @@ describe('resolveOboToken', () => {
   });
 
   it('should respect custom expires_in from resolver', async () => {
-    mockExtractOpenIDTokenInfo.mockReturnValue({ accessToken: 'federated-access-token' });
-    mockIsOpenIDTokenValid.mockReturnValue(true);
+    const shortLivedResolver: OboTokenResolver = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        access_token: 'short-lived-token',
+        expires_in: 300,
+      });
 
-    const shortLivedResolver: OboTokenResolver = jest.fn().mockResolvedValue({
-      access_token: 'short-lived-token',
-      expires_in: 300,
+    mockExtractOpenIDTokenInfo.mockReturnValue({
+      accessToken: 'federated-access-token',
     });
+    mockIsOpenIDTokenValid.mockReturnValue(true);
 
     const result = await resolveOboToken(mockUser as IUser, oboConfig, shortLivedResolver);
 
-    expect(result).not.toBeNull();
-    expect(result!.expires_at).toBe(result!.obtained_at + 300 * 1000);
+    expect(result.expires_at).toBe(result.obtained_at + 300 * 1000);
   });
 });
 
@@ -205,11 +299,13 @@ describe('isOboConfigStillTrusted', () => {
       [Permissions.CONFIGURE_OBO]: true,
     },
   };
+
   const userPerms = {
     [PermissionTypes.MCP_SERVERS]: {
       [Permissions.CONFIGURE_OBO]: false,
     },
   };
+
   const noOboPerms = {
     [PermissionTypes.MCP_SERVERS]: {},
   };
@@ -220,6 +316,7 @@ describe('isOboConfigStillTrusted', () => {
       getUserRoleByAuthorId: jest.fn(),
       getRolePermissions: jest.fn(),
     });
+
     expect(result).toBe(false);
   });
 
@@ -229,6 +326,7 @@ describe('isOboConfigStillTrusted', () => {
       getUserRoleByAuthorId: jest.fn().mockResolvedValue(null),
       getRolePermissions: jest.fn(),
     });
+
     expect(result).toBe(false);
   });
 
@@ -238,6 +336,7 @@ describe('isOboConfigStillTrusted', () => {
       getUserRoleByAuthorId: jest.fn().mockResolvedValue('ADMIN'),
       getRolePermissions: jest.fn().mockRejectedValue(new Error('db down')),
     });
+
     expect(result).toBe(false);
   });
 
@@ -247,6 +346,7 @@ describe('isOboConfigStillTrusted', () => {
       getUserRoleByAuthorId: jest.fn().mockResolvedValue('ADMIN'),
       getRolePermissions: jest.fn().mockResolvedValue(noOboPerms),
     });
+
     expect(result).toBe(false);
   });
 
@@ -256,6 +356,7 @@ describe('isOboConfigStillTrusted', () => {
       getUserRoleByAuthorId: jest.fn().mockResolvedValue('USER'),
       getRolePermissions: jest.fn().mockResolvedValue(userPerms),
     });
+
     expect(result).toBe(false);
   });
 
@@ -265,6 +366,7 @@ describe('isOboConfigStillTrusted', () => {
       getUserRoleByAuthorId: jest.fn().mockResolvedValue('ADMIN'),
       getRolePermissions: jest.fn().mockResolvedValue(adminPerms),
     });
+
     expect(result).toBe(true);
   });
 });

--- a/packages/api/src/mcp/oauth/obo.ts
+++ b/packages/api/src/mcp/oauth/obo.ts
@@ -14,10 +14,11 @@ export interface OboConfig {
  */
 export type OboTokenResolver = (
   user: IUser,
-  accessToken: string,
+  accessToken: string | undefined,
   scopes: string,
   fromCache?: boolean,
-) => Promise<{ access_token: string; expires_in?: number }>;
+  cacheOnly?: boolean,
+) => Promise<{ access_token: string; expires_in?: number } | null>;
 
 export type OboTokenResolutionReason =
   | 'missing_upstream_token'
@@ -113,36 +114,42 @@ function isRetryableOboExchangeError(error: unknown): boolean {
   );
 }
 
-/**
- * Performs an OBO token exchange for the given user and MCP server OBO config.
- * Returns MCPOAuthTokens suitable for injection into the MCP connection.
- */
+// /**
+//  * Performs an OBO token exchange for the given user and MCP server OBO config.
+//  * Returns MCPOAuthTokens suitable for injection into the MCP connection.
+//  */
 export async function resolveOboToken(
   user: IUser,
   oboConfig: OboConfig,
   oboTokenResolver: OboTokenResolver,
 ): Promise<MCPOAuthTokens> {
-  const tokenInfo = extractOpenIDTokenInfo(user);
-  if (!tokenInfo || !isOpenIDTokenValid(tokenInfo)) {
-    logger.warn(
-      `[OBO] No valid OpenID token available for OBO exchange (provider: ${user.provider}, hasOpenidId: ${!!user.openidId}, hasFederatedTokens: ${!!user.federatedTokens})`,
-    );
-    throw new OboTokenResolutionError(
-      'missing_upstream_token',
-      'No valid OpenID access token is available for OBO exchange.',
-    );
-  }
-
-  if (!tokenInfo.accessToken) {
-    logger.warn('[OBO] OpenID token info present but access_token is missing');
-    throw new OboTokenResolutionError(
-      'missing_upstream_access_token',
-      'The upstream OpenID access token is missing for OBO exchange.',
-    );
-  }
-
   try {
-    const response = await oboTokenResolver(user, tokenInfo.accessToken, oboConfig.scopes, true);
+    // Reuse a cached or in-flight OBO token without requiring a valid upstream token
+    let response = await oboTokenResolver(user, undefined, oboConfig.scopes, true, true);
+
+    if (!response?.access_token) {
+      // A cache miss requires a valid upstream OpenID token to perform a new OBO exchange.
+      const tokenInfo = extractOpenIDTokenInfo(user);
+      if (!tokenInfo || !isOpenIDTokenValid(tokenInfo)) {
+        logger.warn(
+          `[OBO] No valid OpenID token available for OBO exchange (provider: ${user.provider}, hasOpenidId: ${!!user.openidId}, hasFederatedTokens: ${!!user.federatedTokens})`,
+        );
+        throw new OboTokenResolutionError(
+          'missing_upstream_token',
+          'No valid OpenID access token is available for OBO exchange.',
+        );
+      }
+
+      if (!tokenInfo.accessToken) {
+        logger.warn('[OBO] OpenID token info present but access_token is missing');
+        throw new OboTokenResolutionError(
+          'missing_upstream_access_token',
+          'The upstream OpenID access token is missing for OBO exchange.',
+        );
+      }
+
+      response = await oboTokenResolver(user, tokenInfo.accessToken, oboConfig.scopes, true);
+    }
 
     if (!response?.access_token) {
       logger.warn('[OBO] Token exchange did not return an access token');


### PR DESCRIPTION
## Summary

Reuse cached OBO tokens even after the upstream OpenID access token has expired.

Previously, the upstream token was validated before checking the OBO token cache. As a result, valid cached OBO tokens became unusable once the upstream token expired.

This change:

- checks the OBO cache before validating the upstream token;
- performs a new OBO exchange only when no cached token is available;
- adds tests covering the new behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)