### PR TITLE
🛰️ fix: Backport Locize Validation Repair

### DIFF
--- a/.github/workflows/locize-i18n-sync.yml
+++ b/.github/workflows/locize-i18n-sync.yml
@@ -74,12 +74,12 @@ jobs:
           project-id: ${{ secrets.LOCIZE_PROJECT_ID }}
           path: "client/src/locales"
           version: latest
-          cdn-type: pro
 
       - name: Validate Downloaded Translations
-        run: node scripts/validate-locize-download.mjs \
-          --base-dir "$RUNNER_TEMP/locize-locale-baseline" \
-          --current-dir client/src/locales
+        run: |
+          node scripts/validate-locize-download.mjs \
+            --base-dir "$RUNNER_TEMP/locize-locale-baseline" \
+            --current-dir client/src/locales
 
       # 3. Create a Pull Request using a dedicated fine-grained PAT so this
       # workflow does not depend on the global GITHUB_TOKEN PR-creation setting.


### PR DESCRIPTION
I backported the Locize validation workflow repair to the default branch so `repository_dispatch` runs use the corrected command immediately.

- Changed the validation step to a shell block so line continuations preserve `--base-dir` and `--current-dir`.
- Removed the unsupported `cdn-type` input from `locize/download@v2`.
- Kept this backport limited to the change merged into `dev` in #14911.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Parsed the workflow YAML successfully.
- Ran `validate-locize-download.mjs` against matching snapshots of all 41 locale files.

### **Test Configuration**:

- Node.js local runtime
- macOS shell

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local validation passes with my changes
