### PR TITLE
🎬 ci(e2e): Install ffmpeg for First-Retry Video Capture

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -144,6 +144,16 @@ jobs:
       - name: Verify Chrome is present
         run: google-chrome --version
 
+      # `video: 'on-first-retry'` needs ffmpeg; without it the first retry dies in
+      # browserContext.newPage before the test body runs, so a flaky test loses the
+      # retry that would have recovered it. The CLI can hang after the download
+      # finishes on these runners, so bound it and keep it non-fatal — worst case is
+      # today's behaviour of retrying without video.
+      - name: Install Playwright ffmpeg (best effort)
+        timeout-minutes: 3
+        continue-on-error: true
+        run: timeout -k 10 90 npx playwright install ffmpeg
+
       # The runner's Chrome is an apt package, so its real library dependencies are
       # already satisfied; all `install-deps` adds here are optional CJK/Thai/Cyrillic
       # font packages (~21MB from azure.archive.ubuntu.com). Nothing in CI asserts on
@@ -234,6 +244,12 @@ jobs:
 
       - name: Verify Chrome is present
         run: google-chrome --version
+
+      # ffmpeg for retry video — see the note in the e2e_shards job.
+      - name: Install Playwright ffmpeg (best effort)
+        timeout-minutes: 3
+        continue-on-error: true
+        run: timeout -k 10 90 npx playwright install ffmpeg
 
       # Optional fonts only — see the note in the e2e_shards job.
       - name: Install optional Playwright font dependencies (best effort)


### PR DESCRIPTION
**Stack 4/4** — base `danny-avila/e2e-quotes-reply-settle`. Content is
independent; only the base is chained.

## Problem

`playwright.config.mock.ts` sets:

```ts
video: 'on-first-retry',
```

but the runner only does `npx playwright install-deps chrome`, which does not
include ffmpeg. Without it the **first retry fails inside
`browserContext.newPage`** while setting up video recording — before the test
body runs.

So the cost isn't a missing video. A genuinely flaky test loses the retry that
would have recovered it, and the reported failure is a video-setup error rather
than the original symptom — actively misleading during triage.

## Change

Install ffmpeg alongside the existing browser deps, in both jobs that run
Playwright (`e2e_shards` and `mcp_tool_list_changed`), since both configure
retries.

**Bounded and non-fatal on purpose.** The CLI has been observed hanging after
the download completes on these runners, so the step is wrapped in `timeout` and
its failure is swallowed:

```bash
timeout -k 10 90 npx playwright install ffmpeg || echo "ffmpeg install did not finish (non-fatal)"
```

If ffmpeg cannot be installed the job proceeds exactly as it does today — no
lane is blocked on it, and the change can only improve retry behaviour.