### PR TITLE
🧭 fix: Remove Legacy Langfuse Ingestion Verification

### DIFF
--- a/packages/api/src/admin/langfuse.handler.spec.ts
+++ b/packages/api/src/admin/langfuse.handler.spec.ts
@@ -583,7 +583,7 @@ describe('createAdminLangfuseHandlers', () => {
       expect(fields['langfuse.destination']).toBe('us');
       expect(fields['langfuse.publicKey']).toBe('pk-2');
       expect(fields['langfuse.projectId']).toBe('project-1');
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       const [url, init] = (global.fetch as unknown as jest.Mock).mock.calls[0];
       expect(url).toBe('https://us.cloud.langfuse.com/api/public/projects');
       expect(
@@ -774,11 +774,8 @@ describe('createAdminLangfuseHandlers', () => {
       expect(res.statusCode).toBe(400);
     });
 
-    it('returns success when Langfuse responds ok', async () => {
-      global.fetch = jest
-        .fn()
-        .mockResolvedValueOnce(projectResponse())
-        .mockResolvedValueOnce({ ok: true, status: 207 }) as unknown as typeof fetch;
+    it('validates the key pair through the current projects API', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce(projectResponse()) as unknown as typeof fetch;
       const { handlers } = createHandlers();
       const res = mockRes();
 
@@ -794,23 +791,16 @@ describe('createAdminLangfuseHandlers', () => {
       expect(url).toBe('https://cloud.langfuse.com/api/public/projects');
       expect(init.headers.Authorization).toMatch(/^Basic /);
       expect(init.signal).toBeInstanceOf(AbortSignal);
-      const [publicUrl, publicInit] = (global.fetch as unknown as jest.Mock).mock.calls[1];
-      expect(publicUrl).toBe('https://cloud.langfuse.com/api/public/ingestion');
-      expect(publicInit.method).toBe('POST');
-      expect(publicInit.headers.Authorization).toBe('Bearer pk');
-      expect(publicInit.headers['X-Langfuse-Public-Key']).toBe('pk');
-      expect(publicInit.headers['Content-Type']).toBe('application/json');
-      expect(JSON.parse(publicInit.body)).toEqual({ batch: [] });
-      expect(publicInit.signal).toBe(init.signal);
+      expect(
+        Buffer.from(init.headers.Authorization.replace('Basic ', ''), 'base64').toString(),
+      ).toBe('pk:sk');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('returns a timeout failure when Langfuse verification exceeds its deadline', async () => {
       const timeoutError = new Error('The operation was aborted due to timeout');
       timeoutError.name = 'TimeoutError';
-      global.fetch = jest
-        .fn()
-        .mockResolvedValueOnce(projectResponse())
-        .mockRejectedValueOnce(timeoutError) as unknown as typeof fetch;
+      global.fetch = jest.fn().mockRejectedValueOnce(timeoutError) as unknown as typeof fetch;
       const { handlers } = createHandlers();
       const res = mockRes();
 
@@ -825,13 +815,12 @@ describe('createAdminLangfuseHandlers', () => {
         success: false,
         errorCode: 'timeout',
       });
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('rejects an invalid public key even when the secret key is valid', async () => {
       global.fetch = jest
         .fn()
-        .mockResolvedValueOnce(projectResponse())
         .mockResolvedValueOnce({ ok: false, status: 401 }) as unknown as typeof fetch;
       const { handlers } = createHandlers();
       const res = mockRes();
@@ -847,7 +836,7 @@ describe('createAdminLangfuseHandlers', () => {
         success: false,
         errorCode: 'invalid_credentials',
       });
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('returns a key-specific failure when Langfuse rejects the credentials', async () => {
@@ -911,10 +900,7 @@ describe('createAdminLangfuseHandlers', () => {
     });
 
     it('falls back to the stored secret only for the unchanged connection', async () => {
-      global.fetch = jest
-        .fn()
-        .mockResolvedValueOnce(projectResponse())
-        .mockResolvedValueOnce({ ok: true, status: 207 }) as unknown as typeof fetch;
+      global.fetch = jest.fn().mockResolvedValueOnce(projectResponse()) as unknown as typeof fetch;
       const { handlers } = createHandlers({
         findConfigByPrincipal: jest.fn().mockResolvedValue(
           baseConfigDoc({
@@ -958,17 +944,14 @@ describe('createAdminLangfuseHandlers', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('sends the deployment headers on both verification requests', async () => {
+    it('sends deployment headers on the project verification request', async () => {
       /** Single-tenant topology with one configured Langfuse origin — the
        *  self-hosted-behind-a-proxy case — so the header map is unambiguous. */
       delete process.env.TENANT_ISOLATION_STRICT;
       delete process.env.LANGFUSE_FANOUT_ENABLED;
       delete process.env.LANGFUSE_FANOUT_COLLECTOR_URL;
       process.env.LANGFUSE_FANOUT_TENANT_EU_BASE_URL = 'https://eu.langfuse.internal';
-      global.fetch = jest
-        .fn()
-        .mockResolvedValueOnce(projectResponse())
-        .mockResolvedValueOnce({ ok: true, status: 207 }) as unknown as typeof fetch;
+      global.fetch = jest.fn().mockResolvedValueOnce(projectResponse()) as unknown as typeof fetch;
       const { handlers } = createHandlers();
       const res = mockRes();
 
@@ -984,9 +967,7 @@ describe('createAdminLangfuseHandlers', () => {
       const [, projectsInit] = (global.fetch as unknown as jest.Mock).mock.calls[0];
       expect(projectsInit.headers['CF-Access-Client-Id']).toBe('proxy-client');
       expect(projectsInit.headers.Authorization).toMatch(/^Basic /);
-      const [, ingestionInit] = (global.fetch as unknown as jest.Mock).mock.calls[1];
-      expect(ingestionInit.headers['CF-Access-Client-Id']).toBe('proxy-client');
-      expect(ingestionInit.headers.Authorization).toBe('Bearer pk');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       delete process.env.LANGFUSE_FANOUT_TENANT_EU_BASE_URL;
     });
 
@@ -994,10 +975,7 @@ describe('createAdminLangfuseHandlers', () => {
       /** The collector from `beforeEach` plus an explicit tenant URL: the map
        *  does not say which of them it authenticates to, so neither gets it. */
       process.env.LANGFUSE_FANOUT_TENANT_EU_BASE_URL = 'https://eu.langfuse.internal';
-      global.fetch = jest
-        .fn()
-        .mockResolvedValueOnce(projectResponse())
-        .mockResolvedValueOnce({ ok: true, status: 207 }) as unknown as typeof fetch;
+      global.fetch = jest.fn().mockResolvedValueOnce(projectResponse()) as unknown as typeof fetch;
       const { handlers } = createHandlers();
       const res = mockRes();
 
@@ -1016,10 +994,7 @@ describe('createAdminLangfuseHandlers', () => {
     });
 
     it('withholds deployment headers when verifying an unconfigured destination', async () => {
-      global.fetch = jest
-        .fn()
-        .mockResolvedValueOnce(projectResponse())
-        .mockResolvedValueOnce({ ok: true, status: 207 }) as unknown as typeof fetch;
+      global.fetch = jest.fn().mockResolvedValueOnce(projectResponse()) as unknown as typeof fetch;
       const { handlers } = createHandlers();
       const res = mockRes();
 
@@ -1042,8 +1017,7 @@ describe('createAdminLangfuseHandlers', () => {
       async (headerName) => {
         global.fetch = jest
           .fn()
-          .mockResolvedValueOnce(projectResponse())
-          .mockResolvedValueOnce({ ok: true, status: 207 }) as unknown as typeof fetch;
+          .mockResolvedValueOnce(projectResponse()) as unknown as typeof fetch;
         const { handlers } = createHandlers();
         const res = mockRes();
 

--- a/packages/api/src/admin/langfuse.ts
+++ b/packages/api/src/admin/langfuse.ts
@@ -185,25 +185,6 @@ async function verifyLangfuseCredentials(
       };
     }
 
-    const publicResponse = await fetch(`${destination.baseUrl}/api/public/ingestion`, {
-      method: 'POST',
-      headers: mergeHeaders(headers, {
-        Authorization: `Bearer ${publicKey}`,
-        'X-Langfuse-Public-Key': publicKey,
-        'Content-Type': 'application/json',
-      }),
-      body: JSON.stringify({ batch: [] }),
-      signal,
-      ...redirectPolicyFor(headers),
-    });
-    if (!publicResponse.ok) {
-      return {
-        success: false,
-        ...getLangfuseTestFailure(publicResponse.status),
-        responseStatus: publicResponse.status >= 500 ? 502 : 400,
-      };
-    }
-
     return { success: true, projectId };
   } catch (error) {
     logger.error('[adminLangfuse] connection verification error:', error);


### PR DESCRIPTION
I removed LibreChat's deprecated Langfuse ingestion request from connection verification while preserving key-pair and project validation through the current projects API.

- Removed the empty `POST /api/public/ingestion` request that triggered Langfuse v4 deprecation reporting.
- Kept Basic-auth key-pair validation and stable project identity discovery through `GET /api/public/projects`.
- Updated connection, timeout, invalid credential, and custom proxy-header tests for the single current API request.
- Prepared the application-side portion of the v4 migration; the tracing-side change is in [agents PR #433](https://github.com/danny-avila/agents/pull/433) and requires a package release and LibreChat dependency bump before runtime rollout is complete.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the focused API Jest suite: 49 tests passed.
- Ran targeted ESLint checks.
- Ran a static deprecated-endpoint audit.
- Attempted the package TypeScript check; it remains blocked by an unrelated existing Redis type mismatch in `src/cache/cacheFactory.ts:53`.
- Did not run live Langfuse project verification because project credentials are not configured.

### **Test Configuration**:

- Node.js v24.16.0
- Code-only migration mode

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass