### PR TITLE
🔊 fix: Exclude Reasoning Content From Manual Read Aloud

### DIFF
--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -12,10 +12,10 @@ import {
 import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
 import { Fork } from '~/components/Conversations';
+import { cn, getAllContentText } from '~/utils';
 import { hoverButtonClasses } from './styles';
 import MessageAudio from './MessageAudio';
 import Feedback from './Feedback';
-import { cn } from '~/utils';
 import store from '~/store';
 
 type THoverButtons = {
@@ -45,38 +45,6 @@ type HoverButtonProps = {
   buttonStyle?: string;
   dataTestId?: string;
   disabled?: boolean;
-};
-
-const extractMessageContent = (message: TMessage): string => {
-  if (typeof message.content === 'string') {
-    return message.content;
-  }
-
-  if (Array.isArray(message.content)) {
-    return message.content
-      .map((part) => {
-        if (part == null) {
-          return '';
-        }
-        if (typeof part === 'string') {
-          return part;
-        }
-        if ('text' in part) {
-          return part.text || '';
-        }
-        if ('think' in part) {
-          const think = part.think;
-          if (typeof think === 'string') {
-            return think;
-          }
-          return think && 'text' in think ? think.text || '' : '';
-        }
-        return '';
-      })
-      .join('');
-  }
-
-  return message.text || '';
 };
 
 const HoverButton = memo(
@@ -192,7 +160,7 @@ const HoverButtons = ({
           index={index}
           isLast={isLast}
           messageId={message.messageId}
-          content={extractMessageContent(message)}
+          content={getAllContentText(message)}
           renderButton={(props) => (
             <HoverButton
               onClick={props.onClick}

--- a/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
@@ -8,10 +8,21 @@ import {
   EModelEndpoint,
   type TConversation,
   type TMessage,
+  type TMessageContentParts,
 } from 'librechat-data-provider';
 import { hasCopyableText } from '~/hooks/Messages/useCopyToClipboard';
 import HoverButtons from '~/components/Chat/Messages/HoverButtons';
 import store from '~/store';
+
+const mockAudioContent = jest.fn();
+
+jest.mock('~/components/Chat/Messages/MessageAudio', () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => {
+    mockAudioContent(content);
+    return null;
+  },
+}));
 
 const conversation = {
   conversationId: 'convo-1',
@@ -71,6 +82,134 @@ function renderHoverButtons({
 
   return container;
 }
+
+function renderReadAloudContent(message: TMessage): string {
+  mockAudioContent.mockClear();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const initializeState = ({ set }: MutableSnapshot) => set(store.textToSpeech, true);
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot initializeState={initializeState}>
+        <MemoryRouter>
+          <HoverButtons
+            index={0}
+            isLast={true}
+            isEditing={false}
+            message={message}
+            conversation={conversation}
+            isSubmitting={false}
+            enterEdit={jest.fn()}
+            regenerate={jest.fn()}
+            handleContinue={jest.fn()}
+            copyToClipboard={jest.fn()}
+            getCanCopy={() => hasCopyableText({ text: message.text, content: message.content })}
+            latestMessageId={message.messageId}
+          />
+        </MemoryRouter>
+      </RecoilRoot>
+    </QueryClientProvider>,
+  );
+
+  expect(mockAudioContent).toHaveBeenCalled();
+  return mockAudioContent.mock.calls[0][0] as string;
+}
+
+const assistantMessage = (overrides: Partial<TMessage>): TMessage =>
+  ({
+    messageId: 'assistant-1',
+    conversationId: 'convo-1',
+    parentMessageId: 'user-1',
+    isCreatedByUser: false,
+    text: '',
+    ...overrides,
+  }) as TMessage;
+
+describe('HoverButtons read aloud content', () => {
+  it('omits reasoning parts so speech matches the visible answer', () => {
+    const content = renderReadAloudContent(
+      assistantMessage({
+        content: [
+          { type: ContentTypes.THINK, think: 'the user wants a haiku, let me count syllables' },
+          { type: ContentTypes.TEXT, text: 'Here is your haiku.' },
+        ] as TMessageContentParts[],
+      }),
+    );
+
+    expect(content).toBe('Here is your haiku.');
+    expect(content).not.toMatch(/syllables/);
+  });
+
+  it('excludes reasoning whether `think` is a string or an object', () => {
+    const content = renderReadAloudContent(
+      assistantMessage({
+        content: [
+          { type: ContentTypes.THINK, think: 'string form reasoning' },
+          { type: ContentTypes.THINK, think: { value: 'object form reasoning' } },
+          { type: ContentTypes.TEXT, text: 'Answer.' },
+        ] as unknown as TMessageContentParts[],
+      }),
+    );
+
+    expect(content).toBe('Answer.');
+  });
+
+  it('reads every text part in order, not just the latest', () => {
+    const content = renderReadAloudContent(
+      assistantMessage({
+        content: [
+          { type: ContentTypes.TEXT, text: 'First part.' },
+          { type: ContentTypes.THINK, think: 'hidden reasoning' },
+          { type: ContentTypes.TEXT, text: 'Second part.' },
+        ] as TMessageContentParts[],
+      }),
+    );
+
+    expect(content).toContain('First part.');
+    expect(content).toContain('Second part.');
+    expect(content.indexOf('First part.')).toBeLessThan(content.indexOf('Second part.'));
+    expect(content).not.toMatch(/hidden reasoning/);
+  });
+
+  it('passes through a plain-text message unchanged', () => {
+    const content = renderReadAloudContent(assistantMessage({ text: 'A simple reply.' }));
+
+    expect(content).toBe('A simple reply.');
+  });
+
+  /** An aborted run persists `content` alongside a `text` copy that still carries
+   *  THINK parts, so the parts array must win over the flattened text. */
+  it('omits reasoning from an aborted message that persisted text alongside content', () => {
+    const content = renderReadAloudContent(
+      assistantMessage({
+        text: 'weighing the options here Partial answer.',
+        content: [
+          { type: ContentTypes.THINK, think: 'weighing the options here' },
+          { type: ContentTypes.TEXT, text: 'Partial answer.' },
+        ] as TMessageContentParts[],
+      }),
+    );
+
+    expect(content).toBe('Partial answer.');
+    expect(content).not.toMatch(/weighing the options/);
+  });
+
+  it('ignores non-text parts such as tool calls', () => {
+    const content = renderReadAloudContent(
+      assistantMessage({
+        content: [
+          { type: ContentTypes.TOOL_CALL, tool_call: { name: 'search', args: 'weather' } },
+          { type: ContentTypes.TEXT, text: 'It is sunny.' },
+        ] as unknown as TMessageContentParts[],
+      }),
+    );
+
+    expect(content).toBe('It is sunny.');
+  });
+});
 
 describe('HoverButtons edit affordance', () => {
   it('keeps edit available on an earlier message while a generation is in flight', () => {

--- a/client/src/utils/__tests__/messages.test.ts
+++ b/client/src/utils/__tests__/messages.test.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
-import { Constants, QueryKeys } from 'librechat-data-provider';
-import type { TMessage, TConversation } from 'librechat-data-provider';
+import { Constants, ContentTypes, QueryKeys } from 'librechat-data-provider';
+import type { TMessage, TConversation, TMessageContentParts } from 'librechat-data-provider';
 import type { TEndpointsConfig } from 'librechat-data-provider';
 import type { LocalizeFunction, TMessageProps } from '~/common';
 import {
@@ -8,6 +8,7 @@ import {
   clearArchivedConversationMessagesCache,
   clearDeletedConversationMessagesCache,
   isValidTimestamp,
+  getAllContentText,
   getMessageAriaLabel,
   getMessageTimestamp,
   getHeaderPrefixForScreenReader,
@@ -165,6 +166,82 @@ describe('clearArchivedConversationMessagesCache', () => {
     expect(queryClient.getQueryData([QueryKeys.messages, Constants.NEW_CONVO])).toEqual(
       newConversationMessages,
     );
+  });
+});
+
+describe('getAllContentText', () => {
+  it('returns an empty string for a missing message', () => {
+    expect(getAllContentText(null)).toBe('');
+  });
+
+  it('falls back to `text` when there are no content parts', () => {
+    expect(getAllContentText(makeMessage({ text: 'legacy reply' }))).toBe('legacy reply');
+  });
+
+  it('falls back to `text` when content holds no readable text parts', () => {
+    const msg = makeMessage({
+      text: 'flattened reply',
+      content: [
+        { type: ContentTypes.TOOL_CALL, tool_call: { name: 'search' } },
+      ] as unknown as TMessageContentParts[],
+    });
+    expect(getAllContentText(msg)).toBe('flattened reply');
+  });
+
+  /** a11y: the error text stays available to announce, so the THINK guard must
+   *  stay keyed to reasoning rather than skipping every non-text part. */
+  it('falls back to `text` for error-only content', () => {
+    const msg = makeMessage({
+      text: 'Something went wrong.',
+      content: [
+        { type: ContentTypes.ERROR, error: 'Something went wrong.' },
+      ] as unknown as TMessageContentParts[],
+    });
+    expect(getAllContentText(msg)).toBe('Something went wrong.');
+  });
+
+  /** Aborting before the first answer token leaves `text` holding only the
+   *  reasoning, so there is nothing safe to fall back to. */
+  it('returns an empty string for reasoning-only content', () => {
+    const msg = makeMessage({
+      text: 'reasoning only',
+      content: [
+        { type: ContentTypes.THINK, think: 'reasoning only' },
+      ] as unknown as TMessageContentParts[],
+    });
+    expect(getAllContentText(msg)).toBe('');
+  });
+
+  it('returns an empty string when reasoning is paired only with a tool call', () => {
+    const msg = makeMessage({
+      text: 'reasoning only',
+      content: [
+        { type: ContentTypes.THINK, think: 'reasoning only' },
+        { type: ContentTypes.TOOL_CALL, tool_call: { name: 'search' } },
+      ] as unknown as TMessageContentParts[],
+    });
+    expect(getAllContentText(msg)).toBe('');
+  });
+
+  it('prefers content parts over `text`, dropping reasoning from aborted runs', () => {
+    const msg = makeMessage({
+      text: 'reasoning leak Partial answer.',
+      content: [
+        { type: ContentTypes.THINK, think: 'reasoning leak' },
+        { type: ContentTypes.TEXT, text: 'Partial answer.' },
+      ] as unknown as TMessageContentParts[],
+    });
+    expect(getAllContentText(msg)).toBe('Partial answer.');
+  });
+
+  it('joins every text part in order', () => {
+    const msg = makeMessage({
+      content: [
+        { type: ContentTypes.TEXT, text: 'first' },
+        { type: ContentTypes.TEXT, text: { value: 'second' } },
+      ] as unknown as TMessageContentParts[],
+    });
+    expect(getAllContentText(msg)).toBe('first\nsecond');
   });
 });
 

--- a/client/src/utils/messages.ts
+++ b/client/src/utils/messages.ts
@@ -167,17 +167,21 @@ export const getLatestText = (message?: TMessage | null, includeIndex?: boolean)
   return '';
 };
 
+/**
+ * Spoken/announced text for a message: the answer only, never reasoning.
+ * `content` wins over `text` because an aborted run persists both, with the
+ * `text` copy including THINK parts — reading it aloud would leak reasoning.
+ * Reasoning-bearing content without any answer yields an empty string rather
+ * than falling back to that same `text` copy, which aborting before the first
+ * answer token leaves holding nothing but the reasoning.
+ */
 export const getAllContentText = (message?: TMessage | null): string => {
   if (!message) {
     return '';
   }
 
-  if (message.text) {
-    return message.text;
-  }
-
   if (message.content && message.content.length > 0) {
-    return message.content
+    const contentText = message.content
       .filter((part) => part != null && part.type === ContentTypes.TEXT)
       .map((part) => {
         if (!('text' in part)) return '';
@@ -187,9 +191,17 @@ export const getAllContentText = (message?: TMessage | null): string => {
       })
       .filter((text) => text.length > 0)
       .join('\n');
+
+    if (contentText.length > 0) {
+      return contentText;
+    }
+
+    if (message.content.some((part) => part?.type === ContentTypes.THINK)) {
+      return '';
+    }
   }
 
-  return '';
+  return message.text || '';
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes #14750

The manual "Read aloud" button used a local helper that flattened every content part — including reasoning — so TTS spoke the model's thoughts alongside the answer, while automatic playback already filtered them out. The button now reuses `getAllContentText`, the same extraction the screen-reader announcement path uses, and the duplicated helper is removed.

`getAllContentText` itself needed its precedence flipped: an aborted run persists both content parts and a flattened `text` copy that still contains the reasoning, so returning `text` first re-leaked reasoning for stopped messages. Content parts now win whenever they yield answer text; `message.text` remains the fallback for messages without content parts. When a stopped response never reached its first answer token, `content` holds only reasoning parts and `text` is that same reasoning re-flattened — the helper now returns an empty string there instead of falling back. Error-only content still falls back to `text`, which is what the helper already did on `dev` (it returned `text` first). In the common agent flow that `text` is empty, so this is behaviour preservation for the announcement path rather than a new announcement (pinned by a test).

This also fixes the same leak in the screen-reader announcement at stream end (`useEventHandlers`), the helper's only other consumer. Note: multiple text parts are now joined with `\n` instead of the removed helper's `''`.

Since #14770, the read-aloud button itself is hidden for error messages and while a response is still streaming, so the error-only `text` fallback mainly matters for the screen-reader announcement path, which has no such guard.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New unit coverage for `getAllContentText` (previously none): multi-part ordering, string/object text forms, think-only and think+tool_call aborted shapes → empty string, error-only → `text` fallback, plain-text messages.
- Component tests for the read-aloud button: reasoning excluded (string and object `think`), multi-part answers, the aborted-message shape, non-text parts ignored.
- Each stage was verified red-first: without the changes, exactly the targeted tests fail with reasoning strings in the spoken content.
- Client suites around the change (utils, Chat/Messages, hooks/SSE, hooks/Audio, hooks/Input, hooks/Messages): the two touched spec files pass 71/71; the wider run is green apart from six suites that already fail identically on current dev, unrelated to this change. ESLint and import-order checks clean.

### **Test Configuration**:

```
cd client && npx jest src/utils/__tests__/messages.test.ts src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes


