### PR TITLE
🔑 fix: Keep Web Search Auth Values With Their Submitted Key

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -229,7 +229,7 @@ const updateUserPluginsController = async (req, res) => {
     }
 
     let keys = Object.keys(auth);
-    const values = Object.values(auth); // Used in 'install' block
+    let values = Object.values(auth); // Used in 'install' block
 
     const isMCPTool = pluginKey.startsWith('mcp_') || pluginKey.includes(Constants.mcp_delimiter);
 
@@ -256,10 +256,32 @@ const updateUserPluginsController = async (req, res) => {
     if (pluginKey === Tools.web_search) {
       /** @type  {TCustomConfig['webSearch']} */
       const webSearchConfig = appConfig?.webSearch;
-      keys = extractWebSearchEnvVars({
-        keys: action === 'install' ? keys : webSearchKeys,
-        config: webSearchConfig,
-      });
+      if (action === 'install') {
+        // extractWebSearchEnvVars drops the submitted fields the config does not define, so
+        // mapping every key in one call can leave `keys` shorter than `values`, and the two
+        // are zipped by index below: a submitted value can then be stored under another
+        // provider's environment variable. Map one field at a time to keep each value with
+        // the key it was submitted under.
+        const mappedKeys = [];
+        const mappedValues = [];
+        for (let i = 0; i < keys.length; i++) {
+          const [envVar] = extractWebSearchEnvVars({
+            keys: [keys[i]],
+            config: webSearchConfig,
+          });
+          if (envVar) {
+            mappedKeys.push(envVar);
+            mappedValues.push(values[i]);
+          }
+        }
+        keys = mappedKeys;
+        values = mappedValues;
+      } else {
+        keys = extractWebSearchEnvVars({
+          keys: webSearchKeys,
+          config: webSearchConfig,
+        });
+      }
     }
 
     if (action === 'install') {

--- a/api/server/controllers/__tests__/UserController.webSearchAuth.spec.js
+++ b/api/server/controllers/__tests__/UserController.webSearchAuth.spec.js
@@ -1,0 +1,177 @@
+const mockUpdateUserPlugins = jest.fn();
+const mockUpdateUserPluginAuth = jest.fn();
+const mockDeleteUserPluginAuth = jest.fn();
+const mockGetAppConfig = jest.fn();
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+  getTenantId: jest.fn(),
+  webSearchKeys: ['serperApiKey', 'firecrawlApiKey', 'jinaApiKey'],
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  Tools: { web_search: 'web_search' },
+  CacheKeys: { FLOWS: 'flows' },
+  Constants: { mcp_delimiter: '_mcp_', mcp_prefix: 'mcp_' },
+  FileSources: {},
+}));
+
+jest.mock('@librechat/api', () => ({
+  MCPOAuthHandler: {
+    generateFlowId: jest.fn(),
+    generateTokenFlowId: jest.fn(),
+    deleteFlowAndStateMapping: jest.fn().mockResolvedValue(undefined),
+    revokeOAuthToken: jest.fn(),
+  },
+  MCPTokenStorage: {
+    getClientInfoAndMetadata: jest.fn(),
+    getTokens: jest.fn(),
+    assertCredentialSetBinding: jest.fn(),
+    deleteUserTokens: jest.fn().mockResolvedValue(undefined),
+  },
+  normalizeHttpError: jest.fn((error) => error),
+  /**
+   * Mirrors the real implementation in packages/api/src/web/web.ts: keep only the
+   * fields the webSearch config defines, and map each to the environment variable
+   * named in its `${VAR}` placeholder.
+   */
+  extractWebSearchEnvVars: jest.fn(({ keys, config }) => {
+    if (!config) {
+      return [];
+    }
+    return keys
+      .filter((key) => key in config)
+      .map((key) => {
+        const value = config[key];
+        const match = typeof value === 'string' ? value.match(/^\$\{(.+)\}$/) : null;
+        return match ? match[1] : null;
+      })
+      .filter(Boolean);
+  }),
+  getAppConfigOptionsFromUser: jest.fn((user) => ({ role: user?.role, userId: user?.id })),
+  needsRefresh: jest.fn(),
+  getNewS3URL: jest.fn(),
+}));
+
+jest.mock('~/models', () => ({
+  updateUserPlugins: (...args) => mockUpdateUserPlugins(...args),
+  findToken: jest.fn(),
+  deleteTokens: jest.fn(),
+}));
+
+jest.mock('~/server/services/PluginService', () => ({
+  updateUserPluginAuth: (...args) => mockUpdateUserPluginAuth(...args),
+  deleteUserPluginAuth: (...args) => mockDeleteUserPluginAuth(...args),
+}));
+
+jest.mock('~/server/services/twoFactorService', () => ({
+  verifyOTPOrBackupCode: jest.fn(),
+}));
+
+jest.mock('~/server/services/AuthService', () => ({
+  verifyEmail: jest.fn(),
+  resendVerificationEmail: jest.fn(),
+}));
+
+jest.mock('~/config', () => ({
+  getMCPManager: jest.fn(),
+  getFlowStateManager: jest.fn(),
+  getMCPServersRegistry: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config/getCachedTools', () => ({
+  invalidateCachedTools: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/process', () => ({
+  processDeleteRequest: jest.fn().mockResolvedValue({ deletedFileIds: [], failedFileIds: [] }),
+}));
+
+jest.mock('~/server/services/Agents/triggers', () => ({
+  drainAgentTriggerDeliveriesForUser: jest.fn(),
+  prepareAgentTriggerUserPurge: jest.fn(),
+  cancelAgentTriggerUserPurge: jest.fn(),
+  purgeAgentTriggerDeliveriesForUser: jest.fn(),
+}));
+
+jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({
+  cancelAndDrainForOwner: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: (...args) => mockGetAppConfig(...args),
+}));
+
+jest.mock('~/cache', () => ({
+  getLogStores: jest.fn(),
+}));
+
+const { updateUserPluginsController } = require('~/server/controllers/UserController');
+
+function createResponse() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function createRequest(auth, webSearch) {
+  return {
+    config: { webSearch },
+    user: { id: 'user-1', _id: 'user-1', plugins: [], role: 'USER' },
+    body: { pluginKey: 'web_search', action: 'install', auth },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateUserPlugins.mockResolvedValue();
+  mockUpdateUserPluginAuth.mockResolvedValue({});
+  mockGetAppConfig.mockResolvedValue({});
+});
+
+describe('updateUserPluginsController web search install', () => {
+  it('stores each submitted value under its own environment variable', async () => {
+    const req = createRequest(
+      { serperApiKey: 'serper-secret', firecrawlApiKey: 'firecrawl-secret' },
+      { serperApiKey: '${SERPER_API_KEY}', firecrawlApiKey: '${FIRECRAWL_API_KEY}' },
+    );
+
+    await updateUserPluginsController(req, createResponse());
+
+    expect(mockUpdateUserPluginAuth.mock.calls.map(([, key, , value]) => [key, value])).toEqual([
+      ['SERPER_API_KEY', 'serper-secret'],
+      ['FIRECRAWL_API_KEY', 'firecrawl-secret'],
+    ]);
+  });
+
+  it('does not shift values onto another provider when a submitted field is not configured', async () => {
+    // The dialog posts every non-empty field it rendered, including fields for services
+    // the deployment has not configured. Those are dropped from the key list, so a value
+    // must not slide into the next key's slot.
+    const req = createRequest(
+      { firecrawlApiKey: 'firecrawl-secret', serperApiKey: 'serper-secret' },
+      { serperApiKey: '${SERPER_API_KEY}' },
+    );
+
+    await updateUserPluginsController(req, createResponse());
+
+    expect(mockUpdateUserPluginAuth.mock.calls.map(([, key, , value]) => [key, value])).toEqual([
+      ['SERPER_API_KEY', 'serper-secret'],
+    ]);
+  });
+
+  it('skips a configured field whose value is not an environment variable placeholder', async () => {
+    const req = createRequest(
+      { jinaApiKey: 'jina-secret', serperApiKey: 'serper-secret' },
+      { jinaApiKey: 'literal-value', serperApiKey: '${SERPER_API_KEY}' },
+    );
+
+    await updateUserPluginsController(req, createResponse());
+
+    expect(mockUpdateUserPluginAuth.mock.calls.map(([, key, , value]) => [key, value])).toEqual([
+      ['SERPER_API_KEY', 'serper-secret'],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`updateUserPluginsController` splits the submitted `auth` object into two parallel arrays and zips them back together by index:

```js
let keys = Object.keys(auth);
let values = Object.values(auth);
// ...
authService = await updateUserPluginAuth(user.id, keys[i], pluginKey, values[i]);
```

For `web_search` it then replaces only `keys`, through `extractWebSearchEnvVars`, which keeps just the fields the `webSearch` config defines and maps each to the environment variable named in its `${VAR}` placeholder. The `values` array is untouched, so as soon as one submitted field is dropped the two no longer line up: a secret is stored under another provider's environment variable, and is later sent to that provider as its API key.

With only `serperApiKey: "${SERPER_API_KEY}"` configured, posting `{ firecrawlApiKey: "A", serperApiKey: "B" }` stores `SERPER_API_KEY = "A"`. The API key dialog posts every non-empty field it rendered, including fields for services the deployment has not configured, so this is reachable from the UI.

Each field is now mapped on its own, so a dropped field takes its value with it. The uninstall path is unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New spec at `api/server/controllers/__tests__/UserController.webSearchAuth.spec.js` with three cases:

- every submitted field is configured, so each value lands under its own environment variable
- a submitted field is not configured, and the remaining value does not shift onto it
- a configured field whose value is not a `${VAR}` placeholder is skipped without shifting

The second and third were confirmed to fail against current `dev` and to pass with this change.

### **Test Configuration**:

- `npx jest server/controllers/__tests__` in `api/`: 10 suites, 92 tests passing
- eslint and prettier clean on both changed files

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
