### PR TITLE
📚 fix: Keep English Source Repository-Owned

### DIFF
--- a/.github/workflows/locize-i18n-sync.yml
+++ b/.github/workflows/locize-i18n-sync.yml
@@ -84,6 +84,9 @@ jobs:
             --base-dir "$RUNNER_TEMP/locize-locale-baseline" \
             --current-dir client/src/locales
 
+      - name: Restore Repository English Source
+        run: cp "$RUNNER_TEMP/locize-locale-baseline/en/translation.json" client/src/locales/en/translation.json
+
       - name: Validate Downloaded Translations
         run: |
           node scripts/validate-locize-download.mjs \


### PR DESCRIPTION
I fixed the generated translation flow so Locize can never add, remove, reorder, or replace English source strings.

- Restore the repository English locale immediately after merging downloaded translations.
- Keep translated locale updates and missing-value preservation unchanged.
- Ensure generated translation pull requests contain translated locales only.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Parsed the workflow YAML successfully.
- Ran `git diff --check`.
- Simulated a Locize-only English key and verified the repository English file is restored byte-for-byte.

### **Test Configuration**:

- GitHub Actions workflow syntax
- Synthetic English locale download

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local validation passes with my changes
