### PR TITLE
🌗 fix: Keep Code Block Header Visible in User Messages

### DIFF
--- a/client/src/components/Messages/Content/CodeBar.tsx
+++ b/client/src/components/Messages/Content/CodeBar.tsx
@@ -13,7 +13,7 @@ const CodeBar: React.FC<CodeBarProps> = React.memo(
     const { isCopied, handleCopy } = useCopyCode(codeRef);
 
     return (
-      <div className="flex items-center justify-between bg-surface-primary-alt px-1.5 py-1.5 font-sans text-xs text-text-secondary dark:bg-transparent">
+      <div className="flex items-center justify-between bg-surface-secondary px-1.5 py-1.5 font-sans text-xs text-text-secondary">
         <span className="flex items-center gap-1.5 text-xs font-medium">
           <LangIcon lang={lang} className="size-3.5" />
           {lang}

--- a/client/src/components/Messages/Content/CodeBar.tsx
+++ b/client/src/components/Messages/Content/CodeBar.tsx
@@ -13,7 +13,7 @@ const CodeBar: React.FC<CodeBarProps> = React.memo(
     const { isCopied, handleCopy } = useCopyCode(codeRef);
 
     return (
-      <div className="flex items-center justify-between bg-surface-secondary px-1.5 py-1.5 font-sans text-xs text-text-secondary">
+      <div className="flex items-center justify-between bg-surface-code px-1.5 py-1.5 font-sans text-xs text-text-secondary">
         <span className="flex items-center gap-1.5 text-xs font-medium">
           <LangIcon lang={lang} className="size-3.5" />
           {lang}

--- a/client/src/components/Messages/Content/CodeBar.tsx
+++ b/client/src/components/Messages/Content/CodeBar.tsx
@@ -13,7 +13,7 @@ const CodeBar: React.FC<CodeBarProps> = React.memo(
     const { isCopied, handleCopy } = useCopyCode(codeRef);
 
     return (
-      <div className="flex items-center justify-between bg-surface-code px-1.5 py-1.5 font-sans text-xs text-text-secondary">
+      <div className="flex items-center justify-between bg-surface-primary-alt px-1.5 py-1.5 font-sans text-xs text-text-secondary dark:bg-transparent [.user-turn_&]:bg-surface-code">
         <span className="flex items-center gap-1.5 text-xs font-medium">
           <LangIcon lang={lang} className="size-3.5" />
           {lang}

--- a/client/src/components/Messages/Content/CodeBlock.tsx
+++ b/client/src/components/Messages/Content/CodeBlock.tsx
@@ -140,7 +140,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       />
       {allowExecution === true && toolCalls && toolCalls.length > 0 && (
         <>
-          <div className="border-t border-border-light bg-surface-primary-alt p-4 text-xs dark:bg-transparent">
+          <div className="border-t border-border-light bg-surface-secondary p-4 text-xs">
             <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-secondary">
               {localize('com_ui_output')}
             </div>

--- a/client/src/components/Messages/Content/CodeBlock.tsx
+++ b/client/src/components/Messages/Content/CodeBlock.tsx
@@ -140,7 +140,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       />
       {allowExecution === true && toolCalls && toolCalls.length > 0 && (
         <>
-          <div className="border-t border-border-light bg-surface-code p-4 text-xs">
+          <div className="border-t border-border-light bg-surface-primary-alt p-4 text-xs dark:bg-transparent [.user-turn_&]:bg-surface-code">
             <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-secondary">
               {localize('com_ui_output')}
             </div>

--- a/client/src/components/Messages/Content/CodeBlock.tsx
+++ b/client/src/components/Messages/Content/CodeBlock.tsx
@@ -140,7 +140,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       />
       {allowExecution === true && toolCalls && toolCalls.length > 0 && (
         <>
-          <div className="border-t border-border-light bg-surface-secondary p-4 text-xs">
+          <div className="border-t border-border-light bg-surface-code p-4 text-xs">
             <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-text-secondary">
               {localize('com_ui_output')}
             </div>

--- a/client/src/components/Messages/Content/ResultSwitcher.tsx
+++ b/client/src/components/Messages/Content/ResultSwitcher.tsx
@@ -26,7 +26,7 @@ export default function ResultSwitcher({
   return (
     <nav
       aria-label={localize('com_ui_navigate_results')}
-      className="flex items-center justify-center gap-1.5 border-t border-border-light px-3 py-1.5 text-xs"
+      className="flex items-center justify-center gap-1.5 border-t border-border-light bg-surface-code px-3 py-1.5 text-xs"
     >
       <button
         type="button"

--- a/client/src/components/Messages/Content/ResultSwitcher.tsx
+++ b/client/src/components/Messages/Content/ResultSwitcher.tsx
@@ -26,7 +26,7 @@ export default function ResultSwitcher({
   return (
     <nav
       aria-label={localize('com_ui_navigate_results')}
-      className="flex items-center justify-center gap-1.5 border-t border-border-light bg-surface-code px-3 py-1.5 text-xs"
+      className="flex items-center justify-center gap-1.5 border-t border-border-light px-3 py-1.5 text-xs [.user-turn_&]:bg-surface-code"
     >
       <button
         type="button"

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -183,6 +183,7 @@ html {
   --surface-destructive: var(--red-700);
   --surface-destructive-hover: var(--red-800);
   --surface-chat: var(--white);
+  --surface-code: var(--surface-primary-alt);
   --surface-qr: var(--white);
   --border-light: var(--gray-200);
   --border-light-alpha: 1;
@@ -271,6 +272,7 @@ html {
   --surface-destructive: var(--red-800);
   --surface-destructive-hover: var(--red-900);
   --surface-chat: var(--gray-700);
+  --surface-code: var(--presentation);
   --surface-qr: var(--white);
   --border-light: var(--gray-700);
   --border-medium-alt: var(--gray-600);

--- a/packages/client/src/theme/utils/createTailwindColors.js
+++ b/packages/client/src/theme/utils/createTailwindColors.js
@@ -104,6 +104,7 @@ function createTailwindColors() {
     'surface-destructive': cssVar('--surface-destructive'),
     'surface-destructive-hover': cssVar('--surface-destructive-hover'),
     'surface-chat': cssVar('--surface-chat'),
+    'surface-code': cssVar('--surface-code'),
     'surface-qr': cssVar('--surface-qr'),
     'surface-inverted': cssVar('--surface-inverted'),
     'surface-inverted-hover': cssVar('--surface-inverted-hover'),


### PR DESCRIPTION
## Summary

A fenced code block inside a user's own message was close to invisible in dark mode.

`CodeBar` was styled `bg-surface-primary-alt dark:bg-transparent`, so in dark mode it painted nothing and inherited whatever sat behind it. That is fine on the chat background, but a user message bubble is `bg-surface-tertiary`, which resolves to `gray-700` in dark, and the code block container's `border-border-light` resolves to `gray-700` as well. Both the header bar and the outline were exactly the bubble's own color, so the block lost its top edge and its frame and only the code body showed as an unattached slab.

The fix adds a `surface-code` role that derives, per mode, from what the bar previously showed, and applies it **only inside a user bubble**:

```css
:root { --surface-code: var(--surface-primary-alt); }  /* what the bar was already set to */
.dark { --surface-code: var(--presentation); }         /* what the transparent bar inherited */
```

```jsx
className="... bg-surface-primary-alt dark:bg-transparent [.user-turn_&]:bg-surface-code"
```

`CodeBar` also renders outside messages, on `surface-dialog` in the terms dialog and `surface-primary` in the subagent panel, and `dark:bg-transparent` is what let it sit on any of them. Scoping with a `.user-turn` ancestor selector, which `MessageRow` and `SteerPart` both already set, keeps those declarations byte for byte the originals everywhere else, so no other surface and no custom theme can drift. Deriving rather than naming a fixed color means the bubble case also tracks each theme's own `presentation`.

`ResultSwitcher` had no background at all, so once the execution output panel above it gained one it became a detached band of bubble color, the same defect one element lower. It takes the same scoped role.

`surface-code` is intentionally derived and not added to `defaultTheme`/`darkTheme`: `resolveTheme` back-fills every registered token into an inline variable and `validateRGB` accepts only literal `r g b` triples, so registering it would force the built-in value onto any custom theme that changes `presentation` without setting the new token. `surface-qr` is the existing precedent for a Tailwind role kept out of the registry.

### Dark mode

| Before | After |
| --- | --- |
| _drop `before-dark.png` here_ | _drop `after-dark.png` here_ |

### Light mode (unchanged)

| Before | After |
| --- | --- |
| _drop `before-light.png` here_ | _drop `after-light.png` here_ |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Captured with Playwright at 2x against a local dev instance, screenshotting the user message bubble in both themes, once with the change reverted and once applied.

- The two light mode captures are byte-identical before and after (matching MD5), confirming the change is a no-op in light mode.
- Measured computed styles in the running app for a user message in dark mode: bubble `rgb(47,47,47)`, code bar `rgb(33,33,33)`, code body `rgb(23,23,23)`. Before the change the bar measured `rgb(47,47,47)`, identical to the bubble.
- Measured in the running app, dark mode: the bar inside a user bubble is `rgb(33,33,33)` while the assistant bar computes to `rgba(0,0,0,0)`, i.e. still fully transparent, confirming every surface outside `.user-turn` inherits exactly as before.
- `--surface-code` resolves to `33 33 33` in dark (equal to `--presentation`) and `247 247 248` in light (equal to `--surface-primary-alt`).
- Seeded a conversation with two executions on one block to render `ResultSwitcher`: it measures `rgb(33,33,33)` in dark and `rgb(247,247,248)` in light, matching the output panel above it.

Commands run:

```
npx eslint client/src/components/Messages/Content/CodeBar.tsx client/src/components/Messages/Content/CodeBlock.tsx
cd client && npx jest src/components/Chat/Messages/Content/__tests__/MarkdownBlocks.test.tsx src/components/Chat/Messages/ui/__tests__/MessageRow.spec.tsx
cd packages/client && npx jest src/theme
```

ESLint reported nothing. Client: 2 suites, 23 tests passed. Theme registry: 6 suites, 62 tests passed, including `semanticTokens.spec.ts` and `createTailwindColors.spec.js`.

To reproduce: send yourself a message containing a fenced code block with "Enable Markdown for user messages" on, and view it in dark mode.

### **Test Configuration**:

Node 24.16.0, MongoDB, Chromium via Playwright, Vite dev server with the Express backend.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
