### PR TITLE
docs: add SayGM custom endpoint example

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -713,6 +713,31 @@ endpoints:
       dropParams: ['stop']
       modelDisplayLabel: 'OpenRouter'
 
+    # SayGM Example
+    # OpenAI-compatible inference gateway. `baseURL` must be the API root that
+    # the OpenAI client appends `/v1/chat/completions` to. SayGM's `/v1/models`
+    # lists every upstream model, including Claude/Gemini models served only on
+    # other wire protocols and models that are currently unavailable — so list
+    # the OpenAI-chat-servable models explicitly and keep `fetch: false`.
+    - name: 'saygm'
+      apiKey: '${SAYGM_API_KEY}'
+      baseURL: 'https://api.saygm.com/v1'
+      models:
+        default:
+          - 'gpt-5.4'
+          - 'gpt-5.6-sol'
+          - 'gpt-5.4-mini'
+          - 'gpt-5.4-nano'
+          - 'gpt-5.5'
+          - 'gpt-5.6-luna'
+          - 'gpt-5.6-terra'
+          - 'o3'
+          - 'o4-mini'
+        fetch: false
+      titleConvo: true
+      titleModel: 'gpt-5.4'
+      modelDisplayLabel: 'SayGM'
+
     # Helicone Example
     - name: 'Helicone'
       # For `apiKey` and `baseURL`, you can use environment variables that you define.


### PR DESCRIPTION
## Summary

Adds a SayGM custom-endpoint example to `librechat.example.yaml`. Closes #14789.

LibreChat already supports OpenAI-compatible gateways, so this is intentionally configuration-only. The example uses `SAYGM_API_KEY`, lists the supported Chat Completions models, and disables unfiltered model fetching because SayGM's catalogue also contains other protocol shapes. Static pricing is omitted because routing prices are dynamic.

## Change Type

- [x] New feature (non-breaking configuration example)

## Testing

- Parsed `librechat.example.yaml` with the repository YAML dependency
- Verified the listed models against the live Chat Completions API
- `git diff --check`

## Checklist

- [x] Style and self-review completed
- [x] Documentation/configuration example updated
- [x] No new warnings introduced