### PR TITLE
🧷 fix: Preserve Elicitation Answers Across Aborts

### DIFF
--- a/api/server/controllers/agents/__tests__/resume.spec.js
+++ b/api/server/controllers/agents/__tests__/resume.spec.js
@@ -1455,6 +1455,7 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
             {
               request: 'What should I name the file?',
               output: 'call it report.pdf',
+              contentMissing: true,
             },
           ],
         },

--- a/api/server/controllers/agents/__tests__/resume.spec.js
+++ b/api/server/controllers/agents/__tests__/resume.spec.js
@@ -1342,6 +1342,18 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
       expect(client.resumeCompletion).toHaveBeenCalledWith(
         expect.objectContaining({ resumeValue: { answer: 'call it report.pdf' } }),
       );
+      expect(mockGenerationJobManager.approvals.resolve).toHaveBeenCalledWith(
+        CONVO_ID,
+        ACTION_ID,
+        {
+          preemptCapable: true,
+          resolvedAskUserQuestion: {
+            request: 'What should I name the file?',
+            output: 'call it report.pdf',
+          },
+        },
+        1000,
+      );
       expect(mockGenerationJobManager.claimTerminalJob).toHaveBeenCalledWith(
         CONVO_ID,
         'complete',
@@ -1368,6 +1380,19 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
       const client = await mockInitializeClient.mock.results[0].value.then((r) => r.client);
       expect(client.resumeCompletion).toHaveBeenCalledWith(
         expect.objectContaining({ resumeValue: { answers } }),
+      );
+      expect(mockGenerationJobManager.approvals.resolve).toHaveBeenCalledWith(
+        CONVO_ID,
+        ACTION_ID,
+        {
+          preemptCapable: true,
+          resolvedAskUserQuestion: {
+            request: { questions: expect.any(Array) },
+            output: JSON.stringify({ answers }),
+            toolCallId: 'tc1',
+          },
+        },
+        1000,
       );
     });
 

--- a/api/server/controllers/agents/__tests__/resume.spec.js
+++ b/api/server/controllers/agents/__tests__/resume.spec.js
@@ -1429,6 +1429,39 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
       );
     });
 
+    it('retains an ID-less answer when earlier text exists but the ask part is missing', async () => {
+      mockGenerationJobManager.getJob.mockResolvedValue(makeAskUserJob());
+      mockGenerationJobManager.getResumeState.mockResolvedValue({
+        aggregatedContent: [{ type: 'text', text: 'Let me check.' }],
+      });
+
+      const res = await post({
+        conversationId: CONVO_ID,
+        actionId: ACTION_ID,
+        agent_id: AGENT_ID,
+        endpoint: 'agents',
+        answer: 'call it report.pdf',
+      });
+
+      expect(res.status).toBe(200);
+      await settled;
+      await flush();
+      expect(mockGenerationJobManager.approvals.resolve).toHaveBeenCalledWith(
+        CONVO_ID,
+        ACTION_ID,
+        {
+          preemptCapable: true,
+          resolvedAskUserQuestions: [
+            {
+              request: 'What should I name the file?',
+              output: 'call it report.pdf',
+            },
+          ],
+        },
+        1000,
+      );
+    });
+
     it('resumes a batched ask_user_question with answers keyed by question id', async () => {
       mockGenerationJobManager.getJob.mockResolvedValue(makeAskUserBatchJob());
       const answers = { environment: 'staging', window: '7d' };

--- a/api/server/controllers/agents/__tests__/resume.spec.js
+++ b/api/server/controllers/agents/__tests__/resume.spec.js
@@ -1378,6 +1378,18 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
 
     it('resumes an ask_user_question with the free-form answer', async () => {
       mockGenerationJobManager.getJob.mockResolvedValue(makeAskUserJob());
+      mockGenerationJobManager.getResumeState.mockResolvedValue({
+        aggregatedContent: [
+          {
+            type: 'tool_call',
+            tool_call: { id: 'older-ask', name: 'ask_user_question', args: '' },
+          },
+          {
+            type: 'tool_call',
+            tool_call: { id: 'current-ask', name: 'ask_user_question', args: '' },
+          },
+        ],
+      });
       const res = await post({
         conversationId: CONVO_ID,
         actionId: ACTION_ID,
@@ -1402,6 +1414,7 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
             {
               request: 'What should I name the file?',
               output: 'call it report.pdf',
+              contentIndex: 1,
             },
           ],
         },

--- a/api/server/controllers/agents/__tests__/resume.spec.js
+++ b/api/server/controllers/agents/__tests__/resume.spec.js
@@ -878,6 +878,57 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
       expect(client.resumeCompletion).toHaveBeenCalledWith(expect.objectContaining({ runSteps }));
     });
 
+    it('reapplies retained ask answers before resuming a later tool approval', async () => {
+      mockGenerationJobManager.getJob.mockResolvedValue(
+        makeToolApprovalJob({
+          metadata: {
+            resolvedAskUserQuestions: [
+              {
+                request: 'Which environment?',
+                output: 'staging',
+                toolCallId: 'ask-1',
+              },
+            ],
+          },
+        }),
+      );
+      mockGenerationJobManager.getResumeState.mockResolvedValue({
+        aggregatedContent: [
+          {
+            type: 'tool_call',
+            tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' },
+          },
+        ],
+        runSteps: [],
+      });
+
+      await post(approveBody());
+      await settled;
+      await flush();
+
+      const client = await mockInitializeClient.mock.results[0].value.then((r) => r.client);
+      expect(client.resumeCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          seedContent: [
+            expect.objectContaining({
+              tool_call: expect.objectContaining({
+                id: 'ask-1',
+                args: JSON.stringify('Which environment?'),
+                output: 'staging',
+                progress: 1,
+              }),
+            }),
+          ],
+        }),
+      );
+      expect(mockGenerationJobManager.approvals.resolve).toHaveBeenCalledWith(
+        CONVO_ID,
+        ACTION_ID,
+        { preemptCapable: true },
+        1000,
+      );
+    });
+
     it('restores the paused user message files before reconstruction (execute-code files)', async () => {
       mockGenerationJobManager.getJob.mockResolvedValue(makeToolApprovalJob());
       // The resume body carries no files; the controller must source them from the
@@ -1347,10 +1398,12 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
         ACTION_ID,
         {
           preemptCapable: true,
-          resolvedAskUserQuestion: {
-            request: 'What should I name the file?',
-            output: 'call it report.pdf',
-          },
+          resolvedAskUserQuestions: [
+            {
+              request: 'What should I name the file?',
+              output: 'call it report.pdf',
+            },
+          ],
         },
         1000,
       );
@@ -1386,11 +1439,13 @@ describe('ResumeAgentController (POST /agents/chat/resume)', () => {
         ACTION_ID,
         {
           preemptCapable: true,
-          resolvedAskUserQuestion: {
-            request: { questions: expect.any(Array) },
-            output: JSON.stringify({ answers }),
-            toolCallId: 'tc1',
-          },
+          resolvedAskUserQuestions: [
+            {
+              request: { questions: expect.any(Array) },
+              output: JSON.stringify({ answers }),
+              toolCallId: 'tc1',
+            },
+          ],
         },
         1000,
       );

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -650,6 +650,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
     );
   }
   let resolvedAskContentIndex;
+  let resolvedAskContentMissing = false;
   if (pendingAction.payload.type === 'ask_user_question' && !pendingAction.payload.tool_call_id) {
     const answerSnapshot = await GenerationJobManager.getResumeState(streamId, job.createdAt);
     if (answerSnapshot == null) {
@@ -666,18 +667,18 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
         askRequest,
       );
       if (resolvedAskContentIndex < 0) {
-        // Legacy streams can omit the paused ask tool part while retaining
-        // earlier text. Keep the answer as an unindexed legacy stamp so the
-        // resume is not permanently blocked; a later reconstruction can bind
-        // it once the missing ask part is available.
         resolvedAskContentIndex = undefined;
+        resolvedAskContentMissing = true;
       }
+    } else {
+      resolvedAskContentMissing = true;
     }
   }
   const resolvedAskUserQuestion = buildResolvedAskUserQuestion(
     pendingAction,
     req.body,
     resolvedAskContentIndex,
+    resolvedAskContentMissing,
   );
   const resolvedAskUserQuestions = appendResolvedAskUserQuestion(
     job.metadata?.resolvedAskUserQuestions,

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -5,7 +5,9 @@ const {
   isPendingActionStale,
   mapToolApprovalResolutions,
   resolveAskUserQuestionResume,
-  attachAskUserQuestionAnswer,
+  buildResolvedAskUserQuestion,
+  appendResolvedAskUserQuestion,
+  attachAskUserQuestionAnswers,
   findUndecidedToolCalls,
   findDisallowedDecisions,
   findIncompleteDecisions,
@@ -227,23 +229,6 @@ function resolveResumeValue(pendingAction, body) {
     return resolveAskUserQuestionResume(payload, body);
   }
   return { status: 400, error: 'Unsupported pending action type' };
-}
-
-/** Build the durable answer stamp committed with the resume ownership CAS. */
-function getResolvedAskUserQuestion(pendingAction, body) {
-  if (pendingAction.payload?.type !== 'ask_user_question') {
-    return null;
-  }
-  const batched = Array.isArray(pendingAction.payload.questions);
-  return {
-    request: batched
-      ? { questions: pendingAction.payload.questions }
-      : pendingAction.payload.question,
-    output: batched ? JSON.stringify({ answers: body.answers }) : body.answer,
-    ...(pendingAction.payload.tool_call_id && {
-      toolCallId: pendingAction.payload.tool_call_id,
-    }),
-  };
 }
 
 /**
@@ -663,7 +648,11 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       generationProtocolVersion,
     );
   }
-  const resolvedAskUserQuestion = getResolvedAskUserQuestion(pendingAction, req.body);
+  const resolvedAskUserQuestion = buildResolvedAskUserQuestion(pendingAction, req.body);
+  const resolvedAskUserQuestions = appendResolvedAskUserQuestion(
+    job.metadata?.resolvedAskUserQuestions,
+    resolvedAskUserQuestion,
+  );
 
   // A legacy job has no saver-level generation namespace, so snapshot its exact
   // durable ids before the atomic resume claim. New jobs can skip this indexed
@@ -719,7 +708,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       pendingAction.actionId,
       {
         preemptCapable: isSteerPreemptSupported(),
-        ...(resolvedAskUserQuestion && { resolvedAskUserQuestion }),
+        ...(resolvedAskUserQuestion && { resolvedAskUserQuestions }),
       },
       job.createdAt,
     );
@@ -906,18 +895,13 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
     // resume state afterward would see the new (empty) client array and lose the seed.
     const resumeState = await GenerationJobManager.getResumeState(streamId, job.createdAt);
     let seedContent = resumeState?.aggregatedContent ?? [];
-    // Stamp the answered question onto the paused ask_user_question tool-call part
+    // Stamp retained answers onto their paused ask_user_question tool-call parts
     // (args = the pendingAction's authoritative question, output = the user's answer):
     // the streamed arg chunks carry no tool name so the aggregator dropped them, and
     // no completion event ever fires for this tool — without this the saved part is
-    // an empty "cancelled-looking" tool call. See attachAskUserQuestionAnswer.
-    if (resolvedAskUserQuestion) {
-      seedContent = attachAskUserQuestionAnswer(
-        seedContent,
-        resolvedAskUserQuestion.request,
-        resolvedAskUserQuestion.output,
-        resolvedAskUserQuestion.toolCallId,
-      );
+    // an empty "cancelled-looking" tool call. See attachAskUserQuestionAnswers.
+    if (resolvedAskUserQuestions) {
+      seedContent = attachAskUserQuestionAnswers(seedContent, resolvedAskUserQuestions);
     }
     if (client.contentParts) {
       GenerationJobManager.setContentParts(streamId, client.contentParts, job.createdAt);

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -666,12 +666,11 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
         askRequest,
       );
       if (resolvedAskContentIndex < 0) {
-        return sendGenerationJson(
-          res,
-          409,
-          { error: 'Pending question content is unavailable; reconnect and retry' },
-          generationProtocolVersion,
-        );
+        // Legacy streams can omit the paused ask tool part while retaining
+        // earlier text. Keep the answer as an unindexed legacy stamp so the
+        // resume is not permanently blocked; a later reconstruction can bind
+        // it once the missing ask part is available.
+        resolvedAskContentIndex = undefined;
       }
     }
   }

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -658,18 +658,21 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
     const askRequest = Array.isArray(pendingAction.payload.questions)
       ? { questions: pendingAction.payload.questions }
       : pendingAction.payload.question;
-    resolvedAskContentIndex = findAskUserQuestionContentIndex(
-      answerSnapshot.aggregatedContent,
-      undefined,
-      askRequest,
-    );
-    if (resolvedAskContentIndex < 0) {
-      return sendGenerationJson(
-        res,
-        409,
-        { error: 'Pending question content is unavailable; reconnect and retry' },
-        generationProtocolVersion,
+    const answerContent = answerSnapshot.aggregatedContent ?? [];
+    if (answerContent.length > 0) {
+      resolvedAskContentIndex = findAskUserQuestionContentIndex(
+        answerContent,
+        undefined,
+        askRequest,
       );
+      if (resolvedAskContentIndex < 0) {
+        return sendGenerationJson(
+          res,
+          409,
+          { error: 'Pending question content is unavailable; reconnect and retry' },
+          generationProtocolVersion,
+        );
+      }
     }
   }
   const resolvedAskUserQuestion = buildResolvedAskUserQuestion(

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -8,6 +8,7 @@ const {
   buildResolvedAskUserQuestion,
   appendResolvedAskUserQuestion,
   attachAskUserQuestionAnswers,
+  findAskUserQuestionContentIndex,
   findUndecidedToolCalls,
   findDisallowedDecisions,
   findIncompleteDecisions,
@@ -648,7 +649,34 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       generationProtocolVersion,
     );
   }
-  const resolvedAskUserQuestion = buildResolvedAskUserQuestion(pendingAction, req.body);
+  let resolvedAskContentIndex;
+  if (pendingAction.payload.type === 'ask_user_question' && !pendingAction.payload.tool_call_id) {
+    const answerSnapshot = await GenerationJobManager.getResumeState(streamId, job.createdAt);
+    if (answerSnapshot == null) {
+      return sendGenerationJson(res, 409, { code: 'RUN_REPLACED' }, generationProtocolVersion);
+    }
+    const askRequest = Array.isArray(pendingAction.payload.questions)
+      ? { questions: pendingAction.payload.questions }
+      : pendingAction.payload.question;
+    resolvedAskContentIndex = findAskUserQuestionContentIndex(
+      answerSnapshot.aggregatedContent,
+      undefined,
+      askRequest,
+    );
+    if (resolvedAskContentIndex < 0) {
+      return sendGenerationJson(
+        res,
+        409,
+        { error: 'Pending question content is unavailable; reconnect and retry' },
+        generationProtocolVersion,
+      );
+    }
+  }
+  const resolvedAskUserQuestion = buildResolvedAskUserQuestion(
+    pendingAction,
+    req.body,
+    resolvedAskContentIndex,
+  );
   const resolvedAskUserQuestions = appendResolvedAskUserQuestion(
     job.metadata?.resolvedAskUserQuestions,
     resolvedAskUserQuestion,

--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -229,6 +229,23 @@ function resolveResumeValue(pendingAction, body) {
   return { status: 400, error: 'Unsupported pending action type' };
 }
 
+/** Build the durable answer stamp committed with the resume ownership CAS. */
+function getResolvedAskUserQuestion(pendingAction, body) {
+  if (pendingAction.payload?.type !== 'ask_user_question') {
+    return null;
+  }
+  const batched = Array.isArray(pendingAction.payload.questions);
+  return {
+    request: batched
+      ? { questions: pendingAction.payload.questions }
+      : pendingAction.payload.question,
+    output: batched ? JSON.stringify({ answers: body.answers }) : body.answer,
+    ...(pendingAction.payload.tool_call_id && {
+      toolCallId: pendingAction.payload.tool_call_id,
+    }),
+  };
+}
+
 /**
  * Finalize a resumed turn that ran to completion: persist the (now complete)
  * response message, emit the terminal event over the existing SSE, complete the
@@ -646,6 +663,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       generationProtocolVersion,
     );
   }
+  const resolvedAskUserQuestion = getResolvedAskUserQuestion(pendingAction, req.body);
 
   // A legacy job has no saver-level generation namespace, so snapshot its exact
   // durable ids before the atomic resume claim. New jobs can skip this indexed
@@ -701,6 +719,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
       pendingAction.actionId,
       {
         preemptCapable: isSteerPreemptSupported(),
+        ...(resolvedAskUserQuestion && { resolvedAskUserQuestion }),
       },
       job.createdAt,
     );
@@ -892,17 +911,12 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
     // the streamed arg chunks carry no tool name so the aggregator dropped them, and
     // no completion event ever fires for this tool — without this the saved part is
     // an empty "cancelled-looking" tool call. See attachAskUserQuestionAnswer.
-    if (pendingAction.payload?.type === 'ask_user_question') {
-      const batched = Array.isArray(pendingAction.payload.questions);
-      const request = batched
-        ? { questions: pendingAction.payload.questions }
-        : pendingAction.payload.question;
-      const output = batched ? JSON.stringify({ answers: req.body.answers }) : req.body.answer;
+    if (resolvedAskUserQuestion) {
       seedContent = attachAskUserQuestionAnswer(
         seedContent,
-        request,
-        output,
-        pendingAction.payload.tool_call_id,
+        resolvedAskUserQuestion.request,
+        resolvedAskUserQuestion.output,
+        resolvedAskUserQuestion.toolCallId,
       );
     }
     if (client.contentParts) {

--- a/api/server/routes/agents/__tests__/abort.spec.js
+++ b/api/server/routes/agents/__tests__/abort.spec.js
@@ -501,11 +501,13 @@ describe('Agent Abort Endpoint', () => {
             { type: 'tool_call', tool_call: { id: 'tc1', name: 'ask_user_question', args: '' } },
           ];
           const content = options.transformAbortContent(rawContent, {
-            resolvedAskUserQuestion: {
-              request: question,
-              output: 'prod',
-              toolCallId: 'tc1',
-            },
+            resolvedAskUserQuestions: [
+              {
+                request: question,
+                output: 'prod',
+                toolCallId: 'tc1',
+              },
+            ],
           });
           const result = {
             success: true,
@@ -562,7 +564,7 @@ describe('Agent Abort Endpoint', () => {
             },
           ];
           const content = options.transformAbortContent(rawContent, {
-            resolvedAskUserQuestion: { request: priorQuestion, output: 'staging' },
+            resolvedAskUserQuestions: [{ request: priorQuestion, output: 'staging' }],
             pendingAction: {
               payload: {
                 type: 'ask_user_question',
@@ -620,11 +622,13 @@ describe('Agent Abort Endpoint', () => {
             },
           ];
           const content = options.transformAbortContent(rawContent, {
-            resolvedAskUserQuestion: {
-              request: priorQuestion,
-              output: 'staging',
-              toolCallId: 'prior-call',
-            },
+            resolvedAskUserQuestions: [
+              {
+                request: priorQuestion,
+                output: 'staging',
+                toolCallId: 'prior-call',
+              },
+            ],
             pendingAction: {
               payload: {
                 type: 'ask_user_question',

--- a/api/server/routes/agents/__tests__/abort.spec.js
+++ b/api/server/routes/agents/__tests__/abort.spec.js
@@ -600,6 +600,68 @@ describe('Agent Abort Endpoint', () => {
         expect(JSON.parse(currentAsk.tool_call.args)).toEqual(currentQuestion);
       });
 
+      it('reconstructs an exact-ID prior answer alongside a later pending ask', async () => {
+        const jobStreamId = 'test-stream-123';
+        const priorQuestion = { question: 'Which environment?' };
+        const currentQuestion = { question: 'Approve deployment?' };
+
+        mockGenerationJobManager.getJob.mockResolvedValue({
+          metadata: { userId: 'test-user-123' },
+        });
+        mockGenerationJobManager.abortJob.mockImplementation(async (_streamId, options) => {
+          const rawContent = [
+            {
+              type: 'tool_call',
+              tool_call: { id: 'prior-call', name: 'ask_user_question', args: '' },
+            },
+            {
+              type: 'tool_call',
+              tool_call: { id: 'current-call', name: 'ask_user_question', args: '' },
+            },
+          ];
+          const content = options.transformAbortContent(rawContent, {
+            resolvedAskUserQuestion: {
+              request: priorQuestion,
+              output: 'staging',
+              toolCallId: 'prior-call',
+            },
+            pendingAction: {
+              payload: {
+                type: 'ask_user_question',
+                question: currentQuestion,
+                tool_call_id: 'current-call',
+              },
+            },
+          });
+          const result = {
+            success: true,
+            jobData: {
+              userMessage: { messageId: 'user-msg-123' },
+              responseMessageId: 'response-msg-456',
+              conversationId: jobStreamId,
+            },
+            content,
+            text: '',
+          };
+          await options.beforePublish(result);
+          return result;
+        });
+
+        const response = await request(app)
+          .post('/api/agents/chat/abort')
+          .send({ conversationId: jobStreamId });
+
+        expect(response.status).toBe(200);
+        const savedMessage = mockSaveMessage.mock.calls
+          .map(([, message]) => message)
+          .find((message) => message.isCreatedByUser === false);
+        const [priorAsk, currentAsk] = savedMessage.content;
+        expect(priorAsk.tool_call.output).toBe('staging');
+        expect(JSON.parse(priorAsk.tool_call.args)).toEqual(priorQuestion);
+        expect(currentAsk.tool_call.output).toBeUndefined();
+        expect(JSON.parse(currentAsk.tool_call.args)).toEqual(currentQuestion);
+      });
+
       it('should handle saveMessage errors gracefully', async () => {
         const jobStreamId = 'test-stream-123';
 

--- a/api/server/routes/agents/__tests__/abort.spec.js
+++ b/api/server/routes/agents/__tests__/abort.spec.js
@@ -481,6 +481,56 @@ describe('Agent Abort Endpoint', () => {
         expect(JSON.parse(askPart.tool_call.args)).toMatchObject({ question: 'Deploy where?' });
       });
 
+      it('preserves an accepted ask answer when abort wins during resume reconstruction', async () => {
+        const jobStreamId = 'test-stream-123';
+        const question = { question: 'Deploy where?', options: [{ label: 'Prod', value: 'prod' }] };
+
+        mockGenerationJobManager.getJob.mockResolvedValue({
+          metadata: {
+            userId: 'test-user-123',
+            resolvedAskUserQuestion: {
+              request: question,
+              output: 'prod',
+              toolCallId: 'tc1',
+            },
+          },
+        });
+
+        mockGenerationJobManager.abortJob.mockImplementation(async (_streamId, options) => {
+          const rawContent = [
+            { type: 'tool_call', tool_call: { id: 'tc1', name: 'ask_user_question', args: '' } },
+          ];
+          const content = options.transformAbortContent(rawContent);
+          const result = {
+            success: true,
+            jobData: {
+              userMessage: { messageId: 'user-msg-123' },
+              responseMessageId: 'response-msg-456',
+              conversationId: jobStreamId,
+            },
+            content,
+            text: '',
+          };
+          await options.beforePublish(result);
+          return result;
+        });
+
+        const response = await request(app)
+          .post('/api/agents/chat/abort')
+          .send({ conversationId: jobStreamId });
+
+        expect(response.status).toBe(200);
+        const savedMessage = mockSaveMessage.mock.calls
+          .map(([, message]) => message)
+          .find((message) => message.isCreatedByUser === false);
+        const askPart = savedMessage.content.find(
+          (part) => part?.tool_call?.name === 'ask_user_question',
+        );
+        expect(JSON.parse(askPart.tool_call.args)).toEqual(question);
+        expect(askPart.tool_call.output).toBe('prod');
+        expect(askPart.tool_call.progress).toBe(1);
+      });
+
       it('should handle saveMessage errors gracefully', async () => {
         const jobStreamId = 'test-stream-123';
 

--- a/api/server/routes/agents/__tests__/abort.spec.js
+++ b/api/server/routes/agents/__tests__/abort.spec.js
@@ -449,7 +449,11 @@ describe('Agent Abort Endpoint', () => {
           const rawContent = [
             { type: 'tool_call', tool_call: { id: 'tc1', name: 'ask_user_question', args: '' } },
           ];
-          const content = capturedTransform ? capturedTransform(rawContent) : rawContent;
+          const content = capturedTransform
+            ? capturedTransform(rawContent, {
+                pendingAction: { payload: { type: 'ask_user_question', question } },
+              })
+            : rawContent;
           const result = {
             success: true,
             jobData: {
@@ -485,22 +489,24 @@ describe('Agent Abort Endpoint', () => {
         const jobStreamId = 'test-stream-123';
         const question = { question: 'Deploy where?', options: [{ label: 'Prod', value: 'prod' }] };
 
+        // The route reads the still-paused snapshot before resume wins. The
+        // manager must supply the newer, terminal-claim snapshot to the
+        // transform rather than letting this initial read go stale.
         mockGenerationJobManager.getJob.mockResolvedValue({
-          metadata: {
-            userId: 'test-user-123',
-            resolvedAskUserQuestion: {
-              request: question,
-              output: 'prod',
-              toolCallId: 'tc1',
-            },
-          },
+          metadata: { userId: 'test-user-123' },
         });
 
         mockGenerationJobManager.abortJob.mockImplementation(async (_streamId, options) => {
           const rawContent = [
             { type: 'tool_call', tool_call: { id: 'tc1', name: 'ask_user_question', args: '' } },
           ];
-          const content = options.transformAbortContent(rawContent);
+          const content = options.transformAbortContent(rawContent, {
+            resolvedAskUserQuestion: {
+              request: question,
+              output: 'prod',
+              toolCallId: 'tc1',
+            },
+          });
           const result = {
             success: true,
             jobData: {
@@ -529,6 +535,69 @@ describe('Agent Abort Endpoint', () => {
         expect(JSON.parse(askPart.tool_call.args)).toEqual(question);
         expect(askPart.tool_call.output).toBe('prod');
         expect(askPart.tool_call.progress).toBe(1);
+      });
+
+      it('does not stamp an ID-less legacy answer onto a later pending ask', async () => {
+        const jobStreamId = 'test-stream-123';
+        const priorQuestion = { question: 'Which environment?' };
+        const currentQuestion = { question: 'Approve deployment?' };
+
+        mockGenerationJobManager.getJob.mockResolvedValue({
+          metadata: { userId: 'test-user-123' },
+        });
+        mockGenerationJobManager.abortJob.mockImplementation(async (_streamId, options) => {
+          const rawContent = [
+            {
+              type: 'tool_call',
+              tool_call: {
+                id: 'legacy-call',
+                name: 'ask_user_question',
+                args: JSON.stringify(priorQuestion),
+                output: 'staging',
+              },
+            },
+            {
+              type: 'tool_call',
+              tool_call: { id: 'current-call', name: 'ask_user_question', args: '' },
+            },
+          ];
+          const content = options.transformAbortContent(rawContent, {
+            resolvedAskUserQuestion: { request: priorQuestion, output: 'staging' },
+            pendingAction: {
+              payload: {
+                type: 'ask_user_question',
+                question: currentQuestion,
+                tool_call_id: 'current-call',
+              },
+            },
+          });
+          const result = {
+            success: true,
+            jobData: {
+              userMessage: { messageId: 'user-msg-123' },
+              responseMessageId: 'response-msg-456',
+              conversationId: jobStreamId,
+            },
+            content,
+            text: '',
+          };
+          await options.beforePublish(result);
+          return result;
+        });
+
+        const response = await request(app)
+          .post('/api/agents/chat/abort')
+          .send({ conversationId: jobStreamId });
+
+        expect(response.status).toBe(200);
+        const savedMessage = mockSaveMessage.mock.calls
+          .map(([, message]) => message)
+          .find((message) => message.isCreatedByUser === false);
+        const [priorAsk, currentAsk] = savedMessage.content;
+        expect(priorAsk.tool_call.output).toBe('staging');
+        expect(JSON.parse(priorAsk.tool_call.args)).toEqual(priorQuestion);
+        expect(currentAsk.tool_call.output).toBeUndefined();
+        expect(JSON.parse(currentAsk.tool_call.args)).toEqual(currentQuestion);
       });
 
       it('should handle saveMessage errors gracefully', async () => {

--- a/api/server/routes/agents/__tests__/abort.spec.js
+++ b/api/server/routes/agents/__tests__/abort.spec.js
@@ -666,6 +666,57 @@ describe('Agent Abort Endpoint', () => {
         expect(JSON.parse(currentAsk.tool_call.args)).toEqual(currentQuestion);
       });
 
+      it('reconstructs an ID-less prior answer while a later tool approval is pending', async () => {
+        const jobStreamId = 'test-stream-123';
+        const priorQuestion = { question: 'Which environment?' };
+
+        mockGenerationJobManager.getJob.mockResolvedValue({
+          metadata: { userId: 'test-user-123' },
+        });
+        mockGenerationJobManager.abortJob.mockImplementation(async (_streamId, options) => {
+          const rawContent = [
+            {
+              type: 'tool_call',
+              tool_call: { id: 'legacy-call', name: 'ask_user_question', args: '' },
+            },
+          ];
+          const content = options.transformAbortContent(rawContent, {
+            resolvedAskUserQuestions: [{ request: priorQuestion, output: 'staging' }],
+            pendingAction: {
+              payload: {
+                type: 'tool_approval',
+                action_requests: [{ tool_call_id: 'tool-1' }],
+                review_configs: [],
+              },
+            },
+          });
+          const result = {
+            success: true,
+            jobData: {
+              userMessage: { messageId: 'user-msg-123' },
+              responseMessageId: 'response-msg-456',
+              conversationId: jobStreamId,
+            },
+            content,
+            text: '',
+          };
+          await options.beforePublish(result);
+          return result;
+        });
+
+        const response = await request(app)
+          .post('/api/agents/chat/abort')
+          .send({ conversationId: jobStreamId });
+
+        expect(response.status).toBe(200);
+        const savedMessage = mockSaveMessage.mock.calls
+          .map(([, message]) => message)
+          .find((message) => message.isCreatedByUser === false);
+        const [priorAsk] = savedMessage.content;
+        expect(priorAsk.tool_call.output).toBe('staging');
+        expect(JSON.parse(priorAsk.tool_call.args)).toEqual(priorQuestion);
+      });
+
       it('should handle saveMessage errors gracefully', async () => {
         const jobStreamId = 'test-stream-123';
 

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -10,7 +10,7 @@ const {
   isHITLEnabled,
   captureAgentCheckpointGeneration,
   deleteAgentCheckpoint,
-  attachAskUserQuestionAnswer,
+  attachAskUserQuestionAnswers,
   attachAskUserQuestionArgs,
   createMessageFilterPii,
 } = require('@librechat/api');
@@ -637,12 +637,12 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
       // chunk log, which never saw the pause-time stamp applied to the in-process
       // contentParts — stamping inside abortJob (not after) means the LIVE client
       // gets the question too, not just the saved message on reload.
-      const initialResolvedAskUserQuestion = job.metadata?.resolvedAskUserQuestion;
+      const initialResolvedAskUserQuestions = job.metadata?.resolvedAskUserQuestions;
       const agentsCfg = req.config?.endpoints?.agents;
       const shouldPruneCheckpoint =
         isHITLEnabled(agentsCfg?.toolApproval) ||
         job.metadata?.pendingAction != null ||
-        initialResolvedAskUserQuestion != null;
+        initialResolvedAskUserQuestions?.length > 0;
       const checkpointNamespace =
         typeof job.metadata?.checkpointNamespace === 'string'
           ? job.metadata.checkpointNamespace
@@ -664,21 +664,15 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
             return content;
           }
           const abortedAskPayload = abortJobData.pendingAction?.payload;
-          const resolvedAskUserQuestion = abortJobData.resolvedAskUserQuestion;
+          const resolvedAskUserQuestions = abortJobData.resolvedAskUserQuestions ?? [];
           /** ID-less stamps are legacy-only. If this generation has reached a
            * later pause, the previous answer was already seeded before that
            * run started and must not target the new unanswered ask. */
-          const canAttachResolvedAnswer =
-            resolvedAskUserQuestion != null &&
-            (resolvedAskUserQuestion.toolCallId != null || abortJobData.pendingAction == null);
-          const answeredContent = canAttachResolvedAnswer
-            ? attachAskUserQuestionAnswer(
-                content,
-                resolvedAskUserQuestion.request,
-                resolvedAskUserQuestion.output,
-                resolvedAskUserQuestion.toolCallId,
-              )
-            : content;
+          const applicableAnswers =
+            abortJobData.pendingAction == null
+              ? resolvedAskUserQuestions
+              : resolvedAskUserQuestions.filter((answer) => answer.toolCallId != null);
+          const answeredContent = attachAskUserQuestionAnswers(content, applicableAnswers);
           return abortedAskPayload?.type === 'ask_user_question'
             ? attachAskUserQuestionArgs(
                 answeredContent,

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -669,9 +669,9 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
            * later pause, the previous answer was already seeded before that
            * run started and must not target the new unanswered ask. */
           const applicableAnswers =
-            abortJobData.pendingAction == null
-              ? resolvedAskUserQuestions
-              : resolvedAskUserQuestions.filter((answer) => answer.toolCallId != null);
+            abortedAskPayload?.type === 'ask_user_question'
+              ? resolvedAskUserQuestions.filter((answer) => answer.toolCallId != null)
+              : resolvedAskUserQuestions;
           const answeredContent = attachAskUserQuestionAnswers(content, applicableAnswers);
           return abortedAskPayload?.type === 'ask_user_question'
             ? attachAskUserQuestionArgs(

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -637,13 +637,12 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
       // chunk log, which never saw the pause-time stamp applied to the in-process
       // contentParts — stamping inside abortJob (not after) means the LIVE client
       // gets the question too, not just the saved message on reload.
-      const abortedAskPayload = job.metadata?.pendingAction?.payload;
-      const resolvedAskUserQuestion = job.metadata?.resolvedAskUserQuestion;
+      const initialResolvedAskUserQuestion = job.metadata?.resolvedAskUserQuestion;
       const agentsCfg = req.config?.endpoints?.agents;
       const shouldPruneCheckpoint =
         isHITLEnabled(agentsCfg?.toolApproval) ||
         job.metadata?.pendingAction != null ||
-        resolvedAskUserQuestion != null;
+        initialResolvedAskUserQuestion != null;
       const checkpointNamespace =
         typeof job.metadata?.checkpointNamespace === 'string'
           ? job.metadata.checkpointNamespace
@@ -660,11 +659,19 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
           : undefined;
       const abortResult = await GenerationJobManager.abortJob(jobStreamId, {
         expectedCreatedAt: job.createdAt,
-        transformAbortContent: (content) => {
+        transformAbortContent: (content, abortJobData) => {
           if (!Array.isArray(content)) {
             return content;
           }
-          const answeredContent = resolvedAskUserQuestion
+          const abortedAskPayload = abortJobData.pendingAction?.payload;
+          const resolvedAskUserQuestion = abortJobData.resolvedAskUserQuestion;
+          /** ID-less stamps are legacy-only. If this generation has reached a
+           * later pause, the previous answer was already seeded before that
+           * run started and must not target the new unanswered ask. */
+          const canAttachResolvedAnswer =
+            resolvedAskUserQuestion != null &&
+            (resolvedAskUserQuestion.toolCallId != null || abortJobData.pendingAction == null);
+          const answeredContent = canAttachResolvedAnswer
             ? attachAskUserQuestionAnswer(
                 content,
                 resolvedAskUserQuestion.request,

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -10,6 +10,7 @@ const {
   isHITLEnabled,
   captureAgentCheckpointGeneration,
   deleteAgentCheckpoint,
+  attachAskUserQuestionAnswer,
   attachAskUserQuestionArgs,
   createMessageFilterPii,
 } = require('@librechat/api');
@@ -637,9 +638,12 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
       // contentParts — stamping inside abortJob (not after) means the LIVE client
       // gets the question too, not just the saved message on reload.
       const abortedAskPayload = job.metadata?.pendingAction?.payload;
+      const resolvedAskUserQuestion = job.metadata?.resolvedAskUserQuestion;
       const agentsCfg = req.config?.endpoints?.agents;
       const shouldPruneCheckpoint =
-        isHITLEnabled(agentsCfg?.toolApproval) || job.metadata?.pendingAction != null;
+        isHITLEnabled(agentsCfg?.toolApproval) ||
+        job.metadata?.pendingAction != null ||
+        resolvedAskUserQuestion != null;
       const checkpointNamespace =
         typeof job.metadata?.checkpointNamespace === 'string'
           ? job.metadata.checkpointNamespace
@@ -656,16 +660,28 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
           : undefined;
       const abortResult = await GenerationJobManager.abortJob(jobStreamId, {
         expectedCreatedAt: job.createdAt,
-        transformAbortContent: (content) =>
-          abortedAskPayload?.type === 'ask_user_question' && Array.isArray(content)
-            ? attachAskUserQuestionArgs(
+        transformAbortContent: (content) => {
+          if (!Array.isArray(content)) {
+            return content;
+          }
+          const answeredContent = resolvedAskUserQuestion
+            ? attachAskUserQuestionAnswer(
                 content,
+                resolvedAskUserQuestion.request,
+                resolvedAskUserQuestion.output,
+                resolvedAskUserQuestion.toolCallId,
+              )
+            : content;
+          return abortedAskPayload?.type === 'ask_user_question'
+            ? attachAskUserQuestionArgs(
+                answeredContent,
                 Array.isArray(abortedAskPayload.questions)
                   ? { questions: abortedAskPayload.questions }
                   : abortedAskPayload.question,
                 abortedAskPayload.tool_call_id,
               )
-            : content,
+            : answeredContent;
+        },
         /** Persist every parent-row prerequisite before publishing the ordinary
          * abort FINAL. That frame can immediately drain a queued follow-up, whose
          * parent must already exist and whose graph must not see a stale HITL

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -665,14 +665,7 @@ router.post('/chat/abort', configMiddleware, async (req, res, next) => {
           }
           const abortedAskPayload = abortJobData.pendingAction?.payload;
           const resolvedAskUserQuestions = abortJobData.resolvedAskUserQuestions ?? [];
-          /** ID-less stamps are legacy-only. If this generation has reached a
-           * later pause, the previous answer was already seeded before that
-           * run started and must not target the new unanswered ask. */
-          const applicableAnswers =
-            abortedAskPayload?.type === 'ask_user_question'
-              ? resolvedAskUserQuestions.filter((answer) => answer.toolCallId != null)
-              : resolvedAskUserQuestions;
-          const answeredContent = attachAskUserQuestionAnswers(content, applicableAnswers);
+          const answeredContent = attachAskUserQuestionAnswers(content, resolvedAskUserQuestions);
           return abortedAskPayload?.type === 'ask_user_question'
             ? attachAskUserQuestionArgs(
                 answeredContent,

--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -2213,6 +2213,64 @@ describe('useStepHandler', () => {
       expect(content[1]).toMatchObject({ type: ContentTypes.TOOL_CALL });
     });
 
+    it('does not compact absolute content indices when dropping an answered ask card', () => {
+      const askPart = {
+        type: 'ask_user_question',
+        ask_user_question: { actionId: 'a-sparse', question: { question: 'Which env?' } },
+      } as unknown as TMessageContentParts;
+      const askToolCall = {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'ask-call-sparse',
+          name: 'ask_user_question',
+          args: '{"question":"Which env?"}',
+          type: ToolCallTypes.TOOL_CALL,
+        },
+      } as unknown as TMessageContentParts;
+      const sparseContent = [{ type: ContentTypes.TEXT, text: 'Before' }] as TMessageContentParts[];
+      sparseContent[2] = askToolCall;
+      sparseContent[3] = askPart;
+      const paused = createResponseMessage({ content: sparseContent });
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      act(() => {
+        result.current.syncStepMessage(paused);
+      });
+      mockGetMessages.mockReturnValue([resolveAskUserQuestionPart(paused, 'a-sparse', 'prod')]);
+
+      const askCompletion = createToolCallRunStep({
+        id: 'step-ask-sparse',
+        index: 2,
+        stepDetails: {
+          type: StepTypes.TOOL_CALLS,
+          tool_calls: [
+            {
+              id: 'ask-call-sparse',
+              name: 'ask_user_question',
+              args: '{"question":"Which env?"}',
+              output: 'prod',
+              type: ToolCallTypes.TOOL_CALL,
+            },
+          ],
+        },
+      } as Partial<Agents.RunStep>);
+
+      act(() => {
+        result.current.stepHandler(
+          { event: StepEvents.ON_RUN_STEP, data: askCompletion },
+          createSubmission(),
+        );
+      });
+
+      const lastCall = mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 1];
+      const updated = (lastCall[0] as TMessage[]).find((m) => m.messageId === 'response-msg-1');
+      expect(updated?.content?.[1]).toBeUndefined();
+      expect(updated?.content?.[2]).toMatchObject({
+        type: ContentTypes.TOOL_CALL,
+        tool_call: { id: 'ask-call-sparse' },
+      });
+    });
+
     it('keeps a still-live ask card when an event streams around its slot', () => {
       /** Only ANSWERED cards are droppable — a late event racing a live pause
        *  must not take the question away before the user can respond. */

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -413,7 +413,7 @@ export default function useStepHandler({
      * — the store-level strip on answer submit can't reach those.
      */
     if (isAskUserQuestionPart(updatedContent[index])) {
-      updatedContent = updatedContent.filter((part) => !isAskUserQuestionPart(part));
+      updatedContent[index] = undefined;
     } else if (updatedContent.some(isAnsweredAskUserQuestionPart)) {
       /**
        * An ALREADY-ANSWERED card the resumed segment streams around rather than
@@ -422,9 +422,13 @@ export default function useStepHandler({
        * cached copy — which still holds the card the answer-submit stripped from
        * the store — gets written back, reopening the popover with its options
        * locked. Only cards the user actually answered are dropped, so an event
-       * racing a still-live pause can't take its card down.
+       * racing a still-live pause can't take its card down. Preserve sparse
+       * absolute indices: compacting holes can move an older tool call into a
+       * text slot until the terminal snapshot repairs the rendered order.
        */
-      updatedContent = updatedContent.filter((part) => !isAnsweredAskUserQuestionPart(part));
+      updatedContent = updatedContent.map((part) =>
+        isAnsweredAskUserQuestionPart(part) ? undefined : part,
+      );
     }
 
     if (!updatedContent[index] && contentType !== ContentTypes.TOOL_CALL) {

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -18,7 +18,10 @@ import {
   createContentIndexOffsetHandlers,
   hydrateResumeRunSteps,
   attachAskUserQuestionAnswer,
+  attachAskUserQuestionAnswers,
   attachAskUserQuestionArgs,
+  buildResolvedAskUserQuestion,
+  appendResolvedAskUserQuestion,
 } from './resume';
 
 describe('mapToolApprovalResolutions', () => {
@@ -580,6 +583,46 @@ describe('attachAskUserQuestionAnswer', () => {
     expect(JSON.parse(toolCall.output)).toEqual({
       answers: { environment: 'staging', window: '7d' },
     });
+  });
+});
+
+describe('durable ask-user answers', () => {
+  it('builds a typed stamp from the validated pending action', () => {
+    const pendingAction = {
+      payload: {
+        type: 'ask_user_question',
+        question: 'Which env?',
+        tool_call_id: 'ask-2',
+      },
+    } as Agents.PendingAction;
+
+    expect(buildResolvedAskUserQuestion(pendingAction, { answer: 'production' })).toEqual({
+      request: 'Which env?',
+      output: 'production',
+      toolCallId: 'ask-2',
+    });
+  });
+
+  it('accumulates exact-ID answers and replaces a repeated tool call', () => {
+    const first = { request: 'First?', output: 'one', toolCallId: 'ask-1' };
+    const second = { request: 'Second?', output: 'two', toolCallId: 'ask-2' };
+    const corrected = { request: 'First?', output: 'corrected', toolCallId: 'ask-1' };
+
+    expect(appendResolvedAskUserQuestion([first, second], corrected)).toEqual([second, corrected]);
+  });
+
+  it('reconstructs multiple retained answers in one content pass', () => {
+    const content = [
+      { type: 'tool_call', tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' } },
+      { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
+    ];
+    const next = attachAskUserQuestionAnswers(content, [
+      { request: 'First?', output: 'one', toolCallId: 'ask-1' },
+      { request: 'Second?', output: 'two', toolCallId: 'ask-2' },
+    ]);
+
+    expect(next.map((part) => part.tool_call.output)).toEqual(['one', 'two']);
+    expect(next.map((part) => JSON.parse(part.tool_call.args))).toEqual(['First?', 'Second?']);
   });
 });
 

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -747,7 +747,10 @@ describe('durable ask-user answers', () => {
   });
 
   it('does not bind a missing-content answer to a later ask', () => {
-    const content = [
+    const content: Array<{
+      type: string;
+      tool_call: { id: string; name: string; args: string; output?: string };
+    }> = [
       { type: 'tool_call', tool_call: { id: 'later-ask', name: 'ask_user_question', args: '' } },
     ];
 

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -22,6 +22,7 @@ import {
   attachAskUserQuestionArgs,
   buildResolvedAskUserQuestion,
   appendResolvedAskUserQuestion,
+  findAskUserQuestionContentIndex,
 } from './resume';
 
 describe('mapToolApprovalResolutions', () => {
@@ -606,6 +607,24 @@ describe('durable ask-user answers', () => {
     });
   });
 
+  it('associates an ID-less answer with its pause-time content slot', () => {
+    const pendingAction = {
+      actionId: 'action-legacy',
+      streamId: 'stream-1',
+      createdAt: 1,
+      payload: {
+        type: 'ask_user_question',
+        question: { question: 'Newest?' },
+      },
+    } satisfies Agents.PendingAction;
+
+    expect(buildResolvedAskUserQuestion(pendingAction, { answer: 'yes' }, 2)).toEqual({
+      request: { question: 'Newest?' },
+      output: 'yes',
+      contentIndex: 2,
+    });
+  });
+
   it('accumulates exact-ID answers and replaces a repeated tool call', () => {
     const first = { request: 'First?', output: 'one', toolCallId: 'ask-1' };
     const second = { request: 'Second?', output: 'two', toolCallId: 'ask-2' };
@@ -644,6 +663,24 @@ describe('durable ask-user answers', () => {
 
     expect(next[0].tool_call.output).toBe('one');
     expect(next[1].tool_call.output).toBeUndefined();
+  });
+
+  it('targets the pause-time slot when an ID-less action has multiple empty asks', () => {
+    const request = { question: 'Newest?' };
+    const content: Array<{
+      type: string;
+      tool_call: { id: string; name: string; args: string; output?: string };
+    }> = [
+      { type: 'tool_call', tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' } },
+      { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
+    ];
+    const contentIndex = findAskUserQuestionContentIndex(content, undefined, request);
+
+    const next = attachAskUserQuestionAnswers(content, [{ request, output: 'yes', contentIndex }]);
+
+    expect(contentIndex).toBe(1);
+    expect(next[0].tool_call.output).toBeUndefined();
+    expect(next[1].tool_call.output).toBe('yes');
   });
 
   it('consumes a legacy stamp already present on content before a later ask', () => {

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -630,6 +630,61 @@ describe('durable ask-user answers', () => {
     expect(next.map((part) => part.tool_call.output)).toEqual(['one', 'two']);
     expect(next.map((part) => JSON.parse(part.tool_call.args))).toEqual(['First?', 'Second?']);
   });
+
+  it('keeps a legacy answer on the earlier ask when a later ask is unanswered', () => {
+    const content = [
+      { type: 'tool_call', tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' } },
+      { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
+    ];
+
+    const next = attachAskUserQuestionAnswers(content, [{ request: 'First?', output: 'one' }]);
+
+    expect(next[0].tool_call.output).toBe('one');
+    expect(next[1].tool_call.output).toBeUndefined();
+  });
+
+  it('consumes a legacy stamp already present on content before a later ask', () => {
+    const firstRequest = { question: 'First?' };
+    const content = [
+      {
+        type: 'tool_call',
+        tool_call: {
+          id: 'ask-1',
+          name: 'ask_user_question',
+          args: JSON.stringify(firstRequest),
+          output: 'one',
+        },
+      },
+      { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
+    ];
+
+    const next = attachAskUserQuestionAnswers(content, [{ request: firstRequest, output: 'one' }]);
+
+    expect(next).toBe(content);
+    expect(next[1].tool_call.output).toBeUndefined();
+  });
+
+  it('does not slide ambiguous legacy metadata past different answered content', () => {
+    const content = [
+      {
+        type: 'tool_call',
+        tool_call: {
+          id: 'ask-1',
+          name: 'ask_user_question',
+          args: JSON.stringify({ question: 'Different?' }),
+          output: 'different',
+        },
+      },
+      { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
+    ];
+
+    const next = attachAskUserQuestionAnswers(content, [
+      { request: { question: 'First?' }, output: 'one' },
+    ]);
+
+    expect(next).toBe(content);
+    expect(next[1].tool_call.output).toBeUndefined();
+  });
 });
 
 describe('attachAskUserQuestionArgs (pause-time stamp)', () => {

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -589,15 +589,18 @@ describe('attachAskUserQuestionAnswer', () => {
 describe('durable ask-user answers', () => {
   it('builds a typed stamp from the validated pending action', () => {
     const pendingAction = {
+      actionId: 'action-2',
+      streamId: 'stream-1',
+      createdAt: 1,
       payload: {
         type: 'ask_user_question',
-        question: 'Which env?',
+        question: { question: 'Which env?' },
         tool_call_id: 'ask-2',
       },
-    } as Agents.PendingAction;
+    } satisfies Agents.PendingAction;
 
     expect(buildResolvedAskUserQuestion(pendingAction, { answer: 'production' })).toEqual({
-      request: 'Which env?',
+      request: { question: 'Which env?' },
       output: 'production',
       toolCallId: 'ask-2',
     });
@@ -612,7 +615,10 @@ describe('durable ask-user answers', () => {
   });
 
   it('reconstructs multiple retained answers in one content pass', () => {
-    const content = [
+    const content: Array<{
+      type: string;
+      tool_call: { id: string; name: string; args: string; output?: string };
+    }> = [
       { type: 'tool_call', tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' } },
       { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
     ];

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -632,7 +632,10 @@ describe('durable ask-user answers', () => {
   });
 
   it('keeps a legacy answer on the earlier ask when a later ask is unanswered', () => {
-    const content = [
+    const content: Array<{
+      type: string;
+      tool_call: { id: string; name: string; args: string; output?: string };
+    }> = [
       { type: 'tool_call', tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' } },
       { type: 'tool_call', tool_call: { id: 'ask-2', name: 'ask_user_question', args: '' } },
     ];

--- a/packages/api/src/agents/hitl/resume.spec.ts
+++ b/packages/api/src/agents/hitl/resume.spec.ts
@@ -625,6 +625,26 @@ describe('durable ask-user answers', () => {
     });
   });
 
+  it('marks an ID-less answer whose paused content part was missing', () => {
+    const pendingAction = {
+      actionId: 'action-missing',
+      streamId: 'stream-1',
+      createdAt: 1,
+      payload: {
+        type: 'ask_user_question',
+        question: { question: 'Missing?' },
+      },
+    } satisfies Agents.PendingAction;
+
+    expect(buildResolvedAskUserQuestion(pendingAction, { answer: 'yes' }, undefined, true)).toEqual(
+      {
+        request: { question: 'Missing?' },
+        output: 'yes',
+        contentMissing: true,
+      },
+    );
+  });
+
   it('accumulates exact-ID answers and replaces a repeated tool call', () => {
     const first = { request: 'First?', output: 'one', toolCallId: 'ask-1' };
     const second = { request: 'Second?', output: 'two', toolCallId: 'ask-2' };
@@ -724,6 +744,19 @@ describe('durable ask-user answers', () => {
 
     expect(next).toBe(content);
     expect(next[1].tool_call.output).toBeUndefined();
+  });
+
+  it('does not bind a missing-content answer to a later ask', () => {
+    const content = [
+      { type: 'tool_call', tool_call: { id: 'later-ask', name: 'ask_user_question', args: '' } },
+    ];
+
+    const next = attachAskUserQuestionAnswers(content, [
+      { request: { question: 'Missing?' }, output: 'old answer', contentMissing: true },
+    ]);
+
+    expect(next).toBe(content);
+    expect(next[0].tool_call.output).toBeUndefined();
   });
 });
 

--- a/packages/api/src/agents/hitl/resume.ts
+++ b/packages/api/src/agents/hitl/resume.ts
@@ -122,6 +122,8 @@ export interface ResolvedAskUserQuestion {
   toolCallId?: string;
   /** Stable association for legacy SDK payloads that omitted tool_call_id. */
   contentIndex?: number;
+  /** The paused ask part was absent, so this answer must not bind to a later ask. */
+  contentMissing?: true;
 }
 
 type AskUserResumeResult =
@@ -179,6 +181,7 @@ export function buildResolvedAskUserQuestion(
   pendingAction: Agents.PendingAction,
   body: AskUserResumeBody,
   contentIndex?: number,
+  contentMissing = false,
 ): ResolvedAskUserQuestion | undefined {
   const payload = pendingAction.payload;
   if (payload?.type !== 'ask_user_question') {
@@ -193,6 +196,7 @@ export function buildResolvedAskUserQuestion(
       output: JSON.stringify({ answers: body.answers }),
       ...(payload.tool_call_id && { toolCallId: payload.tool_call_id }),
       ...(!payload.tool_call_id && contentIndex != null && { contentIndex }),
+      ...(!payload.tool_call_id && contentMissing && { contentMissing: true as const }),
     };
   }
   if (typeof body.answer !== 'string') {
@@ -203,6 +207,7 @@ export function buildResolvedAskUserQuestion(
     output: body.answer,
     ...(payload.tool_call_id && { toolCallId: payload.tool_call_id }),
     ...(!payload.tool_call_id && contentIndex != null && { contentIndex }),
+    ...(!payload.tool_call_id && contentMissing && { contentMissing: true as const }),
   };
 }
 
@@ -215,6 +220,9 @@ export function appendResolvedAskUserQuestion(
     return retained != null && retained.length > 0 ? [...retained] : undefined;
   }
   if (current.toolCallId == null) {
+    if (current.contentMissing === true) {
+      return [...(retained ?? []), current];
+    }
     return [
       ...(retained ?? []).filter(
         (answer) =>
@@ -602,7 +610,9 @@ export function attachAskUserQuestionAnswers<
   const indexedAnswers = new Map<number, ResolvedAskUserQuestion>();
   const legacyAnswers: ResolvedAskUserQuestion[] = [];
   for (const answer of answers) {
-    if (answer.toolCallId != null && answer.toolCallId.length > 0) {
+    if (answer.contentMissing === true) {
+      continue;
+    } else if (answer.toolCallId != null && answer.toolCallId.length > 0) {
       exactAnswers.set(answer.toolCallId, answer);
     } else if (
       answer.contentIndex != null &&

--- a/packages/api/src/agents/hitl/resume.ts
+++ b/packages/api/src/agents/hitl/resume.ts
@@ -515,6 +515,31 @@ export function attachAskUserQuestionAnswer<
   output: string,
   toolCallId?: string,
 ): TPart[] {
+  if (toolCallId == null) {
+    for (let index = content.length - 1; index >= 0; index--) {
+      const part = content[index];
+      const toolCall = part?.tool_call;
+      if (
+        part?.type !== 'tool_call' ||
+        toolCall?.name !== ASK_USER_QUESTION_TOOL_NAME ||
+        (typeof toolCall.output === 'string' && toolCall.output.length > 0)
+      ) {
+        continue;
+      }
+      const next = [...content];
+      next[index] = {
+        ...part,
+        tool_call: {
+          ...toolCall,
+          args: JSON.stringify(request),
+          output,
+          progress: 1,
+        },
+      };
+      return next;
+    }
+    return content;
+  }
   return attachAskUserQuestionAnswers(content, [{ request, output, toolCallId }]);
 }
 
@@ -535,20 +560,47 @@ export function attachAskUserQuestionAnswers<
     }
   }
 
-  let legacyIndex = legacyAnswers.length - 1;
+  /** Legacy stamps have no tool-call id, but their array order is the durable
+   * association: answers are appended as asks resolve, and tool-call parts are
+   * reconstructed in that same chronological order. Walk forward so an
+   * earlier accepted answer cannot slide onto a later unanswered ask. */
+  let legacyIndex = 0;
   let next: TPart[] | undefined;
-  for (let index = content.length - 1; index >= 0; index--) {
+  for (let index = 0; index < content.length; index++) {
     const part = content[index];
     const toolCall = part?.tool_call;
     if (part?.type !== 'tool_call' || toolCall?.name !== ASK_USER_QUESTION_TOOL_NAME) {
       continue;
     }
     const exactAnswer = toolCall.id != null ? exactAnswers.get(toolCall.id) : undefined;
+    const legacyCandidate = legacyAnswers[legacyIndex];
+    if (
+      exactAnswer == null &&
+      legacyCandidate != null &&
+      typeof toolCall.output === 'string' &&
+      toolCall.output.length > 0
+    ) {
+      try {
+        if (
+          toolCall.output === legacyCandidate.output &&
+          JSON.stringify(JSON.parse((toolCall as { args?: string }).args ?? '')) ===
+            JSON.stringify(legacyCandidate.request)
+        ) {
+          legacyIndex++;
+        } else {
+          legacyIndex = legacyAnswers.length;
+        }
+      } catch {
+        // Ambiguous legacy metadata must never slide onto a later ask.
+        legacyIndex = legacyAnswers.length;
+      }
+      continue;
+    }
     const legacyAnswer =
       exactAnswer == null &&
-      legacyIndex >= 0 &&
+      legacyIndex < legacyAnswers.length &&
       !(typeof toolCall.output === 'string' && toolCall.output.length > 0)
-        ? legacyAnswers[legacyIndex--]
+        ? legacyAnswers[legacyIndex++]
         : undefined;
     const answer = exactAnswer ?? legacyAnswer;
     if (answer == null) {

--- a/packages/api/src/agents/hitl/resume.ts
+++ b/packages/api/src/agents/hitl/resume.ts
@@ -120,6 +120,8 @@ export interface ResolvedAskUserQuestion {
   request: Agents.AskUserQuestionRequest | Agents.AskUserQuestionsRequest | string;
   output: string;
   toolCallId?: string;
+  /** Stable association for legacy SDK payloads that omitted tool_call_id. */
+  contentIndex?: number;
 }
 
 type AskUserResumeResult =
@@ -176,6 +178,7 @@ export function resolveAskUserQuestionResume(
 export function buildResolvedAskUserQuestion(
   pendingAction: Agents.PendingAction,
   body: AskUserResumeBody,
+  contentIndex?: number,
 ): ResolvedAskUserQuestion | undefined {
   const payload = pendingAction.payload;
   if (payload?.type !== 'ask_user_question') {
@@ -189,6 +192,7 @@ export function buildResolvedAskUserQuestion(
       request: { questions: payload.questions },
       output: JSON.stringify({ answers: body.answers }),
       ...(payload.tool_call_id && { toolCallId: payload.tool_call_id }),
+      ...(!payload.tool_call_id && contentIndex != null && { contentIndex }),
     };
   }
   if (typeof body.answer !== 'string') {
@@ -198,6 +202,7 @@ export function buildResolvedAskUserQuestion(
     request: payload.question,
     output: body.answer,
     ...(payload.tool_call_id && { toolCallId: payload.tool_call_id }),
+    ...(!payload.tool_call_id && contentIndex != null && { contentIndex }),
   };
 }
 
@@ -210,7 +215,15 @@ export function appendResolvedAskUserQuestion(
     return retained != null && retained.length > 0 ? [...retained] : undefined;
   }
   if (current.toolCallId == null) {
-    return [...(retained ?? []), current];
+    return [
+      ...(retained ?? []).filter(
+        (answer) =>
+          current.contentIndex == null ||
+          answer.toolCallId != null ||
+          answer.contentIndex !== current.contentIndex,
+      ),
+      current,
+    ];
   }
   return [
     ...(retained ?? []).filter((answer) => answer.toolCallId !== current.toolCallId),
@@ -491,6 +504,41 @@ function findAskPartIndex<
   return -1;
 }
 
+/** Locate the exact content slot used by pause-time question stamping. */
+export function findAskUserQuestionContentIndex<
+  TPart extends {
+    type?: string;
+    tool_call?: { id?: string; name?: string; args?: unknown; output?: unknown };
+  },
+>(
+  content: TPart[],
+  toolCallId?: string,
+  request?: Agents.AskUserQuestionRequest | Agents.AskUserQuestionsRequest | string,
+): number {
+  return findAskPartIndex(content, toolCallId, (part) => {
+    const toolCall = part.tool_call;
+    const hasArgs =
+      (typeof toolCall?.args === 'string' && toolCall.args.trim().length > 0) ||
+      (toolCall?.args != null &&
+        typeof toolCall.args === 'object' &&
+        Object.keys(toolCall.args as object).length > 0);
+    if (typeof toolCall?.output === 'string' && toolCall.output.length > 0) {
+      return false;
+    }
+    if (!hasArgs) {
+      return true;
+    }
+    if (request == null || typeof toolCall?.args !== 'string') {
+      return false;
+    }
+    try {
+      return JSON.stringify(JSON.parse(toolCall.args)) === JSON.stringify(request);
+    } catch {
+      return false;
+    }
+  });
+}
+
 /**
  * Stamp the answered question onto the paused `ask_user_question` tool-call part
  * before the resume run seeds it back into the content pipeline.
@@ -551,10 +599,17 @@ export function attachAskUserQuestionAnswers<
     return content;
   }
   const exactAnswers = new Map<string, ResolvedAskUserQuestion>();
+  const indexedAnswers = new Map<number, ResolvedAskUserQuestion>();
   const legacyAnswers: ResolvedAskUserQuestion[] = [];
   for (const answer of answers) {
     if (answer.toolCallId != null && answer.toolCallId.length > 0) {
       exactAnswers.set(answer.toolCallId, answer);
+    } else if (
+      answer.contentIndex != null &&
+      Number.isSafeInteger(answer.contentIndex) &&
+      answer.contentIndex >= 0
+    ) {
+      indexedAnswers.set(answer.contentIndex, answer);
     } else {
       legacyAnswers.push(answer);
     }
@@ -573,9 +628,11 @@ export function attachAskUserQuestionAnswers<
       continue;
     }
     const exactAnswer = toolCall.id != null ? exactAnswers.get(toolCall.id) : undefined;
+    const indexedAnswer = indexedAnswers.get(index);
     const legacyCandidate = legacyAnswers[legacyIndex];
     if (
       exactAnswer == null &&
+      indexedAnswer == null &&
       legacyCandidate != null &&
       typeof toolCall.output === 'string' &&
       toolCall.output.length > 0
@@ -602,12 +659,15 @@ export function attachAskUserQuestionAnswers<
       !(typeof toolCall.output === 'string' && toolCall.output.length > 0)
         ? legacyAnswers[legacyIndex++]
         : undefined;
-    const answer = exactAnswer ?? legacyAnswer;
+    const answer = exactAnswer ?? indexedAnswer ?? legacyAnswer;
     if (answer == null) {
       continue;
     }
     if (exactAnswer != null && toolCall.id != null) {
       exactAnswers.delete(toolCall.id);
+    }
+    if (indexedAnswer != null) {
+      indexedAnswers.delete(index);
     }
     next ??= [...content];
     next[index] = {
@@ -643,15 +703,7 @@ export function attachAskUserQuestionArgs<
   request: Agents.AskUserQuestionRequest | Agents.AskUserQuestionsRequest,
   toolCallId?: string,
 ): TPart[] {
-  const index = findAskPartIndex(content, toolCallId, (part) => {
-    const toolCall = part.tool_call;
-    const hasArgs =
-      (typeof toolCall?.args === 'string' && toolCall.args.trim().length > 0) ||
-      (toolCall?.args != null &&
-        typeof toolCall.args === 'object' &&
-        Object.keys(toolCall.args as object).length > 0);
-    return !hasArgs && !(typeof toolCall?.output === 'string' && toolCall.output.length > 0);
-  });
+  const index = findAskUserQuestionContentIndex(content, toolCallId, request);
   if (index < 0) {
     return content;
   }

--- a/packages/api/src/agents/hitl/resume.ts
+++ b/packages/api/src/agents/hitl/resume.ts
@@ -114,6 +114,14 @@ interface AskUserResumeBody {
   answers?: unknown;
 }
 
+/** Ask-user answer retained with the job until the generation terminalizes. */
+export interface ResolvedAskUserQuestion {
+  /** String supports pending records written before the structured question shape. */
+  request: Agents.AskUserQuestionRequest | Agents.AskUserQuestionsRequest | string;
+  output: string;
+  toolCallId?: string;
+}
+
 type AskUserResumeResult =
   | { resumeValue: AskUserQuestionResolution | AskUserQuestionsResolution }
   | { status: 400; error: string };
@@ -162,6 +170,52 @@ export function resolveAskUserQuestionResume(
     return { status: 400, error: 'Answers contain an unknown question id' };
   }
   return { resumeValue: mapAskUserAnswers({ answers }) };
+}
+
+/** Build the durable answer stamp committed with the resume ownership CAS. */
+export function buildResolvedAskUserQuestion(
+  pendingAction: Agents.PendingAction,
+  body: AskUserResumeBody,
+): ResolvedAskUserQuestion | undefined {
+  const payload = pendingAction.payload;
+  if (payload?.type !== 'ask_user_question') {
+    return undefined;
+  }
+  if (Array.isArray(payload.questions)) {
+    if (body.answers == null || typeof body.answers !== 'object' || Array.isArray(body.answers)) {
+      return undefined;
+    }
+    return {
+      request: { questions: payload.questions },
+      output: JSON.stringify({ answers: body.answers }),
+      ...(payload.tool_call_id && { toolCallId: payload.tool_call_id }),
+    };
+  }
+  if (typeof body.answer !== 'string') {
+    return undefined;
+  }
+  return {
+    request: payload.question,
+    output: body.answer,
+    ...(payload.tool_call_id && { toolCallId: payload.tool_call_id }),
+  };
+}
+
+/** Add the current answer without losing exact-ID stamps from earlier pauses. */
+export function appendResolvedAskUserQuestion(
+  retained: readonly ResolvedAskUserQuestion[] | undefined,
+  current: ResolvedAskUserQuestion | undefined,
+): ResolvedAskUserQuestion[] | undefined {
+  if (current == null) {
+    return retained != null && retained.length > 0 ? [...retained] : undefined;
+  }
+  if (current.toolCallId == null) {
+    return [...(retained ?? []), current];
+  }
+  return [
+    ...(retained ?? []).filter((answer) => answer.toolCallId !== current.toolCallId),
+    current,
+  ];
 }
 
 /**
@@ -461,26 +515,60 @@ export function attachAskUserQuestionAnswer<
   output: string,
   toolCallId?: string,
 ): TPart[] {
-  const index = findAskPartIndex(
-    content,
-    toolCallId,
-    (part) => !(typeof part.tool_call?.output === 'string' && part.tool_call.output.length > 0),
-  );
-  if (index < 0) {
+  return attachAskUserQuestionAnswers(content, [{ request, output, toolCallId }]);
+}
+
+/** Apply retained ask answers in one content pass for Redis reconstruction. */
+export function attachAskUserQuestionAnswers<
+  TPart extends { type?: string; tool_call?: { id?: string; name?: string; output?: unknown } },
+>(content: TPart[], answers: readonly ResolvedAskUserQuestion[]): TPart[] {
+  if (answers.length === 0) {
     return content;
   }
-  const part = content[index];
-  const next = [...content];
-  next[index] = {
-    ...part,
-    tool_call: {
-      ...part.tool_call,
-      args: JSON.stringify(request),
-      output,
-      progress: 1,
-    },
-  };
-  return next;
+  const exactAnswers = new Map<string, ResolvedAskUserQuestion>();
+  const legacyAnswers: ResolvedAskUserQuestion[] = [];
+  for (const answer of answers) {
+    if (answer.toolCallId != null && answer.toolCallId.length > 0) {
+      exactAnswers.set(answer.toolCallId, answer);
+    } else {
+      legacyAnswers.push(answer);
+    }
+  }
+
+  let legacyIndex = legacyAnswers.length - 1;
+  let next: TPart[] | undefined;
+  for (let index = content.length - 1; index >= 0; index--) {
+    const part = content[index];
+    const toolCall = part?.tool_call;
+    if (part?.type !== 'tool_call' || toolCall?.name !== ASK_USER_QUESTION_TOOL_NAME) {
+      continue;
+    }
+    const exactAnswer = toolCall.id != null ? exactAnswers.get(toolCall.id) : undefined;
+    const legacyAnswer =
+      exactAnswer == null &&
+      legacyIndex >= 0 &&
+      !(typeof toolCall.output === 'string' && toolCall.output.length > 0)
+        ? legacyAnswers[legacyIndex--]
+        : undefined;
+    const answer = exactAnswer ?? legacyAnswer;
+    if (answer == null) {
+      continue;
+    }
+    if (exactAnswer != null && toolCall.id != null) {
+      exactAnswers.delete(toolCall.id);
+    }
+    next ??= [...content];
+    next[index] = {
+      ...part,
+      tool_call: {
+        ...toolCall,
+        args: JSON.stringify(answer.request),
+        output: answer.output,
+        progress: 1,
+      },
+    };
+  }
+  return next ?? content;
 }
 
 /**

--- a/packages/api/src/stream/ApprovalLifecycle.ts
+++ b/packages/api/src/stream/ApprovalLifecycle.ts
@@ -105,6 +105,10 @@ export class ApprovalLifecycle {
     const ok = await this.store.transitionStatus(streamId, {
       from: 'running',
       to: 'requires_action',
+      // A prior ask answer is only a reconstruction bridge for the resumed
+      // run. Reaching another pause proves that seed was consumed; retaining
+      // an ID-less legacy stamp could attribute it to this new action.
+      clear: ['resolvedAskUserQuestion'],
       // pendingActionId is the flat mirror the atomic resolve/expire guard on.
       patch: {
         pendingAction,

--- a/packages/api/src/stream/ApprovalLifecycle.ts
+++ b/packages/api/src/stream/ApprovalLifecycle.ts
@@ -103,9 +103,10 @@ export class ApprovalLifecycle {
     );
     const persistenceStartedAt = Date.now();
     const resolvedAskUserQuestions = job.resolvedAskUserQuestions ?? [];
-    const retainedAskUserQuestions = resolvedAskUserQuestions.filter(
-      (answer) => answer.toolCallId != null,
-    );
+    const retainedAskUserQuestions =
+      pendingAction.payload.type === 'ask_user_question'
+        ? resolvedAskUserQuestions.filter((answer) => answer.toolCallId != null)
+        : resolvedAskUserQuestions;
     const replacesResolvedAnswers =
       retainedAskUserQuestions.length !== resolvedAskUserQuestions.length;
     const ok = await this.store.transitionStatus(streamId, {

--- a/packages/api/src/stream/ApprovalLifecycle.ts
+++ b/packages/api/src/stream/ApprovalLifecycle.ts
@@ -102,15 +102,22 @@ export class ApprovalLifecycle {
         : 0,
     );
     const persistenceStartedAt = Date.now();
+    const resolvedAskUserQuestions = job.resolvedAskUserQuestions ?? [];
+    const retainedAskUserQuestions = resolvedAskUserQuestions.filter(
+      (answer) => answer.toolCallId != null,
+    );
+    const replacesResolvedAnswers =
+      retainedAskUserQuestions.length !== resolvedAskUserQuestions.length;
     const ok = await this.store.transitionStatus(streamId, {
       from: 'running',
       to: 'requires_action',
       // Exact-ID answers remain a Redis reconstruction bridge for an earlier
       // ask across replicas. Only legacy ID-less stamps become ambiguous when
       // this run reaches a later pending action.
-      ...(job.resolvedAskUserQuestion?.toolCallId == null && {
-        clear: ['resolvedAskUserQuestion'] as const,
-      }),
+      ...(replacesResolvedAnswers &&
+        retainedAskUserQuestions.length === 0 && {
+          clear: ['resolvedAskUserQuestions'] as const,
+        }),
       // pendingActionId is the flat mirror the atomic resolve/expire guard on.
       patch: {
         pendingAction,
@@ -118,6 +125,10 @@ export class ApprovalLifecycle {
           options.persistencePending === true
             ? pausePersistenceActionId(pendingAction.actionId)
             : pendingAction.actionId,
+        ...(replacesResolvedAnswers &&
+          retainedAskUserQuestions.length > 0 && {
+            resolvedAskUserQuestions: retainedAskUserQuestions,
+          }),
         ...(options.persistencePending === true && {
           terminalPersistencePending: true,
           terminalPersistenceStartedAt: persistenceStartedAt,

--- a/packages/api/src/stream/ApprovalLifecycle.ts
+++ b/packages/api/src/stream/ApprovalLifecycle.ts
@@ -105,10 +105,12 @@ export class ApprovalLifecycle {
     const ok = await this.store.transitionStatus(streamId, {
       from: 'running',
       to: 'requires_action',
-      // A prior ask answer is only a reconstruction bridge for the resumed
-      // run. Reaching another pause proves that seed was consumed; retaining
-      // an ID-less legacy stamp could attribute it to this new action.
-      clear: ['resolvedAskUserQuestion'],
+      // Exact-ID answers remain a Redis reconstruction bridge for an earlier
+      // ask across replicas. Only legacy ID-less stamps become ambiguous when
+      // this run reaches a later pending action.
+      ...(job.resolvedAskUserQuestion?.toolCallId == null && {
+        clear: ['resolvedAskUserQuestion'] as const,
+      }),
       // pendingActionId is the flat mirror the atomic resolve/expire guard on.
       patch: {
         pendingAction,

--- a/packages/api/src/stream/ApprovalLifecycle.ts
+++ b/packages/api/src/stream/ApprovalLifecycle.ts
@@ -102,23 +102,9 @@ export class ApprovalLifecycle {
         : 0,
     );
     const persistenceStartedAt = Date.now();
-    const resolvedAskUserQuestions = job.resolvedAskUserQuestions ?? [];
-    const retainedAskUserQuestions =
-      pendingAction.payload.type === 'ask_user_question'
-        ? resolvedAskUserQuestions.filter((answer) => answer.toolCallId != null)
-        : resolvedAskUserQuestions;
-    const replacesResolvedAnswers =
-      retainedAskUserQuestions.length !== resolvedAskUserQuestions.length;
     const ok = await this.store.transitionStatus(streamId, {
       from: 'running',
       to: 'requires_action',
-      // Exact-ID answers remain a Redis reconstruction bridge for an earlier
-      // ask across replicas. Only legacy ID-less stamps become ambiguous when
-      // this run reaches a later pending action.
-      ...(replacesResolvedAnswers &&
-        retainedAskUserQuestions.length === 0 && {
-          clear: ['resolvedAskUserQuestions'] as const,
-        }),
       // pendingActionId is the flat mirror the atomic resolve/expire guard on.
       patch: {
         pendingAction,
@@ -126,10 +112,6 @@ export class ApprovalLifecycle {
           options.persistencePending === true
             ? pausePersistenceActionId(pendingAction.actionId)
             : pendingAction.actionId,
-        ...(replacesResolvedAnswers &&
-          retainedAskUserQuestions.length > 0 && {
-            resolvedAskUserQuestions: retainedAskUserQuestions,
-          }),
         ...(options.persistencePending === true && {
           terminalPersistencePending: true,
           terminalPersistenceStartedAt: persistenceStartedAt,

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -2391,6 +2391,7 @@ class GenerationJobManagerClass {
         // Surface the pending review so status/resume routes built on the
         // facade can render the prompt for a `requires_action` job.
         pendingAction: jobData.pendingAction,
+        resolvedAskUserQuestion: jobData.resolvedAskUserQuestion,
       },
       readyPromise: runtime.readyPromise,
       resolveReady: runtime.resolveReady,

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -2391,7 +2391,7 @@ class GenerationJobManagerClass {
         // Surface the pending review so status/resume routes built on the
         // facade can render the prompt for a `requires_action` job.
         pendingAction: jobData.pendingAction,
-        resolvedAskUserQuestion: jobData.resolvedAskUserQuestion,
+        resolvedAskUserQuestions: jobData.resolvedAskUserQuestions,
       },
       readyPromise: runtime.readyPromise,
       resolveReady: runtime.resolveReady,

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -6324,8 +6324,8 @@ class GenerationJobManagerClass {
       // cross-replica client can rebuild the prompt from resumeState. Client-safe
       // projection: the stored record's resumeContext/requestFingerprint stay server-only.
       pendingAction:
-        jobData.status === 'requires_action' && !isPendingActionStale(jobData)
-          ? toClientPendingAction(jobData.pendingAction)
+        verifiedJob.status === 'requires_action' && !isPendingActionStale(verifiedJob)
+          ? toClientPendingAction(verifiedJob.pendingAction)
           : undefined,
       pendingSteers: pendingSteers.length > 0 ? pendingSteers : undefined,
     } satisfies t.ResumeState;

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -3500,7 +3500,10 @@ class GenerationJobManagerClass {
   async abortJob(
     streamId: string,
     options?: {
-      transformAbortContent?: (content: TMessageContentParts[]) => TMessageContentParts[];
+      transformAbortContent?: (
+        content: TMessageContentParts[],
+        jobData: SerializableJobData,
+      ) => TMessageContentParts[];
       /** Required durable work (for example saving the partial response and
        * pruning the paused checkpoint) that must finish before the normal
        * FINAL lets the client submit against that history. Throwing emits a
@@ -3605,11 +3608,6 @@ class GenerationJobManagerClass {
     const result = await this.jobStore.getContentParts(streamId, jobData.createdAt);
     let content = result?.content ?? [];
     let abortContent = filterPersistableAbortContent(content);
-    if (options?.transformAbortContent) {
-      abortContent = options.transformAbortContent(
-        abortContent as TMessageContentParts[],
-      ) as typeof abortContent;
-    }
     let shouldPersistAbortContent = abortContent.length > 0;
 
     /** Collected usage for all models */
@@ -3699,6 +3697,10 @@ class GenerationJobManagerClass {
         collectedUsage,
       };
     }
+    // The successful CAS may follow a same-generation approval transition.
+    // Use the snapshot that selected the winning source status so host-side
+    // content transforms see metadata committed by that transition.
+    jobData = currentAfterConflict ?? jobData;
     const terminalClaim: TerminalJobClaim = Object.freeze({
       streamId,
       createdAt: jobData.createdAt,
@@ -3739,17 +3741,6 @@ class GenerationJobManagerClass {
         if (committed) {
           content = committed.content;
           abortContent = filterPersistableAbortContent(content);
-          if (options?.transformAbortContent) {
-            abortContent = options.transformAbortContent(
-              abortContent as TMessageContentParts[],
-            ) as typeof abortContent;
-          }
-          shouldPersistAbortContent = abortContent.length > 0;
-          text = shouldPersistAbortContent
-            ? parseTextParts(abortContent as TMessageContentParts[], false, {
-                includeSteer: true,
-              })
-            : '';
         }
       } catch (contentError) {
         logger.warn(
@@ -3757,6 +3748,16 @@ class GenerationJobManagerClass {
           contentError,
         );
       }
+      if (options?.transformAbortContent) {
+        abortContent = options.transformAbortContent(
+          abortContent as TMessageContentParts[],
+          jobData,
+        ) as typeof abortContent;
+      }
+      shouldPersistAbortContent = abortContent.length > 0;
+      text = shouldPersistAbortContent
+        ? parseTextParts(abortContent as TMessageContentParts[], false, { includeSteer: true })
+        : '';
 
       /** Detect "early abort" - aborted before any generation happened (e.g., during tool loading)
       In this case, no messages were saved to DB, so frontend shouldn't navigate to conversation */

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -66,7 +66,7 @@ import {
 import { synthesizeActivityLabelGapEvents } from '~/agents/activityLabels/wiring';
 import { InMemoryEventTransport } from './implementations/InMemoryEventTransport';
 import { InMemoryJobStore } from './implementations/InMemoryJobStore';
-import { normalizeResumeRunStepIndices } from '~/agents/hitl/resume';
+import { attachAskUserQuestionAnswers, normalizeResumeRunStepIndices } from '~/agents/hitl/resume';
 import { emitChunkWithReceipt } from './internal/chunkPublication';
 import { resolveCoalesceWindowMs } from './internal/coalescing';
 import { filterPersistableAbortContent } from './abortContent';
@@ -6228,7 +6228,7 @@ class GenerationJobManagerClass {
       this.jobStore.peekSteers(streamId, jobData.createdAt),
       this.jobStore.peekClaimedSteers(streamId, jobData.createdAt),
     ]);
-    const aggregatedContent = result?.content ?? [];
+    const reconstructedContent = result?.content ?? [];
     const bufferState = this.runStepBuffers?.get(streamId);
     const bufferedRunSteps = bufferState?.createdAt === jobData.createdAt ? bufferState.steps : [];
     const runStepsById = new Map(runSteps.map((runStep) => [runStep.id, runStep]));
@@ -6237,7 +6237,7 @@ class GenerationJobManagerClass {
     }
     const effectiveRunSteps = normalizeResumeRunStepIndices(
       [...runStepsById.values()],
-      aggregatedContent,
+      reconstructedContent,
     );
     let titleEvent: t.ResumeState['titleEvent'];
     if (jobData.titleEvent) {
@@ -6281,7 +6281,7 @@ class GenerationJobManagerClass {
     /** Steers still queued (not yet injected); injected ones are already in aggregatedContent. */
     const pendingSteers = omitAlreadyAppliedSteers(
       mergeUnresolvedSteers(claimedSteers, queuedSteers),
-      aggregatedContent as unknown[],
+      reconstructedContent as unknown[],
     ).map(toPendingSteer);
 
     /** The four component reads are generation-fenced, but replacement can
@@ -6292,6 +6292,13 @@ class GenerationJobManagerClass {
     if (!verifiedJob || verifiedJob.createdAt !== jobData.createdAt) {
       return null;
     }
+    /** Redis reconstruction has no completion event for ask_user_question.
+     * Apply the answer stamps from the generation-fenced job read so reload,
+     * status, resume, and abort all expose the same authoritative content. */
+    const aggregatedContent = attachAskUserQuestionAnswers(
+      reconstructedContent,
+      verifiedJob.resolvedAskUserQuestions ?? [],
+    );
 
     logger.debug(`[GenerationJobManager] getResumeState:`, {
       streamId,

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -3491,8 +3491,8 @@ class GenerationJobManagerClass {
    * - Emits abort signal via Redis pub/sub
    * - The replica running generation receives signal and aborts its AbortController
    *
-   * `options.transformAbortContent` rewrites the persistable content BEFORE the
-   * final SSE is emitted (and before it is returned for the DB save), so a
+   * `options.transformAbortContent` rewrites the reconstructed content BEFORE
+   * persistence filtering and the final SSE (and before it is returned for the DB save), so a
    * host-side stamp — e.g. re-attaching a paused `ask_user_question`'s args
    * that the Redis chunk-log reconstruction dropped — reaches the LIVE client
    * too, not just the saved message. Pure/optional; identity when omitted.
@@ -3740,7 +3740,6 @@ class GenerationJobManagerClass {
         const committed = await this.jobStore.getContentParts(streamId, jobData.createdAt);
         if (committed) {
           content = committed.content;
-          abortContent = filterPersistableAbortContent(content);
         }
       } catch (contentError) {
         logger.warn(
@@ -3749,11 +3748,15 @@ class GenerationJobManagerClass {
         );
       }
       if (options?.transformAbortContent) {
-        abortContent = options.transformAbortContent(
-          abortContent as TMessageContentParts[],
+        content = options.transformAbortContent(
+          content as TMessageContentParts[],
           jobData,
-        ) as typeof abortContent;
+        ) as typeof content;
       }
+      // Answer stamps use ordinals from the unfiltered chunk reconstruction.
+      // Filter only after the transform so sparse/empty/OAuth parts cannot
+      // shift a retained ID-less ask answer onto a different tool call.
+      abortContent = filterPersistableAbortContent(content);
       shouldPersistAbortContent = abortContent.length > 0;
       text = shouldPersistAbortContent
         ? parseTextParts(abortContent as TMessageContentParts[], false, { includeSteer: true })

--- a/packages/api/src/stream/__tests__/GenerationJobManager.resumeReplay.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.resumeReplay.spec.ts
@@ -230,7 +230,7 @@ describe('GenerationJobManager resume replay events', () => {
 
     const resumeState = await manager.getResumeState(streamId);
 
-    expect(resumeState?.aggregatedContent[0]).toMatchObject({
+    expect(resumeState?.aggregatedContent?.[0]).toMatchObject({
       tool_call: { output: 'staging' },
     });
     expect(resumeState?.pendingAction).toBeUndefined();

--- a/packages/api/src/stream/__tests__/GenerationJobManager.resumeReplay.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.resumeReplay.spec.ts
@@ -189,6 +189,53 @@ describe('GenerationJobManager resume replay events', () => {
     ]);
   });
 
+  test('does not return a stale pending action with a newly resolved answer', async () => {
+    const store = new InMemoryJobStore({ ttlAfterComplete: 60000 });
+    manager = createManagerWithStore(store);
+    const streamId = `ask-answer-lifecycle-resume-${Date.now()}`;
+    const job = await manager.createJob(streamId, 'user-1', streamId);
+    manager.setContentParts(streamId, [
+      {
+        type: 'tool_call',
+        tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' },
+      },
+    ]);
+    await store.updateJob(
+      streamId,
+      {
+        status: 'running',
+        resolvedAskUserQuestions: [
+          { request: { question: 'Which env?' }, output: 'staging', toolCallId: 'ask-1' },
+        ],
+      },
+      job.createdAt,
+    );
+    const getJob = store.getJob.bind(store);
+    jest.spyOn(store, 'getJob').mockImplementationOnce(async (...args) => {
+      const current = await getJob(...args);
+      if (current == null) {
+        return null;
+      }
+      return {
+        ...current,
+        status: 'requires_action',
+        pendingAction: {
+          actionId: 'stale-action',
+          streamId,
+          createdAt: Date.now(),
+          payload: { type: 'ask_user_question', question: { question: 'Which env?' } },
+        },
+      };
+    });
+
+    const resumeState = await manager.getResumeState(streamId);
+
+    expect(resumeState?.aggregatedContent[0]).toMatchObject({
+      tool_call: { output: 'staging' },
+    });
+    expect(resumeState?.pendingAction).toBeUndefined();
+  });
+
   test('realigns a stale run-step index to the aggregated tool card by tool-call id', async () => {
     manager = createInMemoryManager();
     const streamId = `run-step-index-resume-${Date.now()}`;

--- a/packages/api/src/stream/__tests__/GenerationJobManager.resumeReplay.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.resumeReplay.spec.ts
@@ -152,6 +152,43 @@ describe('GenerationJobManager resume replay events', () => {
     expect(resumeState?.runSteps).toEqual([runStep]);
   });
 
+  test('applies retained ask answers to reconnect snapshots', async () => {
+    const store = new InMemoryJobStore({ ttlAfterComplete: 60000 });
+    manager = createManagerWithStore(store);
+    const streamId = `ask-answer-resume-${Date.now()}`;
+    const job = await manager.createJob(streamId, 'user-1', streamId);
+    manager.setContentParts(streamId, [
+      {
+        type: 'tool_call',
+        tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' },
+      },
+    ]);
+    await store.updateJob(
+      streamId,
+      {
+        resolvedAskUserQuestions: [
+          { request: { question: 'Which env?' }, output: 'staging', toolCallId: 'ask-1' },
+        ],
+      },
+      job.createdAt,
+    );
+
+    const resumeState = await manager.getResumeState(streamId);
+
+    expect(resumeState?.aggregatedContent).toEqual([
+      {
+        type: 'tool_call',
+        tool_call: {
+          id: 'ask-1',
+          name: 'ask_user_question',
+          args: JSON.stringify({ question: 'Which env?' }),
+          output: 'staging',
+          progress: 1,
+        },
+      },
+    ]);
+  });
+
   test('realigns a stale run-step index to the aggregated tool card by tool-call id', async () => {
     manager = createInMemoryManager();
     const streamId = `run-step-index-resume-${Date.now()}`;

--- a/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
+++ b/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
@@ -352,6 +352,28 @@ describe('RedisJobStore', () => {
     });
   });
 
+  test.each(['null', '42', '"answer"', '[]'])(
+    'drops non-object resolved ask-user metadata: %s',
+    async (resolvedAskUserQuestion) => {
+      const redis = {
+        isCluster: true,
+        hgetall: jest.fn().mockResolvedValue({
+          streamId: 'stream-malformed-answer',
+          userId: 'user-1',
+          status: 'running',
+          createdAt: '100',
+          resolvedAskUserQuestion,
+        }),
+      } as unknown as Cluster;
+      const store = new RedisJobStore(redis);
+
+      await expect(store.getJob('stream-malformed-answer')).resolves.toMatchObject({
+        streamId: 'stream-malformed-answer',
+        resolvedAskUserQuestion: undefined,
+      });
+    },
+  );
+
   test('atomically resets predecessor state when creating a replacement', async () => {
     const evalJobCreation = jest
       .fn()

--- a/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
+++ b/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
@@ -289,11 +289,13 @@ describe('RedisJobStore', () => {
       discoveredTools: [],
       preemptCapable: true,
       generationProtocolVersion: 2,
-      resolvedAskUserQuestion: {
-        request: { question: 'Deploy where?' },
-        output: 'prod',
-        toolCallId: 'call-1',
-      },
+      resolvedAskUserQuestions: [
+        {
+          request: { question: 'Deploy where?' },
+          output: 'prod',
+          toolCallId: 'call-1',
+        },
+      ],
     });
 
     /**
@@ -305,11 +307,13 @@ describe('RedisJobStore', () => {
     expect(job.preemptCapable).toBe(true);
     expect(job.generationProtocolVersion).toBe(2);
     expect(job.checkpointNamespace).toBe(String(job.createdAt));
-    expect(job.resolvedAskUserQuestion).toEqual({
-      request: { question: 'Deploy where?' },
-      output: 'prod',
-      toolCallId: 'call-1',
-    });
+    expect(job.resolvedAskUserQuestions).toEqual([
+      {
+        request: { question: 'Deploy where?' },
+        output: 'prod',
+        toolCallId: 'call-1',
+      },
+    ]);
 
     expect(job).toMatchObject({
       streamId: 'stream-metadata',
@@ -328,11 +332,13 @@ describe('RedisJobStore', () => {
       isTemporary: false,
       promptTokens: 0,
       discoveredTools: [],
-      resolvedAskUserQuestion: {
-        request: { question: 'Deploy where?' },
-        output: 'prod',
-        toolCallId: 'call-1',
-      },
+      resolvedAskUserQuestions: [
+        {
+          request: { question: 'Deploy where?' },
+          output: 'prod',
+          toolCallId: 'call-1',
+        },
+      ],
     });
 
     const creationArgs = evalJobCreation.mock.calls[0];
@@ -344,17 +350,19 @@ describe('RedisJobStore', () => {
       isTemporary: '0',
       promptTokens: '0',
       discoveredTools: '[]',
-      resolvedAskUserQuestion: JSON.stringify({
-        request: { question: 'Deploy where?' },
-        output: 'prod',
-        toolCallId: 'call-1',
-      }),
+      resolvedAskUserQuestions: JSON.stringify([
+        {
+          request: { question: 'Deploy where?' },
+          output: 'prod',
+          toolCallId: 'call-1',
+        },
+      ]),
     });
   });
 
-  test.each(['null', '42', '"answer"', '[]'])(
-    'drops non-object resolved ask-user metadata: %s',
-    async (resolvedAskUserQuestion) => {
+  test.each(['null', '42', '"answer"', '{}', '[]', '[null]'])(
+    'drops malformed resolved ask-user metadata: %s',
+    async (resolvedAskUserQuestions) => {
       const redis = {
         isCluster: true,
         hgetall: jest.fn().mockResolvedValue({
@@ -362,14 +370,14 @@ describe('RedisJobStore', () => {
           userId: 'user-1',
           status: 'running',
           createdAt: '100',
-          resolvedAskUserQuestion,
+          resolvedAskUserQuestions,
         }),
       } as unknown as Cluster;
       const store = new RedisJobStore(redis);
 
       await expect(store.getJob('stream-malformed-answer')).resolves.toMatchObject({
         streamId: 'stream-malformed-answer',
-        resolvedAskUserQuestion: undefined,
+        resolvedAskUserQuestions: undefined,
       });
     },
   );

--- a/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
+++ b/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
@@ -289,6 +289,11 @@ describe('RedisJobStore', () => {
       discoveredTools: [],
       preemptCapable: true,
       generationProtocolVersion: 2,
+      resolvedAskUserQuestion: {
+        request: { question: 'Deploy where?' },
+        output: 'prod',
+        toolCallId: 'call-1',
+      },
     });
 
     /**
@@ -300,6 +305,11 @@ describe('RedisJobStore', () => {
     expect(job.preemptCapable).toBe(true);
     expect(job.generationProtocolVersion).toBe(2);
     expect(job.checkpointNamespace).toBe(String(job.createdAt));
+    expect(job.resolvedAskUserQuestion).toEqual({
+      request: { question: 'Deploy where?' },
+      output: 'prod',
+      toolCallId: 'call-1',
+    });
 
     expect(job).toMatchObject({
       streamId: 'stream-metadata',
@@ -318,6 +328,11 @@ describe('RedisJobStore', () => {
       isTemporary: false,
       promptTokens: 0,
       discoveredTools: [],
+      resolvedAskUserQuestion: {
+        request: { question: 'Deploy where?' },
+        output: 'prod',
+        toolCallId: 'call-1',
+      },
     });
 
     const creationArgs = evalJobCreation.mock.calls[0];
@@ -329,6 +344,11 @@ describe('RedisJobStore', () => {
       isTemporary: '0',
       promptTokens: '0',
       discoveredTools: '[]',
+      resolvedAskUserQuestion: JSON.stringify({
+        request: { question: 'Deploy where?' },
+        output: 'prod',
+        toolCallId: 'call-1',
+      }),
     });
   });
 

--- a/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
+++ b/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
@@ -295,6 +295,11 @@ describe('RedisJobStore', () => {
           output: 'prod',
           toolCallId: 'call-1',
         },
+        {
+          request: { question: 'Legacy missing?' },
+          output: 'yes',
+          contentMissing: true,
+        },
       ],
     });
 
@@ -312,6 +317,11 @@ describe('RedisJobStore', () => {
         request: { question: 'Deploy where?' },
         output: 'prod',
         toolCallId: 'call-1',
+      },
+      {
+        request: { question: 'Legacy missing?' },
+        output: 'yes',
+        contentMissing: true,
       },
     ]);
 
@@ -338,6 +348,11 @@ describe('RedisJobStore', () => {
           output: 'prod',
           toolCallId: 'call-1',
         },
+        {
+          request: { question: 'Legacy missing?' },
+          output: 'yes',
+          contentMissing: true,
+        },
       ],
     });
 
@@ -356,6 +371,11 @@ describe('RedisJobStore', () => {
           output: 'prod',
           toolCallId: 'call-1',
         },
+        {
+          request: { question: 'Legacy missing?' },
+          output: 'yes',
+          contentMissing: true,
+        },
       ]),
     });
   });
@@ -368,6 +388,7 @@ describe('RedisJobStore', () => {
     '[]',
     '[null]',
     '[{"request":"Question?","output":"answer","contentIndex":-1}]',
+    '[{"request":"Question?","output":"answer","contentMissing":false}]',
   ])('drops malformed resolved ask-user metadata: %s', async (resolvedAskUserQuestions) => {
     const redis = {
       isCluster: true,

--- a/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
+++ b/packages/api/src/stream/__tests__/RedisJobStore.spec.ts
@@ -360,27 +360,32 @@ describe('RedisJobStore', () => {
     });
   });
 
-  test.each(['null', '42', '"answer"', '{}', '[]', '[null]'])(
-    'drops malformed resolved ask-user metadata: %s',
-    async (resolvedAskUserQuestions) => {
-      const redis = {
-        isCluster: true,
-        hgetall: jest.fn().mockResolvedValue({
-          streamId: 'stream-malformed-answer',
-          userId: 'user-1',
-          status: 'running',
-          createdAt: '100',
-          resolvedAskUserQuestions,
-        }),
-      } as unknown as Cluster;
-      const store = new RedisJobStore(redis);
-
-      await expect(store.getJob('stream-malformed-answer')).resolves.toMatchObject({
+  test.each([
+    'null',
+    '42',
+    '"answer"',
+    '{}',
+    '[]',
+    '[null]',
+    '[{"request":"Question?","output":"answer","contentIndex":-1}]',
+  ])('drops malformed resolved ask-user metadata: %s', async (resolvedAskUserQuestions) => {
+    const redis = {
+      isCluster: true,
+      hgetall: jest.fn().mockResolvedValue({
         streamId: 'stream-malformed-answer',
-        resolvedAskUserQuestions: undefined,
-      });
-    },
-  );
+        userId: 'user-1',
+        status: 'running',
+        createdAt: '100',
+        resolvedAskUserQuestions,
+      }),
+    } as unknown as Cluster;
+    const store = new RedisJobStore(redis);
+
+    await expect(store.getJob('stream-malformed-answer')).resolves.toMatchObject({
+      streamId: 'stream-malformed-answer',
+      resolvedAskUserQuestions: undefined,
+    });
+  });
 
   test('atomically resets predecessor state when creating a replacement', async () => {
     const evalJobCreation = jest

--- a/packages/api/src/stream/__tests__/pendingAction.spec.ts
+++ b/packages/api/src/stream/__tests__/pendingAction.spec.ts
@@ -76,11 +76,53 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
         }),
       ).toBe(true);
 
-      expect(await manager.approvals.pause(streamId, buildAction(streamId))).toBe(true);
+      expect(
+        await manager.approvals.pause(
+          streamId,
+          buildAction(streamId, {
+            payload: {
+              type: 'ask_user_question',
+              question: { question: 'Approve deployment?' },
+              tool_call_id: 'ask-2',
+            },
+          }),
+        ),
+      ).toBe(true);
 
       await expect(manager.getJob(streamId)).resolves.toMatchObject({
         status: 'requires_action',
         metadata: { resolvedAskUserQuestions: undefined },
+      });
+    });
+
+    test('a later tool approval retains a legacy answer for cross-replica reconstruction', async () => {
+      const streamId = 'stream-repause-retains-legacy-answer';
+      await manager.createJob(streamId, 'user-1');
+      const firstAction = buildAction(streamId);
+      expect(await manager.approvals.pause(streamId, firstAction)).toBe(true);
+      expect(
+        await manager.approvals.resolve(streamId, firstAction.actionId, {
+          resolvedAskUserQuestions: [
+            {
+              request: 'Which environment?',
+              output: 'staging',
+            },
+          ],
+        }),
+      ).toBe(true);
+
+      expect(await manager.approvals.pause(streamId, buildAction(streamId))).toBe(true);
+
+      await expect(manager.getJob(streamId)).resolves.toMatchObject({
+        status: 'requires_action',
+        metadata: {
+          resolvedAskUserQuestions: [
+            {
+              request: 'Which environment?',
+              output: 'staging',
+            },
+          ],
+        },
       });
     });
 

--- a/packages/api/src/stream/__tests__/pendingAction.spec.ts
+++ b/packages/api/src/stream/__tests__/pendingAction.spec.ts
@@ -60,6 +60,23 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
       }
     });
 
+    test('a later pause clears the resolved answer used to seed the resumed run', async () => {
+      const streamId = 'stream-repause-clears-answer';
+      await manager.createJob(streamId, 'user-1', undefined, {
+        resolvedAskUserQuestion: {
+          request: 'Which environment?',
+          output: 'staging',
+        },
+      });
+
+      expect(await manager.approvals.pause(streamId, buildAction(streamId))).toBe(true);
+
+      await expect(manager.getJob(streamId)).resolves.toMatchObject({
+        status: 'requires_action',
+        metadata: { resolvedAskUserQuestion: undefined },
+      });
+    });
+
     test('persists discovered tools in the same transition that makes the pause visible', async () => {
       const streamId = 'stream-pause-discoveries';
       await manager.createJob(streamId, 'user-1');

--- a/packages/api/src/stream/__tests__/pendingAction.spec.ts
+++ b/packages/api/src/stream/__tests__/pendingAction.spec.ts
@@ -62,18 +62,52 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
 
     test('a later pause clears the resolved answer used to seed the resumed run', async () => {
       const streamId = 'stream-repause-clears-answer';
-      await manager.createJob(streamId, 'user-1', undefined, {
-        resolvedAskUserQuestion: {
-          request: 'Which environment?',
-          output: 'staging',
-        },
-      });
+      await manager.createJob(streamId, 'user-1');
+      const firstAction = buildAction(streamId);
+      expect(await manager.approvals.pause(streamId, firstAction)).toBe(true);
+      expect(
+        await manager.approvals.resolve(streamId, firstAction.actionId, {
+          resolvedAskUserQuestion: {
+            request: 'Which environment?',
+            output: 'staging',
+          },
+        }),
+      ).toBe(true);
 
       expect(await manager.approvals.pause(streamId, buildAction(streamId))).toBe(true);
 
       await expect(manager.getJob(streamId)).resolves.toMatchObject({
         status: 'requires_action',
         metadata: { resolvedAskUserQuestion: undefined },
+      });
+    });
+
+    test('a later pause retains an exact-ID answer for cross-replica reconstruction', async () => {
+      const streamId = 'stream-repause-retains-exact-answer';
+      await manager.createJob(streamId, 'user-1');
+      const firstAction = buildAction(streamId);
+      expect(await manager.approvals.pause(streamId, firstAction)).toBe(true);
+      expect(
+        await manager.approvals.resolve(streamId, firstAction.actionId, {
+          resolvedAskUserQuestion: {
+            request: 'Which environment?',
+            output: 'staging',
+            toolCallId: 'ask-1',
+          },
+        }),
+      ).toBe(true);
+
+      expect(await manager.approvals.pause(streamId, buildAction(streamId))).toBe(true);
+
+      await expect(manager.getJob(streamId)).resolves.toMatchObject({
+        status: 'requires_action',
+        metadata: {
+          resolvedAskUserQuestion: {
+            request: 'Which environment?',
+            output: 'staging',
+            toolCallId: 'ask-1',
+          },
+        },
       });
     });
 

--- a/packages/api/src/stream/__tests__/pendingAction.spec.ts
+++ b/packages/api/src/stream/__tests__/pendingAction.spec.ts
@@ -60,8 +60,8 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
       }
     });
 
-    test('a later pause clears the resolved answer used to seed the resumed run', async () => {
-      const streamId = 'stream-repause-clears-answer';
+    test('a later ask retains a legacy answer for ordered cross-replica reconstruction', async () => {
+      const streamId = 'stream-repause-retains-legacy-answer';
       await manager.createJob(streamId, 'user-1');
       const firstAction = buildAction(streamId);
       expect(await manager.approvals.pause(streamId, firstAction)).toBe(true);
@@ -91,7 +91,14 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
 
       await expect(manager.getJob(streamId)).resolves.toMatchObject({
         status: 'requires_action',
-        metadata: { resolvedAskUserQuestions: undefined },
+        metadata: {
+          resolvedAskUserQuestions: [
+            {
+              request: 'Which environment?',
+              output: 'staging',
+            },
+          ],
+        },
       });
     });
 

--- a/packages/api/src/stream/__tests__/pendingAction.spec.ts
+++ b/packages/api/src/stream/__tests__/pendingAction.spec.ts
@@ -67,10 +67,12 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
       expect(await manager.approvals.pause(streamId, firstAction)).toBe(true);
       expect(
         await manager.approvals.resolve(streamId, firstAction.actionId, {
-          resolvedAskUserQuestion: {
-            request: 'Which environment?',
-            output: 'staging',
-          },
+          resolvedAskUserQuestions: [
+            {
+              request: 'Which environment?',
+              output: 'staging',
+            },
+          ],
         }),
       ).toBe(true);
 
@@ -78,7 +80,7 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
 
       await expect(manager.getJob(streamId)).resolves.toMatchObject({
         status: 'requires_action',
-        metadata: { resolvedAskUserQuestion: undefined },
+        metadata: { resolvedAskUserQuestions: undefined },
       });
     });
 
@@ -89,11 +91,13 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
       expect(await manager.approvals.pause(streamId, firstAction)).toBe(true);
       expect(
         await manager.approvals.resolve(streamId, firstAction.actionId, {
-          resolvedAskUserQuestion: {
-            request: 'Which environment?',
-            output: 'staging',
-            toolCallId: 'ask-1',
-          },
+          resolvedAskUserQuestions: [
+            {
+              request: 'Which environment?',
+              output: 'staging',
+              toolCallId: 'ask-1',
+            },
+          ],
         }),
       ).toBe(true);
 
@@ -102,11 +106,13 @@ describe('ApprovalLifecycle via GenerationJobManager.approvals (in-memory)', () 
       await expect(manager.getJob(streamId)).resolves.toMatchObject({
         status: 'requires_action',
         metadata: {
-          resolvedAskUserQuestion: {
-            request: 'Which environment?',
-            output: 'staging',
-            toolCallId: 'ask-1',
-          },
+          resolvedAskUserQuestions: [
+            {
+              request: 'Which environment?',
+              output: 'staging',
+              toolCallId: 'ask-1',
+            },
+          ],
         },
       });
     });

--- a/packages/api/src/stream/__tests__/steering.spec.ts
+++ b/packages/api/src/stream/__tests__/steering.spec.ts
@@ -580,7 +580,7 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
         const aborting = manager.abortJob(streamId, {
           expectedCreatedAt: job.createdAt,
           transformAbortContent: (content, claimedJob) => {
-            transformedWith = claimedJob.resolvedAskUserQuestion;
+            transformedWith = claimedJob.resolvedAskUserQuestions;
             return content;
           },
         });
@@ -590,10 +590,12 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
             streamId,
             action.actionId,
             {
-              resolvedAskUserQuestion: {
-                request: 'Which environment?',
-                output: 'staging',
-              },
+              resolvedAskUserQuestions: [
+                {
+                  request: 'Which environment?',
+                  output: 'staging',
+                },
+              ],
             },
             job.createdAt,
           ),
@@ -601,10 +603,12 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
         releaseSnapshot?.();
 
         await expect(aborting).resolves.toMatchObject({ success: true });
-        expect(transformedWith).toEqual({
-          request: 'Which environment?',
-          output: 'staging',
-        });
+        expect(transformedWith).toEqual([
+          {
+            request: 'Which environment?',
+            output: 'staging',
+          },
+        ]);
       } finally {
         releaseSnapshot?.();
       }

--- a/packages/api/src/stream/__tests__/steering.spec.ts
+++ b/packages/api/src/stream/__tests__/steering.spec.ts
@@ -1,6 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import { SteerEvents } from 'librechat-data-provider';
-import type { TPendingSteer, Agents } from 'librechat-data-provider';
+import type { TMessageContentParts, TPendingSteer, Agents } from 'librechat-data-provider';
 import type {
   SteerQueueItem,
   IEventTransport,
@@ -645,7 +645,7 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
               output: 'staging',
               progress: 1,
             },
-          };
+          } as unknown as TMessageContentParts;
           return next;
         },
       });

--- a/packages/api/src/stream/__tests__/steering.spec.ts
+++ b/packages/api/src/stream/__tests__/steering.spec.ts
@@ -548,6 +548,68 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
       expect(await manager.steering.peek(streamId)).toEqual([]);
     });
 
+    test('abortJob transforms content with metadata from the winning resume-race snapshot', async () => {
+      const streamId = 'abort-resume-metadata-race';
+      const job = await manager.createJob(streamId, 'user-1');
+      const action = buildPendingAction(
+        buildToolApprovalPayload([
+          { name: 'shell', arguments: { command: 'ls' }, tool_call_id: 'call-1' },
+        ]),
+        { streamId, conversationId: streamId, runId: 'run-1', responseMessageId: 'msg-1' },
+      );
+      expect(await manager.approvals.pause(streamId, action)).toBe(true);
+      jobStore.setContentParts(streamId, [{ type: 'text', text: 'partial' }], job.createdAt);
+
+      const originalGetContentParts = jobStore.getContentParts.bind(jobStore);
+      let signalSnapshotStarted: (() => void) | undefined;
+      const snapshotStarted = new Promise<void>((resolve) => {
+        signalSnapshotStarted = resolve;
+      });
+      let releaseSnapshot: (() => void) | undefined;
+      const snapshotGate = new Promise<void>((resolve) => {
+        releaseSnapshot = resolve;
+      });
+      jest.spyOn(jobStore, 'getContentParts').mockImplementationOnce(async (...args) => {
+        signalSnapshotStarted?.();
+        await snapshotGate;
+        return originalGetContentParts(...args);
+      });
+      let transformedWith: unknown;
+
+      try {
+        const aborting = manager.abortJob(streamId, {
+          expectedCreatedAt: job.createdAt,
+          transformAbortContent: (content, claimedJob) => {
+            transformedWith = claimedJob.resolvedAskUserQuestion;
+            return content;
+          },
+        });
+        await snapshotStarted;
+        await expect(
+          manager.approvals.resolve(
+            streamId,
+            action.actionId,
+            {
+              resolvedAskUserQuestion: {
+                request: 'Which environment?',
+                output: 'staging',
+              },
+            },
+            job.createdAt,
+          ),
+        ).resolves.toBe(true);
+        releaseSnapshot?.();
+
+        await expect(aborting).resolves.toMatchObject({ success: true });
+        expect(transformedWith).toEqual({
+          request: 'Which environment?',
+          output: 'staging',
+        });
+      } finally {
+        releaseSnapshot?.();
+      }
+    });
+
     test('abortJob publishes nothing when natural completion wins its terminal CAS', async () => {
       const streamId = 'steer-abort-loses-terminal-race';
       const eventTransport = new InMemoryEventTransport();

--- a/packages/api/src/stream/__tests__/steering.spec.ts
+++ b/packages/api/src/stream/__tests__/steering.spec.ts
@@ -614,6 +614,46 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
       }
     });
 
+    test('abortJob transforms content before filtering shifts reconstructed indices', async () => {
+      const streamId = 'abort-transform-before-filter';
+      const job = await manager.createJob(streamId, 'user-1');
+      jobStore.setContentParts(
+        streamId,
+        [
+          { type: 'text', text: '' },
+          {
+            type: 'tool_call',
+            tool_call: { id: 'ask-1', name: 'ask_user_question', args: '' },
+          },
+        ],
+        job.createdAt,
+      );
+
+      const result = await manager.abortJob(streamId, {
+        expectedCreatedAt: job.createdAt,
+        transformAbortContent: (content) => {
+          expect(content).toHaveLength(2);
+          const next = [...content];
+          next[1] = {
+            ...next[1],
+            tool_call: {
+              ...next[1].tool_call,
+              output: 'staging',
+              progress: 1,
+            },
+          };
+          return next;
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.content).toEqual([
+        expect.objectContaining({
+          tool_call: expect.objectContaining({ output: 'staging', progress: 1 }),
+        }),
+      ]);
+    });
+
     test('abortJob publishes nothing when natural completion wins its terminal CAS', async () => {
       const streamId = 'steer-abort-loses-terminal-race';
       const eventTransport = new InMemoryEventTransport();

--- a/packages/api/src/stream/__tests__/steering.spec.ts
+++ b/packages/api/src/stream/__tests__/steering.spec.ts
@@ -633,11 +633,15 @@ describe('SteeringLifecycle via GenerationJobManager.steering (in-memory)', () =
         expectedCreatedAt: job.createdAt,
         transformAbortContent: (content) => {
           expect(content).toHaveLength(2);
+          const askPart = content[1];
+          if (askPart?.type !== 'tool_call' || !('tool_call' in askPart)) {
+            throw new Error('Expected reconstructed ask tool call at index 1');
+          }
           const next = [...content];
           next[1] = {
-            ...next[1],
+            ...askPart,
             tool_call: {
-              ...next[1].tool_call,
+              ...askPart.tool_call,
               output: 'staging',
               progress: 1,
             },

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -4253,7 +4253,9 @@ export class RedisJobStore implements IJobStoreV2 {
         return (
           requestOk &&
           typeof answer.output === 'string' &&
-          (answer.toolCallId == null || typeof answer.toolCallId === 'string')
+          (answer.toolCallId == null || typeof answer.toolCallId === 'string') &&
+          (answer.contentIndex == null ||
+            (Number.isSafeInteger(answer.contentIndex) && answer.contentIndex >= 0))
         );
       });
       if (!valid || parsed.length === 0) {

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -22,8 +22,8 @@ import type {
   SteerReceipt,
   SteerReceiptInput,
   ParkedSteerClaim,
-  ResolvedAskUserQuestion,
 } from '~/stream/interfaces/IJobStore';
+import type { ResolvedAskUserQuestion } from '~/agents/hitl/resume';
 import type { RecoveredSteerPayload } from '~/stream/SteerRecovery';
 import {
   JobCreationSupersededError,
@@ -4070,7 +4070,7 @@ export class RedisJobStore implements IJobStoreV2 {
       contextUsage: data.contextUsage || undefined,
       tokenUsage: data.tokenUsage || undefined,
       pendingAction: this.parsePendingAction(data.pendingAction),
-      resolvedAskUserQuestion: this.parseResolvedAskUserQuestion(data.resolvedAskUserQuestion),
+      resolvedAskUserQuestions: this.parseResolvedAskUserQuestions(data.resolvedAskUserQuestions),
       pendingActionId: data.pendingActionId || undefined,
       lastActiveAt: data.lastActiveAt ? parseInt(data.lastActiveAt, 10) : undefined,
       /** `markActivityLabels` persists this, so it has to be read back:
@@ -4226,34 +4226,43 @@ export class RedisJobStore implements IJobStoreV2 {
   }
 
   /** Parse the accepted ask answer retained across resume ownership transfer. */
-  private parseResolvedAskUserQuestion(
+  private parseResolvedAskUserQuestions(
     raw: string | undefined,
-  ): ResolvedAskUserQuestion | undefined {
+  ): ResolvedAskUserQuestion[] | undefined {
     if (!raw) {
       return undefined;
     }
     try {
       const value = JSON.parse(raw) as unknown;
-      if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-        logger.warn('[RedisJobStore] Dropping malformed resolvedAskUserQuestion record');
+      if (!Array.isArray(value)) {
+        logger.warn('[RedisJobStore] Dropping malformed resolvedAskUserQuestions record');
         return undefined;
       }
-      const parsed = value as ResolvedAskUserQuestion;
-      const request = parsed.request;
-      const requestOk =
-        typeof request === 'string' ||
-        (request != null &&
-          typeof request === 'object' &&
-          (typeof (request as Agents.AskUserQuestionRequest).question === 'string' ||
-            Array.isArray((request as Agents.AskUserQuestionsRequest).questions)));
-      const toolCallIdOk = parsed.toolCallId == null || typeof parsed.toolCallId === 'string';
-      if (!requestOk || typeof parsed.output !== 'string' || !toolCallIdOk) {
-        logger.warn('[RedisJobStore] Dropping malformed resolvedAskUserQuestion record');
+      const parsed = value as ResolvedAskUserQuestion[];
+      const valid = parsed.every((answer) => {
+        if (answer == null || typeof answer !== 'object' || Array.isArray(answer)) {
+          return false;
+        }
+        const request = answer.request;
+        const requestOk =
+          typeof request === 'string' ||
+          (request != null &&
+            typeof request === 'object' &&
+            (typeof (request as Agents.AskUserQuestionRequest).question === 'string' ||
+              Array.isArray((request as Agents.AskUserQuestionsRequest).questions)));
+        return (
+          requestOk &&
+          typeof answer.output === 'string' &&
+          (answer.toolCallId == null || typeof answer.toolCallId === 'string')
+        );
+      });
+      if (!valid || parsed.length === 0) {
+        logger.warn('[RedisJobStore] Dropping malformed resolvedAskUserQuestions record');
         return undefined;
       }
       return parsed;
     } catch {
-      logger.warn('[RedisJobStore] Dropping unparseable resolvedAskUserQuestion record');
+      logger.warn('[RedisJobStore] Dropping unparseable resolvedAskUserQuestions record');
       return undefined;
     }
   }

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -22,6 +22,7 @@ import type {
   SteerReceipt,
   SteerReceiptInput,
   ParkedSteerClaim,
+  ResolvedAskUserQuestion,
 } from '~/stream/interfaces/IJobStore';
 import type { RecoveredSteerPayload } from '~/stream/SteerRecovery';
 import {
@@ -4069,6 +4070,7 @@ export class RedisJobStore implements IJobStoreV2 {
       contextUsage: data.contextUsage || undefined,
       tokenUsage: data.tokenUsage || undefined,
       pendingAction: this.parsePendingAction(data.pendingAction),
+      resolvedAskUserQuestion: this.parseResolvedAskUserQuestion(data.resolvedAskUserQuestion),
       pendingActionId: data.pendingActionId || undefined,
       lastActiveAt: data.lastActiveAt ? parseInt(data.lastActiveAt, 10) : undefined,
       /** `markActivityLabels` persists this, so it has to be read back:
@@ -4219,6 +4221,34 @@ export class RedisJobStore implements IJobStoreV2 {
       return parsed;
     } catch {
       logger.warn('[RedisJobStore] Dropping unparseable pendingAction record');
+      return undefined;
+    }
+  }
+
+  /** Parse the accepted ask answer retained across resume ownership transfer. */
+  private parseResolvedAskUserQuestion(
+    raw: string | undefined,
+  ): ResolvedAskUserQuestion | undefined {
+    if (!raw) {
+      return undefined;
+    }
+    try {
+      const parsed = JSON.parse(raw) as ResolvedAskUserQuestion;
+      const request = parsed?.request;
+      const requestOk =
+        typeof request === 'string' ||
+        (request != null &&
+          typeof request === 'object' &&
+          (typeof (request as Agents.AskUserQuestionRequest).question === 'string' ||
+            Array.isArray((request as Agents.AskUserQuestionsRequest).questions)));
+      const toolCallIdOk = parsed.toolCallId == null || typeof parsed.toolCallId === 'string';
+      if (!requestOk || typeof parsed.output !== 'string' || !toolCallIdOk) {
+        logger.warn('[RedisJobStore] Dropping malformed resolvedAskUserQuestion record');
+        return undefined;
+      }
+      return parsed;
+    } catch {
+      logger.warn('[RedisJobStore] Dropping unparseable resolvedAskUserQuestion record');
       return undefined;
     }
   }

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -4255,7 +4255,8 @@ export class RedisJobStore implements IJobStoreV2 {
           typeof answer.output === 'string' &&
           (answer.toolCallId == null || typeof answer.toolCallId === 'string') &&
           (answer.contentIndex == null ||
-            (Number.isSafeInteger(answer.contentIndex) && answer.contentIndex >= 0))
+            (Number.isSafeInteger(answer.contentIndex) && answer.contentIndex >= 0)) &&
+          (answer.contentMissing == null || answer.contentMissing === true)
         );
       });
       if (!valid || parsed.length === 0) {

--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -4233,8 +4233,13 @@ export class RedisJobStore implements IJobStoreV2 {
       return undefined;
     }
     try {
-      const parsed = JSON.parse(raw) as ResolvedAskUserQuestion;
-      const request = parsed?.request;
+      const value = JSON.parse(raw) as unknown;
+      if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+        logger.warn('[RedisJobStore] Dropping malformed resolvedAskUserQuestion record');
+        return undefined;
+      }
+      const parsed = value as ResolvedAskUserQuestion;
+      const request = parsed.request;
       const requestOk =
         typeof request === 'string' ||
         (request != null &&

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -25,6 +25,14 @@ export type JobStatus = 'running' | 'complete' | 'error' | 'aborted' | 'requires
  * Missing markers on pre-rollout records are interpreted as protocol v1. */
 export type GenerationProtocolVersion = 1 | 2;
 
+/** Ask-user answer captured in the same CAS that consumes its pending action. */
+export interface ResolvedAskUserQuestion {
+  /** String supports pending records written before the structured question shape. */
+  request: Agents.AskUserQuestionRequest | Agents.AskUserQuestionsRequest | string;
+  output: string;
+  toolCallId?: string;
+}
+
 /**
  * Serializable job data - no object references, suitable for Redis/external storage
  */
@@ -163,6 +171,12 @@ export interface SerializableJobData {
    */
   pendingAction?: Agents.PendingAction;
 
+  /** Durable bridge between the resume claim and content reconstruction. An
+   * abort can win while the resume controller is still rebuilding the client;
+   * retaining the accepted answer here lets that terminal owner stamp it onto
+   * the persisted partial response instead of losing it with the request. */
+  resolvedAskUserQuestion?: ResolvedAskUserQuestion;
+
   /**
    * Flat mirror of `pendingAction.actionId`, kept as a top-level field so an
    * atomic status transition can guard on it (a nested JSON field can't be
@@ -263,6 +277,7 @@ export type JobMetadataPatch = Partial<
     | 'activityPhaseSnapshot'
     | 'preemptCapable'
     | 'generationProtocolVersion'
+    | 'resolvedAskUserQuestion'
   >
 >;
 

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -1,6 +1,7 @@
 import type { Agents, TFile, TPendingSteer } from 'librechat-data-provider';
 import type { StandardGraph } from '@librechat/agents';
 import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
+import type { ResolvedAskUserQuestion } from '~/agents/hitl/resume';
 import type { RecoveredSteerPayload } from '../SteerRecovery';
 
 /**
@@ -24,14 +25,6 @@ export type JobStatus = 'running' | 'complete' | 'error' | 'aborted' | 'requires
 /** Immutable wire/storage contract selected when a generation is created.
  * Missing markers on pre-rollout records are interpreted as protocol v1. */
 export type GenerationProtocolVersion = 1 | 2;
-
-/** Ask-user answer captured in the same CAS that consumes its pending action. */
-export interface ResolvedAskUserQuestion {
-  /** String supports pending records written before the structured question shape. */
-  request: Agents.AskUserQuestionRequest | Agents.AskUserQuestionsRequest | string;
-  output: string;
-  toolCallId?: string;
-}
 
 /**
  * Serializable job data - no object references, suitable for Redis/external storage
@@ -175,7 +168,7 @@ export interface SerializableJobData {
    * abort can win while the resume controller is still rebuilding the client;
    * retaining the accepted answer here lets that terminal owner stamp it onto
    * the persisted partial response instead of losing it with the request. */
-  resolvedAskUserQuestion?: ResolvedAskUserQuestion;
+  resolvedAskUserQuestions?: ResolvedAskUserQuestion[];
 
   /**
    * Flat mirror of `pendingAction.actionId`, kept as a top-level field so an
@@ -277,7 +270,7 @@ export type JobMetadataPatch = Partial<
     | 'activityPhaseSnapshot'
     | 'preemptCapable'
     | 'generationProtocolVersion'
-    | 'resolvedAskUserQuestion'
+    | 'resolvedAskUserQuestions'
   >
 >;
 

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -1,7 +1,7 @@
 import type { Agents } from 'librechat-data-provider';
 import type { EventEmitter } from 'events';
-import type { ResolvedAskUserQuestion } from '../stream/interfaces/IJobStore';
 import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
+import type { ResolvedAskUserQuestion } from '../agents/hitl/resume';
 import type { ServerSentEvent } from './events';
 
 export interface GenerationJobMetadata {
@@ -53,7 +53,7 @@ export interface GenerationJobMetadata {
   /** Set when the job is paused for human review (status === 'requires_action') */
   pendingAction?: Agents.PendingAction;
   /** Accepted ask-user answer retained until this generation terminalizes. */
-  resolvedAskUserQuestion?: ResolvedAskUserQuestion;
+  resolvedAskUserQuestions?: ResolvedAskUserQuestion[];
 }
 
 export type GenerationJobStatus = 'running' | 'complete' | 'error' | 'aborted' | 'requires_action';

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -1,6 +1,7 @@
 import type { Agents } from 'librechat-data-provider';
 import type { EventEmitter } from 'events';
 import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
+import type { ResolvedAskUserQuestion } from '../stream/interfaces/IJobStore';
 import type { ServerSentEvent } from './events';
 
 export interface GenerationJobMetadata {
@@ -51,6 +52,8 @@ export interface GenerationJobMetadata {
   terminalPersistenceStartedAt?: number;
   /** Set when the job is paused for human review (status === 'requires_action') */
   pendingAction?: Agents.PendingAction;
+  /** Accepted ask-user answer retained until this generation terminalizes. */
+  resolvedAskUserQuestion?: ResolvedAskUserQuestion;
 }
 
 export type GenerationJobStatus = 'running' | 'complete' | 'error' | 'aborted' | 'requires_action';

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -1,7 +1,7 @@
 import type { Agents } from 'librechat-data-provider';
 import type { EventEmitter } from 'events';
-import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
 import type { ResolvedAskUserQuestion } from '../stream/interfaces/IJobStore';
+import type { ActivityPhaseSnapshot } from '~/agents/activityPhases/runtime';
 import type { ServerSentEvent } from './events';
 
 export interface GenerationJobMetadata {


### PR DESCRIPTION
## Summary

I fixed two elicitation races that could lose or temporarily misplace a submitted `ask_user_question` answer.

- Persist the accepted question and answer in the same Redis-backed CAS that consumes the pending action, so Stop can reconstruct the answered tool call while resume initialization is still in flight.
- Restore the durable answer in the abort payload and partial message before publishing the terminal event, including checkpoint cleanup when tool approval is disabled.
- Preserve sparse absolute content indices when removing the answered synthetic question card, preventing older parts from shifting into resumed text slots during streaming.
- Validate Redis deserialization and cover free-form answers, batched answers, abort-during-resume persistence, and sparse SSE ordering.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Built `packages/api` with `tsdown`.
- Ran `api/server/controllers/agents/__tests__/resume.spec.js` and `api/server/routes/agents/__tests__/abort.spec.js`: 94 tests passed.
- Ran `client/src/hooks/SSE/__tests__/useStepHandler.spec.ts`: 81 tests passed.
- Ran `packages/api/src/stream/__tests__/RedisJobStore.spec.ts`: 19 tests passed.

### **Test Configuration**:

- Node.js 24.16.0
- Focused Jest suites with `@librechat/agents` 3.4.5

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes