### PR TITLE
🪶 feat: Resolve Explicit Subagents Lazily

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -16,6 +16,7 @@ const {
   resolveModelSpecSkillIds,
   getAgentStartupTelemetry,
   buildAgentContextAttachmentsByAgentId,
+  getLazySubagentConfigId,
 } = require('@librechat/api');
 const {
   Permissions,
@@ -27,7 +28,9 @@ const {
   isAgentsEndpoint,
   getResponseSender,
   AgentCapabilities,
+  Tools,
   MAX_SUBAGENT_GRAPH_NODES,
+  MAX_SUBAGENT_RUN_CONFIGS,
   isEphemeralAgentId,
 } = require('librechat-data-provider');
 const {
@@ -275,6 +278,8 @@ const initializeClient = async ({
    * }>}
    */
   const agentToolContexts = new Map();
+  /** @type {Map<string, import('@librechat/api').EndpointTokenConfig | undefined>} */
+  const endpointTokenConfigByAgentId = new Map();
 
   const toolExecuteOptions = {
     loadTools: async (toolNames, agentId) => {
@@ -652,176 +657,19 @@ const initializeClient = async ({
   // further normalization is needed before handing this to `createRun`.
   primaryConfig.edges = edges;
 
-  // Subagents: load any explicit subagent configs. Subagents run in isolated
-  // context windows and are invoked via a dedicated spawn tool (not handoff
-  // edges). An agent that is ONLY referenced as a subagent is dropped from
-  // `agentConfigs` so the LangGraph pipeline doesn't treat it as a
-  // parallel/handoff node, but it is KEPT in `agentToolContexts` — the child's
-  // `ON_TOOL_EXECUTE` dispatches resolve tool execution context (agent,
-  // tool_resources, skill ACLs, ...) from that map, so removing it would leave
-  // action tools skipped and resource-scoped tools running without their
-  // configured resources.
+  // Subagents run in isolated context windows and are invoked via a dedicated
+  // spawn tool, not handoff edges. Explicit children are advertised as inert,
+  // VIEW-checked descriptors; model, tool, MCP, file, and skill initialization
+  // happens only when the SDK selects one.
   const subagentsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.subagents);
   /** Track skipped ids locally so repeated failures short-circuit within
    *  the subagent loading loop. Seeded from the discovery helper's skip
    *  list so agents that already failed handoff loading don't get retried. */
   const skippedAgentIds = new Set(discoveredSkippedIds ?? []);
 
-  /** All agent ids referenced on any edge (source OR target). Used by
-   *  `loadSubagentsFor` to decide whether an agent that's only a subagent
-   *  can be safely dropped from `agentConfigs` — LangGraph doesn't treat
-   *  pure subagents as parallel/handoff nodes. */
-  const edgeAgentIds = new Set([primaryConfig.id]);
-  for (const edge of edges ?? []) {
-    const sources = Array.isArray(edge.from) ? edge.from : [edge.from];
-    const targets = Array.isArray(edge.to) ? edge.to : [edge.to];
-    for (const id of sources) {
-      if (typeof id === 'string') edgeAgentIds.add(id);
-    }
-    for (const id of targets) {
-      if (typeof id === 'string') edgeAgentIds.add(id);
-    }
-  }
-
-  /** Lazy per-id agent loader used for subagents that weren't reachable
-   *  via the handoff edge graph (so `discoverConnectedAgents` didn't
-   *  initialize them). Mirrors the helper's internal `processAgent`:
-   *  DB lookup + VIEW check + `initializeAgent`, then inserts into
-   *  `agentConfigs` and `agentToolContexts`. Returns `null` on any
-   *  failure so the caller can skip gracefully. */
-  const loadAgentById = async (agentId) => {
-    if (skippedAgentIds.has(agentId)) return null;
-    const existing = agentConfigs.get(agentId);
-    if (existing) return existing;
-
-    try {
-      const agent = await db.getAgent({ id: agentId });
-      if (!agent) {
-        skippedAgentIds.add(agentId);
-        return null;
-      }
-      const userId = req.user?.id;
-      if (!userId) {
-        skippedAgentIds.add(agentId);
-        return null;
-      }
-      const hasAccess = await checkPermission({
-        userId,
-        role: req.user?.role,
-        resourceType: ResourceType.AGENT,
-        resourceId: agent._id,
-        requiredPermission: PermissionBits.VIEW,
-      });
-      if (!hasAccess) {
-        logger.warn(
-          `[processAgent] User ${userId} lacks VIEW access to subagent ${agentId}, skipping`,
-        );
-        skippedAgentIds.add(agentId);
-        return null;
-      }
-      const validation = await validateAgentModel({
-        req,
-        res,
-        agent,
-        modelsConfig,
-        logViolation,
-      });
-      if (!validation.isValid) {
-        logger.warn(
-          `[processAgent] Subagent ${agentId} failed model validation: ${validation.error?.message}`,
-        );
-        skippedAgentIds.add(agentId);
-        return null;
-      }
-      const scopedSkillIds = resolveAgentScopedSkillIds({
-        agent,
-        accessibleSkillIds,
-        skillsCapabilityEnabled,
-        ephemeralSkillsToggle,
-      });
-      const scopedEditableSkillIds = resolveAgentScopedSkillIds({
-        agent,
-        accessibleSkillIds: editableSkillIds,
-        skillsCapabilityEnabled,
-        ephemeralSkillsToggle,
-      });
-      const config = await initializeAgent(
-        {
-          req,
-          res,
-          agent,
-          loadTools,
-          requestFiles,
-          conversationId,
-          parentMessageId,
-          endpointOption: { ...endpointOption, endpoint: EModelEndpoint.agents },
-          allowedProviders,
-          accessibleSkillIds: scopedSkillIds,
-          skillAuthoringAvailable: canAuthorSkillFiles({
-            agent,
-            scopedEditableSkillIds,
-            skillCreateAllowed,
-            skillsCapabilityEnabled,
-            ephemeralSkillsToggle,
-          }),
-          /** Match the primary / handoff / addedConvo paths: forward the
-           *  endpoint-level admin flag so `initializeAgent` can compute the
-           *  per-agent narrowing (admin AND agent.tools includes
-           *  execute_code) into `InitializedAgent.codeEnvAvailable`. Without
-           *  this, a code-enabled subagent loaded only through
-           *  `subagentAgentConfigs` initializes with `codeEnvAvailable:
-           *  false`, so `bash_tool` / `read_file` sandbox fallback are
-           *  silently gated off even though the seed walk found it. */
-          codeEnvAvailable,
-          /* Background tool calls are intentionally NOT enabled for pure
-           * subagents (spawn-tool child graphs): their tools don't reach the
-           * host ON_TOOL_EXECUTE background interceptor, so injecting the
-           * schema would advertise a poll tool the host can't honor. Backgrounding
-           * subagent work is the durable follow-up. */
-          statefulSessionsAvailable,
-          memoryAvailable,
-          skillStates,
-          defaultActiveOnShare,
-        },
-        {
-          getFiles: db.getFiles,
-          getUserKey: db.getUserKey,
-          getMessages: db.getMessages,
-          getConvoFiles: db.getConvoFiles,
-          getAccessibleMcpServerNames,
-          updateFilesUsage: db.updateFilesUsage,
-          getUserKeyValues: db.getUserKeyValues,
-          getUserCodeFiles: db.getUserCodeFiles,
-          getToolFilesByIds: db.getToolFilesByIds,
-          getCodeGeneratedFiles: db.getCodeGeneratedFiles,
-          filterFilesByAgentAccess,
-          listSkillsByAccess: skillDbMethods.listSkillsByAccess,
-          listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
-          getSkillByName: skillDbMethods.getSkillByName,
-        },
-      );
-      agentConfigs.set(agentId, config);
-      agentToolContexts.set(agentId, buildAgentToolContext({ agent, config }));
-      return config;
-    } catch (err) {
-      if (isFatalAgentInitializationError(err)) {
-        throw err;
-      }
-      logger.error(`[processAgent] Error processing subagent ${agentId}:`, err);
-      skippedAgentIds.add(agentId);
-      return null;
-    }
-  };
-
-  /** Collected during resolution; applied to `agentConfigs` only after
-   *  every config has had its subagents resolved. Eager pruning would
-   *  hide pure-subagent ids from the subsequent `loadSubagentsFor`
-   *  loop, which would leave *their* `subagentAgentConfigs` empty and
-   *  silently break nested delegation like A → B → C where B is only
-   *  a subagent of A. */
-  const pureSubagentIds = new Set();
+  const lazyMetadataByAgentId = new Map();
   const subagentGraphIds = new Set();
-  const loadedSubagentConfigIds = new Set();
+  const expandedSubagentDescriptorState = { configCount: 0, rootAgentIds: [] };
 
   const assertSubagentGraphRoom = (agentId) => {
     if (subagentGraphIds.has(agentId)) {
@@ -840,127 +688,278 @@ const initializeClient = async ({
     }
   };
 
-  /**
-   * Loads `subagentAgentConfigs` for a single agent config. Shared
-   * between the primary agent and handoff-target agents (and pure
-   * subagents, transitively) so an agent used via handoff or
-   * nested-subagent that has its own explicit `subagents.agent_ids`
-   * gets them honored at runtime. Self-spawn works regardless (no DB
-   * lookup needed). Pruning decisions are deferred to `pureSubagentIds`.
-   */
-  const loadSubagentsFor = async (config, depth = 0) => {
-    const sub = config.subagents;
-    if (!subagentsCapabilityEnabled || !sub?.enabled) {
-      config.subagentAgentConfigs = [];
+  const countExpandedSubagentDescriptor = (agentId) => {
+    expandedSubagentDescriptorState.configCount += 1;
+    if (expandedSubagentDescriptorState.configCount <= MAX_SUBAGENT_RUN_CONFIGS) {
       return;
     }
+    logger.warn('[initializeClient] Subagent run configuration limit exceeded', {
+      agentId,
+      expandedConfigCount: expandedSubagentDescriptorState.configCount,
+      maxSubagentRunConfigs: MAX_SUBAGENT_RUN_CONFIGS,
+      rootAgentIds: expandedSubagentDescriptorState.rootAgentIds,
+    });
+    throw new Error(
+      `Subagent run configuration exceeds the maximum of ${MAX_SUBAGENT_RUN_CONFIGS} expanded entries.`,
+    );
+  };
 
-    if (loadedSubagentConfigIds.has(config.id)) {
-      if ((config.subagentAgentConfigs?.length ?? 0) > 0 && depth >= MAX_SUBAGENT_DEPTH) {
-        logger.warn('[initializeClient] Subagent graph depth limit exceeded', {
-          agentId: config.id,
-          primaryAgentId: primaryConfig.id,
-          depth,
-          maxSubagentDepth: MAX_SUBAGENT_DEPTH,
-          childCount: config.subagentAgentConfigs.length,
-        });
-        throw new Error(
-          `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${config.id}.`,
-        );
-      }
-      return;
+  const userId = req.user?.id;
+  const userRole = req.user?.role;
+
+  const throwIfAborted = (abortSignal) => {
+    if (!abortSignal?.aborted) return;
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error('Subagent resolution was aborted.');
+  };
+
+  const hasSubagentViewAccess = async (agent, agentId, abortSignal) => {
+    throwIfAborted(abortSignal);
+    if (!userId) return false;
+    const hasAccess = await checkPermission({
+      userId,
+      role: userRole,
+      resourceType: ResourceType.AGENT,
+      resourceId: agent._id,
+      requiredPermission: PermissionBits.VIEW,
+    });
+    throwIfAborted(abortSignal);
+    if (!hasAccess) {
+      logger.warn(
+        `[processAgent] User ${userId} lacks VIEW access to subagent ${agentId}, skipping`,
+      );
     }
+    return hasAccess;
+  };
 
-    /** Dedupe and filter in one pass — a crafted payload could
-     *  legitimately include the same ID twice; the backend shouldn't
-     *  create duplicate SubagentConfig entries for the LLM to see as
-     *  separate spawn targets. */
-    const explicitSubagentIds = Array.from(
+  const getIncludeReasoningHistory = (agent) => {
+    const customEndpoints = appConfig?.endpoints?.[EModelEndpoint.custom];
+    if (!Array.isArray(customEndpoints) || !agent.provider) return undefined;
+    const provider = agent.provider.toLowerCase();
+    return customEndpoints.find((endpoint) => endpoint.name?.toLowerCase() === provider)
+      ?.customParams?.includeReasoningHistory;
+  };
+
+  const getExplicitSubagentIds = (agent) =>
+    Array.from(
       new Set(
-        Array.isArray(sub.agent_ids)
-          ? sub.agent_ids.filter((id) => typeof id === 'string' && id && id !== config.id)
+        Array.isArray(agent.subagents?.agent_ids)
+          ? agent.subagents.agent_ids.filter(
+              (id) => typeof id === 'string' && id && id !== agent.id,
+            )
           : [],
       ),
     );
 
-    if (explicitSubagentIds.length > 0 && depth >= MAX_SUBAGENT_DEPTH) {
-      logger.warn('[initializeClient] Subagent graph depth limit exceeded', {
-        agentId: config.id,
-        primaryAgentId: primaryConfig.id,
-        depth,
-        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
-        childCount: explicitSubagentIds.length,
-      });
-      throw new Error(
-        `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${config.id}.`,
-      );
+  const toLazySubagentMetadata = (agent) => ({
+    id: agent.id,
+    name: agent.name,
+    description: agent.description,
+    provider: agent.provider,
+    model: agent.model,
+    model_parameters: { model: agent.model_parameters?.model },
+    recursion_limit: agent.recursion_limit,
+    subagents: agent.subagents,
+    configId: getLazySubagentConfigId(agent),
+    codeEnvAvailable:
+      codeEnvAvailable === true && agent.tools?.includes(Tools.execute_code) === true,
+    statefulCodeSessions:
+      statefulSessionsAvailable === true &&
+      codeEnvAvailable === true &&
+      agent.stateful_code_sessions === true &&
+      agent.tools?.includes(Tools.execute_code) === true,
+    includeReasoningHistory: getIncludeReasoningHistory(agent),
+  });
+
+  const loadSubagentMetadata = async (agentId) => {
+    if (skippedAgentIds.has(agentId)) return null;
+    const cached = lazyMetadataByAgentId.get(agentId);
+    if (cached) return cached;
+    const agent = await db.getAgentWithVersionCount({ id: agentId });
+    if (!agent || !(await hasSubagentViewAccess(agent, agentId))) {
+      skippedAgentIds.add(agentId);
+      return null;
     }
-
-    loadedSubagentConfigIds.add(config.id);
-
-    /** @type {Array<Object>} */
-    const resolved = [];
-    for (const subagentId of explicitSubagentIds) {
-      if (skippedAgentIds.has(subagentId)) continue;
-
-      /** Cycle guard: a configuration like A ↔ B (B lists A as its
-       *  subagent) would otherwise trigger `loadAgentById` on the
-       *  primary — inserting a second config for the same primary id,
-       *  which downstream duplicates in the agent array. Reuse the
-       *  existing primary config when a subagent ref points back at it. */
-      if (subagentId === primaryConfig.id) {
-        resolved.push(primaryConfig);
-        continue;
-      }
-
-      assertSubagentGraphRoom(subagentId);
-      const subagentConfig = await loadAgentById(subagentId);
-      if (!subagentConfig) continue;
-
-      subagentGraphIds.add(subagentConfig.id ?? subagentId);
-      resolved.push(subagentConfig);
-
-      if (!edgeAgentIds.has(subagentId)) {
-        pureSubagentIds.add(subagentId);
-      }
-    }
-
-    config.subagentAgentConfigs = resolved;
+    const metadata = toLazySubagentMetadata(agent);
+    lazyMetadataByAgentId.set(agentId, metadata);
+    return metadata;
   };
 
-  const maxResolvedDepthByConfigId = new Map();
+  /**
+   * Resolves the selected descriptor inside the foreground request. The
+   * legacy initializer requires request/response objects for tool and MCP
+   * setup, so this intentionally remains request-scoped until AI-1597 gives
+   * child execution a durable runtime context.
+   */
+  const initializeLazySubagent = async ({ agentId, configId, context, lazyChildren }) => {
+    throwIfAborted(context.signal);
+    const agent = await db.getAgentWithVersionCount({ id: agentId });
+    throwIfAborted(context.signal);
+    if (!agent || getLazySubagentConfigId(agent) !== configId) {
+      throw new Error(`Subagent ${agentId} changed before it could be initialized.`);
+    }
+    if (!(await hasSubagentViewAccess(agent, agentId, context.signal))) {
+      throw new Error(`You no longer have access to subagent ${agentId}.`);
+    }
+    const validation = await validateAgentModel({ req, res, agent, modelsConfig, logViolation });
+    throwIfAborted(context.signal);
+    if (!validation.isValid) {
+      throw new Error(validation.error?.message ?? `Subagent ${agentId} failed model validation.`);
+    }
+    const scopedSkillIds = resolveAgentScopedSkillIds({
+      agent,
+      accessibleSkillIds,
+      skillsCapabilityEnabled,
+      ephemeralSkillsToggle,
+    });
+    const scopedEditableSkillIds = resolveAgentScopedSkillIds({
+      agent,
+      accessibleSkillIds: editableSkillIds,
+      skillsCapabilityEnabled,
+      ephemeralSkillsToggle,
+    });
+    const config = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        requestFiles,
+        conversationId,
+        parentMessageId,
+        endpointOption: { ...endpointOption, endpoint: EModelEndpoint.agents },
+        allowedProviders,
+        accessibleSkillIds: scopedSkillIds,
+        skillAuthoringAvailable: canAuthorSkillFiles({
+          agent,
+          scopedEditableSkillIds,
+          skillCreateAllowed,
+          skillsCapabilityEnabled,
+          ephemeralSkillsToggle,
+        }),
+        codeEnvAvailable,
+        statefulSessionsAvailable,
+        memoryAvailable,
+        skillStates,
+        defaultActiveOnShare,
+      },
+      {
+        getFiles: db.getFiles,
+        getUserKey: db.getUserKey,
+        getMessages: db.getMessages,
+        getConvoFiles: db.getConvoFiles,
+        getAccessibleMcpServerNames,
+        updateFilesUsage: db.updateFilesUsage,
+        getUserKeyValues: db.getUserKeyValues,
+        getUserCodeFiles: db.getUserCodeFiles,
+        getToolFilesByIds: db.getToolFilesByIds,
+        getCodeGeneratedFiles: db.getCodeGeneratedFiles,
+        filterFilesByAgentAccess,
+        listSkillsByAccess: skillDbMethods.listSkillsByAccess,
+        listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
+        getSkillByName: skillDbMethods.getSkillByName,
+      },
+    );
+    throwIfAborted(context.signal);
+    config.lazySubagentConfigs = lazyChildren;
+    agentToolContexts.set(agentId, buildAgentToolContext({ agent, config }));
+    endpointTokenConfigByAgentId.set(agentId, config.endpointTokenConfig);
+    return config;
+  };
 
-  /** BFS across subagent trees so nested chains like A → B → C get
-   *  resolved before any pruning. Agent configs are loaded once, but
-   *  overlapping roots can still be revisited at deeper path depths so
-   *  the depth guard observes the deepest reachable subagent path. */
-  const resolveSubagentTrees = async (rootConfigs) => {
-    const pending = rootConfigs.map((cfg) => ({ cfg, depth: 0 }));
-    for (let index = 0; index < pending.length; index++) {
-      const { cfg, depth } = pending[index];
-      if (!cfg?.id) continue;
-      const previousDepth = maxResolvedDepthByConfigId.get(cfg.id);
-      if (previousDepth != null && previousDepth >= depth) continue;
-      maxResolvedDepthByConfigId.set(cfg.id, depth);
-      await loadSubagentsFor(cfg, depth);
-      for (const child of cfg.subagentAgentConfigs ?? []) {
-        const childDepth = depth + 1;
-        const previousChildDepth = child?.id ? maxResolvedDepthByConfigId.get(child.id) : undefined;
-        if (child?.id && (previousChildDepth == null || previousChildDepth < childDepth)) {
-          pending.push({ cfg: child, depth: childDepth });
-        }
+  const buildLazySubagentDescriptors = async (agent, depth = 0, ancestors = new Set()) => {
+    if (!subagentsCapabilityEnabled || !agent.subagents?.enabled) {
+      return [];
+    }
+    if (agent.subagents.allowSelf !== false) {
+      countExpandedSubagentDescriptor(agent.id);
+    }
+    const subagentIds = getExplicitSubagentIds(agent);
+    if (subagentIds.length > 0 && depth >= MAX_SUBAGENT_DEPTH) {
+      throw new Error(
+        `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${agent.id}.`,
+      );
+    }
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(agent.id);
+    const descriptors = [];
+    for (const subagentId of subagentIds) {
+      if (skippedAgentIds.has(subagentId) || nextAncestors.has(subagentId)) continue;
+      if (subagentId !== primaryConfig.id) {
+        assertSubagentGraphRoom(subagentId);
       }
+      const existing =
+        subagentId === primaryConfig.id ? primaryConfig : agentConfigs.get(subagentId);
+      if (existing) {
+        countExpandedSubagentDescriptor(subagentId);
+        if (subagentId !== primaryConfig.id) {
+          subagentGraphIds.add(subagentId);
+        }
+        const existingChildren = await buildLazySubagentDescriptors(
+          existing,
+          depth + 1,
+          nextAncestors,
+        );
+        existing.lazySubagentConfigs = existingChildren.filter((child) => child.configId);
+        existing.subagentAgentConfigs = existingChildren.filter((child) => !child.configId);
+        descriptors.push(existing);
+        continue;
+      }
+      const metadata = await loadSubagentMetadata(subagentId);
+      if (!metadata) continue;
+      countExpandedSubagentDescriptor(subagentId);
+      subagentGraphIds.add(subagentId);
+      const childDescriptors = await buildLazySubagentDescriptors(
+        metadata,
+        depth + 1,
+        nextAncestors,
+      );
+      const lazyChildren = childDescriptors.filter((child) => child.configId);
+      const eagerChildren = childDescriptors.filter((child) => !child.configId);
+      descriptors.push({
+        id: metadata.id,
+        name: metadata.name,
+        description: metadata.description,
+        provider: metadata.provider,
+        model: metadata.model,
+        model_parameters: metadata.model_parameters,
+        recursion_limit: metadata.recursion_limit,
+        subagents: metadata.subagents,
+        configId: metadata.configId,
+        codeEnvAvailable: metadata.codeEnvAvailable,
+        statefulCodeSessions: metadata.statefulCodeSessions,
+        includeReasoningHistory: metadata.includeReasoningHistory,
+        lazySubagentConfigs: lazyChildren,
+        subagentAgentConfigs: eagerChildren,
+        resolve: (context) =>
+          initializeLazySubagent({
+            agentId: metadata.id,
+            configId: metadata.configId,
+            context,
+            lazyChildren,
+          }).then((config) => {
+            config.subagentAgentConfigs = eagerChildren;
+            return config;
+          }),
+      });
+    }
+    return descriptors;
+  };
+
+  const resolveSubagentTrees = async (rootConfigs) => {
+    expandedSubagentDescriptorState.rootAgentIds = rootConfigs
+      .filter((config) => config?.id)
+      .map((config) => config.id);
+    for (const config of rootConfigs) {
+      if (!config?.id) continue;
+      const descriptors = await buildLazySubagentDescriptors(config);
+      config.lazySubagentConfigs = descriptors.filter((child) => child.configId);
+      config.subagentAgentConfigs = descriptors.filter((child) => !child.configId);
     }
   };
 
   await resolveSubagentTrees([primaryConfig, ...agentConfigs.values()]);
-
-  /** Drop pure-subagent entries now that every reachable config has
-   *  had its subagents resolved. They stay in `agentToolContexts` so
-   *  their tools still execute with the right scoping. */
-  for (const id of pureSubagentIds) {
-    agentConfigs.delete(id);
-  }
 
   primaryConfig.subagents = subagentsCapabilityEnabled ? primaryConfig.subagents : undefined;
 
@@ -971,9 +970,11 @@ const initializeClient = async ({
    *  otherwise still expose self-spawn at runtime even though the admin
    *  has disabled the capability globally. */
   if (!subagentsCapabilityEnabled) {
+    primaryConfig.lazySubagentConfigs = undefined;
     for (const config of agentConfigs.values()) {
       config.subagents = undefined;
       config.subagentAgentConfigs = undefined;
+      config.lazySubagentConfigs = undefined;
     }
   }
 
@@ -1031,7 +1032,6 @@ const initializeClient = async ({
    *  known non-custom agent (built-in pricing) from an untagged/unknown one
    *  (primary fallback).
    *  @type {Map<string, import('@librechat/api').EndpointTokenConfig | undefined>} */
-  const endpointTokenConfigByAgentId = new Map();
   for (const [agentId, ctx] of agentToolContexts) {
     endpointTokenConfigByAgentId.set(agentId, ctx?.endpointTokenConfig);
   }

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -877,6 +877,12 @@ const initializeClient = async ({
     }
     const subagentIds = getExplicitSubagentIds(agent);
     if (subagentIds.length > 0 && depth >= MAX_SUBAGENT_DEPTH) {
+      logger.warn('[initializeClient] Subagent graph depth limit exceeded', {
+        agentId: agent.id,
+        primaryAgentId: primaryConfig.id,
+        depth,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+      });
       throw new Error(
         `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${agent.id}.`,
       );

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -10,6 +10,7 @@ const {
   extractManualSkills,
   GenerationJobManager,
   getCustomEndpointConfig,
+  getProviderConfig,
   discoverConnectedAgents,
   resolveAgentTokenConfig,
   resolveAgentScopedSkillIds,
@@ -714,16 +715,40 @@ const initializeClient = async ({
       : new Error('Subagent resolution was aborted.');
   };
 
+  const waitForAbort = (promise, abortSignal) => {
+    throwIfAborted(abortSignal);
+    if (!abortSignal) return promise;
+    return new Promise((resolve, reject) => {
+      const onAbort = () => {
+        reject(
+          abortSignal.reason instanceof Error
+            ? abortSignal.reason
+            : new Error('Subagent resolution was aborted.'),
+        );
+      };
+      abortSignal.addEventListener('abort', onAbort, { once: true });
+      if (abortSignal.aborted) {
+        onAbort();
+      }
+      promise.then(resolve, reject).finally(() => {
+        abortSignal.removeEventListener('abort', onAbort);
+      });
+    });
+  };
+
   const hasSubagentViewAccess = async (agent, agentId, abortSignal) => {
     throwIfAborted(abortSignal);
     if (!userId) return false;
-    const hasAccess = await checkPermission({
-      userId,
-      role: userRole,
-      resourceType: ResourceType.AGENT,
-      resourceId: agent._id,
-      requiredPermission: PermissionBits.VIEW,
-    });
+    const hasAccess = await waitForAbort(
+      checkPermission({
+        userId,
+        role: userRole,
+        resourceType: ResourceType.AGENT,
+        resourceId: agent._id,
+        requiredPermission: PermissionBits.VIEW,
+      }),
+      abortSignal,
+    );
     throwIfAborted(abortSignal);
     if (!hasAccess) {
       logger.warn(
@@ -734,11 +759,13 @@ const initializeClient = async ({
   };
 
   const getIncludeReasoningHistory = (agent) => {
-    const customEndpoints = appConfig?.endpoints?.[EModelEndpoint.custom];
-    if (!Array.isArray(customEndpoints) || !agent.provider) return undefined;
-    const provider = agent.provider.toLowerCase();
-    return customEndpoints.find((endpoint) => endpoint.name?.toLowerCase() === provider)
-      ?.customParams?.includeReasoningHistory;
+    if (!agent.provider) return undefined;
+    try {
+      return getProviderConfig({ provider: agent.provider, appConfig }).customEndpointConfig
+        ?.customParams?.includeReasoningHistory;
+    } catch {
+      return undefined;
+    }
   };
 
   const getExplicitSubagentIds = (agent) =>
@@ -776,14 +803,23 @@ const initializeClient = async ({
     if (skippedAgentIds.has(agentId)) return null;
     const cached = lazyMetadataByAgentId.get(agentId);
     if (cached) return cached;
-    const agent = await db.getAgentWithVersionCount({ id: agentId });
-    if (!agent || !(await hasSubagentViewAccess(agent, agentId))) {
+    try {
+      const agent = await db.getAgentWithVersionCount({ id: agentId });
+      if (!agent || !(await hasSubagentViewAccess(agent, agentId))) {
+        skippedAgentIds.add(agentId);
+        return null;
+      }
+      const metadata = toLazySubagentMetadata(agent);
+      lazyMetadataByAgentId.set(agentId, metadata);
+      return metadata;
+    } catch (error) {
+      if (isFatalAgentInitializationError(error)) {
+        throw error;
+      }
+      logger.error(`[initializeClient] Error loading subagent metadata ${agentId}:`, error);
       skippedAgentIds.add(agentId);
       return null;
     }
-    const metadata = toLazySubagentMetadata(agent);
-    lazyMetadataByAgentId.set(agentId, metadata);
-    return metadata;
   };
 
   /**
@@ -794,7 +830,7 @@ const initializeClient = async ({
    */
   const initializeLazySubagent = async ({ agentId, configId, context, lazyChildren }) => {
     throwIfAborted(context.signal);
-    const agent = await db.getAgentWithVersionCount({ id: agentId });
+    const agent = await waitForAbort(db.getAgentWithVersionCount({ id: agentId }), context.signal);
     throwIfAborted(context.signal);
     if (!agent || getLazySubagentConfigId(agent) !== configId) {
       throw new Error(`Subagent ${agentId} changed before it could be initialized.`);
@@ -802,7 +838,10 @@ const initializeClient = async ({
     if (!(await hasSubagentViewAccess(agent, agentId, context.signal))) {
       throw new Error(`You no longer have access to subagent ${agentId}.`);
     }
-    const validation = await validateAgentModel({ req, res, agent, modelsConfig, logViolation });
+    const validation = await waitForAbort(
+      validateAgentModel({ req, res, agent, modelsConfig, logViolation }),
+      context.signal,
+    );
     throwIfAborted(context.signal);
     if (!validation.isValid) {
       throw new Error(validation.error?.message ?? `Subagent ${agentId} failed model validation.`);
@@ -819,47 +858,50 @@ const initializeClient = async ({
       skillsCapabilityEnabled,
       ephemeralSkillsToggle,
     });
-    const config = await initializeAgent(
-      {
-        req,
-        res,
-        agent,
-        loadTools,
-        requestFiles,
-        conversationId,
-        parentMessageId,
-        endpointOption: { ...endpointOption, endpoint: EModelEndpoint.agents },
-        allowedProviders,
-        accessibleSkillIds: scopedSkillIds,
-        skillAuthoringAvailable: canAuthorSkillFiles({
+    const config = await waitForAbort(
+      initializeAgent(
+        {
+          req,
+          res,
           agent,
-          scopedEditableSkillIds,
-          skillCreateAllowed,
-          skillsCapabilityEnabled,
-          ephemeralSkillsToggle,
-        }),
-        codeEnvAvailable,
-        statefulSessionsAvailable,
-        memoryAvailable,
-        skillStates,
-        defaultActiveOnShare,
-      },
-      {
-        getFiles: db.getFiles,
-        getUserKey: db.getUserKey,
-        getMessages: db.getMessages,
-        getConvoFiles: db.getConvoFiles,
-        getAccessibleMcpServerNames,
-        updateFilesUsage: db.updateFilesUsage,
-        getUserKeyValues: db.getUserKeyValues,
-        getUserCodeFiles: db.getUserCodeFiles,
-        getToolFilesByIds: db.getToolFilesByIds,
-        getCodeGeneratedFiles: db.getCodeGeneratedFiles,
-        filterFilesByAgentAccess,
-        listSkillsByAccess: skillDbMethods.listSkillsByAccess,
-        listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
-        getSkillByName: skillDbMethods.getSkillByName,
-      },
+          loadTools: createToolLoader(context.signal, streamId, true, jobCreatedAt),
+          requestFiles,
+          conversationId,
+          parentMessageId,
+          endpointOption: { ...endpointOption, endpoint: EModelEndpoint.agents },
+          allowedProviders,
+          accessibleSkillIds: scopedSkillIds,
+          skillAuthoringAvailable: canAuthorSkillFiles({
+            agent,
+            scopedEditableSkillIds,
+            skillCreateAllowed,
+            skillsCapabilityEnabled,
+            ephemeralSkillsToggle,
+          }),
+          codeEnvAvailable,
+          statefulSessionsAvailable,
+          memoryAvailable,
+          skillStates,
+          defaultActiveOnShare,
+        },
+        {
+          getFiles: db.getFiles,
+          getUserKey: db.getUserKey,
+          getMessages: db.getMessages,
+          getConvoFiles: db.getConvoFiles,
+          getAccessibleMcpServerNames,
+          updateFilesUsage: db.updateFilesUsage,
+          getUserKeyValues: db.getUserKeyValues,
+          getUserCodeFiles: db.getUserCodeFiles,
+          getToolFilesByIds: db.getToolFilesByIds,
+          getCodeGeneratedFiles: db.getCodeGeneratedFiles,
+          filterFilesByAgentAccess,
+          listSkillsByAccess: skillDbMethods.listSkillsByAccess,
+          listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
+          getSkillByName: skillDbMethods.getSkillByName,
+        },
+      ),
+      context.signal,
     );
     throwIfAborted(context.signal);
     config.lazySubagentConfigs = lazyChildren;

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1074,12 +1074,10 @@ describe('initializeClient — subagent loading', () => {
     });
     const initialization = deferred();
     const initializationStarted = deferred();
-    mockInitializeAgent
-      .mockResolvedValueOnce(primaryConfig)
-      .mockImplementationOnce((params) => {
-        initializationStarted.resolve(params);
-        return initialization.promise;
-      });
+    mockInitializeAgent.mockResolvedValueOnce(primaryConfig).mockImplementationOnce((params) => {
+      initializationStarted.resolve(params);
+      return initialization.promise;
+    });
 
     await initializeClient({
       req: makeSubagentReq(),

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -91,6 +91,7 @@ const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { logger } = require('@librechat/data-schemas');
 const { User, AclEntry } = require('~/db/models');
 const { createAgent, createSkill, updateAgent } = require('~/models');
+const db = require('~/models');
 
 jest.spyOn(logger, 'warn').mockImplementation(() => {});
 
@@ -816,6 +817,58 @@ describe('initializeClient — subagent loading', () => {
     expect(agentClientArgs.agentConfigs.has(SUBAGENT_ID)).toBe(false);
   });
 
+  it('omits a descriptor when its metadata lookup fails without aborting the primary run', async () => {
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
+    });
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
+    jest.spyOn(db, 'getAgentWithVersionCount').mockRejectedValueOnce(new Error('transient read'));
+
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+
+    expect(agentClientArgs.agent.lazySubagentConfigs).toEqual([]);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(`Error loading subagent metadata ${SUBAGENT_ID}`),
+      expect.any(Error),
+    );
+  });
+
+  it('uses exact custom-endpoint identity for descriptor reasoning history', async () => {
+    const subAgent = await createAgent({
+      id: SUBAGENT_ID,
+      name: 'Custom Subagent',
+      provider: 'caseprovider',
+      model: 'custom-model',
+      author: new mongoose.Types.ObjectId(),
+      tools: [],
+    });
+    await grantView(subAgent);
+    mockInitializeAgent.mockResolvedValue(
+      makePrimaryConfig({
+        subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
+      }),
+    );
+    const req = makeSubagentReq();
+    req.config.endpoints.custom = [
+      { name: 'CaseProvider', customParams: { includeReasoningHistory: true } },
+      { name: 'caseprovider', customParams: { includeReasoningHistory: false } },
+    ];
+
+    await initializeClient({
+      req,
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+
+    expect(agentClientArgs.agent.lazySubagentConfigs[0].includeReasoningHistory).toBe(false);
+  });
+
   it('fails closed when a selected subagent configuration changes after advertisement', async () => {
     await createViewableAgent(SUBAGENT_ID);
     const primaryConfig = makePrimaryConfig({
@@ -1012,6 +1065,37 @@ describe('initializeClient — subagent loading', () => {
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({ signal: controller.signal }),
     ).rejects.toThrow('cancelled');
     expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects promptly when cancellation occurs during lazy initialization', async () => {
+    await createViewableAgent(SUBAGENT_ID);
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
+    });
+    const initialization = deferred();
+    mockInitializeAgent
+      .mockResolvedValueOnce(primaryConfig)
+      .mockImplementationOnce(() => initialization.promise);
+
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+    const controller = new AbortController();
+    const resolution = agentClientArgs.agent.lazySubagentConfigs[0].resolve({
+      signal: controller.signal,
+    });
+    while (mockInitializeAgent.mock.calls.length < 2) {
+      await Promise.resolve();
+    }
+    controller.abort(new Error('cancelled in flight'));
+
+    await expect(resolution).rejects.toThrow('cancelled in flight');
+    const selectedInitParams = mockInitializeAgent.mock.calls[1][0];
+    expect(selectedInitParams.loadTools).not.toBe(mockInitializeAgent.mock.calls[0][0].loadTools);
+    initialization.resolve(makeSubagentConfig(SUBAGENT_ID));
   });
 
   it('rejects nested subagent chains deeper than MAX_SUBAGENT_DEPTH', async () => {

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -90,7 +90,7 @@ const { loadAgentTools } = require('~/server/services/ToolService');
 const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { logger } = require('@librechat/data-schemas');
 const { User, AclEntry } = require('~/db/models');
-const { createAgent, createSkill } = require('~/models');
+const { createAgent, createSkill, updateAgent } = require('~/models');
 
 jest.spyOn(logger, 'warn').mockImplementation(() => {});
 
@@ -817,7 +817,7 @@ describe('initializeClient — subagent loading', () => {
   });
 
   it('fails closed when a selected subagent configuration changes after advertisement', async () => {
-    const subAgent = await createViewableAgent(SUBAGENT_ID);
+    await createViewableAgent(SUBAGENT_ID);
     const primaryConfig = makePrimaryConfig({
       subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
     });
@@ -829,7 +829,10 @@ describe('initializeClient — subagent loading', () => {
       signal: new AbortController().signal,
       endpointOption: makeEndpointOption(),
     });
-    await subAgent.updateOne({ $set: { instructions: 'Changed after descriptor creation.' } });
+    await updateAgent(
+      { id: SUBAGENT_ID },
+      { instructions: 'Changed after descriptor creation.' },
+    );
 
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1040,6 +1040,15 @@ describe('initializeClient — subagent loading', () => {
         endpointOption: makeEndpointOption(),
       }),
     ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[initializeClient] Subagent graph depth limit exceeded',
+      expect.objectContaining({
+        agentId: ids[MAX_SUBAGENT_DEPTH - 1],
+        primaryAgentId: PRIMARY_ID,
+        depth: MAX_SUBAGENT_DEPTH,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+      }),
+    );
     expect(agentClientArgs).toBeUndefined();
   });
 

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1073,9 +1073,13 @@ describe('initializeClient — subagent loading', () => {
       subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
     });
     const initialization = deferred();
+    const initializationStarted = deferred();
     mockInitializeAgent
       .mockResolvedValueOnce(primaryConfig)
-      .mockImplementationOnce(() => initialization.promise);
+      .mockImplementationOnce((params) => {
+        initializationStarted.resolve(params);
+        return initialization.promise;
+      });
 
     await initializeClient({
       req: makeSubagentReq(),
@@ -1087,14 +1091,10 @@ describe('initializeClient — subagent loading', () => {
     const resolution = agentClientArgs.agent.lazySubagentConfigs[0].resolve({
       signal: controller.signal,
     });
-    for (let attempt = 0; attempt < 20 && mockInitializeAgent.mock.calls.length < 2; attempt++) {
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-    expect(mockInitializeAgent).toHaveBeenCalledTimes(2);
+    const selectedInitParams = await initializationStarted.promise;
     controller.abort(new Error('cancelled in flight'));
 
     await expect(resolution).rejects.toThrow('cancelled in flight');
-    const selectedInitParams = mockInitializeAgent.mock.calls[1][0];
     expect(selectedInitParams.loadTools).not.toBe(mockInitializeAgent.mock.calls[0][0].loadTools);
     initialization.resolve(makeSubagentConfig(SUBAGENT_ID));
   });

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -829,10 +829,7 @@ describe('initializeClient — subagent loading', () => {
       signal: new AbortController().signal,
       endpointOption: makeEndpointOption(),
     });
-    await updateAgent(
-      { id: SUBAGENT_ID },
-      { instructions: 'Changed after descriptor creation.' },
-    );
+    await updateAgent({ id: SUBAGENT_ID }, { instructions: 'Changed after descriptor creation.' });
 
     await expect(
       agentClientArgs.agent.lazySubagentConfigs[0].resolve({

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1087,9 +1087,10 @@ describe('initializeClient — subagent loading', () => {
     const resolution = agentClientArgs.agent.lazySubagentConfigs[0].resolve({
       signal: controller.signal,
     });
-    while (mockInitializeAgent.mock.calls.length < 2) {
-      await Promise.resolve();
+    for (let attempt = 0; attempt < 20 && mockInitializeAgent.mock.calls.length < 2; attempt++) {
+      await new Promise((resolve) => setImmediate(resolve));
     }
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(2);
     controller.abort(new Error('cancelled in flight'));
 
     await expect(resolution).rejects.toThrow('cancelled in flight');

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -6,6 +6,7 @@ const {
   PrincipalModel,
   MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_GRAPH_NODES,
+  MAX_SUBAGENT_RUN_CONFIGS,
   Constants,
   ErrorTypes,
 } = require('librechat-data-provider');
@@ -656,7 +657,7 @@ describe('initializeClient — subagent loading', () => {
     subagents: { enabled: true, allowSelf: false, agent_ids: childIds },
   });
 
-  const createViewableAgent = async (id) => {
+  const createViewableAgent = async (id, subagents) => {
     const agent = await createAgent({
       id,
       name: id,
@@ -664,12 +665,13 @@ describe('initializeClient — subagent loading', () => {
       model: 'gpt-4',
       author: new mongoose.Types.ObjectId(),
       tools: [],
+      subagents,
     });
     await grantView(agent);
     return agent;
   };
 
-  it('aborts the run when a pure subagent resolves none of its expected MCP tools', async () => {
+  it('defers pure-subagent MCP initialization until the descriptor is selected', async () => {
     const subAgent = await createAgent({
       id: SUBAGENT_ID,
       name: 'Data Subagent',
@@ -702,17 +704,22 @@ describe('initializeClient — subagent loading', () => {
         });
       });
 
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
     await expect(
-      initializeClient({
-        req: makeSubagentReq(),
-        res: {},
+      agentClientArgs.agent.lazySubagentConfigs[0].resolve({
         signal: new AbortController().signal,
-        endpointOption: makeEndpointOption(),
       }),
     ).rejects.toBe(toolError);
   });
 
-  it('aborts the run when a pure subagent requires CodeAPI resource recovery', async () => {
+  it('defers pure-subagent resource recovery until the descriptor is selected', async () => {
     const subAgent = await createAgent({
       id: SUBAGENT_ID,
       name: 'Code Subagent',
@@ -736,17 +743,21 @@ describe('initializeClient — subagent loading', () => {
       )
       .mockRejectedValueOnce(resourceRecoveryError);
 
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+
     await expect(
-      initializeClient({
-        req: makeSubagentReq(),
-        res: {},
+      agentClientArgs.agent.lazySubagentConfigs[0].resolve({
         signal: new AbortController().signal,
-        endpointOption: makeEndpointOption(),
       }),
     ).rejects.toBe(resourceRecoveryError);
   });
 
-  it('loads a configured subagent, populates `subagentAgentConfigs`, and keeps it out of `agentConfigs`', async () => {
+  it('advertises a configured subagent without initializing it, then initializes it on selection', async () => {
     const subAgent = await createAgent({
       id: SUBAGENT_ID,
       name: 'Explicit Subagent',
@@ -780,21 +791,75 @@ describe('initializeClient — subagent loading', () => {
       endpointOption: makeEndpointOption(),
     });
 
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+    expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(1);
+    expect(agentClientArgs.agent.lazySubagentConfigs[0]).toEqual(
+      expect.objectContaining({ id: SUBAGENT_ID, configId: expect.any(String) }),
+    );
+    expect(agentClientArgs.agent.lazySubagentConfigs[0]).not.toHaveProperty('tools');
+    expect(agentClientArgs.agent.lazySubagentConfigs[0]).not.toHaveProperty('tool_resources');
+    expect(agentClientArgs.agent.lazySubagentConfigs[0]).not.toHaveProperty('_id');
+
+    await agentClientArgs.agent.lazySubagentConfigs[0].resolve({
+      signal: new AbortController().signal,
+    });
+
     expect(mockInitializeAgent).toHaveBeenCalledTimes(2);
     const subagentDbDeps = mockInitializeAgent.mock.calls[1][1];
     expect(subagentDbDeps.getConvoFiles).toBeInstanceOf(Function);
     expect(subagentDbDeps.db).toBeUndefined();
     expect(subagentConvoFileIds).toEqual([]);
 
-    /** The subagent's AgentConfig is attached to the primary for run.ts to
-     *  turn into `SubagentConfig[]` on the parent's `AgentInputs`. */
-    expect(agentClientArgs.agent.subagentAgentConfigs).toHaveLength(1);
-    expect(agentClientArgs.agent.subagentAgentConfigs[0].id).toBe(SUBAGENT_ID);
-
     /** Subagent-only agents must NOT appear in `agentConfigs` — otherwise the
      *  graph would treat them as a parallel/handoff node. */
     expect(agentClientArgs.agentConfigs).toBeDefined();
     expect(agentClientArgs.agentConfigs.has(SUBAGENT_ID)).toBe(false);
+  });
+
+  it('fails closed when a selected subagent configuration changes after advertisement', async () => {
+    const subAgent = await createViewableAgent(SUBAGENT_ID);
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
+    });
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
+
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+    await subAgent.updateOne({ $set: { instructions: 'Changed after descriptor creation.' } });
+
+    await expect(
+      agentClientArgs.agent.lazySubagentConfigs[0].resolve({
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(`Subagent ${SUBAGENT_ID} changed`);
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('rechecks VIEW permission when a descriptor is selected', async () => {
+    const subAgent = await createViewableAgent(SUBAGENT_ID);
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
+    });
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
+
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+    await AclEntry.deleteMany({ resourceId: subAgent._id });
+
+    await expect(
+      agentClientArgs.agent.lazySubagentConfigs[0].resolve({
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow(`no longer have access to subagent ${SUBAGENT_ID}`);
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
   });
 
   it('preserves subagent tool context for ON_TOOL_EXECUTE (Codex P1 regression guard)', async () => {
@@ -831,6 +896,9 @@ describe('initializeClient — subagent loading', () => {
       endpointOption: makeEndpointOption(),
     });
 
+    await agentClientArgs.agent.lazySubagentConfigs[0].resolve({
+      signal: new AbortController().signal,
+    });
     expect(capturedToolExecuteOptions?.loadTools).toBeInstanceOf(Function);
 
     /** Invoke the real closure with the subagent's id. If `agentToolContexts`
@@ -910,13 +978,7 @@ describe('initializeClient — subagent loading', () => {
         agent_ids: [DUPLICATE_SUBAGENT_ID, DUPLICATE_SUBAGENT_ID, DUPLICATE_SUBAGENT_ID],
       },
     });
-    const subagentConfig = makeSubagentConfig(DUPLICATE_SUBAGENT_ID);
-
-    let initCalls = 0;
-    mockInitializeAgent.mockImplementation(() => {
-      initCalls += 1;
-      return Promise.resolve(initCalls === 1 ? primaryConfig : subagentConfig);
-    });
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
 
     await initializeClient({
       req: makeSubagentReq(),
@@ -925,9 +987,31 @@ describe('initializeClient — subagent loading', () => {
       endpointOption: makeEndpointOption(),
     });
 
-    /** One call for primary, one for the subagent — not four. */
-    expect(mockInitializeAgent).toHaveBeenCalledTimes(2);
-    expect(agentClientArgs.agent.subagentAgentConfigs).toHaveLength(1);
+    /** Repeated ids produce one lightweight descriptor and no eager child initialization. */
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+    expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(1);
+  });
+
+  it('does not initialize a descriptor after its SDK cancellation signal aborts', async () => {
+    await createViewableAgent(SUBAGENT_ID);
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: [SUBAGENT_ID] },
+    });
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
+
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled'));
+
+    await expect(
+      agentClientArgs.agent.lazySubagentConfigs[0].resolve({ signal: controller.signal }),
+    ).rejects.toThrow('cancelled');
+    expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
   });
 
   it('rejects nested subagent chains deeper than MAX_SUBAGENT_DEPTH', async () => {
@@ -935,23 +1019,18 @@ describe('initializeClient — subagent loading', () => {
       { length: MAX_SUBAGENT_DEPTH + 1 },
       (_, index) => `agent_depth_${index}`,
     );
-    for (const id of ids) {
-      await createViewableAgent(id);
+    for (const [index, id] of ids.entries()) {
+      await createViewableAgent(id, {
+        enabled: true,
+        allowSelf: false,
+        agent_ids: index < ids.length - 1 ? [ids[index + 1]] : [],
+      });
     }
 
     const primaryConfig = makePrimaryConfig({
       subagents: { enabled: true, allowSelf: false, agent_ids: [ids[0]] },
     });
-    const nestedConfigs = new Map(
-      ids.map((id, index) => [
-        id,
-        makeNestedSubagentConfig(id, index < ids.length - 1 ? [ids[index + 1]] : []),
-      ]),
-    );
-
-    mockInitializeAgent.mockImplementation(({ agent }) =>
-      Promise.resolve(agent.id === PRIMARY_ID ? primaryConfig : nestedConfigs.get(agent.id)),
-    );
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
 
     await expect(
       initializeClient({
@@ -961,16 +1040,6 @@ describe('initializeClient — subagent loading', () => {
         endpointOption: makeEndpointOption(),
       }),
     ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
-    expect(logger.warn).toHaveBeenCalledWith(
-      '[initializeClient] Subagent graph depth limit exceeded',
-      expect.objectContaining({
-        agentId: `agent_depth_${MAX_SUBAGENT_DEPTH - 1}`,
-        primaryAgentId: PRIMARY_ID,
-        depth: MAX_SUBAGENT_DEPTH,
-        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
-        childCount: 1,
-      }),
-    );
     expect(agentClientArgs).toBeUndefined();
   });
 
@@ -979,9 +1048,17 @@ describe('initializeClient — subagent loading', () => {
       { length: MAX_SUBAGENT_DEPTH },
       (_, index) => `agent_overlap_depth_${index}`,
     );
-    const allIds = [HANDOFF_AND_SUB_ID, ...chainIds];
-    for (const id of allIds) {
-      await createViewableAgent(id);
+    await createViewableAgent(HANDOFF_AND_SUB_ID, {
+      enabled: true,
+      allowSelf: false,
+      agent_ids: [chainIds[0]],
+    });
+    for (const [index, id] of chainIds.entries()) {
+      await createViewableAgent(id, {
+        enabled: true,
+        allowSelf: false,
+        agent_ids: index < chainIds.length - 1 ? [chainIds[index + 1]] : [],
+      });
     }
 
     const edges = [{ from: PRIMARY_ID, to: HANDOFF_AND_SUB_ID, edgeType: 'handoff' }];
@@ -989,16 +1066,9 @@ describe('initializeClient — subagent loading', () => {
       edges,
       subagents: { enabled: true, allowSelf: false, agent_ids: [HANDOFF_AND_SUB_ID] },
     });
-    const nestedConfigs = new Map([
-      [HANDOFF_AND_SUB_ID, makeNestedSubagentConfig(HANDOFF_AND_SUB_ID, [chainIds[0]])],
-      ...chainIds.map((id, index) => [
-        id,
-        makeNestedSubagentConfig(id, index < chainIds.length - 1 ? [chainIds[index + 1]] : []),
-      ]),
-    ]);
-
+    const sharedConfig = makeNestedSubagentConfig(HANDOFF_AND_SUB_ID, [chainIds[0]]);
     mockInitializeAgent.mockImplementation(({ agent }) =>
-      Promise.resolve(agent.id === PRIMARY_ID ? primaryConfig : nestedConfigs.get(agent.id)),
+      Promise.resolve(agent.id === PRIMARY_ID ? primaryConfig : sharedConfig),
     );
 
     await expect(
@@ -1009,15 +1079,6 @@ describe('initializeClient — subagent loading', () => {
         endpointOption: makeEndpointOption(),
       }),
     ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
-    expect(logger.warn).toHaveBeenCalledWith(
-      '[initializeClient] Subagent graph depth limit exceeded',
-      expect.objectContaining({
-        primaryAgentId: PRIMARY_ID,
-        depth: MAX_SUBAGENT_DEPTH,
-        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
-        childCount: 1,
-      }),
-    );
     expect(agentClientArgs).toBeUndefined();
   });
 
@@ -1029,25 +1090,21 @@ describe('initializeClient — subagent loading', () => {
         Array.from({ length: 5 }, (_, index) => `${id}_child_${index}`),
       ]),
     );
-    const allIds = [...firstLevelIds, ...Array.from(secondLevelIdsByParent.values()).flat()];
-
-    for (const id of allIds) {
-      await createViewableAgent(id);
+    for (const id of firstLevelIds) {
+      await createViewableAgent(id, {
+        enabled: true,
+        allowSelf: false,
+        agent_ids: secondLevelIdsByParent.get(id),
+      });
+    }
+    for (const id of Array.from(secondLevelIdsByParent.values()).flat()) {
+      await createViewableAgent(id, { enabled: true, allowSelf: false, agent_ids: [] });
     }
 
     const primaryConfig = makePrimaryConfig({
       subagents: { enabled: true, allowSelf: false, agent_ids: firstLevelIds },
     });
-    const nestedConfigs = new Map(
-      firstLevelIds.map((id) => [id, makeNestedSubagentConfig(id, secondLevelIdsByParent.get(id))]),
-    );
-    for (const id of Array.from(secondLevelIdsByParent.values()).flat()) {
-      nestedConfigs.set(id, makeNestedSubagentConfig(id));
-    }
-
-    mockInitializeAgent.mockImplementation(({ agent }) =>
-      Promise.resolve(agent.id === PRIMARY_ID ? primaryConfig : nestedConfigs.get(agent.id)),
-    );
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
 
     await expect(
       initializeClient({
@@ -1063,6 +1120,42 @@ describe('initializeClient — subagent loading', () => {
         primaryAgentId: PRIMARY_ID,
         loadedSubagentCount: MAX_SUBAGENT_GRAPH_NODES,
         maxSubagentGraphNodes: MAX_SUBAGENT_GRAPH_NODES,
+      }),
+    );
+    expect(agentClientArgs).toBeUndefined();
+  });
+
+  it('rejects a branching DAG that exceeds expanded descriptor capacity', async () => {
+    const width = 3;
+    const layers = Array.from({ length: MAX_SUBAGENT_DEPTH }, (_, level) =>
+      Array.from({ length: width }, (_, index) => `agent_descriptor_${level}_${index}`),
+    );
+    for (let level = 0; level < layers.length; level++) {
+      const childIds = level < layers.length - 1 ? layers[level + 1] : [];
+      for (const id of layers[level]) {
+        await createViewableAgent(id, { enabled: true, allowSelf: false, agent_ids: childIds });
+      }
+    }
+
+    const primaryConfig = makePrimaryConfig({
+      subagents: { enabled: true, allowSelf: false, agent_ids: layers[0] },
+    });
+    mockInitializeAgent.mockResolvedValue(primaryConfig);
+
+    await expect(
+      initializeClient({
+        req: makeSubagentReq(),
+        res: {},
+        signal: new AbortController().signal,
+        endpointOption: makeEndpointOption(),
+      }),
+    ).rejects.toThrow(`maximum of ${MAX_SUBAGENT_RUN_CONFIGS} expanded entries`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[initializeClient] Subagent run configuration limit exceeded',
+      expect.objectContaining({
+        expandedConfigCount: MAX_SUBAGENT_RUN_CONFIGS + 1,
+        maxSubagentRunConfigs: MAX_SUBAGENT_RUN_CONFIGS,
+        rootAgentIds: [PRIMARY_ID],
       }),
     );
     expect(agentClientArgs).toBeUndefined();

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1046,6 +1046,88 @@ describe('subagentConfigs', () => {
     expect(configs[0].self).toBeUndefined();
   });
 
+  it('adds explicit lazy subagent descriptors without eager agent inputs', async () => {
+    const resolve = jest
+      .fn()
+      .mockResolvedValue(
+        makeAgent({ id: 'agent_child', name: 'Researcher', description: 'Deep web research' }),
+      );
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_child'] },
+          lazySubagentConfigs: [
+            {
+              id: 'agent_child',
+              name: 'Researcher',
+              description: 'Deep web research',
+              configId: 'agent_child:3:fingerprint',
+              resolve,
+            },
+          ],
+        }),
+      ],
+    });
+    const configs = agents[0].subagentConfigs as Array<Record<string, unknown>>;
+    expect(configs).toHaveLength(1);
+    expect(configs[0]).toMatchObject({
+      type: 'agent_child',
+      configId: 'agent_child:3:fingerprint',
+      allowNested: true,
+    });
+    expect(configs[0].agentInputs).toBeUndefined();
+    expect(configs[0].resolveAgentInputs).toBeInstanceOf(Function);
+    expect(resolve).not.toHaveBeenCalled();
+
+    const childInputs = await (
+      configs[0].resolveAgentInputs as (context: never) => Promise<{
+        name?: string;
+      }>
+    )({ signal: new AbortController().signal } as never);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(childInputs.name).toBe('Researcher');
+  });
+
+  it('uses a fresh expansion budget for each lazy descriptor resolution', async () => {
+    const nestedDescriptors = Array.from({ length: 99 }, (_, index) => ({
+      id: `agent_nested_${index}`,
+      name: `Nested ${index}`,
+      description: 'Nested lazy child',
+      configId: `agent_nested_${index}:1:fingerprint`,
+      resolve: jest.fn(),
+    }));
+    const resolve = jest.fn().mockResolvedValue(
+      makeAgent({
+        id: 'agent_child',
+        subagents: { enabled: true, allowSelf: false },
+        lazySubagentConfigs: nestedDescriptors,
+      }),
+    );
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_child'] },
+          lazySubagentConfigs: [
+            {
+              id: 'agent_child',
+              name: 'Child',
+              description: 'Lazy child',
+              configId: 'agent_child:1:fingerprint',
+              resolve,
+            },
+          ],
+        }),
+      ],
+    });
+    const resolveAgentInputs = (agents[0].subagentConfigs as Array<Record<string, unknown>>)[0]
+      .resolveAgentInputs as (context: never) => Promise<unknown>;
+    const context = { signal: new AbortController().signal } as never;
+
+    await expect(resolveAgentInputs(context)).resolves.toBeDefined();
+    await expect(resolveAgentInputs(context)).resolves.toBeDefined();
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
   it('preserves explicit nested subagents across the SDK child graph boundary', async () => {
     const grandchild = makeAgent({ id: 'agent_grandchild', name: 'Grandchild' });
     const child = makeAgent({

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -15,6 +15,7 @@ export * from './handlers';
 export * from './harvest';
 export * from './initialize';
 export * from './legacy';
+export * from './lazySubagents';
 export * from './memory';
 export * from './orphans';
 export * from './migration';

--- a/packages/api/src/agents/lazySubagents.spec.ts
+++ b/packages/api/src/agents/lazySubagents.spec.ts
@@ -1,0 +1,62 @@
+import { getLazySubagentConfigId } from './lazySubagents';
+
+const agent = {
+  id: 'child-agent',
+  name: 'Child',
+  description: 'Delegated work',
+  provider: 'openAI',
+  model: 'gpt-5',
+  model_parameters: {
+    temperature: 0,
+    maxContextTokens: 128000,
+    max_context_tokens: null,
+    max_output_tokens: null,
+    top_p: null,
+    frequency_penalty: null,
+    presence_penalty: null,
+  },
+  version: 4,
+};
+
+describe('getLazySubagentConfigId', () => {
+  it('changes when initializer-relevant config changes', () => {
+    const original = getLazySubagentConfigId(agent);
+    const changed = getLazySubagentConfigId({
+      ...agent,
+      instructions: 'Use concise answers.',
+    });
+
+    expect(changed).not.toBe(original);
+  });
+
+  it('changes when model-advertised identity changes', () => {
+    expect(getLazySubagentConfigId({ ...agent, name: 'Renamed child' })).not.toBe(
+      getLazySubagentConfigId(agent),
+    );
+  });
+
+  it('is stable across key order and excludes secret values', () => {
+    const first = getLazySubagentConfigId({
+      ...agent,
+      tool_kwargs: { retry: 2, access_token: 'first-secret' },
+    });
+    const second = getLazySubagentConfigId({
+      ...agent,
+      tool_kwargs: { access_token: 'second-secret', retry: 2 },
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it('includes token-budget settings in the descriptor identity', () => {
+    expect(getLazySubagentConfigId({ ...agent, tool_kwargs: { max_tokens: 1024 } })).not.toBe(
+      getLazySubagentConfigId({ ...agent, tool_kwargs: { max_tokens: 2048 } }),
+    );
+  });
+
+  it('includes the persisted version in the descriptor identity', () => {
+    expect(getLazySubagentConfigId({ ...agent, version: 5 })).not.toBe(
+      getLazySubagentConfigId(agent),
+    );
+  });
+});

--- a/packages/api/src/agents/lazySubagents.ts
+++ b/packages/api/src/agents/lazySubagents.ts
@@ -1,0 +1,138 @@
+import { createHash } from 'crypto';
+import type { Agent } from 'librechat-data-provider';
+
+type VersionedAgent = Pick<
+  Agent,
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'instructions'
+  | 'additional_instructions'
+  | 'endpoint'
+  | 'provider'
+  | 'model'
+  | 'model_parameters'
+  | 'tools'
+  | 'tool_kwargs'
+  | 'tool_options'
+  | 'tool_resources'
+  | 'skills'
+  | 'skills_enabled'
+  | 'stateful_code_sessions'
+  | 'artifacts'
+  | 'recursion_limit'
+  | 'agent_ids'
+  | 'edges'
+  | 'end_after_tools'
+  | 'hide_sequential_outputs'
+  | 'subagents'
+  | 'memory_scope'
+> & {
+  version?: number;
+  actions?: string[];
+  mcpServerNames?: string[];
+};
+
+const sensitiveKeyPattern =
+  /(?:^|[_-])(?:api[_-]?key|authorization|credentials?|password|secret|(?:access|refresh|id|auth)?[_-]?token)(?:$|[_-])/i;
+
+function isSensitiveKey(key: string): boolean {
+  return sensitiveKeyPattern.test(key);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  if (typeof value !== 'object') {
+    return 'null';
+  }
+
+  const entries = Object.entries(value)
+    .filter(([key, entry]) => !isSensitiveKey(key) && entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalize(entry)}`).join(',')}}`;
+}
+
+/**
+ * Returns only persisted fields that can change the initialized child graph.
+ * `name` and `description` are intentionally included because they are
+ * advertised to the parent model; request state, ACL-only display fields, and
+ * secret values are excluded.
+ */
+export function selectLazySubagentConfig(agent: VersionedAgent): Omit<VersionedAgent, 'version'> {
+  const {
+    id,
+    name,
+    description,
+    instructions,
+    additional_instructions,
+    endpoint,
+    provider,
+    model,
+    model_parameters,
+    tools,
+    tool_kwargs,
+    tool_options,
+    tool_resources,
+    skills,
+    skills_enabled,
+    stateful_code_sessions,
+    artifacts,
+    recursion_limit,
+    agent_ids,
+    edges,
+    end_after_tools,
+    hide_sequential_outputs,
+    subagents,
+    memory_scope,
+    actions,
+    mcpServerNames,
+  } = agent;
+  return {
+    id,
+    name,
+    description,
+    instructions,
+    additional_instructions,
+    endpoint,
+    provider,
+    model,
+    model_parameters,
+    tools,
+    tool_kwargs,
+    tool_options,
+    tool_resources,
+    skills,
+    skills_enabled,
+    stateful_code_sessions,
+    artifacts,
+    recursion_limit,
+    agent_ids,
+    edges,
+    end_after_tools,
+    hide_sequential_outputs,
+    subagents,
+    memory_scope,
+    actions,
+    mcpServerNames,
+  };
+}
+
+/** Deterministic descriptor identity for a persisted lazy subagent. */
+export function getLazySubagentConfigId(agent: VersionedAgent): string {
+  const version = Number.isInteger(agent.version) && agent.version >= 0 ? agent.version : 0;
+  const fingerprint = createHash('sha256')
+    .update(canonicalize(selectLazySubagentConfig(agent)))
+    .digest('hex');
+  return `${agent.id}:${version}:${fingerprint}`;
+}

--- a/packages/api/src/agents/lazySubagents.ts
+++ b/packages/api/src/agents/lazySubagents.ts
@@ -130,7 +130,10 @@ export function selectLazySubagentConfig(agent: VersionedAgent): Omit<VersionedA
 
 /** Deterministic descriptor identity for a persisted lazy subagent. */
 export function getLazySubagentConfigId(agent: VersionedAgent): string {
-  const version = Number.isInteger(agent.version) && agent.version >= 0 ? agent.version : 0;
+  const version =
+    agent.version != null && Number.isInteger(agent.version) && agent.version >= 0
+      ? agent.version
+      : 0;
   const fingerprint = createHash('sha256')
     .update(canonicalize(selectLazySubagentConfig(agent)))
     .digest('hex');

--- a/packages/api/src/agents/run.spec.ts
+++ b/packages/api/src/agents/run.spec.ts
@@ -381,6 +381,13 @@ describe('anyAgentReplaysReasoningContent', () => {
     expect(anyAgentReplaysReasoningContent([primary])).toBe(true);
   });
 
+  it('returns true when an inert lazy descriptor opts in', () => {
+    const primary = plainAgent('root', {
+      lazySubagentConfigs: [plainAgent('lazy-child', { includeReasoningHistory: true })],
+    });
+    expect(anyAgentReplaysReasoningContent([primary])).toBe(true);
+  });
+
   it('returns false when no reachable agent opts in', () => {
     const primary = plainAgent('root', {
       subagentAgentConfigs: [plainAgent('child')],

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -18,6 +18,7 @@ import type {
   StreamPreemption,
   LCToolRegistry,
   SubagentConfig,
+  SubagentResolveContext,
   HookCallback,
   AgentInputs,
   GenericTool,
@@ -397,8 +398,33 @@ type RunAgent = Omit<Agent, 'tools'> & {
   maxToolResultChars?: number;
   /** Initialized subagent configs (loaded by initialize.js from agent.subagents.agent_ids). */
   subagentAgentConfigs?: RunAgent[];
+  /**
+   * Inert, VIEW-checked descriptors for explicit children that are initialized
+   * only after the SDK selects them. These resolvers are request-scoped: they
+   * may use the active request's authorization and tool-loading context.
+   */
+  lazySubagentConfigs?: LazySubagentAgent[];
   /** Source subagent spawning configuration (enabled / allowSelf / agent_ids). */
   subagents?: AgentSubagentsConfig;
+};
+
+type LazySubagentAgent = Pick<
+  RunAgent,
+  | 'id'
+  | 'name'
+  | 'description'
+  | 'provider'
+  | 'model'
+  | 'model_parameters'
+  | 'recursion_limit'
+  | 'subagents'
+  | 'codeEnvAvailable'
+  | 'statefulCodeSessions'
+  | 'includeReasoningHistory'
+> & {
+  configId: string;
+  lazySubagentConfigs?: LazySubagentAgent[];
+  resolve: (context: SubagentResolveContext) => Promise<RunAgent>;
 };
 
 function isNonEmptyString(value: unknown): value is string {
@@ -743,6 +769,80 @@ function assertSubagentDepth(depth: number, agentId: string): void {
   }
 }
 
+function buildIsolatedSubagentInputs(
+  child: RunAgent,
+  toInput: (child: RunAgent, opts?: { isSubagent?: boolean }) => AgentInputs,
+): AgentInputs {
+  const childInputs = toInput(child, { isSubagent: true });
+  if ((child.backgroundToolNames?.length ?? 0) > 0) {
+    childInputs.toolDefinitions = stripBackgroundFromToolDefinitions(
+      childInputs.toolDefinitions,
+      child.backgroundToolNames,
+    );
+    childInputs.toolRegistry = stripBackgroundFromToolRegistry(
+      childInputs.toolRegistry,
+      child.backgroundToolNames,
+    );
+  }
+  if ((child.intentToolNames?.length ?? 0) > 0) {
+    childInputs.toolDefinitions = stripIntentFromToolDefinitions(
+      childInputs.toolDefinitions,
+      child.intentToolNames,
+    );
+    childInputs.toolRegistry = stripIntentFromToolRegistry(
+      childInputs.toolRegistry,
+      child.intentToolNames,
+    );
+  }
+  return childInputs;
+}
+
+function createLazySubagentConfig(
+  child: LazySubagentAgent,
+  toInput: (child: RunAgent, opts?: { isSubagent?: boolean }) => AgentInputs,
+  agentsEConfig: Partial<TAgentsEndpoint> | undefined,
+  ancestors: Set<string>,
+  depth: number,
+): SubagentConfig {
+  return {
+    type: child.id,
+    name: child.name ?? child.id,
+    description:
+      child.description ??
+      `Delegate a subtask to the ${child.name ?? child.id} agent in an isolated context.`,
+    configId: child.configId,
+    allowNested: true,
+    maxTurns: resolveSubagentMaxTurns(agentsEConfig, child),
+    resolveAgentInputs: async (context) => {
+      if (context.signal.aborted) {
+        throw context.signal.reason ?? new Error('Subagent resolution was aborted.');
+      }
+      const resolvedChild = await child.resolve(context);
+      if (context.signal.aborted) {
+        throw context.signal.reason ?? new Error('Subagent resolution was aborted.');
+      }
+      const childInputs = buildIsolatedSubagentInputs(resolvedChild, toInput);
+      const resolutionState: SubagentBuildState = {
+        configCount: 1,
+        rootAgentIds: [resolvedChild.id],
+      };
+      const grandchildConfigs = buildSubagentConfigs(
+        resolvedChild,
+        childInputs,
+        toInput,
+        resolutionState,
+        agentsEConfig,
+        ancestors,
+        depth,
+      );
+      if (grandchildConfigs.length > 0) {
+        childInputs.subagentConfigs = grandchildConfigs;
+      }
+      return childInputs;
+    },
+  };
+}
+
 /**
  * Recursive any-true check across the agent tree: returns `true` if this
  * agent or any subagent (transitively) has the per-agent codeenv gate
@@ -776,6 +876,11 @@ function anyAgentHasCodeEnv(agents: RunAgent[]): boolean {
     for (const child of agent.subagentAgentConfigs ?? []) {
       if (!visited.has(child.id)) {
         pending.push(child);
+      }
+    }
+    for (const child of agent.lazySubagentConfigs ?? []) {
+      if (!visited.has(child.id)) {
+        pending.push(child as RunAgent);
       }
     }
   }
@@ -853,6 +958,11 @@ export function anyAgentHasStatefulSessions(agents: Array<RunAgent | null | unde
         pending.push(child);
       }
     }
+    for (const child of agent.lazySubagentConfigs ?? []) {
+      if (!visited.has(child.id)) {
+        pending.push(child as RunAgent);
+      }
+    }
   }
   return false;
 }
@@ -883,14 +993,19 @@ export function anyAgentReplaysReasoningContent(
         pending.push(child);
       }
     }
+    for (const child of agent.lazySubagentConfigs ?? []) {
+      if (!visited.has(child.id)) {
+        pending.push(child as RunAgent);
+      }
+    }
   }
   return false;
 }
 
 /**
  * Builds SubagentConfig entries for an agent: optional self-spawn plus any
- * explicit child agents loaded in `agent.subagentAgentConfigs`. Returns an empty
- * array when subagents are disabled or no spawn targets are available.
+ * explicit eager children and inert lazy descriptors. Returns an empty array
+ * when subagents are disabled or no spawn targets are available.
  */
 function buildSubagentConfigs(
   agent: RunAgent,
@@ -968,50 +1083,7 @@ function buildSubagentConfigs(
     const childDepth = depth + 1;
     assertSubagentDepth(childDepth, child.id);
     countSubagentConfig(state);
-    /**
-     * `buildAgentInput` applies parent-run context (initialSummary +
-     * discoveredTools) to the returned AgentInputs *and* to the
-     * passed-in agent's `toolRegistry` / `toolDefinitions` — flipping
-     * `defer_loading: true → false` on tools the parent had previously
-     * searched for, and injecting those tools' definitions into the
-     * child's `toolDefinitions`. Clearing fields on the returned
-     * object post-hoc would leave those side-effects in place, leaking
-     * the parent's tool-search state into an "isolated" subagent and
-     * inflating the child's prompt/token budget. The `isSubagent` flag
-     * skips both the field stamping and the registry mutation at the
-     * source so children truly start fresh.
-     */
-    const childInputs = toInput(child, { isSubagent: true });
-    /**
-     * A child reachable as a top-level/handoff agent is initialized WITH the
-     * background capability, then reused here as a subagent. Isolated child
-     * graphs run subagent tools without the host background dispatch/poll
-     * behavior, so strip the injected `run_in_background` param + the
-     * `check_background_task` def (defs AND registry) so the child doesn't
-     * advertise a background contract it can't honor. Mirrors the self-spawn path.
-     */
-    if ((child.backgroundToolNames?.length ?? 0) > 0) {
-      childInputs.toolDefinitions = stripBackgroundFromToolDefinitions(
-        childInputs.toolDefinitions,
-        child.backgroundToolNames,
-      );
-      childInputs.toolRegistry = stripBackgroundFromToolRegistry(
-        childInputs.toolRegistry,
-        child.backgroundToolNames,
-      );
-    }
-    /** Same sanitization for the host-injected `intent` param (see the
-     *  self-spawn path above). */
-    if ((child.intentToolNames?.length ?? 0) > 0) {
-      childInputs.toolDefinitions = stripIntentFromToolDefinitions(
-        childInputs.toolDefinitions,
-        child.intentToolNames,
-      );
-      childInputs.toolRegistry = stripIntentFromToolRegistry(
-        childInputs.toolRegistry,
-        child.intentToolNames,
-      );
-    }
+    const childInputs = buildIsolatedSubagentInputs(child, toInput);
     /**
      * Recursively resolve the child's own spawn targets so multi-level
      * delegation (A → B → C) works. Without this, a child whose own
@@ -1044,6 +1116,18 @@ function buildSubagentConfigs(
       /** Honor each child agent's own resolved recursion limit. */
       maxTurns: resolveSubagentMaxTurns(agentsEConfig, child),
     });
+  }
+
+  for (const child of agent.lazySubagentConfigs ?? []) {
+    if (!child.id || child.id === agent.id || ancestors.has(child.id)) {
+      continue;
+    }
+    const childDepth = depth + 1;
+    assertSubagentDepth(childDepth, child.id);
+    countSubagentConfig(state);
+    configs.push(
+      createLazySubagentConfig(child, toInput, agentsEConfig, nextAncestors, childDepth),
+    );
   }
 
   return configs;

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -423,8 +423,23 @@ type LazySubagentAgent = Pick<
   | 'includeReasoningHistory'
 > & {
   configId: string;
+  subagentAgentConfigs?: RunAgent[];
   lazySubagentConfigs?: LazySubagentAgent[];
   resolve: (context: SubagentResolveContext) => Promise<RunAgent>;
+};
+
+type SubagentTreeNode = Pick<
+  RunAgent,
+  | 'id'
+  | 'provider'
+  | 'model'
+  | 'model_parameters'
+  | 'codeEnvAvailable'
+  | 'statefulCodeSessions'
+  | 'includeReasoningHistory'
+> & {
+  subagentAgentConfigs?: SubagentTreeNode[];
+  lazySubagentConfigs?: SubagentTreeNode[];
 };
 
 function isNonEmptyString(value: unknown): value is string {
@@ -862,7 +877,7 @@ function createLazySubagentConfig(
  */
 function anyAgentHasCodeEnv(agents: RunAgent[]): boolean {
   const visited = new Set<string>();
-  const pending = [...agents];
+  const pending: SubagentTreeNode[] = [...agents];
 
   for (let index = 0; index < pending.length; index++) {
     const agent = pending[index];
@@ -880,7 +895,7 @@ function anyAgentHasCodeEnv(agents: RunAgent[]): boolean {
     }
     for (const child of agent.lazySubagentConfigs ?? []) {
       if (!visited.has(child.id)) {
-        pending.push(child as RunAgent);
+        pending.push(child);
       }
     }
   }
@@ -942,7 +957,7 @@ function isAskUserQuestionAdminDisabled(appConfig?: AppConfig): boolean {
  */
 export function anyAgentHasStatefulSessions(agents: Array<RunAgent | null | undefined>): boolean {
   const visited = new Set<string>();
-  const pending = [...agents];
+  const pending: Array<SubagentTreeNode | null | undefined> = [...agents];
 
   for (let index = 0; index < pending.length; index++) {
     const agent = pending[index];
@@ -960,7 +975,7 @@ export function anyAgentHasStatefulSessions(agents: Array<RunAgent | null | unde
     }
     for (const child of agent.lazySubagentConfigs ?? []) {
       if (!visited.has(child.id)) {
-        pending.push(child as RunAgent);
+        pending.push(child);
       }
     }
   }
@@ -977,7 +992,7 @@ export function anyAgentReplaysReasoningContent(
   agents: Array<RunAgent | null | undefined>,
 ): boolean {
   const visited = new Set<string>();
-  const pending = [...agents];
+  const pending: Array<SubagentTreeNode | null | undefined> = [...agents];
 
   for (let index = 0; index < pending.length; index++) {
     const agent = pending[index];
@@ -995,7 +1010,7 @@ export function anyAgentReplaysReasoningContent(
     }
     for (const child of agent.lazySubagentConfigs ?? []) {
       if (!visited.has(child.id)) {
-        pending.push(child as RunAgent);
+        pending.push(child);
       }
     }
   }

--- a/packages/api/src/agents/statefulCodeSessions.spec.ts
+++ b/packages/api/src/agents/statefulCodeSessions.spec.ts
@@ -6,6 +6,7 @@ interface TestAgent {
   id: string;
   statefulCodeSessions?: boolean;
   subagentAgentConfigs?: Array<TestAgent | null>;
+  lazySubagentConfigs?: Array<TestAgent | null>;
 }
 
 function agent(
@@ -36,6 +37,10 @@ describe('anyAgentHasStatefulSessions', () => {
     const grandchild = agent('c', true);
     const child = agent('b', false, [grandchild]);
     expect(walk([agent('a', false, [child])])).toBe(true);
+  });
+
+  it('includes inert lazy descriptors when deciding whether to prewarm', () => {
+    expect(walk([{ id: 'a', lazySubagentConfigs: [agent('lazy-child', true)] }])).toBe(true);
   });
 
   it('tolerates null entries and cycles in the subagent graph', () => {

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -2096,6 +2096,16 @@ describe('resolveAgentTokenConfig', () => {
     );
   });
 
+  it('observes a selected lazy subagent added after the resolver is created', () => {
+    const byAgentId = new Map([['primary', primary]]);
+    const resolveForUsage = (agentId: string) =>
+      resolveAgentTokenConfig({ agentId, byAgentId, fallback: primary });
+
+    byAgentId.set('lazy-subagent', subagent);
+
+    expect(resolveForUsage('lazy-subagent')).toBe(subagent);
+  });
+
   it('returns undefined for a known agent with no configured rates (built-in pricing)', () => {
     /** A known non-custom agent (e.g. a normal OpenAI agent) is recorded with an
      *  undefined config; it must NOT inherit the custom-primary rates. */


### PR DESCRIPTION
## Summary

I changed explicit single-agent subagents to advertise lightweight, authorization-checked descriptors and defer their expensive runtime initialization until the SDK selects them. This implements [AI-1714](https://linear.app/clickhouse/issue/AI-1714/resolve-explicit-subagent-inputs-lazily-at-invocation) against the lazy resolver contract in `@librechat/agents` 3.4.3.

- Resolve model validation, tools, MCP servers, files, skills, and isolated agent inputs only for the selected child.
- Recheck VIEW permission and a deterministic versioned configuration fingerprint at invocation, failing closed if access or configuration changed.
- Preserve nested descriptor discovery, cycle/depth/node/expanded-entry limits, handoff overlap behavior, cancellation, reasoning replay, code-environment flags, stateful-session prewarming, and late usage pricing.
- Keep descriptor metadata inert and narrowly retained while the foreground resolver remains request-scoped pending AI-1597.
- Add regressions for unused descriptors, repeated resolution, nested expansion budgets, configuration identity, cancellation, capability traversal, and live pricing-map mutation.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran scoped ESLint across all changed JavaScript and TypeScript files with zero warnings or errors.
- Ran `node --check api/server/services/Endpoints/agents/initialize.js`.
- Ran `git diff --check`.
- Ran the lazy fingerprint suite: 5/5 passing.
- Ran the focused run/subagent summarization suite: 115/115 passing.
- Ran the released SDK lazy-resolver path against OpenAI `gpt-4.1-mini` and Anthropic `claude-haiku-4-5`: both selected resolvers ran exactly once, unused sibling resolvers stayed cold, expected output returned, and positive child usage was emitted.
- Deferred the broad matrix to CI as requested; additional borrowed-worktree suites encounter pre-existing local dependency/API skew before test execution.

### **Test Configuration**:

- macOS
- Node.js local development runtime
- `@librechat/agents` 3.4.3
- Live credentials loaded from the main worktree without printing secret values

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas where the lifecycle is non-obvious
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Any changes dependent on mine have been merged and published in downstream modules
