### PR TITLE
📱 perf: Instant Mobile View Switching + Uniform Sidebar Toggle

### DIFF
--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -1,10 +1,7 @@
-import { startTransition } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { TooltipAnchor, Button, Sidebar } from '@librechat/client';
 import { useShortcutAriaKey, useShortcutHint } from '~/hooks/useKeyboardShortcuts';
-import { kickDrawerAnimation } from '~/hooks/Nav/useDrawerSwipe';
+import useSidebarToggle from '~/hooks/Nav/useSidebarToggle';
 import { useLocalize } from '~/hooks';
-import store from '~/store';
 
 export const CLOSE_SIDEBAR_ID = 'close-sidebar-button';
 export const OPEN_SIDEBAR_ID = 'open-sidebar-button';
@@ -22,21 +19,21 @@ export default function OpenSidebar({
   testId?: string;
 }) {
   const localize = useLocalize();
-  const setSidebarExpanded = useSetRecoilState(store.sidebarExpanded);
+  const setSidebarOpen = useSidebarToggle();
   const tooltipDescription = useShortcutHint('toggleSidebar', localize('com_nav_open_sidebar'));
   const ariaKey = useShortcutAriaKey('toggleSidebar');
 
   const handleClick = () => {
-    /** Slide first, render second: the drawer must move on the next frame,
-     * not after a commit that can run long on large conversations. */
-    kickDrawerAnimation(true, () => {
-      startTransition(() => {
-        setSidebarExpanded(true);
-      });
-    });
-    setTimeout(() => {
-      document.getElementById(CLOSE_SIDEBAR_ID)?.focus();
-    }, 250);
+    const animated = setSidebarOpen(true);
+    if (!animated) {
+      /** Desktop only: the expanded panel claims `CLOSE_SIDEBAR_ID` and has
+       * no commit-driven handoff of its own. The mobile drawer focuses its
+       * toggle from the commit itself — a second timer there would steal
+       * focus back from a keyboard user who has already tabbed onward. */
+      setTimeout(() => {
+        document.getElementById(CLOSE_SIDEBAR_ID)?.focus();
+      }, 250);
+    }
   };
 
   return (

--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -4,19 +4,10 @@ import { TooltipAnchor, Button, Sidebar } from '@librechat/client';
 import { useShortcutAriaKey, useShortcutHint } from '~/hooks/useKeyboardShortcuts';
 import { kickDrawerAnimation } from '~/hooks/Nav/useDrawerSwipe';
 import { useLocalize } from '~/hooks';
-import { cn } from '~/utils';
 import store from '~/store';
 
 export const CLOSE_SIDEBAR_ID = 'close-sidebar-button';
 export const OPEN_SIDEBAR_ID = 'open-sidebar-button';
-
-/**
- * Shared look for the sidebar toggle wherever it appears — the chat header's
- * open button and the drawer header's close button — so the control reads as
- * one persistent button that flips state rather than two different affordances.
- */
-export const SIDEBAR_TOGGLE_CLASSES =
-  'rounded-xl bg-presentation duration-0 hover:bg-surface-active-alt';
 
 /**
  * `testId` exists because the sidebar rail publishes `open-sidebar-button` for its own
@@ -55,13 +46,13 @@ export default function OpenSidebar({
         <Button
           id={OPEN_SIDEBAR_ID}
           size="icon"
-          variant="outline"
+          variant="header-action"
           data-testid={testId}
           aria-label={localize('com_nav_open_sidebar')}
           aria-expanded={false}
           aria-controls="chat-history-nav"
           aria-keyshortcuts={ariaKey}
-          className={cn(SIDEBAR_TOGGLE_CLASSES, className)}
+          className={className}
           onClick={handleClick}
         >
           <Sidebar className="icon-md" aria-hidden="true" />

--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -19,13 +19,13 @@ export default function OpenSidebar({
   testId?: string;
 }) {
   const localize = useLocalize();
-  const setSidebarOpen = useSidebarToggle();
+  const { setSidebarOpen } = useSidebarToggle();
   const tooltipDescription = useShortcutHint('toggleSidebar', localize('com_nav_open_sidebar'));
   const ariaKey = useShortcutAriaKey('toggleSidebar');
 
   const handleClick = () => {
-    const animated = setSidebarOpen(true);
-    if (!animated) {
+    const mode = setSidebarOpen(true);
+    if (mode === 'none') {
       /** Desktop only: the expanded panel claims `CLOSE_SIDEBAR_ID` and has
        * no commit-driven handoff of its own. The mobile drawer focuses its
        * toggle from the commit itself — a second timer there would steal

--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -2,12 +2,21 @@ import { startTransition } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { TooltipAnchor, Button, Sidebar } from '@librechat/client';
 import { useShortcutAriaKey, useShortcutHint } from '~/hooks/useKeyboardShortcuts';
+import { kickDrawerAnimation } from '~/hooks/Nav/useDrawerSwipe';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 import store from '~/store';
 
 export const CLOSE_SIDEBAR_ID = 'close-sidebar-button';
 export const OPEN_SIDEBAR_ID = 'open-sidebar-button';
+
+/**
+ * Shared look for the sidebar toggle wherever it appears — the chat header's
+ * open button and the drawer header's close button — so the control reads as
+ * one persistent button that flips state rather than two different affordances.
+ */
+export const SIDEBAR_TOGGLE_CLASSES =
+  'rounded-xl bg-presentation duration-0 hover:bg-surface-active-alt';
 
 /**
  * `testId` exists because the sidebar rail publishes `open-sidebar-button` for its own
@@ -27,8 +36,12 @@ export default function OpenSidebar({
   const ariaKey = useShortcutAriaKey('toggleSidebar');
 
   const handleClick = () => {
-    startTransition(() => {
-      setSidebarExpanded(true);
+    /** Slide first, render second: the drawer must move on the next frame,
+     * not after a commit that can run long on large conversations. */
+    kickDrawerAnimation(true, () => {
+      startTransition(() => {
+        setSidebarExpanded(true);
+      });
     });
     setTimeout(() => {
       document.getElementById(CLOSE_SIDEBAR_ID)?.focus();
@@ -48,10 +61,7 @@ export default function OpenSidebar({
           aria-expanded={false}
           aria-controls="chat-history-nav"
           aria-keyshortcuts={ariaKey}
-          className={cn(
-            'rounded-xl bg-presentation duration-0 hover:bg-surface-active-alt',
-            className,
-          )}
+          className={cn(SIDEBAR_TOGGLE_CLASSES, className)}
           onClick={handleClick}
         >
           <Sidebar className="icon-md" aria-hidden="true" />

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -19,7 +19,7 @@ import store from '~/store';
 interface ConversationProps {
   conversation: TConversation;
   retainView: () => void;
-  toggleNav: () => void;
+  toggleNav: (afterSlide?: () => void) => void;
   isGenerating?: boolean;
 }
 
@@ -159,12 +159,15 @@ function Conversation({
       return;
     }
 
-    toggleNav();
+    /** The navigation rides `afterSlide`: run synchronously it flushes the
+     * conversation-switch commit in the tap's task, stalling the drawer's
+     * first frame — the exact delay the animated toggle exists to avoid. */
+    toggleNav(() => {
+      setDocumentTitle(title);
 
-    setDocumentTitle(title);
-
-    navigateToConvo(conversation, {
-      currentConvoId,
+      navigateToConvo(conversation, {
+        currentConvoId,
+      });
     });
   };
 

--- a/client/src/components/UnifiedSidebar/ConversationsSection.tsx
+++ b/client/src/components/UnifiedSidebar/ConversationsSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useMemo, memo, lazy, Suspense, useRef } from 'react';
+import { useRecoilValue } from 'recoil';
 import { useMediaQuery } from '@librechat/client';
-import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { InfiniteQueryObserverResult } from '@tanstack/react-query';
 import type { ConversationListResponse } from 'librechat-data-provider';
@@ -20,6 +20,7 @@ import {
 import ProjectsSection from '~/components/Conversations/ProjectsSection';
 import PinnedSection from '~/components/Conversations/PinnedSection';
 import FavoritesList from '~/components/Nav/Favorites/FavoritesList';
+import useSidebarToggle from '~/hooks/Nav/useSidebarToggle';
 import { Conversations } from '~/components/Conversations';
 import { collectPinnedConversations } from '~/utils';
 import SearchBar from '~/components/Nav/SearchBar';
@@ -30,7 +31,7 @@ const BookmarkNav = lazy(() => import('~/components/Nav/Bookmarks/BookmarkNav'))
 const ConversationsSection = memo(() => {
   const localize = useLocalize();
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
-  const setSidebarExpanded = useSetRecoilState(store.sidebarExpanded);
+  const setSidebarOpen = useSidebarToggle();
   const { isAuthenticated } = useAuthContext();
   useTitleGeneration(isAuthenticated);
 
@@ -99,9 +100,12 @@ const ConversationsSection = memo(() => {
 
   const toggleNav = useCallback(() => {
     if (isSmallScreen) {
-      setSidebarExpanded(false);
+      /** Selecting a conversation is the most common close path — it must
+       * take the animated route or the drawer stalls on the new
+       * conversation's commit before it starts sliding. */
+      setSidebarOpen(false);
     }
-  }, [isSmallScreen, setSidebarExpanded]);
+  }, [isSmallScreen, setSidebarOpen]);
 
   const loadMoreConversations = useCallback(() => {
     if (isFetchingNextPage || !computedHasNextPage) {

--- a/client/src/components/UnifiedSidebar/ConversationsSection.tsx
+++ b/client/src/components/UnifiedSidebar/ConversationsSection.tsx
@@ -31,7 +31,7 @@ const BookmarkNav = lazy(() => import('~/components/Nav/Bookmarks/BookmarkNav'))
 const ConversationsSection = memo(() => {
   const localize = useLocalize();
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
-  const setSidebarOpen = useSidebarToggle();
+  const { setSidebarOpen } = useSidebarToggle();
   const { isAuthenticated } = useAuthContext();
   useTitleGeneration(isAuthenticated);
 
@@ -98,14 +98,24 @@ const ConversationsSection = memo(() => {
     [pinnedData?.conversations, conversations],
   );
 
-  const toggleNav = useCallback(() => {
-    if (isSmallScreen) {
-      /** Selecting a conversation is the most common close path — it must
-       * take the animated route or the drawer stalls on the new
-       * conversation's commit before it starts sliding. */
-      setSidebarOpen(false);
-    }
-  }, [isSmallScreen, setSidebarOpen]);
+  /**
+   * Selecting a conversation is the most common close path — it must take
+   * the animated route or the drawer stalls on the new conversation's
+   * commit before it starts sliding. `afterSlide` carries that navigation:
+   * run synchronously it would flush the conversation switch in the tap's
+   * task and stall the slide anyway; deferred, it lands mid-slide. Desktop
+   * runs it immediately (nothing slides).
+   */
+  const toggleNav = useCallback(
+    (afterSlide?: () => void) => {
+      if (isSmallScreen) {
+        setSidebarOpen(false, afterSlide);
+        return;
+      }
+      afterSlide?.();
+    },
+    [isSmallScreen, setSidebarOpen],
+  );
 
   const loadMoreConversations = useCallback(() => {
     if (isFetchingNextPage || !computedHasNextPage) {

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -14,6 +14,7 @@ import {
 import { ChatContext, ChatFormProvider, ActivePanelProvider } from '~/Providers';
 import { MobileHeader, MobileBottomBar, MobileShortcutTargets } from './mobile';
 import useUnifiedSidebarLinks from '~/hooks/Nav/useUnifiedSidebarLinks';
+import { kickDrawerAnimation } from '~/hooks/Nav/useDrawerSwipe';
 import useSidebarState from '~/hooks/Nav/useSidebarState';
 import { useChatHelpers, useLocalize } from '~/hooks';
 import SidePanelNav from '~/components/SidePanel/Nav';
@@ -51,14 +52,22 @@ function UnifiedSidebar() {
   const links = useUnifiedSidebarLinks();
 
   const handleCollapse = useCallback(() => {
-    startTransition(() => {
-      setExpanded(false);
+    /** Slide first, render second — on mobile the swipe hook animates the
+     * drawer imperatively and defers the state flip past the first frame;
+     * on desktop it applies immediately and the width transition animates
+     * as before. */
+    kickDrawerAnimation(false, () => {
+      startTransition(() => {
+        setExpanded(false);
+      });
     });
   }, [setExpanded]);
 
   const handleExpand = useCallback(() => {
-    startTransition(() => {
-      setExpanded(true);
+    kickDrawerAnimation(true, () => {
+      startTransition(() => {
+        setExpanded(true);
+      });
     });
   }, [setExpanded]);
 

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -52,9 +52,12 @@ function UnifiedSidebar() {
 
   const links = useUnifiedSidebarLinks();
 
-  const handleCollapse = useCallback(() => {
-    setSidebarOpen(false);
-  }, [setSidebarOpen]);
+  const handleCollapse = useCallback(
+    (afterSlide?: () => void) => {
+      setSidebarOpen(false, afterSlide);
+    },
+    [setSidebarOpen],
+  );
 
   const handleExpand = useCallback(() => {
     setSidebarOpen(true);

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -45,7 +45,7 @@ function SidebarChatProvider({ children }: { children: ReactNode }) {
 function UnifiedSidebar() {
   const localize = useLocalize();
   const { isSmallScreen, expanded } = useSidebarState();
-  const setSidebarOpen = useSidebarToggle();
+  const { setSidebarOpen } = useSidebarToggle();
   const [sidebarWidth, setSidebarWidth] = useState(getInitialWidth);
   const [isResizing, setIsResizing] = useState(false);
   const resizeHandlers = useRef<{ move: (e: MouseEvent) => void; up: () => void } | null>(null);

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useRef, memo, startTransition } from 'react';
+import { useCallback, useState, useEffect, useRef, memo } from 'react';
 import { useForm } from 'react-hook-form';
 import type { ReactNode } from 'react';
 import type { ChatFormValues } from '~/common';
@@ -14,7 +14,7 @@ import {
 import { ChatContext, ChatFormProvider, ActivePanelProvider } from '~/Providers';
 import { MobileHeader, MobileBottomBar, MobileShortcutTargets } from './mobile';
 import useUnifiedSidebarLinks from '~/hooks/Nav/useUnifiedSidebarLinks';
-import { kickDrawerAnimation } from '~/hooks/Nav/useDrawerSwipe';
+import useSidebarToggle from '~/hooks/Nav/useSidebarToggle';
 import useSidebarState from '~/hooks/Nav/useSidebarState';
 import { useChatHelpers, useLocalize } from '~/hooks';
 import SidePanelNav from '~/components/SidePanel/Nav';
@@ -44,7 +44,8 @@ function SidebarChatProvider({ children }: { children: ReactNode }) {
 
 function UnifiedSidebar() {
   const localize = useLocalize();
-  const { isSmallScreen, expanded, setExpanded } = useSidebarState();
+  const { isSmallScreen, expanded } = useSidebarState();
+  const setSidebarOpen = useSidebarToggle();
   const [sidebarWidth, setSidebarWidth] = useState(getInitialWidth);
   const [isResizing, setIsResizing] = useState(false);
   const resizeHandlers = useRef<{ move: (e: MouseEvent) => void; up: () => void } | null>(null);
@@ -52,24 +53,12 @@ function UnifiedSidebar() {
   const links = useUnifiedSidebarLinks();
 
   const handleCollapse = useCallback(() => {
-    /** Slide first, render second — on mobile the swipe hook animates the
-     * drawer imperatively and defers the state flip past the first frame;
-     * on desktop it applies immediately and the width transition animates
-     * as before. */
-    kickDrawerAnimation(false, () => {
-      startTransition(() => {
-        setExpanded(false);
-      });
-    });
-  }, [setExpanded]);
+    setSidebarOpen(false);
+  }, [setSidebarOpen]);
 
   const handleExpand = useCallback(() => {
-    kickDrawerAnimation(true, () => {
-      startTransition(() => {
-        setExpanded(true);
-      });
-    });
-  }, [setExpanded]);
+    setSidebarOpen(true);
+  }, [setSidebarOpen]);
 
   const handleResizeStart = useCallback(() => {
     setIsResizing(true);

--- a/client/src/components/UnifiedSidebar/mobile/BottomBar.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/BottomBar.tsx
@@ -16,20 +16,44 @@ import store from '~/store';
  * rather than an overlay, so the virtualized list shrinks around it and can
  * never be occluded.
  */
-function BottomBar({ links, onNewChat }: { links: NavLink[]; onNewChat: () => void }) {
+function BottomBar({
+  links,
+  onNewChat,
+}: {
+  links: NavLink[];
+  onNewChat: (afterSlide?: () => void) => void;
+}) {
   const localize = useLocalize();
   const search = useRecoilValue(store.search);
   const switchToHistory = useRecoilValue(store.newChatSwitchToHistory);
   const { active, setActive } = useActivePanel();
 
-  const handleNewChat = useCallback(() => {
-    if (switchToHistory) {
-      setActive(DEFAULT_PANEL);
-    }
-    onNewChat();
-  }, [switchToHistory, setActive, onNewChat]);
+  const { startNewChat } = useNewChat();
 
-  const { handleNewChatClick } = useNewChat({ onNewChat: handleNewChat });
+  /**
+   * Close first, reset second — inverted from `useNewChat`'s own click
+   * handler: `startNewChat` clears the message cache and resets the
+   * conversation, and run synchronously that commit stalls the drawer
+   * slide's first frame on large conversations. The reset (and the panel
+   * switch-back) ride the close's `afterSlide` instead, landing mid-slide.
+   * The modified-click guard mirrors `useNewChat.handleNewChatClick` so a
+   * ctrl/middle click still opens `/c/new` in a new tab.
+   */
+  const handleNewChatClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+      event.preventDefault();
+      onNewChat(() => {
+        if (switchToHistory) {
+          setActive(DEFAULT_PANEL);
+        }
+        startNewChat();
+      });
+    },
+    [onNewChat, switchToHistory, setActive, startNewChat],
+  );
   /** The shortcut fires globally; assistive tech needs it discoverable here too. */
   const newChatAriaKey = useShortcutAriaKey('newChat');
 

--- a/client/src/components/UnifiedSidebar/mobile/Header.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/Header.tsx
@@ -1,18 +1,21 @@
 import { memo, lazy, Suspense } from 'react';
-import { X } from 'lucide-react';
-import { Button, Skeleton } from '@librechat/client';
+import { Button, Sidebar, Skeleton } from '@librechat/client';
 import type { NavLink } from '~/common';
-import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
+import { CLOSE_SIDEBAR_ID, SIDEBAR_TOGGLE_CLASSES } from '~/components/Chat/Menus/OpenSidebar';
 import { useShortcutAriaKey } from '~/hooks/useKeyboardShortcuts';
 import { useLocalize } from '~/hooks';
 import Switcher from './Switcher';
+import { cn } from '~/utils';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
 
 /**
  * At full width there is nothing beside the drawer left to tap, so this close
- * button is the primary dismissal. It keeps `CLOSE_SIDEBAR_ID` because
- * `OpenSidebar` focuses that id shortly after opening.
+ * button is the primary dismissal. It mirrors the chat header's `OpenSidebar`
+ * toggle — same icon, same look, same far-left slot — so opening the drawer
+ * reads as the one persistent control flipping state, not a new X appearing
+ * elsewhere. It keeps `CLOSE_SIDEBAR_ID` because `OpenSidebar` focuses that id
+ * shortly after opening.
  */
 function Header({
   links,
@@ -28,10 +31,6 @@ function Header({
 
   return (
     <div className="flex h-14 flex-shrink-0 items-center gap-2 border-b border-border-light px-2">
-      <Switcher links={links} />
-      <Suspense fallback={<Skeleton className="size-9 rounded-lg" />}>
-        <AccountSettings collapsed />
-      </Suspense>
       <Button
         /**
          * The drawer stays mounted while closed so it can slide, and a
@@ -42,17 +41,22 @@ function Header({
         id={expanded ? CLOSE_SIDEBAR_ID : undefined}
         data-testid={expanded ? 'close-sidebar-button' : undefined}
         size="icon"
-        variant="ghost"
+        variant="outline"
         aria-label={localize('com_nav_close_sidebar')}
         aria-expanded={expanded}
+        aria-controls="chat-history-nav"
         /** The only close control while open, so its binding must be discoverable here. */
         aria-keyshortcuts={toggleSidebarAriaKey}
         tabIndex={expanded ? 0 : -1}
-        className="size-10 flex-shrink-0 rounded-lg"
+        className={cn('flex-shrink-0', SIDEBAR_TOGGLE_CLASSES)}
         onClick={onClose}
       >
-        <X className="size-5 text-text-primary" aria-hidden="true" />
+        <Sidebar className="icon-md" aria-hidden="true" />
       </Button>
+      <Switcher links={links} />
+      <Suspense fallback={<Skeleton className="size-9 rounded-lg" />}>
+        <AccountSettings collapsed />
+      </Suspense>
     </div>
   );
 }

--- a/client/src/components/UnifiedSidebar/mobile/Header.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/Header.tsx
@@ -1,4 +1,4 @@
-import { memo, lazy, Suspense } from 'react';
+import { memo, lazy, Suspense, useEffect, useRef } from 'react';
 import { Button, Sidebar, Skeleton } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
@@ -27,10 +27,22 @@ function Header({
 }) {
   const localize = useLocalize();
   const toggleSidebarAriaKey = useShortcutAriaKey('toggleSidebar');
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  /** Opening makes the chat pane inert, so keyboard/AT focus must move into
+   * the drawer. The commit itself drives the handoff — every opener (button,
+   * swipe, shortcut) lands here, and a wall-clock timer would race the
+   * deferred state flip and silently miss whenever the flip outlasted it. */
+  useEffect(() => {
+    if (expanded) {
+      closeRef.current?.focus();
+    }
+  }, [expanded]);
 
   return (
     <div className="flex h-14 flex-shrink-0 items-center gap-2 border-b border-border-light px-2">
       <Button
+        ref={closeRef}
         /**
          * The drawer stays mounted while closed so it can slide, and a
          * translated element still counts as visible. Only claim the close

--- a/client/src/components/UnifiedSidebar/mobile/Header.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/Header.tsx
@@ -1,11 +1,10 @@
 import { memo, lazy, Suspense } from 'react';
 import { Button, Sidebar, Skeleton } from '@librechat/client';
 import type { NavLink } from '~/common';
-import { CLOSE_SIDEBAR_ID, SIDEBAR_TOGGLE_CLASSES } from '~/components/Chat/Menus/OpenSidebar';
+import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
 import { useShortcutAriaKey } from '~/hooks/useKeyboardShortcuts';
 import { useLocalize } from '~/hooks';
 import Switcher from './Switcher';
-import { cn } from '~/utils';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
 
@@ -41,14 +40,14 @@ function Header({
         id={expanded ? CLOSE_SIDEBAR_ID : undefined}
         data-testid={expanded ? 'close-sidebar-button' : undefined}
         size="icon"
-        variant="outline"
+        variant="header-action"
         aria-label={localize('com_nav_close_sidebar')}
         aria-expanded={expanded}
         aria-controls="chat-history-nav"
         /** The only close control while open, so its binding must be discoverable here. */
         aria-keyshortcuts={toggleSidebarAriaKey}
         tabIndex={expanded ? 0 : -1}
-        className={cn('flex-shrink-0', SIDEBAR_TOGGLE_CLASSES)}
+        className="flex-shrink-0"
         onClick={onClose}
       >
         <Sidebar className="icon-md" aria-hidden="true" />

--- a/client/src/components/UnifiedSidebar/mobile/__tests__/BottomBar.spec.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/__tests__/BottomBar.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { NavLink } from '~/common';
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('~/hooks/useKeyboardShortcuts', () => ({
+  useShortcutAriaKey: () => 'Meta+Shift+O',
+}));
+
+jest.mock('@librechat/client', () => ({
+  Button: ({
+    children,
+    asChild: _asChild,
+    ...props
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <div {...props}>{children}</div>,
+}));
+
+jest.mock('~/Providers', () => ({
+  useActivePanel: () => ({ active: 'conversations', setActive: jest.fn() }),
+  resolveActivePanel: () => 'conversations',
+  DEFAULT_PANEL: 'conversations',
+}));
+
+jest.mock('~/components/Nav/SearchBar', () => ({
+  __esModule: true,
+  default: () => <div data-testid="search-bar" />,
+}));
+
+/** The heavy reset itself is the unit under order-test; only the navigation
+ *  internals below useNewChat are stubbed. */
+const mockNewConversation = jest.fn();
+jest.mock('~/hooks/useNewConvo', () => ({
+  __esModule: true,
+  default: () => ({ newConversation: mockNewConversation }),
+}));
+
+import BottomBar from '../BottomBar';
+
+const links = [] as NavLink[];
+
+describe('mobile bottom bar — new chat ordering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * The drawer close must start BEFORE the conversation reset: run
+   * synchronously, the reset's cache clearing and navigation flush in the
+   * tap's task and stall the slide's first frame. The reset rides the
+   * close's `afterSlide` callback instead.
+   */
+  it('closes the drawer first and defers the conversation reset to afterSlide', () => {
+    const order: string[] = [];
+    let afterSlide: (() => void) | undefined;
+    const onNewChat = jest.fn((callback?: () => void) => {
+      order.push('close');
+      afterSlide = callback;
+    });
+    mockNewConversation.mockImplementation(() => {
+      order.push('reset');
+    });
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <RecoilRoot>
+          <BottomBar links={links} onNewChat={onNewChat} />
+        </RecoilRoot>
+      </QueryClientProvider>,
+    );
+    fireEvent.click(screen.getByTestId('nav-new-chat-fab'));
+
+    expect(order).toEqual(['close']);
+    expect(afterSlide).toBeDefined();
+
+    afterSlide?.();
+    expect(order).toEqual(['close', 'reset']);
+  });
+
+  it('leaves modified clicks to the browser (new tab)', () => {
+    const onNewChat = jest.fn();
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <RecoilRoot>
+          <BottomBar links={links} onNewChat={onNewChat} />
+        </RecoilRoot>
+      </QueryClientProvider>,
+    );
+    fireEvent.click(screen.getByTestId('nav-new-chat-fab'), { ctrlKey: true });
+
+    expect(onNewChat).not.toHaveBeenCalled();
+    expect(mockNewConversation).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/UnifiedSidebar/mobile/__tests__/Header.spec.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/__tests__/Header.spec.tsx
@@ -29,7 +29,6 @@ jest.mock('~/components/Nav/AccountSettings', () => ({
 
 jest.mock('~/components/Chat/Menus/OpenSidebar', () => ({
   CLOSE_SIDEBAR_ID: 'close-sidebar-button',
-  SIDEBAR_TOGGLE_CLASSES: 'sidebar-toggle-classes',
 }));
 
 import Header from '../Header';
@@ -75,15 +74,15 @@ describe('mobile drawer header', () => {
 
   /**
    * The toggle mirrors the chat header's OpenSidebar — same icon, same shared
-   * classes, same far-left slot — so the drawer reads as the one persistent
-   * control flipping state rather than a new X appearing elsewhere.
+   * Button variant, same far-left slot — so the drawer reads as the one
+   * persistent control flipping state rather than a new X appearing elsewhere.
    */
-  it('leads the row with the shared sidebar-toggle look', () => {
+  it('leads the row with the shared header-action toggle', () => {
     const { container } = render(<Header links={links} expanded={true} onClose={jest.fn()} />);
 
     const toggle = screen.getByTestId('close-sidebar-button');
     expect(container.firstElementChild?.firstElementChild).toBe(toggle);
-    expect(toggle.className).toContain('sidebar-toggle-classes');
+    expect(toggle).toHaveAttribute('variant', 'header-action');
     expect(toggle.querySelector('[data-testid="sidebar-icon"]')).not.toBeNull();
   });
 });

--- a/client/src/components/UnifiedSidebar/mobile/__tests__/Header.spec.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/__tests__/Header.spec.tsx
@@ -13,6 +13,7 @@ jest.mock('@librechat/client', () => ({
   Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
     <button {...props}>{children}</button>
   ),
+  Sidebar: (props: React.ComponentProps<'svg'>) => <svg data-testid="sidebar-icon" {...props} />,
   Skeleton: () => <div data-testid="skeleton" />,
 }));
 
@@ -28,6 +29,7 @@ jest.mock('~/components/Nav/AccountSettings', () => ({
 
 jest.mock('~/components/Chat/Menus/OpenSidebar', () => ({
   CLOSE_SIDEBAR_ID: 'close-sidebar-button',
+  SIDEBAR_TOGGLE_CLASSES: 'sidebar-toggle-classes',
 }));
 
 import Header from '../Header';
@@ -69,5 +71,19 @@ describe('mobile drawer header', () => {
     render(<Header links={links} expanded={false} onClose={jest.fn()} />);
 
     expect(screen.getByLabelText('com_nav_close_sidebar')).toHaveAttribute('tabindex', '-1');
+  });
+
+  /**
+   * The toggle mirrors the chat header's OpenSidebar — same icon, same shared
+   * classes, same far-left slot — so the drawer reads as the one persistent
+   * control flipping state rather than a new X appearing elsewhere.
+   */
+  it('leads the row with the shared sidebar-toggle look', () => {
+    const { container } = render(<Header links={links} expanded={true} onClose={jest.fn()} />);
+
+    const toggle = screen.getByTestId('close-sidebar-button');
+    expect(container.firstElementChild?.firstElementChild).toBe(toggle);
+    expect(toggle.className).toContain('sidebar-toggle-classes');
+    expect(toggle.querySelector('[data-testid="sidebar-icon"]')).not.toBeNull();
   });
 });

--- a/client/src/components/UnifiedSidebar/mobile/__tests__/Header.spec.tsx
+++ b/client/src/components/UnifiedSidebar/mobile/__tests__/Header.spec.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { NavLink } from '~/common';
 
@@ -10,9 +11,16 @@ jest.mock('~/hooks/useKeyboardShortcuts', () => ({
 }));
 
 jest.mock('@librechat/client', () => ({
-  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
-    <button {...props}>{children}</button>
-  ),
+  Button: jest
+    .requireActual<typeof import('react')>('react')
+    .forwardRef<
+      HTMLButtonElement,
+      React.ComponentProps<'button'>
+    >(({ children, ...props }, ref) => (
+      <button ref={ref} {...props}>
+        {children}
+      </button>
+    )),
   Sidebar: (props: React.ComponentProps<'svg'>) => <svg data-testid="sidebar-icon" {...props} />,
   Skeleton: () => <div data-testid="skeleton" />,
 }));
@@ -70,6 +78,27 @@ describe('mobile drawer header', () => {
     render(<Header links={links} expanded={false} onClose={jest.fn()} />);
 
     expect(screen.getByLabelText('com_nav_close_sidebar')).toHaveAttribute('tabindex', '-1');
+  });
+
+  /**
+   * Opening makes the chat pane inert, so keyboard/AT focus must move into
+   * the drawer. The commit itself drives the handoff — a wall-clock timer
+   * races the deferred state flip and silently misses when the flip
+   * outlasts it (the id does not exist until `expanded` commits).
+   */
+  it('moves focus to the toggle when the drawer opens', () => {
+    const { rerender } = render(<Header links={links} expanded={false} onClose={jest.fn()} />);
+    expect(document.activeElement).toBe(document.body);
+
+    rerender(<Header links={links} expanded={true} onClose={jest.fn()} />);
+
+    expect(document.activeElement).toBe(screen.getByTestId('close-sidebar-button'));
+  });
+
+  it('never steals focus while closed', () => {
+    render(<Header links={links} expanded={false} onClose={jest.fn()} />);
+
+    expect(document.activeElement).toBe(document.body);
   });
 
   /**

--- a/client/src/hooks/Agents/__tests__/useAgentsMap.spec.tsx
+++ b/client/src/hooks/Agents/__tests__/useAgentsMap.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EModelEndpoint, QueryKeys, dataService } from 'librechat-data-provider';
+import useAgentsMap from '../useAgentsMap';
+
+/** `dataService` methods are non-configurable, so the HTTP boundary is mocked
+ *  at the module seam; everything else stays the real library. */
+jest.mock('librechat-data-provider', () => {
+  const actual =
+    jest.requireActual<typeof import('librechat-data-provider')>('librechat-data-provider');
+  return {
+    ...actual,
+    dataService: {
+      ...actual.dataService,
+      listAgents: jest.fn(),
+    },
+  };
+});
+
+/**
+ * Root feeds this map straight into `AgentsMapContext.Provider`, so its
+ * referential stability decides whether every consumer — message rows,
+ * conversation icons, subagent cards — re-renders on unrelated Root renders
+ * (e.g. the mobile drawer toggle). Real react-query; only HTTP is stubbed.
+ */
+describe('useAgentsMap', () => {
+  const setup = () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData([QueryKeys.endpoints], {
+      [EModelEndpoint.agents]: {},
+    });
+    (dataService.listAgents as jest.Mock).mockResolvedValue({
+      object: 'list',
+      data: [{ id: 'agent_1', name: 'Agent One' }],
+      first_id: 'agent_1',
+      last_id: 'agent_1',
+      has_more: false,
+      after: null,
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    return renderHook(() => useAgentsMap({ isAuthenticated: true }), { wrapper });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the agents map referentially stable across unrelated re-renders', async () => {
+    const { result, rerender } = setup();
+    await waitFor(() => expect(result.current?.agent_1).toBeDefined());
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/client/src/hooks/Assistants/__tests__/useAssistantsMap.spec.tsx
+++ b/client/src/hooks/Assistants/__tests__/useAssistantsMap.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EModelEndpoint, QueryKeys, dataService } from 'librechat-data-provider';
+import useAssistantsMap from '../useAssistantsMap';
+
+/** `dataService` methods are non-configurable, so the HTTP boundary is mocked
+ *  at the module seam; everything else stays the real library. */
+jest.mock('librechat-data-provider', () => {
+  const actual =
+    jest.requireActual<typeof import('librechat-data-provider')>('librechat-data-provider');
+  return {
+    ...actual,
+    dataService: {
+      ...actual.dataService,
+      listAssistants: jest.fn(),
+    },
+  };
+});
+
+/**
+ * Root feeds this map straight into `AssistantsMapContext.Provider`, so its
+ * referential stability decides whether every consumer — message rows
+ * included — re-renders on unrelated Root renders (e.g. the mobile drawer
+ * toggle). Real react-query against a seeded cache; only HTTP is stubbed.
+ */
+describe('useAssistantsMap', () => {
+  const listResponse = {
+    object: 'list',
+    data: [{ id: 'asst_1', name: 'Assistant One' }],
+    first_id: 'asst_1',
+    last_id: 'asst_1',
+    has_more: false,
+  };
+
+  const setup = (isAuthenticated: boolean) => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData([QueryKeys.endpoints], {
+      [EModelEndpoint.assistants]: { userProvide: false },
+    });
+    (dataService.listAssistants as jest.Mock).mockResolvedValue(listResponse);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    return renderHook(() => useAssistantsMap({ isAuthenticated }), { wrapper });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the composite map referentially stable across unrelated re-renders', async () => {
+    const { result, rerender } = setup(true);
+    await waitFor(() => expect(result.current?.[EModelEndpoint.assistants]?.asst_1).toBeDefined());
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('keeps each endpoint map stable across re-renders (memoized select)', async () => {
+    const { result, rerender } = setup(true);
+    await waitFor(() => expect(result.current?.[EModelEndpoint.assistants]?.asst_1).toBeDefined());
+
+    const firstInner = result.current[EModelEndpoint.assistants];
+    rerender();
+
+    expect(result.current[EModelEndpoint.assistants]).toBe(firstInner);
+  });
+
+  it('is stable while unauthenticated (empty maps do not churn identity)', () => {
+    const { result, rerender } = setup(false);
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/client/src/hooks/Assistants/useAssistantsMap.ts
+++ b/client/src/hooks/Assistants/useAssistantsMap.ts
@@ -1,18 +1,26 @@
+import { useMemo } from 'react';
 import { EModelEndpoint } from 'librechat-data-provider';
 import type { TAssistantsMap } from 'librechat-data-provider';
 import { useListAssistantsQuery } from '~/data-provider';
 import { mapAssistants } from '~/utils';
 
+/**
+ * Root feeds this straight into `AssistantsMapContext.Provider`, so the
+ * returned reference must only change when the underlying data does. The
+ * previous bare object literal (and `= {}` defaults) minted a new value every
+ * render, which re-rendered every context consumer — message rows included —
+ * on any unrelated Root render, e.g. the mobile drawer toggle.
+ */
 export default function useAssistantsMap({
   isAuthenticated,
 }: {
   isAuthenticated: boolean;
-}): TAssistantsMap | undefined {
-  const { data: assistants = {} } = useListAssistantsQuery(EModelEndpoint.assistants, undefined, {
+}): TAssistantsMap {
+  const { data: assistants } = useListAssistantsQuery(EModelEndpoint.assistants, undefined, {
     select: (res) => mapAssistants(res.data),
     enabled: isAuthenticated,
   });
-  const { data: azureAssistants = {} } = useListAssistantsQuery(
+  const { data: azureAssistants } = useListAssistantsQuery(
     EModelEndpoint.azureAssistants,
     undefined,
     {
@@ -21,8 +29,11 @@ export default function useAssistantsMap({
     },
   );
 
-  return {
-    [EModelEndpoint.assistants]: assistants,
-    [EModelEndpoint.azureAssistants]: azureAssistants,
-  };
+  return useMemo(
+    () => ({
+      [EModelEndpoint.assistants]: assistants ?? {},
+      [EModelEndpoint.azureAssistants]: azureAssistants ?? {},
+    }),
+    [assistants, azureAssistants],
+  );
 }

--- a/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
@@ -1,5 +1,8 @@
 import { renderHook } from '@testing-library/react';
-import useDrawerSwipe, { findHorizontalScrollBlocker } from '../useDrawerSwipe';
+import useDrawerSwipe, {
+  findHorizontalScrollBlocker,
+  kickDrawerAnimation,
+} from '../useDrawerSwipe';
 import { MOBILE_DRAWER_ID } from '~/components/UnifiedSidebar/constants';
 
 const DRAWER_WIDTH = 375;
@@ -428,6 +431,124 @@ describe('useDrawerSwipe — interruptions and re-arming', () => {
       { x: 220, y: 100, t: 250 },
     ]);
     expect(harness.onOpenChange).toHaveBeenCalledWith(true);
+    harness.unmount();
+  });
+});
+
+describe('useDrawerSwipe — kickDrawerAnimation (button toggles)', () => {
+  it('slides both elements before the state flip runs, then hands off to classes', () => {
+    jest.useFakeTimers();
+    const harness = setup(false);
+    /** The sync rAF mock collapses the two-frame deferral, so capturing the
+     *  transform inside `applyState` proves the slide started first. */
+    const transformAtApply: string[] = [];
+    kickDrawerAnimation(true, () => {
+      transformAtApply.push(harness.drawer.style.transform);
+    });
+
+    expect(transformAtApply).toEqual(['translate3d(0, 0, 0)']);
+    expect(harness.pane.style.transform).toBe('translateX(100%)');
+    expect(harness.drawer.style.willChange).toBe('transform');
+    expect(harness.onOpenChange).not.toHaveBeenCalled();
+
+    harness.rerender({ open: true, enabled: true });
+    expect(harness.drawer.style.transform).toBe('translate3d(0, 0, 0)');
+
+    jest.runAllTimers();
+    expect(harness.drawer.style.transform).toBe('');
+    expect(harness.drawer.style.willChange).toBe('');
+    expect(harness.pane.style.transform).toBe('translateX(100%)');
+    jest.useRealTimers();
+    harness.unmount();
+  });
+
+  it('applies state immediately when the hook is disabled (desktop width animation)', () => {
+    const harness = setup(false);
+    harness.rerender({ open: false, enabled: false });
+
+    const applyState = jest.fn();
+    kickDrawerAnimation(true, applyState);
+
+    expect(applyState).toHaveBeenCalledTimes(1);
+    expect(harness.drawer.style.transform).toBe('');
+    harness.unmount();
+  });
+
+  it('applies state immediately after unmount', () => {
+    const harness = setup(false);
+    harness.unmount();
+
+    const applyState = jest.fn();
+    kickDrawerAnimation(true, applyState);
+
+    expect(applyState).toHaveBeenCalledTimes(1);
+  });
+
+  it('retargets an in-flight slide when the user toggles back', () => {
+    jest.useFakeTimers();
+    const harness = setup(false);
+
+    kickDrawerAnimation(true, jest.fn());
+    harness.rerender({ open: true, enabled: true });
+    kickDrawerAnimation(false, jest.fn());
+
+    expect(harness.drawer.style.transform).toBe('translate3d(-100%, 0, 0)');
+    expect(harness.pane.style.transform).toBe('translate3d(0, 0, 0)');
+
+    harness.rerender({ open: false, enabled: true });
+    jest.runAllTimers();
+    expect(harness.drawer.style.transform).toBe('');
+    expect(harness.pane.style.transform).toBe('');
+    jest.useRealTimers();
+    harness.unmount();
+  });
+
+  it('does not re-start a slide already heading to the same target', () => {
+    jest.useFakeTimers();
+    const harness = setup(false);
+
+    kickDrawerAnimation(true, jest.fn());
+    harness.drawer.style.transform = 'translate3d(-10px, 0, 0)';
+    kickDrawerAnimation(true, jest.fn());
+
+    expect(harness.drawer.style.transform).toBe('translate3d(-10px, 0, 0)');
+    jest.useRealTimers();
+    harness.unmount();
+  });
+
+  it('defers to a drag that owns the inline styles but still applies state', () => {
+    const harness = setup(false);
+    harness.swipe(
+      harness.pane,
+      [
+        { x: 20, y: 100, t: 0 },
+        { x: 120, y: 104, t: 50 },
+      ],
+      false,
+    );
+
+    const applyState = jest.fn();
+    kickDrawerAnimation(true, applyState);
+
+    expect(harness.pane.style.transform).toBe('translate3d(100px, 0, 0)');
+    expect(applyState).toHaveBeenCalledTimes(1);
+    harness.pane.dispatchEvent(touchEvent('touchend', [], 400));
+    harness.unmount();
+  });
+
+  it('snaps without a transition under reduced motion', () => {
+    jest.useFakeTimers();
+    const harness = setup(false, true);
+
+    kickDrawerAnimation(true, jest.fn());
+
+    expect(harness.drawer.style.transition).toBe('none');
+    expect(harness.drawer.style.transform).toBe('');
+
+    harness.rerender({ open: true, enabled: true });
+    jest.runAllTimers();
+    expect(harness.drawer.style.transition).not.toBe('none');
+    jest.useRealTimers();
     harness.unmount();
   });
 });

--- a/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import useDrawerSwipe, {
   findHorizontalScrollBlocker,
+  getPendingDrawerFlip,
   kickDrawerAnimation,
 } from '../useDrawerSwipe';
 import { MOBILE_DRAWER_ID } from '~/components/UnifiedSidebar/constants';
@@ -610,6 +611,51 @@ describe('useDrawerSwipe — kickDrawerAnimation (button toggles)', () => {
     expect(harness.drawer.style.transform).toBe('');
     expect(harness.pane.style.transform).toBe('translateX(100%)');
     jest.useRealTimers();
+    harness.unmount();
+  });
+
+  /** A superseded flip must never transiently commit the old direction —
+   *  its commit would re-register the animator and get the NEWER flip
+   *  dropped, stranding the drawer at the first intent. */
+  it('discards a superseded deferred flip so only the latest intent commits', () => {
+    jest.useFakeTimers();
+    const harness = setup(false);
+    const queued: FrameRequestCallback[] = [];
+    (window.requestAnimationFrame as jest.Mock).mockImplementation((callback) => {
+      queued.push(callback);
+      return queued.length;
+    });
+
+    const applyOpen = jest.fn();
+    const applyClose = jest.fn();
+    kickDrawerAnimation(true, applyOpen);
+    kickDrawerAnimation(false, applyClose);
+    while (queued.length) {
+      queued.shift()?.(0);
+    }
+
+    expect(applyOpen).not.toHaveBeenCalled();
+    expect(applyClose).toHaveBeenCalledTimes(1);
+    jest.runAllTimers();
+    jest.useRealTimers();
+    harness.unmount();
+  });
+
+  /** A desktop toggle right after a breakpoint cross must invert the
+   *  committed value, not a leftover mobile intent. */
+  it('clears the pending flip target when the animator tears down', () => {
+    const harness = setup(false);
+    const queued: FrameRequestCallback[] = [];
+    (window.requestAnimationFrame as jest.Mock).mockImplementation((callback) => {
+      queued.push(callback);
+      return queued.length;
+    });
+
+    kickDrawerAnimation(true, jest.fn());
+    expect(getPendingDrawerFlip()).toBe(true);
+    harness.rerender({ open: false, enabled: false });
+
+    expect(getPendingDrawerFlip()).toBeNull();
     harness.unmount();
   });
 

--- a/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
@@ -551,6 +551,61 @@ describe('useDrawerSwipe — kickDrawerAnimation (button toggles)', () => {
     jest.useRealTimers();
     harness.unmount();
   });
+
+  /** Deferring past the 80ms transition-restore window would let the state
+   *  flip animate at full duration on a slow-frame device — for exactly the
+   *  users who opted out of motion. */
+  it('applies state synchronously under reduced motion, without frame deferral', () => {
+    const harness = setup(false, true);
+    (window.requestAnimationFrame as jest.Mock).mockImplementation(() => 0);
+
+    const applyState = jest.fn();
+    kickDrawerAnimation(true, applyState);
+
+    expect(applyState).toHaveBeenCalledTimes(1);
+    harness.unmount();
+  });
+
+  it('drops a deferred state flip when the animator is torn down mid-deferral', () => {
+    const harness = setup(false);
+    const queued: FrameRequestCallback[] = [];
+    (window.requestAnimationFrame as jest.Mock).mockImplementation((callback) => {
+      queued.push(callback);
+      return queued.length;
+    });
+
+    const applyState = jest.fn();
+    kickDrawerAnimation(true, applyState);
+    harness.rerender({ open: false, enabled: false });
+    while (queued.length) {
+      queued.shift()?.(0);
+    }
+
+    expect(applyState).not.toHaveBeenCalled();
+    expect(harness.drawer.style.transform).toBe('');
+    harness.unmount();
+  });
+
+  it('applies the deferred state flip when the animator is still live', () => {
+    jest.useFakeTimers();
+    const harness = setup(false);
+    const queued: FrameRequestCallback[] = [];
+    (window.requestAnimationFrame as jest.Mock).mockImplementation((callback) => {
+      queued.push(callback);
+      return queued.length;
+    });
+
+    const applyState = jest.fn();
+    kickDrawerAnimation(true, applyState);
+    while (queued.length) {
+      queued.shift()?.(0);
+    }
+
+    expect(applyState).toHaveBeenCalledTimes(1);
+    jest.runAllTimers();
+    jest.useRealTimers();
+    harness.unmount();
+  });
 });
 
 describe('findHorizontalScrollBlocker', () => {

--- a/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
@@ -586,6 +586,33 @@ describe('useDrawerSwipe — kickDrawerAnimation (button toggles)', () => {
     harness.unmount();
   });
 
+  /** The release deadline must run on the same clock as the staged frame:
+   *  armed at kick time, a delayed first frame lets the wall-clock timeout
+   *  clear the settle first, and the frame then aborts the slide. */
+  it('waits for the staged frame before starting the release deadline', () => {
+    jest.useFakeTimers();
+    const harness = setup(false);
+    const queued: FrameRequestCallback[] = [];
+    (window.requestAnimationFrame as jest.Mock).mockImplementation((callback) => {
+      queued.push(callback);
+      return queued.length;
+    });
+
+    kickDrawerAnimation(true, jest.fn());
+    jest.advanceTimersByTime(500);
+    queued.shift()?.(0);
+
+    expect(harness.drawer.style.transform).toBe('translate3d(0, 0, 0)');
+    expect(harness.pane.style.transform).toBe('translateX(100%)');
+
+    harness.rerender({ open: true, enabled: true });
+    jest.advanceTimersByTime(400);
+    expect(harness.drawer.style.transform).toBe('');
+    expect(harness.pane.style.transform).toBe('translateX(100%)');
+    jest.useRealTimers();
+    harness.unmount();
+  });
+
   it('applies the deferred state flip when the animator is still live', () => {
     jest.useFakeTimers();
     const harness = setup(false);

--- a/client/src/hooks/Nav/__tests__/useSidebarToggle.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useSidebarToggle.spec.tsx
@@ -8,10 +8,11 @@ import store from '~/store';
 
 /**
  * Exercises the real seam: useSidebarToggle must start the drawer slide
- * through the swipe hook's animator BEFORE the Recoil flip commits, and fall
- * back to an immediate flip when the animator is not active (desktop).
+ * through the swipe hook's animator BEFORE the Recoil flip commits, defer
+ * follow-up work past the slide, and fall back to immediate application when
+ * the animator is not active (desktop).
  */
-const setup = (enabled: boolean) => {
+const setup = (enabled: boolean, rafMode: 'sync' | 'captured' = 'sync') => {
   const pane = document.createElement('div');
   const drawer = document.createElement('div');
   drawer.id = MOBILE_DRAWER_ID;
@@ -23,22 +24,36 @@ const setup = (enabled: boolean) => {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
   } as unknown as MediaQueryList);
+  const queued: FrameRequestCallback[] = [];
   jest
     .spyOn(window, 'requestAnimationFrame')
     .mockImplementation((callback: FrameRequestCallback) => {
-      callback(0);
-      return 0;
+      if (rafMode === 'sync') {
+        callback(0);
+        return 0;
+      }
+      queued.push(callback);
+      return queued.length;
     });
+  const flushFrames = () => {
+    while (queued.length) {
+      queued.shift()?.(0);
+    }
+  };
 
   const paneRef = { current: pane };
+  /** The atom defaults to true (desktop); every scenario here starts from a
+   *  CLOSED mobile drawer, so seed it closed. */
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <RecoilRoot>{children}</RecoilRoot>
+    <RecoilRoot initializeState={({ set }) => set(store.sidebarExpanded, false)}>
+      {children}
+    </RecoilRoot>
   );
   const rendered = renderHook(
     () => {
       useDrawerSwipe({ paneRef, enabled, open: false, onOpenChange: jest.fn() });
       return {
-        setSidebarOpen: useSidebarToggle(),
+        toggle: useSidebarToggle(),
         expanded: useRecoilValue(store.sidebarExpanded),
       };
     },
@@ -48,6 +63,7 @@ const setup = (enabled: boolean) => {
   return {
     ...rendered,
     drawer,
+    flushFrames,
     cleanup: () => {
       rendered.unmount();
       pane.remove();
@@ -60,18 +76,21 @@ describe('useSidebarToggle', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     document.getElementById(MOBILE_DRAWER_ID)?.remove();
+    /** Committed flips persist through the atom's localStorage effect, which
+     *  overrides the next test's `initializeState` seed. */
+    localStorage.clear();
   });
 
-  it('starts the drawer slide and reports it handled the animation (mobile)', () => {
+  it('starts the drawer slide and reports the slide mode (mobile)', () => {
     jest.useFakeTimers();
     const harness = setup(true);
 
-    let animated = false;
+    let mode = '';
     act(() => {
-      animated = harness.result.current.setSidebarOpen(true);
+      mode = harness.result.current.toggle.setSidebarOpen(true);
     });
 
-    expect(animated).toBe(true);
+    expect(mode).toBe('slide');
     expect(harness.drawer.style.transform).toBe('translate3d(0, 0, 0)');
     expect(harness.result.current.expanded).toBe(true);
     jest.useRealTimers();
@@ -81,14 +100,78 @@ describe('useSidebarToggle', () => {
   it('flips state immediately without animating when the hook is disabled (desktop)', () => {
     const harness = setup(false);
 
-    let animated = true;
+    let mode = '';
     act(() => {
-      animated = harness.result.current.setSidebarOpen(true);
+      mode = harness.result.current.toggle.setSidebarOpen(true);
     });
 
-    expect(animated).toBe(false);
+    expect(mode).toBe('none');
     expect(harness.drawer.style.transform).toBe('');
     expect(harness.result.current.expanded).toBe(true);
+    harness.cleanup();
+  });
+
+  it('defers afterSlide past the slide frames on mobile', () => {
+    const harness = setup(true, 'captured');
+
+    const afterSlide = jest.fn();
+    act(() => {
+      harness.result.current.toggle.setSidebarOpen(true, afterSlide);
+    });
+    expect(afterSlide).not.toHaveBeenCalled();
+
+    act(() => {
+      harness.flushFrames();
+    });
+    expect(afterSlide).toHaveBeenCalledTimes(1);
+    harness.cleanup();
+  });
+
+  it('runs afterSlide immediately on desktop', () => {
+    const harness = setup(false);
+
+    const afterSlide = jest.fn();
+    act(() => {
+      harness.result.current.toggle.setSidebarOpen(true, afterSlide);
+    });
+
+    expect(afterSlide).toHaveBeenCalledTimes(1);
+    harness.cleanup();
+  });
+
+  /** The user action carried by afterSlide (navigation, focus) must survive
+   *  an animator teardown mid-deferral — only the sidebar flip goes stale. */
+  it('still runs afterSlide when the animator is torn down mid-deferral', () => {
+    const harness = setup(true, 'captured');
+
+    const afterSlide = jest.fn();
+    act(() => {
+      harness.result.current.toggle.setSidebarOpen(true, afterSlide);
+    });
+    harness.rerender();
+    harness.cleanup();
+    act(() => {
+      harness.flushFrames();
+    });
+
+    expect(afterSlide).toHaveBeenCalledTimes(1);
+  });
+
+  /** Two presses inside the deferral window must alternate — the second
+   *  inverts the pending target, not the still-uncommitted atom value. */
+  it('alternates rapid toggles instead of piling onto the same direction', () => {
+    const harness = setup(true, 'captured');
+
+    act(() => {
+      harness.result.current.toggle.toggleSidebar();
+      harness.result.current.toggle.toggleSidebar();
+    });
+    act(() => {
+      harness.flushFrames();
+    });
+
+    expect(harness.result.current.expanded).toBe(false);
+    expect(harness.drawer.style.transform).toBe('translate3d(-100%, 0, 0)');
     harness.cleanup();
   });
 });

--- a/client/src/hooks/Nav/__tests__/useSidebarToggle.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useSidebarToggle.spec.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { RecoilRoot, useRecoilValue } from 'recoil';
+import { renderHook, act } from '@testing-library/react';
+import { MOBILE_DRAWER_ID } from '~/components/UnifiedSidebar/constants';
+import useSidebarToggle from '../useSidebarToggle';
+import useDrawerSwipe from '../useDrawerSwipe';
+import store from '~/store';
+
+/**
+ * Exercises the real seam: useSidebarToggle must start the drawer slide
+ * through the swipe hook's animator BEFORE the Recoil flip commits, and fall
+ * back to an immediate flip when the animator is not active (desktop).
+ */
+const setup = (enabled: boolean) => {
+  const pane = document.createElement('div');
+  const drawer = document.createElement('div');
+  drawer.id = MOBILE_DRAWER_ID;
+  Object.defineProperty(drawer, 'clientWidth', { value: 375, configurable: true });
+  document.body.append(pane, drawer);
+
+  jest.spyOn(window, 'matchMedia').mockReturnValue({
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  } as unknown as MediaQueryList);
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+
+  const paneRef = { current: pane };
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <RecoilRoot>{children}</RecoilRoot>
+  );
+  const rendered = renderHook(
+    () => {
+      useDrawerSwipe({ paneRef, enabled, open: false, onOpenChange: jest.fn() });
+      return {
+        setSidebarOpen: useSidebarToggle(),
+        expanded: useRecoilValue(store.sidebarExpanded),
+      };
+    },
+    { wrapper },
+  );
+
+  return {
+    ...rendered,
+    drawer,
+    cleanup: () => {
+      rendered.unmount();
+      pane.remove();
+      drawer.remove();
+    },
+  };
+};
+
+describe('useSidebarToggle', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.getElementById(MOBILE_DRAWER_ID)?.remove();
+  });
+
+  it('starts the drawer slide and reports it handled the animation (mobile)', () => {
+    jest.useFakeTimers();
+    const harness = setup(true);
+
+    let animated = false;
+    act(() => {
+      animated = harness.result.current.setSidebarOpen(true);
+    });
+
+    expect(animated).toBe(true);
+    expect(harness.drawer.style.transform).toBe('translate3d(0, 0, 0)');
+    expect(harness.result.current.expanded).toBe(true);
+    jest.useRealTimers();
+    harness.cleanup();
+  });
+
+  it('flips state immediately without animating when the hook is disabled (desktop)', () => {
+    const harness = setup(false);
+
+    let animated = true;
+    act(() => {
+      animated = harness.result.current.setSidebarOpen(true);
+    });
+
+    expect(animated).toBe(false);
+    expect(harness.drawer.style.transform).toBe('');
+    expect(harness.result.current.expanded).toBe(true);
+    harness.cleanup();
+  });
+});

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -186,8 +186,10 @@ export default function useDrawerSwipe({
   onOpenChange,
 }: DrawerSwipeOptions) {
   const gestureRef = useRef<Gesture | null>(null);
+  /** `id` is null while a kicked settle waits for its staged frame — the
+   * release deadline runs on the frame clock, not the wall clock. */
   const settleRef = useRef<{
-    id: ReturnType<typeof setTimeout>;
+    id: ReturnType<typeof setTimeout> | null;
     target: boolean;
     drawer: HTMLElement;
     pane: HTMLElement;
@@ -203,7 +205,9 @@ export default function useDrawerSwipe({
      * AGREES with `open` keeps running so its handoff finishes undisturbed. */
     const pending = settleRef.current;
     if (pending != null && (!enabled || pending.target !== open)) {
-      clearTimeout(pending.id);
+      if (pending.id != null) {
+        clearTimeout(pending.id);
+      }
       settleRef.current = null;
       releaseInlineStyles(pending.drawer, pending.pane, enabled && open);
     }
@@ -293,7 +297,9 @@ export default function useDrawerSwipe({
         if (pending.target === next) {
           return;
         }
-        clearTimeout(pending.id);
+        if (pending.id != null) {
+          clearTimeout(pending.id);
+        }
         settleRef.current = null;
       }
       if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
@@ -311,19 +317,25 @@ export default function useDrawerSwipe({
       }
       drawer.style.willChange = 'transform';
       pane.style.willChange = 'transform';
-      /** Armed BEFORE the frame below so the staged write can verify its
-       * target is still wanted — a retarget or a reconciliation cancel in
-       * between clears/replaces the settle and thereby voids the write. */
-      scheduleRelease(drawer, pane, next);
+      /** Armed BEFORE the frame below (id: null — no deadline yet) so the
+       * staged write can verify its target is still wanted, and so a
+       * touchstart in between defers to the pending settle. A retarget or
+       * a reconciliation cancel clears/replaces the settle and thereby
+       * voids the write. */
+      settleRef.current = { id: null, target: next, drawer, pane };
       /** The transforms are written in a FRESH frame task, not the tap's own
        * task: a transition armed inside the click task is not reliably
        * created for the offscreen drawer (observed via `transitionrun`
        * firing only after the state-flip commit, ~270ms late, even with a
        * forced reflow in-task), while the same write from a clean task
        * starts interpolating by the following frame. The reflow then pins
-       * the transition-start recalc to this frame instead of 2–3 later. */
+       * the transition-start recalc to this frame instead of 2–3 later.
+       * The release deadline starts HERE, with the transition itself — a
+       * wall-clock deadline armed at kick time can expire before a delayed
+       * first frame (backgrounded tab, long stall) and abort the slide. */
       requestAnimationFrame(() => {
-        if (settleRef.current?.target !== next) {
+        const armed = settleRef.current;
+        if (armed == null || armed.target !== next || armed.id != null) {
           return;
         }
         drawer.style.transition = SIDEBAR_TRANSITION;
@@ -331,6 +343,10 @@ export default function useDrawerSwipe({
         drawer.style.transform = next ? 'translate3d(0, 0, 0)' : 'translate3d(-100%, 0, 0)';
         pane.style.transform = next ? 'translateX(100%)' : 'translate3d(0, 0, 0)';
         void drawer.getBoundingClientRect();
+        armed.id = setTimeout(() => {
+          settleRef.current = null;
+          releaseInlineStyles(drawer, pane, next);
+        }, TRANSITION_MS + SETTLE_BUFFER_MS);
       });
     };
     drawerAnimator = animateTo;
@@ -504,7 +520,7 @@ export default function useDrawerSwipe({
 
   useEffect(
     () => () => {
-      if (settleRef.current != null) {
+      if (settleRef.current?.id != null) {
         clearTimeout(settleRef.current.id);
       }
     },

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -25,6 +25,20 @@ const TEXT_SURFACE_SELECTOR = 'textarea, input, select, [contenteditable="true"]
 
 let drawerAnimator: ((next: boolean) => void) | null = null;
 
+/** How a kicked toggle was handled: no animator (desktop/logged out — state
+ * applied immediately), reduced-motion snap (applied immediately, no slide
+ * frames), or a deferred slide. */
+export type DrawerKickMode = 'none' | 'snap' | 'slide';
+
+/** Target of a slide whose state flip is still deferred, or null when no
+ * flip is pending. Lets rapid toggles invert the LATEST intent instead of
+ * the stale committed atom value. */
+let pendingFlipTarget: boolean | null = null;
+
+export function getPendingDrawerFlip(): boolean | null {
+  return pendingFlipTarget;
+}
+
 /**
  * Starts the drawer/pane slide imperatively and owns WHEN the caller's state
  * flip runs. Wrapping the flip in `startTransition` is not enough: Recoil
@@ -42,15 +56,15 @@ let drawerAnimator: ((next: boolean) => void) | null = null;
  * swipe hook is not active — desktop, logged out — `applyState` runs
  * immediately and React animates the layout as before.
  *
- * Returns whether the drawer animator handled the slide, so callers can keep
- * affordances that only make sense outside the drawer (e.g. the desktop
- * focus timer) off the animated path.
+ * Returns how the toggle was handled, so callers can keep affordances off
+ * the paths where they do not apply — e.g. the desktop focus timer only
+ * runs on 'none', and follow-up work defers only on 'slide'.
  */
-export function kickDrawerAnimation(next: boolean, applyState: () => void): boolean {
+export function kickDrawerAnimation(next: boolean, applyState: () => void): DrawerKickMode {
   const animator = drawerAnimator;
   if (animator == null) {
     applyState();
-    return false;
+    return 'none';
   }
   animator(next);
   /** Reduced motion snaps — there are no slide frames to protect, and
@@ -60,11 +74,15 @@ export function kickDrawerAnimation(next: boolean, applyState: () => void): bool
    * cannot preempt. */
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     applyState();
-    return true;
+    return 'snap';
   }
+  pendingFlipTarget = next;
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
+        /** Cleared unconditionally — a dropped flip is no longer pending
+         * either. */
+        pendingFlipTarget = null;
         /** A teardown or re-register during the deferral — breakpoint
          * cross, logout, route change — makes the captured intent stale:
          * the new world owns the state, and a straggler flip could toggle
@@ -76,7 +94,7 @@ export function kickDrawerAnimation(next: boolean, applyState: () => void): bool
       });
     });
   });
-  return true;
+  return 'slide';
 }
 
 /**
@@ -294,14 +312,16 @@ export default function useDrawerSwipe({
      * inline styles, so it wins; an in-flight settle already heading to
      * `next` needs no second start. */
     const animateTo = (next: boolean) => {
-      if (next === open || gestureRef.current != null) {
+      /** The committed `open` goes stale while a flip is deferred — a rapid
+       * second toggle must compare against the in-flight settle's target or
+       * it early-returns and the visual never retargets (the state would
+       * still alternate, then snap at release). */
+      const effectiveTarget = settleRef.current?.target ?? open;
+      if (next === effectiveTarget || gestureRef.current != null) {
         return;
       }
       const pending = settleRef.current;
       if (pending != null) {
-        if (pending.target === next) {
-          return;
-        }
         if (pending.id != null) {
           clearTimeout(pending.id);
         }

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -43,14 +43,31 @@ let drawerAnimator: ((next: boolean) => void) | null = null;
  * immediately and React animates the layout as before.
  */
 export function kickDrawerAnimation(next: boolean, applyState: () => void): void {
-  if (drawerAnimator == null) {
+  const animator = drawerAnimator;
+  if (animator == null) {
     applyState();
     return;
   }
-  drawerAnimator(next);
+  animator(next);
+  /** Reduced motion snaps — there are no slide frames to protect, and
+   * deferring would let a slow-frame device outrun the 80ms window that
+   * restores transitions, turning the snap back into a full slide. The
+   * urgent commit runs inside this same task, which the restore timer
+   * cannot preempt. */
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    applyState();
+    return;
+  }
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
+        /** A teardown or re-register during the deferral — breakpoint
+         * cross, logout, route change — makes the captured intent stale:
+         * the new world owns the state, and a straggler flip could toggle
+         * the DESKTOP sidebar or persist drawer state past logout. */
+        if (drawerAnimator !== animator) {
+          return;
+        }
         applyState();
       });
     });

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -80,16 +80,18 @@ export function kickDrawerAnimation(next: boolean, applyState: () => void): Draw
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        /** Cleared unconditionally — a dropped flip is no longer pending
-         * either. */
-        pendingFlipTarget = null;
-        /** A teardown or re-register during the deferral — breakpoint
-         * cross, logout, route change — makes the captured intent stale:
-         * the new world owns the state, and a straggler flip could toggle
-         * the DESKTOP sidebar or persist drawer state past logout. */
-        if (drawerAnimator !== animator) {
+        /** Applies only while still the LATEST un-superseded intent. A
+         * retarget hands the state to its own deferred flip — this one
+         * transiently committing the old direction would re-register the
+         * animator and get the newer flip judged stale. Teardown and
+         * re-registration (breakpoint cross, logout, route change) clear
+         * the pending target in the effect cleanup, so stale flips drop
+         * out here as well instead of toggling the DESKTOP sidebar or
+         * persisting drawer state past logout. */
+        if (pendingFlipTarget !== next) {
           return;
         }
+        pendingFlipTarget = null;
         applyState();
       });
     });
@@ -527,6 +529,11 @@ export default function useDrawerSwipe({
     surface.addEventListener('touchcancel', onTouchCancel, { passive: true });
     return () => {
       drawerAnimator = null;
+      /** A pending intent from the torn-down world must not leak into the
+       * next one — a desktop toggle right after a breakpoint cross has to
+       * invert the committed value, and the deferred flip that would have
+       * consumed this target now drops out of its superseded check. */
+      pendingFlipTarget = null;
       surface.removeEventListener('touchstart', onTouchStart);
       surface.removeEventListener('touchmove', onTouchMove);
       surface.removeEventListener('touchend', onTouchEnd);

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -41,12 +41,16 @@ let drawerAnimator: ((next: boolean) => void) | null = null;
  * the commit lands mid-slide without stuttering or delaying it. When the
  * swipe hook is not active — desktop, logged out — `applyState` runs
  * immediately and React animates the layout as before.
+ *
+ * Returns whether the drawer animator handled the slide, so callers can keep
+ * affordances that only make sense outside the drawer (e.g. the desktop
+ * focus timer) off the animated path.
  */
-export function kickDrawerAnimation(next: boolean, applyState: () => void): void {
+export function kickDrawerAnimation(next: boolean, applyState: () => void): boolean {
   const animator = drawerAnimator;
   if (animator == null) {
     applyState();
-    return;
+    return false;
   }
   animator(next);
   /** Reduced motion snaps — there are no slide frames to protect, and
@@ -56,7 +60,7 @@ export function kickDrawerAnimation(next: boolean, applyState: () => void): void
    * cannot preempt. */
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     applyState();
-    return;
+    return true;
   }
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
@@ -72,6 +76,7 @@ export function kickDrawerAnimation(next: boolean, applyState: () => void): void
       });
     });
   });
+  return true;
 }
 
 /**

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -23,6 +23,40 @@ const SETTLE_BUFFER_MS = 80;
 /** Surfaces where a horizontal drag means selection or caret work, never navigation. */
 const TEXT_SURFACE_SELECTOR = 'textarea, input, select, [contenteditable="true"]';
 
+let drawerAnimator: ((next: boolean) => void) | null = null;
+
+/**
+ * Starts the drawer/pane slide imperatively and owns WHEN the caller's state
+ * flip runs. Wrapping the flip in `startTransition` is not enough: Recoil
+ * notifies subscribers outside the transition scope, so the commit — which a
+ * large conversation stretches to hundreds of ms of context re-renders plus
+ * the pane's `inert` recalc — flushes synchronously inside the tap's task and
+ * delays the slide's first frame (measured ~250ms on a 60-message thread at
+ * 4× throttle).
+ *
+ * So: start the slide imperatively, then run `applyState` three frames
+ * later — the animator writes the target transforms in frame 1, frame 2
+ * paints the first interpolated position, and by frame 3 the transform
+ * animation is compositor-driven (`willChange` is set in the tap's task), so
+ * the commit lands mid-slide without stuttering or delaying it. When the
+ * swipe hook is not active — desktop, logged out — `applyState` runs
+ * immediately and React animates the layout as before.
+ */
+export function kickDrawerAnimation(next: boolean, applyState: () => void): void {
+  if (drawerAnimator == null) {
+    applyState();
+    return;
+  }
+  drawerAnimator(next);
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        applyState();
+      });
+    });
+  });
+}
+
 /**
  * Walks from `start` up to `boundary` looking for a horizontal scroller that
  * can still consume a pan in `direction` (1 = finger moving right, which
@@ -187,6 +221,16 @@ export default function useDrawerSwipe({
       gestureRef.current = null;
     };
 
+    /** Arms the inline-style handoff: after the shared transition has played
+     * out, every transient property returns to what React/classes render. */
+    const scheduleRelease = (drawerEl: HTMLElement, paneEl: HTMLElement, next: boolean) => {
+      const id = setTimeout(() => {
+        settleRef.current = null;
+        releaseInlineStyles(drawerEl, paneEl, next);
+      }, TRANSITION_MS + SETTLE_BUFFER_MS);
+      settleRef.current = { id, target: next, drawer: drawerEl, pane: paneEl };
+    };
+
     /** Animates both elements to `next`, flips state, then returns ownership
      * of every inline property to what React/classes render for that state. */
     const settle = (gesture: Gesture, next: boolean) => {
@@ -215,17 +259,64 @@ export default function useDrawerSwipe({
       if (next !== open) {
         onOpenChangeRef.current(next);
       }
-      const id = setTimeout(() => {
-        settleRef.current = null;
-        drawerEl.style.transform = '';
-        drawerEl.style.willChange = '';
-        drawerEl.style.transition = SIDEBAR_TRANSITION;
-        paneEl.style.transform = next ? 'translateX(100%)' : 'none';
-        paneEl.style.willChange = '';
-        paneEl.style.transition = SIDEBAR_TRANSITION;
-      }, TRANSITION_MS + SETTLE_BUFFER_MS);
-      settleRef.current = { id, target: next, drawer: drawerEl, pane: paneEl };
+      scheduleRelease(drawerEl, paneEl, next);
     };
+
+    /** Imperative slide for button/keyboard toggles: same transforms and
+     * release lifecycle as a gesture settle, but the CALLER owns the state
+     * flip — nothing here calls `onOpenChange`. A drag in progress owns the
+     * inline styles, so it wins; an in-flight settle already heading to
+     * `next` needs no second start. */
+    const animateTo = (next: boolean) => {
+      if (next === open || gestureRef.current != null) {
+        return;
+      }
+      const pending = settleRef.current;
+      if (pending != null) {
+        if (pending.target === next) {
+          return;
+        }
+        clearTimeout(pending.id);
+        settleRef.current = null;
+      }
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        /** Snap: suppress the shared transition through the state flip the
+         * caller is about to make, then hand it back once committed. */
+        drawer.style.transition = 'none';
+        pane.style.transition = 'none';
+        const id = setTimeout(() => {
+          settleRef.current = null;
+          drawer.style.transition = SIDEBAR_TRANSITION;
+          pane.style.transition = SIDEBAR_TRANSITION;
+        }, SETTLE_BUFFER_MS);
+        settleRef.current = { id, target: next, drawer, pane };
+        return;
+      }
+      drawer.style.willChange = 'transform';
+      pane.style.willChange = 'transform';
+      /** Armed BEFORE the frame below so the staged write can verify its
+       * target is still wanted — a retarget or a reconciliation cancel in
+       * between clears/replaces the settle and thereby voids the write. */
+      scheduleRelease(drawer, pane, next);
+      /** The transforms are written in a FRESH frame task, not the tap's own
+       * task: a transition armed inside the click task is not reliably
+       * created for the offscreen drawer (observed via `transitionrun`
+       * firing only after the state-flip commit, ~270ms late, even with a
+       * forced reflow in-task), while the same write from a clean task
+       * starts interpolating by the following frame. The reflow then pins
+       * the transition-start recalc to this frame instead of 2–3 later. */
+      requestAnimationFrame(() => {
+        if (settleRef.current?.target !== next) {
+          return;
+        }
+        drawer.style.transition = SIDEBAR_TRANSITION;
+        pane.style.transition = SIDEBAR_TRANSITION;
+        drawer.style.transform = next ? 'translate3d(0, 0, 0)' : 'translate3d(-100%, 0, 0)';
+        pane.style.transform = next ? 'translateX(100%)' : 'translate3d(0, 0, 0)';
+        void drawer.getBoundingClientRect();
+      });
+    };
+    drawerAnimator = animateTo;
 
     const onTouchStart = (event: TouchEvent) => {
       if (gestureRef.current != null || settleRef.current != null || event.touches.length !== 1) {
@@ -377,6 +468,7 @@ export default function useDrawerSwipe({
     surface.addEventListener('touchend', onTouchEnd, { passive: true });
     surface.addEventListener('touchcancel', onTouchCancel, { passive: true });
     return () => {
+      drawerAnimator = null;
       surface.removeEventListener('touchstart', onTouchStart);
       surface.removeEventListener('touchmove', onTouchMove);
       surface.removeEventListener('touchend', onTouchEnd);

--- a/client/src/hooks/Nav/useSidebarToggle.ts
+++ b/client/src/hooks/Nav/useSidebarToggle.ts
@@ -1,7 +1,25 @@
-import { startTransition, useCallback } from 'react';
-import { useSetRecoilState } from 'recoil';
-import { kickDrawerAnimation } from './useDrawerSwipe';
+import { startTransition, useCallback, useMemo } from 'react';
+import { useRecoilCallback, useSetRecoilState } from 'recoil';
+import type { DrawerKickMode } from './useDrawerSwipe';
+import { getPendingDrawerFlip, kickDrawerAnimation } from './useDrawerSwipe';
 import store from '~/store';
+
+export type SidebarToggle = {
+  /**
+   * Opens/closes the sidebar with the slide-first contract. `afterSlide`
+   * carries follow-up work — conversation navigation, focus handoffs — that
+   * would otherwise run in the tap's task and flush its commit before the
+   * slide's first frame. On 'slide' it runs on the same three-frame cadence
+   * as the state flip; otherwise immediately.
+   */
+  setSidebarOpen: (next: boolean, afterSlide?: () => void) => DrawerKickMode;
+  /**
+   * Inverts the LATEST intent: a second press inside the deferral window
+   * reads the pending flip target, not the still-uncommitted atom value, so
+   * rapid presses alternate instead of piling onto the same direction.
+   */
+  toggleSidebar: () => void;
+};
 
 /**
  * The one path every sidebar open/close mutation takes. On mobile the drawer
@@ -12,20 +30,47 @@ import store from '~/store';
  * the keyboard shortcuts route through here too, not just the toggle
  * buttons. On desktop the flip applies immediately and the width transition
  * animates as before.
- *
- * Returns whether the drawer animator handled the slide, so callers can keep
- * non-drawer affordances (like the desktop focus timer) off the animated
- * path.
  */
-export default function useSidebarToggle(): (next: boolean) => boolean {
+export default function useSidebarToggle(): SidebarToggle {
   const setSidebarExpanded = useSetRecoilState(store.sidebarExpanded);
-  return useCallback(
-    (next: boolean) =>
-      kickDrawerAnimation(next, () => {
+
+  const setSidebarOpen = useCallback(
+    (next: boolean, afterSlide?: () => void) => {
+      const mode = kickDrawerAnimation(next, () => {
         startTransition(() => {
           setSidebarExpanded(next);
         });
-      }),
+      });
+      if (afterSlide != null) {
+        if (mode === 'slide') {
+          /** Same cadence as the deferred flip, but deliberately NOT gated
+           * on the animator surviving: the user action carried here (a
+           * navigation, a focus request) must not vanish because the
+           * breakpoint crossed mid-slide. */
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              requestAnimationFrame(afterSlide);
+            });
+          });
+        } else {
+          afterSlide();
+        }
+      }
+      return mode;
+    },
     [setSidebarExpanded],
   );
+
+  const toggleSidebar = useRecoilCallback(
+    ({ snapshot }) =>
+      () => {
+        const committed = snapshot.getLoadable(store.sidebarExpanded).valueMaybe() as
+          | boolean
+          | undefined;
+        setSidebarOpen(!(getPendingDrawerFlip() ?? committed ?? false));
+      },
+    [setSidebarOpen],
+  );
+
+  return useMemo(() => ({ setSidebarOpen, toggleSidebar }), [setSidebarOpen, toggleSidebar]);
 }

--- a/client/src/hooks/Nav/useSidebarToggle.ts
+++ b/client/src/hooks/Nav/useSidebarToggle.ts
@@ -1,0 +1,31 @@
+import { startTransition, useCallback } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { kickDrawerAnimation } from './useDrawerSwipe';
+import store from '~/store';
+
+/**
+ * The one path every sidebar open/close mutation takes. On mobile the drawer
+ * slide starts imperatively (see kickDrawerAnimation) and the Recoil flip is
+ * deferred past the first frames, so the commit — hundreds of ms on a large
+ * conversation — cannot delay first motion. Setting the atom directly
+ * reintroduces exactly that stall, which is why conversation selection and
+ * the keyboard shortcuts route through here too, not just the toggle
+ * buttons. On desktop the flip applies immediately and the width transition
+ * animates as before.
+ *
+ * Returns whether the drawer animator handled the slide, so callers can keep
+ * non-drawer affordances (like the desktop focus timer) off the animated
+ * path.
+ */
+export default function useSidebarToggle(): (next: boolean) => boolean {
+  const setSidebarExpanded = useSetRecoilState(store.sidebarExpanded);
+  return useCallback(
+    (next: boolean) =>
+      kickDrawerAnimation(next, () => {
+        startTransition(() => {
+          setSidebarExpanded(next);
+        });
+      }),
+    [setSidebarExpanded],
+  );
+}

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ import {
   parseBinding,
 } from '~/utils/shortcuts';
 import { mainTextareaId, NotificationSeverity } from '~/common';
+import useSidebarToggle from '~/hooks/Nav/useSidebarToggle';
 import { useArchiveConvoMutation } from '~/data-provider';
 import { useHasAccess, useLocalize } from '~/hooks';
 import useNewChat from '~/hooks/Chat/useNewChat';
@@ -500,7 +501,8 @@ export function useShortcutActions(): ShortcutAction[] {
   const routeConvoId = routeMatch?.params.conversationId ?? null;
   const conversation = useRecoilValue(store.conversationByIndex(0));
   const isSubmitting = useRecoilValue(store.isSubmittingFamily(0));
-  const [sidebarExpanded, setSidebarExpanded] = useRecoilState(store.sidebarExpanded);
+  const sidebarExpanded = useRecoilValue(store.sidebarExpanded);
+  const setSidebarOpen = useSidebarToggle();
   const setShowShortcutsDialog = useSetRecoilState(store.showShortcutsDialog);
   const setIsTemporary = useSetRecoilState(store.isTemporary);
   const setDeleteTarget = useSetRecoilState(store.keyboardDeleteTarget);
@@ -531,9 +533,9 @@ export function useShortcutActions(): ShortcutAction[] {
   }, []);
 
   const handleToggleSidebar = useCallback(() => {
-    setSidebarExpanded((prev) => !prev);
+    setSidebarOpen(!sidebarExpanded);
     return true;
-  }, [setSidebarExpanded]);
+  }, [sidebarExpanded, setSidebarOpen]);
 
   const handleOpenModelSelector = useCallback(
     () => clickElement('[data-testid="model-selector-button"]'),
@@ -566,7 +568,7 @@ export function useShortcutActions(): ShortcutAction[] {
     }
 
     if (!sidebarExpanded) {
-      setSidebarExpanded(true);
+      setSidebarOpen(true);
     }
 
     if (!sidebarExpanded || switchedPanel) {
@@ -575,7 +577,7 @@ export function useShortcutActions(): ShortcutAction[] {
     }
 
     return focusSearchInput();
-  }, [sidebarExpanded, setSidebarExpanded]);
+  }, [sidebarExpanded, setSidebarOpen]);
 
   const handleCopyLastResponse = useCallback(() => {
     return clickLastElement('[data-testid="copy-response-button"]');
@@ -796,14 +798,14 @@ export function useShortcutActions(): ShortcutAction[] {
       }
 
       if (!sidebarExpanded) {
-        setSidebarExpanded(true);
+        setSidebarOpen(true);
         setTimeout(activatePanel, 350);
         return true;
       }
 
       return activatePanel();
     },
-    [sidebarExpanded, setSidebarExpanded],
+    [sidebarExpanded, setSidebarOpen],
   );
 
   const handleOpenAssistants = useCallback(() => handleOpenPanel('assistants'), [handleOpenPanel]);

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -502,7 +502,7 @@ export function useShortcutActions(): ShortcutAction[] {
   const conversation = useRecoilValue(store.conversationByIndex(0));
   const isSubmitting = useRecoilValue(store.isSubmittingFamily(0));
   const sidebarExpanded = useRecoilValue(store.sidebarExpanded);
-  const setSidebarOpen = useSidebarToggle();
+  const { setSidebarOpen, toggleSidebar } = useSidebarToggle();
   const setShowShortcutsDialog = useSetRecoilState(store.showShortcutsDialog);
   const setIsTemporary = useSetRecoilState(store.isTemporary);
   const setDeleteTarget = useSetRecoilState(store.keyboardDeleteTarget);
@@ -533,9 +533,9 @@ export function useShortcutActions(): ShortcutAction[] {
   }, []);
 
   const handleToggleSidebar = useCallback(() => {
-    setSidebarOpen(!sidebarExpanded);
+    toggleSidebar();
     return true;
-  }, [sidebarExpanded, setSidebarOpen]);
+  }, [toggleSidebar]);
 
   const handleOpenModelSelector = useCallback(
     () => clickElement('[data-testid="model-selector-button"]'),
@@ -568,10 +568,17 @@ export function useShortcutActions(): ShortcutAction[] {
     }
 
     if (!sidebarExpanded) {
-      setSidebarOpen(true);
+      /** The focus rides `afterSlide` + a zero timer: it must queue behind
+       * the deferred flip's commit (which un-inerts the drawer), where a
+       * fixed 350ms guess could fire into the still-inert drawer and be
+       * silently ignored. */
+      setSidebarOpen(true, () => {
+        setTimeout(focusSearchInput, 0);
+      });
+      return true;
     }
 
-    if (!sidebarExpanded || switchedPanel) {
+    if (switchedPanel) {
       setTimeout(focusSearchInput, 350);
       return true;
     }
@@ -798,8 +805,12 @@ export function useShortcutActions(): ShortcutAction[] {
       }
 
       if (!sidebarExpanded) {
-        setSidebarOpen(true);
-        setTimeout(activatePanel, 350);
+        /** Queued behind the deferred flip's commit, like the search focus
+         * above — the panel button is unreachable while the drawer is
+         * inert. */
+        setSidebarOpen(true, () => {
+          setTimeout(activatePanel, 0);
+        });
         return true;
       }
 

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -18,7 +18,6 @@ import { UnifiedSidebar, SIDEBAR_TRANSITION } from '~/components/UnifiedSidebar'
 import KeyboardShortcutsDialog from '~/components/Nav/KeyboardShortcutsDialog';
 import KeyboardDeleteDialog from '~/components/Nav/KeyboardDeleteDialog';
 import { useUserTermsQuery, useGetStartupConfig } from '~/data-provider';
-import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
 import useKeyboardShortcuts from '~/hooks/useKeyboardShortcuts';
 import useSidebarState from '~/hooks/Nav/useSidebarState';
 import { TermsAndConditionsModal } from '~/components/ui';
@@ -47,18 +46,14 @@ export default function Root() {
     setExpanded: setSidebarExpanded,
   } = useSidebarState();
   const paneRef = useRef<HTMLDivElement>(null);
+  /** Focus handoff lives in the drawer header's own expanded-effect — the
+   * commit drives it, so every opener (button, swipe) is covered without a
+   * timer racing the deferred state flip. */
   const handleDrawerOpenChange = useCallback(
     (next: boolean) => {
       startTransition(() => {
         setSidebarExpanded(next);
       });
-      if (next) {
-        /** Same handoff as the OpenSidebar button: opening makes the pane
-         * inert, so keyboard/AT focus must land inside the drawer. */
-        setTimeout(() => {
-          document.getElementById(CLOSE_SIDEBAR_ID)?.focus();
-        }, 250);
-      }
     },
     [setSidebarExpanded],
   );

--- a/packages/client/src/components/Button.spec.tsx
+++ b/packages/client/src/components/Button.spec.tsx
@@ -18,6 +18,18 @@ describe('Button', () => {
     );
   });
 
+  it('renders the header-action toggle from semantic tokens', () => {
+    render(<Button variant="header-action">Toggle</Button>);
+
+    expect(screen.getByRole('button', { name: 'Toggle' })).toHaveClass(
+      'bg-presentation',
+      'border-border-light',
+      'rounded-xl',
+      'duration-0',
+      'hover:bg-surface-active-alt',
+    );
+  });
+
   it('preserves variant geometry until a shape is explicitly selected', () => {
     const { rerender } = render(<Button variant="subtle">Subtle</Button>);
     const button = screen.getByRole('button', { name: 'Subtle' });

--- a/packages/client/src/components/Button.tsx
+++ b/packages/client/src/components/Button.tsx
@@ -17,6 +17,7 @@ type ButtonVariantOptions =
         | 'ghost'
         | 'row-action'
         | 'section-action'
+        | 'header-action'
         | null
         | undefined;
       size?: 'default' | 'icon' | 'icon-sm' | 'icon-xs' | 'sm' | 'lg' | 'theme' | null | undefined;
@@ -49,6 +50,16 @@ const buttonVariantRecipe = cva(
          */
         'section-action':
           'rounded-md text-text-secondary hover:bg-surface-active-alt hover:text-text-primary focus-visible:ring-inset focus-visible:ring-offset-0',
+        /**
+         * A control floating on the presentation surface — the sidebar
+         * toggle in the chat header and its mirror in the mobile drawer
+         * header, so the pair reads as one persistent button across views.
+         * `duration-0` makes the hover fill instant: these sit over a
+         * scrolling gradient, where the shared color transition reads as
+         * lag rather than polish.
+         */
+        'header-action':
+          'rounded-xl border border-border-light bg-presentation text-text-primary duration-0 hover:bg-surface-active-alt hover:text-text-primary',
       },
       size: {
         default: 'h-10 px-4 py-2',


### PR DESCRIPTION
## Summary

Follow-up on mobile-redesign device feedback: (1) the drawer's close **X** is replaced by the same sidebar-toggle button the chat header uses, at the same far-left slot; (2) the **noticeable lag when switching views** is diagnosed with a reproducible harness and fixed — first drawer motion on a 60-message thread drops from **~459ms to ~88ms** (open) and **~428ms to ~44ms** (close) at 4× CPU throttle.

## The lag, measured and attributed

Harness: production build, Playwright (390×844 touch viewport), CDP 4× CPU throttle, seeded account (40 conversations, one 60-message markdown-heavy thread). Metric: tap (`pointerdown`) → first frame the drawer's computed transform changes, with `longtask` attribution and `transitionrun/start/end` telemetry.

| Scenario | Before | After |
|---|---|---|
| Open, 60-msg thread | 459ms | **88ms** |
| Close, 60-msg thread | 428ms | **44ms** |
| Open, empty chat | 80ms | **46ms** |

Three stacked causes, one commit each:

1. **`useAssistantsMap` minted a new context value every Root render** (bare object literal + `= {}` defaults), so every drawer toggle re-rendered every `AssistantsMapContext` consumer — message rows (`useMessageHelpers`), conversation icons, inputs. This alone was ~200ms of the block; fixing it took open from 459→258ms. Proven red by referential-stability specs (real react-query against a seeded cache; only the HTTP fetcher is stubbed at the module seam — its methods are non-configurable, so `spyOn` can't).
2. **`startTransition` never protected these toggles.** Recoil notifies subscribers outside the transition scope, so the flip's render flushed synchronously inside the tap's task (one ~200ms long task before any paint) — the slide could not start until the commit finished. `kickDrawerAnimation(next, applyState)` now starts the slide imperatively through the swipe hook's existing settle machinery (same transforms, same release lifecycle, same reconciliation) and runs the state flip three frames later, so the commit lands mid-slide, compositor-driven (`willChange` set in the tap's task). Desktop and logged-out layouts get `applyState` immediately — the width animation is untouched.
3. **A transition armed inside the click task never started for the offscreen drawer.** `transitionrun` fired only *after* the commit (~270ms late), even with a forced reflow in-task — while the identical write from a clean task interpolates by the next frame (isolated probe, four variants). The kick therefore writes the transforms in a fresh frame task with a forced reflow; a target check against the settle state voids the staged write if a retarget or reconciliation cancel lands in between.

`transitionstart→transitionend` spans confirm the slide runs its full 300ms uninterrupted while the commit executes; the rAF-gap "jank" counter reads 1 during that window only because the *sampling loop* starves — the animation is composited.

## Uniform toggle

`SIDEBAR_TOGGLE_CLASSES` is exported from `OpenSidebar` and shared by both buttons so they can't drift. The drawer button keeps its full a11y contract (`CLOSE_SIDEBAR_ID` claimed only while open, `aria-keyshortcuts`, tab-order gating) and now leads the header row — opening the drawer reads as the one persistent control flipping state, matching the chat header.

## Testing

- 162 tests green across the touched suites, including 7 new `kickDrawerAnimation` tests (slide-before-state ordering, desktop no-op, retarget, same-target no-op, drag precedence, reduced-motion snap) and 4 new map-stability specs (red pre-fix).
- All 22 pre-existing gesture tests unchanged and green — the settle refactor (`scheduleRelease`) is behavior-identical for swipes.
- ESLint and `tsc --noEmit` clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
