### PR TITLE
fix: use actual model name as fallback before generic "AI" sender label

### DIFF
--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -260,7 +260,7 @@ export const getResponseSender = (endpointOption: Partial<t.TEndpointOption>): s
       const gptVersion = extractGPTVersion(model);
       return gptVersion || 'GPT';
     }
-    return (alternateName[endpoint] as string | undefined) ?? 'AI';
+    return (alternateName[endpoint] as string | undefined) ?? (model || 'AI');
   }
 
   if (endpoint === EModelEndpoint.anthropic) {
@@ -304,7 +304,7 @@ export const getResponseSender = (endpointOption: Partial<t.TEndpointOption>): s
       return modelDisplayLabel;
     }
 
-    return 'AI';
+    return model || 'AI';
   }
 
   return '';


### PR DESCRIPTION
## Summary

`getResponseSender()` builds the display name shown as the author of an assistant
message. For endpoints where no model-specific pattern and no configured label
matched, it returned the literal string `"AI"` — discarding the model name that
was available all along.

This is most visible on **custom endpoints** with aggregator providers (Together AI,
OpenRouter-style gateways, self-hosted gateways, …): a response from
`Qwen/Qwen2.5-72B-Instruct` was labelled `"AI"` rather than the model that actually
produced it.

This PR inserts the raw model name as a **last-resort fallback directly before**
`"AI"`.

**Deliberately unchanged:** the existing brand/family detection is untouched and
still takes precedence. `modelLabel`, `chatGptLabel`, `modelDisplayLabel`, the
omni/GPT version extraction and the Mistral / DeepSeek / Kimi / Moonshot /
Claude / Gemini / Gemma names all keep winning over the raw model string — those
are better display names than an ID like `mistralai/Mixtral-8x7B-Instruct-v0.1`.
The only behavioural difference is what happens *instead of* `"AI"`.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification:

1. Configure a custom endpoint whose models do not match any known family
   (e.g. Together AI with `Qwen/Qwen2.5-72B-Instruct`).
2. Send a message.
3. **Before:** the response header reads `AI`.
   **After:** it reads `Qwen/Qwen2.5-72B-Instruct`.


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
