### PR TITLE
🧩 fix: Normalize Malformed MCP Required Schemas

### DIFF
--- a/packages/api/src/mcp/__tests__/zod.spec.ts
+++ b/packages/api/src/mcp/__tests__/zod.spec.ts
@@ -2121,6 +2121,50 @@ describe('normalizeJsonSchema', () => {
     expect(result.additionalProperties).toEqual({ type: 'string', enum: ['val'] });
   });
 
+  it('should drop malformed required keywords recursively', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        required: { type: 'boolean' },
+        config: {
+          type: 'object',
+          properties: { host: { type: 'string' } },
+          required: { host: true },
+        },
+      },
+      oneOf: [{ type: 'object', required: 'name' }],
+      items: { type: 'object', required: null },
+      required: {},
+    };
+
+    expect(normalizeJsonSchema(schema)).toEqual({
+      type: 'object',
+      properties: {
+        required: { type: 'boolean' },
+        config: {
+          type: 'object',
+          properties: { host: { type: 'string' } },
+        },
+      },
+      oneOf: [{ type: 'object' }],
+      items: { type: 'object' },
+    });
+  });
+
+  it('should normalize required arrays to unique property names', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+      required: ['name', 42, null, 'age', 'name', { key: 'value' }],
+    };
+
+    expect(normalizeJsonSchema(schema).required).toEqual(['name', 'age']);
+    expect(normalizeJsonSchema({ type: 'object', required: [] }).required).toEqual([]);
+  });
+
   it('should handle null, undefined, and primitive inputs safely', () => {
     expect(normalizeJsonSchema(null as any)).toBeNull();
     expect(normalizeJsonSchema(undefined as any)).toBeUndefined();

--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -337,6 +337,7 @@ export function resolveJsonSchemaRefs<T extends Record<string, unknown>>(
  * - Strips vendor extension fields (`x-*` prefixed keys, e.g. `x-google-enum-descriptions`)
  * - Strips `definitions` and `$`-prefixed schema keywords (`$defs`, `$schema`,
  *   `$id`, `$comment`, ...) that may survive ref resolution
+ * - Drops malformed `required` values and filters arrays to property names
  *
  * Beyond LLM compatibility, dropping every `$`-prefixed keyword also makes the
  * output safe to persist: MongoDB rejects field names beginning with `$`, so a
@@ -374,6 +375,23 @@ const SCHEMA_MAP_KEYWORDS = new Set([
 
 /** Keywords whose value is an array of subschemas. */
 const SCHEMA_LIST_KEYWORDS = new Set(['oneOf', 'anyOf', 'allOf', 'prefixItems']);
+
+function normalizeRequired(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const required: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string' || seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    required.push(entry);
+  }
+  return required;
+}
 
 export function normalizeJsonSchema<T extends Record<string, unknown>>(schema: T): T {
   if (!schema || typeof schema !== 'object') {
@@ -413,6 +431,14 @@ export function normalizeJsonSchema<T extends Record<string, unknown>>(schema: T
 
     if (key === 'const' && 'enum' in schema) {
       // Skip `const` when `enum` already exists
+      continue;
+    }
+
+    if (key === 'required') {
+      const required = normalizeRequired(value);
+      if (required) {
+        result[key] = required;
+      }
       continue;
     }
 


### PR DESCRIPTION
I fixed MCP JSON Schema normalization so malformed `required` values cannot reach strict providers such as AWS Bedrock Converse and reject the entire tool request.

- Normalize `required` arrays to unique string property names while preserving order and valid empty arrays.
- Drop non-array `required` values, including malformed objects emitted by some MCP servers.
- Apply the normalization recursively across nested schema containers without changing properties literally named `required`.
- Add regression coverage for top-level and nested malformed values, mixed and duplicate entries, empty arrays, and literal property names.
- Resolve #14765.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `jest src/mcp/__tests__/zod.spec.ts --runInBand` (152 tests passed).
- Ran ESLint on the changed source and test files.
- Ran Prettier checks on the changed source and test files.
- Ran a strict targeted TypeScript check on the changed source and test files.
- Ran `git diff --check`.
- The full `packages/api` typecheck currently reports unrelated stale generated-package type errors on `dev` (skills sync fields, batched question exports, and Redis client types); the changed files pass the targeted check.

### **Test Configuration**:

- Node.js v24.16.0
- npm 11.16.0
- Jest 30.2.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
