### PR TITLE
🚚 chore: Bump `@librechat/agents` to v3.6.8 For Token, Trace, and Stream Fixes

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.6.6",
+    "@librechat/agents": "^3.6.7",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.6.7",
+    "@librechat/agents": "^3.6.8",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.6.7",
+        "@librechat/agents": "^3.6.8",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10521,22 +10521,22 @@
       }
     },
     "node_modules/@langfuse/core": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.9.1.tgz",
-      "integrity": "sha512-KvyAskAO+2ixJwr9wy148ttR/Zn3oapvOJ2Br4Xcp6zhDpjSIIGB4jW/jkp53/KU9MyEHj0RSFPK/yKoxLC4KA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.10.1.tgz",
+      "integrity": "sha512-W8UArizWSy1DdeLGTsTwJwl7bkA7OQQcGZW8RtoopXyJZ93O0rwG7wzzeiZjhjpj5OtWOUTEaJuNkwOrF31UDw==",
       "license": "MIT",
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@langfuse/langchain": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@langfuse/langchain/-/langchain-5.9.1.tgz",
-      "integrity": "sha512-Qv5Wn8EO2cRiVTBlb/zQwRhjD+93rVjD02in9L0+hyg9OBvc2rzqTfr8zKVDv9pgpsDfWD7Wm/sXyo7vGZmsTA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/langchain/-/langchain-5.10.1.tgz",
+      "integrity": "sha512-roKCdlyTmBVw1mT91yz3TUy+7xnvuBD1FaQqb6eR4H7/U8l40UGThP3c1wPKUOfIO57EGa9A/YwjGoc7YC2AIw==",
       "license": "MIT",
       "dependencies": {
-        "@langfuse/core": "^5.9.1",
-        "@langfuse/tracing": "^5.9.1"
+        "@langfuse/core": "^5.10.1",
+        "@langfuse/tracing": "^5.10.1"
       },
       "peerDependencies": {
         "@langchain/core": ">=0.3.8",
@@ -10544,12 +10544,12 @@
       }
     },
     "node_modules/@langfuse/otel": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.9.1.tgz",
-      "integrity": "sha512-viM5Qq/AIPZPXfO7YdSmDHxEDSrNU/MyGzuE9zKA6hGBII1iLowU+qL99O+TjnXqxoADqlNibhY2pg1/WTIPcw==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.10.1.tgz",
+      "integrity": "sha512-F2153e4PoJ1cN+5tM/xnsS44aQCQwK3p0nPk4NEpITV5pMTqiQVyvpkAvly8GKQ5Qjjr7heJ1dFtghW43ysyPQ==",
       "license": "MIT",
       "dependencies": {
-        "@langfuse/core": "^5.9.1"
+        "@langfuse/core": "^5.10.1"
       },
       "engines": {
         "node": ">=20"
@@ -10562,12 +10562,12 @@
       }
     },
     "node_modules/@langfuse/tracing": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.9.1.tgz",
-      "integrity": "sha512-tJRyVAv1JkuOPh4Uz5eWUNH8U4jcJVtK2F5QNy5cZUzXCSrXobCSHusPbxY6VFZcLcFgtpDtSaxL7ev1tV2JNQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.10.1.tgz",
+      "integrity": "sha512-m2kK4D0MsH8g4Og6KpnlYk8NLdQTYe0JR5M4KKpfNj99XXLlbdpXE/g3uJSqkcrWFhpiIb+3cyS9+uV6wQ6WtA==",
       "license": "MIT",
       "dependencies": {
-        "@langfuse/core": "^5.9.1"
+        "@langfuse/core": "^5.10.1"
       },
       "engines": {
         "node": ">=20"
@@ -10628,9 +10628,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.7.tgz",
-      "integrity": "sha512-P2CxE6CwRXjlBYRSQtgQvwItKBASStoICPM08vyXvXZbYavXxA6MED4hG9Km2Li0OSDAaStMhSjpNLaTzE0Cyw==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.8.tgz",
+      "integrity": "sha512-FiPf8ggOoKJp7hpGKnk6dCtMITN1mzTqld3W9mOmGKgRAKp6PqCKiryseTdL0+5B6Mj1zBBx98GGLSXyxt2Ybg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -10648,10 +10648,10 @@
         "@langchain/openai": "1.5.8",
         "@langchain/textsplitters": "^1.0.1",
         "@langchain/xai": "^1.4.3",
-        "@langfuse/core": "^5.4.1",
-        "@langfuse/langchain": "^5.4.1",
-        "@langfuse/otel": "^5.4.1",
-        "@langfuse/tracing": "^5.4.1",
+        "@langfuse/core": "^5.10.1",
+        "@langfuse/langchain": "^5.10.1",
+        "@langfuse/otel": "^5.10.1",
+        "@langfuse/tracing": "^5.10.1",
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/sdk-node": "^0.220.0",
         "@types/diff": "^7.0.2",
@@ -42875,7 +42875,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.6.7",
+        "@librechat/agents": "^3.6.8",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.6.6",
+        "@librechat/agents": "^3.6.7",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10628,9 +10628,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.6.tgz",
-      "integrity": "sha512-YJqZ4Dsw/+dIu/Kbp3oMAc36zFXIrecHCcxYHdlFZA7WNnBLlBk2RwDSvf2WZUP0KfPACdx5K5LZOhTG4s+7ZQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.7.tgz",
+      "integrity": "sha512-P2CxE6CwRXjlBYRSQtgQvwItKBASStoICPM08vyXvXZbYavXxA6MED4hG9Km2Li0OSDAaStMhSjpNLaTzE0Cyw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42875,7 +42875,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.6.6",
+        "@librechat/agents": "^3.6.7",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.6.6",
+    "@librechat/agents": "^3.6.7",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.6.7",
+    "@librechat/agents": "^3.6.8",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Fixes #14951

## Summary

Bumps `@librechat/agents` from 3.6.6 to 3.6.8, spanning two upstream releases and four changes: a token-counting fix, a Langfuse trace-semantics rework, a Langfuse SDK upgrade, and Responses stream error propagation. Supersedes #14995 from @Battleplus, which carried the 3.6.7 bump against `main`.

Range: [`v3.6.6...v3.6.8`](https://github.com/danny-avila/agents/compare/v3.6.6...v3.6.8).

## What actually changes in the agents SDK

| Upstream PR | Release | Change |
| --- | --- | --- |
| danny-avila/agents#430 | 3.6.7 | Long plain-text token counting |
| danny-avila/agents#436 | 3.6.8 | Langfuse span names and nested label traces |
| danny-avila/agents#433 | 3.6.8 | Langfuse SDK 5.4.1 to 5.10.1 |
| danny-avila/agents#431 | 3.6.8 | Responses stream error propagation |

### Long plain-text token counting (danny-avila/agents#430)

One source file, `src/utils/tokens.ts` (+21 / -15), plus two test files.

Before, `getBoundedTextTokenCount` tokenized only the first 200,000 characters of a plain string and priced every character past that at 4 tokens (`MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR`). That constant is a worst-case bound written for adversarial *structured* content, where the bounded serializer cannot know the omitted size. Applied to prose at roughly 0.23 tokens per character, it overcharged the entire overflow region by about 17x.

Now every plain-text segment is tokenized in full, in 8,192-character chunks (`MAX_TEXT_TOKENIZATION_CHARS`), with a 4-token allowance at each chunk boundary (`TEXT_TOKEN_CHUNK_BOUNDARY_SAFETY_TOKENS`) for BPE segmentation differences across a split. No text is omitted, and per-segment tokenizer work stays bounded. `getBoundedStructuredTokenCount` is unchanged, since the conservative bound is justified there.

### Langfuse span names and nested label traces (danny-avila/agents#436)

The largest change in the range: 20 files, +1,062 / -235, mostly `Graph.ts`, `run.ts`, `langfuse.ts`, `langfuseTraceShaping.ts`, and `langfuseSpanRegistry.ts`.

Graph observations are renamed to `StandardGraph` and `MultiAgentGraph`, agent prompt-to-model sequences to `AgentModelCall`. Generic model calls stay `llm`; auxiliary generations become `ActivityLabel`, `ReasoningLabel`, and `ActivityPhaseLabel`. Those labels now nest under the originating agent run instead of emitting standalone traces, without overwriting parent trace name or metadata. Standalone label traces remain only when no safe source observation exists or the destination differs, and trace parents resolve only within a matching export destination, so per-tenant routing holds.

### Langfuse SDK upgrade (danny-avila/agents#433)

`@langfuse/core`, `@langfuse/langchain`, `@langfuse/otel`, and `@langfuse/tracing` move from 5.4.1 to 5.10.1, with tracing migrated to the v4 observations-first model. Deprecated trace-level input/output attributes are removed and scrubbed before export, while request and response data is preserved on root observations and observation-level tool-output redaction is kept.

### Responses stream errors (danny-avila/agents#431)

`src/llm/openai/index.ts` (+34 / -3). `response.failed` and `error` events are detected before unsupported stream events get skipped, so terminal provider errors propagate through the existing OpenAI error path with structured details instead of the run completing with an empty assistant message. A failed response with no error details returns an explicit failure. Closes danny-avila/agents#429.

## Impact on LibreChat

- Agents whose injected text exceeds 200,000 characters, whether concatenated File Context attachments or long `instructions`, no longer report inflated `instructionTokens` and fail with `empty_messages`. In #14951, 361,473 characters of file context measured 764,834 tokens against a true cost near 82,000.
- Below the failure threshold, usage is no longer silently overstated, removing unnecessary pruning and summarization passes.
- Counts no longer shift with prompt-cache placement. The same content measured 764,834 tokens as a separate `HumanMessage` versus 1,295,401 joined into one `SystemMessage`.
- Responses API streams that fail mid-flight surface the provider error instead of ending with a blank assistant message.
- Operator-visible Langfuse change: observation names differ after this bump, and trace-level input/output is gone in favor of root observations. Saved dashboards, filters, or evaluations keyed on the old names or on trace I/O need updating.
- No LibreChat API surface, type, or configuration changes.

## Files changed

Only the `@librechat/agents` specifier in `api/package.json` and `packages/api/package.json`, plus `package-lock.json`. The lockfile also advances the hoisted `@langfuse/*` packages from 5.9.1 to 5.10.1 and the SDK's declared Langfuse ranges from `^5.4.1` to `^5.10.1`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the diff is limited to the two workspace manifests and resolved lockfile entries with updated integrity hashes.
- Upstream added Claude-tokenizer regressions for the 361,473-character File Context case, mixed token density, chunk boundaries, prompt-cache placement, and callback bounds, and validated issue-sized context against Anthropic's live `count_tokens` endpoint: 117,291 provider tokens versus 117,608 to 117,610 locally, conservative by about 0.27%.
- Upstream Langfuse suites cover trace shaping, routing, span registry, activity labels, deterministic IDs, and root observation I/O, hierarchy, metadata, tags, model data, and usage.
- Upstream added coverage for both terminal Responses error event formats.
- To re-check here: an Anthropic agent with File Context over 200,000 characters, with prompt caching on and off; a Responses model forced into a mid-stream failure; and a Langfuse export confirming `StandardGraph` as root with label generations nested beneath it.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
