### PR TITLE
🧭 refactor: Resolve Activity Phase Position Once Per Boundary

### DIFF
--- a/packages/api/src/agents/activityPhases/runtime.spec.ts
+++ b/packages/api/src/agents/activityPhases/runtime.spec.ts
@@ -1547,6 +1547,63 @@ describe('createActivityPhaseWiring', () => {
     });
   });
 
+  /** Folding is a memory bound, not a data loss: whatever an anchor pair
+   *  represented before the merge it must still represent after. Runs are
+   *  sized to force many merges past the 77-activity tracked window. */
+  it.each([
+    { total: 100, failEvery: 0, agents: 1 },
+    { total: 150, failEvery: 3, agents: 4 },
+    { total: 220, failEvery: 7, agents: 220 },
+  ])('conserves counts and agents while folding %o', async ({ total, failEvery, agents }) => {
+    const parts: LooseContentPart[] = [];
+    const wiring = createActivityPhaseWiring({
+      getContentParts: () => parts,
+      bumpIndexOffset: jest.fn(),
+      emitLabelEvent: jest.fn(async () => undefined),
+      trackPendingFill: jest.fn(),
+      generatePhase: jest.fn(async () => ({})),
+    });
+    let expectedFailed = 0;
+    for (let index = 0; index < total; index += 1) {
+      const id = `tool-${index}`;
+      const failed = failEvery > 0 && index % failEvery === 0;
+      expectedFailed += failed ? 1 : 0;
+      parts.push({ type: ContentTypes.TOOL_CALL, tool_call: { id } });
+      const entry = {
+        toolName: 'web_search',
+        toolInput: { query: id },
+        toolUseId: id,
+        status: failed ? ('error' as const) : ('success' as const),
+        ...(failed ? { error: 'boom' } : { toolOutput: `${id}-result` }),
+      };
+      await wiring.hook(
+        {
+          hook_event_name: 'PostToolBatch',
+          runId: 'run-1',
+          executingAgentId: `agent-${index % agents}`,
+          entries: [entry],
+        } as PostToolBatchHookInput,
+        new AbortController().signal,
+      );
+    }
+
+    const snapshot = wiring.snapshot();
+    expect(snapshot.activityCount).toBe(total);
+    expect(snapshot.failedActivityCount).toBe(expectedFailed);
+    expect(totalTrackedCount(snapshot.activities)).toBe(total);
+    const attributed = new Set(
+      snapshot.activities.flatMap((activity) => [
+        ...(activity.agentId != null ? [activity.agentId] : []),
+        ...(activity.mergedAgentIds ?? []),
+      ]),
+    );
+    expect(attributed.size).toBe(agents);
+    /** Folding must not reorder: a later boundary would otherwise claim work
+     *  that happened before it. */
+    const positions = snapshot.activities.map((activity) => activity.startIndex);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+  });
+
   it('carries an unresolved position through a folded anchor', async () => {
     const parts: LooseContentPart[] = [];
     const wiring = createActivityPhaseWiring({

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -471,6 +471,104 @@ function closesBeforeBoundary(
   return materializedStart == null || materializedStart < boundary;
 }
 
+/**
+ * Every field of a bounded anchor, stated explicitly. Anchors are built by
+ * demoting an activity and by folding two together, and both used to spread
+ * one side and hand-pick the rest — so any field nobody named was dropped
+ * silently, and nothing failed until a boundary happened to land badly.
+ * Mapping over `keyof Required<TrackedActivity>` makes every field mandatory
+ * at the construction site: adding one to `TrackedActivity` is a type error
+ * until its anchor semantics are decided here.
+ */
+type AnchorFields = { [K in keyof Required<TrackedActivity>]: TrackedActivity[K] };
+
+function laterDefinedIndex(earlier?: number, later?: number): number | undefined {
+  if (earlier == null) {
+    return later;
+  }
+  return later == null ? earlier : Math.max(earlier, later);
+}
+
+function foldedAgentIds(earlier: TrackedActivity, later: TrackedActivity): string[] | undefined {
+  const folded = [
+    ...new Set(
+      [
+        ...(earlier.mergedAgentIds ?? []),
+        ...(earlier.agentId != null ? [earlier.agentId] : []),
+        ...(later.mergedAgentIds ?? []),
+        ...(later.agentId != null ? [later.agentId] : []),
+      ].filter((id) => id !== earlier.agentId),
+    ),
+  ];
+  return folded.length > 0 ? folded : undefined;
+}
+
+/** Strips prompt evidence while keeping everything a boundary reasons about. */
+function boundedAnchor(activity: TrackedActivity): TrackedActivity {
+  const fields: AnchorFields = {
+    startIndex: activity.startIndex,
+    bounded: true,
+    status: activity.status,
+    partitionStartIndex: activity.partitionStartIndex,
+    unresolvedToolStartIndex: activity.unresolvedToolStartIndex,
+    toolCallIds: activity.toolCallIds?.slice(-MAX_RETAINED_TOOL_ENTRIES),
+    thinkingExcerpts: activity.thinkingExcerpts
+      ?.slice(-MAX_RETAINED_TOOL_ENTRIES)
+      .map((text) => text.slice(-REASONING_ANCHOR_CHARS)),
+    agentId: activity.agentId,
+    mergedCount: activity.mergedCount,
+    mergedFailedCount: activity.mergedFailedCount,
+    mergedPartialCount: activity.mergedPartialCount,
+    mergedAgentIds: activity.mergedAgentIds,
+    /** An anchor is never summarized directly, so prompt evidence and the
+     *  child-label slot are deliberately not carried. */
+    label: undefined,
+    entries: undefined,
+    childLabelIndex: undefined,
+  };
+  return fields;
+}
+
+/** Folds `later` into `earlier`, which keeps its position. */
+function mergeAnchors(earlier: TrackedActivity, later: TrackedActivity): TrackedActivity {
+  const mergedFailedCount = countFailedActivities([earlier, later]);
+  const mergedPartialCount = countPartialActivities([earlier, later]);
+  const excerpts =
+    earlier.thinkingExcerpts != null || later.thinkingExcerpts != null
+      ? [...(earlier.thinkingExcerpts ?? []), ...(later.thinkingExcerpts ?? [])].slice(
+          -MAX_RETAINED_TOOL_ENTRIES,
+        )
+      : undefined;
+  const fields: AnchorFields = {
+    /** The pair starts where its first activity did; the later side's floor
+     *  describes a position being absorbed and must not move the survivor. */
+    startIndex: earlier.startIndex,
+    partitionStartIndex: earlier.partitionStartIndex,
+    bounded: true,
+    status: earlier.status,
+    /** The later side may still be waiting on a tool call. Dropping its
+     *  fallback lets a boundary close the whole merged count on the earlier
+     *  side; resolution clears it once every retained id materializes. */
+    unresolvedToolStartIndex: laterDefinedIndex(
+      earlier.unresolvedToolStartIndex,
+      later.unresolvedToolStartIndex,
+    ),
+    toolCallIds: [...(earlier.toolCallIds ?? []), ...(later.toolCallIds ?? [])].slice(
+      -MAX_RETAINED_TOOL_ENTRIES,
+    ),
+    thinkingExcerpts: excerpts,
+    agentId: earlier.agentId,
+    mergedCount: (earlier.mergedCount ?? 1) + (later.mergedCount ?? 1),
+    mergedFailedCount: mergedFailedCount > 0 ? mergedFailedCount : undefined,
+    mergedPartialCount: mergedPartialCount > 0 ? mergedPartialCount : undefined,
+    mergedAgentIds: foldedAgentIds(earlier, later),
+    label: undefined,
+    entries: undefined,
+    childLabelIndex: undefined,
+  };
+  return fields;
+}
+
 /** Every activity is represented by exactly one positioned item, so run totals
  *  are a sum over that list rather than a separately maintained scalar. */
 function countActivities(activities: ReadonlyArray<TrackedActivity>): number {
@@ -746,30 +844,6 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
   >();
   const textContextByStepId = new Map<string, AssistantContextEntry>();
 
-  const toBoundedAnchor = (activity: TrackedActivity): TrackedActivity => ({
-    startIndex: activity.startIndex,
-    bounded: true,
-    ...(activity.partitionStartIndex != null && {
-      partitionStartIndex: activity.partitionStartIndex,
-    }),
-    ...(activity.unresolvedToolStartIndex != null && {
-      unresolvedToolStartIndex: activity.unresolvedToolStartIndex,
-    }),
-    ...(activity.toolCallIds != null && {
-      toolCallIds: activity.toolCallIds.slice(-MAX_RETAINED_TOOL_ENTRIES),
-    }),
-    ...(activity.thinkingExcerpts != null && {
-      thinkingExcerpts: activity.thinkingExcerpts
-        .slice(-MAX_RETAINED_TOOL_ENTRIES)
-        .map((text) => text.slice(-REASONING_ANCHOR_CHARS)),
-    }),
-    ...(activity.agentId != null && { agentId: activity.agentId }),
-    ...(activity.mergedCount != null && { mergedCount: activity.mergedCount }),
-    ...(activity.mergedFailedCount != null && { mergedFailedCount: activity.mergedFailedCount }),
-    ...(activity.mergedPartialCount != null && { mergedPartialCount: activity.mergedPartialCount }),
-    status: activity.status,
-  });
-
   /** Keeps memory bounded without letting an activity lose its position:
    *  evidence is dropped first, then the oldest anchors fold forward into their
    *  successor, which is never earlier in the content and so cannot move a
@@ -784,7 +858,7 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
         evidenceBudget -= 1;
         return activity;
       }
-      return toBoundedAnchor(activity);
+      return boundedAnchor(activity);
     });
     /** Merging the closest pair keeps the folded count on the side it was
      *  already on: a boundary can only fall at a content index, so merging
@@ -814,50 +888,9 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       const laterPosition = anchorPositions[mergeAt];
       const earlier = activities[earlierPosition];
       const later = activities[laterPosition];
-      const mergedCount = (earlier.mergedCount ?? 1) + (later.mergedCount ?? 1);
-      const mergedFailedCount = countFailedActivities([earlier, later]);
-      const mergedPartialCount = countPartialActivities([earlier, later]);
       activities.splice(laterPosition, 1);
-      const foldedAgentIds = [
-        ...new Set(
-          [
-            ...(earlier.mergedAgentIds ?? []),
-            ...(earlier.agentId != null ? [earlier.agentId] : []),
-            ...(later.mergedAgentIds ?? []),
-            ...(later.agentId != null ? [later.agentId] : []),
-          ].filter((id) => id !== earlier.agentId),
-        ),
-      ];
-      /** The later side may be waiting on a tool call that has not appeared.
-       *  Dropping its fallback would let a boundary close the whole merged
-       *  count on the earlier side and strand that call outside its parent;
-       *  resolution clears the anchor once every retained id materializes. */
-      const mergedUnresolved = Math.max(
-        earlier.unresolvedToolStartIndex ?? -1,
-        later.unresolvedToolStartIndex ?? -1,
-      );
-      activities[earlierPosition] = {
-        ...earlier,
-        ...(mergedUnresolved >= 0 && { unresolvedToolStartIndex: mergedUnresolved }),
-        ...(foldedAgentIds.length > 0 && { mergedAgentIds: foldedAgentIds }),
-        toolCallIds: [...(earlier.toolCallIds ?? []), ...(later.toolCallIds ?? [])].slice(
-          -MAX_RETAINED_TOOL_ENTRIES,
-        ),
-        ...(earlier.thinkingExcerpts != null || later.thinkingExcerpts != null
-          ? {
-              thinkingExcerpts: [
-                ...(earlier.thinkingExcerpts ?? []),
-                ...(later.thinkingExcerpts ?? []),
-              ].slice(-MAX_RETAINED_TOOL_ENTRIES),
-            }
-          : {}),
-        mergedCount,
-        ...(mergedFailedCount > 0 && { mergedFailedCount }),
-        ...(mergedPartialCount > 0 && { mergedPartialCount }),
-      };
+      activities[earlierPosition] = mergeAnchors(earlier, later);
     }
-    const folded = activities;
-    activities = folded;
   };
 
   const applyRetained = (retained: PhasePartitionSide) => {

--- a/packages/api/src/agents/activityPhases/runtime.ts
+++ b/packages/api/src/agents/activityPhases/runtime.ts
@@ -447,28 +447,70 @@ interface PhasePartition {
 }
 
 /**
- * Whether an activity belongs to the phase closing at `boundary`. Shared by
- * the boundary partition and the completion boundary so the two cannot drift
- * on what counts as work lying after a given index.
+ * Where an activity sits in the live content, resolved once. Positional fields
+ * on `TrackedActivity` are captured at different times against an array that
+ * keeps moving — parts materialize after their hooks fire, label reservations
+ * shift indices, persistence compacts, resume prepends — so each is an input
+ * here rather than something a boundary consults directly.
  */
-function closesBeforeBoundary(
+interface ResolvedPosition {
+  /** Materialized indices of this activity's tool calls, ascending. */
+  toolIndices: number[];
+  /** Where the activity begins once anchors and prior floors are applied. */
+  startsAt: number;
+  /** The highest index this activity is known to reach, including a saved
+   *  fallback for calls that have not materialized yet. `undefined` when
+   *  nothing in the live content locates it at all. */
+  endsAt?: number;
+  /** Whether the saved fallback is still doing work. Once every tracked call
+   *  has materialized it is stale, and persisting it would hold the activity
+   *  past a boundary its real position precedes after a resume. */
+  awaitingTools: boolean;
+}
+
+function resolvePosition(
   parts: ReadonlyArray<LooseContentPart | null | undefined>,
   activity: TrackedActivity,
-  boundary: number | undefined,
-  toolIndices?: number[],
-): boolean {
+): ResolvedPosition {
+  const toolIndices = findTrackedToolIndices(parts, activity);
+  const toolStart = toolIndices[0];
+  /** A saved fallback outlives its purpose once every tracked call has
+   *  materialized; keeping it would hold the activity past a boundary its
+   *  real position precedes. */
+  const trackedToolCount = activity.toolCallIds?.length ?? 0;
+  const awaitingTools = trackedToolCount === 0 || toolIndices.length < trackedToolCount;
+  const fallback = awaitingTools ? activity.unresolvedToolStartIndex : undefined;
+  if (toolStart != null) {
+    return {
+      toolIndices,
+      awaitingTools,
+      startsAt: Math.max(toolStart, activity.partitionStartIndex ?? 0),
+      endsAt: Math.max(toolIndices[toolIndices.length - 1], fallback ?? Number.NEGATIVE_INFINITY),
+    };
+  }
+  /** Anchors carry only stable evidence and must be re-located against the
+   *  current content; a full activity keeps the index maintained live, which
+   *  repeated reasoning must not drag back across a prior phase. */
+  const startsAt =
+    activity.bounded === true ? findTrackedStart(parts, activity) : activity.startIndex;
+  const materializedStart = findMaterializedActivityStart(parts, activity, toolIndices);
+  const located =
+    fallback != null ? Math.max(fallback, materializedStart ?? fallback) : materializedStart;
+  return { toolIndices, awaitingTools, startsAt, ...(located != null && { endsAt: located }) };
+}
+
+/**
+ * Whether an activity belongs to the phase closing at `boundary`. Takes only a
+ * resolved position, so no caller can reach past it to a raw field: an
+ * activity closes early exactly when nothing locates it beyond the boundary.
+ * A completed batch straddling the boundary therefore stays whole on the later
+ * side rather than leaving one tool call outside its own parent.
+ */
+function closesBeforeBoundary(position: ResolvedPosition, boundary: number | undefined): boolean {
   if (boundary == null) {
     return true;
   }
-  if (activity.unresolvedToolStartIndex != null && activity.unresolvedToolStartIndex >= boundary) {
-    return false;
-  }
-  const materializedToolIndices = toolIndices ?? findTrackedToolIndices(parts, activity);
-  if (materializedToolIndices.length > 0) {
-    return materializedToolIndices.every((index) => index < boundary);
-  }
-  const materializedStart = findMaterializedActivityStart(parts, activity, materializedToolIndices);
-  return materializedStart == null || materializedStart < boundary;
+  return position.endsAt == null || position.endsAt < boundary;
 }
 
 /**
@@ -1083,41 +1125,23 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
      *  where a retained straddling batch reanchors — so the shared content
      *  array is walked once per activity and the result carried through. */
     const resolved = activities.map((activity) => {
-      const toolIndices = findTrackedToolIndices(currentParts, activity);
-      const toolStart = toolIndices[0];
-      if (toolStart != null) {
-        /** The saved fallback outlives its purpose once every tracked call has
-         *  materialized. Keeping it would reject the activity at any boundary
-         *  below that stale index even though its real position is earlier. */
-        const fullyMaterialized =
-          (activity.toolCallIds?.length ?? 0) > 0 &&
-          toolIndices.length >= (activity.toolCallIds?.length ?? 0);
-        const { unresolvedToolStartIndex, ...rest } = activity;
-        return {
-          activity: {
-            ...rest,
-            ...(!fullyMaterialized &&
-              unresolvedToolStartIndex != null && { unresolvedToolStartIndex }),
-            startIndex: Math.max(toolStart, activity.partitionStartIndex ?? 0),
-          },
-          toolIndices,
-        };
-      }
-      /** Anchors carry only stable evidence and must be re-located against the
-       *  current content; a full activity keeps the index maintained live,
-       *  which repeated reasoning must not drag back across a prior phase. */
+      const position = resolvePosition(currentParts, activity);
+      const { unresolvedToolStartIndex, ...rest } = activity;
       return {
-        activity:
-          activity.bounded === true
-            ? { ...activity, startIndex: findTrackedStart(currentParts, activity) }
-            : activity,
-        toolIndices,
+        activity: {
+          ...rest,
+          ...(position.awaitingTools &&
+            unresolvedToolStartIndex != null && { unresolvedToolStartIndex }),
+          startIndex: position.startsAt,
+        },
+        toolIndices: position.toolIndices,
+        position,
       };
     });
     const closingActivities: TrackedActivity[] = [];
     const retainedActivities: TrackedActivity[] = [];
-    for (const { activity, toolIndices } of resolved) {
-      if (closesBeforeBoundary(currentParts, activity, requestedEndIndex, toolIndices)) {
+    for (const { activity, toolIndices, position } of resolved) {
+      if (closesBeforeBoundary(position, requestedEndIndex)) {
         closingActivities.push(activity);
         continue;
       }
@@ -1592,7 +1616,11 @@ export function createActivityPhaseWiring(deps: ActivityPhaseHostDeps): Activity
       return undefined;
     }
     const boundary = candidate;
-    if (activities.some((activity) => !closesBeforeBoundary(parts, activity, boundary))) {
+    if (
+      activities.some(
+        (activity) => !closesBeforeBoundary(resolvePosition(parts, activity), boundary),
+      )
+    ) {
       return undefined;
     }
     for (const reasoning of pendingReasoning.values()) {


### PR DESCRIPTION
> **Stacked on #14805** — targets `claude/phase-anchor-merge`, not `dev`. Review that one first; this diff shows only its own commit once the base merges.

## Summary

`closesBeforeBoundary` read three positional fields directly (`unresolvedToolStartIndex`, plus tool indices and a reasoning fallback) and carried four branches to reconcile them. `resolvePosition` now folds tool indices, the prior partition floor, the unmaterialized fallback, and reasoning anchors into one value, and the predicate takes **only** that value:

```ts
function closesBeforeBoundary(position: ResolvedPosition, boundary: number | undefined): boolean {
  if (boundary == null) return true;
  return position.endsAt == null || position.endsAt < boundary;
}
```

An activity closes early exactly when nothing locates it beyond the boundary. Four branches become one comparison.

## Why

`runtime.ts` answers one question — *where did this happen?* — with 13 positional fields across ~29 decision sites. Only one is authoritative: where the part sits in the shared content array right now. Everything else is a cache, and the caching is necessary because the array keeps moving (parts materialize after their hooks fire, label reservations shift indices, persistence compacts, resume prepends).

Roughly two-thirds of the ~38 review findings on #14785 were a cache being trusted at decision time, in five shapes: stale, outranking the truth, ambiguous, discarded, or absent-read-as-a-value. The PR's *first* review comment named the root cause — *"the step map is event-coordinate, not authoritative"* — and eleven rounds of findings followed that same seam.

This is the move that ended the recurring partition-contract bugs, applied to position: `partitionAt` gave "which side of the boundary" one implementation and that class stopped recurring.

## What this does and doesn't reach

Raw positional fields no longer appear in any boundary comparison — they are inputs to resolution only. Grep for `unresolvedToolStartIndex|partitionStartIndex` against a boundary or `requestedEndIndex` now returns nothing.

Context entries keep `activityPosition` as a deliberate fallback, but already follow the same model: `locateTextEntry` reports whether a rendered index is authoritative (anchored by a step index, or a unique text match) and registration order is used only when it is not.

## No behavior change

Resolution also decides when a saved fallback has gone stale, so the stripping that kept it out of snapshots is now a property of the resolved value rather than a separate step — same outcome, one owner.

## Verification

- Activity-phase suite: 68/68
- `src/agents` + `src/stream`: 2515 passing
- Typecheck and ESLint clean
- Mutation-checked in both directions:
  - resolution ignoring the unmaterialized fallback → 4 failures (partially-materialized batch, live unmaterialized batch, delayed reanchor, overflow fallback)
  - `endsAt` taking the first tool instead of the last → 2 failures (both straddle regressions)

## Context

Follow-up from #14785, filed as ClickHouse/LibreChat#347. Second of a stacked pair with #14805.