### PR TITLE
fix(mcp): distinguish request-scoped servers from disconnected ones in status badge

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -33,6 +33,7 @@ const {
   requiresEphemeralUserConnection,
   requiresOAuthMachinery,
   hasRuntimeUrlPlaceholders,
+  hasRuntimeBodyPlaceholders,
   containsGraphTokenPlaceholder,
   isOAuthServer,
 } = require('@librechat/api');
@@ -1355,7 +1356,7 @@ function canDetectMCPRuntimeOAuth(config) {
  * @param {Map<string, import('@librechat/api').MCPConnection>} userConnections - User-level connections
  * @param {Set} oauthServers - Set of OAuth servers
  * @param {{ user?: Partial<IUser>, userMCPAuthMap?: Record<string, Record<string, string>>, loadUserMCPAuthMap?: () => Promise<Record<string, Record<string, string>> | undefined>, loadMCPAllowlists?: () => Promise<{ allowedDomains?: string[] | null, allowedAddresses?: string[] | null }> }} [runtimeContext]
- * @returns {Object} Object containing requiresOAuth and connectionState
+ * @returns {Object} Object containing requiresOAuth, requiresRequestScope, connectionState, and authorizationState
  */
 async function getServerConnectionStatus(
   userId,
@@ -1372,6 +1373,7 @@ async function getServerConnectionStatus(
   const liveConnectionOAuth = connection?.usesOAuth?.() === true;
   const runtimeOAuthCandidate = canDetectMCPRuntimeOAuth(config);
   const effectiveOAuth = configuredOAuth || liveConnectionOAuth;
+  const requiresRequestScope = hasRuntimeBodyPlaceholders(config);
 
   const baseConnectionState = isStaleOrDoNotExist
     ? 'disconnected'
@@ -1416,6 +1418,7 @@ async function getServerConnectionStatus(
 
   return {
     requiresOAuth,
+    requiresRequestScope,
     connectionState: finalConnectionState,
     authorizationState,
   };

--- a/api/server/services/__tests__/MCP.spec.js
+++ b/api/server/services/__tests__/MCP.spec.js
@@ -89,6 +89,7 @@ const {
   resolveAllMcpConfigs,
   resolveMcpServerContext,
   resolveCollisionAuditNames,
+  getServerConnectionStatus,
 } = require('../MCP');
 
 describe('getAssistantToolDefinitions', () => {
@@ -580,5 +581,50 @@ describe('createMCPTool', () => {
     expect(toolInstance).toBeDefined();
     expect(toolInstance.name).toBe(canonicalToolKey);
     expect(reinitMCPServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('getServerConnectionStatus', () => {
+  const appConnections = new Map();
+  const userConnections = new Map();
+  const oauthServers = new Set();
+
+  it('marks request-scoped servers (body placeholders) as requiresRequestScope', async () => {
+    const config = {
+      type: 'streamable-http',
+      url: 'http://my-server:8000/mcp',
+      headers: {
+        'X-Conversation-ID': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+        'X-Parent-Message-ID': '{{LIBRECHAT_BODY_PARENTMESSAGEID}}',
+      },
+    };
+    const result = await getServerConnectionStatus(
+      'user-1',
+      'scoped-server',
+      config,
+      appConnections,
+      userConnections,
+      oauthServers,
+    );
+    expect(result.connectionState).toBe('disconnected');
+    expect(result.requiresRequestScope).toBe(true);
+  });
+
+  it('does not mark regular servers as requiresRequestScope', async () => {
+    const config = {
+      type: 'streamable-http',
+      url: 'http://my-server:8000/mcp',
+      headers: { 'X-Api-Key': 'static-key' },
+    };
+    const result = await getServerConnectionStatus(
+      'user-1',
+      'regular-server',
+      config,
+      appConnections,
+      userConnections,
+      oauthServers,
+    );
+    expect(result.connectionState).toBe('disconnected');
+    expect(result.requiresRequestScope).toBe(false);
   });
 });

--- a/client/src/components/MCP/MCPServerStatusIcon.tsx
+++ b/client/src/components/MCP/MCPServerStatusIcon.tsx
@@ -134,6 +134,8 @@ function CompactStatusDot({ serverStatus, isInitializing }: CompactStatusDotProp
     colorClass = 'bg-status-error';
   } else if (connectionState === 'disconnected' && requiresOAuth) {
     colorClass = 'bg-status-warning';
+  } else if (connectionState === 'disconnected' && serverStatus.requiresRequestScope) {
+    colorClass = 'bg-status-info';
   }
 
   return (

--- a/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
@@ -79,8 +79,11 @@ export default function MCPServerCard({
     if (connectionState === 'connecting') return localize('com_nav_mcp_status_connecting');
     if (connectionState === 'error') return localize('com_nav_mcp_status_error');
     if (connectionState === 'disconnected') {
-      return requiresOAuth
-        ? localize('com_nav_mcp_status_needs_auth')
+      if (requiresOAuth) {
+        return localize('com_nav_mcp_status_needs_auth');
+      }
+      return serverStatus.requiresRequestScope
+        ? localize('com_nav_mcp_status_on_demand')
         : localize('com_nav_mcp_status_disconnected');
     }
     return localize('com_nav_mcp_status_unknown');

--- a/client/src/components/SidePanel/MCPBuilder/MCPStatusBadge.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPStatusBadge.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@librechat/client';
-import { Check, PlugZap } from 'lucide-react';
+import { Check, PlugZap, Zap } from 'lucide-react';
 import type { MCPServerStatus } from 'librechat-data-provider';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
@@ -80,6 +80,18 @@ export default function MCPStatusBadge({
         </div>
       );
     }
+    if (serverStatus.requiresRequestScope) {
+      // Request-scoped server — connects on demand per chat turn, so "disconnected" is the normal idle state
+      return (
+        <div
+          role="status"
+          className={cn(badgeBaseClass, 'bg-status-info-subtle text-status-info')}
+        >
+          <Zap className="size-3" aria-hidden="true" />
+          <span>{localize('com_nav_mcp_status_on_demand')}</span>
+        </div>
+      );
+    }
     // Simply disconnected - gray (neutral)
     return (
       <div
@@ -121,7 +133,7 @@ export default function MCPStatusBadge({
  *
  * Colors:
  * - Green: Connected
- * - Blue: Connecting/Initializing
+ * - Blue: Connecting/Initializing, or request-scoped (on-demand) while disconnected
  * - Amber: Needs action (OAuth required while disconnected)
  * - Gray: Disconnected (neutral)
  * - Red: Error
@@ -153,8 +165,11 @@ export function getStatusDotColor(
   }
 
   if (connectionState === 'disconnected') {
-    // Needs OAuth = amber, otherwise gray
-    return requiresOAuth ? 'bg-status-warning' : 'bg-status-neutral';
+    // Needs OAuth = amber, request-scoped = blue, otherwise gray
+    if (requiresOAuth) {
+      return 'bg-status-warning';
+    }
+    return serverStatus.requiresRequestScope ? 'bg-status-info' : 'bg-status-neutral';
   }
 
   return 'bg-status-neutral';

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -608,6 +608,7 @@
   "com_nav_mcp_status_error": "Error",
   "com_nav_mcp_status_initializing": "Initializing",
   "com_nav_mcp_status_needs_auth": "Needs Auth",
+  "com_nav_mcp_status_on_demand": "On-demand",
   "com_nav_mcp_status_unknown": "Unknown",
   "com_nav_mcp_vars_update_error": "Error updating MCP custom user variables",
   "com_nav_mcp_vars_updated": "MCP custom user variables updated successfully.",

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -209,6 +209,8 @@ export type ListRolesResponse = {
 
 export interface MCPServerStatus {
   requiresOAuth: boolean;
+  /** True when the server config uses LIBRECHAT_BODY_* placeholders — its connection is request-scoped and torn down after each chat turn, so "disconnected" is the normal idle state. */
+  requiresRequestScope?: boolean;
   connectionState: 'disconnected' | 'connecting' | 'connected' | 'error';
   authorizationState?:
     | 'not_required'


### PR DESCRIPTION
## Summary

Closes #14927

Request-scoped MCP servers (configured with `{{LIBRECHAT_BODY_CONVERSATIONID}}` / `{{LIBRECHAT_BODY_PARENTMESSAGEID}}` placeholders) tear down their streamable-http connection shortly after each chat turn, so the connections `Map` is empty almost all the time. `getServerConnectionStatus()` fell back to `'disconnected'` whenever no live entry existed — making a correctly-configured on-demand server look identical to a genuinely broken one in the MCP panel.

This adds a `requiresRequestScope` boolean to the status response (detected via the existing `hasRuntimeBodyPlaceholders` helper from `@librechat/api`), and renders a distinct **On-demand** badge (info blue, `Zap` icon) instead of the neutral gray **Disconnected** treatment. The badge text, status dot color, and server card status label all reflect the new state.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Test Configuration:

- **Backend unit test** (`api/server/services/__tests__/MCP.spec.js`): two new tests for `getServerConnectionStatus` — a request-scoped config (body placeholders in headers) returns `requiresRequestScope: true`; a regular config returns `false`.
- All 31 service tests pass (`npx jest server/services/__tests__/MCP.spec.js`).
- All 137 route tests pass (`npx jest server/routes/__tests__/mcp.spec.js`).
- All 26 frontend MCP component tests pass.
- `tsc --noEmit` clean on the client workspace.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes