### PR TITLE
🔑 fix: Decode Action OAuth Credentials After Decryption

### DIFF
--- a/api/server/services/ActionService.js
+++ b/api/server/services/ActionService.js
@@ -2,7 +2,7 @@ const jwt = require('jsonwebtoken');
 const { nanoid } = require('nanoid');
 const { GraphEvents, sleep } = require('@librechat/agents');
 const { tool } = require('@librechat/agents/langchain/tools');
-const { logger, encryptV2, decryptV2 } = require('@librechat/data-schemas');
+const { logger, decryptV2 } = require('@librechat/data-schemas');
 const {
   sendEvent,
   logAxiosError,
@@ -10,6 +10,8 @@ const {
   refreshAccessToken,
   GenerationJobManager,
   createSSRFSafeAgents,
+  encryptSensitiveValue,
+  decryptSensitiveValue,
   validateActionOAuthMetadata,
 } = require('@librechat/api');
 const {
@@ -405,27 +407,6 @@ async function createActionTool({
   return {
     _call,
   };
-}
-
-/**
- * Encrypts a sensitive value.
- * @param {string} value
- * @returns {Promise<string>}
- */
-async function encryptSensitiveValue(value) {
-  // Encode API key to handle special characters like ":"
-  const encodedValue = encodeURIComponent(value);
-  return await encryptV2(encodedValue);
-}
-
-/**
- * Decrypts a sensitive value.
- * @param {string} value
- * @returns {Promise<string>}
- */
-async function decryptSensitiveValue(value) {
-  const decryptedValue = await decryptV2(value);
-  return decodeURIComponent(decryptedValue);
 }
 
 /**

--- a/api/server/services/ActionService.js
+++ b/api/server/services/ActionService.js
@@ -2,13 +2,15 @@ const jwt = require('jsonwebtoken');
 const { nanoid } = require('nanoid');
 const { GraphEvents, sleep } = require('@librechat/agents');
 const { tool } = require('@librechat/agents/langchain/tools');
-const { logger, encryptV2, decryptV2 } = require('@librechat/data-schemas');
+const { logger, decryptV2 } = require('@librechat/data-schemas');
 const {
   sendEvent,
   logAxiosError,
   refreshAccessToken,
   GenerationJobManager,
   createSSRFSafeAgents,
+  encryptSensitiveValue,
+  decryptSensitiveValue,
   validateActionOAuthMetadata,
 } = require('@librechat/api');
 const {
@@ -404,27 +406,6 @@ async function createActionTool({
   return {
     _call,
   };
-}
-
-/**
- * Encrypts a sensitive value.
- * @param {string} value
- * @returns {Promise<string>}
- */
-async function encryptSensitiveValue(value) {
-  // Encode API key to handle special characters like ":"
-  const encodedValue = encodeURIComponent(value);
-  return await encryptV2(encodedValue);
-}
-
-/**
- * Decrypts a sensitive value.
- * @param {string} value
- * @returns {Promise<string>}
- */
-async function decryptSensitiveValue(value) {
-  const decryptedValue = await decryptV2(value);
-  return decodeURIComponent(decryptedValue);
 }
 
 /**

--- a/packages/api/src/actions/crypto.spec.ts
+++ b/packages/api/src/actions/crypto.spec.ts
@@ -1,0 +1,59 @@
+process.env.CREDS_KEY =
+  process.env.CREDS_KEY ?? '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+// Loaded via dynamic import in beforeAll so encryption initializes after
+// CREDS_KEY is set above (encryptV2 reads the key at module load).
+let encryptSensitiveValue: typeof import('./crypto').encryptSensitiveValue;
+let decryptSensitiveValue: typeof import('./crypto').decryptSensitiveValue;
+let encryptV2: typeof import('@librechat/data-schemas').encryptV2;
+
+beforeAll(async () => {
+  ({ encryptSensitiveValue, decryptSensitiveValue } = await import('./crypto'));
+  ({ encryptV2 } = await import('@librechat/data-schemas'));
+});
+
+describe('action credential encryption', () => {
+  describe('round trip', () => {
+    it.each([
+      ['an email-style client id', 'client@id.com'],
+      ['reserved characters', 's+cret=/end'],
+      ['a colon', 'user:pass'],
+      ['a literal percent sign', '100%secret'],
+      ['a plus sign that must not become a space', 'a+b'],
+      ['a literal percent escape', 'secret%2Fvalue'],
+      ['unicode', 'sécret-π'],
+    ])('preserves %s', async (_label, value) => {
+      expect(await decryptSensitiveValue(await encryptSensitiveValue(value))).toBe(value);
+    });
+  });
+
+  describe('credentials stored before encoding was introduced', () => {
+    it('returns a pre-encoding value unchanged', async () => {
+      const stored = await encryptV2('plain-secret');
+
+      expect(await decryptSensitiveValue(stored)).toBe('plain-secret');
+    });
+
+    /**
+     * Regression: decoding unconditionally threw `URIError` here, which broke every read of the
+     * action rather than just mangling the credential.
+     */
+    it('does not throw on a pre-encoding value containing a stray percent sign', async () => {
+      const stored = await encryptV2('100%secret');
+
+      await expect(decryptSensitiveValue(stored)).resolves.toBe('100%secret');
+    });
+
+    /**
+     * Known, pre-existing limitation rather than desired behaviour: stored values carry no marker
+     * saying whether they were encoded, so a pre-encoding credential that happens to contain a
+     * valid escape is indistinguishable from an encoded one and is still decoded. Re-saving the
+     * action rewrites it in the encoded format and settles the ambiguity.
+     */
+    it('still rewrites a pre-encoding value that happens to contain a valid escape', async () => {
+      const stored = await encryptV2('secret%2Fvalue');
+
+      expect(await decryptSensitiveValue(stored)).toBe('secret/value');
+    });
+  });
+});

--- a/packages/api/src/actions/crypto.ts
+++ b/packages/api/src/actions/crypto.ts
@@ -1,0 +1,29 @@
+import { encryptV2, decryptV2 } from '@librechat/data-schemas';
+
+/**
+ * Encrypts an action credential, encoding it first so that reserved characters (`@`, `+`, `=`,
+ * `/`, `:`) survive storage.
+ */
+export async function encryptSensitiveValue(value: string): Promise<string> {
+  return encryptV2(encodeURIComponent(value));
+}
+
+/**
+ * Decrypts an action credential, reversing the encoding applied by {@link encryptSensitiveValue}.
+ *
+ * Encoding before encryption was introduced in 299cabd6e (March 2025). Credentials stored earlier
+ * were encrypted raw and carry no marker saying so, so a legacy value containing a stray `%` would
+ * make `decodeURIComponent` throw `URIError`; those are returned as decrypted.
+ *
+ * Every reader of these fields must use this helper. Decoding in one read path but not another
+ * sends different credentials to the provider depending on which path ran.
+ */
+export async function decryptSensitiveValue(encryptedValue: string): Promise<string> {
+  const decryptedValue = await decryptV2(encryptedValue);
+
+  try {
+    return decodeURIComponent(decryptedValue);
+  } catch {
+    return decryptedValue;
+  }
+}

--- a/packages/api/src/actions/index.ts
+++ b/packages/api/src/actions/index.ts
@@ -1,4 +1,5 @@
 export * from './credentials';
+export * from './crypto';
 export * from './protection';
 export * from './tools';
 export * from './update';

--- a/packages/api/src/actions/index.ts
+++ b/packages/api/src/actions/index.ts
@@ -1,3 +1,4 @@
 export * from './credentials';
+export * from './crypto';
 export * from './tools';
 export * from './update';

--- a/packages/api/src/oauth/tokens.spec.ts
+++ b/packages/api/src/oauth/tokens.spec.ts
@@ -22,6 +22,18 @@ jest.mock('@librechat/data-schemas', () => ({
     if (value === 'encrypted-refresh-token') {
       return 'refresh-token';
     }
+    if (value === 'encrypted-encoded-client-id') {
+      return 'client%40id.com';
+    }
+    if (value === 'encrypted-encoded-client-secret') {
+      return 's%2Bcret%3D%2Fend';
+    }
+    if (value === 'encrypted-legacy-client-id') {
+      return 'legacy%value';
+    }
+    if (value === 'encrypted-legacy-client-secret') {
+      return '100%secret';
+    }
     return value;
   }),
 }));
@@ -213,6 +225,132 @@ describe('action OAuth token exchange validation', () => {
     );
 
     expect(accessConfig.httpsAgent).toBe(refreshConfig.httpsAgent);
+  });
+
+  describe('URL-encoded stored credentials', () => {
+    const encodedFields = {
+      ...baseFields,
+      encrypted_oauth_client_id: 'encrypted-encoded-client-id',
+      encrypted_oauth_client_secret: 'encrypted-encoded-client-secret',
+    };
+
+    const legacyFields = {
+      ...baseFields,
+      encrypted_oauth_client_id: 'encrypted-legacy-client-id',
+      encrypted_oauth_client_secret: 'encrypted-legacy-client-secret',
+    };
+
+    it('decodes credentials in the authorization-code exchange body', async () => {
+      await getAccessToken(
+        {
+          ...encodedFields,
+          code: 'authorization-code',
+          redirect_uri: 'https://chat.example.com/api/actions/action-1/oauth/callback',
+          token_exchange_method: TokenExchangeMethodEnum.DefaultPost,
+        },
+        createTokenMethods(),
+      );
+
+      const params = new URLSearchParams(getAxiosConfig().data as string);
+
+      expect(params.get('client_id')).toBe('client@id.com');
+      expect(params.get('client_secret')).toBe('s+cret=/end');
+    });
+
+    it('decodes credentials in the authorization-code Basic auth header', async () => {
+      await getAccessToken(
+        {
+          ...encodedFields,
+          code: 'authorization-code',
+          redirect_uri: 'https://chat.example.com/api/actions/action-1/oauth/callback',
+          token_exchange_method: TokenExchangeMethodEnum.BasicAuthHeader,
+        },
+        createTokenMethods(),
+      );
+
+      const headers = getAxiosConfig().headers as Record<string, string>;
+      const credentials = Buffer.from(
+        headers.Authorization.replace('Basic ', ''),
+        'base64',
+      ).toString('utf8');
+
+      expect(credentials).toBe('client@id.com:s+cret=/end');
+    });
+
+    it('decodes credentials in the refresh-token exchange body', async () => {
+      await refreshAccessToken(
+        {
+          ...encodedFields,
+          refresh_token: 'refresh-token',
+          token_exchange_method: TokenExchangeMethodEnum.DefaultPost,
+        },
+        createTokenMethods(),
+      );
+
+      const params = new URLSearchParams(getAxiosConfig().data as string);
+
+      expect(params.get('client_id')).toBe('client@id.com');
+      expect(params.get('client_secret')).toBe('s+cret=/end');
+    });
+
+    it('decodes credentials in the refresh-token Basic auth header', async () => {
+      await refreshAccessToken(
+        {
+          ...encodedFields,
+          refresh_token: 'refresh-token',
+          token_exchange_method: TokenExchangeMethodEnum.BasicAuthHeader,
+        },
+        createTokenMethods(),
+      );
+
+      const headers = getAxiosConfig().headers as Record<string, string>;
+      const credentials = Buffer.from(
+        headers.Authorization.replace('Basic ', ''),
+        'base64',
+      ).toString('utf8');
+
+      expect(credentials).toBe('client@id.com:s+cret=/end');
+    });
+
+    it('passes through legacy unencoded credentials containing a stray percent sign', async () => {
+      await expect(
+        getAccessToken(
+          {
+            ...legacyFields,
+            code: 'authorization-code',
+            redirect_uri: 'https://chat.example.com/api/actions/action-1/oauth/callback',
+            token_exchange_method: TokenExchangeMethodEnum.DefaultPost,
+          },
+          createTokenMethods(),
+        ),
+      ).resolves.toEqual(tokenResponse);
+
+      const params = new URLSearchParams(getAxiosConfig().data as string);
+
+      expect(params.get('client_id')).toBe('legacy%value');
+      expect(params.get('client_secret')).toBe('100%secret');
+    });
+
+    it('passes through legacy unencoded credentials when refreshing', async () => {
+      await expect(
+        refreshAccessToken(
+          {
+            ...legacyFields,
+            refresh_token: 'refresh-token',
+            token_exchange_method: TokenExchangeMethodEnum.BasicAuthHeader,
+          },
+          createTokenMethods(),
+        ),
+      ).resolves.toEqual(tokenResponse);
+
+      const headers = getAxiosConfig().headers as Record<string, string>;
+      const credentials = Buffer.from(
+        headers.Authorization.replace('Basic ', ''),
+        'base64',
+      ).toString('utf8');
+
+      expect(credentials).toBe('legacy%value:100%secret');
+    });
   });
 
   it('allows explicitly exempted private token endpoints', async () => {

--- a/packages/api/src/oauth/tokens.ts
+++ b/packages/api/src/oauth/tokens.ts
@@ -11,6 +11,21 @@ import { logAxiosError } from '~/utils';
 const actionOAuthAgents = createSSRFSafeAgents();
 const actionOAuthAgentsByAddress = new Map<string, ReturnType<typeof createSSRFSafeAgents>>();
 
+/**
+ * Decrypts an action OAuth credential, reversing the `encodeURIComponent` applied before encryption.
+ * Encoding-before-encryption was introduced in 299cabd6e (March 2025); credentials stored earlier
+ * are encrypted without it, so a legacy secret containing a raw `%` would make `decodeURIComponent`
+ * throw `URIError`. In that case the decrypted value is returned unchanged.
+ */
+async function decryptSensitiveValue(encryptedValue: string): Promise<string> {
+  const decryptedValue = await decryptV2(encryptedValue);
+  try {
+    return decodeURIComponent(decryptedValue);
+  } catch {
+    return decryptedValue;
+  }
+}
+
 function getActionOAuthAgents(allowedAddresses?: string[] | null) {
   if (!Array.isArray(allowedAddresses) || allowedAddresses.length === 0) {
     return actionOAuthAgents;
@@ -189,8 +204,8 @@ export async function refreshAccessToken(
   await validateActionOAuthEndpoint(client_url, 'client_url', allowedAddresses);
 
   try {
-    const oauth_client_id = await decryptV2(encrypted_oauth_client_id);
-    const oauth_client_secret = await decryptV2(encrypted_oauth_client_secret);
+    const oauth_client_id = await decryptSensitiveValue(encrypted_oauth_client_id);
+    const oauth_client_secret = await decryptSensitiveValue(encrypted_oauth_client_secret);
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -294,8 +309,8 @@ export async function getAccessToken(
 }> {
   await validateActionOAuthEndpoint(client_url, 'client_url', allowedAddresses);
 
-  const oauth_client_id = await decryptV2(encrypted_oauth_client_id);
-  const oauth_client_secret = await decryptV2(encrypted_oauth_client_secret);
+  const oauth_client_id = await decryptSensitiveValue(encrypted_oauth_client_id);
+  const oauth_client_secret = await decryptSensitiveValue(encrypted_oauth_client_secret);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',

--- a/packages/api/src/oauth/tokens.ts
+++ b/packages/api/src/oauth/tokens.ts
@@ -1,30 +1,16 @@
 import axios from 'axios';
+import { logger, encryptV2 } from '@librechat/data-schemas';
 import { TokenExchangeMethodEnum } from 'librechat-data-provider';
-import { logger, encryptV2, decryptV2 } from '@librechat/data-schemas';
 import type { IToken, TokenMethods } from '@librechat/data-schemas';
 import type { AxiosError } from 'axios';
 import { DEFAULT_OAUTH_TOKEN_TTL_SECONDS, normalizeExpiresIn } from './expiry';
 import { validateActionOAuthEndpoint } from './validation';
+import { decryptSensitiveValue } from '~/actions/crypto';
 import { createSSRFSafeAgents } from '~/auth';
 import { logAxiosError } from '~/utils';
 
 const actionOAuthAgents = createSSRFSafeAgents();
 const actionOAuthAgentsByAddress = new Map<string, ReturnType<typeof createSSRFSafeAgents>>();
-
-/**
- * Decrypts an action OAuth credential, reversing the `encodeURIComponent` applied before encryption.
- * Encoding-before-encryption was introduced in 299cabd6e (March 2025); credentials stored earlier
- * are encrypted without it, so a legacy secret containing a raw `%` would make `decodeURIComponent`
- * throw `URIError`. In that case the decrypted value is returned unchanged.
- */
-async function decryptSensitiveValue(encryptedValue: string): Promise<string> {
-  const decryptedValue = await decryptV2(encryptedValue);
-  try {
-    return decodeURIComponent(decryptedValue);
-  } catch {
-    return decryptedValue;
-  }
-}
 
 function getActionOAuthAgents(allowedAddresses?: string[] | null) {
   if (!Array.isArray(allowedAddresses) || allowedAddresses.length === 0) {

--- a/packages/api/src/oauth/tokens.ts
+++ b/packages/api/src/oauth/tokens.ts
@@ -1,29 +1,15 @@
 import axios from 'axios';
+import { logger, encryptV2 } from '@librechat/data-schemas';
 import { TokenExchangeMethodEnum } from 'librechat-data-provider';
-import { logger, encryptV2, decryptV2 } from '@librechat/data-schemas';
 import type { IToken, TokenMethods } from '@librechat/data-schemas';
 import type { AxiosError } from 'axios';
 import { validateActionOAuthEndpoint } from './validation';
+import { decryptSensitiveValue } from '~/actions/crypto';
 import { createSSRFSafeAgents } from '~/auth';
 import { logAxiosError } from '~/utils';
 
 const actionOAuthAgents = createSSRFSafeAgents();
 const actionOAuthAgentsByAddress = new Map<string, ReturnType<typeof createSSRFSafeAgents>>();
-
-/**
- * Decrypts an action OAuth credential, reversing the `encodeURIComponent` applied before encryption.
- * Encoding-before-encryption was introduced in 299cabd6e (March 2025); credentials stored earlier
- * are encrypted without it, so a legacy secret containing a raw `%` would make `decodeURIComponent`
- * throw `URIError`. In that case the decrypted value is returned unchanged.
- */
-async function decryptSensitiveValue(encryptedValue: string): Promise<string> {
-  const decryptedValue = await decryptV2(encryptedValue);
-  try {
-    return decodeURIComponent(decryptedValue);
-  } catch {
-    return decryptedValue;
-  }
-}
 
 function getActionOAuthAgents(allowedAddresses?: string[] | null) {
   if (!Array.isArray(allowedAddresses) || allowedAddresses.length === 0) {

--- a/packages/api/src/oauth/tokens.ts
+++ b/packages/api/src/oauth/tokens.ts
@@ -10,6 +10,21 @@ import { logAxiosError } from '~/utils';
 const actionOAuthAgents = createSSRFSafeAgents();
 const actionOAuthAgentsByAddress = new Map<string, ReturnType<typeof createSSRFSafeAgents>>();
 
+/**
+ * Decrypts an action OAuth credential, reversing the `encodeURIComponent` applied before encryption.
+ * Encoding-before-encryption was introduced in 299cabd6e (March 2025); credentials stored earlier
+ * are encrypted without it, so a legacy secret containing a raw `%` would make `decodeURIComponent`
+ * throw `URIError`. In that case the decrypted value is returned unchanged.
+ */
+async function decryptSensitiveValue(encryptedValue: string): Promise<string> {
+  const decryptedValue = await decryptV2(encryptedValue);
+  try {
+    return decodeURIComponent(decryptedValue);
+  } catch {
+    return decryptedValue;
+  }
+}
+
 function getActionOAuthAgents(allowedAddresses?: string[] | null) {
   if (!Array.isArray(allowedAddresses) || allowedAddresses.length === 0) {
     return actionOAuthAgents;
@@ -193,8 +208,8 @@ export async function refreshAccessToken(
   await validateActionOAuthEndpoint(client_url, 'client_url', allowedAddresses);
 
   try {
-    const oauth_client_id = await decryptV2(encrypted_oauth_client_id);
-    const oauth_client_secret = await decryptV2(encrypted_oauth_client_secret);
+    const oauth_client_id = await decryptSensitiveValue(encrypted_oauth_client_id);
+    const oauth_client_secret = await decryptSensitiveValue(encrypted_oauth_client_secret);
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -298,8 +313,8 @@ export async function getAccessToken(
 }> {
   await validateActionOAuthEndpoint(client_url, 'client_url', allowedAddresses);
 
-  const oauth_client_id = await decryptV2(encrypted_oauth_client_id);
-  const oauth_client_secret = await decryptV2(encrypted_oauth_client_secret);
+  const oauth_client_id = await decryptSensitiveValue(encrypted_oauth_client_id);
+  const oauth_client_secret = await decryptSensitiveValue(encrypted_oauth_client_secret);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## Summary

Fixes #14636

Action OAuth client credentials are URL-encoded before encryption: `encryptSensitiveValue` in `api/server/services/ActionService.js` applies `encodeURIComponent()` before `encryptV2`. The decrypt helpers in `ActionService.js` reverse both steps, but `getAccessToken` and `refreshAccessToken` in `packages/api/src/oauth/tokens.ts` decrypted with `decryptV2` alone — so any client ID or secret containing special characters (`@`, `+`, `=`, `/`, `:`) was sent to the provider's token endpoint still URL-encoded (e.g. `abc%40domain.com` instead of `abc@domain.com`), causing 401s. Both exchange methods were affected: `default_post` (body params) and `basic_auth_header` (base64 header).

This PR adds a `decryptSensitiveValue` helper in `tokens.ts` that decodes after decrypting and uses it at all four call sites.

**Backward compatibility:** encoding-before-encryption was introduced in 299cabd6e (March 2025); credentials stored before that are encrypted without it. A legacy secret containing a raw `%` would make `decodeURIComponent` throw `URIError`, so the decode is wrapped in try/catch and falls back to the raw decrypted value. `api/server/services/ActionService.js` is untouched.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added 6 test cases to `packages/api/src/oauth/tokens.spec.ts` (existing mock/helper patterns):

- `getAccessToken` + `refreshAccessToken` with `default_post`: request body contains the decoded `client_id`/`client_secret`
- `getAccessToken` + `refreshAccessToken` with `basic_auth_header`: `Authorization` header base64-decodes to `decodedId:decodedSecret`
- Legacy unencoded credentials containing a stray `%`: no throw, passed through unchanged (both paths)

Verified the decode assertions fail against the previous code (reverting the call sites to `decryptV2` makes the 4 decode tests fail), so the tests pin the actual bug.

- `cd packages/api && npx jest src/oauth` → 5 suites, 68 tests passed
- `npx tsc --noEmit -p packages/api` → clean
- `npx eslint` on both touched files → clean

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
