### PR TITLE
🛂 fix: Preserve OpenID Re-Auth Errors Through MCP Tool Error Classification

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -35,6 +35,7 @@ const {
   hasRuntimeUrlPlaceholders,
   containsGraphTokenPlaceholder,
   isOAuthServer,
+  OpenIDReauthRequiredError,
 } = require('@librechat/api');
 const {
   Time,
@@ -1124,6 +1125,11 @@ function createToolInstance({
         `[MCP][${serverName}][${toolName}][User: ${userId}] Error calling MCP tool:`,
         error,
       );
+
+      /** Carries the actionable re-auth message; the substring heuristic below would misreport it as an OAuth configuration problem */
+      if (error instanceof OpenIDReauthRequiredError) {
+        throw error;
+      }
 
       /** OAuth error, provide a helpful message */
       const isOAuthError =

--- a/api/server/services/MCP.spec.js
+++ b/api/server/services/MCP.spec.js
@@ -1642,6 +1642,54 @@ describe('User parameter passing tests', () => {
       );
     });
 
+    it('preserves OpenIDReauthRequiredError through the OAuth error classification', async () => {
+      const { OpenIDReauthRequiredError } = require('@librechat/api');
+      const mockUser = { id: 'reauth-user', role: 'USER' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+      const { getRoleByName } = require('~/models');
+      getRoleByName.mockResolvedValue({
+        permissions: {
+          [PermissionTypes.MCP_SERVERS]: {
+            [Permissions.USE]: true,
+          },
+        },
+      });
+      const reauthError = new OpenIDReauthRequiredError(
+        'OpenID token is expired or unavailable; re-authentication is required to resolve {{LIBRECHAT_OPENID_ACCESS_TOKEN}}.',
+      );
+      mockGetMCPManager.mockReturnValue({
+        callTool: jest.fn().mockRejectedValue(reauthError),
+      });
+
+      const mcpTool = await createMCPTool({
+        res: mockRes,
+        user: mockUser,
+        config: { requiresOAuth: false },
+        toolKey: `test-tool${D}test-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: {
+          [`test-tool${D}test-server`]: {
+            function: {
+              description: 'Cached tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        },
+      });
+
+      await expect(
+        mcpTool.invoke(
+          {},
+          {
+            configurable: { user: mockUser },
+            metadata: { provider: 'openai', thread_id: 'thread-1', run_id: 'run-1' },
+            toolCall: {},
+          },
+        ),
+      ).rejects.toBe(reauthError);
+    });
+
     it('does not label OBO authentication failures as unconfigured MCP OAuth', async () => {
       const mockUser = { id: 'obo-user', role: 'USER' };
       const mockRes = { write: jest.fn(), flush: jest.fn() };


### PR DESCRIPTION
## Summary

Follow-up to #14982, fixing the finding flagged in its review thread. The MCP tool-call catch block in `api/server/services/MCP.js` classifies errors by message substring (`401`, `OAuth`, `authentication`), so the typed `OpenIDReauthRequiredError` introduced by #14982 was captured by the heuristic when a previously loaded tool was called after token expiry: the actionable re-authentication message was rewritten into "upstream authentication failed; MCP OAuth is not configured for this server" (or the generic OAuth prompt), and the rethrow discarded the class identity along with its `statusCode`.

The typed error now passes through ahead of the heuristic, so callers receive the original error intact: the actionable message, the class, and the 401 `statusCode` the error middleware and generation path rely on.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New case in `api/server/services/MCP.spec.js`, mirroring the neighbouring OAuth-classification tests: `callTool` rejects with an `OpenIDReauthRequiredError`, and the tool invocation rejects with that exact instance (`rejects.toBe`), proving neither the message rewrite nor the identity-discarding rethrow fires. The pre-existing classification tests (unconfigured-OAuth rewrite, OAuth flow signals, forwarded-token and OBO cases) all still pass, pinning that the heuristic's behavior for every other error shape is unchanged.

Full `MCP.spec.js` suite: 72 passed.

### **Test Configuration**:

`cd api && npx jest server/services/MCP`

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
