### PR TITLE
🎙️ fix: Prefer Compatible Formats for External STT Recording

### DIFF
--- a/client/src/hooks/Input/useSpeechToTextExternal.spec.ts
+++ b/client/src/hooks/Input/useSpeechToTextExternal.spec.ts
@@ -1,0 +1,40 @@
+import { getBestSupportedMimeType } from './useSpeechToTextExternal';
+
+const preferredMimeTypes = [
+  'audio/ogg;codecs=opus',
+  'audio/ogg',
+  'audio/wav',
+  'audio/webm',
+  'audio/webm;codecs=opus',
+  'audio/mp4',
+];
+
+describe('getBestSupportedMimeType', () => {
+  it.each(
+    preferredMimeTypes.map((expected, index) => ({
+      expected,
+      supportedTypes: new Set(preferredMimeTypes.slice(index)),
+      probedTypes: preferredMimeTypes.slice(0, index + 1),
+    })),
+  )(
+    'selects $expected before lower-priority formats',
+    ({ expected, supportedTypes, probedTypes }) => {
+      const isTypeSupported = jest.fn((type: string) => supportedTypes.has(type));
+
+      expect(getBestSupportedMimeType(isTypeSupported, 'test browser')).toBe(expected);
+      expect(isTypeSupported.mock.calls.map(([type]) => type)).toEqual(probedTypes);
+    },
+  );
+
+  it.each([
+    ['Safari', 'Mozilla/5.0 Version/17.0 Safari/605.1.15', 'audio/mp4'],
+    ['Firefox', 'Mozilla/5.0 Firefox/128.0', 'audio/ogg'],
+    ['Chrome', 'Mozilla/5.0 Chrome/128.0 Safari/537.36', 'audio/webm'],
+    ['an unknown browser', 'test browser', 'audio/webm'],
+  ])('falls back to %s defaults when no format is supported', (_browser, userAgent, expected) => {
+    const isTypeSupported = jest.fn((_type: string) => false);
+
+    expect(getBestSupportedMimeType(isTypeSupported, userAgent)).toBe(expected);
+    expect(isTypeSupported.mock.calls.map(([type]) => type)).toEqual(preferredMimeTypes);
+  });
+});

--- a/client/src/hooks/Input/useSpeechToTextExternal.ts
+++ b/client/src/hooks/Input/useSpeechToTextExternal.ts
@@ -4,6 +4,36 @@ import { useToastContext } from '@librechat/client';
 import { useSpeechToTextMutation } from '~/data-provider';
 import store from '~/store';
 
+export const getBestSupportedMimeType = (
+  isTypeSupported: (type: string) => boolean = (type) =>
+    typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(type),
+  userAgent: string = typeof navigator !== 'undefined' ? navigator.userAgent : '',
+) => {
+  const types = [
+    'audio/ogg;codecs=opus',
+    'audio/ogg',
+    'audio/wav',
+    'audio/webm',
+    'audio/webm;codecs=opus',
+    'audio/mp4',
+  ];
+
+  for (const type of types) {
+    if (isTypeSupported(type)) {
+      return type;
+    }
+  }
+
+  const ua = userAgent.toLowerCase();
+  if (ua.indexOf('safari') !== -1 && ua.indexOf('chrome') === -1) {
+    return 'audio/mp4';
+  } else if (ua.indexOf('firefox') !== -1) {
+    return 'audio/ogg';
+  }
+
+  return 'audio/webm';
+};
+
 const useSpeechToTextExternal = (
   setText: (text: string) => void,
   onTranscriptionComplete: (text: string) => void,
@@ -45,34 +75,6 @@ const useSpeechToTextExternal = (
       setIsRequestBeingMade(false);
     },
   });
-
-  function getBestSupportedMimeType() {
-    const types = [
-      'audio/ogg;codecs=opus',
-      'audio/ogg',
-      'audio/wav',
-      'audio/webm',
-      'audio/webm;codecs=opus',
-      'audio/mp4',
-    ];
-
-    for (const type of types) {
-      if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(type)) {
-        return type;
-      }
-    }
-
-    if (typeof navigator !== 'undefined') {
-      const ua = navigator.userAgent.toLowerCase();
-      if (ua.indexOf('safari') !== -1 && ua.indexOf('chrome') === -1) {
-        return 'audio/mp4';
-      } else if (ua.indexOf('firefox') !== -1) {
-        return 'audio/ogg';
-      }
-    }
-
-    return 'audio/webm';
-  }
 
   const getFileExtension = (mimeType: string) => {
     if (mimeType.includes('mp4')) {

--- a/client/src/hooks/Input/useSpeechToTextExternal.ts
+++ b/client/src/hooks/Input/useSpeechToTextExternal.ts
@@ -48,12 +48,12 @@ const useSpeechToTextExternal = (
 
   function getBestSupportedMimeType() {
     const types = [
-      'audio/webm',
-      'audio/webm;codecs=opus',
-      'audio/mp4',
       'audio/ogg;codecs=opus',
       'audio/ogg',
       'audio/wav',
+      'audio/webm',
+      'audio/webm;codecs=opus',
+      'audio/mp4',
     ];
 
     for (const type of types) {


### PR DESCRIPTION
## Summary

External STT recording now prefers `audio/ogg;codecs=opus`, `audio/ogg`, and `audio/wav` before WebM or MP4 when the browser supports them. Some OpenAI-compatible transcription providers reject WebM and MP4 uploads with an invalid file format response.

This branch preserves the original implementation from #11528 and adds direct regression coverage for the MIME priority and existing browser fallbacks. It supersedes #11528 because its source fork does not allow maintainer edits.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd client && npx jest src/hooks/Input/useSpeechToTextExternal.spec.ts --runInBand --coverage=false`
- `npx eslint client/src/hooks/Input/useSpeechToTextExternal.ts client/src/hooks/Input/useSpeechToTextExternal.spec.ts`
- `cd client && npm run typecheck -- --pretty false`
- The original contributor verified OGG recording and transcription with Firefox, Scaleway STT, and the `whisper-large-v3` model.

### **Test Configuration**:

- Node.js v24.16.0
- Jest with jsdom
- Firefox with Scaleway's OpenAI-compatible Audio Transcriptions API for the manual provider check

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
