### PR TITLE
💄 style: Align the Overflow Menu's Icons and Ease the Assistant Header

### DIFF
--- a/client/src/components/Chat/Menus/HeaderMenu.tsx
+++ b/client/src/components/Chat/Menus/HeaderMenu.tsx
@@ -70,9 +70,9 @@ export default function HeaderMenu({
       id: 'header-bookmarks',
       label: localize('com_ui_bookmarks'),
       icon: bookmarks.hasBookmarks ? (
-        <BookmarkFilledIcon className="icon-md mr-2 text-text-secondary" />
+        <BookmarkFilledIcon className="size-4 text-text-secondary" />
       ) : (
-        <BookmarkIcon className="icon-md mr-2 text-text-secondary" />
+        <BookmarkIcon className="size-4 text-text-secondary" />
       ),
       subItems: bookmarks.items,
     });
@@ -82,7 +82,7 @@ export default function HeaderMenu({
     items.push({
       id: 'header-compare',
       label: localize('com_ui_add_multi_conversation'),
-      icon: <PlusCircle className="icon-md mr-2 text-text-secondary" />,
+      icon: <PlusCircle className="size-4 text-text-secondary" />,
       onClick: multiConvo.addConversation,
     });
   }
@@ -98,9 +98,9 @@ export default function HeaderMenu({
       ariaChecked: temporary.isTemporary,
       className: temporary.isTemporary ? 'bg-surface-active' : undefined,
       icon: temporary.isTemporary ? (
-        <Check className="icon-md mr-2 text-text-primary" />
+        <Check className="size-4 text-text-primary" />
       ) : (
-        <MessageCircleDashed className="icon-md mr-2 text-text-secondary" />
+        <MessageCircleDashed className="size-4 text-text-secondary" />
       ),
       onClick: temporary.toggle,
     });

--- a/client/src/components/Chat/Messages/ui/MessageRow.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRow.tsx
@@ -77,7 +77,8 @@ export default function MessageRow({
               <MessageTimestamp value={timestamp} />
             </h2>
           ) : (
-            <h2 className="flex min-h-7 w-full select-none items-center gap-2 text-sm font-semibold text-text-primary">
+            /** `mb-1` keeps the name off its own first line of body text. */
+            <h2 className="mb-1 flex min-h-7 w-full select-none items-center gap-2 text-sm font-semibold text-text-primary">
               <span
                 aria-hidden="true"
                 className="flex size-6 flex-shrink-0 items-center justify-center overflow-hidden rounded-full"

--- a/client/src/hooks/Chat/useExportShare.tsx
+++ b/client/src/hooks/Chat/useExportShare.tsx
@@ -56,7 +56,7 @@ export default function useExportShare({
     {
       label: localize('com_ui_share'),
       onClick: () => setShowShareDialog(true),
-      icon: <Share2 className="icon-md mr-2 text-text-secondary" />,
+      icon: <Share2 className="size-4 text-text-secondary" />,
       show: isSharedButtonEnabled && canCreateSharedLinks,
       /** NOTE: THE FOLLOWING PROPS ARE REQUIRED FOR MENU ITEMS THAT OPEN DIALOGS */
       hideOnClick: false,
@@ -66,7 +66,7 @@ export default function useExportShare({
     {
       label: localize('com_endpoint_export'),
       onClick: () => setShowExports(true),
-      icon: <Upload className="icon-md mr-2 text-text-secondary" />,
+      icon: <Upload className="size-4 text-text-secondary" />,
       /** NOTE: THE FOLLOWING PROPS ARE REQUIRED FOR MENU ITEMS THAT OPEN DIALOGS */
       hideOnClick: false,
       ref: exportButtonRef,


### PR DESCRIPTION
Two small visual fixes reported from screenshots, both in merged code and unrelated to the open nav work (#14849), so they are here rather than there.

## Overflow menu icons were ragged

`DropdownPopup` already wraps every item icon in its own `mr-2 size-4` span, but the header menu's icons each carried `icon-md mr-2` as well. So the margin was applied twice, and `icon-md` is 18px sitting in a 16px box.

The effect was uneven: `lucide` icons scale to the class they are given, while the `@radix-ui/react-icons` bookmark glyphs render at their own intrinsic size, so items drifted out of line with each other rather than all being wrong together.

The icons now match the box they are handed and let the wrapper own the spacing. Introduced by #14843.

## Assistant name sat on its own text

The header row had no separation from the first line of the response. `mb-1` gives it slight breathing room without opening a gap — deliberately small, since #14851 tightened this column on purpose.

## Checks

Client suite green: 4381 tests, 367 suites. Typecheck clean.

Both are appearance-only: no state, no conditions, no behaviour. The first removes a duplicated declaration rather than adding one, which is why no test changes accompany it — the existing `HeaderMenu` specs already pin which items render and in what order.
