### PR TITLE
⬆️ chore: Bump `@librechat/agents` to v3.6.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.5.1",
+    "@librechat/agents": "^3.6.0",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.5.1",
+        "@librechat/agents": "^3.6.0",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -353,7 +353,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.5.1",
+        "@librechat/agents": "^3.6.0",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",
@@ -1534,7 +1534,7 @@
 
     "@lezer/lr": ["@lezer/lr@1.4.2", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA=="],
 
-    "@librechat/agents": ["@librechat/agents@3.5.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.115.0", "@aws-sdk/client-bedrock-runtime": "^3.1075.0", "@langchain/anthropic": "1.5.2", "@langchain/aws": "^1.4.2", "@langchain/core": "^1.2.3", "@langchain/deepseek": "^1.1.3", "@langchain/google-common": "2.2.0", "@langchain/google-gauth": "2.2.0", "@langchain/google-genai": "2.2.0", "@langchain/google-vertexai": "2.2.0", "@langchain/langgraph": "1.4.8", "@langchain/mistralai": "^1.2.0", "@langchain/openai": "1.5.5", "@langchain/textsplitters": "^1.0.1", "@langchain/xai": "^1.4.3", "@langfuse/core": "^5.4.1", "@langfuse/langchain": "^5.4.1", "@langfuse/otel": "^5.4.1", "@langfuse/tracing": "^5.4.1", "@opentelemetry/context-async-hooks": "^2.9.0", "@opentelemetry/sdk-node": "^0.220.0", "@types/diff": "^7.0.2", "ai-tokenizer": "^1.0.6", "axios": "^1.18.1", "cheerio": "^1.0.0", "diff": "^9.0.0", "dotenv": "^16.4.7", "https-proxy-agent": "^7.0.6", "mathjs": "^15.2.0", "nanoid": "^3.3.18", "okapibm25": "^1.4.1", "openai": "^6.46.0", "reova": "^0.4.1", "socks-proxy-agent": "^8.0.5", "uuid": "^11.1.1" }, "peerDependencies": { "@anthropic-ai/sandbox-runtime": "^0.0.67" }, "optionalPeers": ["@anthropic-ai/sandbox-runtime"] }, "sha512-8y4gfZg8OD5BuykF8xixh71yafgmmk7dUFX8KN9O40/WkqfJTtA/FG7E48Ke+ben3xOoXE6aIc7fwmotrYrhKw=="],
+    "@librechat/agents": ["@librechat/agents@3.6.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.115.0", "@aws-sdk/client-bedrock-runtime": "^3.1075.0", "@langchain/anthropic": "1.5.2", "@langchain/aws": "^1.4.2", "@langchain/core": "^1.2.3", "@langchain/deepseek": "^1.1.3", "@langchain/google-common": "2.2.0", "@langchain/google-gauth": "2.2.0", "@langchain/google-genai": "2.2.0", "@langchain/google-vertexai": "2.2.0", "@langchain/langgraph": "1.4.8", "@langchain/mistralai": "^1.2.0", "@langchain/openai": "1.5.5", "@langchain/textsplitters": "^1.0.1", "@langchain/xai": "^1.4.3", "@langfuse/core": "^5.4.1", "@langfuse/langchain": "^5.4.1", "@langfuse/otel": "^5.4.1", "@langfuse/tracing": "^5.4.1", "@opentelemetry/context-async-hooks": "^2.9.0", "@opentelemetry/sdk-node": "^0.220.0", "@types/diff": "^7.0.2", "ai-tokenizer": "^1.0.6", "axios": "^1.18.1", "cheerio": "^1.0.0", "diff": "^9.0.0", "dotenv": "^16.4.7", "https-proxy-agent": "^7.0.6", "mathjs": "^15.2.0", "nanoid": "^3.3.18", "okapibm25": "^1.4.1", "openai": "^6.46.0", "reova": "^0.4.1", "socks-proxy-agent": "^8.0.5", "uuid": "^11.1.1" }, "peerDependencies": { "@anthropic-ai/sandbox-runtime": "^0.0.67" }, "optionalPeers": ["@anthropic-ai/sandbox-runtime"] }, "sha512-PWDd29NL2MTuomtUl++q8RYozgRXpTY+OA281uws6vssDNTnEcDWLUIsswLPCLIWGh/8DX9vYpxp+biCnKQyZg=="],
 
     "@librechat/api": ["@librechat/api@workspace:packages/api"],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.5.1",
+        "@librechat/agents": "^3.6.0",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10628,9 +10628,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.5.1.tgz",
-      "integrity": "sha512-8y4gfZg8OD5BuykF8xixh71yafgmmk7dUFX8KN9O40/WkqfJTtA/FG7E48Ke+ben3xOoXE6aIc7fwmotrYrhKw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.0.tgz",
+      "integrity": "sha512-PWDd29NL2MTuomtUl++q8RYozgRXpTY+OA281uws6vssDNTnEcDWLUIsswLPCLIWGh/8DX9vYpxp+biCnKQyZg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42849,7 +42849,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.5.1",
+        "@librechat/agents": "^3.6.0",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.5.1",
+    "@librechat/agents": "^3.6.0",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

Bumps `@librechat/agents` from `^3.5.1` to `^3.6.0` in `api/package.json` and `packages/api/package.json`, with the matching `package-lock.json` and `bun.lock` entries. The existing `^3.5.1` caret cannot cross the minor, so the pin has to move explicitly.

`v3.6.0` contains three changes over `v3.5.1`, all additive:

- **`fix: Close Subagent Child-Graph Run Steps`** ([agents#417](https://github.com/danny-avila/agents/pull/417)) — subagent child graphs execute via `workflow.invoke()` outside `Run.processStream`, so the terminal sweep never reached their run steps and they were left open. They now close on both the success and error paths. This is the piece that makes `on_run_step_closed` reliable for subagent tool cards, which #14871 / #14873 consume.
- **`fix: Restore Run Steps Across Process Resumes`** ([agents#419](https://github.com/danny-avila/agents/pull/419)) — open run-step lifecycle state is now persisted in LangGraph checkpoints (`RunStepResumeState`), so a step opened by one process closes correctly after a resume on another. Closes the multi-replica gap that `RedisJobStore`'s reconstruction branch was working around.
- **`feat: route code execution per agent profile`** ([agents#416](https://github.com/danny-avila/agents/pull/416)) — new optional `codeSessionKey` partition for transient code-session ids and file refs, plus optional `baseUrl` / profile assertion on `CodeExecutionToolParams`.

No LibreChat source changes are needed for this bump.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verification performed on the diff itself, since it is a dependency pin with no source changes:

- Confirmed `3.6.0` is published and that the subagent closure fix is present in the tag: `git show v3.6.0:src/tools/subagent/SubagentExecutor.ts` contains `closeChildRunSteps`.
- Reviewed the full public type-surface diff between `v3.5.1` and `v3.6.0` (`src/types/stream.ts`, `src/types/tools.ts`, `src/types/graph.ts`, and the export barrels). Every new field is optional and no existing signature changed, so nothing in `api/` or `packages/api/` needs updating.
- Compared the package's own `dependencies`, `peerDependencies` and `optionalPeers` at `3.6.0` against the registry and against the `3.5.1` entries — identical. That is why both lockfile diffs are confined to the `@librechat/agents` entry (version / resolution id / integrity) and the two workspace specs, with no transitive churn, and why the existing `@librechat/agents/*` hoisting overrides in `bun.lock` stay valid untouched.
- Regenerated `package-lock.json` with `npm install --package-lock-only` to confirm npm resolves to exactly this state, then applied the change surgically so the committed diff carries none of the unrelated `libc` / peer-dedup noise that a full regeneration on a different npm minor introduces.
- Cross-checked that the integrity hash in `bun.lock` equals the one npm independently resolved into `package-lock.json`.

### **Test Configuration**:

Two things could not be executed in this environment, both for the same reason — the `xlsx` dependency is pinned to a direct `cdn.sheetjs.com` tarball URL, which the sandbox network policy denies (403 on `CONNECT cdn.sheetjs.com:443`):

- `npm ci` cannot complete, so the `api` / `packages/api` workspaces were not installed and their test suites were not run locally. CI runs them.
- `bun install --lockfile-only` cannot complete either — bun stores no integrity for URL dependencies and re-fetches that host on every resolve. The `bun.lock` entry was therefore updated directly rather than regenerated by bun. This is exact rather than approximate because the package's dependency graph is unchanged between the two versions (see above), so only three values can move and only those three did. Flagging it explicitly so the lockfile is read as hand-verified, not tool-generated; a `bun install --lockfile-only` on a machine that can reach that host should produce no further change.

CI runs on Node `24.16.0`, which satisfies the `>=24.0.0` engine `3.6.0` declares — the repo's `.nvmrc` and every workflow already pin that version, so the engine bump in the new release is already met.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.