### PR TITLE
fix(mcp): forward uploaded edit images

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -578,6 +578,7 @@ const loadTools = async ({
           continue;
         }
         const mcpParams = {
+          request: options.req,
           mcpPermissionContext,
           index,
           signal,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -63,6 +63,7 @@ const {
   cacheMCPServerTools,
 } = require('./Config');
 const { getLogStores } = require('~/cache');
+const { resolveImageToolArguments } = require('./MCP/images');
 
 const MAX_CACHE_SIZE = 1000;
 const lastReconnectAttempts = new Map();
@@ -725,6 +726,7 @@ async function reconnectServer({
  *
  * @param {Object} params
  * @param {ServerResponse} params.res - The Express response object for sending events.
+ * @param {ServerRequest} [params.request] - The originating request, including resolved upload context.
  * @param {{ canUseServers: (user?: IUser) => Promise<boolean> }} [params.mcpPermissionContext] - Request-scoped MCP permission context.
  * @param {IUser} params.user - The user from the request object.
  * @param {string} params.serverName
@@ -742,6 +744,7 @@ async function reconnectServer({
  */
 async function createMCPTools({
   res,
+  request,
   mcpPermissionContext,
   user,
   index,
@@ -809,6 +812,7 @@ async function createMCPTools({
   for (const tool of result.tools) {
     const toolInstance = await createMCPTool({
       res,
+      request,
       mcpPermissionContext,
       user,
       provider,
@@ -837,6 +841,7 @@ async function createMCPTools({
  * Creates a single tool from the specified MCP Server via `toolKey`.
  * @param {Object} params
  * @param {ServerResponse} params.res - The Express response object for sending events.
+ * @param {ServerRequest} [params.request] - The originating request, including resolved upload context.
  * @param {{ canUseServers: (user?: IUser) => Promise<boolean> }} [params.mcpPermissionContext] - Request-scoped MCP permission context.
  * @param {IUser} params.user - The user from the request object.
  * @param {string} params.toolKey - The toolKey for the tool.
@@ -856,6 +861,7 @@ async function createMCPTools({
  */
 async function createMCPTool({
   res,
+  request,
   mcpPermissionContext,
   user,
   index,
@@ -992,6 +998,7 @@ async function createMCPTool({
 
   return createToolInstance({
     res,
+    request,
     mcpPermissionContext,
     user,
     requestBody,
@@ -1008,6 +1015,7 @@ async function createMCPTool({
 
 function createToolInstance({
   res,
+  request: capturedRequest,
   mcpPermissionContext,
   user: capturedUser = null,
   requestBody: capturedRequestBody,
@@ -1061,6 +1069,13 @@ function createToolInstance({
       const flowManager = getFlowStateManager(flowsCache);
       const derivedSignal = config?.signal ? AbortSignal.any([config.signal]) : undefined;
       const mcpManager = getMCPManager(userId);
+      const resolvedToolArguments = await resolveImageToolArguments({
+        serverName,
+        toolName,
+        toolArguments,
+        request: capturedRequest,
+        user: effectiveUser,
+      });
 
       const { args: _args, stepId, ...toolCall } = config.toolCall ?? {};
       const flowId = `${serverName}:oauth_login:${config.metadata.thread_id}:${config.metadata.run_id}`;
@@ -1092,7 +1107,7 @@ function createToolInstance({
         serverConfig: capturedServerConfig,
         toolName,
         provider,
-        toolArguments,
+        toolArguments: resolvedToolArguments,
         options: {
           signal: derivedSignal,
         },

--- a/api/server/services/MCP.spec.js
+++ b/api/server/services/MCP.spec.js
@@ -1,5 +1,8 @@
 // Mock all dependencies - define mocks before imports
 const mockGetTenantId = jest.fn();
+const mockResolveImageToolArguments = jest.fn(({ toolArguments }) =>
+  Promise.resolve(toolArguments),
+);
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -85,6 +88,10 @@ jest.mock('~/models', () => ({
 
 jest.mock('./Tools/mcp', () => ({
   reinitMCPServer: jest.fn(),
+}));
+
+jest.mock('./MCP/images', () => ({
+  resolveImageToolArguments: (...args) => mockResolveImageToolArguments(...args),
 }));
 
 jest.mock('./GraphTokenService', () => ({
@@ -2087,6 +2094,68 @@ describe('User parameter passing tests', () => {
           serverName: 'test-server',
           toolName: 'test-tool',
           requestBody,
+        }),
+      );
+    });
+
+    it('passes the uploaded-image data URL to ImageTools instead of its local placeholder', async () => {
+      const mockUser = { id: 'image-user', role: 'USER' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+      const request = { body: { files: [{ file_id: 'upload-1', type: 'image/png' }] } };
+      const { getRoleByName } = require('~/models');
+      getRoleByName.mockResolvedValue({
+        permissions: {
+          [PermissionTypes.MCP_SERVERS]: {
+            [Permissions.USE]: true,
+          },
+        },
+      });
+      const mockCallTool = jest.fn().mockResolvedValue(['ok', null]);
+      mockGetMCPManager.mockReturnValue({ callTool: mockCallTool });
+      mockResolveImageToolArguments.mockResolvedValueOnce({
+        images: ['data:image/png;base64,aW1hZ2U='],
+        prompt: 'remove the robot',
+      });
+
+      const mcpTool = await createMCPTool({
+        res: mockRes,
+        request,
+        user: mockUser,
+        toolKey: `edit_image${D}image-generation`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: {
+          [`edit_image${D}image-generation`]: {
+            function: { description: 'Edit image', parameters: { type: 'object', properties: {} } },
+          },
+        },
+      });
+
+      await expect(
+        mcpTool.invoke(
+          { images: ['/mnt/data/0.png'], prompt: 'remove the robot' },
+          {
+            configurable: { user: mockUser },
+            metadata: { provider: 'openai', thread_id: 'thread-1', run_id: 'run-1' },
+            toolCall: {},
+          },
+        ),
+      ).resolves.toBe('ok');
+
+      expect(mockResolveImageToolArguments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverName: 'image-generation',
+          toolName: 'edit_image',
+          request,
+          toolArguments: { images: ['/mnt/data/0.png'], prompt: 'remove the robot' },
+        }),
+      );
+      expect(mockCallTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolArguments: {
+            images: ['data:image/png;base64,aW1hZ2U='],
+            prompt: 'remove the robot',
+          },
         }),
       );
     });

--- a/api/server/services/MCP/README.md
+++ b/api/server/services/MCP/README.md
@@ -1,0 +1,17 @@
+# ImageTools uploaded-image bridge
+
+`edit_image` on the configured `image-generation` MCP server recognizes LibreChat's
+vision-upload placeholders such as `/mnt/data/0.png`. Before the MCP call, LibreChat
+loads the current request's owned image attachment and replaces that placeholder with
+a `data:image/...;base64,...` URL. ImageTools can read that URL without a shared
+upload volume.
+
+Deployment requirements:
+
+- Run a LibreChat image containing this change (the candidate is based on
+  `v0.8.8-rc1`).
+- Keep the ImageTools MCP server configuration name as `image-generation` and its
+  edit tool as `edit_image`.
+- No ImageTools volume or URL configuration is required for uploads. Existing
+  `/app/storage/...` generated-image arguments are deliberately passed through
+  unchanged.

--- a/api/server/services/MCP/images.js
+++ b/api/server/services/MCP/images.js
@@ -1,0 +1,30 @@
+const { resolveImageToolArguments: resolveImageToolArgumentsInApi } = require('@librechat/api');
+
+function getDependencies() {
+  const db = require('~/models');
+  const { encodeAndFormat } = require('~/server/services/Files/images/encode');
+  return {
+    findFiles: db.getFiles,
+    encodeImages: async (request, files) => {
+      const image_urls = await Promise.all(
+        files.map(async (file) => {
+          const { image_urls: encodedImages } = await encodeAndFormat(request, [file], {});
+          const url = encodedImages[0]?.image_url?.url;
+          return typeof url === 'string'
+            ? { file_id: file.file_id, image_url: { url } }
+            : undefined;
+        }),
+      );
+      return { image_urls: image_urls.filter((image) => image !== undefined) };
+    },
+  };
+}
+
+async function resolveImageToolArguments(params) {
+  return await resolveImageToolArgumentsInApi({
+    ...params,
+    dependencies: params.dependencies ?? getDependencies(),
+  });
+}
+
+module.exports = { resolveImageToolArguments };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -25,6 +25,7 @@ export * from './mcp/tools';
 export * from './mcp/catalog/store';
 export * from './mcp/assistants';
 export * from './mcp/request';
+export * from './mcp/images';
 /* Utilities */
 export * from './mcp/utils';
 export * from './mcp/context';

--- a/packages/api/src/mcp/images.spec.ts
+++ b/packages/api/src/mcp/images.spec.ts
@@ -1,0 +1,210 @@
+import { resolveImageToolArguments } from './images';
+
+const uploadedImage = {
+  file_id: 'file-upload-1',
+  filepath: '/images/user-1/upload.png',
+};
+
+const imageUrl = 'data:image/png;base64,aW1hZ2U=';
+
+function createDependencies(overrides = {}) {
+  return {
+    findFiles: jest.fn().mockResolvedValue([uploadedImage]),
+    encodeImages: jest.fn().mockResolvedValue({
+      image_urls: [{ file_id: uploadedImage.file_id, image_url: { url: imageUrl } }],
+    }),
+    ...overrides,
+  };
+}
+
+describe('resolveImageToolArguments', () => {
+  it('substitutes only an owned current-request ImageTools upload placeholder', async () => {
+    const dependencies = createDependencies();
+    const request = {
+      body: { files: [{ file_id: uploadedImage.file_id, type: 'image/png' }] },
+    };
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'image-generation',
+        toolName: 'edit_image',
+        toolArguments: { images: ['/mnt/data/0.png'], prompt: 'remove the robot' },
+        request,
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toEqual({ images: [imageUrl], prompt: 'remove the robot' });
+
+    expect(dependencies.findFiles).toHaveBeenCalledWith({
+      file_id: { $in: [uploadedImage.file_id] },
+      user: 'user-1',
+    });
+    expect(dependencies.encodeImages).toHaveBeenCalledWith(request, [uploadedImage]);
+  });
+
+  it('preserves request image order and generated-image values in a mixed array', async () => {
+    const first = { file_id: 'first', filepath: '/images/first.png' };
+    const second = { file_id: 'second', filepath: '/images/second.jpg' };
+    const dependencies = createDependencies({
+      findFiles: jest.fn().mockResolvedValue([second, first]),
+      encodeImages: jest.fn().mockResolvedValue({
+        image_urls: [
+          { file_id: first.file_id, image_url: { url: 'data:image/png;base64,Zmlyc3Q=' } },
+          { file_id: second.file_id, image_url: { url: 'data:image/jpeg;base64,c2Vjb25k' } },
+        ],
+      }),
+    });
+    const request = {
+      body: {
+        files: [
+          { file_id: first.file_id, type: 'image/png' },
+          { file_id: second.file_id, type: 'image/jpeg' },
+        ],
+      },
+    };
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'image-generation',
+        toolName: 'edit_image',
+        toolArguments: {
+          images: ['/mnt/data/1.jpg', '/app/storage/generated.png', '/mnt/data/0.png'],
+        },
+        request,
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toEqual({
+      images: [
+        'data:image/jpeg;base64,c2Vjb25k',
+        '/app/storage/generated.png',
+        'data:image/png;base64,Zmlyc3Q=',
+      ],
+    });
+
+    expect(dependencies.encodeImages).toHaveBeenCalledWith(request, [first, second]);
+  });
+
+  it('leaves a missing request image placeholder unchanged before an owned image', async () => {
+    const ownedImage = { file_id: 'owned-second', filepath: '/images/owned-second.png' };
+    const dependencies = createDependencies({
+      findFiles: jest.fn().mockResolvedValue([ownedImage]),
+      encodeImages: jest.fn().mockResolvedValue({
+        image_urls: [{ file_id: ownedImage.file_id, image_url: { url: imageUrl } }],
+      }),
+    });
+    const request = {
+      body: {
+        files: [
+          { file_id: 'missing-or-foreign-first', type: 'image/png' },
+          { file_id: ownedImage.file_id, type: 'image/png' },
+        ],
+      },
+    };
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'image-generation',
+        toolName: 'edit_image',
+        toolArguments: { images: ['/mnt/data/0.png', '/mnt/data/1.png'] },
+        request,
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toEqual({ images: ['/mnt/data/0.png', imageUrl] });
+
+    expect(dependencies.encodeImages).toHaveBeenCalledWith(request, [ownedImage]);
+  });
+
+  it('preserves the first owned placeholder when sparse encoder output contains only the second', async () => {
+    const first = { file_id: 'first', filepath: '/images/first.png' };
+    const second = { file_id: 'second', filepath: '/images/second.png' };
+    const secondUrl = 'data:image/png;base64,c2Vjb25k';
+    const dependencies = createDependencies({
+      findFiles: jest.fn().mockResolvedValue([first, second]),
+      encodeImages: jest.fn().mockResolvedValue({
+        image_urls: [{ file_id: second.file_id, image_url: { url: secondUrl } }],
+      }),
+    });
+    const request = {
+      body: {
+        files: [
+          { file_id: first.file_id, type: 'image/png' },
+          { file_id: second.file_id, type: 'image/png' },
+        ],
+      },
+    };
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'image-generation',
+        toolName: 'edit_image',
+        toolArguments: { images: ['/mnt/data/0.png', '/mnt/data/1.png'] },
+        request,
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toEqual({ images: ['/mnt/data/0.png', secondUrl] });
+
+    expect(dependencies.encodeImages).toHaveBeenCalledWith(request, [first, second]);
+  });
+
+  it('leaves non-target MCP calls untouched', async () => {
+    const dependencies = createDependencies();
+    const otherServerArguments = { images: ['/mnt/data/0.png'] };
+    const otherToolArguments = { images: ['/mnt/data/0.png'] };
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'other-server',
+        toolName: 'edit_image',
+        toolArguments: otherServerArguments,
+        request: { body: { files: [{ file_id: uploadedImage.file_id, type: 'image/png' }] } },
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toBe(otherServerArguments);
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'image-generation',
+        toolName: 'create_image',
+        toolArguments: otherToolArguments,
+        request: { body: { files: [{ file_id: uploadedImage.file_id, type: 'image/png' }] } },
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toBe(otherToolArguments);
+
+    expect(dependencies.findFiles).not.toHaveBeenCalled();
+    expect(dependencies.encodeImages).not.toHaveBeenCalled();
+  });
+
+  it('leaves generated, hostile, and non-placeholder image values untouched', async () => {
+    const dependencies = createDependencies();
+    const toolArguments = {
+      images: [
+        '/app/storage/generated.png',
+        'file:///mnt/data/0.png',
+        '/mnt/data/../0.png',
+        '/mnt/data/0.gif',
+        '/mnt/data/0.svg',
+        'https://example.com/0.png',
+      ],
+    };
+
+    await expect(
+      resolveImageToolArguments({
+        serverName: 'image-generation',
+        toolName: 'edit_image',
+        toolArguments,
+        request: { body: { files: [{ file_id: uploadedImage.file_id, type: 'image/png' }] } },
+        user: { id: 'user-1' },
+        dependencies,
+      }),
+    ).resolves.toBe(toolArguments);
+
+    expect(dependencies.findFiles).not.toHaveBeenCalled();
+    expect(dependencies.encodeImages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/mcp/images.ts
+++ b/packages/api/src/mcp/images.ts
@@ -1,0 +1,150 @@
+const IMAGE_GENERATION_SERVER = 'image-generation';
+const EDIT_IMAGE_TOOL = 'edit_image';
+const UPLOAD_PLACEHOLDER = /^\/mnt\/data\/(\d+)\.(?:png|jpe?g|webp)$/i;
+
+type ToolArgumentValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ToolArgumentValue[]
+  | { [key: string]: ToolArgumentValue };
+
+export interface ImageToolArguments {
+  images?: ToolArgumentValue;
+  [key: string]: ToolArgumentValue | undefined;
+}
+
+export interface ImageToolRequestFile {
+  file_id?: string;
+  type?: string;
+}
+
+export interface ImageToolRequest {
+  body?: {
+    files?: ImageToolRequestFile[];
+  };
+}
+
+export interface ImageToolUser {
+  id?: string;
+}
+
+export interface ImageToolFile {
+  file_id: string;
+}
+
+export interface ImageToolFileQuery {
+  file_id: {
+    $in: string[];
+  };
+  user: string;
+}
+
+export interface ImageToolEncoding {
+  image_urls?: Array<{
+    file_id: string;
+    image_url?: {
+      url?: string;
+    };
+  }>;
+}
+
+export interface ImageToolDependencies {
+  findFiles: (query: ImageToolFileQuery) => Promise<readonly ImageToolFile[] | null | undefined>;
+  encodeImages: (
+    request: ImageToolRequest | undefined,
+    files: readonly ImageToolFile[],
+  ) => Promise<ImageToolEncoding>;
+}
+
+export interface ResolveImageToolArgumentsParams {
+  serverName?: string;
+  toolName?: string;
+  toolArguments: ImageToolArguments | string;
+  request?: ImageToolRequest;
+  user?: ImageToolUser;
+  dependencies: ImageToolDependencies;
+}
+
+function isImageToolArguments(value: ImageToolArguments | string): value is ImageToolArguments {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getUploadPlaceholderIndex(image: ToolArgumentValue | undefined): number | undefined {
+  if (typeof image !== 'string') {
+    return undefined;
+  }
+
+  const match = image.match(UPLOAD_PLACEHOLDER);
+  return match ? Number(match[1]) : undefined;
+}
+
+function getRequestImageFileIds(request?: ImageToolRequest): string[] {
+  const files = request?.body?.files;
+  if (!files) {
+    return [];
+  }
+
+  return files
+    .filter((file) => file.type?.startsWith('image/') && typeof file.file_id === 'string')
+    .map((file) => file.file_id!);
+}
+
+export async function resolveImageToolArguments({
+  serverName,
+  toolName,
+  toolArguments,
+  request,
+  user,
+  dependencies,
+}: ResolveImageToolArgumentsParams): Promise<ImageToolArguments | string> {
+  if (
+    serverName !== IMAGE_GENERATION_SERVER ||
+    toolName !== EDIT_IMAGE_TOOL ||
+    !isImageToolArguments(toolArguments) ||
+    !Array.isArray(toolArguments.images)
+  ) {
+    return toolArguments;
+  }
+
+  const placeholderIndexes = toolArguments.images.map(getUploadPlaceholderIndex);
+  if (!placeholderIndexes.some((index) => index !== undefined)) {
+    return toolArguments;
+  }
+
+  const fileIds = getRequestImageFileIds(request);
+  if (!user?.id || fileIds.length === 0) {
+    return toolArguments;
+  }
+
+  const foundFiles = await dependencies.findFiles({
+    file_id: { $in: fileIds },
+    user: user.id,
+  });
+  const filesById = new Map((foundFiles ?? []).map((file) => [file.file_id, file]));
+  const imageFiles = fileIds
+    .map((fileId) => filesById.get(fileId))
+    .filter((file): file is ImageToolFile => file !== undefined);
+  if (imageFiles.length === 0) {
+    return toolArguments;
+  }
+
+  const { image_urls: imageUrls } = await dependencies.encodeImages(request, imageFiles);
+  const imageUrlsByFileId = new Map(
+    (imageUrls ?? [])
+      .filter((image) => typeof image.image_url?.url === 'string')
+      .map((image) => [image.file_id, image.image_url!.url!] as const),
+  );
+  const images = toolArguments.images.map((image, imageIndex) => {
+    const placeholderIndex = placeholderIndexes[imageIndex];
+    if (placeholderIndex === undefined) {
+      return image;
+    }
+    const fileId = fileIds[placeholderIndex];
+    const url = fileId ? imageUrlsByFileId.get(fileId) : undefined;
+    return typeof url === 'string' ? url : image;
+  });
+
+  return { ...toolArguments, images };
+}


### PR DESCRIPTION
## Summary

Fixes the uploaded-image edit path for MCP tools that expect an image reference rather than LibreChat's internal `/mnt/data/...` placeholder.

- expands eligible uploaded-image placeholders only while resolving the current tool call, using the authenticated owner/request/file context;
- implements the resolver as a small TypeScript API adapter and keeps the existing server-side MCP dispatch thin;
- preserves generated `/app/storage` image references and does not broaden access across users, requests, or file IDs.

## Validation

- focused resolver tests cover attachment selection, request ownership/isolation, MIME handling, generated-image pass-through, and replacement behavior;
- focused MCP forwarding tests cover resolved tool arguments;
- focused ESLint and strict TypeScript checks pass for the changed files.

## Security / operational note

No upload URLs, credentials, deployment details, or private image data are exposed by this change. The bridge resolves only attachments authorized for the active request context.

Deployments that proxy MCP Streamable HTTP must set a JSON request-body limit large enough for base64-encoded image payloads. That transport setting is deployment-specific, is being handled separately, and is not a LibreChat source defect.
