### PR TITLE
🏷️ fix: Keep Agent Conversations From Revealing Model Labels

### DIFF
--- a/client/src/components/Chat/Input/AddedConvo.tsx
+++ b/client/src/components/Chat/Input/AddedConvo.tsx
@@ -5,6 +5,7 @@ import type { SetterOrUpdater } from 'recoil';
 import { useGetEndpointsQuery } from '~/data-provider';
 import { EndpointIcon } from '~/components/Endpoints';
 import { useAgentsMapContext } from '~/Providers';
+import { useLocalize } from '~/hooks';
 
 export default function AddedConvo({
   addedConvo,
@@ -15,13 +16,14 @@ export default function AddedConvo({
 }) {
   const agentsMap = useAgentsMapContext();
   const { data: endpointsConfig } = useGetEndpointsQuery();
+  const localize = useLocalize();
   const title = useMemo(() => {
     // Priority: agent name > modelDisplayLabel > modelLabel > model
-    if (isAgentsEndpoint(addedConvo?.endpoint) && addedConvo?.agent_id) {
-      const agent = agentsMap?.[addedConvo.agent_id];
-      if (agent?.name) {
-        return `+ ${agent.name}`;
-      }
+    if (isAgentsEndpoint(addedConvo?.endpoint)) {
+      const agent = addedConvo?.agent_id ? agentsMap?.[addedConvo.agent_id] : undefined;
+      /** Never fall into the model-label chain for agents — it would reveal the
+       *  underlying model an agent author may intend to keep private. */
+      return `+ ${agent?.name || localize('com_ui_agent')}`;
     }
 
     const endpointConfig = endpointsConfig?.[addedConvo?.endpoint ?? ''];
@@ -29,7 +31,7 @@ export default function AddedConvo({
       endpointConfig?.modelDisplayLabel || addedConvo?.modelLabel || addedConvo?.model || 'AI';
 
     return `+ ${displayLabel}`;
-  }, [addedConvo, agentsMap, endpointsConfig]);
+  }, [addedConvo, agentsMap, endpointsConfig, localize]);
 
   if (!addedConvo) {
     return null;

--- a/client/src/hooks/Conversations/__tests__/useGetSender.spec.tsx
+++ b/client/src/hooks/Conversations/__tests__/useGetSender.spec.tsx
@@ -91,4 +91,19 @@ describe('useGetSender', () => {
     };
     expect(getSender(asOption(unknownCustom))).toBe(getResponseSender(asOption(unknownCustom)));
   });
+
+  it('never reveals model or spec labels for agent conversations', () => {
+    const getSender = renderGetSender();
+    expect(
+      getSender(
+        asOption({
+          endpoint: EModelEndpoint.agents,
+          agent_id: 'agent_abc123',
+          model: 'gpt-5.5',
+          modelLabel: 'GPT-5.5 Pro',
+          spec: 'fast-qwen',
+        }),
+      ),
+    ).toBe('');
+  });
 });

--- a/client/src/hooks/Conversations/useGetSender.ts
+++ b/client/src/hooks/Conversations/useGetSender.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { getResponseSender, getEphemeralSender } from 'librechat-data-provider';
+import { getResponseSender, getEphemeralSender, isAgentsEndpoint } from 'librechat-data-provider';
 import type { TEndpointOption, TEndpointsConfig } from 'librechat-data-provider';
 import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
 import { getModelSpec } from '~/utils';
@@ -8,6 +8,10 @@ import { getModelSpec } from '~/utils';
  * Mirrors the server's sender resolution (`modelLabel` → spec label → endpoint
  * `modelDisplayLabel` → `getResponseSender`) so the optimistic streaming label
  * and composer placeholder match the persisted `message.sender`.
+ *
+ * Agent conversations are exempt from the label chain: their display name is
+ * the agent's, and surfacing model or spec labels would reveal the underlying
+ * model an agent author may intend to keep private.
  */
 export default function useGetSender() {
   const { data: startupConfig } = useGetStartupConfig();
@@ -15,6 +19,9 @@ export default function useGetSender() {
   return useCallback(
     (endpointOption: TEndpointOption) => {
       const { modelDisplayLabel } = endpointsConfig?.[endpointOption.endpoint ?? ''] ?? {};
+      if (isAgentsEndpoint(endpointOption.endpoint)) {
+        return getResponseSender({ ...endpointOption, modelDisplayLabel });
+      }
       const modelSpec = getModelSpec({ specName: endpointOption.spec, startupConfig });
       const sender = getEphemeralSender({
         modelLabel: endpointOption.modelLabel,


### PR DESCRIPTION
## Summary

Follow-up to #14899, addressing the post-merge report that sender labels surface on
non-ephemeral (saved) agent conversations. Agent authors may deliberately keep the underlying
model private, so agent conversations must never display model-derived labels.

What #14899 did and didn't change for saved agents:

- The **persisted** `message.sender` is unchanged — `resolveSender` returns the agent's name
  first and only runs the label chain for ephemeral (non-`agent_`) ids; unit tests lock this.
- The **client** `useGetSender` chain, however, had no agents gate: a spec-launched agent
  conversation (`compactAgentsBaseSchema` forwards `spec`) fed the spec label into the
  optimistic streaming sender, and any caller passing a raw conversation could feed `modelLabel`
  through. Where the header falls back to `message.sender` (e.g. the agent lookup in
  `useMessageActions` returns `agentsMap[message.model]` without falling through to `agent_id`
  when `message.model` holds a raw model string), those labels could render on agent messages.

## Changes

- **`useGetSender`**: agent conversations bypass the label chain entirely and return the
  pre-#14899 result (`getResponseSender` → `''`), so every agent display surface keeps resolving
  the agent's name; model/spec labels can never surface. Regression test included (agents
  endpoint with `modelLabel`, `spec`, and `model` all set → `''`).
- **`AddedConvo` pill** (pre-existing leak, same concern): for the agents endpoint the title no
  longer falls into `modelDisplayLabel || modelLabel || model` when the agent is missing from
  the map or unnamed — it shows the agent name or the localized "Agent" label instead of the
  raw model id.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `useGetSender` hook suite: 5 passing, including the new agents-gate regression test.
- Client `tsc --noEmit` clean.
