### PR TITLE
🔗 feat: Open Footer Site Links in a New Tab

### DIFF
--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -63,7 +63,8 @@ function Footer({ className, startupConfig }: FooterProps) {
               <a
                 className="text-text-secondary underline"
                 href={href}
-                rel="noreferrer"
+                target="_blank"
+                rel="noopener noreferrer"
                 {...otherProps}
               >
                 {children}

--- a/client/src/components/Chat/__tests__/Footer.spec.tsx
+++ b/client/src/components/Chat/__tests__/Footer.spec.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Footer from '../Footer';
+
+jest.mock('react-gtm-module', () => ({
+  __esModule: true,
+  default: { initialize: jest.fn() },
+}));
+
+jest.mock('~/data-provider', () => ({
+  useGetStartupConfig: jest.fn(() => ({ data: undefined, isFetching: false, error: null })),
+}));
+
+const mockTranslations: Record<string, string> = {
+  com_ui_latest_footer: 'Every AI for Everyone.',
+  com_ui_privacy_policy: 'Privacy policy',
+  com_ui_terms_of_service: 'Terms of service',
+};
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => mockTranslations[key] ?? key,
+}));
+
+describe('Footer', () => {
+  test('opens the default LibreChat site link in a new tab', () => {
+    render(<Footer startupConfig={null} />);
+    const link = screen.getByRole('link', { name: /LibreChat/ });
+    expect(link).toHaveAttribute('href', 'https://librechat.ai');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('opens custom footer markdown links in a new tab', () => {
+    render(<Footer startupConfig={{ customFooter: '[Docs](https://example.com/docs)' }} />);
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link).toHaveAttribute('href', 'https://example.com/docs');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('keeps privacy policy and terms of service links in the same tab', () => {
+    render(
+      <Footer
+        startupConfig={{
+          interface: {
+            privacyPolicy: { externalUrl: 'https://example.com/privacy' },
+            termsOfService: { externalUrl: 'https://example.com/terms' },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByRole('link', { name: 'Privacy policy' })).not.toHaveAttribute('target');
+    expect(screen.getByRole('link', { name: 'Terms of service' })).not.toHaveAttribute('target');
+  });
+});


### PR DESCRIPTION
## Summary

The footer's LibreChat site link (`LibreChat vX.X.X - Every AI for Everyone.`) opened the site in the current tab, navigating users away from their chat. Footer content links now open in a new tab.

- Links rendered from footer content (the default version link and `customFooter` markdown links) get `target="_blank"` and `rel="noopener noreferrer"`
- Privacy policy and terms of service links keep same-tab navigation, preserving the WCAG decision from #10997

Closes #14302

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Added `client/src/components/Chat/__tests__/Footer.spec.tsx` covering the default version link, `customFooter` markdown links, and the same-tab behavior of privacy/terms links.

Run with:

```
cd client && npx jest src/components/Chat/__tests__/Footer.spec.tsx
```

### **Test Configuration**:

- Node v24.16.0
- `npx jest src/components/Chat/__tests__/Footer.spec.tsx`: 3 passed
- `npx tsc --noEmit` (client): no errors
- `npx eslint client/src/components/Chat/Footer.tsx client/src/components/Chat/__tests__/Footer.spec.tsx`: clean

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
