### PR TITLE
🎬 style: Reveal the Chat on Programmatic Drawer Closes

### DIFF
--- a/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
+++ b/client/src/hooks/Nav/__tests__/useDrawerSwipe.spec.tsx
@@ -494,7 +494,7 @@ describe('useDrawerSwipe — kickDrawerAnimation (button toggles)', () => {
     kickDrawerAnimation(false, jest.fn());
 
     expect(harness.drawer.style.transform).toBe('translate3d(-100%, 0, 0)');
-    expect(harness.pane.style.transform).toBe('translate3d(0, 0, 0)');
+    expect(harness.pane.style.transform).toBe('none');
 
     harness.rerender({ open: false, enabled: true });
     jest.runAllTimers();
@@ -610,6 +610,33 @@ describe('useDrawerSwipe — kickDrawerAnimation (button toggles)', () => {
     jest.advanceTimersByTime(400);
     expect(harness.drawer.style.transform).toBe('');
     expect(harness.pane.style.transform).toBe('translateX(100%)');
+    jest.useRealTimers();
+    harness.unmount();
+  });
+
+  /**
+   * A programmatic close is a REVEAL: the pane repositions instantly under
+   * the opaque drawer's cover and only the drawer animates away. Animating
+   * the pane in from the right made every tap-to-navigate close visibly
+   * shift the chat leftward while the new conversation committed into the
+   * moving layer mid-slide. The gesture keeps the paired motion — a finger
+   * drags both — via `settle`, which this does not touch.
+   */
+  it('reveals on a programmatic close: pane snaps under cover, only the drawer slides', () => {
+    jest.useFakeTimers();
+    const harness = setup(true);
+
+    kickDrawerAnimation(false, jest.fn());
+
+    expect(harness.drawer.style.transform).toBe('translate3d(-100%, 0, 0)');
+    expect(harness.drawer.style.transition).not.toBe('none');
+    expect(harness.pane.style.transform).toBe('none');
+    expect(harness.pane.style.transition).toBe('none');
+
+    harness.rerender({ open: false, enabled: true });
+    jest.runAllTimers();
+    expect(harness.pane.style.transition).not.toBe('none');
+    expect(harness.drawer.style.transform).toBe('');
     jest.useRealTimers();
     harness.unmount();
   });

--- a/client/src/hooks/Nav/useDrawerSwipe.ts
+++ b/client/src/hooks/Nav/useDrawerSwipe.ts
@@ -343,7 +343,9 @@ export default function useDrawerSwipe({
         return;
       }
       drawer.style.willChange = 'transform';
-      pane.style.willChange = 'transform';
+      if (next) {
+        pane.style.willChange = 'transform';
+      }
       /** Armed BEFORE the frame below (id: null — no deadline yet) so the
        * staged write can verify its target is still wanted, and so a
        * touchstart in between defers to the pending settle. A retarget or
@@ -366,9 +368,22 @@ export default function useDrawerSwipe({
           return;
         }
         drawer.style.transition = SIDEBAR_TRANSITION;
-        pane.style.transition = SIDEBAR_TRANSITION;
         drawer.style.transform = next ? 'translate3d(0, 0, 0)' : 'translate3d(-100%, 0, 0)';
-        pane.style.transform = next ? 'translateX(100%)' : 'translate3d(0, 0, 0)';
+        if (next) {
+          pane.style.transition = SIDEBAR_TRANSITION;
+          pane.style.transform = 'translateX(100%)';
+        } else {
+          /** A programmatic close is a REVEAL: the pane repositions
+           * instantly beneath the opaque drawer's cover and only the
+           * drawer slides away, uncovering content already in place.
+           * Animating the pane in from the right made every
+           * tap-to-navigate close visibly shift the chat leftward while
+           * the new conversation committed into the moving layer
+           * mid-slide. The gesture keeps the paired both-move motion in
+           * `settle` — there a finger drags both surfaces. */
+          pane.style.transition = 'none';
+          pane.style.transform = 'none';
+        }
         void drawer.getBoundingClientRect();
         armed.id = setTimeout(() => {
           settleRef.current = null;


### PR DESCRIPTION
## Summary

Follow-up to #14913 from device testing: tapping a conversation closed the drawer with a jarring right-to-left shift — the chat pane animated in from the right while the new conversation committed **into the moving layer** mid-slide. The paired "move as one object" motion is exactly right when a finger drags both surfaces, and exactly wrong for a programmatic close.

## Change

Programmatic closes (conversation tap, toggle button, New Chat, Escape, shortcuts) become a **reveal**: the pane repositions instantly beneath the opaque drawer's cover — an invisible jump — and only the drawer slides away, uncovering content already sitting in place. The navigation's content swap lands in a static pane instead of an animating layer.

- The edge-swipe gesture is untouched: `settle` keeps the paired both-move motion, where the finger owns both surfaces.
- Opens are untouched: nothing swaps content on open, and the paired slide-in reads correctly there.
- `willChange` is no longer set on the pane for closes (nothing animates it), and the pane's suppressed transition is restored by the existing release lifecycle.
- A close→open retarget re-enters the paired path cleanly from the pane's revealed position.

## Testing

- New behavior test proven red first: on a kicked close, the pane must hold `transform: none` with its transition suppressed while the drawer alone carries the slide, and the release must restore the shared transition.
- Retarget expectations updated to the reveal contract; all 42 Nav-hook tests and the UnifiedSidebar suites green; ESLint and `tsc --noEmit` clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
