### PR TITLE
🔖 feat: Bound Parent Activity Phases With an Exclusive End Index

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1295,6 +1295,9 @@ class BaseClient {
       return {
         ...part,
         activity_start_index: part.activity_start_index + phaseIndexOffset,
+        ...(typeof part.activity_end_index === 'number' && {
+          activity_end_index: part.activity_end_index + phaseIndexOffset,
+        }),
       };
     });
 

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1809,6 +1809,7 @@ describe('BaseClient', () => {
           type: ContentTypes.ACTIVITY_LABEL,
           activity_label_type: 'phase',
           activity_start_index: 0,
+          activity_end_index: 1,
           activity_label: 'Verified deployment health',
         },
       ];
@@ -1816,7 +1817,7 @@ describe('BaseClient', () => {
       expect(TestClient.mergeEditedContent(existing, completion, ContentTypes.TEXT)).toEqual([
         existing[0],
         completion[0],
-        { ...completion[1], activity_start_index: 1 },
+        { ...completion[1], activity_start_index: 1, activity_end_index: 2 },
       ]);
     });
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2300,8 +2300,12 @@ class AgentClient extends BaseClient {
      *  SDK event lands after the phase closes; scanning retained identities
      *  in an unchanged array would skip that hole and move the bound past the
      *  delayed tool before it arrives. */
-    const previousDefinedIndexes = Object.keys(previousParts).map(Number);
-    const currentDefinedIndexes = Object.keys(this.contentParts).map(Number);
+    const previousDefinedIndexes = Object.keys(previousParts)
+      .map(Number)
+      .filter((index) => previousParts[index] != null);
+    const currentDefinedIndexes = Object.keys(this.contentParts)
+      .map(Number)
+      .filter((index) => this.contentParts[index] != null);
     if (previousParts.length === this.contentParts.length) {
       const unchanged =
         previousDefinedIndexes.length === currentDefinedIndexes.length &&

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2300,26 +2300,35 @@ class AgentClient extends BaseClient {
      *  SDK event lands after the phase closes; scanning retained identities
      *  in an unchanged array would skip that hole and move the bound past the
      *  delayed tool before it arrives. */
+    const previousDefinedIndexes = Object.keys(previousParts).map(Number);
+    const currentDefinedIndexes = Object.keys(this.contentParts).map(Number);
     if (previousParts.length === this.contentParts.length) {
-      let unchanged = true;
-      for (let index = 0; index < previousParts.length; index += 1) {
-        if (previousParts[index] !== this.contentParts[index]) {
-          unchanged = false;
-          break;
-        }
-      }
+      const unchanged =
+        previousDefinedIndexes.length === currentDefinedIndexes.length &&
+        previousDefinedIndexes.every(
+          (index, position) =>
+            index === currentDefinedIndexes[position] &&
+            previousParts[index] === this.contentParts[index],
+        );
       if (unchanged) {
         return;
       }
     }
     const retainedIndexes = new Map();
-    for (let index = 0; index < this.contentParts.length; index += 1) {
+    for (const index of currentDefinedIndexes) {
       const part = this.contentParts[index];
       if (part != null) {
         retainedIndexes.set(part, index);
       }
     }
-    for (let markerIndex = 0; markerIndex < this.contentParts.length; markerIndex += 1) {
+    const previousIndexesByPart = new Map();
+    for (const index of previousDefinedIndexes) {
+      const part = previousParts[index];
+      if (part != null) {
+        previousIndexesByPart.set(part, index);
+      }
+    }
+    for (const markerIndex of currentDefinedIndexes) {
       const marker = this.contentParts[markerIndex];
       if (
         marker?.type !== ContentTypes.ACTIVITY_LABEL ||
@@ -2328,8 +2337,8 @@ class AgentClient extends BaseClient {
       ) {
         continue;
       }
-      const previousMarkerIndex = previousParts.indexOf(marker);
-      if (previousMarkerIndex < 0) {
+      const previousMarkerIndex = previousIndexesByPart.get(marker);
+      if (previousMarkerIndex == null) {
         continue;
       }
       const previousStartIndex = Math.min(
@@ -2343,7 +2352,10 @@ class AgentClient extends BaseClient {
       let nextStartIndex = markerIndex;
       let nextEndIndex = markerIndex;
       let foundRetainedPart = false;
-      for (let index = previousStartIndex; index < previousEndIndex; index += 1) {
+      for (const index of previousDefinedIndexes) {
+        if (index < previousStartIndex || index >= previousEndIndex) {
+          continue;
+        }
         const retainedIndex = retainedIndexes.get(previousParts[index]);
         if (retainedIndex != null && retainedIndex < markerIndex) {
           if (!foundRetainedPart) {
@@ -2357,7 +2369,10 @@ class AgentClient extends BaseClient {
         }
       }
       if (!foundRetainedPart && hasExplicitEnd) {
-        for (let index = previousEndIndex; index < previousMarkerIndex; index += 1) {
+        for (const index of previousDefinedIndexes) {
+          if (index < previousEndIndex || index >= previousMarkerIndex) {
+            continue;
+          }
           const retainedIndex = retainedIndexes.get(previousParts[index]);
           if (retainedIndex != null && retainedIndex < markerIndex) {
             nextStartIndex = retainedIndex;

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2248,17 +2248,25 @@ class AgentClient extends BaseClient {
    */
   /**
    * @deprecated Agent Chain — strip hidden intermediate sequential-agent content
-   * before persistence, keeping only the last part + tool_call parts. Mirrors the
-   * chat path so a HITL resume doesn't persist/emit intermediate outputs the
-   * agent's `hide_sequential_outputs` setting is meant to hide.
+   * before persistence, keeping only the last non-label part + tool_call parts.
+   * Parent activity markers can be appended after the final answer, so physical
+   * array order alone cannot identify the response output that must survive.
    */
   applyHideSequentialOutputsFilter() {
     if (!this.options.agent?.hide_sequential_outputs || !Array.isArray(this.contentParts)) {
       return;
     }
+    let lastOutputIndex = -1;
+    for (let index = this.contentParts.length - 1; index >= 0; index -= 1) {
+      const part = this.contentParts[index];
+      if (part != null && part.type !== ContentTypes.ACTIVITY_LABEL) {
+        lastOutputIndex = index;
+        break;
+      }
+    }
     this.contentParts = this.contentParts.filter(
       (part, index) =>
-        index >= this.contentParts.length - 1 ||
+        index === lastOutputIndex ||
         part.type === ContentTypes.TOOL_CALL ||
         // Steer parts are user speech, not intermediate agent output — dropping
         // one would erase the user's words from the persisted turn.
@@ -2328,16 +2336,39 @@ class AgentClient extends BaseClient {
         previousMarkerIndex,
         Math.max(0, marker.activity_start_index),
       );
+      const hasExplicitEnd = typeof marker.activity_end_index === 'number';
+      const previousEndIndex = hasExplicitEnd
+        ? Math.max(previousStartIndex, Math.min(previousMarkerIndex, marker.activity_end_index))
+        : previousMarkerIndex;
       let nextStartIndex = markerIndex;
-      for (let index = previousStartIndex; index < previousMarkerIndex; index += 1) {
+      let nextEndIndex = markerIndex;
+      let foundRetainedPart = false;
+      for (let index = previousStartIndex; index < previousEndIndex; index += 1) {
         const retainedIndex = retainedIndexes.get(previousParts[index]);
         if (retainedIndex != null && retainedIndex < markerIndex) {
-          nextStartIndex = retainedIndex;
-          break;
+          if (!foundRetainedPart) {
+            nextStartIndex = retainedIndex;
+            nextEndIndex = retainedIndex + 1;
+            foundRetainedPart = true;
+          } else {
+            nextStartIndex = Math.min(nextStartIndex, retainedIndex);
+            nextEndIndex = Math.min(markerIndex, Math.max(nextEndIndex, retainedIndex + 1));
+          }
         }
       }
       marker.activity_start_index = nextStartIndex;
+      if (hasExplicitEnd) {
+        marker.activity_end_index = Math.max(nextStartIndex, nextEndIndex);
+      }
     }
+  }
+
+  /** Finalize only a completed root run; HITL interruptions retain their snapshot for resume. */
+  completeActivityPhase(run, activityPhase) {
+    if (typeof run?.getInterrupt === 'function' && run.getInterrupt()?.payload) {
+      return;
+    }
+    activityPhase?.complete?.();
   }
 
   /**
@@ -2904,6 +2935,7 @@ class AgentClient extends BaseClient {
             [Callback.TOOL_ERROR]: logToolError,
           },
         });
+        this.completeActivityPhase(run, activityPhase);
 
         // HITL: if the run paused for tool approval, mark the job
         // `requires_action` + emit the prompt and leave the turn unfinalized
@@ -3278,6 +3310,7 @@ class AgentClient extends BaseClient {
         { callbacks: { [Callback.TOOL_ERROR]: logToolError } },
         commandOptions,
       );
+      this.completeActivityPhase(run, activityPhase);
 
       config.signal = null;
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2356,6 +2356,16 @@ class AgentClient extends BaseClient {
           }
         }
       }
+      if (!foundRetainedPart && hasExplicitEnd) {
+        for (let index = previousEndIndex; index < previousMarkerIndex; index += 1) {
+          const retainedIndex = retainedIndexes.get(previousParts[index]);
+          if (retainedIndex != null && retainedIndex < markerIndex) {
+            nextStartIndex = retainedIndex;
+            nextEndIndex = retainedIndex;
+            break;
+          }
+        }
+      }
       marker.activity_start_index = nextStartIndex;
       if (hasExplicitEnd) {
         marker.activity_end_index = Math.max(nextStartIndex, nextEndIndex);

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -180,6 +180,34 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
     expect(phase.activity_end_index).toBe(1);
   });
 
+  it('keeps an appended phase before the final text when all phase children are filtered', () => {
+    const final = textPart('final');
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      activity_label: 'Completed both reasoning activities',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 2,
+    };
+    const ctx = {
+      options: { agent: { hide_sequential_outputs: true } },
+      contentParts: [
+        { type: ContentTypes.THINK, think: 'first' },
+        { type: ContentTypes.THINK, think: 'second' },
+        final,
+        phase,
+      ],
+    };
+    const previousParts = [...ctx.contentParts];
+
+    AgentClient.prototype.applyHideSequentialOutputsFilter.call(ctx);
+    AgentClient.prototype.rebaseActivityPhaseBounds.call(ctx, previousParts);
+
+    expect(ctx.contentParts).toEqual([final, phase]);
+    expect(phase.activity_start_index).toBe(0);
+    expect(phase.activity_end_index).toBe(0);
+  });
+
   it('is a no-op when hide_sequential_outputs is off', () => {
     const parts = [textPart('a'), textPart('b')];
     const ctx = { options: { agent: { hide_sequential_outputs: false } }, contentParts: parts };

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -265,6 +265,26 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
     expect(phase.activity_start_index).toBe(0);
   });
 
+  it('rebases explicit bounds using only defined sparse slots', () => {
+    const toolCall = toolCallPart('tc-large-sparse');
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      activity_label: 'Searched the sparse transcript',
+      activity_label_type: 'phase',
+      activity_start_index: 5,
+      activity_end_index: 999_999,
+    };
+    const previousParts = [];
+    previousParts[5] = toolCall;
+    previousParts[999_999] = phase;
+    const ctx = { options: { agent: {} }, contentParts: [toolCall, phase] };
+
+    AgentClient.prototype.rebaseActivityPhaseBounds.call(ctx, previousParts);
+
+    expect(phase.activity_start_index).toBe(0);
+    expect(phase.activity_end_index).toBe(1);
+  });
+
   it('preserves a sparse phase reservation when completion does not reshape content', () => {
     const firstTool = toolCallPart('tool-1');
     const secondTool = toolCallPart('tool-2');

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -142,7 +142,7 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
   const textPart = (text) => ({ type: ContentTypes.TEXT, text });
   const toolCallPart = (id) => ({ type: ContentTypes.TOOL_CALL, tool_call: { id } });
 
-  it('keeps only the last part + tool_call parts when hide_sequential_outputs is on', () => {
+  it('keeps only the last non-label part + tool_call parts when filtering is on', () => {
     const ctx = {
       options: { agent: { hide_sequential_outputs: true } },
       contentParts: [
@@ -154,6 +154,30 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
     };
     AgentClient.prototype.applyHideSequentialOutputsFilter.call(ctx);
     expect(ctx.contentParts).toEqual([toolCallPart('tc1'), textPart('final')]);
+  });
+
+  it('keeps the final text when a parent phase marker is appended after it', () => {
+    const tool = toolCallPart('tc1');
+    const final = textPart('final');
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      activity_label: 'Completed the investigation',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 2,
+    };
+    const ctx = {
+      options: { agent: { hide_sequential_outputs: true } },
+      contentParts: [textPart('intermediate'), tool, final, phase],
+    };
+    const previousParts = [...ctx.contentParts];
+
+    AgentClient.prototype.applyHideSequentialOutputsFilter.call(ctx);
+    AgentClient.prototype.rebaseActivityPhaseBounds.call(ctx, previousParts);
+
+    expect(ctx.contentParts).toEqual([tool, final, phase]);
+    expect(phase.activity_start_index).toBe(0);
+    expect(phase.activity_end_index).toBe(1);
   });
 
   it('is a no-op when hide_sequential_outputs is off', () => {
@@ -171,6 +195,7 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
       activity_label: 'Resolved the session issue',
       activity_label_type: 'phase',
       activity_start_index: 0,
+      activity_end_index: 2,
     };
     const final = textPart('final');
     const previousParts = [reasoning, activityTool, phase, final];
@@ -185,6 +210,7 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
 
     expect(ctx.contentParts).toEqual([skillCard, activityTool, phase, final]);
     expect(phase.activity_start_index).toBe(1);
+    expect(phase.activity_end_index).toBe(2);
   });
 
   it('rebases phase bounds over reshaped sparse content without retaining holes', () => {
@@ -253,6 +279,28 @@ describe('AgentClient - applyHideSequentialOutputsFilter', () => {
       'tool-1',
       'tool-2',
     ]);
+  });
+});
+
+describe('AgentClient - activity phase completion', () => {
+  it('completes an uninterrupted root run', () => {
+    const complete = jest.fn();
+    AgentClient.prototype.completeActivityPhase.call(
+      {},
+      { getInterrupt: () => undefined },
+      { complete },
+    );
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains phase state when the root run pauses for HITL', () => {
+    const complete = jest.fn();
+    AgentClient.prototype.completeActivityPhase.call(
+      {},
+      { getInterrupt: () => ({ payload: { type: 'tool_approval' } }) },
+      { complete },
+    );
+    expect(complete).not.toHaveBeenCalled();
   });
 });
 

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -10,6 +10,7 @@ import { cn } from '~/utils';
 type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
   activity_label_type?: 'phase';
   activity_start_index?: number;
+  activity_end_index?: number;
 };
 
 export default function ActivityPhaseGroup({

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -153,6 +153,8 @@ type ContentPartsProps = {
   nestedActivityPhase?: boolean;
   /** Absolute transcript index represented by `content[0]` in a phase slice. */
   contentIndexOffset?: number;
+  /** Absolute transcript index for each compacted sparse segment entry. */
+  contentIndices?: ReadonlyArray<number>;
   /** Message-wide steer attribution retained across nested phase segments. */
   resumeAuthors?: ReadonlyMap<number, string | undefined>;
   /** Message-wide tool-group expansion overrides retained across phase slices. */
@@ -184,6 +186,7 @@ const ContentParts = memo(function ContentParts({
   createdAt,
   nestedActivityPhase = false,
   contentIndexOffset = 0,
+  contentIndices,
   resumeAuthors,
   toolGroupExpansionState,
 }: ContentPartsProps) {
@@ -200,6 +203,17 @@ const ContentParts = memo(function ContentParts({
     fallbackScopeRef.current.messageId = messageId;
   }
   const fallbackScope = fallbackScopeRef.current.scope;
+  const localIndexByAbsolute = useMemo(
+    () =>
+      contentIndices == null
+        ? undefined
+        : new Map(contentIndices.map((absoluteIndex, localIndex) => [absoluteIndex, localIndex])),
+    [contentIndices],
+  );
+  const absoluteIndexAt = useCallback(
+    (localIndex: number) => contentIndices?.[localIndex] ?? localIndex + contentIndexOffset,
+    [contentIndexOffset, contentIndices],
+  );
 
   const handleGroupExpansionChange = useCallback(
     (groupId: string, state: ToolCallGroupExpansionState) => {
@@ -271,7 +285,7 @@ const ContentParts = memo(function ContentParts({
 
   const renderPart = useCallback(
     (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
-      const localIdx = idx - contentIndexOffset;
+      const localIdx = localIndexByAbsolute?.get(idx) ?? idx - contentIndexOffset;
       return (
         <PartWithContext
           key={`provider-${messageId}-${idx}`}
@@ -296,6 +310,7 @@ const ContentParts = memo(function ContentParts({
       attachmentMap,
       content,
       contentIndexOffset,
+      localIndexByAbsolute,
       conversationId,
       effectiveIsSubmitting,
       isCreatedByUser,
@@ -307,7 +322,7 @@ const ContentParts = memo(function ContentParts({
 
   const renderGroupedPart = useCallback(
     (part: TMessageContentParts, idx: number, isLastPart: boolean, onToolExpand?: () => void) => {
-      const localIdx = idx - contentIndexOffset;
+      const localIdx = localIndexByAbsolute?.get(idx) ?? idx - contentIndexOffset;
       return (
         <PartWithContext
           key={`provider-${messageId}-${idx}`}
@@ -334,6 +349,7 @@ const ContentParts = memo(function ContentParts({
       attachmentMap,
       content,
       contentIndexOffset,
+      localIndexByAbsolute,
       conversationId,
       effectiveIsSubmitting,
       isCreatedByUser,
@@ -362,7 +378,7 @@ const ContentParts = memo(function ContentParts({
       if (!part) {
         return;
       }
-      const idx = localIdx + contentIndexOffset;
+      const idx = absoluteIndexAt(localIdx);
       if (prevType === ContentTypes.STEER && part.type !== ContentTypes.STEER) {
         authors.set(idx, activeAgentId);
       }
@@ -373,7 +389,7 @@ const ContentParts = memo(function ContentParts({
       parts.push({ part, idx });
     });
     return { sequentialParts: parts, detectedResumeAuthors: authors };
-  }, [content, contentIndexOffset]);
+  }, [absoluteIndexAt, content]);
   const postSteerAuthors = resumeAuthors ?? detectedResumeAuthors;
 
   const groupedParts = useMemo(
@@ -423,7 +439,7 @@ const ContentParts = memo(function ContentParts({
           if (!part) {
             return null;
           }
-          const idx = localIdx + contentIndexOffset;
+          const idx = absoluteIndexAt(localIdx);
           const isTextPart =
             part?.type === ContentTypes.TEXT ||
             typeof (part as unknown as Agents.MessageContentText)?.text === 'string';
@@ -460,13 +476,13 @@ const ContentParts = memo(function ContentParts({
   if (phaseSegments != null) {
     const relativeGlobalLastContentIdx = lastVisibleContentIdx(content ?? []);
     const globalLastContentIdx =
-      relativeGlobalLastContentIdx < 0 ? -1 : relativeGlobalLastContentIdx + contentIndexOffset;
+      relativeGlobalLastContentIdx < 0 ? -1 : absoluteIndexAt(relativeGlobalLastContentIdx);
     const renderSegment = (
       segmentContent: Array<TMessageContentParts | undefined>,
       segmentStartIndex: number,
+      segmentIndices: ReadonlyArray<number>,
       key: string,
     ) => {
-      const localLastContentIdx = globalLastContentIdx - segmentStartIndex;
       return (
         <ContentParts
           key={key}
@@ -478,11 +494,12 @@ const ContentParts = memo(function ContentParts({
           attachments={attachments}
           searchResults={searchResults}
           isCreatedByUser={isCreatedByUser}
-          isLast={isLast && segmentContent[localLastContentIdx] != null}
+          isLast={isLast && segmentIndices.includes(globalLastContentIdx)}
           isSubmitting={isSubmitting}
           isLatestMessage={isLatestMessage}
           nestedActivityPhase
           contentIndexOffset={segmentStartIndex}
+          contentIndices={segmentIndices}
           resumeAuthors={postSteerAuthors}
           toolGroupExpansionState={expansionState}
         />
@@ -506,19 +523,21 @@ const ContentParts = memo(function ContentParts({
                 showCursor={
                   isLast &&
                   effectiveIsSubmitting &&
-                  segment.labelIndex + contentIndexOffset === globalLastContentIdx
+                  absoluteIndexAt(segment.labelIndex) === globalLastContentIdx
                 }
               >
                 {renderSegment(
                   segment.content,
-                  segment.startIndex + contentIndexOffset,
+                  absoluteIndexAt(segment.startIndex),
+                  segment.contentIndices.map(absoluteIndexAt),
                   `phase-content-${index}`,
                 )}
               </ActivityPhaseGroup>
             ) : (
               renderSegment(
                 segment.content,
-                segment.startIndex + contentIndexOffset,
+                absoluteIndexAt(segment.startIndex),
+                segment.contentIndices.map(absoluteIndexAt),
                 `phase-adjacent-${index}`,
               )
             ),
@@ -534,8 +553,7 @@ const ContentParts = memo(function ContentParts({
    *  counting one as last would strip the streaming cursor from the last
    *  VISIBLE part until the next delta. */
   const relativeLastContentIdx = lastVisibleContentIdx(safeContent);
-  const lastContentIdx =
-    relativeLastContentIdx < 0 ? -1 : relativeLastContentIdx + contentIndexOffset;
+  const lastContentIdx = relativeLastContentIdx < 0 ? -1 : absoluteIndexAt(relativeLastContentIdx);
 
   // Parallel content: use dedicated renderer with columns (TMessageContentParts includes ContentMetadata)
   const hasParallelContent = safeContent.some((part) => part?.groupId != null);
@@ -555,6 +573,7 @@ const ContentParts = memo(function ContentParts({
           renderResumeAttribution={renderResumeAttribution}
           showDecorations={!nestedActivityPhase}
           contentIndexOffset={contentIndexOffset}
+          contentIndices={contentIndices}
         />
       </>
     );

--- a/client/src/components/Chat/Messages/Content/ParallelContent.tsx
+++ b/client/src/components/Chat/Messages/Content/ParallelContent.tsx
@@ -36,6 +36,7 @@ export type ParallelSection = {
 export function groupParallelContent(
   content: Array<TMessageContentParts | undefined> | undefined,
   contentIndexOffset = 0,
+  contentIndices?: ReadonlyArray<number>,
 ): { parallelSections: ParallelSection[]; sequentialParts: PartWithIndex[] } {
   if (!content) {
     return { parallelSections: [], sequentialParts: [] };
@@ -50,7 +51,7 @@ export function groupParallelContent(
     if (!part) {
       return;
     }
-    const idx = localIdx + contentIndexOffset;
+    const idx = contentIndices?.[localIdx] ?? localIdx + contentIndexOffset;
 
     // Read metadata directly from content part (TMessageContentParts includes ContentMetadata)
     const { groupId } = part;
@@ -230,6 +231,8 @@ type ParallelContentRendererProps = {
   showDecorations?: boolean;
   /** Absolute transcript index represented by `content[0]` in a phase slice. */
   contentIndexOffset?: number;
+  /** Absolute transcript index for each compacted sparse segment entry. */
+  contentIndices?: ReadonlyArray<number>;
 };
 
 /**
@@ -248,10 +251,11 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
   renderResumeAttribution,
   showDecorations = true,
   contentIndexOffset = 0,
+  contentIndices,
 }: ParallelContentRendererProps) {
   const { parallelSections, sequentialParts } = useMemo(
-    () => groupParallelContent(content, contentIndexOffset),
-    [content, contentIndexOffset],
+    () => groupParallelContent(content, contentIndexOffset, contentIndices),
+    [content, contentIndexOffset, contentIndices],
   );
 
   /** Same walk-back as `ContentParts`: a trailing BLANK label reservation is
@@ -259,7 +263,9 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
    *  rendered part with the last-part cursor until the label fills. */
   const relativeLastContentIdx = lastVisibleContentIdx(content);
   const lastContentIdx =
-    relativeLastContentIdx < 0 ? -1 : relativeLastContentIdx + contentIndexOffset;
+    relativeLastContentIdx < 0
+      ? -1
+      : (contentIndices?.[relativeLastContentIdx] ?? relativeLastContentIdx + contentIndexOffset);
 
   // Split sequential parts into before/after parallel sections
   const { before, after } = useMemo(() => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -327,6 +327,33 @@ describe('ContentParts — post-steer author re-attribution', () => {
 });
 
 describe('ContentParts — activity phase state', () => {
+  it('renders a completion-appended parent before the final root text', () => {
+    const tool = {
+      type: ContentTypes.TOOL_CALL,
+      [ContentTypes.TOOL_CALL]: { id: 'tool-1', name: 'search', args: {}, output: 'done' },
+    } as unknown as TMessageContentParts;
+    const final = {
+      type: ContentTypes.TEXT,
+      text: 'Final answer',
+    } as unknown as TMessageContentParts;
+    const phase = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Completed the full investigation',
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 2,
+      activity_count: 2,
+      pending: false,
+    } as unknown as TMessageContentParts;
+
+    render(<ContentParts {...baseProps} content={[tool, tool, final, phase]} />);
+
+    const parent = screen.getByTestId('activity-phase-group');
+    const finalPart = screen.getByTestId(`real-part-${ContentTypes.TEXT}`);
+    expect(parent.compareDocumentPosition(finalPart)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(finalPart).toHaveAttribute('data-index', '2');
+  });
+
   it('keeps a streaming cursor when a completed phase marker is the visible tail', () => {
     const phase = {
       type: ContentTypes.ACTIVITY_LABEL,

--- a/client/src/components/Chat/Messages/Content/__tests__/ParallelContent.test.ts
+++ b/client/src/components/Chat/Messages/Content/__tests__/ParallelContent.test.ts
@@ -20,4 +20,24 @@ describe('groupParallelContent', () => {
     expect(grouped.sequentialParts).toEqual([{ part: sequential, idx: 4 }]);
     expect(grouped.parallelSections[0]?.columns[0]?.parts).toEqual([{ part: parallel, idx: 5 }]);
   });
+
+  test('preserves absolute indices for a compacted sparse phase segment', () => {
+    const sequential = {
+      type: ContentTypes.TEXT,
+      text: 'before lanes',
+    } as unknown as TMessageContentParts;
+    const parallel = {
+      type: ContentTypes.TEXT,
+      text: 'lane result',
+      groupId: 1,
+      agentId: 'agent-1',
+    } as unknown as TMessageContentParts;
+
+    const grouped = groupParallelContent([sequential, parallel], 0, [2, 10_000]);
+
+    expect(grouped.sequentialParts).toEqual([{ part: sequential, idx: 2 }]);
+    expect(grouped.parallelSections[0]?.columns[0]?.parts).toEqual([
+      { part: parallel, idx: 10_000 },
+    ]);
+  });
 });

--- a/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useStepHandler.spec.ts
@@ -3413,6 +3413,42 @@ describe('useStepHandler', () => {
       const response = currentMessages.find((m) => !m.isCreatedByUser);
       expect(response?.content?.[2]).toMatchObject({ [ContentTypes.TEXT]: 'streamed' });
       expect(response?.content?.[0]).toMatchObject({ [ContentTypes.TEXT]: 'kept a' });
+      expect(
+        (submission as { editPrefixFirstPartFolded?: boolean }).editPrefixFirstPartFolded,
+      ).toBeUndefined();
+    });
+
+    it('records when the first completion part actually folds into the retained tail', () => {
+      const submission = createSubmission({
+        editedContent: { index: 0, type: ContentTypes.TEXT },
+        initialResponse: createResponseMessage({ content: [textPart('kept'), textPart('tail')] }),
+      } as never);
+      (submission as { editPrefixLength?: number }).editPrefixLength = 2;
+      const responseMessage = submission.initialResponse as TMessage;
+      let currentMessages: TMessage[] = [responseMessage];
+      mockGetMessages.mockImplementation(() => currentMessages);
+      mockSetMessages.mockImplementation((messages: TMessage[]) => {
+        currentMessages = messages;
+      });
+
+      const { result } = renderHook(() => useStepHandler(createHookParams()));
+      act(() => {
+        result.current.stepHandler(
+          {
+            event: StepEvents.ON_RUN_STEP,
+            data: createRunStep({ index: 0, runId: responseMessage.messageId }),
+          },
+          submission,
+        );
+        result.current.stepHandler(
+          { event: StepEvents.ON_MESSAGE_DELTA, data: createMessageDelta('step-1', ' continued') },
+          submission,
+        );
+      });
+
+      expect(
+        (submission as { editPrefixFirstPartFolded?: boolean }).editPrefixFirstPartFolded,
+      ).toBe(true);
     });
 
     it('does not merge final-answer text into a retained commentary phase', () => {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -725,6 +725,7 @@ export default function useResumableSSE(
    * `editPrefixLength` must no longer be applied — by run steps or labels.
    */
   const editPrefixClearedRef = useRef(false);
+  const editPrefixFirstPartFoldedRef = useRef(false);
   /** Generation the cleared-prefix state above belongs to, so it is dropped
    *  when a new generation starts rather than when a subscribe happens to be
    *  live. Keyed by response message id — the stream id is the conversation
@@ -1057,13 +1058,15 @@ export default function useResumableSSE(
    * the non-resumable transport, the submission passes through untouched.
    */
   const stepHandler = useCallback(
-    (...[event, submission]: Parameters<typeof rawStepHandler>) =>
-      rawStepHandler(
-        event,
-        editPrefixClearedRef.current
-          ? ({ ...submission, editPrefixCleared: true } as EventSubmission)
-          : submission,
-      ),
+    (...[event, submission]: Parameters<typeof rawStepHandler>) => {
+      const eventSubmission = editPrefixClearedRef.current
+        ? ({ ...submission, editPrefixCleared: true } as EventSubmission)
+        : submission;
+      rawStepHandler(event, eventSubmission);
+      if (eventSubmission.editPrefixFirstPartFolded === true) {
+        editPrefixFirstPartFoldedRef.current = true;
+      }
+    },
     [rawStepHandler],
   );
 
@@ -1166,6 +1169,7 @@ export default function useResumableSSE(
       if (prefixStateGenerationIdRef.current !== generationId) {
         prefixStateGenerationIdRef.current = generationId;
         editPrefixClearedRef.current = false;
+        editPrefixFirstPartFoldedRef.current = false;
       }
       let { userMessage } = currentSubmission;
       let textIndex: number | null = null;
@@ -1371,20 +1375,18 @@ export default function useResumableSSE(
             typeof phasePart.activity_start_index === 'number'
           ) {
             let activityStartIndex = phasePart.activity_start_index + prefixLength;
-            let foldedFirstPart = false;
+            const foldedFirstPart = editPrefixFirstPartFoldedRef.current;
             const targetContent = messages[index]?.content;
-            /** The first completion text/think part can merge into the
-             *  retained edit tail at prefixLength - 1. Tool/nonmatching starts
-             *  occupy the ordinary +prefix slot, so only fold back across the
-             *  recognizable empty merge slot. */
+            /** The step handler records an actual server-index-zero text/think
+             *  merge. An empty +prefix slot is insufficient evidence because
+             *  a delayed tool may not have materialized there yet. */
             if (
               phasePart.activity_start_index === 0 &&
               activityStartIndex > 0 &&
-              targetContent?.[activityStartIndex] == null &&
+              foldedFirstPart &&
               targetContent?.[activityStartIndex - 1] != null
             ) {
               activityStartIndex -= 1;
-              foldedFirstPart = true;
             }
             offsetPart = {
               ...phasePart,

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -1356,12 +1356,14 @@ export default function useResumableSSE(
         const phasePart = event.part as TActivityLabelEvent['part'] & {
           activity_label_type?: 'phase';
           activity_start_index?: number;
+          activity_end_index?: number;
         };
         let offsetEvent = event;
         if (prefixLength > 0) {
           let offsetPart: TActivityLabelEvent['part'] & {
             activity_label_type?: 'phase';
             activity_start_index?: number;
+            activity_end_index?: number;
           } = phasePart;
           if (
             phasePart.activity_label_type === 'phase' &&
@@ -1384,6 +1386,11 @@ export default function useResumableSSE(
             offsetPart = {
               ...phasePart,
               activity_start_index: activityStartIndex,
+              ...(typeof phasePart.activity_end_index === 'number' && {
+                activity_end_index:
+                  phasePart.activity_end_index +
+                  (activityStartIndex - phasePart.activity_start_index),
+              }),
             };
           }
           offsetEvent = {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -45,6 +45,7 @@ import {
   resolveRunEndTarget,
   findSteerMessageIndex,
   applyActivityLabelPart,
+  offsetActivityPhaseBoundary,
   findActivityLabelMessageIndex,
   appendAppliedSteerIds,
   collectAppliedSteerIds,
@@ -1370,6 +1371,7 @@ export default function useResumableSSE(
             typeof phasePart.activity_start_index === 'number'
           ) {
             let activityStartIndex = phasePart.activity_start_index + prefixLength;
+            let foldedFirstPart = false;
             const targetContent = messages[index]?.content;
             /** The first completion text/think part can merge into the
              *  retained edit tail at prefixLength - 1. Tool/nonmatching starts
@@ -1382,14 +1384,17 @@ export default function useResumableSSE(
               targetContent?.[activityStartIndex - 1] != null
             ) {
               activityStartIndex -= 1;
+              foldedFirstPart = true;
             }
             offsetPart = {
               ...phasePart,
               activity_start_index: activityStartIndex,
               ...(typeof phasePart.activity_end_index === 'number' && {
-                activity_end_index:
-                  phasePart.activity_end_index +
-                  (activityStartIndex - phasePart.activity_start_index),
+                activity_end_index: offsetActivityPhaseBoundary(
+                  phasePart.activity_end_index,
+                  prefixLength,
+                  foldedFirstPart,
+                ),
               }),
             };
           }

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -984,6 +984,14 @@ export default function useStepHandler({
               updatedResponse.content,
               phase,
             );
+            if (
+              submission != null &&
+              runStep.index === 0 &&
+              editPrefixOffset > 0 &&
+              currentIndex === editPrefixOffset - 1
+            ) {
+              submission.editPrefixFirstPartFolded = true;
+            }
             updatedResponse = updateContent(
               updatedResponse,
               currentIndex,
@@ -1034,6 +1042,14 @@ export default function useStepHandler({
               contentPart.type || '',
               updatedResponse.content,
             );
+            if (
+              submission != null &&
+              runStep.index === 0 &&
+              editPrefixOffset > 0 &&
+              currentIndex === editPrefixOffset - 1
+            ) {
+              submission.editPrefixFirstPartFolded = true;
+            }
             updatedResponse = updateContent(
               updatedResponse,
               currentIndex,

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -4,6 +4,7 @@ import {
   applyActivityLabelPart,
   groupActivityPhases,
   lastVisibleContentIdx,
+  offsetActivityPhaseBoundary,
 } from '../activityLabels';
 
 const buildMessage = (content: TMessage['content']): TMessage =>
@@ -120,6 +121,15 @@ describe('lastVisibleContentIdx', () => {
   });
 });
 
+describe('offsetActivityPhaseBoundary', () => {
+  it('folds only boundaries covered by the merged first completion part', () => {
+    expect(offsetActivityPhaseBoundary(0, 5, true)).toBe(4);
+    expect(offsetActivityPhaseBoundary(1, 5, true)).toBe(5);
+    expect(offsetActivityPhaseBoundary(3, 5, true)).toBe(8);
+    expect(offsetActivityPhaseBoundary(3, 5, false)).toBe(8);
+  });
+});
+
 describe('groupActivityPhases', () => {
   const text = { type: ContentTypes.TEXT, text: 'final answer' } as TMessageContentParts;
   const tool = {
@@ -166,6 +176,38 @@ describe('groupActivityPhases', () => {
       content: [final],
     });
     expect(lastVisibleContentIdx([tool, tool, final, phase as never])).toBe(2);
+  });
+
+  it('keeps a late child label in the phase while leaving final text outside', () => {
+    const child = labelPart({
+      activity_label: 'Recorded the delayed child result',
+      pending: false,
+      tool_call_ids: ['t1'],
+    });
+    const phase = labelPart({ activity_label: 'Completed the investigation', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 2,
+    });
+    const final = { type: ContentTypes.TEXT, text: 'Final answer' } as TMessageContentParts;
+    const content = [tool, final, child as never, phase as never];
+
+    const segments = groupActivityPhases(content);
+
+    expect(segments).toHaveLength(2);
+    expect(segments?.[0]).toMatchObject({
+      type: 'phase',
+      startIndex: 0,
+      content: [tool, undefined, child],
+    });
+    expect(segments?.[1]).toMatchObject({
+      type: 'content',
+      startIndex: 1,
+      content: [final, undefined],
+    });
+    expect(lastVisibleContentIdx(content)).toBe(1);
   });
 
   it('leaves pending or empty parent markers on the feature-off path', () => {

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -105,6 +105,19 @@ describe('lastVisibleContentIdx', () => {
     sparse[1] = tool;
     expect(lastVisibleContentIdx(sparse)).toBe(1);
   });
+
+  it('keeps an appended phase marker as the visible tail when its final slot is empty', () => {
+    const phase = labelPart({ activity_label: 'Completed the investigation', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 2,
+    });
+    const emptyText = { type: ContentTypes.TEXT, text: '' } as TMessageContentParts;
+
+    expect(lastVisibleContentIdx([tool, emptyText, phase as never])).toBe(2);
+  });
 });
 
 describe('groupActivityPhases', () => {

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -119,6 +119,20 @@ describe('lastVisibleContentIdx', () => {
 
     expect(lastVisibleContentIdx([tool, emptyText, phase as never])).toBe(2);
   });
+
+  it('keeps the phase marker visible when an adopted late label follows an empty final slot', () => {
+    const child = labelPart({ activity_label: 'Recorded the delayed result', pending: false });
+    const phase = labelPart({ activity_label: 'Completed the investigation', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 2,
+    });
+    const emptyText = { type: ContentTypes.TEXT, text: '' } as TMessageContentParts;
+
+    expect(lastVisibleContentIdx([tool, emptyText, child as never, phase as never])).toBe(3);
+  });
 });
 
 describe('offsetActivityPhaseBoundary', () => {

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -107,6 +107,25 @@ describe('lastVisibleContentIdx', () => {
     expect(lastVisibleContentIdx(sparse)).toBe(1);
   });
 
+  it('keeps sparse late-label adoption bounded to defined slots', () => {
+    const sparse = new Array<TMessageContentParts | undefined>(10_000);
+    sparse[0] = tool;
+    sparse[9_998] = labelPart({
+      activity_label: 'Recorded the delayed result',
+      pending: false,
+    }) as never;
+    const phase = labelPart({ activity_label: 'Completed the investigation', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 2,
+    });
+    sparse[9_999] = phase as never;
+
+    expect(lastVisibleContentIdx(sparse)).toBe(9_999);
+  });
+
   it('keeps an appended phase marker as the visible tail when its final slot is empty', () => {
     const phase = labelPart({ activity_label: 'Completed the investigation', pending: false });
     Object.assign(phase, {

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -243,6 +243,36 @@ describe('groupActivityPhases', () => {
     expect(lastVisibleContentIdx(content)).toBe(1);
   });
 
+  it('groups a sparse late child label without walking the empty range', () => {
+    const content = new Array<TMessageContentParts | undefined>(10_000);
+    const child = labelPart({ activity_label: 'Recorded the delayed result', pending: false });
+    const phase = labelPart({
+      activity_label: 'Completed the sparse investigation',
+      pending: false,
+    });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 2,
+    });
+    content[0] = tool;
+    content[9_998] = child as never;
+    content[9_999] = phase as never;
+
+    const segments = groupActivityPhases(content);
+
+    expect(segments?.[0]).toMatchObject({
+      type: 'phase',
+      startIndex: 0,
+      labelIndex: 9_999,
+    });
+    if (segments?.[0]?.type === 'phase') {
+      expect(segments[0].content[0]).toBe(tool);
+      expect(segments[0].content[9_998]).toBe(child);
+    }
+  });
+
   it('leaves pending or empty parent markers on the feature-off path', () => {
     const pending = labelPart();
     Object.assign(pending, { activity_label_type: 'phase', activity_start_index: 0 });

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -72,6 +72,29 @@ describe('applyActivityLabelPart', () => {
       pending: false,
     });
   });
+
+  it('never lets a stale pending placeholder overwrite an empty finalized phase', () => {
+    const finalized = labelPart({ pending: false });
+    Object.assign(finalized, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 2,
+      activity_count: 2,
+    });
+    const message = buildMessage([finalized as never]);
+
+    const updated = applyActivityLabelPart(message, {
+      index: 0,
+      part: labelPart({ pending: true }),
+    });
+
+    expect(updated).toBe(message);
+    expect((updated.content as unknown[])[0]).toMatchObject({
+      activity_label: '',
+      activity_label_type: 'phase',
+      pending: false,
+    });
+  });
 });
 
 describe('lastVisibleContentIdx', () => {

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -277,6 +277,41 @@ describe('groupActivityPhases', () => {
     }
   });
 
+  it('restores a late child label when the parent label resolves empty', () => {
+    const child = labelPart({
+      activity_label: 'Recorded the delayed child result',
+      pending: false,
+      tool_call_ids: ['t1'],
+    });
+    const phase = labelPart({ pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 1,
+      activity_count: 2,
+    });
+    const final = { type: ContentTypes.TEXT, text: 'Final answer' } as TMessageContentParts;
+    const content = [tool, final, child as never, phase as never];
+
+    const segments = groupActivityPhases(content);
+
+    expect(segments).toEqual([
+      expect.objectContaining({
+        type: 'content',
+        startIndex: 0,
+        content: [tool, child],
+        contentIndices: [0, 2],
+      }),
+      expect.objectContaining({
+        type: 'content',
+        startIndex: 1,
+        content: [final],
+        contentIndices: [1],
+      }),
+    ]);
+    expect(lastVisibleContentIdx(content)).toBe(1);
+  });
+
   it('leaves pending or empty parent markers on the feature-off path', () => {
     const pending = labelPart();
     Object.assign(pending, { activity_label_type: 'phase', activity_start_index: 0 });

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -129,6 +129,32 @@ describe('groupActivityPhases', () => {
     }
   });
 
+  it('renders an appended parent marker before the final text using its explicit end', () => {
+    const phase = labelPart({ activity_label: 'Completed the full investigation', pending: false });
+    Object.assign(phase, {
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 2,
+      activity_count: 2,
+    });
+    const final = { type: ContentTypes.TEXT, text: 'Final answer' } as TMessageContentParts;
+    const segments = groupActivityPhases([tool, tool, final, phase as never]);
+
+    expect(segments).toHaveLength(2);
+    expect(segments?.[0]).toMatchObject({
+      type: 'phase',
+      labelIndex: 3,
+      startIndex: 0,
+      content: [tool, tool],
+    });
+    expect(segments?.[1]).toMatchObject({
+      type: 'content',
+      startIndex: 2,
+      content: [final],
+    });
+    expect(lastVisibleContentIdx([tool, tool, final, phase as never])).toBe(2);
+  });
+
   it('leaves pending or empty parent markers on the feature-off path', () => {
     const pending = labelPart();
     Object.assign(pending, { activity_label_type: 'phase', activity_start_index: 0 });

--- a/client/src/utils/__tests__/activityLabels.spec.ts
+++ b/client/src/utils/__tests__/activityLabels.spec.ts
@@ -233,12 +233,14 @@ describe('groupActivityPhases', () => {
     expect(segments?.[0]).toMatchObject({
       type: 'phase',
       startIndex: 0,
-      content: [tool, undefined, child],
+      content: [tool, child],
+      contentIndices: [0, 2],
     });
     expect(segments?.[1]).toMatchObject({
       type: 'content',
       startIndex: 1,
-      content: [final, undefined],
+      content: [final],
+      contentIndices: [1],
     });
     expect(lastVisibleContentIdx(content)).toBe(1);
   });
@@ -269,7 +271,9 @@ describe('groupActivityPhases', () => {
     });
     if (segments?.[0]?.type === 'phase') {
       expect(segments[0].content[0]).toBe(tool);
-      expect(segments[0].content[9_998]).toBe(child);
+      expect(segments[0].content[1]).toBe(child);
+      expect(segments[0].contentIndices).toEqual([0, 9_998]);
+      expect(segments[0].content).toHaveLength(2);
     }
   });
 

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -144,8 +144,9 @@ export function groupActivityPhases(
   if (!content) {
     return undefined;
   }
-  const completed = content
-    .map((part, index) => ({ part: getActivityLabelPart(part), index }))
+  const definedIndices = Object.keys(content).map(Number);
+  const completed = definedIndices
+    .map((index) => ({ part: getActivityLabelPart(content[index]), index }))
     .filter(
       ({ part }) =>
         isPhaseActivityLabel(part) &&
@@ -163,11 +164,20 @@ export function groupActivityPhases(
    *  remain sparse when it adopts a late child label across trailing text;
    *  `startIndex` preserves the label's absolute transcript coordinate. */
   const slice = (start: number, end: number) => {
-    const segmentContent = content.slice(start, end);
+    const segmentContent = new Array<TMessageContentParts | undefined>(end - start);
+    let hasContent = false;
+    for (const index of definedIndices) {
+      if (index < start || index >= end) {
+        continue;
+      }
+      const part = content[index];
+      segmentContent[index - start] = part;
+      hasContent ||= isVisibleContentPart(part);
+    }
     return {
       content: segmentContent,
       startIndex: start,
-      hasContent: segmentContent.some(isVisibleContentPart),
+      hasContent,
     };
   };
   for (const { part, index } of completed) {
@@ -178,7 +188,10 @@ export function groupActivityPhases(
     );
     const end = Math.max(start, Math.min(index, Math.max(0, part.activity_end_index ?? index)));
     const lateLabelIndices: number[] = [];
-    for (let trailingIndex = end; trailingIndex < index; trailingIndex += 1) {
+    for (const trailingIndex of definedIndices) {
+      if (trailingIndex < end || trailingIndex >= index) {
+        continue;
+      }
       if (getBatchActivityLabelPart(content[trailingIndex]) != null) {
         lateLabelIndices.push(trailingIndex);
       }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -363,14 +363,7 @@ export function applyActivityLabelPart(message: TMessage, event: TActivityLabelE
   ) {
     return message;
   }
-  const existingText = existing?.[ContentTypes.ACTIVITY_LABEL];
-  if (
-    existing != null &&
-    existing.pending !== true &&
-    typeof existingText === 'string' &&
-    existingText.length > 0 &&
-    part.pending === true
-  ) {
+  if (existing != null && existing.pending !== true && part.pending === true) {
     return message;
   }
   const nextContent = [...content] as TMessageContentParts[];

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -68,7 +68,9 @@ function findLateActivityLabelsConsumedByPhase(
 ): Set<number> {
   const consumed = new Set<number>();
   let earliestPhaseEnd: number | undefined;
-  for (let index = parts.length - 1; index >= 0; index -= 1) {
+  const definedIndices = Object.keys(parts);
+  for (let position = definedIndices.length - 1; position >= 0; position -= 1) {
+    const index = Number(definedIndices[position]);
     const marker = getActivityLabelPart(parts[index]);
     if (
       isPhaseActivityLabel(marker) &&

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -4,6 +4,7 @@ import type { TMessage, TActivityLabelEvent, TMessageContentParts } from 'librec
 type ActivityLabelPart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
   activity_label_type?: 'phase';
   activity_start_index?: number;
+  activity_end_index?: number;
   activity_count?: number;
   agent_ids?: string[];
 };
@@ -30,6 +31,18 @@ function isVisibleContentPart(part: TMessageContentParts | undefined): boolean {
       part.type === ContentTypes.ACTIVITY_LABEL &&
       getActivityLabelText(getActivityLabelPart(part)).length === 0
     )
+  );
+}
+
+function isLogicallyEarlierPhaseMarker(
+  part: TMessageContentParts | undefined,
+  index: number,
+): boolean {
+  const label = getActivityLabelPart(part);
+  return (
+    isPhaseActivityLabel(label) &&
+    typeof label?.activity_end_index === 'number' &&
+    label.activity_end_index < index
   );
 }
 
@@ -109,6 +122,7 @@ export function groupActivityPhases(
       cursor,
       Math.min(index, Math.max(0, part.activity_start_index ?? index)),
     );
+    const end = Math.max(start, Math.min(index, Math.max(0, part.activity_end_index ?? index)));
     if (start > cursor) {
       const adjacent = slice(cursor, start);
       segments.push({
@@ -117,7 +131,7 @@ export function groupActivityPhases(
         startIndex: adjacent.startIndex,
       });
     }
-    const phase = slice(start, index);
+    const phase = slice(start, end);
     segments.push({
       type: 'phase',
       content: phase.content,
@@ -126,6 +140,14 @@ export function groupActivityPhases(
       labelIndex: index,
       hasContent: phase.hasContent,
     });
+    if (end < index) {
+      const trailing = slice(end, index);
+      segments.push({
+        type: 'content',
+        content: trailing.content,
+        startIndex: trailing.startIndex,
+      });
+    }
     cursor = index + 1;
   }
   if (cursor < content.length) {
@@ -153,7 +175,7 @@ export function lastVisibleContentIdx(
   const parts = content ?? [];
   let last = parts.length - 1;
   while (last >= 0 && last in parts) {
-    if (isVisibleContentPart(parts[last])) {
+    if (isVisibleContentPart(parts[last]) && !isLogicallyEarlierPhaseMarker(parts[last], last)) {
       return last;
     }
     last -= 1;
@@ -166,7 +188,11 @@ export function lastVisibleContentIdx(
   const definedIndices = Object.keys(parts);
   for (let i = definedIndices.length - 1; i >= 0; i -= 1) {
     const index = Number(definedIndices[i]);
-    if (index <= last && isVisibleContentPart(parts[index])) {
+    if (
+      index <= last &&
+      isVisibleContentPart(parts[index]) &&
+      !isLogicallyEarlierPhaseMarker(parts[index], index)
+    ) {
       return index;
     }
   }
@@ -221,6 +247,7 @@ export function applyActivityLabelPart(message: TMessage, event: TActivityLabelE
     existing.pending === part.pending &&
     existing.activity_label_type === incoming.activity_label_type &&
     existing.activity_start_index === incoming.activity_start_index &&
+    existing.activity_end_index === incoming.activity_end_index &&
     existing.activity_count === incoming.activity_count
   ) {
     return message;

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -35,15 +35,29 @@ function isVisibleContentPart(part: TMessageContentParts | undefined): boolean {
 }
 
 function isLogicallyEarlierPhaseMarker(
-  part: TMessageContentParts | undefined,
+  parts: ReadonlyArray<TMessageContentParts | undefined>,
   index: number,
 ): boolean {
+  const part = parts[index];
   const label = getActivityLabelPart(part);
-  return (
-    isPhaseActivityLabel(label) &&
-    typeof label?.activity_end_index === 'number' &&
-    label.activity_end_index < index
-  );
+  if (!isPhaseActivityLabel(label) || typeof label?.activity_end_index !== 'number') {
+    return false;
+  }
+  const endIndex = Math.max(0, Math.min(index, label.activity_end_index));
+  if (endIndex >= index) {
+    return false;
+  }
+  return parts.slice(endIndex, index).some((trailingPart) => {
+    if (!isVisibleContentPart(trailingPart)) {
+      return false;
+    }
+    if (trailingPart?.type !== ContentTypes.TEXT) {
+      return true;
+    }
+    const text =
+      typeof trailingPart.text === 'string' ? trailingPart.text : trailingPart.text?.value;
+    return typeof text === 'string' && text.length > 0;
+  });
 }
 
 export function isPhaseActivityLabel(part: ActivityLabelPart | undefined): boolean {
@@ -175,7 +189,7 @@ export function lastVisibleContentIdx(
   const parts = content ?? [];
   let last = parts.length - 1;
   while (last >= 0 && last in parts) {
-    if (isVisibleContentPart(parts[last]) && !isLogicallyEarlierPhaseMarker(parts[last], last)) {
+    if (isVisibleContentPart(parts[last]) && !isLogicallyEarlierPhaseMarker(parts, last)) {
       return last;
     }
     last -= 1;
@@ -191,7 +205,7 @@ export function lastVisibleContentIdx(
     if (
       index <= last &&
       isVisibleContentPart(parts[index]) &&
-      !isLogicallyEarlierPhaseMarker(parts[index], index)
+      !isLogicallyEarlierPhaseMarker(parts, index)
     ) {
       return index;
     }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -60,6 +60,28 @@ function isLogicallyEarlierPhaseMarker(
   });
 }
 
+function isLateActivityLabelConsumedByPhase(
+  parts: ReadonlyArray<TMessageContentParts | undefined>,
+  index: number,
+): boolean {
+  if (getBatchActivityLabelPart(parts[index]) == null) {
+    return false;
+  }
+  for (let markerIndex = index + 1; markerIndex < parts.length; markerIndex += 1) {
+    const marker = getActivityLabelPart(parts[markerIndex]);
+    if (
+      isPhaseActivityLabel(marker) &&
+      marker?.pending !== true &&
+      getActivityLabelText(marker).length > 0 &&
+      typeof marker.activity_end_index === 'number' &&
+      marker.activity_end_index <= index
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function isPhaseActivityLabel(part: ActivityLabelPart | undefined): boolean {
   return part?.activity_label_type === 'phase';
 }
@@ -94,6 +116,15 @@ export function getActivityLabelText(part: ActivityLabelPart | undefined): strin
   return typeof label === 'string' ? label.trim() : '';
 }
 
+/** Maps a completion-local half-open boundary into edited-response coordinates. */
+export function offsetActivityPhaseBoundary(
+  boundary: number,
+  prefixLength: number,
+  foldedFirstPart: boolean,
+): number {
+  return boundary + prefixLength - (foldedFirstPart && boundary <= 1 ? 1 : 0);
+}
+
 /**
  * Partitions completed phase markers into collapsed parent groups while
  * carrying absolute start offsets alongside dense content slices. Empty/pending
@@ -120,8 +151,9 @@ export function groupActivityPhases(
 
   const segments: ActivityPhaseSegment[] = [];
   let cursor = 0;
-  /** Dense, disjoint slices copy every part at most once. `startIndex` carries
-   *  the absolute transcript position into the recursive renderer. */
+  /** Disjoint slices copy every ordinary part at most once. A phase slice can
+   *  remain sparse when it adopts a late child label across trailing text;
+   *  `startIndex` preserves the label's absolute transcript coordinate. */
   const slice = (start: number, end: number) => {
     const segmentContent = content.slice(start, end);
     return {
@@ -137,6 +169,12 @@ export function groupActivityPhases(
       Math.min(index, Math.max(0, part.activity_start_index ?? index)),
     );
     const end = Math.max(start, Math.min(index, Math.max(0, part.activity_end_index ?? index)));
+    const lateLabelIndices: number[] = [];
+    for (let trailingIndex = end; trailingIndex < index; trailingIndex += 1) {
+      if (getBatchActivityLabelPart(content[trailingIndex]) != null) {
+        lateLabelIndices.push(trailingIndex);
+      }
+    }
     if (start > cursor) {
       const adjacent = slice(cursor, start);
       segments.push({
@@ -146,6 +184,13 @@ export function groupActivityPhases(
       });
     }
     const phase = slice(start, end);
+    if (lateLabelIndices.length > 0) {
+      phase.content.length = index - start;
+      for (const lateLabelIndex of lateLabelIndices) {
+        phase.content[lateLabelIndex - start] = content[lateLabelIndex];
+      }
+      phase.hasContent = phase.content.some(isVisibleContentPart);
+    }
     segments.push({
       type: 'phase',
       content: phase.content,
@@ -156,6 +201,9 @@ export function groupActivityPhases(
     });
     if (end < index) {
       const trailing = slice(end, index);
+      for (const lateLabelIndex of lateLabelIndices) {
+        trailing.content[lateLabelIndex - end] = undefined;
+      }
       segments.push({
         type: 'content',
         content: trailing.content,
@@ -189,7 +237,11 @@ export function lastVisibleContentIdx(
   const parts = content ?? [];
   let last = parts.length - 1;
   while (last >= 0 && last in parts) {
-    if (isVisibleContentPart(parts[last]) && !isLogicallyEarlierPhaseMarker(parts, last)) {
+    if (
+      isVisibleContentPart(parts[last]) &&
+      !isLogicallyEarlierPhaseMarker(parts, last) &&
+      !isLateActivityLabelConsumedByPhase(parts, last)
+    ) {
       return last;
     }
     last -= 1;
@@ -205,7 +257,8 @@ export function lastVisibleContentIdx(
     if (
       index <= last &&
       isVisibleContentPart(parts[index]) &&
-      !isLogicallyEarlierPhaseMarker(parts, index)
+      !isLogicallyEarlierPhaseMarker(parts, index) &&
+      !isLateActivityLabelConsumedByPhase(parts, index)
     ) {
       return index;
     }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -47,7 +47,12 @@ function isLogicallyEarlierPhaseMarker(
   if (endIndex >= index) {
     return false;
   }
-  return parts.slice(endIndex, index).some((trailingPart) => {
+  return Object.keys(parts).some((key) => {
+    const trailingIndex = Number(key);
+    if (trailingIndex < endIndex || trailingIndex >= index) {
+      return false;
+    }
+    const trailingPart = parts[trailingIndex];
     if (!isVisibleContentPart(trailingPart)) {
       return false;
     }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -73,7 +73,7 @@ function isLateActivityLabelConsumedByPhase(
       isPhaseActivityLabel(marker) &&
       marker?.pending !== true &&
       getActivityLabelText(marker).length > 0 &&
-      typeof marker.activity_end_index === 'number' &&
+      typeof marker?.activity_end_index === 'number' &&
       marker.activity_end_index <= index
     ) {
       return true;

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -82,7 +82,6 @@ function findLateActivityLabelsConsumedByPhase(
     if (
       isPhaseActivityLabel(marker) &&
       marker?.pending !== true &&
-      getActivityLabelText(marker).length > 0 &&
       typeof marker?.activity_end_index === 'number'
     ) {
       earliestPhaseEnd = Math.min(earliestPhaseEnd ?? index, marker.activity_end_index);
@@ -142,8 +141,8 @@ export function offsetActivityPhaseBoundary(
 
 /**
  * Partitions completed phase markers into collapsed parent groups while
- * carrying absolute start offsets alongside dense content slices. Empty/pending
- * markers deliberately return no phase segment, preserving feature-off UI.
+ * carrying absolute indexes alongside compact content slices. Pending markers
+ * preserve feature-off UI; finalized empty markers only restore child order.
  */
 export function groupActivityPhases(
   content: Array<TMessageContentParts | undefined> | undefined,
@@ -158,7 +157,6 @@ export function groupActivityPhases(
       ({ part }) =>
         isPhaseActivityLabel(part) &&
         part?.pending !== true &&
-        getActivityLabelText(part).length > 0 &&
         typeof part?.activity_start_index === 'number',
     );
   if (completed.length === 0) {
@@ -167,29 +165,21 @@ export function groupActivityPhases(
 
   const segments: ActivityPhaseSegment[] = [];
   let cursor = 0;
-  /** Disjoint slices copy every ordinary part at most once. Segments stay
-   *  compact even when provider indexes are sparse; `contentIndices` retains
-   *  each part's absolute transcript coordinate for stable keys and grouping. */
-  const slice = (start: number, end: number, excluded?: ReadonlySet<number>) => {
-    const segmentContent: Array<TMessageContentParts | undefined> = [];
-    const contentIndices: number[] = [];
-    let hasContent = false;
-    for (const index of definedIndices) {
-      if (index < start || index >= end || excluded?.has(index) === true) {
-        continue;
-      }
-      const part = content[index];
-      segmentContent.push(part);
-      contentIndices.push(index);
-      hasContent ||= isVisibleContentPart(part);
-    }
-    return {
-      content: segmentContent,
-      contentIndices,
-      startIndex: start,
-      hasContent,
-    };
+  let definedPosition = 0;
+  const collect = () => ({
+    content: [] as Array<TMessageContentParts | undefined>,
+    contentIndices: [] as number[],
+    hasContent: false,
+  });
+  const append = (segment: ReturnType<typeof collect>, partIndex: number) => {
+    const child = content[partIndex];
+    segment.content.push(child);
+    segment.contentIndices.push(partIndex);
+    segment.hasContent ||= isVisibleContentPart(child);
   };
+  /** Phase markers and defined content indexes are both sorted. Walk them in
+   *  lockstep so every ordinary part is classified once, even when a custom
+   *  max permits many parent phases in one long response. */
   for (const { part, index } of completed) {
     if (!part) continue;
     const start = Math.max(
@@ -197,61 +187,80 @@ export function groupActivityPhases(
       Math.min(index, Math.max(0, part.activity_start_index ?? index)),
     );
     const end = Math.max(start, Math.min(index, Math.max(0, part.activity_end_index ?? index)));
-    const lateLabelIndices: number[] = [];
-    for (const trailingIndex of definedIndices) {
-      if (trailingIndex < end || trailingIndex >= index) {
+    const adjacent = collect();
+    const phase = collect();
+    const trailing = collect();
+    while (definedPosition < definedIndices.length && definedIndices[definedPosition] < index) {
+      const childIndex = definedIndices[definedPosition];
+      definedPosition += 1;
+      if (childIndex < cursor) {
         continue;
       }
-      if (getBatchActivityLabelPart(content[trailingIndex]) != null) {
-        lateLabelIndices.push(trailingIndex);
+      if (childIndex < start) {
+        append(adjacent, childIndex);
+      } else if (childIndex < end || getBatchActivityLabelPart(content[childIndex]) != null) {
+        append(phase, childIndex);
+      } else {
+        append(trailing, childIndex);
       }
     }
+    if (definedIndices[definedPosition] === index) {
+      definedPosition += 1;
+    }
     if (start > cursor) {
-      const adjacent = slice(cursor, start);
       segments.push({
         type: 'content',
         content: adjacent.content,
         contentIndices: adjacent.contentIndices,
-        startIndex: adjacent.startIndex,
+        startIndex: cursor,
       });
     }
-    const phase = slice(start, end);
-    if (lateLabelIndices.length > 0) {
-      for (const lateLabelIndex of lateLabelIndices) {
-        phase.content.push(content[lateLabelIndex]);
-        phase.contentIndices.push(lateLabelIndex);
-      }
-      phase.hasContent ||= lateLabelIndices.some((lateLabelIndex) =>
-        isVisibleContentPart(content[lateLabelIndex]),
-      );
+    const labelText = getActivityLabelText(part);
+    if (labelText) {
+      segments.push({
+        type: 'phase',
+        content: phase.content,
+        contentIndices: phase.contentIndices,
+        startIndex: start,
+        labelPart: part,
+        labelIndex: index,
+        hasContent: phase.hasContent,
+      });
+    } else {
+      /** A failed/empty parent stays visually feature-off, but its bounds are
+       *  still authoritative: delayed child labels must move back beside the
+       *  tools they describe instead of rendering after the final answer. */
+      segments.push({
+        type: 'content',
+        content: phase.content,
+        contentIndices: phase.contentIndices,
+        startIndex: start,
+      });
     }
-    segments.push({
-      type: 'phase',
-      content: phase.content,
-      contentIndices: phase.contentIndices,
-      startIndex: phase.startIndex,
-      labelPart: part,
-      labelIndex: index,
-      hasContent: phase.hasContent,
-    });
     if (end < index) {
-      const trailing = slice(end, index, new Set(lateLabelIndices));
       segments.push({
         type: 'content',
         content: trailing.content,
         contentIndices: trailing.contentIndices,
-        startIndex: trailing.startIndex,
+        startIndex: end,
       });
     }
     cursor = index + 1;
   }
   if (cursor < content.length) {
-    const adjacent = slice(cursor, content.length);
+    const adjacent = collect();
+    while (definedPosition < definedIndices.length) {
+      const childIndex = definedIndices[definedPosition];
+      definedPosition += 1;
+      if (childIndex >= cursor) {
+        append(adjacent, childIndex);
+      }
+    }
     segments.push({
       type: 'content',
       content: adjacent.content,
       contentIndices: adjacent.contentIndices,
-      startIndex: adjacent.startIndex,
+      startIndex: cursor,
     });
   }
   return segments;

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -13,11 +13,13 @@ export type ActivityPhaseSegment =
   | {
       type: 'content';
       content: Array<TMessageContentParts | undefined>;
+      contentIndices: number[];
       startIndex: number;
     }
   | {
       type: 'phase';
       content: Array<TMessageContentParts | undefined>;
+      contentIndices: number[];
       startIndex: number;
       labelPart: ActivityLabelPart;
       labelIndex: number;
@@ -165,22 +167,25 @@ export function groupActivityPhases(
 
   const segments: ActivityPhaseSegment[] = [];
   let cursor = 0;
-  /** Disjoint slices copy every ordinary part at most once. A phase slice can
-   *  remain sparse when it adopts a late child label across trailing text;
-   *  `startIndex` preserves the label's absolute transcript coordinate. */
-  const slice = (start: number, end: number) => {
-    const segmentContent = new Array<TMessageContentParts | undefined>(end - start);
+  /** Disjoint slices copy every ordinary part at most once. Segments stay
+   *  compact even when provider indexes are sparse; `contentIndices` retains
+   *  each part's absolute transcript coordinate for stable keys and grouping. */
+  const slice = (start: number, end: number, excluded?: ReadonlySet<number>) => {
+    const segmentContent: Array<TMessageContentParts | undefined> = [];
+    const contentIndices: number[] = [];
     let hasContent = false;
     for (const index of definedIndices) {
-      if (index < start || index >= end) {
+      if (index < start || index >= end || excluded?.has(index) === true) {
         continue;
       }
       const part = content[index];
-      segmentContent[index - start] = part;
+      segmentContent.push(part);
+      contentIndices.push(index);
       hasContent ||= isVisibleContentPart(part);
     }
     return {
       content: segmentContent,
+      contentIndices,
       startIndex: start,
       hasContent,
     };
@@ -206,14 +211,15 @@ export function groupActivityPhases(
       segments.push({
         type: 'content',
         content: adjacent.content,
+        contentIndices: adjacent.contentIndices,
         startIndex: adjacent.startIndex,
       });
     }
     const phase = slice(start, end);
     if (lateLabelIndices.length > 0) {
-      phase.content.length = index - start;
       for (const lateLabelIndex of lateLabelIndices) {
-        phase.content[lateLabelIndex - start] = content[lateLabelIndex];
+        phase.content.push(content[lateLabelIndex]);
+        phase.contentIndices.push(lateLabelIndex);
       }
       phase.hasContent ||= lateLabelIndices.some((lateLabelIndex) =>
         isVisibleContentPart(content[lateLabelIndex]),
@@ -222,19 +228,18 @@ export function groupActivityPhases(
     segments.push({
       type: 'phase',
       content: phase.content,
+      contentIndices: phase.contentIndices,
       startIndex: phase.startIndex,
       labelPart: part,
       labelIndex: index,
       hasContent: phase.hasContent,
     });
     if (end < index) {
-      const trailing = slice(end, index);
-      for (const lateLabelIndex of lateLabelIndices) {
-        trailing.content[lateLabelIndex - end] = undefined;
-      }
+      const trailing = slice(end, index, new Set(lateLabelIndices));
       segments.push({
         type: 'content',
         content: trailing.content,
+        contentIndices: trailing.contentIndices,
         startIndex: trailing.startIndex,
       });
     }
@@ -245,6 +250,7 @@ export function groupActivityPhases(
     segments.push({
       type: 'content',
       content: adjacent.content,
+      contentIndices: adjacent.contentIndices,
       startIndex: adjacent.startIndex,
     });
   }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -215,7 +215,9 @@ export function groupActivityPhases(
       for (const lateLabelIndex of lateLabelIndices) {
         phase.content[lateLabelIndex - start] = content[lateLabelIndex];
       }
-      phase.hasContent = phase.content.some(isVisibleContentPart);
+      phase.hasContent ||= lateLabelIndices.some((lateLabelIndex) =>
+        isVisibleContentPart(content[lateLabelIndex]),
+      );
     }
     segments.push({
       type: 'phase',

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -51,6 +51,9 @@ function isLogicallyEarlierPhaseMarker(
     if (!isVisibleContentPart(trailingPart)) {
       return false;
     }
+    if (getBatchActivityLabelPart(trailingPart) != null) {
+      return false;
+    }
     if (trailingPart?.type !== ContentTypes.TEXT) {
       return true;
     }

--- a/client/src/utils/activityLabels.ts
+++ b/client/src/utils/activityLabels.ts
@@ -63,26 +63,29 @@ function isLogicallyEarlierPhaseMarker(
   });
 }
 
-function isLateActivityLabelConsumedByPhase(
+function findLateActivityLabelsConsumedByPhase(
   parts: ReadonlyArray<TMessageContentParts | undefined>,
-  index: number,
-): boolean {
-  if (getBatchActivityLabelPart(parts[index]) == null) {
-    return false;
-  }
-  for (let markerIndex = index + 1; markerIndex < parts.length; markerIndex += 1) {
-    const marker = getActivityLabelPart(parts[markerIndex]);
+): Set<number> {
+  const consumed = new Set<number>();
+  let earliestPhaseEnd: number | undefined;
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const marker = getActivityLabelPart(parts[index]);
     if (
       isPhaseActivityLabel(marker) &&
       marker?.pending !== true &&
       getActivityLabelText(marker).length > 0 &&
-      typeof marker?.activity_end_index === 'number' &&
-      marker.activity_end_index <= index
+      typeof marker?.activity_end_index === 'number'
     ) {
-      return true;
+      earliestPhaseEnd = Math.min(earliestPhaseEnd ?? index, marker.activity_end_index);
+    } else if (
+      earliestPhaseEnd != null &&
+      earliestPhaseEnd <= index &&
+      getBatchActivityLabelPart(parts[index]) != null
+    ) {
+      consumed.add(index);
     }
   }
-  return false;
+  return consumed;
 }
 
 export function isPhaseActivityLabel(part: ActivityLabelPart | undefined): boolean {
@@ -238,12 +241,13 @@ export function lastVisibleContentIdx(
   content: ReadonlyArray<TMessageContentParts | undefined> | undefined,
 ): number {
   const parts = content ?? [];
+  const consumedLateActivityLabels = findLateActivityLabelsConsumedByPhase(parts);
   let last = parts.length - 1;
   while (last >= 0 && last in parts) {
     if (
       isVisibleContentPart(parts[last]) &&
       !isLogicallyEarlierPhaseMarker(parts, last) &&
-      !isLateActivityLabelConsumedByPhase(parts, last)
+      !consumedLateActivityLabels.has(last)
     ) {
       return last;
     }
@@ -261,7 +265,7 @@ export function lastVisibleContentIdx(
       index <= last &&
       isVisibleContentPart(parts[index]) &&
       !isLogicallyEarlierPhaseMarker(parts, index) &&
-      !isLateActivityLabelConsumedByPhase(parts, index)
+      !consumedLateActivityLabels.has(index)
     ) {
       return index;
     }

--- a/e2e/specs/mock/activity-phases.spec.ts
+++ b/e2e/specs/mock/activity-phases.spec.ts
@@ -149,6 +149,38 @@ test.describe('parent activity phases', () => {
 
     const parent = messagesView(page).locator(`summary[aria-label="${PARENT_LABEL}"]`);
     await expect(parent).toBeVisible({ timeout: 60000 });
+    /** Inspect the durable projection before the live DOM assertion so a
+     *  failure identifies whether the server bound or client grouping is
+     *  wrong. This remains a useful contract assertion after the bug is fixed. */
+    const liveConversationId = await getConversationId(page);
+    const liveToken = await getAccessToken(page);
+    let liveAssistant: PersistedMessage | undefined;
+    await expect
+      .poll(
+        async () => {
+          const messages = await fetchJson<PersistedMessage[]>(
+            page,
+            `/api/messages/${encodeURIComponent(liveConversationId)}`,
+            liveToken,
+          );
+          liveAssistant = messages.find(
+            (message) =>
+              message.isCreatedByUser === false && messageText(message).includes(finalText),
+          );
+          return liveAssistant?.unfinished;
+        },
+        { timeout: 30000 },
+      )
+      .toBe(false);
+    const liveContent = liveAssistant?.content ?? [];
+    const livePhase = liveContent.find(
+      (part) => part?.type === 'activity_label' && part.activity_label_type === 'phase',
+    );
+    const liveFinalTextIndex = liveContent.findIndex((part) =>
+      contentPartText(part).includes(finalText),
+    );
+    expect(liveFinalTextIndex).toBe(livePhase?.activity_end_index);
+
     await expect(messagesView(page).getByText(finalText)).toBeVisible({ timeout: 60000 });
     await parent.click();
     await expect(messagesView(page).getByRole('button', { name: childLabels.first })).toBeVisible();

--- a/e2e/specs/mock/activity-phases.spec.ts
+++ b/e2e/specs/mock/activity-phases.spec.ts
@@ -27,6 +27,7 @@ type PersistedContentPart = {
   activity_label?: string;
   activity_label_type?: string;
   activity_start_index?: number;
+  activity_end_index?: number;
   activity_count?: number;
   pending?: boolean;
   tool_call?: { id?: string };
@@ -210,8 +211,12 @@ test.describe('parent activity phases', () => {
       pending: false,
     });
     expect(phasePart?.activity_start_index).toBeGreaterThanOrEqual(0);
-    expect(phasePart?.activity_start_index).toBeLessThan(phaseIndex);
-    const phaseChildren = content.slice(phasePart?.activity_start_index ?? phaseIndex, phaseIndex);
+    expect(phasePart?.activity_end_index).toBeGreaterThan(phasePart?.activity_start_index ?? -1);
+    expect(phasePart?.activity_end_index).toBeLessThanOrEqual(phaseIndex);
+    const phaseChildren = content.slice(
+      phasePart?.activity_start_index ?? phaseIndex,
+      phasePart?.activity_end_index ?? phaseIndex,
+    );
     expect(phaseChildren.map((part) => part?.tool_call?.id).filter(Boolean)).toEqual(
       expect.arrayContaining([firstToolCallId, secondToolCallId]),
     );
@@ -219,7 +224,7 @@ test.describe('parent activity phases', () => {
       expect.arrayContaining([childLabels.first, childLabels.second]),
     );
     const finalTextIndex = content.findIndex((part) => contentPartText(part).includes(finalText));
-    expect(finalTextIndex).toBeGreaterThan(phaseIndex);
+    expect(finalTextIndex).toBe(phasePart?.activity_end_index);
 
     await page.reload();
     const reloadedParent = messagesView(page).locator(`summary[aria-label="${PARENT_LABEL}"]`);

--- a/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
+++ b/packages/api/src/agents/activityLabels/__tests__/wiring.spec.ts
@@ -187,11 +187,12 @@ describe('synthesizeActivityLabelGapEvents', () => {
         activity_label: 'Inspected and fixed the session',
         activity_label_type: 'phase',
         activity_start_index: 0,
+        activity_end_index: 1,
         activity_count: 2,
         pending: false,
       },
     ];
-    const fresh: LooseContentPart[] = [{ ...snapshot[0], activity_start_index: 1 }];
+    const fresh: LooseContentPart[] = [{ ...snapshot[0], activity_end_index: 2 }];
 
     expect(synthesizeActivityLabelGapEvents(snapshot, fresh, meta)).toHaveLength(1);
   });

--- a/packages/api/src/agents/activityLabels/wiring.ts
+++ b/packages/api/src/agents/activityLabels/wiring.ts
@@ -154,6 +154,7 @@ export function synthesizeActivityLabelGapEvents(
       snapshot[ContentTypes.ACTIVITY_LABEL] === part[ContentTypes.ACTIVITY_LABEL] &&
       snapshot.activity_label_type === part.activity_label_type &&
       snapshot.activity_start_index === part.activity_start_index &&
+      snapshot.activity_end_index === part.activity_end_index &&
       snapshot.activity_count === part.activity_count &&
       snapshot.pending === part.pending;
     if (isSameLabel) {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -725,6 +725,27 @@ describe('createActivityPhaseWiring', () => {
     expect(snapshot.overflowToolCallIds).toEqual(['tool-19']);
   });
 
+  it('retains every overflow tool ID tied at the latest boundary', async () => {
+    const parts: LooseContentPart[] = [];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({})),
+    });
+    for (let index = 0; index < 13; index += 1) {
+      await wiring.hook(batch(`retained-${index}`), new AbortController().signal);
+    }
+    await wiring.hook(batch('overflow-a'), new AbortController().signal);
+    await wiring.hook(batch('overflow-b'), new AbortController().signal);
+
+    expect(wiring.snapshot()).toMatchObject({
+      overflowActivityStartIndex: 0,
+      overflowToolCallIds: ['overflow-a', 'overflow-b'],
+    });
+  });
+
   it('rebases a resumed overflow anchor after content compaction', async () => {
     const parts: LooseContentPart[] = Array.from({ length: 13 }, (_, index) => ({
       type: ContentTypes.TOOL_CALL,

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -956,6 +956,38 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[2]).toMatchObject({ activity_end_index: 2, activity_count: 15 });
   });
 
+  it('extends a sparse phase start using only defined boundary slots', async () => {
+    const parts: LooseContentPart[] = [];
+    parts[999_998] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-a' } };
+    parts[1_000_000] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-b' } };
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 2,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          { startIndex: 999_998, status: 'success', toolCallIds: ['tool-a'] },
+          { startIndex: 1_000_000, status: 'success', toolCallIds: ['tool-b'] },
+        ],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the sparse workflow' })),
+    });
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[1_000_001]).toMatchObject({ activity_start_index: 0, activity_count: 2 });
+  });
+
   it('keeps post-cap activities grouped after the last root text', async () => {
     const parts: LooseContentPart[] = [];
     const generatePhase = jest.fn(async () => ({ label: 'Completed the extended investigation' }));

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -809,6 +809,56 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 3 });
   });
 
+  it('resolves index-less pending reasoning before preserving the final-text boundary', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'This answer preceded more reasoning.' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the extended investigation' })),
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    const handlers = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      [GraphEvents.ON_REASONING_DELTA]: { handle: jest.fn() },
+    });
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'late-reasoning',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'think' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[3] = { type: ContentTypes.THINK, think: 'Verified one more edge case.' };
+    handlers?.[GraphEvents.ON_REASONING_DELTA]?.handle(
+      GraphEvents.ON_REASONING_DELTA,
+      {
+        id: 'late-reasoning',
+        delta: {
+          content: { type: ContentTypes.THINK, think: 'Verified one more edge case.' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[4]).toMatchObject({ activity_end_index: 4, activity_count: 3 });
+  });
+
   it('keeps a partially materialized retained batch after the candidate final text', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'batch-a' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1519,6 +1519,44 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
   });
 
+  it('skips a trailing empty text reservation when choosing the final boundary', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'The materialized answer is complete.' },
+      { type: ContentTypes.TEXT, text: '', phase: 'final_answer' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'empty-final' ? 3 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the workflow' })),
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'empty-final',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[4]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
+  });
+
   it('ignores an empty reasoning reservation after the materialized final text', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -867,6 +867,12 @@ describe('createActivityPhaseWiring', () => {
       undefined,
     );
     parts[5] = { type: ContentTypes.TEXT, text: 'The investigation is complete.' };
+    parts[6] = {
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Recorded the delayed child result',
+      tool_call_ids: ['tool-4'],
+      pending: false,
+    };
 
     expect(generatePhase).not.toHaveBeenCalled();
     wiring.complete();
@@ -874,7 +880,7 @@ describe('createActivityPhaseWiring', () => {
 
     expect(generatePhase).toHaveBeenCalledTimes(1);
     expect(generatePhase).toHaveBeenCalledWith(expect.objectContaining({ totalActivityCount: 4 }));
-    expect(parts[6]).toMatchObject({
+    expect(parts[7]).toMatchObject({
       activity_label_type: 'phase',
       activity_start_index: 0,
       activity_end_index: 5,

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -802,6 +802,57 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[15]).toMatchObject({ activity_end_index: 14, activity_count: 14 });
   });
 
+  it('drops a stale reasoning-only overflow anchor after HITL compaction', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TEXT, text: 'The compacted answer is complete.' },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the resumed workflow' }));
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 14,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: Array.from({ length: 13 }, (_, index) => ({
+          startIndex: 0,
+          status: 'success' as const,
+          thinkingExcerpts: [`Retained reasoning ${index} that was filtered on pause.`],
+        })),
+        overflowActivityStartIndex: 30,
+        overflowReasoningExcerpt: 'Overflow reasoning that was filtered on pause.',
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 0 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[1]).toMatchObject({ activity_end_index: 0, activity_count: 14 });
+  });
+
   it('retains an earlier overflow ID when delayed tools materialize in reverse order', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-b' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -722,7 +722,7 @@ describe('createActivityPhaseWiring', () => {
     expect(snapshot.activityCount).toBe(20);
     expect(snapshot.activities).toHaveLength(13);
     expect(snapshot.overflowActivityStartIndex).toBe(19);
-    expect(snapshot.overflowToolCallIds).toEqual(['tool-19']);
+    expect(snapshot.overflowToolCallIds).toHaveLength(7);
   });
 
   it('retains every overflow tool ID tied at the latest boundary', async () => {
@@ -800,6 +800,58 @@ describe('createActivityPhaseWiring', () => {
     await flushDetached();
 
     expect(parts[15]).toMatchObject({ activity_end_index: 14, activity_count: 14 });
+  });
+
+  it('retains an earlier overflow ID when delayed tools materialize in reverse order', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-b' } },
+      { type: ContentTypes.TEXT, text: 'This answer arrived between delayed tools.' },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-a' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the delayed workflow' }));
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 15,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: Array.from({ length: 13 }, () => ({
+          startIndex: 0,
+          status: 'success' as const,
+        })),
+        overflowActivityStartIndex: 20,
+        overflowToolCallIds: ['overflow-a', 'overflow-b'],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 1 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 15 });
   });
 
   it('keeps post-cap activities grouped after the last root text', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -721,6 +721,53 @@ describe('createActivityPhaseWiring', () => {
     const snapshot = wiring.snapshot();
     expect(snapshot.activityCount).toBe(20);
     expect(snapshot.activities).toHaveLength(13);
+    expect(snapshot.overflowActivityStartIndex).toBe(19);
+    expect(snapshot.overflowToolCallIds).toHaveLength(7);
+  });
+
+  it('keeps post-cap activities grouped after the last root text', async () => {
+    const parts: LooseContentPart[] = [];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the extended investigation' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 13 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    for (let index = 0; index < 13; index += 1) {
+      const id = `tool-${index}`;
+      parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id } });
+      await wiring.hook(batch(id), new AbortController().signal);
+    }
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+    parts[13] = { type: ContentTypes.TEXT, text: 'This may be the final answer.' };
+    parts[14] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-overflow' } };
+    await wiring.hook(batch('tool-overflow'), new AbortController().signal);
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+    expect(parts[15]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 15,
+      activity_count: 14,
+    });
   });
 
   it('keeps a parallel lane final inside the run-wide phase', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -856,6 +856,67 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('keeps later semantic commentary inside a phase after unphased root text', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the commentary phase' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) =>
+        stepId === 'root-text' ? 1 : stepId === 'commentary' ? 3 : undefined,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[1] = { type: ContentTypes.TEXT, text: 'I will keep investigating.' };
+    parts[2] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } };
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'commentary',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'commentary' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[3] = {
+      type: ContentTypes.TEXT,
+      text: 'The second search confirmed it.',
+      phase: 'commentary',
+    };
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[4]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 4,
+      activity_count: 2,
+    });
+  });
+
   it('summarizes all unphased activities once at root-run completion', async () => {
     const parts: LooseContentPart[] = [];
     const stepIndexes = new Map([

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -853,6 +853,108 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[1]).toMatchObject({ activity_end_index: 0, activity_count: 14 });
   });
 
+  it('rejects a text boundary when a duplicate reasoning anchor follows it', async () => {
+    const duplicate = 'The same reasoning prefix identifies both retained activities.';
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.THINK, think: duplicate },
+      { type: ContentTypes.TEXT, text: 'This looked like the final answer.' },
+      { type: ContentTypes.THINK, think: `${duplicate} Later activity details.` },
+    ];
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 2,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          { startIndex: 0, status: 'success', thinkingExcerpts: [duplicate] },
+          { startIndex: 2, status: 'success', thinkingExcerpts: [duplicate] },
+        ],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 1 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed both reasoning passes' })),
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 2 });
+  });
+
+  it('rejects a text boundary when a duplicate overflow reasoning anchor follows it', async () => {
+    const duplicate = 'The overflow reasoning prefix is shared by both positions.';
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.THINK, think: duplicate },
+      { type: ContentTypes.TEXT, text: 'This looked like the final overflow answer.' },
+      { type: ContentTypes.THINK, think: `${duplicate} Later overflow details.` },
+    ];
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 14,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: Array.from({ length: 13 }, () => ({
+          startIndex: 0,
+          status: 'success' as const,
+        })),
+        overflowActivityStartIndex: 2,
+        overflowReasoningExcerpt: duplicate,
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 1 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed overflow reasoning' })),
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 14 });
+  });
+
   it('retains an earlier overflow ID when delayed tools materialize in reverse order', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-b' } },
@@ -1058,6 +1160,45 @@ describe('createActivityPhaseWiring', () => {
       activity_end_index: 2,
       activity_count: 2,
     });
+  });
+
+  it('excludes the persisted final text from the phase summary context', async () => {
+    const finalText = 'The persisted answer is complete.';
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: finalText },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the persisted workflow' }));
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 2,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          { startIndex: 0, status: 'success', toolCallIds: ['tool-1'] },
+          { startIndex: 1, status: 'success', toolCallIds: ['tool-2'] },
+        ],
+        assistantContext: ['I will inspect both sources.', finalText],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(generatePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantContext: ['I will inspect both sources.'] }),
+    );
+    expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
   });
 
   it('prefers the materialized final text over a stale retained step index', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1149,6 +1149,59 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 14 });
   });
 
+  it('checks every overflow reasoning anchor when delayed parts materialize out of order', async () => {
+    const earlier = 'The earlier overflow activity finished after the apparent answer.';
+    const later = 'The later overflow activity materialized before the apparent answer.';
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.THINK, think: later },
+      { type: ContentTypes.TEXT, text: 'This looked like the final overflow answer.' },
+      { type: ContentTypes.THINK, think: earlier },
+    ];
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 15,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: Array.from({ length: 13 }, () => ({
+          startIndex: 0,
+          status: 'success' as const,
+        })),
+        overflowActivityStartIndex: 2,
+        overflowReasoningAnchors: [earlier, later],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 1 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed overflow reasoning' })),
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 15 });
+  });
+
   it('retains an earlier overflow ID when delayed tools materialize in reverse order', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-b' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -860,11 +860,14 @@ describe('createActivityPhaseWiring', () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
     ];
+    const stepIndexes = new Map([
+      ['root-text', 1],
+      ['commentary', 3],
+    ]);
     const generatePhase = jest.fn(async () => ({ label: 'Completed the commentary phase' }));
     const wiring = createActivityPhaseWiring({
       getContentParts: () => parts,
-      getStepIndex: (stepId) =>
-        stepId === 'root-text' ? 1 : stepId === 'commentary' ? 3 : undefined,
+      getStepIndex: (stepId) => stepIndexes.get(stepId),
       bumpIndexOffset: jest.fn(),
       emitLabelEvent: jest.fn(async () => undefined),
       trackPendingFill: jest.fn(),

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1037,6 +1037,58 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('keeps a parallel tool batch grouped when it straddles the last root text', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'parallel-1' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the parallel workflow' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 2 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    const parallelBatch = batch('parallel-1');
+    parallelBatch.entries.push({
+      ...parallelBatch.entries[0],
+      toolUseId: 'parallel-2',
+      toolInput: { query: 'parallel-2' },
+      toolOutput: 'parallel-2-result',
+    });
+    await wiring.hook(parallelBatch, new AbortController().signal);
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[2] = { type: ContentTypes.TEXT, text: 'The parallel work may be complete.' };
+    parts[3] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'parallel-2' } };
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+    expect(parts[4]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 4,
+      activity_count: 2,
+    });
+  });
+
   it('preserves mixed batch failures as a partial phase outcome', async () => {
     const mixed = batch('tool-1');
     mixed.entries.push({

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1335,7 +1335,7 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
-  it('keeps semantic commentary inside a completion-finalized phase', async () => {
+  it('leaves final semantic commentary outside a completion-finalized phase', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
     ];
@@ -1373,12 +1373,12 @@ describe('createActivityPhaseWiring', () => {
 
     expect(parts[3]).toMatchObject({
       activity_start_index: 0,
-      activity_end_index: 3,
+      activity_end_index: 2,
       activity_count: 2,
     });
   });
 
-  it('keeps later semantic commentary inside a phase after unphased root text', async () => {
+  it('leaves the last semantic commentary outside after earlier unphased text', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
     ];
@@ -1437,12 +1437,12 @@ describe('createActivityPhaseWiring', () => {
 
     expect(parts[4]).toMatchObject({
       activity_start_index: 0,
-      activity_end_index: 4,
+      activity_end_index: 3,
       activity_count: 2,
     });
   });
 
-  it('keeps persisted semantic commentary inside the phase after HITL resume', async () => {
+  it('leaves persisted final commentary outside the phase after HITL resume', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
       { type: ContentTypes.TEXT, text: 'I will keep investigating.' },
@@ -1477,7 +1477,7 @@ describe('createActivityPhaseWiring', () => {
 
     expect(parts[4]).toMatchObject({
       activity_start_index: 0,
-      activity_end_index: 4,
+      activity_end_index: 3,
       activity_count: 2,
     });
   });

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1060,6 +1060,48 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('prefers the materialized final text over a stale retained step index', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the indexed workflow' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 3 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[2] = { type: ContentTypes.TEXT, text: 'The indexed answer is complete.' };
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 2,
+      activity_count: 2,
+    });
+  });
+
   it('keeps a parallel lane final inside the run-wide phase', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -722,7 +722,63 @@ describe('createActivityPhaseWiring', () => {
     expect(snapshot.activityCount).toBe(20);
     expect(snapshot.activities).toHaveLength(13);
     expect(snapshot.overflowActivityStartIndex).toBe(19);
-    expect(snapshot.overflowToolCallIds).toHaveLength(7);
+    expect(snapshot.overflowToolCallIds).toEqual(['tool-19']);
+  });
+
+  it('rebases a resumed overflow anchor after content compaction', async () => {
+    const parts: LooseContentPart[] = Array.from({ length: 13 }, (_, index) => ({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: { id: `retained-${index}` },
+    }));
+    parts.push(
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-tool' } },
+      { type: ContentTypes.TEXT, text: 'The compacted answer is complete.' },
+    );
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the resumed workflow' }));
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 14,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: Array.from({ length: 13 }, (_, index) => ({
+          startIndex: index,
+          status: 'success' as const,
+          toolCallIds: [`retained-${index}`],
+        })),
+        overflowActivityStartIndex: 30,
+        overflowToolCallIds: ['overflow-tool'],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 14 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[15]).toMatchObject({ activity_end_index: 14, activity_count: 14 });
   });
 
   it('keeps post-cap activities grouped after the last root text', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1071,6 +1071,46 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('keeps persisted semantic commentary inside the phase after HITL resume', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TEXT, text: 'I will keep investigating.' },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'The second search confirmed it.', phase: 'commentary' },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the resumed commentary' }));
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 2,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          { startIndex: 0, status: 'success', toolCallIds: ['tool-1'] },
+          { startIndex: 2, status: 'success', toolCallIds: ['tool-2'] },
+        ],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[4]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 4,
+      activity_count: 2,
+    });
+  });
+
   it('summarizes all unphased activities once at root-run completion', async () => {
     const parts: LooseContentPart[] = [];
     const stepIndexes = new Map([

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -106,6 +106,72 @@ describe('createActivityPhaseWiring', () => {
     expect(emitLabelEvent).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps interleaved parallel text context keyed to its run step', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Compared both parallel findings' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    const handlers = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      [GraphEvents.ON_MESSAGE_DELTA]: { handle: jest.fn() },
+    });
+    const emitTextStep = (id: string, agentId: string) =>
+      handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id,
+          agentId,
+          groupId: agentId,
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+    const emitTextDelta = (id: string, text: string) =>
+      handlers?.[GraphEvents.ON_MESSAGE_DELTA]?.handle(
+        GraphEvents.ON_MESSAGE_DELTA,
+        { id, delta: { content: { type: ContentTypes.TEXT, text } } },
+        undefined,
+        undefined,
+      );
+
+    emitTextStep('lane-a', 'agent-a');
+    emitTextStep('lane-b', 'agent-b');
+    emitTextDelta('lane-a', 'First lane ');
+    emitTextDelta('lane-b', 'Second lane');
+    emitTextDelta('lane-a', 'completed');
+    handlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-final',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'final_answer' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+
+    await flushDetached();
+    expect(generatePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ assistantContext: ['First lane completed', 'Second lane'] }),
+    );
+  });
+
   it('reanchors a tool that lands after the phase hook observes its child label', async () => {
     const parts: LooseContentPart[] = [];
     const wiring = createActivityPhaseWiring({

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -882,6 +882,48 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('keeps later activities grouped when the last root text preceded them', async () => {
+    const parts: LooseContentPart[] = [{ type: ContentTypes.TEXT, text: 'I will investigate.' }];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the direct-return workflow' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 0 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[1] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } };
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts[2] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } };
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+    expect(parts[3]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 3,
+      activity_count: 2,
+    });
+  });
+
   it('preserves mixed batch failures as a partial phase outcome', async () => {
     const mixed = batch('tool-1');
     mixed.entries.push({

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1466,6 +1466,46 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
   });
 
+  it('ignores an empty reasoning reservation after the materialized final text', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'The answer is complete.' },
+      { type: ContentTypes.THINK, think: '' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'empty-reasoning' ? 3 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the workflow' })),
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    wiring
+      .handlers({
+        [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'empty-reasoning',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'think' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[4]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
+  });
+
   it('keeps a parallel lane final inside the run-wide phase', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -85,6 +85,7 @@ describe('createActivityPhaseWiring', () => {
       type: ContentTypes.ACTIVITY_LABEL,
       activity_label_type: 'phase',
       activity_start_index: 0,
+      activity_end_index: 2,
       activity_count: 2,
       pending: true,
     });
@@ -799,7 +800,86 @@ describe('createActivityPhaseWiring', () => {
       undefined,
     );
     await flushDetached();
+    expect(generatePhase).not.toHaveBeenCalled();
+
+    parts[2] = { type: ContentTypes.TEXT, text: 'Finished the run' };
+    wiring.complete();
+    await flushDetached();
     expect(generatePhase).toHaveBeenCalledTimes(1);
+    expect(parts[3]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 2,
+      activity_count: 2,
+    });
+  });
+
+  it('summarizes all unphased activities once at root-run completion', async () => {
+    const parts: LooseContentPart[] = [];
+    const stepIndexes = new Map([
+      ['intermediate-text', 2],
+      ['final-text', 5],
+    ]);
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the full investigation' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => stepIndexes.get(stepId),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+
+    parts[0] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } };
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts[1] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } };
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'intermediate-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[2] = { type: ContentTypes.TEXT, text: 'I will try another approach.' };
+
+    parts[3] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-3' } };
+    await wiring.hook(batch('tool-3'), new AbortController().signal);
+    parts[4] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-4' } };
+    await wiring.hook(batch('tool-4'), new AbortController().signal);
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'final-text',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[5] = { type: ContentTypes.TEXT, text: 'The investigation is complete.' };
+
+    expect(generatePhase).not.toHaveBeenCalled();
+    wiring.complete();
+    await flushDetached();
+
+    expect(generatePhase).toHaveBeenCalledTimes(1);
+    expect(generatePhase).toHaveBeenCalledWith(expect.objectContaining({ totalActivityCount: 4 }));
+    expect(parts[6]).toMatchObject({
+      activity_label_type: 'phase',
+      activity_start_index: 0,
+      activity_end_index: 5,
+      activity_count: 4,
+    });
   });
 
   it('preserves mixed batch failures as a partial phase outcome', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -905,6 +905,57 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 15 });
   });
 
+  it('keeps the overflow fallback while a boundary tool remains unresolved', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'overflow-a' } },
+      { type: ContentTypes.TEXT, text: 'This answer preceded a delayed overflow tool.' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 15,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: Array.from({ length: 13 }, () => ({
+          startIndex: 0,
+          status: 'success' as const,
+        })),
+        overflowActivityStartIndex: 20,
+        overflowToolCallIds: ['overflow-a', 'overflow-b'],
+        overflowBoundaryToolCallIds: ['overflow-a', 'overflow-b'],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-text' ? 1 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the delayed workflow' })),
+    });
+    wiring
+      .handlers({ [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() } })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
+        },
+        undefined,
+        undefined,
+      );
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[2]).toMatchObject({ activity_end_index: 2, activity_count: 15 });
+  });
+
   it('keeps post-cap activities grouped after the last root text', async () => {
     const parts: LooseContentPart[] = [];
     const generatePhase = jest.fn(async () => ({ label: 'Completed the extended investigation' }));

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -703,6 +703,84 @@ describe('createActivityPhaseWiring', () => {
     expect(parts[parts.length - 1]).toMatchObject({ activity_start_index: 0 });
   });
 
+  it('drops a stale pending-reasoning index after HITL content compaction', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'The resumed answer is complete.' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 2,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          { startIndex: 0, status: 'success', toolCallIds: ['tool-1'] },
+          { startIndex: 1, status: 'success', toolCallIds: ['tool-2'] },
+        ],
+        assistantContext: [],
+        pendingReasoning: [
+          {
+            key: 'root',
+            text: 'Reasoning removed by hide_sequential_outputs.',
+            startIndex: 20,
+          },
+        ],
+      },
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the resumed workflow' })),
+    });
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
+  });
+
+  it('keeps a partially materialized retained batch after the candidate final text', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'batch-a' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'This answer preceded the delayed batch tool.' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      initialSnapshot: {
+        version: 1,
+        generated: 0,
+        activityCount: 2,
+        failedActivityCount: 0,
+        partialActivityCount: 0,
+        agentIds: [],
+        activities: [
+          {
+            startIndex: 20,
+            status: 'success',
+            toolCallIds: ['batch-a', 'batch-b'],
+          },
+          { startIndex: 1, status: 'success', toolCallIds: ['tool-2'] },
+        ],
+        assistantContext: [],
+        pendingReasoning: [],
+      },
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the delayed batch workflow' })),
+    });
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 3, activity_count: 2 });
+  });
+
   it('bounds persisted evidence while preserving the full activity count', async () => {
     const parts: LooseContentPart[] = [];
     const wiring = createActivityPhaseWiring({

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -806,7 +806,7 @@ describe('createActivityPhaseWiring', () => {
     wiring.complete();
     await flushDetached();
 
-    expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
+    expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 3 });
   });
 
   it('keeps a partially materialized retained batch after the candidate final text', async () => {

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1245,6 +1245,28 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('leaves the last materialized text outside even when it retains a lane id', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'The lane answer is complete.', groupId: 'lane-a' },
+    ];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({ label: 'Completed the lane workflow' })),
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({ activity_end_index: 2, activity_count: 2 });
+  });
+
   it('keeps a parallel lane final inside the run-wide phase', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1217,20 +1217,22 @@ describe('createActivityPhaseWiring', () => {
     });
     await wiring.hook(batch('tool-1'), new AbortController().signal);
     await wiring.hook(batch('tool-2'), new AbortController().signal);
-    wiring.handlers({
-      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
-    })?.[GraphEvents.ON_RUN_STEP]?.handle(
-      GraphEvents.ON_RUN_STEP,
-      {
-        id: 'root-text',
-        stepDetails: {
-          type: StepTypes.MESSAGE_CREATION,
-          message_creation: { message_id: 'm', content_type: 'text' },
+    wiring
+      .handlers({
+        [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+      })
+      ?.[GraphEvents.ON_RUN_STEP]?.handle(
+        GraphEvents.ON_RUN_STEP,
+        {
+          id: 'root-text',
+          stepDetails: {
+            type: StepTypes.MESSAGE_CREATION,
+            message_creation: { message_id: 'm', content_type: 'text' },
+          },
         },
-      },
-      undefined,
-      undefined,
-    );
+        undefined,
+        undefined,
+      );
     parts[2] = { type: ContentTypes.TEXT, text: 'The indexed answer is complete.' };
 
     wiring.complete();

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -813,6 +813,49 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('keeps semantic commentary inside a completion-finalized phase', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the commentary phase' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      getStepIndex: (stepId) => (stepId === 'root-commentary' ? 2 : undefined),
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    parts[1] = { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } };
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+    const handler = wiring.handlers({
+      [GraphEvents.ON_RUN_STEP]: { handle: jest.fn() },
+    })?.[GraphEvents.ON_RUN_STEP];
+    handler?.handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'root-commentary',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'm', content_type: 'text', phase: 'commentary' },
+        },
+      },
+      undefined,
+      undefined,
+    );
+    parts[2] = { type: ContentTypes.TEXT, text: 'Intermediate commentary', phase: 'commentary' };
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 3,
+      activity_count: 2,
+    });
+  });
+
   it('summarizes all unphased activities once at root-run completion', async () => {
     const parts: LooseContentPart[] = [];
     const stepIndexes = new Map([

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -770,6 +770,33 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  it('finds an unphased final content part without a retained run-step boundary', async () => {
+    const parts: LooseContentPart[] = [
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
+      { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
+      { type: ContentTypes.TEXT, text: 'The persisted answer is complete.' },
+    ];
+    const generatePhase = jest.fn(async () => ({ label: 'Completed the persisted workflow' }));
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase,
+    });
+    await wiring.hook(batch('tool-1'), new AbortController().signal);
+    await wiring.hook(batch('tool-2'), new AbortController().signal);
+
+    wiring.complete();
+    await flushDetached();
+
+    expect(parts[3]).toMatchObject({
+      activity_start_index: 0,
+      activity_end_index: 2,
+      activity_count: 2,
+    });
+  });
+
   it('keeps a parallel lane final inside the run-wide phase', async () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },

--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1443,7 +1443,12 @@ describe('createActivityPhaseWiring', () => {
     const parts: LooseContentPart[] = [
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-1' } },
       { type: ContentTypes.TOOL_CALL, tool_call: { id: 'tool-2' } },
-      { type: ContentTypes.TEXT, text: 'The lane answer is complete.', groupId: 'lane-a' },
+      {
+        type: ContentTypes.TEXT,
+        text: 'The lane answer is complete.',
+        phase: 'final_answer',
+        groupId: 'lane-a',
+      },
     ];
     const wiring = createActivityPhaseWiring({
       getContentParts: () => parts,

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -1028,6 +1028,13 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     let finalTextIndex =
       lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
     const parts = deps.getContentParts();
+    if (
+      finalTextIndex != null &&
+      (parts[finalTextIndex]?.type !== ContentTypes.TEXT ||
+        !textValue(parts[finalTextIndex]?.text).trim())
+    ) {
+      finalTextIndex = undefined;
+    }
     /** The host step map is an event-coordinate hint, not the authoritative
      *  rendered position. Activity-label reservations advance the shared
      *  content offset after earlier steps were indexed, and a provider can
@@ -1045,7 +1052,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
        *  An already-closed phase has no remaining activities and completion
        *  is a no-op. The later-activity checks below still reject an
        *  intermediate lane text when tools or reasoning follow it. */
-      if (part?.type === ContentTypes.TEXT) {
+      if (part?.type === ContentTypes.TEXT && textValue(part.text).trim()) {
         finalTextIndex = index;
         break;
       }
@@ -1091,19 +1098,32 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);
-      const hasLaterPendingReasoning = [...pendingReasoning.values()].some((reasoning) => {
+      const pendingReasoningAnchors = new Set<string>();
+      const pendingReasoningAnchorIndex: ReasoningAnchorIndex = new Map();
+      let hasLaterPendingReasoningIndex = false;
+      for (const reasoning of pendingReasoning.values()) {
         /** Empty reasoning reservations are not activities: addPendingReasoning
          *  deliberately drops them. They can still receive a later sparse
          *  index from the SDK, so do not let that placeholder pull a fully
          *  materialized final answer into the completed parent phase. */
         if (!reasoning.text.trim()) {
-          return false;
+          continue;
         }
-        return (
-          (reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex) ||
-          hasReasoningExcerptAtOrAfter(parts, reasoning.text, candidateFinalTextIndex)
+        hasLaterPendingReasoningIndex ||=
+          reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex;
+        addReasoningAnchor(
+          pendingReasoningAnchors,
+          pendingReasoningAnchorIndex,
+          reasoning.text,
         );
-      });
+      }
+      const hasLaterPendingReasoning =
+        hasLaterPendingReasoningIndex ||
+        hasIndexedReasoningAtOrAfter(
+          parts,
+          pendingReasoningAnchorIndex,
+          candidateFinalTextIndex,
+        );
       if (hasLaterTrackedActivity || hasLaterOverflowActivity || hasLaterPendingReasoning) {
         finalTextIndex = undefined;
       }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -758,8 +758,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           index > candidateFinalTextIndex &&
           (part?.type === ContentTypes.TOOL_CALL ||
             part?.type === ContentTypes.THINK ||
-            (part?.type === ContentTypes.ACTIVITY_LABEL &&
-              part.activity_label_type !== 'phase')),
+            (part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type !== 'phase')),
       );
       const hasLaterTrackedActivity = activities.some(
         (activity) => activity.startIndex >= candidateFinalTextIndex,

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -670,8 +670,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
               }
               return result;
             } else {
-              if (step.groupId == null && phase == null) {
-                lastRootTextStepId = step.id;
+              if (step.groupId == null) {
+                lastRootTextStepId = phase == null ? step.id : undefined;
               }
               if (phase === 'final_answer' && step.groupId == null) {
                 addPendingReasoning(step.agentId ?? 'root');

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -596,8 +596,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     /** Pull leading commentary/reasoning into the parent card. A prior phase
      *  marker or steer is the only hard UI boundary; plain text can be
      *  intermediate context on providers that do not expose phase metadata. */
-    for (let i = startIndex - 1; i >= 0; i--) {
-      const prior = currentParts[i];
+    const definedIndices = definedPartIndices(currentParts);
+    let extendedStartIndex = 0;
+    for (let position = definedIndices.length - 1; position >= 0; position -= 1) {
+      const priorIndex = definedIndices[position];
+      if (priorIndex >= startIndex) {
+        continue;
+      }
+      const prior = currentParts[priorIndex];
       if (
         prior?.type === ContentTypes.STEER ||
         (prior?.type === ContentTypes.ACTIVITY_LABEL && prior.activity_label_type === 'phase') ||
@@ -605,10 +611,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           prior.phase === 'final_answer' &&
           textValue(prior.text).trim().length > 0)
       ) {
+        extendedStartIndex = priorIndex + 1;
         break;
       }
-      startIndex = i;
     }
+    startIndex = extendedStartIndex;
     const agentIds = [...contributingAgentIds];
     let phaseStatus: 'ok' | 'partial' | 'failed' = 'ok';
     if (failedCount === totalActivityCount) {

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -1015,9 +1015,19 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
-        (reasoning) =>
-          (reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex) ||
-          hasReasoningExcerptAtOrAfter(parts, reasoning.text, candidateFinalTextIndex),
+        (reasoning) => {
+          /** Empty reasoning reservations are not activities: addPendingReasoning
+           *  deliberately drops them. They can still receive a later sparse
+           *  index from the SDK, so do not let that placeholder pull a fully
+           *  materialized final answer into the completed parent phase. */
+          if (!reasoning.text.trim()) {
+            return false;
+          }
+          return (
+            (reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex) ||
+            hasReasoningExcerptAtOrAfter(parts, reasoning.text, candidateFinalTextIndex)
+          );
+        },
       );
       if (hasLaterTrackedActivity || hasLaterOverflowActivity || hasLaterPendingReasoning) {
         finalTextIndex = undefined;

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -371,6 +371,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     { kind: 'text' | 'think'; phase?: AssistantTextPhase; captureContext?: boolean }
   >();
   let lastRootTextStepId: string | undefined;
+  let lastRootTextWasSemantic = false;
 
   const clear = () => {
     activities = [];
@@ -385,6 +386,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     overflowToolCallIds.clear();
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
+    lastRootTextWasSemantic = false;
   };
 
   const trackActivity = (activity: TrackedActivity) => {
@@ -707,6 +709,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
             } else {
               if (step.groupId == null) {
                 lastRootTextStepId = phase == null ? step.id : undefined;
+                lastRootTextWasSemantic = phase != null;
               }
               if (phase === 'final_answer' && step.groupId == null) {
                 addPendingReasoning(step.agentId ?? 'root');
@@ -777,10 +780,10 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     let finalTextIndex =
       lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
     const parts = deps.getContentParts();
-    if (lastRootTextStepId != null && finalTextIndex == null) {
+    if (!lastRootTextWasSemantic && finalTextIndex == null) {
       for (let index = parts.length - 1; index >= 0; index -= 1) {
         const part = parts[index];
-        if (part?.type === ContentTypes.TEXT && part.groupId == null) {
+        if (part?.type === ContentTypes.TEXT && part.groupId == null && part.phase == null) {
           finalTextIndex = index;
           break;
         }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -28,6 +28,8 @@ type TrackedActivity = ActivityPhaseEntry & {
   childLabelIndex?: number;
   /** Stable anchors survive content filtering and prepends across HITL resume. */
   toolCallIds?: string[];
+  /** Original boundary retained while only part of a saved tool batch is materialized. */
+  unresolvedToolStartIndex?: number;
 };
 
 export interface ActivityPhaseSnapshot {
@@ -373,11 +375,30 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       return part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type === 'phase';
     }).length,
   );
+  const initiallyMaterializedToolIds = new Set(
+    definedPartIndices(content).flatMap((index) => {
+      const part = content[index];
+      const id = part?.type === ContentTypes.TOOL_CALL ? part.tool_call?.id : undefined;
+      return typeof id === 'string' ? [id] : [];
+    }),
+  );
   let activities: TrackedActivity[] =
-    initialSnapshot?.activities.map((activity) => ({
-      ...activity,
-      startIndex: findTrackedStart(content, activity),
-    })) ?? [];
+    initialSnapshot?.activities.map((activity) => {
+      const { unresolvedToolStartIndex, ...retainedActivity } = activity;
+      const startIndex = findTrackedStart(content, activity);
+      const toolCallIds = activity.toolCallIds ?? [];
+      const hasUnresolvedTool = toolCallIds.some((id) => !initiallyMaterializedToolIds.has(id));
+      return {
+        ...retainedActivity,
+        startIndex,
+        ...(hasUnresolvedTool && {
+          unresolvedToolStartIndex: Math.max(
+            unresolvedToolStartIndex ?? activity.startIndex,
+            startIndex,
+          ),
+        }),
+      };
+    }) ?? [];
   let activityCount = initialSnapshot?.activityCount ?? activities.length;
   let failedActivityCount =
     initialSnapshot?.failedActivityCount ??
@@ -432,14 +453,23 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
   const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
-    (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId, startIndex }) => [
-      key,
-      {
-        text: text.slice(-MAX_EXCERPT_CHARS),
-        ...(agentId != null && { agentId }),
-        ...(startIndex != null && { startIndex }),
-      },
-    ]),
+    (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId, startIndex }) => {
+      const boundedText = text.slice(-MAX_EXCERPT_CHARS);
+      const needle = boundedText.trim().slice(0, 80);
+      const rebasedStartIndex = needle ? findReasoningStart(content, boundedText, startIndex) : -1;
+      const hasMaterializedReasoning =
+        needle.length > 0 &&
+        content[rebasedStartIndex]?.type === ContentTypes.THINK &&
+        textValue(content[rebasedStartIndex]?.think).includes(needle);
+      return [
+        key,
+        {
+          text: boundedText,
+          ...(agentId != null && { agentId }),
+          ...(hasMaterializedReasoning && { startIndex: rebasedStartIndex }),
+        },
+      ] as const;
+    }),
   );
   const reasoningStepKeys = new Map<string, string>();
   const stepKinds = new Map<
@@ -560,7 +590,13 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   const resolveActivities = (snapshot: TrackedActivity[]): ActivityPhaseEntry[] => {
     const parts = deps.getContentParts();
     return snapshot.map(
-      ({ childLabelIndex, toolCallIds, startIndex: _startIndex, ...activity }) => {
+      ({
+        childLabelIndex,
+        toolCallIds,
+        startIndex: _startIndex,
+        unresolvedToolStartIndex: _unresolvedToolStartIndex,
+        ...activity
+      }) => {
         const matchesToolIds = (part: LooseContentPart | null | undefined): boolean => {
           if (part?.type !== ContentTypes.ACTIVITY_LABEL || part.activity_label_type === 'phase') {
             return false;
@@ -948,8 +984,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           return hasReasoningExcerptAtOrAfter(parts, reasoningExcerpt, candidateFinalTextIndex);
         }
         return (
-          !toolCallIds.some((id) => materializedToolIds.has(id)) &&
-          activity.startIndex >= candidateFinalTextIndex
+          toolCallIds.some((id) => !materializedToolIds.has(id)) &&
+          (activity.unresolvedToolStartIndex ?? activity.startIndex) >= candidateFinalTextIndex
         );
       });
       const overflowIds = [...overflowToolCallIds];

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -794,11 +794,15 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     let finalTextIndex =
       lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
     const parts = deps.getContentParts();
-    if (!lastRootTextWasSemantic && finalTextIndex == null) {
-      for (let index = parts.length - 1; index >= 0; index -= 1) {
+    if (finalTextIndex == null) {
+      const definedIndices = Object.keys(parts);
+      for (let position = definedIndices.length - 1; position >= 0; position -= 1) {
+        const index = Number(definedIndices[position]);
         const part = parts[index];
-        if (part?.type === ContentTypes.TEXT && part.groupId == null && part.phase == null) {
-          finalTextIndex = index;
+        if (part?.type === ContentTypes.TEXT && part.groupId == null) {
+          if (!lastRootTextWasSemantic && part.phase == null) {
+            finalTextIndex = index;
+          }
           break;
         }
       }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -938,11 +938,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         }
         const reasoningExcerpt = activity.thinkingExcerpts?.[0];
         if (toolCallIds.length === 0 && reasoningExcerpt) {
-          return hasReasoningExcerptAtOrAfter(
-            parts,
-            reasoningExcerpt,
-            candidateFinalTextIndex,
-          );
+          return hasReasoningExcerptAtOrAfter(parts, reasoningExcerpt, candidateFinalTextIndex);
         }
         return (
           !toolCallIds.some((id) => materializedToolIds.has(id)) &&
@@ -954,11 +950,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const hasLaterOverflowActivity =
         overflowIds.some((id) => trailingToolIds.has(id)) ||
         (overflowReasoningExcerpt != null &&
-          hasReasoningExcerptAtOrAfter(
-            parts,
-            overflowReasoningExcerpt,
-            candidateFinalTextIndex,
-          )) ||
+          hasReasoningExcerptAtOrAfter(parts, overflowReasoningExcerpt, candidateFinalTextIndex)) ||
         (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -87,6 +87,8 @@ export interface ActivityPhaseWiring {
   ) => Record<string, EventHandler> | undefined;
   /** A steer is a hard semantic boundary; incomplete evidence is discarded. */
   drop: () => void;
+  /** Finalizes unphased evidence once the root AgentRun has actually completed. */
+  complete: () => void;
   /** Bounded state needed to continue the same phase after a HITL pause. */
   snapshot: () => ActivityPhaseSnapshot;
 }
@@ -301,9 +303,9 @@ export function createAssistantPhaseStampingHandlers(
 }
 
 /**
- * Collects run-wide logical activities and emits one parent summary at a text
- * boundary. The summary call is detached; the boundary only pays the cheap
- * synchronous slot claim needed to keep streamed content indices stable.
+ * Collects run-wide logical activities and emits one parent summary at an
+ * explicit final-answer boundary or root-run completion. The summary call is
+ * detached; final-answer streams only pay the synchronous slot reservation.
  */
 export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): ActivityPhaseWiring {
   const maxPerRun = deps.maxPerRun ?? DEFAULT_MAX_PER_RUN;
@@ -345,6 +347,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     string,
     { kind: 'text' | 'think'; phase?: AssistantTextPhase; captureContext?: boolean }
   >();
+  let lastRootTextStepId: string | undefined;
 
   const clear = () => {
     activities = [];
@@ -356,6 +359,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     failedActivityCount = 0;
     partialActivityCount = 0;
     contributingAgentIds.clear();
+    lastRootTextStepId = undefined;
   };
 
   const trackActivity = (activity: TrackedActivity) => {
@@ -456,14 +460,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     );
   };
 
-  const close = (closingTextPhase?: AssistantTextPhase, hardBoundary = false) => {
+  const close = (closingTextPhase?: AssistantTextPhase, requestedEndIndex?: number) => {
     addPendingReasoning();
     if (generated >= maxPerRun) {
       clear();
       return;
     }
     if (activityCount < MIN_ACTIVITIES) {
-      if (hardBoundary) clear();
+      clear();
       return;
     }
 
@@ -509,11 +513,13 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       phaseStatus = 'partial';
     }
     const index = deps.getContentParts().length;
+    const endIndex = Math.max(startIndex, Math.min(index, requestedEndIndex ?? index));
     const part: LooseContentPart = {
       type: ContentTypes.ACTIVITY_LABEL,
       [ContentTypes.ACTIVITY_LABEL]: '',
       activity_label_type: 'phase',
       activity_start_index: startIndex,
+      activity_end_index: endIndex,
       activity_count: totalActivityCount,
       ...(agentIds.length > 0 && { agent_ids: agentIds }),
       status: phaseStatus,
@@ -664,27 +670,24 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
               }
               return result;
             } else {
+              if (step.groupId == null) {
+                lastRootTextStepId = step.id;
+              }
               if (phase === 'final_answer' && step.groupId == null) {
                 addPendingReasoning(step.agentId ?? 'root');
                 stepKinds.set(step.id, { kind, phase, captureContext: false });
-                close(phase, true);
+                close(phase);
               } else {
                 if (phase == null && step.groupId == null) {
                   addPendingReasoning(step.agentId ?? 'root');
                 }
-                const closesPhase =
-                  phase == null && step.groupId == null && activityCount >= MIN_ACTIVITIES;
                 stepKinds.set(step.id, {
                   kind,
                   ...(phase != null && { phase }),
-                  captureContext: !closesPhase,
+                  captureContext: true,
                 });
-                if (closesPhase) {
-                  close(undefined, false);
-                } else {
-                  assistantContext.push('');
-                  if (assistantContext.length > MAX_CONTEXT_ITEMS) assistantContext.shift();
-                }
+                assistantContext.push('');
+                if (assistantContext.length > MAX_CONTEXT_ITEMS) assistantContext.shift();
               }
             }
           }
@@ -735,5 +738,21 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     return wrapped;
   };
 
-  return { hook, handlers: wrapHandlers, drop: clear, snapshot };
+  const complete = () => {
+    let finalTextIndex =
+      lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
+    if (finalTextIndex == null) {
+      const parts = deps.getContentParts();
+      for (let index = parts.length - 1; index >= 0; index -= 1) {
+        const part = parts[index];
+        if (part?.type === ContentTypes.TEXT && part.groupId == null) {
+          finalTextIndex = index;
+          break;
+        }
+      }
+    }
+    close(undefined, finalTextIndex);
+  };
+
+  return { hook, handlers: wrapHandlers, drop: clear, complete, snapshot };
 }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -966,13 +966,13 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const part = parts[index];
       /** The UI contract is the last materialized TEXT part, not the last
        *  part whose provider lane metadata happens to look root-scoped.
-       *  Some MCP runs retain a groupId on their final response. The later-
-       *  activity checks below still reject an intermediate lane text when
-       *  tools or reasoning follow it. */
+       *  Some MCP runs retain a groupId on their final response, so even a
+       *  `final_answer` part may not have taken the immediate-close branch.
+       *  An already-closed phase has no remaining activities and completion
+       *  is a no-op. The later-activity checks below still reject an
+       *  intermediate lane text when tools or reasoning follow it. */
       if (part?.type === ContentTypes.TEXT) {
-        if (part.phase !== 'final_answer') {
-          finalTextIndex = index;
-        }
+        finalTextIndex = index;
         break;
       }
     }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -164,13 +164,19 @@ function buildSignal(signal?: AbortSignal): AbortSignal {
     : timeout;
 }
 
+function definedPartIndices(parts: ReadonlyArray<LooseContentPart | null | undefined>): number[] {
+  return Object.keys(parts).map(Number);
+}
+
 function findLastPartIndex(
   parts: ReadonlyArray<LooseContentPart | null | undefined>,
   type: string,
 ): number {
-  for (let i = parts.length - 1; i >= 0; i--) {
-    if (parts[i]?.type === type) {
-      return i;
+  const indices = definedPartIndices(parts);
+  for (let position = indices.length - 1; position >= 0; position -= 1) {
+    const index = indices[position];
+    if (parts[index]?.type === type) {
+      return index;
     }
   }
   return Math.max(0, parts.length - 1);
@@ -181,14 +187,14 @@ function findBatchStart(
   toolCallIds: Set<string>,
 ): number {
   let first = -1;
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+  for (const index of definedPartIndices(parts)) {
+    const part = parts[index];
     if (
       part?.type === ContentTypes.TOOL_CALL &&
       typeof part.tool_call?.id === 'string' &&
       toolCallIds.has(part.tool_call.id)
     ) {
-      first = first < 0 ? i : Math.min(first, i);
+      first = first < 0 ? index : Math.min(first, index);
     }
   }
   return first >= 0 ? first : Math.max(0, parts.length - 1);
@@ -205,9 +211,12 @@ function findTrackedStart(
   const excerpt = activity.thinkingExcerpts?.[0]?.trim();
   if (excerpt) {
     const needle = excerpt.slice(0, 80);
-    for (let i = 0; i < parts.length; i++) {
-      if (parts[i]?.type === ContentTypes.THINK && textValue(parts[i]?.think).includes(needle)) {
-        return i;
+    for (const index of definedPartIndices(parts)) {
+      if (
+        parts[index]?.type === ContentTypes.THINK &&
+        textValue(parts[index]?.think).includes(needle)
+      ) {
+        return index;
       }
     }
   }
@@ -241,7 +250,7 @@ function findReasoningStart(
   if (startIndex != null && matches(parts[startIndex])) {
     return startIndex;
   }
-  for (let index = 0; index < parts.length; index += 1) {
+  for (const index of definedPartIndices(parts)) {
     if (matches(parts[index])) {
       return index;
     }
@@ -316,9 +325,10 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   const initialSnapshot = deps.initialSnapshot?.version === 1 ? deps.initialSnapshot : undefined;
   let generated = Math.max(
     initialSnapshot?.generated ?? 0,
-    content.filter(
-      (part) => part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type === 'phase',
-    ).length,
+    definedPartIndices(content).filter((index) => {
+      const part = content[index];
+      return part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type === 'phase';
+    }).length,
   );
   let activities: TrackedActivity[] =
     initialSnapshot?.activities.map((activity) => ({
@@ -333,15 +343,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     initialSnapshot?.partialActivityCount ??
     activities.filter((activity) => activity.status === 'partial').length;
   const overflowToolCallIds = new Set(initialSnapshot?.overflowToolCallIds ?? []);
-  const rebasedOverflowToolIndexes = content
-    .map((part, index) => ({ part, index }))
-    .filter(
-      ({ part }) =>
-        part?.type === ContentTypes.TOOL_CALL &&
-        typeof part.tool_call?.id === 'string' &&
-        overflowToolCallIds.has(part.tool_call.id),
-    )
-    .map(({ index }) => index);
+  const rebasedOverflowToolIndexes = definedPartIndices(content).filter((index) => {
+    const part = content[index];
+    return (
+      part?.type === ContentTypes.TOOL_CALL &&
+      typeof part.tool_call?.id === 'string' &&
+      overflowToolCallIds.has(part.tool_call.id)
+    );
+  });
   let overflowActivityStartIndex =
     rebasedOverflowToolIndexes.length > 0
       ? Math.max(...rebasedOverflowToolIndexes)
@@ -477,7 +486,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         };
         let child = childLabelIndex == null ? undefined : parts[childLabelIndex];
         if (!matchesToolIds(child) && toolCallIds != null && toolCallIds.length > 0) {
-          child = parts.find(matchesToolIds);
+          child = definedPartIndices(parts)
+            .map((index) => parts[index])
+            .find(matchesToolIds);
         }
         if (!matchesToolIds(child)) {
           return activity;
@@ -618,14 +629,16 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     const ids = new Set(input.entries.map((entry) => entry.toolUseId));
     const parts = deps.getContentParts();
     let childLabelIndex: number | undefined;
-    for (let i = parts.length - 1; i >= 0; i--) {
-      const part = parts[i];
+    const indices = definedPartIndices(parts);
+    for (let position = indices.length - 1; position >= 0; position -= 1) {
+      const index = indices[position];
+      const part = parts[index];
       if (part?.type !== ContentTypes.ACTIVITY_LABEL || part.activity_label_type === 'phase') {
         continue;
       }
       const childIds = Array.isArray(part.tool_call_ids) ? part.tool_call_ids : [];
       if (childIds.some((id) => typeof id === 'string' && ids.has(id))) {
-        childLabelIndex = i;
+        childLabelIndex = index;
         break;
       }
     }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -670,7 +670,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
               }
               return result;
             } else {
-              if (step.groupId == null) {
+              if (step.groupId == null && phase == null) {
                 lastRootTextStepId = step.id;
               }
               if (phase === 'final_answer' && step.groupId == null) {
@@ -742,7 +742,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     let finalTextIndex =
       lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
     const parts = deps.getContentParts();
-    if (finalTextIndex == null) {
+    if (lastRootTextStepId != null && finalTextIndex == null) {
       for (let index = parts.length - 1; index >= 0; index -= 1) {
         const part = parts[index];
         if (part?.type === ContentTypes.TEXT && part.groupId == null) {

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -230,25 +230,6 @@ function findTrackedToolStart(
   return undefined;
 }
 
-function hasTrackedToolAtOrAfter(
-  parts: ReadonlyArray<LooseContentPart | null | undefined>,
-  activity: TrackedActivity,
-  index: number,
-): boolean {
-  const toolCallIds = new Set(activity.toolCallIds ?? []);
-  if (toolCallIds.size === 0) {
-    return false;
-  }
-  return parts
-    .slice(index)
-    .some(
-      (part) =>
-        part?.type === ContentTypes.TOOL_CALL &&
-        typeof part.tool_call?.id === 'string' &&
-        toolCallIds.has(part.tool_call.id),
-    );
-}
-
 function findReasoningStart(
   parts: ReadonlyArray<LooseContentPart | null | undefined>,
   text: string,
@@ -416,12 +397,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     } else {
       if (overflowActivityStartIndex == null || activity.startIndex > overflowActivityStartIndex) {
         overflowActivityStartIndex = activity.startIndex;
-        overflowToolCallIds.clear();
       }
-      if (activity.startIndex === overflowActivityStartIndex) {
-        for (const id of activity.toolCallIds ?? []) {
-          overflowToolCallIds.add(id);
-        }
+      for (const id of activity.toolCallIds ?? []) {
+        overflowToolCallIds.add(id);
       }
     }
   };
@@ -809,26 +787,35 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     }
     if (finalTextIndex != null) {
       const candidateFinalTextIndex = finalTextIndex;
+      const materializedToolIds = new Set<string>();
+      const trailingToolIds = new Set<string>();
+      for (const key of Object.keys(parts)) {
+        const index = Number(key);
+        const part = parts[index];
+        if (part?.type !== ContentTypes.TOOL_CALL || typeof part.tool_call?.id !== 'string') {
+          continue;
+        }
+        materializedToolIds.add(part.tool_call.id);
+        if (index >= candidateFinalTextIndex) {
+          trailingToolIds.add(part.tool_call.id);
+        }
+      }
       const hasLaterTrackedActivity = activities.some((activity) => {
-        if (hasTrackedToolAtOrAfter(parts, activity, candidateFinalTextIndex)) {
+        const toolCallIds = activity.toolCallIds ?? [];
+        if (toolCallIds.some((id) => trailingToolIds.has(id))) {
           return true;
         }
         return (
-          findTrackedToolStart(parts, activity) == null &&
+          !toolCallIds.some((id) => materializedToolIds.has(id)) &&
           activity.startIndex >= candidateFinalTextIndex
         );
       });
+      const overflowIds = [...overflowToolCallIds];
       const hasLaterOverflowActivity =
-        (overflowActivityStartIndex != null &&
-          overflowActivityStartIndex >= candidateFinalTextIndex) ||
-        parts
-          .slice(candidateFinalTextIndex)
-          .some(
-            (part) =>
-              part?.type === ContentTypes.TOOL_CALL &&
-              typeof part.tool_call?.id === 'string' &&
-              overflowToolCallIds.has(part.tool_call.id),
-          );
+        overflowIds.some((id) => trailingToolIds.has(id)) ||
+        (!overflowIds.some((id) => materializedToolIds.has(id)) &&
+          overflowActivityStartIndex != null &&
+          overflowActivityStartIndex >= candidateFinalTextIndex);
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
         (reasoning) =>
           reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex,

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -228,6 +228,25 @@ function findTrackedToolStart(
   return undefined;
 }
 
+function hasTrackedToolAtOrAfter(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  activity: TrackedActivity,
+  index: number,
+): boolean {
+  const toolCallIds = new Set(activity.toolCallIds ?? []);
+  if (toolCallIds.size === 0) {
+    return false;
+  }
+  return parts
+    .slice(index)
+    .some(
+      (part) =>
+        part?.type === ContentTypes.TOOL_CALL &&
+        typeof part.tool_call?.id === 'string' &&
+        toolCallIds.has(part.tool_call.id),
+    );
+}
+
 function findReasoningStart(
   parts: ReadonlyArray<LooseContentPart | null | undefined>,
   text: string,
@@ -753,10 +772,15 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     }
     if (finalTextIndex != null) {
       const candidateFinalTextIndex = finalTextIndex;
-      const hasLaterTrackedActivity = activities.some(
-        (activity) =>
-          (findTrackedToolStart(parts, activity) ?? activity.startIndex) >= candidateFinalTextIndex,
-      );
+      const hasLaterTrackedActivity = activities.some((activity) => {
+        if (hasTrackedToolAtOrAfter(parts, activity, candidateFinalTextIndex)) {
+          return true;
+        }
+        return (
+          findTrackedToolStart(parts, activity) == null &&
+          activity.startIndex >= candidateFinalTextIndex
+        );
+      });
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
         (reasoning) =>
           reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex,

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -856,17 +856,21 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     let finalTextIndex =
       lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
     const parts = deps.getContentParts();
-    if (finalTextIndex == null) {
-      const definedIndices = Object.keys(parts);
-      for (let position = definedIndices.length - 1; position >= 0; position -= 1) {
-        const index = Number(definedIndices[position]);
-        const part = parts[index];
-        if (part?.type === ContentTypes.TEXT && part.groupId == null) {
-          if (!lastRootTextWasSemantic && part.phase == null) {
-            finalTextIndex = index;
-          }
-          break;
+    /** The host step map is an event-coordinate hint, not the authoritative
+     *  rendered position. Activity-label reservations advance the shared
+     *  content offset after earlier steps were indexed, and a provider can
+     *  materialize the final text at a later slot. Always reconcile against
+     *  the live parts so a stale-but-defined step index cannot pull the final
+     *  answer into the parent phase. */
+    const definedIndices = Object.keys(parts);
+    for (let position = definedIndices.length - 1; position >= 0; position -= 1) {
+      const index = Number(definedIndices[position]);
+      const part = parts[index];
+      if (part?.type === ContentTypes.TEXT && part.groupId == null) {
+        if (!lastRootTextWasSemantic && part.phase == null) {
+          finalTextIndex = index;
         }
+        break;
       }
     }
     if (finalTextIndex != null) {

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -441,7 +441,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       if (overflowActivityStartIndex == null || activity.startIndex > overflowActivityStartIndex) {
         overflowActivityStartIndex = activity.startIndex;
       }
-      const reasoningExcerpt = activity.thinkingExcerpts?.at(-1)?.trim();
+      const reasoningExcerpts = activity.thinkingExcerpts;
+      const reasoningExcerpt = reasoningExcerpts?.[reasoningExcerpts.length - 1]?.trim();
       if (reasoningExcerpt && activity.startIndex >= overflowActivityStartIndex) {
         overflowReasoningExcerpt = reasoningExcerpt.slice(0, MAX_EXCERPT_CHARS);
       }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -38,6 +38,8 @@ export interface ActivityPhaseSnapshot {
   partialActivityCount: number;
   agentIds: string[];
   activities: TrackedActivity[];
+  overflowActivityStartIndex?: number;
+  overflowToolCallIds?: string[];
   assistantContext: string[];
   pendingReasoning: Array<{
     key: string;
@@ -349,6 +351,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   let partialActivityCount =
     initialSnapshot?.partialActivityCount ??
     activities.filter((activity) => activity.status === 'partial').length;
+  let overflowActivityStartIndex = initialSnapshot?.overflowActivityStartIndex;
+  const overflowToolCallIds = new Set(initialSnapshot?.overflowToolCallIds ?? []);
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
   const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
@@ -377,6 +381,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     activityCount = 0;
     failedActivityCount = 0;
     partialActivityCount = 0;
+    overflowActivityStartIndex = undefined;
+    overflowToolCallIds.clear();
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
   };
@@ -393,6 +399,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     }
     if (activities.length < MAX_RETAINED_ACTIVITIES) {
       activities.push(activity);
+    } else {
+      overflowActivityStartIndex = Math.max(
+        overflowActivityStartIndex ?? activity.startIndex,
+        activity.startIndex,
+      );
+      for (const id of activity.toolCallIds ?? []) {
+        overflowToolCallIds.add(id);
+      }
     }
   };
 
@@ -403,6 +417,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     failedActivityCount,
     partialActivityCount,
     agentIds: [...contributingAgentIds],
+    ...(overflowActivityStartIndex != null && { overflowActivityStartIndex }),
+    ...(overflowToolCallIds.size > 0 && { overflowToolCallIds: [...overflowToolCallIds] }),
     activities: activities.map((activity) => ({
       ...activity,
       ...(activity.entries != null && {
@@ -781,11 +797,22 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           activity.startIndex >= candidateFinalTextIndex
         );
       });
+      const hasLaterOverflowActivity =
+        (overflowActivityStartIndex != null &&
+          overflowActivityStartIndex >= candidateFinalTextIndex) ||
+        parts
+          .slice(candidateFinalTextIndex)
+          .some(
+            (part) =>
+              part?.type === ContentTypes.TOOL_CALL &&
+              typeof part.tool_call?.id === 'string' &&
+              overflowToolCallIds.has(part.tool_call.id),
+          );
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
         (reasoning) =>
           reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex,
       );
-      if (hasLaterTrackedActivity || hasLaterPendingReasoning) {
+      if (hasLaterTrackedActivity || hasLaterOverflowActivity || hasLaterPendingReasoning) {
         finalTextIndex = undefined;
       }
     }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -741,14 +741,35 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   const complete = () => {
     let finalTextIndex =
       lastRootTextStepId == null ? undefined : deps.getStepIndex?.(lastRootTextStepId);
+    const parts = deps.getContentParts();
     if (finalTextIndex == null) {
-      const parts = deps.getContentParts();
       for (let index = parts.length - 1; index >= 0; index -= 1) {
         const part = parts[index];
         if (part?.type === ContentTypes.TEXT && part.groupId == null) {
           finalTextIndex = index;
           break;
         }
+      }
+    }
+    if (finalTextIndex != null) {
+      const candidateFinalTextIndex = finalTextIndex;
+      const hasLaterActivityPart = parts.some(
+        (part, index) =>
+          index > candidateFinalTextIndex &&
+          (part?.type === ContentTypes.TOOL_CALL ||
+            part?.type === ContentTypes.THINK ||
+            (part?.type === ContentTypes.ACTIVITY_LABEL &&
+              part.activity_label_type !== 'phase')),
+      );
+      const hasLaterTrackedActivity = activities.some(
+        (activity) => activity.startIndex >= candidateFinalTextIndex,
+      );
+      const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
+        (reasoning) =>
+          reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex,
+      );
+      if (hasLaterActivityPart || hasLaterTrackedActivity || hasLaterPendingReasoning) {
+        finalTextIndex = undefined;
       }
     }
     close(undefined, finalTextIndex);

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -351,8 +351,20 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   let partialActivityCount =
     initialSnapshot?.partialActivityCount ??
     activities.filter((activity) => activity.status === 'partial').length;
-  let overflowActivityStartIndex = initialSnapshot?.overflowActivityStartIndex;
   const overflowToolCallIds = new Set(initialSnapshot?.overflowToolCallIds ?? []);
+  const rebasedOverflowToolIndexes = content
+    .map((part, index) => ({ part, index }))
+    .filter(
+      ({ part }) =>
+        part?.type === ContentTypes.TOOL_CALL &&
+        typeof part.tool_call?.id === 'string' &&
+        overflowToolCallIds.has(part.tool_call.id),
+    )
+    .map(({ index }) => index);
+  let overflowActivityStartIndex =
+    rebasedOverflowToolIndexes.length > 0
+      ? Math.max(...rebasedOverflowToolIndexes)
+      : initialSnapshot?.overflowActivityStartIndex;
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
   const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
@@ -402,12 +414,12 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     if (activities.length < MAX_RETAINED_ACTIVITIES) {
       activities.push(activity);
     } else {
-      overflowActivityStartIndex = Math.max(
-        overflowActivityStartIndex ?? activity.startIndex,
-        activity.startIndex,
-      );
-      for (const id of activity.toolCallIds ?? []) {
-        overflowToolCallIds.add(id);
+      if (overflowActivityStartIndex == null || activity.startIndex >= overflowActivityStartIndex) {
+        overflowActivityStartIndex = activity.startIndex;
+        overflowToolCallIds.clear();
+        for (const id of activity.toolCallIds ?? []) {
+          overflowToolCallIds.add(id);
+        }
       }
     }
   };

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -447,7 +447,6 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     { kind: 'text' | 'think'; phase?: AssistantTextPhase; captureContext?: boolean }
   >();
   let lastRootTextStepId: string | undefined;
-  let lastRootTextWasSemantic = false;
 
   const clear = () => {
     activities = [];
@@ -464,7 +463,6 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     overflowReasoningExcerpt = undefined;
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
-    lastRootTextWasSemantic = false;
   };
 
   const trackActivity = (activity: TrackedActivity) => {
@@ -827,8 +825,12 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
               return result;
             } else {
               if (step.groupId == null) {
-                lastRootTextStepId = phase == null ? step.id : undefined;
-                lastRootTextWasSemantic = phase != null;
+                /** `final_answer` closes immediately before its text streams.
+                 *  Commentary does not: if it is the root run's last text,
+                 *  completion must leave it outside the parent like any
+                 *  unphased answer. Later activities still invalidate this
+                 *  candidate in `complete`. */
+                lastRootTextStepId = phase === 'final_answer' ? undefined : step.id;
               }
               if (phase === 'final_answer' && step.groupId == null) {
                 addPendingReasoning(step.agentId ?? 'root');
@@ -910,7 +912,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const index = Number(definedIndices[position]);
       const part = parts[index];
       if (part?.type === ContentTypes.TEXT && part.groupId == null) {
-        if (!lastRootTextWasSemantic && part.phase == null) {
+        if (part.phase !== 'final_answer') {
           finalTextIndex = index;
         }
         break;

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -6,6 +6,7 @@ import { stringifyActivityEvidence } from '~/agents/activityLabels/runtime';
 
 type PostToolBatchInput = HookInputByEvent['PostToolBatch'];
 type BatchEntry = PostToolBatchInput['entries'][number];
+type AssistantContextEntry = { stepId?: string; text: string };
 
 export type AssistantTextPhase = 'commentary' | 'final_answer';
 
@@ -451,7 +452,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   }
   let overflowReasoningExcerpt = initialSnapshot?.overflowReasoningExcerpt;
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
-  let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
+  let assistantContext: AssistantContextEntry[] = (initialSnapshot?.assistantContext ?? [])
+    .slice(-MAX_CONTEXT_ITEMS)
+    .map((text) => ({ text }));
   const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
     (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId, startIndex }) => {
       const boundedText = text.slice(-MAX_EXCERPT_CHARS);
@@ -476,6 +479,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     string,
     { kind: 'text' | 'think'; phase?: AssistantTextPhase; captureContext?: boolean }
   >();
+  const textContextByStepId = new Map<string, AssistantContextEntry>();
   let lastRootTextStepId: string | undefined;
 
   const clear = () => {
@@ -484,6 +488,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     pendingReasoning.clear();
     reasoningStepKeys.clear();
     stepKinds.clear();
+    textContextByStepId.clear();
     activityCount = 0;
     failedActivityCount = 0;
     partialActivityCount = 0;
@@ -555,7 +560,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         thinkingExcerpts: activity.thinkingExcerpts.map((text) => text.slice(-MAX_EXCERPT_CHARS)),
       }),
     })),
-    assistantContext: assistantContext.slice(-MAX_CONTEXT_ITEMS),
+    assistantContext: assistantContext.slice(-MAX_CONTEXT_ITEMS).map(({ text }) => text),
     pendingReasoning: [...pendingReasoning].map(([key, reasoning]) => ({
       key,
       text: reasoning.text.slice(-MAX_EXCERPT_CHARS),
@@ -647,7 +652,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const toolStart = findTrackedToolStart(currentParts, activity);
       return toolStart != null ? { ...activity, startIndex: toolStart } : activity;
     });
-    const contextSnapshot = [...assistantContext];
+    const contextSnapshot = assistantContext.map(({ text }) => text);
     /** Completion-finalized phases leave the final root text outside their
      *  UI bounds. Remove its matching retained excerpt from the label prompt
      *  as well, or the parent can paraphrase the answer it does not contain.
@@ -777,17 +782,27 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     const ids = new Set(input.entries.map((entry) => entry.toolUseId));
     const parts = deps.getContentParts();
     let childLabelIndex: number | undefined;
+    let batchStartIndex: number | undefined;
     const indices = definedPartIndices(parts);
     for (let position = indices.length - 1; position >= 0; position -= 1) {
       const index = indices[position];
       const part = parts[index];
-      if (part?.type !== ContentTypes.ACTIVITY_LABEL || part.activity_label_type === 'phase') {
-        continue;
+      if (
+        part?.type === ContentTypes.TOOL_CALL &&
+        typeof part.tool_call?.id === 'string' &&
+        ids.has(part.tool_call.id)
+      ) {
+        batchStartIndex = index;
       }
-      const childIds = Array.isArray(part.tool_call_ids) ? part.tool_call_ids : [];
-      if (childIds.some((id) => typeof id === 'string' && ids.has(id))) {
-        childLabelIndex = index;
-        break;
+      if (
+        childLabelIndex == null &&
+        part?.type === ContentTypes.ACTIVITY_LABEL &&
+        part.activity_label_type !== 'phase'
+      ) {
+        const childIds = Array.isArray(part.tool_call_ids) ? part.tool_call_ids : [];
+        if (childIds.some((id) => typeof id === 'string' && ids.has(id))) {
+          childLabelIndex = index;
+        }
       }
     }
     const entries = input.entries.map((entry: BatchEntry) => ({
@@ -809,7 +824,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       ...(reasoning ? { thinkingExcerpts: [reasoning.slice(0, MAX_EXCERPT_CHARS)] } : {}),
       ...(input.executingAgentId != null && { agentId: input.executingAgentId }),
       status: activityStatus,
-      startIndex: findBatchStart(parts, ids),
+      startIndex: batchStartIndex ?? Math.max(0, parts.length - 1),
       toolCallIds: [...ids],
       ...(childLabelIndex != null && { childLabelIndex }),
     });
@@ -881,8 +896,15 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
                   ...(phase != null && { phase }),
                   captureContext: true,
                 });
-                assistantContext.push('');
-                if (assistantContext.length > MAX_CONTEXT_ITEMS) assistantContext.shift();
+                const contextEntry: AssistantContextEntry = { stepId: step.id, text: '' };
+                assistantContext.push(contextEntry);
+                textContextByStepId.set(step.id, contextEntry);
+                if (assistantContext.length > MAX_CONTEXT_ITEMS) {
+                  const removed = assistantContext.shift();
+                  if (removed?.stepId != null) {
+                    textContextByStepId.delete(removed.stepId);
+                  }
+                }
               }
             }
           }
@@ -899,14 +921,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           const tracked = id ? stepKinds.get(id) : undefined;
           if (tracked?.kind === 'text' && tracked.captureContext === true) {
             const text = deltaText(data, 'text');
-            if (text) {
-              const last = assistantContext.length - 1;
-              const next = `${last >= 0 ? assistantContext[last] : ''}${text}`.slice(
-                -MAX_EXCERPT_CHARS,
-              );
-              if (last >= 0) assistantContext[last] = next;
-              else assistantContext.push(next);
-              if (assistantContext.length > MAX_CONTEXT_ITEMS) assistantContext.shift();
+            const contextEntry = id ? textContextByStepId.get(id) : undefined;
+            if (text && contextEntry != null) {
+              contextEntry.text = `${contextEntry.text}${text}`.slice(-MAX_EXCERPT_CHARS);
             }
           }
           return messageHandler.handle(event, data, metadata, graph);

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -1014,21 +1014,19 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);
-      const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
-        (reasoning) => {
-          /** Empty reasoning reservations are not activities: addPendingReasoning
-           *  deliberately drops them. They can still receive a later sparse
-           *  index from the SDK, so do not let that placeholder pull a fully
-           *  materialized final answer into the completed parent phase. */
-          if (!reasoning.text.trim()) {
-            return false;
-          }
-          return (
-            (reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex) ||
-            hasReasoningExcerptAtOrAfter(parts, reasoning.text, candidateFinalTextIndex)
-          );
-        },
-      );
+      const hasLaterPendingReasoning = [...pendingReasoning.values()].some((reasoning) => {
+        /** Empty reasoning reservations are not activities: addPendingReasoning
+         *  deliberately drops them. They can still receive a later sparse
+         *  index from the SDK, so do not let that placeholder pull a fully
+         *  materialized final answer into the completed parent phase. */
+        if (!reasoning.text.trim()) {
+          return false;
+        }
+        return (
+          (reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex) ||
+          hasReasoningExcerptAtOrAfter(parts, reasoning.text, candidateFinalTextIndex)
+        );
+      });
       if (hasLaterTrackedActivity || hasLaterOverflowActivity || hasLaterPendingReasoning) {
         finalTextIndex = undefined;
       }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -109,6 +109,7 @@ const DEFAULT_CHAR_LIMIT = 600;
 const MIN_ACTIVITIES = 2;
 const MAX_CONTEXT_ITEMS = 6;
 const MAX_EXCERPT_CHARS = 600;
+const REASONING_ANCHOR_CHARS = 80;
 const OUTPUT_CHAR_LIMIT = 160;
 const PHASE_TIMEOUT_MS = 12_000;
 /** Twelve enter the SDK prompt; one extra preserves its omitted-activity row. */
@@ -231,7 +232,7 @@ function findReasoningExcerptStart(
   parts: ReadonlyArray<LooseContentPart | null | undefined>,
   excerpt: string,
 ): number | undefined {
-  const needle = excerpt.trim().slice(0, 80);
+  const needle = excerpt.trim().slice(0, REASONING_ANCHOR_CHARS);
   if (!needle) {
     return undefined;
   }
@@ -251,7 +252,7 @@ function hasReasoningExcerptAtOrAfter(
   excerpt: string,
   minimumIndex: number,
 ): boolean {
-  const needle = excerpt.trim().slice(0, 80);
+  const needle = excerpt.trim().slice(0, REASONING_ANCHOR_CHARS);
   if (!needle) {
     return false;
   }
@@ -264,6 +265,59 @@ function hasReasoningExcerptAtOrAfter(
     if (
       parts[index]?.type === ContentTypes.THINK &&
       textValue(parts[index]?.think).includes(needle)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+type ReasoningAnchorIndex = Map<number, Set<string>>;
+
+function addReasoningAnchor(
+  anchors: Set<string>,
+  index: ReasoningAnchorIndex,
+  excerpt: string,
+): void {
+  const anchor = excerpt.trim().slice(0, REASONING_ANCHOR_CHARS);
+  if (!anchor || anchors.has(anchor)) {
+    return;
+  }
+  anchors.add(anchor);
+  const matchingLength = index.get(anchor.length);
+  if (matchingLength != null) {
+    matchingLength.add(anchor);
+  } else {
+    index.set(anchor.length, new Set([anchor]));
+  }
+}
+
+function includesReasoningAnchor(text: string, index: ReasoningAnchorIndex): boolean {
+  for (const [length, anchors] of index) {
+    for (let offset = 0; offset <= text.length - length; offset += 1) {
+      if (anchors.has(text.slice(offset, offset + length))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function hasIndexedReasoningAtOrAfter(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  index: ReasoningAnchorIndex,
+  minimumIndex: number,
+): boolean {
+  const indices = definedPartIndices(parts);
+  for (let position = indices.length - 1; position >= 0; position -= 1) {
+    const partIndex = indices[position];
+    if (partIndex < minimumIndex) {
+      break;
+    }
+    const part = parts[partIndex];
+    if (
+      part?.type === ContentTypes.THINK &&
+      includesReasoningAnchor(textValue(part.think), index)
     ) {
       return true;
     }
@@ -423,19 +477,23 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     }
     return matches;
   });
-  const overflowReasoningAnchors = new Set(
+  const overflowReasoningAnchors = new Set<string>();
+  const overflowReasoningAnchorIndex: ReasoningAnchorIndex = new Map();
+  const initialOverflowReasoningAnchors =
     initialSnapshot?.overflowReasoningAnchors ??
-      (initialSnapshot?.overflowReasoningExcerpt != null
-        ? [initialSnapshot.overflowReasoningExcerpt.slice(0, 80)]
-        : []),
-  );
+    (initialSnapshot?.overflowReasoningExcerpt != null
+      ? [initialSnapshot.overflowReasoningExcerpt]
+      : []);
+  for (const anchor of initialOverflowReasoningAnchors) {
+    addReasoningAnchor(overflowReasoningAnchors, overflowReasoningAnchorIndex, anchor);
+  }
   let rebasedOverflowReasoningIndex: number | undefined;
   if (overflowReasoningAnchors.size > 0) {
     for (const index of definedPartIndices(content)) {
       const part = content[index];
       if (
         part?.type === ContentTypes.THINK &&
-        [...overflowReasoningAnchors].some((anchor) => textValue(part.think).includes(anchor))
+        includesReasoningAnchor(textValue(part.think), overflowReasoningAnchorIndex)
       ) {
         rebasedOverflowReasoningIndex = index;
       }
@@ -464,7 +522,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
     (initialSnapshot?.pendingReasoning ?? []).map(({ key, text, agentId, startIndex }) => {
       const boundedText = text.slice(-MAX_EXCERPT_CHARS);
-      const needle = boundedText.trim().slice(0, 80);
+      const needle = boundedText.trim().slice(0, REASONING_ANCHOR_CHARS);
       const rebasedStartIndex = needle ? findReasoningStart(content, boundedText, startIndex) : -1;
       const hasMaterializedReasoning =
         needle.length > 0 &&
@@ -502,6 +560,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     overflowToolCallIds.clear();
     overflowBoundaryToolCallIds.clear();
     overflowReasoningAnchors.clear();
+    overflowReasoningAnchorIndex.clear();
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
   };
@@ -526,7 +585,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const reasoningExcerpts = activity.thinkingExcerpts;
       const reasoningExcerpt = reasoningExcerpts?.[reasoningExcerpts.length - 1]?.trim();
       if (reasoningExcerpt) {
-        overflowReasoningAnchors.add(reasoningExcerpt.slice(0, 80));
+        addReasoningAnchor(
+          overflowReasoningAnchors,
+          overflowReasoningAnchorIndex,
+          reasoningExcerpt,
+        );
       }
       for (const id of activity.toolCallIds ?? []) {
         overflowToolCallIds.add(id);
@@ -1017,8 +1080,10 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const overflowBoundaryIds = [...overflowBoundaryToolCallIds];
       const hasLaterOverflowActivity =
         overflowIds.some((id) => trailingToolIds.has(id)) ||
-        [...overflowReasoningAnchors].some((anchor) =>
-          hasReasoningExcerptAtOrAfter(parts, anchor, candidateFinalTextIndex),
+        hasIndexedReasoningAtOrAfter(
+          parts,
+          overflowReasoningAnchorIndex,
+          candidateFinalTextIndex,
         ) ||
         (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -308,6 +308,9 @@ function hasIndexedReasoningAtOrAfter(
   index: ReasoningAnchorIndex,
   minimumIndex: number,
 ): boolean {
+  if (index.size === 0) {
+    return false;
+  }
   const indices = definedPartIndices(parts);
   for (let position = indices.length - 1; position >= 0; position -= 1) {
     const partIndex = indices[position];

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -241,6 +241,31 @@ function findReasoningExcerptStart(
   return undefined;
 }
 
+function hasReasoningExcerptAtOrAfter(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  excerpt: string,
+  minimumIndex: number,
+): boolean {
+  const needle = excerpt.trim().slice(0, 80);
+  if (!needle) {
+    return false;
+  }
+  const indices = definedPartIndices(parts);
+  for (let position = indices.length - 1; position >= 0; position -= 1) {
+    const index = indices[position];
+    if (index < minimumIndex) {
+      break;
+    }
+    if (
+      parts[index]?.type === ContentTypes.THINK &&
+      textValue(parts[index]?.think).includes(needle)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function findTrackedToolStart(
   parts: ReadonlyArray<LooseContentPart | null | undefined>,
   activity: TrackedActivity,
@@ -589,6 +614,24 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       return toolStart != null ? { ...activity, startIndex: toolStart } : activity;
     });
     const contextSnapshot = [...assistantContext];
+    /** Completion-finalized phases leave the final root text outside their
+     *  UI bounds. Remove its matching retained excerpt from the label prompt
+     *  as well, or the parent can paraphrase the answer it does not contain.
+     *  Search from the tail because identical intermediate/final text should
+     *  discard only the most recent capture. */
+    if (requestedEndIndex != null) {
+      const excludedText = textValue(currentParts[requestedEndIndex]?.text)
+        .trim()
+        .slice(-MAX_EXCERPT_CHARS);
+      if (excludedText) {
+        for (let position = contextSnapshot.length - 1; position >= 0; position -= 1) {
+          if (contextSnapshot[position].trim() === excludedText) {
+            contextSnapshot.splice(position, 1);
+            break;
+          }
+        }
+      }
+    }
     const totalActivityCount = activityCount;
     const failedCount = failedActivityCount;
     const partialCount = partialActivityCount;
@@ -895,8 +938,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         }
         const reasoningExcerpt = activity.thinkingExcerpts?.[0];
         if (toolCallIds.length === 0 && reasoningExcerpt) {
-          const reasoningStart = findReasoningExcerptStart(parts, reasoningExcerpt);
-          return reasoningStart != null && reasoningStart >= candidateFinalTextIndex;
+          return hasReasoningExcerptAtOrAfter(
+            parts,
+            reasoningExcerpt,
+            candidateFinalTextIndex,
+          );
         }
         return (
           !toolCallIds.some((id) => materializedToolIds.has(id)) &&
@@ -905,12 +951,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       });
       const overflowIds = [...overflowToolCallIds];
       const overflowBoundaryIds = [...overflowBoundaryToolCallIds];
-      const overflowReasoningStart = overflowReasoningExcerpt
-        ? findReasoningExcerptStart(parts, overflowReasoningExcerpt)
-        : undefined;
       const hasLaterOverflowActivity =
         overflowIds.some((id) => trailingToolIds.has(id)) ||
-        (overflowReasoningStart != null && overflowReasoningStart >= candidateFinalTextIndex) ||
+        (overflowReasoningExcerpt != null &&
+          hasReasoningExcerptAtOrAfter(
+            parts,
+            overflowReasoningExcerpt,
+            candidateFinalTextIndex,
+          )) ||
         (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -45,8 +45,10 @@ export interface ActivityPhaseSnapshot {
   overflowToolCallIds?: string[];
   /** IDs tied to the saved numeric overflow boundary, including equal-index batches. */
   overflowBoundaryToolCallIds?: string[];
-  /** Stable anchor for reasoning-only overflow after HITL content compaction. */
+  /** @deprecated Stable anchor retained for snapshots created before multi-anchor support. */
   overflowReasoningExcerpt?: string;
+  /** Bounded stable anchors for reasoning-only overflow after HITL content compaction. */
+  overflowReasoningAnchors?: string[];
   assistantContext: string[];
   pendingReasoning: Array<{
     key: string;
@@ -421,14 +423,19 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     }
     return matches;
   });
-  const overflowReasoningNeedle = initialSnapshot?.overflowReasoningExcerpt?.slice(0, 80);
+  const overflowReasoningAnchors = new Set(
+    initialSnapshot?.overflowReasoningAnchors ??
+      (initialSnapshot?.overflowReasoningExcerpt != null
+        ? [initialSnapshot.overflowReasoningExcerpt.slice(0, 80)]
+        : []),
+  );
   let rebasedOverflowReasoningIndex: number | undefined;
-  if (overflowReasoningNeedle) {
+  if (overflowReasoningAnchors.size > 0) {
     for (const index of definedPartIndices(content)) {
       const part = content[index];
       if (
         part?.type === ContentTypes.THINK &&
-        textValue(part.think).includes(overflowReasoningNeedle)
+        [...overflowReasoningAnchors].some((anchor) => textValue(part.think).includes(anchor))
       ) {
         rebasedOverflowReasoningIndex = index;
       }
@@ -444,13 +451,12 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   let overflowActivityStartIndex = hasUnresolvedBoundaryTool
     ? Math.max(rebasedOverflowStartIndex ?? -1, initialSnapshot?.overflowActivityStartIndex ?? -1)
     : (rebasedOverflowStartIndex ??
-      (initialSnapshot?.overflowReasoningExcerpt == null
+      (overflowReasoningAnchors.size === 0
         ? initialSnapshot?.overflowActivityStartIndex
         : undefined));
   if (overflowActivityStartIndex != null && overflowActivityStartIndex < 0) {
     overflowActivityStartIndex = undefined;
   }
-  let overflowReasoningExcerpt = initialSnapshot?.overflowReasoningExcerpt;
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext: AssistantContextEntry[] = (initialSnapshot?.assistantContext ?? [])
     .slice(-MAX_CONTEXT_ITEMS)
@@ -495,7 +501,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     overflowActivityStartIndex = undefined;
     overflowToolCallIds.clear();
     overflowBoundaryToolCallIds.clear();
-    overflowReasoningExcerpt = undefined;
+    overflowReasoningAnchors.clear();
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
   };
@@ -519,8 +525,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       }
       const reasoningExcerpts = activity.thinkingExcerpts;
       const reasoningExcerpt = reasoningExcerpts?.[reasoningExcerpts.length - 1]?.trim();
-      if (reasoningExcerpt && activity.startIndex >= overflowActivityStartIndex) {
-        overflowReasoningExcerpt = reasoningExcerpt.slice(0, MAX_EXCERPT_CHARS);
+      if (reasoningExcerpt) {
+        overflowReasoningAnchors.add(reasoningExcerpt.slice(0, 80));
       }
       for (const id of activity.toolCallIds ?? []) {
         overflowToolCallIds.add(id);
@@ -543,7 +549,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     ...(overflowActivityStartIndex != null && {
       overflowBoundaryToolCallIds: [...overflowBoundaryToolCallIds],
     }),
-    ...(overflowReasoningExcerpt != null && { overflowReasoningExcerpt }),
+    ...(overflowReasoningAnchors.size > 0 && {
+      overflowReasoningAnchors: [...overflowReasoningAnchors],
+    }),
     activities: activities.map((activity) => ({
       ...activity,
       ...(activity.entries != null && {
@@ -1009,8 +1017,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const overflowBoundaryIds = [...overflowBoundaryToolCallIds];
       const hasLaterOverflowActivity =
         overflowIds.some((id) => trailingToolIds.has(id)) ||
-        (overflowReasoningExcerpt != null &&
-          hasReasoningExcerptAtOrAfter(parts, overflowReasoningExcerpt, candidateFinalTextIndex)) ||
+        [...overflowReasoningAnchors].some((anchor) =>
+          hasReasoningExcerptAtOrAfter(parts, anchor, candidateFinalTextIndex),
+        ) ||
         (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -40,6 +40,8 @@ export interface ActivityPhaseSnapshot {
   activities: TrackedActivity[];
   overflowActivityStartIndex?: number;
   overflowToolCallIds?: string[];
+  /** IDs tied to the saved numeric overflow boundary, including equal-index batches. */
+  overflowBoundaryToolCallIds?: string[];
   /** Stable anchor for reasoning-only overflow after HITL content compaction. */
   overflowReasoningExcerpt?: string;
   assistantContext: string[];
@@ -359,13 +361,18 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     initialSnapshot?.partialActivityCount ??
     activities.filter((activity) => activity.status === 'partial').length;
   const overflowToolCallIds = new Set(initialSnapshot?.overflowToolCallIds ?? []);
+  const overflowBoundaryToolCallIds = new Set(
+    initialSnapshot?.overflowBoundaryToolCallIds ?? initialSnapshot?.overflowToolCallIds ?? [],
+  );
+  const materializedOverflowToolIds = new Set<string>();
   const rebasedOverflowToolIndexes = definedPartIndices(content).filter((index) => {
     const part = content[index];
-    return (
-      part?.type === ContentTypes.TOOL_CALL &&
-      typeof part.tool_call?.id === 'string' &&
-      overflowToolCallIds.has(part.tool_call.id)
-    );
+    const toolCallId = part?.type === ContentTypes.TOOL_CALL ? part.tool_call?.id : undefined;
+    const matches = typeof toolCallId === 'string' && overflowToolCallIds.has(toolCallId);
+    if (matches) {
+      materializedOverflowToolIds.add(toolCallId);
+    }
+    return matches;
   });
   const overflowReasoningNeedle = initialSnapshot?.overflowReasoningExcerpt?.slice(0, 80);
   let rebasedOverflowReasoningIndex: number | undefined;
@@ -380,13 +387,22 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       }
     }
   }
-  let overflowActivityStartIndex =
+  const rebasedOverflowStartIndex =
     rebasedOverflowToolIndexes.length > 0
       ? Math.max(...rebasedOverflowToolIndexes, rebasedOverflowReasoningIndex ?? -1)
-      : (rebasedOverflowReasoningIndex ??
-        (initialSnapshot?.overflowReasoningExcerpt == null
-          ? initialSnapshot?.overflowActivityStartIndex
-          : undefined));
+      : rebasedOverflowReasoningIndex;
+  const hasUnresolvedBoundaryTool = [...overflowBoundaryToolCallIds].some(
+    (id) => !materializedOverflowToolIds.has(id),
+  );
+  let overflowActivityStartIndex = hasUnresolvedBoundaryTool
+    ? Math.max(rebasedOverflowStartIndex ?? -1, initialSnapshot?.overflowActivityStartIndex ?? -1)
+    : (rebasedOverflowStartIndex ??
+      (initialSnapshot?.overflowReasoningExcerpt == null
+        ? initialSnapshot?.overflowActivityStartIndex
+        : undefined));
+  if (overflowActivityStartIndex != null && overflowActivityStartIndex < 0) {
+    overflowActivityStartIndex = undefined;
+  }
   let overflowReasoningExcerpt = initialSnapshot?.overflowReasoningExcerpt;
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
@@ -419,6 +435,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     partialActivityCount = 0;
     overflowActivityStartIndex = undefined;
     overflowToolCallIds.clear();
+    overflowBoundaryToolCallIds.clear();
     overflowReasoningExcerpt = undefined;
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
@@ -440,6 +457,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     } else {
       if (overflowActivityStartIndex == null || activity.startIndex > overflowActivityStartIndex) {
         overflowActivityStartIndex = activity.startIndex;
+        overflowBoundaryToolCallIds.clear();
       }
       const reasoningExcerpts = activity.thinkingExcerpts;
       const reasoningExcerpt = reasoningExcerpts?.[reasoningExcerpts.length - 1]?.trim();
@@ -448,6 +466,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       }
       for (const id of activity.toolCallIds ?? []) {
         overflowToolCallIds.add(id);
+        if (activity.startIndex === overflowActivityStartIndex) {
+          overflowBoundaryToolCallIds.add(id);
+        }
       }
     }
   };
@@ -461,6 +482,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     agentIds: [...contributingAgentIds],
     ...(overflowActivityStartIndex != null && { overflowActivityStartIndex }),
     ...(overflowToolCallIds.size > 0 && { overflowToolCallIds: [...overflowToolCallIds] }),
+    ...(overflowActivityStartIndex != null && {
+      overflowBoundaryToolCallIds: [...overflowBoundaryToolCallIds],
+    }),
     ...(overflowReasoningExcerpt != null && { overflowReasoningExcerpt }),
     activities: activities.map((activity) => ({
       ...activity,
@@ -869,9 +893,14 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         );
       });
       const overflowIds = [...overflowToolCallIds];
+      const overflowBoundaryIds = [...overflowBoundaryToolCallIds];
+      const overflowReasoningStart = overflowReasoningExcerpt
+        ? findReasoningExcerptStart(parts, overflowReasoningExcerpt)
+        : undefined;
       const hasLaterOverflowActivity =
         overflowIds.some((id) => trailingToolIds.has(id)) ||
-        (!overflowIds.some((id) => materializedToolIds.has(id)) &&
+        (overflowReasoningStart != null && overflowReasoningStart >= candidateFinalTextIndex) ||
+        (!overflowBoundaryIds.every((id) => materializedToolIds.has(id)) &&
           overflowActivityStartIndex != null &&
           overflowActivityStartIndex >= candidateFinalTextIndex);
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -911,7 +911,12 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     for (let position = definedIndices.length - 1; position >= 0; position -= 1) {
       const index = Number(definedIndices[position]);
       const part = parts[index];
-      if (part?.type === ContentTypes.TEXT && part.groupId == null) {
+      /** The UI contract is the last materialized TEXT part, not the last
+       *  part whose provider lane metadata happens to look root-scoped.
+       *  Some MCP runs retain a groupId on their final response. The later-
+       *  activity checks below still reject an intermediate lane text when
+       *  tools or reasoning follow it. */
+      if (part?.type === ContentTypes.TEXT) {
         if (part.phase !== 'final_answer') {
           finalTextIndex = index;
         }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -414,9 +414,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     if (activities.length < MAX_RETAINED_ACTIVITIES) {
       activities.push(activity);
     } else {
-      if (overflowActivityStartIndex == null || activity.startIndex >= overflowActivityStartIndex) {
+      if (overflowActivityStartIndex == null || activity.startIndex > overflowActivityStartIndex) {
         overflowActivityStartIndex = activity.startIndex;
         overflowToolCallIds.clear();
+      }
+      if (activity.startIndex === overflowActivityStartIndex) {
         for (const id of activity.toolCallIds ?? []) {
           overflowToolCallIds.add(id);
         }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -1016,7 +1016,8 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
           overflowActivityStartIndex >= candidateFinalTextIndex);
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
         (reasoning) =>
-          reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex,
+          (reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex) ||
+          hasReasoningExcerptAtOrAfter(parts, reasoning.text, candidateFinalTextIndex),
       );
       if (hasLaterTrackedActivity || hasLaterOverflowActivity || hasLaterPendingReasoning) {
         finalTextIndex = undefined;

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -753,21 +753,15 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     }
     if (finalTextIndex != null) {
       const candidateFinalTextIndex = finalTextIndex;
-      const hasLaterActivityPart = parts.some(
-        (part, index) =>
-          index > candidateFinalTextIndex &&
-          (part?.type === ContentTypes.TOOL_CALL ||
-            part?.type === ContentTypes.THINK ||
-            (part?.type === ContentTypes.ACTIVITY_LABEL && part.activity_label_type !== 'phase')),
-      );
       const hasLaterTrackedActivity = activities.some(
-        (activity) => activity.startIndex >= candidateFinalTextIndex,
+        (activity) =>
+          (findTrackedToolStart(parts, activity) ?? activity.startIndex) >= candidateFinalTextIndex,
       );
       const hasLaterPendingReasoning = [...pendingReasoning.values()].some(
         (reasoning) =>
           reasoning.startIndex != null && reasoning.startIndex >= candidateFinalTextIndex,
       );
-      if (hasLaterActivityPart || hasLaterTrackedActivity || hasLaterPendingReasoning) {
+      if (hasLaterTrackedActivity || hasLaterPendingReasoning) {
         finalTextIndex = undefined;
       }
     }

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -40,6 +40,8 @@ export interface ActivityPhaseSnapshot {
   activities: TrackedActivity[];
   overflowActivityStartIndex?: number;
   overflowToolCallIds?: string[];
+  /** Stable anchor for reasoning-only overflow after HITL content compaction. */
+  overflowReasoningExcerpt?: string;
   assistantContext: string[];
   pendingReasoning: Array<{
     key: string;
@@ -210,17 +212,31 @@ function findTrackedStart(
   }
   const excerpt = activity.thinkingExcerpts?.[0]?.trim();
   if (excerpt) {
-    const needle = excerpt.slice(0, 80);
-    for (const index of definedPartIndices(parts)) {
-      if (
-        parts[index]?.type === ContentTypes.THINK &&
-        textValue(parts[index]?.think).includes(needle)
-      ) {
-        return index;
-      }
+    const reasoningStart = findReasoningExcerptStart(parts, excerpt);
+    if (reasoningStart != null) {
+      return reasoningStart;
     }
   }
   return Math.min(activity.startIndex, Math.max(0, parts.length - 1));
+}
+
+function findReasoningExcerptStart(
+  parts: ReadonlyArray<LooseContentPart | null | undefined>,
+  excerpt: string,
+): number | undefined {
+  const needle = excerpt.trim().slice(0, 80);
+  if (!needle) {
+    return undefined;
+  }
+  for (const index of definedPartIndices(parts)) {
+    if (
+      parts[index]?.type === ContentTypes.THINK &&
+      textValue(parts[index]?.think).includes(needle)
+    ) {
+      return index;
+    }
+  }
+  return undefined;
 }
 
 function findTrackedToolStart(
@@ -351,10 +367,27 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       overflowToolCallIds.has(part.tool_call.id)
     );
   });
+  const overflowReasoningNeedle = initialSnapshot?.overflowReasoningExcerpt?.slice(0, 80);
+  let rebasedOverflowReasoningIndex: number | undefined;
+  if (overflowReasoningNeedle) {
+    for (const index of definedPartIndices(content)) {
+      const part = content[index];
+      if (
+        part?.type === ContentTypes.THINK &&
+        textValue(part.think).includes(overflowReasoningNeedle)
+      ) {
+        rebasedOverflowReasoningIndex = index;
+      }
+    }
+  }
   let overflowActivityStartIndex =
     rebasedOverflowToolIndexes.length > 0
-      ? Math.max(...rebasedOverflowToolIndexes)
-      : initialSnapshot?.overflowActivityStartIndex;
+      ? Math.max(...rebasedOverflowToolIndexes, rebasedOverflowReasoningIndex ?? -1)
+      : (rebasedOverflowReasoningIndex ??
+        (initialSnapshot?.overflowReasoningExcerpt == null
+          ? initialSnapshot?.overflowActivityStartIndex
+          : undefined));
+  let overflowReasoningExcerpt = initialSnapshot?.overflowReasoningExcerpt;
   const contributingAgentIds = new Set(initialSnapshot?.agentIds ?? []);
   let assistantContext = (initialSnapshot?.assistantContext ?? []).slice(-MAX_CONTEXT_ITEMS);
   const pendingReasoning = new Map<string, { text: string; agentId?: string; startIndex?: number }>(
@@ -386,6 +419,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     partialActivityCount = 0;
     overflowActivityStartIndex = undefined;
     overflowToolCallIds.clear();
+    overflowReasoningExcerpt = undefined;
     contributingAgentIds.clear();
     lastRootTextStepId = undefined;
     lastRootTextWasSemantic = false;
@@ -407,6 +441,10 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       if (overflowActivityStartIndex == null || activity.startIndex > overflowActivityStartIndex) {
         overflowActivityStartIndex = activity.startIndex;
       }
+      const reasoningExcerpt = activity.thinkingExcerpts?.at(-1)?.trim();
+      if (reasoningExcerpt && activity.startIndex >= overflowActivityStartIndex) {
+        overflowReasoningExcerpt = reasoningExcerpt.slice(0, MAX_EXCERPT_CHARS);
+      }
       for (const id of activity.toolCallIds ?? []) {
         overflowToolCallIds.add(id);
       }
@@ -422,6 +460,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
     agentIds: [...contributingAgentIds],
     ...(overflowActivityStartIndex != null && { overflowActivityStartIndex }),
     ...(overflowToolCallIds.size > 0 && { overflowToolCallIds: [...overflowToolCallIds] }),
+    ...(overflowReasoningExcerpt != null && { overflowReasoningExcerpt }),
     activities: activities.map((activity) => ({
       ...activity,
       ...(activity.entries != null && {
@@ -817,6 +856,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         const toolCallIds = activity.toolCallIds ?? [];
         if (toolCallIds.some((id) => trailingToolIds.has(id))) {
           return true;
+        }
+        const reasoningExcerpt = activity.thinkingExcerpts?.[0];
+        if (toolCallIds.length === 0 && reasoningExcerpt) {
+          const reasoningStart = findReasoningExcerptStart(parts, reasoningExcerpt);
+          return reasoningStart != null && reasoningStart >= candidateFinalTextIndex;
         }
         return (
           !toolCallIds.some((id) => materializedToolIds.has(id)) &&

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -201,6 +201,8 @@ export type TSubmission = {
    * resumes for run steps and activity labels alike.
    */
   editPrefixLength?: number;
+  /** True once server index 0 text/reasoning actually merged into the retained tail. */
+  editPrefixFirstPartFolded?: boolean;
   /**
    * Set once a resume SYNC has replaced the response's retained prefix with
    * the server's completion-local snapshot. From that point the prefix is

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -662,6 +662,8 @@ export type TMessageContentParts =
       tool_call_ids?: string[];
       /** Parent phase bounds and telemetry. */
       activity_start_index?: number;
+      /** Exclusive end of the grouped content; may precede the marker itself. */
+      activity_end_index?: number;
       activity_count?: number;
       agent_ids?: string[];
       /** ok = all tools succeeded, failed = all failed, partial = mixed. */

--- a/packages/data-provider/src/types/runs.ts
+++ b/packages/data-provider/src/types/runs.ts
@@ -102,6 +102,7 @@ export type TActivityLabelEvent = {
     activity_label_type?: 'phase';
     tool_call_ids?: string[];
     activity_start_index?: number;
+    activity_end_index?: number;
     activity_count?: number;
     agent_ids?: string[];
     counts?: {


### PR DESCRIPTION
# Pull Request Template

## Summary

Finalizes unphased parent activity labels at root `AgentRun` completion so one label summarizes the complete run instead of splitting at each intermediate text step.

- preserves the immediate `final_answer` boundary when semantic phase metadata is available
- retains accumulated phase state across HITL pauses and completes it after resume
- adds an exclusive `activity_end_index`, allowing the marker to be appended after the final root text while the UI renders the summarized phase before that text
- carries the new bound through SSE resume offsets, edited-content merges, gap reconciliation, and completion-time content reshaping
- preserves the final answer when `hide_sequential_outputs` is enabled
- keeps the existing two-activity minimum, avoiding a phase-label model call for trivial runs

This is intentionally scoped to LibreChat's phase lifecycle and rendering contract. Langfuse observation topology and naming are being handled separately.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- `packages/api`: activity phase runtime + activity label wiring — 32 tests passed
- `git diff --check` passed
- Added focused runtime, HITL, edit/rebase, resume/gap, client grouping/rendering, filtering, and mock E2E coverage
- Full API client suites could not start in this checkout because the shared dependency tree is missing `winston-daily-rotate-file`; client suites likewise depend on missing shared Babel/Prettier plugins. CI is the broad test gate per the repository workflow.

### **Test Configuration**:

- Base: current `origin/dev` (`5ff282f90`)
- Node dependencies reused from the existing shared checkout; no dependency install or repair performed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Any changes dependent on mine have been merged and published in downstream modules.
