### PR TITLE
🧯 fix: Disarm the Graceful-Shutdown Force-Exit Timer on Test Reset

### DIFF
--- a/packages/api/src/app/shutdown.spec.ts
+++ b/packages/api/src/app/shutdown.spec.ts
@@ -368,4 +368,42 @@ describe('setupGracefulShutdown', () => {
       jest.useRealTimers();
     }
   });
+
+  it("keeps a later shutdown's safety net when an earlier drain settles late", async () => {
+    // `setImmediate` stays real so the first shutdown's continuation can actually
+    // reach its `finally`; only the force-exit timer is faked.
+    jest.useFakeTimers({ doNotFake: ['setImmediate'] });
+    try {
+      let releaseFirstClose: (() => void) | undefined;
+      jest.spyOn(server, 'close').mockImplementation((cb?: (err?: Error) => void) => {
+        if (cb) {
+          releaseFirstClose = () => cb();
+        }
+        return server;
+      });
+      setupGracefulShutdown(server);
+      triggerSignal('SIGTERM');
+      await flush();
+
+      // A second shutdown arms its own net after the first is reset away.
+      __resetShutdownStateForTests();
+      const secondServer = http.createServer();
+      Object.defineProperty(secondServer, 'listening', { value: true, configurable: true });
+      jest.spyOn(secondServer, 'close').mockImplementation(() => secondServer);
+      setupGracefulShutdown(secondServer);
+      triggerSignal('SIGTERM');
+      await flush();
+
+      // The first drain settles only now; its `finally` must not disarm the second.
+      releaseFirstClose?.();
+      await flush();
+      await flush();
+      await flush();
+
+      jest.advanceTimersByTime(120_000);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/packages/api/src/app/shutdown.spec.ts
+++ b/packages/api/src/app/shutdown.spec.ts
@@ -347,4 +347,25 @@ describe('setupGracefulShutdown', () => {
     expect(calls).toEqual(['async-done']);
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
+  it('disarms the force-exit timer when shutdown state is reset', async () => {
+    jest.useFakeTimers();
+    try {
+      // A drain that never settles: the server close callback is never invoked,
+      // so `shutdown` stays awaiting and never reaches its own `clearTimeout`.
+      jest.spyOn(server, 'close').mockImplementation(() => server);
+      setupGracefulShutdown(server);
+      triggerSignal('SIGTERM');
+      await Promise.resolve();
+
+      // The safety net is armed and would exit the process on its own.
+      __resetShutdownStateForTests();
+      jest.advanceTimersByTime(120_000);
+
+      // Without the reset clearing it, this timer fires long after the suite
+      // that armed it has finished, killing the run with code 1.
+      expect(exitSpy).not.toHaveBeenCalledWith(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/packages/api/src/app/shutdown.ts
+++ b/packages/api/src/app/shutdown.ts
@@ -23,6 +23,7 @@ const tasks: ShutdownTask[] = [];
 let nextRegistrationOrder = 0;
 let isShuttingDown = false;
 let httpServer: Server | null = null;
+let forceExitTimer: NodeJS.Timeout | null = null;
 
 /**
  * Register a cleanup task for graceful shutdown. Post-drain is the default phase.
@@ -73,6 +74,11 @@ export function __resetShutdownStateForTests(): void {
   nextRegistrationOrder = 0;
   isShuttingDown = false;
   httpServer = null;
+  /** A drain that never settles leaves this armed. It is `unref`'d, so it does
+   *  not hold the process open — but it does fire if anything else keeps the
+   *  process alive past the timeout, exiting a suite that had long since moved
+   *  on with code 1 and no attributable failure. */
+  clearForceExitTimer();
 }
 
 async function runShutdownTasks(phase: ShutdownPhase): Promise<void> {
@@ -93,6 +99,13 @@ async function runShutdownTasks(phase: ShutdownPhase): Promise<void> {
   }
 }
 
+function clearForceExitTimer(): void {
+  if (forceExitTimer) {
+    clearTimeout(forceExitTimer);
+    forceExitTimer = null;
+  }
+}
+
 async function shutdown(signal: NodeJS.Signals): Promise<void> {
   if (isShuttingDown) {
     return;
@@ -100,24 +113,27 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   isShuttingDown = true;
   logger.info(`Received ${signal}, draining HTTP server...`);
 
-  const forceExit = setTimeout(() => {
+  forceExitTimer = setTimeout(() => {
     logger.warn(`Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms, forcing exit`);
     process.exit(1);
   }, SHUTDOWN_TIMEOUT_MS);
-  forceExit.unref();
+  forceExitTimer.unref();
 
   let exitCode = 0;
 
-  const serverClosePromise = closeHttpServer().catch((err) => {
-    logger.error('Error closing HTTP server during graceful shutdown:', err);
-    exitCode = 1;
-  });
+  try {
+    const serverClosePromise = closeHttpServer().catch((err) => {
+      logger.error('Error closing HTTP server during graceful shutdown:', err);
+      exitCode = 1;
+    });
 
-  await runShutdownTasks('pre-drain');
-  await serverClosePromise;
-  await runShutdownTasks('post-drain');
+    await runShutdownTasks('pre-drain');
+    await serverClosePromise;
+    await runShutdownTasks('post-drain');
+  } finally {
+    clearForceExitTimer();
+  }
 
-  clearTimeout(forceExit);
   logger.info('Graceful shutdown complete, exiting');
   process.exit(exitCode);
 }

--- a/packages/api/src/app/shutdown.ts
+++ b/packages/api/src/app/shutdown.ts
@@ -113,11 +113,14 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   isShuttingDown = true;
   logger.info(`Received ${signal}, draining HTTP server...`);
 
-  forceExitTimer = setTimeout(() => {
+  /** Owned locally so a late `finally` from a superseded drain cannot clear the
+   *  safety net belonging to a shutdown that started after it. */
+  const forceExit = setTimeout(() => {
     logger.warn(`Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms, forcing exit`);
     process.exit(1);
   }, SHUTDOWN_TIMEOUT_MS);
-  forceExitTimer.unref();
+  forceExit.unref();
+  forceExitTimer = forceExit;
 
   let exitCode = 0;
 
@@ -131,7 +134,10 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     await serverClosePromise;
     await runShutdownTasks('post-drain');
   } finally {
-    clearForceExitTimer();
+    clearTimeout(forceExit);
+    if (forceExitTimer === forceExit) {
+      forceExitTimer = null;
+    }
   }
 
   logger.info('Graceful shutdown complete, exiting');


### PR DESCRIPTION
`shutdown()` arms a 60-second safety net:

```ts
const forceExit = setTimeout(() => {
  logger.warn(`Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms, forcing exit`);
  process.exit(1);
}, SHUTDOWN_TIMEOUT_MS);
```

It is cleared only once the drain runs to completion, so a drain that never settles — an HTTP server whose `close` callback never fires, a shutdown task that hangs — leaves it armed.

`__resetShutdownStateForTests()` then clears the task list, the shutting-down flag and the server reference, **but not that timer**. A suite that triggers a signal leaves a live self-destruct behind. `unref()` stops it holding the process open, but it still fires if anything else keeps the process alive to the timeout — and `process.exit(1)` takes down whatever is running a minute later.

Jest surfaces that as a bare:

```
●  process.exit called with "1"
    at Timeout._onTimeout (src/app/shutdown.ts)
```

with **no failing test and no summary**, because the run is killed before it can print one. Every suite shows `PASS`, then the job dies.

## Why it is not visible on `dev`

It needs the run to still be alive 60s after the spec arms the timer. On `dev` the `@librechat/api` shards finish well inside that window, so the armed timer is collected harmlessly and the shards are green.

I hit it on a downstream deployment that adds a few dozen test files. The extra volume changes the `--shard` split and lengthens the shard, so the fuse gets to burn down mid-run. Bisecting confirmed it: excluding the one spec that group-signals (`agents/hooks/reaper.spec.ts`) from that shard turns the job green at 2157 passing tests, with nothing else changed.

Nothing about the defect is specific to that deployment though — it is a test-only timer leak in shared code, and any run that grows past the threshold hits it.

## Change

- Track the timer at module scope so it can be cleared from more than one place.
- Clear it in `__resetShutdownStateForTests()`.
- Clear it from a `finally`, so a throwing drain step cannot leak it either.

No production behaviour changes: the timer is still armed on shutdown, still `unref`'d, and still cleared on the normal completion path.

## Test

The added case fails without the reset change and passes with it:

```
✕ disarms the force-exit timer when shutdown state is reset
  Expected: not 1
```

It starts a drain that never settles (`server.close` never invokes its callback), resets state, advances fake timers by 120s, and asserts the process was never exited.

`packages/api` `src/app`: **267 passing**, `tsc --noEmit` clean, ESLint and Prettier clean.
