### PR TITLE
🪑 fix: Rebase Activity Phase Bounds Onto Compacted Content and Unskip the MCPManager Suite

### DIFF
--- a/packages/api/src/agents/__tests__/run-codeTools.test.ts
+++ b/packages/api/src/agents/__tests__/run-codeTools.test.ts
@@ -35,11 +35,6 @@ jest.mock('winston', () => ({
   transports: { Console: jest.fn(), DailyRotateFile: jest.fn(), File: jest.fn() },
 }));
 
-jest.mock('~/utils/env', () => ({
-  resolveHeaders: jest.fn((opts: { headers: unknown }) => opts?.headers ?? {}),
-  createSafeUser: jest.fn(() => ({})),
-}));
-
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
   logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn() },

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -40,11 +40,12 @@ jest.mock('winston', () => ({
   },
 }));
 
-// Mock env utilities so header resolution doesn't fail
-jest.mock('~/utils/env', () => ({
-  resolveHeaders: jest.fn((opts: { headers: unknown }) => opts?.headers ?? {}),
-  createSafeUser: jest.fn(() => ({})),
-}));
+/** Spy on the real `resolveHeaders` instead of replacing it — the templated-header
+ *  case below only proves anything if the actual substitution runs. */
+jest.mock('~/utils/env', () => {
+  const actual = jest.requireActual<typeof import('~/utils/env')>('~/utils/env');
+  return { ...actual, resolveHeaders: jest.fn(actual.resolveHeaders) };
+});
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),

--- a/packages/api/src/agents/activityLabels/__tests__/host.spec.ts
+++ b/packages/api/src/agents/activityLabels/__tests__/host.spec.ts
@@ -17,7 +17,6 @@ jest.mock('~/endpoints/config/providers', () => ({
   })),
 }));
 jest.mock('~/utils/headers', () => ({ resolveConfigHeaders: jest.fn() }));
-jest.mock('~/utils/env', () => ({ createSafeUser: jest.fn(() => undefined) }));
 
 const appConfig = (endpoints: Record<string, unknown>): AppConfig =>
   ({ endpoints }) as unknown as AppConfig;

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -37,10 +37,13 @@ jest.mock('~/mcp/oauth', () => ({
   resolveOboToken: jest.fn(),
 }));
 
+/** Only `processMCPEnv` is a deliberate seam — the cases below drive it to hand
+ *  the manager a specific processed config. Everything else stays real:
+ *  `~/mcp/utils` reads `ALLOWED_BODY_FIELDS` from here at module scope, so a
+ *  replacing factory breaks the suite at import time. */
 jest.mock('~/utils/env', () => ({
+  ...jest.requireActual('~/utils/env'),
   processMCPEnv: jest.fn((params) => params.options),
-  MCP_PLUGIN_SOURCE: 'plugin',
-  isPluginSourced: jest.fn((config) => config?.source === 'plugin'),
 }));
 
 jest.mock('~/auth/domain', () => ({

--- a/packages/api/src/utils/content.spec.ts
+++ b/packages/api/src/utils/content.spec.ts
@@ -197,4 +197,138 @@ describe('filterMalformedContentParts', () => {
       expect(result).toHaveLength(1);
     });
   });
+
+  describe('parent activity phase bounds', () => {
+    const toolPart = (id: string): TMessageContentParts => ({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id,
+        name: 'fetch_fact',
+        type: ToolCallTypes.TOOL_CALL,
+        args: '{}',
+        progress: 1,
+        output: 'result',
+      },
+    });
+    const childLabel = (label: string): TMessageContentParts =>
+      ({ type: ContentTypes.ACTIVITY_LABEL, activity_label: label }) as TMessageContentParts;
+    const phaseMarker = (start: number, end: number): TMessageContentParts =>
+      ({
+        type: ContentTypes.ACTIVITY_LABEL,
+        activity_label: 'Gathered both facts',
+        activity_label_type: 'phase',
+        activity_start_index: start,
+        activity_end_index: end,
+        activity_count: 2,
+      }) as TMessageContentParts;
+    const phaseOf = (parts: TMessageContentParts[]) =>
+      parts.find(
+        (part) =>
+          part.type === ContentTypes.ACTIVITY_LABEL &&
+          (part as { activity_label_type?: string }).activity_label_type === 'phase',
+      ) as { activity_start_index?: number; activity_end_index?: number } | undefined;
+
+    /** A model turn that emits no text before its tool calls leaves the source
+     *  slot empty, so the aggregator's array arrives here sparse. */
+    const sparseRun = (): TMessageContentParts[] => {
+      const parts: TMessageContentParts[] = [];
+      parts[1] = toolPart('call_alpha');
+      parts[2] = childLabel('Looked up alpha');
+      parts[4] = toolPart('call_beta');
+      parts[5] = childLabel('Looked up beta');
+      parts[6] = { type: ContentTypes.TEXT, text: 'Final answer' };
+      parts[7] = phaseMarker(0, 6);
+      parts.length = 8;
+      return parts;
+    };
+
+    it('rebases bounds onto compacted coordinates when holes are removed', () => {
+      const result = filterMalformedContentParts(sparseRun());
+
+      expect(result).toHaveLength(6);
+      const finalTextIndex = result.findIndex(
+        (part) => part.type === ContentTypes.TEXT && part.text === 'Final answer',
+      );
+      expect(finalTextIndex).toBe(4);
+      /** The exclusive end must still land on the final answer so the parent
+       *  card groups the two activities and nothing more. */
+      expect(phaseOf(result)?.activity_end_index).toBe(finalTextIndex);
+      expect(phaseOf(result)?.activity_start_index).toBe(0);
+    });
+
+    it('keeps the grouped children exactly the tool and label parts', () => {
+      const result = filterMalformedContentParts(sparseRun());
+      const phase = phaseOf(result);
+      const children = result.slice(phase?.activity_start_index ?? 0, phase?.activity_end_index);
+
+      expect(children).toHaveLength(4);
+      expect(
+        children
+          .map((part) => (part.type === ContentTypes.TOOL_CALL ? part.tool_call?.id : undefined))
+          .filter(Boolean),
+      ).toEqual(['call_alpha', 'call_beta']);
+      expect(children.some((part) => part.type === ContentTypes.TEXT)).toBe(false);
+    });
+
+    it('leaves the source array in its own coordinate space', () => {
+      const parts = sparseRun();
+      filterMalformedContentParts(parts);
+
+      expect(phaseOf(parts.filter(Boolean) as TMessageContentParts[])?.activity_end_index).toBe(6);
+    });
+
+    it('rebases past a dropped malformed tool_call', () => {
+      const parts: TMessageContentParts[] = [
+        toolPart('call_alpha'),
+        { type: ContentTypes.TOOL_CALL } as TMessageContentParts,
+        { type: ContentTypes.TEXT, text: 'Final answer' },
+        phaseMarker(0, 2),
+      ];
+
+      const result = filterMalformedContentParts(parts);
+
+      expect(result).toHaveLength(3);
+      expect(phaseOf(result)?.activity_end_index).toBe(1);
+      expect(result[1]).toMatchObject({ type: ContentTypes.TEXT, text: 'Final answer' });
+    });
+
+    it('maps a bound that lands on a dropped slot to the next retained part', () => {
+      const parts: TMessageContentParts[] = [];
+      parts[0] = toolPart('call_alpha');
+      parts[2] = { type: ContentTypes.TEXT, text: 'Final answer' };
+      parts[3] = phaseMarker(1, 2);
+      parts.length = 4;
+
+      const result = filterMalformedContentParts(parts);
+
+      expect(phaseOf(result)?.activity_start_index).toBe(1);
+      expect(phaseOf(result)?.activity_end_index).toBe(1);
+    });
+
+    it('leaves bounds and part identity untouched when nothing is dropped', () => {
+      const parts: TMessageContentParts[] = [
+        toolPart('call_alpha'),
+        { type: ContentTypes.TEXT, text: 'Final answer' },
+        phaseMarker(0, 1),
+      ];
+
+      const result = filterMalformedContentParts(parts);
+
+      expect(result[2]).toBe(parts[2]);
+      expect(phaseOf(result)?.activity_start_index).toBe(0);
+      expect(phaseOf(result)?.activity_end_index).toBe(1);
+    });
+
+    it('does not touch per-batch activity labels', () => {
+      const parts: TMessageContentParts[] = [];
+      parts[1] = toolPart('call_alpha');
+      parts[2] = childLabel('Looked up alpha');
+      parts.length = 3;
+
+      const result = filterMalformedContentParts(parts);
+
+      expect(result).toHaveLength(2);
+      expect(result[1]).toBe(parts[2]);
+    });
+  });
 });

--- a/packages/api/src/utils/content.ts
+++ b/packages/api/src/utils/content.ts
@@ -1,6 +1,99 @@
 import { ContentTypes } from 'librechat-data-provider';
 import type { TMessageContentParts } from 'librechat-data-provider';
 
+type ActivityLabelPart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }>;
+
+function isRetainablePart(
+  part: TMessageContentParts | null | undefined,
+): part is TMessageContentParts {
+  if (!part || typeof part !== 'object') {
+    return false;
+  }
+
+  if (part.type === ContentTypes.TOOL_CALL) {
+    return 'tool_call' in part && part.tool_call != null && typeof part.tool_call === 'object';
+  }
+
+  return true;
+}
+
+function isPhaseMarker(part: TMessageContentParts): part is ActivityLabelPart {
+  return (
+    part.type === ContentTypes.ACTIVITY_LABEL &&
+    (part as ActivityLabelPart).activity_label_type === 'phase'
+  );
+}
+
+/**
+ * Rebase a parent-phase bound from source coordinates onto compacted ones.
+ * `retainedBefore[i]` counts the parts kept ahead of source index `i`, which is
+ * the compacted position of source `i` for an inclusive start and the exclusive
+ * end for a bound that lands on a dropped slot.
+ */
+function rebaseBound(bound: number, retainedBefore: number[], sourceLength: number): number {
+  return retainedBefore[Math.max(0, Math.min(sourceLength, bound))];
+}
+
+/**
+ * Removes malformed tool call parts and any empty slots, then rebases parent
+ * activity-phase bounds onto the compacted coordinates.
+ *
+ * The source array is frequently sparse: the aggregator writes parts at
+ * provider-source indexes, so a model turn that emits no text before its tool
+ * calls leaves holes. Compacting shifts every part after a hole, while a phase
+ * marker's `activity_start_index`/`activity_end_index` still address the source
+ * positions — leaving the persisted bounds pointing at the wrong parts (the
+ * final answer gets swallowed into the parent card, or the marker's own slot is
+ * claimed as a child).
+ *
+ * Markers are copied rather than mutated: the caller's array stays in its own
+ * coordinate space, which the live stream and the resume snapshot still use.
+ */
+function compactContentParts(contentParts: TMessageContentParts[]): TMessageContentParts[] {
+  const retained: TMessageContentParts[] = [];
+  const retainedBefore: number[] = new Array<number>(contentParts.length + 1);
+  let phaseMarkerCount = 0;
+
+  for (let index = 0; index < contentParts.length; index += 1) {
+    retainedBefore[index] = retained.length;
+    const part = contentParts[index];
+    if (!isRetainablePart(part)) {
+      continue;
+    }
+    if (isPhaseMarker(part)) {
+      phaseMarkerCount += 1;
+    }
+    retained.push(part);
+  }
+  retainedBefore[contentParts.length] = retained.length;
+
+  if (phaseMarkerCount === 0 || retained.length === contentParts.length) {
+    return retained;
+  }
+
+  for (let index = 0; index < retained.length; index += 1) {
+    const part = retained[index];
+    if (!isPhaseMarker(part)) {
+      continue;
+    }
+    const { activity_start_index: start, activity_end_index: end } = part;
+    const nextStart =
+      typeof start === 'number' ? rebaseBound(start, retainedBefore, contentParts.length) : start;
+    const nextEnd =
+      typeof end === 'number' ? rebaseBound(end, retainedBefore, contentParts.length) : end;
+    if (nextStart === start && nextEnd === end) {
+      continue;
+    }
+    retained[index] = {
+      ...part,
+      ...(typeof nextStart === 'number' && { activity_start_index: nextStart }),
+      ...(typeof nextEnd === 'number' && { activity_end_index: nextEnd }),
+    };
+  }
+
+  return retained;
+}
+
 /**
  * Filters out malformed tool call content parts that don't have the required tool_call property.
  * This handles edge cases where tool_call content parts may be created with only a type property
@@ -30,17 +123,5 @@ export function filterMalformedContentParts<T>(
     return contentParts;
   }
 
-  return contentParts.filter((part) => {
-    if (!part || typeof part !== 'object') {
-      return false;
-    }
-
-    const { type } = part;
-
-    if (type === ContentTypes.TOOL_CALL) {
-      return 'tool_call' in part && part.tool_call != null && typeof part.tool_call === 'object';
-    }
-
-    return true;
-  });
+  return compactContentParts(contentParts);
 }

--- a/packages/api/src/utils/content.ts
+++ b/packages/api/src/utils/content.ts
@@ -95,12 +95,18 @@ function compactContentParts(contentParts: TMessageContentParts[]): TMessageCont
 }
 
 /**
- * Filters out malformed tool call content parts that don't have the required tool_call property.
- * This handles edge cases where tool_call content parts may be created with only a type property
- * but missing the actual tool_call data.
+ * Produces the durable content array: drops malformed tool call parts that lack the
+ * required tool_call property, compacts away empty slots, and rebases parent
+ * activity-phase bounds onto the resulting coordinates.
  *
- * @param contentParts - Array of content parts to filter
- * @returns Filtered array with malformed tool calls removed
+ * Compaction is not incidental — the source array is frequently sparse, because the
+ * aggregator writes parts at provider-source indexes. Since that shifts positions, any
+ * index-referencing metadata is rebased to match; see {@link compactContentParts}.
+ *
+ * Non-array input is returned unchanged.
+ *
+ * @param contentParts - Array of content parts to compact
+ * @returns Compacted array with malformed tool calls removed and phase bounds rebased
  *
  * @example
  * // Removes malformed tool_call without the tool_call property
@@ -111,6 +117,16 @@ function compactContentParts(contentParts: TMessageContentParts[]): TMessageCont
  * ];
  * const filtered = filterMalformedContentParts(parts);
  * // Returns all parts except the malformed tool_call
+ *
+ * @example
+ * // A hole shifts later parts, so a phase marker's bounds move with them
+ * const parts = []; // parts[0] never materialized
+ * parts[1] = { type: 'tool_call', tool_call: { id: 'a' } };
+ * parts[2] = { type: 'text', text: 'Final answer' };
+ * parts[3] = { type: 'activity_label', activity_label_type: 'phase',
+ *              activity_start_index: 0, activity_end_index: 2 };
+ * const filtered = filterMalformedContentParts(parts);
+ * // Final answer is now at index 1, and activity_end_index is rebased to 1
  */
 export function filterMalformedContentParts(
   contentParts: TMessageContentParts[],


### PR DESCRIPTION
## Summary

Two independent CI failures, both **pre-existing on `dev`** and neither introduced here:

| Check | Cause | Landed via |
|---|---|---|
| `e2e (memory/redis, shard 1/2)` | Phase bounds addressed pre-compaction positions | #14768 (`df6e15a0de`) |
| `Tests: @librechat/api (shard 2/4)` | A test replaced `~/utils/env` wholesale | #14780 (`1a3e2aebcb`) |

Each was reproduced locally, root-caused, and verified against a pre-fix build.

---

# 1. Rebase activity phase bounds onto compacted content

The e2e failure is deterministic, not a flake. It reproduces on `dev` itself ([run 31666545988](https://github.com/danny-avila/LibreChat/actions/runs/31666897128), head `df6e15a0de`) and on every branch rebased onto it, on both the memory and redis shard 1, surviving two retries.

```
activity-phases.spec.ts:182
expect(liveFinalTextIndex).toBe(livePhase?.activity_end_index);
  Expected: 6
  Received: 4
```

## Root cause

`filterMalformedContentParts` **compacts** the content array — `Array.prototype.filter` skips holes and drops malformed tool calls — but a parent phase marker's `activity_start_index` / `activity_end_index` still address the *pre-filter* positions.

The array is routinely sparse. The aggregator writes parts at provider-source indexes, so a model turn that emits no text before its tool calls leaves an empty slot. Instrumenting `complete()` on the failing run shows the runtime is entirely correct in its own coordinates:

```
candidateFinalTextIndex: 6, partsLength: 7, all three later-activity guards false
parts: 1=tool_call(alpha) 2=activity_label 4=tool_call(beta) 5=activity_label 6=text(final)
        ^ indexes 0 and 3 are holes — the two empty pre-tool-call text turns
```

`activity_end_index: 6` correctly points at the final answer. Persistence then compacts those six parts to indexes 0–4, moving the final answer to 4 while the bound stays at 6. The stored phase claims a range that swallows the final answer and counts the marker's own slot as a child.

The in-run analogue already handles this: `rebaseActivityPhaseBounds` rebases after completion-time reshaping (`applyHideSequentialOutputsFilter`). The *final* compaction in `sendCompletion` had no such step.

## Fix

Rebase the bounds as part of the compaction, mapping each bound to the number of retained parts ahead of it.

- The mapping is monotonic, so the `start <= end <= markerIndex` invariant survives.
- An identity mapping (nothing dropped) leaves the array and its marker objects untouched, by reference.
- Markers are **copied, not mutated** — the caller's array keeps its own coordinate space, which the live SSE stream and the `GenerationJobManager` resume snapshot still address.

Fixing it at the compaction covers all three persistence sites at once: `sendCompletion` plus the two in `resume.js`, which had the same defect.

Not touched: `aggregator.contentParts.filter(...)` for `subagent_content` — that array never carries phase markers.

---

# 2. Stop replacing the env module in the MCPManager suite

`MCPManager.test.ts` mocked `~/utils/env` with a factory that **replaced the whole module**:

```js
jest.mock('~/utils/env', () => ({
  processMCPEnv: ..., MCP_PLUGIN_SOURCE: 'plugin', isPluginSourced: ...,
}));
```

#14780 then made `~/mcp/utils` read `ALLOWED_BODY_FIELDS` from that module **at module scope** (`ALLOWED_BODY_FIELDS.map(...)`, `utils.ts:184`). The factory does not provide it, so as soon as `~/mcp/oauth` → `handler.ts:37` pulls in `~/mcp/utils`, it evaluates `undefined.map(...)` and the suite dies at import time.

#14780 changed `mcp/utils.ts` and `utils/env.ts` but never touched the test. **Its own `shard 2/4` was red with this exact failure and it merged anyway**, so `dev` has been red since — as is `release-v0.8.8-rc1`. All 111 tests in the suite have been silently skipped that whole time.

Spread the real module and keep only the mock that earns its place:

- **`processMCPEnv` stays a seam** — fifteen cases drive it with `mockReturnValue` / `mockImplementation` to hand the manager a specific processed config, and one asserts `toHaveBeenCalledTimes(1)`. Making it real would couple these tests to env-substitution logic.
- **`isPluginSourced` and `MCP_PLUGIN_SOURCE` dropped** — the factory restated the real implementations verbatim (`config?.source === 'plugin'` *is* the real body) and no test referenced either. Duplication, not a seam.

**111 tests now run and pass**, with `ALLOWED_BODY_FIELDS`, `isPluginSourced`, and `MCP_PLUGIN_SOURCE` all real.

---

# 3. The same trap in three more suites

`run-codeTools`, `run-summarization`, and `activityLabels/host.spec` replace `~/utils/env` the same way. They pass today only because their import graphs never reach `~/mcp/utils` — the next module-scope constant added to `env.ts` breaks all three the same silent way. Each mock is kept only where it earns its place:

- **`activityLabels/host.spec.ts`** — dropped. `createSafeUser` was never referenced, and the stub returned `undefined` where the real function returns `{}`, so the mock was strictly *less* faithful than the real, pure implementation.
- **`run-codeTools.test.ts`** — dropped. Neither `resolveHeaders` nor `createSafeUser` was referenced by any case.
- **`run-summarization.test.ts`** — `resolveHeaders` converted from an identity stub to a **spy wrapping the real implementation**. One case asserts templated header values go through it, which only proves something if the real substitution runs; it was previously asserting against a stub that returned headers unchanged. `createSafeUser` dropped as unreferenced.

Only two `~/utils/env` mocks remain repo-wide, both spreading the real module with exactly one deliberate seam.

---

## Verification

**Reproduced locally first**, with CI's exact numbers (expected 6, received 4), then fixed and re-verified.

**New tests fail against the pre-fix build.** 4 of the 7 added `content.spec.ts` tests fail when `content.ts` is reverted to `HEAD`; the other 3 are deliberate no-op invariants (identity mapping, per-batch labels, source array untouched) and correctly pass both ways.

| Suite | Result |
|---|---|
| `activity-phases.spec.ts` | passes, including post-reload assertions |
| e2e, all four shards | green on `1541e4b388` (memory + redis, both shards) |
| e2e content sweep | 31/31 — `activity-labels`, `agent-handoffs`, `steering`, `subagent-results`, `thread-fold`, `completion` |
| `MCPManager.test.ts` | 111/111 (previously 0 ran) |
| `src/agents` + `src/utils` + MCPManager | 103 suites / 2708 tests |
| `api/client.test.js` | 102 — covers `rebaseActivityPhaseBounds` |
| Typecheck, eslint | clean |

The full `packages/api` suite was also run **against stock dev for comparison**: the same 7 suites fail identically with and without these changes — all Redis/Mongo/integration-dependent local-environment failures. `MCPManager` is no longer among them.
