### PR TITLE
♿ fix: Keep Portaled Dropdown Menus Clickable Inside Modal Dialogs

### DIFF
--- a/packages/client/src/components/DropdownPopup.spec.tsx
+++ b/packages/client/src/components/DropdownPopup.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import * as Ariakit from '@ariakit/react';
+import { render } from '@testing-library/react';
 import DropdownPopup from './DropdownPopup';
 
 describe('DropdownPopup', () => {

--- a/packages/client/src/components/DropdownPopup.spec.tsx
+++ b/packages/client/src/components/DropdownPopup.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import * as Ariakit from '@ariakit/react';
+import DropdownPopup from './DropdownPopup';
+
+describe('DropdownPopup', () => {
+  it('restores pointer events on portaled menus so they stay clickable inside modal dialogs', () => {
+    // A modal Radix dialog (OGDialog) sets `pointer-events: none` on body and only
+    // re-enables it on its own content. A portaled menu is a body-level sibling and
+    // would inherit `none`, making every item hit-transparent (#14487).
+    document.body.style.pointerEvents = 'none';
+
+    render(
+      <DropdownPopup
+        menuId="portal-click-test-menu"
+        isOpen={true}
+        setIsOpen={jest.fn()}
+        modal={true}
+        unmountOnHide={true}
+        trigger={
+          <Ariakit.MenuButton>
+            <span>trigger</span>
+          </Ariakit.MenuButton>
+        }
+        items={[{ label: 'From Local Computer', onClick: jest.fn() }]}
+      />,
+    );
+
+    const menu = document.getElementById('portal-click-test-menu');
+    expect(menu).not.toBeNull();
+    expect(menu?.style.pointerEvents).toBe('auto');
+
+    document.body.style.pointerEvents = '';
+  });
+});

--- a/packages/client/src/components/DropdownPopup.tsx
+++ b/packages/client/src/components/DropdownPopup.tsx
@@ -89,7 +89,11 @@ const Menu: React.FC<MenuProps> = ({
       finalFocus={finalFocus}
       unmountOnHide={unmountOnHide}
       preserveTabOrder={preserveTabOrder}
-      style={{ zIndex, ...style }}
+      /* Portaled menus land beside modal OGDialog layers, which set
+         `pointer-events: none` on body and re-enable it only on their own
+         content. Without this the menu inherits `none` and its items become
+         hit-transparent (danny-avila/LibreChat#14487). */
+      style={{ zIndex, pointerEvents: 'auto', ...style }}
       className={cn('popover-ui', className)}
       {...props}
     >


### PR DESCRIPTION
## Summary

The Agent File Search and File Context upload menus were dead when SharePoint integration was enabled: opening the menu showed "From Local Computer" / "From SharePoint", but neither item responded to hover or click, and any click simply dismissed the menu. No console errors, no network requests.

Root cause: those menus render through `DropdownPopup` with `portal` enabled, which appends the menu to `document.body` as a sibling of the modal OGDialog layers (Tool Library + tool ItemDialog). Radix modal dialogs set `pointer-events: none` on `body` and re-enable it only on their own overlay/content, so the portaled menu inherited `pointer-events: none`. Hit-testing fell through to `<html>` (verified with `document.elementFromPoint`), and Ariakit classified every click as an outside interaction, closing the menu without running any handler.

The fix restores `pointer-events: auto` on the menu element itself, so a portaled menu stays clickable regardless of the modal layers around it. This covers every portaled `DropdownPopup` usage inside modal dialogs, not just the two upload menus.

Why only with SharePoint enabled: that flag is what switches the agent upload control from a plain in-dialog button (clickable, inside the dialog content) to the portaled dropdown menu. The regular chat attach menu was unaffected because no modal dialog is open there.

Fixes #14487

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Reproduced first on a dev instance with `ENABLE_SHAREPOINT_FILEPICKER=true`, then verified the fix in the browser against the agent File Search tool dialog.

- `elementFromPoint` at both menu item centers returned `<html>` before the fix and the actual item after it; computed cursor on the items changed from `default` to `pointer`.
- Real click on "From SharePoint" now opens the Pick Files dialog; before the fix the menu just closed.
- Verified in both light and dark themes.

Commands run:

- `npx jest src/components/DropdownPopup.spec.tsx` (new regression spec: fails before, passes after)
- `npx jest` in `packages/client` (29 suites, 282 tests, all pass)
- `npx jest src/components/SidePanel/Agents/__tests__/FileSearch.spec.tsx src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx` (33 tests pass)
- `npx eslint packages/client/src/components/DropdownPopup.tsx packages/client/src/components/DropdownPopup.spec.tsx` (clean)

### Test Configuration

- Dev server with `ENABLE_SHAREPOINT_FILEPICKER=true`, agent created via the Agent Builder, File Search tool configured from the Tool Library.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes