### PR TITLE
🪆 fix: Rebase Activity Phase Bounds over Sparse Content

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2276,13 +2276,24 @@ class AgentClient extends BaseClient {
    * so prepended skill cards cannot enter a phase and a filtered-away leading
    * reasoning part advances the bound to the first retained child.
    *
+   * Both arrays may be sparse: the aggregator writes parts at provider-source
+   * indexes, which can skip slots. Holes must not enter the identity map — a
+   * hole reads as `undefined`, and one `undefined` key would falsely match
+   * every hole in `previousParts` as a retained part.
+   *
    * @param {Array<import('librechat-data-provider').ContentPart | null | undefined>} previousParts
    */
   rebaseActivityPhaseBounds(previousParts) {
     if (!Array.isArray(previousParts) || !Array.isArray(this.contentParts)) {
       return;
     }
-    const retainedIndexes = new Map(this.contentParts.map((part, index) => [part, index]));
+    const retainedIndexes = new Map();
+    for (let index = 0; index < this.contentParts.length; index += 1) {
+      const part = this.contentParts[index];
+      if (part != null) {
+        retainedIndexes.set(part, index);
+      }
+    }
     for (let markerIndex = 0; markerIndex < this.contentParts.length; markerIndex += 1) {
       const marker = this.contentParts[markerIndex];
       if (

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -186,6 +186,30 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
     expect(ctx.contentParts).toEqual([skillCard, activityTool, phase, final]);
     expect(phase.activity_start_index).toBe(1);
   });
+
+  it('rebases phase bounds over sparse content without treating holes as retained parts', () => {
+    const reasoning = { type: ContentTypes.THINK, think: 'planning' };
+    const toolCall = toolCallPart('tc-sparse');
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      activity_label: 'Searched for tools',
+      activity_label_type: 'phase',
+      activity_start_index: 1,
+    };
+    const final = textPart('answer');
+    const contentParts = [];
+    contentParts[0] = reasoning;
+    contentParts[2] = toolCall;
+    contentParts[3] = phase;
+    contentParts[4] = final;
+    const previousParts = [...contentParts];
+    const ctx = { options: { agent: {} }, contentParts };
+
+    expect(() =>
+      AgentClient.prototype.rebaseActivityPhaseBounds.call(ctx, previousParts),
+    ).not.toThrow();
+    expect(phase.activity_start_index).toBe(2);
+  });
 });
 
 describe('AgentClient - startup telemetry', () => {


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Iterator value undefined is not an entry object` thrown by `rebaseActivityPhaseBounds` (added in #14721) at the end of every run whose `contentParts` array is sparse — deterministically reproducible with parent phase summaries enabled. The throw lands in `chatCompletion`'s catch, so the finished response is finalized with an error part appended.

## Root cause

The aggregator writes content parts at provider-source indexes (`allocateContentIndex` takes `Math.max(nextContentIndex, sourceIndex)`), which can skip slots and leave holes in `contentParts` — the existing JSDoc already types the array as `ContentPart | null | undefined` for this reason. The rebase built its identity map with:

```js
new Map(this.contentParts.map((part, index) => [part, index]));
```

`Array.prototype.map` preserves holes, and the `Map` constructor iterates each hole as `undefined` → TypeError. Because the map is built before the marker loop, the crash was unconditional on sparse content — no phase marker needed to be present. Both call sites (completion and HITL resume) go through this method.

## Fix

Build the map with an index loop that skips nullish slots. Excluding holes is semantically required, not just crash-proofing: with holes included they all collapse onto a single `undefined` key, so any hole in `previousParts` would falsely match as a retained part and corrupt the rebased bound.

## Tests

- New regression test with a sparse `contentParts` — verified it reproduces the exact production TypeError against the unfixed code, and asserts the bound advances past a hole to the first real retained part (distinguishes the correct fix from one that maps holes as keys).
- Full `client.test.js` suite: 96/96 passing; eslint clean.