### PR TITLE
🖱️ fix: Reveal Message Metadata on Hover, Not on Click

### DIFF
--- a/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
+++ b/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
@@ -2,6 +2,8 @@ import { useState, useMemo } from 'react';
 import { Button, Clipboard, CheckMark, TooltipAnchor } from '@librechat/client';
 import type { TMessage, SearchResultData } from 'librechat-data-provider';
 import { useLocalize, useCopyToClipboard, hasCopyableText } from '~/hooks';
+import { revealOnRowHoverClasses } from './styles';
+import { cn } from '~/utils';
 
 type THoverButtons = {
   message: TMessage;
@@ -36,7 +38,12 @@ export default function MinimalHoverButtons({ message, searchResults }: THoverBu
                 ? localize('com_ui_copied_to_clipboard')
                 : localize('com_ui_copy_to_clipboard')
             }
-            className="ml-0 flex size-auto items-center gap-1.5 rounded-lg p-1.5 text-xs text-text-secondary-alt transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 [@media(hover:hover)]:opacity-0"
+            className={cn(
+              'ml-0 flex size-auto items-center gap-1.5 rounded-lg p-1.5 text-xs text-text-secondary-alt',
+              'hover:bg-surface-hover hover:text-text-primary',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary',
+              revealOnRowHoverClasses,
+            )}
             disabled={!canCopy}
             onClick={() => copyToClipboard(setIsCopied)}
           >

--- a/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
+++ b/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
@@ -36,7 +36,7 @@ export default function MinimalHoverButtons({ message, searchResults }: THoverBu
                 ? localize('com_ui_copied_to_clipboard')
                 : localize('com_ui_copy_to_clipboard')
             }
-            className="ml-0 flex size-auto items-center gap-1.5 rounded-lg p-1.5 text-xs text-text-secondary-alt transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary group-focus-within:opacity-100 group-hover:opacity-100 [@media(hover:hover)]:opacity-0"
+            className="ml-0 flex size-auto items-center gap-1.5 rounded-lg p-1.5 text-xs text-text-secondary-alt transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 [@media(hover:hover)]:opacity-0"
             disabled={!canCopy}
             onClick={() => copyToClipboard(setIsCopied)}
           >

--- a/client/src/components/Chat/Messages/SiblingSwitch.tsx
+++ b/client/src/components/Chat/Messages/SiblingSwitch.tsx
@@ -33,7 +33,7 @@ export default function SiblingSwitch({
   const buttonStyle = cn(
     'hover-button h-auto rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
+    'group-hover:visible group-has-[:focus-visible]:visible group-[.final-completion]:visible',
     'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',
   );
 

--- a/client/src/components/Chat/Messages/SiblingSwitch.tsx
+++ b/client/src/components/Chat/Messages/SiblingSwitch.tsx
@@ -33,7 +33,7 @@ export default function SiblingSwitch({
   const buttonStyle = cn(
     'hover-button h-auto rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'group-hover:visible group-has-[:focus-visible]:visible group-[.final-completion]:visible',
+    'group-hover:visible group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:visible group-[.final-completion]:visible',
     'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',
   );
 

--- a/client/src/components/Chat/Messages/SiblingSwitch.tsx
+++ b/client/src/components/Chat/Messages/SiblingSwitch.tsx
@@ -33,7 +33,7 @@ export default function SiblingSwitch({
   const buttonStyle = cn(
     'hover-button h-auto rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'group-hover:visible group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:visible group-[.final-completion]:visible',
+    'group-hover:visible group-focus-visible:visible group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:visible group-[.final-completion]:visible',
     'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',
   );
 

--- a/client/src/components/Chat/Messages/__tests__/styles.spec.ts
+++ b/client/src/components/Chat/Messages/__tests__/styles.spec.ts
@@ -14,6 +14,20 @@ describe('revealOnRowHoverClasses', () => {
   it('does not reveal on plain focus-within', () => {
     expect(revealOnRowHoverClasses).not.toContain('group-focus-within:');
   });
+
+  it('fades on the shared motion role rather than snapping', () => {
+    expect(revealOnRowHoverClasses).toContain('duration-theme-normal');
+    expect(revealOnRowHoverClasses).toContain('ease-out');
+    expect(revealOnRowHoverClasses).toContain('motion-reduce:transition-none');
+  });
+
+  /* `cn` merges the whole `transition-*` group, so a bare `transition-opacity`
+     would replace the `transition-colors` a `Button` contributes and the hover
+     tint would snap. The colour properties have to ride along explicitly. */
+  it('names the colour properties alongside opacity', () => {
+    expect(revealOnRowHoverClasses).toContain('transition-[opacity,color,background-color]');
+    expect(revealOnRowHoverClasses).not.toContain('transition-opacity');
+  });
 });
 
 describe('hoverButtonClasses', () => {

--- a/client/src/components/Chat/Messages/__tests__/styles.spec.ts
+++ b/client/src/components/Chat/Messages/__tests__/styles.spec.ts
@@ -2,16 +2,17 @@ import { hoverButtonClasses, messageFooterClasses, revealOnRowHoverClasses } fro
 
 const FADE = '[@media(hover:hover)]:opacity-0';
 
-/** The row-wide keyboard-focus condition: the row itself, or a descendant that
- *  is not a text-entry control. */
-const KEYBOARD_FOCUS =
-  'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]';
+/** The row-wide keyboard-focus condition, as two variants. It cannot be one
+ *  `group-[&:is(...)]`: that form makes Tailwind emit a bare `.group$` rule
+ *  that lightningcss rejects, which fails the production CSS build. */
+const FOCUS_SELF = 'group-focus-visible';
+const FOCUS_DESCENDANT = 'group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]';
 
 describe('revealOnRowHoverClasses', () => {
   it('reveals on row hover and on keyboard focus', () => {
     expect(revealOnRowHoverClasses).toContain(FADE);
     expect(revealOnRowHoverClasses).toContain('group-hover:opacity-100');
-    expect(revealOnRowHoverClasses).toContain(`${KEYBOARD_FOCUS}:opacity-100`);
+    expect(revealOnRowHoverClasses).toContain(`${FOCUS_DESCENDANT}:opacity-100`);
   });
 
   /* Clicking a tool card in the message body parks focus there. `:focus-within`
@@ -23,15 +24,19 @@ describe('revealOnRowHoverClasses', () => {
   /* MessageNav moves the reader by focusing the row itself through
      tabindex="-1", and :has() never matches its own subject. */
   it('reveals when the row element itself is focus-visible', () => {
-    expect(revealOnRowHoverClasses).toContain('&:is(:focus-visible,');
+    expect(revealOnRowHoverClasses).toContain(`${FOCUS_SELF}:opacity-100`);
   });
 
   /* Text-entry controls match :focus-visible even on a mouse click, and
      ToolApproval and AskUserQuestion both render textareas inside a row. */
   it('ignores focus that landed in a text-entry control', () => {
-    expect(revealOnRowHoverClasses).toContain(
-      ':has(:focus-visible:not(:is(input,textarea,[contenteditable])))',
-    );
+    expect(revealOnRowHoverClasses).toContain(':not(:is(input,textarea,[contenteditable]))');
+  });
+
+  /* A bare `.group$` rule in the emitted CSS fails the lightningcss minify
+     step, so the variant form itself is worth pinning. */
+  it('does not use a group-[&:...] variant', () => {
+    expect(revealOnRowHoverClasses).not.toContain('group-[&');
   });
 
   it('fades on the shared motion role rather than snapping', () => {
@@ -56,7 +61,7 @@ describe('hoverButtonClasses', () => {
   });
 
   it('reveals an idle action on keyboard focus, not on a click parking focus in the row', () => {
-    expect(hoverButtonClasses()).toContain(`${KEYBOARD_FOCUS}:opacity-100`);
+    expect(hoverButtonClasses()).toContain(`${FOCUS_DESCENDANT}:opacity-100`);
     expect(hoverButtonClasses()).not.toContain('group-focus-within:');
   });
 

--- a/client/src/components/Chat/Messages/__tests__/styles.spec.ts
+++ b/client/src/components/Chat/Messages/__tests__/styles.spec.ts
@@ -1,11 +1,30 @@
-import { hoverButtonClasses, messageFooterClasses } from '../styles';
+import { hoverButtonClasses, messageFooterClasses, revealOnRowHoverClasses } from '../styles';
 
 const FADE = '[@media(hover:hover)]:opacity-0';
+
+describe('revealOnRowHoverClasses', () => {
+  it('reveals on row hover and on keyboard focus', () => {
+    expect(revealOnRowHoverClasses).toContain(FADE);
+    expect(revealOnRowHoverClasses).toContain('group-hover:opacity-100');
+    expect(revealOnRowHoverClasses).toContain('group-has-[:focus-visible]:opacity-100');
+  });
+
+  /* Clicking a tool card in the message body parks focus there. `:focus-within`
+     would hold the footer open with the pointer nowhere near the row. */
+  it('does not reveal on plain focus-within', () => {
+    expect(revealOnRowHoverClasses).not.toContain('group-focus-within:');
+  });
+});
 
 describe('hoverButtonClasses', () => {
   it('fades an idle action out until the row is hovered', () => {
     expect(hoverButtonClasses()).toContain(FADE);
     expect(hoverButtonClasses()).toContain('group-hover:opacity-100');
+  });
+
+  it('reveals an idle action on keyboard focus, not on a click parking focus in the row', () => {
+    expect(hoverButtonClasses()).toContain('group-has-[:focus-visible]:opacity-100');
+    expect(hoverButtonClasses()).not.toContain('group-focus-within:');
   });
 
   it('marks an active action so the toolbar can key off it', () => {

--- a/client/src/components/Chat/Messages/__tests__/styles.spec.ts
+++ b/client/src/components/Chat/Messages/__tests__/styles.spec.ts
@@ -2,17 +2,36 @@ import { hoverButtonClasses, messageFooterClasses, revealOnRowHoverClasses } fro
 
 const FADE = '[@media(hover:hover)]:opacity-0';
 
+/** The row-wide keyboard-focus condition: the row itself, or a descendant that
+ *  is not a text-entry control. */
+const KEYBOARD_FOCUS =
+  'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]';
+
 describe('revealOnRowHoverClasses', () => {
   it('reveals on row hover and on keyboard focus', () => {
     expect(revealOnRowHoverClasses).toContain(FADE);
     expect(revealOnRowHoverClasses).toContain('group-hover:opacity-100');
-    expect(revealOnRowHoverClasses).toContain('group-has-[:focus-visible]:opacity-100');
+    expect(revealOnRowHoverClasses).toContain(`${KEYBOARD_FOCUS}:opacity-100`);
   });
 
   /* Clicking a tool card in the message body parks focus there. `:focus-within`
      would hold the footer open with the pointer nowhere near the row. */
   it('does not reveal on plain focus-within', () => {
     expect(revealOnRowHoverClasses).not.toContain('group-focus-within:');
+  });
+
+  /* MessageNav moves the reader by focusing the row itself through
+     tabindex="-1", and :has() never matches its own subject. */
+  it('reveals when the row element itself is focus-visible', () => {
+    expect(revealOnRowHoverClasses).toContain('&:is(:focus-visible,');
+  });
+
+  /* Text-entry controls match :focus-visible even on a mouse click, and
+     ToolApproval and AskUserQuestion both render textareas inside a row. */
+  it('ignores focus that landed in a text-entry control', () => {
+    expect(revealOnRowHoverClasses).toContain(
+      ':has(:focus-visible:not(:is(input,textarea,[contenteditable])))',
+    );
   });
 
   it('fades on the shared motion role rather than snapping', () => {
@@ -37,7 +56,7 @@ describe('hoverButtonClasses', () => {
   });
 
   it('reveals an idle action on keyboard focus, not on a click parking focus in the row', () => {
-    expect(hoverButtonClasses()).toContain('group-has-[:focus-visible]:opacity-100');
+    expect(hoverButtonClasses()).toContain(`${KEYBOARD_FOCUS}:opacity-100`);
     expect(hoverButtonClasses()).not.toContain('group-focus-within:');
   });
 

--- a/client/src/components/Chat/Messages/styles.ts
+++ b/client/src/components/Chat/Messages/styles.ts
@@ -25,13 +25,18 @@ import { cn } from '~/utils';
  *   clicking one pins the row open with the pointer somewhere else entirely. Every
  *   toolbar action is a button, so a keyboard user still never focuses a hidden one.
  *
+ * The two halves stay two variants on purpose. Folding them into a single
+ * `group-[&:is(...)]` makes Tailwind emit a bare `.group$ { opacity: 1 }` rule, which
+ * lightningcss rejects and which fails the production CSS build while leaving `jest`
+ * and `tsc` perfectly green.
+ *
  * The transition names `color` and `background-color` alongside `opacity` rather than
  * naming opacity alone: `cn` merges the whole `transition-*` group, so a bare
  * `transition-opacity` here would replace the `transition-colors` a `Button` brings and
  * the hover tint would snap instead of fading.
  */
 export const revealOnRowHoverClasses =
-  'transition-[opacity,color,background-color] duration-theme-normal ease-out group-hover:opacity-100 group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:opacity-100 motion-reduce:transition-none [@media(hover:hover)]:opacity-0';
+  'transition-[opacity,color,background-color] duration-theme-normal ease-out group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:opacity-100 motion-reduce:transition-none [@media(hover:hover)]:opacity-0';
 
 /**
  * The message footer, holding the height of its action row.
@@ -72,7 +77,7 @@ export const hoverButtonClasses = ({
   cn(
     'hover-button size-auto rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'group-hover:visible group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:visible group-[.final-completion]:visible',
+    'group-hover:visible group-focus-visible:visible group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:visible group-[.final-completion]:visible',
     !isLast && revealOnRowHoverClasses,
     'group-has-[.hover-button-active]:visible group-has-[.hover-button-active]:opacity-100',
     'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',

--- a/client/src/components/Chat/Messages/styles.ts
+++ b/client/src/components/Chat/Messages/styles.ts
@@ -11,13 +11,27 @@ import { cn } from '~/utils';
  * would hold the whole footer open with the pointer nowhere near the row. An action
  * that opens a surface keeps the toolbar up through `hover-button-active` instead.
  *
+ * That focus half reads
+ * `:is(:focus-visible, :has(:focus-visible:not(:is(input, textarea, [contenteditable]))))`
+ * on the row, and both halves earn their keep:
+ *
+ * - The row itself has to be tested, not only its descendants. `MessageNav` moves the
+ *   reader by setting `tabindex="-1"` on the row and focusing it, and `:has()` never
+ *   matches its own subject, so a plain `:has(:focus-visible)` leaves a focused row
+ *   showing its focus ring with its metadata and its actions still hidden.
+ * - Text-entry controls are excluded from the descendant half, because they match
+ *   `:focus-visible` even when a mouse clicks them. `ToolApproval` and
+ *   `AskUserQuestion` both render textareas inside a row, and without the exclusion
+ *   clicking one pins the row open with the pointer somewhere else entirely. Every
+ *   toolbar action is a button, so a keyboard user still never focuses a hidden one.
+ *
  * The transition names `color` and `background-color` alongside `opacity` rather than
  * naming opacity alone: `cn` merges the whole `transition-*` group, so a bare
  * `transition-opacity` here would replace the `transition-colors` a `Button` brings and
  * the hover tint would snap instead of fading.
  */
 export const revealOnRowHoverClasses =
-  'transition-[opacity,color,background-color] duration-theme-normal ease-out group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 motion-reduce:transition-none [@media(hover:hover)]:opacity-0';
+  'transition-[opacity,color,background-color] duration-theme-normal ease-out group-hover:opacity-100 group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:opacity-100 motion-reduce:transition-none [@media(hover:hover)]:opacity-0';
 
 /**
  * The message footer, holding the height of its action row.
@@ -58,7 +72,7 @@ export const hoverButtonClasses = ({
   cn(
     'hover-button size-auto rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'group-hover:visible group-has-[:focus-visible]:visible group-[.final-completion]:visible',
+    'group-hover:visible group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:visible group-[.final-completion]:visible',
     !isLast && revealOnRowHoverClasses,
     'group-has-[.hover-button-active]:visible group-has-[.hover-button-active]:opacity-100',
     'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',

--- a/client/src/components/Chat/Messages/styles.ts
+++ b/client/src/components/Chat/Messages/styles.ts
@@ -3,11 +3,16 @@ import { cn } from '~/utils';
 /**
  * Reveal-on-hover for a control that shares the message footer with the hover actions.
  *
- * Pointer devices fade it out until the row is hovered or something inside it takes
- * focus. Touch devices, which cannot hover, keep it visible.
+ * Pointer devices fade it out until the row is hovered or keyboard focus lands inside
+ * it. Touch devices, which cannot hover, keep it visible.
+ *
+ * The focus half is `:focus-visible`, not `:focus-within`: clicking a tool card or an
+ * expand toggle in the message body leaves focus parked there, and `:focus-within`
+ * would hold the whole footer open with the pointer nowhere near the row. An action
+ * that opens a surface keeps the toolbar up through `hover-button-active` instead.
  */
 export const revealOnRowHoverClasses =
-  'group-focus-within:opacity-100 group-hover:opacity-100 [@media(hover:hover)]:opacity-0';
+  'group-has-[:focus-visible]:opacity-100 group-hover:opacity-100 [@media(hover:hover)]:opacity-0';
 
 /**
  * The message footer, holding the height of its action row.
@@ -48,7 +53,7 @@ export const hoverButtonClasses = ({
   cn(
     'hover-button size-auto rounded-lg p-1.5 text-text-secondary-alt',
     'hover:text-text-primary hover:bg-surface-hover',
-    'group-hover:visible group-focus-within:visible group-[.final-completion]:visible',
+    'group-hover:visible group-has-[:focus-visible]:visible group-[.final-completion]:visible',
     !isLast && revealOnRowHoverClasses,
     'group-has-[.hover-button-active]:visible group-has-[.hover-button-active]:opacity-100',
     'focus-visible:ring-2 focus-visible:ring-text-primary focus-visible:outline-none',

--- a/client/src/components/Chat/Messages/styles.ts
+++ b/client/src/components/Chat/Messages/styles.ts
@@ -10,9 +10,14 @@ import { cn } from '~/utils';
  * expand toggle in the message body leaves focus parked there, and `:focus-within`
  * would hold the whole footer open with the pointer nowhere near the row. An action
  * that opens a surface keeps the toolbar up through `hover-button-active` instead.
+ *
+ * The transition names `color` and `background-color` alongside `opacity` rather than
+ * naming opacity alone: `cn` merges the whole `transition-*` group, so a bare
+ * `transition-opacity` here would replace the `transition-colors` a `Button` brings and
+ * the hover tint would snap instead of fading.
  */
 export const revealOnRowHoverClasses =
-  'group-has-[:focus-visible]:opacity-100 group-hover:opacity-100 [@media(hover:hover)]:opacity-0';
+  'transition-[opacity,color,background-color] duration-theme-normal ease-out group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 motion-reduce:transition-none [@media(hover:hover)]:opacity-0';
 
 /**
  * The message footer, holding the height of its action row.

--- a/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
+++ b/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
@@ -55,9 +55,9 @@ export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
         className={cn(
           labelSlot,
           'group-hover/label:-translate-y-1 group-hover/label:opacity-0 group-hover/label:blur-[2px]',
-          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:-translate-y-1',
-          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:opacity-0',
-          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:blur-[2px]',
+          'group-focus-visible:-translate-y-1 group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:-translate-y-1',
+          'group-focus-visible:opacity-0 group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:opacity-0',
+          'group-focus-visible:blur-[2px] group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:blur-[2px]',
         )}
       >
         {label}
@@ -68,9 +68,9 @@ export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
           labelSlot,
           'translate-y-1 opacity-0 blur-[2px]',
           'group-hover/label:translate-y-0 group-hover/label:opacity-100 group-hover/label:blur-0',
-          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:translate-y-0',
-          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:opacity-100',
-          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:blur-0',
+          'group-focus-visible:translate-y-0 group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:translate-y-0',
+          'group-focus-visible:opacity-100 group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:opacity-100',
+          'group-focus-visible:blur-0 group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]:blur-0',
         )}
       >
         {hoverLabel}

--- a/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
+++ b/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
@@ -33,13 +33,15 @@ const labelSlot =
   '[grid-area:1/1] truncate transition-[opacity,transform,filter] duration-theme-normal ease-out motion-reduce:transition-none motion-reduce:transform-none motion-reduce:blur-none';
 
 /** Provider name that crossfades to the model name. A pointer swaps it on the
- *  label itself; keyboard focus landing anywhere in the message row swaps it
- *  too, so a sighted keyboard user reaches the model the same way they reach
- *  the timestamp. That second path is keyed on `:focus-visible` rather than
- *  `:focus-within`, because a pointer clicking a tool card inside the row also
- *  leaves focus there, and the swap would then outlast the pointer. The model
- *  is additionally carried in text that never hides, for screen readers that
- *  never move the visual focus at all. */
+ *  label itself; keyboard focus landing on the message row swaps it too, so a
+ *  sighted keyboard user reaches the model the same way they reach the
+ *  timestamp. The model is additionally carried in text that never hides, for
+ *  screen readers that never move the visual focus at all.
+ *
+ *  The focus condition is the row-wide one documented on
+ *  `revealOnRowHoverClasses` in `../styles`: the row itself or a descendant
+ *  that is not a text-entry control. Both halves matter here for the same
+ *  reasons they matter to the timestamp and the footer actions. */
 export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
   const localize = useLocalize();
 
@@ -53,7 +55,9 @@ export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
         className={cn(
           labelSlot,
           'group-hover/label:-translate-y-1 group-hover/label:opacity-0 group-hover/label:blur-[2px]',
-          'group-has-[:focus-visible]:-translate-y-1 group-has-[:focus-visible]:opacity-0 group-has-[:focus-visible]:blur-[2px]',
+          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:-translate-y-1',
+          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:opacity-0',
+          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:blur-[2px]',
         )}
       >
         {label}
@@ -64,7 +68,9 @@ export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
           labelSlot,
           'translate-y-1 opacity-0 blur-[2px]',
           'group-hover/label:translate-y-0 group-hover/label:opacity-100 group-hover/label:blur-0',
-          'group-has-[:focus-visible]:translate-y-0 group-has-[:focus-visible]:opacity-100 group-has-[:focus-visible]:blur-0',
+          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:translate-y-0',
+          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:opacity-100',
+          'group-[&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))]:blur-0',
         )}
       >
         {hoverLabel}

--- a/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
+++ b/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
@@ -29,10 +29,13 @@ const labelSlot =
   '[grid-area:1/1] truncate transition-[opacity,transform,filter] [transition-duration:var(--resize-dur)] [transition-timing-function:var(--resize-ease)] motion-reduce:transition-none motion-reduce:transform-none motion-reduce:blur-none';
 
 /** Provider name that crossfades to the model name. A pointer swaps it on the
- *  label itself; focusing anything in the message row swaps it too, so a
- *  sighted keyboard user reaches the model the same way they reach the
- *  timestamp. The model is additionally carried in text that never hides, for
- *  screen readers that never move the visual focus at all. */
+ *  label itself; keyboard focus landing anywhere in the message row swaps it
+ *  too, so a sighted keyboard user reaches the model the same way they reach
+ *  the timestamp. That second path is keyed on `:focus-visible` rather than
+ *  `:focus-within`, because a pointer clicking a tool card inside the row also
+ *  leaves focus there, and the swap would then outlast the pointer. The model
+ *  is additionally carried in text that never hides, for screen readers that
+ *  never move the visual focus at all. */
 export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
   const localize = useLocalize();
 
@@ -46,7 +49,7 @@ export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
         className={cn(
           labelSlot,
           'group-hover/label:-translate-y-1 group-hover/label:opacity-0 group-hover/label:blur-[2px]',
-          'group-focus-within:-translate-y-1 group-focus-within:opacity-0 group-focus-within:blur-[2px]',
+          'group-has-[:focus-visible]:-translate-y-1 group-has-[:focus-visible]:opacity-0 group-has-[:focus-visible]:blur-[2px]',
         )}
       >
         {label}
@@ -57,7 +60,7 @@ export default function HeaderLabel({ label, hoverLabel }: HeaderLabelProps) {
           labelSlot,
           'translate-y-1 opacity-0 blur-[2px]',
           'group-hover/label:translate-y-0 group-hover/label:opacity-100 group-hover/label:blur-0',
-          'group-focus-within:translate-y-0 group-focus-within:opacity-100 group-focus-within:blur-0',
+          'group-has-[:focus-visible]:translate-y-0 group-has-[:focus-visible]:opacity-100 group-has-[:focus-visible]:blur-0',
         )}
       >
         {hoverLabel}

--- a/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
+++ b/client/src/components/Chat/Messages/ui/HeaderLabel.tsx
@@ -24,9 +24,13 @@ export function getHeaderModelName(
 }
 
 /** Both names occupy one grid cell so the slot is sized by the longer of the
- *  two and neither reflows the header as they cross over. */
+ *  two and neither reflows the header as they cross over.
+ *
+ *  Timed off the same motion role as the timestamp and the footer actions, so a
+ *  keyboard focus that reveals all three lands them together instead of staggering
+ *  across the card-resize spring this used to borrow. */
 const labelSlot =
-  '[grid-area:1/1] truncate transition-[opacity,transform,filter] [transition-duration:var(--resize-dur)] [transition-timing-function:var(--resize-ease)] motion-reduce:transition-none motion-reduce:transform-none motion-reduce:blur-none';
+  '[grid-area:1/1] truncate transition-[opacity,transform,filter] duration-theme-normal ease-out motion-reduce:transition-none motion-reduce:transform-none motion-reduce:blur-none';
 
 /** Provider name that crossfades to the model name. A pointer swaps it on the
  *  label itself; keyboard focus landing anywhere in the message row swaps it

--- a/client/src/components/Chat/Messages/ui/MessageTimestamp.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageTimestamp.tsx
@@ -19,7 +19,8 @@ function TimestampText({
       title={timestamp.isRecent ? timestamp.absolute : undefined}
       className={cn(
         'message-timestamp text-xs font-normal text-text-secondary',
-        revealOnHover && 'ml-2 transition-opacity duration-200',
+        revealOnHover &&
+          'ml-2 transition-opacity duration-theme-normal ease-out motion-reduce:transition-none',
         className,
       )}
     >

--- a/client/src/components/Chat/Messages/ui/__tests__/HeaderLabel.spec.tsx
+++ b/client/src/components/Chat/Messages/ui/__tests__/HeaderLabel.spec.tsx
@@ -41,13 +41,16 @@ describe('HeaderLabel', () => {
   it('also swaps the model in when the message row takes keyboard focus', () => {
     render(<HeaderLabel label="Ollama" hoverLabel="gemma4:12b-it-qat" />);
 
-    const swap =
-      '&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))';
+    const self = 'group-focus-visible';
+    const descendant = 'group-has-[:focus-visible:not(:is(input,textarea,[contenteditable]))]';
 
-    expect(screen.getByText('Ollama').className).toContain(`group-[${swap}]:opacity-0`);
-    expect(screen.getByText('gemma4:12b-it-qat').className).toContain(
-      `group-[${swap}]:opacity-100`,
-    );
+    const provider = screen.getByText('Ollama').className;
+    const model = screen.getByText('gemma4:12b-it-qat').className;
+
+    expect(provider).toContain(`${self}:opacity-0`);
+    expect(provider).toContain(`${descendant}:opacity-0`);
+    expect(model).toContain(`${self}:opacity-100`);
+    expect(model).toContain(`${descendant}:opacity-100`);
   });
 
   /* Clicking a tool card inside the row leaves focus on it. `:focus-within`

--- a/client/src/components/Chat/Messages/ui/__tests__/HeaderLabel.spec.tsx
+++ b/client/src/components/Chat/Messages/ui/__tests__/HeaderLabel.spec.tsx
@@ -41,9 +41,12 @@ describe('HeaderLabel', () => {
   it('also swaps the model in when the message row takes keyboard focus', () => {
     render(<HeaderLabel label="Ollama" hoverLabel="gemma4:12b-it-qat" />);
 
-    expect(screen.getByText('Ollama')).toHaveClass('group-has-[:focus-visible]:opacity-0');
-    expect(screen.getByText('gemma4:12b-it-qat')).toHaveClass(
-      'group-has-[:focus-visible]:opacity-100',
+    const swap =
+      '&:is(:focus-visible,:has(:focus-visible:not(:is(input,textarea,[contenteditable]))))';
+
+    expect(screen.getByText('Ollama').className).toContain(`group-[${swap}]:opacity-0`);
+    expect(screen.getByText('gemma4:12b-it-qat').className).toContain(
+      `group-[${swap}]:opacity-100`,
     );
   });
 

--- a/client/src/components/Chat/Messages/ui/__tests__/HeaderLabel.spec.tsx
+++ b/client/src/components/Chat/Messages/ui/__tests__/HeaderLabel.spec.tsx
@@ -38,11 +38,22 @@ describe('HeaderLabel', () => {
 
   /* A pointer swap alone would strand a sighted keyboard user, who reaches the
      row by focus. `.message-render` carries the `group` this keys off. */
-  it('also swaps the model in when the message row takes focus', () => {
+  it('also swaps the model in when the message row takes keyboard focus', () => {
     render(<HeaderLabel label="Ollama" hoverLabel="gemma4:12b-it-qat" />);
 
-    expect(screen.getByText('Ollama')).toHaveClass('group-focus-within:opacity-0');
-    expect(screen.getByText('gemma4:12b-it-qat')).toHaveClass('group-focus-within:opacity-100');
+    expect(screen.getByText('Ollama')).toHaveClass('group-has-[:focus-visible]:opacity-0');
+    expect(screen.getByText('gemma4:12b-it-qat')).toHaveClass(
+      'group-has-[:focus-visible]:opacity-100',
+    );
+  });
+
+  /* Clicking a tool card inside the row leaves focus on it. `:focus-within`
+     would hold the model in place with the pointer nowhere near the row. */
+  it('does not key the swap off plain focus-within', () => {
+    render(<HeaderLabel label="Ollama" hoverLabel="gemma4:12b-it-qat" />);
+
+    expect(screen.getByText('Ollama').className).not.toContain('group-focus-within:');
+    expect(screen.getByText('gemma4:12b-it-qat').className).not.toContain('group-focus-within:');
   });
 
   /* Screen readers never move the visual focus, so the model also has to reach

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -587,14 +587,21 @@ pre {
    Keyboard focus reveals it too, but only `:focus-visible`: a pointer that
    clicks a tool card or an expand toggle inside the row leaves focus sitting
    there, and plain `:focus-within` would pin the time open long after the
-   pointer moved away. */
+   pointer moved away.
+
+   The condition matches the row itself as well as its descendants, because
+   `MessageNav` focuses the row through `tabindex="-1"` and `:has()` never
+   matches its own subject. Text-entry controls are excluded, because they
+   match `:focus-visible` on a plain mouse click. See `revealOnRowHoverClasses`
+   in `components/Chat/Messages/styles.ts` for the full reasoning. */
 @media (hover: hover) {
   .message-render .message-timestamp {
     opacity: 0;
   }
 
   .message-render:hover .message-timestamp,
-  .message-render:has(:focus-visible) .message-timestamp {
+  .message-render:is(:focus-visible, :has(:focus-visible:not(:is(input, textarea, [contenteditable]))))
+    .message-timestamp {
     opacity: 1;
   }
 }

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -582,14 +582,19 @@ pre {
 }
 
 /* Show the message time when the row is hovered. Tailwind group-hover
-   loses to `[@media(hover:hover)]:opacity-0` (same specificity, :where()). */
+   loses to `[@media(hover:hover)]:opacity-0` (same specificity, :where()).
+
+   Keyboard focus reveals it too, but only `:focus-visible`: a pointer that
+   clicks a tool card or an expand toggle inside the row leaves focus sitting
+   there, and plain `:focus-within` would pin the time open long after the
+   pointer moved away. */
 @media (hover: hover) {
   .message-render .message-timestamp {
     opacity: 0;
   }
 
   .message-render:hover .message-timestamp,
-  .message-render:focus-within .message-timestamp {
+  .message-render:has(:focus-visible) .message-timestamp {
     opacity: 1;
   }
 }

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -600,7 +600,8 @@ pre {
   }
 
   .message-render:hover .message-timestamp,
-  .message-render:is(:focus-visible, :has(:focus-visible:not(:is(input, textarea, [contenteditable]))))
+  .message-render:focus-visible .message-timestamp,
+  .message-render:has(:focus-visible:not(:is(input, textarea, [contenteditable])))
     .message-timestamp {
     opacity: 1;
   }


### PR DESCRIPTION
## Summary

The message timestamp, the provider/model label crossfade, and the hover action toolbar all revealed on `:focus-within` over the message row. A mouse click sets focus, so clicking a tool card, an expand toggle, or a code block button parked focus inside the row and pinned all three open long after the pointer had left the message.

Each reveal now keys its focus half on `:focus-visible` instead of `:focus-within`:

- `client/src/style.css` for the timestamp
- `HeaderLabel.tsx` for the provider/model crossfade
- `revealOnRowHoverClasses` and `hoverButtonClasses` in `Messages/styles.ts`, plus `SiblingSwitch.tsx` and `MinimalHoverButtons.tsx` for the footer actions

A pointer click no longer counts, while keyboard focus still does, so a sighted keyboard user still reaches the model name and the timestamp by tabbing. An action that opens a surface (edit, fork, feedback, playing audio) keeps the toolbar up through the existing `hover-button-active` marker, unchanged.

Left alone deliberately: `Thinking.tsx`, `Summary.tsx` and `MessageNav.tsx` use `:focus-within` on their own named groups rather than the message row, where focus inside genuinely means you are interacting with that widget.

## Motion

The three reveals fired on one hover but arrived at three different times, and the footer actions had no opacity transition at all, so they appeared in a single frame:

| element | before | after |
|---|---|---|
| footer actions | **not animated**, 1 frame | `opacity, color, background-color`, 200ms `ease-out` |
| timestamp | 200ms `cubic-bezier(0.4, 0, 0.2, 1)` | 200ms `ease-out` |
| provider/model crossfade | 300ms `--resize-ease` (card-resize spring) | 200ms `ease-out` |

All three now use the project's `duration-theme-normal` role, so they land together, and the timestamp and footer gained the `motion-reduce:transition-none` guard they were missing.

Sampled opacity per animation frame while hovering a row, footer action button:

- before: 2 distinct values (`0.000` then `1.000` on the next frame)
- after: 12 distinct values, `0.000 -> 0.442 -> 0.771 -> 0.934 -> 0.996 -> 1.000`, settling at 200ms, tracking the timestamp exactly
- with `prefers-reduced-motion: reduce`: back to 2 values, no tween

The reveal transition enumerates `color` and `background-color` next to `opacity` on purpose. `cn` merges the whole `transition-*` group, so a bare `transition-opacity` would have replaced the `transition-colors` that `Button` contributes and made the hover tint snap. There is a unit test pinning that.

`MinimalHoverButtons` now composes the shared reveal helper instead of repeating the class string inline.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Measured opacity on a live message row after each interaction, driving the real app with Playwright. Values are timestamp / provider label / model label / footer actions:

| state | before | after |
|---|---|---|
| idle | `0.00 / 1.00 / 0.00 / 0.00` | `0.00 / 1.00 / 0.00 / 0.00` |
| pointer over row | `1.00 / 1.00 / 0.00 / 1.00` | `1.00 / 1.00 / 0.00 / 1.00` |
| **clicked a control in the body, pointer moved away** | **`1.00 / 0.00 / 1.00 / 1.00`** | **`0.00 / 1.00 / 0.00 / 0.00`** |
| keyboard focus inside the row | `1.00 / 0.00 / 1.00 / 1.00` | `1.00 / 0.00 / 1.00 / 1.00` |

Checked the case this change could plausibly break, an action that opens a surface:

| state | footer opacity | `hover-button-active` |
|---|---|---|
| hovering the fork button | 1.00 | no |
| fork popover open, pointer away | 1.00 | yes |
| closed with Escape, pointer away | 1.00 | no, focus returned to the fork button as `:focus-visible` |
| blurred by an outside click | 0.00 | no |

The Escape case keeping the toolbar visible is correct: focus sits on the fork button with a visible ring, and hiding it would hide a focused control.

Verified visually in both light and dark themes.

Commands run:

```
npx eslint <the 6 changed TS files>          # clean
cd client && npx tsc --noEmit                # exit 0, no output
cd client && npx jest src/components/Chat/Messages   # 59 suites, 811 tests, all pass
```

### **Test Configuration**:

Node v24.16.0, Chromium via Playwright 1.56.1, Vite dev server against a local backend, light and dark themes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
