### PR TITLE
🧱 fix: Backport Locize Contract Validation

### DIFF
--- a/scripts/validate-locize-download.mjs
+++ b/scripts/validate-locize-download.mjs
@@ -55,21 +55,16 @@ function placeholders(value) {
   return (value.match(placeholderPattern) ?? []).sort().join('\u0000');
 }
 
+function boundaryWhitespace(value) {
+  return [value.match(/^\s*/u)?.[0] ?? '', value.match(/\s*$/u)?.[0] ?? ''].join('\u0000');
+}
+
 function compareFile(relative, base, current) {
   const baseValues = flatten(base);
   const currentValues = flatten(current);
-  for (const [key, baseValue] of baseValues) {
+  for (const [key] of baseValues) {
     if (!currentValues.has(key)) {
       errors.push(`${relative}: deleted key ${key}`);
-      continue;
-    }
-    const currentValue = currentValues.get(key);
-    if (typeof baseValue !== 'string' || typeof currentValue !== 'string') continue;
-    if (placeholders(baseValue) !== placeholders(currentValue)) {
-      errors.push(`${relative}: changed placeholders for ${key}`);
-    }
-    if (currentValue !== baseValue && currentValue !== currentValue.trim()) {
-      errors.push(`${relative}: introduced leading/trailing whitespace for ${key}`);
     }
   }
 }
@@ -106,8 +101,13 @@ if (currentSet.has(englishRelative)) {
         const source = englishValues.get(key);
         const baseline = baselineValuesByFile.get(relative)?.get(key);
         const changedSinceBaseline = baseline === undefined || baseline !== value;
-        if (changedSinceBaseline && typeof source === 'string' && typeof value === 'string' && placeholders(source) !== placeholders(value)) {
-          errors.push(`${relative}: placeholder mismatch with English for ${key}`);
+        if (changedSinceBaseline && typeof source === 'string' && typeof value === 'string') {
+          if (placeholders(source) !== placeholders(value)) {
+            errors.push(`${relative}: placeholder mismatch with English for ${key}`);
+          }
+          if (value !== value.trim() && boundaryWhitespace(source) !== boundaryWhitespace(value)) {
+            errors.push(`${relative}: introduced leading/trailing whitespace for ${key}`);
+          }
         }
       }
     }


### PR DESCRIPTION
I backported the source-contract validation refinement so default-branch Locize dispatches accept safe placeholder and whitespace corrections.

- Allow placeholder changes that restore the exact English placeholder set.
- Allow leading or trailing whitespace changes that mirror the English source value.
- Continue blocking deleted keys, placeholder mismatches, and unintended boundary whitespace.
- Keep this backport limited to the change merged into `dev` in #14914.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Ran the validator against matching snapshots of all 41 locale files.
- Verified the original `dev` change with safe and unsafe placeholder/whitespace fixtures.

### **Test Configuration**:

- Node.js local runtime
- macOS shell

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local validation passes with my changes
