### PR TITLE
fix: Mirror deferred-preview terminal status onto message attachments

### DIFF
--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const mongoose = require('mongoose');
 const { v4 } = require('uuid');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
@@ -88,6 +89,50 @@ const createDownloadFallback = ({
  * with `previewError: 'timeout'` and the UI shows download-only.
  */
 const PREVIEW_FINALIZE_TIMEOUT_MS = 60_000;
+
+/**
+ * Mirror the terminal deferred-preview status onto every message
+ * attachment referencing this `file_id`, so a re-opened conversation
+ * never keeps the stale `status: 'pending'` that the immediate-persist
+ * step wrote on the message attachment descriptor. The background render
+ * only ever updated the `files` record; without this mirror the message
+ * attachment stays `pending` forever, leaving the conversation page to
+ * re-poll `GET /api/files/:id/preview` on every load.
+ *
+ * Fire-and-forget and failure-tolerant: any error is logged and
+ * swallowed — it must never affect the `finalizePreview` return value
+ * or the render pipeline. The match is purely by `file_id`, so one
+ * render repairs all sibling attachments that reference the same
+ * claimed file (multiple tool calls / handoff agents can legitimately
+ * share a single code-output file).
+ */
+const syncMessageAttachment = async ({ file_id, status, text, textFormat, previewError }) => {
+  try {
+    const result = await mongoose.connection.collection('messages').updateMany(
+      { 'attachments.file_id': file_id },
+      {
+        $set: {
+          'attachments.$[a].status': status,
+          'attachments.$[a].text': text ?? null,
+          'attachments.$[a].textFormat': textFormat ?? null,
+          'attachments.$[a].previewError': previewError ?? null,
+        },
+      },
+      { arrayFilters: [{ 'a.file_id': file_id }] },
+    );
+    if (result?.modifiedCount) {
+      logger.debug(
+        `[syncMessageAttachment] ${file_id}: mirrored ${result.modifiedCount} message attachment(s) -> ${status}`,
+      );
+    }
+  } catch (error) {
+    logger.error(
+      `[syncMessageAttachment] ${file_id}: failed to mirror status onto message attachment: ${
+        error?.message ?? error
+      }`,
+    );
+  }
+};
 
 /**
  * Render the inline HTML preview for a code-execution file (or plain
@@ -184,6 +229,19 @@ const finalizePreview = async ({
       logger.debug(
         `[finalizePreview] ${file_id}: stale render skipped — newer emit has superseded revision ${previewRevision}`,
       );
+    }
+    /* Mirror the resolved status onto the message attachment(s) so a
+     * re-opened conversation never keeps `status: 'pending'` (see
+     * `syncMessageAttachment`). Only on a committed update — a
+     * revision-guard rejection means a newer emit superseded this one. */
+    if (updated) {
+      void syncMessageAttachment({
+        file_id,
+        status,
+        text,
+        textFormat,
+        previewError: failed ? previewError : null,
+      });
     }
     return updated;
   } catch (error) {

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -123,6 +123,17 @@ jest.mock('~/models', () => ({
   claimCodeFile: (...args) => mockClaimCodeFile(...args),
 }));
 
+/* `syncMessageAttachment` (added alongside `finalizePreview`) mirrors
+ * the resolved preview status onto the message attachments collection
+ * via a raw `mongoose` write. Stub the collection handle so the
+ * deferred-preview tests can assert the mirror fires (and tolerate its
+ * failures). Arrow indirection keeps the binding call-time — jest.mock
+ * factories are hoisted above the const declarations. */
+const mockUpdateMany = jest.fn();
+jest.mock('mongoose', () => ({
+  connection: { collection: jest.fn(() => ({ updateMany: mockUpdateMany })) },
+}));
+
 // Mock permissions (must be before process.js import)
 jest.mock('~/server/services/Files/permissions', () => ({
   filterFilesByAgentAccess: jest.fn((options) => Promise.resolve(options.files)),
@@ -1227,6 +1238,7 @@ describe('Code Process', () => {
       beforeEach(() => {
         mockHasOfficeHtmlPath.mockReturnValue(true);
         updateFile.mockResolvedValue({ file_id: 'mock-uuid-1234', status: 'ready' });
+        mockUpdateMany.mockReset();
       });
 
       afterEach(() => {
@@ -1353,6 +1365,95 @@ describe('Code Process', () => {
         await expect(finalize()).resolves.toBeNull();
         expect(logger.error).toHaveBeenCalledWith(
           expect.stringContaining('failed to persist preview result'),
+        );
+      });
+
+      it('finalize() mirrors ready+text onto message attachments after a committed update', async () => {
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+        determineFileType.mockResolvedValue({
+          mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        });
+        mockExtractCodeArtifactText.mockResolvedValueOnce('<table><tr><td>1</td></tr></table>');
+        mockGetExtractedTextFormat.mockReturnValueOnce('html');
+
+        const { finalize } = await processCodeOutput({ ...baseParams, name: 'data.xlsx' });
+        await finalize();
+
+        /* The mirror is the whole point of this fix: the `files` record
+         * is ready, and the message attachment(s) must follow, so a
+         * re-opened conversation renders the artifact card without a
+         * stale-`pending` re-poll. */
+        expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+        expect(mockUpdateMany).toHaveBeenCalledWith(
+          { 'attachments.file_id': 'mock-uuid-1234' },
+          {
+            $set: {
+              'attachments.$[a].status': 'ready',
+              'attachments.$[a].text': '<table><tr><td>1</td></tr></table>',
+              'attachments.$[a].textFormat': 'html',
+              'attachments.$[a].previewError': null,
+            },
+          },
+          { arrayFilters: [{ 'a.file_id': 'mock-uuid-1234' }] },
+        );
+      });
+
+      it('finalize() mirrors failed+previewError onto message attachments on a failed render', async () => {
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+        determineFileType.mockResolvedValue({
+          mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        });
+        mockExtractCodeArtifactText.mockResolvedValueOnce(null);
+
+        const { finalize } = await processCodeOutput({ ...baseParams, name: 'data.xlsx' });
+        await finalize();
+
+        expect(mockUpdateMany).toHaveBeenCalledWith(
+          { 'attachments.file_id': 'mock-uuid-1234' },
+          expect.objectContaining({
+            $set: expect.objectContaining({
+              'attachments.$[a].status': 'failed',
+              'attachments.$[a].previewError': 'parser-error',
+            }),
+          }),
+          { arrayFilters: [{ 'a.file_id': 'mock-uuid-1234' }] },
+        );
+      });
+
+      it('does NOT mirror when the stale-revision guard rejects the updateFile write', async () => {
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+        determineFileType.mockResolvedValue({
+          mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        });
+        mockExtractCodeArtifactText.mockResolvedValueOnce('<table></table>');
+        /* Newer emit rotated the revision → the conditional write returns
+         * null. The stale render is discarded and the message attachment
+         * must be left untouched (the newer render owns it). */
+        updateFile.mockResolvedValueOnce(null);
+
+        const { finalize } = await processCodeOutput({ ...baseParams, name: 'data.xlsx' });
+        await finalize();
+
+        expect(updateFile).toHaveBeenCalled();
+        expect(mockUpdateMany).not.toHaveBeenCalled();
+      });
+
+      it('survives a failing message sync without affecting the finalize result', async () => {
+        mockAxios.mockResolvedValue({ data: Buffer.alloc(100) });
+        determineFileType.mockResolvedValue({
+          mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        });
+        mockExtractCodeArtifactText.mockResolvedValueOnce('<table></table>');
+        mockUpdateMany.mockRejectedValueOnce(new Error('mongo down'));
+
+        const { finalize } = await processCodeOutput({ ...baseParams, name: 'data.xlsx' });
+        await expect(finalize()).resolves.toMatchObject({ file_id: 'mock-uuid-1234', status: 'ready' });
+        /* Fire-and-forget: the sync failure must never affect the
+         * finalize result — flush the microtask so the caught error is
+         * observed before asserting. */
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(logger.error).toHaveBeenCalledWith(
+          expect.stringContaining('failed to mirror status'),
         );
       });
     });


### PR DESCRIPTION
# fix: Mirror deferred-preview terminal status onto message attachments

When code-execution office artifacts (CSV/DOCX/XLSX) take the deferred-preview path, the **message attachment** is persisted at `status: 'pending'` during the immediate-persist step, and the background render later resolves only the `files` record to `ready`/`failed`. The message attachment descriptor keeps `status: 'pending'` indefinitely — so on every page load the conversation re-polls `GET /api/files/:id/preview` for that file, and the DB message data stays stale forever.

This PR mirrors the terminal preview status onto the message attachment(s) after a committed finalize, keeping the DB message descriptor in the same terminal state as the file record.

## Context

The client-side half of the stale-pending problem (the write-back loop in `useAttachmentPreviewSync` that caused React #185 "Maximum update depth exceeded") has **already landed upstream** as the no-op guard in that hook. This change is the complementary server-side fix: it makes the *database* message attachment reach the terminal state too, so:

- A re-opened conversation renders the artifact card (or the download-with-error state) immediately, without relying on a client poll round-trip on every load.
- Message data stored in Mongo reflects reality for any consumer (API responses, exports, next-turn model context) instead of stranding `pending` forever.
- Sibling attachments sharing one claimed `file_id` (multiple tool calls / handoff agents legitimately holding the same code-output file) are all repaired by a single render.

## Fix

`finalizePreview` (`api/server/services/Files/Code/process.js`) now calls `syncMessageAttachment` after a **committed** `updateFile`. It matches every message attachment by `file_id` and `$set`s `status` / `text` / `textFormat` / `previewError` onto it via an array-filters `updateMany`.

- **Fire-and-forget and failure-tolerant** (`void ...`, own try/catch): the sync can never change the `finalizePreview` return value or break the render pipeline.
- **Guarded on the committed write**: if the `previewRevision` conditional update returns `null` (a newer emit superseded this render), the message is left untouched — the newer render owns it.

## Tests

`api/server/services/Files/Code/process.spec.js` — +4 in the existing deferred-preview block:

- mirrors `ready` + `text` + `textFormat` onto message attachments after a committed update,
- mirrors `failed` + `previewError` when the render fails (HTML-or-null contract),
- does **not** mirror when the stale-revision guard rejects the write,
- survives a failing message sync without affecting the `finalize` result.

`api/server/services/Files/Code`: **144/144 pass** (3 suites). (In the broader `Files` tree, `Audio/speechSSRF` and `Files/process.integration` fail identically on clean `main` — pre-existing and unrelated to this change.)
