### PR TITLE
perf(auth): enable user document cache with Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -991,6 +991,8 @@ HELP_AND_FAQ_URL=https://librechat.ai
 
 # Enable Redis for caching and session storage
 # USE_REDIS=true
+# Cache authenticated user documents for 5 seconds when Redis is enabled (defaults to on)
+# AUTH_USER_CACHE_MODE=off
 # Enable Redis for resumable LLM streams (defaults to USE_REDIS value if not set)
 # Set to false to use in-memory storage for streams while keeping Redis for other caches
 # USE_REDIS_STREAMS=true

--- a/packages/api/src/auth/userDocCache.spec.ts
+++ b/packages/api/src/auth/userDocCache.spec.ts
@@ -64,13 +64,11 @@ describe('auth user document cache helpers', () => {
     restoreEnv();
   });
 
-  it('only enables user request burst caching when Redis backs the auth user namespace', () => {
-    process.env.AUTH_USER_CACHE_MODE = 'on';
+  it('defaults user request burst caching on when Redis backs the auth user namespace', () => {
+    delete process.env.AUTH_USER_CACHE_MODE;
     cacheConfig.USE_REDIS = false;
     expect(getAuthUserDocCacheMode()).toBe('off');
-    expect(logger.warn).toHaveBeenCalledWith(
-      '[authUserDocCache] User request burst caching requires Redis; disabling auth user cache',
-    );
+    expect(logger.warn).not.toHaveBeenCalled();
 
     cacheConfig.USE_REDIS = true;
     cacheConfig.FORCED_IN_MEMORY_CACHE_NAMESPACES = [CacheKeys.AUTH_USER_DOC];
@@ -79,11 +77,18 @@ describe('auth user document cache helpers', () => {
     cacheConfig.FORCED_IN_MEMORY_CACHE_NAMESPACES = [CacheKeys.APP_CONFIG];
     expect(getAuthUserDocCacheMode()).toBe('on');
 
-    process.env.AUTH_USER_CACHE_MODE = 'shadow';
+    process.env.AUTH_USER_CACHE_MODE = 'off';
     expect(getAuthUserDocCacheMode()).toBe('off');
 
     process.env.AUTH_USER_CACHE_MODE = 'invalid';
     expect(getAuthUserDocCacheMode()).toBe('off');
+
+    process.env.AUTH_USER_CACHE_MODE = 'on';
+    cacheConfig.USE_REDIS = false;
+    expect(getAuthUserDocCacheMode()).toBe('off');
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[authUserDocCache] User request burst caching requires Redis; disabling auth user cache',
+    );
   });
 
   it('builds stable keys from strategy, subject, issuer, and scope', () => {

--- a/packages/api/src/auth/userDocCache.ts
+++ b/packages/api/src/auth/userDocCache.ts
@@ -52,11 +52,12 @@ function isAuthUserDocCacheRedisBacked(): boolean {
 }
 
 export function getAuthUserDocCacheMode(): AuthUserDocCacheMode {
-  if (process.env.AUTH_USER_CACHE_MODE !== 'on') {
+  const configuredMode = process.env.AUTH_USER_CACHE_MODE;
+  if (configuredMode !== undefined && configuredMode !== 'on') {
     return 'off';
   }
   if (!isAuthUserDocCacheRedisBacked()) {
-    if (!warnedAuthUserDocCacheRequiresRedis) {
+    if (configuredMode === 'on' && !warnedAuthUserDocCacheRequiresRedis) {
       warnedAuthUserDocCacheRequiresRedis = true;
       logger.warn(
         '[authUserDocCache] User request burst caching requires Redis; disabling auth user cache',

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -914,7 +914,6 @@ describe('deleteRoleByName', () => {
   });
 
   it('invalidates cached auth user documents for reassigned users', async () => {
-    process.env.AUTH_USER_CACHE_MODE = 'on';
     await createRoleByName({ name: 'editor' });
     const [alice, bob] = await User.create([
       { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
@@ -1067,7 +1066,6 @@ describe('updateUsersByRole', () => {
   });
 
   it('invalidates cached auth user documents for migrated users', async () => {
-    process.env.AUTH_USER_CACHE_MODE = 'on';
     const [alice, bob] = await User.create([
       { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
       { name: 'Bob', email: 'bob@test.com', role: 'editor', username: 'bob' },
@@ -1098,7 +1096,6 @@ describe('updateUsersByRole', () => {
 
 describe('updateUsersRoleByIds', () => {
   it('invalidates cached auth user documents for explicitly reassigned users', async () => {
-    process.env.AUTH_USER_CACHE_MODE = 'on';
     const [alice, bob] = await User.create([
       { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
       { name: 'Bob', email: 'bob@test.com', role: 'viewer', username: 'bob' },

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -20,7 +20,8 @@ function isSystemRoleName(name: string): boolean {
 }
 
 function isAuthUserDocCacheEnabled(): boolean {
-  return process.env.AUTH_USER_CACHE_MODE === 'on';
+  const configuredMode = process.env.AUTH_USER_CACHE_MODE;
+  return configuredMode === undefined || configuredMode === 'on';
 }
 
 export class RoleConflictError extends Error {

--- a/packages/data-schemas/src/methods/user.methods.spec.ts
+++ b/packages/data-schemas/src/methods/user.methods.spec.ts
@@ -30,10 +30,6 @@ function restoreAuthUserCacheEnv() {
   }
 }
 
-function enableAuthUserDocCache() {
-  process.env.AUTH_USER_CACHE_MODE = 'on';
-}
-
 beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create();
   const mongoUri = mongoServer.getUri();
@@ -348,7 +344,6 @@ describe('User Methods - Database Tests', () => {
     });
 
     test('should invalidate cached auth user documents on update', async () => {
-      enableAuthUserDocCache();
       const user = await User.create({
         name: 'Cached Auth User',
         email: 'cached-auth@example.com',
@@ -374,7 +369,6 @@ describe('User Methods - Database Tests', () => {
     });
 
     test('should invalidate cached auth user documents on delete', async () => {
-      enableAuthUserDocCache();
       const user = await User.create({
         name: 'Deleted Cached Auth User',
         email: 'deleted-cached-auth@example.com',
@@ -558,7 +552,6 @@ describe('User Methods - Database Tests', () => {
     });
 
     test('should invalidate cached auth user documents on acceptance', async () => {
-      enableAuthUserDocCache();
       const user = await User.create({
         name: 'Cached Terms User',
         email: 'cached-terms@example.com',
@@ -804,7 +797,6 @@ describe('User Methods - Database Tests', () => {
     });
 
     test('should invalidate cached auth user documents when memories preference changes', async () => {
-      enableAuthUserDocCache();
       const user = await User.create({
         name: 'Cached Memory User',
         email: 'cached-memory@example.com',

--- a/packages/data-schemas/src/methods/user.ts
+++ b/packages/data-schemas/src/methods/user.ts
@@ -17,7 +17,8 @@ interface UserMethodDeps {
 }
 
 function isAuthUserDocCacheEnabled(): boolean {
-  return process.env.AUTH_USER_CACHE_MODE === 'on';
+  const configuredMode = process.env.AUTH_USER_CACHE_MODE;
+  return configuredMode === undefined || configuredMode === 'on';
 }
 
 /** Factory function that takes mongoose instance and returns the methods */


### PR DESCRIPTION
## Summary

- enable the 5-second authenticated user document cache by default when Redis backs the cache namespace
- keep `AUTH_USER_CACHE_MODE=off` as an explicit opt-out and preserve invalid values as disabled
- align user and role mutation invalidation with the new default
- document the opt-out in `.env.example`

Follow-up to #14187.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- built `data-provider`, `data-schemas`, and `api`
- ran the focused auth user document cache Jest suite
- ran the focused user and role method Jest suites against `mongodb-memory-server`
- ran ESLint and Prettier checks on the changed source and test files
- ran `git diff --check`

### **Test Configuration**:

- Node.js 24.14.1
- 3 test suites, 141 tests passed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes