### PR TITLE
🩹 ci: Quote Colon in Codegraph Votes Workflow (Invalid YAML)

### DIFF
--- a/.github/workflows/codegraph-e2e-votes.yml
+++ b/.github/workflows/codegraph-e2e-votes.yml
@@ -189,4 +189,4 @@ jobs:
 
       - name: Done
         if: always()
-        run: echo "codegraph-votes: complete"
+        run: 'echo "codegraph-votes: complete"'


### PR DESCRIPTION
#14947's final step used an inline `run:` scalar containing a colon-space — `echo "codegraph-votes: complete"` — which YAML parses as a nested mapping, making the whole workflow file invalid (GitHub: *error in your yaml syntax on line 192*).

Because parsing fails before branch filters are evaluated, **every push to any branch carrying the file has been spawning a red startup-failure run** (zero jobs) — that's the string of ✗ marks on dev and feature branches since the merge. No vote has actually executed yet.

Fix: quote the scalar. Verified by strict-parsing both codegraph workflows with js-yaml (the same message on line 78 was always legal — it lives in a `run: |` block).

After this merges, pushes to dev parse the file, the `branches: [dev]` filter applies, and branch pushes stop generating runs — existing feature branches stop showing red once they rebase past this fix.