### PR TITLE
📁 fix: Consistent Export Filenames Across Formats

### DIFF
--- a/client/src/components/Nav/ExportConversation/ExportModal.tsx
+++ b/client/src/components/Nav/ExportConversation/ExportModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@librechat/client';
 import type { TConversation } from 'librechat-data-provider';
 import { useLocalize, useExportConversation } from '~/hooks';
+import { normalizeExportFilename } from '~/utils';
 
 const TYPE_OPTIONS = [
   { value: 'screenshot', label: 'screenshot (.png)' },
@@ -72,7 +73,7 @@ export default function ExportModal({
 
   const { exportConversation } = useExportConversation({
     conversation,
-    filename: filenamify(filename),
+    filename: normalizeExportFilename(filenamify(filename)),
     type,
     includeOptions,
     exportBranches,

--- a/client/src/components/Nav/ExportConversation/ExportModal.tsx
+++ b/client/src/components/Nav/ExportConversation/ExportModal.tsx
@@ -1,5 +1,5 @@
-import filenamify from 'filenamify';
 import { useEffect, useState, useMemo, useCallback } from 'react';
+import filenamify from 'filenamify';
 import {
   Input,
   Label,

--- a/client/src/hooks/Conversations/usePresets.ts
+++ b/client/src/hooks/Conversations/usePresets.ts
@@ -1,23 +1,23 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import filenamify from 'filenamify';
 import exportFromJSON from 'export-from-json';
 import { useToastContext } from '@librechat/client';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
 import { useCreatePresetMutation, useGetModelsQuery } from 'librechat-data-provider/react-query';
 import type { TPreset, TEndpointsConfig } from 'librechat-data-provider';
-import {
-  useUpdatePresetMutation,
-  useDeletePresetMutation,
-  useGetPresetsQuery,
-} from '~/data-provider';
 import {
   normalizeExportFilename,
   removeUnavailableTools,
   getConvoSwitchLogic,
   cleanupPreset,
 } from '~/utils';
+import {
+  useUpdatePresetMutation,
+  useDeletePresetMutation,
+  useGetPresetsQuery,
+} from '~/data-provider';
 import useGetConversation from '~/hooks/Conversations/useGetConversation';
 import useDefaultConvo from '~/hooks/Conversations/useDefaultConvo';
 import { useAuthContext } from '~/hooks/AuthContext';

--- a/client/src/hooks/Conversations/usePresets.ts
+++ b/client/src/hooks/Conversations/usePresets.ts
@@ -12,7 +12,12 @@ import {
   useDeletePresetMutation,
   useGetPresetsQuery,
 } from '~/data-provider';
-import { cleanupPreset, removeUnavailableTools, getConvoSwitchLogic } from '~/utils';
+import {
+  normalizeExportFilename,
+  removeUnavailableTools,
+  getConvoSwitchLogic,
+  cleanupPreset,
+} from '~/utils';
 import useGetConversation from '~/hooks/Conversations/useGetConversation';
 import useDefaultConvo from '~/hooks/Conversations/useDefaultConvo';
 import { useAuthContext } from '~/hooks/AuthContext';
@@ -264,7 +269,7 @@ export default function usePresets(index = 0) {
     if (!preset) {
       return;
     }
-    const fileName = filenamify(preset.title || 'preset');
+    const fileName = normalizeExportFilename(filenamify(preset.title || 'preset'));
     exportFromJSON({
       data: cleanupPreset({ preset }),
       fileName,

--- a/client/src/utils/files.spec.ts
+++ b/client/src/utils/files.spec.ts
@@ -1,0 +1,26 @@
+import { normalizeExportFilename } from './files';
+
+describe('normalizeExportFilename', () => {
+  it('replaces every whitespace run with a single underscore', () => {
+    expect(normalizeExportFilename('Word1 Word2 Word3')).toBe('Word1_Word2_Word3');
+  });
+
+  it('collapses consecutive whitespace into one underscore', () => {
+    expect(normalizeExportFilename('Word1  Word2\tWord3')).toBe('Word1_Word2_Word3');
+  });
+
+  it('leaves filenames without whitespace unchanged', () => {
+    expect(normalizeExportFilename('single-word_name')).toBe('single-word_name');
+  });
+
+  it('handles an empty string', () => {
+    expect(normalizeExportFilename('')).toBe('');
+  });
+
+  it('never leaves whitespace, so downstream whitespace-based formatters are no-ops', () => {
+    const inputs = ['Word1 Word2 Word3', ' leading', 'trailing ', 'tab\there', 'a  b   c'];
+    for (const input of inputs) {
+      expect(normalizeExportFilename(input)).not.toMatch(/\s/);
+    }
+  });
+});

--- a/client/src/utils/files.ts
+++ b/client/src/utils/files.ts
@@ -439,3 +439,12 @@ export function sortPagesByRelevance(
   }
   return [...pages].sort((a, b) => (pageRelevance[b] || 0) - (pageRelevance[a] || 0));
 }
+
+/**
+ * Collapses whitespace runs to underscores so export filenames come out
+ * identical across all export formats: `export-from-json`'s default formatter
+ * only replaces the first whitespace run, while direct downloads replace none.
+ */
+export function normalizeExportFilename(filename: string): string {
+  return filename.replace(/\s+/g, '_');
+}


### PR DESCRIPTION
## Summary

Fixes #14703

Conversation exports produced different filenames depending on the format: **txt/md/csv** go through `export-from-json`, whose default `fileNameFormatter` is `name.replace(/\s+/, '_')` — a non-global regex that replaces only the first whitespace run — while **png/json** use a direct `download()` call with the raw name. A title like `Word1 Word2 Word3` therefore exported as `Word1_Word2 Word3.txt` but `Word1 Word2 Word3.png`.

This PR adds a small `normalizeExportFilename` helper (`replace(/\s+/g, '_')`) and applies it once at each export entry point:

- `ExportModal.tsx` — feeds all five conversation export formats through `useExportConversation`, so every format now yields `Word1_Word2_Word3.ext` (the resolution direction the issue suggests). Since the normalized name contains no whitespace, the library's default formatter becomes a no-op and both worlds converge.
- `usePresets.ts` (`exportPreset`) — the preset JSON export shared the same defect (`My Cool Preset` → `My_Cool Preset.json`) and is fixed the same way.

Note on behavior: png/json filenames change from spaces to underscores for multi-word titles — that is the point of making all formats consistent, and matches the issue's expected example.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New unit tests in `client/src/utils/files.spec.ts` (5 cases): the issue's exact `Word1 Word2 Word3` case, consecutive whitespace/tabs, names without whitespace unchanged, empty string, and an invariant test asserting the output never contains whitespace — which is precisely the property that makes the library's whitespace-based default formatter a no-op, protecting the fix across future dependency bumps.
- Verified the composition empirically against the installed `export-from-json@1.7.4` and `filenamify`: after normalization, the library formatter leaves the name unchanged, so all formats produce identical filenames; `filenamify`'s character replacements compose cleanly (no whitespace is ever introduced).
- Searched all other client download sites (`downloadjs`, `link.download`) — none derive filenames from titles, so nothing else becomes inconsistent.
- `npx jest src/utils/files.spec.ts` → 5 passed; `npx tsc --noEmit` (client) and ESLint on all touched files → clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
