### PR TITLE
⌨️ fix: allow file upload shortcut when editing

### DIFF
--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -299,6 +299,7 @@ export const EDITING_ALLOWED_SHORTCUTS: ReadonlySet<ShortcutActionId> = new Set(
   'showShortcuts',
   'submitMessage',
   'escalateSteer',
+  'uploadFile',
 ]);
 
 export type ShortcutAction = ShortcutDefinition & {


### PR DESCRIPTION
## Summary

This fixes https://github.com/danny-avila/LibreChat/issues/14763 by allowing the file upload shortcut while editing.

## Change Type

Bug fix (non-breaking change which fixes an issue)

## Testing

on the main branch
1. Start a new chat
2. Focus on the chatbot
2. Try the upload shortcut (CMD/CTR+Shift+U) and see that it **doesn't** work

on this branch
Start a new chat
Focus on the chatbot
Try the upload shortcut (CMD/CTR+Shift+U) and see that it **does** work

### **Test Configuration**:
Ensure sure shortcuts are enabled