### PR TITLE
fix: serve text uploads from persisted content

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -1,4 +1,5 @@
 const fs = require('fs').promises;
+const mime = require('mime');
 const express = require('express');
 const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
@@ -315,6 +316,21 @@ function isValidID(str) {
 }
 
 /**
+ * Headers describing the download that was abandoned. They have to go before the error body
+ * replaces it: the code-output route copies the upstream response's headers verbatim, so a
+ * proxied `Transfer-Encoding: chunked` would survive alongside the `Content-Length` that
+ * `send` adds and clients reject a message carrying both framings.
+ */
+const ABANDONED_DOWNLOAD_HEADERS = [
+  'Content-Disposition',
+  'Content-Type',
+  'Content-Length',
+  'Content-Encoding',
+  'Transfer-Encoding',
+  'X-File-Metadata',
+];
+
+/**
  * Pipes a download to the response, terminating it when the source fails.
  *
  * `pipe` does not end the destination on a source error, and the stream errors after the
@@ -334,9 +350,9 @@ const pipeDownloadStream = (stream, res) => {
       res.destroy(streamError);
       return;
     }
-    res.removeHeader('Content-Disposition');
-    res.removeHeader('Content-Type');
-    res.removeHeader('X-File-Metadata');
+    for (const header of ABANDONED_DOWNLOAD_HEADERS) {
+      res.removeHeader(header);
+    }
     res.status(500).send('Error downloading file');
   });
   stream.pipe(res);
@@ -494,6 +510,30 @@ const getDirectDownloadURL = async ({
   });
 };
 
+/** Types whose payload is plain text, including the `application/*` ones `mime` reports for
+ *  structured text formats. */
+const TEXTUAL_MIME_PATTERN =
+  /^text\/|^application\/(json|xml|javascript|x-sh|x-httpd-php)|\+(json|xml)$/;
+
+/**
+ * Resolves the name a `FileSources.text` download is served under.
+ *
+ * Every `createTextFile` caller in `processAgentFileUpload` stores extracted or transcribed
+ * UTF-8 text while keeping the upload's original name, so an OCR'd `report.pdf`, a parsed
+ * `notes.docx` and a transcribed `meeting.mp3` all hold text under a name that promises
+ * something else — the download would look corrupt or unplayable. Rename only when the name
+ * makes that promise: a genuine `.txt`/`.md`/`.yaml` upload keeps its extension, and so does
+ * an extensionless `Dockerfile` or a `.go`/`.py` source `mime` has no type for, since neither
+ * misrepresents its contents.
+ */
+const getTextDownloadFilename = (filename) => {
+  const promisedType = filename && mime.getType(filename);
+  if (!promisedType || TEXTUAL_MIME_PATTERN.test(promisedType)) {
+    return filename;
+  }
+  return `${filename.replace(/\.[^./\\]*$/, '')}.txt`;
+};
+
 // Security allowlist: excludes internal ids, owner/tenant identifiers, and extracted text.
 // `filepath` stays included because cached TFile records need it for previews/deletes.
 const DOWNLOAD_METADATA_FIELDS = [
@@ -586,8 +626,8 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
       return res.status(400).send('The model used when creating this file is not available');
     }
 
-    const setHeaders = () => {
-      res.setHeader('Content-Disposition', getContentDisposition(file.filename));
+    const setHeaders = (downloadFilename = file.filename) => {
+      res.setHeader('Content-Disposition', getContentDisposition(downloadFilename));
       res.setHeader('Content-Type', 'application/octet-stream');
       res.setHeader(
         'X-File-Metadata',
@@ -604,7 +644,7 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
         return res.status(500).send('Error downloading file');
       }
 
-      setHeaders();
+      setHeaders(getTextDownloadFilename(file.filename));
       /** Sent as a buffer so the body carries a `Content-Length`: a string body would make
        *  Express append a charset to the octet-stream content type. */
       return res.status(200).send(Buffer.from(textFile.text, 'utf8'));

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -314,6 +314,34 @@ function isValidID(str) {
   return /^[A-Za-z0-9_-]{21}$/.test(str);
 }
 
+/**
+ * Pipes a download to the response, terminating it when the source fails.
+ *
+ * `pipe` does not end the destination on a source error, and the stream errors after the
+ * handler has already returned, so the route's try/catch never sees it. Without this the
+ * response stays open until the reverse proxy times out — the 504 in #14754. A stream with
+ * no `error` listener at all is worse still: the emit becomes an uncaught exception.
+ *
+ * Nothing is written before the first chunk, so a failure that early can still answer with a
+ * status; once the body has started, destroying the socket is the only way to signal a
+ * truncated download instead of a short but well-formed one. Mirrors what the shared-link
+ * download in `routes/share.js` already does.
+ */
+const pipeDownloadStream = (stream, res) => {
+  stream.on('error', (streamError) => {
+    logger.error('[DOWNLOAD ROUTE] Stream error:', streamError);
+    if (res.headersSent) {
+      res.destroy(streamError);
+      return;
+    }
+    res.removeHeader('Content-Disposition');
+    res.removeHeader('Content-Type');
+    res.removeHeader('X-File-Metadata');
+    res.status(500).send('Error downloading file');
+  });
+  stream.pipe(res);
+};
+
 router.get('/code/download/:session_id/:fileId', async (req, res) => {
   try {
     const { session_id, fileId } = req.params;
@@ -354,7 +382,7 @@ router.get('/code/download/:session_id/:fileId', async (req, res) => {
       req,
     );
     res.set(response.headers);
-    response.data.pipe(res);
+    pipeDownloadStream(response.data, res);
   } catch (error) {
     /* `logAxiosError` redacts buffer/stream response bodies — without
      * it, a stream-typed axios failure dumps the entire `Readable`'s
@@ -577,7 +605,9 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
       }
 
       setHeaders();
-      return res.status(200).end(textFile.text);
+      /** Sent as a buffer so the body carries a `Content-Length`: a string body would make
+       *  Express append a charset to the octet-stream content type. */
+      return res.status(200).send(Buffer.from(textFile.text, 'utf8'));
     }
 
     const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
@@ -610,7 +640,7 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
           ? Readable.fromWeb(passThrough.body)
           : passThrough.body;
 
-      stream.pipe(res);
+      pipeDownloadStream(stream, res);
     } else {
       if (getDownloadURL && req.query.direct === 'true') {
         try {
@@ -636,12 +666,8 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
 
       const fileStream = await getDownloadStream(req, file.storageKey || file.filepath);
 
-      fileStream.on('error', (streamError) => {
-        logger.error('[DOWNLOAD ROUTE] Stream error:', streamError);
-      });
-
       setHeaders();
-      fileStream.pipe(res);
+      pipeDownloadStream(fileStream, res);
     }
   } catch (error) {
     logger.error('[DOWNLOAD ROUTE] Error downloading file:', error);

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -1,14 +1,15 @@
 const fs = require('fs').promises;
-const mime = require('mime');
 const express = require('express');
 const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
   logAxiosError,
   getApprovalTtlMs,
   refreshS3FileUrls,
+  pipeDownloadStream,
   handleFilesUsageRequest,
   shouldUseUploadSse,
   startUploadSseStream,
+  getTextDownloadFilename,
   resolveUploadErrorMessage,
   verifyAgentUploadPermission,
 } = require('@librechat/api');
@@ -315,49 +316,6 @@ function isValidID(str) {
   return /^[A-Za-z0-9_-]{21}$/.test(str);
 }
 
-/**
- * Headers describing the download that was abandoned. They have to go before the error body
- * replaces it: the code-output route copies the upstream response's headers verbatim, so a
- * proxied `Transfer-Encoding: chunked` would survive alongside the `Content-Length` that
- * `send` adds and clients reject a message carrying both framings.
- */
-const ABANDONED_DOWNLOAD_HEADERS = [
-  'Content-Disposition',
-  'Content-Type',
-  'Content-Length',
-  'Content-Encoding',
-  'Transfer-Encoding',
-  'X-File-Metadata',
-];
-
-/**
- * Pipes a download to the response, terminating it when the source fails.
- *
- * `pipe` does not end the destination on a source error, and the stream errors after the
- * handler has already returned, so the route's try/catch never sees it. Without this the
- * response stays open until the reverse proxy times out — the 504 in #14754. A stream with
- * no `error` listener at all is worse still: the emit becomes an uncaught exception.
- *
- * Nothing is written before the first chunk, so a failure that early can still answer with a
- * status; once the body has started, destroying the socket is the only way to signal a
- * truncated download instead of a short but well-formed one. Mirrors what the shared-link
- * download in `routes/share.js` already does.
- */
-const pipeDownloadStream = (stream, res) => {
-  stream.on('error', (streamError) => {
-    logger.error('[DOWNLOAD ROUTE] Stream error:', streamError);
-    if (res.headersSent) {
-      res.destroy(streamError);
-      return;
-    }
-    for (const header of ABANDONED_DOWNLOAD_HEADERS) {
-      res.removeHeader(header);
-    }
-    res.status(500).send('Error downloading file');
-  });
-  stream.pipe(res);
-};
-
 router.get('/code/download/:session_id/:fileId', async (req, res) => {
   try {
     const { session_id, fileId } = req.params;
@@ -508,30 +466,6 @@ const getDirectDownloadURL = async ({
     customFilename,
     contentType: file.type || 'application/octet-stream',
   });
-};
-
-/** Types whose payload is plain text, including the `application/*` ones `mime` reports for
- *  structured text formats. */
-const TEXTUAL_MIME_PATTERN =
-  /^text\/|^application\/(json|xml|javascript|x-sh|x-httpd-php)|\+(json|xml)$/;
-
-/**
- * Resolves the name a `FileSources.text` download is served under.
- *
- * Every `createTextFile` caller in `processAgentFileUpload` stores extracted or transcribed
- * UTF-8 text while keeping the upload's original name, so an OCR'd `report.pdf`, a parsed
- * `notes.docx` and a transcribed `meeting.mp3` all hold text under a name that promises
- * something else — the download would look corrupt or unplayable. Rename only when the name
- * makes that promise: a genuine `.txt`/`.md`/`.yaml` upload keeps its extension, and so does
- * an extensionless `Dockerfile` or a `.go`/`.py` source `mime` has no type for, since neither
- * misrepresents its contents.
- */
-const getTextDownloadFilename = (filename) => {
-  const promisedType = filename && mime.getType(filename);
-  if (!promisedType || TEXTUAL_MIME_PATTERN.test(promisedType)) {
-    return filename;
-  }
-  return `${filename.replace(/\.[^./\\]*$/, '')}.txt`;
 };
 
 // Security allowlist: excludes internal ids, owner/tenant identifiers, and extracted text.

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -558,14 +558,6 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
       return res.status(400).send('The model used when creating this file is not available');
     }
 
-    const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
-    if (!getDownloadStream && !getDownloadURL) {
-      logger.warn(
-        `File download requested by user ${userId} has no download method implemented: ${file.source}`,
-      );
-      return res.status(501).send('Not Implemented');
-    }
-
     const setHeaders = () => {
       res.setHeader('Content-Disposition', getContentDisposition(file.filename));
       res.setHeader('Content-Type', 'application/octet-stream');
@@ -574,6 +566,27 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
         encodeURIComponent(JSON.stringify(getDownloadFileMetadata(file))),
       );
     };
+
+    if (file.source === FileSources.text) {
+      const textFile = await db.findFileById(file_id);
+      if (typeof textFile?.text !== 'string') {
+        logger.warn(
+          `File download requested by user ${userId} has invalid text content: ${file_id}`,
+        );
+        return res.status(500).send('Error downloading file');
+      }
+
+      setHeaders();
+      return res.status(200).end(textFile.text);
+    }
+
+    const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
+    if (!getDownloadStream && !getDownloadURL) {
+      logger.warn(
+        `File download requested by user ${userId} has no download method implemented: ${file.source}`,
+      );
+      return res.status(501).send('Not Implemented');
+    }
 
     if (checkOpenAIStorage(file.source)) {
       req.body = { model: file.model };

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -799,6 +799,83 @@ describe('File Routes - Delete with Agent Access', () => {
   });
 
   describe('GET /files/download/:userId/:file_id', () => {
+    it('downloads persisted text without invoking a storage strategy', async () => {
+      const userFileId = uuidv4();
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'notes.txt',
+        filepath: '/uploads/temp/deleted-notes.txt',
+        bytes: Buffer.byteLength('saved notes'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: 'saved notes',
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.toString()).toBe('saved notes');
+      expect(response.headers['content-disposition']).toContain('filename="notes.txt"');
+      expect(response.headers['content-type']).toBe('application/octet-stream');
+      const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
+      expect(metadata).toMatchObject({
+        file_id: userFileId,
+        filename: 'notes.txt',
+        filepath: '/uploads/temp/deleted-notes.txt',
+        source: FileSources.text,
+      });
+      expect(metadata).not.toHaveProperty('text');
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
+    it('returns a safe error when persisted text is missing', async () => {
+      const userFileId = uuidv4();
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'missing.txt',
+        filepath: '/uploads/temp/deleted-missing.txt',
+        bytes: 0,
+        type: 'text/plain',
+        source: FileSources.text,
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(500);
+      expect(response.text).toBe('Error downloading file');
+      expect(response.headers['x-file-metadata']).toBeUndefined();
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
+    it('returns a safe error when persisted text is not a string', async () => {
+      const userFileId = uuidv4();
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'invalid.txt',
+        filepath: '/uploads/temp/deleted-invalid.txt',
+        bytes: 0,
+        type: 'text/plain',
+        source: FileSources.text,
+      });
+      await File.collection.updateOne(
+        { file_id: userFileId },
+        { $set: { text: { unexpected: true } } },
+      );
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(500);
+      expect(response.text).toBe('Error downloading file');
+      expect(response.headers['x-file-metadata']).toBeUndefined();
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
     it('streams proxied downloads by default when a direct URL is available', async () => {
       const userFileId = uuidv4();
       const getDownloadURL = jest.fn().mockResolvedValue('https://cdn.example.com/file.pdf?signed');

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -878,6 +878,72 @@ describe('File Routes - Delete with Agent Access', () => {
       expect(getStrategyFunctions).not.toHaveBeenCalled();
     });
 
+    it('serves derived text under a text filename rather than the original binary name', async () => {
+      const userFileId = uuidv4();
+
+      /** The OCR, document-parser and STT paths all persist extracted text while keeping the
+       *  upload's original name, so the stored filename promises a PDF the body is not. */
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'report.pdf',
+        filepath: '/uploads/temp/deleted-report.pdf',
+        bytes: Buffer.byteLength('extracted page one'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: 'extracted page one',
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.toString()).toBe('extracted page one');
+      expect(response.headers['content-disposition']).toContain('filename="report.txt"');
+      /** The record itself is untouched — only the download name is derived. */
+      const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
+      expect(metadata.filename).toBe('report.pdf');
+    });
+
+    it('keeps the original filename when the upload was genuinely text', async () => {
+      const userFileId = uuidv4();
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'librechat.yaml',
+        filepath: '/uploads/temp/deleted-librechat.yaml',
+        bytes: Buffer.byteLength('version: 1.3.13'),
+        type: 'text/yaml',
+        source: FileSources.text,
+        text: 'version: 1.3.13',
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-disposition']).toContain('filename="librechat.yaml"');
+    });
+
+    it('keeps an extensionless filename, which promises nothing to correct', async () => {
+      const userFileId = uuidv4();
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'Dockerfile',
+        filepath: '/uploads/temp/deleted-Dockerfile',
+        bytes: Buffer.byteLength('FROM node:24'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: 'FROM node:24',
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-disposition']).toContain('filename="Dockerfile"');
+    });
+
     it('streams proxied downloads by default when a direct URL is available', async () => {
       const userFileId = uuidv4();
       const getDownloadURL = jest.fn().mockResolvedValue('https://cdn.example.com/file.pdf?signed');
@@ -1108,6 +1174,40 @@ describe('File Routes - Delete with Agent Access', () => {
       await expect(
         request(app).get(`/files/download/${otherUserId}/${userFileId}`),
       ).rejects.toThrow();
+    });
+  });
+
+  describe('GET /files/code/download/:session_id/:fileId', () => {
+    const sessionId = 'a'.repeat(21);
+    const codeFileId = 'b'.repeat(21);
+
+    it('drops the upstream framing headers when the stream fails', async () => {
+      /** This route copies the upstream response's headers verbatim, so a proxied
+       *  `Transfer-Encoding: chunked` would otherwise survive onto the error body alongside
+       *  the `Content-Length` `send` adds, and a client rejects a message carrying both. */
+      const getDownloadStream = jest.fn().mockResolvedValue({
+        headers: {
+          'transfer-encoding': 'chunked',
+          'content-type': 'application/pdf',
+          'content-disposition': 'attachment; filename="plot.pdf"',
+        },
+        data: new Readable({
+          read() {
+            this.destroy(new Error('code interpreter session expired'));
+          },
+        }),
+      });
+      getStrategyFunctions.mockReturnValue({ getDownloadStream });
+
+      const response = await request(app).get(`/files/code/download/${sessionId}/${codeFileId}`);
+
+      expect(response.status).toBe(500);
+      expect(response.text).toBe('Error downloading file');
+      expect(response.headers['transfer-encoding']).toBeUndefined();
+      expect(response.headers['content-disposition']).toBeUndefined();
+      expect(response.headers['content-length']).toBe(
+        String(Buffer.byteLength('Error downloading file')),
+      );
     });
   });
 

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -64,6 +64,7 @@ jest.mock('~/config', () => ({
 
 const { processDeleteRequest } = require('~/server/services/Files/process');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 
 // Import the router after mocks
 const router = require('./files');
@@ -819,6 +820,7 @@ describe('File Routes - Delete with Agent Access', () => {
       expect(response.body.toString()).toBe('saved notes');
       expect(response.headers['content-disposition']).toContain('filename="notes.txt"');
       expect(response.headers['content-type']).toBe('application/octet-stream');
+      expect(response.headers['content-length']).toBe(String(Buffer.byteLength('saved notes')));
       const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
       expect(metadata).toMatchObject({
         file_id: userFileId,
@@ -1011,6 +1013,101 @@ describe('File Routes - Delete with Agent Access', () => {
           contentType: 'text/plain',
         }),
       );
+    });
+
+    it('answers 500 when the file stream fails before any bytes are written', async () => {
+      const userFileId = uuidv4();
+      const getDownloadStream = jest.fn().mockResolvedValue(
+        new Readable({
+          read() {
+            this.destroy(
+              Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' }),
+            );
+          },
+        }),
+      );
+      getStrategyFunctions.mockReturnValue({ getDownloadStream });
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'deleted.txt',
+        filepath: '/uploads/temp/deleted.txt',
+        bytes: 200,
+        type: 'text/plain',
+        source: FileSources.local,
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(500);
+      expect(response.text).toBe('Error downloading file');
+      expect(response.headers['content-disposition']).toBeUndefined();
+      expect(response.headers['x-file-metadata']).toBeUndefined();
+    });
+
+    it('answers 500 when an assistants storage stream fails', async () => {
+      const userFileId = uuidv4();
+      getOpenAIClient.mockResolvedValue({ openai: {} });
+      const getDownloadStream = jest.fn().mockResolvedValue({
+        body: new Readable({
+          read() {
+            this.destroy(new Error('upstream reset'));
+          },
+        }),
+      });
+      getStrategyFunctions.mockReturnValue({ getDownloadStream });
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'assistant.txt',
+        filepath: 'uploads/user/assistant.txt',
+        bytes: 200,
+        type: 'text/plain',
+        model: 'gpt-4o',
+        source: FileSources.openai,
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(500);
+      expect(response.text).toBe('Error downloading file');
+      expect(response.headers['x-file-metadata']).toBeUndefined();
+    });
+
+    it('aborts the response when the stream fails after the body has started', async () => {
+      const userFileId = uuidv4();
+      let pushed = false;
+      const getDownloadStream = jest.fn().mockResolvedValue(
+        new Readable({
+          read() {
+            if (pushed) {
+              this.destroy(new Error('connection reset mid-transfer'));
+              return;
+            }
+            pushed = true;
+            this.push('partial payload');
+          },
+        }),
+      );
+      getStrategyFunctions.mockReturnValue({ getDownloadStream });
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'truncated.txt',
+        filepath: 'uploads/user/truncated.txt',
+        bytes: 200,
+        type: 'text/plain',
+        source: FileSources.s3,
+      });
+
+      /** A truncated download must not look like a complete one, so the socket is destroyed
+       *  rather than closed cleanly after the partial body. */
+      await expect(
+        request(app).get(`/files/download/${otherUserId}/${userFileId}`),
+      ).rejects.toThrow();
     });
   });
 

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -64,7 +64,6 @@ jest.mock('~/config', () => ({
 
 const { processDeleteRequest } = require('~/server/services/Files/process');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
-const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 
 // Import the router after mocks
 const router = require('./files');
@@ -1109,36 +1108,6 @@ describe('File Routes - Delete with Agent Access', () => {
       expect(response.status).toBe(500);
       expect(response.text).toBe('Error downloading file');
       expect(response.headers['content-disposition']).toBeUndefined();
-      expect(response.headers['x-file-metadata']).toBeUndefined();
-    });
-
-    it('answers 500 when an assistants storage stream fails', async () => {
-      const userFileId = uuidv4();
-      getOpenAIClient.mockResolvedValue({ openai: {} });
-      const getDownloadStream = jest.fn().mockResolvedValue({
-        body: new Readable({
-          read() {
-            this.destroy(new Error('upstream reset'));
-          },
-        }),
-      });
-      getStrategyFunctions.mockReturnValue({ getDownloadStream });
-
-      await createFile({
-        user: otherUserId,
-        file_id: userFileId,
-        filename: 'assistant.txt',
-        filepath: 'uploads/user/assistant.txt',
-        bytes: 200,
-        type: 'text/plain',
-        model: 'gpt-4o',
-        source: FileSources.openai,
-      });
-
-      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
-
-      expect(response.status).toBe(500);
-      expect(response.text).toBe('Error downloading file');
       expect(response.headers['x-file-metadata']).toBeUndefined();
     });
 

--- a/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
+++ b/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
@@ -169,14 +169,14 @@ export default function FilePreviewDialog({
 
     try {
       const result = await downloadFile();
-      if (cancelledRef.current || !result.data) {
+      if (cancelledRef.current || !result.data?.url) {
         if (!cancelledRef.current) {
           setPreviewError(true);
         }
         return;
       }
 
-      const resp = await fetch(result.data);
+      const resp = await fetch(result.data.url);
       const blob = await resp.blob();
 
       if (cancelledRef.current) {
@@ -207,10 +207,10 @@ export default function FilePreviewDialog({
     }
     try {
       const result = await downloadFile();
-      if (!result.data) {
+      if (!result.data?.url) {
         return;
       }
-      triggerDownload(result.data, fileName);
+      triggerDownload(result.data.url, result.data.filename ?? fileName);
     } catch (err) {
       logger.error('[FilePreviewDialog] Download failed:', err);
     }

--- a/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
@@ -146,7 +146,7 @@ export const a: React.ElementType = memo(function MarkdownAnchor({ href, childre
     event.preventDefault();
     try {
       const stream = await downloadFile();
-      if (stream.data == null || stream.data === '') {
+      if (!stream.data?.url) {
         console.error('Error downloading file: No data found');
         showToast({
           status: 'error',
@@ -154,7 +154,7 @@ export const a: React.ElementType = memo(function MarkdownAnchor({ href, childre
         });
         return;
       }
-      triggerDownload(stream.data, filename);
+      triggerDownload(stream.data.url, stream.data.filename ?? filename);
     } catch (error) {
       console.error('Error downloading file:', error);
     }

--- a/client/src/components/Chat/Messages/Content/Parts/LogLink.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/LogLink.tsx
@@ -81,7 +81,9 @@ export const useAttachmentLink = ({
       }
 
       const stream = useLocalDownload ? await downloadFromApi() : await downloadFromUrl();
-      if (stream.data == null || stream.data === '') {
+      const download = stream.data;
+      const downloadURL = typeof download === 'string' ? download : download?.url;
+      if (!downloadURL) {
         console.error('Error downloading file: No data found');
         showToast({
           status: 'error',
@@ -89,7 +91,9 @@ export const useAttachmentLink = ({
         });
         return false;
       }
-      triggerDownload(stream.data, filename);
+      const downloadFilename =
+        typeof download === 'string' ? filename : (download?.filename ?? filename);
+      triggerDownload(downloadURL, downloadFilename);
       return true;
     } catch (error) {
       console.error('Error downloading file:', error);

--- a/client/src/components/Chat/Messages/Content/Parts/LogLink.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/LogLink.tsx
@@ -23,9 +23,13 @@ interface AttachmentLinkOptions {
 }
 
 /**
- * Determines if a file is stored locally (not an external API URL).
- * Files with these sources are stored on the LibreChat server and should
- * use the /api/files/download endpoint instead of direct URL access.
+ * Determines if a file is served by the LibreChat server (not an external API URL).
+ * Files with these sources should use the /api/files/download endpoint instead of
+ * direct URL access.
+ *
+ * `text` is included even though nothing is on disk for it: the upload route deletes the
+ * Multer temp file once the extracted text is persisted to MongoDB, so its `filepath` is
+ * stale and only the download route can serve it.
  */
 export const isLocallyStoredSource = (source?: string): boolean => {
   if (!source) {
@@ -37,6 +41,7 @@ export const isLocallyStoredSource = (source?: string): boolean => {
     FileSources.s3,
     FileSources.cloudfront,
     FileSources.azure_blob,
+    FileSources.text,
   ].includes(source as FileSources);
 };
 

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/LogLink.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/LogLink.test.tsx
@@ -56,7 +56,9 @@ describe('LogLink download routing', () => {
 
   it('uses the authorized file download route when stored metadata is available', async () => {
     const filename = 'file.pdf';
-    mockDownloadFromApi.mockResolvedValue({ data: 'https://cdn.example.com/signed/file.pdf' });
+    mockDownloadFromApi.mockResolvedValue({
+      data: { url: 'https://cdn.example.com/signed/file.pdf', filename },
+    });
 
     render(
       <LogLink
@@ -76,6 +78,36 @@ describe('LogLink download routing', () => {
       expect(mockTriggerDownload).toHaveBeenCalledWith(
         'https://cdn.example.com/signed/file.pdf',
         'file.pdf',
+      );
+    });
+    expect(mockDownloadFromApi).toHaveBeenCalledTimes(1);
+    expect(mockDownloadFromUrl).not.toHaveBeenCalled();
+  });
+
+  it('uses the filename returned by the authorized download route', async () => {
+    const filename = 'report.pdf';
+    mockDownloadFromApi.mockResolvedValue({
+      data: { url: 'blob:https://app.example.com/file', filename: 'report.txt' },
+    });
+
+    render(
+      <LogLink
+        user="user-1"
+        file_id="file-1"
+        filename={filename}
+        source={FileSources.local}
+        href="/api/files/user-1/file-1"
+      >
+        {filename}
+      </LogLink>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: filename }));
+
+    await waitFor(() => {
+      expect(mockTriggerDownload).toHaveBeenCalledWith(
+        'blob:https://app.example.com/file',
+        'report.txt',
       );
     });
     expect(mockDownloadFromApi).toHaveBeenCalledTimes(1);

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/LogLink.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/LogLink.test.tsx
@@ -114,6 +114,38 @@ describe('LogLink download routing', () => {
     expect(mockDownloadFromUrl).not.toHaveBeenCalled();
   });
 
+  it('routes persisted-text attachments through the file API, not their stale temp path', async () => {
+    /** The upload route deletes the Multer temp file once the extracted text is persisted,
+     *  so `filepath` points at nothing and only the download route can serve the file. */
+    const filename = 'librechat.yaml';
+    mockDownloadFromApi.mockResolvedValue({
+      data: { url: 'blob:https://app.example.com/text', filename },
+    });
+
+    render(
+      <LogLink
+        user="user-1"
+        file_id="file-1"
+        filename={filename}
+        source={FileSources.text}
+        href="/uploads/temp/user-1/librechat.yaml"
+      >
+        {filename}
+      </LogLink>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: filename }));
+
+    await waitFor(() => {
+      expect(mockTriggerDownload).toHaveBeenCalledWith(
+        'blob:https://app.example.com/text',
+        filename,
+      );
+    });
+    expect(mockDownloadFromApi).toHaveBeenCalledTimes(1);
+    expect(mockDownloadFromUrl).not.toHaveBeenCalled();
+  });
+
   it('routes downloads through the share-scoped route in a shared view', async () => {
     mockShareContext = { shareId: 'share-9' };
     const filename = 'file.pdf';

--- a/client/src/components/Web/Sources.tsx
+++ b/client/src/components/Web/Sources.tsx
@@ -250,7 +250,7 @@ const FileItem = React.memo(function FileItem({
       }
       try {
         const stream = await downloadFile();
-        if (stream.data == null || stream.data === '') {
+        if (!stream.data?.url) {
           console.error('Error downloading file: No data found');
           showToast({
             status: 'error',
@@ -258,7 +258,7 @@ const FileItem = React.memo(function FileItem({
           });
           return;
         }
-        triggerDownload(stream.data, file.filename);
+        triggerDownload(stream.data.url, stream.data.filename ?? file.filename);
       } catch (error) {
         console.error('Error downloading file:', error);
       }

--- a/client/src/data-provider/Files/__tests__/download.spec.ts
+++ b/client/src/data-provider/Files/__tests__/download.spec.ts
@@ -1,0 +1,30 @@
+import { getDownloadFilename } from '../download';
+
+describe('getDownloadFilename', () => {
+  it('prefers and decodes the RFC 5987 filename', () => {
+    expect(
+      getDownloadFilename(
+        `attachment; filename="r_sum_.txt"; filename*=UTF-8''r%C3%A9sum%C3%A9.txt`,
+      ),
+    ).toBe('résumé.txt');
+  });
+
+  it('falls back to the quoted filename', () => {
+    expect(getDownloadFilename('attachment; filename="report.txt"')).toBe('report.txt');
+  });
+
+  it('unescapes quotes and backslashes in the quoted filename', () => {
+    expect(getDownloadFilename('attachment; filename="a\\"b\\\\c.txt"')).toBe('a"b\\c.txt');
+  });
+
+  it('uses the plain filename when the extended value is malformed', () => {
+    expect(
+      getDownloadFilename(`attachment; filename="report.txt"; filename*=UTF-8''bad%ZZname`),
+    ).toBe('report.txt');
+  });
+
+  it('returns undefined when no filename is present', () => {
+    expect(getDownloadFilename('attachment')).toBeUndefined();
+    expect(getDownloadFilename(undefined)).toBeUndefined();
+  });
+});

--- a/client/src/data-provider/Files/download.ts
+++ b/client/src/data-provider/Files/download.ts
@@ -1,0 +1,39 @@
+export type FileDownloadResult = {
+  url: string;
+  filename?: string;
+};
+
+const getParameterValue = (match: RegExpMatchArray | null): string | undefined => {
+  const value = match?.[1] ?? match?.[2];
+  return value?.trim() || undefined;
+};
+
+/**
+ * Extracts a filename from Content-Disposition, preferring RFC 5987's
+ * UTF-8-aware filename* parameter over the ASCII filename fallback.
+ */
+export const getDownloadFilename = (contentDisposition: unknown): string | undefined => {
+  if (typeof contentDisposition !== 'string') {
+    return undefined;
+  }
+
+  const extendedValue = getParameterValue(
+    contentDisposition.match(/(?:^|;)\s*filename\*\s*=\s*(?:"([^"]*)"|([^;]*))/i),
+  );
+  if (extendedValue) {
+    const encodedFilename = extendedValue.match(/^[^']*'[^']*'(.*)$/)?.[1] ?? extendedValue;
+    try {
+      const decodedFilename = decodeURIComponent(encodedFilename);
+      if (decodedFilename) {
+        return decodedFilename;
+      }
+    } catch {
+      // Fall through to the plain filename parameter.
+    }
+  }
+
+  const filename = getParameterValue(
+    contentDisposition.match(/(?:^|;)\s*filename\s*=\s*(?:"((?:\\.|[^"])*)"|([^;]*))/i),
+  );
+  return filename?.replace(/\\(["\\])/g, '$1') || undefined;
+};

--- a/client/src/data-provider/Files/index.ts
+++ b/client/src/data-provider/Files/index.ts
@@ -1,3 +1,4 @@
 export * from './mutations';
 export * from './queries';
 export * from './sharepoint';
+export * from './download';

--- a/client/src/data-provider/Files/queries.ts
+++ b/client/src/data-provider/Files/queries.ts
@@ -6,6 +6,7 @@ import type t from 'librechat-data-provider';
 import { isEphemeralAgent } from '~/common';
 import { addFileToCache } from '~/utils';
 import store from '~/store';
+import { getDownloadFilename, type FileDownloadResult } from './download';
 
 export const useGetFiles = <TData = t.TFile[] | boolean>(
   config?: UseQueryOptions<t.TFile[], unknown, TData>,
@@ -72,9 +73,9 @@ export const useFileDownload = (
   userId?: string,
   file_id?: string,
   options: FileDownloadOptions = {},
-): QueryObserverResult<string> => {
+): QueryObserverResult<FileDownloadResult | undefined> => {
   const queryClient = useQueryClient();
-  return useQuery(
+  return useQuery<FileDownloadResult | undefined>(
     [QueryKeys.fileDownload, file_id, options.source ?? '', options.direct ?? true],
     async () => {
       if (!userId || !file_id) {
@@ -85,7 +86,7 @@ export const useFileDownload = (
         try {
           const directDownload = await dataService.getFileDownloadURL(userId, file_id);
           if (directDownload.url) {
-            return directDownload.url;
+            return { url: directDownload.url, filename: directDownload.filename };
           }
         } catch {
           // Fall back to the legacy proxied download for direct URL failures.
@@ -95,21 +96,25 @@ export const useFileDownload = (
       const response = await dataService.getFileDownload(userId, file_id);
       const blob = response.data;
       const downloadURL = window.URL.createObjectURL(blob);
+      let metadataFilename: string | undefined;
       try {
         const metadata: t.TFile | undefined = JSON.parse(
           decodeURIComponent(response.headers['x-file-metadata']),
         );
         if (!metadata) {
           console.warn('No metadata found for file download', response.headers);
-          return downloadURL;
+        } else {
+          metadataFilename = metadata.filename;
+          addFileToCache(queryClient, metadata);
         }
-
-        addFileToCache(queryClient, metadata);
       } catch (e) {
         console.error('Error parsing file metadata, skipped updating file query cache', e);
       }
 
-      return downloadURL;
+      return {
+        url: downloadURL,
+        filename: getDownloadFilename(response.headers['content-disposition']) ?? metadataFilename,
+      };
     },
     {
       enabled: false,
@@ -126,15 +131,18 @@ export const useFileDownload = (
 export const useSharedFileDownload = (
   shareId?: string,
   file_id?: string,
-): QueryObserverResult<string> => {
-  return useQuery(
+): QueryObserverResult<FileDownloadResult | undefined> => {
+  return useQuery<FileDownloadResult | undefined>(
     [QueryKeys.fileDownload, 'share', shareId ?? '', file_id ?? ''],
     async () => {
       if (!shareId || !file_id) {
         return;
       }
       const response = await dataService.getSharedFileDownload(shareId, file_id);
-      return window.URL.createObjectURL(response.data);
+      return {
+        url: window.URL.createObjectURL(response.data),
+        filename: getDownloadFilename(response.headers['content-disposition']),
+      };
     },
     {
       enabled: false,

--- a/packages/api/src/files/download.spec.ts
+++ b/packages/api/src/files/download.spec.ts
@@ -1,0 +1,143 @@
+import { PassThrough, Readable } from 'stream';
+import type { Response } from 'express';
+import { getTextDownloadFilename, pipeDownloadStream } from './download';
+
+describe('getTextDownloadFilename', () => {
+  describe('renames when the extension promises something the text payload is not', () => {
+    /** The OCR, STT, document-parser and configured-text paths all persist extracted text
+     *  under the upload's original name. */
+    test.each([
+      ['report.pdf', 'report.txt'],
+      ['meeting.mp3', 'meeting.txt'],
+      ['notes.docx', 'notes.txt'],
+      ['slides.pptx', 'slides.txt'],
+      ['sheet.xlsx', 'sheet.txt'],
+      ['scan.png', 'scan.txt'],
+      ['bundle.zip', 'bundle.txt'],
+      ['quarterly report.v2.pdf', 'quarterly report.v2.txt'],
+    ])('%s -> %s', (filename, expected) => {
+      expect(getTextDownloadFilename(filename)).toBe(expected);
+    });
+  });
+
+  describe('keeps names that do not misrepresent text', () => {
+    test.each([
+      'notes.txt',
+      'librechat.yaml',
+      'config.toml',
+      'settings.ini',
+      'main.go',
+      'app.ts',
+      'App.tsx',
+      'script.py',
+      'notes.md',
+      'data.json',
+      'schema.proto',
+      'deploy.sh',
+      'query.sql',
+      'style.css',
+      /** No extension promises nothing, so there is nothing to correct. */
+      'Dockerfile',
+      'Makefile',
+      'README',
+    ])('%s', (filename) => {
+      expect(getTextDownloadFilename(filename)).toBe(filename);
+    });
+  });
+
+  test('is case-insensitive about the extension', () => {
+    expect(getTextDownloadFilename('REPORT.PDF')).toBe('REPORT.txt');
+    expect(getTextDownloadFilename('NOTES.YAML')).toBe('NOTES.YAML');
+  });
+
+  test('passes an empty filename through untouched', () => {
+    expect(getTextDownloadFilename('')).toBe('');
+  });
+});
+
+describe('pipeDownloadStream', () => {
+  const createResponse = () => {
+    const headers = new Map<string, string>();
+    const res = new PassThrough() as unknown as Response & {
+      statusCode?: number;
+      body?: string;
+      destroyedWith?: Error;
+    };
+    res.headersSent = false;
+    res.removeHeader = ((name: string) =>
+      headers.delete(name.toLowerCase())) as Response['removeHeader'];
+    res.setHeader = ((name: string, value: string) => {
+      headers.set(name.toLowerCase(), value);
+      return res;
+    }) as Response['setHeader'];
+    res.status = ((code: number) => {
+      res.statusCode = code;
+      return res;
+    }) as Response['status'];
+    res.send = ((body: string) => {
+      res.body = body;
+      return res;
+    }) as Response['send'];
+    res.destroy = ((error?: Error) => {
+      res.destroyedWith = error;
+      return res;
+    }) as Response['destroy'];
+    return { res, headers };
+  };
+
+  test('pipes a healthy stream through untouched', async () => {
+    const { res } = createResponse();
+    const chunks: Buffer[] = [];
+    (res as unknown as PassThrough).on('data', (chunk: Buffer) => chunks.push(chunk));
+
+    pipeDownloadStream(Readable.from(['file ', 'content']), res);
+    await new Promise((resolve) => (res as unknown as PassThrough).on('end', resolve));
+
+    expect(Buffer.concat(chunks).toString()).toBe('file content');
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  test('answers 500 and clears the abandoned download headers before any bytes', async () => {
+    const { res, headers } = createResponse();
+    res.setHeader('Content-Disposition', 'attachment; filename="plot.pdf"');
+    res.setHeader('Transfer-Encoding', 'chunked');
+    res.setHeader('Content-Encoding', 'gzip');
+    res.setHeader('X-File-Metadata', 'encoded');
+    res.setHeader('X-Request-Id', 'keep-me');
+
+    const stream = new Readable({
+      read() {
+        this.destroy(new Error('ENOENT: no such file or directory'));
+      },
+    });
+    pipeDownloadStream(stream, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toBe('Error downloading file');
+    expect(headers.has('content-disposition')).toBe(false);
+    expect(headers.has('transfer-encoding')).toBe(false);
+    expect(headers.has('content-encoding')).toBe(false);
+    expect(headers.has('x-file-metadata')).toBe(false);
+    /** Unrelated headers set by middleware are none of this helper's business. */
+    expect(headers.get('x-request-id')).toBe('keep-me');
+  });
+
+  test('destroys the response once the body has started, rather than ending it cleanly', async () => {
+    const { res } = createResponse();
+    res.headersSent = true;
+
+    const truncation = new Error('connection reset mid-transfer');
+    const stream = new Readable({
+      read() {
+        this.destroy(truncation);
+      },
+    });
+    pipeDownloadStream(stream, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(res.destroyedWith).toBe(truncation);
+    expect(res.statusCode).toBeUndefined();
+    expect(res.body).toBeUndefined();
+  });
+});

--- a/packages/api/src/files/download.spec.ts
+++ b/packages/api/src/files/download.spec.ts
@@ -36,6 +36,8 @@ describe('getTextDownloadFilename', () => {
       'deploy.sh',
       'query.sql',
       'style.css',
+      /** `parseTextNative` stores a `.eml` as its own RFC 822 source, which is text. */
+      'mail.eml',
       /** No extension promises nothing, so there is nothing to correct. */
       'Dockerfile',
       'Makefile',

--- a/packages/api/src/files/download.spec.ts
+++ b/packages/api/src/files/download.spec.ts
@@ -21,6 +21,12 @@ describe('getTextDownloadFilename', () => {
       ['standup.m4a', 'standup.txt'],
       ['manual.epub', 'manual.txt'],
       ['memo.rtf', 'memo.txt'],
+      /** `audio/mpeg` is accepted by `audioMimeTypes`, so its containers reach STT too. */
+      ['interview.mpeg', 'interview.txt'],
+      ['interview.mpg', 'interview.txt'],
+      /** Reachable whenever a deployment widens `stt.supportedMimeTypes` to video. */
+      ['keynote.mov', 'keynote.txt'],
+      ['keynote.mkv', 'keynote.txt'],
     ])('%s -> %s', (filename, expected) => {
       expect(getTextDownloadFilename(filename)).toBe(expected);
     });
@@ -53,6 +59,8 @@ describe('getTextDownloadFilename', () => {
       'default.nix',
       'events.jsonl',
       'init.vim',
+      /** SVG is XML: an uploaded one is stored as its own source, not an OCR transcript. */
+      'diagram.svg',
       /** No extension promises nothing, so there is nothing to correct. */
       'Dockerfile',
       'Makefile',

--- a/packages/api/src/files/download.spec.ts
+++ b/packages/api/src/files/download.spec.ts
@@ -15,6 +15,12 @@ describe('getTextDownloadFilename', () => {
       ['scan.png', 'scan.txt'],
       ['bundle.zip', 'bundle.txt'],
       ['quarterly report.v2.pdf', 'quarterly report.v2.txt'],
+      /** OCR reads images, STT reads audio; neither survives as its own bytes. */
+      ['invoice.png', 'invoice.txt'],
+      ['scan.HEIC', 'scan.txt'],
+      ['standup.m4a', 'standup.txt'],
+      ['manual.epub', 'manual.txt'],
+      ['memo.rtf', 'memo.txt'],
     ])('%s -> %s', (filename, expected) => {
       expect(getTextDownloadFilename(filename)).toBe(expected);
     });
@@ -38,6 +44,15 @@ describe('getTextDownloadFilename', () => {
       'style.css',
       /** `parseTextNative` stores a `.eml` as its own RFC 822 source, which is text. */
       'mail.eml',
+      /** Uncatalogued extensions are far likelier to be text formats nobody listed than
+       *  binaries, so they keep their name rather than being assumed binary. */
+      'README.rst',
+      'notes.adoc',
+      'main.tf',
+      'main.hcl',
+      'default.nix',
+      'events.jsonl',
+      'init.vim',
       /** No extension promises nothing, so there is nothing to correct. */
       'Dockerfile',
       'Makefile',

--- a/packages/api/src/files/download.ts
+++ b/packages/api/src/files/download.ts
@@ -30,14 +30,21 @@ const TEXTUAL_MIME_PATTERN =
  * and images, STT reads audio — and which `codeTypeMapping` does not already classify. A
  * `.text` record wearing one of these names holds the extracted transcript, never the file.
  *
- * Kept as a closed list because the inverse assumption does not hold: an extension nobody has
- * catalogued is far likelier to be an uncatalogued text format (`.rst`, `.hcl`, `.jsonl`) than a
- * binary one, and mislabelling those costs a valid extension for no benefit.
+ * It stays a list rather than an inversion because the opposite assumption does not hold: an
+ * extension nobody has catalogued is far likelier to be an uncatalogued text format (`.rst`,
+ * `.hcl`, `.jsonl`) than a binary one, and mislabelling those costs a valid extension for no
+ * benefit. Being generous here is the cheap direction — no text file is named `.mov` — so this
+ * covers the container extensions for `imageMimeTypes`, `audioMimeTypes` and `videoMimeTypes`
+ * rather than only the defaults, since `stt.supportedMimeTypes` is deployment-configurable.
+ *
+ * `svg` is excluded on purpose: it is XML, so an uploaded one is stored as its own source.
  */
 const EXTRACTED_INPUT_EXTENSIONS = new Set([
+  /** Documents `codeTypeMapping` has no entry for; office formats it does are handled above. */
   'pdf',
   'rtf',
   'epub',
+  /** `imageMimeTypes`, plus formats an OCR provider may accept ahead of the allowlist. */
   'png',
   'jpg',
   'jpeg',
@@ -49,9 +56,13 @@ const EXTRACTED_INPUT_EXTENSIONS = new Set([
   'heic',
   'heif',
   'avif',
+  /** `audioMimeTypes` container extensions. */
   'mp3',
+  'mpeg',
   'mpga',
+  'mpg',
   'm4a',
+  'm4b',
   'wav',
   'wave',
   'ogg',
@@ -63,6 +74,15 @@ const EXTRACTED_INPUT_EXTENSIONS = new Set([
   'weba',
   'webm',
   'mp4',
+  '3gp',
+  /** `videoMimeTypes`, reachable whenever a deployment widens `stt.supportedMimeTypes`. */
+  'avi',
+  'mov',
+  'wmv',
+  'flv',
+  'mkv',
+  'm4v',
+  'ogv',
 ]);
 
 /**

--- a/packages/api/src/files/download.ts
+++ b/packages/api/src/files/download.ts
@@ -1,0 +1,78 @@
+import { logger } from '@librechat/data-schemas';
+import { codeTypeMapping } from 'librechat-data-provider';
+import type { Response } from 'express';
+import type { Readable } from 'stream';
+
+/**
+ * Headers describing the download that was abandoned. They have to go before an error body
+ * replaces it: the code-output route copies the upstream response's headers verbatim, so a
+ * proxied `Transfer-Encoding: chunked` would survive alongside the `Content-Length` that
+ * `send` adds, and clients reject a message carrying both framings.
+ */
+const ABANDONED_DOWNLOAD_HEADERS = [
+  'Content-Disposition',
+  'Content-Type',
+  'Content-Length',
+  'Content-Encoding',
+  'Transfer-Encoding',
+  'X-File-Metadata',
+];
+
+/** The textual entries of `codeTypeMapping`, whose payload really is the bytes on disk. Its
+ *  remaining values are office documents and archives (`application/vnd.*`, `application/zip`). */
+const TEXTUAL_MIME_PATTERN =
+  /^text\/|^application\/(json|sql|typescript|xml|yaml|x-sh|vnd\.coffeescript)$/;
+
+/**
+ * Resolves the name a `FileSources.text` download is served under.
+ *
+ * Every `createTextFile` caller in `processAgentFileUpload` persists extracted or transcribed
+ * UTF-8 text while keeping the upload's original name, so an OCR'd `report.pdf`, a parsed
+ * `notes.docx` and a transcribed `meeting.mp3` all hold text under a name that promises
+ * something else — the download would look corrupt or unplayable. The stored `type` cannot
+ * tell those apart from a genuine text upload: the OCR, STT and document-parser paths leave it
+ * at the `text/plain` default while the configured-text path stores the original `application/pdf`,
+ * so both a derived and a genuine case exist at either value.
+ *
+ * The extension can, so rename only when it makes a non-text promise. A `.yaml`/`.go`/`.md`
+ * upload keeps its own, and so does an extensionless `Dockerfile`, which promises nothing to
+ * correct.
+ */
+export function getTextDownloadFilename(filename: string): string {
+  if (!filename || !filename.includes('.')) {
+    return filename;
+  }
+  const extension = filename.split('.').pop()?.toLowerCase() ?? '';
+  const promisedType = codeTypeMapping[extension];
+  if (promisedType && TEXTUAL_MIME_PATTERN.test(promisedType)) {
+    return filename;
+  }
+  return `${filename.replace(/\.[^./\\]*$/, '')}.txt`;
+}
+
+/**
+ * Pipes a download to the response, terminating it when the source fails.
+ *
+ * `pipe` does not end the destination on a source error, and the stream errors after the route
+ * handler has already returned, so its try/catch never sees it. Without this the response stays
+ * open until the reverse proxy times out. A stream with no `error` listener at all is worse
+ * still: the emit becomes an uncaught exception.
+ *
+ * Nothing is written before the first chunk, so a failure that early can still answer with a
+ * status; once the body has started, destroying the socket is the only way to signal a
+ * truncated download instead of a short but well-formed one.
+ */
+export function pipeDownloadStream(stream: Readable, res: Response): void {
+  stream.on('error', (streamError: Error) => {
+    logger.error('[DOWNLOAD ROUTE] Stream error:', streamError);
+    if (res.headersSent) {
+      res.destroy(streamError);
+      return;
+    }
+    for (const header of ABANDONED_DOWNLOAD_HEADERS) {
+      res.removeHeader(header);
+    }
+    res.status(500).send('Error downloading file');
+  });
+  stream.pipe(res);
+}

--- a/packages/api/src/files/download.ts
+++ b/packages/api/src/files/download.ts
@@ -26,6 +26,46 @@ const TEXTUAL_MIME_PATTERN =
   /^text\/|^message\/rfc822$|^application\/(json|sql|typescript|xml|yaml|x-sh|vnd\.coffeescript)$/;
 
 /**
+ * Extensions the text pipeline only ever reads as an extraction *input* — OCR reads documents
+ * and images, STT reads audio — and which `codeTypeMapping` does not already classify. A
+ * `.text` record wearing one of these names holds the extracted transcript, never the file.
+ *
+ * Kept as a closed list because the inverse assumption does not hold: an extension nobody has
+ * catalogued is far likelier to be an uncatalogued text format (`.rst`, `.hcl`, `.jsonl`) than a
+ * binary one, and mislabelling those costs a valid extension for no benefit.
+ */
+const EXTRACTED_INPUT_EXTENSIONS = new Set([
+  'pdf',
+  'rtf',
+  'epub',
+  'png',
+  'jpg',
+  'jpeg',
+  'webp',
+  'gif',
+  'bmp',
+  'tiff',
+  'tif',
+  'heic',
+  'heif',
+  'avif',
+  'mp3',
+  'mpga',
+  'm4a',
+  'wav',
+  'wave',
+  'ogg',
+  'oga',
+  'opus',
+  'flac',
+  'aac',
+  'wma',
+  'weba',
+  'webm',
+  'mp4',
+]);
+
+/**
  * Resolves the name a `FileSources.text` download is served under.
  *
  * Every `createTextFile` caller in `processAgentFileUpload` persists extracted or transcribed
@@ -36,9 +76,9 @@ const TEXTUAL_MIME_PATTERN =
  * at the `text/plain` default while the configured-text path stores the original `application/pdf`,
  * so both a derived and a genuine case exist at either value.
  *
- * The extension can, so rename only when it makes a non-text promise. A `.yaml`/`.go`/`.md`
- * upload keeps its own, and so does an extensionless `Dockerfile`, which promises nothing to
- * correct.
+ * The extension can, so rename only where it positively promises something other than text —
+ * a catalogued non-text type, or a known extraction input. Anything else keeps its name: a
+ * `.yaml`/`.go`/`.md` upload, an unlisted `.rst`, and an extensionless `Dockerfile` alike.
  */
 export function getTextDownloadFilename(filename: string): string {
   if (!filename || !filename.includes('.')) {
@@ -46,7 +86,10 @@ export function getTextDownloadFilename(filename: string): string {
   }
   const extension = filename.split('.').pop()?.toLowerCase() ?? '';
   const promisedType = codeTypeMapping[extension];
-  if (promisedType && TEXTUAL_MIME_PATTERN.test(promisedType)) {
+  const promisesNonText = promisedType
+    ? !TEXTUAL_MIME_PATTERN.test(promisedType)
+    : EXTRACTED_INPUT_EXTENSIONS.has(extension);
+  if (!promisesNonText) {
     return filename;
   }
   return `${filename.replace(/\.[^./\\]*$/, '')}.txt`;

--- a/packages/api/src/files/download.ts
+++ b/packages/api/src/files/download.ts
@@ -18,10 +18,12 @@ const ABANDONED_DOWNLOAD_HEADERS = [
   'X-File-Metadata',
 ];
 
-/** The textual entries of `codeTypeMapping`, whose payload really is the bytes on disk. Its
- *  remaining values are office documents and archives (`application/vnd.*`, `application/zip`). */
+/** The textual entries of `codeTypeMapping`, whose payload really is the bytes on disk —
+ *  `message/rfc822` among them, since a `.eml` reaching the text pipeline is stored as its own
+ *  RFC 822 source. Its remaining values are office documents and archives
+ *  (`application/vnd.*`, `application/zip`). */
 const TEXTUAL_MIME_PATTERN =
-  /^text\/|^application\/(json|sql|typescript|xml|yaml|x-sh|vnd\.coffeescript)$/;
+  /^text\/|^message\/rfc822$|^application\/(json|sql|typescript|xml|yaml|x-sh|vnd\.coffeescript)$/;
 
 /**
  * Resolves the name a `FileSources.text` download is served under.

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -3,6 +3,7 @@ export * from './audio';
 export * from './code';
 export * from './context';
 export * from './documents/crud';
+export * from './download';
 export * from './encode';
 export * from './filter';
 export * from './mistral/crud';


### PR DESCRIPTION
## Summary

- serve `FileSources.text` downloads from the text persisted in MongoDB instead of the deleted temporary upload path
- preserve the existing file-access middleware and metadata allowlist, and return a safe error for missing or malformed stored text
- add route-level coverage for successful, missing, and invalid persisted text

Fixes #14754

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run build:packages`
- `cd api && npx jest server/routes/files/files.test.js --runInBand` — 31 passed
- `npx prettier --check api/server/routes/files/files.js api/server/routes/files/files.test.js`
- `npx eslint api/server/routes/files/files.js api/server/routes/files/files.test.js`
- `git diff --check origin/main...HEAD`

### Test Configuration

- macOS
- Node.js 24.19.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
