### PR TITLE
🗂️ feat: Display Chat Title in Tab Setting

### DIFF
--- a/client/src/components/Chat/Messages/SearchButtons.tsx
+++ b/client/src/components/Chat/Messages/SearchButtons.tsx
@@ -5,8 +5,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { TMessage, TConversation } from 'librechat-data-provider';
 import type { InfiniteData } from '@tanstack/react-query';
 import type { ConversationCursorData } from '~/utils';
+import { findConversationInInfinite, setDocumentTitle } from '~/utils';
 import { useLocalize, useNavigateToConvo } from '~/hooks';
-import { findConversationInInfinite } from '~/utils';
 import store from '~/store';
 
 export default function SearchButtons({ message }: { message: TMessage }) {
@@ -38,7 +38,7 @@ export default function SearchButtons({ message }: { message: TMessage }) {
       title = cachedConvo?.title ?? '';
     }
 
-    document.title = title;
+    setDocumentTitle(title);
     navigateToConvo(
       cachedConvo ??
         ({

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -9,10 +9,10 @@ import { useGetStartupConfig, useUpdateConversationMutation } from '~/data-provi
 import { useNavigateToConvo, useLocalize, useShiftKey } from '~/hooks';
 import ConversationEndpointIcon from './ConversationEndpointIcon';
 import { areConversationRenderPropsEqual } from './utils';
+import { cn, logger, setDocumentTitle } from '~/utils';
 import { NotificationSeverity } from '~/common';
 import { ConvoOptions } from './ConvoOptions';
 import RenameForm from './RenameForm';
-import { cn, logger } from '~/utils';
 import ConvoLink from './ConvoLink';
 import store from '~/store';
 
@@ -162,7 +162,7 @@ function Conversation({
     toggleNav();
 
     if (typeof title === 'string' && title.length > 0) {
-      document.title = title;
+      setDocumentTitle(title);
     }
 
     navigateToConvo(conversation, {

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -161,9 +161,7 @@ function Conversation({
 
     toggleNav();
 
-    if (typeof title === 'string' && title.length > 0) {
-      setDocumentTitle(title);
-    }
+    setDocumentTitle(title);
 
     navigateToConvo(conversation, {
       currentConvoId,

--- a/client/src/components/Nav/Settings/registry.tsx
+++ b/client/src/components/Nav/Settings/registry.tsx
@@ -24,6 +24,7 @@ import { toggleControl, ThemeSetting, LangSetting } from './controls';
 import BackupCodesItem from '../SettingsTabs/Account/BackupCodesItem';
 import { EngineSTTSetting, EngineTTSSetting } from './SpeechControls';
 import FontSizeSelector from '../SettingsTabs/Chat/FontSizeSelector';
+import ChatTitleInTab from '../SettingsTabs/General/ChatTitleInTab';
 import AdvancedPrompts from '../SettingsTabs/Chat/AdvancedPrompts';
 import DuringRunAction from '../SettingsTabs/Chat/DuringRunAction';
 import DeleteAccount from '../SettingsTabs/Account/DeleteAccount';
@@ -114,6 +115,14 @@ export const registry: SettingEntry[] = [
       localizationKey: 'com_nav_scroll_button',
       switchId: 'showScrollButton',
     }),
+  },
+  {
+    id: 'chatTitleInTab',
+    tab: GENERAL,
+    section: 'layout',
+    labelKey: 'com_nav_chat_title_in_tab',
+    keywords: ['tab', 'title', 'browser', 'window'],
+    Component: ChatTitleInTab,
   },
   // General · Accessibility
   {

--- a/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.spec.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.spec.tsx
@@ -1,0 +1,97 @@
+import { RecoilRoot } from 'recoil';
+import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryKeys, LocalStorageKeys } from 'librechat-data-provider';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TConversation } from 'librechat-data-provider';
+import ChatTitleInTab from './ChatTitleInTab';
+import store from '~/store';
+
+jest.mock('../ToggleSwitch', () => ({
+  __esModule: true,
+  default: ({ onCheckedChange }: { onCheckedChange?: (value: boolean) => void }) => (
+    <>
+      <button aria-label={String(true)} onClick={() => onCheckedChange?.(true)} />
+      <button aria-label={String(false)} onClick={() => onCheckedChange?.(false)} />
+    </>
+  ),
+}));
+
+const createConversation = (conversationId: string, title: string): TConversation =>
+  ({ conversationId, title }) as TConversation;
+
+function renderToggle({
+  route,
+  recoilConversation,
+  cachedConversation,
+}: {
+  route: string;
+  recoilConversation?: TConversation;
+  cachedConversation?: TConversation;
+}) {
+  const queryClient = new QueryClient();
+  if (cachedConversation) {
+    queryClient.setQueryData(
+      [QueryKeys.conversation, cachedConversation.conversationId],
+      cachedConversation,
+    );
+  }
+
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <QueryClientProvider client={queryClient}>
+        <RecoilRoot
+          initializeState={({ set }) => {
+            if (recoilConversation) {
+              set(store.conversationByIndex(0), recoilConversation);
+            }
+          }}
+        >
+          <ChatTitleInTab />
+        </RecoilRoot>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatTitleInTab', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(LocalStorageKeys.APP_TITLE, 'LibreChat');
+  });
+
+  it('restores the active conversation title from the query cache', () => {
+    renderToggle({
+      route: '/c/conversation-1',
+      recoilConversation: createConversation('conversation-1', 'New Chat'),
+      cachedConversation: createConversation('conversation-1', 'Generated title'),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+
+    expect(document.title).toBe('Generated title');
+  });
+
+  it('falls back to the matching Recoil conversation when the query cache is empty', () => {
+    renderToggle({
+      route: '/c/conversation-1',
+      recoilConversation: createConversation('conversation-1', 'Cached sidebar title'),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+
+    expect(document.title).toBe('Cached sidebar title');
+  });
+
+  it('preserves page-specific titles outside chat routes', () => {
+    document.title = 'Agent Marketplace | LibreChat';
+    renderToggle({
+      route: '/agents',
+      recoilConversation: createConversation('conversation-1', 'Previous chat'),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'false' }));
+
+    expect(document.title).toBe('Agent Marketplace | LibreChat');
+  });
+});

--- a/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.tsx
@@ -1,7 +1,7 @@
 import { useRecoilCallback } from 'recoil';
 import { useMatch } from 'react-router-dom';
-import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
+import { Constants, QueryKeys } from 'librechat-data-provider';
 import type { TConversation } from 'librechat-data-provider';
 import ToggleSwitch from '../ToggleSwitch';
 import { setDocumentTitle } from '~/utils';
@@ -27,7 +27,10 @@ export default function ChatTitleInTab() {
           cachedConversation ??
           (recoilConversation?.conversationId === conversationId ? recoilConversation : undefined);
 
-        setDocumentTitle(conversation?.title, value);
+        setDocumentTitle(
+          conversationId === Constants.NEW_CONVO ? undefined : conversation?.title,
+          value,
+        );
       },
     [conversationId, queryClient],
   );

--- a/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.tsx
@@ -1,0 +1,21 @@
+import { useRecoilValue } from 'recoil';
+import ToggleSwitch from '../ToggleSwitch';
+import { setDocumentTitle } from '~/utils';
+import store from '~/store';
+
+export default function ChatTitleInTab() {
+  const conversation = useRecoilValue(store.conversationByIndex(0));
+
+  const handleCheckedChange = (value: boolean) => {
+    setDocumentTitle(conversation?.title, value);
+  };
+
+  return (
+    <ToggleSwitch
+      stateAtom={store.chatTitleInTab}
+      localizationKey="com_nav_chat_title_in_tab"
+      switchId="chatTitleInTab"
+      onCheckedChange={handleCheckedChange}
+    />
+  );
+}

--- a/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ChatTitleInTab.tsx
@@ -1,14 +1,36 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilCallback } from 'recoil';
+import { useMatch } from 'react-router-dom';
+import { QueryKeys } from 'librechat-data-provider';
+import { useQueryClient } from '@tanstack/react-query';
+import type { TConversation } from 'librechat-data-provider';
 import ToggleSwitch from '../ToggleSwitch';
 import { setDocumentTitle } from '~/utils';
 import store from '~/store';
 
 export default function ChatTitleInTab() {
-  const conversation = useRecoilValue(store.conversationByIndex(0));
+  const queryClient = useQueryClient();
+  const conversationId = useMatch('/c/:conversationId')?.params.conversationId;
 
-  const handleCheckedChange = (value: boolean) => {
-    setDocumentTitle(conversation?.title, value);
-  };
+  const handleCheckedChange = useRecoilCallback(
+    ({ snapshot }) =>
+      (value: boolean) => {
+        if (!conversationId) {
+          return;
+        }
+
+        const cachedConversation = queryClient.getQueryData<TConversation>([
+          QueryKeys.conversation,
+          conversationId,
+        ]);
+        const recoilConversation = snapshot.getLoadable(store.conversationByIndex(0)).getValue();
+        const conversation =
+          cachedConversation ??
+          (recoilConversation?.conversationId === conversationId ? recoilConversation : undefined);
+
+        setDocumentTitle(conversation?.title, value);
+      },
+    [conversationId, queryClient],
+  );
 
   return (
     <ToggleSwitch

--- a/client/src/components/Nav/SettingsTabs/General/__tests__/ChatTitleInTab.spec.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/__tests__/ChatTitleInTab.spec.tsx
@@ -4,10 +4,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryKeys, LocalStorageKeys } from 'librechat-data-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TConversation } from 'librechat-data-provider';
-import ChatTitleInTab from './ChatTitleInTab';
+import ChatTitleInTab from '../ChatTitleInTab';
 import store from '~/store';
 
-jest.mock('../ToggleSwitch', () => ({
+jest.mock('../../ToggleSwitch', () => ({
   __esModule: true,
   default: ({ onCheckedChange }: { onCheckedChange?: (value: boolean) => void }) => (
     <>
@@ -81,6 +81,19 @@ describe('ChatTitleInTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'true' }));
 
     expect(document.title).toBe('Cached sidebar title');
+  });
+
+  it('keeps the app title when enabling titles for a new chat', () => {
+    localStorage.setItem(LocalStorageKeys.APP_TITLE, 'Custom LibreChat');
+    document.title = 'Custom LibreChat';
+    renderToggle({
+      route: '/c/new',
+      recoilConversation: createConversation('new', 'New Chat'),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+
+    expect(document.title).toBe('Custom LibreChat');
   });
 
   it('preserves page-specific titles outside chat routes', () => {

--- a/client/src/components/Nav/SettingsTabs/General/__tests__/ChatTitleInTab.spec.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/__tests__/ChatTitleInTab.spec.tsx
@@ -4,21 +4,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryKeys, LocalStorageKeys } from 'librechat-data-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TConversation } from 'librechat-data-provider';
+import { CHAT_TITLE_IN_TAB_KEY } from '~/utils';
 import ChatTitleInTab from '../ChatTitleInTab';
 import store from '~/store';
 
-jest.mock('../../ToggleSwitch', () => ({
-  __esModule: true,
-  default: ({ onCheckedChange }: { onCheckedChange?: (value: boolean) => void }) => (
-    <>
-      <button aria-label={String(true)} onClick={() => onCheckedChange?.(true)} />
-      <button aria-label={String(false)} onClick={() => onCheckedChange?.(false)} />
-    </>
-  ),
-}));
-
 const createConversation = (conversationId: string, title: string): TConversation =>
   ({ conversationId, title }) as TConversation;
+
+const getToggle = () => screen.getByRole('switch', { name: 'Display chat title in tab' });
 
 function renderToggle({
   route,
@@ -58,6 +51,8 @@ describe('ChatTitleInTab', () => {
   beforeEach(() => {
     localStorage.clear();
     localStorage.setItem(LocalStorageKeys.APP_TITLE, 'LibreChat');
+    localStorage.setItem(CHAT_TITLE_IN_TAB_KEY, JSON.stringify(false));
+    document.title = '';
   });
 
   it('restores the active conversation title from the query cache', () => {
@@ -67,8 +62,13 @@ describe('ChatTitleInTab', () => {
       cachedConversation: createConversation('conversation-1', 'Generated title'),
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+    const toggle = getToggle();
+    expect(toggle).not.toBeChecked();
 
+    fireEvent.click(toggle);
+
+    expect(toggle).toBeChecked();
+    expect(localStorage.getItem(CHAT_TITLE_IN_TAB_KEY)).toBe('true');
     expect(document.title).toBe('Generated title');
   });
 
@@ -78,9 +78,30 @@ describe('ChatTitleInTab', () => {
       recoilConversation: createConversation('conversation-1', 'Cached sidebar title'),
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+    const toggle = getToggle();
+    expect(toggle).not.toBeChecked();
 
+    fireEvent.click(toggle);
+
+    expect(toggle).toBeChecked();
+    expect(localStorage.getItem(CHAT_TITLE_IN_TAB_KEY)).toBe('true');
     expect(document.title).toBe('Cached sidebar title');
+  });
+
+  it('shows an existing conversation deliberately titled New Chat', () => {
+    renderToggle({
+      route: '/c/conversation-1',
+      recoilConversation: createConversation('conversation-1', 'New Chat'),
+    });
+
+    const toggle = getToggle();
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toBeChecked();
+    expect(localStorage.getItem(CHAT_TITLE_IN_TAB_KEY)).toBe('true');
+    expect(document.title).toBe('New Chat');
   });
 
   it('keeps the app title when enabling titles for a new chat', () => {
@@ -91,20 +112,31 @@ describe('ChatTitleInTab', () => {
       recoilConversation: createConversation('new', 'New Chat'),
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'true' }));
+    const toggle = getToggle();
+    expect(toggle).not.toBeChecked();
 
+    fireEvent.click(toggle);
+
+    expect(toggle).toBeChecked();
+    expect(localStorage.getItem(CHAT_TITLE_IN_TAB_KEY)).toBe('true');
     expect(document.title).toBe('Custom LibreChat');
   });
 
   it('preserves page-specific titles outside chat routes', () => {
+    localStorage.setItem(CHAT_TITLE_IN_TAB_KEY, JSON.stringify(true));
     document.title = 'Agent Marketplace | LibreChat';
     renderToggle({
       route: '/agents',
       recoilConversation: createConversation('conversation-1', 'Previous chat'),
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'false' }));
+    const toggle = getToggle();
+    expect(toggle).toBeChecked();
 
+    fireEvent.click(toggle);
+
+    expect(toggle).not.toBeChecked();
+    expect(localStorage.getItem(CHAT_TITLE_IN_TAB_KEY)).toBe('false');
     expect(document.title).toBe('Agent Marketplace | LibreChat');
   });
 });

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -19,7 +19,7 @@ import {
   useToastContext,
 } from '@librechat/client';
 import { ThemeSelector, LangSelector } from '~/components/Nav/SettingsTabs/General/Selectors';
-import { cn, getResponseStatus, selectActiveBranchTail } from '~/utils';
+import { cn, DEFAULT_APP_TITLE, getResponseStatus, selectActiveBranchTail } from '~/utils';
 import { ShareMessagesProvider } from './ShareMessagesProvider';
 import { useForkSharedConvoMutation } from '~/data-provider';
 import { useGetSharedStartupConfig } from '~/data-provider';
@@ -120,7 +120,7 @@ function SharedView() {
   const chatTitleInTab = useRecoilValue(store.chatTitleInTab);
   let docTitle = '';
   if (!chatTitleInTab) {
-    docTitle = config?.appTitle ?? document.title;
+    docTitle = config?.appTitle || DEFAULT_APP_TITLE;
   } else if (config?.appTitle != null && data?.title != null) {
     docTitle = `${data.title} | ${config.appTitle}`;
   } else {

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -2,8 +2,8 @@ import { memo, useState, useCallback, useContext } from 'react';
 import Cookies from 'js-cookie';
 import { buildTree } from 'librechat-data-provider';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useRecoilState, useRecoilCallback } from 'recoil';
 import { CalendarDays, Settings, MessageSquarePlus } from 'lucide-react';
+import { useRecoilState, useRecoilValue, useRecoilCallback } from 'recoil';
 import { useGetSharedMessages } from 'librechat-data-provider/react-query';
 import {
   Spinner,
@@ -117,8 +117,11 @@ function SharedView() {
   }, [shareId, forkSharedConvo, getActiveTargetIndex, data?.updatedAt]);
 
   // configure document title
+  const chatTitleInTab = useRecoilValue(store.chatTitleInTab);
   let docTitle = '';
-  if (config?.appTitle != null && data?.title != null) {
+  if (!chatTitleInTab) {
+    docTitle = config?.appTitle ?? document.title;
+  } else if (config?.appTitle != null && data?.title != null) {
     docTitle = `${data.title} | ${config.appTitle}`;
   } else {
     docTitle = data?.title ?? config?.appTitle ?? document.title;

--- a/client/src/data-provider/SSE/queries.ts
+++ b/client/src/data-provider/SSE/queries.ts
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import { apiBaseUrl, QueryKeys, request, dataService } from 'librechat-data-provider';
 import type { Agents, TConversation, TPendingSteer } from 'librechat-data-provider';
+import { isNotFoundError, updateConvoInAllQueries, setDocumentTitle } from '~/utils';
 import { generationProtocolHeaders, withGenerationProtocolQuery } from './protocol';
-import { isNotFoundError, updateConvoInAllQueries } from '~/utils';
 import { useGetStartupConfig } from '../Endpoints';
 
 export interface StreamStatusResponse {
@@ -179,7 +179,7 @@ export function useTitleGeneration(enabled = true) {
         updateConvoInAllQueries(queryClient, conversationId, (c) => ({ ...c, title }));
         // Only update document title if this conversation is currently active
         if (window.location.pathname.includes(conversationId)) {
-          document.title = title;
+          setDocumentTitle(title);
         }
         markTitleGenerationProcessed(conversationId);
         setReadyToFetch((prev) => prev.filter((id) => id !== conversationId));

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -27,6 +27,7 @@ import {
   logger,
   setDraft,
   scrollToEnd,
+  hasRealTitle,
   setDocumentTitle,
   requestChatFocus,
   getAllContentText,
@@ -67,9 +68,6 @@ type TTitleEvent = {
     title?: string;
   };
 };
-
-const hasRealTitle = (title?: string | null): title is string =>
-  title != null && title !== '' && title !== 'New Chat';
 
 /** Skill caches refreshed when a chat turn authors a skill via `create_file`/`edit_file`. */
 const SKILL_QUERY_KEYS = [

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -27,6 +27,7 @@ import {
   logger,
   setDraft,
   scrollToEnd,
+  setDocumentTitle,
   requestChatFocus,
   getAllContentText,
   upsertConvoInAllQueries,
@@ -632,7 +633,7 @@ export default function useEventHandlers({
       markTitleGenerationProcessed(conversationId);
 
       if (location.pathname.includes(conversationId)) {
-        document.title = title;
+        setDocumentTitle(title);
       }
 
       if (setConversation && !isAddedRequest) {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -477,6 +477,7 @@
   "com_nav_change_picture": "Change picture",
   "com_nav_chat_direction": "Chat direction",
   "com_nav_chat_direction_selected": "Chat direction: {{direction}}",
+  "com_nav_chat_title_in_tab": "Display chat title in tab",
   "com_nav_clear_all_chats": "Clear all chats",
   "com_nav_clear_cache_confirm_message": "Are you sure you want to clear the cache?",
   "com_nav_clear_conversation": "Clear conversations",

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -1,6 +1,7 @@
 import { atom } from 'recoil';
 import { SettingsViews, LocalStorageKeys } from 'librechat-data-provider';
 import type { TOptionSettings } from '~/common';
+import { CHAT_TITLE_IN_TAB_KEY } from '~/utils/documentTitle';
 import { atomWithLocalStorage } from '~/store/utils';
 import { STTEndpoints } from '~/common';
 
@@ -46,6 +47,7 @@ const localStorageAtoms = {
   ),
   keepScreenAwake: atomWithLocalStorage('keepScreenAwake', true),
   newChatSwitchToHistory: atomWithLocalStorage('newChatSwitchToHistory', true),
+  chatTitleInTab: atomWithLocalStorage(CHAT_TITLE_IN_TAB_KEY, true),
 
   // Chat settings
   enterToSend: atomWithLocalStorage('enterToSend', true),

--- a/client/src/utils/__tests__/documentTitle.test.ts
+++ b/client/src/utils/__tests__/documentTitle.test.ts
@@ -1,5 +1,10 @@
 import { LocalStorageKeys } from 'librechat-data-provider';
-import { CHAT_TITLE_IN_TAB_KEY, isChatTitleInTabEnabled, setDocumentTitle } from '../documentTitle';
+import {
+  hasRealTitle,
+  setDocumentTitle,
+  CHAT_TITLE_IN_TAB_KEY,
+  isChatTitleInTabEnabled,
+} from '../documentTitle';
 
 describe('document title', () => {
   beforeEach(() => {
@@ -30,10 +35,14 @@ describe('document title', () => {
     expect(document.title).toBe('LibreChat');
   });
 
-  it('uses the app title when the conversation title is the new chat placeholder', () => {
+  it('uses a conversation deliberately titled New Chat when enabled', () => {
     setDocumentTitle('New Chat', true);
 
-    expect(document.title).toBe('LibreChat');
+    expect(document.title).toBe('New Chat');
+  });
+
+  it('keeps rejecting the generated new chat placeholder as a real title', () => {
+    expect(hasRealTitle('New Chat')).toBe(false);
   });
 
   it('uses the default app title when no app title is stored', () => {

--- a/client/src/utils/__tests__/documentTitle.test.ts
+++ b/client/src/utils/__tests__/documentTitle.test.ts
@@ -30,6 +30,12 @@ describe('document title', () => {
     expect(document.title).toBe('LibreChat');
   });
 
+  it('uses the app title when the conversation title is the new chat placeholder', () => {
+    setDocumentTitle('New Chat', true);
+
+    expect(document.title).toBe('LibreChat');
+  });
+
   it('uses the default app title when no app title is stored', () => {
     localStorage.removeItem(LocalStorageKeys.APP_TITLE);
 

--- a/client/src/utils/__tests__/documentTitle.test.ts
+++ b/client/src/utils/__tests__/documentTitle.test.ts
@@ -8,6 +8,10 @@ describe('document title', () => {
     document.title = '';
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('uses a conversation title when chat titles are enabled', () => {
     setDocumentTitle('Project status', true);
 
@@ -21,6 +25,32 @@ describe('document title', () => {
   });
 
   it('uses the app title when the conversation title is empty', () => {
+    setDocumentTitle('', true);
+
+    expect(document.title).toBe('LibreChat');
+  });
+
+  it('uses the default app title when no app title is stored', () => {
+    localStorage.removeItem(LocalStorageKeys.APP_TITLE);
+
+    setDocumentTitle('', true);
+
+    expect(document.title).toBe('LibreChat');
+  });
+
+  it('uses the default app title when the stored app title is empty', () => {
+    localStorage.setItem(LocalStorageKeys.APP_TITLE, '');
+
+    setDocumentTitle('', true);
+
+    expect(document.title).toBe('LibreChat');
+  });
+
+  it('uses the default app title when storage is unavailable', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
     setDocumentTitle('', true);
 
     expect(document.title).toBe('LibreChat');

--- a/client/src/utils/__tests__/documentTitle.test.ts
+++ b/client/src/utils/__tests__/documentTitle.test.ts
@@ -1,0 +1,34 @@
+import { LocalStorageKeys } from 'librechat-data-provider';
+import { CHAT_TITLE_IN_TAB_KEY, isChatTitleInTabEnabled, setDocumentTitle } from '../documentTitle';
+
+describe('document title', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem(LocalStorageKeys.APP_TITLE, 'LibreChat');
+    document.title = '';
+  });
+
+  it('uses a conversation title when chat titles are enabled', () => {
+    setDocumentTitle('Project status', true);
+
+    expect(document.title).toBe('Project status');
+  });
+
+  it('uses the app title when chat titles are disabled', () => {
+    setDocumentTitle('Project status', false);
+
+    expect(document.title).toBe('LibreChat');
+  });
+
+  it('uses the app title when the conversation title is empty', () => {
+    setDocumentTitle('', true);
+
+    expect(document.title).toBe('LibreChat');
+  });
+
+  it('defaults to enabled when the stored setting is malformed', () => {
+    localStorage.setItem(CHAT_TITLE_IN_TAB_KEY, 'not-json');
+
+    expect(isChatTitleInTabEnabled()).toBe(true);
+  });
+});

--- a/client/src/utils/documentTitle.ts
+++ b/client/src/utils/documentTitle.ts
@@ -1,0 +1,26 @@
+import { LocalStorageKeys } from 'librechat-data-provider';
+
+export const CHAT_TITLE_IN_TAB_KEY = 'chatTitleInTab';
+
+const getAppTitle = (): string => localStorage.getItem(LocalStorageKeys.APP_TITLE) ?? '';
+
+/** Reads the setting straight from localStorage so non-React callers stay in sync with the atom. */
+export const isChatTitleInTabEnabled = (): boolean => {
+  try {
+    const saved = localStorage.getItem(CHAT_TITLE_IN_TAB_KEY);
+    return saved === null ? true : (JSON.parse(saved) as boolean);
+  } catch {
+    return true;
+  }
+};
+
+/**
+ * Sets the tab title to the conversation title, or to the app title when the
+ * conversation title is empty or the user opted out of chat titles in the tab.
+ * Pass `enabled` when the atom's value is already known, since Recoil writes to
+ * localStorage after the change handler runs.
+ */
+export const setDocumentTitle = (title?: string | null, enabled?: boolean): void => {
+  const showChatTitle = enabled ?? isChatTitleInTabEnabled();
+  document.title = showChatTitle && title != null && title !== '' ? title : getAppTitle();
+};

--- a/client/src/utils/documentTitle.ts
+++ b/client/src/utils/documentTitle.ts
@@ -1,8 +1,15 @@
 import { LocalStorageKeys } from 'librechat-data-provider';
 
 export const CHAT_TITLE_IN_TAB_KEY = 'chatTitleInTab';
+export const DEFAULT_APP_TITLE = 'LibreChat';
 
-const getAppTitle = (): string => localStorage.getItem(LocalStorageKeys.APP_TITLE) ?? '';
+const getAppTitle = (): string => {
+  try {
+    return localStorage.getItem(LocalStorageKeys.APP_TITLE) || DEFAULT_APP_TITLE;
+  } catch {
+    return DEFAULT_APP_TITLE;
+  }
+};
 
 /** Reads the setting straight from localStorage so non-React callers stay in sync with the atom. */
 export const isChatTitleInTabEnabled = (): boolean => {

--- a/client/src/utils/documentTitle.ts
+++ b/client/src/utils/documentTitle.ts
@@ -26,11 +26,11 @@ export const isChatTitleInTabEnabled = (): boolean => {
 
 /**
  * Sets the tab title to the conversation title, or to the app title when the
- * conversation title is empty, is a placeholder, or the user opted out.
+ * conversation title is empty or the user opted out.
  * Pass `enabled` when the atom's value is already known, since Recoil writes to
  * localStorage after the change handler runs.
  */
 export const setDocumentTitle = (title?: string | null, enabled?: boolean): void => {
   const showChatTitle = enabled ?? isChatTitleInTabEnabled();
-  document.title = showChatTitle && hasRealTitle(title) ? title : getAppTitle();
+  document.title = showChatTitle && title != null && title !== '' ? title : getAppTitle();
 };

--- a/client/src/utils/documentTitle.ts
+++ b/client/src/utils/documentTitle.ts
@@ -3,6 +3,9 @@ import { LocalStorageKeys } from 'librechat-data-provider';
 export const CHAT_TITLE_IN_TAB_KEY = 'chatTitleInTab';
 export const DEFAULT_APP_TITLE = 'LibreChat';
 
+export const hasRealTitle = (title?: string | null): title is string =>
+  title != null && title !== '' && title !== 'New Chat';
+
 const getAppTitle = (): string => {
   try {
     return localStorage.getItem(LocalStorageKeys.APP_TITLE) || DEFAULT_APP_TITLE;
@@ -23,11 +26,11 @@ export const isChatTitleInTabEnabled = (): boolean => {
 
 /**
  * Sets the tab title to the conversation title, or to the app title when the
- * conversation title is empty or the user opted out of chat titles in the tab.
+ * conversation title is empty, is a placeholder, or the user opted out.
  * Pass `enabled` when the atom's value is already known, since Recoil writes to
  * localStorage after the change handler runs.
  */
 export const setDocumentTitle = (title?: string | null, enabled?: boolean): void => {
   const showChatTitle = enabled ?? isChatTitleInTabEnabled();
-  document.title = showChatTitle && title != null && title !== '' ? title : getAppTitle();
+  document.title = showChatTitle && hasRealTitle(title) ? title : getAppTitle();
 };

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -44,6 +44,7 @@ export * from './favoritesError';
 export * from './approval';
 export * from './steer';
 export * from './activityLabels';
+export * from './documentTitle';
 export * from './numbers';
 export { default as cn } from './cn';
 export { default as logger } from './logger';


### PR DESCRIPTION
## Summary

Adds a **Display chat title in tab** toggle under Settings → General → Layout, controlling whether the browser tab shows the current conversation's title or the app title. It defaults to on, so existing behaviour is unchanged for everyone who does not touch it.

The tab title had no single owner: several call sites assigned `document.title` directly, so gating the behaviour in one place was not possible. This adds a shared `setDocumentTitle(title, enabled?)` helper in `client/src/utils/documentTitle.ts` and routes the chat-title writers through it, so the setting applies consistently to:

- sidebar conversation clicks (`Convo.tsx`)
- search result navigation (`SearchButtons.tsx`)
- SSE title generation (`useEventHandlers.ts`)
- title generation polling (`queries.ts`)
- the shared conversation view (`ShareView.tsx`, gated on the atom and keeping its `Title | App` format)

The setting is a Recoil `atomWithLocalStorage` (`chatTitleInTab`, default `true`) registered in the declarative settings registry. The helper reads the value from localStorage so the non-React callers stay in sync, and accepts an explicit `enabled` override for the toggle's own change handler, since Recoil persists to localStorage after that handler runs.

A deliberate choice worth flagging for review: I did not add a global reactive effect syncing the atom's title to `document.title`. `useEventHandlers.ts` updates the Recoil conversation atom alongside the tab title, but the polling path in `queries.ts` updates only the React Query cache. An effect keyed on the atom's title would therefore have reverted freshly polled titles. Per-site routing avoids that.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Verified in the browser against a local dev stack (backend + Vite dev server), in both light and dark mode:

- The toggle renders in General → Layout, defaulting to on, styled identically to its siblings (it reuses the shared `ToggleSwitch` primitive rather than restyling).
- Toggling **off** immediately changed the tab title from a conversation title to the app title, and persisted `chatTitleInTab: false` to localStorage.
- Toggling **on** immediately restored the live conversation title read from the conversation atom, and persisted `chatTitleInTab: true`.
- Searching "browser" in the settings search surfaces the entry under General › Layout via its keywords.

Commands run:

```
npx eslint <10 changed files>          # clean
cd client && npm run typecheck         # tsc --noEmit, exit 0
npx prettier --check <11 changed files># all matched files use Prettier code style
cd client && npx jest --ci \
  src/components/Nav/Settings/__tests__/registry.spec.ts \
  src/components/Nav/Settings/__tests__/search.spec.ts \
  src/hooks/SSE/__tests__/useEventHandlers.spec.ts \
  src/data-provider/SSE/__tests__/useTitleGeneration.test.ts
# 4 suites passed, 27 tests passed
```

### **Test Configuration**:

Node v24.16.0, MongoDB, local backend and Vite dev server, Chromium.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
