### PR TITLE
🧾 test: Pin the Transactions Config Wiring on the Fallback Path

### DIFF
--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1240,6 +1240,80 @@ describe('BaseClient', () => {
     });
   });
 
+  /**
+   * The `transactions.enabled` guard lives in `createTransaction`, which reads it off
+   * the object it is handed. Dropping the config anywhere between here and there
+   * silently re-enables the writes rather than failing, so pin the wiring itself.
+   */
+  describe('recordTokenUsage transactions config', () => {
+    let priorEndpoint;
+    let priorEndpointType;
+
+    const arrangeFallbackPath = () => {
+      TestClient.getTokenCountForResponse = jest.fn().mockReturnValue(50);
+      TestClient.recordTokenUsage = jest.fn().mockResolvedValue(undefined);
+      TestClient.buildMessages.mockReturnValue({
+        prompt: [],
+        tokenCountMap: { res: 50 },
+      });
+    };
+
+    /** `options` is shared across this file's tests, so an endpoint left behind by an earlier
+     * case would route the balance-enabled arrangement into `checkBalance`. */
+    beforeEach(() => {
+      priorEndpoint = TestClient.options.endpoint;
+      priorEndpointType = TestClient.options.endpointType;
+      delete TestClient.options.endpoint;
+      delete TestClient.options.endpointType;
+    });
+
+    afterEach(() => {
+      delete TestClient.options.req;
+      TestClient.options.endpoint = priorEndpoint;
+      TestClient.options.endpointType = priorEndpointType;
+    });
+
+    test('should forward the resolved transactions config to recordTokenUsage', async () => {
+      TestClient.options.req = { config: { transactions: { enabled: false } } };
+      arrangeFallbackPath();
+
+      await TestClient.sendMessage('Hello', {});
+
+      expect(TestClient.recordTokenUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactions: { enabled: false },
+        }),
+      );
+    });
+
+    test('should default to enabled transactions when no app config is present', async () => {
+      arrangeFallbackPath();
+
+      await TestClient.sendMessage('Hello', {});
+
+      expect(TestClient.recordTokenUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactions: { enabled: true },
+        }),
+      );
+    });
+
+    test('should forward transactions as enabled when balance tracking overrides the setting', async () => {
+      TestClient.options.req = {
+        config: { transactions: { enabled: false }, balance: { enabled: true } },
+      };
+      arrangeFallbackPath();
+
+      await TestClient.sendMessage('Hello', {});
+
+      expect(TestClient.recordTokenUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transactions: { enabled: true },
+        }),
+      );
+    });
+  });
+
   describe('getMessagesWithinTokenLimit with instructions', () => {
     test('should always include instructions when present', async () => {
       TestClient.maxContextTokens = 50;


### PR DESCRIPTION
Follow-up to #14774 (merged as e696b07619).

## Why

`client.transactions.spec.js` covers `AgentClient.recordTokenUsage` in isolation. That leaves the `BaseClient` half of the fix unpinned: deleting the `transactions` property from the call site — half the fix, and the line most exposed to a future refactor of that block — restores the bug with the whole suite still green.

These cases drive `sendMessage` with a real app config on `req` and assert the resolved value arrives at `recordTokenUsage`: disabled, the default when no config is present, and the balance-enabled override that force-enables it. Each fails if either half of #14774 is reverted. The resolver's own semantics stay covered where they already are, in `packages/api/src/app/config.test.ts`.

They also isolate `options.endpoint` for the duration of the block — `options` is shared across that file and assigned by reference, so an endpoint left behind by an earlier case routes the balance-enabled arrangement into `checkBalance`.

## Scope

This PR originally also threaded the config through `abortMiddleware.js`. That change has been dropped.

Codex correctly pointed out the path is unreachable: agent stops post to `/api/agents/chat/abort`, whose inline handler in `api/server/routes/agents/index.js` never invokes `abortMessage`; the only routed callers of `handleAbort()` are the assistants V1/V2 routes, and those divert to `abortRun` before the spend block. The tests I wrote for it hid that by invoking `handleAbort()` directly with an `endpoint: 'agents'` request no client produces. Fixing config threading in code nothing reaches, with tests that imply coverage of the agent abort path, is worse than leaving it alone.

The remaining call site named in #14773 — `api/server/services/Threads/manage.js` (`recordUsage`, assistants path) — still drops the setting and is left for an assistants-side change.
