### PR TITLE
⏲️ test: Give ServerConfigsDB Mongo Hooks a 60s Timeout Budget

### DIFF
--- a/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
@@ -77,12 +77,15 @@ beforeAll(async () => {
   await dbMethods.seedDefaultRoles();
 
   serverConfigsDB = new ServerConfigsDB(mongoose);
-});
+  /** Booting a real mongod, resetting the module registry and re-importing
+   *  data-schemas costs more than the 15s global `testTimeout`, once the runner
+   *  is busy enough. Matches `checkpointer.integration.spec.ts`. */
+}, 60000);
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer.stop();
-});
+}, 60000);
 
 beforeEach(async () => {
   // Clear collections except AccessRole


### PR DESCRIPTION
## Problem

`ServerConfigsDB.test.ts`'s `beforeAll` does a lot before a single test runs:

```ts
jest.resetModules();
await import('@librechat/data-schemas');   // + ServerConfigsDB, ~/mcp/oauth
mongoServer = await MongoMemoryServer.create();   // boots a real mongod
await mongoose.connect(mongoUri);
createModels(mongoose);
await dbMethods.seedDefaultRoles();
```

That exceeds the 15s global `testTimeout` in `packages/api/jest.config.mjs` once
the runner is busy. The suite completes in **~4.5s on its own**, but has been
observed at **16.8s** under a loaded `@librechat/api` shard — and when the hook
times out, *every* test in the file fails with:

```
thrown: "Exceeded timeout of 15000 ms for a hook.
  at Object.beforeAll (src/mcp/registry/__tests__/ServerConfigsDB.test.ts:43:1)
```

It reproduces the same way locally: green run alone, times out when run
alongside the rest of the MCP suites.

## Change

Give both mongo hooks an explicit 60s budget.

This follows the existing convention rather than introducing one —
`checkpointer.integration.spec.ts` is the other `MongoMemoryServer` suite in
this package and already opts out of the global default with `}, 60000)`
(`load.spec.ts` uses `}, 20000)`).

`afterAll` gets the same treatment, since `mongoServer.stop()` is subject to the
same contention as the boot.

## Why not raise `testTimeout` globally

15s is a reasonable guard for ordinary tests, and raising it would slow down
detection of genuine hangs across the whole package. Only the hooks that boot a
database need the larger budget.

## Verification

- `82/82` pass, 11.3s.
- ESLint + Prettier clean.
- No behaviour change: the timeout only bounds setup, and the suite still
  finishes well inside it.