### PR TITLE
feat: wire You.com web-search provider into config, schema, and UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1197,6 +1197,12 @@ OPENWEATHER_API_KEY=
 # Tavily (Search Provider and/or Scraper)
 # TAVILY_API_KEY=your_tavily_api_key
 
+# You.com (Search Provider)
+# YDC_API_KEY=your_youcom_api_key
+# Optional: override the You.com endpoint (defaults to the keyless endpoint
+# when YDC_API_KEY is unset, and to the Search API when it is set)
+# YDC_API_URL=your_youcom_api_url
+
 # Scraper (Required)
 # FIRECRAWL_API_KEY=your_firecrawl_api_key
 # Optional: Custom Firecrawl API URL

--- a/client/src/components/SidePanel/Agents/Search/ApiKeyDialog.tsx
+++ b/client/src/components/SidePanel/Agents/Search/ApiKeyDialog.tsx
@@ -92,6 +92,20 @@ export default function ApiKeyDialog({
         },
       },
     },
+    {
+      key: SearchProviders.YOU,
+      label: localize('com_ui_web_search_provider_you'),
+      inputs: {
+        youApiKey: {
+          placeholder: localize('com_ui_enter_api_key'),
+          type: 'password' as const,
+          link: {
+            url: 'https://you.com/platform?utm_source=danny-avila-librechat&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=app',
+            text: localize('com_ui_web_search_provider_you_key'),
+          },
+        },
+      },
+    },
   ];
 
   const rerankerOptions: DropdownOption[] = [

--- a/client/src/hooks/Plugins/useAuthSearchTool.ts
+++ b/client/src/hooks/Plugins/useAuthSearchTool.ts
@@ -15,6 +15,7 @@ export type SearchApiKeyFormData = {
   firecrawlApiKey: string;
   firecrawlApiUrl: string;
   tavilyApiKey: string;
+  youApiKey: string;
   jinaApiKey: string;
   jinaApiUrl: string;
   cohereApiKey: string;
@@ -56,6 +57,7 @@ const useAuthSearchTool = (options?: { isEntityTool: boolean }) => {
         firecrawlApiKey: data.firecrawlApiKey,
         firecrawlApiUrl: data.firecrawlApiUrl,
         tavilyApiKey: data.tavilyApiKey,
+        youApiKey: data.youApiKey,
         jinaApiKey: data.jinaApiKey,
         jinaApiUrl: data.jinaApiUrl,
         cohereApiKey: data.cohereApiKey,

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -2272,6 +2272,8 @@
   "com_ui_web_search_provider_serper_key": "Get your Serper API key",
   "com_ui_web_search_provider_tavily": "Tavily API",
   "com_ui_web_search_provider_tavily_key": "Get your Tavily API key",
+  "com_ui_web_search_provider_you": "You.com API",
+  "com_ui_web_search_provider_you_key": "Get your You.com API key",
   "com_ui_web_search_reading": "Reading results",
   "com_ui_web_search_reranker": "Reranker",
   "com_ui_web_search_reranker_cohere": "Cohere",

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -975,6 +975,13 @@ endpoints:
 #   searxngApiKey: '${SEARXNG_API_KEY}'
 #   # Tavily (search provider and/or scraper)
 #   tavilyApiKey: '${TAVILY_API_KEY}'
+#   # You.com (search provider)
+#   youApiKey: '${YDC_API_KEY}'
+#   # youApiUrl: '${YDC_API_URL}'   # Optional endpoint override
+#   # youSearchOptions:
+#   #   maxResults: 8
+#   #   attributionTitle: 'LibreChat'   # Sent as the User-Agent to You.com
+#   #   timeout: 15000
 #   # Content scrapers
 #   firecrawlApiKey: '${FIRECRAWL_API_KEY}'
 #   firecrawlApiUrl: '${FIRECRAWL_API_URL}'

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -42,6 +42,7 @@ const CONFIG_SECRET_FIELDS: readonly ConfigSecretField[] = (
     { path: 'webSearch.tavilyApiKey', allowEnvPlaceholder: true },
     { path: 'webSearch.jinaApiKey', allowEnvPlaceholder: true },
     { path: 'webSearch.cohereApiKey', allowEnvPlaceholder: true },
+    { path: 'webSearch.youApiKey', allowEnvPlaceholder: true },
     { path: 'endpoints.assistants.apiKey', allowEnvPlaceholder: true },
     { path: 'endpoints.azureAssistants.apiKey', allowEnvPlaceholder: true },
   ] satisfies ConfigSecretFieldInput[]

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -259,6 +259,105 @@ describe('web.ts', () => {
       expect(result.authResult.firecrawlApiUrl).toBeUndefined();
     });
 
+    it('should authenticate You.com and pass its search options through', async () => {
+      const originalEnv = process.env;
+      try {
+        process.env = {
+          ...originalEnv,
+          YDC_API_KEY: 'system-ydc-api-key',
+          FIRECRAWL_API_KEY: 'test-firecrawl-key',
+        };
+
+        const youConfig = {
+          youApiKey: '${YDC_API_KEY}',
+          youApiUrl: '${YDC_API_URL}',
+          firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+          youSearchOptions: { maxResults: 8, attributionTitle: 'LibreChat' },
+          searchProvider: 'you' as SearchProviders,
+          scraperProvider: 'firecrawl' as ScraperProviders,
+          rerankerType: 'none' as RerankerTypes,
+        } as TWebSearchConfig;
+
+        mockLoadAuthValues.mockImplementation(({ authFields }) => {
+          const result: Record<string, string> = {};
+          authFields.forEach((field: string) => {
+            if (field === 'YDC_API_KEY') {
+              result[field] = 'system-ydc-api-key';
+            } else if (field === 'FIRECRAWL_API_KEY') {
+              result[field] = 'test-firecrawl-key';
+            }
+          });
+          return Promise.resolve(result);
+        });
+
+        const result = await loadWebSearchAuth({
+          userId,
+          webSearchConfig: youConfig,
+          loadAuthValues: mockLoadAuthValues,
+        });
+
+        expect(result.authenticated).toBe(true);
+        expect(result.authResult.searchProvider).toBe('you');
+        expect(result.authResult.youApiKey).toBe('system-ydc-api-key');
+        /** The URL override is unset, so it must not reach the provider. */
+        expect(result.authResult.youApiUrl).toBeUndefined();
+        expect(result.authResult.youSearchOptions).toEqual({
+          maxResults: 8,
+          attributionTitle: 'LibreChat',
+        });
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it('should ignore a user-provided You.com URL override unless explicitly enabled', async () => {
+      const originalEnv = process.env;
+      try {
+        process.env = {
+          ...originalEnv,
+          YDC_API_KEY: 'system-ydc-api-key',
+          YDC_API_URL: 'https://api.you.com/v1/search',
+          FIRECRAWL_API_KEY: 'test-firecrawl-key',
+        };
+
+        const youConfig = {
+          youApiKey: '${YDC_API_KEY}',
+          youApiUrl: '${YDC_API_URL}',
+          firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+          searchProvider: 'you' as SearchProviders,
+          scraperProvider: 'firecrawl' as ScraperProviders,
+          rerankerType: 'none' as RerankerTypes,
+        } as TWebSearchConfig;
+
+        mockLoadAuthValues.mockImplementation(({ authFields }) => {
+          const result: Record<string, string> = {};
+          authFields.forEach((field: string) => {
+            if (field === 'YDC_API_KEY') {
+              result[field] = 'system-ydc-api-key';
+            } else if (field === 'YDC_API_URL') {
+              result[field] = 'https://attacker.example/search';
+            } else if (field === 'FIRECRAWL_API_KEY') {
+              result[field] = 'test-firecrawl-key';
+            }
+          });
+          return Promise.resolve(result);
+        });
+
+        const result = await loadWebSearchAuth({
+          userId,
+          webSearchConfig: youConfig,
+          loadAuthValues: mockLoadAuthValues,
+        });
+
+        expect(result.authenticated).toBe(true);
+        expect(result.authResult.searchProvider).toBe('you');
+        expect(result.authResult.youApiKey).toBe('system-ydc-api-key');
+        expect(result.authResult.youApiUrl).toBeUndefined();
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
     it('should ignore user-provided Tavily custom URLs unless explicitly enabled', async () => {
       const originalEnv = process.env;
       try {

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -26,6 +26,7 @@ const USER_PROVIDED_URL_KEYS = new Set<TWebSearchKeys>([
 const USER_PROVIDED_OPT_IN_URL_KEYS = new Set<TWebSearchKeys>([
   'tavilySearchUrl',
   'tavilyExtractUrl',
+  'youApiUrl',
 ]);
 
 function isUserProvidedEnabled(field: string): boolean {
@@ -295,6 +296,7 @@ export async function loadWebSearchAuth({
   authResult.firecrawlOptions = webSearchConfig?.firecrawlOptions;
   authResult.tavilySearchOptions = webSearchConfig?.tavilySearchOptions;
   authResult.tavilyScraperOptions = webSearchConfig?.tavilyScraperOptions;
+  authResult.youSearchOptions = webSearchConfig?.youSearchOptions;
 
   return {
     authTypes,

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -665,6 +665,38 @@ describe('webSearchSchema', () => {
       }),
     ).toThrow();
   });
+
+  it('accepts you as a search provider and defaults the You.com placeholders', () => {
+    const result = webSearchSchema.parse({ searchProvider: 'you' });
+
+    expect(result.searchProvider).toBe('you');
+    expect(result.youApiKey).toBe('${YDC_API_KEY}');
+    expect(result.youApiUrl).toBe('${YDC_API_URL}');
+  });
+
+  it('accepts You.com search options', () => {
+    const result = webSearchSchema.parse({
+      youSearchOptions: {
+        maxResults: 8,
+        attributionTitle: 'LibreChat',
+        timeout: 15000,
+      },
+    });
+
+    expect(result.youSearchOptions?.maxResults).toBe(8);
+    expect(result.youSearchOptions?.attributionTitle).toBe('LibreChat');
+    expect(result.youSearchOptions?.timeout).toBe(15000);
+  });
+
+  it('rejects invalid You.com search options', () => {
+    expect(() =>
+      webSearchSchema.parse({
+        youSearchOptions: {
+          maxResults: 0,
+        },
+      }),
+    ).toThrow();
+  });
 });
 
 describe('bedrockModels defaults', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1780,6 +1780,7 @@ export enum SearchProviders {
   SERPER = 'serper',
   SEARXNG = 'searxng',
   TAVILY = 'tavily',
+  YOU = 'you',
 }
 
 export enum ScraperProviders {
@@ -1820,6 +1821,16 @@ export const webSearchSchema = z.object({
   jinaApiUrl: z.string().optional().default('${JINA_API_URL}'),
   cohereApiKey: z.string().optional().default('${COHERE_API_KEY}'),
   cohereApiKeyPreview: apiKeyPreviewSchema,
+  youApiKey: z.string().optional().default('${YDC_API_KEY}'),
+  youApiKeyPreview: apiKeyPreviewSchema,
+  youApiUrl: z.string().optional().default('${YDC_API_URL}'),
+  youSearchOptions: z
+    .object({
+      maxResults: z.number().int().positive().optional(),
+      attributionTitle: z.string().optional(),
+      timeout: z.number().int().nonnegative().optional(),
+    })
+    .optional(),
   searchProvider: z.nativeEnum(SearchProviders).optional(),
   scraperProvider: z.nativeEnum(ScraperProviders).optional(),
   rerankerType: z.nativeEnum(RerankerTypes).optional(),

--- a/packages/data-provider/src/types/web.ts
+++ b/packages/data-provider/src/types/web.ts
@@ -12,7 +12,7 @@ export enum DATE_RANGE {
   PAST_YEAR = 'y',
 }
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'you';
 export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
@@ -79,6 +79,19 @@ export interface SearchConfig {
   tavilyApiKey?: string;
   tavilySearchUrl?: string;
   tavilySearchOptions?: TavilyConfig['tavilySearchOptions'];
+  youApiKey?: string;
+  youApiUrl?: string;
+  youSearchOptions?: YouConfig['youSearchOptions'];
+}
+
+export interface YouConfig {
+  youApiKey?: string;
+  youApiUrl?: string;
+  youSearchOptions?: {
+    maxResults?: number;
+    attributionTitle?: string;
+    timeout?: number;
+  };
 }
 
 export type References = {

--- a/packages/data-schemas/src/app/web.spec.ts
+++ b/packages/data-schemas/src/app/web.spec.ts
@@ -1,6 +1,6 @@
 import { SafeSearchTypes, SearchProviders, ScraperProviders } from 'librechat-data-provider';
 import type { TCustomConfig } from 'librechat-data-provider';
-import { loadWebSearchConfig } from './web';
+import { loadWebSearchConfig, webSearchAuth, webSearchKeys } from './web';
 
 describe('loadWebSearchConfig', () => {
   describe('firecrawlVersion', () => {
@@ -60,6 +60,8 @@ describe('loadWebSearchConfig', () => {
         tavilyApiKey: '${TAVILY_API_KEY}',
         tavilySearchUrl: '${TAVILY_SEARCH_URL}',
         tavilyExtractUrl: '${TAVILY_EXTRACT_URL}',
+        youApiKey: '${YDC_API_KEY}',
+        youApiUrl: '${YDC_API_URL}',
       });
     });
 
@@ -148,6 +150,38 @@ describe('loadWebSearchConfig', () => {
       expect(result?.serperApiKey).toBe('actual-serper-key');
       expect(result?.jinaApiKey).toBe('actual-jina-key');
       expect(result?.cohereApiKey).toBe('actual-cohere-key');
+    });
+  });
+
+  describe('You.com', () => {
+    it('should apply default placeholders for the key and URL', () => {
+      const result = loadWebSearchConfig({});
+
+      expect(result?.youApiKey).toBe('${YDC_API_KEY}');
+      expect(result?.youApiUrl).toBe('${YDC_API_URL}');
+    });
+
+    it('should preserve provided You.com values', () => {
+      const result = loadWebSearchConfig({
+        youApiKey: 'custom-you-key',
+        youApiUrl: 'https://custom-you.example/search',
+        searchProvider: SearchProviders.YOU,
+      });
+
+      expect(result?.youApiKey).toBe('custom-you-key');
+      expect(result?.youApiUrl).toBe('https://custom-you.example/search');
+      expect(result?.searchProvider).toBe('you');
+    });
+
+    it('should register you as a provider with an optional URL override', () => {
+      expect(webSearchAuth.providers.you).toEqual({
+        youApiKey: 1,
+        youApiUrl: 0,
+      });
+    });
+
+    it('should include the You.com keys in the extracted key set', () => {
+      expect(webSearchKeys).toEqual(expect.arrayContaining(['youApiKey', 'youApiUrl']));
     });
   });
 

--- a/packages/data-schemas/src/app/web.ts
+++ b/packages/data-schemas/src/app/web.ts
@@ -16,6 +16,11 @@ export const webSearchAuth = {
       tavilyApiKey: 1 as const,
       tavilySearchUrl: 0 as const,
     },
+    you: {
+      youApiKey: 1 as const,
+      /** Optional (0) */
+      youApiUrl: 0 as const,
+    },
   },
   scrapers: {
     firecrawl: {
@@ -83,6 +88,8 @@ export function loadWebSearchConfig(
   const jinaApiKey = config?.jinaApiKey ?? '${JINA_API_KEY}';
   const jinaApiUrl = config?.jinaApiUrl ?? '${JINA_API_URL}';
   const cohereApiKey = config?.cohereApiKey ?? '${COHERE_API_KEY}';
+  const youApiKey = config?.youApiKey ?? '${YDC_API_KEY}';
+  const youApiUrl = config?.youApiUrl ?? '${YDC_API_URL}';
   const safeSearch = config?.safeSearch ?? SafeSearchTypes.MODERATE;
   const rerankerType = config?.rerankerType;
 
@@ -101,6 +108,8 @@ export function loadWebSearchConfig(
     firecrawlApiUrl,
     firecrawlVersion,
     searxngInstanceUrl,
+    youApiKey,
+    youApiUrl,
     rerankerType,
   };
 }

--- a/packages/data-schemas/src/types/web.ts
+++ b/packages/data-schemas/src/types/web.ts
@@ -12,7 +12,9 @@ export type TWebSearchKeys =
   | 'tavilyExtractUrl'
   | 'jinaApiKey'
   | 'jinaApiUrl'
-  | 'cohereApiKey';
+  | 'cohereApiKey'
+  | 'youApiKey'
+  | 'youApiUrl';
 
 export type TWebSearchCategories =
   | SearchCategories.PROVIDERS


### PR DESCRIPTION
⚠️ **Depends on danny-avila/agents#432** — the provider implementation lives in `@librechat/agents`. This PR is the LibreChat-side glue and should land after a release that includes it. Same sequencing as #285 → #14194.

## Summary

Adds You.com as a selectable `webSearch.searchProvider`, mirroring the existing Tavily provider. No search logic here — `createSearchAPI` / `createSearchTool` resolve the provider inside `@librechat/agents`; this PR only makes it selectable and configurable.

**Why:** the provider list a new self-hoster meets is Serper (carried in `.env.example` as the "Search Provider (Required)"), SearXNG, and Tavily. You.com runs its own web index and returns several extracted passages per result rather than a single meta description, so sources arrive with usable context before the scraping/reranking pipeline runs. It also has a keyless free tier, which matters below.

### What changed

- **data-provider** — `you` added to the `SearchProvider` type and `SearchProviders` enum; `youApiKey` / `youApiUrl` schema fields with `${YDC_API_KEY}` / `${YDC_API_URL}` placeholder defaults; a `youSearchOptions` block (`maxResults`, `attributionTitle`, `timeout`).
- **data-schemas** — `you` registered in `webSearchAuth.providers`; both placeholders defaulted in `loadWebSearchConfig`.
- **api/web** — `youSearchOptions` passed through to the provider. `youApiUrl` is added to `USER_PROVIDED_OPT_IN_URL_KEYS`, so a user-supplied endpoint override is ignored without admin opt-in and SSRF-preflighted when opted in, exactly like `tavilySearchUrl` / `tavilyExtractUrl`.
- **api/admin** — `webSearch.youApiKey` registered in `CONFIG_SECRET_FIELDS` so it masks like the other provider keys.
- **client** — You.com in the provider dropdown with an API-key input; `youApiKey` added to the search auth form payload; two `en` translation keys.
- **docs** — `YDC_API_KEY` / `YDC_API_URL` in `.env.example`; a `webSearch` example in `librechat.example.yaml`.

### One thing to flag: the key is marked required here, and it doesn't have to be

The provider works with **no key at all** — `@librechat/agents` falls back to You.com's keyless endpoint and only sends `X-API-Key` when one is set, the same shape Keenable already ships. But `loadWebSearchAuth` has `if (requiredKeys.length === 0) continue;`, so a provider whose keys are all optional is skipped and never authenticates.

Rather than change that shared branch here, I registered `youApiKey: 1`. #14194 already proposes a keyless carve-out for exactly this reason; if it lands, dropping You.com to `youApiKey: 0` is a one-line follow-up and the keyless path opens up. Happy to rebase onto that instead if you'd prefer them to land together.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

### Test Configuration

Node 22, `npm ci`, `npm run build:packages`.

- `packages/data-schemas` — **2195 passed / 64 suites.** `web.spec.ts` gains 4 You.com cases (placeholder defaults, provided-value passthrough, `webSearchAuth.providers.you` shape, key extraction); the existing exhaustive `loadWebSearchConfig({})` assertion was updated with the two new defaults.
- `packages/data-provider` — **1563 passed / 30 suites.** `config.spec.ts` gains 3 cases (`searchProvider: 'you'` parse + placeholder defaults, `youSearchOptions` accepted, invalid `maxResults` rejected).
- `packages/api` — `src/web/web.spec.ts` **56 passed**, including 2 new cases: full auth resolution for `searchProvider: 'you'` with `youSearchOptions` passthrough, and the URL override being stripped without admin opt-in.
- `client` — `ApiKeyDialog.test.tsx` 8 passed; `src/locales/Translation.spec.ts` 11 passed (locale-key parity); `tsc --noEmit` clean.
- `prettier --check` and `eslint` clean on every changed file.

The wider `packages/api` run has 25 failing suites, all `*_integration.spec.ts` / redis / mongo / MCP suites that need infrastructure. I confirmed these are pre-existing by stashing the branch and re-running: identical **8 failed / 156 passed** on `src/admin/secrets.integration.spec.ts` + `src/agents/hooks/executor.spec.ts` before and after.

Provider behaviour itself (keyless vs keyed endpoint selection, response mapping, date/country/safe-search parameters) is tested and live-verified in danny-avila/agents#432.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [ ] **Any changes dependent on mine have been merged and published in downstream modules** — blocked on danny-avila/agents#432 and a release
- [ ] A pull request for updating the documentation has been submitted — will open against `LibreChat-AI/librechat.ai` (`/features/web_search`) once this is approved