### PR TITLE
🐛 fix: Give the Header's Sidebar Toggle Its Own Test Id

### DIFF
--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -50,7 +50,7 @@ function Header() {
   return (
     <div className="absolute top-0 z-10 flex h-[52px] w-full items-center gap-2 bg-gradient-to-b from-presentation via-presentation/70 to-transparent p-2 font-semibold text-text-primary md:from-presentation/80 md:via-presentation/50 2xl:from-presentation/0 2xl:via-transparent">
       <div className="flex flex-shrink-0 items-center md:hidden">
-        <OpenSidebar />
+        <OpenSidebar testId="header-open-sidebar-button" />
       </div>
 
       <div

--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -9,7 +9,18 @@ import store from '~/store';
 export const CLOSE_SIDEBAR_ID = 'close-sidebar-button';
 export const OPEN_SIDEBAR_ID = 'open-sidebar-button';
 
-export default function OpenSidebar({ className }: { className?: string }) {
+/**
+ * `testId` exists because the sidebar rail publishes `open-sidebar-button` for its own
+ * collapsed toggle. Any caller that can stay mounted alongside the rail must claim a
+ * distinct id, or `getByTestId` resolves to two elements.
+ */
+export default function OpenSidebar({
+  className,
+  testId = OPEN_SIDEBAR_ID,
+}: {
+  className?: string;
+  testId?: string;
+}) {
   const localize = useLocalize();
   const setSidebarExpanded = useSetRecoilState(store.sidebarExpanded);
   const tooltipDescription = useShortcutHint('toggleSidebar', localize('com_nav_open_sidebar'));
@@ -32,7 +43,7 @@ export default function OpenSidebar({ className }: { className?: string }) {
           id={OPEN_SIDEBAR_ID}
           size="icon"
           variant="outline"
-          data-testid="open-sidebar-button"
+          data-testid={testId}
           aria-label={localize('com_nav_open_sidebar')}
           aria-expanded={false}
           aria-controls="chat-history-nav"

--- a/e2e/specs/mock/sidebar.spec.ts
+++ b/e2e/specs/mock/sidebar.spec.ts
@@ -159,6 +159,10 @@ test.describe('sidebar conversation grouping', () => {
       localStorage.setItem('unifiedSidebarExpanded', JSON.stringify(false)),
     );
     await page.reload({ timeout: 10000 });
+    // The chat header keeps its own mobile toggle mounted and hides it with CSS, so this
+    // testid belongs to the rail alone — a second holder makes the click below strict-mode
+    // flaky rather than failing outright.
+    await expect(page.getByTestId('open-sidebar-button')).toHaveCount(1);
     await expect(page.getByTestId('open-sidebar-button')).toBeVisible();
 
     // Expand: rows first measure during the width animation — the regression window.


### PR DESCRIPTION
## Summary

`sidebar.spec.ts:143` fails on `dev` with a strict-mode violation:

```
locator.click: Error: strict mode violation: getByTestId('open-sidebar-button') resolved to 2 elements
```

#14843 replaced the header's `useMediaQuery` branch with CSS-only branching, so its mobile `OpenSidebar` now stays mounted at every breakpoint (`md:hidden` only hides it). The sidebar rail already publishes `open-sidebar-button` for its own collapsed toggle, so on desktop both elements hold that testid at once.

The duplicate testid is not new — `OpenSidebar.tsx` and `ExpandedPanel.tsx` have both used it for a long time. What changed is the *mount condition*: `{isSmallScreen ? <OpenSidebar /> : null}` used to keep the header's copy out of the desktop DOM entirely.

## Fix

Scope the header's copy to `header-open-sidebar-button`, matching the `header-*` convention already used by `header-new-chat-button`, `header-overflow-menu`, and `header-shared-link-indicator`. `open-sidebar-button` again means the rail alone, so no existing selector had to change — all three e2e references to it target the rail.

## Why the count assertion

The old failure was timing-dependent, not deterministic: line 162's `toBeVisible()` passed and line 165's `click()` failed, because the assertion lands before the header inside `messages-view` has mounted. A re-run could have gone green with the collision still present. `toHaveCount(1)` pins it.

## Verification

Ran the real spec against a local mock e2e harness, with a negative control:

- Reverted source fix, rebuilt, ran → **fails**: `toHaveCount` expected 1, received 2 (`12 × locator resolved to 2 elements`) — reproduces CI exactly.
- Restored fix, rebuilt (bundle re-checked for the new testid), ran → **passes**.
- `sidebar.spec.ts`, `shared-links.spec.ts`, `shortcuts.spec.ts` on this branch's base: 5 passed.
- Client unit tests for `ExpandedPanel`, `HeaderMenu`, `useNewChat`: 23 passed. Typecheck and lint clean.

## Note on the stacked PR

#14849 inherits this failure on e2e shard 3. It also has a separate, unrelated failure on shard 2 — `message-visual.spec.ts:163` (light + dark mobile) times out clicking `close-sidebar-button` with `element is not stable`, pointing at the new full-width drawer's `transform` transition never settling. That one is not addressed here.