### PR TITLE
fix: preserve original agent files when detaching a duplicate

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -943,18 +943,23 @@ const duplicateAgentHandler = async (req, res) => {
       hour12: false,
     })})`;
 
-    if (_tool_resources?.[EToolResources.context]) {
-      cloneData.tool_resources = {
-        [EToolResources.context]: _tool_resources[EToolResources.context],
-      };
-    }
-
-    if (_tool_resources?.[EToolResources.ocr]) {
-      cloneData.tool_resources = {
+    /**
+     * Copy File Context onto the clone with a new `file_ids` array. Sharing the
+     * source object's array meant pruning or later edits mutated the original
+     * agent in memory (issue #14609).
+     */
+    const contextResource = _tool_resources?.[EToolResources.context];
+    const ocrResource = _tool_resources?.[EToolResources.ocr];
+    if (contextResource || ocrResource) {
+      const merged = {
+        ...(contextResource ?? {}),
         /** Legacy conversion from `ocr` to `context` */
+        ...(ocrResource ?? {}),
+      };
+      cloneData.tool_resources = {
         [EToolResources.context]: {
-          ...(_tool_resources[EToolResources.context] ?? {}),
-          ..._tool_resources[EToolResources.ocr],
+          ...merged,
+          file_ids: Array.isArray(merged.file_ids) ? [...merged.file_ids] : [],
         },
       };
     }

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -1325,6 +1325,43 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(agent.tool_resources.context.file_ids).toEqual([cloneAuthorFileId]);
     });
 
+    test('duplicateAgentHandler should copy File Context file_ids without mutating the source agent', async () => {
+      const authorId = new mongoose.Types.ObjectId();
+      const fileIdA = `file_${uuidv4()}`;
+      const fileIdB = `file_${uuidv4()}`;
+
+      await createFileDoc(fileIdA, authorId);
+      await createFileDoc(fileIdB, authorId);
+      const sourceAgent = await Agent.create({
+        id: `agent_${uuidv4()}`,
+        name: 'Source Agent',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: authorId,
+        tool_resources: {
+          context: { file_ids: [fileIdA, fileIdB] },
+        },
+      });
+
+      const db = require('~/models');
+      jest.spyOn(db, 'getActions').mockResolvedValueOnce([]);
+
+      mockReq.user.id = authorId.toString();
+      mockReq.params.id = sourceAgent.id;
+
+      await duplicateAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+      const { agent } = mockRes.json.mock.calls[0][0];
+      expect(agent.tool_resources.context.file_ids).toEqual([fileIdA, fileIdB]);
+      expect(agent.tool_resources.context.file_ids).not.toBe(
+        sourceAgent.tool_resources.context.file_ids,
+      );
+
+      const sourceInDb = await Agent.findOne({ id: sourceAgent.id }).lean();
+      expect(sourceInDb.tool_resources.context.file_ids).toEqual([fileIdA, fileIdB]);
+    });
+
     test('revertAgentVersionHandler should preserve restored attached file_ids with metadata', async () => {
       const agentAuthorId = new mongoose.Types.ObjectId();
       const otherUserId = new mongoose.Types.ObjectId();

--- a/api/server/services/Files/process.integration.spec.js
+++ b/api/server/services/Files/process.integration.spec.js
@@ -182,6 +182,35 @@ describe('processDeleteRequest — agent reference cleanup (issue #12776)', () =
     expect(after.tool_resources.file_search.file_ids).toEqual(['other_id']);
   });
 
+  test('detaching a duplicated agent file leaves the original agent and file intact', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const sharedId = `file_shared_${Math.random().toString(36).slice(2, 10)}`;
+    const sharedFile = await seedFile(sharedId, userId);
+
+    const originalAgent = await seedAgent(userId, {
+      context: { file_ids: [sharedId] },
+    });
+    const clonedAgent = await seedAgent(userId, {
+      context: { file_ids: [sharedId] },
+    });
+
+    await processDeleteRequest({
+      req: buildReq([sharedFile.toObject()], {
+        agent_id: clonedAgent.id,
+        tool_resource: 'context',
+      }),
+      files: [sharedFile],
+    });
+
+    expect(await File.findOne({ file_id: sharedId })).not.toBeNull();
+
+    const updatedOriginal = await Agent.findOne({ id: originalAgent.id }).lean();
+    const updatedClone = await Agent.findOne({ id: clonedAgent.id }).lean();
+
+    expect(updatedOriginal.tool_resources.context.file_ids).toEqual([sharedId]);
+    expect(updatedClone.tool_resources.context.file_ids).toEqual([]);
+  });
+
   test('still deletes the file when the agent cleanup step throws', async () => {
     const userId = new mongoose.Types.ObjectId();
     const targetId = `file_target_${Math.random().toString(36).slice(2, 10)}`;

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -241,6 +241,23 @@ const processDeleteRequest = async ({ req, files }) => {
   }
 
   const agentFiles = [];
+  const fileIdsToDelete = files.map((file) => file.file_id).filter(Boolean);
+  /**
+   * Duplicate Agent copies File Context `file_ids` onto the clone. Deleting
+   * from the clone's File Context must detach that agent only — physically
+   * deleting a file still referenced by another agent (then unlinking every
+   * agent via `removeAgentResourceFilesFromAllAgents`) is issue #14609.
+   */
+  const sharedFileIds = new Set();
+  if (req.body.agent_id && fileIdsToDelete.length > 0) {
+    const referenced = await db.findFileIdsReferencedByAgents({
+      file_ids: fileIdsToDelete,
+      excludeAgentId: req.body.agent_id,
+    });
+    for (const id of referenced ?? []) {
+      sharedFileIds.add(id);
+    }
+  }
 
   for (const file of files) {
     const source = file.source ?? FileSources.local;
@@ -249,6 +266,10 @@ const processDeleteRequest = async ({ req, files }) => {
         tool_resource: req.body.tool_resource,
         file_id: file.file_id,
       });
+    }
+
+    if (sharedFileIds.has(file.file_id)) {
+      continue;
     }
 
     if (source === FileSources.text) {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -96,6 +96,7 @@ jest.mock('~/models', () => ({
   addAgentResourceFile: jest.fn().mockResolvedValue({}),
   removeAgentResourceFiles: jest.fn(),
   removeAgentResourceFilesFromAllAgents: jest.fn(),
+  findFileIdsReferencedByAgents: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('~/server/utils/getFileStrategy', () => ({
@@ -1378,6 +1379,73 @@ describe('processDeleteRequest', () => {
     expect(codeDelete).toHaveBeenCalledWith(req, file);
     expect(db.deleteFiles).toHaveBeenCalledWith(['code-resource-file']);
     expect(result).toEqual({ deletedFileIds: ['code-resource-file'], failedFileIds: [] });
+  });
+
+  it('detaches a shared agent file without deleting storage still used by another agent', async () => {
+    db.findFileIdsReferencedByAgents.mockResolvedValue(['shared-file']);
+    db.removeAgentResourceFiles.mockResolvedValue({});
+
+    const result = await processDeleteRequest({
+      req: {
+        body: { agent_id: 'clone-agent', tool_resource: EToolResources.context },
+        config: {},
+        user: { id: 'user-123', tenantId: 'tenant-a' },
+      },
+      files: [
+        {
+          file_id: 'shared-file',
+          filepath: FileSources.text,
+          source: FileSources.text,
+        },
+      ],
+    });
+
+    expect(db.findFileIdsReferencedByAgents).toHaveBeenCalledWith({
+      file_ids: ['shared-file'],
+      excludeAgentId: 'clone-agent',
+    });
+    expect(db.removeAgentResourceFiles).toHaveBeenCalledWith({
+      agent_id: 'clone-agent',
+      files: [{ tool_resource: EToolResources.context, file_id: 'shared-file' }],
+    });
+    expect(db.deleteFiles).not.toHaveBeenCalled();
+    expect(db.removeAgentResourceFilesFromAllAgents).not.toHaveBeenCalled();
+    expect(result).toEqual({ deletedFileIds: [], failedFileIds: [] });
+  });
+
+  it('still deletes an agent file that no other agent references', async () => {
+    db.findFileIdsReferencedByAgents.mockResolvedValue([]);
+    db.removeAgentResourceFiles.mockResolvedValue({});
+    db.deleteFiles.mockResolvedValue({ deletedCount: 1 });
+    db.removeAgentResourceFilesFromAllAgents.mockResolvedValue({
+      matchedCount: 0,
+      modifiedCount: 0,
+    });
+
+    const result = await processDeleteRequest({
+      req: {
+        body: { agent_id: 'clone-agent', tool_resource: EToolResources.context },
+        config: {},
+        user: { id: 'user-123', tenantId: 'tenant-a' },
+      },
+      files: [
+        {
+          file_id: 'solo-file',
+          filepath: FileSources.text,
+          source: FileSources.text,
+        },
+      ],
+    });
+
+    expect(db.removeAgentResourceFiles).toHaveBeenCalledWith({
+      agent_id: 'clone-agent',
+      files: [{ tool_resource: EToolResources.context, file_id: 'solo-file' }],
+    });
+    expect(db.deleteFiles).toHaveBeenCalledWith(['solo-file']);
+    expect(db.removeAgentResourceFilesFromAllAgents).toHaveBeenCalledWith({
+      file_ids: ['solo-file'],
+    });
+    expect(result).toEqual({ deletedFileIds: ['solo-file'], failedFileIds: [] });
   });
 });
 

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -56,6 +56,7 @@ let revertAgentVersion: AgentMethods['revertAgentVersion'];
 let addAgentResourceFile: AgentMethods['addAgentResourceFile'];
 let removeAgentResourceFiles: AgentMethods['removeAgentResourceFiles'];
 let removeAgentResourceFilesFromAllAgents: AgentMethods['removeAgentResourceFilesFromAllAgents'];
+let findFileIdsReferencedByAgents: AgentMethods['findFileIdsReferencedByAgents'];
 let getListAgentsByAccess: AgentMethods['getListAgentsByAccess'];
 let generateActionMetadataHash: AgentMethods['generateActionMetadataHash'];
 
@@ -103,6 +104,7 @@ beforeAll(async () => {
   addAgentResourceFile = methods.addAgentResourceFile;
   removeAgentResourceFiles = methods.removeAgentResourceFiles;
   removeAgentResourceFilesFromAllAgents = methods.removeAgentResourceFilesFromAllAgents;
+  findFileIdsReferencedByAgents = methods.findFileIdsReferencedByAgents;
   getListAgentsByAccess = methods.getListAgentsByAccess;
   generateActionMetadataHash = methods.generateActionMetadataHash;
 
@@ -3255,6 +3257,46 @@ describe('Agent Methods', () => {
         const result = await removeAgentResourceFilesFromAllAgents({ file_ids: [fileId] });
         expect(result.matchedCount).toBe(0);
         expect(result.modifiedCount).toBe(0);
+      });
+    });
+
+    describe('findFileIdsReferencedByAgents', () => {
+      beforeEach(async () => {
+        await Agent.deleteMany({});
+      });
+
+      test('returns file_ids still attached to other agents', async () => {
+        const sharedFileId = `file_${uuidv4()}`;
+        const exclusiveFileId = `file_${uuidv4()}`;
+        const agentA = await createBasicAgent();
+        const agentB = await createBasicAgent();
+
+        await addAgentResourceFile({
+          agent_id: agentA.id,
+          tool_resource: EToolResources.context,
+          file_id: sharedFileId,
+        });
+        await addAgentResourceFile({
+          agent_id: agentA.id,
+          tool_resource: EToolResources.context,
+          file_id: exclusiveFileId,
+        });
+        await addAgentResourceFile({
+          agent_id: agentB.id,
+          tool_resource: EToolResources.context,
+          file_id: sharedFileId,
+        });
+
+        const referenced = await findFileIdsReferencedByAgents({
+          file_ids: [sharedFileId, exclusiveFileId],
+          excludeAgentId: agentA.id,
+        });
+
+        expect(referenced).toEqual([sharedFileId]);
+      });
+
+      test('returns empty when file_ids is empty', async () => {
+        await expect(findFileIdsReferencedByAgents({ file_ids: [] })).resolves.toEqual([]);
       });
     });
 

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -450,6 +450,13 @@ export function createAgentMethods(
   }: {
     file_ids: string[];
   }) => Promise<{ matchedCount: number; modifiedCount: number }>;
+  findFileIdsReferencedByAgents: ({
+    file_ids,
+    excludeAgentId,
+  }: {
+    file_ids: string[];
+    excludeAgentId?: string;
+  }) => Promise<string[]>;
 } {
   const { removeAllPermissions, getActions, getSoleOwnedResourceIds, isExternalSkillId } = deps;
 
@@ -874,6 +881,52 @@ export function createAgentMethods(
   }
 
   /**
+   * Returns the subset of `file_ids` that are still listed on at least one
+   * agent's `tool_resources.*.file_ids`. Used so detaching a file from one
+   * agent (e.g. after Duplicate) does not delete storage still needed by
+   * another agent. See issue #14609.
+   */
+  async function findFileIdsReferencedByAgents({
+    file_ids,
+    excludeAgentId,
+  }: {
+    file_ids: string[];
+    excludeAgentId?: string;
+  }): Promise<string[]> {
+    if (!file_ids || file_ids.length === 0) {
+      return [];
+    }
+
+    const Agent = mongoose.models.Agent as Model<IAgent>;
+    const wanted = new Set(file_ids);
+    const query: FilterQuery<IAgent> = {
+      $or: TOOL_RESOURCE_KEYS.map((key) => ({
+        [`tool_resources.${key}.file_ids`]: { $in: file_ids },
+      })),
+    };
+    if (excludeAgentId) {
+      query.id = { $ne: excludeAgentId };
+    }
+
+    const agents = await Agent.find(query, { tool_resources: 1 }).lean<IAgent[]>();
+    const referenced = new Set<string>();
+    for (const agent of agents) {
+      for (const key of TOOL_RESOURCE_KEYS) {
+        const ids = agent.tool_resources?.[key]?.file_ids;
+        if (!Array.isArray(ids)) {
+          continue;
+        }
+        for (const id of ids) {
+          if (wanted.has(id)) {
+            referenced.add(id);
+          }
+        }
+      }
+    }
+    return Array.from(referenced);
+  }
+
+  /**
    * Deletes an agent based on the provided search parameter.
    */
   async function deleteAgent(searchParameter: FilterQuery<IAgent>): Promise<IAgent | null> {
@@ -1200,6 +1253,7 @@ export function createAgentMethods(
     generateActionMetadataHash,
     removeAgentFromUserFavorites,
     removeAgentResourceFilesFromAllAgents,
+    findFileIdsReferencedByAgents,
   };
 }
 


### PR DESCRIPTION
## Summary
- Duplicate Agent copied File Context `file_ids` by reference instead of cloning the array.
- Deleting a file from the clone then ran the global cleanup from #12776, which unlinked that file from **every** agent — including the original.
- The clone now gets its own `file_ids` copy. Detaching a file from one agent's File Context no longer deletes storage still referenced by another agent. Deleting from My Files is unchanged.

Fixes #14609

## Test plan
- [ ] Create an agent with 2+ File Context documents, duplicate it, delete a file from the clone's File Context, and confirm the original agent still has those files
- [ ] Delete a file from My Files and confirm it is still stripped from every agent that referenced it (#12776)
- [ ] Duplicate an agent as another user and confirm File Context ids not owned by the clone author are still pruned