### PR TITLE
🙋 fix: Free the Composer When a Question Pause Collapses

### DIFF
--- a/client/src/components/Chat/Input/AskUserQuestionPopover.tsx
+++ b/client/src/components/Chat/Input/AskUserQuestionPopover.tsx
@@ -193,21 +193,23 @@ function AskUserQuestionPopoverPanel({
           {options.map((option, index) => {
             const isChecked = multiSelect && checked.includes(index);
             return (
-              <button
+              <Button
                 key={option.value}
                 ref={(el) => {
                   optionRefs.current[index] = el;
                 }}
                 type="button"
+                size="sm"
+                variant="choice"
                 role={multiSelect ? 'checkbox' : undefined}
                 aria-checked={multiSelect ? isChecked : undefined}
                 disabled={locked}
+                /** Layout and the keyboard highlight are the only things the
+                 *  popover owns here — these rows are the same answer controls
+                 *  as the cards', so their appearance stays in the variant. */
                 className={cn(
-                  'mt-1 flex w-full items-center gap-3 rounded-lg border border-border-xheavy p-2 text-left text-sm text-text-primary',
-                  selected === index
-                    ? 'bg-surface-active'
-                    : 'bg-surface-tertiary hover:bg-surface-hover',
-                  locked ? 'cursor-not-allowed opacity-60' : '',
+                  'mt-1 h-auto min-h-9 w-full justify-start gap-3 whitespace-normal p-2 text-left',
+                  selected === index && 'bg-surface-active hover:bg-surface-active',
                 )}
                 onClick={() => (multiSelect ? toggleChecked(index) : submitOption(index))}
               >
@@ -222,7 +224,7 @@ function AskUserQuestionPopoverPanel({
                   {isChecked ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : index + 1}
                 </span>
                 <span className="min-w-0 flex-1 [overflow-wrap:anywhere]">{option.label}</span>
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/client/src/components/Chat/Input/AskUserQuestionPopover.tsx
+++ b/client/src/components/Chat/Input/AskUserQuestionPopover.tsx
@@ -156,7 +156,7 @@ function AskUserQuestionPopoverPanel({
           scroll region: the panel is absolutely positioned, so anything that
           overflows it is unreachable by page scroll. */}
       <div
-        className="popover border-token-border-light flex max-h-[60vh] flex-col rounded-2xl border bg-white p-2 shadow-lg dark:bg-gray-700"
+        className="popover border-token-border-light flex max-h-[60vh] flex-col rounded-2xl border bg-surface-secondary p-2 shadow-lg"
         onKeyDown={handlePopoverKeyDown}
       >
         <div className="flex shrink-0 items-start justify-between gap-2 p-2">
@@ -165,7 +165,7 @@ function AskUserQuestionPopoverPanel({
               {liveAsk.question.question}
             </p>
             {liveAsk.question.description != null && liveAsk.question.description.length > 0 && (
-              <p className="mt-0.5 text-xs text-text-secondary [overflow-wrap:anywhere]">
+              <p className="mt-1 text-sm text-text-secondary [overflow-wrap:anywhere]">
                 {liveAsk.question.description}
               </p>
             )}
@@ -203,8 +203,10 @@ function AskUserQuestionPopoverPanel({
                 aria-checked={multiSelect ? isChecked : undefined}
                 disabled={locked}
                 className={cn(
-                  'flex w-full items-center gap-3 rounded-lg p-2 text-left text-sm text-text-primary',
-                  selected === index ? 'bg-surface-active' : 'hover:bg-surface-hover',
+                  'mt-1 flex w-full items-center gap-3 rounded-lg border border-border-xheavy p-2 text-left text-sm text-text-primary',
+                  selected === index
+                    ? 'bg-surface-active'
+                    : 'bg-surface-tertiary hover:bg-surface-hover',
                   locked ? 'cursor-not-allowed opacity-60' : '',
                 )}
                 onClick={() => (multiSelect ? toggleChecked(index) : submitOption(index))}
@@ -213,8 +215,8 @@ function AskUserQuestionPopoverPanel({
                   className={cn(
                     'flex h-5 w-5 shrink-0 items-center justify-center rounded text-xs',
                     isChecked
-                      ? 'bg-surface-submit text-white'
-                      : 'bg-surface-tertiary text-text-secondary',
+                      ? 'bg-surface-submit text-text-on-status'
+                      : 'border border-border-xheavy text-text-secondary',
                   )}
                 >
                   {isChecked ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : index + 1}

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -179,6 +179,10 @@ const ChatForm = memo(function ChatForm({
   const answerPlaceholder = answerMode.batchMode
     ? localize('com_ui_answer_questions_above')
     : (answerMode.otherLabel ?? localize('com_ui_something_else'));
+  /** The composer is not a plain chat composer: it either IS this pause's
+   *  answer box, or is locked behind the batch card that owns the answer. A
+   *  collapsed batch is neither — it hands the composer back to the thread. */
+  const composerReserved = answerMode.composerAnswers || answerMode.composerLocked;
 
   useAutoSave({
     index,
@@ -269,7 +273,7 @@ const ChatForm = memo(function ChatForm({
     conversationId,
     conversation,
     isSubmitting,
-    answerModeActive: answerMode.active,
+    answerModeActive: composerReserved,
     files,
     setFiles,
     filesLoading,
@@ -287,8 +291,8 @@ const ChatForm = memo(function ChatForm({
   const liveFilesRef = useRef(files);
   liveFilesRef.current = files;
   /** Same reason: the run can pause on `ask_user_question` mid-reclaim. */
-  const liveAnswerModeRef = useRef(answerMode.active);
-  liveAnswerModeRef.current = answerMode.active;
+  const liveAnswerModeRef = useRef(composerReserved);
+  liveAnswerModeRef.current = composerReserved;
   /** A reclaim can resolve after this form unmounts (left the route, closed the
    *  pane). Its refs still hold the origin chat, so the restore would pass its
    *  checks and write into a dead form — reporting success and making the caller
@@ -393,11 +397,11 @@ const ChatForm = memo(function ChatForm({
     setIsScrollable,
     disabled: disableInputs,
     // The composer IS the free-form answer box while a question pause is live.
-    placeholder: answerMode.active ? answerPlaceholder : placeholder,
+    placeholder: composerReserved ? answerPlaceholder : placeholder,
     // Enter stays live during a run when it can steer/queue instead of send.
     allowSubmitWhileGenerating: steering.duringRunActive,
     onDuringRunModifier: steering.duringRunActive ? handleDuringRunModifier : undefined,
-    answerModeActive: answerMode.active && !answerMode.batchMode,
+    answerModeActive: answerMode.composerAnswers,
   });
 
   useQueryParams({ textAreaRef });
@@ -406,7 +410,7 @@ const ChatForm = memo(function ChatForm({
    *  hands the composer text straight to the paused run, which answers with
    *  values and cannot consume files, so an empty draft must stay unsubmittable
    *  there rather than enabling a button whose submit is silently dropped. */
-  const submittableFileCount = answerMode.active ? 0 : files.size;
+  const submittableFileCount = composerReserved ? 0 : files.size;
 
   const { ref, ...registerProps } = methods.register('text', {
     required: submittableFileCount === 0,
@@ -485,7 +489,8 @@ const ChatForm = memo(function ChatForm({
       onSubmit={methods.handleSubmit((data) => {
         // Answer mode: composer text answers the paused run instead of
         // starting a new turn (submitText resets the composer itself).
-        // Dismissing the popover restores normal sends.
+        // Dismissing the popover — or collapsing a batch, which answers in its
+        // own card — restores normal sends.
         if (answerMode.active && answerMode.submitText(data.text)) {
           return;
         }
@@ -608,11 +613,7 @@ const ChatForm = memo(function ChatForm({
                           textAreaRef as React.MutableRefObject<HTMLTextAreaElement | null>
                         ).current = e;
                       }}
-                      disabled={
-                        disableInputs ||
-                        isNotAppendable ||
-                        (answerMode.active && answerMode.batchMode)
-                      }
+                      disabled={disableInputs || isNotAppendable || answerMode.composerLocked}
                       onPaste={handlePaste}
                       onKeyDown={(e) => {
                         // Answer mode consumes option-navigation keys from the
@@ -705,7 +706,7 @@ const ChatForm = memo(function ChatForm({
                 <div className={`${isRTL ? 'ml-2' : 'mr-2'}`}>
                   {isSubmitting &&
                   (showStopButton || steering.duringRunActive) &&
-                  !answerMode.active
+                  !answerMode.composerAnswers
                     ? duringRunSlot
                     : endpoint && (
                         <SendButton
@@ -716,8 +717,8 @@ const ChatForm = memo(function ChatForm({
                             filesLoading ||
                             disableInputs ||
                             isNotAppendable ||
-                            (answerMode.active && answerMode.batchMode) ||
-                            (isSubmitting && !answerMode.active)
+                            answerMode.composerLocked ||
+                            (isSubmitting && !answerMode.composerAnswers)
                           }
                         />
                       )}

--- a/client/src/components/Chat/Messages/Content/AskUserQuestion.tsx
+++ b/client/src/components/Chat/Messages/Content/AskUserQuestion.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo, useState } from 'react';
-import { ChevronUp, TriangleAlert } from 'lucide-react';
+import { ChevronUp, TriangleAlert, X } from 'lucide-react';
 import { Button, TextareaAutosize } from '@librechat/client';
 import type { Agents } from 'librechat-data-provider';
 import { useApprovalContext, useAskSubmitStatus, useResumeSubmit } from './ApprovalContext';
@@ -40,6 +40,7 @@ export default function AskUserQuestion({
         questions={questions}
         className="my-2 max-h-[70vh] w-full rounded-lg border border-border-light bg-surface-secondary"
         onExpand={answerMode.collapsed && isLivePause ? answerMode.expand : undefined}
+        onDismiss={answerMode.collapsed && isLivePause ? answerMode.dismiss : undefined}
       />
     );
   }
@@ -68,7 +69,7 @@ function AskUserQuestionSingle({
    * chevron re-expands it) or dismissed (and in contexts without a
    * ChatContext, where the popover can't exist).
    */
-  const { popoverVisible, collapsed, expand, liveAsk } = answerMode;
+  const { popoverVisible, collapsed, expand, dismiss, liveAsk } = answerMode;
   const isLivePause = liveAsk?.actionId === actionId;
 
   /** Same fold as the popover: a model-supplied catch-all "Other" option
@@ -144,14 +145,26 @@ function AskUserQuestionSingle({
           {question.question}
         </p>
         {collapsed && isLivePause && (
-          <button
-            type="button"
-            aria-label={localize('com_ui_expand')}
-            className="rounded p-1 text-text-secondary hover:bg-surface-hover"
-            onClick={expand}
-          >
-            <ChevronUp className="h-4 w-4" aria-hidden="true" />
-          </button>
+          <div className="flex shrink-0 items-center">
+            <button
+              type="button"
+              aria-label={localize('com_ui_expand')}
+              className="rounded p-1 text-text-secondary hover:bg-surface-hover"
+              onClick={expand}
+            >
+              <ChevronUp className="h-4 w-4" aria-hidden="true" />
+            </button>
+            {/** Mirrors the popover's ×: the collapsed card is the only chrome
+             *   left, so the way out of answer mode has to live here too. */}
+            <button
+              type="button"
+              aria-label={localize('com_ui_close')}
+              className="rounded p-1 text-text-secondary hover:bg-surface-hover"
+              onClick={dismiss}
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
         )}
       </div>
       {question.description != null && question.description.length > 0 && (
@@ -166,7 +179,7 @@ function AskUserQuestionSingle({
             <Button
               key={option.value}
               size="sm"
-              variant={multiSelect && checkedIndices.includes(index) ? 'submit' : 'outline'}
+              variant={multiSelect && checkedIndices.includes(index) ? 'submit' : 'choice'}
               role={multiSelect ? 'checkbox' : undefined}
               aria-checked={multiSelect ? checkedIndices.includes(index) : undefined}
               disabled={locked}
@@ -189,7 +202,7 @@ function AskUserQuestionSingle({
         minRows={2}
         maxRows={12}
         placeholder={otherLabel ?? localize('com_ui_your_answer')}
-        className="w-full resize-none rounded-md border border-border-light bg-surface-primary p-2 text-sm text-text-primary"
+        className="w-full resize-none rounded-md border border-border-xheavy bg-surface-primary p-2 text-sm text-text-primary"
         aria-label={localize('com_ui_your_answer')}
       />
 

--- a/client/src/components/Chat/Messages/Content/AskUserQuestions.tsx
+++ b/client/src/components/Chat/Messages/Content/AskUserQuestions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
 import { Button, TextareaAutosize } from '@librechat/client';
-import { Check, ChevronUp, TriangleAlert } from 'lucide-react';
+import { Check, ChevronUp, TriangleAlert, X } from 'lucide-react';
 import type { Agents } from 'librechat-data-provider';
 import useAskQuestionsForm from '~/hooks/Input/useAskQuestionsForm';
 import { splitOtherOption } from '~/utils/approval';
@@ -18,11 +18,13 @@ export default function AskUserQuestions({
   questions,
   className,
   onExpand,
+  onDismiss,
 }: {
   actionId: string;
   questions: Agents.AskUserQuestionBatchItem[];
   className?: string;
   onExpand?: () => void;
+  onDismiss?: () => void;
 }) {
   const localize = useLocalize();
   const promptId = useId();
@@ -102,16 +104,31 @@ export default function AskUserQuestions({
 
   return (
     <div className={cn('flex min-h-0 flex-col', className)}>
-      {onExpand != null && (
-        <div className="flex shrink-0 justify-end border-b border-border-light px-2 py-1">
-          <button
-            type="button"
-            aria-label={localize('com_ui_expand')}
-            className="rounded p-1 text-text-secondary hover:bg-surface-hover"
-            onClick={onExpand}
-          >
-            <ChevronUp className="h-4 w-4" aria-hidden="true" />
-          </button>
+      {(onExpand != null || onDismiss != null) && (
+        <div className="flex shrink-0 items-center justify-end border-b border-border-light px-2 py-1">
+          {onExpand != null && (
+            <button
+              type="button"
+              aria-label={localize('com_ui_expand')}
+              className="rounded p-1 text-text-secondary hover:bg-surface-hover"
+              onClick={onExpand}
+            >
+              <ChevronUp className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+          {/** The collapsed card is the ONLY surface left for a collapsed
+           *   batch, so it has to carry the popover's dismiss too — without it
+           *   the pause can only be answered or skipped. */}
+          {onDismiss != null && (
+            <button
+              type="button"
+              aria-label={localize('com_ui_close')}
+              className="rounded p-1 text-text-secondary hover:bg-surface-hover"
+              onClick={onDismiss}
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
         </div>
       )}
       {stepped && (
@@ -175,7 +192,7 @@ export default function AskUserQuestions({
             {question.question}
           </p>
           {question.description != null && question.description.length > 0 && (
-            <p className="mt-1 text-xs text-text-secondary [overflow-wrap:anywhere]">
+            <p className="mt-1 text-sm text-text-secondary [overflow-wrap:anywhere]">
               {question.description}
             </p>
           )}
@@ -188,7 +205,7 @@ export default function AskUserQuestions({
                     key={option.value}
                     type="button"
                     size="sm"
-                    variant={isSelected ? 'submit' : 'outline'}
+                    variant={isSelected ? 'submit' : 'choice'}
                     role={question.multiSelect === true ? 'checkbox' : undefined}
                     aria-checked={question.multiSelect === true ? isSelected : undefined}
                     aria-pressed={question.multiSelect === true ? undefined : isSelected}
@@ -212,7 +229,7 @@ export default function AskUserQuestions({
             minRows={1}
             maxRows={6}
             placeholder={otherLabel ?? localize('com_ui_your_answer')}
-            className="mt-2 w-full resize-none rounded-md border border-border-light bg-surface-primary p-2 text-sm text-text-primary"
+            className="mt-2 w-full resize-none rounded-md border border-border-xheavy bg-surface-primary p-2 text-sm text-text-primary"
             aria-label={`${question.question} ${localize('com_ui_your_answer')}`}
           />
         </fieldset>

--- a/client/src/components/Chat/Messages/Content/__tests__/AskUserQuestionCollapse.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/AskUserQuestionCollapse.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Agents } from 'librechat-data-provider';
+import useAskAnswerMode from '~/hooks/Input/useAskAnswerMode';
+import { ChatContext } from '~/Providers/ChatContext';
+import AskUserQuestion from '../AskUserQuestion';
+
+/**
+ * Collapsing a live pause used to strand the user: the popover carried the only
+ * dismiss, and a batch kept the composer disabled for as long as the pause was
+ * active — so after the chevron there was nothing to type in, nothing to send
+ * with, no stop button, and no × anywhere. Reloading the page was the only way
+ * out. These cover both halves of the handover across the REAL recoil atoms the
+ * popover and the chat card share.
+ */
+
+const mockBatch: Agents.AskUserQuestionBatchItem[] = [
+  { id: 'scope', header: 'Dashboard scope', question: 'North star or full funnel?' },
+  { id: 'window', question: 'Which time window?' },
+];
+
+const mockSingle = {
+  question: 'Which environment?',
+  options: [{ label: 'Staging', value: 'staging' }],
+} as Agents.AskUserQuestionRequest;
+
+let mockLiveAsk: {
+  actionId: string;
+  question: Agents.AskUserQuestionRequest;
+  questions?: Agents.AskUserQuestionBatchItem[];
+  messageId: string;
+} = {
+  actionId: 'act-1',
+  question: mockSingle,
+  questions: mockBatch,
+  messageId: 'message-1',
+};
+
+jest.mock('~/data-provider', () => ({
+  useGetMessagesByConvoId: () => ({ data: mockLiveAsk }),
+}));
+jest.mock('~/components/Chat/Messages/Content/ApprovalContext', () => ({
+  useApprovalContext: () => ({ getAskAnswerDraft: () => '', setAskAnswerDraft: jest.fn() }),
+  useAskSubmitStatus: () => ({ getAskStatus: () => 'idle' }),
+  useResumeSubmit: () => ({ submitAskAnswer: jest.fn() }),
+}));
+jest.mock('~/Providers', () => ({ useOptionalChatFormContext: () => null }));
+
+/** Stands in for the composer: publishes the flags ChatForm gates on. */
+function ComposerProbe() {
+  const ask = useAskAnswerMode('conversation-1');
+  return (
+    <div>
+      <span data-testid="composer-locked">{String(ask.composerLocked)}</span>
+      <span data-testid="composer-answers">{String(ask.composerAnswers)}</span>
+      <span data-testid="popover-visible">{String(ask.popoverVisible)}</span>
+      <span data-testid="active">{String(ask.active)}</span>
+      <button data-testid="collapse-from-popover" onClick={ask.collapse} />
+    </div>
+  );
+}
+
+const renderPause = () =>
+  render(
+    <RecoilRoot>
+      <ChatContext.Provider value={{ conversation: { conversationId: 'conversation-1' } } as never}>
+        <ComposerProbe />
+        <AskUserQuestion
+          actionId="act-1"
+          question={mockLiveAsk.question}
+          questions={mockLiveAsk.questions}
+        />
+      </ChatContext.Provider>
+    </RecoilRoot>,
+  );
+
+describe('collapsing a live ask_user_question', () => {
+  describe('batched questions', () => {
+    beforeEach(() => {
+      mockLiveAsk = {
+        actionId: 'act-1',
+        question: mockSingle,
+        questions: mockBatch,
+        messageId: 'message-1',
+      };
+    });
+
+    it('locks the composer only while the popover is up', () => {
+      renderPause();
+      expect(screen.getByTestId('composer-locked').textContent).toBe('true');
+      /** The popover owns the question, so the card stays out of the way. */
+      expect(screen.queryByText('North star or full funnel?')).toBeNull();
+
+      fireEvent.click(screen.getByTestId('collapse-from-popover'));
+
+      expect(screen.getByTestId('popover-visible').textContent).toBe('false');
+      /** The pause is still live — the card has it now... */
+      expect(screen.getByTestId('active').textContent).toBe('true');
+      expect(screen.getByText('North star or full funnel?')).toBeInTheDocument();
+      /** ...and the composer is a composer again. */
+      expect(screen.getByTestId('composer-locked').textContent).toBe('false');
+      expect(screen.getByTestId('composer-answers').textContent).toBe('false');
+    });
+
+    it('gives the collapsed card the popover’s dismiss', () => {
+      renderPause();
+      fireEvent.click(screen.getByTestId('collapse-from-popover'));
+
+      expect(screen.getByLabelText('Expand')).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText('Close'));
+
+      /** Dismiss exits answer mode entirely, exactly as the popover’s × did. */
+      expect(screen.getByTestId('active').textContent).toBe('false');
+    });
+  });
+
+  describe('a single question', () => {
+    beforeEach(() => {
+      mockLiveAsk = { actionId: 'act-1', question: mockSingle, messageId: 'message-1' };
+    });
+
+    it('keeps the composer as the answer box, and still offers a dismiss', () => {
+      renderPause();
+      expect(screen.getByTestId('composer-answers').textContent).toBe('true');
+      expect(screen.getByTestId('composer-locked').textContent).toBe('false');
+
+      fireEvent.click(screen.getByTestId('collapse-from-popover'));
+
+      /** A single question is answered IN the composer, so it stays the answer
+       *  box past collapse — the card is only the display handing over. */
+      expect(screen.getByTestId('composer-answers').textContent).toBe('true');
+      expect(screen.getByText('Which environment?')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByLabelText('Close'));
+
+      expect(screen.getByTestId('active').textContent).toBe('false');
+      expect(screen.getByTestId('composer-answers').textContent).toBe('false');
+    });
+  });
+});

--- a/client/src/hooks/Input/useAskAnswerMode.spec.ts
+++ b/client/src/hooks/Input/useAskAnswerMode.spec.ts
@@ -75,7 +75,7 @@ describe('useAskAnswerMode', () => {
     expect(result.current.popoverVisible).toBe(false);
   });
 
-  it('keeps batch mode active while reserving answers for the bounded form', () => {
+  it('locks the composer for a batch, and hands it back the moment it collapses', () => {
     mockUseGetMessages.mockReturnValue({
       data: {
         ...liveAsk,
@@ -92,7 +92,12 @@ describe('useAskAnswerMode', () => {
     expect(result.current.batchMode).toBe(true);
     expect(result.current.options).toEqual([]);
     expect(result.current.draftId).toBeNull();
-    expect(result.current.submitText('must stay out of the normal send path')).toBe(true);
+    /** The bounded form owns the answer, so the composer never speaks for it. */
+    expect(result.current.composerAnswers).toBe(false);
+    expect(result.current.composerLocked).toBe(true);
+    /** Text is declined, not claimed: claiming it dropped whatever was staged
+     *  when the pause began. */
+    expect(result.current.submitText('must stay out of the normal send path')).toBe(false);
     expect(mockSubmitAskAnswer).not.toHaveBeenCalled();
   });
 

--- a/client/src/hooks/Input/useAskAnswerMode.ts
+++ b/client/src/hooks/Input/useAskAnswerMode.ts
@@ -52,9 +52,10 @@ const askAnswerCheckedAtom = atom<number[]>({
  * resolves.
  *
  * Two ways out short of answering: `collapse` hides the popover chrome but
- * KEEPS answer mode live (the question renders in the chat card; the composer
- * still answers), while the × `dismiss` exits answer mode entirely. `Skip`
- * resumes the run with a canned decline notice.
+ * KEEPS the pause live (the question renders in the chat card, which still
+ * answers it), while the × `dismiss` exits answer mode entirely. `Skip`
+ * resumes the run with a canned decline notice. Collapsing always returns the
+ * composer to normal chat — see `composerLocked`.
  *
  * `handleComposerKeyDown` only steers selection from the EMPTY composer and
  * reports whether it consumed the key.
@@ -128,10 +129,22 @@ export default function useAskAnswerMode(conversationId?: string | null) {
    */
   const active = liveAsk != null && !dismissed && status !== 'expired' && status !== 'submitted';
   const collapsed = active && collapsedIds.includes(liveAsk.actionId);
-  /** The popover renders only while expanded; collapse keeps `active` (and the
-   *  composer's answer role) but hands the question display to the chat card. */
+  /** The popover renders only while expanded; collapse keeps `active` but
+   *  hands the question display to the chat card. */
   const popoverVisible = active && !collapsed;
   const batchMode = (liveAsk?.questions?.length ?? 0) > 0;
+  /**
+   * Which role the composer plays for this pause. A single question is
+   * answered IN the composer, so it stays live for as long as the pause does.
+   * A batch is answered in its own card, so the composer has nothing to
+   * contribute and locks — but ONLY while the popover is up. Collapsing has to
+   * hand the composer back, because every other way out is gone once the
+   * popover closes: the stop button hides behind `composerAnswers` and Escape
+   * would reach a disabled textarea. Staying locked past collapse left no way
+   * to type, send, or stop the run short of reloading the page.
+   */
+  const composerAnswers = active && !batchMode;
+  const composerLocked = popoverVisible && batchMode;
   const multiSelect = !batchMode && liveAsk != null && liveAsk.question.multiSelect === true;
   /** Answer-phase draft key: handed to useAutoSave so the composer drafts
    *  under the question's own key while answer mode is live, leaving the
@@ -291,15 +304,19 @@ export default function useAskAnswerMode(conversationId?: string | null) {
     [multiSelect, checkedValues, selected, submitValues, submitOption],
   );
 
-  /** Composer text answers the question directly; true when consumed. On a
-   *  multi-select question any checked options ride along with the text. */
+  /**
+   * Composer text answers the question directly; true when consumed. On a
+   * multi-select question any checked options ride along with the text.
+   *
+   * A batch answers in its card, so the composer's text is none of its
+   * business: report it UNconsumed and let the normal send/steer path have it.
+   * Claiming it (the old `return true`) silently swallowed whatever was staged
+   * when the pause began — the submit reported success and dropped the words.
+   */
   const submitText = useCallback(
     (text: string): boolean => {
-      if (!active || !liveAsk) {
+      if (!active || !liveAsk || batchMode) {
         return false;
-      }
-      if (batchMode) {
-        return true;
       }
       const trimmed = text.trim();
       if (trimmed.length > 0) {
@@ -353,8 +370,11 @@ export default function useAskAnswerMode(conversationId?: string | null) {
       const composerText = e.currentTarget.value;
       if (composerText.trim().length > 0) {
         // The composer IS the free-form answer box: Enter submits the typed
-        // text (before useTextarea's submitting-lock can swallow it).
-        if (e.key === 'Enter' && !e.shiftKey) {
+        // text (before useTextarea's submitting-lock can swallow it). Not for
+        // a batch, which answers in its card — its Enter belongs to the normal
+        // send path, so leave the event untouched rather than preventDefault
+        // an event we are about to decline.
+        if (e.key === 'Enter' && !e.shiftKey && !batchMode) {
           e.preventDefault();
           return submitText(composerText);
         }
@@ -409,6 +429,7 @@ export default function useAskAnswerMode(conversationId?: string | null) {
       active,
       options,
       selected,
+      batchMode,
       multiSelect,
       popoverVisible,
       canSubmit,
@@ -460,6 +481,8 @@ export default function useAskAnswerMode(conversationId?: string | null) {
     collapse,
     expand,
     popoverVisible,
+    composerAnswers,
+    composerLocked,
     multiSelect,
     locked,
     selected,

--- a/packages/client/src/components/Button.tsx
+++ b/packages/client/src/components/Button.tsx
@@ -11,6 +11,7 @@ type ButtonVariantOptions =
         | 'link'
         | 'submit'
         | 'outline'
+        | 'choice'
         | 'subtle'
         | 'destructive'
         | 'secondary'
@@ -35,6 +36,16 @@ const buttonVariantRecipe = cva(
           'bg-surface-destructive text-text-on-status hover:bg-surface-destructive-hover',
         outline:
           'text-text-primary border border-border-light bg-transparent hover:bg-surface-hover hover:text-text-primary',
+        /**
+         * A selectable answer inside a question card. `outline` is wrong here:
+         * its `border-light` edge measures ~1.2:1 against the panel these sit
+         * on, well under WCAG 1.4.11's 3:1 for a UI component boundary, so a
+         * column of choices reads as flat text rather than as controls. Carries
+         * its own fill so the answers are a different colour from the prompt,
+         * and drops to `font-normal` so the question above stays the heading.
+         */
+        choice:
+          'border border-border-xheavy bg-surface-tertiary font-normal text-text-primary hover:bg-surface-hover hover:text-text-primary',
         subtle:
           'border border-border-light bg-transparent text-text-primary hover:bg-surface-secondary focus-visible:ring-text-primary focus-visible:ring-offset-0',
         secondary: 'bg-surface-secondary text-text-primary hover:bg-surface-hover',


### PR DESCRIPTION
## Summary

I fixed a trap in the live `ask_user_question` UI where collapsing the popover left the chat unusable, and raised the contrast of the question cards after feedback that the questions were hard to read and the answers were indistinguishable from the prompt.

A batch of questions disables the composer, the send button, and the stop button for as long as the pause is `active` — and `collapse` deliberately keeps it active while hiding the popover, which carried the only dismiss. After the chevron there was no way to type, no way to send, no stop button, and no ×; Escape was routed through a keydown handler on a now-disabled textarea. Reloading the page was the only way out, which is exactly what the reporter had to do.

- Split the composer's role out of `active` in `useAskAnswerMode`: `composerAnswers` (a single question, answered **in** the composer) and `composerLocked` (a batch, answered in its own card — and only while the popover is up). Collapsing a batch now hands the composer back to the thread.
- Gated the stop button on `composerAnswers` instead of `active`, so a paused run stays stoppable rather than presenting a disabled send button and nothing else.
- Routed `ChatForm`'s placeholder, submittable file count, and steering handoff through the same split, so a collapsed batch steers/queues normally instead of falling into a send path that drops the turn.
- Added the popover's × to both collapsed cards, so dismiss survives the handover — previously a collapsed pause could only be answered or skipped.
- Made `submitText` decline a batch's composer text instead of claiming it. The old `return true` reported success and silently dropped whatever was staged when the pause began; the matching `Enter` branch no longer calls `preventDefault` on an event it is about to decline.
- Added a `choice` Button variant for answer options. `outline` draws its edge from `border-light`, which measures **1.20:1** against the panel these sit on — well under WCAG 1.4.11's 3:1 for a UI component boundary, so a column of choices read as flat text. `choice` carries its own fill and a `border-xheavy` edge (**5.49:1** dark / **6.54:1** light), and drops to `font-normal` so the question above stays the heading.
- Applied the same boundary to the answer textarea (was 1.21:1 dark / 1.07:1 light) and to the digit chips, which sat at **1.00:1** — literally invisible — because `surface-tertiary` was painted on a hardcoded `dark:bg-gray-700` panel.
- Replaced that hardcoded `bg-white`/`dark:bg-gray-700` in the single-question popover with the semantic `surface-secondary` role, matching the batched panel and the project's theming rules.
- Aligned question descriptions to `text-sm` across the popover and both cards, which previously disagreed at `text-xs` vs `text-sm`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `AskUserQuestionCollapse.test.tsx`, which drives the collapse handover across the **real** Recoil atoms the popover and the chat card share, rather than mocking `useAskAnswerMode`. It covers a batch (composer locks only while the popover is up, card takes the question, card carries a working dismiss) and a single question (composer stays the answer box past collapse, dismiss still exits answer mode). I confirmed the first assertion fails against the previous behavior.

Updated the `useAskAnswerMode` spec that pinned the old `submitText` contract to assert the text is declined, plus the new `composerAnswers`/`composerLocked` flags.

To reproduce manually: have an agent call `ask_user_question` with multiple questions, click the chevron on the popover, and confirm the composer accepts text, the stop button is present, and the card in the thread offers both expand and dismiss.

### **Test Configuration**:

- `cd client && npx jest src/components/Chat src/hooks` — 175 suites, 2415 tests passing
- `cd packages/client && npx jest` — 27 suites, 278 tests passing
- `cd client && npx tsc --noEmit` — clean
- `npx eslint` on all changed files — clean

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01UPtmUb6VLBhhxXkS3PfV6r)_