### PR TITLE
🧩 refactor: Extend Step Status To Remaining Cards; Separate Cancelled From Failed

### DIFF
--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -226,6 +226,7 @@ const Part = memo(function Part({
             <ImageGen
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}
+              runStepStatus={toolCall.runStepStatus}
               toolName={toolCall.name}
               args={toolCall.args ?? ''}
               output={toolCall.output ?? ''}
@@ -331,6 +332,7 @@ const Part = memo(function Part({
               output={toolCall.output ?? ''}
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}
+              runStepStatus={toolCall.runStepStatus}
               attachments={attachments}
               isLast={isLast}
               onExpand={onToolExpand}
@@ -341,6 +343,7 @@ const Part = memo(function Part({
             <RetrievalCall
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}
+              runStepStatus={toolCall.runStepStatus}
               args={toolCall.args}
               output={toolCall.output ?? undefined}
               attachments={attachments}
@@ -403,6 +406,7 @@ const Part = memo(function Part({
         <RetrievalCall
           initialProgress={toolCall.progress ?? 0.1}
           isSubmitting={isSubmitting}
+          runStepStatus={toolCall.runStepStatus}
           output={(toolCall as { output?: string }).output}
           attachments={attachments}
           onExpand={onToolExpand}
@@ -418,6 +422,7 @@ const Part = memo(function Part({
           initialProgress={toolCall.progress ?? 0.1}
           args={toolCall.function.arguments as string}
           isSubmitting={isSubmitting}
+          runStepStatus={toolCall.runStepStatus}
           toolName={toolCall.function.name}
           output={toolCall.function.output ?? ''}
         />

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -279,6 +279,7 @@ const Part = memo(function Part({
               output={toolCall.output ?? ''}
               initialProgress={toolCall.progress ?? 0.1}
               isSubmitting={isSubmitting}
+              runStepStatus={toolCall.runStepStatus}
               attachments={attachments}
               persistedContent={persistedContent}
               hideAttachments={hideAttachments}

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -66,10 +66,13 @@ export default function OpenAIImageGen({
   const intent = useToolCallIntent(_args);
   const isAgentStyle = toolName != null && AGENT_STYLE_TOOLS.has(toolName);
   const [agentProgress, setAgentProgress] = useState(initialProgress);
-  const legacyProgress = useProgress(isAgentStyle ? 1 : initialProgress);
+  const isClosed = runStepStatus != null;
+  /** Passed the terminal value rather than masked afterwards: `useProgress`
+   *  keeps a 200ms interval alive whenever its input is below 1, so masking
+   *  the result would leave a closed card scheduling work forever. */
+  const legacyProgress = useProgress(isAgentStyle || isClosed ? 1 : initialProgress);
   const livingProgress = isAgentStyle ? agentProgress : legacyProgress;
-  /** A closed step is terminal, so neither path may keep animating. */
-  const progress = runStepStatus != null ? 1 : livingProgress;
+  const progress = isClosed ? 1 : livingProgress;
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   /** A step the run closed as `failed` is an error even when its output text
@@ -156,7 +159,7 @@ export default function OpenAIImageGen({
       return;
     }
 
-    if (isSubmitting) {
+    if (isSubmitting && !isClosed) {
       setAgentProgress(initialProgress);
 
       if (intervalRef.current) {
@@ -202,20 +205,20 @@ export default function OpenAIImageGen({
         clearInterval(intervalRef.current);
       }
     };
-  }, [isSubmitting, initialProgress, quality, isAgentStyle]);
+  }, [isSubmitting, initialProgress, quality, isAgentStyle, isClosed]);
 
   useEffect(() => {
     if (!isAgentStyle) {
       return;
     }
 
-    if (initialProgress >= 1 || cancelled) {
+    if (initialProgress >= 1 || cancelled || isClosed) {
       setAgentProgress(initialProgress);
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
     }
-  }, [initialProgress, cancelled, isAgentStyle]);
+  }, [initialProgress, cancelled, isAgentStyle, isClosed]);
 
   useEffect(() => {
     updateDimensions();
@@ -239,21 +242,27 @@ export default function OpenAIImageGen({
     <>
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {(() => {
-          if (progress < 1 && !cancelled) {
+          if (progress < 1 && !cancelled && !hasError) {
             return '';
-          }
-          if (cancelled && hasError) {
-            return localize('com_ui_image_gen_failed');
           }
           if (cancelled) {
             return localize('com_ui_cancelled');
+          }
+          if (hasError) {
+            return localize('com_ui_image_gen_failed');
           }
           return intent ?? localize('com_ui_image_created');
         })()}
       </span>
       <div className="relative my-1 flex h-5 shrink-0 items-center gap-2">
         <ToolIcon type="image_gen" isAnimating={isInProgress} />
-        <ProgressText progress={progress} error={cancelled} toolName={toolName} intent={intent} />
+        <ProgressText
+          progress={progress}
+          error={hasError}
+          cancelled={cancelled}
+          toolName={toolName}
+          intent={intent}
+        />
       </div>
       {isAgentStyle && !hideAttachments && (
         <div className="relative mb-2 flex w-full justify-start">

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -245,11 +245,13 @@ export default function OpenAIImageGen({
           if (progress < 1 && !cancelled && !hasError) {
             return '';
           }
-          if (cancelled) {
-            return localize('com_ui_cancelled');
-          }
+          /** Failure outranks cancellation, matching `ProgressText`: the legacy
+           *  inference folds errors into its cancellation signal. */
           if (hasError) {
             return localize('com_ui_image_gen_failed');
+          }
+          if (cancelled) {
+            return localize('com_ui_cancelled');
           }
           return intent ?? localize('com_ui_image_created');
         })()}

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -72,7 +72,10 @@ export default function OpenAIImageGen({
   const progress = runStepStatus != null ? 1 : livingProgress;
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  const hasError = typeof output === 'string' && isError(output);
+  /** A step the run closed as `failed` is an error even when its output text
+   *  does not parse as one. Without this, forcing a closed step's progress to
+   *  1 would present a failed generation as a finished image. */
+  const hasError = (typeof output === 'string' && isError(output)) || runStepStatus === 'failed';
 
   /**
    * Determines if the image generation was cancelled.

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -67,9 +67,9 @@ export default function OpenAIImageGen({
   const isAgentStyle = toolName != null && AGENT_STYLE_TOOLS.has(toolName);
   const [agentProgress, setAgentProgress] = useState(initialProgress);
   const isClosed = runStepStatus != null;
-  /** Passed the terminal value rather than masked afterwards: `useProgress`
-   *  keeps a 200ms interval alive whenever its input is below 1, so masking
-   *  the result would leave a closed card scheduling work forever. */
+  /** Passing 1 in stops `useProgress` scheduling its interval; masking the
+   *  result makes the terminal value observable on the same render, since the
+   *  hook settles through 0.99 and a 200ms timeout. */
   const legacyProgress = useProgress(isAgentStyle || isClosed ? 1 : initialProgress);
   const livingProgress = isAgentStyle ? agentProgress : legacyProgress;
   const progress = isClosed ? 1 : livingProgress;
@@ -87,6 +87,13 @@ export default function OpenAIImageGen({
    *   because legacy image gen lacks a submitting signal — only errors cancel.
    */
   const cancelled = computeCancelled(isSubmitting, initialProgress, hasError, runStepStatus);
+  /**
+   * An explicit `cancelled` close is authoritative and outranks an
+   * error-formatted output — aborting a tool can itself produce one. The
+   * legacy inference keeps the opposite precedence, because it folds
+   * `hasError` into its own cancellation signal.
+   */
+  const reportsError = hasError && runStepStatus !== 'cancelled';
 
   let width: number | undefined;
   let height: number | undefined;
@@ -242,12 +249,10 @@ export default function OpenAIImageGen({
     <>
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {(() => {
-          if (progress < 1 && !cancelled && !hasError) {
+          if (progress < 1 && !cancelled && !reportsError) {
             return '';
           }
-          /** Failure outranks cancellation, matching `ProgressText`: the legacy
-           *  inference folds errors into its cancellation signal. */
-          if (hasError) {
+          if (reportsError) {
             return localize('com_ui_image_gen_failed');
           }
           if (cancelled) {
@@ -260,7 +265,7 @@ export default function OpenAIImageGen({
         <ToolIcon type="image_gen" isAnimating={isInProgress} />
         <ProgressText
           progress={progress}
-          error={hasError}
+          error={reportsError}
           cancelled={cancelled}
           toolName={toolName}
           intent={intent}

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -75,9 +75,6 @@ export default function OpenAIImageGen({
   const progress = isClosed ? 1 : livingProgress;
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  /** A step the run closed as `failed` is an error even when its output text
-   *  does not parse as one. Without this, forcing a closed step's progress to
-   *  1 would present a failed generation as a finished image. */
   const hasError = (typeof output === 'string' && isError(output)) || runStepStatus === 'failed';
 
   /**

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { AGENT_STYLE_TOOLS } from '.';
 import { PixelCard } from '@librechat/client';
-import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
+import type {
+  TAttachment,
+  TFile,
+  TAttachmentMetadata,
+  PartMetadata,
+} from 'librechat-data-provider';
 import { ToolIcon, isError } from '~/components/Chat/Messages/Content/ToolOutput';
 import Image from '~/components/Chat/Messages/Content/Image';
 import { useProgress, useLocalize } from '~/hooks';
@@ -13,7 +18,18 @@ function computeCancelled(
   isSubmitting: boolean | undefined,
   initialProgress: number,
   hasError: boolean,
+  runStepStatus?: PartMetadata['runStepStatus'],
 ): boolean {
+  /**
+   * The step's own terminal status wins when the run emitted one. Checked
+   * first and not gated on `hasError`, so output parsing cannot demote a step
+   * the run reported as stopped. Everything below is the pre-existing
+   * inference, kept for messages saved before `on_run_step_closed` and for the
+   * legacy path that has no submitting signal at all.
+   */
+  if (runStepStatus != null) {
+    return runStepStatus === 'cancelled';
+  }
   if (isSubmitting !== undefined) {
     return (!isSubmitting && initialProgress < 1) || hasError;
   }
@@ -33,6 +49,7 @@ export default function OpenAIImageGen({
   output,
   attachments,
   hideAttachments = false,
+  runStepStatus,
 }: {
   initialProgress: number;
   isSubmitting?: boolean;
@@ -41,6 +58,7 @@ export default function OpenAIImageGen({
   output?: string | null;
   attachments?: TAttachment[];
   hideAttachments?: boolean;
+  runStepStatus?: PartMetadata['runStepStatus'];
 }) {
   const localize = useLocalize();
   /** Model-authored live label (injected when the tool is opted into
@@ -49,7 +67,9 @@ export default function OpenAIImageGen({
   const isAgentStyle = toolName != null && AGENT_STYLE_TOOLS.has(toolName);
   const [agentProgress, setAgentProgress] = useState(initialProgress);
   const legacyProgress = useProgress(isAgentStyle ? 1 : initialProgress);
-  const progress = isAgentStyle ? agentProgress : legacyProgress;
+  const livingProgress = isAgentStyle ? agentProgress : legacyProgress;
+  /** A closed step is terminal, so neither path may keep animating. */
+  const progress = runStepStatus != null ? 1 : livingProgress;
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const hasError = typeof output === 'string' && isError(output);
@@ -60,7 +80,7 @@ export default function OpenAIImageGen({
    * - Legacy path (isSubmitting undefined): in-progress (0 < progress < 1) is never cancelled
    *   because legacy image gen lacks a submitting signal — only errors cancel.
    */
-  const cancelled = computeCancelled(isSubmitting, initialProgress, hasError);
+  const cancelled = computeCancelled(isSubmitting, initialProgress, hasError, runStepStatus);
 
   let width: number | undefined;
   let height: number | undefined;

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/ProgressText.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/ProgressText.tsx
@@ -5,11 +5,15 @@ import { cn } from '~/utils';
 export default function ProgressText({
   progress,
   error,
+  cancelled,
   toolName = '',
   intent,
 }: {
   progress: number;
   error?: boolean;
+  /** Stopped rather than failed — kept separate from `error` so a generation
+   *  the user cancelled is not labelled a failure. */
+  cancelled?: boolean;
   toolName?: string;
   /** Model-authored label; wins over the phase texts (error state excepted). */
   intent?: string;
@@ -17,6 +21,9 @@ export default function ProgressText({
   const localize = useLocalize();
 
   const getText = () => {
+    if (cancelled) {
+      return localize('com_ui_cancelled');
+    }
     if (error) {
       return localize('com_ui_image_gen_failed');
     }

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/ProgressText.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/ProgressText.tsx
@@ -21,11 +21,14 @@ export default function ProgressText({
   const localize = useLocalize();
 
   const getText = () => {
-    if (cancelled) {
-      return localize('com_ui_cancelled');
-    }
+    /** Failure outranks cancellation: the legacy inference folds errors into
+     *  its cancellation signal, so checking `cancelled` first would relabel a
+     *  genuine failure as a user stop. */
     if (error) {
       return localize('com_ui_image_gen_failed');
+    }
+    if (cancelled) {
+      return localize('com_ui_cancelled');
     }
     if (intent != null) {
       return intent;

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -9,7 +9,13 @@ import {
   OGDialogContent,
   OGDialogDescription,
 } from '@librechat/client';
-import type { Agents, TAttachment, TMessage, TMessageContentParts } from 'librechat-data-provider';
+import type {
+  Agents,
+  TAttachment,
+  TMessage,
+  TMessageContentParts,
+  PartMetadata,
+} from 'librechat-data-provider';
 import type { PartWithIndex } from '~/components/Chat/Messages/Content/ParallelContent';
 import type { SubagentTickerLine } from '~/utils/subagentContent';
 import ToolCallGroup from '~/components/Chat/Messages/Content/ToolCallGroup';
@@ -36,6 +42,9 @@ interface SubagentCallProps {
    *  tool_call's `progress` and any terminal subagent envelope — to decide
    *  whether the subagent is `running`, `cancelled`, or `finished`. */
   isSubmitting?: boolean;
+  /** Terminal lifecycle status from `on_run_step_closed`, when the run
+   *  emitted one. Authoritative over the `isSubmitting` inference. */
+  runStepStatus?: PartMetadata['runStepStatus'];
   args?: string | Record<string, unknown>;
   output?: string | null;
   attachments?: TAttachment[];
@@ -165,6 +174,7 @@ export default function SubagentCall({
   toolCallId,
   initialProgress,
   isSubmitting = false,
+  runStepStatus,
   args,
   output,
   attachments,
@@ -198,9 +208,19 @@ export default function SubagentCall({
    * - `running`: the parent is still streaming and no terminal signal has
    *   arrived yet.
    */
-  const hasError = progress?.status === 'error';
-  const finished = initialProgress >= 1 || progress?.status === 'stop' || hasError;
-  const cancelled = !isSubmitting && !finished;
+  /**
+   * A closed run step resolves the tri-state directly. It is the only signal
+   * that distinguishes "this subagent was stopped" from "the parent stream
+   * ended for some other reason", which the `!isSubmitting` inference below
+   * cannot tell apart. That inference stays as the fallback for messages
+   * saved before `on_run_step_closed` and endpoints that do not emit it.
+   */
+  const isClosed = runStepStatus != null;
+  const hasError = progress?.status === 'error' || runStepStatus === 'failed';
+  const finished = isClosed
+    ? runStepStatus !== 'cancelled'
+    : initialProgress >= 1 || progress?.status === 'stop' || hasError;
+  const cancelled = isClosed ? runStepStatus === 'cancelled' : !isSubmitting && !finished;
   const running = !finished && !cancelled;
 
   /**

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -216,7 +216,13 @@ export default function SubagentCall({
    * saved before `on_run_step_closed` and endpoints that do not emit it.
    */
   const isClosed = runStepStatus != null;
-  const hasError = progress?.status === 'error' || runStepStatus === 'failed';
+  /**
+   * An explicit `cancelled` close outranks a live `error` phase: aborting a
+   * child can surface through its execution as an error, and the run's own
+   * status is the authority on why it stopped.
+   */
+  const hasError =
+    (progress?.status === 'error' || runStepStatus === 'failed') && runStepStatus !== 'cancelled';
   const finished = isClosed
     ? runStepStatus !== 'cancelled'
     : initialProgress >= 1 || progress?.status === 'stop' || hasError;

--- a/client/src/components/Chat/Messages/Content/Parts/useToolCallState.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/useToolCallState.ts
@@ -27,10 +27,6 @@ export default function useToolCallState(
 ): ToolCallState {
   const autoExpand = useRecoilValue(store.autoExpandTools);
   const hasOutput = output.length > 0;
-  /**
-   * A step the run closed as `failed` is an error even when its output does
-   * not look like one — the run knows something the output text does not.
-   */
   const hasError = (hasOutput && isError(output)) || runStepStatus === 'failed';
   const hasContent = hasInput || hasOutput;
 

--- a/client/src/components/Chat/Messages/Content/Parts/useToolCallState.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/useToolCallState.ts
@@ -43,14 +43,11 @@ export default function useToolCallState(
     }
   }, [autoExpand, hasContent]);
 
-  /**
-   * A closed step is terminal by definition, so it must never animate. Forcing
-   * the bar complete keeps the shimmer from outliving a step that closed
-   * without ever emitting a completion event.
-   */
   const isClosed = runStepStatus != null;
-  const rawProgress = useProgress(initialProgress);
-  const progress = isClosed ? 1 : rawProgress;
+  /** Passed the terminal value rather than masked afterwards: `useProgress`
+   *  keeps a 200ms interval alive whenever its input is below 1, and a closed
+   *  step usually never receives the completion that would raise it. */
+  const progress = useProgress(isClosed ? 1 : initialProgress);
   const toggleCode = useCallback(() => {
     setShowCode((prev) => {
       const next = !prev;
@@ -72,7 +69,7 @@ export default function useToolCallState(
    */
   const cancelled = isClosed
     ? runStepStatus === 'cancelled'
-    : !isSubmitting && rawProgress < 1 && !hasError;
+    : !isSubmitting && progress < 1 && !hasError;
 
   return {
     showCode,

--- a/client/src/components/Chat/Messages/Content/Parts/useToolCallState.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/useToolCallState.ts
@@ -44,10 +44,13 @@ export default function useToolCallState(
   }, [autoExpand, hasContent]);
 
   const isClosed = runStepStatus != null;
-  /** Passed the terminal value rather than masked afterwards: `useProgress`
-   *  keeps a 200ms interval alive whenever its input is below 1, and a closed
-   *  step usually never receives the completion that would raise it. */
-  const progress = useProgress(isClosed ? 1 : initialProgress);
+  /**
+   * Both halves are load-bearing: passing 1 in stops `useProgress` scheduling
+   * its 200ms interval, and masking the result makes the terminal value
+   * observable on the same render rather than after the hook settles.
+   */
+  const rawProgress = useProgress(isClosed ? 1 : initialProgress);
+  const progress = isClosed ? 1 : rawProgress;
   const toggleCode = useCallback(() => {
     setShowCode((prev) => {
       const next = !prev;
@@ -69,7 +72,7 @@ export default function useToolCallState(
    */
   const cancelled = isClosed
     ? runStepStatus === 'cancelled'
-    : !isSubmitting && progress < 1 && !hasError;
+    : !isSubmitting && rawProgress < 1 && !hasError;
 
   return {
     showCode,

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { Tools } from 'librechat-data-provider';
 import { TooltipAnchor } from '@librechat/client';
 import { FileText, FileSpreadsheet, FileCode, FileImage, File } from 'lucide-react';
-import type { TAttachment, TFile } from 'librechat-data-provider';
+import type { TAttachment, TFile, PartMetadata } from 'librechat-data-provider';
 import { useLocalize, useProgress, useExpandCollapse } from '~/hooks';
 import { ToolIcon, OutputRenderer, isError } from './ToolOutput';
 import FilePreviewDialog from './FilePreviewDialog';
@@ -329,6 +329,7 @@ export default function RetrievalCall({
   output,
   attachments,
   onExpand,
+  runStepStatus,
 }: {
   initialProgress: number;
   isSubmitting: boolean;
@@ -336,16 +337,32 @@ export default function RetrievalCall({
   output?: string;
   attachments?: TAttachment[];
   onExpand?: () => void;
+  runStepStatus?: PartMetadata['runStepStatus'];
 }) {
-  const progress = useProgress(initialProgress);
+  /** A closed step is terminal, so it must never keep animating. */
+  const isClosed = runStepStatus != null;
+  const rawProgress = useProgress(initialProgress);
+  const progress = isClosed ? 1 : rawProgress;
   const localize = useLocalize();
   /** Model-authored live label (injected when file_search is opted into
    *  describe_intent); persists as the settled label. The sr-only live
    *  region below deliberately keeps its stable generic value. */
   const intent = useToolCallIntent(args);
 
-  const errorState = typeof output === 'string' && isError(output);
-  const cancelled = !isSubmitting && initialProgress < 1 && !errorState;
+  /** A step the run closed as `failed` is an error even when its output text
+   *  does not parse as one. */
+  const errorState = (typeof output === 'string' && isError(output)) || runStepStatus === 'failed';
+  /**
+   * The step's own terminal status wins when the run emitted one; the
+   * `isSubmitting` heuristic is a whole-message inference that cannot tell
+   * which step stopped. Authoritative on its own terms — not gated on
+   * `errorState`, so output parsing cannot demote a stopped step back into an
+   * in-flight state. Fallback retained for messages saved before
+   * `on_run_step_closed` and endpoints that do not emit it.
+   */
+  const cancelled = isClosed
+    ? runStepStatus === 'cancelled'
+    : !isSubmitting && initialProgress < 1 && !errorState;
   const hasOutput = !!output && !isError(output);
   const autoExpand = useRecoilValue(store.autoExpandTools);
   const [showOutput, setShowOutput] = useState(() => autoExpand && hasOutput);

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -461,7 +461,13 @@ export default function RetrievalCall({
           progress={progress}
           onClick={hasOutput ? handleToggleOutput : undefined}
           inProgressText={intent ?? localize('com_ui_searching_files')}
-          finishedText={intent ?? localize('com_ui_retrieved_files')}
+          /** A cancelled step must not read "Retrieved files" beside a
+           *  cancellation icon while the live region says "Cancelled". */
+          finishedText={
+            cancelled
+              ? localize('com_ui_cancelled')
+              : (intent ?? localize('com_ui_retrieved_files'))
+          }
           errorSuffix={errorState && !cancelled ? localize('com_ui_tool_failed') : undefined}
           icon={
             <ToolIcon type="file_search" isAnimating={progress < 1 && !cancelled && !errorState} />

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -339,10 +339,11 @@ export default function RetrievalCall({
   onExpand?: () => void;
   runStepStatus?: PartMetadata['runStepStatus'];
 }) {
-  /** A closed step is terminal, so it must never keep animating. */
   const isClosed = runStepStatus != null;
-  const rawProgress = useProgress(initialProgress);
-  const progress = isClosed ? 1 : rawProgress;
+  /** Passed the terminal value rather than masked afterwards: `useProgress`
+   *  keeps a 200ms interval alive whenever its input is below 1, and a closed
+   *  step usually never receives the completion that would raise it. */
+  const progress = useProgress(isClosed ? 1 : initialProgress);
   const localize = useLocalize();
   /** Model-authored live label (injected when file_search is opted into
    *  describe_intent); persists as the settled label. The sr-only live

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -355,8 +355,6 @@ export default function RetrievalCall({
    *  region below deliberately keeps its stable generic value. */
   const intent = useToolCallIntent(args);
 
-  /** A step the run closed as `failed` is an error even when its output text
-   *  does not parse as one. */
   const errorState = (typeof output === 'string' && isError(output)) || runStepStatus === 'failed';
   /**
    * The step's own terminal status wins when the run emitted one; the

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -446,6 +446,12 @@ export default function RetrievalCall({
           if (cancelled) {
             return localize('com_ui_cancelled');
           }
+          /** Announced before the success string: a terminal step that errored
+           *  must not reach the live region as "retrieved files", which would
+           *  tell a screen-reader user the opposite of what the card shows. */
+          if (errorState) {
+            return localize('com_ui_failed');
+          }
           return intent ?? localize('com_ui_retrieved_files');
         })()}
       </span>

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -340,10 +340,15 @@ export default function RetrievalCall({
   runStepStatus?: PartMetadata['runStepStatus'];
 }) {
   const isClosed = runStepStatus != null;
-  /** Passed the terminal value rather than masked afterwards: `useProgress`
-   *  keeps a 200ms interval alive whenever its input is below 1, and a closed
-   *  step usually never receives the completion that would raise it. */
-  const progress = useProgress(isClosed ? 1 : initialProgress);
+  /**
+   * Both halves are load-bearing. Passing 1 in stops `useProgress` scheduling
+   * its 200ms interval, which it keeps alive for any input below 1. Masking
+   * the result makes the terminal value observable on the same render — the
+   * hook settles through 0.99 and a 200ms timeout, so a step closing while
+   * mounted would otherwise render as still in progress for that window.
+   */
+  const rawProgress = useProgress(isClosed ? 1 : initialProgress);
+  const progress = isClosed ? 1 : rawProgress;
   const localize = useLocalize();
   /** Model-authored live label (injected when file_search is opted into
    *  describe_intent); persists as the settled label. The sr-only live

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -139,8 +139,6 @@ export default function ToolCall({
     window.open(auth, '_blank', 'noopener,noreferrer');
   }, [auth, isMCPToolCall, mcpServerName, actionId]);
 
-  /** A step the run closed as `failed` is an error even when its output text
-   *  does not parse as one. */
   const hasError = (typeof output === 'string' && isError(output)) || runStepStatus === 'failed';
   /**
    * The step's own terminal status wins when the run emitted one. The

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -184,9 +184,10 @@ export default function ToolCall({
     return parsedAuthUrl?.hostname ?? '';
   }, [parsedAuthUrl]);
 
-  /** A closed step is terminal, so it must never keep animating. */
-  const rawProgress = useProgress(initialProgress);
-  const progress = isClosed ? 1 : rawProgress;
+  /** Passed the terminal value rather than masked afterwards: `useProgress`
+   *  keeps a 200ms interval alive whenever its input is below 1, and a closed
+   *  step usually never receives the completion that would raise it. */
+  const progress = useProgress(isClosed ? 1 : initialProgress);
   const showCancelled = cancelled || (errorState && !output);
 
   const handleToggleInfo = useCallback(() => {

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -184,10 +184,13 @@ export default function ToolCall({
     return parsedAuthUrl?.hostname ?? '';
   }, [parsedAuthUrl]);
 
-  /** Passed the terminal value rather than masked afterwards: `useProgress`
-   *  keeps a 200ms interval alive whenever its input is below 1, and a closed
-   *  step usually never receives the completion that would raise it. */
-  const progress = useProgress(isClosed ? 1 : initialProgress);
+  /**
+   * Both halves are load-bearing: passing 1 in stops `useProgress` scheduling
+   * its 200ms interval, and masking the result makes the terminal value
+   * observable on the same render rather than after the hook settles.
+   */
+  const rawProgress = useProgress(isClosed ? 1 : initialProgress);
+  const progress = isClosed ? 1 : rawProgress;
   const showCancelled = cancelled || (errorState && !output);
 
   const handleToggleInfo = useCallback(() => {

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -2,7 +2,12 @@ import { useMemo, useState, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Tools } from 'librechat-data-provider';
 import { Globe, ChevronDown } from 'lucide-react';
-import type { TAttachment, ValidSource, SearchResultData } from 'librechat-data-provider';
+import type {
+  TAttachment,
+  ValidSource,
+  SearchResultData,
+  PartMetadata,
+} from 'librechat-data-provider';
 import { FaviconImage, getCleanDomain } from '~/components/Web/SourceHovercard';
 import { StackedFavicons } from '~/components/Web/Sources';
 import { useLocalize, useExpandCollapse } from '~/hooks';
@@ -85,6 +90,7 @@ export default function WebSearch({
   output,
   attachments,
   onExpand,
+  runStepStatus,
 }: {
   isLast?: boolean;
   isSubmitting: boolean;
@@ -93,13 +99,21 @@ export default function WebSearch({
   initialProgress: number;
   attachments?: TAttachment[];
   onExpand?: () => void;
+  runStepStatus?: PartMetadata['runStepStatus'];
 }) {
   const localize = useLocalize();
   /** Model-authored live label (web_search carries `intent` natively);
    *  persists as the settled label like the other tool cards. */
   const intent = useToolCallIntent(args);
   const { searchResults } = useSearchContext();
-  const error = typeof output === 'string' && output.toLowerCase().includes('error processing');
+  /** A step the run closed as `failed` is an error even when its output text
+   *  does not say so. */
+  const error =
+    (typeof output === 'string' && output.toLowerCase().includes('error processing')) ||
+    runStepStatus === 'failed';
+  /** A closed step is terminal: it can neither animate nor sit "finalizing"
+   *  waiting on a submission that no longer concerns it. */
+  const isClosed = runStepStatus != null;
 
   // Server tool calls (srvtoolu_) never receive ON_RUN_STEP_COMPLETED, so progress
   // stays at the default 0.1. Treat the search as complete if attachments have results.
@@ -108,15 +122,20 @@ export default function WebSearch({
       attachments?.some((att) => att.type === Tools.web_search && att[Tools.web_search]) ?? false,
     [attachments],
   );
-  const effectiveProgress = hasResults && !isSubmitting ? 1 : progress;
-  const cancelled = (!isSubmitting && effectiveProgress < 1) || error === true;
+  const effectiveProgress = isClosed || (hasResults && !isSubmitting) ? 1 : progress;
+  const cancelled = isClosed
+    ? runStepStatus === 'cancelled'
+    : (!isSubmitting && effectiveProgress < 1) || error === true;
 
-  const finalizing = isSubmitting && isLast && effectiveProgress === 1;
+  const finalizing = !isClosed && isSubmitting && isLast && effectiveProgress === 1;
   /** A search that is the message's FINAL part stays "finalizing" only while
    *  the submission is live — afterwards it must settle like any other call,
    *  or the completed label (and its settled intent announcement) never
-   *  renders and the card shimmers forever. */
-  const complete = effectiveProgress === 1 && !finalizing && (!isLast || !isSubmitting);
+   *  renders and the card shimmers forever. A closed step settles immediately
+   *  on its own status instead of waiting for the submission to end. */
+  const complete = isClosed
+    ? !cancelled && !error
+    : effectiveProgress === 1 && !finalizing && (!isLast || !isSubmitting);
 
   const ownTurn = useMemo((): string => {
     if (!attachments) {

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -123,8 +123,15 @@ export default function WebSearch({
     [attachments],
   );
   const effectiveProgress = isClosed || (hasResults && !isSubmitting) ? 1 : progress;
+  /**
+   * `error` folds into this branch deliberately: an errored search has always
+   * rendered as nothing (the `cancelled` early-return below), so a step closed
+   * as `failed` lands in the same place rather than inventing a failure UI
+   * this component has never had — or worse, falling through to the streaming
+   * branch and shimmering forever.
+   */
   const cancelled = isClosed
-    ? runStepStatus === 'cancelled'
+    ? runStepStatus === 'cancelled' || error
     : (!isSubmitting && effectiveProgress < 1) || error === true;
 
   const finalizing = !isClosed && isSubmitting && isLast && effectiveProgress === 1;
@@ -134,7 +141,7 @@ export default function WebSearch({
    *  renders and the card shimmers forever. A closed step settles immediately
    *  on its own status instead of waiting for the submission to end. */
   const complete = isClosed
-    ? !cancelled && !error
+    ? !cancelled
     : effectiveProgress === 1 && !finalizing && (!isLast || !isSubmitting);
 
   const ownTurn = useMemo((): string => {

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -111,8 +111,6 @@ export default function WebSearch({
   const error =
     (typeof output === 'string' && output.toLowerCase().includes('error processing')) ||
     runStepStatus === 'failed';
-  /** A closed step is terminal: it can neither animate nor sit "finalizing"
-   *  waiting on a submission that no longer concerns it. */
   const isClosed = runStepStatus != null;
 
   // Server tool calls (srvtoolu_) never receive ON_RUN_STEP_COMPLETED, so progress

--- a/client/src/components/Chat/Messages/Content/WebSearch.tsx
+++ b/client/src/components/Chat/Messages/Content/WebSearch.tsx
@@ -106,8 +106,6 @@ export default function WebSearch({
    *  persists as the settled label like the other tool cards. */
   const intent = useToolCallIntent(args);
   const { searchResults } = useSearchContext();
-  /** A step the run closed as `failed` is an error even when its output text
-   *  does not say so. */
   const error =
     (typeof output === 'string' && output.toLowerCase().includes('error processing')) ||
     runStepStatus === 'failed';

--- a/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
@@ -189,6 +189,20 @@ describe('OpenAIImageGen', () => {
       expect(progressText).toHaveAttribute('data-cancelled', 'false');
     });
 
+    it('lets an explicit cancellation outrank an error-formatted output', () => {
+      render(
+        <OpenAIImageGen
+          {...defaultProps}
+          output="Error processing tool call"
+          isSubmitting={true}
+          runStepStatus="cancelled"
+        />,
+      );
+      const progressText = screen.getByTestId('progress-text');
+      expect(progressText).toHaveAttribute('data-cancelled', 'true');
+      expect(progressText).toHaveAttribute('data-error', 'false');
+    });
+
     it('keeps failure precedence when the legacy inference folds an error into cancellation', () => {
       render(
         <OpenAIImageGen

--- a/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
@@ -171,8 +171,6 @@ describe('OpenAIImageGen', () => {
     it('shows cancelled state when not submitting and incomplete', () => {
       render(<OpenAIImageGen {...defaultProps} isSubmitting={false} initialProgress={0.5} />);
       const progressText = screen.getByTestId('progress-text');
-      /** Cancellation is reported on its own channel now: a stop is not a
-       *  failure, so it must not surface through `error`. */
       expect(progressText).toHaveAttribute('data-cancelled', 'true');
       expect(progressText).toHaveAttribute('data-error', 'false');
     });

--- a/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
@@ -38,8 +38,21 @@ jest.mock('../ToolOutput', () => ({
 
 jest.mock('../Parts/OpenAIImageGen/ProgressText', () => ({
   __esModule: true,
-  default: ({ progress, error }: { progress: number; error: boolean }) => (
-    <div data-testid="progress-text" data-progress={progress} data-error={String(error)} />
+  default: ({
+    progress,
+    error,
+    cancelled,
+  }: {
+    progress: number;
+    error: boolean;
+    cancelled?: boolean;
+  }) => (
+    <div
+      data-testid="progress-text"
+      data-progress={progress}
+      data-error={String(error)}
+      data-cancelled={String(cancelled === true)}
+    />
   ),
 }));
 
@@ -157,6 +170,36 @@ describe('OpenAIImageGen', () => {
 
     it('shows cancelled state when not submitting and incomplete', () => {
       render(<OpenAIImageGen {...defaultProps} isSubmitting={false} initialProgress={0.5} />);
+      const progressText = screen.getByTestId('progress-text');
+      /** Cancellation is reported on its own channel now: a stop is not a
+       *  failure, so it must not surface through `error`. */
+      expect(progressText).toHaveAttribute('data-cancelled', 'true');
+      expect(progressText).toHaveAttribute('data-error', 'false');
+    });
+
+    it('reports a run-step cancellation as cancelled, not failed', () => {
+      render(<OpenAIImageGen {...defaultProps} isSubmitting={true} runStepStatus="cancelled" />);
+      const progressText = screen.getByTestId('progress-text');
+      expect(progressText).toHaveAttribute('data-cancelled', 'true');
+      expect(progressText).toHaveAttribute('data-error', 'false');
+    });
+
+    it('reports a run-step failure as an error even when the output is benign', () => {
+      render(<OpenAIImageGen {...defaultProps} isSubmitting={true} runStepStatus="failed" />);
+      const progressText = screen.getByTestId('progress-text');
+      expect(progressText).toHaveAttribute('data-error', 'true');
+      expect(progressText).toHaveAttribute('data-cancelled', 'false');
+    });
+
+    it('keeps failure precedence when the legacy inference folds an error into cancellation', () => {
+      render(
+        <OpenAIImageGen
+          {...defaultProps}
+          output="Error processing tool call"
+          isSubmitting={false}
+          initialProgress={0.5}
+        />,
+      );
       const progressText = screen.getByTestId('progress-text');
       expect(progressText).toHaveAttribute('data-error', 'true');
     });


### PR DESCRIPTION
## Summary

Completes the coverage gap disclosed in #14871. That PR replaced the whole-message `!isSubmitting && progress < 1` heuristic with the SDK's per-step `on_run_step_closed` status for the generic tool card and the five cards sharing `useToolCallState`, but left four cards that implement their own cancellation logic still inferring. This PR finishes them — and, through review, grew two further changes described below.

Each card needed its own treatment rather than a forwarded prop, because each models "stopped" differently:

- **`RetrievalCall`** — the exact analog of the reviewed shape.
- **`WebSearch`** — its `effectiveProgress` also feeds `finalizing` and `complete`. Forcing it terminal naively would have stranded a cancelled final search as "finalizing" forever, so a closed step settles on its own status instead of waiting for the submission to end.
- **`OpenAIImageGen`** — resolves through `computeCancelled`, which now short-circuits on explicit status ahead of both the agent and legacy paths. The legacy path has no submitting signal at all, so this is the first real stop signal it has ever had.
- **`SubagentCall`** — a tri-state (`running`/`cancelled`/`finished`) built from subagent phase envelopes plus `!isSubmitting`, which could not distinguish "this subagent was stopped" from "the parent stream ended for another reason". A closed step resolves the tri-state directly.

The prior heuristic remains the fallback everywhere, so **messages saved before `on_run_step_closed` and endpoints that never emit it behave exactly as they do today**.

`CodeAnalyze` is intentionally untouched: it has no cancelled state, only progress-driven rendering.

## Scope beyond the title

Two changes came out of review and are worth a reviewer's attention, since the title does not imply them:

**1. Cancellation and failure are now distinct states.** They were being squeezed through a single `error` prop and reconstructed differently at each consumer, so the two kept trading places: a cancelled generation rendered "image generation failed" while its live region announced "Cancelled", and a `failed` close reached neither consumer. `ProgressText` (image-gen) gained a `cancelled` prop; `RetrievalCall`'s finished label became state-aware; live regions were reordered so failure outranks cancellation *for the legacy inference only* — that path folds errors into its own cancellation signal, whereas an explicit `cancelled` close is authoritative and outranks an error-formatted output.

**2. A `useProgress` timer leak, including in already-merged code.** `useProgress` keeps a 200ms interval alive whenever its input is below 1, and a closed step usually never receives the completion that would raise it. Every site now passes the terminal value in **and** masks the result — the first stops the timer, the second makes the terminal value observable on the same render, since the hook settles through 0.99 and a 200ms timeout. `ToolCall` and `useToolCallState` carried this from #14871 and are fixed here rather than left on `dev`. `OpenAIImageGen`'s agent-style ticker had the same problem a layer up, with cleanup keyed on `cancelled` (false for `failed`).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run locally — building the `@librechat/client` and `data-provider` workspaces made the client suite executable here:

- `client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx` — **16/16**
- `src/components/Chat/Messages/Content` + `src/hooks/SSE` — **852/852 across 54 suites**

`npx tsc --noEmit -p client/tsconfig.json` reports **1 error** — `useRum.ts`, a `fetch.preconnect` typing issue unrelated to this work — and it is 1 both with this diff and at the `dev` branch point, so this diff adds none.

> **Correction to earlier claims in this PR and #14871.** I previously reported a baseline of "487 errors, identical with and without the diff". That figure was an artifact of `@librechat/client` not being built in my environment; 486 of them were `Cannot find module`. The conclusion is unchanged, but the earlier evidence was much weaker than presented — a diff could have introduced errors inside those unresolved modules and gone unseen. The number above is measured against real resolution.

`npx eslint` clean on all touched files.

`OpenAIImageGen.test.tsx` previously asserted `data-error === 'true'` for a cancelled step, encoding the exact conflation this PR removes. It is updated to the new contract and extended with cases for explicit cancellation, explicit failure with benign output, and precedence in both directions.

Remaining limitation: the `api` suites still cannot run here (`npm ci` 403s on `https://cdn.sheetjs.com` for `xlsx`). Nothing in this PR touches server code.

`WebSearch` and `SubagentCall` are worth the closest read — both have state machines where a terminal status interacts with more than one derived flag.

Suggested manual verification:

1. Stop a run mid-web-search — the card should settle as cancelled rather than sitting in "finalizing".
2. Stop a run while a subagent is mid-flight — the subagent card should read cancelled, not "working…".
3. Stop an image generation — it should read "Cancelled", not "image generation failed".
4. Reload a conversation saved before this change and confirm rendering is unchanged.

## A note on the review cycle

Seven Codex rounds produced seventeen findings, and thirteen shared one shape: each card derives its visible label, its live-region announcement, and its progress/animation from separate expressions, so a change landing in one kept missing the others. Twice, my fix for a finding introduced the next by correcting a rule globally that was only right locally.

That suggests the residual risk here is structural rather than a matter of undiscovered bugs. This PR is a net improvement — every case it touches was already broken or is newly correct, and the fallback path is untouched — but a follow-up consolidating each card to one state derivation feeding label, announcement and progress alike would be worth more than further rounds on this one.

## Checklist

- [x] My code adheres to this project&#39;s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5