### PR TITLE
🔒 feat: Privacy Controls for Langfuse Trace Content

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -40,6 +40,21 @@ cache: true
 #   headers:
 #     CF-Access-Client-Id: "${CF_ACCESS_CLIENT_ID}"
 #     CF-Access-Client-Secret: "${CF_ACCESS_CLIENT_SECRET}"
+#
+# Content privacy controls for exported traces. With `metricsOnly`, message
+# content (user, system, and assistant), tool arguments and outputs, trace
+# metadata, and media are replaced by a redaction marker before trace data
+# leaves the server; trace structure, timing, model, token usage, cost, and
+# error status remain available. The default `full` mode exports content
+# unchanged.
+#
+# Fails closed: if the installed tracing runtime cannot enforce the policy,
+# trace export is disabled for the run instead of sending unmasked content.
+#
+# langfuse:
+#   privacy:
+#     mode: metricsOnly
+#     redactionText: "[CONTENT REDACTED]"
 
 # File storage configuration
 # Single strategy for all file types (legacy format, still supported)

--- a/packages/api/src/langfuse/config.spec.ts
+++ b/packages/api/src/langfuse/config.spec.ts
@@ -3,6 +3,11 @@ import type { AppConfig } from '@librechat/data-schemas';
 process.env.CREDS_KEY =
   process.env.CREDS_KEY ?? '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
+const mockAgentsRuntime: { LANGFUSE_PRIVACY_MASKING_SUPPORTED?: boolean } = {
+  LANGFUSE_PRIVACY_MASKING_SUPPORTED: true,
+};
+jest.mock('@librechat/agents', () => mockAgentsRuntime);
+
 const CENTRAL_EXPORT_ATTRIBUTE = 'librechat.langfuse.central_export.enabled';
 const envKeys = [
   'LANGFUSE_PUBLIC_KEY',
@@ -912,5 +917,82 @@ describe('buildLangfuseConfig', () => {
         appConfig: { langfuse: { headers: {} } } as unknown as AppConfig,
       }),
     ).not.toHaveProperty('additionalHeaders');
+  });
+
+  it('attaches metricsOnly privacy to an otherwise unchanged export', async () => {
+    delete process.env.TENANT_ISOLATION_STRICT;
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    process.env.LANGFUSE_BASE_URL = 'https://env.langfuse.example';
+    const { buildLangfuseConfig } = await import('./config');
+
+    expect(
+      buildLangfuseConfig({
+        runId: 'run-1',
+        tenantId: 'tenant-7',
+        appConfig: {
+          langfuse: {
+            privacy: { mode: 'metricsOnly', redactionText: ' [private] ' },
+          },
+        } as unknown as AppConfig,
+      }),
+    ).toEqual({
+      deterministicTraceId: true,
+      privacy: { mode: 'metricsOnly', redactionText: '[private]' },
+      publicKey: 'pk-env',
+      secretKey: 'sk-env',
+      baseUrl: 'https://env.langfuse.example',
+    });
+  });
+
+  it('fails closed when the runtime cannot enforce privacy masking', async () => {
+    delete process.env.TENANT_ISOLATION_STRICT;
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    const policyModule = await import('./policy');
+    const supportSpy = jest
+      .spyOn(policyModule, 'isLangfusePrivacyMaskingSupported')
+      .mockReturnValue(false);
+    const { buildLangfuseConfig } = await import('./config');
+
+    try {
+      expect(
+        buildLangfuseConfig({
+          runId: 'run-1',
+          appConfig: {
+            langfuse: { privacy: { mode: 'metricsOnly' } },
+          } as unknown as AppConfig,
+        }),
+      ).toEqual({
+        deterministicTraceId: true,
+        privacy: { mode: 'metricsOnly' },
+        enabled: false,
+      });
+    } finally {
+      supportSpy.mockRestore();
+    }
+  });
+
+  it('keeps full privacy mode exporting tenant trace data untouched', async () => {
+    delete process.env.TENANT_ISOLATION_STRICT;
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    const { buildLangfuseConfig } = await import('./config');
+
+    const built = buildLangfuseConfig({
+      runId: 'run-1',
+      tenantId: 'tenant-7',
+      appConfig: {
+        langfuse: { privacy: { mode: 'full' } },
+      } as unknown as AppConfig,
+    });
+
+    expect(built).not.toHaveProperty('privacy');
+    expect(built).toEqual(
+      expect.objectContaining({
+        metadata: { 'librechat.tenant.id': 'tenant-7' },
+        tags: ['tenant:tenant-7'],
+      }),
+    );
   });
 });

--- a/packages/api/src/langfuse/config.spec.ts
+++ b/packages/api/src/langfuse/config.spec.ts
@@ -3,8 +3,8 @@ import type { AppConfig } from '@librechat/data-schemas';
 process.env.CREDS_KEY =
   process.env.CREDS_KEY ?? '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-const mockAgentsRuntime: { LANGFUSE_PRIVACY_MASKING_SUPPORTED?: boolean } = {
-  LANGFUSE_PRIVACY_MASKING_SUPPORTED: true,
+const mockAgentsRuntime: { LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED?: boolean } = {
+  LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED: true,
 };
 jest.mock('@librechat/agents', () => mockAgentsRuntime);
 

--- a/packages/api/src/langfuse/config.ts
+++ b/packages/api/src/langfuse/config.ts
@@ -1,9 +1,10 @@
-import type { AppConfig } from '@librechat/data-schemas';
+import { logger, type AppConfig } from '@librechat/data-schemas';
 import type { RunConfig } from '@librechat/agents';
 import {
   hasLangfuseEnvCredentials,
   isLangfuseCentralMediaUploadDisabled,
   isLangfuseFanoutEnabled,
+  isLangfusePrivacyMaskingSupported,
   isLangfuseTenantExportEnabled,
   isLangfuseTraceSampled,
   isLangfuseTracingEnabled,
@@ -16,10 +17,17 @@ import { normalizeString } from '~/utils/text';
 import { traceIdForMessage } from './trace';
 
 type LangfuseRunConfig = NonNullable<RunConfig['langfuse']>;
+type LangfusePrivacyPolicy = { mode: 'metricsOnly'; redactionText?: string };
 type LangfuseRunConfigWithTraceAttributes = LangfuseRunConfig & {
   librechatTraceAttributes?: Record<string, string | number | boolean | null | undefined>;
   mediaUploadEnabled?: boolean;
   additionalHeaders?: Record<string, string>;
+  /**
+   * Content privacy policy enforced by the span processor. Requires
+   * `@librechat/agents` >= 3.6.9; older runtimes ignore the field, which the
+   * fail-closed gate below turns into disabled export.
+   */
+  privacy?: LangfusePrivacyPolicy;
 };
 type LangfuseTenantDestination = NonNullable<ReturnType<typeof resolveLangfuseTenantDestination>>;
 type LangfuseExportPlan =
@@ -77,6 +85,34 @@ function applyCentralEnvConfig(langfuse: LangfuseRunConfigWithTraceAttributes): 
       normalizeString(process.env.LANGFUSE_BASEURL) ??
       DEFAULT_BASE_URL;
   }
+}
+
+/** Active only for `metricsOnly`; `full` and absent both keep current behavior. */
+function resolveActivePrivacy(
+  privacy?: NonNullable<AppConfig['langfuse']>['privacy'],
+): LangfusePrivacyPolicy | undefined {
+  if (privacy?.mode !== 'metricsOnly') {
+    return undefined;
+  }
+  const redactionText = normalizeString(privacy.redactionText);
+  return redactionText != null ? { mode: 'metricsOnly', redactionText } : { mode: 'metricsOnly' };
+}
+
+let privacySupportWarningLogged = false;
+
+/**
+ * A privacy mode the runtime cannot enforce must not degrade into a full
+ * export: the run's trace export is disabled instead, and the operator hears
+ * about it once per process rather than once per run.
+ */
+function failClosedForUnsupportedPrivacy(langfuse: LangfuseRunConfigWithTraceAttributes): void {
+  if (!privacySupportWarningLogged) {
+    privacySupportWarningLogged = true;
+    logger.warn(
+      'langfuse.privacy.mode "metricsOnly" requires @librechat/agents >= 3.6.9 to mask trace content; disabling Langfuse trace export until the runtime is upgraded',
+    );
+  }
+  langfuse.enabled = false;
 }
 
 /**
@@ -169,12 +205,19 @@ export function buildLangfuseConfig({
 } = {}): LangfuseRunConfig {
   const normalizedTenantId = normalizeString(tenantId);
   const config = appConfig?.langfuse;
+  const privacy = resolveActivePrivacy(config?.privacy);
 
   const langfuse: LangfuseRunConfigWithTraceAttributes = {
     deterministicTraceId: true,
   };
-  const metadata = mergeTraceMetadata(undefined, normalizedTenantId);
-  const tags = mergeTags(undefined, normalizedTenantId);
+  if (privacy != null) {
+    langfuse.privacy = privacy;
+  }
+  // metricsOnly suppresses app-derived trace data outright; the mask covers
+  // metadata values later, but tenant tags are not part of the masked
+  // attribute families, so they are skipped at the source.
+  const metadata = mergeTraceMetadata(undefined, privacy == null ? normalizedTenantId : undefined);
+  const tags = mergeTags(undefined, privacy == null ? normalizedTenantId : undefined);
   if (metadata) {
     langfuse.metadata = metadata;
   }
@@ -187,6 +230,11 @@ export function buildLangfuseConfig({
     (runId != null && !isLangfuseTraceSampled(traceIdForMessage(runId)))
   ) {
     langfuse.enabled = false;
+    return langfuse;
+  }
+
+  if (privacy != null && !isLangfusePrivacyMaskingSupported()) {
+    failClosedForUnsupportedPrivacy(langfuse);
     return langfuse;
   }
 

--- a/packages/api/src/langfuse/feedback.spec.ts
+++ b/packages/api/src/langfuse/feedback.spec.ts
@@ -150,7 +150,7 @@ describe('Langfuse feedback scores', () => {
       name: 'user-feedback',
       value: 1,
       dataType: 'BOOLEAN',
-      comment: 'helpful — nice',
+      comment: 'helpful: nice',
       observationId: 'observation-id',
       metadata: {
         rating: 'thumbsUp',
@@ -164,6 +164,49 @@ describe('Langfuse feedback scores', () => {
     });
     expect(JSON.parse(init?.body as string).metadata).not.toHaveProperty('empty');
     expect(JSON.parse(init?.body as string).metadata).not.toHaveProperty('missing');
+  });
+
+  it('suppresses feedback content under metricsOnly privacy', async () => {
+    const { sendFeedbackScore } = await loadFeedback();
+
+    await sendFeedbackScore({
+      traceId: 'trace-id',
+      feedback: {
+        rating: 'thumbsDown',
+        tag: 'wrong',
+        text: 'the answer leaked my key',
+      },
+      metadata: {
+        messageId: 'message-id',
+        conversationId: 'conversation-id',
+        userId: 'user-id',
+        sender: 'Alice Example',
+        endpoint: 'agents',
+        tokenCount: 42,
+      },
+      appConfig: appConfigWithLangfuse({
+        privacy: { mode: 'metricsOnly' },
+      }),
+    });
+
+    const [, init] = getFetchMock().mock.calls[0];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toMatchObject({
+      id: 'feedback-trace-id',
+      traceId: 'trace-id',
+      name: 'user-feedback',
+      value: 0,
+      dataType: 'BOOLEAN',
+    });
+    expect(body.comment).toBeUndefined();
+    expect(body.metadata).toEqual({
+      rating: 'thumbsDown',
+      messageId: 'message-id',
+      conversationId: 'conversation-id',
+      userId: 'user-id',
+      endpoint: 'agents',
+      tokenCount: 42,
+    });
   });
 
   it('posts feedback scores to the configured Langfuse host', async () => {

--- a/packages/api/src/langfuse/feedback.ts
+++ b/packages/api/src/langfuse/feedback.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import type { AppConfig } from '@librechat/data-schemas';
 import { getScoreDestinations, type LangfuseScoreDestination } from './destinations';
+import { isLangfuseMetricsOnlyPrivacy } from './policy';
 import { mergeHeaders } from '~/utils/headers';
 import { redirectPolicyFor } from './utils';
 
@@ -90,27 +91,48 @@ async function createScore(
   }
 }
 
+/** Metadata keys carrying user-written or personal values, dropped under
+ *  metricsOnly: the sender is a person's display name, tag is user input. */
+const FEEDBACK_CONTENT_METADATA_KEYS = new Set(['sender', 'tag']);
+
+function stripFeedbackContent(
+  metadata: Record<string, string | number | boolean>,
+): Record<string, string | number | boolean> {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([key]) => !FEEDBACK_CONTENT_METADATA_KEYS.has(key)),
+  );
+}
+
 function buildScorePayload({
   scoreId,
   traceId,
   feedback,
   metadata,
   observationId,
+  metricsOnly,
 }: {
   scoreId: string;
   traceId: string;
   feedback: LangfuseFeedback;
   metadata: LangfuseFeedbackMetadata;
   observationId?: string;
+  metricsOnly: boolean;
 }): LangfuseScorePayload {
+  const fullMetadata = cleanMetadata({
+    ...metadata,
+    rating: feedback.rating,
+    tag: feedback.tag,
+  });
   return {
     id: scoreId,
     traceId,
     name: 'user-feedback',
     value: feedback.rating === 'thumbsUp' ? 1 : 0,
     dataType: 'BOOLEAN',
-    comment: [feedback.tag, feedback.text].filter(Boolean).join(' — ') || undefined,
-    metadata: cleanMetadata({ ...metadata, rating: feedback.rating, tag: feedback.tag }),
+    comment: metricsOnly
+      ? undefined
+      : [feedback.tag, feedback.text].filter(Boolean).join(': ') || undefined,
+    metadata: metricsOnly ? stripFeedbackContent(fullMetadata) : fullMetadata,
     ...(observationId ? { observationId } : {}),
     ...(ENVIRONMENT ? { environment: ENVIRONMENT } : {}),
   };
@@ -140,7 +162,14 @@ export async function sendFeedbackScore({
 
   const scoreId = `feedback-${traceId}`;
   const payload = feedback?.rating
-    ? buildScorePayload({ scoreId, traceId, feedback, metadata, observationId })
+    ? buildScorePayload({
+        scoreId,
+        traceId,
+        feedback,
+        metadata,
+        observationId,
+        metricsOnly: isLangfuseMetricsOnlyPrivacy(appConfig),
+      })
     : undefined;
 
   const results = await Promise.allSettled(

--- a/packages/api/src/langfuse/policy.spec.ts
+++ b/packages/api/src/langfuse/policy.spec.ts
@@ -9,7 +9,7 @@ const envKeys = [
   'TENANT_ISOLATION_STRICT',
 ];
 
-const mockAgentsRuntimeExports: { LANGFUSE_PRIVACY_MASKING_SUPPORTED?: boolean } = {};
+const mockAgentsRuntimeExports: { LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED?: boolean } = {};
 jest.mock('@librechat/agents', () => mockAgentsRuntimeExports);
 
 function clearEnv() {
@@ -123,13 +123,13 @@ describe('Langfuse policy', () => {
   });
 
   it('detects privacy masking support from the agents runtime export', async () => {
-    mockAgentsRuntimeExports.LANGFUSE_PRIVACY_MASKING_SUPPORTED = true;
+    mockAgentsRuntimeExports.LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED = true;
     await jest.isolateModulesAsync(async () => {
       const { isLangfusePrivacyMaskingSupported } = await import('./policy');
       expect(isLangfusePrivacyMaskingSupported()).toBe(true);
     });
 
-    mockAgentsRuntimeExports.LANGFUSE_PRIVACY_MASKING_SUPPORTED = undefined;
+    mockAgentsRuntimeExports.LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED = undefined;
     await jest.isolateModulesAsync(async () => {
       const { isLangfusePrivacyMaskingSupported } = await import('./policy');
       expect(isLangfusePrivacyMaskingSupported()).toBe(false);

--- a/packages/api/src/langfuse/policy.spec.ts
+++ b/packages/api/src/langfuse/policy.spec.ts
@@ -9,6 +9,9 @@ const envKeys = [
   'TENANT_ISOLATION_STRICT',
 ];
 
+const mockAgentsRuntimeExports: { LANGFUSE_PRIVACY_MASKING_SUPPORTED?: boolean } = {};
+jest.mock('@librechat/agents', () => mockAgentsRuntimeExports);
+
 function clearEnv() {
   for (const key of envKeys) {
     delete process.env[key];
@@ -117,5 +120,19 @@ describe('Langfuse policy', () => {
 
     process.env.LANGFUSE_SAMPLE_RATE = 'invalid';
     expect(getLangfuseSampleRate()).toBe(1);
+  });
+
+  it('detects privacy masking support from the agents runtime export', async () => {
+    mockAgentsRuntimeExports.LANGFUSE_PRIVACY_MASKING_SUPPORTED = true;
+    await jest.isolateModulesAsync(async () => {
+      const { isLangfusePrivacyMaskingSupported } = await import('./policy');
+      expect(isLangfusePrivacyMaskingSupported()).toBe(true);
+    });
+
+    mockAgentsRuntimeExports.LANGFUSE_PRIVACY_MASKING_SUPPORTED = undefined;
+    await jest.isolateModulesAsync(async () => {
+      const { isLangfusePrivacyMaskingSupported } = await import('./policy');
+      expect(isLangfusePrivacyMaskingSupported()).toBe(false);
+    });
   });
 });

--- a/packages/api/src/langfuse/policy.ts
+++ b/packages/api/src/langfuse/policy.ts
@@ -1,4 +1,5 @@
 import * as agentsRuntime from '@librechat/agents';
+import type { AppConfig } from '@librechat/data-schemas';
 import { isFalseEnv, isTrueEnv } from './utils';
 import { normalizeString } from '~/utils/text';
 
@@ -7,6 +8,16 @@ const MAX_TRACE_ID_ACCUMULATION = 0xffffffff;
 
 export function isLangfuseTenantExportEnabled(): boolean {
   return !isTrueEnv(process.env.LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED);
+}
+
+/**
+ * Whether the deployment's Langfuse privacy policy suppresses exported
+ * content. Applies to every Langfuse egress, not only trace spans: feedback
+ * scores must drop user-written text and personal names too, keeping only
+ * the rating and correlation ids.
+ */
+export function isLangfuseMetricsOnlyPrivacy(appConfig?: Pick<AppConfig, 'langfuse'>): boolean {
+  return appConfig?.langfuse?.privacy?.mode === 'metricsOnly';
 }
 
 /**

--- a/packages/api/src/langfuse/policy.ts
+++ b/packages/api/src/langfuse/policy.ts
@@ -1,3 +1,4 @@
+import * as agentsRuntime from '@librechat/agents';
 import { isFalseEnv, isTrueEnv } from './utils';
 import { normalizeString } from '~/utils/text';
 
@@ -6,6 +7,22 @@ const MAX_TRACE_ID_ACCUMULATION = 0xffffffff;
 
 export function isLangfuseTenantExportEnabled(): boolean {
   return !isTrueEnv(process.env.LANGFUSE_FANOUT_TENANT_EXPORT_DISABLED);
+}
+
+/**
+ * Whether the installed `@librechat/agents` runtime enforces
+ * `LangfuseConfig.privacy` (content masking and media suppression). Runtimes
+ * without the export ignore the field, so a privacy mode must disable trace
+ * export for the run rather than send unmasked content.
+ */
+export function isLangfusePrivacyMaskingSupported(): boolean {
+  return (
+    (
+      agentsRuntime as {
+        LANGFUSE_PRIVACY_MASKING_SUPPORTED?: boolean;
+      }
+    ).LANGFUSE_PRIVACY_MASKING_SUPPORTED === true
+  );
 }
 
 export function isLangfuseCentralMediaUploadDisabled(): boolean {

--- a/packages/api/src/langfuse/policy.ts
+++ b/packages/api/src/langfuse/policy.ts
@@ -22,17 +22,17 @@ export function isLangfuseMetricsOnlyPrivacy(appConfig?: Pick<AppConfig, 'langfu
 
 /**
  * Whether the installed `@librechat/agents` runtime enforces
- * `LangfuseConfig.privacy` (content masking and media suppression). Runtimes
- * without the export ignore the field, so a privacy mode must disable trace
- * export for the run rather than send unmasked content.
+ * `LangfuseConfig.privacy` (content redaction and media suppression).
+ * Runtimes without the export ignore the field, so a privacy mode must
+ * disable trace export for the run rather than send unmasked content.
  */
 export function isLangfusePrivacyMaskingSupported(): boolean {
   return (
     (
       agentsRuntime as {
-        LANGFUSE_PRIVACY_MASKING_SUPPORTED?: boolean;
+        LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED?: boolean;
       }
-    ).LANGFUSE_PRIVACY_MASKING_SUPPORTED === true
+    ).LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED === true
   );
 }
 

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -1375,4 +1375,37 @@ describe('configSchema langfuse', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('accepts Langfuse privacy controls', () => {
+    const result = configSchema.safeParse({
+      version: '1.3.7',
+      langfuse: {
+        privacy: {
+          mode: 'metricsOnly',
+          redactionText: '[CONTENT REDACTED]',
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown Langfuse privacy modes and blank redaction text', () => {
+    const unknownMode = configSchema.safeParse({
+      version: '1.3.7',
+      langfuse: {
+        privacy: { mode: 'redacted' },
+      },
+    });
+
+    const blankRedactionText = configSchema.safeParse({
+      version: '1.3.7',
+      langfuse: {
+        privacy: { mode: 'metricsOnly', redactionText: '' },
+      },
+    });
+
+    expect(unknownMode.success).toBe(false);
+    expect(blankRedactionText.success).toBe(false);
+  });
 });

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -1405,7 +1405,29 @@ describe('configSchema langfuse', () => {
       },
     });
 
+    const whitespaceRedactionText = configSchema.safeParse({
+      version: '1.3.7',
+      langfuse: {
+        privacy: { mode: 'metricsOnly', redactionText: '   ' },
+      },
+    });
+
     expect(unknownMode.success).toBe(false);
     expect(blankRedactionText.success).toBe(false);
+    expect(whitespaceRedactionText.success).toBe(false);
+  });
+
+  it('trims Langfuse privacy redaction text before storing it', () => {
+    const result = configSchema.safeParse({
+      version: '1.3.7',
+      langfuse: {
+        privacy: { mode: 'metricsOnly', redactionText: ' [private] ' },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.langfuse?.privacy?.redactionText).toBe('[private]');
+    }
   });
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2063,6 +2063,23 @@ export const langfuseConfigSchema = z.object({
    * `Authorization` upstream regardless.
    */
   headers: z.record(z.string()).optional(),
+  /**
+   * Content privacy policy for exported traces, applied before trace data
+   * leaves the server. `metricsOnly` replaces message, tool, and media
+   * content with a redaction marker while keeping trace structure, timing,
+   * model, token usage, cost, and error status. The default `full` mode
+   * exports content unchanged.
+   *
+   * Fails closed: when the tracing runtime cannot enforce the policy, trace
+   * export is disabled for the run instead of sending unmasked content.
+   */
+  privacy: z
+    .object({
+      mode: z.enum(['full', 'metricsOnly']).optional(),
+      /** Replacement text used for suppressed content. */
+      redactionText: z.string().min(1).max(128).optional(),
+    })
+    .optional(),
 });
 
 export type LangfuseConfig = z.infer<typeof langfuseConfigSchema>;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2076,8 +2076,9 @@ export const langfuseConfigSchema = z.object({
   privacy: z
     .object({
       mode: z.enum(['full', 'metricsOnly']).optional(),
-      /** Replacement text used for suppressed content. */
-      redactionText: z.string().min(1).max(128).optional(),
+      /** Replacement text used for suppressed content. Blank after
+       * trimming is rejected so a configured marker always exists. */
+      redactionText: z.string().trim().min(1).max(128).optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary

Langfuse tracing exported conversation content, tool arguments and outputs, trace metadata, and media with no way to suppress any of it, which blocks deployments that need operational telemetry (latency, model, token usage, cost, errors) without conversation content leaving the server. Resolves #14362.

This adds a `langfuse.privacy` block to `librechat.yaml` with a `mode` (`full` default, or `metricsOnly`) and a configurable `redactionText`. In `metricsOnly`, message content, tool arguments, tool outputs, and trace/observation metadata are replaced with the redaction marker before trace data leaves the server on every export destination, media upload is disabled, and tenant trace metadata and tags are skipped at the source. Trace structure, timing, model, token usage, cost, and error status remain available.

The policy fails closed: when the installed `@librechat/agents` runtime cannot enforce masking, trace export is disabled for the run and the operator is warned once per process. Masking is enforced by the tracing runtime in danny-avila/agents#440, which needs a `@librechat/agents` release above 3.6.8; merging earlier is safe because of the fail-closed gate. The `redacted` mode from the issue is not accepted by the schema yet, since no rules engine exists.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `cd packages/data-provider && npx jest specs/config-schemas.spec.ts`: 108 passed
- `cd packages/api && npx jest src/langfuse/`: config 49, policy 16, feedback suites green
- `cd packages/api && npx jest src/admin/secrets.spec.ts src/admin/config.handler.spec.ts`: 190 passed
- `cd api && npx jest server/services/Config/loadCustomConfig.spec.js`: 22 passed
- `cd packages/api && npx tsc --noEmit -p tsconfig.json`, plus eslint on touched files

Manual checks: schema accepts `metricsOnly` and rejects unknown modes and blank redaction text; `buildLangfuseConfig` attaches the policy with trimmed redaction text, suppresses tenant metadata and tags, and produces a full export in `full` mode; the fail-closed path disables export when the runtime lacks the capability export. Not run: a live round-trip against a real Langfuse instance (the masking path is verified in danny-avila/agents#440 against the real span processor).

### **Test Configuration**:

Node v24.16.0, local MongoDB, `@librechat/agents` 3.6.8 installed (exercises the fail-closed path), agents branch built locally for the supported-path unit tests.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
