### PR TITLE
➡️ style: Flush the In-Flight Steer Stack to the Composer Edge

### DIFF
--- a/client/src/components/Chat/Input/InFlightSteers.tsx
+++ b/client/src/components/Chat/Input/InFlightSteers.tsx
@@ -636,11 +636,17 @@ const InFlightSteers = memo(function InFlightSteers({
       aria-label={localize('com_ui_steer_in_flight')}
       data-testid="in-flight-steers"
       /* Floats above the composer over the bottom of the thread instead of
-       * displacing it, so scrolling up reveals the messages behind. Capped: a
-       * steer runs to 16k chars and a run takes up to 10 of them; unbounded it
-       * would cover the whole thread. pointer-events-none lets wheeling over
-       * the gaps reach those messages (each bubble opts back in). */
-      className="pointer-events-none absolute inset-x-0 bottom-full mx-auto flex max-h-[35vh] max-w-3xl flex-col items-end gap-2 overflow-y-auto p-2"
+       * displacing it, so scrolling up reveals the messages behind. Height is
+       * capped: a steer runs to 16k chars and a run takes up to 10 of them;
+       * unbounded it would cover the whole thread. Width is not — `inset-x-0`
+       * takes the width of the composer the steer was typed into, so the stack
+       * ends where that composer ends at every desktop width (`xl:max-w-4xl`,
+       * maximized chat space) instead of drifting inboard against a second,
+       * narrower cap of its own; `p-2` then lands the send-now arrow in the
+       * same column as the composer's own send button (`mr-2` + border).
+       * pointer-events-none lets wheeling over the gaps reach those messages
+       * (each bubble opts back in). */
+      className="pointer-events-none absolute inset-x-0 bottom-full flex max-h-[35vh] flex-col items-end gap-2 overflow-y-auto p-2"
     >
       {inFlight.map((steer) => (
         <InFlightSteer

--- a/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/InFlightSteers.test.tsx
@@ -672,6 +672,18 @@ describe('InFlightSteers', () => {
     expect(screen.getByText('**bold** steer')).toBeInTheDocument();
   });
 
+  it('hugs the composer edge instead of a narrower cap of its own', () => {
+    renderSteers([{ steerId: 's1', text: 'flush right', status: 'pending', createdAt: 1 }]);
+    const stack = screen.getByTestId('in-flight-steers');
+    // `inset-x-0` inherits the composer's width, so the stack ends where the
+    // composer ends at every desktop width. A cap of its own (the old
+    // `max-w-3xl`) drifts inboard the moment the composer is wider —
+    // `xl:max-w-4xl`, or maximized chat space.
+    expect(stack.className).toContain('inset-x-0');
+    expect(stack.className).toContain('items-end');
+    expect(stack.className).not.toMatch(/\bmax-w-/);
+  });
+
   it('floats the stack over the thread instead of displacing it', () => {
     // Anchored above the composer and pulled out of flow so the messages keep
     // their full height and slide behind it when the user scrolls up.


### PR DESCRIPTION
## Summary

The in-flight steer stack sat inboard of the composer on desktop. It carried its own `mx-auto max-w-3xl` cap — a second width constant beside the composer's — and the two agree only at `md`. Past that the composer widens to `xl:max-w-4xl` (or to the full pane under maximized chat space) while the stack stays pinned at 768px and centered, so the bubble drifts left of the edge it is supposed to hug.

`inset-x-0` already spans the composer wrapper, so the cap was never adding a bound the composer didn't already impose — it was overriding one. Dropping it leaves a single source of truth for the column width.

| Viewport | Before | After |
|---|---|---|
| ≥1280px (`xl`) | composer `max-w-4xl` (896px), stack capped at 768px and centered → bubble ends ~64px inside the composer's edge | ends 8px inside it |
| 768–1279px (`md`–`lg`) | composer `max-w-3xl` — same as the cap | unchanged |
| Maximized chat space | stack stuck in a centered 768px band while the composer spans the pane | tracks the composer |
| <768px | wrapper already narrower than the cap | unchanged |

The 8px that remains is the stack's own `p-2`, and it pays off: the composer's send/stop button is inset `mr-2` plus the 1px border = 9px, so the send-now arrow now sits in the same column as the button directly below it.

## Scroll-to-bottom

This puts the stack in the scroll-to-bottom button's lane at every desktop width, where before `xl` kept them 64px apart by accident. No new mechanism is needed — that is what `steerOverlayHeightFamily` is for. The button offsets by the published overlay height, and both are measured from the same edge (the messages region's bottom = the composer's top = the stack's `bottom-full` origin), so it rests 20px above the top of the stack (#14844).

Both sides key the atom off the same `useChatContext()` conversation (`InFlightSteers` writes, `MessagesView` reads), so the lift cannot silently no-op on a key mismatch.

## Tradeoff

At `xl` the message column is `max-w-3xl` while the composer is `max-w-4xl`, so the steer bubbles no longer line up with the user's own message bubbles above them — they line up with the composer instead. That is the intent here ("all the way to the right"), but it is a deliberate break from the "mirrors the user turn" alignment the component started with.

## Testing

- `client`: `InFlightSteers.test.tsx` (+1 regression test pinning the stack to the composer's width) and `ScrollToBottom.spec.tsx` — 61 passed.
- Verified by geometry rather than a screenshot; the change is class-strings only.
