### PR TITLE
fix/wrong-file-size-on-uploaded-files

### DIFF
--- a/packages/api/src/files/mistral/crud.spec.ts
+++ b/packages/api/src/files/mistral/crud.spec.ts
@@ -560,6 +560,7 @@ describe('MistralOCR Service', () => {
         path: '/tmp/upload/file.pdf',
         originalname: 'document.pdf',
         mimetype: 'application/pdf',
+        size: 4096,
       } as Express.Multer.File;
 
       const result = await uploadMistralOCR({
@@ -581,7 +582,7 @@ describe('MistralOCR Service', () => {
       // Verify OCR result
       expect(result).toEqual({
         filename: 'document.pdf',
-        bytes: expect.any(Number),
+        bytes: 4096,
         filepath: 'mistral_ocr',
         text: expect.stringContaining('# PAGE 1'),
         images: ['base64image1', 'base64image2'],
@@ -659,6 +660,7 @@ describe('MistralOCR Service', () => {
         path: '/tmp/upload/image.png',
         originalname: 'image.png',
         mimetype: 'image/png',
+        size: 2048,
       } as Express.Multer.File;
 
       const result = await uploadMistralOCR({
@@ -691,7 +693,7 @@ describe('MistralOCR Service', () => {
 
       expect(result).toEqual({
         filename: 'image.png',
-        bytes: expect.any(Number),
+        bytes: 2048,
         filepath: 'mistral_ocr',
         text: expect.stringContaining('Image OCR result'),
         images: ['imgbase64'],
@@ -1775,6 +1777,7 @@ describe('MistralOCR Service', () => {
           path: '/tmp/upload/file.pdf',
           originalname: 'document.pdf',
           mimetype: 'application/pdf',
+          size: 4096,
         } as Express.Multer.File;
 
         // Should not throw even if delete fails
@@ -1786,7 +1789,7 @@ describe('MistralOCR Service', () => {
 
         expect(result).toEqual({
           filename: 'document.pdf',
-          bytes: expect.any(Number),
+          bytes: 4096,
           filepath: 'mistral_ocr',
           text: 'OCR content\n\n',
           images: [],
@@ -2324,6 +2327,7 @@ describe('MistralOCR Service', () => {
         path: '/tmp/upload/azure-file.pdf',
         originalname: 'azure-document.pdf',
         mimetype: 'application/pdf',
+        size: 4096,
       } as Express.Multer.File;
 
       const result = await uploadAzureMistralOCR({
@@ -2333,7 +2337,7 @@ describe('MistralOCR Service', () => {
       });
 
       expect(readFileAsBuffer).toHaveBeenCalledWith('/tmp/upload/azure-file.pdf', {
-        fileSize: undefined,
+        fileSize: 4096,
       });
 
       // Verify OCR was called with base64 data URL
@@ -2350,7 +2354,7 @@ describe('MistralOCR Service', () => {
 
       expect(result).toEqual({
         filename: 'azure-document.pdf',
-        bytes: expect.any(Number),
+        bytes: 4096,
         filepath: 'azure_mistral_ocr',
         text: 'Azure OCR content\n\n',
         images: ['azure-base64'],

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -121,7 +121,7 @@ export async function getSignedUrl({
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
-  };
+  }; 
 
   const signedUrlTarget = `${baseURL}/files/${fileId}/url?expiry=${expiry}`;
   applyAxiosProxyConfig(config, signedUrlTarget);
@@ -449,7 +449,7 @@ export const uploadMistralOCR = async (context: OCRContext): Promise<MistralOCRU
 
     return {
       filename: context.file.originalname,
-      bytes: text.length * 4,
+      bytes: context.file.size,
       filepath: FileSources.mistral_ocr,
       text,
       images,
@@ -510,7 +510,7 @@ export const uploadAzureMistralOCR = async (
 
     return {
       filename: context.file.originalname,
-      bytes: text.length * 4,
+      bytes: context.file.size,
       filepath: FileSources.azure_mistral_ocr,
       text,
       images,
@@ -734,7 +734,7 @@ export const uploadGoogleVertexMistralOCR = async (
 
     return {
       filename: context.file.originalname,
-      bytes: text.length * 4,
+      bytes: context.file.size,
       filepath: FileSources.vertexai_mistral_ocr as string,
       text,
       images,


### PR DESCRIPTION
## Summary

Fixes https://github.com/danny-avila/LibreChat/issues/14825

The file sizes under Settings --> My Files contain estimates of the OCR size that do not reflect the actual file size

## Change Type

Bug fix (non-breaking change which fixes an issue)

## Testing

on main
1. Upload a PDF file
2. Go to Settings --> My Files
3. See that the file size **is not** reflecting the actual file size

on this branch
1. Upload a PDF file
2. Go to Settings --> My Files
3. See that the file size **is** reflecting the actual file size

### **Test Configuration**:

no special configuration needed, ensure file uploads are enabled

## Checklist

Please delete any irrelevant options.

- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
