### PR TITLE
📱 style: Reclaim the Assistant Avatar Gutter on Mobile

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/AuthorHeader.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/AuthorHeader.tsx
@@ -6,7 +6,8 @@ import type { ReactNode } from 'react';
  * renders a full user turn inside the response, so the parts that resume
  * after it need the author's icon and label restated — the message-level
  * header only renders once, above the first part. Outdented past the icon
- * column (like `SteerPart`) so it aligns with the top-level header.
+ * column (like `SteerPart`) so it aligns with the top-level header; that
+ * column only exists from `md` up, so the outdent is gated to match.
  */
 const AuthorHeader = memo(function AuthorHeader({
   icon,
@@ -16,7 +17,10 @@ const AuthorHeader = memo(function AuthorHeader({
   label: string;
 }) {
   return (
-    <div className="relative -ml-9 flex w-[calc(100%+2.25rem)] gap-3" data-testid="author-header">
+    <div
+      className="relative flex w-full gap-2 md:-ml-9 md:w-[calc(100%+2.25rem)] md:gap-3"
+      data-testid="author-header"
+    >
       <div className="relative flex flex-shrink-0 flex-col items-center" aria-hidden="true">
         <div className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full">
           {icon}

--- a/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SteerPart.tsx
@@ -75,7 +75,7 @@ const SteerPart = memo(function SteerPart({
   return (
     <div
       id={steerId ? `steer-${steerId}` : undefined}
-      className="steer-render group relative my-5 -ml-9 flex w-[calc(100%+2.25rem)] justify-end"
+      className="steer-render group relative my-5 flex w-full justify-end md:-ml-9 md:w-[calc(100%+2.25rem)]"
       data-testid="steer-part"
     >
       <div className="user-turn relative flex w-fit max-w-[90%] flex-col items-end sm:max-w-[85%]">

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/AuthorHeader.spec.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/AuthorHeader.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import AuthorHeader from '../AuthorHeader';
+
+const renderHeader = () =>
+  render(<AuthorHeader icon={<span data-testid="author-icon" />} label="GitHub Agent" />);
+
+describe('AuthorHeader', () => {
+  it('restates the author with an icon and a heading', () => {
+    renderHeader();
+
+    expect(screen.getByTestId('author-icon')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'GitHub Agent' })).toBeVisible();
+  });
+
+  it('only outdents past the avatar gutter where that gutter exists', () => {
+    renderHeader();
+
+    const header = screen.getByTestId('author-header');
+
+    expect(header).toHaveClass('w-full', 'md:-ml-9', 'md:w-[calc(100%+2.25rem)]');
+    expect(header).not.toHaveClass('-ml-9');
+  });
+
+  it('keeps the icon out of the accessible name', () => {
+    renderHeader();
+
+    expect(screen.getByTestId('author-icon').closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+});

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SteerPart.test.tsx
@@ -142,6 +142,13 @@ describe('SteerPart presentation', () => {
     expect(part).toHaveClass('steer-render');
   });
 
+  it('only outdents past the avatar gutter where that gutter exists', () => {
+    renderPart();
+    const part = screen.getByTestId('steer-part');
+    expect(part).toHaveClass('w-full', 'md:-ml-9', 'md:w-[calc(100%+2.25rem)]');
+    expect(part).not.toHaveClass('-ml-9');
+  });
+
   it('renders steer attachments', () => {
     renderPart([
       { file_id: 'f1', filename: 'notes.pdf', type: 'application/pdf' },

--- a/client/src/components/Chat/Messages/ui/MessageRow.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRow.tsx
@@ -49,26 +49,16 @@ export default function MessageRow({
       className={cn(
         'message-render group mx-auto flex min-w-0 flex-1 font-theme-ui transition-[max-width] duration-theme-normal motion-reduce:transition-none',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary',
-        isCreatedByUser ? 'justify-end' : 'items-start gap-3',
+        isCreatedByUser ? 'justify-end' : 'items-start',
         widthClass,
         className,
       )}
     >
-      {showAssistantHeader && (
-        <div
-          className="relative flex flex-shrink-0 flex-col items-center pt-0.5"
-          aria-hidden="true"
-        >
-          <div className="flex size-6 items-center justify-center overflow-hidden rounded-full">
-            {icon}
-          </div>
-        </div>
-      )}
-
       <div
         className={cn(
           'relative flex min-w-0 flex-col',
           isCreatedByUser ? 'user-turn' : 'agent-turn',
+          showAssistantHeader && 'md:pl-9',
           (hasParallelContent || isEditing) && 'w-full',
           !hasParallelContent &&
             isCreatedByUser &&
@@ -85,6 +75,12 @@ export default function MessageRow({
             </h2>
           ) : (
             <h2 className="flex min-h-7 select-none items-center text-sm font-semibold text-text-primary">
+              <span
+                aria-hidden="true"
+                className="mr-2 flex size-6 flex-shrink-0 items-center justify-center overflow-hidden rounded-full md:absolute md:left-0 md:top-0.5 md:mr-0"
+              >
+                {icon}
+              </span>
               <span className="sr-only">{headerPrefix}</span>
               {label}
               <MessageTimestamp value={timestamp} />

--- a/client/src/components/Chat/Messages/ui/__tests__/MessageRow.spec.tsx
+++ b/client/src/components/Chat/Messages/ui/__tests__/MessageRow.spec.tsx
@@ -62,6 +62,32 @@ describe('MessageRow', () => {
     expect(screen.getByRole('heading', { name: /Assistant/ })).toBeVisible();
   });
 
+  it('carries the assistant avatar inside the heading without naming it', () => {
+    renderRow({ isCreatedByUser: false });
+
+    const avatar = screen.getByTestId('message-icon').parentElement;
+
+    /** The accessible name resolves only when `aria-hidden` excludes the avatar. */
+    expect(screen.getByRole('heading', { name: 'Message from Assistant' })).toContainElement(
+      screen.getByTestId('message-icon'),
+    );
+    expect(avatar).toHaveAttribute('aria-hidden', 'true');
+    expect(avatar).toHaveClass('size-6', 'md:absolute', 'md:left-0', 'md:top-0.5');
+  });
+
+  it('reserves the avatar gutter on desktop only so mobile content starts flush left', () => {
+    renderRow({ isCreatedByUser: false });
+
+    const row = screen.getByLabelText('Assistant message');
+    const agentTurn = row.querySelector('.agent-turn');
+
+    expect(agentTurn).toHaveClass('md:pl-9');
+    expect(agentTurn).not.toHaveClass('pl-9');
+    expect(row).not.toHaveClass('gap-3');
+    expect(row.children).toHaveLength(1);
+    expect(screen.getAllByTestId('message-icon')).toHaveLength(1);
+  });
+
   it('preserves the assistant turn marker for parallel content', () => {
     renderRow({ isCreatedByUser: false, hasParallelContent: true });
 
@@ -89,7 +115,7 @@ describe('MessageRow', () => {
     const row = screen.getByLabelText('Assistant message');
     const messageSurface = screen.getByTestId('message-body');
 
-    expect(row.querySelector('.agent-turn')).toHaveClass('w-full');
+    expect(row.querySelector('.agent-turn')).toHaveClass('w-full', 'md:pl-9');
     expect(messageSurface).toHaveClass('w-full');
   });
 


### PR DESCRIPTION
## Summary

On mobile, assistant content started **36px** from the left edge against a **16px** gutter on the right. The dead space isn't padding — it's a real 24px avatar column plus `gap-3`, hard-coded in `MessageRow` with no mobile branch. That costs ~13% of the reading width on every response.

This moves the avatar into the assistant heading and restores the gutter as `md:pl-9` on the content column, so the column only exists from `md` up.

First of a short mobile-UI series. Follow-ups (header consolidation, full-width nav, edge-swipe) are separate PRs.

## Change

- **`MessageRow.tsx`** — drop the separate avatar column; render the avatar as the first child of the assistant `<h2>`, absolutely positioned back into the gutter at `md`. Content column gains `md:pl-9`. The row's now-inert `gap-3` is removed.
- **`AuthorHeader.tsx` / `SteerPart.tsx`** — both hard-coded `-ml-9 w-[calc(100%+2.25rem)]` to reach back past that column. With no gutter on mobile the outdent would push content off the left edge, so it's gated to `md`.

### Why the desktop geometry is provably unchanged

Today: `max-w-3xl` (768px), `gap-3`, two children → content column = 768 − 24 − 12 = **732px**.
After: one child at 768px, `border-box`, `padding-left: 36px` → content box = **732px**.

An absolutely positioned child resolves against its containing block's *padding box*, so `md:left-0` lands the avatar exactly where the old column started.

### Why `md:` variants and not `useMediaQuery`

`useMediaQuery` initializes `matches = false` and resolves in `useEffect`, so a JS branch here would paint the desktop layout first and reflow — on every message row in the thread. CSS breakpoints avoid it entirely and keep the icon a single DOM node.

## Verification

Compiled the real Tailwind config against the exact class strings and measured in a headless browser:

| viewport | before, text x | after, text x | delta |
|---|---|---|---|
| 390 (mobile) | 52 | 16 | **36px reclaimed** |
| 1024 (desktop) | 164 | 164 | **0 — unchanged** |

The avatar box lands at `(0, 2)` relative to its row in **both** variants at **both** breakpoints — pixel-identical.

- `cd client && npx jest` over the message/share areas: **802 passing, 63 suites**.
- New `AuthorHeader.spec.tsx`; added assertions to `MessageRow.spec.tsx` and `SteerPart.test.tsx` pinning the `md:`-gated contract so the outdents can't silently drift.
- The `MessageRow` heading assertion uses `getByRole('heading', { name: 'Message from Assistant' })`, which passes only if `aria-hidden` correctly excludes the avatar from the accessible name.

## Blast radius

`MessageRow` is shared by all three message paths (`MessageRender`, `ContentRender`, `MessageParts`) **and** by the shared-conversation view (`Share/Message.tsx`) and search results (`SearchMessage.tsx`). One fix covers all five surfaces consistently — worth spot-checking each on a phone.

## Note for reviewers

There is currently **no mobile e2e coverage** — both mobile Playwright projects are commented out in `e2e/playwright.config.ts`, so only Desktop Chrome runs. Enabling them wholesale would run every existing desktop-assuming spec at phone viewports and likely go red; the right shape is a project scoped by `testMatch` to mobile-only specs. Tracked as separate work.