### PR TITLE
🐛 fix: decode percent-encoded S3 keys extracted from URLs

### DIFF
--- a/packages/api/src/storage/s3/__tests__/crud.test.ts
+++ b/packages/api/src/storage/s3/__tests__/crud.test.ts
@@ -1107,6 +1107,17 @@ describe('S3 CRUD', () => {
   });
 
   describe('getS3FileStream', () => {
+    it('requests the decoded key for a non-ASCII file name', async () => {
+      const { getS3FileStream } = await import('../crud');
+      await getS3FileStream(
+        {} as ServerRequest,
+        'https://test-bucket.s3.amazonaws.com/images/user123/%D0%94%D0%BE%D0%B3%D0%BE%D0%B2%D0%BE%D1%80.pdf',
+      );
+
+      const [call] = s3Mock.commandCalls(GetObjectCommand);
+      expect(call.args[0].input.Key).toBe('images/user123/Договор.pdf');
+    });
+
     it('returns a readable stream for a file', async () => {
       const { getS3FileStream } = await import('../crud');
       const result = await getS3FileStream(
@@ -1511,12 +1522,30 @@ describe('S3 CRUD', () => {
       expect(key).toBe('folder/file.txt');
     });
 
-    it('handles URLs with encoded characters', async () => {
+    // Keys are stored decoded (`getS3Key` does not encode the file name), so a
+    // key taken from a URL path has to be decoded to match the stored object.
+    it('decodes escaped characters taken from the URL path', async () => {
       const { extractKeyFromS3Url } = await import('../crud');
       const key = extractKeyFromS3Url(
         'https://bucket.s3.amazonaws.com/test-bucket/images/user123/my%20file%20name.jpg',
       );
-      expect(key).toBe('images/user123/my%20file%20name.jpg');
+      expect(key).toBe('images/user123/my file name.jpg');
+    });
+
+    it('decodes a non-ASCII file name taken from the URL path', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url(
+        'https://bucket.s3.amazonaws.com/test-bucket/images/user123/%D0%94%D0%BE%D0%B3%D0%BE%D0%B2%D0%BE%D1%80.pdf',
+      );
+      expect(key).toBe('images/user123/Договор.pdf');
+    });
+
+    // A key supplied directly is already a key: a `%` in it is part of the
+    // file name, not an escape, and decoding it would corrupt the lookup.
+    it('leaves a literal percent alone when given a key rather than a URL', async () => {
+      const { extractKeyFromS3Url } = await import('../crud');
+      const key = extractKeyFromS3Url('images/user123/100%_final.pdf');
+      expect(key).toBe('images/user123/100%_final.pdf');
     });
 
     it('handles deep nested paths', async () => {

--- a/packages/api/src/storage/s3/crud.ts
+++ b/packages/api/src/storage/s3/crud.ts
@@ -638,6 +638,23 @@ export async function saveURLToS3(
   return filepath;
 }
 
+/**
+ * Decodes a key taken from a URL path.
+ *
+ * `URL.pathname` is percent-encoded, but S3 object keys are stored decoded, so
+ * a key derived from a URL has to be decoded before it is used in a command —
+ * otherwise the SDK encodes the `%` again and the request asks for a key that
+ * does not exist. Only applies to keys derived from URLs: a key supplied
+ * directly may legitimately contain a literal `%`.
+ */
+function decodeKeyFromUrlPath(key: string): string {
+  try {
+    return decodeURIComponent(key);
+  } catch {
+    return key;
+  }
+}
+
 export function extractKeyFromS3Url(fileUrlOrKey: string): string {
   if (!fileUrlOrKey) {
     throw new Error('Invalid input: URL or key is empty');
@@ -667,7 +684,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
       } else {
         logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${key}`);
       }
-      return key;
+      return decodeKeyFromUrlPath(key);
     }
 
     if (
@@ -687,7 +704,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
             `[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${key}`,
           );
         }
-        return key;
+        return decodeKeyFromUrlPath(key);
       }
       logger.warn(
         `[extractKeyFromS3Url] Unable to extract key from path-style URL: ${fileUrlOrKey}`,
@@ -696,7 +713,7 @@ export function extractKeyFromS3Url(fileUrlOrKey: string): string {
     }
 
     logger.debug(`[extractKeyFromS3Url] fileUrlOrKey: ${fileUrlOrKey}, Extracted key: ${pathname}`);
-    return pathname;
+    return decodeKeyFromUrlPath(pathname);
   } catch (error) {
     if (fileUrlOrKey.startsWith('http://') || fileUrlOrKey.startsWith('https://')) {
       logger.error(


### PR DESCRIPTION
## What happened

On a deployment with `fileStrategy: "s3"`, any file whose name contains non-ASCII characters uploads fine but can never be read back. Every later read fails:

```
[getS3FileStream] Error retrieving S3 file stream: The specified key does not exist.
  Resource: '/my-bucket/uploads/<userId>/<uuid>__%25D0%2594%25D0%25BE%25D0%25B3%25D0%25BE%25D0%25B2%25D0%25BE%25D1%2580....pdf'
```

For the user this is silent: the file appears to attach, but the model never receives it and answers that no file was provided.

## Root cause

`extractKeyFromS3Url()` derives the object key from `URL.pathname`, which is percent-encoded. Keys, however, are stored **decoded** — `getS3Key()` builds the key from the raw file name and `PutObject` stores it as-is. Listing the bucket confirms it:

```
key: uploads/<userId>/<uuid>__Договор_....pdf     ← what is stored
```

So the extracted key is `...__%D0%94%D0%BE%D0%B3...`, the SDK then escapes the `%`, and the request that goes out asks for `...__%25D0%2594%25D0%25BE%25D0%25B3...` — a key that does not exist.

Note that the correct key is already available: `resolveStoredS3Key()` prefers `file.storageKey`, and the DB record has it. But `getS3FileStream(_req, filePath)` receives only the path string, so it cannot use it — which is why the fix belongs in key extraction rather than in the caller.

This affects every non-ASCII alphabet (Cyrillic, CJK, accented Latin) and spaces, on both virtual-hosted and path-style URLs, so custom endpoints (MinIO, R2, Yandex Object Storage) are hit as well.

## The fix

Decode keys that were derived from a URL path.

Keys supplied directly are deliberately left untouched: `extractKeyFromS3Url('images/user/100%_final.pdf')` must not be decoded, because there the `%` is part of the file name rather than an escape. The same reasoning applies to the fallback branch in `catch`, which also receives a key rather than a URL.

## Tests

`packages/api/src/storage/s3/__tests__/crud.test.ts`:

- decoding of escaped characters and of a non-ASCII file name taken from the URL path;
- a literal `%` preserved when a key is passed instead of a URL;
- a regression test asserting that `getS3FileStream` issues `GetObjectCommand` with the decoded key.

One existing expectation changed. `handles URLs with encoded characters` asserted `images/user123/my%20file%20name.jpg`, i.e. it codified the buggy behaviour; it now asserts `images/user123/my file name.jpg`, which is what the bucket actually contains.

`npx jest src/storage` in `packages/api`: 165 passed, 1 skipped (the integration spec, which needs live S3).

## Verified in production

Patched image running against Yandex Object Storage (S3-compatible, path-style endpoint). The same 21 MB PDF that previously failed now streams in full:

```
прочитано байт: 21619868
сигнатура файла: "%PDF-"
```
