### PR TITLE
⚓ ci: Settle the E2E Reply Before the Double-Click Quote

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -144,6 +144,16 @@ jobs:
       - name: Verify Chrome is present
         run: google-chrome --version
 
+      # `video: 'on-first-retry'` needs ffmpeg; without it the first retry dies in
+      # browserContext.newPage before the test body runs, so a flaky test loses the
+      # retry that would have recovered it. The CLI can hang after the download
+      # finishes on these runners, so bound it and keep it non-fatal — worst case is
+      # today's behaviour of retrying without video.
+      - name: Install Playwright ffmpeg (best effort)
+        timeout-minutes: 3
+        continue-on-error: true
+        run: timeout -k 10 90 npx playwright install ffmpeg
+
       # The runner's Chrome is an apt package, so its real library dependencies are
       # already satisfied; all `install-deps` adds here are optional CJK/Thai/Cyrillic
       # font packages (~21MB from azure.archive.ubuntu.com). Nothing in CI asserts on
@@ -234,6 +244,12 @@ jobs:
 
       - name: Verify Chrome is present
         run: google-chrome --version
+
+      # ffmpeg for retry video — see the note in the e2e_shards job.
+      - name: Install Playwright ffmpeg (best effort)
+        timeout-minutes: 3
+        continue-on-error: true
+        run: timeout -k 10 90 npx playwright install ffmpeg
 
       # Optional fonts only — see the note in the e2e_shards job.
       - name: Install optional Playwright font dependencies (best effort)

--- a/e2e/config/librechat.e2e.yaml
+++ b/e2e/config/librechat.e2e.yaml
@@ -8,6 +8,11 @@ interface:
   # Exercises the cost row in the context usage gauge (off by default).
   # Mock models price at the default rate, so synthetic usage yields a value.
   contextCost: true
+  # Grants MULTI_CONVO.USE so the composer's `+` command opens the added-model
+  # popover. agent-skills-added.spec.ts drives that flow; without an explicit
+  # value the permission falls through to the seeded role default and
+  # `handlePlusCommand` returns before opening the popover.
+  multiConvo: true
 
 # Enables the memory feature so the MEMORIES.USE permission is granted and the
 # ephemeral memory badge (inline set_memory/delete_memory tools) is available.

--- a/e2e/specs/mock/quotes.spec.ts
+++ b/e2e/specs/mock/quotes.spec.ts
@@ -99,6 +99,33 @@ async function doubleClickWord(page: Page, needle: string) {
 }
 
 /**
+ * Wait for the reply to stop re-rendering before selecting text inside it.
+ *
+ * Distinct from the settle window `QuoteButton` applies to a *selection*: this
+ * is the reply itself still streaming. A markdown re-render swaps out the text
+ * node the selection points at, which collapses it — so a double-click landing
+ * mid-stream loses its selection before the popup can be clicked, and every
+ * `toPass` retry loses the same race rather than recovering from it.
+ *
+ * `sendMessage` resolves on the stream *response*, not on the final render, so
+ * the wait has to be explicit.
+ */
+async function waitForReplyToSettle(page: Page, needle: string) {
+  const readReply = () =>
+    page.evaluate((text) => {
+      const renders = Array.from(document.querySelectorAll('.message-render'));
+      const host = [...renders].reverse().find((el) => (el.textContent ?? '').includes(text));
+      return host?.textContent ?? '';
+    }, needle);
+
+  await expect(async () => {
+    const before = await readReply();
+    await page.waitForTimeout(250);
+    expect(await readReply()).toBe(before);
+  }).toPass({ timeout: 20000 });
+}
+
+/**
  * Triple-click the block containing `needle` with native mouse events, which
  * makes Chromium select that whole block and park the selection's far boundary
  * at the start of the *next* one. For a message's closing block that boundary
@@ -311,6 +338,7 @@ test.describe('quote references', () => {
     const response = await sendMessage(page, 'seed for dblclick');
     expect(response.ok()).toBeTruthy();
     await expect(mockReply(page)).toBeVisible({ timeout: 20000 });
+    await waitForReplyToSettle(page, MOCK_REPLY_TEXT);
 
     // A real double-click selects the word under the cursor. Chromium commits
     // that selection on `dblclick`, AFTER `mouseup` fires, so only a `dblclick`


### PR DESCRIPTION
**Stack 3/4** — base `danny-avila/e2e-multiconvo-permission`. Content is
independent; only the base is chained.

## Problem

`quotes.spec.ts` › *summons the popup from a native double-click word selection*
double-clicks as soon as `mockReply` is visible. But `sendMessage` resolves on
the stream **response**, not the final render — so the reply can still be
re-rendering.

A streaming markdown re-render swaps out the text node the selection points at,
collapsing the selection. That's the same mechanism the sibling
`selectionchange` test documents deliberately. A double-click landing mid-stream
loses its selection before the popup can be clicked — and because the gesture is
wrapped in `toPass`, **every retry re-runs into the same still-streaming reply**
rather than recovering from a one-off.

## This is not the race #14777 fixed

| | race | handled |
|---|---|---|
| #14777 | the **selection** is still settling (touch long-press, handle drags, block gestures) | in `QuoteButton` |
| here | the **reply** is still streaming | needs an explicit wait |

No amount of component-side selection settling absorbs a text node that gets
replaced underneath it.

## Evidence

Observed on a downstream fork running this suite on slower hardware: the test
fails all three attempts, and does so **deterministically on the in-memory
stream store while the Redis lane passes the same shard** — the in-memory
store's final re-renders land late enough to outlive the gesture. Four separate
runs, same split.

## Change

Wait for the reply text to hold steady before selecting. Local helper, no
change to any other test.