### PR TITLE
🛂 ci: Grant Multi-Convo Permission in E2E Mock Config

### DIFF
--- a/e2e/config/librechat.e2e.yaml
+++ b/e2e/config/librechat.e2e.yaml
@@ -8,6 +8,11 @@ interface:
   # Exercises the cost row in the context usage gauge (off by default).
   # Mock models price at the default rate, so synthetic usage yields a value.
   contextCost: true
+  # Grants MULTI_CONVO.USE so the composer's `+` command opens the added-model
+  # popover. agent-skills-added.spec.ts drives that flow; without an explicit
+  # value the permission falls through to the seeded role default and
+  # `handlePlusCommand` returns before opening the popover.
+  multiConvo: true
 
 # Enables the memory feature so the MEMORIES.USE permission is granted and the
 # ephemeral memory badge (inline set_memory/delete_memory tools) is available.


### PR DESCRIPTION
**Stack 2/4** — base `danny-avila/upstream-fork-deltas` (#14838). Content is
independent; only the base is chained.

## Problem

`agent-skills-added.spec.ts` drives the composer's `+` command, which opens the
added-model popover. `handlePlusCommand` is gated on MULTI_CONVO.USE:

```ts
if (!hasMultiConvoAccess || !plusCommandEnabled || isAssistantsEndpoint(endpoint)) return;
```

The mock config never sets `interface.multiConvo`, so the permission falls
through to the seeded role default and the handler returns before opening the
popover.

The spec then fails on a popover that is absent from the DOM entirely — which
reads as a selector or timing bug rather than a missing permission, and costs
real time to diagnose.

## Change

Set it explicitly, the same way `contextCost` is set immediately above for the
usage gauge. The mock config's job is to make each exercised feature's gate
explicit rather than inherit a role default that can drift.

One line plus a comment naming the spec that depends on it.