### PR TITLE
⛴️ feat: Add ServiceAccount and initContainers Support to RAG API Chart

### DIFF
--- a/helm/librechat-rag-api/Chart.yaml
+++ b/helm/librechat-rag-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/librechat-rag-api/templates/rag-deployment.yaml
+++ b/helm/librechat-rag-api/templates/rag-deployment.yaml
@@ -26,11 +26,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "rag.serviceAccountName" . }}
       {{- if kindIs "bool" .Values.enableServiceLinks }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- range $key, $value := .Values.initContainers }}
+        {{- if . }}
+        - name: {{ $key }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "rag.fullname" $ }}-rag
           securityContext:

--- a/helm/librechat-rag-api/templates/serviceaccount.yaml
+++ b/helm/librechat-rag-api/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rag.serviceAccountName" . }}
+  labels:
+    {{- include "rag.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/librechat-rag-api/values.yaml
+++ b/helm/librechat-rag-api/values.yaml
@@ -37,6 +37,18 @@ imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
 
+serviceAccount:
+  create: false
+  automount: true
+  # Annotations to add to the service account.
+  # Can be used to set up workload identity, for example:
+  #   iam.gke.io/gcp-service-account: my-app@my-project.iam.gserviceaccount.com
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/my-role
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
 podAnnotations: {}
 podLabels: {}
 
@@ -100,5 +112,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+initContainers: {}
 
 extraContainers: {}

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -41,6 +41,6 @@ dependencies:
     condition: redis.enabled
     repository: "https://charts.bitnami.com/bitnami"
   - name: librechat-rag-api
-    version: "0.5.3"
+    version: "0.6.0"
     condition: librechat-rag-api.enabled
     repository: file://../librechat-rag-api


### PR DESCRIPTION
## Summary

The `librechat-rag-api` Deployment sets no `serviceAccountName` and has no `initContainers` hook, so its pod always runs under the namespace's `default` service account and nothing can be started before it.

This PR adds both, reusing the shapes already present in the sibling `librechat` chart:

- New `templates/serviceaccount.yaml`, plus a `serviceAccount` values block
- `serviceAccountName` on the rag-api Deployment, via the existing (previously unused) `rag.serviceAccountName` helper
- An `initContainers` map hook, same `range`-over-map shape as `librechat/templates/deployment.yaml`

Version bumps: `librechat-rag-api` 0.5.3 → 0.6.0, and `librechat` 2.0.7 → 2.1.0

```yaml
# let the chart create a dedicated SA for the RAG API
librechat-rag-api:
  serviceAccount:
    create: true
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/rag-api

# or reuse an existing one, e.g. the parent chart's
librechat-rag-api:
  serviceAccount:
    create: false
    name: librechat
```

This PR doesn't bring any breaking change, the default are `create: false` and `name: ''` resolve to `default`, which is what the pod already got implicitly. `initContainers` is empty. Upgrading creates no object and modifies none, both hooks are strictly opt-in.

### Why this is useful

- Being able to set a service account let the user bind it to a cloud provider workload identity
- The `initContainers` hook covers the usual pre-start work: waiting on a dependency, running a migration, fetching certificates...

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- **Defaults are unchanged:** `helm template rc helm/librechat --set librechat-rag-api.enabled=true` renders no rag-api ServiceAccount, no `initContainers`, and `serviceAccountName: default` on the pod. Same as `main`.

- **Both hooks work.** With `serviceAccount.create: true`, `name: rag-api-sa`, an annotation, and one `initContainers` entry:

```yaml
kind: ServiceAccount
metadata:
  name: rag-api-sa
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/rag-api
---
# rag-api Deployment
    spec:
      serviceAccountName: rag-api-sa
      initContainers:
        - name: wait-for-db
          image: busybox
          restartPolicy: Always
```

- `helm lint helm/librechat` passes, and `helm dependency build` succeeds for both charts.

### **Test Configuration**:

- Helm 3 on MacOS, rendered through the umbrella `helm/librechat`

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes