### PR TITLE
📋 fix: Copy Only the Assistant Response Text

### DIFF
--- a/client/src/hooks/Messages/useCopyToClipboard.spec.ts
+++ b/client/src/hooks/Messages/useCopyToClipboard.spec.ts
@@ -64,7 +64,7 @@ describe('useCopyToClipboard', () => {
       });
     });
 
-    it('copies errors and tool input and output with surrounding text', () => {
+    it('copies only response text and skips tools, errors, and thinking', () => {
       const content = [
         { type: ContentTypes.TEXT, text: 'I checked the deployment.' },
         {
@@ -76,7 +76,9 @@ describe('useCopyToClipboard', () => {
             output: '{"status":"failed"}',
           },
         },
+        { type: ContentTypes.THINK, think: 'Let me reason about this' },
         { type: ContentTypes.ERROR, error: 'Deployment lookup failed' },
+        { type: ContentTypes.TEXT, text: 'The service is down.' },
       ] as TMessageContentParts[];
 
       const { result } = renderHook(() => useCopyToClipboard({ content }));
@@ -85,12 +87,9 @@ describe('useCopyToClipboard', () => {
         result.current(mockSetIsCopied);
       });
 
-      const copiedText = mockCopy.mock.calls[0]?.[0];
-      expect(copiedText).toContain('I checked the deployment.');
-      expect(copiedText).toContain('get_deployment');
-      expect(copiedText).toContain('service');
-      expect(copiedText).toContain('status');
-      expect(copiedText).toContain('Deployment lookup failed');
+      expect(mockCopy).toHaveBeenCalledWith('I checked the deployment.\nThe service is down.', {
+        format: 'text/plain',
+      });
     });
 
     it('should reset isCopied after timeout', () => {

--- a/client/src/hooks/Messages/useCopyToClipboard.ts
+++ b/client/src/hooks/Messages/useCopyToClipboard.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import copy from 'copy-to-clipboard';
-import { SearchResultData } from 'librechat-data-provider';
+import { ContentTypes, SearchResultData } from 'librechat-data-provider';
 import type { TMessage } from 'librechat-data-provider';
-import type { LocalizeFunction } from '~/common';
 import {
   SPAN_REGEX,
   CLEANUP_REGEX,
@@ -10,8 +9,6 @@ import {
   STANDALONE_PATTERN,
   INVALID_CITATION_REGEX,
 } from '~/utils/citations';
-import { formatMessageContent } from '~/hooks/Conversations/format';
-import useLocalize from '~/hooks/useLocalize';
 
 type Source = {
   link: string;
@@ -33,30 +30,18 @@ const refTypeMap: Record<string, string> = {
 export function serializeMessageForClipboard({
   text,
   content,
-  localize,
-}: Partial<Pick<TMessage, 'text' | 'content'>> & { localize: LocalizeFunction }): string {
+}: Partial<Pick<TMessage, 'text' | 'content'>>): string {
   if (!Array.isArray(content) || content.length === 0) {
     return text ?? '';
   }
 
-  return content
-    .filter((part) => part != null)
-    .map((part) => {
-      const formatted = formatMessageContent({
-        sender: '',
-        content: part,
-        format: 'text',
-        localize,
-      });
-      if (formatted.length === 0) {
-        return '';
-      }
-
-      const [label, value] = formatted;
-      return label ? `${label}:\n${value}` : value;
-    })
-    .filter((value) => value.trim().length > 0)
-    .join('\n');
+  return content.reduce((acc, curr, i) => {
+    if (curr?.type === ContentTypes.TEXT) {
+      const partText = typeof curr.text === 'string' ? curr.text : (curr.text?.value ?? '');
+      return acc + partText + (i === content.length - 1 ? '' : '\n');
+    }
+    return acc;
+  }, '');
 }
 
 export default function useCopyToClipboard({
@@ -66,7 +51,6 @@ export default function useCopyToClipboard({
 }: Partial<Pick<TMessage, 'text' | 'content'>> & {
   searchResults?: { [key: string]: SearchResultData };
 }) {
-  const localize = useLocalize();
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
@@ -84,7 +68,7 @@ export default function useCopyToClipboard({
       }
       setIsCopied(true);
 
-      const messageText = serializeMessageForClipboard({ text, content, localize });
+      const messageText = serializeMessageForClipboard({ text, content });
 
       // Early return if no search data
       if (!searchResults || Object.keys(searchResults).length === 0) {
@@ -123,7 +107,7 @@ export default function useCopyToClipboard({
         setIsCopied(false);
       }, 3000);
     },
-    [text, content, searchResults, localize],
+    [text, content, searchResults],
   );
 
   return copyToClipboard;


### PR DESCRIPTION
## Summary

#14770 started serializing every message content part when the copy button was clicked, so the clipboard included tool calls, thinking, errors, and export labels. This restores the previous path: copy only `TEXT` parts, which is the assistant response.

Conversation export is unchanged. It still uses `formatMessageContent`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced the regression with a content array that mixed reply text, a tool call, thinking, and an error. Before the fix, copy included all of those. After the fix, copy is only the two text parts joined by a newline.

### **Test Configuration**:

- Client unit tests: `cd client && npx jest --ci --watchAll=false src/hooks/Messages/useCopyToClipboard.spec.ts --no-coverage`
- Result: 16 passed, including `copies only response text and skips tools, errors, and thinking`
- ESLint on the two touched files: clean
- Browser check: running in parallel against this worktree's frontend

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes