### PR TITLE
🪆 feat: Add Parent Activity Phase Summaries

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1268,11 +1268,11 @@ class BaseClient {
     const lastIndex = existingContent.length - 1;
     const lastExisting = existingContent[lastIndex];
     const firstNew = newCompletion[0];
+    /** Phased and legacy/unphased text are distinct semantic streams. Merging
+     *  either direction would stamp retained text with the wrong phase. */
     const textPhaseCompatible =
       editedType !== ContentTypes.TEXT ||
-      lastExisting?.phase == null ||
-      firstNew?.phase == null ||
-      lastExisting.phase === firstNew.phase;
+      (lastExisting?.phase ?? null) === (firstNew?.phase ?? null);
     const mergesFirstPart =
       (editedType === ContentTypes.TEXT || editedType === ContentTypes.THINK) &&
       lastExisting?.type === firstNew?.type &&

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1265,16 +1265,39 @@ class BaseClient {
       return existingContent.concat(newCompletion);
     }
 
-    if (editedType !== ContentTypes.TEXT && editedType !== ContentTypes.THINK) {
-      return existingContent.concat(newCompletion);
-    }
-
     const lastIndex = existingContent.length - 1;
     const lastExisting = existingContent[lastIndex];
     const firstNew = newCompletion[0];
+    const mergesFirstPart =
+      (editedType === ContentTypes.TEXT || editedType === ContentTypes.THINK) &&
+      lastExisting?.type === firstNew?.type &&
+      firstNew?.type === editedType;
+    /** Phase bounds are completion-local while the run streams. Persist them
+     *  in the same absolute index space as the edited response assembled
+     *  here. When the first new text/think part merges into the retained tail,
+     *  every completion index shifts by prefixLength - 1; otherwise it shifts
+     *  by the full retained prefix. */
+    const phaseIndexOffset = mergesFirstPart ? lastIndex : existingContent.length;
+    const adjustedCompletion = newCompletion.map((part) => {
+      if (
+        part?.type !== ContentTypes.ACTIVITY_LABEL ||
+        part.activity_label_type !== 'phase' ||
+        typeof part.activity_start_index !== 'number'
+      ) {
+        return part;
+      }
+      return {
+        ...part,
+        activity_start_index: part.activity_start_index + phaseIndexOffset,
+      };
+    });
 
-    if (lastExisting?.type !== firstNew?.type || firstNew?.type !== editedType) {
-      return existingContent.concat(newCompletion);
+    if (editedType !== ContentTypes.TEXT && editedType !== ContentTypes.THINK) {
+      return existingContent.concat(adjustedCompletion);
+    }
+
+    if (!mergesFirstPart) {
+      return existingContent.concat(adjustedCompletion);
     }
 
     const mergedContent = [...existingContent];
@@ -1282,19 +1305,20 @@ class BaseClient {
       mergedContent[lastIndex] = {
         ...mergedContent[lastIndex],
         [ContentTypes.TEXT]:
-          (mergedContent[lastIndex][ContentTypes.TEXT] || '') + (firstNew[ContentTypes.TEXT] || ''),
+          (mergedContent[lastIndex][ContentTypes.TEXT] || '') +
+          (adjustedCompletion[0][ContentTypes.TEXT] || ''),
       };
     } else {
       mergedContent[lastIndex] = {
         ...mergedContent[lastIndex],
         [ContentTypes.THINK]:
           (mergedContent[lastIndex][ContentTypes.THINK] || '') +
-          (firstNew[ContentTypes.THINK] || ''),
+          (adjustedCompletion[0][ContentTypes.THINK] || ''),
       };
     }
 
     // Add remaining completion items
-    return mergedContent.concat(newCompletion.slice(1));
+    return mergedContent.concat(adjustedCompletion.slice(1));
   }
 
   async sendPayload(payload, opts = {}) {

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1268,10 +1268,16 @@ class BaseClient {
     const lastIndex = existingContent.length - 1;
     const lastExisting = existingContent[lastIndex];
     const firstNew = newCompletion[0];
+    const textPhaseCompatible =
+      editedType !== ContentTypes.TEXT ||
+      lastExisting?.phase == null ||
+      firstNew?.phase == null ||
+      lastExisting.phase === firstNew.phase;
     const mergesFirstPart =
       (editedType === ContentTypes.TEXT || editedType === ContentTypes.THINK) &&
       lastExisting?.type === firstNew?.type &&
-      firstNew?.type === editedType;
+      firstNew?.type === editedType &&
+      textPhaseCompatible;
     /** Phase bounds are completion-local while the run streams. Persist them
      *  in the same absolute index space as the edited response assembled
      *  here. When the first new text/think part merges into the retained tail,
@@ -1304,6 +1310,7 @@ class BaseClient {
     if (editedType === ContentTypes.TEXT) {
       mergedContent[lastIndex] = {
         ...mergedContent[lastIndex],
+        ...(firstNew.phase != null && { phase: firstNew.phase }),
         [ContentTypes.TEXT]:
           (mergedContent[lastIndex][ContentTypes.TEXT] || '') +
           (adjustedCompletion[0][ContentTypes.TEXT] || ''),

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1819,5 +1819,30 @@ describe('BaseClient', () => {
         { ...completion[1], activity_start_index: 1 },
       ]);
     });
+
+    test.each([
+      [undefined, 'commentary'],
+      ['commentary', undefined],
+    ])('does not merge phased and unphased text (%s → %s)', (existingPhase, completionPhase) => {
+      const existing = [
+        {
+          type: ContentTypes.TEXT,
+          text: 'Retained text. ',
+          ...(existingPhase != null && { phase: existingPhase }),
+        },
+      ];
+      const completion = [
+        {
+          type: ContentTypes.TEXT,
+          text: 'New text.',
+          ...(completionPhase != null && { phase: completionPhase }),
+        },
+      ];
+
+      expect(TestClient.mergeEditedContent(existing, completion, ContentTypes.TEXT)).toEqual([
+        existing[0],
+        completion[0],
+      ]);
+    });
   });
 });

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1,4 +1,4 @@
-const { Constants } = require('librechat-data-provider');
+const { Constants, ContentTypes } = require('librechat-data-provider');
 const { FakeClient, initializeFakeClient } = require('./FakeClient');
 
 function deferred() {
@@ -1795,6 +1795,29 @@ describe('BaseClient', () => {
       );
       expect(userSave[0].text).toBe('Just a question');
       expect(userSave[0].quotes).toBeUndefined();
+    });
+  });
+
+  describe('mergeEditedContent phase boundaries', () => {
+    test('does not merge commentary into a final answer', () => {
+      const existing = [
+        { type: ContentTypes.TEXT, text: 'Checked the deployment. ', phase: 'commentary' },
+      ];
+      const completion = [
+        { type: ContentTypes.TEXT, text: 'Everything is healthy.', phase: 'final_answer' },
+        {
+          type: ContentTypes.ACTIVITY_LABEL,
+          activity_label_type: 'phase',
+          activity_start_index: 0,
+          activity_label: 'Verified deployment health',
+        },
+      ];
+
+      expect(TestClient.mergeEditedContent(existing, completion, ContentTypes.TEXT)).toEqual([
+        existing[0],
+        completion[0],
+        { ...completion[1], activity_start_index: 1 },
+      ]);
     });
   });
 });

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.4.3",
+    "@librechat/agents": "^3.4.4",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1135,6 +1135,7 @@ class AgentClient extends BaseClient {
       abortSignal: scope.abort.signal,
       isClosed: () => scope.closed,
       getContentParts: () => this.contentParts,
+      getStepIndex: (stepId) => this.stepMap?.get(stepId)?.index,
       bumpIndexOffset: () => {
         this.steerOffsetState.offset += 1;
       },

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -831,6 +831,7 @@ class AgentClient extends BaseClient {
           configurable: {
             thread_id: this.conversationId,
             user_id: this.user ?? this.options.req?.user?.id,
+            requestBody: { parentMessageId: this.parentMessageId },
           },
         },
       }));

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2269,6 +2269,48 @@ class AgentClient extends BaseClient {
   }
 
   /**
+   * Rebase parent activity bounds after completion-time content reshaping.
+   * Object identity links retained parts back to their pre-reshape positions,
+   * so prepended skill cards cannot enter a phase and a filtered-away leading
+   * reasoning part advances the bound to the first retained child.
+   *
+   * @param {Array<import('librechat-data-provider').ContentPart | null | undefined>} previousParts
+   */
+  rebaseActivityPhaseBounds(previousParts) {
+    if (!Array.isArray(previousParts) || !Array.isArray(this.contentParts)) {
+      return;
+    }
+    const retainedIndexes = new Map(this.contentParts.map((part, index) => [part, index]));
+    for (let markerIndex = 0; markerIndex < this.contentParts.length; markerIndex += 1) {
+      const marker = this.contentParts[markerIndex];
+      if (
+        marker?.type !== ContentTypes.ACTIVITY_LABEL ||
+        marker.activity_label_type !== 'phase' ||
+        typeof marker.activity_start_index !== 'number'
+      ) {
+        continue;
+      }
+      const previousMarkerIndex = previousParts.indexOf(marker);
+      if (previousMarkerIndex < 0) {
+        continue;
+      }
+      const previousStartIndex = Math.min(
+        previousMarkerIndex,
+        Math.max(0, marker.activity_start_index),
+      );
+      let nextStartIndex = markerIndex;
+      for (let index = previousStartIndex; index < previousMarkerIndex; index += 1) {
+        const retainedIndex = retainedIndexes.get(previousParts[index]);
+        if (retainedIndex != null && retainedIndex < markerIndex) {
+          nextStartIndex = retainedIndex;
+          break;
+        }
+      }
+      marker.activity_start_index = nextStartIndex;
+    }
+  }
+
+  /**
    * Surface any human-in-the-loop interrupt the SDK captured during the most
    * recent `processStream` / `resume`. When the run paused for tool approval (or
    * an ask-user question), mark the job `requires_action`, persist the pending
@@ -2884,6 +2926,7 @@ class AgentClient extends BaseClient {
        */
       await this.settleActivityLabels();
 
+      const contentBeforeReshape = [...this.contentParts];
       const manualPrimed = this.options.agent?.manualSkillPrimes ?? [];
       if (manualPrimed.length > 0) {
         const runId = this.responseMessageId ?? 'skill-prime';
@@ -2892,6 +2935,7 @@ class AgentClient extends BaseClient {
       }
 
       this.applyHideSequentialOutputsFilter();
+      this.rebaseActivityPhaseBounds(contentBeforeReshape);
     } catch (err) {
       if (abortController.signal.aborted) {
         logger.debug(
@@ -3214,7 +3258,9 @@ class AgentClient extends BaseClient {
       // before resume finalize/re-pause persistence reads `this.contentParts`, so a
       // resumed sequential chain doesn't persist/emit outputs hide_sequential_outputs
       // is meant to hide.
+      const contentBeforeReshape = [...this.contentParts];
       this.applyHideSequentialOutputsFilter();
+      this.rebaseActivityPhaseBounds(contentBeforeReshape);
     } catch (err) {
       if (abortController.signal.aborted) {
         logger.debug(

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -65,6 +65,7 @@ const {
   mapCollectedMetadataToUsage,
   resolveActivityLabelModel,
   resolveActivityPhaseLabelModel,
+  traceIdForMessage,
   settlePendingLabelFills,
   stripActivityLabelParts,
   getRequestMemories,
@@ -773,6 +774,7 @@ class AgentClient extends BaseClient {
     assistantContext,
     closingTextPhase,
     phaseIndex,
+    totalActivityCount,
     status,
     agentIds,
     charLimit,
@@ -805,29 +807,38 @@ class AgentClient extends BaseClient {
         }
       },
     };
-    const { label } = await this.run.generateActivityPhaseLabel({
-      provider,
-      clientOptions,
-      activities,
-      assistantContext,
-      closingTextPhase,
-      phaseIndex,
-      status,
-      agentIds,
-      charLimit,
-      ...(prompt != null && { prompt }),
-      sourceRunId: this.responseMessageId,
-      responseId: this.responseMessageId,
-      traceSeed: `${this.responseMessageId}-activity-phase-${phaseIndex}`,
-      chainOptions: {
-        signal,
-        callbacks: [{ handleLLMEnd, ...capturePrompt }],
-        configurable: {
-          thread_id: this.conversationId,
-          user_id: this.user ?? this.options.req?.user?.id,
+    let label;
+    try {
+      ({ label } = await this.run.generateActivityPhaseLabel({
+        provider,
+        clientOptions,
+        activities,
+        assistantContext,
+        closingTextPhase,
+        phaseIndex,
+        totalActivityCount,
+        status,
+        agentIds,
+        charLimit,
+        prompt,
+        sourceRunId: this.responseMessageId,
+        sourceTraceId: traceIdForMessage(this.responseMessageId),
+        responseId: this.responseMessageId,
+        traceSeed: `${this.responseMessageId}-activity-phase-${phaseIndex}`,
+        chainOptions: {
+          signal,
+          callbacks: [{ handleLLMEnd, ...capturePrompt }],
+          configurable: {
+            thread_id: this.conversationId,
+            user_id: this.user ?? this.options.req?.user?.id,
+          },
         },
-      },
-    });
+      }));
+    } catch (error) {
+      if (!signal?.aborted) {
+        logger.warn('[AgentClient] Activity phase generation failed', error);
+      }
+    }
     return {
       label,
       collectUsage: async (completionText) =>
@@ -1064,7 +1075,7 @@ class AgentClient extends BaseClient {
   }
 
   /** Builds the independently opt-in parent activity-phase collector. */
-  buildActivityPhaseWiring(streamId, abortSignal) {
+  buildActivityPhaseWiring(streamId, abortSignal, initialSnapshot) {
     if (!streamId || typeof Run?.prototype?.generateActivityPhaseLabel !== 'function') {
       return undefined;
     }
@@ -1119,6 +1130,7 @@ class AgentClient extends BaseClient {
       maxPerRun: phaseConfig.maxPerRun,
       charLimit: phaseConfig.charLimit,
       prompt: phaseConfig.prompt,
+      initialSnapshot,
       abortSignal: scope.abort.signal,
       isClosed: () => scope.closed,
       getContentParts: () => this.contentParts,
@@ -2363,6 +2375,9 @@ class AgentClient extends BaseClient {
     const paused = await GenerationJobManager.approvals.pause(streamId, pendingAction, {
       expectedCreatedAt: this.jobCreatedAt,
       ...(discoveredTools.length > 0 ? { discoveredTools } : {}),
+      ...(this.activityPhaseWiring?.snapshot != null && {
+        activityPhaseSnapshot: this.activityPhaseWiring.snapshot(),
+      }),
       persistencePending: true,
     });
     if (!paused) {
@@ -2994,6 +3009,7 @@ class AgentClient extends BaseClient {
    * @param {Agents.ToolApprovalDecisionMap | { answer: string }} params.resumeValue
    * @param {Array} [params.seedContent] - content aggregated before the pause
    * @param {Array<import('@librechat/agents').RunStep>} [params.runSteps] - run steps emitted before the pause
+   * @param {import('@librechat/api').ActivityPhaseSnapshot} [params.activityPhaseSnapshot]
    * @param {AbortController} [params.abortController]
    * @param {Pick<import('@langchain/langgraph').Command, 'update' | 'goto'>} [params.commandOptions]
    */
@@ -3005,6 +3021,7 @@ class AgentClient extends BaseClient {
     commandOptions,
     userMCPAuthMap,
     discoveredToolNames,
+    activityPhaseSnapshot,
   }) {
     /** @type {Partial<GraphRunnableConfig>} */
     let config;
@@ -3085,7 +3102,11 @@ class AgentClient extends BaseClient {
 
       const streamId = this.options.req?._resumableStreamId;
       const activityLabel = this.buildActivityLabelWiring(streamId, abortController.signal);
-      const activityPhase = this.buildActivityPhaseWiring(streamId, abortController.signal);
+      const activityPhase = this.buildActivityPhaseWiring(
+        streamId,
+        abortController.signal,
+        activityPhaseSnapshot,
+      );
       const offsetHandlers = createSteerIndexOffsetHandlers(
         createContentIndexOffsetHandlers(
           this.options.eventHandlers,

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -57,10 +57,14 @@ const {
   buildSteerMedia,
   stampSteerPartMedia,
   createActivityLabelWiring,
+  createActivityPhaseWiring,
+  createAssistantPhaseStampingHandlers,
   resolveActivityConfig,
+  resolveActivityPhaseConfig,
   getCustomEndpointConfig,
   mapCollectedMetadataToUsage,
   resolveActivityLabelModel,
+  resolveActivityPhaseLabelModel,
   settlePendingLabelFills,
   stripActivityLabelParts,
   getRequestMemories,
@@ -334,6 +338,10 @@ class AgentClient extends BaseClient {
           deliveredSteer: item,
         },
       );
+      /** Only a COMMITTED steer is a hard semantic boundary. If its durable
+       *  append failed, the drain restores the queue item and the current
+       *  phase evidence must remain intact for the eventual retry. */
+      this.activityPhaseWiring?.drop?.();
     } catch (error) {
       /** The part and its receipt commit as one durable unit. Roll the local
        * projection back when that commit fails so the drain can restore the
@@ -419,6 +427,27 @@ class AgentClient extends BaseClient {
     return this.activityLabelLLMPromise;
   }
 
+  /** Phase resolution is independently configurable and memoized per response. */
+  async resolveActivityPhaseLabelLLM() {
+    this.activityPhaseLabelLLMPromise =
+      this.activityPhaseLabelLLMPromise ??
+      resolveActivityPhaseLabelModel({
+        req: this.options.req,
+        agent: this.options.agent,
+        publicEndpoint: this.options.endpoint,
+        ids: {
+          messageId: this.responseMessageId,
+          conversationId: this.conversationId,
+          parentMessageId: this.parentMessageId,
+        },
+        db: { getUserKey: db.getUserKey, getUserKeyValues: db.getUserKeyValues },
+      }).catch((error) => {
+        this.activityPhaseLabelLLMPromise = null;
+        throw error;
+      });
+    return this.activityPhaseLabelLLMPromise;
+  }
+
   /**
    * Bills the label call and folds its usage into the response rollup with
    * an `activity-label` tag (subagent precedent) so `metadata.usage` and the
@@ -445,6 +474,8 @@ class AgentClient extends BaseClient {
      *  the title convention — from locally counted text rather than going
      *  unbilled. Invoked only when no entry carries a real token count. */
     estimate = undefined,
+    /** Separate telemetry bucket for parent phase summaries. */
+    usageType = 'activity-label',
   ) {
     const appConfig = this.options.req?.config;
     /** Provider ON EVERY ENTRY, not just the streamed event: `splitUsage`
@@ -517,7 +548,7 @@ class AgentClient extends BaseClient {
         }),
         ...(provider != null && { provider }),
         model,
-        usage_type: 'activity-label',
+        usage_type: usageType,
         /**
          * Scoped to the GENERATION, not just the response. Editing one
          * assistant response reuses its `responseMessageId` while each fresh
@@ -561,14 +592,14 @@ class AgentClient extends BaseClient {
            *  generation replaced it. */
           { expectedCreatedAt: this.jobCreatedAt },
         ).catch((err) => {
-          logger.warn(`[AgentClient] Failed to emit activity-label usage: ${err?.message ?? err}`);
+          logger.warn(`[AgentClient] Failed to emit ${usageType} usage: ${err?.message ?? err}`);
         });
         this.pendingSubagentEmits.push(emit);
       }
     }
     await this.recordCollectedUsage({
       collectedUsage,
-      context: 'activity-label',
+      context: usageType,
       model,
       endpointTokenConfig: labelTokenConfig,
       /** The label ran elsewhere, so its config governs even when undefined. */
@@ -698,6 +729,7 @@ class AgentClient extends BaseClient {
         })),
         thinkingExcerpts: context.thinkingExcerpts,
         lastAssistantText: context.lastAssistantText,
+        lastAssistantPhase: context.lastAssistantPhase,
         ...(previousLabels != null && { previousLabels }),
         traceSeed,
         charLimit,
@@ -729,6 +761,87 @@ class AgentClient extends BaseClient {
         await recordUsage();
       }
     }
+  }
+
+  /**
+   * SDK bridge for parent phase summaries. Usage is returned as a deferred
+   * collector so the runtime can commit the durable label first and bill
+   * only summaries that actually became visible.
+   */
+  async generateActivityPhaseViaRun({
+    activities,
+    assistantContext,
+    closingTextPhase,
+    phaseIndex,
+    status,
+    agentIds,
+    charLimit,
+    prompt,
+    signal,
+  }) {
+    if (typeof this.run?.generateActivityPhaseLabel !== 'function') {
+      return {};
+    }
+    const { provider, clientOptions, endpointTokenConfig, sameEndpoint } =
+      await this.resolveActivityPhaseLabelLLM();
+    const { handleLLMEnd, collected } = createMetadataAggregator();
+    let sdkPromptText;
+    const capturePrompt = {
+      handleLLMStart: (_llm, prompts) => {
+        sdkPromptText = Array.isArray(prompts) ? prompts.join('\n') : undefined;
+      },
+      handleChatModelStart: (_llm, messages) => {
+        try {
+          sdkPromptText = (messages ?? [])
+            .flat()
+            .map((message) =>
+              typeof message?.content === 'string'
+                ? message.content
+                : JSON.stringify(message?.content ?? ''),
+            )
+            .join('\n');
+        } catch {
+          // Providers with usage metadata do not need the estimate fallback.
+        }
+      },
+    };
+    const { label } = await this.run.generateActivityPhaseLabel({
+      provider,
+      clientOptions,
+      activities,
+      assistantContext,
+      closingTextPhase,
+      phaseIndex,
+      status,
+      agentIds,
+      charLimit,
+      ...(prompt != null && { prompt }),
+      sourceRunId: this.responseMessageId,
+      responseId: this.responseMessageId,
+      traceSeed: `${this.responseMessageId}-activity-phase-${phaseIndex}`,
+      chainOptions: {
+        signal,
+        callbacks: [{ handleLLMEnd, ...capturePrompt }],
+        configurable: {
+          thread_id: this.conversationId,
+          user_id: this.user ?? this.options.req?.user?.id,
+        },
+      },
+    });
+    return {
+      label,
+      collectUsage: async (completionText) =>
+        this.recordActivityLabelUsage(
+          collected,
+          clientOptions.model,
+          endpointTokenConfig,
+          sameEndpoint,
+          undefined,
+          provider,
+          () => ({ promptText: sdkPromptText ?? '', completionText: completionText ?? '' }),
+          'activity-phase',
+        ),
+    };
   }
 
   /** Bounded settle for in-flight label fills before finalization. On
@@ -821,16 +934,15 @@ class AgentClient extends BaseClient {
      *  emit, whose ordering against shifted SDK indices is load-bearing.
      *  The chain settles on failure (warned retry), so a lost write can
      *  never wedge run startup. */
-    this.activityLabelsMarkedPromise = GenerationJobManager.markActivityLabels(
-      streamId,
-      this.jobCreatedAt,
-    ).catch(() =>
-      GenerationJobManager.markActivityLabels(streamId, this.jobCreatedAt).catch(() => {
-        logger.warn(
-          `[AgentClient] Could not flag activity labels for ${streamId}; a label resolving during a resume gap may not be reconciled.`,
-        );
-      }),
-    );
+    this.activityLabelsMarkedPromise =
+      this.activityLabelsMarkedPromise ??
+      GenerationJobManager.markActivityLabels(streamId, this.jobCreatedAt).catch(() =>
+        GenerationJobManager.markActivityLabels(streamId, this.jobCreatedAt).catch(() => {
+          logger.warn(
+            `[AgentClient] Could not flag activity labels for ${streamId}; a label resolving during a resume gap may not be reconciled.`,
+          );
+        }),
+      );
     /** SDK support probe (steering-style): the Run method and the formatter
      *  replay skip ship together, so method presence is the capability. */
     const sdkCapable = typeof Run?.prototype?.generateActivityLabel === 'function';
@@ -949,6 +1061,92 @@ class AgentClient extends BaseClient {
         generateLabel: (payload) => this.generateActivityLabelViaRun(payload),
       }),
     });
+  }
+
+  /** Builds the independently opt-in parent activity-phase collector. */
+  buildActivityPhaseWiring(streamId, abortSignal) {
+    if (!streamId || typeof Run?.prototype?.generateActivityPhaseLabel !== 'function') {
+      return undefined;
+    }
+    const agentEndpoint = this.options.agent?.endpoint ?? '';
+    const appConfig = this.options.req?.config;
+    let customEndpointConfig;
+    try {
+      customEndpointConfig = getCustomEndpointConfig({ endpoint: agentEndpoint, appConfig });
+    } catch {
+      customEndpointConfig = undefined;
+    }
+    const phaseConfig = resolveActivityPhaseConfig(
+      appConfig,
+      agentEndpoint,
+      customEndpointConfig,
+      this.options.endpoint,
+    );
+    if (!phaseConfig.enabled) {
+      return undefined;
+    }
+
+    this.activityLabelsMarkedPromise =
+      this.activityLabelsMarkedPromise ??
+      GenerationJobManager.markActivityLabels(streamId, this.jobCreatedAt).catch(() =>
+        GenerationJobManager.markActivityLabels(streamId, this.jobCreatedAt).catch(() => {
+          logger.warn(
+            `[AgentClient] Could not flag activity phases for ${streamId}; a phase resolving during a resume gap may not be reconciled.`,
+          );
+        }),
+      );
+
+    const scope = { closed: false, abort: new AbortController() };
+    this.activityLabelScopes = this.activityLabelScopes ?? [];
+    this.activityLabelScopes.push(scope);
+    const closeOnAbort = () => {
+      scope.closed = true;
+      scope.abort.abort();
+    };
+    if (abortSignal != null) {
+      if (abortSignal.aborted) {
+        closeOnAbort();
+      } else {
+        abortSignal.addEventListener('abort', closeOnAbort, { once: true });
+        scope.detach = () => abortSignal.removeEventListener('abort', closeOnAbort);
+      }
+    }
+    this.activityLabelUsageSeq =
+      this.activityLabelUsageSeq ??
+      (this.contentParts ?? []).filter((part) => part?.type === ContentTypes.ACTIVITY_LABEL).length;
+
+    const wiring = createActivityPhaseWiring({
+      maxPerRun: phaseConfig.maxPerRun,
+      charLimit: phaseConfig.charLimit,
+      prompt: phaseConfig.prompt,
+      abortSignal: scope.abort.signal,
+      isClosed: () => scope.closed,
+      getContentParts: () => this.contentParts,
+      bumpIndexOffset: () => {
+        this.steerOffsetState.offset += 1;
+      },
+      emitLabelEvent: (index, part) =>
+        GenerationJobManager.emitChunk(
+          streamId,
+          {
+            event: ActivityLabelEvents.ON_ACTIVITY_LABEL,
+            data: {
+              index,
+              part,
+              responseMessageId: this.responseMessageId,
+              conversationId: this.conversationId,
+            },
+          },
+          { durable: true, expectedCreatedAt: this.jobCreatedAt },
+        ),
+      trackPendingFill: (fillDone) => {
+        this.pendingActivityLabelFills = this.pendingActivityLabelFills ?? [];
+        this.pendingActivityLabelFills.push(fillDone);
+      },
+      generatePhase: (payload) => this.generateActivityPhaseViaRun(payload),
+    });
+    this.activityPhaseWiring = wiring;
+    return wiring;
   }
 
   /**
@@ -2518,6 +2716,12 @@ class AgentClient extends BaseClient {
           });
         }
 
+        const activityLabel = this.buildActivityLabelWiring(streamId, abortController.signal);
+        const activityPhase = this.buildActivityPhaseWiring(streamId, abortController.signal);
+        const offsetHandlers = createSteerIndexOffsetHandlers(
+          this.options.eventHandlers,
+          this.steerOffsetState,
+        );
         const createRunPromise = createRun({
           agents,
           messages,
@@ -2531,17 +2735,19 @@ class AgentClient extends BaseClient {
           // boundary and inject them into graph state. The offset wrapper
           // shifts SDK content indices past any spliced steer parts.
           steering: this.buildSteerWiring(streamId),
-          activityLabel: this.buildActivityLabelWiring(streamId, abortController.signal),
+          activityLabel,
+          activityPhase,
           indexTokenCountMap,
           initialSummary,
           initialSessions,
           calibrationRatio,
           runId: this.responseMessageId,
           signal: abortController.signal,
-          customHandlers: createSteerIndexOffsetHandlers(
-            this.options.eventHandlers,
-            this.steerOffsetState,
-          ),
+          /** The phase wrapper stays outermost: it claims and offsets the
+           *  parent slot before the text step reaches the normal handlers. */
+          customHandlers:
+            activityPhase?.handlers(offsetHandlers) ??
+            (activityLabel ? createAssistantPhaseStampingHandlers(offsetHandlers) : offsetHandlers),
           requestBody: config.configurable.requestBody,
           user: createSafeUser(this.options.req?.user),
           tenantId: this.options.req?.user?.tenantId,
@@ -2878,6 +3084,15 @@ class AgentClient extends BaseClient {
       const initialSessions = buildInitialToolSessions({ skillSessions, agents });
 
       const streamId = this.options.req?._resumableStreamId;
+      const activityLabel = this.buildActivityLabelWiring(streamId, abortController.signal);
+      const activityPhase = this.buildActivityPhaseWiring(streamId, abortController.signal);
+      const offsetHandlers = createSteerIndexOffsetHandlers(
+        createContentIndexOffsetHandlers(
+          this.options.eventHandlers,
+          Array.isArray(seedContent) ? seedContent : [],
+        ),
+        this.steerOffsetState,
+      );
       run = await createRun({
         agents,
         // State (messages, tool calls) is rehydrated from the checkpoint by
@@ -2892,7 +3107,8 @@ class AgentClient extends BaseClient {
         steering: this.buildSteerWiring(streamId),
         // Activity labels likewise survive pause/resume: post-resume tool
         // batches keep claiming slots and generating group headers.
-        activityLabel: this.buildActivityLabelWiring(streamId, abortController.signal),
+        activityLabel,
+        activityPhase,
         // Replay deferred tools discovered before the pause. With `messages: []` the
         // discovery scan finds nothing, so these names restore the schemas to the
         // rebuilt model binding. Undefined/empty for non-deferred turns is a no-op.
@@ -2906,13 +3122,9 @@ class AgentClient extends BaseClient {
         // type mismatch, is silently dropped against) the pre-pause content. The
         // steer wrapper composes on top: resumed indices shift by seed + any
         // steer parts spliced in while the resumed segment streams.
-        customHandlers: createSteerIndexOffsetHandlers(
-          createContentIndexOffsetHandlers(
-            this.options.eventHandlers,
-            Array.isArray(seedContent) ? seedContent : [],
-          ),
-          this.steerOffsetState,
-        ),
+        customHandlers:
+          activityPhase?.handlers(offsetHandlers) ??
+          (activityLabel ? createAssistantPhaseStampingHandlers(offsetHandlers) : offsetHandlers),
         requestBody: config.configurable.requestBody,
         user: createSafeUser(this.options.req?.user),
         tenantId: this.options.req?.user?.tenantId,

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -162,6 +162,30 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
     AgentClient.prototype.applyHideSequentialOutputsFilter.call(ctx);
     expect(ctx.contentParts).toEqual([textPart('a'), textPart('b')]);
   });
+
+  it('rebases phase bounds across skill prepends and sequential filtering', () => {
+    const reasoning = { type: ContentTypes.THINK, think: 'checking' };
+    const activityTool = toolCallPart('activity-tool');
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      activity_label: 'Resolved the session issue',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+    };
+    const final = textPart('final');
+    const previousParts = [reasoning, activityTool, phase, final];
+    const skillCard = toolCallPart('manual-skill');
+    const ctx = {
+      options: { agent: { hide_sequential_outputs: true } },
+      contentParts: [skillCard, ...previousParts],
+    };
+
+    AgentClient.prototype.applyHideSequentialOutputsFilter.call(ctx);
+    AgentClient.prototype.rebaseActivityPhaseBounds.call(ctx, previousParts);
+
+    expect(ctx.contentParts).toEqual([skillCard, activityTool, phase, final]);
+    expect(phase.activity_start_index).toBe(1);
+  });
 });
 
 describe('AgentClient - startup telemetry', () => {

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -929,6 +929,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       // Replay deferred tools discovered before the pause (captured at pause). The rebuilt
       // graph passes `messages: []`, so without these the model would lose their schemas.
       discoveredToolNames: job.metadata?.discoveredTools,
+      activityPhaseSnapshot: job.metadata?.activityPhaseSnapshot,
     });
 
     // The model may pause AGAIN (another tool, or a follow-up question). The pending

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import { ChevronDown, ListTree } from 'lucide-react';
+import { ContentTypes } from 'librechat-data-provider';
+import type { TMessageContentParts } from 'librechat-data-provider';
+import { getActivityLabelText } from '~/utils/activityLabels';
+
+type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
+  activity_label_type?: 'phase';
+  activity_start_index?: number;
+};
+
+export default function ActivityPhaseGroup({
+  labelPart,
+  children,
+}: {
+  labelPart: ActivityPhasePart;
+  children: ReactNode;
+}) {
+  const label = getActivityLabelText(labelPart);
+  if (!label) {
+    return <>{children}</>;
+  }
+  return (
+    <details className="group/activity-phase my-2 w-full rounded-lg border border-border-light bg-surface-secondary/40">
+      <summary
+        className="flex min-h-10 cursor-pointer list-none items-center gap-2 px-3 py-2 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary [&::-webkit-details-marker]:hidden"
+        aria-label={label}
+        title={label}
+      >
+        <ListTree className="size-4 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium" role="status">
+          {label}
+        </span>
+        <ChevronDown
+          className="size-4 shrink-0 transition-transform duration-200 group-open/activity-phase:rotate-180"
+          aria-hidden="true"
+        />
+      </summary>
+      <div className="border-t border-border-light px-3 py-2">{children}</div>
+    </details>
+  );
+}

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -13,14 +13,36 @@ type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTI
 export default function ActivityPhaseGroup({
   labelPart,
   children,
+  hasContent,
 }: {
   labelPart: ActivityPhasePart;
   children: ReactNode;
+  hasContent: boolean;
 }) {
   const label = getActivityLabelText(labelPart);
   const hasFailure = labelPart.status === 'failed' || labelPart.status === 'partial';
   if (!label) {
     return <>{children}</>;
+  }
+  if (!hasContent) {
+    return (
+      <div className="my-2 flex min-h-10 w-full items-center gap-2 rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary">
+        <ListTree
+          className={cn('size-4 shrink-0', hasFailure && 'text-amber-600 dark:text-amber-400')}
+          aria-hidden="true"
+        />
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate text-sm font-medium',
+            hasFailure && 'text-amber-600 dark:text-amber-400',
+          )}
+          role="status"
+          title={label}
+        >
+          {label}
+        </span>
+      </div>
+    );
   }
   return (
     <details className="group/activity-phase my-2 w-full rounded-lg border border-border-light bg-surface-secondary/40">

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from 'react';
 import { ChevronDown, ListTree } from 'lucide-react';
 import { ContentTypes } from 'librechat-data-provider';
 import type { TMessageContentParts } from 'librechat-data-provider';
+import type { ReactNode } from 'react';
 import { getActivityLabelText } from '~/utils/activityLabels';
+import { cn } from '~/utils';
 
 type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
   activity_label_type?: 'phase';
@@ -17,6 +18,7 @@ export default function ActivityPhaseGroup({
   children: ReactNode;
 }) {
   const label = getActivityLabelText(labelPart);
+  const hasFailure = labelPart.status === 'failed' || labelPart.status === 'partial';
   if (!label) {
     return <>{children}</>;
   }
@@ -27,8 +29,20 @@ export default function ActivityPhaseGroup({
         aria-label={label}
         title={label}
       >
-        <ListTree className="size-4 shrink-0" aria-hidden="true" />
-        <span className="min-w-0 flex-1 truncate text-sm font-medium" role="status">
+        <ListTree
+          className={cn(
+            'size-4 shrink-0',
+            hasFailure && 'text-amber-600 dark:text-amber-400',
+          )}
+          aria-hidden="true"
+        />
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate text-sm font-medium',
+            hasFailure && 'text-amber-600 dark:text-amber-400',
+          )}
+          role="status"
+        >
           {label}
         </span>
         <ChevronDown

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -3,6 +3,8 @@ import { ContentTypes } from 'librechat-data-provider';
 import type { TMessageContentParts } from 'librechat-data-provider';
 import type { ReactNode } from 'react';
 import { getActivityLabelText } from '~/utils/activityLabels';
+import { EmptyText } from './Parts';
+import Container from './Container';
 import { cn } from '~/utils';
 
 type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
@@ -14,37 +16,41 @@ export default function ActivityPhaseGroup({
   labelPart,
   children,
   hasContent,
+  showCursor = false,
 }: {
   labelPart: ActivityPhasePart;
   children: ReactNode;
   hasContent: boolean;
+  showCursor?: boolean;
 }) {
   const label = getActivityLabelText(labelPart);
   const hasFailure = labelPart.status === 'failed' || labelPart.status === 'partial';
+  const cursor = showCursor ? (
+    <Container>
+      <EmptyText />
+    </Container>
+  ) : null;
   if (!label) {
     return <>{children}</>;
   }
-  if (!hasContent) {
-    return (
-      <div className="my-2 flex min-h-10 w-full items-center gap-2 rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary">
-        <ListTree
-          className={cn('size-4 shrink-0', hasFailure && 'text-amber-600 dark:text-amber-400')}
-          aria-hidden="true"
-        />
-        <span
-          className={cn(
-            'min-w-0 flex-1 truncate text-sm font-medium',
-            hasFailure && 'text-amber-600 dark:text-amber-400',
-          )}
-          role="status"
-          title={label}
-        >
-          {label}
-        </span>
-      </div>
-    );
-  }
-  return (
+  const group = !hasContent ? (
+    <div className="my-2 flex min-h-10 w-full items-center gap-2 rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary">
+      <ListTree
+        className={cn('size-4 shrink-0', hasFailure && 'text-amber-600 dark:text-amber-400')}
+        aria-hidden="true"
+      />
+      <span
+        className={cn(
+          'min-w-0 flex-1 truncate text-sm font-medium',
+          hasFailure && 'text-amber-600 dark:text-amber-400',
+        )}
+        role="status"
+        title={label}
+      >
+        {label}
+      </span>
+    </div>
+  ) : (
     <details className="group/activity-phase my-2 w-full rounded-lg border border-border-light bg-surface-secondary/40">
       <summary
         className="flex min-h-10 cursor-pointer list-none items-center gap-2 px-3 py-2 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary [&::-webkit-details-marker]:hidden"
@@ -71,5 +77,11 @@ export default function ActivityPhaseGroup({
       </summary>
       <div className="border-t border-border-light px-3 py-2">{children}</div>
     </details>
+  );
+  return (
+    <>
+      {group}
+      {cursor}
+    </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -30,10 +30,7 @@ export default function ActivityPhaseGroup({
         title={label}
       >
         <ListTree
-          className={cn(
-            'size-4 shrink-0',
-            hasFailure && 'text-amber-600 dark:text-amber-400',
-          )}
+          className={cn('size-4 shrink-0', hasFailure && 'text-amber-600 dark:text-amber-400')}
           aria-hidden="true"
         />
         <span

--- a/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
+++ b/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
@@ -162,12 +162,14 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
         return;
       }
       set.delete(toolCallId);
-      // Also drop any decision it held so a stale entry can't linger.
-      decisionsRef.current.get(actionId)?.delete(toolCallId);
       if (set.size === 0) {
         registeredRef.current.delete(actionId);
-        decisionsRef.current.delete(actionId);
       }
+      /** Keep the decision for the provider's message-scoped lifetime. A
+       *  phase label can resolve while an approval card is visible, moving
+       *  that card through a sparse render slice; its transient unmount must
+       *  not erase the user's selection. Unregistered decisions are excluded
+       *  from submit/readiness and disappear with this provider. */
       rerender();
     },
     [rerender],
@@ -202,10 +204,17 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
     [],
   );
 
-  const getDecisions = useCallback(
-    (actionId: string) => Array.from(decisionsRef.current.get(actionId)?.values() ?? []),
-    [],
-  );
+  const getDecisions = useCallback((actionId: string) => {
+    const registered = registeredRef.current.get(actionId);
+    const decisions = decisionsRef.current.get(actionId);
+    if (registered == null || decisions == null) {
+      return [];
+    }
+    return [...registered].flatMap((toolCallId) => {
+      const decision = decisions.get(toolCallId);
+      return decision == null ? [] : [decision];
+    });
+  }, []);
 
   const isReady = useCallback((actionId: string) => {
     const registered = registeredRef.current.get(actionId);

--- a/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
+++ b/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
@@ -174,7 +174,7 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
       }
       /** Keep the decision for the provider's message-scoped lifetime. A
        *  phase label can resolve while an approval card is visible, moving
-       *  that card through a sparse render slice; its transient unmount must
+       *  that card through a nested phase segment; its transient unmount must
        *  not erase the user's selection. Unregistered decisions are excluded
        *  from submit/readiness and disappear with this provider. */
       rerender();

--- a/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
+++ b/client/src/components/Chat/Messages/Content/ApprovalContext.tsx
@@ -84,6 +84,10 @@ interface ApprovalContextValue {
   getStatus: (actionId: string) => ActionStatus;
   /** Set an action's submission status (driven by the cards' submit via `useResumeSubmit`). */
   setStatus: (actionId: string, status: ActionStatus) => void;
+  /** Restore a free-form question answer after transient phase-slice remounts. */
+  getAskAnswerDraft: (actionId: string) => string;
+  /** Retain a free-form question answer for this response message's lifetime. */
+  setAskAnswerDraft: (actionId: string, answer: string) => void;
 }
 
 const ApprovalContext = createContext<ApprovalContextValue | null>(null);
@@ -107,6 +111,8 @@ const FALLBACK: ApprovalContextValue = {
   isReady: () => false,
   getStatus: () => 'idle',
   setStatus: () => undefined,
+  getAskAnswerDraft: () => '',
+  setAskAnswerDraft: () => undefined,
 };
 
 const isExpiredError = (error: unknown): boolean => {
@@ -136,6 +142,7 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
    *  never propagate past the memoized value). */
   const decisionsRef = useRef(new Map<string, Map<string, Agents.ToolApprovalResolution>>());
   const registeredRef = useRef(new Map<string, Set<string>>());
+  const askAnswerDraftsRef = useRef(new Map<string, string>());
   const [version, bump] = useState(0);
   const rerender = useCallback(() => bump((v) => v + 1), []);
   const [statusByAction, setStatusByAction] = useState<Record<string, ActionStatus>>({});
@@ -239,6 +246,19 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
     setStatusByAction((prev) => ({ ...prev, [actionId]: status }));
   }, []);
 
+  const getAskAnswerDraft = useCallback(
+    (actionId: string) => askAnswerDraftsRef.current.get(actionId) ?? '',
+    [],
+  );
+
+  const setAskAnswerDraft = useCallback((actionId: string, answer: string) => {
+    if (answer.length === 0) {
+      askAnswerDraftsRef.current.delete(actionId);
+      return;
+    }
+    askAnswerDraftsRef.current.set(actionId, answer);
+  }, []);
+
   const value = useMemo<ApprovalContextValue>(
     () => ({
       version,
@@ -252,6 +272,8 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
       isReady,
       getStatus,
       setStatus,
+      getAskAnswerDraft,
+      setAskAnswerDraft,
     }),
     [
       version,
@@ -265,6 +287,8 @@ export default function ApprovalProvider({ children }: { children: React.ReactNo
       isReady,
       getStatus,
       setStatus,
+      getAskAnswerDraft,
+      setAskAnswerDraft,
     ],
   );
 

--- a/client/src/components/Chat/Messages/Content/AskUserQuestion.tsx
+++ b/client/src/components/Chat/Messages/Content/AskUserQuestion.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo, useState } from 'react';
 import { ChevronUp, TriangleAlert } from 'lucide-react';
 import { Button, TextareaAutosize } from '@librechat/client';
 import type { Agents } from 'librechat-data-provider';
-import { useAskSubmitStatus, useResumeSubmit } from './ApprovalContext';
+import { useApprovalContext, useAskSubmitStatus, useResumeSubmit } from './ApprovalContext';
 import useAskAnswerMode from '~/hooks/Input/useAskAnswerMode';
 import { ChatContext } from '~/Providers/ChatContext';
 import { splitOtherOption } from '~/utils/approval';
@@ -25,9 +25,10 @@ export default function AskUserQuestion({
   question: Agents.AskUserQuestionRequest;
 }) {
   const localize = useLocalize();
+  const { getAskAnswerDraft, setAskAnswerDraft } = useApprovalContext();
   const { getAskStatus } = useAskSubmitStatus();
   const { submitAskAnswer } = useResumeSubmit();
-  const [answer, setAnswer] = useState('');
+  const [answer, setAnswer] = useState(() => getAskAnswerDraft(actionId));
   const [localChecked, setLocalChecked] = useState<number[]>([]);
   /**
    * The composer popover is the primary answer surface — while it's VISIBLE
@@ -152,7 +153,10 @@ export default function AskUserQuestion({
       <TextareaAutosize
         value={answer}
         disabled={locked}
-        onChange={(e) => setAnswer(e.target.value)}
+        onChange={(e) => {
+          setAnswer(e.target.value);
+          setAskAnswerDraft(actionId, e.target.value);
+        }}
         minRows={2}
         maxRows={12}
         placeholder={otherLabel ?? localize('com_ui_your_answer')}

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -460,9 +460,7 @@ const ContentParts = memo(function ContentParts({
   if (phaseSegments != null) {
     const relativeGlobalLastContentIdx = lastVisibleContentIdx(content ?? []);
     const globalLastContentIdx =
-      relativeGlobalLastContentIdx < 0
-        ? -1
-        : relativeGlobalLastContentIdx + contentIndexOffset;
+      relativeGlobalLastContentIdx < 0 ? -1 : relativeGlobalLastContentIdx + contentIndexOffset;
     const renderSegment = (
       segmentContent: Array<TMessageContentParts | undefined>,
       segmentStartIndex: number,

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -11,12 +11,14 @@ import type { ToolCallGroupExpansionState } from './ToolCallGroup';
 import { mapAttachments, filterAttachmentsForPart, groupSequentialToolCalls } from '~/utils';
 import { ParallelContentRenderer, type PartWithIndex } from './ParallelContent';
 import { EditTextPart, EmptyText, AgentUpdate } from './Parts';
-import { lastVisibleContentIdx } from '~/utils/activityLabels';
+import { groupActivityPhases, lastVisibleContentIdx } from '~/utils/activityLabels';
+import Sources from '~/components/Web/Sources';
 import { MessageContext, SearchContext } from '~/Providers';
 import PendingSkillCall from './Parts/PendingSkillCall';
 import ApprovalProvider from './ApprovalContext';
 import MemoryArtifacts from './MemoryArtifacts';
 import ToolCallGroup from './ToolCallGroup';
+import ActivityPhaseGroup from './ActivityPhaseGroup';
 import Container from './Container';
 import Part from './Part';
 
@@ -147,6 +149,8 @@ type ContentPartsProps = {
     | ((value: number) => void | React.Dispatch<React.SetStateAction<number>>)
     | null
     | undefined;
+  /** Internal recursion guard for sparse phase slices. */
+  nestedActivityPhase?: boolean;
 };
 
 /**
@@ -172,6 +176,7 @@ const ContentParts = memo(function ContentParts({
   isCreatedByUser,
   isLatestMessage,
   createdAt,
+  nestedActivityPhase = false,
 }: ContentPartsProps) {
   const attachmentMap = useMemo(() => mapAttachments(attachments ?? []), [attachments]);
   const effectiveIsSubmitting = isLatestMessage ? isSubmitting : false;
@@ -434,6 +439,54 @@ const ContentParts = memo(function ContentParts({
     );
   }
 
+  const phaseSegments = nestedActivityPhase ? undefined : groupActivityPhases(content);
+  if (phaseSegments != null) {
+    const renderSegment = (
+      segmentContent: Array<TMessageContentParts | undefined>,
+      key: string,
+    ) => (
+      <ContentParts
+        key={key}
+        content={segmentContent}
+        messageId={messageId}
+        createdAt={createdAt}
+        authorHeader={authorHeader}
+        conversationId={conversationId}
+        attachments={attachments}
+        searchResults={searchResults}
+        isCreatedByUser={isCreatedByUser}
+        isLast={isLast}
+        isSubmitting={isSubmitting}
+        isLatestMessage={isLatestMessage}
+        nestedActivityPhase
+      />
+    );
+    const hasParallelContent = content?.some((part) => part?.groupId != null) === true;
+    return (
+      <ApprovalProvider>
+        <SearchContext.Provider value={{ searchResults }}>
+          <MemoryArtifacts attachments={attachments} />
+          {hasParallelContent && (
+            <Sources messageId={messageId} conversationId={conversationId || undefined} />
+          )}
+          {renderPendingSkills()}
+          {phaseSegments.map((segment, index) =>
+            segment.type === 'phase' ? (
+              <ActivityPhaseGroup
+                key={`activity-phase-${messageId}-${segment.labelIndex}`}
+                labelPart={segment.labelPart}
+              >
+                {renderSegment(segment.content, `phase-content-${index}`)}
+              </ActivityPhaseGroup>
+            ) : (
+              renderSegment(segment.content, `phase-adjacent-${index}`)
+            ),
+          )}
+        </SearchContext.Provider>
+      </ApprovalProvider>
+    );
+  }
+
   const safeContent = content ?? [];
   const showEmptyCursor = safeContent.length === 0 && effectiveIsSubmitting;
   /** Skips trailing BLANK label reservations — they render nothing, and
@@ -457,6 +510,7 @@ const ContentParts = memo(function ContentParts({
           isSubmitting={effectiveIsSubmitting}
           renderPart={renderPart}
           renderResumeAttribution={renderResumeAttribution}
+          showDecorations={!nestedActivityPhase}
         />
       </ApprovalProvider>
     );
@@ -466,8 +520,8 @@ const ContentParts = memo(function ContentParts({
   return (
     <ApprovalProvider>
       <SearchContext.Provider value={{ searchResults }}>
-        <MemoryArtifacts attachments={attachments} />
-        {renderPendingSkills()}
+        {!nestedActivityPhase && <MemoryArtifacts attachments={attachments} />}
+        {!nestedActivityPhase && renderPendingSkills()}
         {showEmptyCursor && (
           <Container>
             <EmptyText />

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -9,16 +9,16 @@ import type {
 import type { ReactNode, ReactElement } from 'react';
 import type { ToolCallGroupExpansionState } from './ToolCallGroup';
 import { mapAttachments, filterAttachmentsForPart, groupSequentialToolCalls } from '~/utils';
+import { groupActivityPhases, lastVisibleContentIdx } from '~/utils/activityLabels';
 import { ParallelContentRenderer, type PartWithIndex } from './ParallelContent';
 import { EditTextPart, EmptyText, AgentUpdate } from './Parts';
-import { groupActivityPhases, lastVisibleContentIdx } from '~/utils/activityLabels';
-import Sources from '~/components/Web/Sources';
 import { MessageContext, SearchContext } from '~/Providers';
 import PendingSkillCall from './Parts/PendingSkillCall';
+import ActivityPhaseGroup from './ActivityPhaseGroup';
 import ApprovalProvider from './ApprovalContext';
 import MemoryArtifacts from './MemoryArtifacts';
+import Sources from '~/components/Web/Sources';
 import ToolCallGroup from './ToolCallGroup';
-import ActivityPhaseGroup from './ActivityPhaseGroup';
 import Container from './Container';
 import Part from './Part';
 
@@ -444,23 +444,26 @@ const ContentParts = memo(function ContentParts({
     const renderSegment = (
       segmentContent: Array<TMessageContentParts | undefined>,
       key: string,
-    ) => (
-      <ContentParts
-        key={key}
-        content={segmentContent}
-        messageId={messageId}
-        createdAt={createdAt}
-        authorHeader={authorHeader}
-        conversationId={conversationId}
-        attachments={attachments}
-        searchResults={searchResults}
-        isCreatedByUser={isCreatedByUser}
-        isLast={isLast}
-        isSubmitting={isSubmitting}
-        isLatestMessage={isLatestMessage}
-        nestedActivityPhase
-      />
-    );
+    ) => {
+      const globalLastContentIdx = lastVisibleContentIdx(content ?? []);
+      return (
+        <ContentParts
+          key={key}
+          content={segmentContent}
+          messageId={messageId}
+          createdAt={createdAt}
+          authorHeader={authorHeader}
+          conversationId={conversationId}
+          attachments={attachments}
+          searchResults={searchResults}
+          isCreatedByUser={isCreatedByUser}
+          isLast={isLast && segmentContent[globalLastContentIdx] != null}
+          isSubmitting={isSubmitting}
+          isLatestMessage={isLatestMessage}
+          nestedActivityPhase
+        />
+      );
+    };
     const hasParallelContent = content?.some((part) => part?.groupId != null) === true;
     return (
       <ApprovalProvider>
@@ -497,8 +500,8 @@ const ContentParts = memo(function ContentParts({
   // Parallel content: use dedicated renderer with columns (TMessageContentParts includes ContentMetadata)
   const hasParallelContent = safeContent.some((part) => part?.groupId != null);
   if (hasParallelContent) {
-    return (
-      <ApprovalProvider>
+    const parallelContent = (
+      <>
         {renderPendingSkills()}
         <ParallelContentRenderer
           content={content}
@@ -512,60 +515,67 @@ const ContentParts = memo(function ContentParts({
           renderResumeAttribution={renderResumeAttribution}
           showDecorations={!nestedActivityPhase}
         />
-      </ApprovalProvider>
+      </>
+    );
+    return nestedActivityPhase ? (
+      parallelContent
+    ) : (
+      <ApprovalProvider>{parallelContent}</ApprovalProvider>
     );
   }
 
   // Sequential content: render parts in order (90% of cases)
-  return (
-    <ApprovalProvider>
-      <SearchContext.Provider value={{ searchResults }}>
-        {!nestedActivityPhase && <MemoryArtifacts attachments={attachments} />}
-        {!nestedActivityPhase && renderPendingSkills()}
-        {showEmptyCursor && (
-          <Container>
-            <EmptyText />
-          </Container>
-        )}
-        {groupedParts.flatMap((group) => {
-          const firstIdx = group.type === 'single' ? group.part.idx : (group.parts[0]?.idx ?? -1);
-          const nodes: ReactElement[] = [];
-          const attribution = renderResumeAttribution(firstIdx);
-          if (attribution != null) {
-            nodes.push(attribution);
-          }
-          if (group.type === 'single') {
-            const { part, idx } = group.part;
-            nodes.push(renderPart(part, idx, idx === lastContentIdx));
-            return nodes;
-          }
-          const { groupId } = group;
-          nodes.push(
-            <ToolCallGroup
-              key={`tool-group-${groupId}`}
-              parts={group.parts}
-              isSubmitting={effectiveIsSubmitting}
-              /** The label part is CONSUMED into the header, not listed in
-               *  `parts` — a filled label at the content tail must still
-               *  mark its group as last or nothing holds the streaming
-               *  cursor until the next delta. */
-              isLast={
-                group.parts.some((p) => p.idx === lastContentIdx) ||
-                group.labelPart?.idx === lastContentIdx
-              }
-              renderPart={renderGroupedPart}
-              lastContentIdx={lastContentIdx}
-              groupAttachments={group.groupAttachments}
-              initialExpansionState={toolGroupExpansionRef.current.get(groupId)}
-              onExpansionChange={(state) => handleGroupExpansionChange(groupId, state)}
-              labelPart={group.labelPart}
-            />,
-          );
+  const sequentialContent = (
+    <SearchContext.Provider value={{ searchResults }}>
+      {!nestedActivityPhase && <MemoryArtifacts attachments={attachments} />}
+      {!nestedActivityPhase && renderPendingSkills()}
+      {showEmptyCursor && (
+        <Container>
+          <EmptyText />
+        </Container>
+      )}
+      {groupedParts.flatMap((group) => {
+        const firstIdx = group.type === 'single' ? group.part.idx : (group.parts[0]?.idx ?? -1);
+        const nodes: ReactElement[] = [];
+        const attribution = renderResumeAttribution(firstIdx);
+        if (attribution != null) {
+          nodes.push(attribution);
+        }
+        if (group.type === 'single') {
+          const { part, idx } = group.part;
+          nodes.push(renderPart(part, idx, idx === lastContentIdx));
           return nodes;
-        })}
-      </SearchContext.Provider>
-    </ApprovalProvider>
+        }
+        const { groupId } = group;
+        nodes.push(
+          <ToolCallGroup
+            key={`tool-group-${groupId}`}
+            parts={group.parts}
+            isSubmitting={effectiveIsSubmitting}
+            /** The label part is CONSUMED into the header, not listed in
+             *  `parts` — a filled label at the content tail must still
+             *  mark its group as last or nothing holds the streaming
+             *  cursor until the next delta. */
+            isLast={
+              group.parts.some((p) => p.idx === lastContentIdx) ||
+              group.labelPart?.idx === lastContentIdx
+            }
+            renderPart={renderGroupedPart}
+            lastContentIdx={lastContentIdx}
+            groupAttachments={group.groupAttachments}
+            initialExpansionState={toolGroupExpansionRef.current.get(groupId)}
+            onExpansionChange={(state) => handleGroupExpansionChange(groupId, state)}
+            labelPart={group.labelPart}
+          />,
+        );
+        return nodes;
+      })}
+    </SearchContext.Provider>
   );
+  if (nestedActivityPhase) {
+    return sequentialContent;
+  }
+  return <ApprovalProvider>{sequentialContent}</ApprovalProvider>;
 });
 
 export default ContentParts;

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -505,6 +505,11 @@ const ContentParts = memo(function ContentParts({
                 key={`activity-phase-${messageId}-${segment.labelIndex}`}
                 labelPart={segment.labelPart}
                 hasContent={segment.hasContent}
+                showCursor={
+                  isLast &&
+                  effectiveIsSubmitting &&
+                  segment.labelIndex + contentIndexOffset === globalLastContentIdx
+                }
               >
                 {renderSegment(
                   segment.content,

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -149,9 +149,11 @@ type ContentPartsProps = {
     | ((value: number) => void | React.Dispatch<React.SetStateAction<number>>)
     | null
     | undefined;
-  /** Internal recursion guard for sparse phase slices. */
+  /** Internal recursion guard for nested phase segments. */
   nestedActivityPhase?: boolean;
-  /** Message-wide steer attribution retained across sparse phase slices. */
+  /** Absolute transcript index represented by `content[0]` in a phase slice. */
+  contentIndexOffset?: number;
+  /** Message-wide steer attribution retained across nested phase segments. */
   resumeAuthors?: ReadonlyMap<number, string | undefined>;
   /** Message-wide tool-group expansion overrides retained across phase slices. */
   toolGroupExpansionState?: Map<string, ToolCallGroupExpansionState>;
@@ -181,6 +183,7 @@ const ContentParts = memo(function ContentParts({
   isLatestMessage,
   createdAt,
   nestedActivityPhase = false,
+  contentIndexOffset = 0,
   resumeAuthors,
   toolGroupExpansionState,
 }: ContentPartsProps) {
@@ -268,6 +271,7 @@ const ContentParts = memo(function ContentParts({
 
   const renderPart = useCallback(
     (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
+      const localIdx = idx - contentIndexOffset;
       return (
         <PartWithContext
           key={`provider-${messageId}-${idx}`}
@@ -279,7 +283,7 @@ const ContentParts = memo(function ContentParts({
           conversationId={conversationId}
           isLatestMessage={isLatestMessage}
           isCreatedByUser={isCreatedByUser}
-          nextType={content?.[idx + 1]?.type}
+          nextType={content?.[localIdx + 1]?.type}
           isSubmitting={effectiveIsSubmitting}
           partAttachments={filterAttachmentsForPart(
             attachmentMap[getToolCallId(part)],
@@ -291,6 +295,7 @@ const ContentParts = memo(function ContentParts({
     [
       attachmentMap,
       content,
+      contentIndexOffset,
       conversationId,
       effectiveIsSubmitting,
       isCreatedByUser,
@@ -302,6 +307,7 @@ const ContentParts = memo(function ContentParts({
 
   const renderGroupedPart = useCallback(
     (part: TMessageContentParts, idx: number, isLastPart: boolean, onToolExpand?: () => void) => {
+      const localIdx = idx - contentIndexOffset;
       return (
         <PartWithContext
           key={`provider-${messageId}-${idx}`}
@@ -313,7 +319,7 @@ const ContentParts = memo(function ContentParts({
           conversationId={conversationId}
           isLatestMessage={isLatestMessage}
           isCreatedByUser={isCreatedByUser}
-          nextType={content?.[idx + 1]?.type}
+          nextType={content?.[localIdx + 1]?.type}
           isSubmitting={effectiveIsSubmitting}
           partAttachments={filterAttachmentsForPart(
             attachmentMap[getToolCallId(part)],
@@ -327,6 +333,7 @@ const ContentParts = memo(function ContentParts({
     [
       attachmentMap,
       content,
+      contentIndexOffset,
       conversationId,
       effectiveIsSubmitting,
       isCreatedByUser,
@@ -351,10 +358,11 @@ const ContentParts = memo(function ContentParts({
     }
     let prevType: string | undefined;
     let activeAgentId: string | undefined;
-    content.forEach((part, idx) => {
+    content.forEach((part, localIdx) => {
       if (!part) {
         return;
       }
+      const idx = localIdx + contentIndexOffset;
       if (prevType === ContentTypes.STEER && part.type !== ContentTypes.STEER) {
         authors.set(idx, activeAgentId);
       }
@@ -365,7 +373,7 @@ const ContentParts = memo(function ContentParts({
       parts.push({ part, idx });
     });
     return { sequentialParts: parts, detectedResumeAuthors: authors };
-  }, [content]);
+  }, [content, contentIndexOffset]);
   const postSteerAuthors = resumeAuthors ?? detectedResumeAuthors;
 
   const groupedParts = useMemo(
@@ -411,10 +419,11 @@ const ContentParts = memo(function ContentParts({
   if (edit === true && enterEdit && setSiblingIdx) {
     return (
       <>
-        {(content ?? []).map((part, idx) => {
+        {(content ?? []).map((part, localIdx) => {
           if (!part) {
             return null;
           }
+          const idx = localIdx + contentIndexOffset;
           const isTextPart =
             part?.type === ContentTypes.TEXT ||
             typeof (part as unknown as Agents.MessageContentText)?.text === 'string';
@@ -449,11 +458,17 @@ const ContentParts = memo(function ContentParts({
 
   const phaseSegments = nestedActivityPhase ? undefined : groupActivityPhases(content);
   if (phaseSegments != null) {
+    const relativeGlobalLastContentIdx = lastVisibleContentIdx(content ?? []);
+    const globalLastContentIdx =
+      relativeGlobalLastContentIdx < 0
+        ? -1
+        : relativeGlobalLastContentIdx + contentIndexOffset;
     const renderSegment = (
       segmentContent: Array<TMessageContentParts | undefined>,
+      segmentStartIndex: number,
       key: string,
     ) => {
-      const globalLastContentIdx = lastVisibleContentIdx(content ?? []);
+      const localLastContentIdx = globalLastContentIdx - segmentStartIndex;
       return (
         <ContentParts
           key={key}
@@ -465,10 +480,11 @@ const ContentParts = memo(function ContentParts({
           attachments={attachments}
           searchResults={searchResults}
           isCreatedByUser={isCreatedByUser}
-          isLast={isLast && segmentContent[globalLastContentIdx] != null}
+          isLast={isLast && segmentContent[localLastContentIdx] != null}
           isSubmitting={isSubmitting}
           isLatestMessage={isLatestMessage}
           nestedActivityPhase
+          contentIndexOffset={segmentStartIndex}
           resumeAuthors={postSteerAuthors}
           toolGroupExpansionState={expansionState}
         />
@@ -490,10 +506,18 @@ const ContentParts = memo(function ContentParts({
                 labelPart={segment.labelPart}
                 hasContent={segment.hasContent}
               >
-                {renderSegment(segment.content, `phase-content-${index}`)}
+                {renderSegment(
+                  segment.content,
+                  segment.startIndex + contentIndexOffset,
+                  `phase-content-${index}`,
+                )}
               </ActivityPhaseGroup>
             ) : (
-              renderSegment(segment.content, `phase-adjacent-${index}`)
+              renderSegment(
+                segment.content,
+                segment.startIndex + contentIndexOffset,
+                `phase-adjacent-${index}`,
+              )
             ),
           )}
         </SearchContext.Provider>
@@ -506,7 +530,9 @@ const ContentParts = memo(function ContentParts({
   /** Skips trailing BLANK label reservations — they render nothing, and
    *  counting one as last would strip the streaming cursor from the last
    *  VISIBLE part until the next delta. */
-  const lastContentIdx = lastVisibleContentIdx(safeContent);
+  const relativeLastContentIdx = lastVisibleContentIdx(safeContent);
+  const lastContentIdx =
+    relativeLastContentIdx < 0 ? -1 : relativeLastContentIdx + contentIndexOffset;
 
   // Parallel content: use dedicated renderer with columns (TMessageContentParts includes ContentMetadata)
   const hasParallelContent = safeContent.some((part) => part?.groupId != null);
@@ -525,6 +551,7 @@ const ContentParts = memo(function ContentParts({
           renderPart={renderPart}
           renderResumeAttribution={renderResumeAttribution}
           showDecorations={!nestedActivityPhase}
+          contentIndexOffset={contentIndexOffset}
         />
       </>
     );

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -151,6 +151,8 @@ type ContentPartsProps = {
     | undefined;
   /** Internal recursion guard for sparse phase slices. */
   nestedActivityPhase?: boolean;
+  /** Message-wide steer attribution retained across sparse phase slices. */
+  resumeAuthors?: ReadonlyMap<number, string | undefined>;
 };
 
 /**
@@ -177,6 +179,7 @@ const ContentParts = memo(function ContentParts({
   isLatestMessage,
   createdAt,
   nestedActivityPhase = false,
+  resumeAuthors,
 }: ContentPartsProps) {
   const attachmentMap = useMemo(() => mapAttachments(attachments ?? []), [attachments]);
   const effectiveIsSubmitting = isLatestMessage ? isSubmitting : false;
@@ -336,11 +339,11 @@ const ContentParts = memo(function ContentParts({
    *  for the top-level `authorHeader`. Read BEFORE applying the current
    *  part's own handoff, so a resume point that IS an agent update keeps the
    *  pre-handoff author and lets the real marker announce the transition. */
-  const { sequentialParts, postSteerAuthors } = useMemo(() => {
+  const { sequentialParts, detectedResumeAuthors } = useMemo(() => {
     const parts: PartWithIndex[] = [];
     const authors = new Map<number, string | undefined>();
     if (!content) {
-      return { sequentialParts: parts, postSteerAuthors: authors };
+      return { sequentialParts: parts, detectedResumeAuthors: authors };
     }
     let prevType: string | undefined;
     let activeAgentId: string | undefined;
@@ -357,8 +360,9 @@ const ContentParts = memo(function ContentParts({
       prevType = part.type;
       parts.push({ part, idx });
     });
-    return { sequentialParts: parts, postSteerAuthors: authors };
+    return { sequentialParts: parts, detectedResumeAuthors: authors };
   }, [content]);
+  const postSteerAuthors = resumeAuthors ?? detectedResumeAuthors;
 
   const groupedParts = useMemo(
     () =>
@@ -461,6 +465,7 @@ const ContentParts = memo(function ContentParts({
           isSubmitting={isSubmitting}
           isLatestMessage={isLatestMessage}
           nestedActivityPhase
+          resumeAuthors={postSteerAuthors}
         />
       );
     };
@@ -478,6 +483,7 @@ const ContentParts = memo(function ContentParts({
               <ActivityPhaseGroup
                 key={`activity-phase-${messageId}-${segment.labelIndex}`}
                 labelPart={segment.labelPart}
+                hasContent={segment.hasContent}
               >
                 {renderSegment(segment.content, `phase-content-${index}`)}
               </ActivityPhaseGroup>

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -153,6 +153,8 @@ type ContentPartsProps = {
   nestedActivityPhase?: boolean;
   /** Message-wide steer attribution retained across sparse phase slices. */
   resumeAuthors?: ReadonlyMap<number, string | undefined>;
+  /** Message-wide tool-group expansion overrides retained across phase slices. */
+  toolGroupExpansionState?: Map<string, ToolCallGroupExpansionState>;
 };
 
 /**
@@ -180,15 +182,17 @@ const ContentParts = memo(function ContentParts({
   createdAt,
   nestedActivityPhase = false,
   resumeAuthors,
+  toolGroupExpansionState,
 }: ContentPartsProps) {
   const attachmentMap = useMemo(() => mapAttachments(attachments ?? []), [attachments]);
   const effectiveIsSubmitting = isLatestMessage ? isSubmitting : false;
-  const toolGroupExpansionRef = useRef(new Map<string, ToolCallGroupExpansionState>());
+  const localToolGroupExpansionRef = useRef(new Map<string, ToolCallGroupExpansionState>());
+  const expansionState = toolGroupExpansionState ?? localToolGroupExpansionRef.current;
   const fallbackScopeRef = useRef({ messageId, scope: 0 });
   if (fallbackScopeRef.current.messageId !== messageId) {
     if (!effectiveIsSubmitting) {
       fallbackScopeRef.current.scope += 1;
-      toolGroupExpansionRef.current.clear();
+      expansionState.clear();
     }
     fallbackScopeRef.current.messageId = messageId;
   }
@@ -197,12 +201,12 @@ const ContentParts = memo(function ContentParts({
   const handleGroupExpansionChange = useCallback(
     (groupId: string, state: ToolCallGroupExpansionState) => {
       if (!state.userOverride) {
-        toolGroupExpansionRef.current.delete(groupId);
+        expansionState.delete(groupId);
         return;
       }
-      toolGroupExpansionRef.current.set(groupId, state);
+      expansionState.set(groupId, state);
     },
-    [],
+    [expansionState],
   );
 
   /**
@@ -466,6 +470,7 @@ const ContentParts = memo(function ContentParts({
           isLatestMessage={isLatestMessage}
           nestedActivityPhase
           resumeAuthors={postSteerAuthors}
+          toolGroupExpansionState={expansionState}
         />
       );
     };
@@ -569,7 +574,7 @@ const ContentParts = memo(function ContentParts({
             renderPart={renderGroupedPart}
             lastContentIdx={lastContentIdx}
             groupAttachments={group.groupAttachments}
-            initialExpansionState={toolGroupExpansionRef.current.get(groupId)}
+            initialExpansionState={expansionState.get(groupId)}
             onExpansionChange={(state) => handleGroupExpansionChange(groupId, state)}
             labelPart={group.labelPart}
           />,

--- a/client/src/components/Chat/Messages/Content/ParallelContent.tsx
+++ b/client/src/components/Chat/Messages/Content/ParallelContent.tsx
@@ -225,6 +225,7 @@ type ParallelContentRendererProps = {
    * carries per-agent identity.
    */
   renderResumeAttribution?: (idx: number) => React.ReactNode;
+  showDecorations?: boolean;
 };
 
 /**
@@ -241,6 +242,7 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
   isSubmitting,
   renderPart,
   renderResumeAttribution,
+  showDecorations = true,
 }: ParallelContentRendererProps) {
   const { parallelSections, sequentialParts } = useMemo(
     () => groupParallelContent(content),
@@ -272,8 +274,10 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
 
   return (
     <SearchContext.Provider value={{ searchResults }}>
-      <MemoryArtifacts attachments={attachments} />
-      <Sources messageId={messageId} conversationId={conversationId || undefined} />
+      {showDecorations && <MemoryArtifacts attachments={attachments} />}
+      {showDecorations && (
+        <Sources messageId={messageId} conversationId={conversationId || undefined} />
+      )}
 
       {/* Sequential content BEFORE parallel sections */}
       {before.flatMap(({ part, idx }) => {

--- a/client/src/components/Chat/Messages/Content/ParallelContent.tsx
+++ b/client/src/components/Chat/Messages/Content/ParallelContent.tsx
@@ -35,6 +35,7 @@ export type ParallelSection = {
  */
 export function groupParallelContent(
   content: Array<TMessageContentParts | undefined> | undefined,
+  contentIndexOffset = 0,
 ): { parallelSections: ParallelSection[]; sequentialParts: PartWithIndex[] } {
   if (!content) {
     return { parallelSections: [], sequentialParts: [] };
@@ -45,10 +46,11 @@ export function groupParallelContent(
   const placeholderAgents = new Map<number, Set<string>>();
   const noGroup: PartWithIndex[] = [];
 
-  content.forEach((part, idx) => {
+  content.forEach((part, localIdx) => {
     if (!part) {
       return;
     }
+    const idx = localIdx + contentIndexOffset;
 
     // Read metadata directly from content part (TMessageContentParts includes ContentMetadata)
     const { groupId } = part;
@@ -226,6 +228,8 @@ type ParallelContentRendererProps = {
    */
   renderResumeAttribution?: (idx: number) => React.ReactNode;
   showDecorations?: boolean;
+  /** Absolute transcript index represented by `content[0]` in a phase slice. */
+  contentIndexOffset?: number;
 };
 
 /**
@@ -243,16 +247,19 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
   renderPart,
   renderResumeAttribution,
   showDecorations = true,
+  contentIndexOffset = 0,
 }: ParallelContentRendererProps) {
   const { parallelSections, sequentialParts } = useMemo(
-    () => groupParallelContent(content),
-    [content],
+    () => groupParallelContent(content, contentIndexOffset),
+    [content, contentIndexOffset],
   );
 
   /** Same walk-back as `ContentParts`: a trailing BLANK label reservation is
    *  filtered out of every lane, so counting it as last would leave NO
    *  rendered part with the last-part cursor until the label fills. */
-  const lastContentIdx = lastVisibleContentIdx(content);
+  const relativeLastContentIdx = lastVisibleContentIdx(content);
+  const lastContentIdx =
+    relativeLastContentIdx < 0 ? -1 : relativeLastContentIdx + contentIndexOffset;
 
   // Split sequential parts into before/after parallel sections
   const { before, after } = useMemo(() => {

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -67,6 +67,7 @@ const Part = memo(function Part({
   if (askUserQuestion) {
     return (
       <AskUserQuestion
+        key={askUserQuestion.ask_user_question.actionId}
         actionId={askUserQuestion.ask_user_question.actionId}
         question={askUserQuestion.ask_user_question.question}
       />

--- a/client/src/components/Chat/Messages/Content/ToolApproval.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolApproval.tsx
@@ -73,6 +73,7 @@ export default function ToolApproval({
     registerToolCall,
     unregisterToolCall,
     setDecision,
+    getDecision,
     isReady,
     getStatus,
     getLeadToolCallId,
@@ -80,10 +81,25 @@ export default function ToolApproval({
   } = useApprovalContext();
   const { submitToolApproval } = useResumeSubmit();
 
-  const [active, setActive] = useState<DecisionType | null>(null);
-  const [editText, setEditText] = useState(() => seedArgs(args));
-  const [responseText, setResponseText] = useState('');
-  const [reason, setReason] = useState('');
+  const retainedDecision = getDecision(actionId, toolCallId);
+  const initialDecision =
+    retainedDecision != null && allowedDecisions.includes(retainedDecision.decision)
+      ? retainedDecision
+      : undefined;
+  const [active, setActive] = useState<DecisionType | null>(
+    () => initialDecision?.decision ?? null,
+  );
+  const [editText, setEditText] = useState(() =>
+    initialDecision?.decision === 'edit'
+      ? (JSON.stringify(initialDecision.editedArguments, null, 2) ?? '{}')
+      : seedArgs(args),
+  );
+  const [responseText, setResponseText] = useState(() =>
+    initialDecision?.decision === 'respond' ? (initialDecision.responseText ?? '') : '',
+  );
+  const [reason, setReason] = useState(() =>
+    initialDecision?.decision === 'reject' ? (initialDecision.reason ?? '') : '',
+  );
 
   useEffect(() => {
     registerToolCall(actionId, toolCallId);

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -10,8 +10,8 @@ import type {
   FunctionToolCall,
 } from 'librechat-data-provider';
 import type { PartWithIndex } from './ParallelContent';
-import { useLocalize, useExpandCollapse, scheduleMessageContentLayoutReconcile } from '~/hooks';
 import { cn, getToolDisplayLabel, getBatchActivityLabelPart, getActivityLabelText } from '~/utils';
+import { useLocalize, useExpandCollapse, scheduleMessageContentLayoutReconcile } from '~/hooks';
 import { useMCPIconMap, useMCPServerNames } from '~/hooks/MCP';
 import { isBashProgrammaticToolCall } from './routing';
 import { ASK_USER_QUESTION } from '~/utils/approval';

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -11,7 +11,7 @@ import type {
 } from 'librechat-data-provider';
 import type { PartWithIndex } from './ParallelContent';
 import { useLocalize, useExpandCollapse, scheduleMessageContentLayoutReconcile } from '~/hooks';
-import { cn, getToolDisplayLabel, getActivityLabelPart, getActivityLabelText } from '~/utils';
+import { cn, getToolDisplayLabel, getBatchActivityLabelPart, getActivityLabelText } from '~/utils';
 import { useMCPIconMap, useMCPServerNames } from '~/hooks/MCP';
 import { isBashProgrammaticToolCall } from './routing';
 import { ASK_USER_QUESTION } from '~/utils/approval';
@@ -152,7 +152,7 @@ export default function ToolCallGroup({
     () => parts.some(({ part }) => hasPendingApprovalInPart(part)),
     [parts],
   );
-  const activityLabel = getActivityLabelPart(labelPart?.part);
+  const activityLabel = getBatchActivityLabelPart(labelPart?.part);
   const activityLabelText = getActivityLabelText(activityLabel);
   const activityFailed = activityLabel?.status === 'failed' || activityLabel?.status === 'partial';
   /** A settled, filled label is itself a completion proof: the PostToolBatch

--- a/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
@@ -15,7 +15,7 @@ describe('ActivityPhaseGroup', () => {
   test('renders a streaming cursor after an active tail phase', () => {
     const { container } = render(
       <ActivityPhaseGroup labelPart={labelPart} hasContent showCursor>
-        <div>phase content</div>
+        <div data-testid="phase-content" />
       </ActivityPhaseGroup>,
     );
 

--- a/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { ContentTypes } from 'librechat-data-provider';
+import type { TMessageContentParts } from 'librechat-data-provider';
+import ActivityPhaseGroup from '../ActivityPhaseGroup';
+
+const labelPart = {
+  type: ContentTypes.ACTIVITY_LABEL,
+  [ContentTypes.ACTIVITY_LABEL]: 'Compared both release paths',
+  activity_label_type: 'phase',
+  activity_start_index: 0,
+  pending: false,
+} as unknown as Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }>;
+
+describe('ActivityPhaseGroup', () => {
+  test('renders a streaming cursor after an active tail phase', () => {
+    const { container } = render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent showCursor>
+        <div>phase content</div>
+      </ActivityPhaseGroup>,
+    );
+
+    expect(container.querySelector('.result-thinking')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/ApprovalContext.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ApprovalContext.test.tsx
@@ -95,6 +95,24 @@ describe('useResumeSubmit', () => {
     expect(mockApprovalMutate).toHaveBeenCalledTimes(2);
   });
 
+  test('retains a decision across a transient card unregister and re-register', () => {
+    const { result } = renderHook(() => useApprovalContext(), { wrapper });
+    const decision = { tool_call_id: 'call-1', decision: 'approve' } as const;
+
+    act(() => {
+      result.current.registerToolCall('action-1', 'call-1');
+      result.current.setDecision('action-1', 'call-1', decision);
+    });
+    act(() => result.current.unregisterToolCall('action-1', 'call-1'));
+
+    expect(result.current.getDecisions('action-1')).toEqual([]);
+    expect(result.current.getDecision('action-1', 'call-1')).toEqual(decision);
+
+    act(() => result.current.registerToolCall('action-1', 'call-1'));
+    expect(result.current.getDecisions('action-1')).toEqual([decision]);
+    expect(result.current.isReady('action-1')).toBe(true);
+  });
+
   test('keeps approval and ask-answer resume controls inert before the generation epoch exists', () => {
     const { result } = renderHook(
       () => ({

--- a/client/src/components/Chat/Messages/Content/__tests__/AskUserQuestion.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/AskUserQuestion.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ApprovalProvider from '../ApprovalContext';
+import AskUserQuestion from '../AskUserQuestion';
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => {
+    const labels: Record<string, string> = {
+      com_ui_your_answer: 'Your answer',
+      com_ui_submit: 'Submit',
+      com_ui_submitting: 'Submitting',
+    };
+    return labels[key] ?? key;
+  },
+}));
+
+jest.mock('~/hooks/Input/useAskAnswerMode', () => ({
+  __esModule: true,
+  default: () => ({
+    popoverVisible: false,
+    collapsed: false,
+    expand: jest.fn(),
+    liveAsk: null,
+    checked: [],
+    toggleChecked: jest.fn(),
+    submitOption: jest.fn(),
+    submitAnswer: jest.fn(),
+  }),
+}));
+
+jest.mock('~/data-provider', () => ({
+  useSubmitToolApprovalMutation: () => ({ mutate: jest.fn() }),
+  useSubmitAskAnswerMutation: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock('~/store/agents', () => ({
+  useGetEphemeralAgent: () => () => undefined,
+}));
+
+jest.mock('~/Providers/ChatContext', () => ({
+  ChatContext: jest.requireActual('react').createContext(null),
+}));
+
+const tree = (key: string) => (
+  <RecoilRoot>
+    <ApprovalProvider>
+      <AskUserQuestion
+        key={key}
+        actionId="ask-1"
+        question={{ question: 'Which environment?' }}
+      />
+    </ApprovalProvider>
+  </RecoilRoot>
+);
+
+describe('AskUserQuestion', () => {
+  test('restores a typed answer after the card remounts inside the same message', () => {
+    const view = render(tree('direct'));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Your answer' }), {
+      target: { value: 'Use staging first' },
+    });
+
+    view.rerender(tree('phase-slice'));
+
+    expect(screen.getByRole('textbox', { name: 'Your answer' })).toHaveValue('Use staging first');
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/AskUserQuestion.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/AskUserQuestion.test.tsx
@@ -45,11 +45,7 @@ jest.mock('~/Providers/ChatContext', () => ({
 const tree = (key: string) => (
   <RecoilRoot>
     <ApprovalProvider>
-      <AskUserQuestion
-        key={key}
-        actionId="ask-1"
-        question={{ question: 'Which environment?' }}
-      />
+      <AskUserQuestion key={key} actionId="ask-1" question={{ question: 'Which environment?' }} />
     </ApprovalProvider>
   </RecoilRoot>
 );

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -13,7 +13,13 @@ jest.mock('~/utils', () => ({
 
 jest.mock('~/Providers', () => ({
   MessageContext: {
-    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Provider: ({
+      children,
+      value,
+    }: {
+      children: React.ReactElement<{ idx?: number }>;
+      value: { partIndex: number };
+    }) => React.cloneElement(children, { idx: value.partIndex }),
   },
   SearchContext: {
     Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -341,10 +347,7 @@ describe('ContentParts — activity phase state', () => {
       />,
     );
 
-    expect(screen.getByTestId('activity-phase-group')).toHaveAttribute(
-      'data-show-cursor',
-      'true',
-    );
+    expect(screen.getByTestId('activity-phase-group')).toHaveAttribute('data-show-cursor', 'true');
   });
 
   it('carries the absolute index offset into a parallel phase segment', () => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -336,9 +336,7 @@ describe('ContentParts — activity phase state', () => {
       activity_count: 2,
       pending: true,
     } as unknown as TMessageContentParts;
-    const { rerender } = render(
-      <ContentParts {...baseProps} content={[...tools, pendingPhase]} />,
-    );
+    const { rerender } = render(<ContentParts {...baseProps} content={[...tools, pendingPhase]} />);
 
     const pendingGroup = screen.getByTestId('tool-call-group');
     expect(pendingGroup).toHaveAttribute('data-initial-expanded', 'unset');
@@ -352,9 +350,6 @@ describe('ContentParts — activity phase state', () => {
     rerender(<ContentParts {...baseProps} content={[...tools, completedPhase]} />);
 
     expect(screen.getByTestId('activity-phase-group')).toBeInTheDocument();
-    expect(screen.getByTestId('tool-call-group')).toHaveAttribute(
-      'data-initial-expanded',
-      'false',
-    );
+    expect(screen.getByTestId('tool-call-group')).toHaveAttribute('data-initial-expanded', 'false');
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -75,8 +75,8 @@ jest.mock('../Container', () => ({
 
 jest.mock('../Part', () => ({
   __esModule: true,
-  default: ({ part }: { part: TMessageContentParts }) => (
-    <div data-testid={`real-part-${part.type}`} />
+  default: ({ part, idx }: { part: TMessageContentParts; idx: number }) => (
+    <div data-testid={`real-part-${part.type}`} data-index={idx} />
   ),
 }));
 
@@ -85,13 +85,15 @@ jest.mock('../ParallelContent', () => ({
    *  renderer does for its sequential stretches, so the wiring is testable. */
   ParallelContentRenderer: ({
     content,
+    contentIndexOffset = 0,
     renderResumeAttribution,
   }: {
     content?: Array<TMessageContentParts | undefined>;
+    contentIndexOffset?: number;
     renderResumeAttribution?: (idx: number) => React.ReactNode;
   }) => (
-    <div data-testid="parallel-renderer">
-      {content?.map((_, idx) => renderResumeAttribution?.(idx))}
+    <div data-testid="parallel-renderer" data-index-offset={contentIndexOffset}>
+      {content?.map((_, idx) => renderResumeAttribution?.(idx + contentIndexOffset))}
     </div>
   ),
 }));
@@ -306,10 +308,43 @@ describe('ContentParts — post-steer author re-attribution', () => {
 
     expect(screen.getByTestId('activity-phase-group')).toBeTruthy();
     expect(screen.getAllByTestId('author-header')).toHaveLength(1);
+    expect(screen.getAllByTestId(`real-part-${ContentTypes.TEXT}`)[1]).toHaveAttribute(
+      'data-index',
+      '2',
+    );
   });
 });
 
 describe('ContentParts — activity phase state', () => {
+  it('carries the absolute index offset into a parallel phase segment', () => {
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Compared both agent results',
+      activity_label_type: 'phase',
+      activity_start_index: 1,
+      activity_count: 2,
+      pending: false,
+    } as unknown as TMessageContentParts;
+    const parallel = {
+      type: ContentTypes.TEXT,
+      text: 'lane result',
+      groupId: 1,
+    } as unknown as TMessageContentParts;
+
+    render(
+      <ContentParts
+        {...baseProps}
+        content={[
+          { type: ContentTypes.TEXT, text: 'before' } as unknown as TMessageContentParts,
+          parallel,
+          phase,
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('parallel-renderer')).toHaveAttribute('data-index-offset', '1');
+  });
+
   it('retains a tool-group expansion override when a completed phase remounts the group', () => {
     jest.mocked(groupSequentialToolCalls).mockImplementation((parts) => {
       const toolParts = parts.filter(({ part }) => part.type === ContentTypes.TOOL_CALL);

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -61,8 +61,10 @@ jest.mock('../ToolCallGroup', () => ({
 
 jest.mock('../ActivityPhaseGroup', () => ({
   __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="activity-phase-group">{children}</div>
+  default: ({ children, showCursor }: { children: React.ReactNode; showCursor?: boolean }) => (
+    <div data-testid="activity-phase-group" data-show-cursor={String(showCursor === true)}>
+      {children}
+    </div>
   ),
 }));
 
@@ -316,6 +318,35 @@ describe('ContentParts — post-steer author re-attribution', () => {
 });
 
 describe('ContentParts — activity phase state', () => {
+  it('keeps a streaming cursor when a completed phase marker is the visible tail', () => {
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Compared both search results',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_count: 2,
+      pending: false,
+    } as unknown as TMessageContentParts;
+
+    render(
+      <ContentParts
+        {...baseProps}
+        content={[
+          { type: ContentTypes.TEXT, text: 'working' } as unknown as TMessageContentParts,
+          phase,
+        ]}
+        isLast
+        isSubmitting
+        isLatestMessage
+      />,
+    );
+
+    expect(screen.getByTestId('activity-phase-group')).toHaveAttribute(
+      'data-show-cursor',
+      'true',
+    );
+  });
+
   it('carries the absolute index offset into a parallel phase segment', () => {
     const phase = {
       type: ContentTypes.ACTIVITY_LABEL,

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import type { TMessageContentParts } from 'librechat-data-provider';
 
 jest.mock('~/utils', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
   mapAttachments: () => ({}),
   filterAttachmentsForPart: (attachments: unknown) => attachments,
   groupSequentialToolCalls: (parts: Array<{ part: unknown; idx: number }>) =>

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -45,6 +45,13 @@ jest.mock('../ToolCallGroup', () => ({
   default: () => <div data-testid="tool-call-group" />,
 }));
 
+jest.mock('../ActivityPhaseGroup', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="activity-phase-group">{children}</div>
+  ),
+}));
+
 jest.mock('../Container', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => (
@@ -258,5 +265,26 @@ describe('ContentParts — post-steer author re-attribution', () => {
     );
     expect(screen.getAllByTestId('author-header')).toHaveLength(1);
     expect(screen.queryByTestId('post-steer-agent-update')).toBeNull();
+  });
+
+  it('retains steer attribution when resumed content moves into a phase slice', () => {
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Reconciled both release paths',
+      activity_label_type: 'phase',
+      activity_start_index: 2,
+      activity_count: 2,
+      pending: false,
+    } as unknown as TMessageContentParts;
+    render(
+      <ContentParts
+        {...baseProps}
+        content={[textPart('a'), steerPart, textPart('resumed'), phase]}
+        authorHeader={header}
+      />,
+    );
+
+    expect(screen.getByTestId('activity-phase-group')).toBeTruthy();
+    expect(screen.getAllByTestId('author-header')).toHaveLength(1);
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { ContentTypes } from 'librechat-data-provider';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { TMessageContentParts } from 'librechat-data-provider';
+import { groupSequentialToolCalls } from '~/utils';
 
 jest.mock('~/utils', () => ({
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
   mapAttachments: () => ({}),
   filterAttachmentsForPart: (attachments: unknown) => attachments,
-  groupSequentialToolCalls: (parts: Array<{ part: unknown; idx: number }>) =>
-    parts.map((p) => ({ type: 'single' as const, part: p })),
+  groupSequentialToolCalls: jest.fn(),
 }));
 
 jest.mock('~/Providers', () => ({
@@ -42,7 +42,21 @@ jest.mock('../Parts/PendingSkillCall', () => ({
 
 jest.mock('../ToolCallGroup', () => ({
   __esModule: true,
-  default: () => <div data-testid="tool-call-group" />,
+  default: ({
+    initialExpansionState,
+    onExpansionChange,
+  }: {
+    initialExpansionState?: { isExpanded: boolean; userOverride: boolean };
+    onExpansionChange?: (state: { isExpanded: boolean; userOverride: boolean }) => void;
+  }) => (
+    <button
+      data-testid="tool-call-group"
+      data-initial-expanded={
+        initialExpansionState == null ? 'unset' : String(initialExpansionState.isExpanded)
+      }
+      onClick={() => onExpansionChange?.({ isExpanded: false, userOverride: true })}
+    />
+  ),
 }));
 
 jest.mock('../ActivityPhaseGroup', () => ({
@@ -92,6 +106,12 @@ const baseProps = {
   isCreatedByUser: false,
   content: [],
 };
+
+beforeEach(() => {
+  jest
+    .mocked(groupSequentialToolCalls)
+    .mockImplementation((parts) => parts.map((part) => ({ type: 'single', part })));
+});
 
 describe('ContentParts — interim skill cards', () => {
   it('renders a PendingSkillCall per manual skill on assistant messages', () => {
@@ -286,5 +306,55 @@ describe('ContentParts — post-steer author re-attribution', () => {
 
     expect(screen.getByTestId('activity-phase-group')).toBeTruthy();
     expect(screen.getAllByTestId('author-header')).toHaveLength(1);
+  });
+});
+
+describe('ContentParts — activity phase state', () => {
+  it('retains a tool-group expansion override when a completed phase remounts the group', () => {
+    jest.mocked(groupSequentialToolCalls).mockImplementation((parts) => {
+      const toolParts = parts.filter(({ part }) => part.type === ContentTypes.TOOL_CALL);
+      if (toolParts.length > 0) {
+        return [{ type: 'tool-group', parts: toolParts }];
+      }
+      return parts.map((part) => ({ type: 'single', part }));
+    });
+    const tools = [
+      {
+        type: ContentTypes.TOOL_CALL,
+        [ContentTypes.TOOL_CALL]: { id: 'tool-1', name: 'search', args: {}, output: 'one' },
+      },
+      {
+        type: ContentTypes.TOOL_CALL,
+        [ContentTypes.TOOL_CALL]: { id: 'tool-2', name: 'search', args: {}, output: 'two' },
+      },
+    ] as unknown as TMessageContentParts[];
+    const pendingPhase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: '',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_count: 2,
+      pending: true,
+    } as unknown as TMessageContentParts;
+    const { rerender } = render(
+      <ContentParts {...baseProps} content={[...tools, pendingPhase]} />,
+    );
+
+    const pendingGroup = screen.getByTestId('tool-call-group');
+    expect(pendingGroup).toHaveAttribute('data-initial-expanded', 'unset');
+    fireEvent.click(pendingGroup);
+
+    const completedPhase = {
+      ...pendingPhase,
+      [ContentTypes.ACTIVITY_LABEL]: 'Compared both search results',
+      pending: false,
+    } as unknown as TMessageContentParts;
+    rerender(<ContentParts {...baseProps} content={[...tools, completedPhase]} />);
+
+    expect(screen.getByTestId('activity-phase-group')).toBeInTheDocument();
+    expect(screen.getByTestId('tool-call-group')).toHaveAttribute(
+      'data-initial-expanded',
+      'false',
+    );
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -11,20 +11,23 @@ jest.mock('~/utils', () => ({
   groupSequentialToolCalls: jest.fn(),
 }));
 
-jest.mock('~/Providers', () => ({
-  MessageContext: {
-    Provider: ({
-      children,
-      value,
-    }: {
-      children: React.ReactElement<{ idx?: number }>;
-      value: { partIndex: number };
-    }) => React.cloneElement(children, { idx: value.partIndex }),
-  },
-  SearchContext: {
-    Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  },
-}));
+jest.mock('~/Providers', () => {
+  const react = jest.requireActual<typeof import('react')>('react');
+  return {
+    MessageContext: {
+      Provider: ({
+        children,
+        value,
+      }: {
+        children: React.ReactElement<{ idx?: number }>;
+        value: { partIndex: number };
+      }) => react.cloneElement(children, { idx: value.partIndex }),
+    },
+    SearchContext: {
+      Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    },
+  };
+});
 
 jest.mock('../Parts', () => ({
   EditTextPart: () => <div data-testid="edit-text-part" />,

--- a/client/src/components/Chat/Messages/Content/__tests__/ParallelContent.test.ts
+++ b/client/src/components/Chat/Messages/Content/__tests__/ParallelContent.test.ts
@@ -1,0 +1,23 @@
+import { ContentTypes } from 'librechat-data-provider';
+import type { TMessageContentParts } from 'librechat-data-provider';
+import { groupParallelContent } from '../ParallelContent';
+
+describe('groupParallelContent', () => {
+  test('reports absolute indices for a dense phase segment', () => {
+    const sequential = {
+      type: ContentTypes.TEXT,
+      text: 'before lanes',
+    } as unknown as TMessageContentParts;
+    const parallel = {
+      type: ContentTypes.TEXT,
+      text: 'lane result',
+      groupId: 1,
+      agentId: 'agent-1',
+    } as unknown as TMessageContentParts;
+
+    const grouped = groupParallelContent([sequential, parallel], 4);
+
+    expect(grouped.sequentialParts).toEqual([{ part: sequential, idx: 4 }]);
+    expect(grouped.parallelSections[0]?.columns[0]?.parts).toEqual([{ part: parallel, idx: 5 }]);
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolApproval.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolApproval.test.tsx
@@ -102,4 +102,22 @@ describe('ToolApproval', () => {
     fireEvent.click(approveSecond);
     expect(submit).toBeEnabled();
   });
+
+  test('restores a selected decision when the card remounts inside the same message', () => {
+    const tree = (key: string) => (
+      <RecoilRoot>
+        <ApprovalProvider>
+          <ToolApproval key={key} approval={approval()} toolCallId="call-1" args={{ a: 1 }} />
+        </ApprovalProvider>
+      </RecoilRoot>
+    );
+    const view = render(tree('direct'));
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    expect(screen.getByRole('button', { name: 'Approve' })).toHaveAttribute('aria-pressed', 'true');
+
+    view.rerender(tree('phase-slice'));
+
+    expect(screen.getByRole('button', { name: 'Approve' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+  });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -65,8 +65,7 @@ jest.mock('~/utils', () => ({
       : name,
   /** Real implementations: the group header resolves its text through these,
    *  so stubbing them out would hide the header logic under test. */
-  getBatchActivityLabelPart:
-    jest.requireActual('~/utils/activityLabels').getBatchActivityLabelPart,
+  getBatchActivityLabelPart: jest.requireActual('~/utils/activityLabels').getBatchActivityLabelPart,
   getActivityLabelText: jest.requireActual('~/utils/activityLabels').getActivityLabelText,
 }));
 

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -65,7 +65,8 @@ jest.mock('~/utils', () => ({
       : name,
   /** Real implementations: the group header resolves its text through these,
    *  so stubbing them out would hide the header logic under test. */
-  getActivityLabelPart: jest.requireActual('~/utils/activityLabels').getActivityLabelPart,
+  getBatchActivityLabelPart:
+    jest.requireActual('~/utils/activityLabels').getBatchActivityLabelPart,
   getActivityLabelText: jest.requireActual('~/utils/activityLabels').getActivityLabelText,
 }));
 

--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -3357,6 +3357,55 @@ describe('useStepHandler', () => {
       expect(response?.content?.[0]).toMatchObject({ [ContentTypes.TEXT]: 'kept a' });
     });
 
+    it('does not merge final-answer text into a retained commentary phase', () => {
+      const commentary = {
+        type: ContentTypes.TEXT,
+        [ContentTypes.TEXT]: 'Checked the current deployment. ',
+        phase: 'commentary',
+      } as TMessageContentParts;
+      const submission = createSubmission({
+        editedContent: { index: 0, type: ContentTypes.TEXT },
+        initialResponse: createResponseMessage({ content: [textPart('kept'), commentary] }),
+      } as never);
+      (submission as { editPrefixLength?: number }).editPrefixLength = 2;
+      const responseMessage = submission.initialResponse as TMessage;
+      let currentMessages: TMessage[] = [responseMessage];
+      mockGetMessages.mockImplementation(() => currentMessages);
+      mockSetMessages.mockImplementation((messages: TMessage[]) => {
+        currentMessages = messages;
+      });
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      act(() => {
+        result.current.stepHandler(
+          {
+            event: StepEvents.ON_RUN_STEP,
+            data: createRunStep({
+              stepDetails: {
+                type: StepTypes.MESSAGE_CREATION,
+                message_creation: { message_id: 'msg-1', phase: 'final_answer' },
+              },
+            }),
+          },
+          submission,
+        );
+        result.current.stepHandler(
+          { event: StepEvents.ON_MESSAGE_DELTA, data: createMessageDelta('step-1', 'Done') },
+          submission,
+        );
+      });
+
+      const response = currentMessages.find((message) => !message.isCreatedByUser);
+      expect(response?.content?.[1]).toMatchObject({
+        [ContentTypes.TEXT]: 'Checked the current deployment. ',
+        phase: 'commentary',
+      });
+      expect(response?.content?.[2]).toMatchObject({
+        [ContentTypes.TEXT]: 'Done',
+        phase: 'final_answer',
+      });
+    });
+
     /**
      * Post-sync a delta continues at the snapshot's NEXT absolute slot. With
      * the offset still applied it would jump past that slot and leave a hole

--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -3406,6 +3406,61 @@ describe('useStepHandler', () => {
       });
     });
 
+    it.each([
+      [undefined, 'commentary'],
+      ['commentary', undefined],
+    ] as const)(
+      'does not merge phased and unphased text (%s → %s)',
+      (retainedPhase, incomingPhase) => {
+        const retained = {
+          type: ContentTypes.TEXT,
+          [ContentTypes.TEXT]: 'Retained text. ',
+          ...(retainedPhase != null && { phase: retainedPhase }),
+        } as TMessageContentParts;
+        const submission = createSubmission({
+          editedContent: { index: 0, type: ContentTypes.TEXT },
+          initialResponse: createResponseMessage({ content: [textPart('kept'), retained] }),
+        } as never);
+        (submission as { editPrefixLength?: number }).editPrefixLength = 2;
+        const responseMessage = submission.initialResponse as TMessage;
+        let currentMessages: TMessage[] = [responseMessage];
+        mockGetMessages.mockImplementation(() => currentMessages);
+        mockSetMessages.mockImplementation((messages: TMessage[]) => {
+          currentMessages = messages;
+        });
+
+        const { result } = renderHook(() => useStepHandler(createHookParams()));
+        act(() => {
+          result.current.stepHandler(
+            {
+              event: StepEvents.ON_RUN_STEP,
+              data: createRunStep({
+                stepDetails: {
+                  type: StepTypes.MESSAGE_CREATION,
+                  message_creation: {
+                    message_id: 'msg-1',
+                    ...(incomingPhase != null && { phase: incomingPhase }),
+                  },
+                },
+              }),
+            },
+            submission,
+          );
+          result.current.stepHandler(
+            { event: StepEvents.ON_MESSAGE_DELTA, data: createMessageDelta('step-1', 'New text') },
+            submission,
+          );
+        });
+
+        const response = currentMessages.find((message) => !message.isCreatedByUser);
+        expect(response?.content?.[1]).toMatchObject(retained);
+        expect(response?.content?.[2]).toMatchObject({
+          [ContentTypes.TEXT]: 'New text',
+          ...(incomingPhase != null && { phase: incomingPhase }),
+        });
+      },
+    );
+
     /**
      * Post-sync a delta continues at the snapshot's NEXT absolute slot. With
      * the offset still applied it would jump past that slot and leave a hole

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -1374,6 +1374,7 @@ export default function useResumableSSE(
              *  occupy the ordinary +prefix slot, so only fold back across the
              *  recognizable empty merge slot. */
             if (
+              phasePart.activity_start_index === 0 &&
               activityStartIndex > 0 &&
               targetContent?.[activityStartIndex] == null &&
               targetContent?.[activityStartIndex - 1] != null

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -1353,8 +1353,44 @@ export default function useResumableSSE(
               (currentSubmission.initialResponse as TMessage | undefined)?.content?.length ??
               0)
             : 0;
-        const offsetEvent =
-          prefixLength > 0 ? { ...event, index: event.index + prefixLength } : event;
+        const phasePart = event.part as TActivityLabelEvent['part'] & {
+          activity_label_type?: 'phase';
+          activity_start_index?: number;
+        };
+        let offsetEvent = event;
+        if (prefixLength > 0) {
+          let offsetPart: TActivityLabelEvent['part'] & {
+            activity_label_type?: 'phase';
+            activity_start_index?: number;
+          } = phasePart;
+          if (
+            phasePart.activity_label_type === 'phase' &&
+            typeof phasePart.activity_start_index === 'number'
+          ) {
+            let activityStartIndex = phasePart.activity_start_index + prefixLength;
+            const targetContent = messages[index]?.content;
+            /** The first completion text/think part can merge into the
+             *  retained edit tail at prefixLength - 1. Tool/nonmatching starts
+             *  occupy the ordinary +prefix slot, so only fold back across the
+             *  recognizable empty merge slot. */
+            if (
+              activityStartIndex > 0 &&
+              targetContent?.[activityStartIndex] == null &&
+              targetContent?.[activityStartIndex - 1] != null
+            ) {
+              activityStartIndex -= 1;
+            }
+            offsetPart = {
+              ...phasePart,
+              activity_start_index: activityStartIndex,
+            };
+          }
+          offsetEvent = {
+            ...event,
+            index: event.index + prefixLength,
+            part: offsetPart,
+          };
+        }
         const updated = applyActivityLabelPart(messages[index], offsetEvent);
         if (updated !== messages[index]) {
           const nextMessages = [...messages];

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -360,11 +360,11 @@ export default function useStepHandler({
         const existingType = existingPart?.type;
         const existingPhase =
           existingPart?.type === ContentTypes.TEXT ? existingPart.phase : undefined;
+        /** Match final assembly: phased and legacy/unphased text cannot share
+         *  a content part because the phase controls client grouping. */
         const phaseCompatible =
           incomingContentType !== ContentTypes.TEXT ||
-          incomingPhase == null ||
-          existingPhase == null ||
-          incomingPhase === existingPhase;
+          (incomingPhase ?? null) === (existingPhase ?? null);
         if (existingType === incomingContentType && phaseCompatible) {
           return targetIndex;
         }

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -449,12 +449,12 @@ export default function useStepHandler({
       typeof contentPart.text === 'string'
     ) {
       const currentContent = updatedContent[index] as MessageDeltaUpdate;
+      const incomingContent = contentPart as MessageDeltaUpdate;
+      const phase = incomingContent.phase ?? currentContent.phase;
       const update: MessageDeltaUpdate = {
         type: ContentTypes.TEXT,
-        text: (currentContent.text || '') + contentPart.text,
-        ...((contentPart.phase ?? currentContent.phase) != null && {
-          phase: contentPart.phase ?? currentContent.phase,
-        }),
+        text: (currentContent.text || '') + incomingContent.text,
+        ...(phase != null && { phase }),
       };
 
       if ('tool_call_ids' in contentPart && contentPart.tool_call_ids != null) {

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -944,16 +944,28 @@ export default function useStepHandler({
             if (contentPart == null) {
               continue;
             }
+            const messageCreation =
+              runStep.stepDetails.type === StepTypes.MESSAGE_CREATION
+                ? (runStep.stepDetails.message_creation as {
+                    phase?: 'commentary' | 'final_answer';
+                  })
+                : undefined;
+            const phase = messageCreation?.phase;
+            const phasedContentPart =
+              contentPart.type === ContentTypes.TEXT &&
+              (phase === 'commentary' || phase === 'final_answer')
+                ? { ...contentPart, phase }
+                : contentPart;
             const currentIndex = calculateContentIndex(
               runStep.index,
               editPrefixOffset,
-              contentPart.type || '',
+              phasedContentPart.type || '',
               updatedResponse.content,
             );
             updatedResponse = updateContent(
               updatedResponse,
               currentIndex,
-              contentPart,
+              phasedContentPart,
               false,
               getStepMetadata(runStep),
             );

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -59,7 +59,12 @@ type TStepEvent =
   | { event: StepEvents.ON_SUBAGENT_UPDATE; data: SubagentUpdateEvent }
   | { event: StepEvents.ON_SANDBOX_STARTING; data: SandboxStartingEvent };
 
-type MessageDeltaUpdate = { type: ContentTypes.TEXT; text: string; tool_call_ids?: string[] };
+type MessageDeltaUpdate = {
+  type: ContentTypes.TEXT;
+  text: string;
+  tool_call_ids?: string[];
+  phase?: 'commentary' | 'final_answer';
+};
 
 type ReasoningDeltaUpdate = { type: ContentTypes.THINK; think: string };
 
@@ -343,6 +348,7 @@ export default function useStepHandler({
       editPrefixOffset: number,
       incomingContentType: string,
       existingContent?: TMessageContentParts[],
+      incomingPhase?: 'commentary' | 'final_answer',
     ): number => {
       /** Only apply -1 adjustment for TEXT or THINK types when they match existing content */
       if (
@@ -350,8 +356,16 @@ export default function useStepHandler({
         (incomingContentType === ContentTypes.TEXT || incomingContentType === ContentTypes.THINK)
       ) {
         const targetIndex = serverIndex + editPrefixOffset - 1;
-        const existingType = existingContent?.[targetIndex]?.type;
-        if (existingType === incomingContentType) {
+        const existingPart = existingContent?.[targetIndex];
+        const existingType = existingPart?.type;
+        const existingPhase =
+          existingPart?.type === ContentTypes.TEXT ? existingPart.phase : undefined;
+        const phaseCompatible =
+          incomingContentType !== ContentTypes.TEXT ||
+          incomingPhase == null ||
+          existingPhase == null ||
+          incomingPhase === existingPhase;
+        if (existingType === incomingContentType && phaseCompatible) {
           return targetIndex;
         }
       }
@@ -438,6 +452,9 @@ export default function useStepHandler({
       const update: MessageDeltaUpdate = {
         type: ContentTypes.TEXT,
         text: (currentContent.text || '') + contentPart.text,
+        ...((contentPart.phase ?? currentContent.phase) != null && {
+          phase: contentPart.phase ?? currentContent.phase,
+        }),
       };
 
       if ('tool_call_ids' in contentPart && contentPart.tool_call_ids != null) {
@@ -961,6 +978,7 @@ export default function useStepHandler({
               editPrefixOffset,
               phasedContentPart.type || '',
               updatedResponse.content,
+              phase,
             );
             updatedResponse = updateContent(
               updatedResponse,

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -101,6 +101,9 @@ describe('lastVisibleContentIdx', () => {
 
   it('skips sparse trailing slots used by phase slices', () => {
     expect(lastVisibleContentIdx([undefined, tool, undefined, undefined])).toBe(1);
+    const sparse = new Array<TMessageContentParts | undefined>(10_000);
+    sparse[1] = tool;
+    expect(lastVisibleContentIdx(sparse)).toBe(1);
   });
 });
 

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -122,6 +122,8 @@ describe('groupActivityPhases', () => {
     expect(segments).toHaveLength(3);
     expect(segments?.[1]).toMatchObject({ type: 'phase', labelIndex: 3 });
     if (segments?.[1]?.type === 'phase') {
+      expect(segments[1].content).toHaveLength(3);
+      expect(0 in segments[1].content).toBe(false);
       expect(segments[1].content[0]).toBeUndefined();
       expect(segments[1].content[1]).toBe(tool);
       expect(segments[1].content[2]).toBe(tool);

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -99,7 +99,7 @@ describe('lastVisibleContentIdx', () => {
     expect(lastVisibleContentIdx(undefined)).toBe(-1);
   });
 
-  it('skips sparse trailing slots used by phase slices', () => {
+  it('skips large sparse trailing gaps', () => {
     expect(lastVisibleContentIdx([undefined, tool, undefined, undefined])).toBe(1);
     const sparse = new Array<TMessageContentParts | undefined>(10_000);
     sparse[1] = tool;
@@ -114,7 +114,7 @@ describe('groupActivityPhases', () => {
     tool_call: { id: 't1', name: 'web_search', args: '{}', output: 'ok' },
   } as unknown as TMessageContentParts;
 
-  it('keeps absolute indices while consuming a completed parent marker', () => {
+  it('carries absolute offsets while consuming a completed parent marker', () => {
     const phase = labelPart({ activity_label: 'Compared both release paths', pending: false });
     Object.assign(phase, {
       activity_label_type: 'phase',
@@ -123,14 +123,9 @@ describe('groupActivityPhases', () => {
     });
     const segments = groupActivityPhases([text, tool, tool, phase as never, text]);
     expect(segments).toHaveLength(3);
-    expect(segments?.[1]).toMatchObject({ type: 'phase', labelIndex: 3 });
+    expect(segments?.[1]).toMatchObject({ type: 'phase', labelIndex: 3, startIndex: 1 });
     if (segments?.[1]?.type === 'phase') {
-      expect(segments[1].content).toHaveLength(3);
-      expect(0 in segments[1].content).toBe(false);
-      expect(segments[1].content[0]).toBeUndefined();
-      expect(segments[1].content[1]).toBe(tool);
-      expect(segments[1].content[2]).toBe(tool);
-      expect(segments[1].content[3]).toBeUndefined();
+      expect(segments[1].content).toEqual([tool, tool]);
     }
   });
 

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -36,6 +36,25 @@ describe('applyActivityLabelPart', () => {
     expect(updated).toBe(message);
   });
 
+  it('applies a bounds-only update to a completed phase', () => {
+    const existing = labelPart({ activity_label: 'Fixed the session', pending: false });
+    Object.assign(existing, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_count: 2,
+    });
+    const incoming = { ...existing, activity_start_index: 1 };
+    const message = buildMessage([existing as never]);
+
+    const updated = applyActivityLabelPart(message, { index: 0, part: incoming });
+
+    expect(updated).not.toBe(message);
+    expect((updated.content as unknown[])[0]).toMatchObject({
+      activity_start_index: 1,
+      activity_count: 2,
+    });
+  });
+
   it('never lets a stale pending placeholder overwrite a resolved label', () => {
     const resolved = labelPart({
       activity_label: 'Searched runtime release notes',

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -134,4 +134,21 @@ describe('groupActivityPhases', () => {
     Object.assign(pending, { activity_label_type: 'phase', activity_start_index: 0 });
     expect(groupActivityPhases([tool, pending as never])).toBeUndefined();
   });
+
+  it('preserves a completed summary when every phase child was filtered out', () => {
+    const phase = labelPart({ activity_label: 'Reconciled both release paths', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_count: 2,
+    });
+
+    expect(groupActivityPhases([phase as never])).toEqual([
+      expect.objectContaining({
+        type: 'phase',
+        labelIndex: 0,
+        hasContent: false,
+      }),
+    ]);
+  });
 });

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -1,6 +1,10 @@
 import { ContentTypes } from 'librechat-data-provider';
 import type { TActivityLabelEvent, TMessage, TMessageContentParts } from 'librechat-data-provider';
-import { applyActivityLabelPart, lastVisibleContentIdx } from '../activityLabels';
+import {
+  applyActivityLabelPart,
+  groupActivityPhases,
+  lastVisibleContentIdx,
+} from '../activityLabels';
 
 const buildMessage = (content: TMessage['content']): TMessage =>
   ({ messageId: 'm1', isCreatedByUser: false, content }) as TMessage;
@@ -74,5 +78,41 @@ describe('lastVisibleContentIdx', () => {
     expect(lastVisibleContentIdx([text, tool])).toBe(1);
     expect(lastVisibleContentIdx([])).toBe(-1);
     expect(lastVisibleContentIdx(undefined)).toBe(-1);
+  });
+
+  it('skips sparse trailing slots used by phase slices', () => {
+    expect(lastVisibleContentIdx([undefined, tool, undefined, undefined])).toBe(1);
+  });
+});
+
+describe('groupActivityPhases', () => {
+  const text = { type: ContentTypes.TEXT, text: 'final answer' } as TMessageContentParts;
+  const tool = {
+    type: ContentTypes.TOOL_CALL,
+    tool_call: { id: 't1', name: 'web_search', args: '{}', output: 'ok' },
+  } as unknown as TMessageContentParts;
+
+  it('keeps absolute indices while consuming a completed parent marker', () => {
+    const phase = labelPart({ activity_label: 'Compared both release paths', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 1,
+      activity_count: 2,
+    });
+    const segments = groupActivityPhases([text, tool, tool, phase as never, text]);
+    expect(segments).toHaveLength(3);
+    expect(segments?.[1]).toMatchObject({ type: 'phase', labelIndex: 3 });
+    if (segments?.[1]?.type === 'phase') {
+      expect(segments[1].content[0]).toBeUndefined();
+      expect(segments[1].content[1]).toBe(tool);
+      expect(segments[1].content[2]).toBe(tool);
+      expect(segments[1].content[3]).toBeUndefined();
+    }
+  });
+
+  it('leaves pending or empty parent markers on the feature-off path', () => {
+    const pending = labelPart();
+    Object.assign(pending, { activity_label_type: 'phase', activity_start_index: 0 });
+    expect(groupActivityPhases([tool, pending as never])).toBeUndefined();
   });
 });

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -143,10 +143,10 @@ describe('groupActivityPhases', () => {
       activity_count: 2,
     });
 
-    expect(groupActivityPhases([phase as never])).toEqual([
+    expect(groupActivityPhases([labelPart() as never, phase as never])).toEqual([
       expect.objectContaining({
         type: 'phase',
-        labelIndex: 0,
+        labelIndex: 1,
         hasContent: false,
       }),
     ]);

--- a/client/src/utils/__tests__/groupToolCalls.test.ts
+++ b/client/src/utils/__tests__/groupToolCalls.test.ts
@@ -12,6 +12,9 @@ const toolCall = (id: string): TMessageContentParts =>
 const think = (text: string): TMessageContentParts =>
   ({ type: ContentTypes.THINK, [ContentTypes.THINK]: text }) as unknown as TMessageContentParts;
 
+const text = (value: string, phase?: 'commentary' | 'final_answer'): TMessageContentParts =>
+  ({ type: ContentTypes.TEXT, [ContentTypes.TEXT]: value, phase }) as TMessageContentParts;
+
 const label = (text: string): TMessageContentParts =>
   ({
     type: ContentTypes.ACTIVITY_LABEL,
@@ -70,6 +73,26 @@ describe('groupSequentialToolCalls with activity labels', () => {
     expect(group.labelPart?.part).toMatchObject({
       [ContentTypes.ACTIVITY_LABEL]: 'Found the failing spec',
     });
+  });
+
+  it('nests typed commentary with its labeled tool batch, but never final text', () => {
+    const commentary = groupSequentialToolCalls(
+      withIndex([
+        text('I will compare both releases.', 'commentary'),
+        toolCall('t1'),
+        label('Compared both releases'),
+      ]),
+    );
+    expect(commentary).toHaveLength(1);
+    expect(commentary[0]).toMatchObject({ type: 'tool-group' });
+    expect((commentary[0] as { parts: PartWithIndex[] }).parts).toHaveLength(2);
+
+    const final = groupSequentialToolCalls(
+      withIndex([text('Here is the answer.', 'final_answer'), toolCall('t1'), label('Found it')]),
+    );
+    expect(final).toHaveLength(2);
+    expect(final[0]).toMatchObject({ type: 'single' });
+    expect(final[1]).toMatchObject({ type: 'tool-group' });
   });
 
   /** An empty orphan label has nothing to render and no block to delimit. */

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -95,7 +95,7 @@ export function groupActivityPhases(
       content: phaseContent,
       labelPart: part,
       labelIndex: index,
-      hasContent: phaseContent.some((child) => child != null),
+      hasContent: lastVisibleContentIdx(phaseContent) >= 0,
     });
     cursor = index + 1;
   }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -1,7 +1,32 @@
 import { ContentTypes } from 'librechat-data-provider';
 import type { TMessage, TActivityLabelEvent, TMessageContentParts } from 'librechat-data-provider';
 
-type ActivityLabelPart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }>;
+type ActivityLabelPart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
+  activity_label_type?: 'phase';
+  activity_start_index?: number;
+  activity_count?: number;
+  agent_ids?: string[];
+};
+
+export type ActivityPhaseSegment =
+  | { type: 'content'; content: Array<TMessageContentParts | undefined> }
+  | {
+      type: 'phase';
+      content: Array<TMessageContentParts | undefined>;
+      labelPart: ActivityLabelPart;
+      labelIndex: number;
+    };
+
+export function isPhaseActivityLabel(part: ActivityLabelPart | undefined): boolean {
+  return part?.activity_label_type === 'phase';
+}
+
+export function getBatchActivityLabelPart(
+  part: TMessageContentParts | undefined,
+): ActivityLabelPart | undefined {
+  const label = getActivityLabelPart(part);
+  return label != null && !isPhaseActivityLabel(label) ? label : undefined;
+}
 
 /** Returns the activity-label content part when `part` is one, else undefined. */
 export function getActivityLabelPart(
@@ -27,6 +52,59 @@ export function getActivityLabelText(part: ActivityLabelPart | undefined): strin
 }
 
 /**
+ * Partitions completed phase markers into collapsed parent groups while
+ * retaining absolute indices through sparse content arrays. Empty/pending
+ * markers deliberately return no phase segment, preserving feature-off UI.
+ */
+export function groupActivityPhases(
+  content: Array<TMessageContentParts | undefined> | undefined,
+): ActivityPhaseSegment[] | undefined {
+  if (!content) {
+    return undefined;
+  }
+  const completed = content
+    .map((part, index) => ({ part: getActivityLabelPart(part), index }))
+    .filter(
+      ({ part }) =>
+        isPhaseActivityLabel(part) &&
+        part?.pending !== true &&
+        getActivityLabelText(part).length > 0 &&
+        typeof part?.activity_start_index === 'number',
+    );
+  if (completed.length === 0) {
+    return undefined;
+  }
+
+  const segments: ActivityPhaseSegment[] = [];
+  let cursor = 0;
+  const sliceSparse = (start: number, end: number) =>
+    content.map((part, index) => (index >= start && index < end ? part : undefined));
+  for (const { part, index } of completed) {
+    if (!part) continue;
+    const start = Math.max(
+      cursor,
+      Math.min(index, Math.max(0, part.activity_start_index ?? index)),
+    );
+    if (start > cursor) {
+      segments.push({ type: 'content', content: sliceSparse(cursor, start) });
+    }
+    if (index > start) {
+      segments.push({
+        type: 'phase',
+        content: sliceSparse(start, index),
+        labelPart: part,
+        labelIndex: index,
+      });
+    }
+    cursor = index + 1;
+  }
+  if (cursor < content.length) {
+    segments.push({ type: 'content', content: sliceSparse(cursor, content.length) });
+  }
+  return segments;
+}
+
+/**
  * Last content index that actually renders something. Trailing BLANK label
  * reservations are invisible (every batch publishes one at batch end), so
  * counting one as the last part would suppress the streaming cursor and
@@ -39,10 +117,12 @@ export function lastVisibleContentIdx(
 ): number {
   const parts = content ?? [];
   let last = parts.length - 1;
-  while (last > 0) {
+  while (last >= 0) {
     const tail = parts[last];
-    if (
-      tail?.type === ContentTypes.ACTIVITY_LABEL &&
+    if (tail == null) {
+      last -= 1;
+    } else if (
+      tail.type === ContentTypes.ACTIVITY_LABEL &&
       getActivityLabelText(getActivityLabelPart(tail)).length === 0
     ) {
       last -= 1;
@@ -97,7 +177,9 @@ export function applyActivityLabelPart(message: TMessage, event: TActivityLabelE
   if (
     existing != null &&
     existing[ContentTypes.ACTIVITY_LABEL] === part[ContentTypes.ACTIVITY_LABEL] &&
-    existing.pending === part.pending
+    existing.pending === part.pending &&
+    existing.activity_label_type ===
+      (part as TActivityLabelEvent['part'] & { activity_label_type?: 'phase' }).activity_label_type
   ) {
     return message;
   }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -9,10 +9,15 @@ type ActivityLabelPart = Extract<TMessageContentParts, { type: ContentTypes.ACTI
 };
 
 export type ActivityPhaseSegment =
-  | { type: 'content'; content: Array<TMessageContentParts | undefined> }
+  | {
+      type: 'content';
+      content: Array<TMessageContentParts | undefined>;
+      startIndex: number;
+    }
   | {
       type: 'phase';
       content: Array<TMessageContentParts | undefined>;
+      startIndex: number;
       labelPart: ActivityLabelPart;
       labelIndex: number;
       hasContent: boolean;
@@ -64,7 +69,7 @@ export function getActivityLabelText(part: ActivityLabelPart | undefined): strin
 
 /**
  * Partitions completed phase markers into collapsed parent groups while
- * retaining absolute indices through sparse content arrays. Empty/pending
+ * carrying absolute start offsets alongside dense content slices. Empty/pending
  * markers deliberately return no phase segment, preserving feature-off UI.
  */
 export function groupActivityPhases(
@@ -88,21 +93,15 @@ export function groupActivityPhases(
 
   const segments: ActivityPhaseSegment[] = [];
   let cursor = 0;
-  /** True holes preserve absolute indices while array iteration visits only
-   *  this segment's parts. Building disjoint ranges keeps partitioning linear
-   *  even when an operator raises the per-run phase cap. */
-  const sliceSparse = (start: number, end: number) => {
-    const sparse = new Array<TMessageContentParts | undefined>(end);
-    let hasContent = false;
-    for (let index = start; index < end; index += 1) {
-      const part = content[index];
-      if (part === undefined) {
-        continue;
-      }
-      sparse[index] = part;
-      hasContent ||= isVisibleContentPart(part);
-    }
-    return { content: sparse, hasContent };
+  /** Dense, disjoint slices copy every part at most once. `startIndex` carries
+   *  the absolute transcript position into the recursive renderer. */
+  const slice = (start: number, end: number) => {
+    const segmentContent = content.slice(start, end);
+    return {
+      content: segmentContent,
+      startIndex: start,
+      hasContent: segmentContent.some(isVisibleContentPart),
+    };
   };
   for (const { part, index } of completed) {
     if (!part) continue;
@@ -111,12 +110,18 @@ export function groupActivityPhases(
       Math.min(index, Math.max(0, part.activity_start_index ?? index)),
     );
     if (start > cursor) {
-      segments.push({ type: 'content', content: sliceSparse(cursor, start).content });
+      const adjacent = slice(cursor, start);
+      segments.push({
+        type: 'content',
+        content: adjacent.content,
+        startIndex: adjacent.startIndex,
+      });
     }
-    const phase = sliceSparse(start, index);
+    const phase = slice(start, index);
     segments.push({
       type: 'phase',
       content: phase.content,
+      startIndex: phase.startIndex,
       labelPart: part,
       labelIndex: index,
       hasContent: phase.hasContent,
@@ -124,7 +129,12 @@ export function groupActivityPhases(
     cursor = index + 1;
   }
   if (cursor < content.length) {
-    segments.push({ type: 'content', content: sliceSparse(cursor, content.length).content });
+    const adjacent = slice(cursor, content.length);
+    segments.push({
+      type: 'content',
+      content: adjacent.content,
+      startIndex: adjacent.startIndex,
+    });
   }
   return segments;
 }
@@ -151,8 +161,8 @@ export function lastVisibleContentIdx(
   if (last < 0) {
     return -1;
   }
-  /** Phase slices retain absolute indices as true holes. Jump between their
-   *  defined slots instead of walking the whole message-length index space. */
+  /** Streaming/resume arrays can retain absolute indices as true holes. Jump
+   *  between defined slots instead of walking the whole index space. */
   const definedIndices = Object.keys(parts);
   for (let i = definedIndices.length - 1; i >= 0; i -= 1) {
     const index = Number(definedIndices[i]);

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -174,12 +174,14 @@ export function applyActivityLabelPart(message: TMessage, event: TActivityLabelE
   }
   const content = Array.isArray(message.content) ? message.content : [];
   const existing = getActivityLabelPart(content[index] as TMessageContentParts | undefined);
+  const incoming = part as ActivityLabelPart;
   if (
     existing != null &&
     existing[ContentTypes.ACTIVITY_LABEL] === part[ContentTypes.ACTIVITY_LABEL] &&
     existing.pending === part.pending &&
-    existing.activity_label_type ===
-      (part as TActivityLabelEvent['part'] & { activity_label_type?: 'phase' }).activity_label_type
+    existing.activity_label_type === incoming.activity_label_type &&
+    existing.activity_start_index === incoming.activity_start_index &&
+    existing.activity_count === incoming.activity_count
   ) {
     return message;
   }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -15,6 +15,7 @@ export type ActivityPhaseSegment =
       content: Array<TMessageContentParts | undefined>;
       labelPart: ActivityLabelPart;
       labelIndex: number;
+      hasContent: boolean;
     };
 
 export function isPhaseActivityLabel(part: ActivityLabelPart | undefined): boolean {
@@ -88,14 +89,14 @@ export function groupActivityPhases(
     if (start > cursor) {
       segments.push({ type: 'content', content: sliceSparse(cursor, start) });
     }
-    if (index > start) {
-      segments.push({
-        type: 'phase',
-        content: sliceSparse(start, index),
-        labelPart: part,
-        labelIndex: index,
-      });
-    }
+    const phaseContent = sliceSparse(start, index);
+    segments.push({
+      type: 'phase',
+      content: phaseContent,
+      labelPart: part,
+      labelIndex: index,
+      hasContent: phaseContent.some((child) => child != null),
+    });
     cursor = index + 1;
   }
   if (cursor < content.length) {

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -142,15 +142,25 @@ export function lastVisibleContentIdx(
 ): number {
   const parts = content ?? [];
   let last = parts.length - 1;
-  while (last >= 0) {
-    const tail = parts[last];
-    if (!isVisibleContentPart(tail)) {
-      last -= 1;
-    } else {
-      break;
+  while (last >= 0 && last in parts) {
+    if (isVisibleContentPart(parts[last])) {
+      return last;
+    }
+    last -= 1;
+  }
+  if (last < 0) {
+    return -1;
+  }
+  /** Phase slices retain absolute indices as true holes. Jump between their
+   *  defined slots instead of walking the whole message-length index space. */
+  const definedIndices = Object.keys(parts);
+  for (let i = definedIndices.length - 1; i >= 0; i -= 1) {
+    const index = Number(definedIndices[i]);
+    if (index <= last && isVisibleContentPart(parts[index])) {
+      return index;
     }
   }
-  return last;
+  return -1;
 }
 
 /**

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -18,6 +18,16 @@ export type ActivityPhaseSegment =
       hasContent: boolean;
     };
 
+function isVisibleContentPart(part: TMessageContentParts | undefined): boolean {
+  return (
+    part != null &&
+    !(
+      part.type === ContentTypes.ACTIVITY_LABEL &&
+      getActivityLabelText(getActivityLabelPart(part)).length === 0
+    )
+  );
+}
+
 export function isPhaseActivityLabel(part: ActivityLabelPart | undefined): boolean {
   return part?.activity_label_type === 'phase';
 }
@@ -78,8 +88,22 @@ export function groupActivityPhases(
 
   const segments: ActivityPhaseSegment[] = [];
   let cursor = 0;
-  const sliceSparse = (start: number, end: number) =>
-    content.map((part, index) => (index >= start && index < end ? part : undefined));
+  /** True holes preserve absolute indices while array iteration visits only
+   *  this segment's parts. Building disjoint ranges keeps partitioning linear
+   *  even when an operator raises the per-run phase cap. */
+  const sliceSparse = (start: number, end: number) => {
+    const sparse = new Array<TMessageContentParts | undefined>(end);
+    let hasContent = false;
+    for (let index = start; index < end; index += 1) {
+      const part = content[index];
+      if (part === undefined) {
+        continue;
+      }
+      sparse[index] = part;
+      hasContent ||= isVisibleContentPart(part);
+    }
+    return { content: sparse, hasContent };
+  };
   for (const { part, index } of completed) {
     if (!part) continue;
     const start = Math.max(
@@ -87,20 +111,20 @@ export function groupActivityPhases(
       Math.min(index, Math.max(0, part.activity_start_index ?? index)),
     );
     if (start > cursor) {
-      segments.push({ type: 'content', content: sliceSparse(cursor, start) });
+      segments.push({ type: 'content', content: sliceSparse(cursor, start).content });
     }
-    const phaseContent = sliceSparse(start, index);
+    const phase = sliceSparse(start, index);
     segments.push({
       type: 'phase',
-      content: phaseContent,
+      content: phase.content,
       labelPart: part,
       labelIndex: index,
-      hasContent: lastVisibleContentIdx(phaseContent) >= 0,
+      hasContent: phase.hasContent,
     });
     cursor = index + 1;
   }
   if (cursor < content.length) {
-    segments.push({ type: 'content', content: sliceSparse(cursor, content.length) });
+    segments.push({ type: 'content', content: sliceSparse(cursor, content.length).content });
   }
   return segments;
 }
@@ -120,12 +144,7 @@ export function lastVisibleContentIdx(
   let last = parts.length - 1;
   while (last >= 0) {
     const tail = parts[last];
-    if (tail == null) {
-      last -= 1;
-    } else if (
-      tail.type === ContentTypes.ACTIVITY_LABEL &&
-      getActivityLabelText(getActivityLabelPart(tail)).length === 0
-    ) {
+    if (!isVisibleContentPart(tail)) {
       last -= 1;
     } else {
       break;

--- a/client/src/utils/groupToolCalls.ts
+++ b/client/src/utils/groupToolCalls.ts
@@ -1,7 +1,7 @@
 import { Constants, ContentTypes, ToolCallTypes } from 'librechat-data-provider';
 import type { TMessageContentParts, Agents } from 'librechat-data-provider';
 import type { PartWithIndex } from '~/components/Chat/Messages/Content/ParallelContent';
-import { getActivityLabelPart, getActivityLabelText } from '~/utils/activityLabels';
+import { getBatchActivityLabelPart, getActivityLabelText } from '~/utils/activityLabels';
 
 export type GroupedPart =
   | { type: 'single'; part: PartWithIndex }
@@ -95,12 +95,21 @@ export function groupSequentialToolCalls(parts: PartWithIndex[]): GroupedPart[] 
   };
 
   for (const item of parts) {
-    if (isGroupableToolCall(item.part) || item.part.type === ContentTypes.THINK) {
+    const isCommentary =
+      item.part.type === ContentTypes.TEXT &&
+      (item.part as { phase?: string }).phase === 'commentary';
+    if (isGroupableToolCall(item.part) || item.part.type === ContentTypes.THINK || isCommentary) {
       currentBlock.push(item);
       continue;
     }
     if (item.part.type === ContentTypes.ACTIVITY_LABEL) {
-      const hasText = getActivityLabelText(getActivityLabelPart(item.part)).length > 0;
+      const batchLabel = getBatchActivityLabelPart(item.part);
+      if (batchLabel == null) {
+        flushWithoutLabel();
+        result.push({ type: 'single', part: item });
+        continue;
+      }
+      const hasText = getActivityLabelText(batchLabel).length > 0;
       if (!hasText) {
         /** A reserved-but-unfilled slot (and a failed/blank fill) must be
          *  INVISIBLE. Every batch now publishes its reservation immediately,

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -602,6 +602,13 @@ endpoints:
       # activityPrompt: 'Write a 5-9 word past-tense label...'
       # activityMaxPerRun: 20           # cost cap per response
       # activityCharLimit: 600          # per-entry prompt truncation
+      # Parent phase summaries are an independent opt-in. They collapse 2+
+      # logical activities before the answer into one run-level summary.
+      # activityPhaseLabel: true
+      # activityPhaseModel: 'claude-3-5-haiku' # falls back to activity/title/run model
+      # activityPhaseEndpoint: 'anthropic'     # falls back to activity/run endpoint
+      # activityPhasePrompt: 'Summarize the completed agent phase...'
+      # activityPhaseMaxPerRun: 5               # cost cap per response
       modelDisplayLabel: 'Claude (Compatible)'
 
     # Groq Example

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.4.3",
+        "@librechat/agents": "^3.4.4",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10627,9 +10627,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.4.3.tgz",
-      "integrity": "sha512-adFenD8ezDF4ZbKvzamw/eGzo9tpGLdM8Hom5G2ekvhEUlRSvneURJXCib7EJ45mCPDjxihhfDE7EQa2mOwMAg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.4.4.tgz",
+      "integrity": "sha512-Sv1+my/28jqjV+Dz+RQjxM53itVVcQNOfI9hJ4puxpdjZpDYCPDQzUJT73d9yvI5IO1NoDYA8wULlIJJ5FCI9w==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42721,7 +42721,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.4.3",
+        "@librechat/agents": "^3.4.4",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.4.3",
+    "@librechat/agents": "^3.4.4",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/activityLabels/__tests__/host.spec.ts
+++ b/packages/api/src/agents/activityLabels/__tests__/host.spec.ts
@@ -3,6 +3,7 @@ import type { EndpointDbMethods, ServerRequest } from '~/types';
 import {
   mapCollectedMetadataToUsage,
   resolveActivityConfig,
+  resolveActivityPhaseConfig,
   resolveActivityLabelModel,
 } from '../host';
 
@@ -120,6 +121,52 @@ describe('resolveActivityConfig', () => {
       'agents',
     );
     expect(config.model).toBe('shared-model');
+  });
+});
+
+describe('resolveActivityPhaseConfig', () => {
+  it('is independently opt-in and inherits activity model/endpoint tuning', () => {
+    const config = resolveActivityPhaseConfig(
+      appConfig({
+        openAI: {
+          activityLabel: true,
+          activityModel: 'batch-model',
+          activityEndpoint: 'anthropic',
+        },
+      }),
+      'openAI',
+    );
+    expect(config).toMatchObject({
+      enabled: false,
+      model: 'batch-model',
+      endpoint: 'anthropic',
+    });
+  });
+
+  it('prefers dedicated phase settings and reuses activityCharLimit', () => {
+    const config = resolveActivityPhaseConfig(
+      appConfig({
+        openAI: {
+          activityPhaseLabel: true,
+          activityPhaseModel: 'phase-model',
+          activityModel: 'batch-model',
+          activityPhaseEndpoint: 'google',
+          activityEndpoint: 'anthropic',
+          activityPhasePrompt: 'phase prompt',
+          activityPhaseMaxPerRun: 3,
+          activityCharLimit: 240,
+        },
+      }),
+      'openAI',
+    );
+    expect(config).toEqual({
+      enabled: true,
+      model: 'phase-model',
+      endpoint: 'google',
+      prompt: 'phase prompt',
+      maxPerRun: 3,
+      charLimit: 240,
+    });
   });
 });
 

--- a/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
+++ b/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
@@ -179,6 +179,24 @@ describe('synthesizeActivityLabelGapEvents', () => {
     ];
     expect(synthesizeActivityLabelGapEvents(parts, parts, meta)).toEqual([]);
   });
+
+  it('re-emits a completed phase when its reconciled bounds changed', () => {
+    const snapshot: LooseContentPart[] = [
+      {
+        type: 'activity_label',
+        activity_label: 'Inspected and fixed the session',
+        activity_label_type: 'phase',
+        activity_start_index: 0,
+        activity_count: 2,
+        pending: false,
+      },
+    ];
+    const fresh: LooseContentPart[] = [
+      { ...snapshot[0], activity_start_index: 1 },
+    ];
+
+    expect(synthesizeActivityLabelGapEvents(snapshot, fresh, meta)).toHaveLength(1);
+  });
 });
 
 describe('createActivityLabelWiring close gate', () => {

--- a/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
+++ b/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
@@ -191,11 +191,11 @@ describe('synthesizeActivityLabelGapEvents', () => {
         pending: false,
       },
     ];
-    const fresh: LooseContentPart[] = [
-      { ...snapshot[0], activity_start_index: 1 },
-    ];
+    const fresh: LooseContentPart[] = [{ ...snapshot[0], activity_start_index: 1 }];
 
-    expect(synthesizeActivityLabelGapEvents(snapshot, fresh, meta)).toHaveLength(1);
+    expect(synthesizeActivityLabelGapEvents(snapshot, fresh, meta)).toHaveLength(
+      1,
+    );
   });
 });
 

--- a/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
+++ b/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
@@ -193,9 +193,7 @@ describe('synthesizeActivityLabelGapEvents', () => {
     ];
     const fresh: LooseContentPart[] = [{ ...snapshot[0], activity_start_index: 1 }];
 
-    expect(synthesizeActivityLabelGapEvents(snapshot, fresh, meta)).toHaveLength(
-      1,
-    );
+    expect(synthesizeActivityLabelGapEvents(snapshot, fresh, meta)).toHaveLength(1);
   });
 });
 

--- a/packages/api/src/agents/activityLabels/host.ts
+++ b/packages/api/src/agents/activityLabels/host.ts
@@ -11,6 +11,16 @@ import { resolveConfigHeaders } from '~/utils/headers';
 import { omitTitleOptions } from '~/agents/client';
 import { createSafeUser } from '~/utils/env';
 
+/** Additive phase fields may precede the rebuilt data-provider artifact in a
+ *  package-local typecheck, so keep the endpoint view structural here. */
+type ActivityEndpoint = TEndpoint & {
+  activityPhaseLabel?: boolean;
+  activityPhaseModel?: string;
+  activityPhaseEndpoint?: string;
+  activityPhasePrompt?: string;
+  activityPhaseMaxPerRun?: number;
+};
+
 /** Cache-token details in the LangChain-standard normalized shape. */
 interface CacheTokenDetails {
   cache_read?: number;
@@ -134,6 +144,16 @@ export interface ResolvedActivityConfig {
   charLimit?: number;
 }
 
+/** Effective parent activity-phase settings for one endpoint. */
+export interface ResolvedActivityPhaseConfig {
+  enabled: boolean;
+  model?: string;
+  endpoint?: string;
+  prompt?: string;
+  maxPerRun?: number;
+  charLimit?: number;
+}
+
 /**
  * Reads the per-endpoint `activity*` settings, mirroring how titles resolve
  * theirs: an `endpoints.all` block wins over the named endpoint, which wins
@@ -149,17 +169,17 @@ export interface ResolvedActivityConfig {
  * `titleModel` fallback. Global still wins per field, so a real
  * `all.activityLabel` keeps overriding the endpoint.
  */
-function pickEndpointField<K extends keyof TEndpoint>(
+function pickEndpointField<K extends keyof ActivityEndpoint>(
   appConfig: AppConfig | undefined,
   endpoint: string,
-  customEndpointConfig: Partial<TEndpoint> | undefined,
+  customEndpointConfig: Partial<ActivityEndpoint> | undefined,
   key: K,
   publicEndpoint?: string,
-): TEndpoint[K] | undefined {
+): ActivityEndpoint[K] | undefined {
   const endpoints = appConfig?.endpoints as
-    | (Record<string, TEndpoint | undefined> & { all?: TEndpoint })
+    | (Record<string, ActivityEndpoint | undefined> & { all?: ActivityEndpoint })
     | undefined;
-  const all = endpoints?.all as Partial<TEndpoint> | undefined;
+  const all = endpoints?.all as Partial<ActivityEndpoint> | undefined;
   /** The PUBLIC endpoint the request came in on, when it differs from the
    *  backing provider. `initializeAgent` rewrites `agent.endpoint` to the
    *  provider (an agents-endpoint run backed by OpenAI reads `openAI`), so
@@ -169,9 +189,11 @@ function pickEndpointField<K extends keyof TEndpoint>(
    *  mirroring how request-path options resolve. */
   const publicBlock =
     publicEndpoint != null && publicEndpoint !== endpoint
-      ? (endpoints?.[publicEndpoint] as Partial<TEndpoint> | undefined)
+      ? (endpoints?.[publicEndpoint] as Partial<ActivityEndpoint> | undefined)
       : undefined;
-  const named = (endpoints?.[endpoint] ?? customEndpointConfig) as Partial<TEndpoint> | undefined;
+  const named = (endpoints?.[endpoint] ?? customEndpointConfig) as
+    | Partial<ActivityEndpoint>
+    | undefined;
   return all?.[key] ?? publicBlock?.[key] ?? named?.[key];
 }
 
@@ -181,7 +203,7 @@ export function resolveActivityConfig(
   customEndpointConfig?: Partial<TEndpoint>,
   publicEndpoint?: string,
 ): ResolvedActivityConfig {
-  const pick = <K extends keyof TEndpoint>(key: K): TEndpoint[K] | undefined =>
+  const pick = <K extends keyof ActivityEndpoint>(key: K): ActivityEndpoint[K] | undefined =>
     pickEndpointField(appConfig, endpoint, customEndpointConfig, key, publicEndpoint);
   return {
     enabled: pick('activityLabel') === true,
@@ -191,6 +213,24 @@ export function resolveActivityConfig(
     maxPerRun: pick('activityMaxPerRun'),
     charLimit: pick('activityCharLimit'),
     /** `titleModel` is the documented fallback below, not a field here. */
+  };
+}
+
+export function resolveActivityPhaseConfig(
+  appConfig: AppConfig | undefined,
+  endpoint: string,
+  customEndpointConfig?: Partial<TEndpoint>,
+  publicEndpoint?: string,
+): ResolvedActivityPhaseConfig {
+  const pick = <K extends keyof ActivityEndpoint>(key: K): ActivityEndpoint[K] | undefined =>
+    pickEndpointField(appConfig, endpoint, customEndpointConfig, key, publicEndpoint);
+  return {
+    enabled: pick('activityPhaseLabel') === true,
+    model: pick('activityPhaseModel') ?? pick('activityModel'),
+    endpoint: pick('activityPhaseEndpoint') ?? pick('activityEndpoint'),
+    prompt: pick('activityPhasePrompt'),
+    maxPerRun: pick('activityPhaseMaxPerRun'),
+    charLimit: pick('activityCharLimit'),
   };
 }
 
@@ -208,16 +248,24 @@ export async function resolveActivityLabelModel({
   publicEndpoint,
   ids,
   db,
-}: ResolveActivityLabelModelParams): Promise<ActivityLabelLLM> {
+  phase = false,
+}: ResolveActivityLabelModelParams & { phase?: boolean }): Promise<ActivityLabelLLM> {
   const appConfig = req.config as AppConfig | undefined;
   const agentEndpoint = agent.endpoint ?? '';
   let providerConfig = getProviderConfig({ provider: agentEndpoint, appConfig });
-  const activity = resolveActivityConfig(
-    appConfig,
-    agentEndpoint,
-    providerConfig.customEndpointConfig,
-    publicEndpoint,
-  );
+  const activity = phase
+    ? resolveActivityPhaseConfig(
+        appConfig,
+        agentEndpoint,
+        providerConfig.customEndpointConfig,
+        publicEndpoint,
+      )
+    : resolveActivityConfig(
+        appConfig,
+        agentEndpoint,
+        providerConfig.customEndpointConfig,
+        publicEndpoint,
+      );
 
   /**
    * Captured from the ORIGINATING endpoint, before any `activityEndpoint`
@@ -383,6 +431,13 @@ export async function resolveActivityLabelModel({
     endpointTokenConfig: options.endpointTokenConfig,
     sameEndpoint: endpoint === agentEndpoint,
   };
+}
+
+/** Phase-model resolution shares credentials and sanitization with child labels. */
+export function resolveActivityPhaseLabelModel(
+  params: ResolveActivityLabelModelParams,
+): Promise<ActivityLabelLLM> {
+  return resolveActivityLabelModel({ ...params, phase: true });
 }
 
 /**

--- a/packages/api/src/agents/activityLabels/index.ts
+++ b/packages/api/src/agents/activityLabels/index.ts
@@ -23,12 +23,15 @@ export type { ActivityLabelHostDeps, LooseContentPart } from './wiring';
 export {
   mapCollectedMetadataToUsage,
   resolveActivityConfig,
+  resolveActivityPhaseConfig,
   resolveActivityLabelModel,
+  resolveActivityPhaseLabelModel,
   settlePendingLabelFills,
 } from './host';
 export type {
   ActivityLabelAgent,
   ResolvedActivityConfig,
+  ResolvedActivityPhaseConfig,
   ActivityLabelUsage,
   CollectedMetadataEntry,
   ResolveActivityLabelModelParams,

--- a/packages/api/src/agents/activityLabels/index.ts
+++ b/packages/api/src/agents/activityLabels/index.ts
@@ -3,6 +3,7 @@ export {
   buildPrompt,
   classifyBatch,
   createActivityLabelHook,
+  stringifyActivityEvidence,
 } from './runtime';
 export type {
   ActivityLabelBatchMeta,

--- a/packages/api/src/agents/activityLabels/runtime.ts
+++ b/packages/api/src/agents/activityLabels/runtime.ts
@@ -318,7 +318,7 @@ function stringifyBounded(value: unknown, limit: number): string {
   return out.join('').slice(0, limit + 1);
 }
 
-function stringifyUnknown(value: unknown, limit: number): string {
+export function stringifyActivityEvidence(value: unknown, limit: number): string {
   if (value == null) {
     return '';
   }
@@ -427,11 +427,11 @@ export function buildPrompt(
       omitted += 1;
       continue;
     }
-    const input = truncate(stringifyUnknown(entry.toolInput, charLimit), charLimit);
+    const input = truncate(stringifyActivityEvidence(entry.toolInput, charLimit), charLimit);
     const outcome =
       entry.status === 'error'
         ? `ERROR: ${truncate(entry.error ?? 'unknown error', charLimit)}`
-        : truncate(stringifyUnknown(entry.toolOutput, charLimit), charLimit);
+        : truncate(stringifyActivityEvidence(entry.toolOutput, charLimit), charLimit);
     const line = `- ${entry.toolName}(${input}) → ${outcome}`;
     lines.push(line);
     used += line.length;

--- a/packages/api/src/agents/activityLabels/runtime.ts
+++ b/packages/api/src/agents/activityLabels/runtime.ts
@@ -49,6 +49,7 @@ export interface ActivityLabelBatchMeta {
 export interface ActivityLabelBlockContext {
   thinkingExcerpts?: string[];
   lastAssistantText?: string;
+  lastAssistantPhase?: 'commentary' | 'final_answer';
 }
 
 /**
@@ -398,7 +399,7 @@ export function buildPrompt(
           .join('\n'),
     );
   }
-  if (context?.lastAssistantText) {
+  if (context?.lastAssistantText && context.lastAssistantPhase !== 'final_answer') {
     sections.push(
       `Intent (assistant's last message): ${truncate(context.lastAssistantText, INTENT_CHAR_LIMIT)}`,
     );

--- a/packages/api/src/agents/activityLabels/wiring.ts
+++ b/packages/api/src/agents/activityLabels/wiring.ts
@@ -17,6 +17,7 @@ export interface LooseContentPart {
   groupId?: unknown;
   tool_call?: { id?: unknown };
   pending?: boolean;
+  phase?: unknown;
   [key: string]: unknown;
 }
 
@@ -48,6 +49,7 @@ export function captureActivityBlockContext(
 ): ActivityLabelBlockContext {
   const thinkingExcerpts: string[] = [];
   let lastAssistantText: string | undefined;
+  let lastAssistantPhase: ActivityLabelBlockContext['lastAssistantPhase'];
   let collectThinking = true;
   for (let i = parts.length - 1; i >= 0; i--) {
     const part = parts[i];
@@ -68,6 +70,9 @@ export function captureActivityBlockContext(
       const text = textValue(part.text).trim();
       if (text.length > 0) {
         lastAssistantText = text.slice(-INTENT_CHARS);
+        if (part.phase === 'commentary' || part.phase === 'final_answer') {
+          lastAssistantPhase = part.phase;
+        }
         break;
       }
       continue;
@@ -84,7 +89,7 @@ export function captureActivityBlockContext(
       }
     }
   }
-  return { thinkingExcerpts, lastAssistantText };
+  return { thinkingExcerpts, lastAssistantText, lastAssistantPhase };
 }
 
 /**
@@ -147,6 +152,7 @@ export function synthesizeActivityLabelGapEvents(
     const isSameLabel =
       snapshot?.type === ContentTypes.ACTIVITY_LABEL &&
       snapshot[ContentTypes.ACTIVITY_LABEL] === part[ContentTypes.ACTIVITY_LABEL] &&
+      snapshot.activity_label_type === part.activity_label_type &&
       snapshot.pending === part.pending;
     if (isSameLabel) {
       continue;
@@ -218,7 +224,7 @@ export function createActivityLabelWiring(deps: ActivityLabelHostDeps): {
   const initialLabels: Array<{ index: number; text: string }> = [];
   for (let i = 0; i < resumedParts.length; i++) {
     const part = resumedParts[i];
-    if (part?.type !== ContentTypes.ACTIVITY_LABEL) {
+    if (part?.type !== ContentTypes.ACTIVITY_LABEL || part.activity_label_type === 'phase') {
       continue;
     }
     initialGeneratedCount += 1;

--- a/packages/api/src/agents/activityLabels/wiring.ts
+++ b/packages/api/src/agents/activityLabels/wiring.ts
@@ -133,9 +133,9 @@ interface ActivityLabelGapEvent {
  * label publish is fire-and-forget and the sync payload carries only the
  * snapshot, so a label claimed or resolved in that window would otherwise
  * never reach the reconnecting client. Compares by index: a fresh label part
- * whose text or pending state differs from the snapshot's (or that has no
- * snapshot counterpart) is re-emitted. Idempotent - the client applier
- * ignores duplicates and refuses stale pending placeholders.
+ * whose text, pending state, or phase bounds differ from the snapshot's (or
+ * that has no snapshot counterpart) is re-emitted. Idempotent - the client
+ * applier ignores duplicates and refuses stale pending placeholders.
  */
 export function synthesizeActivityLabelGapEvents(
   snapshotContent: ReadonlyArray<LooseContentPart | null | undefined>,
@@ -153,6 +153,8 @@ export function synthesizeActivityLabelGapEvents(
       snapshot?.type === ContentTypes.ACTIVITY_LABEL &&
       snapshot[ContentTypes.ACTIVITY_LABEL] === part[ContentTypes.ACTIVITY_LABEL] &&
       snapshot.activity_label_type === part.activity_label_type &&
+      snapshot.activity_start_index === part.activity_start_index &&
+      snapshot.activity_count === part.activity_count &&
       snapshot.pending === part.pending;
     if (isSameLabel) {
       continue;

--- a/packages/api/src/agents/activityPhases/index.ts
+++ b/packages/api/src/agents/activityPhases/index.ts
@@ -1,0 +1,1 @@
+export * from './runtime';

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -2,6 +2,7 @@ import { GraphEvents } from '@librechat/agents';
 import { ContentTypes, StepTypes } from 'librechat-data-provider';
 import type { PostToolBatchHookInput } from '@librechat/agents';
 import type { LooseContentPart } from '~/agents/activityLabels/wiring';
+import type { GenerateActivityPhasePayload } from './runtime';
 import {
   ACTIVITY_PHASE_INSTRUCTION,
   createActivityPhaseWiring,
@@ -154,7 +155,11 @@ describe('createActivityPhaseWiring', () => {
      *  snapshot, so restoration must re-anchor by tool id rather than index. */
     parts.shift();
 
-    const generatePhase = jest.fn(async () => ({ label: 'Completed the resumed investigation' }));
+    let generatedActivities: GenerateActivityPhasePayload['activities'] | undefined;
+    const generatePhase = jest.fn(async (payload: GenerateActivityPhasePayload) => {
+      generatedActivities = payload.activities;
+      return { label: 'Completed the resumed investigation' };
+    });
     const resumed = createActivityPhaseWiring({
       initialSnapshot: first.snapshot(),
       getContentParts: () => parts,
@@ -184,8 +189,8 @@ describe('createActivityPhaseWiring', () => {
     expect(generatePhase).toHaveBeenCalledWith(
       expect.objectContaining({ activities: expect.arrayContaining([expect.any(Object)]) }),
     );
-    expect(generatePhase.mock.calls[0][0].activities).toHaveLength(2);
-    expect(parts.at(-1)).toMatchObject({ activity_start_index: 0 });
+    expect(generatedActivities).toHaveLength(2);
+    expect(parts[parts.length - 1]).toMatchObject({ activity_start_index: 0 });
   });
 
   it('bounds persisted evidence while preserving the full activity count', async () => {
@@ -291,7 +296,7 @@ describe('createActivityPhaseWiring', () => {
     expect(generatePhase).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'partial' }),
     );
-    expect(parts.at(-1)).toMatchObject({ status: 'partial' });
+    expect(parts[parts.length - 1]).toMatchObject({ status: 'partial' });
   });
 
   it('collects usage after a committed blank phase result', async () => {
@@ -326,7 +331,7 @@ describe('createActivityPhaseWiring', () => {
 
     await flushDetached();
     expect(collectUsage).toHaveBeenCalledWith(undefined);
-    expect(parts.at(-1)).toMatchObject({ activity_label: '', pending: false });
+    expect(parts[parts.length - 1]).toMatchObject({ activity_label: '', pending: false });
   });
 });
 

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -170,20 +170,22 @@ describe('createActivityPhaseWiring', () => {
     });
     parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
     await resumed.hook(batch('tool-2'), new AbortController().signal);
-    resumed.handlers({
-      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
-    })?.[GraphEvents.ON_RUN_STEP]?.handle(
-      GraphEvents.ON_RUN_STEP,
-      {
-        id: 'final-step',
-        stepDetails: {
-          type: StepTypes.MESSAGE_CREATION,
-          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+    resumed
+      .handlers({
+        [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'final-step',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+          },
         },
-      },
-      undefined,
-      undefined,
-    );
+        undefined,
+        undefined,
+      );
 
     await flushDetached();
     expect(generatePhase).toHaveBeenCalledWith(
@@ -277,25 +279,25 @@ describe('createActivityPhaseWiring', () => {
     await wiring.hook(mixed, new AbortController().signal);
     parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
     await wiring.hook(batch('tool-2'), new AbortController().signal);
-    wiring.handlers({
-      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
-    })?.[GraphEvents.ON_RUN_STEP]?.handle(
-      GraphEvents.ON_RUN_STEP,
-      {
-        id: 'final-step',
-        stepDetails: {
-          type: StepTypes.MESSAGE_CREATION,
-          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+    wiring
+      .handlers({
+        [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'final-step',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+          },
         },
-      },
-      undefined,
-      undefined,
-    );
+        undefined,
+        undefined,
+      );
 
     await flushDetached();
-    expect(generatePhase).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'partial' }),
-    );
+    expect(generatePhase).toHaveBeenCalledWith(expect.objectContaining({ status: 'partial' }));
     expect(parts[parts.length - 1]).toMatchObject({ status: 'partial' });
   });
 
@@ -314,20 +316,22 @@ describe('createActivityPhaseWiring', () => {
     await wiring.hook(batch('tool-1'), new AbortController().signal);
     parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
     await wiring.hook(batch('tool-2'), new AbortController().signal);
-    wiring.handlers({
-      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
-    })?.[GraphEvents.ON_RUN_STEP]?.handle(
-      GraphEvents.ON_RUN_STEP,
-      {
-        id: 'final-step',
-        stepDetails: {
-          type: StepTypes.MESSAGE_CREATION,
-          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+    wiring
+      .handlers({
+        [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'final-step',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+          },
         },
-      },
-      undefined,
-      undefined,
-    );
+        undefined,
+        undefined,
+      );
 
     await flushDetached();
     expect(collectUsage).toHaveBeenCalledWith(undefined);

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -138,6 +138,87 @@ describe('createActivityPhaseWiring', () => {
     expect(parts).toHaveLength(1);
   });
 
+  it('keeps reasoning attached to a tool batch across commentary', async () => {
+    const parts: LooseContentPart[] = [];
+    const generatePhase = jest.fn(async () => ({ label: 'unused' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    const handlers = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      [GraphEvents.ON_REASONING_DELTA]: { handle: jest.fn() },
+    });
+
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'reasoning-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'think' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    handlers?.[GraphEvents.ON_REASONING_DELTA]?.handle(
+      GraphEvents.ON_REASONING_DELTA,
+      {
+        id: 'reasoning-step',
+        delta: { content: { type: ContentTypes.THINK, think: 'Compared both auth paths.' } },
+      },
+      undefined,
+      undefined,
+    );
+    parts.push({ type: ContentTypes.THINK, think: 'Compared both auth paths.' });
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'commentary-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'commentary' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    expect(wiring.snapshot()).toMatchObject({
+      activityCount: 0,
+      pendingReasoning: [{ key: 'root', text: 'Compared both auth paths.' }],
+    });
+
+    parts.push({ type: ContentTypes.TEXT, text: 'I will verify the middleware.' });
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    expect(wiring.snapshot()).toMatchObject({
+      activityCount: 1,
+      activities: [expect.objectContaining({ thinkingExcerpts: ['Compared both auth paths.'] })],
+      pendingReasoning: [],
+    });
+
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    await flushDetached();
+    expect(generatePhase).not.toHaveBeenCalled();
+    expect(parts.some((part) => part.activity_label_type === 'phase')).toBe(false);
+  });
+
   it('restores bounded activity state after a HITL pause', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TEXT, text: 'Hidden intermediate output' },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1,8 +1,12 @@
 import { GraphEvents } from '@librechat/agents';
 import { ContentTypes, StepTypes } from 'librechat-data-provider';
-import type { EventHandler, PostToolBatchHookInput } from '@librechat/agents';
+import type { PostToolBatchHookInput } from '@librechat/agents';
 import type { LooseContentPart } from '~/agents/activityLabels/wiring';
-import { createActivityPhaseWiring, createAssistantPhaseStampingHandlers } from './runtime';
+import {
+  ACTIVITY_PHASE_INSTRUCTION,
+  createActivityPhaseWiring,
+  createAssistantPhaseStampingHandlers,
+} from './runtime';
 
 const batch = (id: string): PostToolBatchHookInput =>
   ({
@@ -52,8 +56,10 @@ describe('createActivityPhaseWiring', () => {
 
     const handlers = wiring.handlers({
       [GraphEvents.ON_RUN_STEP]: {
-        handle: (_event, data) => forwarded.push(data),
-      } as EventHandler,
+        handle: (_event, data) => {
+          forwarded.push(data);
+        },
+      },
     });
     handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
       GraphEvents.ON_RUN_STEP,
@@ -86,7 +92,9 @@ describe('createActivityPhaseWiring', () => {
       expect.objectContaining({
         closingTextPhase: 'final_answer',
         phaseIndex: 0,
+        totalActivityCount: 2,
         activities: expect.any(Array),
+        prompt: ACTIVITY_PHASE_INSTRUCTION,
       }),
     );
     expect(parts[2]).toMatchObject({
@@ -110,7 +118,7 @@ describe('createActivityPhaseWiring', () => {
     });
     await wiring.hook(batch('tool-1'), new AbortController().signal);
     const handler = wiring.handlers({
-      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } as EventHandler,
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
     })?.[GraphEvents.ON_RUN_STEP];
     handler?.handle(
       GraphEvents.ON_RUN_STEP,
@@ -128,16 +136,210 @@ describe('createActivityPhaseWiring', () => {
     expect(generatePhase).not.toHaveBeenCalled();
     expect(parts).toHaveLength(1);
   });
+
+  it('restores bounded activity state after a HITL pause', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TEXT, text: 'Hidden intermediate output' },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const first = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({})),
+    });
+    await first.hook(batch('tool-1'), new AbortController().signal);
+    /** `hide_sequential_outputs` reshapes the persisted prefix after the pause
+     *  snapshot, so restoration must re-anchor by tool id rather than index. */
+    parts.shift();
+
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the resumed investigation' }));
+    const resumed = createActivityPhaseWiring({
+      initialSnapshot: first.snapshot(),
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
+    await resumed.hook(batch('tool-2'), new AbortController().signal);
+    resumed.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ activities: expect.arrayContaining([expect.any(Object)]) }),
+    );
+    expect(generatePhase.mock.calls[0][0].activities).toHaveLength(2);
+    expect(parts.at(-1)).toMatchObject({ activity_start_index: 0 });
+  });
+
+  it('bounds persisted evidence while preserving the full activity count', async () => {
+    const parts: LooseContentPart[] = [];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({})),
+    });
+    for (let index = 0; index < 20; index += 1) {
+      const id = `tool-${index}`;
+      parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id } });
+      await wiring.hook(batch(id), new AbortController().signal);
+    }
+
+    const snapshot = wiring.snapshot();
+    expect(snapshot.activityCount).toBe(20);
+    expect(snapshot.activities).toHaveLength(13);
+  });
+
+  it('keeps a parallel lane final inside the run-wide phase', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Combined both agent outcomes' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+    const finalStep = {
+      id: 'lane-final',
+      groupId: 'lane-a',
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+      },
+    };
+    handler?.handle(GraphEvents.ON_RUN_STEP, finalStep, undefined, undefined);
+    await flushDetached();
+    expect(generatePhase).not.toHaveBeenCalled();
+
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      { ...finalStep, id: 'root-final', groupId: undefined },
+      undefined,
+      undefined,
+    );
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves mixed batch failures as a partial phase outcome', async () => {
+    const mixed = batch('tool-1');
+    mixed.entries.push({
+      toolName: 'web_search',
+      toolInput: { query: 'failed' },
+      toolUseId: 'tool-1b',
+      status: 'error',
+      error: 'unavailable',
+    });
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1b' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Recovered part of the search scope' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(mixed, new AbortController().signal);
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'partial' }),
+    );
+    expect(parts.at(-1)).toMatchObject({ status: 'partial' });
+  });
+
+  it('collects usage after a committed blank phase result', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const collectUsage = jest.fn(async () => undefined);
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ collectUsage })),
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    await flushDetached();
+    expect(collectUsage).toHaveBeenCalledWith(undefined);
+    expect(parts.at(-1)).toMatchObject({ activity_label: '', pending: false });
+  });
 });
 
 describe('createAssistantPhaseStampingHandlers', () => {
   it('stamps commentary onto persisted text deltas for child activity-label intent', () => {
     const received: unknown[] = [];
     const handlers = createAssistantPhaseStampingHandlers({
-      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } as EventHandler,
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
       [GraphEvents.ON_MESSAGE_DELTA]: {
-        handle: (_event, data) => received.push(data),
-      } as EventHandler,
+        handle: (_event, data) => {
+          received.push(data);
+        },
+      },
     });
     handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
       GraphEvents.ON_RUN_STEP,

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -219,6 +219,94 @@ describe('createActivityPhaseWiring', () => {
     expect(parts.some((part) => part.activity_label_type === 'phase')).toBe(false);
   });
 
+  it('keeps reasoning attached to an unphased parallel tool batch', async () => {
+    const parts: LooseContentPart[] = [];
+    const generatePhase = jest.fn(async () => ({ label: 'unused' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    const handlers = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      [GraphEvents.ON_REASONING_DELTA]: { handle: jest.fn() },
+    });
+
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'lane-reasoning',
+        agentId: 'agent-a',
+        groupId: 'lane-a',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'think' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    handlers?.[GraphEvents.ON_REASONING_DELTA]?.handle(
+      GraphEvents.ON_REASONING_DELTA,
+      {
+        id: 'lane-reasoning',
+        delta: { content: { type: ContentTypes.THINK, think: 'Checked the lane input.' } },
+      },
+      undefined,
+      undefined,
+    );
+    parts.push({ type: ContentTypes.THINK, think: 'Checked the lane input.' });
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'lane-text',
+        agentId: 'agent-a',
+        groupId: 'lane-a',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    expect(wiring.snapshot()).toMatchObject({
+      activityCount: 0,
+      pendingReasoning: [{ key: 'agent-a', text: 'Checked the lane input.' }],
+    });
+
+    parts.push({ type: ContentTypes.TEXT, text: 'I will inspect the tool result.' });
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } });
+    await wiring.hook(
+      { ...batch('tool-1'), executingAgentId: 'agent-a' },
+      new AbortController().signal,
+    );
+    expect(wiring.snapshot()).toMatchObject({
+      activityCount: 1,
+      activities: [expect.objectContaining({ thinkingExcerpts: ['Checked the lane input.'] })],
+      pendingReasoning: [],
+    });
+
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    await flushDetached();
+    expect(generatePhase).not.toHaveBeenCalled();
+    expect(parts.some((part) => part.activity_label_type === 'phase')).toBe(false);
+  });
+
   it('anchors parallel standalone reasoning to each lane content part', async () => {
     const parts: LooseContentPart[] = [];
     const stepIndexes = new Map([

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1,0 +1,167 @@
+import { GraphEvents } from '@librechat/agents';
+import { ContentTypes, StepTypes } from 'librechat-data-provider';
+import type { EventHandler, PostToolBatchHookInput } from '@librechat/agents';
+import type { LooseContentPart } from '~/agents/activityLabels/wiring';
+import { createActivityPhaseWiring, createAssistantPhaseStampingHandlers } from './runtime';
+
+const batch = (id: string): PostToolBatchHookInput =>
+  ({
+    hook_event_name: 'PostToolBatch',
+    runId: 'run-1',
+    entries: [
+      {
+        toolName: 'web_search',
+        toolInput: { query: id },
+        toolUseId: id,
+        status: 'success',
+        toolOutput: `${id}-result`,
+      },
+    ],
+  }) as PostToolBatchHookInput;
+
+async function flushDetached(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe('createActivityPhaseWiring', () => {
+  it('claims one parent phase before forwarding the final text step', async () => {
+    const parts: LooseContentPart[] = [];
+    const forwarded: unknown[] = [];
+    const emitLabelEvent = jest.fn(async () => undefined);
+    const generatePhase = jest.fn(async () => ({ label: 'Resolved the release compatibility' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent,
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+
+    parts.push({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: { id: 'tool-1' },
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts.push({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: { id: 'tool-2' },
+    });
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+
+    const handlers = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: {
+        handle: (_event, data) => forwarded.push(data),
+      } as EventHandler,
+    });
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-step',
+        index: 2,
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: {
+            message_id: 'message-1',
+            content_type: 'text',
+            phase: 'final_answer',
+          },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    expect(forwarded).toHaveLength(1);
+    expect(parts[2]).toMatchObject({
+      type: ContentTypes.ACTIVITY_LABEL,
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_count: 2,
+      pending: true,
+    });
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        closingTextPhase: 'final_answer',
+        phaseIndex: 0,
+        activities: expect.any(Array),
+      }),
+    );
+    expect(parts[2]).toMatchObject({
+      activity_label: 'Resolved the release compatibility',
+      pending: false,
+    });
+    expect(emitLabelEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not spend a phase call on one logical activity', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'unused' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } as EventHandler,
+    })?.[GraphEvents.ON_RUN_STEP];
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    await flushDetached();
+    expect(generatePhase).not.toHaveBeenCalled();
+    expect(parts).toHaveLength(1);
+  });
+});
+
+describe('createAssistantPhaseStampingHandlers', () => {
+  it('stamps commentary onto persisted text deltas for child activity-label intent', () => {
+    const received: unknown[] = [];
+    const handlers = createAssistantPhaseStampingHandlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } as EventHandler,
+      [GraphEvents.ON_MESSAGE_DELTA]: {
+        handle: (_event, data) => received.push(data),
+      } as EventHandler,
+    });
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'commentary-step',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', phase: 'commentary' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    handlers?.[GraphEvents.ON_MESSAGE_DELTA]?.handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'commentary-step',
+        delta: { content: { type: ContentTypes.TEXT, text: 'I will compare both paths.' } },
+      },
+      undefined,
+      undefined,
+    );
+    expect(received[0]).toMatchObject({
+      delta: { content: { type: ContentTypes.TEXT, phase: 'commentary' } },
+    });
+  });
+});

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -219,6 +219,51 @@ describe('createActivityPhaseWiring', () => {
     expect(parts.some((part) => part.activity_label_type === 'phase')).toBe(false);
   });
 
+  it('counts a top-level handoff as a logical phase activity', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'handoff-1' } },
+    ];
+    let generatedActivities: GenerateActivityPhasePayload['activities'] | undefined;
+    const generatePhase = jest.fn(async (payload: GenerateActivityPhasePayload) => {
+      generatedActivities = payload.activities;
+      return { label: 'Transferred ownership and verified the account state' };
+    });
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    const handoff = batch('handoff-1');
+    handoff.entries[0].toolName = 'lc_transfer_to_billing_agent';
+    await wiring.hook(handoff, new AbortController().signal);
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'final-step',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+    expect(generatedActivities).toHaveLength(2);
+    expect(generatedActivities?.[0]?.entries?.[0]?.toolName).toBe(
+      'lc_transfer_to_billing_agent',
+    );
+  });
+
   it('keeps reasoning attached to an unphased parallel tool batch', async () => {
     const parts: LooseContentPart[] = [];
     const generatePhase = jest.fn(async () => ({ label: 'unused' }));

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -219,6 +219,82 @@ describe('createActivityPhaseWiring', () => {
     expect(parts.some((part) => part.activity_label_type === 'phase')).toBe(false);
   });
 
+  it('anchors parallel standalone reasoning to each lane content part', async () => {
+    const parts: LooseContentPart[] = [];
+    const stepIndexes = new Map([
+      ['reasoning-a', 0],
+      ['reasoning-b', 1],
+    ]);
+    const generatePhase = jest.fn(async () => ({ label: 'Reconciled both agent analyses' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => stepIndexes.get(stepId),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    const handlers = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      [GraphEvents.ON_REASONING_DELTA]: { handle: jest.fn() },
+    });
+    const emitReasoning = (id: string, agentId: string, index: number, text: string) => {
+      handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id,
+          index,
+          agentId,
+          groupId: agentId,
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'think' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+      parts[index] = { type: ContentTypes.THINK, think: text, agentId, groupId: index + 1 };
+      handlers?.[GraphEvents.ON_REASONING_DELTA]?.handle(
+        GraphEvents.ON_REASONING_DELTA,
+        {
+          id,
+          delta: { content: { type: ContentTypes.THINK, think: text } },
+        },
+        undefined,
+        undefined,
+      );
+    };
+    emitReasoning('reasoning-a', 'agent-a', 0, 'Checked the first path.');
+    emitReasoning('reasoning-b', 'agent-b', 1, 'Checked the second path.');
+
+    expect(wiring.snapshot().pendingReasoning).toEqual([
+      expect.objectContaining({ key: 'agent-a', startIndex: 0 }),
+      expect.objectContaining({ key: 'agent-b', startIndex: 1 }),
+    ]);
+
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-final',
+        index: 2,
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ activities: expect.arrayContaining([expect.any(Object)]) }),
+    );
+    expect(generatePhase.mock.calls[0][0].activities).toHaveLength(2);
+    expect(parts[2]).toMatchObject({ activity_start_index: 0, activity_count: 2 });
+  });
+
   it('restores bounded activity state after a HITL pause', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TEXT, text: 'Hidden intermediate output' },
@@ -329,6 +405,46 @@ describe('createActivityPhaseWiring', () => {
     handler?.handle(
       GraphEvents.ON_RUN_STEP,
       { ...finalStep, id: 'root-final', groupId: undefined },
+      undefined,
+      undefined,
+    );
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps unphased parallel text inside the run-wide fallback phase', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Combined both agent outcomes' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } });
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+    const textStep = {
+      id: 'lane-text',
+      groupId: 'lane-a',
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'm', content_type: 'text' },
+      },
+    };
+    handler?.handle(GraphEvents.ON_RUN_STEP, textStep, undefined, undefined);
+    await flushDetached();
+    expect(generatePhase).not.toHaveBeenCalled();
+
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      { ...textStep, id: 'root-text', groupId: undefined },
       undefined,
       undefined,
     );

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -225,7 +225,11 @@ describe('createActivityPhaseWiring', () => {
       ['reasoning-a', 0],
       ['reasoning-b', 1],
     ]);
-    const generatePhase = jest.fn(async () => ({ label: 'Reconciled both agent analyses' }));
+    let generatedActivities: GenerateActivityPhasePayload['activities'] | undefined;
+    const generatePhase = jest.fn(async (payload: GenerateActivityPhasePayload) => {
+      generatedActivities = payload.activities;
+      return { label: 'Reconciled both agent analyses' };
+    });
     const wiring = createActivityPhaseWiring({
       getContentParts: () => parts,
       getStepIndex: (stepId) => stepIndexes.get(stepId),
@@ -291,7 +295,7 @@ describe('createActivityPhaseWiring', () => {
     expect(generatePhase).toHaveBeenCalledWith(
       expect.objectContaining({ activities: expect.arrayContaining([expect.any(Object)]) }),
     );
-    expect(generatePhase.mock.calls[0][0].activities).toHaveLength(2);
+    expect(generatedActivities).toHaveLength(2);
     expect(parts[2]).toMatchObject({ activity_start_index: 0, activity_count: 2 });
   });
 

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -259,9 +259,7 @@ describe('createActivityPhaseWiring', () => {
     await flushDetached();
     expect(generatePhase).toHaveBeenCalledTimes(1);
     expect(generatedActivities).toHaveLength(2);
-    expect(generatedActivities?.[0]?.entries?.[0]?.toolName).toBe(
-      'lc_transfer_to_billing_agent',
-    );
+    expect(generatedActivities?.[0]?.entries?.[0]?.toolName).toBe('lc_transfer_to_billing_agent');
   });
 
   it('keeps reasoning attached to an unphased parallel tool batch', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -486,12 +486,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           ...(closingTextPhase != null && { closingTextPhase }),
           phaseIndex,
           totalActivityCount,
-          status:
-            failedCount === totalActivityCount
-              ? 'failed'
-              : failedCount > 0 || partialCount > 0
-                ? 'partial'
-                : 'completed',
+          status: phaseStatus === 'ok' ? 'completed' : phaseStatus,
           agentIds,
           charLimit,
           prompt: deps.prompt ?? ACTIVITY_PHASE_INSTRUCTION,
@@ -555,12 +550,17 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       status: entry.status,
     }));
     const failures = entries.filter((entry) => entry.status === 'error').length;
+    let activityStatus: TrackedActivity['status'] = 'success';
+    if (failures === entries.length) {
+      activityStatus = 'error';
+    } else if (failures > 0) {
+      activityStatus = 'partial';
+    }
     trackActivity({
       entries,
       ...(reasoning ? { thinkingExcerpts: [reasoning.slice(0, MAX_EXCERPT_CHARS)] } : {}),
       ...(input.executingAgentId != null && { agentId: input.executingAgentId }),
-      status:
-        failures === 0 ? 'success' : failures === entries.length ? 'error' : 'partial',
+      status: activityStatus,
       startIndex: findBatchStart(parts, ids),
       toolCallIds: [...ids],
       ...(childLabelIndex != null && { childLabelIndex }),

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -551,6 +551,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     if (input.agentId != null || input.entries.length === 0 || deps.abortSignal?.aborted) {
       return {};
     }
+    /** A top-level handoff is intentionally one logical phase activity. The
+     *  child-label hook skips it because a transfer card cannot join a tool
+     *  group; the parent phase can contain that card and should summarize the
+     *  material agent transition. `input.agentId` above still excludes nested
+     *  subagent internals. */
     const reasoningKey = input.executingAgentId ?? 'root';
     const reasoning = pendingReasoning.get(reasoningKey)?.text.trim();
     const ids = new Set(input.entries.map((entry) => entry.toolUseId));

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -2,6 +2,7 @@ import { GraphEvents } from '@librechat/agents';
 import { ContentTypes, StepTypes } from 'librechat-data-provider';
 import type { EventHandler, HookCallback, HookInputByEvent } from '@librechat/agents';
 import type { LooseContentPart } from '~/agents/activityLabels/wiring';
+import { stringifyActivityEvidence } from '~/agents/activityLabels/runtime';
 
 type PostToolBatchInput = HookInputByEvent['PostToolBatch'];
 type BatchEntry = PostToolBatchInput['entries'][number];
@@ -19,7 +20,26 @@ export interface ActivityPhaseEntry {
   }>;
   thinkingExcerpts?: string[];
   agentId?: string;
-  status?: 'success' | 'error';
+  status?: 'success' | 'partial' | 'error';
+}
+
+type TrackedActivity = ActivityPhaseEntry & {
+  startIndex: number;
+  childLabelIndex?: number;
+  /** Stable anchors survive content filtering and prepends across HITL resume. */
+  toolCallIds?: string[];
+};
+
+export interface ActivityPhaseSnapshot {
+  version: 1;
+  generated: number;
+  activityCount: number;
+  failedActivityCount: number;
+  partialActivityCount: number;
+  agentIds: string[];
+  activities: TrackedActivity[];
+  assistantContext: string[];
+  pendingReasoning: Array<{ key: string; text: string; agentId?: string }>;
 }
 
 export interface GenerateActivityPhasePayload {
@@ -27,7 +47,8 @@ export interface GenerateActivityPhasePayload {
   assistantContext?: string[];
   closingTextPhase?: AssistantTextPhase;
   phaseIndex: number;
-  status: 'completed' | 'failed';
+  totalActivityCount: number;
+  status: 'completed' | 'partial' | 'failed';
   agentIds: string[];
   charLimit: number;
   prompt?: string;
@@ -44,6 +65,7 @@ export interface ActivityPhaseHostDeps {
   charLimit?: number;
   prompt?: string;
   abortSignal?: AbortSignal;
+  initialSnapshot?: ActivityPhaseSnapshot;
   getContentParts: () => Array<LooseContentPart | null | undefined>;
   bumpIndexOffset: () => void;
   emitLabelEvent: (index: number, part: LooseContentPart) => Promise<unknown>;
@@ -59,12 +81,9 @@ export interface ActivityPhaseWiring {
   ) => Record<string, EventHandler> | undefined;
   /** A steer is a hard semantic boundary; incomplete evidence is discarded. */
   drop: () => void;
+  /** Bounded state needed to continue the same phase after a HITL pause. */
+  snapshot: () => ActivityPhaseSnapshot;
 }
-
-type TrackedActivity = ActivityPhaseEntry & {
-  startIndex: number;
-  childLabelIndex?: number;
-};
 
 const DEFAULT_MAX_PER_RUN = 5;
 const DEFAULT_CHAR_LIMIT = 600;
@@ -72,6 +91,34 @@ const MIN_ACTIVITIES = 2;
 const MAX_CONTEXT_ITEMS = 6;
 const MAX_EXCERPT_CHARS = 600;
 const OUTPUT_CHAR_LIMIT = 160;
+const PHASE_TIMEOUT_MS = 12_000;
+/** Twelve enter the SDK prompt; one extra preserves its omitted-activity row. */
+const MAX_RETAINED_ACTIVITIES = 13;
+const MAX_RETAINED_TOOL_ENTRIES = 6;
+
+export const ACTIVITY_PHASE_INSTRUCTION = `Summarize what this phase of an agent run accomplished. The result appears as the header of one collapsed parent group containing several activities.
+
+Rules:
+- One line, 8 to 18 words, past tense
+- Lead with the concrete outcome and name the most distinctive subject
+- Synthesize the phase; do not enumerate, count, or restate individual activities
+- Describe failures plainly when they are the phase's material outcome
+- Never mention tool names, calls, arguments, reasoning, commentary, or activity counts
+- Output only the summary — no quotes, no trailing punctuation, no preamble
+
+Examples:
+- Reconciled authentication behavior and fixed the failing session refresh path
+- Compared deployment options and documented the safest production rollout
+- Investigated database latency but could not confirm the suspected index regression
+
+Bad examples:
+- Used three tools to inspect files and run tests
+- Searched code, read configuration, and updated middleware`;
+
+interface DeltaPart {
+  text?: unknown;
+  think?: unknown;
+}
 
 function textValue(value: unknown): string {
   if (typeof value === 'string') {
@@ -97,7 +144,14 @@ function deltaText(data: unknown, key: 'text' | 'think'): string {
   } else if (raw != null) {
     parts = [raw];
   }
-  return parts.map((part) => textValue((part as Record<string, unknown> | null)?.[key])).join('');
+  return parts.map((part) => textValue((part as DeltaPart | null)?.[key])).join('');
+}
+
+function buildSignal(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(PHASE_TIMEOUT_MS);
+  return signal != null && typeof AbortSignal.any === 'function'
+    ? AbortSignal.any([signal, timeout])
+    : timeout;
 }
 
 function findLastPartIndex(
@@ -128,6 +182,34 @@ function findBatchStart(
     }
   }
   return first >= 0 ? first : Math.max(0, parts.length - 1);
+}
+
+function findTrackedStart(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  activity: TrackedActivity,
+): number {
+  if (activity.toolCallIds != null && activity.toolCallIds.length > 0) {
+    const toolStart = findBatchStart(parts, new Set(activity.toolCallIds));
+    if (
+      parts[toolStart]?.type === ContentTypes.TOOL_CALL &&
+      activity.toolCallIds.includes(String(parts[toolStart]?.tool_call?.id ?? ''))
+    ) {
+      return toolStart;
+    }
+  }
+  const excerpt = activity.thinkingExcerpts?.[0]?.trim();
+  if (excerpt) {
+    const needle = excerpt.slice(0, 80);
+    for (let i = 0; i < parts.length; i++) {
+      if (
+        parts[i]?.type === ContentTypes.THINK &&
+        textValue(parts[i]?.think).includes(needle)
+      ) {
+        return i;
+      }
+    }
+  }
+  return Math.min(activity.startIndex, Math.max(0, parts.length - 1));
 }
 
 /** Persists Open Responses text-phase metadata onto LibreChat text parts.
@@ -194,12 +276,33 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   const maxPerRun = deps.maxPerRun ?? DEFAULT_MAX_PER_RUN;
   const charLimit = deps.charLimit ?? DEFAULT_CHAR_LIMIT;
   const content = deps.getContentParts();
-  let generated = content.filter(
-    (part) => part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type === 'phase',
-  ).length;
-  let activities: TrackedActivity[] = [];
-  let assistantContext: string[] = [];
-  const pendingReasoning = new Map<string, { text: string; agentId?: string }>();
+  const initialSnapshot = deps.initialSnapshot?.version === 1 ? deps.initialSnapshot : undefined;
+  let generated = Math.max(
+    initialSnapshot?.generated ?? 0,
+    content.filter(
+      (part) => part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type === 'phase',
+    ).length,
+  );
+  let activities: TrackedActivity[] =
+    initialSnapshot?.activities.map((activity) => ({
+      ...activity,
+      startIndex: findTrackedStart(content, activity),
+    })) ?? [];
+  let activityCount = initialSnapshot?.activityCount ?? activities.length;
+  let failedActivityCount =
+    initialSnapshot?.failedActivityCount ??
+    activities.filter((activity) => activity.status === 'error').length;
+  let partialActivityCount =
+    initialSnapshot?.partialActivityCount ??
+    activities.filter((activity) => activity.status === 'partial').length;
+  const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
+  let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
+  const pendingReasoning = new Map<string, { text: string; agentId?: string }>(
+    (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId }) => [
+      key,
+      { text: text.slice(-MAX_EXCERPT_CHARS), ...(agentId != null && { agentId }) },
+    ]),
+  );
   const reasoningStepKeys = new Map<string, string>();
   const stepKinds = new Map<
     string,
@@ -212,7 +315,59 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     pendingReasoning.clear();
     reasoningStepKeys.clear();
     stepKinds.clear();
+    activityCount = 0;
+    failedActivityCount = 0;
+    partialActivityCount = 0;
+    contributingAgentIds.clear();
   };
+
+  const trackActivity = (activity: TrackedActivity) => {
+    activityCount += 1;
+    if (activity.status === 'error') {
+      failedActivityCount += 1;
+    } else if (activity.status === 'partial') {
+      partialActivityCount += 1;
+    }
+    if (activity.agentId != null) {
+      contributingAgentIds.add(activity.agentId);
+    }
+    if (activities.length < MAX_RETAINED_ACTIVITIES) {
+      activities.push(activity);
+    }
+  };
+
+  const snapshot = (): ActivityPhaseSnapshot => ({
+    version: 1,
+    generated,
+    activityCount,
+    failedActivityCount,
+    partialActivityCount,
+    agentIds: [...contributingAgentIds],
+    activities: activities.map((activity) => ({
+      ...activity,
+      ...(activity.entries != null && {
+        entries: activity.entries.slice(0, MAX_RETAINED_TOOL_ENTRIES).map((entry) => ({
+          ...entry,
+          toolInput: stringifyActivityEvidence(entry.toolInput, charLimit),
+          ...(entry.toolOutput != null && {
+            toolOutput: stringifyActivityEvidence(entry.toolOutput, charLimit),
+          }),
+          ...(entry.error != null && { error: entry.error.slice(0, charLimit) }),
+        })),
+      }),
+      ...(activity.thinkingExcerpts != null && {
+        thinkingExcerpts: activity.thinkingExcerpts.map((text) =>
+          text.slice(-MAX_EXCERPT_CHARS),
+        ),
+      }),
+    })),
+    assistantContext: assistantContext.slice(-MAX_CONTEXT_ITEMS),
+    pendingReasoning: [...pendingReasoning].map(([key, reasoning]) => ({
+      key,
+      text: reasoning.text.slice(-MAX_EXCERPT_CHARS),
+      ...(reasoning.agentId != null && { agentId: reasoning.agentId }),
+    })),
+  });
 
   const addPendingReasoning = (onlyKey?: string) => {
     let selected = [...pendingReasoning.entries()] as Array<
@@ -226,7 +381,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const text = reasoning.text.trim();
       if (text) {
         const parts = deps.getContentParts();
-        activities.push({
+        trackActivity({
           thinkingExcerpts: [text.slice(0, MAX_EXCERPT_CHARS)],
           ...(reasoning.agentId != null && { agentId: reasoning.agentId }),
           status: 'success',
@@ -239,19 +394,30 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
 
   const resolveActivities = (snapshot: TrackedActivity[]): ActivityPhaseEntry[] => {
     const parts = deps.getContentParts();
-    return snapshot.map(({ childLabelIndex, startIndex: _startIndex, ...activity }) => {
-      if (childLabelIndex == null) {
-        return activity;
-      }
-      const child = parts[childLabelIndex];
-      const label =
-        child?.type === ContentTypes.ACTIVITY_LABEL &&
-        child.activity_label_type !== 'phase' &&
-        child.pending !== true
-          ? textValue(child[ContentTypes.ACTIVITY_LABEL]).trim()
-          : '';
-      return label ? { ...activity, label, entries: undefined } : activity;
-    });
+    return snapshot.map(
+      ({ childLabelIndex, toolCallIds, startIndex: _startIndex, ...activity }) => {
+        const matchesToolIds = (part: LooseContentPart | null | undefined): boolean => {
+          if (part?.type !== ContentTypes.ACTIVITY_LABEL || part.activity_label_type === 'phase') {
+            return false;
+          }
+          if (toolCallIds == null || toolCallIds.length === 0) {
+            return true;
+          }
+          const childIds = Array.isArray(part.tool_call_ids) ? part.tool_call_ids : [];
+          return childIds.some((id) => typeof id === 'string' && toolCallIds.includes(id));
+        };
+        let child = childLabelIndex == null ? undefined : parts[childLabelIndex];
+        if (!matchesToolIds(child) && toolCallIds != null && toolCallIds.length > 0) {
+          child = parts.find(matchesToolIds);
+        }
+        if (!matchesToolIds(child)) {
+          return activity;
+        }
+        const label =
+          child?.pending !== true ? textValue(child?.[ContentTypes.ACTIVITY_LABEL]).trim() : '';
+        return label ? { ...activity, label, entries: undefined } : activity;
+      },
+    );
   };
 
   const close = (closingTextPhase?: AssistantTextPhase, hardBoundary = false) => {
@@ -260,7 +426,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       clear();
       return;
     }
-    if (activities.length < MIN_ACTIVITIES) {
+    if (activityCount < MIN_ACTIVITIES) {
       if (hardBoundary) clear();
       return;
     }
@@ -269,6 +435,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     const phaseIndex = generated - 1;
     const snapshot = [...activities];
     const contextSnapshot = [...assistantContext];
+    const totalActivityCount = activityCount;
+    const failedCount = failedActivityCount;
+    const partialCount = partialActivityCount;
     let startIndex = Math.min(...snapshot.map((activity) => activity.startIndex));
     const currentParts = deps.getContentParts();
     /** Pull leading commentary/reasoning into the parent card. A prior phase
@@ -285,14 +454,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       }
       startIndex = i;
     }
-    const agentIds = [
-      ...new Set(snapshot.flatMap((activity) => (activity.agentId ? [activity.agentId] : []))),
-    ];
-    const failedCount = snapshot.filter((activity) => activity.status === 'error').length;
+    const agentIds = [...contributingAgentIds];
     let phaseStatus: 'ok' | 'partial' | 'failed' = 'ok';
-    if (failedCount === snapshot.length) {
+    if (failedCount === totalActivityCount) {
       phaseStatus = 'failed';
-    } else if (failedCount > 0) {
+    } else if (failedCount > 0 || partialCount > 0) {
       phaseStatus = 'partial';
     }
     const index = deps.getContentParts().length;
@@ -301,7 +467,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       [ContentTypes.ACTIVITY_LABEL]: '',
       activity_label_type: 'phase',
       activity_start_index: startIndex,
-      activity_count: snapshot.length,
+      activity_count: totalActivityCount,
       ...(agentIds.length > 0 && { agent_ids: agentIds }),
       status: phaseStatus,
       pending: true,
@@ -319,11 +485,17 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           ...(contextSnapshot.length > 0 && { assistantContext: contextSnapshot }),
           ...(closingTextPhase != null && { closingTextPhase }),
           phaseIndex,
-          status: failedCount === snapshot.length ? 'failed' : 'completed',
+          totalActivityCount,
+          status:
+            failedCount === totalActivityCount
+              ? 'failed'
+              : failedCount > 0 || partialCount > 0
+                ? 'partial'
+                : 'completed',
           agentIds,
           charLimit,
-          ...(deps.prompt != null && { prompt: deps.prompt }),
-          signal: deps.abortSignal ?? new AbortController().signal,
+          prompt: deps.prompt ?? ACTIVITY_PHASE_INSTRUCTION,
+          signal: buildSignal(deps.abortSignal),
         });
       } catch {
         generatedPhase = {};
@@ -340,11 +512,16 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       try {
         await deps.emitLabelEvent(index, next);
         Object.assign(part, next);
-        if (label && generatedPhase.collectUsage != null) {
-          await generatedPhase.collectUsage(label);
-        }
       } catch {
         // A failed durable fill leaves the pending marker invisible and unbilled.
+        return;
+      }
+      try {
+        if (generatedPhase.collectUsage != null) {
+          await generatedPhase.collectUsage(label || undefined);
+        }
+      } catch {
+        // The committed UI projection must not regress when accounting fails.
       }
     })();
     deps.trackPendingFill(task);
@@ -378,12 +555,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       status: entry.status,
     }));
     const failures = entries.filter((entry) => entry.status === 'error').length;
-    activities.push({
+    trackActivity({
       entries,
       ...(reasoning ? { thinkingExcerpts: [reasoning.slice(0, MAX_EXCERPT_CHARS)] } : {}),
       ...(input.executingAgentId != null && { agentId: input.executingAgentId }),
-      status: failures === entries.length ? 'error' : 'success',
+      status:
+        failures === 0 ? 'success' : failures === entries.length ? 'error' : 'partial',
       startIndex: findBatchStart(parts, ids),
+      toolCallIds: [...ids],
       ...(childLabelIndex != null && { childLabelIndex }),
     });
     pendingReasoning.delete(reasoningKey);
@@ -405,6 +584,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           const step = data as {
             id?: string;
             agentId?: string;
+            groupId?: string | number;
             stepDetails?: {
               type?: string;
               message_creation?: { content_type?: string; phase?: string };
@@ -428,12 +608,12 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
                 });
               }
             } else {
-              addPendingReasoning();
-              if (phase === 'final_answer') {
+              addPendingReasoning(step.agentId ?? 'root');
+              if (phase === 'final_answer' && step.groupId == null) {
                 stepKinds.set(step.id, { kind, phase, captureContext: false });
                 close(phase, true);
               } else {
-                const closesPhase = phase == null && activities.length >= MIN_ACTIVITIES;
+                const closesPhase = phase == null && activityCount >= MIN_ACTIVITIES;
                 stepKinds.set(step.id, {
                   kind,
                   ...(phase != null && { phase }),
@@ -495,5 +675,5 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     return wrapped;
   };
 
-  return { hook, handlers: wrapHandlers, drop: clear };
+  return { hook, handlers: wrapHandlers, drop: clear, snapshot };
 }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -39,7 +39,12 @@ export interface ActivityPhaseSnapshot {
   agentIds: string[];
   activities: TrackedActivity[];
   assistantContext: string[];
-  pendingReasoning: Array<{ key: string; text: string; agentId?: string }>;
+  pendingReasoning: Array<{
+    key: string;
+    text: string;
+    agentId?: string;
+    startIndex?: number;
+  }>;
 }
 
 export interface GenerateActivityPhasePayload {
@@ -67,6 +72,7 @@ export interface ActivityPhaseHostDeps {
   abortSignal?: AbortSignal;
   initialSnapshot?: ActivityPhaseSnapshot;
   getContentParts: () => Array<LooseContentPart | null | undefined>;
+  getStepIndex?: (stepId: string) => number | undefined;
   bumpIndexOffset: () => void;
   emitLabelEvent: (index: number, part: LooseContentPart) => Promise<unknown>;
   trackPendingFill: (fillDone: Promise<void>) => void;
@@ -209,6 +215,25 @@ function findTrackedStart(
   return Math.min(activity.startIndex, Math.max(0, parts.length - 1));
 }
 
+function findReasoningStart(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  text: string,
+  startIndex?: number,
+): number {
+  const needle = text.trim().slice(0, 80);
+  const matches = (part: LooseContentPart | null | undefined) =>
+    part?.type === ContentTypes.THINK && textValue(part.think).includes(needle);
+  if (startIndex != null && matches(parts[startIndex])) {
+    return startIndex;
+  }
+  for (let index = 0; index < parts.length; index += 1) {
+    if (matches(parts[index])) {
+      return index;
+    }
+  }
+  return startIndex ?? findLastPartIndex(parts, ContentTypes.THINK);
+}
+
 /** Persists Open Responses text-phase metadata onto LibreChat text parts.
  *  Installed for existing batch labels too, so commentary can supply intent
  *  even when parent phase summaries are disabled. */
@@ -294,10 +319,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     activities.filter((activity) => activity.status === 'partial').length;
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
-  const pendingReasoning = new Map<string, { text: string; agentId?: string }>(
-    (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId }) => [
+  const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
+    (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId, startIndex }) => [
       key,
-      { text: text.slice(-MAX_EXCERPT_CHARS), ...(agentId != null && { agentId }) },
+      {
+        text: text.slice(-MAX_EXCERPT_CHARS),
+        ...(agentId != null && { agentId }),
+        ...(startIndex != null && { startIndex }),
+      },
     ]),
   );
   const reasoningStepKeys = new Map<string, string>();
@@ -361,12 +390,13 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       key,
       text: reasoning.text.slice(-MAX_EXCERPT_CHARS),
       ...(reasoning.agentId != null && { agentId: reasoning.agentId }),
+      ...(reasoning.startIndex != null && { startIndex: reasoning.startIndex }),
     })),
   });
 
   const addPendingReasoning = (onlyKey?: string) => {
     let selected = [...pendingReasoning.entries()] as Array<
-      readonly [string, { text: string; agentId?: string }]
+      readonly [string, { text: string; agentId?: string; startIndex?: number }]
     >;
     if (onlyKey != null) {
       const reasoning = pendingReasoning.get(onlyKey);
@@ -380,7 +410,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           thinkingExcerpts: [text.slice(0, MAX_EXCERPT_CHARS)],
           ...(reasoning.agentId != null && { agentId: reasoning.agentId }),
           status: 'success',
-          startIndex: findLastPartIndex(parts, ContentTypes.THINK),
+          startIndex: findReasoningStart(parts, text, reasoning.startIndex),
         });
       }
       pendingReasoning.delete(key);
@@ -596,12 +626,16 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
               stepKinds.set(step.id, { kind });
               const reasoningKey = step.agentId ?? 'root';
               reasoningStepKeys.set(step.id, reasoningKey);
+              const result = runStepHandler.handle(event, data, metadata, graph);
               if (!pendingReasoning.has(reasoningKey)) {
+                const startIndex = deps.getStepIndex?.(step.id);
                 pendingReasoning.set(reasoningKey, {
                   text: '',
                   ...(step.agentId != null && { agentId: step.agentId }),
+                  ...(startIndex != null && { startIndex }),
                 });
               }
+              return result;
             } else {
               if (phase === 'final_answer' && step.groupId == null) {
                 addPendingReasoning(step.agentId ?? 'root');
@@ -611,7 +645,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
                 if (phase == null) {
                   addPendingReasoning(step.agentId ?? 'root');
                 }
-                const closesPhase = phase == null && activityCount >= MIN_ACTIVITIES;
+                const closesPhase =
+                  phase == null && step.groupId == null && activityCount >= MIN_ACTIVITIES;
                 stepKinds.set(step.id, {
                   kind,
                   ...(phase != null && { phase }),

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -201,10 +201,7 @@ function findTrackedStart(
   if (excerpt) {
     const needle = excerpt.slice(0, 80);
     for (let i = 0; i < parts.length; i++) {
-      if (
-        parts[i]?.type === ContentTypes.THINK &&
-        textValue(parts[i]?.think).includes(needle)
-      ) {
+      if (parts[i]?.type === ContentTypes.THINK && textValue(parts[i]?.think).includes(needle)) {
         return i;
       }
     }
@@ -356,9 +353,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         })),
       }),
       ...(activity.thinkingExcerpts != null && {
-        thinkingExcerpts: activity.thinkingExcerpts.map((text) =>
-          text.slice(-MAX_EXCERPT_CHARS),
-        ),
+        thinkingExcerpts: activity.thinkingExcerpts.map((text) => text.slice(-MAX_EXCERPT_CHARS)),
       }),
     })),
     assistantContext: assistantContext.slice(-MAX_CONTEXT_ITEMS),

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -642,7 +642,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
                 stepKinds.set(step.id, { kind, phase, captureContext: false });
                 close(phase, true);
               } else {
-                if (phase == null) {
+                if (phase == null && step.groupId == null) {
                   addPendingReasoning(step.agentId ?? 'root');
                 }
                 const closesPhase =

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -1,0 +1,499 @@
+import { GraphEvents } from '@librechat/agents';
+import { ContentTypes, StepTypes } from 'librechat-data-provider';
+import type { EventHandler, HookCallback, HookInputByEvent } from '@librechat/agents';
+import type { LooseContentPart } from '~/agents/activityLabels/wiring';
+
+type PostToolBatchInput = HookInputByEvent['PostToolBatch'];
+type BatchEntry = PostToolBatchInput['entries'][number];
+
+export type AssistantTextPhase = 'commentary' | 'final_answer';
+
+export interface ActivityPhaseEntry {
+  label?: string;
+  entries?: Array<{
+    toolName: string;
+    toolInput: unknown;
+    toolOutput?: unknown;
+    error?: string;
+    status: 'success' | 'error';
+  }>;
+  thinkingExcerpts?: string[];
+  agentId?: string;
+  status?: 'success' | 'error';
+}
+
+export interface GenerateActivityPhasePayload {
+  activities: ActivityPhaseEntry[];
+  assistantContext?: string[];
+  closingTextPhase?: AssistantTextPhase;
+  phaseIndex: number;
+  status: 'completed' | 'failed';
+  agentIds: string[];
+  charLimit: number;
+  prompt?: string;
+  signal: AbortSignal;
+}
+
+export interface GeneratedActivityPhase {
+  label?: string;
+  collectUsage?: (label?: string) => void | Promise<void>;
+}
+
+export interface ActivityPhaseHostDeps {
+  maxPerRun?: number;
+  charLimit?: number;
+  prompt?: string;
+  abortSignal?: AbortSignal;
+  getContentParts: () => Array<LooseContentPart | null | undefined>;
+  bumpIndexOffset: () => void;
+  emitLabelEvent: (index: number, part: LooseContentPart) => Promise<unknown>;
+  trackPendingFill: (fillDone: Promise<void>) => void;
+  isClosed?: () => boolean;
+  generatePhase: (payload: GenerateActivityPhasePayload) => Promise<GeneratedActivityPhase>;
+}
+
+export interface ActivityPhaseWiring {
+  hook: HookCallback<'PostToolBatch'>;
+  handlers: (
+    handlers: Record<string, EventHandler> | undefined,
+  ) => Record<string, EventHandler> | undefined;
+  /** A steer is a hard semantic boundary; incomplete evidence is discarded. */
+  drop: () => void;
+}
+
+type TrackedActivity = ActivityPhaseEntry & {
+  startIndex: number;
+  childLabelIndex?: number;
+};
+
+const DEFAULT_MAX_PER_RUN = 5;
+const DEFAULT_CHAR_LIMIT = 600;
+const MIN_ACTIVITIES = 2;
+const MAX_CONTEXT_ITEMS = 6;
+const MAX_EXCERPT_CHARS = 600;
+const OUTPUT_CHAR_LIMIT = 160;
+
+function textValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  const nested = (value as { value?: unknown } | null | undefined)?.value;
+  return typeof nested === 'string' ? nested : '';
+}
+
+function normalizeLabel(value: string | undefined): string {
+  const firstLine = value?.split(/\r?\n/).find((line) => line.trim().length > 0) ?? '';
+  const normalized = firstLine.replace(/\s+/g, ' ').trim();
+  return normalized.length > OUTPUT_CHAR_LIMIT
+    ? `${normalized.slice(0, OUTPUT_CHAR_LIMIT - 1)}…`
+    : normalized;
+}
+
+function deltaText(data: unknown, key: 'text' | 'think'): string {
+  const raw = (data as { delta?: { content?: unknown } } | null)?.delta?.content;
+  let parts: unknown[] = [];
+  if (Array.isArray(raw)) {
+    parts = raw;
+  } else if (raw != null) {
+    parts = [raw];
+  }
+  return parts.map((part) => textValue((part as Record<string, unknown> | null)?.[key])).join('');
+}
+
+function findLastPartIndex(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  type: string,
+): number {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i]?.type === type) {
+      return i;
+    }
+  }
+  return Math.max(0, parts.length - 1);
+}
+
+function findBatchStart(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  toolCallIds: Set<string>,
+): number {
+  let first = -1;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (
+      part?.type === ContentTypes.TOOL_CALL &&
+      typeof part.tool_call?.id === 'string' &&
+      toolCallIds.has(part.tool_call.id)
+    ) {
+      first = first < 0 ? i : Math.min(first, i);
+    }
+  }
+  return first >= 0 ? first : Math.max(0, parts.length - 1);
+}
+
+/** Persists Open Responses text-phase metadata onto LibreChat text parts.
+ *  Installed for existing batch labels too, so commentary can supply intent
+ *  even when parent phase summaries are disabled. */
+export function createAssistantPhaseStampingHandlers(
+  handlers: Record<string, EventHandler> | undefined,
+): Record<string, EventHandler> | undefined {
+  if (handlers == null) {
+    return handlers;
+  }
+  const phases = new Map<string, AssistantTextPhase>();
+  const wrapped = { ...handlers };
+  const runStepHandler = handlers[GraphEvents.ON_RUN_STEP];
+  if (runStepHandler != null) {
+    wrapped[GraphEvents.ON_RUN_STEP] = {
+      handle: (event, data, metadata, graph) => {
+        const step = data as {
+          id?: string;
+          stepDetails?: { message_creation?: { phase?: string } };
+        };
+        const phase = step.stepDetails?.message_creation?.phase;
+        if (step.id && (phase === 'commentary' || phase === 'final_answer')) {
+          phases.set(step.id, phase);
+        }
+        return runStepHandler.handle(event, data, metadata, graph);
+      },
+    };
+  }
+  const messageHandler = handlers[GraphEvents.ON_MESSAGE_DELTA];
+  if (messageHandler != null) {
+    wrapped[GraphEvents.ON_MESSAGE_DELTA] = {
+      handle: (event, data, metadata, graph) => {
+        const phase = phases.get((data as { id?: string }).id ?? '');
+        const delta = (data as { delta?: { content?: unknown } }).delta;
+        const raw = delta?.content;
+        if (phase == null || raw == null) {
+          return messageHandler.handle(event, data, metadata, graph);
+        }
+        const stamp = (part: unknown) =>
+          (part as { type?: string } | null)?.type === ContentTypes.TEXT
+            ? { ...(part as Record<string, unknown>), phase }
+            : part;
+        const forwarded = {
+          ...(data as Record<string, unknown>),
+          delta: {
+            ...delta,
+            content: Array.isArray(raw) ? raw.map(stamp) : stamp(raw),
+          },
+        };
+        return messageHandler.handle(event, forwarded, metadata, graph);
+      },
+    };
+  }
+  return wrapped;
+}
+
+/**
+ * Collects run-wide logical activities and emits one parent summary at a text
+ * boundary. The summary call is detached; the boundary only pays the cheap
+ * synchronous slot claim needed to keep streamed content indices stable.
+ */
+export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): ActivityPhaseWiring {
+  const maxPerRun = deps.maxPerRun ?? DEFAULT_MAX_PER_RUN;
+  const charLimit = deps.charLimit ?? DEFAULT_CHAR_LIMIT;
+  const content = deps.getContentParts();
+  let generated = content.filter(
+    (part) => part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type === 'phase',
+  ).length;
+  let activities: TrackedActivity[] = [];
+  let assistantContext: string[] = [];
+  const pendingReasoning = new Map<string, { text: string; agentId?: string }>();
+  const reasoningStepKeys = new Map<string, string>();
+  const stepKinds = new Map<
+    string,
+    { kind: 'text' | 'think'; phase?: AssistantTextPhase; captureContext?: boolean }
+  >();
+
+  const clear = () => {
+    activities = [];
+    assistantContext = [];
+    pendingReasoning.clear();
+    reasoningStepKeys.clear();
+    stepKinds.clear();
+  };
+
+  const addPendingReasoning = (onlyKey?: string) => {
+    let selected = [...pendingReasoning.entries()] as Array<
+      readonly [string, { text: string; agentId?: string }]
+    >;
+    if (onlyKey != null) {
+      const reasoning = pendingReasoning.get(onlyKey);
+      selected = reasoning == null ? [] : [[onlyKey, reasoning] as const];
+    }
+    for (const [key, reasoning] of selected) {
+      const text = reasoning.text.trim();
+      if (text) {
+        const parts = deps.getContentParts();
+        activities.push({
+          thinkingExcerpts: [text.slice(0, MAX_EXCERPT_CHARS)],
+          ...(reasoning.agentId != null && { agentId: reasoning.agentId }),
+          status: 'success',
+          startIndex: findLastPartIndex(parts, ContentTypes.THINK),
+        });
+      }
+      pendingReasoning.delete(key);
+    }
+  };
+
+  const resolveActivities = (snapshot: TrackedActivity[]): ActivityPhaseEntry[] => {
+    const parts = deps.getContentParts();
+    return snapshot.map(({ childLabelIndex, startIndex: _startIndex, ...activity }) => {
+      if (childLabelIndex == null) {
+        return activity;
+      }
+      const child = parts[childLabelIndex];
+      const label =
+        child?.type === ContentTypes.ACTIVITY_LABEL &&
+        child.activity_label_type !== 'phase' &&
+        child.pending !== true
+          ? textValue(child[ContentTypes.ACTIVITY_LABEL]).trim()
+          : '';
+      return label ? { ...activity, label, entries: undefined } : activity;
+    });
+  };
+
+  const close = (closingTextPhase?: AssistantTextPhase, hardBoundary = false) => {
+    addPendingReasoning();
+    if (generated >= maxPerRun) {
+      clear();
+      return;
+    }
+    if (activities.length < MIN_ACTIVITIES) {
+      if (hardBoundary) clear();
+      return;
+    }
+
+    generated += 1;
+    const phaseIndex = generated - 1;
+    const snapshot = [...activities];
+    const contextSnapshot = [...assistantContext];
+    let startIndex = Math.min(...snapshot.map((activity) => activity.startIndex));
+    const currentParts = deps.getContentParts();
+    /** Pull leading commentary/reasoning into the parent card. A prior phase
+     *  marker or steer is the only hard UI boundary; plain text can be
+     *  intermediate context on providers that do not expose phase metadata. */
+    for (let i = startIndex - 1; i >= 0; i--) {
+      const prior = currentParts[i];
+      if (
+        prior?.type === ContentTypes.STEER ||
+        (prior?.type === ContentTypes.ACTIVITY_LABEL && prior.activity_label_type === 'phase') ||
+        (prior?.type === ContentTypes.TEXT && prior.phase === 'final_answer')
+      ) {
+        break;
+      }
+      startIndex = i;
+    }
+    const agentIds = [
+      ...new Set(snapshot.flatMap((activity) => (activity.agentId ? [activity.agentId] : []))),
+    ];
+    const failedCount = snapshot.filter((activity) => activity.status === 'error').length;
+    let phaseStatus: 'ok' | 'partial' | 'failed' = 'ok';
+    if (failedCount === snapshot.length) {
+      phaseStatus = 'failed';
+    } else if (failedCount > 0) {
+      phaseStatus = 'partial';
+    }
+    const index = deps.getContentParts().length;
+    const part: LooseContentPart = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: '',
+      activity_label_type: 'phase',
+      activity_start_index: startIndex,
+      activity_count: snapshot.length,
+      ...(agentIds.length > 0 && { agent_ids: agentIds }),
+      status: phaseStatus,
+      pending: true,
+    };
+    deps.getContentParts().push(part);
+    deps.bumpIndexOffset();
+    void Promise.resolve(deps.emitLabelEvent(index, part)).catch(() => undefined);
+    clear();
+
+    const task = (async () => {
+      let generatedPhase: GeneratedActivityPhase = {};
+      try {
+        generatedPhase = await deps.generatePhase({
+          activities: resolveActivities(snapshot),
+          ...(contextSnapshot.length > 0 && { assistantContext: contextSnapshot }),
+          ...(closingTextPhase != null && { closingTextPhase }),
+          phaseIndex,
+          status: failedCount === snapshot.length ? 'failed' : 'completed',
+          agentIds,
+          charLimit,
+          ...(deps.prompt != null && { prompt: deps.prompt }),
+          signal: deps.abortSignal ?? new AbortController().signal,
+        });
+      } catch {
+        generatedPhase = {};
+      }
+      if (deps.isClosed?.() === true) {
+        return;
+      }
+      const label = normalizeLabel(generatedPhase.label);
+      const next: LooseContentPart = {
+        ...part,
+        [ContentTypes.ACTIVITY_LABEL]: label,
+        pending: false,
+      };
+      try {
+        await deps.emitLabelEvent(index, next);
+        Object.assign(part, next);
+        if (label && generatedPhase.collectUsage != null) {
+          await generatedPhase.collectUsage(label);
+        }
+      } catch {
+        // A failed durable fill leaves the pending marker invisible and unbilled.
+      }
+    })();
+    deps.trackPendingFill(task);
+  };
+
+  const hook: HookCallback<'PostToolBatch'> = async (input: PostToolBatchInput) => {
+    if (input.agentId != null || input.entries.length === 0 || deps.abortSignal?.aborted) {
+      return {};
+    }
+    const reasoningKey = input.executingAgentId ?? 'root';
+    const reasoning = pendingReasoning.get(reasoningKey)?.text.trim();
+    const ids = new Set(input.entries.map((entry) => entry.toolUseId));
+    const parts = deps.getContentParts();
+    let childLabelIndex: number | undefined;
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const part = parts[i];
+      if (part?.type !== ContentTypes.ACTIVITY_LABEL || part.activity_label_type === 'phase') {
+        continue;
+      }
+      const childIds = Array.isArray(part.tool_call_ids) ? part.tool_call_ids : [];
+      if (childIds.some((id) => typeof id === 'string' && ids.has(id))) {
+        childLabelIndex = i;
+        break;
+      }
+    }
+    const entries = input.entries.map((entry: BatchEntry) => ({
+      toolName: entry.toolName,
+      toolInput: entry.toolInput,
+      toolOutput: entry.toolOutput,
+      error: entry.error,
+      status: entry.status,
+    }));
+    const failures = entries.filter((entry) => entry.status === 'error').length;
+    activities.push({
+      entries,
+      ...(reasoning ? { thinkingExcerpts: [reasoning.slice(0, MAX_EXCERPT_CHARS)] } : {}),
+      ...(input.executingAgentId != null && { agentId: input.executingAgentId }),
+      status: failures === entries.length ? 'error' : 'success',
+      startIndex: findBatchStart(parts, ids),
+      ...(childLabelIndex != null && { childLabelIndex }),
+    });
+    pendingReasoning.delete(reasoningKey);
+    return {};
+  };
+
+  const wrapHandlers = (
+    handlers: Record<string, EventHandler> | undefined,
+  ): Record<string, EventHandler> | undefined => {
+    if (handlers == null) {
+      return handlers;
+    }
+    const phaseHandlers = createAssistantPhaseStampingHandlers(handlers) ?? handlers;
+    const wrapped = { ...phaseHandlers };
+    const runStepHandler = phaseHandlers[GraphEvents.ON_RUN_STEP];
+    if (runStepHandler != null) {
+      wrapped[GraphEvents.ON_RUN_STEP] = {
+        handle: (event, data, metadata, graph) => {
+          const step = data as {
+            id?: string;
+            agentId?: string;
+            stepDetails?: {
+              type?: string;
+              message_creation?: { content_type?: string; phase?: string };
+            };
+          };
+          if (step.stepDetails?.type === StepTypes.MESSAGE_CREATION && step.id) {
+            const creation = step.stepDetails.message_creation;
+            const kind = creation?.content_type === 'think' ? 'think' : 'text';
+            const phase =
+              creation?.phase === 'commentary' || creation?.phase === 'final_answer'
+                ? creation.phase
+                : undefined;
+            if (kind === 'think') {
+              stepKinds.set(step.id, { kind });
+              const reasoningKey = step.agentId ?? 'root';
+              reasoningStepKeys.set(step.id, reasoningKey);
+              if (!pendingReasoning.has(reasoningKey)) {
+                pendingReasoning.set(reasoningKey, {
+                  text: '',
+                  ...(step.agentId != null && { agentId: step.agentId }),
+                });
+              }
+            } else {
+              addPendingReasoning();
+              if (phase === 'final_answer') {
+                stepKinds.set(step.id, { kind, phase, captureContext: false });
+                close(phase, true);
+              } else {
+                const closesPhase = phase == null && activities.length >= MIN_ACTIVITIES;
+                stepKinds.set(step.id, {
+                  kind,
+                  ...(phase != null && { phase }),
+                  captureContext: !closesPhase,
+                });
+                if (closesPhase) {
+                  close(undefined, false);
+                } else {
+                  assistantContext.push('');
+                  if (assistantContext.length > MAX_CONTEXT_ITEMS) assistantContext.shift();
+                }
+              }
+            }
+          }
+          return runStepHandler.handle(event, data, metadata, graph);
+        },
+      };
+    }
+
+    const messageHandler = phaseHandlers[GraphEvents.ON_MESSAGE_DELTA];
+    if (messageHandler != null) {
+      wrapped[GraphEvents.ON_MESSAGE_DELTA] = {
+        handle: (event, data, metadata, graph) => {
+          const id = (data as { id?: string }).id;
+          const tracked = id ? stepKinds.get(id) : undefined;
+          if (tracked?.kind === 'text' && tracked.captureContext === true) {
+            const text = deltaText(data, 'text');
+            if (text) {
+              const last = assistantContext.length - 1;
+              const next = `${last >= 0 ? assistantContext[last] : ''}${text}`.slice(
+                -MAX_EXCERPT_CHARS,
+              );
+              if (last >= 0) assistantContext[last] = next;
+              else assistantContext.push(next);
+              if (assistantContext.length > MAX_CONTEXT_ITEMS) assistantContext.shift();
+            }
+          }
+          return messageHandler.handle(event, data, metadata, graph);
+        },
+      };
+    }
+
+    const reasoningHandler = phaseHandlers[GraphEvents.ON_REASONING_DELTA];
+    if (reasoningHandler != null) {
+      wrapped[GraphEvents.ON_REASONING_DELTA] = {
+        handle: (event, data, metadata, graph) => {
+          const id = (data as { id?: string }).id;
+          const reasoningKey = id ? reasoningStepKeys.get(id) : undefined;
+          const reasoning = reasoningKey ? pendingReasoning.get(reasoningKey) : undefined;
+          if (reasoning != null) {
+            reasoning.text = `${reasoning.text}${deltaText(data, 'think')}`.slice(
+              -MAX_EXCERPT_CHARS,
+            );
+          }
+          return reasoningHandler.handle(event, data, metadata, graph);
+        },
+      };
+    }
+    return wrapped;
+  };
+
+  return { hook, handlers: wrapHandlers, drop: clear };
+}

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -603,11 +603,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
                 });
               }
             } else {
-              addPendingReasoning(step.agentId ?? 'root');
               if (phase === 'final_answer' && step.groupId == null) {
+                addPendingReasoning(step.agentId ?? 'root');
                 stepKinds.set(step.id, { kind, phase, captureContext: false });
                 close(phase, true);
               } else {
+                if (phase == null) {
+                  addPendingReasoning(step.agentId ?? 'root');
+                }
                 const closesPhase = phase == null && activityCount >= MIN_ACTIVITIES;
                 stepKinds.set(step.id, {
                   kind,

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -42,4 +42,5 @@ export * from './hitl';
 export * from './hooks';
 export * from './steering';
 export * from './activityLabels';
+export * from './activityPhases';
 export * from './toolValidation';

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1184,6 +1184,7 @@ export async function createRun({
   subagentUsageSink,
   steering,
   activityLabel,
+  activityPhase,
   hitlCapable = false,
   toolInputValidationErrors,
   streaming = true,
@@ -1262,6 +1263,8 @@ export async function createRun({
    * the hook returns immediately and generates off the critical path.
    */
   activityLabel?: { hook: HookCallback<'PostToolBatch'> };
+  /** Run-wide parent phase collector; registered after child batch labels. */
+  activityPhase?: { hook: HookCallback<'PostToolBatch'> };
   /**
    * Whether the caller implements the HITL pause/resume lifecycle (inspects
    * `run.getInterrupt()`, persists a pending action, exposes a resume route). Gates the
@@ -1630,6 +1633,10 @@ export async function createRun({
   if (activityLabel != null) {
     hooks = hooks ?? new HookRegistry();
     hooks.register('PostToolBatch', { hooks: [activityLabel.hook] });
+  }
+  if (activityPhase != null) {
+    hooks = hooks ?? new HookRegistry();
+    hooks.register('PostToolBatch', { hooks: [activityPhase.hook] });
   }
   if (steering != null && isSteeringSupported()) {
     hooks = hooks ?? new HookRegistry();

--- a/packages/api/src/stream/ApprovalLifecycle.ts
+++ b/packages/api/src/stream/ApprovalLifecycle.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import type { Agents } from 'librechat-data-provider';
 import type { IJobStoreV2, JobMetadataPatch, SteerQueueItem } from '~/stream/interfaces/IJobStore';
+import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
 import {
   isPendingActionExpired,
   isPendingActionStale,
@@ -22,6 +23,7 @@ export interface ApprovalLifecycleCallbacks {
 
 export interface ApprovalPauseOptions {
   discoveredTools?: string[];
+  activityPhaseSnapshot?: ActivityPhaseSnapshot;
   /** Generation identity observed by the interrupted run. */
   expectedCreatedAt?: number;
   /** Hold Stop/resume until the paused assistant row is durably unfinished. */
@@ -88,6 +90,7 @@ export class ApprovalLifecycle {
     }
     const expectedCreatedAt = options.expectedCreatedAt ?? job.createdAt;
     const discoveredTools = options.discoveredTools;
+    const activityPhaseSnapshot = options.activityPhaseSnapshot;
     /** The normal receipt TTL matches a running job, but a review pause can
      * live for 24h or an explicit later expiry. The store extends every
      * receipt in the SAME CAS that closes running enqueues: a separate pass
@@ -116,6 +119,7 @@ export class ApprovalLifecycle {
         ...(discoveredTools != null && discoveredTools.length > 0
           ? { discoveredTools: [...discoveredTools] }
           : {}),
+        ...(activityPhaseSnapshot != null ? { activityPhaseSnapshot } : {}),
       },
       expectCreatedAt: expectedCreatedAt,
       steerReceiptTtlSeconds: pauseReceiptTtl,

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -2380,6 +2380,7 @@ class GenerationJobManagerClass {
         // Surface deferred tools discovered before the pause so the resume route can
         // replay them into createRun (the rebuilt graph passes `messages: []`).
         discoveredTools: jobData.discoveredTools,
+        activityPhaseSnapshot: jobData.activityPhaseSnapshot,
         // Surface the owning replica's seal capability so the steer route can
         // honour it instead of probing its own (possibly older) SDK.
         preemptCapable: jobData.preemptCapable,

--- a/packages/api/src/stream/__tests__/pendingAction.spec.ts
+++ b/packages/api/src/stream/__tests__/pendingAction.spec.ts
@@ -76,6 +76,37 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
       expect(paused?.metadata.discoveredTools).toEqual(['save_issue_mcp_linear']);
     });
 
+    test('persists activity phase state in the same transition as the pause', async () => {
+      const streamId = 'stream-pause-activity-phase';
+      await manager.createJob(streamId, 'user-1');
+      const activityPhaseSnapshot = {
+        version: 1 as const,
+        generated: 0,
+        activityCount: 1,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          {
+            label: 'Inspected the deployment',
+            status: 'success' as const,
+            startIndex: 0,
+          },
+        ],
+        assistantContext: ['Checking the remaining replicas'],
+        pendingReasoning: [],
+      };
+
+      expect(
+        await manager.approvals.pause(streamId, buildAction(streamId), {
+          activityPhaseSnapshot,
+        }),
+      ).toBe(true);
+
+      const paused = await manager.getJob(streamId);
+      expect(paused?.metadata.activityPhaseSnapshot).toEqual(activityPhaseSnapshot);
+    });
+
     test('does not write a stale pause or discoveries onto a replacement job', async () => {
       const streamId = 'stream-pause-replaced';
       const original = await manager.createJob(streamId, 'user-1');

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -4053,6 +4053,9 @@ export class RedisJobStore implements IJobStoreV2 {
       isTemporary: data.isTemporary != null ? data.isTemporary === '1' : undefined,
       // Deferred tools discovered before a HITL pause; replayed into createRun on resume.
       discoveredTools: data.discoveredTools ? JSON.parse(data.discoveredTools) : undefined,
+      activityPhaseSnapshot: data.activityPhaseSnapshot
+        ? JSON.parse(data.activityPhaseSnapshot)
+        : undefined,
       /** The owning replica's seal capability. `serializeJob` writes every
        *  boolean generically, but this mapper is explicit — omitting it here
        *  drops the flag on every read, so the steer route would compute

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -1,5 +1,6 @@
 import type { Agents, TFile, TPendingSteer } from 'librechat-data-provider';
 import type { StandardGraph } from '@librechat/agents';
+import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
 import type { RecoveredSteerPayload } from '../SteerRecovery';
 
 /**
@@ -89,6 +90,8 @@ export interface SerializableJobData {
    * the discovered tool schemas.
    */
   discoveredTools?: string[];
+  /** Bounded collector state for continuing a phase across HITL resume. */
+  activityPhaseSnapshot?: ActivityPhaseSnapshot;
   /**
    * Whether the replica that OWNS this generation can seal mid-stream
    * (`PreemptBoundary` wiring). Recorded at createJob because the steer route
@@ -257,6 +260,7 @@ export type JobMetadataPatch = Partial<
     | 'isTemporary'
     | 'promptTokens'
     | 'discoveredTools'
+    | 'activityPhaseSnapshot'
     | 'preemptCapable'
     | 'generationProtocolVersion'
   >

--- a/packages/api/src/stream/metadata.ts
+++ b/packages/api/src/stream/metadata.ts
@@ -42,5 +42,8 @@ export function sanitizeJobMetadata(metadata: Partial<GenerationJobMetadata>): J
   if (metadata.discoveredTools) {
     patch.discoveredTools = metadata.discoveredTools;
   }
+  if (metadata.activityPhaseSnapshot) {
+    patch.activityPhaseSnapshot = metadata.activityPhaseSnapshot;
+  }
   return patch;
 }

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -1,5 +1,6 @@
 import type { Agents } from 'librechat-data-provider';
 import type { EventEmitter } from 'events';
+import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
 import type { ServerSentEvent } from './events';
 
 export interface GenerationJobMetadata {
@@ -35,6 +36,8 @@ export interface GenerationJobMetadata {
    * without them the rebuilt model would lose the discovered tool schemas.
    */
   discoveredTools?: string[];
+  /** Bounded collector state for continuing a phase across HITL resume. */
+  activityPhaseSnapshot?: ActivityPhaseSnapshot;
   /** See `SerializableJobData.preemptCapable`. */
   preemptCapable?: boolean;
   /** Terminal close has atomically stopped new steer acceptance, even if the

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -677,6 +677,16 @@ export const baseEndpointSchema = z.object({
   activityMaxPerRun: z.number().int().positive().optional(),
   /** Per-entry truncation of tool input/output in the label prompt. Default 600. */
   activityCharLimit: z.number().int().positive().optional(),
+  /** Generates one parent summary for each run phase containing 2+ activities. */
+  activityPhaseLabel: z.boolean().optional(),
+  /** Model used for phase summaries. Defaults to activityModel, titleModel, then the run model. */
+  activityPhaseModel: z.string().optional(),
+  /** Endpoint whose credentials the phase summary model uses. Defaults to activityEndpoint. */
+  activityPhaseEndpoint: z.string().optional(),
+  /** Overrides the dedicated phase-summary system prompt. */
+  activityPhasePrompt: z.string().optional(),
+  /** Cost cap: maximum phase summaries generated per run. Default 5. */
+  activityPhaseMaxPerRun: z.number().int().positive().optional(),
   /** Maximum characters allowed in a single tool result before truncation. */
   maxToolResultChars: z.number().positive().optional(),
 });
@@ -1122,6 +1132,11 @@ export const azureEndpointSchema = z
         activityPrompt: true,
         activityMaxPerRun: true,
         activityCharLimit: true,
+        activityPhaseLabel: true,
+        activityPhaseModel: true,
+        activityPhaseEndpoint: true,
+        activityPhasePrompt: true,
+        activityPhaseMaxPerRun: true,
       })
       .partial(),
   );

--- a/packages/data-provider/src/types/agents.ts
+++ b/packages/data-provider/src/types/agents.ts
@@ -285,6 +285,9 @@ export namespace Agents {
     type: StepTypes.MESSAGE_CREATION;
     message_creation: {
       message_id: string;
+      /** Provider content kind and Open Responses semantic text channel. */
+      content_type?: 'text' | 'think';
+      phase?: 'commentary' | 'final_answer';
     };
   };
   export type ToolCallsDetails = {

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -636,6 +636,8 @@ export type TMessageContentParts =
       type: ContentTypes.TEXT;
       text?: string | TextData;
       tool_call_ids?: string[];
+      /** Open Responses semantic channel for assistant text. */
+      phase?: 'commentary' | 'final_answer';
     } & ContentMetadata)
   | ({
       type: ContentTypes.TOOL_CALL;
@@ -655,7 +657,13 @@ export type TMessageContentParts =
        *  never sent to the model (stripped before payload formatting). */
       type: ContentTypes.ACTIVITY_LABEL;
       activity_label?: string;
+      /** Missing means the legacy/per-batch activity label. */
+      activity_label_type?: 'phase';
       tool_call_ids?: string[];
+      /** Parent phase bounds and telemetry. */
+      activity_start_index?: number;
+      activity_count?: number;
+      agent_ids?: string[];
       /** ok = all tools succeeded, failed = all failed, partial = mixed. */
       status?: 'ok' | 'partial' | 'failed';
       pending?: boolean;

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -83,9 +83,9 @@ export enum SteerEvents {
 
 /**
  * Activity-label event names. `on_activity_label` streams to live clients
- * when a tool-batch label part is claimed (deterministic counts) and again
- * when the fast-model label resolves; reconnecting clients recover applied
- * labels from `aggregatedContent` like any other content part.
+ * when a tool-batch or parent-phase label part is claimed and again when the
+ * fast-model label resolves; reconnecting clients recover applied labels
+ * from `aggregatedContent` like any other content part.
  */
 export enum ActivityLabelEvents {
   ON_ACTIVITY_LABEL = 'on_activity_label',
@@ -98,7 +98,12 @@ export type TActivityLabelEvent = {
   part: {
     type: ContentTypes.ACTIVITY_LABEL;
     [ContentTypes.ACTIVITY_LABEL]: string;
+    /** Missing means a per-batch activity label. */
+    activity_label_type?: 'phase';
     tool_call_ids?: string[];
+    activity_start_index?: number;
+    activity_count?: number;
+    agent_ids?: string[];
     counts?: {
       searches: number;
       reads: number;
@@ -230,8 +235,8 @@ export type TTokenUsageEvent = {
   /** Non-primary buckets fold into session cost/totals but not the live
    *  context gauge: hidden sequential-agent calls (`sequential`), summary
    *  passes (`summarization`), isolated subagent runs (`subagent`), and
-   *  fast-model activity headers (`activity-label`) */
-  usage_type?: 'summarization' | 'subagent' | 'sequential' | 'activity-label';
+   *  fast-model activity headers (`activity-label`, `activity-phase`) */
+  usage_type?: 'summarization' | 'subagent' | 'sequential' | 'activity-label' | 'activity-phase';
   runId?: string;
   /** Per-run emission sequence; keeps identical payloads from distinct model calls unique */
   seq?: number;


### PR DESCRIPTION
## Summary

I added an independently configurable parent activity phase that summarizes two or more logical agent activities before the final answer.

- Add native `activityPhaseLabel`, model, endpoint, prompt, and per-run limit configuration with phase → activity → title/run fallback precedence.
- Use Open Responses `commentary` and `final_answer` metadata as semantic boundaries, with hard steer boundaries and a conservative root-only plain-text fallback.
- Reuse the durable activity-label transport while preserving pending, failed, resumed, and feature-off rendering semantics.
- Render completed phases as collapsed, theme-token-based parent groups across sequential and parallel content, while preserving the summary when all children are filtered.$'\n'- Preserve message-level tool-group expansion overrides and typed HITL drafts while pending phases resolve into nested slices.$'\n'- Keep phased and legacy/unphased text separate during streaming and final assembly, with cursor continuity while a resolved phase is the active tail.
- Preserve stable group identity, steer attribution, HITL decisions, approval scope, and phase bounds through streaming, reconnects, HITL resume, manual-skill prepends, and sequential-output filtering.
- Keep phased and phase-less parallel-lane reasoning attached to its subsequent tool batch so one logical action cannot trigger a duplicate phase activity.
- Record phase usage separately and link each run summary to its source AgentRun/session for Langfuse observability.
- Bound retained evidence and require two activities before spending a phase-label model call.$'\n'- Partition phase segments with dense disjoint ranges with absolute offsets so configured phase caps do not create quadratic render work.
- Require the published `@librechat/agents@^3.4.4` release that provides `Run.generateActivityPhaseLabel` and Open Responses phase metadata.

The SDK implementation from [danny-avila/agents#400](https://github.com/danny-avila/agents/pull/400) is merged and published in `@librechat/agents@3.4.4`. The host retains its capability probe for mixed-version safety, while the declared dependency now enables the feature on supported installs.

Example:

```yaml
activityPhaseLabel: true
activityPhaseModel: gpt-4o-mini
activityPhaseEndpoint: openAI
activityPhasePrompt: ...
activityPhaseMaxPerRun: 5
```

`activityCharLimit` is shared with child activity labels. A completed tool batch is one activity; attached reasoning does not double-count it; standalone reasoning, failed batches, handoffs, and parent subagent calls each count once. Nested subagent internals are excluded.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

GitHub Actions passed all 31 checks on exact head `7664b30cf`: static checks; backend and client typechecks; package, client, data-provider, data-schema, and API test shards; Redis and MongoDB integration; runtime and Docker smoke tests; Vite and package builds; MCP replica checks; and all four memory/Redis Playwright E2E shards.

For the dependency bump, `npm install --package-lock-only --dry-run` reports the lockfile current, all three JSON files parse, registry integrity matches the lock entry, and the published tarball exposes `Run.generateActivityPhaseLabel`. `git diff --check` passes. Focused regressions cover phased and phase-less reasoning-to-tool transitions. The local Jest and Prettier launchers remain blocked by missing shared-checkout modules (`winston-daily-rotate-file` and `prettier-plugin-tailwindcss`), so per request I delegated the refreshed full matrix to CI rather than repairing the dependency installation.

### **Test Configuration**:

- Node.js from the existing LibreChat checkout and GitHub-hosted Ubuntu runners
- Focused published-package, lockfile, JSON, and activity-phase regression validation
- Exact-head full matrix in GitHub Actions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of the code
- [x] I have made pertinent configuration documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective