### PR TITLE
♿ fix: Resolve axe Violations in Sidebar, Tools Dropdown and Footer

### DIFF
--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -90,7 +90,6 @@ function Footer({ className, startupConfig }: FooterProps) {
           className ??
           'absolute bottom-0 left-0 right-0 hidden items-center justify-center gap-2 px-2 py-2 text-center text-xs text-text-primary sm:flex md:px-[60px]'
         }
-        role="contentinfo"
       >
         {footerElements.map((contentRender, index) => {
           const isLastElement = index === footerElements.length - 1;

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -27,6 +27,10 @@ interface ToolsDropdownProps {
   disabled?: boolean;
 }
 
+/** Ariakit portals to document.body by default, which puts the menu outside every landmark.
+ *  Returning null falls back to that default. */
+const getMainLandmark = () => document.querySelector<HTMLElement>('main');
+
 const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
   const localize = useLocalize();
   const { user } = useAuthContext();
@@ -400,7 +404,10 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
       menuId="tools-dropdown-menu"
       isOpen={isPopoverActive}
       setIsOpen={setIsPopoverActive}
-      modal={true}
+      modal={false}
+      portal={true}
+      portalElement={getMainLandmark}
+      preserveTabOrder={false}
       unmountOnHide={true}
       trigger={menuTrigger}
       items={dropdownItems}

--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -53,7 +53,9 @@ interface MeasuredRowProps {
   children: React.ReactNode;
 }
 
-/** Reusable wrapper for virtualized row measurement */
+/** Reusable wrapper for virtualized row measurement.
+ *  The List renders role="grid" over a role="rowgroup" container, so each row carries the
+ *  row/gridcell roles those parents require of their children. */
 const MeasuredRow: FC<MeasuredRowProps> = memo(
   ({ cache, rowKey, parent, index, style, children }) => (
     <CellMeasurer cache={cache} columnIndex={0} key={rowKey} parent={parent} rowIndex={index}>
@@ -63,8 +65,9 @@ const MeasuredRow: FC<MeasuredRowProps> = memo(
           style={style}
           className="px-3"
           data-testid="convo-list-row"
+          role="row"
         >
-          {children}
+          <div role="gridcell">{children}</div>
         </div>
       )}
     </CellMeasurer>

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -222,17 +222,6 @@ function Conversation({
           ? 'bg-surface-active-alt before:absolute before:bottom-1 before:left-0 before:top-1 before:w-0.5 before:rounded-full before:bg-text-primary'
           : 'hover:bg-surface-active-alt',
       )}
-      role="button"
-      tabIndex={renaming ? -1 : 0}
-      aria-label={
-        isSharedBadgeVisible
-          ? localize('com_ui_conversation_label_shared', {
-              title: title || localize('com_ui_untitled'),
-            })
-          : localize('com_ui_conversation_label', {
-              title: title || localize('com_ui_untitled'),
-            })
-      }
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onFocus={handleMouseEnter}
@@ -243,18 +232,6 @@ function Conversation({
         }
         if (e.button === 0) {
           handleNavigation(e.ctrlKey || e.metaKey);
-        }
-      }}
-      onKeyDown={(e) => {
-        if (renaming) {
-          return;
-        }
-        if (e.target !== e.currentTarget) {
-          return;
-        }
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleNavigation(false);
         }
       }}
       style={{ cursor: renaming ? 'default' : 'pointer' }}
@@ -272,6 +249,7 @@ function Conversation({
         <ConvoLink
           isActiveConvo={isActiveConvo}
           isPopoverActive={isPopoverActive}
+          isSharedBadgeVisible={isSharedBadgeVisible}
           title={title}
           onRename={handleRename}
           isSmallScreen={isSmallScreen}

--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -4,6 +4,7 @@ import { cn } from '~/utils';
 interface ConvoLinkProps {
   isActiveConvo: boolean;
   isPopoverActive: boolean;
+  isSharedBadgeVisible: boolean;
   title: string | null;
   onRename: () => void;
   isSmallScreen: boolean;
@@ -14,6 +15,7 @@ interface ConvoLinkProps {
 const ConvoLink: React.FC<ConvoLinkProps> = ({
   isActiveConvo,
   isPopoverActive,
+  isSharedBadgeVisible,
   title,
   onRename,
   isSmallScreen,
@@ -21,13 +23,23 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
   children,
 }) => {
   return (
-    <div
+    <button
+      type="button"
       className={cn(
-        'flex min-w-0 grow items-center gap-2 overflow-hidden rounded-lg px-2',
+        'flex min-w-0 grow cursor-pointer items-center gap-2 overflow-hidden rounded-lg px-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-text-primary',
         isActiveConvo || isPopoverActive ? 'bg-surface-active-alt' : '',
       )}
       title={title ?? undefined}
       aria-current={isActiveConvo ? 'page' : undefined}
+      aria-label={
+        isSharedBadgeVisible
+          ? localize('com_ui_conversation_label_shared', {
+              title: title || localize('com_ui_untitled'),
+            })
+          : localize('com_ui_conversation_label', {
+              title: title || localize('com_ui_untitled'),
+            })
+      }
       style={{ width: '100%' }}
     >
       {children}
@@ -42,7 +54,6 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
           e.stopPropagation();
           onRename();
         }}
-        aria-label={title || localize('com_ui_untitled')}
       >
         {title || localize('com_ui_untitled')}
         <div
@@ -55,7 +66,7 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
           aria-hidden="true"
         />
       </div>
-    </div>
+    </button>
   );
 };
 

--- a/client/src/components/UnifiedSidebar/Sidebar.tsx
+++ b/client/src/components/UnifiedSidebar/Sidebar.tsx
@@ -7,6 +7,9 @@ import { cn } from '~/utils';
 function Sidebar({
   links,
   expanded,
+  width,
+  minWidth,
+  maxWidth,
   onCollapse,
   onExpand,
   onLeaveInsights,
@@ -15,6 +18,9 @@ function Sidebar({
 }: {
   links: NavLink[];
   expanded: boolean;
+  width: number;
+  minWidth: number;
+  maxWidth: number;
   onCollapse: () => void;
   onExpand: () => void;
   onLeaveInsights: () => void;
@@ -46,6 +52,9 @@ function Sidebar({
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize sidebar"
+        aria-valuenow={Math.round(width)}
+        aria-valuemin={Math.round(minWidth)}
+        aria-valuemax={Math.round(maxWidth)}
         tabIndex={expanded ? 0 : -1}
         className={cn(
           'absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-border-medium active:bg-border-heavy',

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -50,6 +50,7 @@ function UnifiedSidebar() {
   const { isSmallScreen, expanded } = useSidebarState();
   const { setSidebarOpen } = useSidebarToggle();
   const [sidebarWidth, setSidebarWidth] = useState(getInitialWidth);
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const [isResizing, setIsResizing] = useState(false);
   const resizeHandlers = useRef<{ move: (e: MouseEvent) => void; up: () => void } | null>(null);
 
@@ -57,10 +58,18 @@ function UnifiedSidebar() {
   const isInsightsRoute = location.pathname.startsWith('/insights');
   const panelExpanded = expanded && !isInsightsRoute;
 
-  /** Mirrors the bounds the aside is rendered with, so the resize handle never announces a
-   *  value outside its own range: a width restored from a wider window can exceed the
-   *  current maximum, and while collapsed the range narrows to the collapsed width. */
-  const resizeMax = Math.round(window.innerWidth * 0.4);
+  /** The aside's max width is a viewport percentage, so the announced range has to track
+   *  the viewport rather than a render-time snapshot of it. */
+  useEffect(() => {
+    const handleViewportResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener('resize', handleViewportResize);
+    return () => window.removeEventListener('resize', handleViewportResize);
+  }, []);
+
+  /** Mirrors the bounds the aside is rendered with, so the handle never announces a value
+   *  outside its own range. CSS resolves a 40% that falls under `min-width` in favor of the
+   *  minimum, and the resize handlers clamp the same way, so the floor belongs here too. */
+  const resizeMax = Math.max(EXPANDED_MIN, Math.round(viewportWidth * 0.4));
   const resizeNow = panelExpanded
     ? Math.min(Math.max(sidebarWidth, EXPANDED_MIN), resizeMax)
     : COLLAPSED_WIDTH;

--- a/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
+++ b/client/src/components/UnifiedSidebar/UnifiedSidebar.tsx
@@ -57,6 +57,14 @@ function UnifiedSidebar() {
   const isInsightsRoute = location.pathname.startsWith('/insights');
   const panelExpanded = expanded && !isInsightsRoute;
 
+  /** Mirrors the bounds the aside is rendered with, so the resize handle never announces a
+   *  value outside its own range: a width restored from a wider window can exceed the
+   *  current maximum, and while collapsed the range narrows to the collapsed width. */
+  const resizeMax = Math.round(window.innerWidth * 0.4);
+  const resizeNow = panelExpanded
+    ? Math.min(Math.max(sidebarWidth, EXPANDED_MIN), resizeMax)
+    : COLLAPSED_WIDTH;
+
   const handleCollapse = useCallback(
     (afterSlide?: () => void) => {
       setSidebarOpen(false, afterSlide);
@@ -222,6 +230,9 @@ function UnifiedSidebar() {
           <Sidebar
             links={links}
             expanded={panelExpanded}
+            width={resizeNow}
+            minWidth={panelExpanded ? EXPANDED_MIN : COLLAPSED_WIDTH}
+            maxWidth={panelExpanded ? resizeMax : COLLAPSED_WIDTH}
             onCollapse={handleCollapse}
             onExpand={handlePanelExpand}
             onLeaveInsights={handleLeaveInsights}

--- a/e2e/specs/a11y.spec.ts
+++ b/e2e/specs/a11y.spec.ts
@@ -1,10 +1,43 @@
 import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright'; // 1
+import { deleteConversations, seedConversations } from './mock/db';
+import { getE2EUser } from '../setup/user';
+
+const SEEDED_IDS = ['a11y-spec-convo-1', 'a11y-spec-convo-2'];
+
+/** A fresh e2e user has no conversations, so without seeding the sidebar renders no rows
+ *  and no scan below reaches the conversation row markup. The pre-delete keeps the suite
+ *  idempotent: the ids are fixed and conversations are uniquely indexed, so a run that
+ *  dies before afterAll would otherwise leave the next one to fail on insert. */
+test.beforeAll(async () => {
+  await deleteConversations(SEEDED_IDS);
+  await seedConversations(
+    getE2EUser().email,
+    SEEDED_IDS.map((conversationId, i) => ({
+      conversationId,
+      title: `A11y conversation ${i + 1}`,
+      updatedAt: new Date(),
+    })),
+  );
+});
+
+test.afterAll(async () => {
+  await deleteConversations(SEEDED_IDS);
+});
+
+/** Scanning straight after navigation catches a pre-render DOM with no main landmark and
+ *  no composer, so waiting for the composer keeps every scan on the loaded app. Navigate
+ *  relative to the config `baseURL` rather than a hardcoded port. */
+async function loadApp(page: Page) {
+  await page.goto('/', { timeout: 30000 });
+  await page.getByTestId('text-input').waitFor({ state: 'visible', timeout: 30000 });
+}
 
 test('Landing page should not have any automatically detectable accessibility issues', async ({
   page,
 }) => {
-  await page.goto('http://localhost:3080/', { timeout: 5000 });
+  await loadApp(page);
 
   const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 
@@ -12,7 +45,7 @@ test('Landing page should not have any automatically detectable accessibility is
 });
 
 test('Conversation page should be accessible', async ({ page }) => {
-  await page.goto('http://localhost:3080/', { timeout: 5000 });
+  await loadApp(page);
 
   // Create a conversation (you may need to adjust this based on your app's behavior)
   const input = await page.locator('form').getByRole('textbox');
@@ -27,7 +60,7 @@ test('Conversation page should be accessible', async ({ page }) => {
 });
 
 test('Navigation elements should be accessible', async ({ page }) => {
-  await page.goto('http://localhost:3080/', { timeout: 5000 });
+  await loadApp(page);
 
   const navAccessibilityScanResults = await new AxeBuilder({ page }).include('nav').analyze();
 
@@ -35,9 +68,39 @@ test('Navigation elements should be accessible', async ({ page }) => {
 });
 
 test('Input form should be accessible', async ({ page }) => {
-  await page.goto('http://localhost:3080/', { timeout: 5000 });
+  await loadApp(page);
 
   const formAccessibilityScanResults = await new AxeBuilder({ page }).include('form').analyze();
 
   expect(formAccessibilityScanResults.violations).toEqual([]);
+});
+
+/** Hovering reveals the row's options button, which is what makes the row an interactive
+ *  control containing another interactive control. Wait on that button by id rather than
+ *  on any button in the row: the row's title control is always present, so a role match
+ *  would be satisfied with the options control still unmounted. */
+test('Conversation list rows should be accessible with their controls revealed', async ({
+  page,
+}) => {
+  await loadApp(page);
+
+  const row = page.getByTestId('convo-item').first();
+  await expect(row).toBeVisible({ timeout: 15000 });
+  await row.hover();
+  await expect(row.locator('[id^="conversation-menu-"]')).toBeVisible();
+
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
+});
+
+test('Tools menu should be accessible when open', async ({ page }) => {
+  await loadApp(page);
+
+  await page.locator('#tools-dropdown-button').first().click();
+  await expect(page.locator('#tools-dropdown-menu')).toBeVisible({ timeout: 10000 });
+
+  const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
 });

--- a/packages/client/src/components/DropdownPopup.tsx
+++ b/packages/client/src/components/DropdownPopup.tsx
@@ -19,7 +19,7 @@ interface DropdownProps {
   gutter?: number;
   modal?: boolean;
   portal?: boolean;
-  portalElement?: HTMLElement | null;
+  portalElement?: Ariakit.MenuProps['portalElement'];
   preserveTabOrder?: boolean;
   focusLoop?: boolean;
   menuId: string;


### PR DESCRIPTION
## Summary

Fixes the six `axe-core` violations reported in #14978 across the conversation sidebar, the composer's tools dropdown, the composer footer and the sidebar resize handle.

- **`aria-required-children` (sidebar)**: `react-virtualized`'s `List` renders `role="grid"` over a `role="rowgroup"` container, but `MeasuredRow` emitted roleless `<div>`s, so the date heading and the conversation rows were reported as disallowed children of both parents. Each row now wraps `role="row"` around a `role="gridcell"`.
- **`nested-interactive` (sidebar)**: the row was `role="button"` while containing the conversation-options `<button>`. The row is no longer interactive; `ConvoLink`'s container is now the `<button>` carrying the accessible name, `aria-current` and the focus ring. Its click bubbles to the row's existing `onClick`, so mouse and keyboard share one navigation path and the row's own keydown handler is redundant.
- **`aria-required-children` (tools menu)**: the disallowed `role="menu"` child was Ariakit's hidden "Dismiss popup" button, which exists only under `modal={true}`. Now `modal={false}`.
- **`region` (tools menu)**: non-modal alone stops the portal, but the composer's overflow then clips the menu to about one item. It keeps `portal={true}` with `portalElement` targeting the `main` landmark. That combination surfaced Ariakit's tab-order focus traps (`aria-hidden` elements carrying `tabindex="0"`), cleared with `preserveTabOrder={false}`. `DropdownPopup` widens `portalElement` to Ariakit's own type so it accepts the callback form.
- **`aria-required-attr` (resize handle)**: the focusable `role="separator"` had no value attributes. It now receives `aria-valuenow`/`aria-valuemin`/`aria-valuemax` from `UnifiedSidebar`, using the same bounds its mouse and keyboard resize paths already enforce.
- **`landmark-contentinfo-is-top-level` (footer)**: `role="contentinfo"` removed. Both call sites (`ChatView`, `ShareView`) render the footer inside a `<main>`, so the landmark was never valid.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`e2e/specs/a11y.spec.ts` gained the coverage these fixes need, since nothing in the suite previously reached the affected markup: a fresh e2e user has no conversations, no test hovered a row, and `unmountOnHide` keeps the tools menu out of the DOM until it is opened. Conversations are seeded through the existing `e2e/specs/mock/db.ts` helpers and deleted afterwards.

Every scan now waits for the composer before running. The stock spec scanned immediately after `page.goto` and could catch a pre-render DOM, which is why `Input form should be accessible` failed with `No elements found for include in page Context`, and why `landmark-one-main` and `page-has-heading-one` appeared intermittently. Both clear once the scan waits, so neither is a real defect. Navigation is relative to the config `baseURL` rather than a hardcoded port.

Same spec, same server, `npm run e2e:a11y`:

- before: **5 failed, 1 passed**: `aria-required-children`, `nested-interactive`, `region`, `aria-required-attr`, `landmark-contentinfo-is-top-level`
- after: **6 passed**, zero violations

### **Test Configuration**:

`e2e/playwright.config.a11y.ts`, Chromium, local MongoDB. On an IPv6-preferring host the local e2e configs need `E2E_BASE_URL=http://127.0.0.1:3080`: `getBaseE2EEnv` derives `HOST` from the base URL, so the default `localhost` binds Node to `[::1]` only while Playwright's readiness probe resolves `127.0.0.1` and the web server never comes up. Unrelated to these changes, and left alone here.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
