### PR TITLE
🚏 fix: Preserve Endpoint Routing on HITL Resume Replay

### DIFF
--- a/api/server/routes/agents/chat.js
+++ b/api/server/routes/agents/chat.js
@@ -5,6 +5,7 @@ const {
   generateCheckAccess,
   skipAgentCheck,
   applyResumeContext,
+  applyResumeModelParameters,
   GenerationJobManager,
 } = require('@librechat/api');
 const { PermissionTypes, Permissions, PermissionBits } = require('librechat-data-provider');
@@ -56,14 +57,9 @@ const restoreResumeContext = async (req, res, next) => {
       // resume payload omits — without this the continuation runs with defaults. They're
       // scattered top-level fields (folded into model_parameters by buildOptions' rest
       // spread), not part of the RESUME_CONTEXT_KEYS allowlist, so merge them back here.
-      // Authoritative: overwrites any client-supplied values with the captured set.
-      // `model` is excluded — it's replayed via RESUME_CONTEXT_KEYS to the exact value the
-      // resume fingerprint was pinned on, so overwriting it here could trip that check.
-      const resumedModelParameters = resumeContext?.model_parameters;
-      if (resumedModelParameters && typeof resumedModelParameters === 'object') {
-        const { model: _replayedModel, ...replayParams } = resumedModelParameters;
-        Object.assign(req.body, replayParams);
-      }
+      // Generation params are authoritative, but routing, graph identity, and resume-action
+      // fields remain owned by the restored context/request envelope.
+      applyResumeModelParameters(req.body, resumeContext?.model_parameters);
     }
   } catch (err) {
     logger.warn('[agents/chat] Failed to restore resume context', err?.message ?? err);

--- a/packages/api/src/agents/hitl/policy.spec.ts
+++ b/packages/api/src/agents/hitl/policy.spec.ts
@@ -12,6 +12,7 @@ import {
   sanitizeResumeModelParameters,
   pickResumeContext,
   applyResumeContext,
+  applyResumeModelParameters,
   exemptAskUserQuestionFromApproval,
 } from './policy';
 
@@ -319,6 +320,7 @@ describe('sanitizeResumeModelParameters', () => {
       authOptions: { credentials: { private_key: 'google-secret' } },
       credentials: { accessKeyId: 'aws-id', secretAccessKey: 'aws-secret' },
       client: { config: { token: { token: 'bedrock-bearer' } } },
+      endpoint: 'aiplatform.eu.rep.googleapis.com',
       endpointHost: 'vpce.internal.example',
       baseURL: 'https://internal-gateway.example',
     });
@@ -472,6 +474,19 @@ describe('captureResumeModelParameters', () => {
     expect(captureResumeModelParameters({ temperature: 0.5 }, undefined)).toEqual({
       temperature: 0.5,
     });
+  });
+
+  test('does not capture a provider transport endpoint for request replay (#14946)', () => {
+    expect(
+      captureResumeModelParameters(
+        { temperature: 0.2 },
+        {
+          model: 'gemini-3.7-flash',
+          temperature: 0.2,
+          endpoint: 'aiplatform.eu.rep.googleapis.com',
+        },
+      ),
+    ).toEqual({ model: 'gemini-3.7-flash', temperature: 0.2 });
   });
 
   test('only replays schema-known generation params; identity fields stay owned elsewhere', () => {
@@ -691,6 +706,52 @@ describe('pickResumeContext / applyResumeContext', () => {
     applyResumeContext(reloadedBody, action.resumeContext);
     expect(reloadedBody.ephemeralAgent).toEqual({ execute_code: true });
     expect(reloadedBody.promptPrefix).toBe('p');
+  });
+});
+
+describe('applyResumeModelParameters', () => {
+  it('replays generation params without replacing routing or resume identity fields (#14946)', () => {
+    const body: Record<string, unknown> = {
+      conversationId: 'conversation-1',
+      generationCreatedAt: 123,
+      actionId: 'action-1',
+      endpoint: 'agents',
+      endpointType: 'google',
+      agent_id: 'agent-1',
+      model: 'gemini-3.7-flash',
+      temperature: 1,
+    };
+
+    applyResumeModelParameters(body, {
+      conversationId: 'provider-conversation',
+      generationCreatedAt: 999,
+      actionId: 'provider-action',
+      endpoint: 'aiplatform.eu.rep.googleapis.com',
+      endpointType: 'custom',
+      agent_id: 'provider-agent',
+      model: 'provider-model',
+      temperature: 0.2,
+      maxOutputTokens: 2048,
+    });
+
+    expect(body).toEqual({
+      conversationId: 'conversation-1',
+      generationCreatedAt: 123,
+      actionId: 'action-1',
+      endpoint: 'agents',
+      endpointType: 'google',
+      agent_id: 'agent-1',
+      model: 'gemini-3.7-flash',
+      temperature: 0.2,
+      maxOutputTokens: 2048,
+    });
+  });
+
+  it('is a no-op for invalid captured parameters', () => {
+    const body: Record<string, unknown> = { endpoint: 'agents' };
+    applyResumeModelParameters(body, undefined);
+    applyResumeModelParameters(body, ['aiplatform.eu.rep.googleapis.com']);
+    expect(body).toEqual({ endpoint: 'agents' });
   });
 });
 

--- a/packages/api/src/agents/hitl/policy.ts
+++ b/packages/api/src/agents/hitl/policy.ts
@@ -278,6 +278,7 @@ const SENSITIVE_PARAM_KEYS = new Set([
   'httpagent',
   'httpsagent',
   'callbacks',
+  'endpoint',
   'endpointhost',
   'endpoint_host',
 ]);
@@ -511,6 +512,38 @@ export function applyResumeContext(
       body[key] = ctx[key];
     } else {
       delete body[key];
+    }
+  }
+}
+
+/** Request-envelope fields that resolved provider params must never replace. */
+const RESUME_REQUEST_CONTROL_KEYS = new Set<string>([
+  ...RESUME_CONTEXT_KEYS,
+  'conversationId',
+  'generationCreatedAt',
+  'generationProtocolVersion',
+  'actionId',
+  'decisions',
+  'answer',
+  'answers',
+  'isTemporary',
+]);
+
+/**
+ * Replay captured generation parameters without allowing provider configuration to
+ * replace routing, graph identity, or resume-action fields. This guard also makes
+ * pending actions captured by older versions safe to resume after an upgrade.
+ */
+export function applyResumeModelParameters(
+  body: Record<string, unknown> | undefined | null,
+  params: unknown,
+): void {
+  if (body == null || params == null || typeof params !== 'object' || Array.isArray(params)) {
+    return;
+  }
+  for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+    if (!RESUME_REQUEST_CONTROL_KEYS.has(key)) {
+      body[key] = value;
     }
   }
 }


### PR DESCRIPTION
## Summary

I fixed HITL resume replay so resolved provider transport settings cannot overwrite LibreChat routing and resume-control fields.

- Filter plain provider `endpoint` values from persisted resume model parameters so Vertex AI hostnames are re-derived server-side.
- Add shared protected replay logic for endpoint routing, agent identity, generation identity, and answer/approval fields.
- Preserve authoritative generation parameters such as temperature and maximum output tokens during resume.
- Cover the Gemini Enterprise Agent Platform EU hostname regression and older pending actions that already contain conflicting fields.
- Fix #14946.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the focused HITL policy suite: `npx jest src/agents/hitl/policy.spec.ts --runInBand --coverage=false` (58 tests passed).
- Checked the changed files with Prettier.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js: v24.16.0
- Platform: macOS
- Target branch: `dev`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes