### PR TITLE
fix(agents): remove unreachable recordUsage code

### DIFF
--- a/api/server/controllers/agents/errors.js
+++ b/api/server/controllers/agents/errors.js
@@ -2,7 +2,6 @@
 const { logger } = require('@librechat/data-schemas');
 const { CacheKeys, ViolationTypes } = require('librechat-data-provider');
 const { sendResponse } = require('~/server/middleware/error');
-const { recordUsage } = require('~/server/services/Threads');
 const getLogStores = require('~/cache/getLogStores');
 const { getConvo } = require('~/models');
 
@@ -110,18 +109,6 @@ const createErrorHandler = ({ req, res, getContext, originPath = '/assistants/ch
     }
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    let run;
-    try {
-      await recordUsage({
-        ...run.usage,
-        model: run.model,
-        user: req.user.id,
-        conversationId,
-      });
-    } catch (error) {
-      logger.error(`[${originPath}] Error fetching or processing run`, error);
-    }
 
     let finalEvent;
     try {


### PR DESCRIPTION
## Problem

The `recordUsage` call in `agents/errors.js` was unreachable because:

1. `run` variable was declared but never assigned (`let run;`)
2. `run.usage` and `run.model` would always throw `TypeError: Cannot read properties of undefined`
3. The catch block swallowed the error with misleading log message "Error fetching or processing run"

This was a copy/paste regression from `assistants/errors.js` where `run` is properly assigned via `openai.beta.threads.runs.retrieve()`. Since agents have no equivalent API, the entire block was dead code.

## Fix

Removed the unreachable code block and unused `recordUsage` import.

Closes #14792