### PR TITLE
🛡️ fix: Validate Locize Changes Against Source Contracts

### DIFF
--- a/scripts/validate-locize-download.mjs
+++ b/scripts/validate-locize-download.mjs
@@ -55,21 +55,16 @@ function placeholders(value) {
   return (value.match(placeholderPattern) ?? []).sort().join('\u0000');
 }
 
+function boundaryWhitespace(value) {
+  return [value.match(/^\s*/u)?.[0] ?? '', value.match(/\s*$/u)?.[0] ?? ''].join('\u0000');
+}
+
 function compareFile(relative, base, current) {
   const baseValues = flatten(base);
   const currentValues = flatten(current);
-  for (const [key, baseValue] of baseValues) {
+  for (const [key] of baseValues) {
     if (!currentValues.has(key)) {
       errors.push(`${relative}: deleted key ${key}`);
-      continue;
-    }
-    const currentValue = currentValues.get(key);
-    if (typeof baseValue !== 'string' || typeof currentValue !== 'string') continue;
-    if (placeholders(baseValue) !== placeholders(currentValue)) {
-      errors.push(`${relative}: changed placeholders for ${key}`);
-    }
-    if (currentValue !== baseValue && currentValue !== currentValue.trim()) {
-      errors.push(`${relative}: introduced leading/trailing whitespace for ${key}`);
     }
   }
 }
@@ -106,8 +101,13 @@ if (currentSet.has(englishRelative)) {
         const source = englishValues.get(key);
         const baseline = baselineValuesByFile.get(relative)?.get(key);
         const changedSinceBaseline = baseline === undefined || baseline !== value;
-        if (changedSinceBaseline && typeof source === 'string' && typeof value === 'string' && placeholders(source) !== placeholders(value)) {
-          errors.push(`${relative}: placeholder mismatch with English for ${key}`);
+        if (changedSinceBaseline && typeof source === 'string' && typeof value === 'string') {
+          if (placeholders(source) !== placeholders(value)) {
+            errors.push(`${relative}: placeholder mismatch with English for ${key}`);
+          }
+          if (value !== value.trim() && boundaryWhitespace(source) !== boundaryWhitespace(value)) {
+            errors.push(`${relative}: introduced leading/trailing whitespace for ${key}`);
+          }
         }
       }
     }


### PR DESCRIPTION
I refined the Locize download guard so safe corrections to placeholders and boundary whitespace are accepted when they match the English source contract.

- Allow placeholder changes that restore the exact English placeholder set.
- Allow leading or trailing whitespace changes that mirror the English source value.
- Continue blocking deleted keys, placeholder mismatches, and unintended boundary whitespace.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Verified corrected Portuguese and Lithuanian fixture values pass validation.
- Verified a wrong placeholder and unintended trailing whitespace still fail validation.

### **Test Configuration**:

- Node.js local runtime
- Synthetic copies of all 41 locale files

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local validation passes with my changes
