### PR TITLE
📸 fix: Guard Screenshot Export Against Main-Thread Freezes

### DIFF
--- a/client/src/components/Chat/Messages/MessagesView.tsx
+++ b/client/src/components/Chat/Messages/MessagesView.tsx
@@ -143,7 +143,7 @@ function MessagesViewContent({
                 </div>
               ) : (
                 <>
-                  <div ref={screenshotTargetRef}>
+                  <div ref={screenshotTargetRef} data-testid="screenshot-target">
                     <MultiMessage
                       messagesTree={_messagesTree}
                       messageId={conversationId ?? null}

--- a/client/src/components/Nav/ExportConversation/ExportModal.tsx
+++ b/client/src/components/Nav/ExportConversation/ExportModal.tsx
@@ -14,12 +14,14 @@ import { useLocalize, useExportConversation } from '~/hooks';
 import { normalizeExportFilename } from '~/utils';
 
 const TYPE_OPTIONS = [
-  { value: 'screenshot', label: 'screenshot (.png)' },
-  { value: 'text', label: 'text (.txt)' },
   { value: 'markdown', label: 'markdown (.md)' },
+  { value: 'text', label: 'text (.txt)' },
   { value: 'json', label: 'json (.json)' },
   { value: 'csv', label: 'csv (.csv)' },
+  { value: 'screenshot', label: 'screenshot (.png)' },
 ];
+
+const DEFAULT_TYPE = 'markdown';
 
 export default function ExportModal({
   open,
@@ -37,7 +39,7 @@ export default function ExportModal({
   const localize = useLocalize();
 
   const [filename, setFileName] = useState('');
-  const [type, setType] = useState<string>('screenshot');
+  const [type, setType] = useState<string>(DEFAULT_TYPE);
 
   const [includeOptions, setIncludeOptions] = useState<boolean | 'indeterminate'>(true);
   const [exportBranches, setExportBranches] = useState<boolean | 'indeterminate'>(false);
@@ -51,24 +53,21 @@ export default function ExportModal({
 
   useEffect(() => {
     setFileName(filenamify(String(conversation?.title ?? 'file')));
-    setType('screenshot');
+    setType(DEFAULT_TYPE);
     setIncludeOptions(true);
     setExportBranches(false);
     setRecursive(true);
   }, [conversation?.title, open]);
 
   const handleTypeChange = useCallback((newType: string) => {
-    const branches = newType === 'json' || newType === 'csv' || newType === 'webpage';
+    const branches = newType === 'json' || newType === 'csv';
     const options = newType !== 'csv' && newType !== 'screenshot';
     setExportBranches(branches);
     setIncludeOptions(options);
     setType(newType);
   }, []);
 
-  const exportBranchesSupport = useMemo(
-    () => type === 'json' || type === 'csv' || type === 'webpage',
-    [type],
-  );
+  const exportBranchesSupport = useMemo(() => type === 'json' || type === 'csv', [type]);
   const exportOptionsSupport = useMemo(() => type !== 'csv' && type !== 'screenshot', [type]);
 
   const { exportConversation } = useExportConversation({

--- a/client/src/hooks/Conversations/useExportConversation.ts
+++ b/client/src/hooks/Conversations/useExportConversation.ts
@@ -2,11 +2,13 @@ import { useCallback } from 'react';
 import download from 'downloadjs';
 import { useParams } from 'react-router-dom';
 import exportFromJSON from 'export-from-json';
+import { useToastContext } from '@librechat/client';
 import { useQueryClient } from '@tanstack/react-query';
 import { buildTree, QueryKeys } from 'librechat-data-provider';
 import type { TConversation, TMessage, TPreset } from 'librechat-data-provider';
+import { ScreenshotLimitError, useScreenshot } from '~/hooks/ScreenshotContext';
 import useBuildMessageTree from '~/hooks/Messages/useBuildMessageTree';
-import { useScreenshot } from '~/hooks/ScreenshotContext';
+import { NotificationSeverity } from '~/common';
 import { formatMessageText } from './format';
 import { cleanupPreset } from '~/utils';
 import { useLocalize } from '~/hooks';
@@ -33,6 +35,7 @@ export default function useExportConversation({
   recursive: boolean | 'indeterminate';
 }) {
   const queryClient = useQueryClient();
+  const { showToast } = useToastContext();
   const { captureScreenshot } = useScreenshot();
   const buildMessageTree = useBuildMessageTree();
   const localize = useLocalize();
@@ -48,12 +51,21 @@ export default function useExportConversation({
   }, [paramId, conversation?.conversationId, queryClient]);
 
   const exportScreenshot = async () => {
-    let data;
+    let data: Blob;
     try {
       data = await captureScreenshot();
     } catch (err) {
-      console.error('Failed to capture screenshot');
-      return console.error(err);
+      console.error('Failed to capture screenshot', err);
+      showToast({
+        message: localize(
+          err instanceof ScreenshotLimitError
+            ? 'com_nav_export_screenshot_too_large'
+            : 'com_nav_export_screenshot_error',
+        ),
+        severity: NotificationSeverity.ERROR,
+        showIcon: true,
+      });
+      return;
     }
     download(data, `${filename}.png`, 'image/png');
   };

--- a/client/src/hooks/ScreenshotContext.tsx
+++ b/client/src/hooks/ScreenshotContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useRef, useContext, RefObject } from 'react';
+import { createContext, useRef, useContext, RefObject, ReactNode } from 'react';
 import { toCanvas } from 'html-to-image';
 import { ThemeContext, isDark } from '@librechat/client';
 
@@ -6,47 +6,73 @@ type ScreenshotContextType = {
   ref?: RefObject<HTMLDivElement>;
 };
 
+/** Canvas area ceiling (~16.7 MP, 4096²) — WebKit rejects larger canvases and PNG encode cost grows linearly past it */
+const MAX_CAPTURE_AREA = 16_777_216;
+/** Chromium/Firefox cap a canvas edge at 32767px; beyond it drawing silently produces a blank canvas */
+const MAX_CANVAS_EDGE = 32_767;
+/** Below half-resolution the capture is illegible, so abort rather than degrade further */
+const MIN_PIXEL_RATIO = 0.5;
+/** html-to-image clones every node and copies ~340 computed styles each; cap the synchronous clone work */
+const MAX_CAPTURE_ELEMENTS = 50_000;
+
+export class ScreenshotLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScreenshotLimitError';
+  }
+}
+
 const ScreenshotContext = createContext<ScreenshotContextType>({});
 
 export const useScreenshot = () => {
   const { ref } = useContext(ScreenshotContext);
   const { theme } = useContext(ThemeContext);
 
-  const takeScreenShot = async (node?: HTMLElement) => {
+  const takeScreenShot = async (node?: HTMLElement): Promise<Blob> => {
     if (!node) {
       throw new Error('You should provide correct html node.');
     }
 
-    const backgroundColor = isDark(theme) ? '#171717' : 'white';
+    const width = node.scrollWidth;
+    const height = node.scrollHeight;
+    if (!width || !height) {
+      throw new Error('Cannot capture an empty node.');
+    }
 
+    const elementCount = node.querySelectorAll('*').length;
+    if (elementCount > MAX_CAPTURE_ELEMENTS) {
+      throw new ScreenshotLimitError(
+        `Screenshot capture aborted: ${elementCount} elements exceed the ${MAX_CAPTURE_ELEMENTS} limit`,
+      );
+    }
+
+    const pixelRatio = Math.min(
+      window.devicePixelRatio || 1,
+      Math.sqrt(MAX_CAPTURE_AREA / (width * height)),
+      MAX_CANVAS_EDGE / Math.max(width, height),
+    );
+    if (pixelRatio < MIN_PIXEL_RATIO) {
+      throw new ScreenshotLimitError(
+        `Screenshot capture aborted: ${width}x${height} CSS px cannot fit within ${MAX_CAPTURE_AREA} device px`,
+      );
+    }
+
+    const backgroundColor = isDark(theme) ? '#171717' : 'white';
     const canvas = await toCanvas(node, {
       backgroundColor,
+      pixelRatio,
       imagePlaceholder:
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=',
     });
 
-    const croppedCanvas = document.createElement('canvas');
-    const croppedCanvasContext = croppedCanvas.getContext('2d') as CanvasRenderingContext2D;
-    // init data
-    const cropPositionTop = 0;
-    const cropPositionLeft = 0;
-    const cropWidth = canvas.width;
-    const cropHeight = canvas.height;
-
-    croppedCanvas.width = cropWidth;
-    croppedCanvas.height = cropHeight;
-
-    croppedCanvasContext.fillStyle = backgroundColor;
-    croppedCanvasContext.fillRect(0, 0, cropWidth, cropHeight);
-
-    croppedCanvasContext.drawImage(canvas, cropPositionLeft, cropPositionTop);
-
-    const base64Image = croppedCanvas.toDataURL('image/png', 1);
-
-    return base64Image;
+    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) {
+      throw new Error('Failed to encode screenshot canvas.');
+    }
+    return blob;
   };
 
-  const captureScreenshot = async () => {
+  const captureScreenshot = async (): Promise<Blob> => {
     if (ref instanceof Function) {
       throw new Error('Ref callback is not supported.');
     }
@@ -59,8 +85,8 @@ export const useScreenshot = () => {
   return { screenshotTargetRef: ref, captureScreenshot };
 };
 
-export const ScreenshotProvider = ({ children }) => {
-  const ref = useRef(null);
+export const ScreenshotProvider = ({ children }: { children: ReactNode }) => {
+  const ref = useRef<HTMLDivElement>(null);
 
   return <ScreenshotContext.Provider value={{ ref }}>{children}</ScreenshotContext.Provider>;
 };

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -509,6 +509,8 @@
   "com_nav_export_include_endpoint_options": "Include endpoint options",
   "com_nav_export_recursive": "Recursive",
   "com_nav_export_recursive_or_sequential": "Recursive or sequential?",
+  "com_nav_export_screenshot_error": "Couldn't capture the screenshot. Try a different export type.",
+  "com_nav_export_screenshot_too_large": "This conversation is too large to export as a screenshot. Try a different export type.",
   "com_nav_export_type": "Type",
   "com_nav_external": "External",
   "com_nav_font_size": "Message Font Size",

--- a/e2e/specs/mock/db.ts
+++ b/e2e/specs/mock/db.ts
@@ -81,6 +81,47 @@ export async function deleteConversations(conversationIds: string[]): Promise<vo
   });
 }
 
+export interface SeedMessage {
+  messageId: string;
+  parentMessageId: string;
+  text: string;
+  isCreatedByUser: boolean;
+  sender: string;
+}
+
+/**
+ * Inserts message documents directly so specs can build conversations far larger
+ * than the mock model could produce through the UI in reasonable time.
+ */
+export async function seedMessages(
+  userEmail: string,
+  conversationId: string,
+  messages: SeedMessage[],
+): Promise<void> {
+  await withMongo(async (db) => {
+    const userId = await resolveUserId(db, userEmail);
+    const start = Date.now();
+    const docs = messages.map((message, index) => ({
+      ...message,
+      conversationId,
+      user: userId,
+      endpoint: 'openAI',
+      error: false,
+      unfinished: false,
+      createdAt: new Date(start + index * 1000),
+      updatedAt: new Date(start + index * 1000),
+      __v: 0,
+    }));
+    await db.collection('messages').insertMany(docs);
+  });
+}
+
+export async function deleteMessagesByConversation(conversationIds: string[]): Promise<void> {
+  await withMongo(async (db) => {
+    await db.collection('messages').deleteMany({ conversationId: { $in: conversationIds } });
+  });
+}
+
 /** Clears every conversation for the user so the seeded date groups are not pushed
  *  below the virtualized viewport by rows left behind by other specs. */
 export async function clearUserConversations(userEmail: string): Promise<void> {

--- a/e2e/specs/mock/export.spec.ts
+++ b/e2e/specs/mock/export.spec.ts
@@ -148,7 +148,9 @@ test.describe('conversation export', () => {
     expect(csvDownload.suggestedFilename()).toMatch(/\.csv$/);
     const csv = await downloadText(csvDownload);
     expect(csv).toContain('sender');
-    expect(csv).toContain(MOCK_REPLY_TEXT);
+    /** CSV export maps only the legacy `text` field, which is empty for the mock
+     *  model's content-parts reply — assert on the user message instead. */
+    expect(csv).toContain('Export fixture prompt');
 
     await selectExportType(page, dialog, 'screenshot (.png)');
     const screenshotDownload = await exportCurrentType(page, dialog);
@@ -187,7 +189,7 @@ test.describe('conversation export', () => {
     });
     await dialog.getByRole('button', { name: 'Export', exact: true }).click();
 
-    await expect(page.getByText('too large to export as a screenshot')).toBeVisible({
+    await expect(page.getByText('too large to export as a screenshot').first()).toBeVisible({
       timeout: 15000,
     });
     expect(downloadFired).toBe(false);

--- a/e2e/specs/mock/export.spec.ts
+++ b/e2e/specs/mock/export.spec.ts
@@ -1,0 +1,200 @@
+import fs from 'fs';
+import { randomUUID } from 'crypto';
+import { expect, test } from '@playwright/test';
+import type { Download, Locator, Page } from '@playwright/test';
+import { getE2EUser } from '../../setup/user';
+import {
+  MOCK_ENDPOINTS,
+  MOCK_REPLY_TEXT,
+  NEW_CHAT_PATH,
+  messagesView,
+  mockReply,
+  selectMockEndpoint,
+  sendMessage,
+} from './helpers';
+import {
+  deleteConversations,
+  deleteMessagesByConversation,
+  seedConversations,
+  seedMessages,
+} from './db';
+import type { SeedMessage } from './db';
+
+const NO_PARENT = '00000000-0000-0000-0000-000000000000';
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Mirrors MAX_CAPTURE_AREA in client/src/hooks/ScreenshotContext.tsx. */
+const MAX_CAPTURE_AREA = 16_777_216;
+/** The capture aborts once the CSS area needs a pixel ratio below 0.5, i.e. above 4× the max area. */
+const ABORT_CSS_AREA = 4 * MAX_CAPTURE_AREA;
+
+const OVERSIZED_TITLE = 'Oversized export fixture';
+const OVERSIZED_PARAGRAPH = 'Oversized export fixture paragraph';
+const OVERSIZED_MESSAGES = 80;
+const OVERSIZED_PARAGRAPHS_PER_MESSAGE = 50;
+
+const userEmail = getE2EUser().email;
+const cleanupConversationIds: string[] = [];
+
+async function startMockConversation(page: Page): Promise<string> {
+  await page.goto(NEW_CHAT_PATH, { timeout: 15000 });
+  await selectMockEndpoint(page, MOCK_ENDPOINTS[0]);
+  await sendMessage(page, 'Export fixture prompt');
+  await expect(mockReply(page).first()).toBeVisible({ timeout: 15000 });
+  await expect(page).toHaveURL(/\/c\/(?!new$)[\w-]+/, { timeout: 15000 });
+  const conversationId = new URL(page.url()).pathname.split('/').pop();
+  if (!conversationId) {
+    throw new Error(`Could not parse conversation id from ${page.url()}`);
+  }
+  cleanupConversationIds.push(conversationId);
+  return conversationId;
+}
+
+async function openExportModal(page: Page): Promise<Locator> {
+  await page.getByRole('button', { name: 'Export/Share' }).click();
+  await page.getByRole('menuitem', { name: 'Export' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Export conversation' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+const typeDropdown = (dialog: Locator) => dialog.getByTestId('dropdown-menu');
+
+async function selectExportType(page: Page, dialog: Locator, label: string) {
+  await typeDropdown(dialog).click();
+  await page.getByRole('option', { name: label }).click();
+  await expect(typeDropdown(dialog)).toContainText(label);
+}
+
+/** The modal stays open after exporting, so consecutive exports reuse one dialog. */
+async function exportCurrentType(page: Page, dialog: Locator): Promise<Download> {
+  const [download] = await Promise.all([
+    page.waitForEvent('download', { timeout: 30000 }),
+    dialog.getByRole('button', { name: 'Export', exact: true }).click(),
+  ]);
+  return download;
+}
+
+async function downloadText(download: Download): Promise<string> {
+  return fs.promises.readFile(await download.path(), 'utf8');
+}
+
+function buildOversizedMessages(): SeedMessage[] {
+  const text = Array.from(
+    { length: OVERSIZED_PARAGRAPHS_PER_MESSAGE },
+    (_, index) => `${OVERSIZED_PARAGRAPH} ${index}.`,
+  ).join('\n\n');
+  const messages: SeedMessage[] = [];
+  let parentMessageId = NO_PARENT;
+  for (let i = 0; i < OVERSIZED_MESSAGES; i++) {
+    const messageId = randomUUID();
+    messages.push({
+      messageId,
+      parentMessageId,
+      text,
+      isCreatedByUser: i % 2 === 0,
+      sender: i % 2 === 0 ? 'User' : 'Assistant',
+    });
+    parentMessageId = messageId;
+  }
+  return messages;
+}
+
+test.afterAll(async () => {
+  if (cleanupConversationIds.length === 0) {
+    return;
+  }
+  await deleteMessagesByConversation(cleanupConversationIds);
+  await deleteConversations(cleanupConversationIds);
+});
+
+test.describe('conversation export', () => {
+  test('defaults to markdown with screenshot demoted to the last option', async ({ page }) => {
+    await startMockConversation(page);
+    const dialog = await openExportModal(page);
+
+    await expect(typeDropdown(dialog)).toContainText('markdown (.md)');
+
+    await typeDropdown(dialog).click();
+    const options = page.getByRole('option');
+    await expect(options.first()).toContainText('markdown (.md)');
+    await expect(options.last()).toContainText('screenshot (.png)');
+  });
+
+  test('exports the conversation in every format', async ({ page }) => {
+    test.setTimeout(120_000);
+    await startMockConversation(page);
+    const dialog = await openExportModal(page);
+
+    const markdownDownload = await exportCurrentType(page, dialog);
+    expect(markdownDownload.suggestedFilename()).toMatch(/\.md$/);
+    const markdown = await downloadText(markdownDownload);
+    expect(markdown).toContain('# Conversation');
+    expect(markdown).toContain(MOCK_REPLY_TEXT);
+
+    await selectExportType(page, dialog, 'text (.txt)');
+    const textDownload = await exportCurrentType(page, dialog);
+    expect(textDownload.suggestedFilename()).toMatch(/\.txt$/);
+    expect(await downloadText(textDownload)).toContain(MOCK_REPLY_TEXT);
+
+    await selectExportType(page, dialog, 'json (.json)');
+    const jsonDownload = await exportCurrentType(page, dialog);
+    expect(jsonDownload.suggestedFilename()).toMatch(/\.json$/);
+    const parsed = JSON.parse(await downloadText(jsonDownload)) as Record<string, unknown>;
+    expect(JSON.stringify(parsed)).toContain(MOCK_REPLY_TEXT);
+
+    await selectExportType(page, dialog, 'csv (.csv)');
+    const csvDownload = await exportCurrentType(page, dialog);
+    expect(csvDownload.suggestedFilename()).toMatch(/\.csv$/);
+    const csv = await downloadText(csvDownload);
+    expect(csv).toContain('sender');
+    expect(csv).toContain(MOCK_REPLY_TEXT);
+
+    await selectExportType(page, dialog, 'screenshot (.png)');
+    const screenshotDownload = await exportCurrentType(page, dialog);
+    expect(screenshotDownload.suggestedFilename()).toMatch(/\.png$/);
+    const png = await fs.promises.readFile(await screenshotDownload.path());
+    expect(png.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC)).toBe(true);
+    expect(png.byteLength).toBeGreaterThan(1000);
+  });
+
+  test('aborts screenshot export of an oversized conversation with an error toast', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const conversationId = randomUUID();
+    cleanupConversationIds.push(conversationId);
+    await seedConversations(userEmail, [
+      { conversationId, title: OVERSIZED_TITLE, updatedAt: new Date() },
+    ]);
+    await seedMessages(userEmail, conversationId, buildOversizedMessages());
+
+    await page.goto(`/c/${conversationId}`, { timeout: 30000 });
+    await expect(messagesView(page).getByText(`${OVERSIZED_PARAGRAPH} 0.`).first()).toBeVisible({
+      timeout: 60000,
+    });
+
+    const target = page.getByTestId('screenshot-target');
+    const area = await target.evaluate((node) => node.scrollWidth * node.scrollHeight);
+    expect(area).toBeGreaterThan(ABORT_CSS_AREA * 1.15);
+
+    const dialog = await openExportModal(page);
+    await selectExportType(page, dialog, 'screenshot (.png)');
+
+    let downloadFired = false;
+    page.on('download', () => {
+      downloadFired = true;
+    });
+    await dialog.getByRole('button', { name: 'Export', exact: true }).click();
+
+    await expect(page.getByText('too large to export as a screenshot')).toBeVisible({
+      timeout: 15000,
+    });
+    expect(downloadFired).toBe(false);
+
+    await selectExportType(page, dialog, 'markdown (.md)');
+    const fallbackDownload = await exportCurrentType(page, dialog);
+    expect(fallbackDownload.suggestedFilename()).toMatch(/\.md$/);
+    expect(await downloadText(fallbackDownload)).toContain(`${OVERSIZED_PARAGRAPH} 0.`);
+  });
+});


### PR DESCRIPTION
## Summary

Export-as-screenshot can freeze the tab on large conversations. `html-to-image`'s `toCanvas` runs on the main thread over the entire message tree: it deep-clones every DOM node (~340 computed styles each), rasterizes one giant SVG, then synchronously PNG-encodes a canvas that reached ~28 MP on a real conversation (2720×10348). Screenshot was also the **default** export type, so users hit this path by accident. Reported internally by Dustin Healy; known unfixed bug class in `html-to-image` 1.11.11 (upstream issues #536/#544/#542/#347, reportedly worse on Chrome 138+).

The capture path also had two aggravating defects beyond the library itself:
- A "crop" step that copied the full canvas 1:1 into a second identically-sized canvas (hardcoded 0/0/full-width/full-height) — a no-op that doubled peak memory (~112 MB extra at 28 MP).
- `toDataURL('image/png', 1)` — a second synchronous main-thread encode producing a multi-MB base64 string, which `downloadjs` then decoded right back into bytes (the `1` quality arg is meaningless for PNG).

### Changes

**`ScreenshotContext.tsx`**
- **Size guard**: effective `pixelRatio` is clamped so the output canvas stays ≤ ~16.7 MP (4096², the conservative cross-browser canvas-area limit) and ≤ 32767 px per edge (Chromium/Firefox hard cap, beyond which drawing silently yields a blank canvas). Small conversations are unaffected (ratio stays at `devicePixelRatio`); long ones degrade resolution gracefully instead of freezing.
- **Hard limits**: if a legible capture is impossible (`pixelRatio` would fall below 0.5) or the subtree exceeds 50k elements (bounds the synchronous clone/style-copy work), capture aborts with a typed `ScreenshotLimitError`.
- **Removed the no-op crop copy** — the `toCanvas` result is encoded directly.
- **`toDataURL` → `toBlob`**: async encode, no base64 round-trip; `downloadjs` accepts the Blob directly. Encode failures (e.g. Safari returning `null` on an oversized canvas) now throw instead of silently downloading a broken image.

**`ExportModal.tsx`**
- Default export type is now **markdown** (lossless for message content, O(text) cost); screenshot remains available but moved to the bottom of the list. This also fixes the "Include endpoint options" checkbox initializing checked-but-unsupported for the screenshot default.
- Removed dead `webpage` type references (never in `TYPE_OPTIONS`, no handler).

**`useExportConversation.ts`**
- Screenshot failures now surface a localized error toast (specific message for the too-large case) instead of failing silently in the console.

### Notes
- #14221 (force `pixelRatio ≥ 3`) conflicts with this fix: it would multiply output pixels 2.25× on dpr-2 displays and 9× on dpr-1 displays on this same code path. It should be reworked on top of the clamp (e.g. allow upscaling only when the capture area is small) or closed.
- Playwright e2e coverage for the export flows lands in a follow-up commit on this PR; react-scan/perf measurements of all export types will be posted here as a comment.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx tsc --noEmit` (client): no errors in changed files (3 pre-existing environmental errors in unrelated `Files/` components).
- `npx eslint` + `prettier --check` on changed files: clean; lint-staged pre-commit hooks passed.
- `npx jest ExportAndShareMenu` (client): 2/2 pass.
- Playwright e2e specs for export flows (default type, all five formats, oversized-conversation guard) added on this branch — run in CI (`playwright-mock.yml`).

### **Test Configuration**:
- Node v24.16.0, mock-LLM e2e harness (`e2e/playwright.config.mock.ts`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes