### PR TITLE
🖌️ style: Use correct text colour for answer textarea in dark mode

### DIFF
--- a/client/src/components/Chat/Messages/Content/AskUserQuestion.tsx
+++ b/client/src/components/Chat/Messages/Content/AskUserQuestion.tsx
@@ -189,7 +189,7 @@ function AskUserQuestionSingle({
         minRows={2}
         maxRows={12}
         placeholder={otherLabel ?? localize('com_ui_your_answer')}
-        className="w-full resize-none rounded-md border border-border-light bg-surface-primary p-2 text-sm"
+        className="w-full resize-none rounded-md border border-border-light bg-surface-primary p-2 text-sm text-text-primary"
         aria-label={localize('com_ui_your_answer')}
       />
 

--- a/client/src/components/Chat/Messages/Content/AskUserQuestions.tsx
+++ b/client/src/components/Chat/Messages/Content/AskUserQuestions.tsx
@@ -96,7 +96,7 @@ export default function AskUserQuestions({
                 minRows={1}
                 maxRows={6}
                 placeholder={otherLabel ?? localize('com_ui_your_answer')}
-                className="mt-2 w-full resize-none rounded-md border border-border-light bg-surface-primary p-2 text-sm"
+                className="mt-2 w-full resize-none rounded-md border border-border-light bg-surface-primary p-2 text-sm text-text-primary"
                 aria-label={`${question.question} ${localize('com_ui_your_answer')}`}
               />
             </fieldset>


### PR DESCRIPTION
## Summary

Fix dark-mode text visibility for answers entered in the Ask User Questions text areas.

In dark mode, the text entered into both the single-question and multi-question text areas did not use an explicit foreground colour, which could make the answer difficult or impossible to read. This change applies the semantic `text-text-primary` class to both text areas.

### Before
<img width="636" height="238" alt="Screenshot 2026-08-13 at 14 40 02" src="https://github.com/user-attachments/assets/444a3fca-1719-4419-a15e-f16833dc95b9" />

### After
<img width="629" height="241" alt="Screenshot 2026-08-13 at 14 40 25" src="https://github.com/user-attachments/assets/602421a4-ee5d-4920-abd0-a8860a53d1d7" />


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (code or feature that would cause existing functionality to work differently)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Verified the change in the following components:

- `AskUserQuestion.tsx`
- `AskUserQuestions.tsx`

Validation performed:

- `git diff --check`
- Focused ESLint on both changed files

### Test Configuration

No special configuration required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes, or documentation is not applicable
- [x] My changes do not introduce new warnings in the changed files
- [x] Local focused validation passes