### PR TITLE
⬇️ fix: Keep Scroll-to-Bottom Clear of the In-Flight Steer Stack

### DIFF
--- a/client/src/components/Chat/Messages/MessagesView.tsx
+++ b/client/src/components/Chat/Messages/MessagesView.tsx
@@ -28,11 +28,13 @@ const ScrollButton = memo(function ScrollButton({
   messagesEndRef,
   scrollHandler,
   onNearBottomChange,
+  overlayHeight,
 }: {
   scrollableRef: React.RefObject<HTMLDivElement | null>;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
   scrollHandler: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   onNearBottomChange: (isNearBottom: boolean) => void;
+  overlayHeight: number;
 }) {
   const scrollButtonPreference = useRecoilValue(store.showScrollButton);
   const [showScrollButton, setShowScrollButton] = useState(false);
@@ -75,7 +77,11 @@ const ScrollButton = memo(function ScrollButton({
       appear={true}
       nodeRef={scrollToBottomRef}
     >
-      <ScrollToBottom ref={scrollToBottomRef} scrollHandler={scrollHandler} />
+      <ScrollToBottom
+        ref={scrollToBottomRef}
+        scrollHandler={scrollHandler}
+        overlayHeight={overlayHeight}
+      />
     </CSSTransition>
   );
 });
@@ -166,6 +172,7 @@ function MessagesViewContent({
             messagesEndRef={messagesEndRef}
             scrollHandler={handleSmoothToRef}
             onNearBottomChange={handleNearBottomChange}
+            overlayHeight={steerOverlayHeight}
           />
 
           <MessageNav scrollableRef={scrollableRef} />

--- a/client/src/components/Messages/ScrollToBottom.tsx
+++ b/client/src/components/Messages/ScrollToBottom.tsx
@@ -7,30 +7,38 @@ import store from '~/store';
 
 type Props = {
   scrollHandler: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Height of the in-flight steer overlay, which stacks upward from the
+   * composer into this same corner. Lifts the button clear of it.
+   */
+  overlayHeight?: number;
 };
 
-const ScrollToBottom = forwardRef<HTMLDivElement, Props>(({ scrollHandler }, ref) => {
-  const localize = useLocalize();
-  const maximizeChatSpace = useRecoilValue(store.maximizeChatSpace);
+const ScrollToBottom = forwardRef<HTMLDivElement, Props>(
+  ({ scrollHandler, overlayHeight = 0 }, ref) => {
+    const localize = useLocalize();
+    const maximizeChatSpace = useRecoilValue(store.maximizeChatSpace);
 
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        'pointer-events-none absolute bottom-5 left-0 right-0 mx-auto flex justify-end',
-        maximizeChatSpace ? 'max-w-full' : 'md:max-w-3xl xl:max-w-4xl',
-      )}
-    >
-      <button
-        onClick={scrollHandler}
-        className="premium-scroll-button pointer-events-auto cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy"
-        aria-label={localize('com_ui_scroll_to_bottom')}
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'pointer-events-none absolute left-0 right-0 mx-auto flex justify-end px-4 md:px-0',
+          maximizeChatSpace ? 'max-w-full' : 'md:max-w-3xl xl:max-w-4xl',
+        )}
+        style={{ bottom: `calc(1.25rem + ${overlayHeight}px)` }}
       >
-        <ChevronDown className="h-4 w-4 text-text-secondary" />
-      </button>
-    </div>
-  );
-});
+        <button
+          onClick={scrollHandler}
+          className="premium-scroll-button pointer-events-auto cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-xheavy"
+          aria-label={localize('com_ui_scroll_to_bottom')}
+        >
+          <ChevronDown className="h-4 w-4 text-text-secondary" />
+        </button>
+      </div>
+    );
+  },
+);
 
 ScrollToBottom.displayName = 'ScrollToBottom';
 

--- a/client/src/components/Messages/__tests__/ScrollToBottom.spec.tsx
+++ b/client/src/components/Messages/__tests__/ScrollToBottom.spec.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('recoil', () => ({
+  useRecoilValue: () => false,
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: { maximizeChatSpace: 'maximizeChatSpace' },
+}));
+
+import ScrollToBottom from '../ScrollToBottom';
+
+const renderButton = (overlayHeight?: number) =>
+  render(<ScrollToBottom scrollHandler={jest.fn()} overlayHeight={overlayHeight} />);
+
+const container = () => screen.getByLabelText('com_ui_scroll_to_bottom').parentElement;
+
+describe('ScrollToBottom', () => {
+  it('rests just above the composer when nothing is queued', () => {
+    renderButton();
+
+    expect(container()).toHaveStyle({ bottom: 'calc(1.25rem + 0px)' });
+  });
+
+  it('lifts clear of the in-flight steer overlay', () => {
+    renderButton(96);
+
+    expect(container()).toHaveStyle({ bottom: 'calc(1.25rem + 96px)' });
+  });
+
+  it('stays inside the message column on mobile', () => {
+    renderButton();
+
+    /** Without a mobile gutter the button escapes to the viewport edge while
+     *  the steer bubbles inset, so the two visibly disagree. */
+    expect(container()).toHaveClass('px-4', 'md:px-0');
+  });
+
+  it('keeps the desktop width constraint', () => {
+    renderButton();
+
+    expect(container()).toHaveClass('md:max-w-3xl', 'xl:max-w-4xl');
+  });
+});


### PR DESCRIPTION
Independent of the mobile-UI series (#14836, #14843) — touches one component and an existing atom, so it can merge in any order.

## The collision

Two elements claim the same corner:

| | position | anchor |
|---|---|---|
| `ScrollToBottom` | `bottom-5`, right-aligned | the message scroll region |
| `InFlightSteers` | `bottom-full`, right-aligned, up to `max-h-[35vh]` | the composer wrapper |

`bottom-full` means the steer bubbles stack **upward** from the composer's top edge — which is exactly where the scroll button sits, 20px up. They overlap at every breakpoint. They also live in different stacking contexts, so which one paints on top depends on ancestor DOM order rather than intent.

It reads as a mobile bug because a second issue compounds it there: the button's width is `md:max-w-3xl xl:max-w-4xl` with **no base value**, so on a phone it escapes the message column entirely and pins to the viewport edge while the bubbles inset by 8px.

## The fix

The reservation mechanism already exists and is already correct — the button was just never included in it.

`InFlightSteers` measures itself into `steerOverlayHeightFamily`, and `MessagesView` reads that to pad the thread so the newest message rests above the overlay (see the comment at `MessagesView.tsx`). This threads the same value through to `ScrollToBottom` and offsets its `bottom` by it:

```
bottom: calc(1.25rem + ${overlayHeight}px)
```

No new state, no second measurement, no new source of truth. The overlay is capped at `max-h-[35vh]`, so the button can rise at most a third of the screen — landing at the top of the stack, which is where you want it when steers are covering the bottom.

Separately, `px-4 md:px-0` gives the button a mobile gutter matching the message column. Desktop keeps its existing alignment exactly.

## Checks

- New `ScrollToBottom.spec.tsx` covering the resting offset, the lifted offset, the mobile gutter, and the preserved desktop width constraint.
- 840 tests / 59 suites green across the message area, including the `InFlightSteers` overlay-height contract.
- Typecheck clean.

## Verifying by hand

Start a run, queue three or four steers, then scroll up so the button appears. It should sit clear of the topmost bubble and stay inside the message column. Worth checking desktop too — the overlap is not mobile-only.