### PR TITLE
feat: customizable login branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1022,6 +1022,9 @@ ALLOW_SHARED_LINKS_PUBLIC=false
 APP_TITLE=LibreChat
 # CUSTOM_FOOTER="My custom footer"
 # CUSTOM_LOGIN_FOOTER="My custom login page footer"
+# Custom app icon, replaces the favicon, apple-touch-icon, web app manifest
+# icons, and login page logo. Path to a file in client/public/assets.
+# APP_ICON_URL="assets/custom-icon.png"
 HELP_AND_FAQ_URL=https://librechat.ai
 
 # SHOW_BIRTHDAY_ICON=true

--- a/.env.example
+++ b/.env.example
@@ -1021,6 +1021,7 @@ ALLOW_SHARED_LINKS_PUBLIC=false
 
 APP_TITLE=LibreChat
 # CUSTOM_FOOTER="My custom footer"
+# CUSTOM_LOGIN_FOOTER="My custom login page footer"
 HELP_AND_FAQ_URL=https://librechat.ai
 
 # SHOW_BIRTHDAY_ICON=true

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -208,6 +208,21 @@ const startServer = async () => {
     }
   }
 
+  /** Point the icon links, web app manifest, and login page logo at the custom app icon */
+  let webManifest;
+  if (process.env.APP_ICON_URL) {
+    const appIcon = process.env.APP_ICON_URL.replace(/"/g, '&quot;');
+    indexHTML = indexHTML
+      .replace(/<link rel="(icon|apple-touch-icon)"[^>]*>/g, `<link rel="$1" href="${appIcon}" />`)
+      .replace('</head>', `  <meta name="app-icon" content="${appIcon}" />\n  </head>`);
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(appConfig.paths.dist, 'manifest.webmanifest'), 'utf8'),
+    );
+    manifest.icons = manifest.icons.map((icon) => ({ ...icon, src: process.env.APP_ICON_URL }));
+    webManifest = JSON.stringify(manifest);
+  }
+
   const sendIndexHtml = (req, res) => {
     res.set({
       'Cache-Control': process.env.INDEX_CACHE_CONTROL || 'no-cache, no-store, must-revalidate',
@@ -267,6 +282,11 @@ const startServer = async () => {
   }
 
   app.get('/index.html', sendIndexHtml);
+  if (webManifest) {
+    app.get('/manifest.webmanifest', (_req, res) =>
+      res.set('Cache-Control', 'no-store').type('application/manifest+json').send(webManifest),
+    );
+  }
   app.use(staticCache(appConfig.paths.dist));
   app.use(staticCache(appConfig.paths.fonts));
   app.use(staticCache(appConfig.paths.assets));

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -107,6 +107,10 @@ function buildPreLoginPayload() {
     payload.ldap = ldap;
   }
 
+  if (typeof process.env.CUSTOM_LOGIN_FOOTER === 'string') {
+    payload.customLoginFooter = process.env.CUSTOM_LOGIN_FOOTER;
+  }
+
   return payload;
 }
 

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -230,7 +230,12 @@ router.get('/', async function (req, res) {
 
       const interfaceConfig = baseConfig?.interfaceConfig;
       const buildInfoDisabled = interfaceConfig?.buildInfo === false;
-      if (interfaceConfig?.privacyPolicy || interfaceConfig?.termsOfService || buildInfoDisabled) {
+      if (
+        interfaceConfig?.privacyPolicy ||
+        interfaceConfig?.termsOfService ||
+        buildInfoDisabled ||
+        interfaceConfig?.loginLogoHeight != null
+      ) {
         payload.interface = {};
         if (interfaceConfig.privacyPolicy) {
           payload.interface.privacyPolicy = interfaceConfig.privacyPolicy;
@@ -240,6 +245,9 @@ router.get('/', async function (req, res) {
         }
         if (buildInfoDisabled) {
           payload.interface.buildInfo = false;
+        }
+        if (interfaceConfig.loginLogoHeight != null) {
+          payload.interface.loginLogoHeight = interfaceConfig.loginLogoHeight;
         }
       }
 

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -234,7 +234,8 @@ router.get('/', async function (req, res) {
         interfaceConfig?.privacyPolicy ||
         interfaceConfig?.termsOfService ||
         buildInfoDisabled ||
-        interfaceConfig?.loginLogoHeight != null
+        interfaceConfig?.loginLogoHeight != null ||
+        interfaceConfig?.showLoginTitle != null
       ) {
         payload.interface = {};
         if (interfaceConfig.privacyPolicy) {
@@ -248,6 +249,9 @@ router.get('/', async function (req, res) {
         }
         if (interfaceConfig.loginLogoHeight != null) {
           payload.interface.loginLogoHeight = interfaceConfig.loginLogoHeight;
+        }
+        if (interfaceConfig.showLoginTitle != null) {
+          payload.interface.showLoginTitle = interfaceConfig.showLoginTitle;
         }
       }
 

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -63,7 +63,10 @@ function AuthLayout({
     <div className="relative flex min-h-screen flex-col bg-surface-primary">
       <Banner />
       <BlinkAnimation active={isFetching}>
-        <div className="mt-6 h-10 w-full bg-cover">
+        <div
+          className="mt-6 w-full bg-cover"
+          style={{ height: `${startupConfig?.interface?.loginLogoHeight ?? 40}px` }}
+        >
           <img
             src="assets/logo.svg"
             className="h-full w-full object-contain"

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -7,6 +7,9 @@ import { BlinkAnimation } from './BlinkAnimation';
 import { Banner } from '../Banners';
 import Footer from './Footer';
 
+/** Injected into index.html by the server when APP_ICON_URL is set */
+const appIcon = document.querySelector('meta[name="app-icon"]')?.getAttribute('content');
+
 function AuthLayout({
   children,
   header,
@@ -68,7 +71,7 @@ function AuthLayout({
           style={{ height: `${startupConfig?.interface?.loginLogoHeight ?? 40}px` }}
         >
           <img
-            src="assets/logo.svg"
+            src={appIcon || 'assets/logo.svg'}
             className="h-full w-full object-contain"
             alt={localize('com_ui_logo', { 0: startupConfig?.appTitle ?? 'LibreChat' })}
           />

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -76,6 +76,14 @@ function AuthLayout({
             alt={localize('com_ui_logo', { 0: startupConfig?.appTitle ?? 'LibreChat' })}
           />
         </div>
+        {startupConfig?.interface?.showLoginTitle && (
+          <h1
+            className="mb-4 mt-2 text-center text-3xl font-semibold text-text-primary"
+            style={{ userSelect: 'none' }}
+          >
+            {startupConfig.appTitle}
+          </h1>
+        )}
       </BlinkAnimation>
       <DisplayError />
       <div className="absolute bottom-0 left-0 md:m-4">

--- a/client/src/components/Auth/Footer.tsx
+++ b/client/src/components/Auth/Footer.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import { TStartupConfig } from 'librechat-data-provider';
 import { useLocalize } from '~/hooks';
 
@@ -8,6 +10,33 @@ function Footer({ startupConfig }: { startupConfig: TStartupConfig | null | unde
   }
   const privacyPolicy = startupConfig.interface?.privacyPolicy;
   const termsOfService = startupConfig.interface?.termsOfService;
+
+  const mainContentParts =
+    typeof startupConfig.customLoginFooter === 'string'
+      ? startupConfig.customLoginFooter.split('|')
+      : [];
+
+  const mainContentRender = mainContentParts.map((text, index) => (
+    <React.Fragment key={`main-content-part-${index}`}>
+      <ReactMarkdown
+        components={{
+          a: ({ node: _n, href, children, ...otherProps }) => (
+            <a
+              className="text-sm text-accent-primary underline decoration-transparent transition-all duration-200 hover:text-accent-primary-hover hover:decoration-accent-primary-hover focus:text-accent-primary-hover focus:decoration-accent-primary-hover"
+              href={href}
+              rel="noreferrer"
+              {...otherProps}
+            >
+              {children}
+            </a>
+          ),
+          p: ({ node: _n, ...props }) => <span className="text-sm" {...props} />,
+        }}
+      >
+        {text.trim()}
+      </ReactMarkdown>
+    </React.Fragment>
+  ));
 
   const privacyPolicyRender = privacyPolicy?.externalUrl && (
     <a
@@ -33,13 +62,21 @@ function Footer({ startupConfig }: { startupConfig: TStartupConfig | null | unde
     </a>
   );
 
+  const footerElements = [...mainContentRender, privacyPolicyRender, termsOfServiceRender].filter(
+    Boolean,
+  );
+
   return (
-    <div className="align-end m-4 flex justify-center gap-2" role="contentinfo">
-      {privacyPolicyRender}
-      {privacyPolicyRender && termsOfServiceRender && (
-        <div className="border-r-[1px] border-border-medium" />
-      )}
-      {termsOfServiceRender}
+    <div className="align-end m-4 flex justify-center gap-2 text-text-primary" role="contentinfo">
+      {footerElements.map((contentRender, index) => {
+        const isLastElement = index === footerElements.length - 1;
+        return (
+          <React.Fragment key={`footer-element-${index}`}>
+            {contentRender}
+            {!isLastElement && <div className="border-r-[1px] border-border-medium" />}
+          </React.Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -103,6 +103,9 @@ interface:
   # Height, in pixels, of the app logo shown on the login/registration page.
   # Leave unset to use the default size (40px).
   # loginLogoHeight: 80
+  # Show the app title (APP_TITLE) below the logo on the login/registration
+  # page. Disabled by default.
+  # showLoginTitle: true
   # Enable/disable file search as a chatarea selection (default: true)
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -100,6 +100,9 @@ cache: true
 # Custom interface configuration
 interface:
   customWelcome: 'Welcome to LibreChat! Enjoy your experience.'
+  # Height, in pixels, of the app logo shown on the login/registration page.
+  # Leave unset to use the default size (40px).
+  # loginLogoHeight: 80
   # Enable/disable file search as a chatarea selection (default: true)
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1417,6 +1417,7 @@ export const interfaceSchema = z
     termsOfService: termsOfServiceSchema.optional(),
     customWelcome: z.string().optional(),
     loginLogoHeight: z.number().positive().optional(),
+    showLoginTitle: z.boolean().optional(),
     mcpServers: mcpServersSchema.optional(),
     modelSelect: z.boolean().optional(),
     parameters: z.boolean().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1416,6 +1416,7 @@ export const interfaceSchema = z
       .optional(),
     termsOfService: termsOfServiceSchema.optional(),
     customWelcome: z.string().optional(),
+    loginLogoHeight: z.number().positive().optional(),
     mcpServers: mcpServersSchema.optional(),
     modelSelect: z.boolean().optional(),
     parameters: z.boolean().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1649,6 +1649,7 @@ export type TStartupConfig = {
   /** Admin panel link, only present for users with admin access */
   adminPanelURL?: string;
   customFooter?: string;
+  customLoginFooter?: string;
   modelSpecs?: TSpecsConfig;
   modelDescriptions?: Record<string, Record<string, string>>;
   sharedLinksEnabled: boolean;

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -39,6 +39,7 @@ export async function loadDefaultInterface({
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
     loginLogoHeight: interfaceConfig?.loginLogoHeight ?? defaults.loginLogoHeight,
+    showLoginTitle: interfaceConfig?.showLoginTitle ?? defaults.showLoginTitle,
     autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
     buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo,
     contextUsage: interfaceConfig?.contextUsage ?? defaults.contextUsage,

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -38,6 +38,7 @@ export async function loadDefaultInterface({
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    loginLogoHeight: interfaceConfig?.loginLogoHeight ?? defaults.loginLogoHeight,
     autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
     buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo,
     contextUsage: interfaceConfig?.contextUsage ?? defaults.contextUsage,


### PR DESCRIPTION
# Customizable Login Page Branding

## Summary

This PR adds four small, independent branding options for the login/registration page. All of them are **opt-in and disabled by default** — when unset, nothing changes and existing deployments render exactly as before.

**Motivation:**

We run LibreChat as a company deployment and want the login page to reflect our corporate identity — a common requirement for organizations hosting LibreChat for their employees or customers. Today, most of this is only achievable by patching source files and maintaining a fork (replacing `assets/logo.svg`, editing `Auth/Footer.tsx`, `index.html`, `vite.config.ts`, …), which has to be re-applied on every upgrade. These options make the most common branding needs configurable through `.env` / `librechat.yaml` instead. We have been running these changes in our deployment and are contributing them upstream as we believe they are useful for other installations as well.

**Changes** — one commit per option, each independent of the others; they can be cherry-picked individually if only some of them are wanted:

1. **`feat: Add Configurable Custom Footer to the Login Page`** — new optional `CUSTOM_LOGIN_FOOTER` environment variable that renders a custom footer on the login page, alongside the existing privacy policy and terms of service links. Mirrors the existing `CUSTOM_FOOTER` setting for the chat view: supports Markdown links and multiple `|`-separated segments. *(Why: the chat footer is already customizable via `CUSTOM_FOOTER`, but the login page footer is not — organizations typically need their own legal/company links there.)*

2. **`feat: Add Configurable Login Page Logo Height`** — new optional `interface.loginLogoHeight` setting (pixels) for the size of the logo on the login page, defaulting to the current 40px. Also adds the field to the explicit allowlist that builds the `interface` payload of the unauthenticated `/api/config` response, since the login page is served pre-login. *(Why: custom logos often have different proportions than the LibreChat wordmark and render too small at the hardcoded height.)*

3. **`feat: Add Configurable App Icon`** — new optional `APP_ICON_URL` environment variable that replaces the favicon, apple-touch-icon, web app manifest icons, and the login page logo with a single custom icon (e.g. a file placed in `client/public/assets`). The icon links and manifest are rewritten once at server startup, alongside the existing `base href` rewrite, so the icon is in place before the browser parses the page — no rebuild required to change it. *(Why: replacing the product icon set currently requires overwriting five asset files and editing `index.html`/`vite.config.ts` in a fork.)*

4. **`feat: Add Configurable Login Page Title`** — new optional `interface.showLoginTitle` setting that displays the configured `APP_TITLE` as a heading below the logo on the login page. Off by default, since `appTitle` always has a value (defaulting to "LibreChat") and was previously only used as the logo's alt text — rendering it unconditionally would change every existing deployment. *(Why: with a custom icon-only logo, the product name is otherwise not visible anywhere on the login page.)*

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

We tested all four options in our Docker Compose based deployment:

1. Baseline: start LibreChat with none of the new options set → login page, footer, favicon, manifest, and title render exactly as before (defaults unchanged).
2. `CUSTOM_LOGIN_FOOTER="[Company](https://example.com) - All rights reserved."` → footer text with working Markdown link appears next to the privacy policy / ToS links, correct colors in both light and dark mode; unset → only the existing links render.
3. `interface.loginLogoHeight: 80` in `librechat.yaml` → logo renders at 80px; unset → 40px as before.
4. `APP_ICON_URL="assets/custom-icon.png"` → browser tab favicon, apple-touch-icon, login page logo, and the installed web app icon (verified via `GET /manifest.webmanifest` and by installing the PWA on Android/Chrome) all show the custom icon; unset → default LibreChat icons everywhere, `/manifest.webmanifest` is served statically as before.
5. `interface.showLoginTitle: true` → the configured `APP_TITLE` appears as a heading below the logo; unset/false → no title, as before.

Additionally ran the existing automated unit tests covering the touched code, all passing.

### **Test Configuration**:

```bash
# .env
CUSTOM_LOGIN_FOOTER="[Company](https://example.com) - All rights reserved."
APP_ICON_URL="assets/custom-icon.png"
```

```yaml
# librechat.yaml
interface:
  loginLogoHeight: 80
  showLoginTitle: true
```

## Checklist

- [x] Our code adheres to this project's style guidelines
- [x] We have performed a self-review of our own code
- [x] Our changes do not introduce new warnings
- [x] Local unit tests pass with our changes
