### PR TITLE
fix: coerce malformed MCP `required` schemas for Bedrock compatibility

### DIFF
--- a/packages/api/src/mcp/__tests__/zod.spec.ts
+++ b/packages/api/src/mcp/__tests__/zod.spec.ts
@@ -2121,6 +2121,80 @@ describe('normalizeJsonSchema', () => {
     expect(result.additionalProperties).toEqual({ type: 'string', enum: ['val'] });
   });
 
+  it('should drop a malformed object-valued `required` (Bedrock rejects it)', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: {},
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result).not.toHaveProperty('required');
+    expect(result.properties.name).toEqual({ type: 'string' });
+  });
+
+  it('should drop malformed `required` in nested subschemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        config: {
+          type: 'object',
+          properties: { host: { type: 'string' } },
+          required: { host: true },
+        },
+      },
+      oneOf: [{ type: 'object', required: {} }],
+      items: { type: 'object', required: 'name' },
+      required: ['config'],
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result.required).toEqual(['config']);
+    expect(result.properties.config).not.toHaveProperty('required');
+    expect(result.oneOf[0]).not.toHaveProperty('required');
+    expect(result.items).not.toHaveProperty('required');
+  });
+
+  it('should filter non-string entries out of a `required` array', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' }, age: { type: 'number' } },
+      required: ['name', 42, null, 'age', { key: 'value' }],
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result.required).toEqual(['name', 'age']);
+  });
+
+  it('should preserve a valid `required` array, including an empty one', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    } as any;
+    expect(normalizeJsonSchema(schema).required).toEqual(['name']);
+
+    const emptyRequired = { type: 'object', properties: {}, required: [] } as any;
+    expect(normalizeJsonSchema(emptyRequired).required).toEqual([]);
+  });
+
+  it('should not touch a property literally named `required`', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        required: { type: 'boolean', description: 'Whether the field is mandatory' },
+      },
+      required: ['required'],
+    } as any;
+
+    const result = normalizeJsonSchema(schema);
+    expect(result.properties.required).toEqual({
+      type: 'boolean',
+      description: 'Whether the field is mandatory',
+    });
+    expect(result.required).toEqual(['required']);
+  });
+
   it('should handle null, undefined, and primitive inputs safely', () => {
     expect(normalizeJsonSchema(null as any)).toBeNull();
     expect(normalizeJsonSchema(undefined as any)).toBeUndefined();

--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -337,6 +337,8 @@ export function resolveJsonSchemaRefs<T extends Record<string, unknown>>(
  * - Strips vendor extension fields (`x-*` prefixed keys, e.g. `x-google-enum-descriptions`)
  * - Strips `definitions` and `$`-prefixed schema keywords (`$defs`, `$schema`,
  *   `$id`, `$comment`, ...) that may survive ref resolution
+ * - Coerces `required` to an array of strings, dropping the keyword when a
+ *   server emits a non-array value (Bedrock Converse rejects `required: {}`)
  *
  * Beyond LLM compatibility, dropping every `$`-prefixed keyword also makes the
  * output safe to persist: MongoDB rejects field names beginning with `$`, so a
@@ -413,6 +415,18 @@ export function normalizeJsonSchema<T extends Record<string, unknown>>(schema: T
 
     if (key === 'const' && 'enum' in schema) {
       // Skip `const` when `enum` already exists
+      continue;
+    }
+
+    // `required` must be an array of property names. Some MCP servers emit an
+    // object (e.g. `{}` from an SDK serializing an empty map); Anthropic's API
+    // tolerates it but Bedrock Converse rejects the whole request. Keep only a
+    // string-filtered array, dropping the keyword otherwise — an absent
+    // `required` is the permissive, spec-valid reading of a malformed one.
+    if (key === 'required') {
+      if (Array.isArray(value)) {
+        result[key] = value.filter((entry) => typeof entry === 'string');
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

Some MCP servers emit `required` as an object rather than an array of property names — classically `{}`, from an SDK serializing an empty map instead of an empty list. Anthropic's API tolerates this, but AWS Bedrock Converse validates strictly and rejects the entire request:

```
The json schema definition at toolConfig.tools.30.toolSpec.inputSchema is invalid.
Fix the following errors and try again: $.required: object found, array expected
```

Nothing between an MCP server's `tools/list` response and the provider payload validated this keyword. `normalizeJsonSchema` handles `const`, `x-*` extensions and `$`-prefixed keywords, but `required` is in none of its keyword sets, so it fell to the catch-all and was copied byte-for-byte into the tool spec. Two existing guards look like they would have caught it but do not: `convertJsonSchemaToZod` checks `Array.isArray(schema.required)` yet is not on the runtime path, and `mergeRequired` performs the correct coercion but only runs inside `sanitizeGeminiSchema`, which is gated to Google/Vertex and only when an `allOf`/`anyOf`/`oneOf` is present.

This adds a `required` branch to `normalizeJsonSchema`: keep the value only when it is an array, filtered to string entries, and drop the keyword otherwise — an absent `required` is the permissive, spec-valid reading of a malformed one.

`normalizeJsonSchema` is the single chokepoint every MCP tool schema crosses, so one branch covers all four consumers:

| Consumer | Call site |
|---|---|
| `tools/list` cache (model-facing tool map) | `packages/api/src/mcp/tools.ts` |
| Registry persistence | `packages/api/src/mcp/registry/MCPServerInspector.ts` |
| Event-driven / deferred definitions | `packages/api/src/tools/definitions.ts` |
| Runtime tool instance schema | `api/server/services/MCP.js` |

Because the function already recurses through `properties`, `items` and `oneOf`/`anyOf`/`allOf`, nested subschemas are covered by the same change. Normalizing before persistence also means already-cached malformed schemas heal on the next `tools/list` refresh.

Worth noting the failure is not specific to deferred tools. It surfaced immediately after a tool search revealed a `defer_loading: true` tool (growing the array past index 30), but an eagerly-loaded tool carrying the same schema fails identically.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Five cases added to the existing `normalizeJsonSchema` block in `packages/api/src/mcp/__tests__/zod.spec.ts`:

- drops `required: {}` at the top level (the exact Bedrock failure)
- drops malformed `required` nested under `properties`, `oneOf` and `items`, while preserving a valid top-level array alongside them
- filters non-string entries out of a `required` array (`['name', 42, null, 'age', { key: 'value' }]` → `['name', 'age']`)
- preserves valid arrays, including an empty `[]`
- leaves a property literally named `required` untouched, since property names are only iterated inside the schema-map keyword handling

```bash
cd packages/api && npx jest src/mcp/__tests__/zod.spec.ts
# Tests: 155 passed, 155 total
```

`tsc --noEmit` reports no errors in either changed file, and ESLint is clean on both.

### **Test Configuration**:

Node.js v24.16.0. No configuration variables required — the change is a pure schema transform covered by unit tests.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzJmt2qXaWMVU8n1BsHRft

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzJmt2qXaWMVU8n1BsHRft)_