### PR TITLE
📎 fix: Alias Shell Script MIME Variants to `application/x-sh`

### DIFF
--- a/api/server/routes/files/multer.js
+++ b/api/server/routes/files/multer.js
@@ -28,13 +28,25 @@ const storage = multer.diskStorage({
   },
 });
 
+/**
+ * Multer forwards file-filter rejections to the shared error handler, which only relays a status and
+ * message for errors carrying `statusCode` and `body`. A plain `Error` falls through to a bare 500,
+ * so the client can't tell the user why the upload was refused.
+ */
+const uploadError = (statusCode, message) => {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  error.body = { message };
+  return error;
+};
+
 const importFileFilter = (req, file, cb) => {
   if (file.mimetype === 'application/json') {
     cb(null, true);
   } else if (path.extname(file.originalname).toLowerCase() === '.json') {
     cb(null, true);
   } else {
-    cb(new Error('Only JSON files are allowed'), false);
+    cb(uploadError(415, 'Only JSON files are allowed'), false);
   }
 };
 
@@ -58,7 +70,7 @@ const createFileFilter = (customFileConfig) => {
    */
   const fileFilter = (req, file, cb) => {
     if (!file) {
-      return cb(new Error('No file provided'), false);
+      return cb(uploadError(400, 'No file provided'), false);
     }
 
     const mimeType = normalizeUploadMimeType(file);
@@ -76,7 +88,7 @@ const createFileFilter = (customFileConfig) => {
     });
 
     if (!defaultFileConfig.checkType(mimeType, endpointFileConfig.supportedMimeTypes)) {
-      return cb(new Error('Unsupported file type: ' + (file.mimetype || mimeType)), false);
+      return cb(uploadError(415, 'Unsupported file type: ' + (file.mimetype || mimeType)), false);
     }
 
     cb(null, true);

--- a/api/server/routes/files/multer.js
+++ b/api/server/routes/files/multer.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const multer = require('multer');
-const { sanitizeFilename } = require('@librechat/api');
+const { sanitizeFilename, createCustomError } = require('@librechat/api');
 const {
   mergeFileConfig,
   inferMimeType,
@@ -28,25 +28,13 @@ const storage = multer.diskStorage({
   },
 });
 
-/**
- * Multer forwards file-filter rejections to the shared error handler, which only relays a status and
- * message for errors carrying `statusCode` and `body`. A plain `Error` falls through to a bare 500,
- * so the client can't tell the user why the upload was refused.
- */
-const uploadError = (statusCode, message) => {
-  const error = new Error(message);
-  error.statusCode = statusCode;
-  error.body = { message };
-  return error;
-};
-
 const importFileFilter = (req, file, cb) => {
   if (file.mimetype === 'application/json') {
     cb(null, true);
   } else if (path.extname(file.originalname).toLowerCase() === '.json') {
     cb(null, true);
   } else {
-    cb(uploadError(415, 'Only JSON files are allowed'), false);
+    cb(createCustomError(415, 'Only JSON files are allowed'), false);
   }
 };
 
@@ -70,7 +58,7 @@ const createFileFilter = (customFileConfig) => {
    */
   const fileFilter = (req, file, cb) => {
     if (!file) {
-      return cb(uploadError(400, 'No file provided'), false);
+      return cb(createCustomError(400, 'No file provided'), false);
     }
 
     const mimeType = normalizeUploadMimeType(file);
@@ -88,7 +76,10 @@ const createFileFilter = (customFileConfig) => {
     });
 
     if (!defaultFileConfig.checkType(mimeType, endpointFileConfig.supportedMimeTypes)) {
-      return cb(uploadError(415, 'Unsupported file type: ' + (file.mimetype || mimeType)), false);
+      return cb(
+        createCustomError(415, 'Unsupported file type: ' + (file.mimetype || mimeType)),
+        false,
+      );
     }
 
     cb(null, true);

--- a/api/server/routes/files/multer.spec.js
+++ b/api/server/routes/files/multer.spec.js
@@ -321,6 +321,33 @@ describe('Multer Configuration', () => {
       },
     );
 
+    /** Normalization runs before the allowlist check, so an admin who applied one of the documented
+     *  `.sh` workarounds must not be broken by it. Both recipes target `application/x-sh`, which is
+     *  exactly what the alias now produces. */
+    it.each([
+      ['the canonical type (#4660, #5689, #6297)', ['application/x-sh']],
+      ['broad patterns (#14804)', ['image/.*', 'text/.*', 'application/.*']],
+    ])(
+      'should keep accepting .sh for an existing workaround config allowing %s',
+      (_label, supportedMimeTypes) => {
+        const { mergeFileConfig } = require('librechat-data-provider');
+        const fileFilter = createFileFilter(
+          mergeFileConfig({ endpoints: { agents: { supportedMimeTypes } } }),
+        );
+        mockReq.body.endpoint = 'agents';
+        const shellFile = {
+          ...mockFile,
+          originalname: 'script.sh',
+          mimetype: 'application/x-shellscript',
+        };
+
+        const cb = jest.fn();
+        fileFilter(mockReq, shellFile, cb);
+
+        expect(cb).toHaveBeenCalledWith(null, true);
+      },
+    );
+
     it('should reject an unsupported type with a 415 the client can surface', () => {
       const { mergeFileConfig } = require('librechat-data-provider');
       const fileFilter = createFileFilter(mergeFileConfig());

--- a/api/server/routes/files/multer.spec.js
+++ b/api/server/routes/files/multer.spec.js
@@ -215,6 +215,8 @@ describe('Multer Configuration', () => {
       const cb = jest.fn((err, result) => {
         expect(err).toBeInstanceOf(Error);
         expect(err.message).toBe('Only JSON files are allowed');
+        expect(err.statusCode).toBe(415);
+        expect(err.body).toEqual({ message: 'Only JSON files are allowed' });
         expect(result).toBe(false);
         done();
       });
@@ -298,6 +300,45 @@ describe('Multer Configuration', () => {
       });
 
       fileFilter(mockReq, zipFile, cb);
+    });
+
+    it.each(['application/x-shellscript', 'text/x-shellscript'])(
+      'should normalize %s to application/x-sh and accept the upload',
+      (reportedType) => {
+        const { mergeFileConfig } = require('librechat-data-provider');
+        const fileFilter = createFileFilter(mergeFileConfig());
+        const shellFile = {
+          ...mockFile,
+          originalname: 'script.sh',
+          mimetype: reportedType,
+        };
+
+        const cb = jest.fn();
+        fileFilter(mockReq, shellFile, cb);
+
+        expect(cb).toHaveBeenCalledWith(null, true);
+        expect(shellFile.mimetype).toBe('application/x-sh');
+      },
+    );
+
+    it('should reject an unsupported type with a 415 the client can surface', () => {
+      const { mergeFileConfig } = require('librechat-data-provider');
+      const fileFilter = createFileFilter(mergeFileConfig());
+      const binaryFile = {
+        ...mockFile,
+        originalname: 'program.exe',
+        mimetype: 'application/x-msdownload',
+      };
+
+      const cb = jest.fn();
+      fileFilter(mockReq, binaryFile, cb);
+
+      expect(cb).toHaveBeenCalledTimes(1);
+      const [error, result] = cb.mock.calls[0];
+      expect(result).toBe(false);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.statusCode).toBe(415);
+      expect(error.body).toEqual({ message: 'Unsupported file type: application/x-msdownload' });
     });
 
     it('should use real mergeFileConfig function', async () => {

--- a/packages/api/src/middleware/error.spec.ts
+++ b/packages/api/src/middleware/error.spec.ts
@@ -1,7 +1,7 @@
 import { logger, tenantStorage } from '@librechat/data-schemas';
 import type { Request, Response } from 'express';
 import type { ValidationError, MongoServerError, CustomError } from '~/types';
-import { ErrorController } from './error';
+import { ErrorController, createCustomError } from './error';
 
 // Mock the logger
 jest.mock('@librechat/data-schemas', () => ({
@@ -192,6 +192,31 @@ describe('ErrorController', () => {
       } as CustomError;
 
       ErrorController(partialError, mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith('An unknown error occurred.');
+    });
+  });
+
+  describe('createCustomError', () => {
+    it('should build an Error carrying the status and a message body', () => {
+      const error = createCustomError(415, 'Unsupported file type: application/x-shellscript');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Unsupported file type: application/x-shellscript');
+      expect(error.statusCode).toBe(415);
+      expect(error.body).toEqual({ message: 'Unsupported file type: application/x-shellscript' });
+    });
+
+    it('should reach the client through ErrorController instead of a bare 500', () => {
+      ErrorController(createCustomError(415, 'Unsupported file type'), mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(415);
+      expect(mockRes.send).toHaveBeenCalledWith({ message: 'Unsupported file type' });
+    });
+
+    it('should be the piece a plain Error lacks, which falls through to 500', () => {
+      ErrorController(new Error('Unsupported file type'), mockReq, mockRes, mockNext);
 
       expect(mockRes.status).toHaveBeenCalledWith(500);
       expect(mockRes.send).toHaveBeenCalledWith('An unknown error occurred.');

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -41,6 +41,18 @@ function isCustomError(err: unknown): err is CustomError {
   return err !== null && typeof err === 'object' && 'statusCode' in err && 'body' in err;
 }
 
+/**
+ * Builds an error that `ErrorController` relays to the client verbatim. `isCustomError` matches only
+ * when both `statusCode` and `body` are present, so a plain `Error` falls through to a bare 500 and
+ * its message never leaves the server log. Use this wherever the caller needs to see the reason.
+ */
+export const createCustomError = (statusCode: number, message: string): CustomError => {
+  const error = new Error(message) as CustomError;
+  error.statusCode = statusCode;
+  error.body = { message };
+  return error;
+};
+
 export const ErrorController = (
   err: Error | CustomError,
   req: Request,

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -33,6 +33,14 @@ describe('inferMimeType', () => {
     expect(inferMimeType('archive.zip', 'application/x-zip-compressed')).toBe('application/zip');
   });
 
+  it('should normalize application/x-shellscript to application/x-sh', () => {
+    expect(inferMimeType('test.sh', 'application/x-shellscript')).toBe('application/x-sh');
+  });
+
+  it('should normalize text/x-shellscript to application/x-sh', () => {
+    expect(inferMimeType('test.sh', 'text/x-shellscript')).toBe('application/x-sh');
+  });
+
   it('should return a type that matches textMimeTypes after normalization', () => {
     const normalized = inferMimeType('test.py', 'text/x-python-script');
     expect(textMimeTypes.test(normalized)).toBe(true);
@@ -64,6 +72,20 @@ describe('inferMimeType', () => {
     const normalized = inferMimeType('test.md', 'text/x-markdown');
     expect(baseFileConfig.checkType(normalized)).toBe(true);
   });
+
+  it.each(['application/x-shellscript', 'text/x-shellscript'])(
+    'should produce a type accepted by checkType after normalizing %s',
+    (browserType) => {
+      expect(baseFileConfig.checkType(inferMimeType('test.sh', browserType))).toBe(true);
+    },
+  );
+
+  it.each(['application/x-shellscript', 'text/x-shellscript'])(
+    'should reject raw %s without normalization',
+    (browserType) => {
+      expect(baseFileConfig.checkType(browserType)).toBe(false);
+    },
+  );
 
   it('should reject raw text/x-python-script without normalization', () => {
     expect(baseFileConfig.checkType('text/x-python-script')).toBe(false);

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -411,6 +411,10 @@ export const mimeTypeAliases: Readonly<Record<string, string>> = {
   'application/x-zip-compressed': 'application/zip',
   'text/x-python-script': 'text/x-python',
   'text/x-markdown': 'text/markdown',
+  /** freedesktop shared-mime-info (Chrome on Linux) */
+  'application/x-shellscript': 'application/x-sh',
+  /** libmagic, i.e. `file --mime-type` */
+  'text/x-shellscript': 'application/x-sh',
 };
 
 /**


### PR DESCRIPTION
Fixes #14804

## Summary

Uploading a `.sh` file failed with `Unsupported file type: application/x-shellscript`, even though `application/x-sh` is in the default allowlist and `codeTypeMapping` maps `sh → application/x-sh`.

A single `.sh` file arrives as one of three MIME types depending on the client:

| Source | Reported |
|---|---|
| Chrome on Linux (freedesktop shared-mime-info) | `application/x-shellscript` |
| `file --mime-type` / libmagic | `text/x-shellscript` |
| IANA / `mime-db` | `application/x-sh` |

Only the last was accepted. `inferMimeType` consults `codeTypeMapping` **only** when the client sends no type at all, so a non-empty browser value passed straight through to the allowlist check:

```ts
if (currentType) {
  return mimeTypeAliases[currentType] ?? currentType;   // ← browser value passes through
}
```

Both variants are now aliased to the canonical `application/x-sh`, matching how `text/x-markdown` (#12608), `text/x-python-script` (#12240), and `application/x-zip-compressed` are already handled. One entry normalizes the variant for every client, rather than each admin having to guess which spelling their users' browsers send.

I checked `mime-db` before adding anything speculative — it registers only `application/x-sh`, so the two variants in the report are the ones that exist in the wild; no others were invented.

## Secondary: the rejection reached the client as a bare 500

The file filter rejected with a plain `Error`, which has no `statusCode`/`body` and so misses the `isCustomError` branch in `ErrorController` and falls through to `res.status(500).send('An unknown error occurred.')`. The reason was logged server-side but never reached the user — the browser console just showed a 500 and the UI showed a generic upload failure.

The three rejection sites in `multer.js` now build the error through a small helper that attaches `statusCode` and `body`. `useFileHandling` already surfaces `error.response.data.message`, so a rejected file explains itself. This also covers the conversation-import filter (`Only JSON files are allowed`), which had the identical problem.

Related: #7553 asks for the same improvement on the OCR path — not touched here.

## Testing

`packages/data-provider/src/file-config.spec.ts` — both variants normalize to `application/x-sh` and are accepted by `checkType`; both are still rejected raw, documenting why the alias is needed.

`api/server/routes/files/multer.spec.js` — the real `createFileFilter` with real `mergeFileConfig()` accepts a `.sh` file reported as either variant and rewrites `file.mimetype`; an unsupported type is rejected with `statusCode: 415` and a `body.message` the client can render.

Every new assertion was confirmed to fail against the unfixed source — the source change was reverted, `data-provider` rebuilt, and both suites re-run, giving 4 failures in each before restoring. Full runs after the fix: 179/179 data-provider, 31/31 multer, 7/7 `server/routes/files`, 301/301 `server/services/Files`. `tsc`, `eslint`, and `prettier` clean.

Not exercised in a running app — the fix is verified at the exact layer the rejection happens (the shared `POST /api/files` file filter), against real config rather than mocks.