### PR TITLE
fix(agents): warn when skill descriptions are truncated in the model catalog

### DIFF
--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -897,6 +897,38 @@ describe('injectSkillCatalog', () => {
     expect(agent.additional_instructions).toContain('desc-my-skill');
   });
 
+  it('warns when a skill description exceeds the catalog entry cap', async () => {
+    const { logger } = await import('@librechat/data-schemas');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    const longDesc = 'x'.repeat(400);
+    const longSkill: PageSkill = {
+      ...makeSkill('long-skill', userObjectId),
+      description: longDesc,
+    };
+    const shortSkill = makeSkill('short-skill', userObjectId);
+    const listSkillsByAccess = buildPager([[longSkill, shortSkill]]);
+    const agent = makeAgent();
+    await injectSkillCatalog(baseParams({ listSkillsByAccess, agent }));
+
+    const truncWarns = warnSpy.mock.calls
+      .map((call) => String(call[0]))
+      .filter((msg) => msg.includes('truncated to'));
+    expect(truncWarns).toHaveLength(1);
+    expect(truncWarns[0]).toContain('"long-skill"');
+    expect(truncWarns[0]).toContain('was 400');
+    /* Short description is not flagged. */
+    expect(
+      warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .filter((msg) => msg.includes('"short-skill"') && msg.includes('truncated')),
+    ).toHaveLength(0);
+
+    /* The catalog still reaches the model — the warning is additive. */
+    expect(agent.additional_instructions).toContain('long-skill');
+    expect(agent.additional_instructions).toContain('short-skill');
+    warnSpy.mockRestore();
+  });
+
   it('honors a configured maxCatalogSkills below the default hard limit', async () => {
     const first = makeSkill('first-skill', userObjectId);
     const second = makeSkill('second-skill', userObjectId);

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -89,6 +89,13 @@ const MIN_SKILL_CATALOG_LIMIT = 1;
 const MAX_CATALOG_PAGES = 10;
 /** Page size used when paginating to fill the active-skill quota. */
 const CATALOG_PAGE_SIZE = 100;
+/**
+ * Per-entry description cap applied by `formatSkillCatalog` before the
+ * catalog is injected into agent context. `@librechat/agents` truncates
+ * silently, so this mirrors the default so we can warn when authors' skill
+ * descriptions will not reach the model verbatim.
+ */
+const SKILL_CATALOG_MAX_ENTRY_CHARS = 250;
 /** Hard ceiling on skill names a model spec can request by config. */
 const MAX_MODEL_SPEC_SKILLS = SKILL_CATALOG_LIMIT;
 /**
@@ -620,9 +627,19 @@ export async function injectSkillCatalog(
    * and those reads would otherwise be impossible.
    */
   if (catalogVisibleSkills.length > 0) {
+    for (const s of catalogVisibleSkills) {
+      if (s.description.length > SKILL_CATALOG_MAX_ENTRY_CHARS) {
+        logger.warn(
+          `[injectSkillCatalog] skill "${s.name}" description truncated to ${SKILL_CATALOG_MAX_ENTRY_CHARS} chars for the model catalog (was ${s.description.length})`,
+        );
+      }
+    }
     const catalog = formatSkillCatalog(
       catalogVisibleSkills.map((s) => ({ name: s.name, description: s.description })),
-      { contextWindowTokens: contextWindowTokens || 200_000 },
+      {
+        contextWindowTokens: contextWindowTokens || 200_000,
+        maxEntryChars: SKILL_CATALOG_MAX_ENTRY_CHARS,
+      },
     );
     if (catalog) {
       agent.additional_instructions = agent.additional_instructions


### PR DESCRIPTION
## Summary

`formatSkillCatalog` caps every catalog entry at 250 characters and truncates silently. The import validator allows descriptions up to 1024 chars, so an author can write a description, have it accepted, and never learn that two thirds of it is cut from the model-visible catalog. Since the catalog is the only signal a model has for choosing a skill, and trigger phrases tend to live at the end of a description ("use when the user asks..."), the truncation removes exactly the part that makes a skill fire.

The fix logs one warning per truncated skill when the catalog is injected:

```
[injectSkillCatalog] skill "people" description truncated to 250 chars for the model catalog (was 625)
```

I also pass the cap explicitly to `formatSkillCatalog` instead of relying on its default, so the warning and the catalog text cannot drift apart if the agents package changes the default later.

This addresses #14657. I kept it to the log + explicit cap rather than raising the limit or changing the truncation strategy, since that touches the context budget logic and deserves its own discussion.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

- Added a regression test in `packages/api/src/agents/__tests__/skills.test.ts` that injects a 400-char description and asserts exactly one warning, naming the skill and the original length, while a short description stays silent.
- Verified the test fails without the fix (red) and passes with it (green).
- `npx jest src/agents/`: 1842 passed, 4 skipped, 0 failed.
- `eslint` clean on both changed files; `tsc --noEmit` clean.

### Test Configuration

- Node v22, npm ci from the lockfile, data-schemas + data-provider built from source.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
