### PR TITLE
🩹 fix: Stop the Header Stretching the Model Selector on Desktop

### DIFF
--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -61,7 +61,7 @@ function Header() {
            * on desktop too stretches a short model name to 448px instead of
            * letting it size to its content.
            */
-          'flex items-center gap-2 max-md:min-w-0 max-md:flex-1 md:pl-3 md:transition-all md:duration-200 md:ease-in-out',
+          'flex min-w-0 items-center gap-2 max-md:flex-1 md:pl-3 md:transition-all md:duration-200 md:ease-in-out',
           hiddenBehindNav,
         )}
       >

--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -55,7 +55,13 @@ function Header() {
 
       <div
         className={cn(
-          'flex min-w-0 flex-1 items-center gap-2 md:pl-3 md:transition-all md:duration-200 md:ease-in-out',
+          /**
+           * Grows only on mobile, where the selector should span the middle and
+           * truncate. `ModelSelector` is `w-full max-w-md`, so a zone that grows
+           * on desktop too stretches a short model name to 448px instead of
+           * letting it size to its content.
+           */
+          'flex items-center gap-2 max-md:min-w-0 max-md:flex-1 md:pl-3 md:transition-all md:duration-200 md:ease-in-out',
           hiddenBehindNav,
         )}
       >
@@ -75,7 +81,8 @@ function Header() {
         )}
       </div>
 
-      <div className={cn('flex flex-shrink-0 items-center gap-2', hiddenBehindNav)}>
+      {/* `ml-auto` holds the right cluster to the edge now that the centre no longer grows. */}
+      <div className={cn('flex flex-shrink-0 items-center gap-2 md:ml-auto', hiddenBehindNav)}>
         <NewChat className="md:hidden" />
         <HeaderMenu startupConfig={startupConfig} className="md:hidden" />
         <div className="hidden items-center gap-2 md:flex">

--- a/client/src/components/Chat/__tests__/Header.layout.spec.tsx
+++ b/client/src/components/Chat/__tests__/Header.layout.spec.tsx
@@ -65,9 +65,19 @@ describe('chat header layout', () => {
 
     const centre = screen.getByTestId('model-selector').parentElement;
 
-    expect(centre).toHaveClass('max-md:flex-1', 'max-md:min-w-0');
+    expect(centre).toHaveClass('max-md:flex-1');
     expect(centre).not.toHaveClass('flex-1');
-    expect(centre).not.toHaveClass('min-w-0');
+  });
+
+  /**
+   * Growing and shrinking are separate decisions. In a pane narrower than the
+   * viewport — expanded sidebar, open artifacts panel — the zone must still
+   * yield space, or the trailing controls are pushed outside and clipped.
+   */
+  it('still lets the centre zone shrink at every width', () => {
+    render(<Header />);
+
+    expect(screen.getByTestId('model-selector').parentElement).toHaveClass('min-w-0');
   });
 
   it('holds the trailing cluster to the edge without a growing centre', () => {

--- a/client/src/components/Chat/__tests__/Header.layout.spec.tsx
+++ b/client/src/components/Chat/__tests__/Header.layout.spec.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('recoil', () => ({
+  useRecoilValue: () => false,
+}));
+
+jest.mock('~/hooks', () => ({
+  useHasAccess: () => false,
+}));
+
+jest.mock('~/data-provider', () => ({
+  useGetStartupConfig: () => ({ data: undefined }),
+}));
+
+jest.mock('~/utils', () => ({
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
+}));
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: { sidebarExpanded: 'sidebarExpanded' },
+}));
+
+jest.mock('../Menus', () => ({
+  OpenSidebar: () => <div data-testid="open-sidebar" />,
+  PresetsMenu: () => <div data-testid="presets" />,
+  NewChat: () => <div data-testid="new-chat" />,
+  HeaderMenu: () => <div data-testid="header-menu" />,
+}));
+
+jest.mock('../Menus/Endpoints/ModelSelector', () => ({
+  __esModule: true,
+  default: () => <div data-testid="model-selector" />,
+}));
+
+jest.mock('../ExportAndShareMenu', () => ({
+  __esModule: true,
+  default: () => <div data-testid="export-share" />,
+}));
+
+jest.mock('../Menus/BookmarkMenu', () => ({
+  __esModule: true,
+  default: () => <div data-testid="bookmarks" />,
+}));
+
+jest.mock('../TemporaryChat', () => ({
+  TemporaryChat: () => <div data-testid="temporary" />,
+}));
+
+jest.mock('../AddMultiConvo', () => ({
+  __esModule: true,
+  default: () => <div data-testid="multi-convo" />,
+}));
+
+import Header from '../Header';
+
+describe('chat header layout', () => {
+  /**
+   * `ModelSelector` is `w-full max-w-md`, so it fills whatever it is given. A
+   * centre zone that grows on desktop stretches a short model name to 448px
+   * instead of letting it size to its content.
+   */
+  it('only lets the centre zone grow on mobile', () => {
+    render(<Header />);
+
+    const centre = screen.getByTestId('model-selector').parentElement;
+
+    expect(centre).toHaveClass('max-md:flex-1', 'max-md:min-w-0');
+    expect(centre).not.toHaveClass('flex-1');
+    expect(centre).not.toHaveClass('min-w-0');
+  });
+
+  it('holds the trailing cluster to the edge without a growing centre', () => {
+    render(<Header />);
+
+    const trailing = screen.getByTestId('header-menu').parentElement;
+
+    expect(trailing).toHaveClass('md:ml-auto', 'flex-shrink-0');
+  });
+
+  it('keeps the row from becoming a horizontal scroller again', () => {
+    const { container } = render(<Header />);
+
+    expect(container.querySelector('.overflow-x-auto')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes a regression from #14843, reported from a screenshot: the model selector stretches across the header on desktop.

## Cause

`ModelSelector` renders `w-full max-w-md`, so it fills whatever width it is handed.

The old header kept it in a shrink-to-fit cluster, so it sized to its content. #14843 restructured the bar into three zones and made the centre one `flex-1` — which hands the selector the entire middle.

Measured against the compiled Tailwind config, rendering the real class strings:

| viewport | before #14843 | after #14843 | this PR |
|---|---|---|---|
| 1280 | **107px** | **448px** | **97px** |
| 390 | 107px | 273px | 273px |

448px is `max-w-md`. The mobile number is intended — there the selector should span the middle and truncate.

## Fix

Grow the centre zone on mobile only, and hold the trailing cluster to the edge with `ml-auto` now that nothing between them expands. `ModelSelector` itself is untouched.

The remaining 10px difference at 1280 is `w-full` resolving ambiguously in a shrink-to-fit flex context; 97px is the true content width. Both render as a compact pill.

## Checks

New `Header.layout.spec.tsx` pins the contract: the centre zone carries `max-md:flex-1` and not bare `flex-1`, the trailing cluster carries `md:ml-auto`, and the row has no `overflow-x-auto` (which #14843 removed deliberately — it hid overflow rather than fixing it, and it swallows horizontal swipes).

Client suite green: 4307 tests, 363 suites.

`TokenUsage/Breakdown` is excluded from that number — it fails only in a worktree whose `@librechat/client` symlink points at a build predating #14855's `Collapsible`/`SegmentedMeter`. Unrelated to this diff and expected to pass on a fresh CI build.

## Note

This class of bug is invisible to jsdom, which does not do layout. I verified it by compiling the real Tailwind config against the actual class strings and measuring in a headless browser — the same approach that caught the P1 gutter geometry in #14836. Worth considering a mobile Playwright project so header layout has some automated floor.
