### PR TITLE
🧬 fix: Normalize Legacy MCP Null Headers

### DIFF
--- a/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
@@ -7,6 +7,7 @@ import {
   PermissionBits,
   PrincipalModel,
   TokenExchangeMethodEnum,
+  MCPOptionsSchema,
 } from 'librechat-data-provider';
 import type { ParsedServerConfig } from '~/mcp/types';
 
@@ -1033,6 +1034,35 @@ describe('ServerConfigsDB', () => {
   });
 
   describe('get()', () => {
+    it('normalizes null headers from historical stored configs before runtime use', async () => {
+      const server = await mongoose.models.MCPServer.create({
+        serverName: 'legacy-null-headers',
+        normalizedServerName: 'legacy-null-headers',
+        author: new mongoose.Types.ObjectId(userId),
+        config: {
+          type: 'streamable-http',
+          url: 'https://example.com/mcp',
+          title: 'Legacy Null Headers',
+          headers: null,
+        },
+      });
+      await mongoose.models.AclEntry.create({
+        principalType: PrincipalType.USER,
+        principalModel: PrincipalModel.USER,
+        principalId: new mongoose.Types.ObjectId(userId),
+        resourceType: ResourceType.MCPSERVER,
+        resourceId: server._id,
+        permBits: PermissionBits.VIEW,
+        grantedBy: new mongoose.Types.ObjectId(userId),
+      });
+
+      const result = await serverConfigsDB.get('legacy-null-headers', userId);
+
+      expect(result).toBeDefined();
+      expect(result).not.toHaveProperty('headers');
+      expect(MCPOptionsSchema.safeParse(result).success).toBe(true);
+    });
+
     describe('public access (no userId)', () => {
       it('should return undefined for non-public server without userId', async () => {
         const config = createSSEConfig('Private Server');

--- a/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
@@ -6,8 +6,8 @@ import {
   PrincipalType,
   PermissionBits,
   PrincipalModel,
-  TokenExchangeMethodEnum,
   MCPOptionsSchema,
+  TokenExchangeMethodEnum,
 } from 'librechat-data-provider';
 import type { ParsedServerConfig } from '~/mcp/types';
 

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -95,6 +95,19 @@ function sanitizeUserManagedOAuthConfig(config: ParsedServerConfig): ParsedServe
   };
 }
 
+/** Normalizes legacy values that predate the current runtime config schemas. */
+function normalizePersistedConfig(config: ParsedServerConfig): ParsedServerConfig {
+  const persistedConfig = config as ParsedServerConfig & {
+    headers?: Record<string, string> | null;
+  };
+  if (persistedConfig.headers !== null) {
+    return config;
+  }
+
+  const { headers: _legacyNullHeaders, ...normalizedConfig } = persistedConfig;
+  return normalizedConfig as ParsedServerConfig;
+}
+
 function normalizeOAuthUrl(value?: string): string | undefined {
   if (!value) {
     return value;
@@ -577,7 +590,9 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
       updatedAt: serverDBDoc.updatedAt?.getTime(),
       ...(authorId ? { author: authorId } : {}),
     };
-    return sanitizeUserManagedOAuthConfig(await this.decryptConfig(config));
+    return sanitizeUserManagedOAuthConfig(
+      await this.decryptConfig(normalizePersistedConfig(config)),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

I restored compatibility for historical database-backed MCP server records that stored `headers: null`, preventing publication-generation validation from breaking server startup and tool loading after the tools-list change work.

- Normalize legacy null headers when MongoDB records cross the persisted-config seam.
- Preserve strict MCP transport schemas for newly authored YAML and API configurations.
- Cover the real MongoDB repository read path with a historical streamable HTTP record.
- Verify the normalized result satisfies the production `MCPOptionsSchema`.
- Apply the same deterministic normalization in every pod before in-process registry caching.

Fixes #14718

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `ServerConfigsDB.test.ts`: 82 tests passed.
- Ran `toolsChanged.spec.ts`: 14 tests passed.
- Ran ESLint and Prettier checks on both changed files.
- Ran `git diff --check`.

### **Test Configuration**:

- macOS
- Node.js with the existing LibreChat workspace dependencies
- `mongodb-memory-server` for the persisted historical record

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
