### PR TITLE
🩹 fix: apply agent updates that match the newest version entry

### DIFF
--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -1980,6 +1980,40 @@ describe('Agent Methods', () => {
       }
     });
 
+    test('should persist an update matching the newest version when the document has diverged from it', async () => {
+      const agentId = `agent_${uuidv4()}`;
+      const authorId = new mongoose.Types.ObjectId();
+
+      await createAgent({
+        id: agentId,
+        provider: 'test',
+        model: 'test-model',
+        author: authorId,
+        tools: [],
+      });
+
+      /** Atomic-operator updates snapshot the pre-update state as the new version, so the
+       *  document and `versions[versions.length - 1]` legitimately diverge. This is the
+       *  same shape `addAgentResourceFile` produces when it attaches a file. */
+      await updateAgent({ id: agentId }, { $addToSet: { tools: 'file_search' } });
+
+      const afterAdd = await getAgent({ id: agentId });
+      expect(afterAdd!.tools).toEqual(['file_search']);
+      expect(afterAdd!.versions).toHaveLength(2);
+      expect((afterAdd!.versions![1] as VersionEntry).tools).toEqual([]);
+
+      /** Removing the tool lands the document back on the newest version's content. That
+       *  adds no history, but the removal itself must still be written. */
+      const removed = await updateAgent({ id: agentId }, { tools: [] });
+
+      expect(removed!.tools).toEqual([]);
+      expect(removed!.versions).toHaveLength(2);
+
+      const reloaded = await getAgent({ id: agentId });
+      expect(reloaded!.tools).toEqual([]);
+      expect(reloaded!.versions).toHaveLength(2);
+    });
+
     test('should track updatedBy when a different user updates an agent', async () => {
       const agentId = `agent_${uuidv4()}`;
       const originalAuthor = new mongoose.Types.ObjectId();

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -604,6 +604,9 @@ export function createAgentMethods(
     const Agent = mongoose.models.Agent as Model<IAgent>;
     const { updatingUserId = null, forceVersion = false, skipVersioning = false } = options;
     const mongoOptions = { new: true, upsert: false };
+    /** Set when the update would snapshot a version identical to the newest one. The write
+     *  still lands; only the `versions` entry is dropped. */
+    let suppressedVersionEntry = false;
 
     const currentAgent = await Agent.findOne(searchParameter);
     if (currentAgent) {
@@ -694,12 +697,14 @@ export function createAgentMethods(
           actionsHash,
         );
         if (duplicateVersion && !forceVersion) {
-          const agentObj = currentAgent.toObject() as IAgent & {
-            version?: number;
-            versions?: unknown[];
-          };
-          agentObj.version = (versions as unknown[]).length;
-          return agentObj;
+          /** A snapshot identical to the newest version adds no history, but the update
+           *  itself must still be applied. The document is not always equal to that
+           *  version: `$push`/`$pull`/`$addToSet` updates snapshot the pre-update state,
+           *  and `skipVersioning` writes snapshot nothing at all. Whenever the caller
+           *  moves the document back onto the newest version's content — removing a tool
+           *  `addAgentResourceFile` added, for instance — returning here dropped a real
+           *  change and reported success. */
+          suppressedVersionEntry = true;
         }
       }
 
@@ -717,7 +722,7 @@ export function createAgentMethods(
         versionEntry.updatedBy = new mongoose.Types.ObjectId(updatingUserId);
       }
 
-      if (shouldCreateVersion) {
+      if (shouldCreateVersion && !suppressedVersionEntry) {
         updateData.$push = {
           ...(($push as Record<string, unknown>) || {}),
           versions: versionEntry,
@@ -725,11 +730,20 @@ export function createAgentMethods(
       }
     }
 
-    return (await Agent.findOneAndUpdate(
+    const updatedAgent = (await Agent.findOneAndUpdate(
       searchParameter,
       updateData,
       mongoOptions,
     ).lean()) as IAgent | null;
+
+    /** Callers that create a version read `version` back from their own count of
+     *  `versions`; a suppressed entry leaves that count unchanged, so report it here to
+     *  keep the "no new version" signal these callers already relied on. */
+    if (updatedAgent && suppressedVersionEntry) {
+      (updatedAgent as IAgent & { version?: number }).version = updatedAgent.versions?.length ?? 0;
+    }
+
+    return updatedAgent;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #14809.

`updateAgent` returned early whenever the resulting state matched the newest entry in `versions`, so `findOneAndUpdate` never ran. The caller's update was discarded and a 200 was returned carrying the agent as it was *before* the update. In the Agent Builder this reads as "I changed my agent's tools, clicked Save, and it reverted" — and nothing shows up in the database, because nothing was ever written.

Suppressing a redundant *version entry* is the right behaviour. Suppressing the *write* is not, and the two are not interchangeable, because the agent document is regularly not equal to its newest version entry:

- `$push` / `$pull` / `$addToSet` updates snapshot the **pre-update** state — `versionEntry` is built from `versionData` plus `directUpdates`, so operator changes never reach the snapshot. `addAgentResourceFile` uses `$addToSet` on every file attach.
- `skipVersioning: true` writes snapshot nothing (`packages/api/src/agents/avatars.ts`).
- `removeAgentResourceFiles` bypasses `updateAgent` with a raw `$pullAll`.

Once the document has drifted, any update moving it back onto the newest entry's content was dropped, and the drifted state stayed.

The client then caches the loss: `useUpdateAgentMutation`'s `onSuccess` writes the returned pre-update agent into `[QueryKeys.agent, agent_id]` and `[QueryKeys.agent, agent_id, 'expanded']`, which is what the Agent Builder form reads.

### What changed

The duplicate-version branch now sets a `suppressedVersionEntry` flag instead of returning. The `versions` entry is still not pushed, the write is applied, and the unchanged `versions` count is reported back as `version` so callers keep the "no new version" signal they already relied on.

Deliberately unchanged: `isDuplicateVersion` still compares against the newest version only, and a genuine no-op still adds no history. The only behavioural difference for a true no-op is that `updatedAt` now advances, which matches every other write path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `should persist an update matching the newest version when the document has diverged from it` to `packages/data-schemas/src/methods/agent.spec.ts`. It reproduces the defect with the same shape `addAgentResourceFile` produces:

1. create an agent with `tools: []`
2. `updateAgent({ id }, { $addToSet: { tools: 'file_search' } })` — document has `tools: ['file_search']`, newest version entry records `tools: []`
3. `updateAgent({ id }, { tools: [] })` — a real change

Before this change step 3 resolves successfully and leaves `tools: ['file_search']` on the document. After it, the document has `tools: []` and `versions` correctly stays at 2.

The existing duplicate-version tests are unmodified and still pass — for a true no-op, applying the write changes nothing observable.

### **Test Configuration**:

```
cd packages/data-schemas && npx jest                      # 59 suites, 1999 tests pass
cd api && npx jest server/controllers/agents/v1.spec.js server/controllers/agents/filterAuthorizedTools.spec.js
cd packages/api && npx jest src/agents/avatars.spec.ts    # covers the skipVersioning caller
```

`eslint` clean on both changed files; `tsc --noEmit` reports nothing new (the pre-existing `src/app/ocr.ts` errors on `main` are untouched).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
