### PR TITLE
⏱️ ci: Give the E2E Redis Transport Lane Its Own Timing Budget

### DIFF
--- a/e2e/playwright.config.redis.ts
+++ b/e2e/playwright.config.redis.ts
@@ -4,6 +4,16 @@ import mockConfig from './playwright.config.mock';
 /** Browser scenarios whose behavior crosses the generation stream-store boundary. */
 export default defineConfig({
   ...mockConfig,
+  /**
+   * Every stream event crosses a real Redis round-trip on this lane, so waits that
+   * sit comfortably against the in-memory store run much closer to their budget —
+   * pause/resume and rehydrate paths most of all, since they replay a whole job.
+   * The suite is serial (`workers: 1`), so this is per-operation latency rather
+   * than contention, and it is why this lane reports flaky runs the memory shards
+   * never produce. Give it a larger default assertion budget and one more retry.
+   */
+  retries: process.env.CI ? 3 : 0,
+  expect: { ...mockConfig.expect, timeout: 20_000 },
   testMatch: [
     /completion\.spec\.ts/,
     /deferred-tools-hitl\.spec\.ts/,


### PR DESCRIPTION
`playwright.config.redis.ts` spreads `playwright.config.mock.ts` wholesale, so it inherits a **10s default assertion budget** and **2 CI retries** — both tuned against the in-memory stream store.

That lane is not equivalent work. Every stream event crosses a real Redis round-trip, and its most involved scenarios (`tool-approvals` pause/resume/rehydrate, `deferred-tools-hitl` resume) replay an entire job before asserting. The same waits therefore run much closer to their budget than on the memory shards.

The suite is serial (`workers: 1`), so this is **per-operation latency, not worker contention** — which is why this lane produces flaky runs the memory shards never do.

## Change

For this config only:

- `expect.timeout` 10s → **20s**
- CI `retries` 2 → **3**

Memory shards are untouched.

## Why now

The lane already flakes on `dev` — a recent run finished `37 passed, 1 flaky (7.7m)`. It is marginal by construction rather than broken, and it fails in a shifting set: whichever resume-heavy test happens to tip past its wait that run.

I measured the same 38 tests against a slower downstream deployment, where per-operation latency is ~55% higher end to end:

| | result | duration |
|---|---|---|
| `dev` | 37 passed, 1 flaky | 7.7m |
| slower deployment | 35 passed, 3 failed/flaky | 12.0m |

Identical specs, identical config, identical `RedisJobStore` — only latency differs, and the extra latency is enough to push several of these waits over the line. That is the clearest evidence available that the budget, not the code, is what's tight: nothing about the failures is deterministic, and the failing set moves between runs.

## Scope

Deliberately config-only. The transport specs carry ~179 explicit per-assertion timeouts between them; threading a scale factor through all of those would be large, mechanical churn for the same effect, and would bury the reason in the specs rather than stating it once where the lane is defined.

This raises headroom on a lane that is genuinely slower than the one whose settings it inherited. It does not change what is asserted, and it does not touch the memory shards that provide the fast signal.