### PR TITLE
Add MiniMax text-to-speech provider

### DIFF
--- a/api/server/services/Files/Audio/TTSService.js
+++ b/api/server/services/Files/Audio/TTSService.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { Readable } = require('stream');
 const { logger } = require('@librechat/data-schemas');
 const {
   genAzureEndpoint,
@@ -10,6 +11,11 @@ const {
 const { extractEnvVariable, TTSProviders } = require('librechat-data-provider');
 const { getRandomVoiceId, createChunkProcessor, splitTextIntoChunks } = require('./streamAudio');
 const { getAppConfig } = require('~/server/services/Config');
+
+const MINIMAX_TTS_ENDPOINTS = {
+  global_en: 'https://api.minimax.io/v1/t2a_v2',
+  cn_zh: 'https://api.minimaxi.com/v1/t2a_v2',
+};
 
 /**
  * Service class for handling Text-to-Speech (TTS) operations.
@@ -25,6 +31,7 @@ class TTSService {
       [TTSProviders.AZURE_OPENAI]: this.azureOpenAIProvider.bind(this),
       [TTSProviders.ELEVENLABS]: this.elevenLabsProvider.bind(this),
       [TTSProviders.LOCALAI]: this.localAIProvider.bind(this),
+      [TTSProviders.MINIMAX]: this.miniMaxProvider.bind(this),
     };
   }
 
@@ -248,6 +255,75 @@ class TTSService {
   }
 
   /**
+   * Prepares the request for MiniMax TTS provider.
+   * @param {Object} ttsSchema - The TTS schema for MiniMax.
+   * @param {string} input - The input text.
+   * @param {string} voice - The selected voice.
+   * @returns {Array} An array containing the URL, data, and headers for the request.
+   * @throws {Error} If the selected voice is not available.
+   */
+  miniMaxProvider(ttsSchema, input, voice) {
+    const url = ttsSchema?.url || MINIMAX_TTS_ENDPOINTS[ttsSchema?.region || 'global_en'];
+
+    if (
+      ttsSchema?.voices &&
+      ttsSchema.voices.length > 0 &&
+      !ttsSchema.voices.includes(voice) &&
+      !ttsSchema.voices.includes('ALL')
+    ) {
+      throw new Error(`Voice ${voice} is not available.`);
+    }
+
+    const data = {
+      model: ttsSchema?.model,
+      text: input,
+      stream: false,
+      output_format: 'hex',
+      language_boost: ttsSchema?.language_boost,
+      voice_setting: {
+        voice_id: ttsSchema?.voices && ttsSchema.voices.length > 0 ? voice : undefined,
+        ...ttsSchema?.voice_settings,
+      },
+      audio_setting: {
+        format: 'mp3',
+        ...ttsSchema?.audio_settings,
+      },
+    };
+
+    const apiKey = resolveConfigSecret(ttsSchema?.apiKey) || '';
+    const headers = {
+      'Content-Type': 'application/json',
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+    };
+
+    return [url, data, headers];
+  }
+
+  /**
+   * Converts a MiniMax JSON response into the audio stream expected by callers.
+   * @param {Object} response - The Axios response object.
+   * @returns {Object} The Axios response with a readable audio stream.
+   */
+  parseMiniMaxResponse(response) {
+    const statusCode = response.data?.base_resp?.status_code;
+    if (statusCode !== 0) {
+      throw new Error(`MiniMax TTS request failed with status code ${statusCode}`);
+    }
+
+    const audio = response.data?.data?.audio;
+    if (
+      typeof audio !== 'string' ||
+      audio.length === 0 ||
+      audio.length % 2 !== 0 ||
+      /[^\da-f]/i.test(audio)
+    ) {
+      throw new Error('MiniMax TTS response did not contain valid hex audio');
+    }
+
+    return { ...response, data: Readable.from(Buffer.from(audio, 'hex')) };
+  }
+
+  /**
    * Sends a TTS request to the specified provider.
    * @async
    * @param {string} provider - The TTS provider to use.
@@ -270,13 +346,22 @@ class TTSService {
 
     [data, headers].forEach(this.removeUndefined.bind(this));
 
-    const options = { headers, responseType: stream ? 'stream' : 'arraybuffer' };
+    const isMiniMax = provider === TTSProviders.MINIMAX;
+    let responseType = stream ? 'stream' : 'arraybuffer';
+    if (isMiniMax) {
+      responseType = 'json';
+    }
+    const options = {
+      headers,
+      responseType,
+    };
 
     applyAxiosProxyConfig(options, url);
     applySSRFSafeAgentIfDirect(options, url, allowedAddresses);
 
     try {
-      return await axios.post(url, data, options);
+      const response = await axios.post(url, data, options);
+      return isMiniMax ? this.parseMiniMaxResponse(response) : response;
     } catch (error) {
       logAxiosError({ message: `TTS request failed for provider ${provider}:`, error });
       throw error;

--- a/api/server/services/Files/Audio/TTSService.spec.js
+++ b/api/server/services/Files/Audio/TTSService.spec.js
@@ -4,6 +4,7 @@ jest.mock('@librechat/api', () => ({
   genAzureEndpoint: jest.fn(),
   logAxiosError: jest.fn(),
   applyAxiosProxyConfig: jest.fn(),
+  applySSRFSafeAgentIfDirect: jest.fn(),
   resolveConfigSecret: jest.fn(),
 }));
 jest.mock('librechat-data-provider', () => ({
@@ -13,6 +14,7 @@ jest.mock('librechat-data-provider', () => ({
     AZURE_OPENAI: 'azureOpenAI',
     ELEVENLABS: 'elevenlabs',
     LOCALAI: 'localai',
+    MINIMAX: 'minimax',
   },
 }));
 jest.mock('./streamAudio', () => ({
@@ -22,6 +24,7 @@ jest.mock('./streamAudio', () => ({
 }));
 jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
 
+const axios = require('axios');
 const { resolveConfigSecret } = require('@librechat/api');
 const { TTSService, getProvider } = require('./TTSService');
 
@@ -68,6 +71,94 @@ describe('TTSService provider header construction with an undecryptable apiKey',
       'voice1',
     );
     expect(headers).not.toHaveProperty('Authorization');
+  });
+
+  it('omits the Authorization header for miniMaxProvider instead of sending "Bearer undefined"', () => {
+    resolveConfigSecret.mockReturnValue(undefined);
+    const [, , headers] = service.miniMaxProvider(
+      { apiKey: 'v3:corrupted', voices: [] },
+      'hi',
+      'English_expressive_narrator',
+    );
+    expect(headers).not.toHaveProperty('Authorization');
+  });
+});
+
+describe('TTSService MiniMax integration', () => {
+  let service;
+
+  beforeEach(() => {
+    service = new TTSService();
+    axios.post.mockReset();
+    resolveConfigSecret.mockReset();
+    resolveConfigSecret.mockReturnValue('resolved-key');
+  });
+
+  it.each([
+    ['global_en', 'https://api.minimax.io/v1/t2a_v2'],
+    ['cn_zh', 'https://api.minimaxi.com/v1/t2a_v2'],
+  ])('maps %s configuration to its regional endpoint', (region, expectedUrl) => {
+    const [url, data, headers] = service.miniMaxProvider(
+      {
+        apiKey: 'configured-key',
+        region,
+        model: 'speech-2.8-hd',
+        voices: ['English_expressive_narrator'],
+        language_boost: 'English',
+        voice_settings: { speed: 1.1 },
+        audio_settings: { format: 'mp3', sample_rate: 32000 },
+      },
+      'Hello',
+      'English_expressive_narrator',
+    );
+
+    expect(url).toBe(expectedUrl);
+    expect(data).toEqual({
+      model: 'speech-2.8-hd',
+      text: 'Hello',
+      stream: false,
+      output_format: 'hex',
+      language_boost: 'English',
+      voice_setting: { voice_id: 'English_expressive_narrator', speed: 1.1 },
+      audio_setting: { format: 'mp3', sample_rate: 32000 },
+    });
+    expect(headers.Authorization).toBe('Bearer resolved-key');
+  });
+
+  it('decodes response audio from hex into a readable stream', async () => {
+    axios.post.mockResolvedValue({
+      data: { data: { audio: '494433' }, base_resp: { status_code: 0 } },
+    });
+
+    const response = await service.ttsRequest(
+      'minimax',
+      {
+        apiKey: 'configured-key',
+        region: 'global_en',
+        model: 'speech-2.8-hd',
+        voices: ['English_expressive_narrator'],
+      },
+      { input: 'Hello', voice: 'English_expressive_narrator' },
+    );
+    const chunks = [];
+    for await (const chunk of response.data) {
+      chunks.push(chunk);
+    }
+
+    expect(Buffer.concat(chunks)).toEqual(Buffer.from('ID3'));
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://api.minimax.io/v1/t2a_v2',
+      expect.objectContaining({ model: 'speech-2.8-hd', text: 'Hello' }),
+      expect.objectContaining({ responseType: 'json' }),
+    );
+  });
+
+  it('rejects unsuccessful API responses', () => {
+    expect(() =>
+      service.parseMiniMaxResponse({
+        data: { data: { audio: '' }, base_resp: { status_code: 1004 } },
+      }),
+    ).toThrow('MiniMax TTS request failed with status code 1004');
   });
 });
 

--- a/api/server/services/Files/Audio/getVoices.js
+++ b/api/server/services/Files/Audio/getVoices.js
@@ -43,6 +43,9 @@ async function getVoices(req, res) {
       case TTSProviders.LOCALAI:
         voices = ttsSchema.localai?.voices;
         break;
+      case TTSProviders.MINIMAX:
+        voices = ttsSchema.minimax?.voices;
+        break;
       default:
         throw new Error('Invalid provider');
     }

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -278,6 +278,11 @@ registration:
 #       apiKey: '${TTS_API_KEY}'
 #       model: ''
 #       voices: ['']
+#     minimax:
+#       apiKey: '${MINIMAX_API_KEY}'
+#       region: 'global_en' # Use 'cn_zh' for the China endpoint
+#       model: 'speech-2.8-hd'
+#       voices: ['English_expressive_narrator']
 #     allowedAddresses:
 #       - 'localhost:8020'
 #       - '127.0.0.1:8020'

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -515,6 +515,26 @@ describe('allowedAddressesSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('accepts MiniMax TTS configuration with regional and audio settings', () => {
+      const result = configSchema.safeParse({
+        version: '1.0',
+        speech: {
+          tts: {
+            minimax: {
+              apiKey: '${TTS_API_KEY}',
+              region: 'cn_zh',
+              voices: ['Chinese_Mandarin_Gentleman'],
+              audio_settings: { format: 'wav', sample_rate: 32000 },
+            },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.speech?.tts?.minimax?.model).toBe('speech-2.8-hd');
+      }
+    });
+
     it('accepts the field on ocr', () => {
       const result = configSchema.safeParse({
         version: '1.0',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1253,12 +1253,39 @@ const ttsLocalaiSchema = z.object({
   backend: z.string(),
 });
 
+const ttsMiniMaxSchema = z.object({
+  url: z.string().optional(),
+  apiKey: z.string(),
+  apiKeyPreview: apiKeyPreviewSchema,
+  region: z.enum(['global_en', 'cn_zh']).default('global_en'),
+  model: z.string().default('speech-2.8-hd'),
+  voices: z.array(z.string()),
+  language_boost: z.string().optional(),
+  voice_settings: z
+    .object({
+      speed: z.number().optional(),
+      vol: z.number().optional(),
+      pitch: z.number().optional(),
+      emotion: z.string().optional(),
+    })
+    .optional(),
+  audio_settings: z
+    .object({
+      sample_rate: z.number().optional(),
+      bitrate: z.number().optional(),
+      format: z.enum(['mp3', 'wav', 'flac', 'pcm']).default('mp3'),
+      channel: z.number().optional(),
+    })
+    .optional(),
+});
+
 const ttsSchema = z.object({
   allowedAddresses: allowedAddressesSchema,
   openai: ttsOpenaiSchema.optional(),
   azureOpenAI: ttsAzureOpenAISchema.optional(),
   elevenlabs: ttsElevenLabsSchema.optional(),
   localai: ttsLocalaiSchema.optional(),
+  minimax: ttsMiniMaxSchema.optional(),
 });
 
 const sttOpenaiSchema = z.object({
@@ -1306,7 +1333,9 @@ const speechTab = z
       .or(
         z.object({
           /** Keep in sync with TTSProviders enum (defined below — cannot reference due to eval order) */
-          engineTTS: z.enum(['openai', 'azureOpenAI', 'elevenlabs', 'localai']).optional(),
+          engineTTS: z
+            .enum(['openai', 'azureOpenAI', 'elevenlabs', 'localai', 'minimax'])
+            .optional(),
           voice: z.string().optional(),
           languageTTS: z.string().optional(),
           automaticPlayback: z.boolean().optional(),
@@ -2843,6 +2872,10 @@ export enum TTSProviders {
    * Provider for LocalAI TTS
    */
   LOCALAI = 'localai',
+  /**
+   * Provider for MiniMax TTS
+   */
+  MINIMAX = 'minimax',
 }
 
 /** Enum for app-wide constants */


### PR DESCRIPTION
Reason: LibreChat lacks MiniMax TTS configuration, regional routing, request mapping, and audio response decoding.

This adds a first-class TTS provider configuration with global and China endpoint selection, the current speech model default, voice and audio controls, bearer authentication, and hex audio decoding into LibreChat's existing stream path. It also exposes configured voices and documents the minimal YAML setup.

Checks:

- `npx jest server/services/Files/Audio/TTSService.spec.js --runInBand`
- `npx jest src/config.spec.ts --runInBand`
- `npm run build:packages`
- `npm run build:data-provider`
- `npx eslint api/server/services/Files/Audio/TTSService.js api/server/services/Files/Audio/TTSService.spec.js api/server/services/Files/Audio/getVoices.js packages/data-provider/src/config.ts packages/data-provider/src/config.spec.ts`
- `git diff --check`
