### PR TITLE
📐 fix: Size the Model Picker to Its Content

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -72,7 +72,7 @@ function ModelSelectorContent() {
         <button
           data-testid="model-selector-button"
           aria-keyshortcuts={modelSelectorAriaKey}
-          className="my-1 flex h-9 w-full max-w-[70vw] items-center justify-center gap-2 rounded-xl border border-border-light bg-presentation px-3 py-2 text-sm text-text-primary hover:bg-surface-active-alt"
+          className="my-1 flex h-9 max-w-full items-center gap-2 rounded-xl border border-border-light bg-presentation px-3 py-2 text-sm text-text-primary hover:bg-surface-active-alt"
           aria-label={localize('com_ui_select_model')}
         >
           {selectedIcon && React.isValidElement(selectedIcon) && (
@@ -80,14 +80,14 @@ function ModelSelectorContent() {
               {selectedIcon}
             </div>
           )}
-          <span className="flex-grow truncate text-left">{selectedDisplayValue}</span>
+          <span className="truncate text-left">{selectedDisplayValue}</span>
         </button>
       }
     />
   );
 
   return (
-    <div className="relative flex w-full max-w-md flex-col items-center gap-2">
+    <div className="relative flex min-w-0 max-w-[60vw] flex-col items-center gap-2 sm:max-w-xs">
       <Menu
         values={selectedValues}
         onValuesChange={(values: Record<string, any>) => {


### PR DESCRIPTION
## Summary

The header model picker rendered at a fixed width regardless of the selected model. The trigger button was `w-full` inside a `w-full max-w-md` wrapper, so it always painted a 448px pill even for a label as short as `gpt-5.6`, pushing the presets and multi-conversation buttons far to the right and leaving a large dead zone in the header.

The wrapper now shrink-wraps the trigger instead of stretching: `w-full max-w-md` becomes `min-w-0 max-w-[60vw] sm:max-w-xs`, and the button drops `w-full max-w-[70vw]` for `max-w-full`. The pill hugs its label, and a long model name truncates at the cap rather than claiming the whole row. `justify-center` and `flex-grow` are removed since a content-sized button has no free space to distribute.

The dropdown is unaffected: it is anchored with its own `min-w-[300px]` / `sm:max-w-[400px]` in `CustomMenu` and never derived its width from the trigger.

## Before

<img width="1800" height="260" alt="image" src="https://github.com/user-attachments/assets/22c5ac65-394d-4a3b-a4e9-9ad0430244bb" />

## After

<img width="1800" height="260" alt="image" src="https://github.com/user-attachments/assets/8fb1d37e-335f-4f4e-9409-4160fe0d92a5" />

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Measured the trigger with `getBoundingClientRect()` in the running app before and after the change, at 1440x900 with the same conversation and model:

- Before: 448px wide for the label `gpt-5.6`
- After: 103px wide, height unchanged at 36px

Injected a 50-character model name into the label to check the cap: the button stops at exactly 320px (`sm:max-w-xs`) and the label ellipsizes (`scrollWidth` 383 > `clientWidth` 268), so it never pushes the neighbouring header controls out of place.

Also checked by hand:

- Desktop 1440x900 in dark and light
- Mobile 390x844 with the sidebar closed, where the pill now sits next to the sidebar toggle instead of spanning most of the row
- Opened the dropdown to confirm its width and anchoring are unchanged

Commands run:

- `npx eslint client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx` (clean)
- `cd client && npx jest src/components/Chat/Menus/Endpoints` (8 suites, 38 tests passed)

### **Test Configuration**:

Node v24, local backend and Vite dev server, Chromium at 1440x900 and 390x844, dark and light themes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
