### PR TITLE
✨ v0.8.8-rc2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1249,6 +1249,10 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Redis connection limits
 # REDIS_MAX_LISTENERS=40
 
+# Minimum interval in milliseconds between Keyv reconnect attempts after a
+# READONLY reply during standalone or Sentinel failover (default: 5000)
+# REDIS_READONLY_RECOVERY_INTERVAL=5000
+
 # Redis ping interval in seconds (0 = disabled, >0 = enabled)
 # When set to a positive integer, Redis clients will ping the server at this interval to keep connections alive
 # When unset or 0, no pinging is performed (recommended for most use cases)

--- a/.env.example
+++ b/.env.example
@@ -719,6 +719,25 @@ TTS_API_KEY=
 
 # LIBRECHAT_CODE_API_KEY=
 # LIBRECHAT_CODE_BASEURL=
+# Current self-hosted Code Interpreter deployments use per-user LibreChat JWTs outside local mode.
+# Configure the matching public verifier on Code Interpreter; see:
+# https://www.librechat.ai/docs/features/code_interpreter#self-hosted-jwt-authentication
+# CODEAPI_AUTH_PROVIDER=librechat-jwt
+# CODEAPI_JWT_ENABLED=false
+# Set at least one private-key source. Precedence: PEM, base64-encoded PEM, then private JWK JSON.
+# CODEAPI_JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# CODEAPI_JWT_PRIVATE_KEY_BASE64=
+# CODEAPI_JWT_PRIVATE_JWK_JSON=
+# CODEAPI_JWT_ALGORITHM=EdDSA
+# CODEAPI_JWT_KID=lc-codeapi-2026-05
+# CODEAPI_JWT_ISSUER=librechat
+# CODEAPI_JWT_AUDIENCE=codeapi
+# CODEAPI_JWT_TTL_SECONDS=300
+# CODEAPI_JWT_MINT_CACHE_SECONDS=30
+# CODEAPI_JWT_SINGLE_TENANT_ID=legacy
+# Multi-tenant deployments can reject requests without authenticated tenant context.
+# The Code Interpreter service must also set CODEAPI_TENANT_ISOLATION_STRICT=true.
+# TENANT_ISOLATION_STRICT=false
 # Optional dedicated Code API deployment for agents with Stateful code sessions enabled.
 # When configured, stateless agents continue using LIBRECHAT_CODE_BASEURL while stateful
 # agents fail closed onto this endpoint. The endpoint must advertise the `stateful` profile.
@@ -945,6 +964,9 @@ OPENID_REUSE_TOKENS=
 #is not rotated/revoked out from under downstream consumers (e.g. MCP servers that introspect the bearer).
 #When OPENID_REUSE_TOKENS=true, the OpenID session cookie maxAge is extended to at least this value.
 OPENID_REUSE_MAX_SESSION_AGE_MS=
+#Short recovery window for a rotated OpenID refresh token while LibreChat publishes the refreshed session. Default 60000 ms (1 min).
+#Accepts arithmetic expressions. Increase only when slow session persistence or cross-replica publication needs more time.
+OPENID_REFRESH_BRIDGE_GRACE_MS=
 #By default, signing key verification results are cached in order to prevent excessive HTTP requests to the JWKS endpoint.
 #If a signing key matching the kid is found, this will be cached and the next time this kid is requested the signing key will be served from the cache.
 #Default is true.
@@ -1023,6 +1045,11 @@ ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS=false
 # Microsoft Graph API scopes needed for people/group search
 # Default scopes provide access to user profiles and group memberships
 OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All
+
+# Space-separated Microsoft Graph scopes requested by the OBO exchange for
+# {{LIBRECHAT_GRAPH_ACCESS_TOKEN}} placeholders in YAML-defined MCP servers.
+# This is separate from OPENID_GRAPH_SCOPES above.
+# GRAPH_API_SCOPES=https://graph.microsoft.com/.default
 
 # LDAP
 LDAP_URL=

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,7 +8,7 @@ At LibreChat, we prioritize the security of our project and value the contributi
 
 When reporting a security vulnerability, you have the following options to reach out to us:
 
-- **Option 1: GitHub Security Advisory System**: We encourage you to use GitHub's Security Advisory system to report any security vulnerabilities you find. This allows us to receive vulnerability reports directly through GitHub. For more information on how to submit a security advisory report, please refer to the [GitHub Security Advisories documentation](https://docs.github.com/en/code-security/getting-started-with-security-vulnerability-alerts/about-github-security-advisories).
+- **Option 1: GitHub Private Vulnerability Reporting**: Submit sensitive vulnerability details through LibreChat's [private vulnerability reporting form](https://github.com/danny-avila/LibreChat/security/advisories/new). This sends the report confidentially to the project maintainers.
 
 - **Option 2: GitHub Issues**: You can initiate first contact via GitHub Issues. However, please note that initial contact through GitHub Issues should not include any sensitive details.
 
@@ -53,9 +53,10 @@ We would like to express our gratitude to the security researchers and community
 
 We currently do not have a bug bounty program in place. However, we welcome and appreciate any
 
- security-related contributions through pull requests (PRs) that address vulnerabilities in our codebase. We believe in the power of collaboration to improve the security of our project and invite you to join us in making it more robust.
+security-related contributions through pull requests (PRs) that address vulnerabilities in our codebase. We believe in the power of collaboration to improve the security of our project and invite you to join us in making it more robust.
 
 **Reference**
+
 - https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html
 
 ---

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,7 +8,7 @@ At LibreChat, we prioritize the security of our project and value the contributi
 
 When reporting a security vulnerability, you have the following options to reach out to us:
 
-- **Option 1: GitHub Security Advisory System**: We encourage you to use GitHub's Security Advisory system to report any security vulnerabilities you find. This allows us to receive vulnerability reports directly through GitHub. For more information on how to submit a security advisory report, please refer to the [GitHub Security Advisories documentation](https://docs.github.com/en/code-security/getting-started-with-security-vulnerability-alerts/about-github-security-advisories).
+- **Option 1: GitHub Security Advisory System**: We encourage you to use GitHub's Security Advisory system to report any security vulnerabilities you find. This allows us to receive vulnerability reports directly through GitHub. For more information on how to submit a security advisory report, please refer to the [GitHub Security Advisories documentation](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/github-advisory-database). To see the list of existing vulnerability reports, visit the [GitHub Security Advisories page](https://github.com/advisories).
 
 - **Option 2: GitHub Issues**: You can initiate first contact via GitHub Issues. However, please note that initial contact through GitHub Issues should not include any sensitive details.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# v0.8.8-rc1
+# v0.8.8-rc2
 
 # Base node image
 FROM node:24.16.0-alpine AS node

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,5 @@
 # Dockerfile.multi
-# v0.8.8-rc1
+# v0.8.8-rc2
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144

--- a/README.md
+++ b/README.md
@@ -51,25 +51,30 @@
   </a>
 </p>
 
-## 🚀 What's New in v0.8.8-rc1
+## 🚀 What's New in v0.8.8-rc2
 
-- **Agent run control:** Interrupt or steer an Agent mid-run, queue follow-up messages, and reclaim, edit, or escalate pending steers.
-- **Human-in-the-loop Agents:** Agents stream question progress, ask up to four related questions in one form, pause for input or tool approval, and resume.
-- **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
-- **Readable Agent activity:** Generated activity-group headers, parent phase summaries, and live tool intent labels make long reasoning and tool runs easier to scan.
-- **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.
-- **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills, MCP servers, and opt-in command hooks, while explicit subagents initialize only when selected.
-- **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
-- **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
-- **Artifact workflows:** Open previews fullscreen, work with PowerPoint `.potx` templates across upload, search, and code execution, upload shell scripts across common MIME variants, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
-- **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.7 and 3.6 Flash, and Gemini 3.5 Flash-Lite.
-- **Langfuse observability:** Configure encrypted Langfuse connections in-app, let authorized admins open sampled sessions directly, optionally fan out traces by tenant, and suppress central export per run.
-- **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
-- **Messages and navigation:** Right-aligned user turns, unified multi-part editing, full-message copy, a dock-style message rail, virtualized search, smooth streaming, and faster Agent startup.
-- **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, parsed MCP response media types, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
-- **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
+- **Agent run control:** Interrupt or steer runs with files and quoted excerpts, track delivery receipts, and durably queue follow-ups across reconnects, restarts, and replicas.
+- **Agent activity:** Optional generated labels group reasoning and tool work, fold completed groups into live phase cards, keep generated files visible, summarize multi-step phases, and show the current reasoning direction.
+- **Human-in-the-loop Agents:** Stream up to four related questions, pause for input or tool approval, and resume durably.
+- **Unified Agent Builder:** Configure Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings in one Tools marketplace.
+- **Durable Agent automation:** Authenticated Agent Events support bound child actors, expected-action receipts, per-actor mailboxes, event batching, durable human pauses, and automatic detached Actions across built-in stream stores.
+- **Deeper Subagent history:** Browse branch-aware child turns with bounded reasoning and stable live event views, load earlier activity, inspect event details, continue completed child chats, and automatically wake saved parent Agents when detached work settles.
+- **Background tools:** Eligible Code Interpreter, MCP, Plugin, and Action tools can run while an Agent keeps working, with automatic delivery for supported completions and polling controls when needed.
+- **Code Interpreter workflows:** Sandbox images return as viewable artifacts; highly experimental stateful sessions add scoped workspaces, named managed or attached execution environments, and per-message file downloads.
+- **Agent extensibility:** Experimental Agent Plugins bundle deployment Skills, MCP servers, and opt-in command hooks; saved Agent teams run as isolated Subagent graphs.
+- **Scheduled Chats (experimental):** Run saved Agents with presets or custom cron, selectable time zones, multi-day weekly cadence, and optional Chat Project destinations.
+- **Memory and context:** Agents can use optionally isolated memory, while the categorized Context Usage gauge shows current-window usage, tokens, and optional cost.
+- **Editable long pastes:** Long pasted text becomes an editable attachment that can be moved back into the composer; attachment-only turns and reliable Upload as Text downloads are also supported.
+- **Projects, settings, and navigation:** Search and manage project chats, use searchable settings and shortcuts, pin chats, choose clock/week conventions, and navigate faster on mobile.
+- **Sharing and artifacts:** Stable shared links support personal copies; fullscreen previews, Mermaid export, PowerPoint templates, shell scripts, and original Office downloads expand file workflows.
+- **Web search:** Keenable adds keyless search and page fetch, while SearXNG and Tavily gain richer controls and all web-tool egress uses stronger SSRF protection.
+- **Security and authentication:** Default HTTP security headers, opt-in nonce CSP, authenticated local images, per-user Code Interpreter JWTs, stable SAML identity binding, live-session OpenID token refresh, and retired JWT-secret rejection harden deployments.
+- **Models and reasoning:** Added GPT-5.6 with Responses reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.7/3.6 Flash, and Gemini 3.5 Flash-Lite; Vertex AI Agents share the Google model catalog.
+- **Langfuse observability:** Configure encrypted in-app connections, tenant fanout, authenticated gateways, export-decision telemetry, and authorized session links in chats and shared views.
+- **Administration:** Source-aware content filters cover model-bound data, while tenant Insights, delegated configuration, encrypted secrets, and expiring violation scores improve operations.
+- **Streaming and reliability:** Adaptive smoothing, Redis delta batching, automatic generation protocol v2, live MCP catalog refresh, Agent circuit breakers, and DocumentDB support improve long runs and scaled deployments.
 
-Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-rc1).
+Read the [full v0.8.8-rc2 changelog](https://www.librechat.ai/changelog/v0.8.8-rc2).
 
 # ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@
 
 ## 🚀 What's New in v0.8.8-rc2
 
-- **Agent run control:** Interrupt or steer runs with files and quoted excerpts, track delivery receipts, and durably queue follow-ups across reconnects, restarts, and replicas.
+- **Agent run control:** Interrupt or steer runs with files and quoted excerpts, durably queue follow-ups, and recover saved partial work with **Keep going** or **Answer now** when a turn reaches its tool-call limit.
 - **Agent activity:** Optional generated labels group reasoning and tool work, fold completed groups into live phase cards, keep generated files visible, summarize multi-step phases, and show the current reasoning direction.
 - **Human-in-the-loop Agents:** Stream up to four related questions, pause for input or tool approval, and resume durably.
-- **Unified Agent Builder:** Configure Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings in one Tools marketplace.
+- **Unified Agent Builder:** Configure Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings in one Tools marketplace; Skills can be enabled for standalone runtime authoring without exposing the existing catalog.
 - **Durable Agent automation:** Authenticated Agent Events support bound child actors, expected-action receipts, per-actor mailboxes, event batching, durable human pauses, and automatic detached Actions across built-in stream stores.
 - **Deeper Subagent history:** Browse branch-aware child turns with bounded reasoning and stable live event views, load earlier activity, inspect event details, continue completed child chats, and automatically wake saved parent Agents when detached work settles.
 - **Background tools:** Eligible Code Interpreter, MCP, Plugin, and Action tools can run while an Agent keeps working, with automatic delivery for supported completions and polling controls when needed.
-- **Code Interpreter workflows:** Sandbox images return as viewable artifacts; highly experimental stateful sessions add scoped workspaces, named managed or attached execution environments, and per-message file downloads.
+- **Code Interpreter workflows:** Sandbox images return as viewable artifacts; highly experimental stateful sessions add scoped workspaces, managed, attached, or self-service personal execution environments, and per-message file downloads.
 - **Agent extensibility:** Experimental Agent Plugins bundle deployment Skills, MCP servers, and opt-in command hooks; saved Agent teams run as isolated Subagent graphs.
 - **Scheduled Chats (experimental):** Run saved Agents with presets or custom cron, selectable time zones, multi-day weekly cadence, and optional Chat Project destinations.
 - **Memory and context:** Agents can use optionally isolated memory, while the categorized Context Usage gauge shows current-window usage, tokens, and optional cost.
 - **Editable long pastes:** Long pasted text becomes an editable attachment that can be moved back into the composer; attachment-only turns and reliable Upload as Text downloads are also supported.
-- **Projects, settings, and navigation:** Search and manage project chats, use searchable settings and shortcuts, pin chats, choose clock/week conventions, and navigate faster on mobile.
+- **Projects, settings, and navigation:** Search conversation titles and message contents, manage project chats, use searchable settings and shortcuts, pin chats, choose clock/week conventions, and navigate faster on mobile.
 - **Sharing and artifacts:** Stable shared links support personal copies; fullscreen previews, Mermaid export, PowerPoint templates, shell scripts, and original Office downloads expand file workflows.
 - **Web search:** Keenable adds keyless search and page fetch, while SearXNG and Tavily gain richer controls and all web-tool egress uses stronger SSRF protection.
 - **Security and authentication:** Default HTTP security headers, opt-in nonce CSP, authenticated local images, per-user Code Interpreter JWTs, stable SAML identity binding, live-session OpenID token refresh, and retired JWT-secret rejection harden deployments.

--- a/README.md
+++ b/README.md
@@ -53,26 +53,26 @@
 
 ## 🚀 What's New in v0.8.8-rc2
 
-- **Agent run control:** Interrupt or steer runs with files and quoted excerpts, durably queue follow-ups, and recover saved partial work with **Keep going** or **Answer now** when a turn reaches its tool-call limit.
+- **Agent run control:** Interrupt an Agent before visible answer text, steer runs with files and quoted excerpts, durably queue follow-ups, and recover saved partial work with **Keep going** or **Answer now**.
 - **Agent activity:** Optional generated labels group reasoning and tool work, fold completed groups into live phase cards, keep generated files visible, summarize multi-step phases, and show the current reasoning direction.
 - **Human-in-the-loop Agents:** Stream up to four related questions, pause for input or tool approval, and resume durably.
 - **Unified Agent Builder:** Configure Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings in one Tools marketplace; Skills can be enabled for standalone runtime authoring without exposing the existing catalog.
 - **Durable Agent automation:** Authenticated Agent Events support bound child actors, expected-action receipts, per-actor mailboxes, event batching, durable human pauses, and automatic detached Actions across built-in stream stores.
 - **Deeper Subagent history:** Browse branch-aware child turns with bounded reasoning and stable live event views, load earlier activity, inspect event details, continue completed child chats, and automatically wake saved parent Agents when detached work settles.
 - **Background tools:** Eligible Code Interpreter, MCP, Plugin, and Action tools can run while an Agent keeps working, with automatic delivery for supported completions and polling controls when needed.
-- **Code Interpreter workflows:** Sandbox images return as viewable artifacts; highly experimental stateful sessions add scoped workspaces, managed, attached, or self-service personal execution environments, and per-message file downloads.
+- **Code Interpreter workflows:** Sandbox images return as viewable artifacts; highly experimental stateful sessions add scoped managed, attached, or personal environments, per-message file downloads, and guarded file-write and command permissions.
 - **Agent extensibility:** Experimental Agent Plugins bundle deployment Skills, MCP servers, and opt-in command hooks; saved Agent teams run as isolated Subagent graphs.
 - **Scheduled Chats (experimental):** Run saved Agents with presets or custom cron, selectable time zones, multi-day weekly cadence, and optional Chat Project destinations.
-- **Memory and context:** Agents can use optionally isolated memory, while the categorized Context Usage gauge shows current-window usage, tokens, and optional cost.
+- **Memory and context:** Agents can use optionally isolated memory, preserve adaptive context fading across turns, and show categorized current-window usage, tokens, and optional cost.
 - **Editable long pastes:** Long pasted text becomes an editable attachment that can be moved back into the composer; attachment-only turns and reliable Upload as Text downloads are also supported.
 - **Projects, settings, and navigation:** Search conversation titles and message contents, manage project chats, use searchable settings and shortcuts, pin chats, choose clock/week conventions, and navigate faster on mobile.
 - **Sharing and artifacts:** Stable shared links support personal copies; fullscreen previews, Mermaid export, PowerPoint templates, shell scripts, and original Office downloads expand file workflows.
 - **Web search:** Keenable adds keyless search and page fetch, while SearXNG and Tavily gain richer controls and all web-tool egress uses stronger SSRF protection.
 - **Security and authentication:** Default HTTP security headers, opt-in nonce CSP, authenticated local images, per-user Code Interpreter JWTs, stable SAML identity binding, live-session OpenID token refresh, and retired JWT-secret rejection harden deployments.
-- **Models and reasoning:** Added GPT-5.6 with Responses reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.7/3.6 Flash, and Gemini 3.5 Flash-Lite; Vertex AI Agents share the Google model catalog.
+- **Models and reasoning:** Added GPT-5.6 with Responses reasoning controls, Claude Fable 5.1, Opus 5, and Sonnet 5, plus Gemini 3.8/3.7/3.6 Flash and Gemini 3.5 Flash-Lite.
 - **Langfuse observability:** Configure encrypted in-app connections, tenant fanout, authenticated gateways, export-decision telemetry, and authorized session links in chats and shared views.
-- **Administration:** Source-aware content filters cover model-bound data, while tenant Insights, delegated configuration, encrypted secrets, and expiring violation scores improve operations.
-- **Streaming and reliability:** Adaptive smoothing, Redis delta batching, automatic generation protocol v2, live MCP catalog refresh, Agent circuit breakers, and DocumentDB support improve long runs and scaled deployments.
+- **Administration:** Source-aware content filters can audit or block model-bound data, while tenant Insights, delegated configuration, encrypted secrets, and expiring violation scores improve operations.
+- **Streaming and reliability:** Adaptive smoothing, Redis delta batching and failover recovery, automatic generation protocol v2, live MCP catalog refresh, Agent circuit breakers, and DocumentDB support improve long runs and scaled deployments.
 
 Read the [full v0.8.8-rc2 changelog](https://www.librechat.ai/changelog/v0.8.8-rc2).
 

--- a/README.md
+++ b/README.md
@@ -51,25 +51,29 @@
   </a>
 </p>
 
-## 🚀 What's New in v0.8.8-rc1
+## 🚀 What's New in v0.8.8-rc2
 
 - **Agent run control:** Interrupt or steer an Agent mid-run, queue follow-up messages, and reclaim, edit, or escalate pending steers.
-- **Human-in-the-loop Agents:** Agents stream question progress, ask up to four related questions in one form, pause for input or tool approval, and resume.
+- **Human-in-the-loop Agents:** Agents stream question progress, step through up to four related questions, pause for input or tool approval, and resume.
 - **Unified Agent Builder:** A redesigned Tools marketplace brings together Skills, MCP, Code Interpreter, orchestration, Programmatic Tool Calling, model-spec controls, and per-tool background and intent settings.
-- **Readable Agent activity:** Generated activity-group headers, parent phase summaries, and live tool intent labels make long reasoning and tool runs easier to scan.
-- **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions can reuse prewarmed conversation workspaces.
-- **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills, MCP servers, and opt-in command hooks, while explicit subagents initialize only when selected.
-- **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a more faithful Context Usage gauge.
+- **Readable Agent activity:** Generated activity and phase summaries, live reasoning headings and tool intent labels, tool-step durations, and follow-scrolling code and command panes make long runs easier to scan.
+- **Code Interpreter workflows:** Code and shell tools can run in the background, sandbox images return as viewable artifacts, and highly experimental stateful sessions add scoped workspaces with per-message file downloads.
+- **Agent extensibility:** Experimental Agent Plugins can bundle deployment Skills, MCP servers, and opt-in command hooks; detached subagents preserve child threads and route live controls across Redis-backed replicas.
+- **Scheduled Chats (experimental):** Run saved Agents hourly, daily, on weekdays, or weekly, with run-now controls, status, and last-conversation links; disabled by default.
+- **Agent automation:** Durable fire, continue, and steer delivery supports Scheduled Chats, optional subagent completion wakeups, and trusted deployment-owned adapters.
+- **Memory, context, and identity:** Agents can manage memory with optional per-agent isolation, expose support contacts safely, and show a categorized Context Usage gauge with a collapsible breakdown.
 - **Sharing and files:** Shared conversations show a badge and update at a stable URL, while signed-in viewers can continue them as personal copies.
+- **Projects:** Search and sort personal workspaces, add descriptions, start scoped chats, and manage conversations directly from project views.
+- **Settings and controls:** Search settings, toggle all keyboard shortcuts without losing custom bindings, display chat titles in tabs, choose client-side image resizing, and archive all chats without deleting them.
 - **Artifact workflows:** Open previews fullscreen, work with PowerPoint `.potx` templates across upload, search, and code execution, upload shell scripts across common MIME variants, export Mermaid diagrams as SVG or PNG, and download original Office files from the artifact panel.
 - **Models and reasoning:** Added GPT-5.6 with Responses API reasoning controls, Claude Opus 5 and Sonnet 5, Gemini 3.7 and 3.6 Flash, and Gemini 3.5 Flash-Lite.
-- **Langfuse observability:** Configure encrypted Langfuse connections in-app, let authorized admins open sampled sessions directly, optionally fan out traces by tenant, and suppress central export per run.
-- **Administration and security:** Delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
-- **Messages and navigation:** Right-aligned user turns, unified multi-part editing, full-message copy, a dock-style message rail, virtualized search, smooth streaming, and faster Agent startup.
+- **Langfuse observability:** Configure encrypted connections in-app, authenticate self-hosted gateways with deployment headers, open sampled sessions as an authorized admin, fan out traces by tenant, and suppress central export per run.
+- **Administration and security:** Review tenant-scoped MongoDB activity in opt-in Insights, delegate config sections, encrypt registered secrets, enforce SSRF checks for speech, OCR, and web tools, and generate unique temporary credentials when secrets are blank.
+- **Messages and navigation:** Instant mobile drawer switching with reveal-style closes, aligned message and composer columns, long-paste and attachment-only turns, code-block downloads, assistant-text copy, virtualized search, smooth streaming, and faster Agent startup.
 - **Streaming and tool reliability:** Adaptive provider smoothing, Redis delta batching, dynamic MCP tool refresh, parsed MCP response media types, runtime OAuth recovery, and Agent stream circuit breakers improve long-running workflows.
 - **Deployment and reliability:** Added configurable HTTP timeouts, Amazon DocumentDB 5.0+ support, low-noise Redis and browser observability, and a rolling-upgrade-safe generation protocol.
 
-Read the [full v0.8.8-rc1 changelog](https://www.librechat.ai/changelog/v0.8.8-rc1).
+Read the [full v0.8.8-rc2 changelog](https://www.librechat.ai/changelog/v0.8.8-rc2).
 
 # ✨ Features
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "v0.8.8-rc1",
+  "version": "v0.8.8-rc2",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.8-rc1",
+      "version": "0.8.8-rc2",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1013.0",
@@ -151,7 +151,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.8-rc1",
+      "version": "0.8.8-rc2",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
         "@ariakit/react-components": "^0.1.2",
@@ -295,7 +295,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.46",
+      "version": "1.7.58",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -408,7 +408,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.76",
+      "version": "0.4.87",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -491,7 +491,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.521",
+      "version": "0.8.533",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -526,7 +526,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.68",
+      "version": "0.0.80",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -295,7 +295,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.58",
+      "version": "1.7.59",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -408,7 +408,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.87",
+      "version": "0.4.88",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -491,7 +491,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.533",
+      "version": "0.8.534",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -526,7 +526,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -295,7 +295,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.59",
+      "version": "1.7.47",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -408,7 +408,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.88",
+      "version": "0.4.77",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -491,7 +491,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.534",
+      "version": "0.8.522",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -526,7 +526,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.81",
+      "version": "0.0.69",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.8-rc1",
+      "version": "0.8.8-rc2",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1013.0",
@@ -151,7 +151,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.8-rc1",
+      "version": "0.8.8-rc2",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
         "@ariakit/react-components": "^0.1.2",
@@ -295,7 +295,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.46",
+      "version": "1.7.51",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
         "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
@@ -408,7 +408,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.76",
+      "version": "0.4.80",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -491,7 +491,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.521",
+      "version": "0.8.526",
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -526,7 +526,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.68",
+      "version": "0.0.73",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.1",

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,4 @@
-/** v0.8.8-rc1 */
+/** v0.8.8-rc2 */
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "v0.8.8-rc1",
+  "version": "v0.8.8-rc2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/e2e/jestSetup.js
+++ b/e2e/jestSetup.js
@@ -1,3 +1,3 @@
-// v0.8.8-rc1
+// v0.8.8-rc2
 // See .env.test.example for an example of the '.env.test' file.
 require('dotenv').config({ path: './e2e/.env.test' });

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.8
+version: 2.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,7 +23,7 @@ version: 2.0.8
 # It is recommended to use it with quotes.
 
 # renovate: image=registry.librechat.ai/danny-avila/librechat
-appVersion: "v0.8.8-rc1"
+appVersion: "v0.8.8-rc2"
 
 home: https://www.librechat.ai
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -591,6 +591,15 @@ endpoints:
   #         # receive a one-time code for an outbound @librechat/code worker.
   #         # The administrator secret stays in the named environment variable.
   #         owner: deployment
+  #         # Optionally expose only these bounded preferences to environment owners.
+  #         configSchema:
+  #           permissions:
+  #             fileWrite:
+  #               allowed: [allow, ask, deny]
+  #               default: ask
+  #             commandExecution:
+  #               allowed: [ask, deny]
+  #               default: ask
   #         pairing:
   #           allowPrincipalWorkers: true
   #           tokenEnv: CODE_BRIDGE_ADMIN_TOKEN

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -2,7 +2,7 @@
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.14
+version: 1.3.15
 
 # Cache settings: Set to true to enable caching
 cache: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -42576,7 +42576,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.59",
+      "version": "1.7.47",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43267,7 +43267,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.88",
+      "version": "0.4.77",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44404,7 +44404,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.534",
+      "version": "0.8.522",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.20.0",
@@ -45014,7 +45014,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.81",
+      "version": "0.0.69",
       "license": "MIT",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.8-rc1",
+  "version": "v0.8.8-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.8-rc1",
+      "version": "v0.8.8-rc2",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -48,7 +48,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.8-rc1",
+      "version": "v0.8.8-rc2",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -921,7 +921,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.8-rc1",
+      "version": "v0.8.8-rc2",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
@@ -42576,7 +42576,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.46",
+      "version": "1.7.58",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43267,7 +43267,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.76",
+      "version": "0.4.87",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44404,7 +44404,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.521",
+      "version": "0.8.533",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.20.0",
@@ -45014,7 +45014,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.68",
+      "version": "0.0.80",
       "license": "MIT",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42576,7 +42576,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.58",
+      "version": "1.7.59",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43267,7 +43267,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.87",
+      "version": "0.4.88",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44404,7 +44404,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.533",
+      "version": "0.8.534",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.20.0",
@@ -45014,7 +45014,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "license": "MIT",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.8-rc1",
+  "version": "v0.8.8-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.8-rc1",
+      "version": "v0.8.8-rc2",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -48,7 +48,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.8-rc1",
+      "version": "v0.8.8-rc2",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -920,7 +920,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.8-rc1",
+      "version": "v0.8.8-rc2",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.29",
@@ -42835,7 +42835,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.46",
+      "version": "1.7.51",
       "license": "ISC",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.2",
@@ -43540,7 +43540,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.76",
+      "version": "0.4.80",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -44676,7 +44676,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.521",
+      "version": "0.8.526",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45284,7 +45284,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.68",
+      "version": "0.0.73",
       "license": "MIT",
       "dependencies": {
         "mdast-util-directive": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.8-rc1",
+  "version": "v0.8.8-rc2",
   "description": "",
   "packageManager": "npm@11.13.0",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.59",
+  "version": "1.7.47",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.58",
+  "version": "1.7.59",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.46",
+  "version": "1.7.58",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.46",
+  "version": "1.7.51",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.76",
+  "version": "0.4.87",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.88",
+  "version": "0.4.77",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.87",
+  "version": "0.4.88",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.76",
+  "version": "0.4.80",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.521",
+  "version": "0.8.533",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.534",
+  "version": "0.8.522",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.533",
+  "version": "0.8.534",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.521",
+  "version": "0.8.526",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -3356,7 +3356,7 @@ export enum Constants {
    */
   VERSION = '__LIBRECHAT_VERSION__',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.3.14',
+  CONFIG_VERSION = '1.3.15',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value to use whatever the submission prelim. `responseMessageId` is */

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.81",
+  "version": "0.0.69",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.68",
+  "version": "0.0.80",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.68",
+  "version": "0.0.73",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/src/models/plugins/mongoMeili.findOneAndUpdate.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.findOneAndUpdate.spec.ts
@@ -164,7 +164,7 @@ describe('mongoMeili findOneAndUpdate with includeResultMetadata (saveConvo path
 
     await updateTitle(conversationId, user, 'Indexed Conversation');
     await waitForMock(mockAddDocuments);
-    await wait(50);
+    await waitForIndexAcknowledgment(conversationId);
 
     const storedDoc = await conversationModel.collection.findOne({ conversationId });
     expect(storedDoc?._meiliIndex).toBe(true);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1,8 +1,11 @@
 import mongoose from 'mongoose';
 import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
-import mongoMeili, { MEILI_INDEX_SCHEMA_VERSION } from '~/models/plugins/mongoMeili';
+import meiliLogger from '~/config/meiliLogger';
+import mongoMeili, {
+  MEILI_INDEX_SCHEMA_VERSION,
+  type SchemaWithMeiliMethods,
+} from '~/models/plugins/mongoMeili';
 import { createConversationModel } from '~/models/convo';
 import { createMessageModel } from '~/models/message';
 
@@ -1210,7 +1213,10 @@ describe('Meilisearch Mongoose plugin', () => {
 
       rejectMeiliWrite!(new Error('Network error'));
       await waitForMockCalls(mockAddDocuments, 2);
-      await wait(25);
+      await waitForCondition(async () => {
+        const storedDoc = await conversationModel.collection.findOne({ _id: conversation._id });
+        return storedDoc?._meiliIndex === true && storedDoc?._meiliIndexAttempted === true;
+      });
 
       const storedConversation = await conversationModel.collection.findOne({
         _id: conversation._id,
@@ -1225,6 +1231,8 @@ describe('Meilisearch Mongoose plugin', () => {
       const conversationModel = createConversationModel(
         mongoose,
       ) as unknown as SchemaWithMeiliMethods;
+      const finalError = new Error('Final network error');
+      const errorSpy = jest.spyOn(meiliLogger, 'error').mockImplementation(() => meiliLogger);
       await conversationModel.deleteMany({});
 
       const conversation = await conversationModel.create({
@@ -1234,11 +1242,14 @@ describe('Meilisearch Mongoose plugin', () => {
         endpoint: EModelEndpoint.openAI,
       });
       await waitForMock(mockAddDocuments);
-      await wait(25);
+      await waitForCondition(async () => {
+        const storedDoc = await conversationModel.collection.findOne({ _id: conversation._id });
+        return storedDoc?._meiliIndex === true;
+      });
       mockUpdateDocuments
         .mockRejectedValueOnce(new Error('Network error'))
         .mockRejectedValueOnce(new Error('Network error'))
-        .mockRejectedValueOnce(new Error('Network error'));
+        .mockRejectedValueOnce(finalError);
 
       conversation._meiliIndex = true;
       conversation.title = 'Updated Conversation';
@@ -1248,11 +1259,21 @@ describe('Meilisearch Mongoose plugin', () => {
         (await conversationModel.collection.findOne({ _id: conversation._id }))?._meiliIndex,
       ).toBe(false);
       await waitForMockCalls(mockUpdateDocuments, 3);
-      await wait(25);
+      await waitForCondition(() =>
+        errorSpy.mock.calls.some(
+          ([message, error]) =>
+            message === '[updateObjectToMeili] Error updating document in Meili:' &&
+            error === finalError,
+        ),
+      );
 
       const storedConversation = await conversationModel.collection.findOne({
         _id: conversation._id,
       });
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[updateObjectToMeili] Error updating document in Meili:',
+        finalError,
+      );
       expect(mockUpdateDocuments).toHaveBeenCalledTimes(3);
       expect(storedConversation?._meiliIndex).toBe(false);
       expect(storedConversation?._meiliIndexAttempted).toBe(true);
@@ -1288,13 +1309,21 @@ describe('Meilisearch Mongoose plugin', () => {
             _meiliIndex: true,
             _meiliIndexAttempted: true,
             _meiliIndexVersion: latestVersion,
+            _meiliCleanupVersion: 0,
           },
         },
       );
 
       resolveStaleWrite!({ taskUid: 1 });
       await waitForMockCalls(mockAddDocuments, 2);
-      await wait(25);
+      await waitForCondition(async () => {
+        const storedDoc = await conversationModel.collection.findOne({ _id: conversation._id });
+        return (
+          storedDoc?._meiliIndex === true &&
+          storedDoc?._meiliIndexVersion === latestVersion &&
+          storedDoc?._meiliCleanupVersion === 1
+        );
+      });
 
       expect(mockAddDocuments.mock.calls[1]).toEqual([
         [expect.objectContaining({ title: 'Latest Replica Snapshot' })],
@@ -1303,6 +1332,7 @@ describe('Meilisearch Mongoose plugin', () => {
       expect(await conversationModel.collection.findOne({ _id: conversation._id })).toMatchObject({
         _meiliIndex: true,
         _meiliIndexVersion: latestVersion,
+        _meiliCleanupVersion: 1,
       });
     });
 

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1246,6 +1246,7 @@ describe('Meilisearch Mongoose plugin', () => {
         const storedDoc = await conversationModel.collection.findOne({ _id: conversation._id });
         return storedDoc?._meiliIndex === true;
       });
+      errorSpy.mockClear();
       mockUpdateDocuments
         .mockRejectedValueOnce(new Error('Network error'))
         .mockRejectedValueOnce(new Error('Network error'))
@@ -1259,13 +1260,7 @@ describe('Meilisearch Mongoose plugin', () => {
         (await conversationModel.collection.findOne({ _id: conversation._id }))?._meiliIndex,
       ).toBe(false);
       await waitForMockCalls(mockUpdateDocuments, 3);
-      await waitForCondition(() =>
-        (errorSpy.mock.calls as unknown as Array<[string, unknown]>).some(
-          ([message, error]) =>
-            message === '[updateObjectToMeili] Error updating document in Meili:' &&
-            error === finalError,
-        ),
-      );
+      await waitForCondition(() => errorSpy.mock.calls.length > 0);
 
       const storedConversation = await conversationModel.collection.findOne({
         _id: conversation._id,

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1,10 +1,8 @@
 import mongoose from 'mongoose';
 import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import mongoMeili, {
-  MEILI_INDEX_SCHEMA_VERSION,
-  type SchemaWithMeiliMethods,
-} from '~/models/plugins/mongoMeili';
+import type { SchemaWithMeiliMethods } from '~/models/plugins/mongoMeili';
+import mongoMeili, { MEILI_INDEX_SCHEMA_VERSION } from '~/models/plugins/mongoMeili';
 import { createConversationModel } from '~/models/convo';
 import { createMessageModel } from '~/models/message';
 import meiliLogger from '~/config/meiliLogger';
@@ -133,6 +131,10 @@ describe('Meilisearch Mongoose plugin', () => {
     mockGetDocument.mockClear();
     mockGetDocuments.mockReset().mockResolvedValue({ results: [] });
     mockWaitForTask.mockReset().mockResolvedValue({ status: 'succeeded' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   afterAll(async () => {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1,13 +1,13 @@
 import mongoose from 'mongoose';
 import { EModelEndpoint } from 'librechat-data-provider';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import meiliLogger from '~/config/meiliLogger';
 import mongoMeili, {
   MEILI_INDEX_SCHEMA_VERSION,
   type SchemaWithMeiliMethods,
 } from '~/models/plugins/mongoMeili';
 import { createConversationModel } from '~/models/convo';
 import { createMessageModel } from '~/models/message';
+import meiliLogger from '~/config/meiliLogger';
 
 interface DynamicMeiliDocument extends mongoose.Document {
   docId: string;
@@ -1260,7 +1260,7 @@ describe('Meilisearch Mongoose plugin', () => {
       ).toBe(false);
       await waitForMockCalls(mockUpdateDocuments, 3);
       await waitForCondition(() =>
-        errorSpy.mock.calls.some(
+        (errorSpy.mock.calls as unknown as Array<[string, unknown]>).some(
           ([message, error]) =>
             message === '[updateObjectToMeili] Error updating document in Meili:' &&
             error === finalError,


### PR DESCRIPTION
## Summary

I prepared LibreChat v0.8.8-rc2 from the latest `dev` at `90cdcb384e` and refreshed every release surface.

- Bumped the root, API, and client versions from `v0.8.8-rc1` to `v0.8.8-rc2`.
- Bumped each publishable package exactly once above `dev`: `@librechat/api@1.7.47`, `@librechat/client@0.4.77`, `librechat-data-provider@0.8.522`, and `@librechat/data-schemas@0.0.69`.
- Updated the npm and Bun workspace lock entries for the package releases.
- Bumped the Helm chart once to `2.0.9` with `appVersion: v0.8.8-rc2`.
- Bumped the configuration version once from `1.3.14` to `1.3.15`.
- Refreshed the README with the latest RC2 features.
- Added the Redis READONLY recovery interval to `.env.example` and documented attached Code environment permission bounds in `librechat.example.yaml`.
- Preserved the focused Mongo/Meili test-isolation fixes required by the release branch.

## Change Type

- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- Ran `npm run test:config -- --runInBand`: 6 suites and 32 tests passed.
- Ran the focused data-provider configuration and filter suites: 2 suites and 182 tests passed.
- Built `librechat-data-provider` and ran the focused API suites for BYOM approvals, Code environment settings, Redis recovery, and attached environment settings.
- Ran `npm run static-checks -- --against origin/dev`.
- Ran `npm run build:packages`.
- Ran `helm lint helm/librechat`: one chart passed with the existing MongoDB `initContainers` warning.
- Verified every app, package, config, chart, dependency, and lockfile version against the latest `dev`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js 24.16.0
- npm 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
