### PR TITLE
🧯 test: Restore MCP Startup Test Mocks

### DIFF
--- a/api/server/index.metrics.spec.js
+++ b/api/server/index.metrics.spec.js
@@ -4,6 +4,7 @@ const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
 
 jest.mock('~/server/services/Config', () => ({
+  syncStaticTools: jest.fn().mockResolvedValue(undefined),
   loadCustomConfig: jest.fn(() => Promise.resolve({})),
   getAppConfig: jest.fn().mockResolvedValue({
     paths: {

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -5,6 +5,7 @@ const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
 
 jest.mock('~/server/services/Config', () => ({
+  syncStaticTools: jest.fn().mockResolvedValue(undefined),
   mergeAppTools: jest.fn().mockResolvedValue(undefined),
   loadCustomConfig: jest.fn(() => Promise.resolve({})),
   getAppConfig: jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

I restored the Config service contract used by the server startup tests after MCP static-tool synchronization was added in #14686.

- Mock syncStaticTools in both full server startup suites.
- Prevent post-listen initialization from invoking process.exit during these tests.
- Keep runtime behavior unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the two affected Jest suites together with runInBand and detectOpenHandles: 24 tests passed.
- Ran targeted ESLint on both changed test files.
- Ran git diff --check.

### **Test Configuration**:

- macOS
- Node.js workspace dependencies from the existing LibreChat development installation
- mongodb-memory-server

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes