### PR TITLE
🪢 fix(langfuse): mark provider-backed agent traces

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -726,7 +726,8 @@ class BaseClient {
       this.abortController.requestCompleted = true;
     }
 
-    const isAgentResponse = isAgentsEndpoint(this.options.endpoint);
+    const isAgentResponse =
+      this.clientName === EModelEndpoint.agents || isAgentsEndpoint(this.options.endpoint);
     const langfuseTraceId = isAgentResponse ? traceIdForMessage(responseMessageId) : undefined;
     const langfuseSampled =
       langfuseTraceId != null ? isLangfuseTraceSampled(langfuseTraceId) : undefined;

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -13,9 +13,7 @@ const {
   encodeAndFormatVideos,
   getTransactionsConfig,
   encodeAndFormatDocuments,
-  getLangfuseTraceDestinationIds,
-  isLangfuseTraceSampled,
-  traceIdForMessage,
+  getLangfuseTraceMessageFields,
 } = require('@librechat/api');
 const {
   Constants,
@@ -728,9 +726,9 @@ class BaseClient {
 
     const isAgentResponse =
       this.clientName === EModelEndpoint.agents || isAgentsEndpoint(this.options.endpoint);
-    const langfuseTraceId = isAgentResponse ? traceIdForMessage(responseMessageId) : undefined;
-    const langfuseSampled =
-      langfuseTraceId != null ? isLangfuseTraceSampled(langfuseTraceId) : undefined;
+    const langfuseTraceFields = isAgentResponse
+      ? await getLangfuseTraceMessageFields(appConfig, responseMessageId)
+      : undefined;
 
     /** @type {TMessage} */
     const responseMessage = {
@@ -738,14 +736,7 @@ class BaseClient {
       conversationId,
       parentMessageId: userMessage.messageId,
       isCreatedByUser: false,
-      ...(isAgentResponse && {
-        langfuseSampled,
-        langfuseDestinationIds: await getLangfuseTraceDestinationIds(
-          appConfig,
-          langfuseTraceId,
-          langfuseSampled,
-        ),
-      }),
+      ...(langfuseTraceFields ?? {}),
       isEdited,
       model: this.getResponseModel(),
       sender: this.sender,

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -879,6 +879,8 @@ describe('BaseClient', () => {
 
     test('persists the Langfuse sampling decision for agent clients using a provider endpoint', async () => {
       const previousSampleRate = process.env.LANGFUSE_SAMPLE_RATE;
+      const previousClientName = TestClient.clientName;
+      const previousEndpoint = TestClient.options.endpoint;
       process.env.LANGFUSE_SAMPLE_RATE = '0';
       TestClient.clientName = 'agents';
       TestClient.options.endpoint = 'bedrock';
@@ -904,6 +906,8 @@ describe('BaseClient', () => {
         } else {
           process.env.LANGFUSE_SAMPLE_RATE = previousSampleRate;
         }
+        TestClient.clientName = previousClientName;
+        TestClient.options.endpoint = previousEndpoint;
       }
     });
 

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -877,6 +877,36 @@ describe('BaseClient', () => {
       }
     });
 
+    test('persists the Langfuse sampling decision for agent clients using a provider endpoint', async () => {
+      const previousSampleRate = process.env.LANGFUSE_SAMPLE_RATE;
+      process.env.LANGFUSE_SAMPLE_RATE = '0';
+      TestClient.clientName = 'agents';
+      TestClient.options.endpoint = 'bedrock';
+      const saveSpy = jest.spyOn(TestClient, 'saveMessageToDatabase');
+
+      try {
+        const response = await TestClient.sendMessage('Hello, world!', { user: {} });
+
+        expect(response.langfuseSampled).toBe(false);
+        expect(response.langfuseDestinationIds).toEqual([]);
+        expect(saveSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            endpoint: 'bedrock',
+            langfuseSampled: false,
+            langfuseDestinationIds: [],
+          }),
+          expect.any(Object),
+          expect.any(Object),
+        );
+      } finally {
+        if (previousSampleRate == null) {
+          delete process.env.LANGFUSE_SAMPLE_RATE;
+        } else {
+          process.env.LANGFUSE_SAMPLE_RATE = previousSampleRate;
+        }
+      }
+    });
+
     test('persists no Langfuse destination when a sampled trace has no configured export', async () => {
       const envKeys = [
         'LANGFUSE_PUBLIC_KEY',

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -152,6 +152,10 @@ jest.mock('@librechat/api', () => ({
   getTransactionsConfig: mockGetTransactionsConfig,
   recordCollectedUsage: mockRecordCollectedUsage,
   createSubagentUsageSink: jest.fn().mockReturnValue(jest.fn()),
+  getLangfuseTraceMessageFields: jest.fn().mockResolvedValue({
+    langfuseSampled: true,
+    langfuseDestinationIds: ['destination-1'],
+  }),
   extractManualSkills: jest.fn().mockReturnValue(undefined),
   injectSkillPrimes: jest.fn().mockReturnValue({
     initialMessages: [],
@@ -404,6 +408,28 @@ describe('createResponse controller', () => {
       'resource recovery required',
       'invalid_request',
       ErrorTypes.RESOURCE_RECOVERY_REQUIRED,
+    );
+  });
+
+  it('stores Langfuse trace markers with a persisted response', async () => {
+    const api = require('@librechat/api');
+    const { saveMessage } = require('~/models');
+    api.validateResponseRequest.mockReturnValueOnce({
+      request: { ...req.body, store: true },
+    });
+
+    await createResponse(req, res);
+
+    expect(api.getLangfuseTraceMessageFields).toHaveBeenCalledWith(req.config, 'resp_mock-123');
+    expect(saveMessage).toHaveBeenCalledWith(
+      req,
+      expect.objectContaining({
+        messageId: 'resp_mock-123',
+        isCreatedByUser: false,
+        langfuseSampled: true,
+        langfuseDestinationIds: ['destination-1'],
+      }),
+      { context: 'Responses API - save assistant response' },
     );
   });
 

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -48,6 +48,7 @@ const {
   sendResponsesErrorResponse,
   createResponsesEventHandlers,
   createAggregatorEventHandlers,
+  getLangfuseTraceMessageFields,
   stripActivityLabelParts,
 } = require('@librechat/api');
 const {
@@ -223,6 +224,8 @@ async function saveResponseOutput(req, conversationId, responseId, response, age
     }
   }
 
+  const langfuseTraceFields = await getLangfuseTraceMessageFields(req.config, responseId);
+
   // Save the assistant message
   await db.saveMessage(
     req,
@@ -231,6 +234,7 @@ async function saveResponseOutput(req, conversationId, responseId, response, age
       conversationId,
       parentMessageId: null,
       isCreatedByUser: false,
+      ...langfuseTraceFields,
       text: responseText,
       sender: 'Agent',
       endpoint: EModelEndpoint.agents,

--- a/packages/api/src/langfuse/destinations.ts
+++ b/packages/api/src/langfuse/destinations.ts
@@ -11,6 +11,7 @@ import {
 import { normalizeBoolean, resolveTenantCredentials, toBasicAuthorization } from './utils';
 import { resolveLangfuseTenantDestination } from './tenantDestinations';
 import { normalizeString } from '~/utils/text';
+import { traceIdForMessage } from './trace';
 
 const DEFAULT_BASE_URL = 'https://cloud.langfuse.com';
 const PROJECT_LOOKUP_TIMEOUT_MS = 10_000;
@@ -258,6 +259,22 @@ export async function getLangfuseTraceDestinationIds(
     return undefined;
   }
   return destinations.map(({ id }) => id as string);
+}
+
+export async function getLangfuseTraceMessageFields(
+  appConfig: AppConfig | undefined,
+  messageId: string,
+): Promise<{ langfuseSampled: boolean; langfuseDestinationIds?: string[] }> {
+  const traceId = traceIdForMessage(messageId);
+  const langfuseSampled = isLangfuseTraceSampled(traceId);
+  return {
+    langfuseSampled,
+    langfuseDestinationIds: await getLangfuseTraceDestinationIds(
+      appConfig,
+      traceId,
+      langfuseSampled,
+    ),
+  };
 }
 
 const centralPublicKey = normalizeString(process.env.LANGFUSE_PUBLIC_KEY);


### PR DESCRIPTION
## Summary

- recognize agent clients that persist their provider endpoint, such as Bedrock
- persist Langfuse sampling and destination markers for stored Responses API messages
- centralize message marker calculation across both persistence paths
- add regression coverage for provider-backed agents and stored Responses runs

Without these markers, traced conversations did not expose the Langfuse session link added in #14776. The OpenAI-compatible controller does not currently persist messages; future persistence can use the same marker helper.
