### PR TITLE
feat: Add WaveSpeed AI image generation tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -575,6 +575,13 @@ FLUX_API_BASE_URL=https://api.us1.bfl.ai
 # Get your API key at https://api.us1.bfl.ai/auth/profile
 # FLUX_API_KEY=
 
+# WaveSpeed
+#-----------------
+# WAVESPEED_API_BASE_URL=https://api.wavespeed.ai
+
+# Get your API key at https://wavespeed.ai/
+# WAVESPEED_API_KEY=
+
 # Google
 #-----------------
 GOOGLE_SEARCH_API_KEY=

--- a/api/app/clients/tools/index.js
+++ b/api/app/clients/tools/index.js
@@ -3,6 +3,7 @@ const manifest = require('./manifest');
 // Structured Tools
 const DALLE3 = require('./structured/DALLE3');
 const FluxAPI = require('./structured/FluxAPI');
+const WaveSpeedAPI = require('./structured/WaveSpeedAPI');
 const OpenWeather = require('./structured/OpenWeather');
 const StructuredWolfram = require('./structured/Wolfram');
 const StructuredACS = require('./structured/AzureAISearch');
@@ -18,6 +19,7 @@ module.exports = {
   // Structured Tools
   DALLE3,
   FluxAPI,
+  WaveSpeedAPI,
   OpenWeather,
   StructuredSD,
   StructuredACS,

--- a/api/app/clients/tools/manifest.json
+++ b/api/app/clients/tools/manifest.json
@@ -161,6 +161,20 @@
     ]
   },
   {
+    "name": "WaveSpeed",
+    "pluginKey": "wavespeed",
+    "description": "Generate images using text with WaveSpeed AI, including Seedream and the full WaveSpeed model catalog.",
+    "icon": "https://wavespeed.ai/favicon.ico",
+    "isAuthRequired": "true",
+    "authConfig": [
+      {
+        "authField": "WAVESPEED_API_KEY",
+        "label": "Your WaveSpeed API Key",
+        "description": "Get your API key from your <a href=\"https://wavespeed.ai/\" target=\"_blank\">WaveSpeed AI</a> account settings."
+      }
+    ]
+  },
+  {
     "name": "Gemini Image Tools",
     "pluginKey": "gemini_image_gen",
     "description": "Generate high-quality images using Google's Gemini Image Models. Supports Gemini API or Vertex AI.",

--- a/api/app/clients/tools/structured/WaveSpeedAPI.js
+++ b/api/app/clients/tools/structured/WaveSpeedAPI.js
@@ -1,0 +1,282 @@
+const axios = require('axios');
+const fetch = require('node-fetch');
+const { v4: uuidv4 } = require('uuid');
+const { logger } = require('@librechat/data-schemas');
+const { Tool } = require('@librechat/agents/langchain/tools');
+const {
+  applyAxiosProxyConfig,
+  createMinimalRetentionRequest,
+  getHttpsProxyAgent,
+} = require('@librechat/api');
+const { FileContext, ContentTypes } = require('librechat-data-provider');
+
+const DEFAULT_MODEL = 'bytedance/seedream-v5.0-pro';
+
+const wavespeedJsonSchema = {
+  type: 'object',
+  properties: {
+    prompt: {
+      type: 'string',
+      description: 'Text prompt describing the image to generate.',
+    },
+    model: {
+      type: 'string',
+      description: `WaveSpeed model ID to use for generation, e.g. "${DEFAULT_MODEL}". Defaults to "${DEFAULT_MODEL}" when omitted. Only set this when the user explicitly asks for a different WaveSpeed model.`,
+    },
+    size: {
+      type: 'string',
+      description:
+        'Output image size as "width*height" in pixels, e.g. "2048*2048" or "1920*1080". Omit to use the model default.',
+    },
+  },
+  required: ['prompt'],
+};
+
+const displayMessage =
+  "WaveSpeed displayed an image. All generated images are already plainly visible, so don't repeat the descriptions in detail. Do not list download links as they are available in the UI already. The user may download the images by clicking on them, but do not mention anything about downloading to the user.";
+
+/**
+ * WaveSpeedAPI - A tool for generating high-quality images from text prompts using the WaveSpeed AI API.
+ * Submits a prediction, then polls until it reaches a terminal status.
+ * Each call generates one image. If multiple images are needed, make multiple consecutive calls.
+ */
+class WaveSpeedAPI extends Tool {
+  constructor(fields = {}) {
+    super();
+
+    /** @type {boolean} Used to initialize the Tool without necessary variables. */
+    this.override = fields.override ?? false;
+
+    this.userId = fields.userId;
+    this.tenantId = fields.req?.user?.tenantId;
+    this.retentionRequest = createMinimalRetentionRequest(fields.req);
+    this.fileStrategy = fields.fileStrategy;
+
+    /** @type {boolean} **/
+    this.isAgent = fields.isAgent;
+    if (this.isAgent) {
+      /** Ensures LangChain maps [content, artifact] tuple to ToolMessage fields instead of serializing it into content. */
+      this.responseFormat = 'content_and_artifact';
+    }
+    this.returnMetadata = fields.returnMetadata ?? false;
+
+    if (fields.processFileURL) {
+      /** @type {processFileURL} Necessary for output to contain all image metadata. */
+      this.processFileURL = fields.processFileURL.bind(this);
+    }
+
+    this.apiKey = fields.WAVESPEED_API_KEY || this.getApiKey();
+
+    this.name = 'wavespeed';
+    this.description =
+      'Use WaveSpeed AI to generate images from text descriptions. Each call creates one image. For multiple images, make multiple consecutive calls.';
+
+    this.description_for_model = `// Generate images from text prompts with WaveSpeed AI. Follow these rules:
+    // 1. Prompts should be detailed and descriptive, covering subject, composition, lighting, mood, and style.
+    // 2. Leave "model" unset unless the user explicitly requests a specific WaveSpeed model; the default ("${DEFAULT_MODEL}") is a high-quality general-purpose image model.
+    // 3. "size" is "width*height" in pixels (e.g. "2048*2048"); omit it unless the user asks for specific dimensions or an aspect ratio.`;
+
+    // Add base URL from environment variable with fallback
+    this.baseUrl = process.env.WAVESPEED_API_BASE_URL || 'https://api.wavespeed.ai';
+
+    this.schema = wavespeedJsonSchema;
+  }
+
+  static get jsonSchema() {
+    return wavespeedJsonSchema;
+  }
+
+  getAxiosConfig() {
+    const config = {};
+    return applyAxiosProxyConfig(config, this.baseUrl);
+  }
+
+  /** @param {Object|string} value */
+  getDetails(value) {
+    if (typeof value === 'string') {
+      return value;
+    }
+    return JSON.stringify(value, null, 2);
+  }
+
+  getApiKey() {
+    const apiKey = process.env.WAVESPEED_API_KEY || '';
+    if (!apiKey && !this.override) {
+      throw new Error('Missing WAVESPEED_API_KEY environment variable.');
+    }
+    return apiKey;
+  }
+
+  wrapInMarkdown(imageUrl) {
+    const serverDomain = process.env.DOMAIN_SERVER || 'http://localhost:3080';
+    return `![generated image](${serverDomain}${imageUrl})`;
+  }
+
+  returnValue(value) {
+    if (this.isAgent === true && typeof value === 'string') {
+      return [value, {}];
+    } else if (this.isAgent === true && typeof value === 'object') {
+      if (Array.isArray(value)) {
+        return value;
+      }
+      return [displayMessage, value];
+    }
+    return value;
+  }
+
+  async _call(data) {
+    const { prompt, model, size } = data;
+
+    if (!prompt) {
+      throw new Error('Missing required field: prompt');
+    }
+
+    // Use provided API key for this request if available, otherwise use default
+    const requestApiKey = this.apiKey || this.getApiKey();
+    const modelId = model || DEFAULT_MODEL;
+
+    const payload = { prompt };
+    if (size) {
+      payload.size = size;
+    }
+
+    const generateUrl = `${this.baseUrl}/api/v3/${modelId}`;
+
+    logger.debug('[WaveSpeedAPI] Generating image with payload:', payload);
+    logger.debug('[WaveSpeedAPI] Using model endpoint:', generateUrl);
+
+    const headers = {
+      Authorization: `Bearer ${requestApiKey}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+
+    let taskResponse;
+    try {
+      taskResponse = await axios.post(generateUrl, payload, {
+        headers,
+        ...this.getAxiosConfig(),
+      });
+    } catch (error) {
+      const details = this.getDetails(error?.response?.data || error.message);
+      logger.error('[WaveSpeedAPI] Error while submitting task:', details);
+
+      return this.returnValue(
+        `Something went wrong when trying to generate the image. The WaveSpeed API may be unavailable:
+        Error Message: ${details}`,
+      );
+    }
+
+    const taskId = taskResponse.data?.data?.id;
+    if (!taskId) {
+      logger.error('[WaveSpeedAPI] No prediction ID received from API:', taskResponse.data);
+      return this.returnValue('No prediction ID received from the WaveSpeed API.');
+    }
+
+    const resultUrl = `${this.baseUrl}/api/v3/predictions/${taskId}/result`;
+
+    // Polling for the result; predictions terminate as completed/failed/cancelled/timeout
+    const pollIntervalMs = 1000;
+    const maxAttempts = 600;
+    let resultData = null;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+        const resultResponse = await axios.get(resultUrl, {
+          headers: {
+            Authorization: `Bearer ${requestApiKey}`,
+            Accept: 'application/json',
+          },
+          ...this.getAxiosConfig(),
+        });
+        const prediction = resultResponse.data?.data;
+        const status = prediction?.status;
+
+        if (status === 'completed') {
+          resultData = prediction;
+          break;
+        } else if (status === 'failed' || status === 'cancelled' || status === 'timeout') {
+          logger.error('[WaveSpeedAPI] Error in task:', resultResponse.data);
+          return this.returnValue(
+            `An error occurred during image generation: prediction ${status}${
+              prediction?.error ? ` - ${prediction.error}` : ''
+            }`,
+          );
+        }
+      } catch (error) {
+        const details = this.getDetails(error?.response?.data || error.message);
+        logger.error('[WaveSpeedAPI] Error while getting result:', details);
+        return this.returnValue('An error occurred while retrieving the image.');
+      }
+    }
+
+    // If no result data
+    if (!resultData || !resultData.outputs || !resultData.outputs.length) {
+      logger.error('[WaveSpeedAPI] No image data received from API. Response:', resultData);
+      return this.returnValue('No image data received from the WaveSpeed API.');
+    }
+
+    // Try saving the image locally
+    const imageUrl = resultData.outputs[0];
+    const imageName = `img-${uuidv4()}.png`;
+
+    if (this.isAgent) {
+      try {
+        // Fetch the image and convert to base64
+        const fetchOptions = {};
+        const agent = getHttpsProxyAgent(imageUrl);
+        if (agent) {
+          fetchOptions.agent = agent;
+        }
+        const imageResponse = await fetch(imageUrl, fetchOptions);
+        const arrayBuffer = await imageResponse.arrayBuffer();
+        const base64 = Buffer.from(arrayBuffer).toString('base64');
+        const mimeType = imageResponse.headers?.get?.('content-type') || 'image/png';
+        const content = [
+          {
+            type: ContentTypes.IMAGE_URL,
+            image_url: {
+              url: `data:${mimeType};base64,${base64}`,
+            },
+          },
+        ];
+
+        const response = [
+          {
+            type: ContentTypes.TEXT,
+            text: displayMessage,
+          },
+        ];
+        return [response, { content }];
+      } catch (error) {
+        logger.error('Error processing image for agent:', error);
+        return this.returnValue(`Failed to process the image. ${error.message}`);
+      }
+    }
+
+    try {
+      logger.debug('[WaveSpeedAPI] Saving image:', imageUrl);
+      const result = await this.processFileURL({
+        fileStrategy: this.fileStrategy,
+        userId: this.userId,
+        URL: imageUrl,
+        fileName: imageName,
+        basePath: 'images',
+        context: FileContext.image_generation,
+        tenantId: this.tenantId,
+        req: this.retentionRequest,
+      });
+
+      logger.debug('[WaveSpeedAPI] Image saved to path:', result.filepath);
+
+      this.result = this.returnMetadata ? result : this.wrapInMarkdown(result.filepath);
+      return this.returnValue(this.result);
+    } catch (error) {
+      const details = this.getDetails(error?.message ?? 'No additional error details.');
+      logger.error('Error while saving the image:', details);
+      return this.returnValue(`Failed to save the image locally. ${details}`);
+    }
+  }
+}
+
+module.exports = WaveSpeedAPI;

--- a/api/app/clients/tools/structured/specs/WaveSpeedAPI.spec.js
+++ b/api/app/clients/tools/structured/specs/WaveSpeedAPI.spec.js
@@ -1,0 +1,262 @@
+/**
+ * Tests for the WaveSpeed image generation tool — verifies the submit + poll
+ * flow against the WaveSpeed prediction API and that agent mode returns a
+ * ToolMessage with base64 in artifact.content rather than serialized into
+ * content (mirrors the FluxAPI coverage in imageTools-agent.spec.js).
+ */
+
+const axios = require('axios');
+const fetch = require('node-fetch');
+const { ContentTypes } = require('librechat-data-provider');
+const { ToolMessage } = require('@librechat/agents/langchain/messages');
+const WaveSpeedAPI = require('../WaveSpeedAPI');
+
+jest.mock('axios');
+jest.mock('node-fetch');
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+
+const FAKE_BASE64 = 'aGVsbG8=';
+
+const makeToolCall = (name, args) => ({
+  id: 'call_test_123',
+  name,
+  args,
+  type: 'tool_call',
+});
+
+describe('WaveSpeedAPI', () => {
+  const ENV_KEYS = ['WAVESPEED_API_KEY', 'WAVESPEED_API_BASE_URL', 'PROXY'];
+  let savedEnv = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.WAVESPEED_API_KEY = 'test-wavespeed-key';
+    delete process.env.WAVESPEED_API_BASE_URL;
+    delete process.env.PROXY;
+
+    axios.post.mockResolvedValue({ data: { code: 200, data: { id: 'prediction-123' } } });
+    axios.get.mockResolvedValue({
+      data: {
+        code: 200,
+        data: {
+          id: 'prediction-123',
+          status: 'completed',
+          outputs: ['https://example.com/image.png'],
+        },
+      },
+    });
+    fetch.mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(Buffer.from(FAKE_BASE64, 'base64')),
+      headers: { get: () => 'image/png' },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    savedEnv = {};
+  });
+
+  it('throws when WAVESPEED_API_KEY is missing and override is not set', () => {
+    delete process.env.WAVESPEED_API_KEY;
+    expect(() => new WaveSpeedAPI()).toThrow('Missing WAVESPEED_API_KEY environment variable.');
+  });
+
+  it('sets responseFormat to content_and_artifact when isAgent is true', () => {
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    expect(wavespeed.responseFormat).toBe('content_and_artifact');
+  });
+
+  it('does not set responseFormat when isAgent is false', () => {
+    const wavespeed = new WaveSpeedAPI({ isAgent: false, processFileURL: jest.fn() });
+    expect(wavespeed.responseFormat).not.toBe('content_and_artifact');
+  });
+
+  it('keeps tenant context without retaining the request object', () => {
+    const req = {
+      user: { id: 'user-1', tenantId: 'tenant-a' },
+      body: { conversationId: 'convo-1', isTemporary: 'true' },
+      config: { interfaceConfig: { retentionMode: 'all' } },
+      socket: {},
+    };
+    const wavespeed = new WaveSpeedAPI({ isAgent: false, processFileURL: jest.fn(), req });
+
+    expect(wavespeed.tenantId).toBe('tenant-a');
+    expect(wavespeed.req).toBeUndefined();
+    expect(wavespeed.retentionRequest).toEqual({
+      user: { id: 'user-1', tenantId: 'tenant-a' },
+      body: { conversationId: 'convo-1', isTemporary: 'true' },
+      config: { interfaceConfig: { retentionMode: 'all' } },
+    });
+  });
+
+  it('submits to the default model with a Bearer token and polls the prediction result', async () => {
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    await invokePromise;
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://api.wavespeed.ai/api/v3/bytedance/seedream-v5.0-pro',
+      { prompt: 'a box' },
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-wavespeed-key' }),
+      }),
+    );
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://api.wavespeed.ai/api/v3/predictions/prediction-123/result',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-wavespeed-key' }),
+      }),
+    );
+  });
+
+  it('submits to a custom model and forwards the size parameter', async () => {
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(
+      makeToolCall('wavespeed', {
+        prompt: 'a box',
+        model: 'wavespeed-ai/flux-dev',
+        size: '1024*1024',
+      }),
+    );
+    await jest.runAllTimersAsync();
+    await invokePromise;
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://api.wavespeed.ai/api/v3/wavespeed-ai/flux-dev',
+      { prompt: 'a box', size: '1024*1024' },
+      expect.anything(),
+    );
+  });
+
+  it('keeps polling while the prediction is in progress', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: { code: 200, data: { status: 'created' } } })
+      .mockResolvedValueOnce({ data: { code: 200, data: { status: 'processing' } } })
+      .mockResolvedValueOnce({
+        data: {
+          code: 200,
+          data: { status: 'completed', outputs: ['https://example.com/image.png'] },
+        },
+      });
+
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    const result = await invokePromise;
+
+    expect(axios.get).toHaveBeenCalledTimes(3);
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect(result.artifact?.content?.[0].type).toBe(ContentTypes.IMAGE_URL);
+  });
+
+  it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    const result = await invokePromise;
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    const contentStr =
+      typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+    expect(contentStr).not.toContain(FAKE_BASE64);
+
+    expect(result.artifact).toBeDefined();
+    const artifactContent = result.artifact?.content;
+    expect(Array.isArray(artifactContent)).toBe(true);
+    expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
+    expect(artifactContent[0].image_url.url).toContain('base64');
+  });
+
+  it('passes minimal retention context when saving generated images', async () => {
+    const processFileURL = jest.fn().mockResolvedValue({ filepath: '/images/generated.png' });
+    const req = {
+      user: { id: 'user-1', tenantId: 'tenant-a' },
+      body: { conversationId: 'convo-1', isTemporary: 'true' },
+      config: { interfaceConfig: { retentionMode: 'all' } },
+      socket: {},
+    };
+    const wavespeed = new WaveSpeedAPI({
+      isAgent: false,
+      processFileURL,
+      req,
+      userId: 'user-1',
+      fileStrategy: 'local',
+    });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    await invokePromise;
+
+    expect(processFileURL).toHaveBeenCalledWith(
+      expect.objectContaining({
+        URL: 'https://example.com/image.png',
+        req: {
+          user: { id: 'user-1', tenantId: 'tenant-a' },
+          body: { conversationId: 'convo-1', isTemporary: 'true' },
+          config: { interfaceConfig: { retentionMode: 'all' } },
+        },
+      }),
+    );
+  });
+
+  it('invoke() returns ToolMessage with error string in content when task submission fails', async () => {
+    axios.post.mockRejectedValue(new Error('Network error'));
+
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    const result = await invokePromise;
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    const contentStr =
+      typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+    expect(contentStr).toContain('Something went wrong');
+    expect(result.artifact).toBeDefined();
+  });
+
+  it('invoke() returns ToolMessage with error string in content when the prediction fails', async () => {
+    axios.get.mockResolvedValue({
+      data: { code: 200, data: { status: 'failed', error: 'NSFW content detected' } },
+    });
+
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    const result = await invokePromise;
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    const contentStr =
+      typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+    expect(contentStr).toContain('failed');
+    expect(contentStr).toContain('NSFW content detected');
+  });
+
+  it('invoke() returns ToolMessage with error string when the prediction completes without outputs', async () => {
+    axios.get.mockResolvedValue({
+      data: { code: 200, data: { status: 'completed', outputs: [] } },
+    });
+
+    const wavespeed = new WaveSpeedAPI({ isAgent: true });
+    const invokePromise = wavespeed.invoke(makeToolCall('wavespeed', { prompt: 'a box' }));
+    await jest.runAllTimersAsync();
+    const result = await invokePromise;
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    const contentStr =
+      typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+    expect(contentStr).toContain('No image data received');
+  });
+});

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -38,6 +38,7 @@ const {
   // Structured Tools
   DALLE3,
   FluxAPI,
+  WaveSpeedAPI,
   OpenWeather,
   StructuredSD,
   StructuredACS,
@@ -190,6 +191,7 @@ const loadTools = async ({
 }) => {
   const toolConstructors = {
     flux: FluxAPI,
+    wavespeed: WaveSpeedAPI,
     calculator: Calculator,
     google: GoogleSearchAPI,
     open_weather: OpenWeather,
@@ -270,6 +272,7 @@ const loadTools = async ({
 
   const toolOptions = {
     flux: imageGenOptions,
+    wavespeed: imageGenOptions,
     dalle: imageGenOptions,
     'stable-diffusion': imageGenOptions,
     gemini_image_gen: imageGenOptions,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2478,6 +2478,7 @@ export const imageGenTools = new Set([
   'dall-e',
   'stable-diffusion',
   'flux',
+  'wavespeed',
   'gemini_image_gen',
 ]);
 


### PR DESCRIPTION
## Summary

Adds a **WaveSpeed** ([wavespeed.ai](https://wavespeed.ai)) image generation tool, mirroring the existing Flux tool pattern. WaveSpeed is a fast image/video generation platform; the tool defaults to Seedream (`bytedance/seedream-v5.0-pro`) and supports the full WaveSpeed model catalog via an optional `model` parameter.

Implementation details:

- New structured tool `api/app/clients/tools/structured/WaveSpeedAPI.js`: submits a prediction to `POST /api/v3/{model_id}`, polls `GET /api/v3/predictions/{id}/result` until a terminal status (`completed` / `failed` / `cancelled` / `timeout`), then returns the image per LibreChat conventions — base64 artifact content for agents (`responseFormat = 'content_and_artifact'`), or saved via `processFileURL` with the minimal retention request otherwise.
- Tool schema: `prompt` (required), optional `model` and `size` (`"width*height"`).
- Registered alongside Flux everywhere: tools `index.js`, `handleTools.js` (`toolConstructors` + `toolOptions` with `imageGenOptions`), `manifest.json` (pluginKey `wavespeed`), and the `imageGenTools` set in `packages/data-provider`.
- Env wiring: `WAVESPEED_API_KEY` (authConfig field) and optional `WAVESPEED_API_BASE_URL`, documented in `.env.example`.

Disclosure: this is an official contribution from the WaveSpeedAI team (I am the founder), and it was developed with AI assistance (Claude Code) with human review.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Added `api/app/clients/tools/structured/specs/WaveSpeedAPI.spec.js` (11 tests, HTTP fully mocked): submit + poll flow with Bearer auth, custom model/size forwarding, in-progress polling, agent-mode ToolMessage artifact format (base64 kept out of `content`), minimal retention context passed to `processFileURL`, and error paths (submission failure, failed prediction, empty outputs, missing API key).
- Ran the existing image tool suites to confirm no regressions.

### **Test Configuration**:

```
cd api
npx jest app/clients/tools/structured/specs/WaveSpeedAPI.spec.js app/clients/tools/structured/specs/imageTools-agent.spec.js
# 2 suites, 29 tests passed
npx jest app/clients/tools/util/handleTools.test.js
# 1 suite, 28 tests passed
```

ESLint passes on all changed files.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted. (Happy to follow up with a docs PR to librechat.ai.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJJXU9zyoDSBjApcUpteDt