### PR TITLE
🎛️ feat: Configurable SearXNG Search Options

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -1051,6 +1051,29 @@ endpoints:
 #     # includeFavicon: false   # Include favicon URL for each result
 #     # format: markdown        # 'markdown' (default) or 'text' (plain text, may increase latency)
 #     # timeout: 15000          # HTTP request timeout in milliseconds (max 120000); Tavily Extract receives seconds clamped to 1-60
+#
+# SearXNG as the search provider example:
+# webSearch:
+#   searchProvider: searxng
+#   searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}'
+#   # searxngApiKey: '${SEARXNG_API_KEY}'
+#   searxngSearchOptions:
+#     # Engines your instance should query. Accepts a comma-separated string or a list.
+#     # Defaults to 'google,bing,duckduckgo'; DuckDuckGo serves CAPTCHAs to most
+#     # self-hosted instances, so override it when results come back empty.
+#     #
+#     # Names must match engines enabled on your own instance. SearXNG ignores an
+#     # engine it does not know instead of reporting an error, so a typo or a
+#     # disabled engine shows up as fewer results rather than a failure. Check the
+#     # enabled list at https://your-instance/config before setting this.
+#     engines:
+#       - google
+#       - bing
+#       - startpage
+#       - qwant
+#     # language: en            # Result language code (default: 'all')
+#     # timeRange: month        # 'day', 'month', or 'year'
+#     # timeout: 10000          # HTTP request timeout in milliseconds (1-120000, default: 10000)
 
 # Memory configuration for user memories
 # memory:

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -958,6 +958,87 @@ describe('web.ts', () => {
       }
     });
 
+    it('should authenticate SearXNG as a search provider and pass search options through', async () => {
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        searchProvider: 'searxng' as SearchProviders,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+        rerankerType: 'none' as RerankerTypes,
+        searxngSearchOptions: {
+          engines: 'google,bing,startpage,qwant',
+          language: 'en',
+          timeRange: 'month',
+          timeout: 15000,
+        },
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'SEARXNG_INSTANCE_URL') {
+            result[field] = 'https://search.example';
+          } else if (field === 'SEARXNG_API_KEY') {
+            result[field] = 'searxng-api-key';
+          } else if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'https://api.firecrawl.dev';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.searchProvider).toBe('searxng');
+      expect(result.authResult.searxngInstanceUrl).toBe('https://search.example');
+      expect(result.authResult.searxngSearchOptions).toEqual(webSearchConfig.searxngSearchOptions);
+    });
+
+    it('should leave searxngSearchOptions undefined when not configured', async () => {
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        searchProvider: 'searxng' as SearchProviders,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+        rerankerType: 'none' as RerankerTypes,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'SEARXNG_INSTANCE_URL') {
+            result[field] = 'https://search.example';
+          } else if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'https://api.firecrawl.dev';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.searxngSearchOptions).toBeUndefined();
+    });
+
     it('should fail authentication when Tavily search API key is missing', async () => {
       const webSearchConfig: TCustomConfig['webSearch'] = {
         tavilyApiKey: '${TAVILY_API_KEY}',

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -293,6 +293,7 @@ export async function loadWebSearchAuth({
   }
   authResult.scraperTimeout = webSearchConfig?.scraperTimeout ?? scraperOptionsTimeout ?? 7500;
   authResult.firecrawlOptions = webSearchConfig?.firecrawlOptions;
+  authResult.searxngSearchOptions = webSearchConfig?.searxngSearchOptions;
   authResult.tavilySearchOptions = webSearchConfig?.tavilySearchOptions;
   authResult.tavilyScraperOptions = webSearchConfig?.tavilyScraperOptions;
 

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -665,6 +665,88 @@ describe('webSearchSchema', () => {
       }),
     ).toThrow();
   });
+
+  it('accepts SearXNG search options', () => {
+    const result = webSearchSchema.parse({
+      searxngSearchOptions: {
+        engines: 'google,bing,startpage,qwant',
+        language: 'en',
+        timeRange: 'month',
+        timeout: 15000,
+      },
+    });
+
+    expect(result.searxngSearchOptions?.engines).toBe('google,bing,startpage,qwant');
+    expect(result.searxngSearchOptions?.language).toBe('en');
+    expect(result.searxngSearchOptions?.timeRange).toBe('month');
+    expect(result.searxngSearchOptions?.timeout).toBe(15000);
+  });
+
+  it('normalizes a SearXNG engine list into a comma-separated string', () => {
+    const result = webSearchSchema.parse({
+      searxngSearchOptions: {
+        engines: ['google', 'bing', 'startpage', 'qwant'],
+      },
+    });
+
+    expect(result.searxngSearchOptions?.engines).toBe('google,bing,startpage,qwant');
+  });
+
+  it('trims whitespace and empty entries from SearXNG engines', () => {
+    const result = webSearchSchema.parse({
+      searxngSearchOptions: {
+        engines: 'google, bing , , startpage',
+      },
+    });
+
+    expect(result.searxngSearchOptions?.engines).toBe('google,bing,startpage');
+  });
+
+  it('treats a blank SearXNG engines value as unset', () => {
+    const result = webSearchSchema.parse({
+      searxngSearchOptions: {
+        engines: '  ,  ',
+      },
+    });
+
+    expect(result.searxngSearchOptions?.engines).toBeUndefined();
+  });
+
+  it('rejects invalid SearXNG search options', () => {
+    expect(() =>
+      webSearchSchema.parse({
+        searxngSearchOptions: {
+          timeRange: 'week',
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      webSearchSchema.parse({
+        searxngSearchOptions: {
+          timeout: 120001,
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      webSearchSchema.parse({
+        searxngSearchOptions: {
+          engines: 42,
+        },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a zero SearXNG timeout, which axios reads as no timeout at all', () => {
+    expect(() =>
+      webSearchSchema.parse({
+        searxngSearchOptions: {
+          timeout: 0,
+        },
+      }),
+    ).toThrow();
+  });
 });
 
 describe('bedrockModels defaults', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1833,6 +1833,22 @@ export enum SafeSearchTypes {
   STRICT = 2,
 }
 
+/**
+ * Normalizes a SearXNG engine list into the comma-separated form the API expects.
+ * Accepts the YAML list or comma-separated string an operator may write, and is
+ * applied both at the schema boundary and when loading the runtime config, since
+ * `loadCustomConfig` returns the raw YAML object rather than the parsed result.
+ */
+export function normalizeSearxngEngines(engines?: string | string[]): string | undefined {
+  if (engines == null) {
+    return undefined;
+  }
+  const normalized = (Array.isArray(engines) ? engines : engines.split(','))
+    .map((engine) => engine.trim())
+    .filter(Boolean);
+  return normalized.length ? normalized.join(',') : undefined;
+}
+
 export const webSearchSchema = z.object({
   allowedAddresses: allowedAddressesSchema,
   serperApiKey: z.string().optional().default('${SERPER_API_KEY}'),
@@ -1895,12 +1911,7 @@ export const webSearchSchema = z.object({
     .object({
       engines: z
         .union([z.string(), z.array(z.string())])
-        .transform((value) => {
-          const engines = (Array.isArray(value) ? value : value.split(','))
-            .map((engine) => engine.trim())
-            .filter(Boolean);
-          return engines.length ? engines.join(',') : undefined;
-        })
+        .transform(normalizeSearxngEngines)
         .optional(),
       language: z.string().optional(),
       timeRange: z.enum(['day', 'month', 'year']).optional(),
@@ -2215,6 +2226,19 @@ export type DeepPartial<T> = T extends (infer U)[]
 
 export const getConfigDefaults = () => getSchemaDefaults(configSchema);
 export type TCustomConfig = DeepPartial<z.infer<typeof configSchema>>;
+
+/**
+ * Shape of the `webSearch` block as written in `librechat.yaml`, where
+ * `searxngSearchOptions.engines` may still be the YAML list or untrimmed string an
+ * operator wrote. `loadCustomConfig` returns the raw YAML object rather than the
+ * parsed result, so the runtime loader receives this shape, not the parsed one.
+ */
+export type TWebSearchConfigInput = Omit<
+  NonNullable<TCustomConfig['webSearch']>,
+  'searxngSearchOptions'
+> & {
+  searxngSearchOptions?: z.input<typeof webSearchSchema>['searxngSearchOptions'];
+};
 export type TCustomEndpoints = z.infer<typeof customEndpointsSchema>;
 
 export type TProviderSchema =

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1891,6 +1891,22 @@ export const webSearchSchema = z.object({
         .optional(),
     })
     .optional(),
+  searxngSearchOptions: z
+    .object({
+      engines: z
+        .union([z.string(), z.array(z.string())])
+        .transform((value) => {
+          const engines = (Array.isArray(value) ? value : value.split(','))
+            .map((engine) => engine.trim())
+            .filter(Boolean);
+          return engines.length ? engines.join(',') : undefined;
+        })
+        .optional(),
+      language: z.string().optional(),
+      timeRange: z.enum(['day', 'month', 'year']).optional(),
+      timeout: z.number().int().positive().max(120000).optional(),
+    })
+    .optional(),
   tavilySearchOptions: z
     .object({
       searchDepth: z.enum(['basic', 'advanced', 'fast', 'ultra-fast']).optional(),

--- a/packages/data-provider/src/types/web.ts
+++ b/packages/data-provider/src/types/web.ts
@@ -76,6 +76,7 @@ export interface SearchConfig {
   serperApiKey?: string;
   searxngInstanceUrl?: string;
   searxngApiKey?: string;
+  searxngSearchOptions?: z.infer<typeof webSearchSchema>['searxngSearchOptions'];
   tavilyApiKey?: string;
   tavilySearchUrl?: string;
   tavilySearchOptions?: TavilyConfig['tavilySearchOptions'];

--- a/packages/data-schemas/src/app/web.spec.ts
+++ b/packages/data-schemas/src/app/web.spec.ts
@@ -93,6 +93,23 @@ describe('loadWebSearchConfig', () => {
       expect(result?.searchProvider).toBe('serper');
       expect(result?.serperApiKey).toBe('test-key');
     });
+
+    it('should preserve searxngSearchOptions', () => {
+      const config: TCustomConfig['webSearch'] = {
+        searchProvider: SearchProviders.SEARXNG,
+        searxngSearchOptions: {
+          engines: 'google,bing,startpage,qwant',
+          language: 'en',
+        },
+      };
+
+      const result = loadWebSearchConfig(config);
+
+      expect(result?.searxngSearchOptions).toEqual({
+        engines: 'google,bing,startpage,qwant',
+        language: 'en',
+      });
+    });
   });
 
   describe('safeSearch', () => {

--- a/packages/data-schemas/src/app/web.spec.ts
+++ b/packages/data-schemas/src/app/web.spec.ts
@@ -110,6 +110,42 @@ describe('loadWebSearchConfig', () => {
         language: 'en',
       });
     });
+
+    it('should normalize a YAML engine list, which reaches this loader unparsed', () => {
+      const result = loadWebSearchConfig({
+        searchProvider: SearchProviders.SEARXNG,
+        searxngSearchOptions: {
+          engines: ['google', 'bing', 'startpage'],
+          language: 'en',
+        },
+      });
+
+      expect(result?.searxngSearchOptions?.engines).toBe('google,bing,startpage');
+    });
+
+    it('should trim whitespace and empty entries from a raw engines string', () => {
+      const result = loadWebSearchConfig({
+        searchProvider: SearchProviders.SEARXNG,
+        searxngSearchOptions: { engines: 'google, bing , , startpage' },
+      });
+
+      expect(result?.searxngSearchOptions?.engines).toBe('google,bing,startpage');
+    });
+
+    it('should treat an all-blank engines value as unset', () => {
+      const result = loadWebSearchConfig({
+        searchProvider: SearchProviders.SEARXNG,
+        searxngSearchOptions: { engines: '  ,  ' },
+      });
+
+      expect(result?.searxngSearchOptions?.engines).toBeUndefined();
+    });
+
+    it('should leave searxngSearchOptions undefined when the block is absent', () => {
+      const result = loadWebSearchConfig({ searchProvider: SearchProviders.SEARXNG });
+
+      expect(result?.searxngSearchOptions).toBeUndefined();
+    });
   });
 
   describe('safeSearch', () => {

--- a/packages/data-schemas/src/app/web.ts
+++ b/packages/data-schemas/src/app/web.ts
@@ -1,4 +1,4 @@
-import { RerankerTypes, SafeSearchTypes, normalizeSearxngEngines } from 'librechat-data-provider';
+import { SafeSearchTypes, normalizeSearxngEngines } from 'librechat-data-provider';
 import type { TCustomConfig, TWebSearchConfigInput } from 'librechat-data-provider';
 import type { TWebSearchKeys, TWebSearchCategories } from '~/types/web';
 

--- a/packages/data-schemas/src/app/web.ts
+++ b/packages/data-schemas/src/app/web.ts
@@ -1,5 +1,5 @@
-import { RerankerTypes, SafeSearchTypes } from 'librechat-data-provider';
-import type { TCustomConfig } from 'librechat-data-provider';
+import { RerankerTypes, SafeSearchTypes, normalizeSearxngEngines } from 'librechat-data-provider';
+import type { TCustomConfig, TWebSearchConfigInput } from 'librechat-data-provider';
 import type { TWebSearchKeys, TWebSearchCategories } from '~/types/web';
 
 export const webSearchAuth = {
@@ -69,7 +69,7 @@ export function getWebSearchKeys(): TWebSearchKeys[] {
 export const webSearchKeys: TWebSearchKeys[] = getWebSearchKeys();
 
 export function loadWebSearchConfig(
-  config: TCustomConfig['webSearch'],
+  config: TWebSearchConfigInput | undefined,
 ): TCustomConfig['webSearch'] {
   const serperApiKey = config?.serperApiKey ?? '${SERPER_API_KEY}';
   const searxngInstanceUrl = config?.searxngInstanceUrl ?? '${SEARXNG_INSTANCE_URL}';
@@ -85,10 +85,15 @@ export function loadWebSearchConfig(
   const cohereApiKey = config?.cohereApiKey ?? '${COHERE_API_KEY}';
   const safeSearch = config?.safeSearch ?? SafeSearchTypes.MODERATE;
   const rerankerType = config?.rerankerType;
+  const searxngSearchOptions = config?.searxngSearchOptions && {
+    ...config.searxngSearchOptions,
+    engines: normalizeSearxngEngines(config.searxngSearchOptions.engines),
+  };
 
   return {
     ...config, // Preserve provider-specific option blocks such as firecrawlOptions and tavilySearchOptions.
     safeSearch,
+    searxngSearchOptions,
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,


### PR DESCRIPTION
## Summary

SearXNG queries always ran with `engines=google,bing,duckduckgo`, hardcoded inside `@librechat/agents`, with no way to change the engine list, the result language, the time range, or the request timeout. DuckDuckGo serves persistent CAPTCHAs to most self-hosted instances, so a third of every query silently returns nothing and operators have no lever to pull. That is the confusion reported in #14117 (originally #14010, later converted to a discussion): users set a `searxngSettings.engines` block that LibreChat never read, and the workaround so far has been to volume-mount a patched `search.cjs` over the SDK after every update.

This adds a `searxngSearchOptions` block to `webSearch`, named and shaped to match `tavilySearchOptions` and `firecrawlOptions` rather than the `searxngSettings` key users were trying:

```yaml
webSearch:
  searchProvider: searxng
  searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}'
  searxngSearchOptions:
    engines:
      - google
      - bing
      - startpage
      - qwant
    language: en
    timeRange: month
    timeout: 10000
```

`engines` accepts either a comma-separated string or a YAML list and is normalized to the comma-separated form SearXNG expects. Blank entries are trimmed and dropped, so a stray comma cannot produce an empty `engines=` parameter that returns nothing. `timeout` rejects `0`, which axios reads as no timeout at all. Every field is optional and the existing defaults are unchanged when the block is absent, so this is a no-op for current deployments.

The example yaml notes to check `https://your-instance/config` before setting `engines`, because SearXNG ignores an engine it does not recognize rather than reporting an error. Without that note, a typo or a disabled engine looks identical to the failure this PR fixes.

The SDK half of this shipped as danny-avila/agents#439 in `@librechat/agents` 3.6.9, which added `SearxNGSearchOptions`, threaded it through `createSearXNGAPI`, and made `createSearchTool` forward it. `dev` is already on 3.6.9 (#15037), so this branch carries the LibreChat side only and needs no version bump.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

`searxngSearchOptions` is validated at the schema boundary, preserved through config loading, and carried onto the auth result that is spread into `createSearchTool`. Each of those three hops has a test. Rebased onto current `dev` (3.6.9) and re-verified:

```bash
cd packages/data-provider && npx jest src/config.spec.ts                  # 156 passed
cd packages/data-schemas && npx jest src/app/web.spec.ts                  #  15 passed
cd packages/api          && npx jest src/web/web.spec.ts                  #  56 passed
cd api                   && npx jest app/clients/tools/util/handleTools.test.js  # 28 passed
npx eslint <the six touched files>                                       # clean
```

New coverage: options accepted as given; a YAML list normalized to a comma-separated string; whitespace and empty entries trimmed; an all-blank value treated as unset; `timeRange` outside the SearXNG enum, an over-max timeout, a zero timeout, and a non-string engine all rejected; the block preserved by `loadWebSearchConfig`; the block carried onto the auth result, and left `undefined` when unconfigured.

Beyond the unit tests, I ran the built tool against a stub SearXNG instance to confirm the block survives every hop and lands on the wire. With the block configured as `engines: [google, ' bing ', '', startpage]`, `language: en`, `timeRange: month`, `timeout: 4000`, the instance received:

```
q=test&format=json&pageno=1&categories=general&language=en&safesearch=1
&engines=google,bing,startpage&time_range=month
```

With no block configured it received `engines=google,bing,duckduckgo`, `language=all`, and no `time_range`, so existing deployments are byte-identical to before. A `timeout: 800` against a deliberately slow instance aborted at 805 ms with `timeout of 800ms exceeded`, confirming the value reaches axios.

### **Test Configuration**:

Node v24.16.0, rebased on `dev` at `b4593f80b`, `@librechat/agents` 3.6.9.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] I have made pertinent documentation changes (new block documented in `librechat.example.yaml`)
