### PR TITLE
feat: add configurable AI disclaimer below chat messages

### DIFF
--- a/client/src/components/Chat/Messages/ChatDisclaimer.tsx
+++ b/client/src/components/Chat/Messages/ChatDisclaimer.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+import { useGetStartupConfig } from '~/data-provider';
+
+export default function ChatDisclaimer() {
+  const { t } = useTranslation();
+  const { data: config } = useGetStartupConfig();
+
+  const key = config?.interface?.aiDisclaimer;
+  if (!key?.trim()) {
+    return null;
+  }
+
+  const text = t(key, { defaultValue: key });
+
+  return (
+    <div
+      className="pointer-events-none flex select-none items-center justify-center px-6 pb-2 pt-1 text-center text-xs leading-normal text-gray-500 dark:text-gray-400"
+      role="note"
+      aria-label={text}
+    >
+      {text}
+    </div>
+  );
+}

--- a/client/src/components/Chat/Messages/MessagesView.tsx
+++ b/client/src/components/Chat/Messages/MessagesView.tsx
@@ -9,6 +9,7 @@ import ScrollToBottom from '~/components/Messages/ScrollToBottom';
 import { steerOverlayHeightFamily } from '~/store/steer';
 import { MessagesViewProvider } from '~/Providers';
 import { fontSizeAtom } from '~/store/fontSize';
+import ChatDisclaimer from './ChatDisclaimer';
 import MultiMessage from './MultiMessage';
 import MessageNav from './MessageNav';
 import { cn } from '~/utils';
@@ -153,6 +154,7 @@ function MessagesViewContent({
                   </div>
                 </>
               )}
+              <ChatDisclaimer />
               <div
                 id="messages-end"
                 className="group h-0 w-full flex-shrink-0"

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -825,6 +825,7 @@
   "com_ui_agents_allow_share": "Allow sharing Agents",
   "com_ui_agents_allow_share_public": "Allow sharing Agents publicly",
   "com_ui_agents_allow_use": "Allow using Agents",
+  "com_ui_ai_disclaimer": "AI can make mistakes, so you should verify the answers.",
   "com_ui_all": "all",
   "com_ui_all_projects": "All projects",
   "com_ui_all_proper": "All",

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -95,6 +95,9 @@ cache: true
 # Custom interface configuration
 interface:
   customWelcome: 'Welcome to LibreChat! Enjoy your experience.'
+  # Optional disclaimer shown below the chat. Accepts an i18n key (e.g. the
+  # default 'com_ui_ai_disclaimer') or plain text. Leave unset to disable.
+  # aiDisclaimer: 'com_ui_ai_disclaimer'
   # Enable/disable file search as a chatarea selection (default: true)
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1416,6 +1416,7 @@ export const interfaceSchema = z
       .optional(),
     termsOfService: termsOfServiceSchema.optional(),
     customWelcome: z.string().optional(),
+    aiDisclaimer: z.string().optional(),
     mcpServers: mcpServersSchema.optional(),
     modelSelect: z.boolean().optional(),
     parameters: z.boolean().optional(),

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -38,6 +38,7 @@ export async function loadDefaultInterface({
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    aiDisclaimer: interfaceConfig?.aiDisclaimer ?? defaults.aiDisclaimer,
     autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
     buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo,
     contextUsage: interfaceConfig?.contextUsage ?? defaults.contextUsage,


### PR DESCRIPTION
## Summary

We add an optional `interface.aiDisclaimer` setting that renders a small, unobtrusive disclaimer note below the chat messages (e.g. *"AI can make mistakes, so you should verify the answers."*). The setting accepts either an i18n key (such as the provided `com_ui_ai_disclaimer`) or arbitrary plain text, and is **disabled by default** — when unset or empty, nothing is rendered and existing deployments are unaffected.

**Motivation:**

For our company deployment of LibreChat we needed a persistent AI disclaimer that stays visible while chatting — a common requirement, especially in corporate or regulated environments. The only natural place for such a note today is the footer, which did not work for us for two reasons:

- The footer is quite limited in space, and we already use it for other content (company link, "all rights reserved", legal notices), so a disclaimer would compete with that content.
- More importantly, the footer is **not visible on mobile devices**, so mobile users would never see the disclaimer at all.

Rendering the note directly below the chat messages keeps it visible on all screen sizes without occupying the footer. We have been running this change in our deployment and are contributing it upstream as we believe it is useful for other installations as well.

**Changes:**

- New `ChatDisclaimer` component (`client/src/components/Chat/Messages/ChatDisclaimer.tsx`), rendered at the bottom of `MessagesView`. It resolves the configured value as an i18n key with the raw value as fallback, so plain text works transparently. Marked as `role="note"`, `pointer-events-none` and excluded from text selection.
- New optional `aiDisclaimer` field in the `interface` config schema (`packages/data-provider/src/config.ts`), wired through `loadDefaultInterface` (`packages/data-schemas/src/app/interface.ts`).
- New English translation key `com_ui_ai_disclaimer` (English only — other locales are handled by the translation automation).
- Documented the new option in `librechat.example.yaml`.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

We tested the change in our Docker Compose based deployment as follows:

1. Start LibreChat without setting `interface.aiDisclaimer` → no disclaimer is rendered (default behavior unchanged).
2. Set `aiDisclaimer: 'com_ui_ai_disclaimer'` in `librechat.yaml` under `interface:` → the localized default disclaimer appears below the chat messages, in the language of the UI.
3. Set `aiDisclaimer: 'Some custom plain text'` → the plain text is shown verbatim.
4. Set `aiDisclaimer: ''` (empty/whitespace) → nothing is rendered.
5. Verified on desktop and mobile viewports that the note stays visible below the conversation, where the footer would not be visible on mobile.

### **Test Configuration**:

```yaml
interface:
  aiDisclaimer: 'com_ui_ai_disclaimer'
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
