### PR TITLE
🩹 ci: Codegraph Probe Summary Rendering

### DIFF
--- a/.github/workflows/codegraph-select.yml
+++ b/.github/workflows/codegraph-select.yml
@@ -50,7 +50,7 @@ jobs:
             exit 0
           fi
 
-          echo "$RESP" | jq -r '
+          TABLE=$(echo "$RESP" | jq -r '
             "graph `\(.gate.head[0:12] // "?")` · \(.engine) · \(.mode) · \(.ms)ms · reached \(.reached)",
             "",
             "| workspace | decision |",
@@ -62,11 +62,20 @@ jobs:
             "",
             "matrix: " + ([.matrix | to_entries[] | .key as $wf | .value | to_entries[] |
               "\($wf)/\(.key)=" + (if .value then "run" else "SKIP" end)] | join("  ")),
-            (if .shards then "shards: " + (.shards | to_json) else empty end),
-            (if .lock_workspaces then "lockfile → " + (.lock_workspaces | to_json) else empty end),
+            (if .shards then "shards: " + (.shards | tojson) else empty end),
+            (if .lock_workspaces then "lockfile → " + (.lock_workspaces | tojson) else empty end),
             (if .e2e and (.e2e.error | not) then
               "e2e tiers: must \(.e2e.must_run | length) · floor \(.e2e.floor | length) · skippable \(.e2e.skippable | length)" +
               (if (.e2e.must_run | length) > 0 then " — must: " + (.e2e.must_run[:4] | join(", ")) else "" end)
             else empty end)
-          ' >> "$GITHUB_STEP_SUMMARY"
+          ' 2>render.err)
+          if [ -n "$TABLE" ]; then
+            echo "$TABLE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            note "_summary render failed: $(head -c 200 render.err 2>/dev/null)_"
+            note '~~~'
+            note "${RESP:0:600}"
+            note '~~~'
+          fi
+          echo "rendered summary: ${#TABLE} chars"
           exit 0


### PR DESCRIPTION
## Problem

Every probe run since #14936 merged has rendered an **empty summary** — just the header line. The render program used `to_json`, which is not a jq builtin (`tojson` is), so the single jq invocation that renders the whole table failed to compile on every run. The observe-only exit-0 design masked it: runs showed green, summaries showed nothing.

## Fix

- `to_json` → `tojson` (both occurrences)
- Render failures are now **visible instead of silent**: if the renderer produces nothing, the summary gets the render error plus the first 600 chars of the raw response — still exit 0, still gating nothing
- The job log now prints `rendered summary: N chars` so render health is checkable via the API

## Verification

The exact `run:` script was executed locally (env-isolated, same gh files fetch, live endpoint) against four response shapes: floor-forced FULL, scoped FILES selection, e2e-error, and gate-fail. All render correctly. Replaying #14941 (the agents 3.6.3 bump) produces the intended showcase table — lockfile attribution narrowing to `[api, packages/api]`, client suites `no tests`, three matrix jobs SKIP.

(Server-side, two companion bugs found during the same investigation were already fixed and deployed to the service: null `patch` fields on oversized diffs no longer 400 the request, and lockfile attribution now works from the sandboxed API's own mirror instead of silently degrading to ALL.)

The probe run on **this PR** demonstrates the fixed render.