### PR TITLE
⚡ feat: Add Gemini 3.7 Flash Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -419,10 +419,10 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
+# GOOGLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
+# GOOGLE_MODELS=gemini-3.7-flash,gemini-3.6-flash,gemini-3.5-flash,gemini-3.5-flash-lite,gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
 
 # GOOGLE_TITLE_MODEL=gemini-2.0-flash-lite-001
 

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.4.6",
+    "@librechat/agents": "^3.4.7",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -356,6 +356,9 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gemini-3.6-flash', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-3.6-flash'],
     );
+    expect(getModelMaxTokens('gemini-3.7-flash', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemini-3.7-flash'],
+    );
     expect(getModelMaxTokens('gemini-2.5-pro', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-2.5-pro'],
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.4.6",
+        "@librechat/agents": "^3.4.7",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10628,9 +10628,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.4.6.tgz",
-      "integrity": "sha512-ZgFNhOGZpFUGZVh+K+E18SzV53iXbmnhN8Z+B/5KbIPwrZ3WLXw9whJ2xCpVpDk0VBGy9oZu8SSPD4cl0eUiQQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.4.7.tgz",
+      "integrity": "sha512-0JPTM/rYjudtl6uhVbAMDyq1vxa40oeacVLWuEF+S611hwpO9kuXho+X4+XbTrRAGTzkGJrYBsvc/ddzxtEBAA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42849,7 +42849,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.4.6",
+        "@librechat/agents": "^3.4.7",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.4.6",
+    "@librechat/agents": "^3.4.7",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -964,6 +964,111 @@ describe('getGoogleConfig', () => {
       expect(result.llmConfig).not.toHaveProperty('thinking_budget');
     });
 
+    it('should default Gemini 3.7 Flash to medium thinkingLevel', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.7-flash',
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'MEDIUM',
+      });
+    });
+
+    it('should remove legacy sampling params for Gemini 3.7 Flash', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const modelOptions = {
+        model: 'gemini-3.7-flash',
+        temperature: 0.7,
+        topP: 0.9,
+        topK: 40,
+        top_p: 0.9,
+        top_k: 40,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.5,
+        thinking_budget: 5000,
+      } as unknown as t.GoogleParameters;
+
+      const result = getGoogleConfig(credentials, { modelOptions });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect(result.llmConfig).not.toHaveProperty('topP');
+      expect(result.llmConfig).not.toHaveProperty('topK');
+      expect(result.llmConfig).not.toHaveProperty('top_p');
+      expect(result.llmConfig).not.toHaveProperty('top_k');
+      expect(result.llmConfig).not.toHaveProperty('presencePenalty');
+      expect(result.llmConfig).not.toHaveProperty('frequencyPenalty');
+      expect(result.llmConfig).not.toHaveProperty('thinking_budget');
+    });
+
+    it.each([
+      [ThinkingLevel.low, 'LOW'],
+      [ThinkingLevel.medium, 'MEDIUM'],
+      [ThinkingLevel.high, 'HIGH'],
+    ])('should preserve explicit Gemini 3.7 Flash thinkingLevel "%s"', (level, expected) => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.7-flash',
+          thinkingLevel: level,
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: expected,
+      });
+    });
+
+    it('should substitute minimal thinkingLevel with low for Gemini 3.7 Flash', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemini-3.7-flash',
+          thinkingLevel: ThinkingLevel.minimal,
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'LOW',
+      });
+    });
+
+    it('should apply Gemini 3.7 Flash handling to versioned aliases', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'models/gemini-3.7-flash-latest',
+          temperature: 0.7,
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'MEDIUM',
+      });
+    });
+
     it('should remove unsupported penalty params for Gemini 3.5 Flash-Lite', () => {
       const credentials = {
         [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -13,6 +13,15 @@ type GoogleThinkingConfig = {
   thinkingLevel?: GoogleThinkingLevel;
 };
 
+type GeminiFlashThinkingRule = {
+  /** Model id, matched exactly or as a `${id}-` prefix for versioned aliases */
+  id: string;
+  /** Thinking level applied when the request doesn't set one */
+  default: GoogleThinkingLevel;
+  /** Levels the model rejects, mapped to the nearest level it accepts */
+  substitutions?: Partial<Record<GoogleThinkingLevel, GoogleThinkingLevel>>;
+};
+
 /**
  * Gemini Flash models (3.5+) that drop the deprecated sampling parameters
  * (`temperature`/`topP`/`topK`) and `thinkingBudget` in favor of the qualitative
@@ -22,12 +31,17 @@ type GoogleThinkingConfig = {
  * default thinking level when the request doesn't set one. Ordered
  * most-specific-first so `gemini-3.5-flash-lite` resolves before the
  * `gemini-3.5-flash` prefix.
+ *
+ * Gemini 3.7 Flash supports only `low`/`medium`/`high` and errors on `minimal`,
+ * so an explicit `minimal` is substituted with the nearest supported level.
  * @see https://ai.google.dev/gemini-api/docs/latest-model#api-changes-and-parameter-updates
+ * @see https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
  */
-const geminiFlashThinkingDefaults: ReadonlyArray<readonly [string, GoogleThinkingLevel]> = [
-  ['gemini-3.6-flash', 'MEDIUM'],
-  ['gemini-3.5-flash-lite', 'MINIMAL'],
-  ['gemini-3.5-flash', 'MEDIUM'],
+const geminiFlashThinkingRules: ReadonlyArray<GeminiFlashThinkingRule> = [
+  { id: 'gemini-3.7-flash', default: 'MEDIUM', substitutions: { MINIMAL: 'LOW' } },
+  { id: 'gemini-3.6-flash', default: 'MEDIUM' },
+  { id: 'gemini-3.5-flash-lite', default: 'MINIMAL' },
+  { id: 'gemini-3.5-flash', default: 'MEDIUM' },
 ];
 
 const geminiFlashLegacyParams = [
@@ -149,12 +163,12 @@ function normalizeGoogleThinkingLevel(value: unknown): GoogleThinkingLevel | und
   return normalized;
 }
 
-function getGeminiFlashDefaultThinkingLevel(model: string): GoogleThinkingLevel | undefined {
+function getGeminiFlashThinkingRule(model: string): GeminiFlashThinkingRule | undefined {
   const normalized = model.toLowerCase();
   const modelId = normalized.split('/').pop() ?? normalized;
-  for (const [id, level] of geminiFlashThinkingDefaults) {
-    if (modelId === id || modelId.startsWith(`${id}-`)) {
-      return level;
+  for (const rule of geminiFlashThinkingRules) {
+    if (modelId === rule.id || modelId.startsWith(`${rule.id}-`)) {
+      return rule;
     }
   }
   return undefined;
@@ -173,7 +187,7 @@ export function stripGeminiFlashBlockedParams<T extends Record<string, unknown> 
   params: T,
   model: string | undefined,
 ): T {
-  if (params == null || getGeminiFlashDefaultThinkingLevel(model ?? '') == null) {
+  if (params == null || getGeminiFlashThinkingRule(model ?? '') == null) {
     return params;
   }
   const sanitized = { ...params };
@@ -233,8 +247,8 @@ function applyGeminiFlashOverrides({
   if (typeof model !== 'string') {
     return;
   }
-  const defaultThinkingLevel = getGeminiFlashDefaultThinkingLevel(model);
-  if (!defaultThinkingLevel) {
+  const thinkingRule = getGeminiFlashThinkingRule(model);
+  if (!thinkingRule) {
     return;
   }
 
@@ -268,8 +282,14 @@ function applyGeminiFlashOverrides({
     thinkingConfig.includeThoughts = true;
   }
 
-  if (!shouldDropThinkingLevel && !thinkingConfig.thinkingLevel) {
-    thinkingConfig.thinkingLevel = defaultThinkingLevel;
+  if (!shouldDropThinkingLevel) {
+    if (!thinkingConfig.thinkingLevel) {
+      thinkingConfig.thinkingLevel = thinkingRule.default;
+    }
+    const substitute = thinkingRule.substitutions?.[thinkingConfig.thinkingLevel];
+    if (substitute) {
+      thinkingConfig.thinkingLevel = substitute;
+    }
   }
 
   if (Object.keys(thinkingConfig).length > 0) {

--- a/packages/api/src/endpoints/openai/config.google.spec.ts
+++ b/packages/api/src/endpoints/openai/config.google.spec.ts
@@ -153,37 +153,40 @@ describe('getOpenAIConfig - Google Compatibility', () => {
         expect(result.tools).toEqual([]);
       });
 
-      it('should strip Flash-blocked addParams so the transform cannot re-add them', () => {
-        const apiKey = JSON.stringify({ GOOGLE_API_KEY: 'test-google-key' });
-        const endpoint = 'Gemini (Custom)';
-        const options = {
-          modelOptions: {
-            model: 'gemini-3.6-flash',
-          },
-          customParams: {
-            defaultParamsEndpoint: 'google',
-          },
-          addParams: {
-            temperature: 0.8,
-            topP: 0.95,
-            topK: 40,
-            presencePenalty: 0.5,
-            frequencyPenalty: 0.5,
-            maxOutputTokens: 8192, // Supported Google param, should survive
-          },
-          reverseProxyUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
-        };
+      it.each(['gemini-3.6-flash', 'gemini-3.7-flash'])(
+        'should strip Flash-blocked addParams so the transform cannot re-add them (%s)',
+        (model) => {
+          const apiKey = JSON.stringify({ GOOGLE_API_KEY: 'test-google-key' });
+          const endpoint = 'Gemini (Custom)';
+          const options = {
+            modelOptions: {
+              model,
+            },
+            customParams: {
+              defaultParamsEndpoint: 'google',
+            },
+            addParams: {
+              temperature: 0.8,
+              topP: 0.95,
+              topK: 40,
+              presencePenalty: 0.5,
+              frequencyPenalty: 0.5,
+              maxOutputTokens: 8192, // Supported Google param, should survive
+            },
+            reverseProxyUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+          };
 
-        const result = getOpenAIConfig(apiKey, options, endpoint);
+          const result = getOpenAIConfig(apiKey, options, endpoint);
 
-        expect(result.llmConfig).not.toHaveProperty('temperature');
-        expect(result.llmConfig).not.toHaveProperty('topP');
-        expect(result.llmConfig).not.toHaveProperty('presencePenalty');
-        expect(result.llmConfig).not.toHaveProperty('frequencyPenalty');
-        expect(result.llmConfig.modelKwargs ?? {}).not.toHaveProperty('topK');
-        expect(result.llmConfig.modelKwargs ?? {}).not.toHaveProperty('presencePenalty');
-        expect(result.llmConfig.modelKwargs).toMatchObject({ maxOutputTokens: 8192 });
-      });
+          expect(result.llmConfig).not.toHaveProperty('temperature');
+          expect(result.llmConfig).not.toHaveProperty('topP');
+          expect(result.llmConfig).not.toHaveProperty('presencePenalty');
+          expect(result.llmConfig).not.toHaveProperty('frequencyPenalty');
+          expect(result.llmConfig.modelKwargs ?? {}).not.toHaveProperty('topK');
+          expect(result.llmConfig.modelKwargs ?? {}).not.toHaveProperty('presencePenalty');
+          expect(result.llmConfig.modelKwargs).toMatchObject({ maxOutputTokens: 8192 });
+        },
+      );
 
       it('should drop Google native params with dropParams', () => {
         const apiKey = JSON.stringify({ GOOGLE_API_KEY: 'test-google-key' });

--- a/packages/api/src/utils/tokens.spec.ts
+++ b/packages/api/src/utils/tokens.spec.ts
@@ -47,3 +47,16 @@ describe('gpt-5.6 tiers', () => {
     expect(getModelMaxTokens('gpt-5', EModelEndpoint.openAI)).toBe(400000);
   });
 });
+
+describe('Gemini 3.7 Flash', () => {
+  it('resolves the 1,048,576-token context window', () => {
+    expect(getModelMaxTokens('gemini-3.7-flash', EModelEndpoint.google)).toBe(1048576);
+  });
+
+  it('matches the longest key over the shorter gemini-3 pattern for aliases', () => {
+    expect(getModelMaxTokens('models/gemini-3.7-flash-latest', EModelEndpoint.google)).toBe(
+      1048576,
+    );
+    expect(getModelMaxTokens('gemini-3', EModelEndpoint.google)).toBe(1000000);
+  });
+});

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -135,6 +135,7 @@ const googleModels = {
   'gemini-3.5-flash': 1048576,
   'gemini-3.5-flash-lite': 1048576,
   'gemini-3.6-flash': 1048576,
+  'gemini-3.7-flash': 1048576,
 };
 
 const anthropicModels = {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2271,6 +2271,8 @@ export const defaultModels = {
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
   [EModelEndpoint.google]: [
+    // Gemini 3.7 Models
+    'gemini-3.7-flash',
     // Gemini 3.6 Models
     'gemini-3.6-flash',
     // Gemini 3.5 Models

--- a/packages/data-schemas/src/methods/tx.spec.ts
+++ b/packages/data-schemas/src/methods/tx.spec.ts
@@ -1526,6 +1526,7 @@ describe('Google Model Tests', () => {
     'gemini-3.1-pro-preview',
     'gemini-3.1-pro-preview-customtools',
     'gemini-3.1-flash-lite-preview',
+    'gemini-3.7-flash',
     'gemini-3.6-flash',
     'gemini-3.5-flash',
     'gemini-3.5-flash-lite',
@@ -1576,6 +1577,7 @@ describe('Google Model Tests', () => {
       'gemini-3.1-pro-preview': 'gemini-3.1',
       'gemini-3.1-pro-preview-customtools': 'gemini-3.1',
       'gemini-3.1-flash-lite-preview': 'gemini-3.1-flash-lite',
+      'gemini-3.7-flash': 'gemini-3.7-flash',
       'gemini-3.6-flash': 'gemini-3.6-flash',
       'gemini-3.5-flash': 'gemini-3.5-flash',
       'gemini-3.5-flash-lite': 'gemini-3.5-flash-lite',
@@ -1711,6 +1713,35 @@ describe('Google Model Tests', () => {
     expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(
       cacheTokenValues['gemini-3.6-flash'].read,
     );
+  });
+
+  it('should return correct rates for Gemini 3.7 Flash', () => {
+    const model = 'gemini-3.7-flash';
+    expect(getMultiplier({ model, tokenType: 'prompt', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.7-flash'].prompt,
+    );
+    expect(getMultiplier({ model, tokenType: 'completion', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.7-flash'].completion,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'write' })).toBe(
+      cacheTokenValues['gemini-3.7-flash'].write,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(
+      cacheTokenValues['gemini-3.7-flash'].read,
+    );
+  });
+
+  it('should apply the introductory Flash rates to Gemini 3.6 and 3.7 Flash', () => {
+    for (const model of ['gemini-3.6-flash', 'gemini-3.7-flash']) {
+      expect(getMultiplier({ model, tokenType: 'prompt', endpoint: EModelEndpoint.google })).toBe(
+        0.75,
+      );
+      expect(
+        getMultiplier({ model, tokenType: 'completion', endpoint: EModelEndpoint.google }),
+      ).toBe(3.75);
+      expect(getCacheMultiplier({ model, cacheType: 'write' })).toBe(0.75);
+      expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(0.075);
+    }
   });
 
   it('should return correct rates for Gemini 3.5 Flash-Lite', () => {

--- a/packages/data-schemas/src/methods/tx.ts
+++ b/packages/data-schemas/src/methods/tx.ts
@@ -205,7 +205,7 @@ export const tokenValues: Record<string, { prompt: number; completion: number }>
     'gemini-3.1-flash-lite': { prompt: 0.25, completion: 1.5 },
     'gemini-3.5-flash': { prompt: 1.5, completion: 9 },
     'gemini-3.5-flash-lite': { prompt: 0.3, completion: 2.5 },
-    /** Introductory rates through 2026-12-31; both revert to `1.5`/`7.5` on 2027-01-01 */
+    // Gemini 3.6/3.7 Flash introductory pricing through 2026-12-31; revert to { prompt: 1.5, completion: 7.5 } after.
     'gemini-3.6-flash': { prompt: 0.75, completion: 3.75 },
     'gemini-3.7-flash': { prompt: 0.75, completion: 3.75 },
     'gemini-pro-vision': { prompt: 0.5, completion: 1.5 },
@@ -376,11 +376,8 @@ export const cacheTokenValues: Record<string, { write: number; read: number }> =
   'gemini-3.5-flash': { write: 1.5, read: 0.15 },
   // Gemini 3.5 Flash-Lite - cache write: $0.30/1M, cache read: $0.03/1M
   'gemini-3.5-flash-lite': { write: 0.3, read: 0.03 },
-  // Gemini 3.6 Flash - cache write: $0.75/1M, cache read: $0.075/1M
-  // Introductory rates through 2026-12-31; revert to $1.50/$0.15 on 2027-01-01
+  // Gemini 3.6/3.7 Flash introductory pricing through 2026-12-31; revert to { write: 1.5, read: 0.15 } after.
   'gemini-3.6-flash': { write: 0.75, read: 0.075 },
-  // Gemini 3.7 Flash - cache write: $0.75/1M, cache read: $0.075/1M
-  // Introductory rates through 2026-12-31; revert to $1.50/$0.15 on 2027-01-01
   'gemini-3.7-flash': { write: 0.75, read: 0.075 },
 };
 

--- a/packages/data-schemas/src/methods/tx.ts
+++ b/packages/data-schemas/src/methods/tx.ts
@@ -205,7 +205,9 @@ export const tokenValues: Record<string, { prompt: number; completion: number }>
     'gemini-3.1-flash-lite': { prompt: 0.25, completion: 1.5 },
     'gemini-3.5-flash': { prompt: 1.5, completion: 9 },
     'gemini-3.5-flash-lite': { prompt: 0.3, completion: 2.5 },
-    'gemini-3.6-flash': { prompt: 1.5, completion: 7.5 },
+    /** Introductory rates through 2026-12-31; both revert to `1.5`/`7.5` on 2027-01-01 */
+    'gemini-3.6-flash': { prompt: 0.75, completion: 3.75 },
+    'gemini-3.7-flash': { prompt: 0.75, completion: 3.75 },
     'gemini-pro-vision': { prompt: 0.5, completion: 1.5 },
     grok: { prompt: 2.0, completion: 10.0 },
     'grok-beta': { prompt: 5.0, completion: 15.0 },
@@ -374,8 +376,12 @@ export const cacheTokenValues: Record<string, { write: number; read: number }> =
   'gemini-3.5-flash': { write: 1.5, read: 0.15 },
   // Gemini 3.5 Flash-Lite - cache write: $0.30/1M, cache read: $0.03/1M
   'gemini-3.5-flash-lite': { write: 0.3, read: 0.03 },
-  // Gemini 3.6 Flash - cache write: $1.50/1M, cache read: $0.15/1M
-  'gemini-3.6-flash': { write: 1.5, read: 0.15 },
+  // Gemini 3.6 Flash - cache write: $0.75/1M, cache read: $0.075/1M
+  // Introductory rates through 2026-12-31; revert to $1.50/$0.15 on 2027-01-01
+  'gemini-3.6-flash': { write: 0.75, read: 0.075 },
+  // Gemini 3.7 Flash - cache write: $0.75/1M, cache read: $0.075/1M
+  // Introductory rates through 2026-12-31; revert to $1.50/$0.15 on 2027-01-01
+  'gemini-3.7-flash': { write: 0.75, read: 0.075 },
 };
 
 /**


### PR DESCRIPTION
Resolves #14802

## Summary

Adds first-class support for Google's **Gemini 3.7 Flash** (`gemini-3.7-flash`) for both the Gemini API (AI Studio) and the Google Cloud Gemini Enterprise Agent Platform, following the Gemini 3.6 Flash integration in #14369.

Model facts were verified against Google's docs rather than taken from the issue: 1,048,576-token context, 65,536 max output, thinking levels `low`/`medium`/`high` with `medium` as the default.

## Changes

- **Context window** — `gemini-3.7-flash: 1048576` in `googleModels` (`packages/api/src/utils/tokens.ts`). Max output already resolves to 65,535 via the existing regex in `googleSettings.maxOutputTokens`, so no change was needed there.
- **Model list** — added to `defaultModels[EModelEndpoint.google]` and to both `GOOGLE_MODELS` examples in `.env.example` (Gemini API and Vertex).
- **Flash-family handler** (`packages/api/src/endpoints/google/llm.ts`) — registered the model so it inherits the existing strip of deprecated sampling params (`temperature`/`topP`/`topK`), rejected penalty params (`presencePenalty`/`frequencyPenalty`), and `thinkingBudget`, and defaults to `medium` thinking. This also covers the custom-endpoint path (`getOpenAIConfig` → `stripGeminiFlashBlockedParams`).
- **Pricing** (`packages/data-schemas/src/methods/tx.ts`) — API and cache rates for 3.7 Flash.

## One addition beyond the issue

The issue lists 3.7 Flash's levels as `low`/`medium`/`high`. Google's docs are more specific: **`minimal` is not supported and returns an error**. LibreChat's Google `thinkingLevel` slider offers `minimal`, so selecting it with this model would have been a guaranteed HTTP 400 on a model we're advertising as supported.

To keep that path working, the handler's enumerated table changes from a `[id, level]` tuple to a rule object that can also declare levels a model rejects:

```ts
const geminiFlashThinkingRules: ReadonlyArray<GeminiFlashThinkingRule> = [
  { id: 'gemini-3.7-flash', default: 'MEDIUM', substitutions: { MINIMAL: 'LOW' } },
  { id: 'gemini-3.6-flash', default: 'MEDIUM' },
  { id: 'gemini-3.5-flash-lite', default: 'MINIMAL' },
  { id: 'gemini-3.5-flash', default: 'MEDIUM' },
];
```

An explicit `minimal` is substituted with `low` — the nearest level the model accepts, and the one Google documents as the latency-oriented choice. Explicit `low`/`medium`/`high` pass through unchanged, and behavior for every other model is untouched. Happy to drop this and let `minimal` 400 instead if you'd rather not paper over it.

## Pricing note

Google is running introductory pricing through **2026-12-31**, and now applies the same rates to **Gemini 3.6 Flash** — which the issue flags and I confirmed on the pricing page. So this PR also corrects 3.6 Flash, which was still configured at the old `$1.50`/`$7.50`:

| Model | Input | Output | Cached |
|---|---:|---:|---:|
| 3.7 Flash | $0.75 | $3.75 | $0.075 |
| 3.6 Flash (was $1.50 / $7.50 / $0.15) | $0.75 | $3.75 | $0.075 |

**Both revert to $1.50 / $7.50 / $0.15 on 2027-01-01.** Dated notes sit at both call sites in `tx.ts` (`tokenValues` and `cacheTokenValues`).

## Dependency: `@librechat/agents` 3.4.7 ✅

Google's model-turn prefill restriction also applies to 3.7 Flash, and that list (`NO_PREFILL_GEMINI_MODELS`) lives in the agents SDK: **danny-avila/agents#412**, released as **3.4.7** via danny-avila/agents#413.

I originally called these two PRs independent. That's true of compilation but wrong about merge order, and codex was right to flag it. Merging this on 3.4.6 would have advertised `gemini-3.7-flash` in the default list while editing an assistant reply and resubmitting returned HTTP 400 — the flow already fixed for 3.6 Flash and 3.5 Flash-Lite.

**Resolved in `3024bfe2f9`:** `^3.4.6` → `^3.4.7` in `api/package.json` and `packages/api/package.json`, plus the lockfile pin. `^3.4.6` already permitted 3.4.7, but the fix is required rather than merely compatible, so the declared floor now says so.

Verified the published tarball rather than trusting the version number — `3.4.6...3.4.7` touches only `dist/{cjs,esm}/llm/google/utils/common.*` (the prefill array and its comment). `dist/types` is byte-identical, so there is no API surface change and no build risk. The lockfile diff is 10 lines, confined to `@librechat/agents`.

## Testing

- `packages/api` — 825 passed across `src/endpoints/` + `src/utils/tokens`
- `packages/data-schemas` — 231 passed (`tx.spec.ts`)
- `api` — 200 passed (`utils/tokens.spec.js`)
- `tsc --noEmit` clean in `packages/api`, `data-schemas`, `data-provider`; ESLint clean on all changed files

New coverage: 3.7 Flash thinking default, legacy/penalty param strip, explicit low/medium/high pass-through, `minimal` → `low` substitution, versioned aliases, custom-endpoint `addParams` strip, context window and longest-key resolution over the shorter `gemini-3` pattern, and pricing/cache rates.

Each new test was verified to fail with the source changes reverted, so none of them are passing vacuously. (`api/utils/tokens.spec.js` resolves `@librechat/api` from the built dist — I rebuilt `packages/api` locally so it ran against this change rather than a stale build.)

