### PR TITLE
🔒 fix: Add SAS download URLs for private Azure Blob containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -991,6 +991,8 @@ AWS_BUCKET_NAME=
 AZURE_STORAGE_CONNECTION_STRING=
 AZURE_STORAGE_PUBLIC_ACCESS=false
 AZURE_CONTAINER_NAME=files
+# Lifetime of generated read-only SAS download URLs, in seconds (default 3600)
+# AZURE_STORAGE_URL_EXPIRY_SECONDS=3600
 
 #========================#
 # Shared Links           #

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -1,20 +1,26 @@
 const fs = require('fs');
 const path = require('path');
 const mime = require('mime');
-const axios = require('axios');
 const fetch = require('node-fetch');
 const { logger } = require('@librechat/data-schemas');
 const {
   deleteRagFile,
   assertRemoteFileURL,
   getAzureContainerClient,
+  initializeAzureBlobService,
   getRemoteFileFetchMaxBytes,
   getRemoteFileFetchTimeoutMs,
   assertRemoteFileContentLength,
+  sanitizeContentDispositionFilename,
 } = require('@librechat/api');
 
 const defaultBasePath = 'images';
 const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } = process.env;
+/** Lifetime of a generated SAS URL, in seconds. */
+const azureUrlExpirySeconds =
+  parseInt(process.env.AZURE_STORAGE_URL_EXPIRY_SECONDS ?? '', 10) || 3600;
+/** How far in the past a SAS URL starts, to absorb host clock drift. */
+const sasClockSkewMs = 5 * 60 * 1000;
 
 /**
  * Uploads a buffer to Azure Blob Storage.
@@ -244,22 +250,123 @@ async function uploadFileToAzure({
 }
 
 /**
+ * Resolves the blob name (the path within the container) from a stored filepath.
+ * Records hold the absolute blob URL, but a container-relative path is accepted too.
+ *
+ * @param {import('@azure/storage-blob').ContainerClient} containerClient
+ * @param {string} fileURL - The stored blob URL or container-relative path.
+ * @returns {string} The blob name.
+ */
+function getBlobName(containerClient, fileURL) {
+  if (!fileURL) {
+    throw new Error('No file path provided');
+  }
+
+  if (!/^https?:\/\//i.test(fileURL)) {
+    return fileURL.replace(/^\/+/, '');
+  }
+
+  const { pathname } = new URL(fileURL);
+  const blobPath = decodeURIComponent(pathname).replace(/^\/+/, '');
+  const containerPrefix = `${containerClient.containerName}/`;
+  return blobPath.startsWith(containerPrefix) ? blobPath.slice(containerPrefix.length) : blobPath;
+}
+
+/**
  * Retrieves a readable stream for a blob from Azure Blob Storage.
+ *
+ * Uses the authenticated client rather than a plain HTTP GET: an unauthenticated
+ * request only works when the container allows anonymous access, so on a private
+ * container every read (vision, previews, downloads, avatars) fails.
  *
  * @param {object} _req - The Express request object.
  * @param {string} fileURL - The URL of the blob.
- * @returns {Promise<ReadableStream>} A readable stream of the blob.
+ * @returns {Promise<NodeJS.ReadableStream>} A readable stream of the blob.
  */
 async function getAzureFileStream(_req, fileURL) {
   try {
-    const response = await axios({
-      method: 'get',
-      url: fileURL,
-      responseType: 'stream',
-    });
-    return response.data;
+    const containerClient = await getAzureContainerClient();
+    if (!containerClient) {
+      throw new Error('Azure Blob Service not initialized');
+    }
+    const blobClient = containerClient.getBlobClient(getBlobName(containerClient, fileURL));
+    const response = await blobClient.download();
+    return response.readableStreamBody;
   } catch (error) {
     logger.error('[getAzureFileStream] Error getting blob stream:', error);
+    throw error;
+  }
+}
+
+/**
+ * Generates a short-lived, read-only SAS URL for a blob, so private containers can
+ * serve direct downloads the way S3 presigned URLs do.
+ *
+ * Signs with the account key when one is configured, and falls back to a user
+ * delegation key (Managed Identity) when it is not.
+ *
+ * @param {object} params
+ * @param {MongoFile} params.file - The file object.
+ * @param {string | null} [params.customFilename] - Optional download filename.
+ * @param {string | null} [params.contentType] - Optional response content type.
+ * @returns {Promise<string>} The SAS URL.
+ */
+async function getAzureDownloadURL({ file, customFilename = null, contentType = null }) {
+  try {
+    const containerClient = await getAzureContainerClient();
+    if (!containerClient) {
+      throw new Error('Azure Blob Service not initialized');
+    }
+
+    const { BlobSASPermissions, generateBlobSASQueryParameters } = await import(
+      '@azure/storage-blob'
+    );
+
+    const blobName = getBlobName(containerClient, file.filepath);
+    const blobClient = containerClient.getBlobClient(blobName);
+
+    const now = Date.now();
+    /** Azure validates `st`/`se` against its own clock, so start in the past to
+     * absorb clock drift on the host rather than returning "Signature not valid
+     * in the specified time frame". */
+    const startsOn = new Date(now - sasClockSkewMs);
+    const expiresOn = new Date(now + azureUrlExpirySeconds * 1000);
+
+    /** @type {import('@azure/storage-blob').BlobGenerateSasUrlOptions} */
+    const options = {
+      permissions: BlobSASPermissions.parse('r'),
+      startsOn,
+      expiresOn,
+    };
+    if (customFilename) {
+      const safeFilename = sanitizeContentDispositionFilename(customFilename);
+      options.contentDisposition = `attachment; filename="${safeFilename}"`;
+    }
+    if (contentType) {
+      options.contentType = contentType;
+    }
+
+    try {
+      return await blobClient.generateSasUrl(options);
+    } catch (error) {
+      logger.debug(
+        '[getAzureDownloadURL] No account key available for signing, using a user delegation key',
+        error?.message,
+      );
+      const serviceClient = await initializeAzureBlobService();
+      if (!serviceClient) {
+        throw new Error('Azure Blob Service not initialized');
+      }
+      const userDelegationKey = await serviceClient.getUserDelegationKey(startsOn, expiresOn);
+      const sasToken = generateBlobSASQueryParameters(
+        { containerName: containerClient.containerName, blobName, ...options },
+        userDelegationKey,
+        containerClient.accountName,
+      ).toString();
+      return `${blobClient.url}?${sasToken}`;
+    }
+  } catch (error) {
+    logger.error('[getAzureDownloadURL] Error generating SAS URL:', error);
     throw error;
   }
 }
@@ -271,4 +378,5 @@ module.exports = {
   deleteFileFromAzure,
   uploadFileToAzure,
   getAzureFileStream,
+  getAzureDownloadURL,
 };

--- a/api/server/services/Files/Azure/crud.spec.js
+++ b/api/server/services/Files/Azure/crud.spec.js
@@ -1,0 +1,115 @@
+const { getAzureFileStream, getAzureDownloadURL } = require('./crud');
+const { getAzureContainerClient, initializeAzureBlobService } = require('@librechat/api');
+
+jest.mock('@librechat/api', () => ({
+  deleteRagFile: jest.fn(),
+  assertRemoteFileURL: jest.fn((url) => url),
+  getAzureContainerClient: jest.fn(),
+  initializeAzureBlobService: jest.fn(),
+  getRemoteFileFetchMaxBytes: jest.fn(() => 1024),
+  getRemoteFileFetchTimeoutMs: jest.fn(() => 1000),
+  assertRemoteFileContentLength: jest.fn(),
+  sanitizeContentDispositionFilename: jest.fn((name) => name),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('~/models', () => ({ updateUser: jest.fn(), updateFile: jest.fn() }), {
+  virtual: true,
+});
+
+const BLOB_URL =
+  'https://acct.blob.core.windows.net/files/images/507f1f77bcf86cd799439011/a%20file.png';
+
+/** @returns {{ containerClient: object, blobClient: object }} */
+function mockContainer(blobClient) {
+  const containerClient = {
+    containerName: 'files',
+    accountName: 'acct',
+    getBlobClient: jest.fn(() => blobClient),
+  };
+  getAzureContainerClient.mockResolvedValue(containerClient);
+  return containerClient;
+}
+
+describe('getAzureFileStream', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('downloads through the authenticated client, so private containers work', async () => {
+    const readableStreamBody = { pipe: jest.fn() };
+    const blobClient = { download: jest.fn().mockResolvedValue({ readableStreamBody }) };
+    const containerClient = mockContainer(blobClient);
+
+    const stream = await getAzureFileStream({}, BLOB_URL);
+
+    expect(stream).toBe(readableStreamBody);
+    expect(blobClient.download).toHaveBeenCalled();
+    /** container prefix stripped, path decoded */
+    expect(containerClient.getBlobClient).toHaveBeenCalledWith(
+      'images/507f1f77bcf86cd799439011/a file.png',
+    );
+  });
+
+  it('accepts a container-relative path', async () => {
+    const blobClient = { download: jest.fn().mockResolvedValue({ readableStreamBody: {} }) };
+    const containerClient = mockContainer(blobClient);
+
+    await getAzureFileStream({}, '/images/507f1f77bcf86cd799439011/file.png');
+
+    expect(containerClient.getBlobClient).toHaveBeenCalledWith(
+      'images/507f1f77bcf86cd799439011/file.png',
+    );
+  });
+
+  it('throws when the service is not initialized', async () => {
+    getAzureContainerClient.mockResolvedValue(null);
+    await expect(getAzureFileStream({}, BLOB_URL)).rejects.toThrow(
+      'Azure Blob Service not initialized',
+    );
+  });
+});
+
+describe('getAzureDownloadURL', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('signs a read-only URL with the account key', async () => {
+    const blobClient = {
+      url: 'https://acct.blob.core.windows.net/files/images/u/f.png',
+      generateSasUrl: jest.fn().mockResolvedValue('https://signed.example/f.png?sig=abc'),
+    };
+    mockContainer(blobClient);
+
+    const url = await getAzureDownloadURL({
+      file: { filepath: BLOB_URL },
+      customFilename: 'report.png',
+      contentType: 'image/png',
+    });
+
+    expect(url).toBe('https://signed.example/f.png?sig=abc');
+    const options = blobClient.generateSasUrl.mock.calls[0][0];
+    expect(options.permissions.read).toBe(true);
+    expect(options.permissions.write).toBeFalsy();
+    expect(options.contentDisposition).toBe('attachment; filename="report.png"');
+    expect(options.contentType).toBe('image/png');
+    /** starts in the past, so host clock drift cannot invalidate the signature */
+    expect(options.startsOn.getTime()).toBeLessThan(Date.now());
+    expect(options.expiresOn.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('falls back to a user delegation key when no account key is configured', async () => {
+    const blobClient = {
+      url: 'https://acct.blob.core.windows.net/files/images/u/f.png',
+      generateSasUrl: jest.fn().mockRejectedValue(new Error('Cannot generate SAS')),
+    };
+    mockContainer(blobClient);
+    const getUserDelegationKey = jest.fn().mockResolvedValue({ value: 'delegation-key' });
+    initializeAzureBlobService.mockResolvedValue({ getUserDelegationKey });
+
+    const url = await getAzureDownloadURL({ file: { filepath: BLOB_URL } });
+
+    expect(getUserDelegationKey).toHaveBeenCalled();
+    expect(url.startsWith(`${blobClient.url}?`)).toBe(true);
+  });
+});

--- a/api/server/services/Files/strategies.js
+++ b/api/server/services/Files/strategies.js
@@ -67,6 +67,7 @@ const {
   deleteFileFromAzure,
   uploadFileToAzure,
   getAzureFileStream,
+  getAzureDownloadURL,
   uploadImageToAzure,
   prepareAzureImageURL,
   processAzureAvatar,
@@ -155,6 +156,7 @@ const azureStrategy = () => ({
   processAvatar: processAzureAvatar,
   handleImageUpload: uploadImageToAzure,
   getDownloadStream: getAzureFileStream,
+  getDownloadURL: getAzureDownloadURL,
 });
 
 /**

--- a/packages/api/src/storage/index.ts
+++ b/packages/api/src/storage/index.ts
@@ -5,3 +5,4 @@ export * from './images';
 export * from './avatar';
 export * from './metadata';
 export * from './url';
+export * from './validation';


### PR DESCRIPTION
Fixes #14955.

## Summary

`azure_blob` was only usable against a **public** container: uploads authenticated, reads did not. Since #15763 (`ec15075dc`) `getAzureFileStream` reads through the authenticated container client, so server-side reads — vision, previews, downloads, avatars, code-interpreter re-priming — now work on a private container. That closes the first half of #14955.

What is still missing is the second half: the Azure strategy has no `getDownloadURL`, so `/api/files/download-url/...` answers `501 Not Implemented` for `azure_blob` while S3 returns a presigned URL. This PR adds that, and nothing else.

## Change

- **New `getAzureDownloadURL`**: a short-lived, **read-only, HTTPS-only** SAS URL, wired into the strategy as `getDownloadURL`. It signs with the account key when one is configured and falls back to a **user delegation key** when running under Managed Identity.
- Lifetime is configurable with `AZURE_STORAGE_URL_EXPIRY_SECONDS` (default 3600), mirroring `S3_URL_EXPIRY_SECONDS`.
- `packages/api/src/storage/validation.ts` is exported from the storage index so the Azure code reuses `sanitizeContentDispositionFilename` rather than duplicate it.

One detail that is easy to miss: the SAS start time is **backdated 5 minutes**. Azure validates the `st`/`se` window against its own clock, so a token minted with `startsOn = now` is rejected with "Signature not valid in the specified time frame" whenever the host clock runs slightly ahead — an intermittent 403 that is painful to diagnose.

No behaviour change for public containers, and no config change is required for existing deployments.

## Testing

Four cases added to the existing `api/server/services/Files/Azure/crud.spec.js` (the two `getAzureFileStream` cases from #15763 are untouched):

- SAS URL is read-only and HTTPS-only, carries the content-disposition/content-type, and starts in the past
- container prefix stripping and URL decoding in blob-name resolution
- container-relative paths
- the user-delegation-key fallback when no account key is available

```
PASS server/services/Files/Azure/crud.spec.js
Tests:       6 passed, 6 total
```

The original bug was found on a real deployment against a private Azure Storage account (account-level `allowBlobPublicAccess: false`). The SAS path is covered by the unit tests above; I have not run the patched build in that deployment, since it moved to local storage on a mounted share in the meantime.

## History

Earlier revisions of this PR also replaced the anonymous `axios.get` in `getAzureFileStream`. That part was superseded by #15763, which handles more cases (Azurite paths, per-container URLs, abort signals), so it was dropped here on rebase.
