### PR TITLE
🪄 feat: Smooth Activity Phase Transitions

### DIFF
--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -36,9 +36,7 @@ export default function ActivityPhaseGroup({
   /** Capture the marker's arrival state. The parent renderer records the new
    *  marker after this commit; a later sibling update must not cancel the
    *  already-scheduled compression before its first animation frame. */
-  const [shouldAnimateEntrance] = useState(
-    smoothStreaming && animateEntrance && label.length > 0,
-  );
+  const [shouldAnimateEntrance] = useState(smoothStreaming && animateEntrance && label.length > 0);
   /** A newly filled phase replaces activity that was already visible in the
    *  transcript. Keep that content in place for the first painted frame,
    *  then compress it into the summary instead of replacing it with a closed

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -1,7 +1,11 @@
+import { useId, useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@librechat/client';
 import { ChevronDown, ListTree } from 'lucide-react';
 import { ContentTypes } from 'librechat-data-provider';
 import type { TMessageContentParts } from 'librechat-data-provider';
 import type { ReactNode } from 'react';
+import { useExpandCollapse, scheduleMessageContentLayoutReconcile } from '~/hooks';
+import useSmoothStreaming from '~/hooks/Messages/useSmoothStreaming';
 import { getActivityLabelText } from '~/utils/activityLabels';
 import { EmptyText } from './Parts';
 import Container from './Container';
@@ -18,14 +22,78 @@ export default function ActivityPhaseGroup({
   children,
   hasContent,
   showCursor = false,
+  animateEntrance = false,
 }: {
   labelPart: ActivityPhasePart;
   children: ReactNode;
   hasContent: boolean;
   showCursor?: boolean;
+  animateEntrance?: boolean;
 }) {
   const label = getActivityLabelText(labelPart);
   const hasFailure = labelPart.status === 'failed' || labelPart.status === 'partial';
+  const smoothStreaming = useSmoothStreaming();
+  /** Capture the marker's arrival state. The parent renderer records the new
+   *  marker after this commit; a later sibling update must not cancel the
+   *  already-scheduled compression before its first animation frame. */
+  const [shouldAnimateEntrance] = useState(
+    smoothStreaming && animateEntrance && label.length > 0,
+  );
+  /** A newly filled phase replaces activity that was already visible in the
+   *  transcript. Keep that content in place for the first painted frame,
+   *  then compress it into the summary instead of replacing it with a closed
+   *  disclosure in one jarring cut. Historical phases remain closed. */
+  const [isExpanded, setIsExpanded] = useState(shouldAnimateEntrance && hasContent);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const panelId = useId();
+  const collapseFrameRef = useRef<number>();
+  const cancelLayoutReconcileRef = useRef<(() => void) | null>(null);
+  const previousIsExpandedRef = useRef(isExpanded);
+  const userOverrideRef = useRef(false);
+  const { style: expandStyle, ref: expandRef } = useExpandCollapse(isExpanded);
+
+  useEffect(() => {
+    if (!shouldAnimateEntrance || !hasContent || userOverrideRef.current) {
+      return;
+    }
+    collapseFrameRef.current = window.requestAnimationFrame(() => {
+      collapseFrameRef.current = undefined;
+      if (!userOverrideRef.current) {
+        setIsExpanded(false);
+      }
+    });
+    return () => {
+      if (collapseFrameRef.current != null) {
+        window.cancelAnimationFrame(collapseFrameRef.current);
+        collapseFrameRef.current = undefined;
+      }
+    };
+  }, [shouldAnimateEntrance, hasContent]);
+
+  useEffect(() => {
+    const wasExpanded = previousIsExpandedRef.current;
+    previousIsExpandedRef.current = isExpanded;
+    if (wasExpanded && !isExpanded) {
+      cancelLayoutReconcileRef.current?.();
+      cancelLayoutReconcileRef.current = scheduleMessageContentLayoutReconcile(rootRef.current);
+    }
+  }, [isExpanded]);
+
+  useEffect(
+    () => () => {
+      cancelLayoutReconcileRef.current?.();
+    },
+    [],
+  );
+
+  const handleToggle = useCallback(() => {
+    userOverrideRef.current = true;
+    if (collapseFrameRef.current != null) {
+      window.cancelAnimationFrame(collapseFrameRef.current);
+      collapseFrameRef.current = undefined;
+    }
+    setIsExpanded((expanded) => !expanded);
+  }, []);
   const cursor = showCursor ? (
     <Container>
       <EmptyText />
@@ -35,15 +103,21 @@ export default function ActivityPhaseGroup({
     return <>{children}</>;
   }
   const group = !hasContent ? (
-    <div className="my-2 flex min-h-10 w-full items-center gap-2 rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary">
+    <div
+      className={cn(
+        'my-2 flex min-h-10 w-full items-center gap-2 rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary',
+        shouldAnimateEntrance &&
+          'duration-300 animate-in fade-in-0 slide-in-from-bottom-1 motion-reduce:animate-none',
+      )}
+    >
       <ListTree
-        className={cn('size-4 shrink-0', hasFailure && 'text-amber-600 dark:text-amber-400')}
+        className={cn('size-4 shrink-0', hasFailure && 'text-text-warning')}
         aria-hidden="true"
       />
       <span
         className={cn(
           'min-w-0 flex-1 truncate text-sm font-medium',
-          hasFailure && 'text-amber-600 dark:text-amber-400',
+          hasFailure && 'text-text-warning',
         )}
         role="status"
         title={label}
@@ -52,32 +126,56 @@ export default function ActivityPhaseGroup({
       </span>
     </div>
   ) : (
-    <details className="group/activity-phase my-2 w-full rounded-lg border border-border-light bg-surface-secondary/40">
-      <summary
-        className="flex min-h-10 cursor-pointer list-none items-center gap-2 px-3 py-2 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary [&::-webkit-details-marker]:hidden"
+    <div
+      className="my-2 w-full rounded-lg border border-border-light bg-surface-secondary/40"
+      ref={rootRef}
+    >
+      <Button
+        variant="ghost"
+        type="button"
+        className={cn(
+          'flex h-auto min-h-10 w-full items-center justify-start gap-2 rounded-lg bg-transparent px-3 py-2 text-text-secondary hover:bg-surface-hover hover:text-text-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary focus-visible:ring-offset-0',
+          shouldAnimateEntrance &&
+            'duration-300 animate-in fade-in-0 slide-in-from-bottom-1 motion-reduce:animate-none',
+        )}
+        onClick={handleToggle}
+        aria-expanded={isExpanded}
+        aria-controls={panelId}
         aria-label={label}
         title={label}
       >
         <ListTree
-          className={cn('size-4 shrink-0', hasFailure && 'text-amber-600 dark:text-amber-400')}
+          className={cn('size-4 shrink-0', hasFailure && 'text-text-warning')}
           aria-hidden="true"
         />
         <span
           className={cn(
             'min-w-0 flex-1 truncate text-sm font-medium',
-            hasFailure && 'text-amber-600 dark:text-amber-400',
+            hasFailure && 'text-text-warning',
           )}
           role="status"
         >
           {label}
         </span>
         <ChevronDown
-          className="size-4 shrink-0 transition-transform duration-200 group-open/activity-phase:rotate-180"
+          className={cn(
+            'size-4 shrink-0 transition-transform duration-200 ease-out',
+            isExpanded && 'rotate-180',
+          )}
           aria-hidden="true"
         />
-      </summary>
-      <div className="border-t border-border-light px-3 py-2">{children}</div>
-    </details>
+      </Button>
+      <div
+        id={panelId}
+        style={expandStyle}
+        aria-hidden={!isExpanded}
+        data-testid="activity-phase-panel"
+      >
+        <div className="overflow-hidden" ref={expandRef}>
+          <div className="border-t border-border-light px-3 py-2">{children}</div>
+        </div>
+      </div>
+    </div>
   );
   return (
     <>

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -1,21 +1,52 @@
-import { useId, useCallback, useEffect, useRef, useState } from 'react';
+import { useId, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@librechat/client';
-import { ChevronDown, ListTree } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { ContentTypes } from 'librechat-data-provider';
 import type { TMessageContentParts } from 'librechat-data-provider';
-import type { ReactNode } from 'react';
-import { useExpandCollapse, scheduleMessageContentLayoutReconcile } from '~/hooks';
+import type { CSSProperties, ReactNode } from 'react';
+import {
+  useExpandCollapse,
+  scheduleMessageContentLayoutReconcile,
+  EXPAND_TRANSITION,
+} from '~/hooks';
 import useSmoothStreaming from '~/hooks/Messages/useSmoothStreaming';
 import { getActivityLabelText } from '~/utils/activityLabels';
 import { EmptyText } from './Parts';
 import Container from './Container';
 import { cn } from '~/utils';
 
+/** Matches `EXPAND_TRANSITION` so the header, the panel, and the card chrome
+ *  all resolve on the same curve — three properties animating on two different
+ *  easings is what makes a fold read as two separate movements. */
+const FOLD_EASING = 'duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]';
+
 type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
   activity_label_type?: 'phase';
   activity_start_index?: number;
   activity_end_index?: number;
 };
+
+/**
+ * Runs `callback` once the browser has painted the current styles. One frame
+ * is not enough: React can flush passive effects before paint, and a start
+ * value the compositor never saw produces an instant jump rather than a
+ * transition. Returns a canceller for whichever frame is still pending.
+ */
+function schedulePostPaint(callback: () => void): () => void {
+  let frameId: number | undefined;
+  frameId = window.requestAnimationFrame(() => {
+    frameId = window.requestAnimationFrame(() => {
+      frameId = undefined;
+      callback();
+    });
+  });
+  return () => {
+    if (frameId != null) {
+      window.cancelAnimationFrame(frameId);
+      frameId = undefined;
+    }
+  };
+}
 
 export default function ActivityPhaseGroup({
   labelPart,
@@ -35,38 +66,43 @@ export default function ActivityPhaseGroup({
   const smoothStreaming = useSmoothStreaming();
   /** Capture the marker's arrival state. The parent renderer records the new
    *  marker after this commit; a later sibling update must not cancel the
-   *  already-scheduled compression before its first animation frame. */
+   *  already-scheduled fold before its first animation frame. */
   const [shouldAnimateEntrance] = useState(smoothStreaming && animateEntrance && label.length > 0);
-  /** A newly filled phase replaces activity that was already visible in the
-   *  transcript. Keep that content in place for the first painted frame,
-   *  then compress it into the summary instead of replacing it with a closed
-   *  disclosure in one jarring cut. Historical phases remain closed. */
-  const [isExpanded, setIsExpanded] = useState(shouldAnimateEntrance && hasContent);
+  /** A filled phase marker lands on top of activity the reader is already
+   *  looking at. The card therefore mounts in the shape of what was there
+   *  BEFORE it — header at zero height, panel open, chrome transparent — and
+   *  folds into the summary on the next painted frame. Growing the header
+   *  while the panel collapses keeps the block's height strictly decreasing,
+   *  so the content compresses upward instead of being shoved down by a
+   *  header that appeared underneath it and then yanked back up. */
+  const foldsIn = shouldAnimateEntrance && hasContent;
+  const [isExpanded, setIsExpanded] = useState(foldsIn);
+  const [isSettled, setIsSettled] = useState(!foldsIn);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const panelId = useId();
-  const collapseFrameRef = useRef<number>();
+  const cancelEntranceRef = useRef<(() => void) | null>(null);
   const cancelLayoutReconcileRef = useRef<(() => void) | null>(null);
   const previousIsExpandedRef = useRef(isExpanded);
   const userOverrideRef = useRef(false);
   const { style: expandStyle, ref: expandRef } = useExpandCollapse(isExpanded);
 
   useEffect(() => {
-    if (!shouldAnimateEntrance || !hasContent || userOverrideRef.current) {
+    if (!foldsIn || userOverrideRef.current) {
       return;
     }
-    collapseFrameRef.current = window.requestAnimationFrame(() => {
-      collapseFrameRef.current = undefined;
-      if (!userOverrideRef.current) {
-        setIsExpanded(false);
+    cancelEntranceRef.current = schedulePostPaint(() => {
+      cancelEntranceRef.current = null;
+      if (userOverrideRef.current) {
+        return;
       }
+      setIsSettled(true);
+      setIsExpanded(false);
     });
     return () => {
-      if (collapseFrameRef.current != null) {
-        window.cancelAnimationFrame(collapseFrameRef.current);
-        collapseFrameRef.current = undefined;
-      }
+      cancelEntranceRef.current?.();
+      cancelEntranceRef.current = null;
     };
-  }, [shouldAnimateEntrance, hasContent]);
+  }, [foldsIn]);
 
   useEffect(() => {
     const wasExpanded = previousIsExpandedRef.current;
@@ -86,12 +122,26 @@ export default function ActivityPhaseGroup({
 
   const handleToggle = useCallback(() => {
     userOverrideRef.current = true;
-    if (collapseFrameRef.current != null) {
-      window.cancelAnimationFrame(collapseFrameRef.current);
-      collapseFrameRef.current = undefined;
-    }
+    cancelEntranceRef.current?.();
+    cancelEntranceRef.current = null;
+    setIsSettled(true);
     setIsExpanded((expanded) => !expanded);
   }, []);
+
+  /** Only the folding entrance drives the header off its natural height.
+   *  History and reduced-motion render the plain, unstyled row. */
+  const headerStyle = useMemo<CSSProperties | undefined>(() => {
+    if (!foldsIn) {
+      return undefined;
+    }
+    return {
+      display: 'grid',
+      gridTemplateRows: isSettled ? '1fr' : '0fr',
+      transition: EXPAND_TRANSITION,
+      opacity: isSettled ? 1 : 0,
+    };
+  }, [foldsIn, isSettled]);
+
   const cursor = showCursor ? (
     <Container>
       <EmptyText />
@@ -103,18 +153,13 @@ export default function ActivityPhaseGroup({
   const group = !hasContent ? (
     <div
       className={cn(
-        'my-2 flex min-h-10 w-full items-center gap-2 rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary',
-        shouldAnimateEntrance &&
-          'duration-300 animate-in fade-in-0 slide-in-from-bottom-1 motion-reduce:animate-none',
+        'my-2 flex min-h-10 w-full items-center rounded-lg border border-border-light bg-surface-secondary/40 px-3 py-2 text-text-secondary',
+        shouldAnimateEntrance && `animate-in fade-in-0 motion-reduce:animate-none ${FOLD_EASING}`,
       )}
     >
-      <ListTree
-        className={cn('size-4 shrink-0', hasFailure && 'text-text-warning')}
-        aria-hidden="true"
-      />
       <span
         className={cn(
-          'min-w-0 flex-1 truncate text-sm font-medium',
+          'min-w-0 flex-1 truncate text-left text-sm font-medium',
           hasFailure && 'text-text-warning',
         )}
         role="status"
@@ -125,44 +170,44 @@ export default function ActivityPhaseGroup({
     </div>
   ) : (
     <div
-      className="my-2 w-full rounded-lg border border-border-light bg-surface-secondary/40"
+      className={cn(
+        'my-2 w-full rounded-lg border transition-colors',
+        FOLD_EASING,
+        isSettled ? 'border-border-light bg-surface-secondary/40' : 'border-transparent',
+      )}
       ref={rootRef}
     >
-      <Button
-        variant="ghost"
-        type="button"
-        className={cn(
-          'flex h-auto min-h-10 w-full items-center justify-start gap-2 rounded-lg bg-transparent px-3 py-2 text-text-secondary hover:bg-surface-hover hover:text-text-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary focus-visible:ring-offset-0',
-          shouldAnimateEntrance &&
-            'duration-300 animate-in fade-in-0 slide-in-from-bottom-1 motion-reduce:animate-none',
-        )}
-        onClick={handleToggle}
-        aria-expanded={isExpanded}
-        aria-controls={panelId}
-        aria-label={label}
-        title={label}
-      >
-        <ListTree
-          className={cn('size-4 shrink-0', hasFailure && 'text-text-warning')}
-          aria-hidden="true"
-        />
-        <span
-          className={cn(
-            'min-w-0 flex-1 truncate text-sm font-medium',
-            hasFailure && 'text-text-warning',
-          )}
-          role="status"
-        >
-          {label}
-        </span>
-        <ChevronDown
-          className={cn(
-            'size-4 shrink-0 transition-transform duration-200 ease-out',
-            isExpanded && 'rotate-180',
-          )}
-          aria-hidden="true"
-        />
-      </Button>
+      <div style={headerStyle}>
+        <div className="overflow-hidden">
+          <Button
+            variant="ghost"
+            type="button"
+            className="flex h-auto min-h-10 w-full items-center justify-start gap-2 rounded-lg bg-transparent px-3 py-2 text-left text-text-secondary hover:bg-surface-hover hover:text-text-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary focus-visible:ring-offset-0"
+            onClick={handleToggle}
+            aria-expanded={isExpanded}
+            aria-controls={panelId}
+            aria-label={label}
+            title={label}
+          >
+            <span
+              className={cn(
+                'min-w-0 flex-1 truncate text-left text-sm font-medium',
+                hasFailure && 'text-text-warning',
+              )}
+              role="status"
+            >
+              {label}
+            </span>
+            <ChevronDown
+              className={cn(
+                'size-4 shrink-0 transition-transform duration-200 ease-out',
+                isExpanded && 'rotate-180',
+              )}
+              aria-hidden="true"
+            />
+          </Button>
+        </div>
+      </div>
       <div
         id={panelId}
         style={expandStyle}
@@ -170,7 +215,19 @@ export default function ActivityPhaseGroup({
         data-testid="activity-phase-panel"
       >
         <div className="overflow-hidden" ref={expandRef}>
-          <div className="border-t border-border-light px-3 py-2">{children}</div>
+          {/** Padding and the divider ride the same curve as the fold: the
+           *   children occupy the exact position they held before the marker
+           *   arrived and settle into the card as it materializes, instead of
+           *   stepping sideways by the card's inset on the first frame. */}
+          <div
+            className={cn(
+              'border-t transition-[border-color,padding]',
+              FOLD_EASING,
+              isSettled ? 'border-border-light px-3 py-2' : 'border-transparent px-0 py-0',
+            )}
+          >
+            {children}
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ActivityPhaseGroup.tsx
@@ -18,7 +18,7 @@ import { cn } from '~/utils';
 /** Matches `EXPAND_TRANSITION` so the header, the panel, and the card chrome
  *  all resolve on the same curve — three properties animating on two different
  *  easings is what makes a fold read as two separate movements. */
-const FOLD_EASING = 'duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]';
+const FOLD_EASING = 'duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none';
 
 type ActivityPhasePart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }> & {
   activity_label_type?: 'phase';
@@ -200,7 +200,7 @@ export default function ActivityPhaseGroup({
             </span>
             <ChevronDown
               className={cn(
-                'size-4 shrink-0 transition-transform duration-200 ease-out',
+                'size-4 shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none',
                 isExpanded && 'rotate-180',
               )}
               aria-hidden="true"

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useMemo, useCallback, Fragment } from 'react';
+import { memo, useRef, useMemo, useEffect, useCallback, Fragment } from 'react';
 import { ContentTypes } from 'librechat-data-provider';
 import type {
   TMessageContentParts,
@@ -215,6 +215,20 @@ const ContentParts = memo(function ContentParts({
     (localIndex: number) => contentIndices?.[localIndex] ?? localIndex + contentIndexOffset,
     [contentIndexOffset, contentIndices],
   );
+  const phaseSegments = nestedActivityPhase ? undefined : groupActivityPhases(content);
+  const completedPhaseIndices = new Set(
+    phaseSegments?.flatMap((segment) => (segment.type === 'phase' ? [segment.labelIndex] : [])) ??
+      [],
+  );
+  /** A phase label can finish after the root text stream settles, so
+   *  `isSubmitting` is not a reliable entrance signal. Compare committed
+   *  phase markers instead: a marker that appears after this renderer has
+   *  mounted is live; markers present on the first render are history. */
+  const previousPhaseIndicesRef = useRef<Set<number> | null>(null);
+  const previousPhaseIndices = previousPhaseIndicesRef.current;
+  useEffect(() => {
+    previousPhaseIndicesRef.current = completedPhaseIndices;
+  });
 
   const handleGroupExpansionChange = useCallback(
     (groupId: string, state: ToolCallGroupExpansionState) => {
@@ -452,7 +466,6 @@ const ContentParts = memo(function ContentParts({
     );
   }
 
-  const phaseSegments = nestedActivityPhase ? undefined : groupActivityPhases(content);
   if (phaseSegments != null) {
     const relativeGlobalLastContentIdx = lastVisibleContentIdx(content ?? []);
     const globalLastContentIdx =
@@ -500,6 +513,9 @@ const ContentParts = memo(function ContentParts({
                 key={`activity-phase-${messageId}-${segment.labelIndex}`}
                 labelPart={segment.labelPart}
                 hasContent={segment.hasContent}
+                animateEntrance={
+                  previousPhaseIndices != null && !previousPhaseIndices.has(segment.labelIndex)
+                }
                 showCursor={
                   isLast &&
                   effectiveIsSubmitting &&

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -215,11 +215,22 @@ const ContentParts = memo(function ContentParts({
     (localIndex: number) => contentIndices?.[localIndex] ?? localIndex + contentIndexOffset,
     [contentIndexOffset, contentIndices],
   );
-  const phaseSegments = nestedActivityPhase ? undefined : groupActivityPhases(content);
-  const completedPhaseIndices = new Set(
-    phaseSegments?.flatMap((segment) => (segment.type === 'phase' ? [segment.labelIndex] : [])) ??
-      [],
+  /** Hoisted above the early returns to feed the entrance-detection hook
+   *  below, so it is memoized rather than re-walked on every unrelated
+   *  re-render of a message that has no phases at all. */
+  const phaseSegments = useMemo(
+    () => (nestedActivityPhase ? undefined : groupActivityPhases(content)),
+    [nestedActivityPhase, content],
   );
+  const completedPhaseIndices = useMemo(() => {
+    const indices = new Set<number>();
+    for (const segment of phaseSegments ?? []) {
+      if (segment.type === 'phase') {
+        indices.add(segment.labelIndex);
+      }
+    }
+    return indices;
+  }, [phaseSegments]);
   /** A phase label can finish after the root text stream settles, so
    *  `isSubmitting` is not a reliable entrance signal. Compare committed
    *  phase markers instead: a marker that appears after this renderer has
@@ -228,7 +239,7 @@ const ContentParts = memo(function ContentParts({
   const previousPhaseIndices = previousPhaseIndicesRef.current;
   useEffect(() => {
     previousPhaseIndicesRef.current = completedPhaseIndices;
-  });
+  }, [completedPhaseIndices]);
 
   const handleGroupExpansionChange = useCallback(
     (groupId: string, state: ToolCallGroupExpansionState) => {

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -234,12 +234,18 @@ const ContentParts = memo(function ContentParts({
   /** A phase label can finish after the root text stream settles, so
    *  `isSubmitting` is not a reliable entrance signal. Compare committed
    *  phase markers instead: a marker that appears after this renderer has
-   *  mounted is live; markers present on the first render are history. */
-  const previousPhaseIndicesRef = useRef<Set<number> | null>(null);
-  const previousPhaseIndices = previousPhaseIndicesRef.current;
+   *  mounted is live; markers present on the first render are history.
+   *
+   *  The recorded set is scoped to the message it described. `MultiMessage`
+   *  renders siblings without a key, so this instance survives a sibling
+   *  switch with its refs intact — an unscoped set would report the previous
+   *  sibling's phases and animate the newly selected sibling's history. */
+  const previousPhaseRef = useRef<{ messageId: string; indices: Set<number> } | null>(null);
+  const previousPhaseIndices =
+    previousPhaseRef.current?.messageId === messageId ? previousPhaseRef.current.indices : null;
   useEffect(() => {
-    previousPhaseIndicesRef.current = completedPhaseIndices;
-  }, [completedPhaseIndices]);
+    previousPhaseRef.current = { messageId, indices: completedPhaseIndices };
+  }, [messageId, completedPhaseIndices]);
 
   const handleGroupExpansionChange = useCallback(
     (groupId: string, state: ToolCallGroupExpansionState) => {

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -166,7 +166,7 @@ const Part = memo(function Part({
     const failed = part.status === 'failed' || part.status === 'partial';
     return (
       <div
-        className={`my-1 break-words pl-1 text-sm italic ${failed ? 'text-amber-600 dark:text-amber-400' : 'text-text-secondary'}`}
+        className={`my-1 break-words pl-1 text-sm italic ${failed ? 'text-text-warning' : 'text-text-secondary'}`}
       >
         {display}
       </div>

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -379,7 +379,7 @@ export default function ToolCallGroup({
         <span
           className={cn(
             'tool-status-text min-w-0 truncate font-medium',
-            activityFailed && 'text-amber-600 dark:text-amber-400',
+            activityFailed && 'text-text-warning',
           )}
           role="status"
           title={groupLabel}

--- a/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
@@ -12,42 +12,58 @@ jest.mock('~/hooks/Messages/useSmoothStreaming', () => ({
 }));
 
 jest.mock('~/hooks', () => {
+  const expandCollapse = jest.requireActual('~/hooks/Messages/useExpandCollapse');
   return {
-    useExpandCollapse: jest.requireActual('~/hooks/Messages/useExpandCollapse').default,
+    useExpandCollapse: expandCollapse.default,
+    EXPAND_TRANSITION: expandCollapse.EXPAND_TRANSITION,
     scheduleMessageContentLayoutReconcile: (target: HTMLElement | null) =>
       mockScheduleLayoutReconcile(target),
   };
 });
 
+const LABEL = 'Compared both release paths';
+
 const labelPart = {
   type: ContentTypes.ACTIVITY_LABEL,
-  [ContentTypes.ACTIVITY_LABEL]: 'Compared both release paths',
+  [ContentTypes.ACTIVITY_LABEL]: LABEL,
   activity_label_type: 'phase',
   activity_start_index: 0,
   pending: false,
 } as unknown as Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }>;
 
 describe('ActivityPhaseGroup', () => {
-  let collapseFrame: FrameRequestCallback | undefined;
+  let frames: Array<FrameRequestCallback | undefined>;
   const originalRequestAnimationFrame = window.requestAnimationFrame;
   const originalCancelAnimationFrame = window.cancelAnimationFrame;
 
+  /** The fold waits for a painted start value, so it spans more than one
+   *  frame. Drain the queue the way a real compositor would. */
+  const flushFrames = () =>
+    act(() => {
+      for (let index = 0; index < frames.length; index += 1) {
+        const frame = frames[index];
+        frames[index] = undefined;
+        frame?.(index);
+      }
+    });
+
+  const pendingFrames = () => frames.filter((frame) => frame != null).length;
+
   beforeEach(() => {
-    collapseFrame = undefined;
+    frames = [];
     mockUseSmoothStreaming.mockReturnValue(true);
     mockScheduleLayoutReconcile.mockClear();
     Object.defineProperty(window, 'requestAnimationFrame', {
       configurable: true,
       writable: true,
-      value: jest.fn((callback: FrameRequestCallback) => {
-        collapseFrame = callback;
-        return 1;
-      }),
+      value: jest.fn((callback: FrameRequestCallback) => frames.push(callback)),
     });
     Object.defineProperty(window, 'cancelAnimationFrame', {
       configurable: true,
       writable: true,
-      value: jest.fn(),
+      value: jest.fn((handle: number) => {
+        frames[handle - 1] = undefined;
+      }),
     });
   });
 
@@ -75,21 +91,43 @@ describe('ActivityPhaseGroup', () => {
     expect(container.querySelector('.result-thinking')).toBeInTheDocument();
   });
 
-  test('compresses visible activity into a newly streamed parent label', () => {
+  test('renders the label flush left with no leading glyph', () => {
     render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    const trigger = screen.getByRole('button', { name: LABEL });
+    expect(trigger).toHaveClass('justify-start', 'text-left');
+    expect(screen.getByText(LABEL)).toHaveClass('flex-1', 'text-left');
+    expect(trigger.querySelectorAll('svg')).toHaveLength(1);
+  });
+
+  test('mounts in the pre-marker shape, then folds the activity into the summary', () => {
+    const { container } = render(
       <ActivityPhaseGroup labelPart={labelPart} hasContent animateEntrance>
         <div data-testid="phase-content" />
       </ActivityPhaseGroup>,
     );
 
-    const trigger = screen.getByRole('button', { name: 'Compared both release paths' });
+    const card = container.querySelector('.my-2') as HTMLElement;
+    const trigger = screen.getByRole('button', { name: LABEL });
+    const header = trigger.parentElement?.parentElement as HTMLElement;
     const panel = screen.getByTestId('activity-phase-panel');
+
+    /** Frame zero must be indistinguishable from the layout the marker
+     *  replaced: no chrome, no header height, activity still open. */
+    expect(card).toHaveClass('border-transparent');
+    expect(card).not.toHaveClass('bg-surface-secondary/40');
+    expect(header).toHaveStyle({ gridTemplateRows: '0fr', opacity: '0' });
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
     expect(panel).toHaveAttribute('aria-hidden', 'false');
-    expect(trigger).toHaveClass('animate-in', 'fade-in-0', 'slide-in-from-bottom-1');
 
-    act(() => collapseFrame?.(0));
+    flushFrames();
 
+    expect(header).toHaveStyle({ gridTemplateRows: '1fr', opacity: '1' });
+    expect(card).toHaveClass('border-border-light', 'bg-surface-secondary/40');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(panel).toHaveAttribute('aria-hidden', 'true');
     expect(mockScheduleLayoutReconcile).toHaveBeenCalledTimes(1);
@@ -102,10 +140,11 @@ describe('ActivityPhaseGroup', () => {
       </ActivityPhaseGroup>,
     );
 
-    const trigger = screen.getByRole('button', { name: 'Compared both release paths' });
+    const trigger = screen.getByRole('button', { name: LABEL });
+    const header = trigger.parentElement?.parentElement as HTMLElement;
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    expect(trigger).not.toHaveClass('animate-in');
-    expect(collapseFrame).toBeUndefined();
+    expect(header.getAttribute('style')).toBeNull();
+    expect(pendingFrames()).toBe(0);
 
     fireEvent.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -114,15 +153,43 @@ describe('ActivityPhaseGroup', () => {
   test('honors the smooth-streaming preference', () => {
     mockUseSmoothStreaming.mockReturnValue(false);
 
+    const { container } = render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent animateEntrance>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    const trigger = screen.getByRole('button', { name: LABEL });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(container.querySelector('.my-2')).toHaveClass('border-border-light');
+    expect(pendingFrames()).toBe(0);
+  });
+
+  test('a click during the entrance wins over the scheduled fold', () => {
     render(
       <ActivityPhaseGroup labelPart={labelPart} hasContent animateEntrance>
         <div data-testid="phase-content" />
       </ActivityPhaseGroup>,
     );
 
-    const trigger = screen.getByRole('button', { name: 'Compared both release paths' });
+    const trigger = screen.getByRole('button', { name: LABEL });
+    fireEvent.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    expect(trigger).not.toHaveClass('animate-in');
-    expect(collapseFrame).toBeUndefined();
+
+    flushFrames();
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('a phase without activity renders a label-only header', () => {
+    render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent={false} animateEntrance>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText(LABEL)).toHaveClass('text-left');
+    expect(pendingFrames()).toBe(0);
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ActivityPhaseGroup.test.tsx
@@ -1,7 +1,23 @@
-import { render } from '@testing-library/react';
 import { ContentTypes } from 'librechat-data-provider';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { TMessageContentParts } from 'librechat-data-provider';
 import ActivityPhaseGroup from '../ActivityPhaseGroup';
+
+const mockUseSmoothStreaming = jest.fn(() => true);
+const mockScheduleLayoutReconcile = jest.fn((_target: HTMLElement | null) => jest.fn());
+
+jest.mock('~/hooks/Messages/useSmoothStreaming', () => ({
+  __esModule: true,
+  default: () => mockUseSmoothStreaming(),
+}));
+
+jest.mock('~/hooks', () => {
+  return {
+    useExpandCollapse: jest.requireActual('~/hooks/Messages/useExpandCollapse').default,
+    scheduleMessageContentLayoutReconcile: (target: HTMLElement | null) =>
+      mockScheduleLayoutReconcile(target),
+  };
+});
 
 const labelPart = {
   type: ContentTypes.ACTIVITY_LABEL,
@@ -12,6 +28,43 @@ const labelPart = {
 } as unknown as Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }>;
 
 describe('ActivityPhaseGroup', () => {
+  let collapseFrame: FrameRequestCallback | undefined;
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  beforeEach(() => {
+    collapseFrame = undefined;
+    mockUseSmoothStreaming.mockReturnValue(true);
+    mockScheduleLayoutReconcile.mockClear();
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: jest.fn((callback: FrameRequestCallback) => {
+        collapseFrame = callback;
+        return 1;
+      }),
+    });
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalRequestAnimationFrame == null) {
+      Reflect.deleteProperty(window, 'requestAnimationFrame');
+    } else {
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+    if (originalCancelAnimationFrame == null) {
+      Reflect.deleteProperty(window, 'cancelAnimationFrame');
+    } else {
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   test('renders a streaming cursor after an active tail phase', () => {
     const { container } = render(
       <ActivityPhaseGroup labelPart={labelPart} hasContent showCursor>
@@ -20,5 +73,56 @@ describe('ActivityPhaseGroup', () => {
     );
 
     expect(container.querySelector('.result-thinking')).toBeInTheDocument();
+  });
+
+  test('compresses visible activity into a newly streamed parent label', () => {
+    render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent animateEntrance>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Compared both release paths' });
+    const panel = screen.getByTestId('activity-phase-panel');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(panel).toHaveAttribute('aria-hidden', 'false');
+    expect(trigger).toHaveClass('animate-in', 'fade-in-0', 'slide-in-from-bottom-1');
+
+    act(() => collapseFrame?.(0));
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(panel).toHaveAttribute('aria-hidden', 'true');
+    expect(mockScheduleLayoutReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps historical phases closed without replaying the entrance', () => {
+    render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Compared both release paths' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveClass('animate-in');
+    expect(collapseFrame).toBeUndefined();
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('honors the smooth-streaming preference', () => {
+    mockUseSmoothStreaming.mockReturnValue(false);
+
+    render(
+      <ActivityPhaseGroup labelPart={labelPart} hasContent animateEntrance>
+        <div data-testid="phase-content" />
+      </ActivityPhaseGroup>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Compared both release paths' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveClass('animate-in');
+    expect(collapseFrame).toBeUndefined();
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -69,8 +69,20 @@ jest.mock('../ToolCallGroup', () => ({
 
 jest.mock('../ActivityPhaseGroup', () => ({
   __esModule: true,
-  default: ({ children, showCursor }: { children: React.ReactNode; showCursor?: boolean }) => (
-    <div data-testid="activity-phase-group" data-show-cursor={String(showCursor === true)}>
+  default: ({
+    children,
+    showCursor,
+    animateEntrance,
+  }: {
+    children: React.ReactNode;
+    showCursor?: boolean;
+    animateEntrance?: boolean;
+  }) => (
+    <div
+      data-testid="activity-phase-group"
+      data-show-cursor={String(showCursor === true)}
+      data-animate-entrance={String(animateEntrance === true)}
+    >
       {children}
     </div>
   ),
@@ -350,6 +362,7 @@ describe('ContentParts — activity phase state', () => {
     const parent = screen.getByTestId('activity-phase-group');
     const finalPart = screen.getByTestId(`real-part-${ContentTypes.TEXT}`);
     expect(parent.compareDocumentPosition(finalPart)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(parent).toHaveAttribute('data-animate-entrance', 'false');
     expect(finalPart).toHaveAttribute('data-index', '2');
   });
 
@@ -448,6 +461,10 @@ describe('ContentParts — activity phase state', () => {
     rerender(<ContentParts {...baseProps} content={[...tools, completedPhase]} />);
 
     expect(screen.getByTestId('activity-phase-group')).toBeInTheDocument();
+    expect(screen.getByTestId('activity-phase-group')).toHaveAttribute(
+      'data-animate-entrance',
+      'true',
+    );
     expect(screen.getByTestId('tool-call-group')).toHaveAttribute('data-initial-expanded', 'false');
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -467,4 +467,41 @@ describe('ContentParts — activity phase state', () => {
     );
     expect(screen.getByTestId('tool-call-group')).toHaveAttribute('data-initial-expanded', 'false');
   });
+
+  test('does not replay the entrance when switching to a sibling with its own phases', () => {
+    const phase = (label: string) =>
+      ({
+        type: ContentTypes.ACTIVITY_LABEL,
+        [ContentTypes.ACTIVITY_LABEL]: label,
+        activity_label_type: 'phase',
+        activity_start_index: 0,
+        activity_count: 1,
+        pending: false,
+      }) as unknown as TMessageContentParts;
+
+    const tool = {
+      type: ContentTypes.TOOL_CALL,
+      [ContentTypes.TOOL_CALL]: { id: 'tool-1', name: 'search', args: {}, output: 'one' },
+    } as unknown as TMessageContentParts;
+
+    const { rerender } = render(
+      <ContentParts {...baseProps} messageId="sibling-a" content={[tool, phase('First')]} />,
+    );
+    expect(screen.getByTestId('activity-phase-group')).toHaveAttribute(
+      'data-animate-entrance',
+      'false',
+    );
+
+    /** MultiMessage swaps siblings without a key, so this instance keeps its
+     *  refs while messageId and content change wholesale. The incoming
+     *  sibling's phase is history and must not animate. */
+    rerender(
+      <ContentParts {...baseProps} messageId="sibling-b" content={[tool, tool, phase('Second')]} />,
+    );
+
+    expect(screen.getByTestId('activity-phase-group')).toHaveAttribute(
+      'data-animate-entrance',
+      'false',
+    );
+  });
 });

--- a/client/src/hooks/Messages/__tests__/useExpandCollapse.spec.tsx
+++ b/client/src/hooks/Messages/__tests__/useExpandCollapse.spec.tsx
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react';
+import useExpandCollapse, { EXPAND_TRANSITION } from '../useExpandCollapse';
+
+function stubReducedMotion(reduce: boolean) {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query.includes('prefers-reduced-motion') ? reduce : false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+describe('useExpandCollapse', () => {
+  const original = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = original;
+  });
+
+  test('animates the disclosure by default', () => {
+    stubReducedMotion(false);
+
+    const { result } = renderHook(() => useExpandCollapse(true));
+
+    expect(result.current.style.transition).toBe(EXPAND_TRANSITION);
+    expect(result.current.style.gridTemplateRows).toBe('1fr');
+    expect(result.current.style.opacity).toBe(1);
+  });
+
+  /** The transition is an inline style, so it cannot carry a media query.
+   *  Without this the panel still folds over 300ms for a reader who asked
+   *  the platform for no motion. */
+  test('drops the transition under prefers-reduced-motion', () => {
+    stubReducedMotion(true);
+
+    const { result } = renderHook(() => useExpandCollapse(true));
+
+    expect(result.current.style.transition).toBe('none');
+  });
+
+  test('still collapses to a zero row under reduced motion', () => {
+    stubReducedMotion(true);
+
+    const { result } = renderHook(() => useExpandCollapse(false));
+
+    expect(result.current.style.transition).toBe('none');
+    expect(result.current.style.gridTemplateRows).toBe('0fr');
+    expect(result.current.style.opacity).toBe(0);
+  });
+});

--- a/client/src/hooks/Messages/__tests__/useExpandCollapse.spec.tsx
+++ b/client/src/hooks/Messages/__tests__/useExpandCollapse.spec.tsx
@@ -1,5 +1,8 @@
 import { renderHook } from '@testing-library/react';
-import useExpandCollapse, { EXPAND_TRANSITION } from '../useExpandCollapse';
+import useExpandCollapse, {
+  EXPAND_TRANSITION,
+  REDUCED_MOTION_EXPAND_TRANSITION,
+} from '../useExpandCollapse';
 
 function stubReducedMotion(reduce: boolean) {
   window.matchMedia = jest.fn().mockImplementation((query: string) => ({
@@ -34,12 +37,26 @@ describe('useExpandCollapse', () => {
   /** The transition is an inline style, so it cannot carry a media query.
    *  Without this the panel still folds over 300ms for a reader who asked
    *  the platform for no motion. */
-  test('drops the transition under prefers-reduced-motion', () => {
+  test('collapses the duration under prefers-reduced-motion', () => {
     stubReducedMotion(true);
 
     const { result } = renderHook(() => useExpandCollapse(true));
 
-    expect(result.current.style.transition).toBe('none');
+    expect(result.current.style.transition).toBe(REDUCED_MOTION_EXPAND_TRANSITION);
+    expect(result.current.style.transition).not.toBe(EXPAND_TRANSITION);
+  });
+
+  /** `transition: none` would emit no `transitionend`, and ToolCallGroup
+   *  waits on that event to unmount a collapsed body. Keeping a real (if
+   *  imperceptible) transition preserves that completion signal. */
+  test('keeps a transition that still emits transitionend', () => {
+    stubReducedMotion(true);
+
+    const { result } = renderHook(() => useExpandCollapse(false));
+
+    expect(result.current.style.transition).not.toBe('none');
+    expect(result.current.style.transition).toContain('grid-template-rows');
+    expect(result.current.style.transition).toContain('opacity');
   });
 
   test('still collapses to a zero row under reduced motion', () => {
@@ -47,7 +64,6 @@ describe('useExpandCollapse', () => {
 
     const { result } = renderHook(() => useExpandCollapse(false));
 
-    expect(result.current.style.transition).toBe('none');
     expect(result.current.style.gridTemplateRows).toBe('0fr');
     expect(result.current.style.opacity).toBe(0);
   });

--- a/client/src/hooks/Messages/useExpandCollapse.ts
+++ b/client/src/hooks/Messages/useExpandCollapse.ts
@@ -6,6 +6,16 @@ export const EXPAND_TRANSITION =
   'grid-template-rows 0.3s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s cubic-bezier(0.16, 1, 0.3, 1)';
 
 /**
+ * Reduced motion shortens the duration instead of removing the transition.
+ * `transition: none` emits no `transitionend`, and consumers wait on that
+ * event to unmount a collapsed subtree — dropping it would leave every closed
+ * panel's children mounted for exactly the readers who opted out of motion.
+ * 0.01ms is imperceptible and still fires.
+ */
+export const REDUCED_MOTION_EXPAND_TRANSITION =
+  'grid-template-rows 0.01ms linear, opacity 0.01ms linear';
+
+/**
  * The disclosure motion is an inline style, so it cannot carry a
  * `prefers-reduced-motion` media query the way a utility class can. Resolve
  * the preference here instead and drop the transition outright — every
@@ -35,7 +45,7 @@ export default function useExpandCollapse(isExpanded: boolean): {
     () => ({
       display: 'grid',
       gridTemplateRows: isExpanded ? '1fr' : '0fr',
-      transition: reducedMotion ? 'none' : EXPAND_TRANSITION,
+      transition: reducedMotion ? REDUCED_MOTION_EXPAND_TRANSITION : EXPAND_TRANSITION,
       opacity: isExpanded ? 1 : 0,
     }),
     [isExpanded, reducedMotion],

--- a/client/src/hooks/Messages/useExpandCollapse.ts
+++ b/client/src/hooks/Messages/useExpandCollapse.ts
@@ -1,14 +1,22 @@
 import { useRef, useLayoutEffect, useMemo } from 'react';
+import { useMediaQuery } from '@librechat/client';
 import type { CSSProperties } from 'react';
 
 export const EXPAND_TRANSITION =
   'grid-template-rows 0.3s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s cubic-bezier(0.16, 1, 0.3, 1)';
 
+/**
+ * The disclosure motion is an inline style, so it cannot carry a
+ * `prefers-reduced-motion` media query the way a utility class can. Resolve
+ * the preference here instead and drop the transition outright — every
+ * expanding panel in the message content shares this hook.
+ */
 export default function useExpandCollapse(isExpanded: boolean): {
   style: CSSProperties;
   ref: React.RefObject<HTMLDivElement>;
 } {
   const ref = useRef<HTMLDivElement>(null);
+  const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
 
   useLayoutEffect(() => {
     const el = ref.current;
@@ -27,10 +35,10 @@ export default function useExpandCollapse(isExpanded: boolean): {
     () => ({
       display: 'grid',
       gridTemplateRows: isExpanded ? '1fr' : '0fr',
-      transition: EXPAND_TRANSITION,
+      transition: reducedMotion ? 'none' : EXPAND_TRANSITION,
       opacity: isExpanded ? 1 : 0,
     }),
-    [isExpanded],
+    [isExpanded, reducedMotion],
   );
 
   return { style, ref };

--- a/e2e/specs/mock/activity-phases.spec.ts
+++ b/e2e/specs/mock/activity-phases.spec.ts
@@ -214,7 +214,7 @@ test.describe('parent activity phases', () => {
     const finalTextIndex = content.findIndex((part) => contentPartText(part).includes(finalText));
     expect(finalTextIndex).toBe(phasePart?.activity_end_index);
 
-    const parent = messagesView(page).locator(`summary[aria-label="${PARENT_LABEL}"]`);
+    const parent = messagesView(page).getByRole('button', { name: PARENT_LABEL, exact: true });
     await expect(parent).toBeVisible({ timeout: 30000 });
     await expect(messagesView(page).getByText(finalText)).toBeVisible({ timeout: 30000 });
     await parent.click();
@@ -241,7 +241,10 @@ test.describe('parent activity phases', () => {
     ).toBe(true);
 
     await page.reload();
-    const reloadedParent = messagesView(page).locator(`summary[aria-label="${PARENT_LABEL}"]`);
+    const reloadedParent = messagesView(page).getByRole('button', {
+      name: PARENT_LABEL,
+      exact: true,
+    });
     await expect(reloadedParent).toBeVisible({ timeout: 30000 });
     await expect(messagesView(page).getByText(finalText)).toBeVisible();
     await reloadedParent.click();

--- a/packages/client/src/hooks/__tests__/useMediaQuery.spec.tsx
+++ b/packages/client/src/hooks/__tests__/useMediaQuery.spec.tsx
@@ -1,0 +1,66 @@
+import { renderHook, act } from '@testing-library/react';
+import useMediaQuery from '../useMediaQuery';
+
+type Listener = () => void;
+
+/** The shared setup installs a writable (not configurable) `matchMedia`, so
+ *  these stubs assign over it rather than redefining the property. */
+function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<Listener>();
+  const media = {
+    matches,
+    addEventListener: (_event: string, listener: Listener) => listeners.add(listener),
+    removeEventListener: (_event: string, listener: Listener) => listeners.delete(listener),
+  };
+  window.matchMedia = jest.fn(() => media) as unknown as typeof window.matchMedia;
+  return (next: boolean) => {
+    media.matches = next;
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+}
+
+describe('useMediaQuery', () => {
+  const original = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = original;
+  });
+
+  /** Callers that branch once at mount — freezing an entrance animation,
+   *  choosing a layout before paint — only ever see the first render. */
+  test('reports a match on the first render, before any effect runs', () => {
+    stubMatchMedia(true);
+
+    const { result } = renderHook(() => useMediaQuery('(prefers-reduced-motion: reduce)'));
+
+    expect(result.current).toBe(true);
+  });
+
+  test('reports no match on the first render when the query does not match', () => {
+    stubMatchMedia(false);
+
+    const { result } = renderHook(() => useMediaQuery('(prefers-reduced-motion: reduce)'));
+
+    expect(result.current).toBe(false);
+  });
+
+  test('tracks later changes to the query', () => {
+    const change = stubMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(false);
+
+    act(() => change(true));
+
+    expect(result.current).toBe(true);
+  });
+
+  test('falls back to no match where matchMedia is unavailable', () => {
+    window.matchMedia = undefined as unknown as typeof window.matchMedia;
+
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/client/src/hooks/useMediaQuery.tsx
+++ b/packages/client/src/hooks/useMediaQuery.tsx
@@ -1,9 +1,25 @@
 import { useEffect, useState } from 'react';
 
+function readMatches(query: string): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(query).matches;
+}
+
+/**
+ * Resolves the query on the FIRST render rather than after a passive effect.
+ * Callers that branch once at mount — freezing an entrance animation, picking
+ * a layout before paint — read the deferred value as "no match" and never see
+ * the correction, which is how `prefers-reduced-motion` came to be ignored.
+ */
 export default function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => readMatches(query));
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
     const media = window.matchMedia(query);
     if (media.matches !== matches) {
       setMatches(media.matches);


### PR DESCRIPTION
## Summary

I smoothed the moment a generated parent activity label replaces visible agent activity, aligning phase grouping with the recent smooth-streaming experience.

- Animate newly arriving phase headers with the existing fade and slide utilities.
- Preserve the visible activity for the first painted frame, then compress it into the parent summary with the shared expand/collapse motion.
- Detect labels added after the message renderer mounts so late label completions animate even after text streaming ends, while loaded history remains still.
- Respect the smooth-streaming and reduced-motion preference for automatic entrance motion.
- Reconcile message scroll position throughout the collapse and retain an accessible controlled disclosure afterward.
- Replace phase failure palette colors with the semantic warning text role.
- Cover live arrival, history hydration, preference gating, manual expansion, cursor rendering, and late phase completion.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran targeted import sorting checks for the four changed files.
- Ran `git diff --check` successfully.
- Added focused ActivityPhaseGroup and ContentParts tests. The focused Jest command could not start in the dependency-free worktree because the shared local install is missing `babel-plugin-transform-import-meta`; CI will run the test and typecheck matrix with the locked dependencies.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
