### PR TITLE
🧾 fix: Honor Disabled Transactions on the Token-Count Fallback Path

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -11,6 +11,7 @@ const {
   getReferencedQuotes,
   encodeAndFormatAudios,
   encodeAndFormatVideos,
+  getTransactionsConfig,
   encodeAndFormatDocuments,
   getLangfuseTraceDestinationIds,
   isLangfuseTraceSampled,
@@ -262,11 +263,19 @@ class BaseClient {
    * @param {string} [messageId]
    * @returns {Promise<void>}
    */
-  async recordTokenUsage({ model, balance, promptTokens, completionTokens, messageId }) {
+  async recordTokenUsage({
+    model,
+    balance,
+    messageId,
+    transactions,
+    promptTokens,
+    completionTokens,
+  }) {
     logger.debug('[BaseClient] `recordTokenUsage` not implemented.', {
       model,
       balance,
       messageId,
+      transactions,
       promptTokens,
       completionTokens,
     });
@@ -682,6 +691,7 @@ class BaseClient {
     }
 
     const balanceConfig = getBalanceConfig(appConfig);
+    const transactionsConfig = getTransactionsConfig(appConfig);
     if (
       balanceConfig?.enabled &&
       supportsBalanceCheck[this.options.endpointType ?? this.options.endpoint]
@@ -794,6 +804,7 @@ class BaseClient {
           promptTokens,
           completionTokens,
           balance: balanceConfig,
+          transactions: transactionsConfig,
           /** Note: When using agents, responseMessage.model is the agent ID, not the model */
           model: this.model,
           messageId: this.responseMessageId,

--- a/api/server/controllers/agents/__tests__/client.transactions.spec.js
+++ b/api/server/controllers/agents/__tests__/client.transactions.spec.js
@@ -1,0 +1,69 @@
+const mockSpendTokens = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('~/models', () => ({
+  spendTokens: mockSpendTokens,
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+const AgentClient = require('../client');
+
+describe('AgentClient#recordTokenUsage transactions config', () => {
+  /** @returns {AgentClient} */
+  const createClient = () =>
+    Object.create(AgentClient.prototype, {
+      user: { value: 'user-1' },
+      conversationId: { value: 'convo-1' },
+      responseMessageId: { value: 'msg-1' },
+      options: { value: { req: { user: { id: 'user-1' } }, endpointTokenConfig: undefined } },
+    });
+
+  beforeEach(() => {
+    mockSpendTokens.mockClear();
+  });
+
+  it('forwards the transactions config to spendTokens', async () => {
+    await createClient().recordTokenUsage({
+      model: 'gpt-4o-mini',
+      promptTokens: 10,
+      completionTokens: 5,
+      balance: { enabled: false },
+      transactions: { enabled: false },
+    });
+
+    expect(mockSpendTokens).toHaveBeenCalledTimes(1);
+    expect(mockSpendTokens.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ transactions: { enabled: false } }),
+    );
+  });
+
+  it('forwards the transactions config on the reasoning-token spend', async () => {
+    await createClient().recordTokenUsage({
+      model: 'gpt-4o-mini',
+      promptTokens: 10,
+      completionTokens: 5,
+      transactions: { enabled: false },
+      usage: { reasoning_tokens: 7 },
+    });
+
+    expect(mockSpendTokens).toHaveBeenCalledTimes(2);
+    expect(mockSpendTokens.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ context: 'reasoning', transactions: { enabled: false } }),
+    );
+  });
+
+  it('still records when transactions are enabled', async () => {
+    await createClient().recordTokenUsage({
+      model: 'gpt-4o-mini',
+      promptTokens: 10,
+      completionTokens: 5,
+      transactions: { enabled: true },
+    });
+
+    expect(mockSpendTokens.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ transactions: { enabled: true } }),
+    );
+  });
+});

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -3636,6 +3636,7 @@ class AgentClient extends BaseClient {
    * @param {string} [params.model]
    * @param {OpenAIUsageMetadata} [params.usage]
    * @param {AppConfig['balance']} [params.balance]
+   * @param {AppConfig['transactions']} [params.transactions]
    * @param {string} [params.context='message']
    * @returns {Promise<void>}
    */
@@ -3643,6 +3644,7 @@ class AgentClient extends BaseClient {
     model,
     usage,
     balance,
+    transactions,
     promptTokens,
     completionTokens,
     context = 'message',
@@ -3653,6 +3655,7 @@ class AgentClient extends BaseClient {
           model,
           context,
           balance,
+          transactions,
           messageId: this.responseMessageId,
           conversationId: this.conversationId,
           user: this.user ?? this.options.req.user?.id,
@@ -3671,6 +3674,7 @@ class AgentClient extends BaseClient {
           {
             model,
             balance,
+            transactions,
             context: 'reasoning',
             messageId: this.responseMessageId,
             conversationId: this.conversationId,


### PR DESCRIPTION
Fixes #14773

## Summary

`transactions.enabled: false` had no effect on agent messages. `AgentClient.recordTokenUsage` had no `transactions` parameter, so the setting never reached `createTransaction`, which reads it from the object it is handed. The guard `transactions?.enabled === false` saw `undefined`, which is not `false`, and the write proceeded.

This adds the parameter and passes it from `BaseClient` alongside the `balance` config that was already being forwarded.

## Why it went unnoticed

The bulk path (`recordCollectedUsage` → `prepareStandardTx`) honours the setting correctly. `recordTokenUsage` is reached only from `BaseClient`'s `else` branch — when `usage[this.outputTokensKey] > 0` is false and the client falls back to counting tokens itself. Wherever a response does not populate that field, the branch is taken on every request and the setting looks entirely non-functional.

Records are written with `context: 'message'`, indistinguishable from ordinary traffic, so the symptom is silent growth of the `transactions` collection rather than an error.

## Changes

- `api/server/controllers/agents/client.js` — `recordTokenUsage` accepts `transactions` and forwards it to both spends, including the reasoning-token spend
- `api/app/clients/BaseClient.js` — resolves `getTransactionsConfig(appConfig)` beside the existing `getBalanceConfig(appConfig)` and passes it at the call site; the base-class stub takes the parameter so the signatures match

## Tests

`api/server/controllers/agents/__tests__/client.transactions.spec.js` — three cases covering the message spend, the reasoning-token spend, and the enabled case.

Verified against this branch's base: with `client.js` reverted to `main`, all three fail; with the fix, all three pass.

## Not included

Two other call sites drop the same parameter and would leak once this path is fixed. Left out to keep this reviewable — happy to fold them in here if you would prefer a single change:

- `api/server/middleware/abortMiddleware.js` — `spendCollectedUsage`, forwards neither `balance` nor `transactions`
- `api/server/services/Threads/manage.js` — `recordUsage`

## Verification

Confirmed on a deployed instance before writing the fix. Instrumentation immediately after `getTransactionsConfig(appConfig)` showed `{"enabled":false}` resolving correctly, with two transaction records written ~1s later in the same request, same `conversationId` and `messageId`. Details and log output are in #14773.
