### PR TITLE
fix: bump @librechat/agents to 3.6.7 — fix 17x token overcount for large File Context (#14951)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.6.6",
+    "@librechat/agents": "^3.6.7",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.6.6",
+        "@librechat/agents": "^3.6.7",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10628,9 +10628,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.6.tgz",
-      "integrity": "sha512-YJqZ4Dsw/+dIu/Kbp3oMAc36zFXIrecHCcxYHdlFZA7WNnBLlBk2RwDSvf2WZUP0KfPACdx5K5LZOhTG4s+7ZQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.7.tgz",
+      "integrity": "sha512-P2CxE6CwRXjlBYRSQtgQvwItKBASStoICPM08vyXvXZbYavXxA6MED4hG9Km2Li0OSDAaStMhSjpNLaTzE0Cyw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42875,7 +42875,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.6.6",
+        "@librechat/agents": "^3.6.7",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.6.6",
+    "@librechat/agents": "^3.6.7",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Fixes #14951

## Before this PR:

`@librechat/agents@3.6.6` (what the lockfile currently pins) overcounts long text by roughly **17×**. Any agent whose injected text exceeds 200,000 characters — e.g. a large **File Context** attachment — reports a wildly inflated instruction-token count and fails preflight with `empty_messages`, even when the real prompt is a small fraction of the context window. From the issue: 118,315 chars of instructions + ~362,000 chars of attached files should be ~110,000 tokens, but the counter reported **764,834 tokens for the files alone**.

## After this PR:

The dependency is bumped to `@librechat/agents@3.6.7`, whose `getBoundedTextTokenCount` tokenizes long text in exact 8,192-char chunks (with a small boundary-safety margin) instead of slicing at 200k and pricing every omitted character at 4 tokens. Verified on the issue's exact input (361,473 chars): 3.6.6 reports ~692k tokens (8.3× overcount, matching the issue's ~765k report) vs 3.6.7's ~83k (1.00×, matching the expected ~82k).

## Why we need it:

The overcount fails large File Context agents with `empty_messages` before the request is even sent — a real user-facing failure. The fix is already released upstream (v3.6.7 was published the day after the issue, specifically addressing this tokenizer bug), so the LibreChat-side change is a version bump plus lockfile update only.

## Verification

- Upstream `tokens.test.ts` (v3.6.7): **64/64 tests pass**, including "counts long plain-text messages close to the real Claude tokenizer result" (361,473 chars) and the high-density-suffix regression test.
- Side-by-side comparison of both counting strategies on 361,473 chars (~0.23 tok/char): 3.6.6 = ~692k (8.3× overcount) → 3.6.7 = ~83k (1.00× of real).
- Lockfile resolved + integrity updated for 3.6.7; no other dependency changes.