### PR TITLE
fix(client): restore preset prompt insertion on mobile

### DIFF
--- a/client/src/hooks/Input/useTextarea.spec.ts
+++ b/client/src/hooks/Input/useTextarea.spec.ts
@@ -1,0 +1,125 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import { renderHook } from '@testing-library/react';
+import { useChatFormContext } from '~/Providers';
+import useTextarea from './useTextarea';
+
+const mockSetActivePrompt = jest.fn();
+const mockSetValue = jest.fn();
+const mockInsertTextAtCursor = jest.fn();
+
+jest.mock('recoil', () => ({
+  useRecoilValue: jest.fn(() => true),
+  useRecoilState: jest.fn(() => ['selected prompt', mockSetActivePrompt]),
+}));
+
+jest.mock('@librechat/client', () => ({
+  useToastContext: () => ({ showToast: jest.fn() }),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  EToolResources: { context: 'context' },
+  isAssistantsEndpoint: jest.fn(() => false),
+}));
+
+jest.mock('~/utils', () => ({
+  forceResize: jest.fn(),
+  insertTextAtCursor: (...args: [HTMLTextAreaElement, string]) => mockInsertTextAtCursor(...args),
+  getEntityName: jest.fn(() => ''),
+  getEntity: jest.fn(() => ({ entity: null, isAgent: false, isAssistant: false })),
+  checkIfScrollable: jest.fn(() => false),
+}));
+
+jest.mock('~/utils/shortcuts', () => ({
+  resolveComposerKeyDown: jest.fn(() => 'none'),
+}));
+
+jest.mock('~/Providers', () => ({
+  useChatFormContext: jest.fn(() => ({ setValue: mockSetValue })),
+  useUploadModalContext: jest.fn(() => ({ openModal: jest.fn() })),
+}));
+
+jest.mock('~/Providers/AssistantsMapContext', () => ({
+  useAssistantsMapContext: jest.fn(() => ({})),
+}));
+
+jest.mock('~/Providers/AgentsMapContext', () => ({
+  useAgentsMapContext: jest.fn(() => ({})),
+}));
+
+jest.mock('~/Providers/ChatContext', () => ({
+  useChatContext: jest.fn(() => ({
+    index: 0,
+    conversation: { endpoint: 'openAI' },
+    isSubmitting: false,
+    setFilesLoading: jest.fn(),
+  })),
+}));
+
+jest.mock('~/hooks/Messages/useLatestMessage', () => ({
+  useLatestMessageMeta: jest.fn(() => null),
+}));
+
+jest.mock('~/hooks/Input/useComposerBindings', () =>
+  jest.fn(() => ({ submitOverride: null, yieldedChords: [] })),
+);
+
+jest.mock('~/hooks/Files/useFileUploadRouter', () => jest.fn(() => jest.fn()));
+jest.mock('~/hooks/Files/useUploadOptions', () =>
+  jest.fn(() => ({ getOptions: jest.fn(() => []), uploadsDisabled: false })),
+);
+jest.mock('~/hooks/Conversations/useGetSender', () => jest.fn(() => jest.fn(() => '')));
+
+jest.mock('~/data-provider', () => ({
+  useInteractionHealthCheck: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: jest.fn(() => (key: string) => key),
+}));
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: {
+    enterToSend: 'enterToSend',
+    activePromptByIndex: jest.fn(() => 'activePromptByIndex'),
+  },
+}));
+
+const mockUseRecoilState = useRecoilState as jest.Mock;
+const mockUseChatFormContext = useChatFormContext as jest.Mock;
+
+describe('useTextarea prompt insertion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRecoilState.mockReturnValue(['selected prompt', mockSetActivePrompt]);
+    mockUseChatFormContext.mockReturnValue({ setValue: mockSetValue });
+  });
+
+  it('inserts a prompt into form state without requiring DOM focus', () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'draft text';
+    textarea.setSelectionRange(6, 10);
+    mockSetValue.mockImplementation((_name, value) => {
+      textarea.value = value;
+    });
+    const textAreaRef = { current: textarea } as React.RefObject<HTMLTextAreaElement>;
+
+    renderHook(() =>
+      useTextarea({
+        textAreaRef,
+        submitButtonRef: { current: null },
+        setIsScrollable: jest.fn(),
+      }),
+    );
+
+    expect(mockInsertTextAtCursor).not.toHaveBeenCalled();
+    expect(mockSetValue).toHaveBeenCalledWith('text', 'draft selected prompt', {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    expect(textarea.selectionStart).toBe(21);
+    expect(textarea.selectionEnd).toBe(21);
+    expect(mockSetActivePrompt).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -22,7 +22,7 @@ import useUploadOptions from '~/hooks/Files/useUploadOptions';
 import { useInteractionHealthCheck } from '~/data-provider';
 import { resolveComposerKeyDown } from '~/utils/shortcuts';
 import { useChatContext } from '~/Providers/ChatContext';
-import { useUploadModalContext } from '~/Providers';
+import { useChatFormContext, useUploadModalContext } from '~/Providers';
 import { globalAudioId } from '~/common';
 import { useLocalize } from '~/hooks';
 import store from '~/store';
@@ -51,6 +51,7 @@ export default function useTextarea({
 }) {
   const localize = useLocalize();
   const getSender = useGetSender();
+  const { setValue } = useChatFormContext();
   const isComposing = useRef(false);
   const agentsMap = useAgentsMapContext();
   const { showToast } = useToastContext();
@@ -82,12 +83,19 @@ export default function useTextarea({
 
   useEffect(() => {
     const prompt = activePrompt ?? '';
-    if (prompt && textAreaRef.current) {
-      insertTextAtCursor(textAreaRef.current, prompt);
-      forceResize(textAreaRef.current);
-      setActivePrompt(undefined);
+    const textarea = textAreaRef.current;
+    if (!prompt || !textarea) {
+      return;
     }
-  }, [activePrompt, setActivePrompt, textAreaRef]);
+
+    const { value, selectionStart, selectionEnd } = textarea;
+    const nextValue = `${value.slice(0, selectionStart)}${prompt}${value.slice(selectionEnd)}`;
+    const nextCursor = selectionStart + prompt.length;
+    setValue('text', nextValue, { shouldDirty: true, shouldValidate: true });
+    textarea.setSelectionRange(nextCursor, nextCursor);
+    forceResize(textarea);
+    setActivePrompt(undefined);
+  }, [activePrompt, setActivePrompt, setValue, textAreaRef]);
 
   useEffect(() => {
     const currentValue = textAreaRef.current?.value ?? '';


### PR DESCRIPTION
## Summary

Fixes #14620.

On mobile, selecting a preset prompt with **Send prompts on select** disabled left the composer unchanged. The insertion path relied on a DOM editing helper, which did not synchronize the selected text with the chat form state in the affected flow.

This change:

- writes the selected prompt directly through the chat form state;
- inserts it at the textarea's current selection and places the cursor after the new text;
- keeps textarea resizing and active-prompt cleanup behavior;
- adds a regression test proving that prompt insertion no longer depends on the DOM editing helper.

Users can now tap any preset prompt on mobile and have it appear in the composer for editing or manual submission.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd client && npm run test:ci -- src/hooks/Input/useTextarea.spec.ts` — passed (1 suite, 1 test).
- `npx eslint client/src/hooks/Input/useTextarea.ts client/src/hooks/Input/useTextarea.spec.ts` — passed.
- `npm --prefix client run typecheck` — currently blocked by existing generated package/export mismatches on `dev`; none of the diagnostics reference the two files changed by this PR.

### **Test Configuration**:

- Node.js v24.13.1
- Jest with jsdom via the client `test:ci` script

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
