### PR TITLE
🪢 ci: Prevent Playwright Apt Lock Leakage

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -251,12 +251,17 @@ jobs:
         continue-on-error: true
         run: timeout -k 10 90 npx playwright install ffmpeg
 
+      # This job deliberately skips the optional font install: its bounded
+      # Playwright apt process can outlive the wrapper on a slow mirror and
+      # retain the package-manager lock needed by the required Redis install.
+      # The MCP suite does not enable visual snapshot assertions.
+
       # Redis is a hard requirement for this job, so this step stays fatal.
       - name: Install Redis runtime dependencies
         timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y redis-server redis-tools
+          sudo apt-get -o DPkg::Lock::Timeout=300 update
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y redis-server redis-tools
 
       - name: Start standalone Redis and Redis Cluster
         run: |


### PR DESCRIPTION
I hardened the MCP Playwright job's required Redis installation against package-manager lock contention after `dev` removed the orphan-prone optional font step in #14971.

- Documented why the MCP job deliberately skips optional Playwright font installation while regular Playwright shards retain it.
- Added a five-minute `DPkg::Lock::Timeout` to the Redis update and installation commands as defense against independently held package-manager locks.
- Avoided broad process termination such as `pkill apt-get|dpkg`, which could kill unrelated package-manager work on the runner.
- Addressed the setup failure observed on #14939 and superseded the unsafe implementation approach in #14985.

Fixes #14983

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Parsed `.github/workflows/playwright-mock.yml` with Ruby's YAML parser.
- Confirmed the rebased workflow diff changes only the MCP Redis apt setup and its explanatory comment.
- Left end-to-end verification to GitHub Actions because the failure depends on Ubuntu runner package-manager timing.

### **Test Configuration**:

- macOS local workflow syntax validation
- GitHub Actions `ubuntu-latest` for runtime verification

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
