### PR TITLE
🐇 perf: Bound MCP Agent Access Scan by MCP Referencing Agents and Share the Read-Through Cache

### DIFF
--- a/packages/api/src/acl/accessControlService.ts
+++ b/packages/api/src/acl/accessControlService.ts
@@ -126,6 +126,8 @@ export class AccessControlService {
    * @param {string} [params.role] - Optional user role (if not provided, will query from DB)
    * @param {string} params.resourceType - Type of resource (e.g., 'agent')
    * @param {number} params.requiredPermissions - The minimum permission bits required (e.g., 1 for VIEW, 3 for VIEW+EDIT)
+   * @param {Types.ObjectId[]} [params.resourceIds] - Optional candidate bound; only these
+   *   resources are considered, so the query cost scales with the candidate set
    * @returns {Promise<Array>} Array of resource IDs
    */
   public async findAccessibleResources({
@@ -133,11 +135,13 @@ export class AccessControlService {
     role,
     resourceType,
     requiredPermissions,
+    resourceIds,
   }: {
     userId: string | Types.ObjectId;
     role?: string;
     resourceType: string;
     requiredPermissions: number;
+    resourceIds?: Types.ObjectId[];
   }): Promise<Types.ObjectId[]> {
     try {
       const principalsList = await this.getUserPrincipals({ userId, role });
@@ -145,6 +149,7 @@ export class AccessControlService {
         principalsList,
         resourceType,
         requiredPermissions,
+        resourceIds,
       });
     } catch (error) {
       if (error instanceof Error) {
@@ -172,10 +177,12 @@ export class AccessControlService {
     principalsList,
     resourceType,
     requiredPermissions,
+    resourceIds,
   }: {
     principalsList: ResolvedPrincipal[];
     resourceType: string;
     requiredPermissions: number;
+    resourceIds?: Types.ObjectId[];
   }): Promise<Types.ObjectId[]> {
     try {
       if (typeof requiredPermissions !== 'number' || requiredPermissions < 1) {
@@ -192,6 +199,7 @@ export class AccessControlService {
         principalsList,
         resourceType,
         requiredPermissions,
+        resourceIds,
       );
     } catch (error) {
       if (error instanceof Error) {
@@ -211,14 +219,18 @@ export class AccessControlService {
    * @param {Object} params - Parameters for finding publicly accessible resources
    * @param {ResourceType} params.resourceType - Type of resource (e.g., 'agent')
    * @param {number} params.requiredPermissions - The minimum permission bits required (e.g., 1 for VIEW, 3 for VIEW+EDIT)
+   * @param {Types.ObjectId[]} [params.resourceIds] - Optional candidate bound; only these
+   *   resources are considered, so the query cost scales with the candidate set
    * @returns {Promise<Types.ObjectId[]>} Array of resource IDs
    */
   public async findPubliclyAccessibleResources({
     resourceType,
     requiredPermissions,
+    resourceIds,
   }: {
     resourceType: ResourceType;
     requiredPermissions: number;
+    resourceIds?: Types.ObjectId[];
   }): Promise<Types.ObjectId[]> {
     try {
       if (typeof requiredPermissions !== 'number' || requiredPermissions < 1) {
@@ -227,7 +239,11 @@ export class AccessControlService {
 
       this.validateResourceType(resourceType);
 
-      return await this._dbMethods.findPublicResourceIds(resourceType, requiredPermissions);
+      return await this._dbMethods.findPublicResourceIds(
+        resourceType,
+        requiredPermissions,
+        resourceIds,
+      );
     } catch (error) {
       if (error instanceof Error) {
         logger.error(`[PermissionService.findPubliclyAccessibleResources] Error: ${error.message}`);

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -864,7 +864,8 @@ export class MCPServersRegistry {
       this.configCacheRepo.reset(),
       // Only invalidate readThroughCacheAll (merged results that may include stale config servers).
       // readThroughCache (individual YAML/user lookups) is unaffected by config mutations.
-      this.readThroughCacheAll.invalidateAll(),
+      // Operator config changes are global, so the eviction crosses tenants.
+      this.readThroughCacheAll.invalidateAllGlobal(),
     ]);
 
     if (evictedNames.length > 0) {
@@ -889,7 +890,7 @@ export class MCPServersRegistry {
     await this.cacheConfigsRepo.reset();
     await this.configCacheRepo.reset();
     await this.readThroughCache.clear();
-    await this.readThroughCacheAll.invalidateAll();
+    await this.readThroughCacheAll.invalidateAllGlobal();
     this.resetYamlServerNamesMemo();
   }
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { isProcessMCPServerConfig } from 'librechat-data-provider';
 import { logger, encryptV2, decryptV2, scopedCacheKey } from '@librechat/data-schemas';
 import type { IServerConfigsRepositoryInterface } from './ServerConfigsRepositoryInterface';
-import type { ReadThroughTransforms } from './cache/ReadThroughAllCache';
+import type { ReadThroughTransforms, FillToken } from './cache/ReadThroughAllCache';
 import type * as t from '~/mcp/types';
 import {
   ServerConfigsCacheFactory,
@@ -364,7 +364,7 @@ export class MCPServersRegistry {
       } else {
         base = await this.dbConfigsRepo.get(serverName, userId);
       }
-      await this.readThroughCache.set(cacheKey, base);
+      await this.readThroughCache.set(cacheKey, base, cached.fill);
     }
 
     if (!candidate) return base;
@@ -442,8 +442,8 @@ export class MCPServersRegistry {
     const cacheKey = scopedCacheKey(userId ?? '__no_user__');
 
     const cached = await this.readThroughCacheAll.get(cacheKey);
-    if (cached !== undefined) {
-      return cached;
+    if (cached.hit) {
+      return cached.value ?? {};
     }
 
     const pending = this.pendingGetAllPromises.get(cacheKey);
@@ -451,7 +451,7 @@ export class MCPServersRegistry {
       return pending;
     }
 
-    const fetchPromise = this.fetchBaseServerConfigs(cacheKey, userId, role);
+    const fetchPromise = this.fetchBaseServerConfigs(cacheKey, userId, role, cached.fill);
     this.pendingGetAllPromises.set(cacheKey, fetchPromise);
 
     try {
@@ -465,6 +465,7 @@ export class MCPServersRegistry {
     cacheKey: string,
     userId?: string,
     role?: string,
+    fill?: FillToken,
   ): Promise<Record<string, t.ParsedServerConfig>> {
     const [dbConfigs, yamlConfigs] = await Promise.all([
       this.dbConfigsRepo.getAll(userId, role),
@@ -475,7 +476,7 @@ export class MCPServersRegistry {
 
     const result = { ...dbConfigs, ...yamlConfigs };
 
-    await this.readThroughCacheAll.set(cacheKey, result);
+    await this.readThroughCacheAll.set(cacheKey, result, fill);
     return result;
   }
 
@@ -589,7 +590,7 @@ export class MCPServersRegistry {
 
     const updatedConfig = { ...parsedConfig, updatedAt: Date.now() };
     await configRepo.update(serverName, updatedConfig, userId);
-    await this.invalidateServerReadCaches(serverName, userId, 'CACHE');
+    await this.invalidateServerReadCaches(serverName, userId, storageLocation);
     return { serverName, config: updatedConfig };
   }
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -200,7 +200,10 @@ export class MCPServersRegistry {
   private readonly readThroughCacheAll: ReadThroughAllCache<Record<string, t.ParsedServerConfig>>;
   private readonly pendingGetAllPromises = new Map<
     string,
-    Promise<Record<string, t.ParsedServerConfig>>
+    {
+      generation: string;
+      promise: Promise<Record<string, t.ParsedServerConfig>>;
+    }
   >();
 
   /** Tracks in-flight config server initializations to prevent duplicate work. */
@@ -446,18 +449,26 @@ export class MCPServersRegistry {
       return cached.value ?? {};
     }
 
-    const pending = this.pendingGetAllPromises.get(cacheKey);
-    if (pending) {
-      return pending;
+    const fill = cached.fill;
+    if (fill?.generation == null) {
+      return this.fetchBaseServerConfigs(cacheKey, userId, role, fill);
     }
 
-    const fetchPromise = this.fetchBaseServerConfigs(cacheKey, userId, role, cached.fill);
-    this.pendingGetAllPromises.set(cacheKey, fetchPromise);
+    const pending = this.pendingGetAllPromises.get(cacheKey);
+    if (pending?.generation === fill.generation) {
+      return pending.promise;
+    }
+
+    const fetchPromise = this.fetchBaseServerConfigs(cacheKey, userId, role, fill);
+    const pendingFill = { generation: fill.generation, promise: fetchPromise };
+    this.pendingGetAllPromises.set(cacheKey, pendingFill);
 
     try {
       return await fetchPromise;
     } finally {
-      this.pendingGetAllPromises.delete(cacheKey);
+      if (this.pendingGetAllPromises.get(cacheKey) === pendingFill) {
+        this.pendingGetAllPromises.delete(cacheKey);
+      }
     }
   }
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -9,8 +9,8 @@ import {
   APP_CACHE_NAMESPACE,
   CONFIG_CACHE_NAMESPACE,
 } from './cache/ServerConfigsCacheFactory';
-import { ReadThroughAllCache } from './cache/ReadThroughAllCache';
 import { MCPInspectionFailedError, isMCPDomainNotAllowedError } from '~/mcp/errors';
+import { ReadThroughAllCache } from './cache/ReadThroughAllCache';
 import { isPluginSourced, MCP_PLUGIN_SOURCE } from '~/utils/env';
 import { MCPServerInspector } from './MCPServerInspector';
 import { ServerConfigsDB } from './db/ServerConfigsDB';

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'crypto';
 import { isProcessMCPServerConfig } from 'librechat-data-provider';
 import { logger, encryptV2, decryptV2 } from '@librechat/data-schemas';
-import type { Keyv } from 'keyv';
 import type { IServerConfigsRepositoryInterface } from './ServerConfigsRepositoryInterface';
+import type { ReadThroughTransforms } from './cache/ReadThroughAllCache';
 import type * as t from '~/mcp/types';
 import {
   ServerConfigsCacheFactory,
@@ -12,13 +12,38 @@ import {
 import { MCPInspectionFailedError, isMCPDomainNotAllowedError } from '~/mcp/errors';
 import { ReadThroughAllCache } from './cache/ReadThroughAllCache';
 import { isPluginSourced, MCP_PLUGIN_SOURCE } from '~/utils/env';
+import { ReadThroughCache } from './cache/ReadThroughCache';
 import { MCPServerInspector } from './MCPServerInspector';
 import { ServerConfigsDB } from './db/ServerConfigsDB';
-import { cacheConfig, standardCache } from '~/cache';
+import { cacheConfig } from '~/cache';
 import { withTimeout } from '~/utils';
 
 /** How long a failure stub is considered fresh before re-attempting inspection (5 minutes). */
 const CONFIG_STUB_RETRY_MS = 5 * 60 * 1000;
+
+/** Cached configs carry decrypted oauth/apiKey credentials, so the shared
+ *  stores only ever see ciphertext; plaintext stays in process memory,
+ *  exactly where it lived before these caches became shared. */
+function encryptedStoreTransforms<T>(): ReadThroughTransforms<T> {
+  return {
+    encode: async (value) => encryptV2(JSON.stringify(value)),
+    decode: async (raw) => JSON.parse(await decryptV2(raw)),
+  };
+}
+
+/** The per-server cache also negative-caches lookups, so its envelope keeps a
+ *  stored "absent" (null) distinguishable from "not cached". */
+function perServerStoreTransforms(): ReadThroughTransforms<t.ParsedServerConfig | undefined> {
+  return {
+    encode: async (value) => encryptV2(JSON.stringify({ config: value ?? null })),
+    decode: async (raw) => {
+      const decoded = JSON.parse(await decryptV2(raw)) as {
+        config: t.ParsedServerConfig | null;
+      };
+      return decoded.config ?? undefined;
+    },
+  };
+}
 
 /**
  * Provenance to persist for a config being stored in `tier`.
@@ -171,7 +196,7 @@ export class MCPServersRegistry {
   private readonly allowedAddresses?: string[] | null;
   /** Resolves the per-request (tenant-scoped) merged allowlists; falls back to the base above. */
   private readonly allowlistResolver?: MCPAllowlistResolver;
-  private readonly readThroughCache: Keyv<t.ParsedServerConfig>;
+  private readonly readThroughCache: ReadThroughCache<t.ParsedServerConfig | undefined>;
   private readonly readThroughCacheAll: ReadThroughAllCache<Record<string, t.ParsedServerConfig>>;
   private readonly pendingGetAllPromises = new Map<
     string,
@@ -203,23 +228,17 @@ export class MCPServersRegistry {
 
     const ttl = cacheConfig.MCP_REGISTRY_CACHE_TTL;
 
-    /** Redis-backed when configured, in-memory otherwise; per-server keys are
-     *  invalidated by targeted deletes, so a plain store suffices. */
-    this.readThroughCache = standardCache(
+    /** Per-server entries are invalidated by targeted deletes. */
+    this.readThroughCache = new ReadThroughCache<t.ParsedServerConfig | undefined>(
       'mcp-registry-read-through',
       ttl,
-    ) as Keyv<t.ParsedServerConfig>;
+      perServerStoreTransforms(),
+    );
 
     this.readThroughCacheAll = new ReadThroughAllCache<Record<string, t.ParsedServerConfig>>(
       'mcp-registry-read-through-all',
       ttl,
-      {
-        /** The resolved map carries decrypted oauth/apiKey credentials, so the
-         *  shared store only ever sees ciphertext; plaintext stays in process
-         *  memory, exactly where it lived before this cache became shared. */
-        encode: async (value) => encryptV2(JSON.stringify(value)),
-        decode: async (raw) => JSON.parse(await decryptV2(raw)),
-      },
+      encryptedStoreTransforms<Record<string, t.ParsedServerConfig>>(),
     );
   }
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -496,7 +496,7 @@ export class MCPServersRegistry {
       source: resolveServerSource(config, 'yaml'),
     };
     const result = await configRepo.add(serverName, stubConfig, userId);
-    await this.invalidateServerReadCaches(result.serverName, userId);
+    await this.invalidateServerReadCaches(result.serverName, userId, 'CACHE');
     this.resetYamlServerNamesMemo();
     return result;
   }
@@ -541,7 +541,7 @@ export class MCPServersRegistry {
             await this.getOperatorManagedServerNames(reservedServerNames),
           )
         : await configRepo.add(serverName, tagged, userId);
-    await this.invalidateServerReadCaches(result.serverName, userId);
+    await this.invalidateServerReadCaches(result.serverName, userId, storageLocation);
     if (storageLocation === 'CACHE') {
       this.resetYamlServerNamesMemo();
     }
@@ -589,7 +589,7 @@ export class MCPServersRegistry {
 
     const updatedConfig = { ...parsedConfig, updatedAt: Date.now() };
     await configRepo.update(serverName, updatedConfig, userId);
-    await this.invalidateServerReadCaches(serverName, userId);
+    await this.invalidateServerReadCaches(serverName, userId, 'CACHE');
     return { serverName, config: updatedConfig };
   }
 
@@ -651,7 +651,7 @@ export class MCPServersRegistry {
   ): Promise<t.ParsedServerConfig> {
     const configRepo = this.getConfigRepository(storageLocation);
     await configRepo.update(serverName, parsedConfig, userId);
-    await this.invalidateServerReadCaches(serverName, userId);
+    await this.invalidateServerReadCaches(serverName, userId, storageLocation);
     return parsedConfig;
   }
 
@@ -901,7 +901,7 @@ export class MCPServersRegistry {
   ): Promise<void> {
     const configRepo = this.getConfigRepository(storageLocation);
     await configRepo.remove(serverName, userId);
-    await this.invalidateServerReadCaches(serverName, userId);
+    await this.invalidateServerReadCaches(serverName, userId, storageLocation);
     if (storageLocation === 'CACHE') {
       this.resetYamlServerNamesMemo();
     }
@@ -926,7 +926,26 @@ export class MCPServersRegistry {
     return scopedCacheKey(userId ? `${serverName}::${userId}` : serverName);
   }
 
-  private async invalidateServerReadCaches(serverName: string, userId?: string): Promise<void> {
+  /**
+   * DB-backed servers and their ACL grants are tenant-scoped data, so their
+   * invalidation stays within the acting tenant. CACHE-tier (YAML/App
+   * repository) entries are global, so those mutations evict across tenants:
+   * the per-server cache cannot enumerate tenant-scoped keys, so it clears the
+   * namespace, and the aggregate map uses its global path.
+   */
+  private async invalidateServerReadCaches(
+    serverName: string,
+    userId?: string,
+    storageLocation?: 'CACHE' | 'DB',
+  ): Promise<void> {
+    if (storageLocation === 'CACHE') {
+      await Promise.all([
+        this.readThroughCache.clear(),
+        this.readThroughCacheAll.invalidateAllGlobal(),
+      ]);
+      return;
+    }
+
     const deletes = [
       this.readThroughCache.delete(this.getReadThroughCacheKey(serverName)),
       this.readThroughCacheAll.invalidateAll(),

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
 import { isProcessMCPServerConfig } from 'librechat-data-provider';
-import { logger, encryptV2, decryptV2 } from '@librechat/data-schemas';
+import { logger, encryptV2, decryptV2, scopedCacheKey } from '@librechat/data-schemas';
 import type { IServerConfigsRepositoryInterface } from './ServerConfigsRepositoryInterface';
 import type { ReadThroughTransforms } from './cache/ReadThroughAllCache';
 import type * as t from '~/mcp/types';
@@ -354,8 +354,9 @@ export class MCPServersRegistry {
 
     const cacheKey = this.getReadThroughCacheKey(serverName, userId);
     let base: t.ParsedServerConfig | undefined;
-    if (await this.readThroughCache.has(cacheKey)) {
-      base = await this.readThroughCache.get(cacheKey);
+    const cached = await this.readThroughCache.getEntry(cacheKey);
+    if (cached.hit) {
+      base = cached.value;
     } else {
       const configFromYaml = await this.cacheConfigsRepo.get(serverName);
       if (configFromYaml) {
@@ -435,7 +436,10 @@ export class MCPServersRegistry {
     userId?: string,
     role?: string,
   ): Promise<Record<string, t.ParsedServerConfig>> {
-    const cacheKey = userId ?? '__no_user__';
+    /** Tenant-scoped (also covering the single-flight map): the DB read behind
+     *  a miss is filtered by the active tenant, so entries and in-flight
+     *  builds must partition the same way. */
+    const cacheKey = scopedCacheKey(userId ?? '__no_user__');
 
     const cached = await this.readThroughCacheAll.get(cacheKey);
     if (cached !== undefined) {
@@ -915,8 +919,10 @@ export class MCPServersRegistry {
     }
   }
 
+  /** Tenant-scoped because DB-backed lookups are filtered by the active tenant:
+   *  an entry populated in one tenant's context must never satisfy another's. */
   private getReadThroughCacheKey(serverName: string, userId?: string): string {
-    return userId ? `${serverName}::${userId}` : serverName;
+    return scopedCacheKey(userId ? `${serverName}::${userId}` : serverName);
   }
 
   private async invalidateServerReadCaches(serverName: string, userId?: string): Promise<void> {

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -1,7 +1,7 @@
-import { Keyv } from 'keyv';
 import { createHash } from 'crypto';
 import { logger } from '@librechat/data-schemas';
 import { isProcessMCPServerConfig } from 'librechat-data-provider';
+import type { Keyv } from 'keyv';
 import type { IServerConfigsRepositoryInterface } from './ServerConfigsRepositoryInterface';
 import type * as t from '~/mcp/types';
 import {
@@ -9,11 +9,12 @@ import {
   APP_CACHE_NAMESPACE,
   CONFIG_CACHE_NAMESPACE,
 } from './cache/ServerConfigsCacheFactory';
+import { ReadThroughAllCache } from './cache/ReadThroughAllCache';
 import { MCPInspectionFailedError, isMCPDomainNotAllowedError } from '~/mcp/errors';
 import { isPluginSourced, MCP_PLUGIN_SOURCE } from '~/utils/env';
 import { MCPServerInspector } from './MCPServerInspector';
 import { ServerConfigsDB } from './db/ServerConfigsDB';
-import { cacheConfig } from '~/cache/cacheConfig';
+import { cacheConfig, standardCache } from '~/cache';
 import { withTimeout } from '~/utils';
 
 /** How long a failure stub is considered fresh before re-attempting inspection (5 minutes). */
@@ -171,7 +172,7 @@ export class MCPServersRegistry {
   /** Resolves the per-request (tenant-scoped) merged allowlists; falls back to the base above. */
   private readonly allowlistResolver?: MCPAllowlistResolver;
   private readonly readThroughCache: Keyv<t.ParsedServerConfig>;
-  private readonly readThroughCacheAll: Keyv<Record<string, t.ParsedServerConfig>>;
+  private readonly readThroughCacheAll: ReadThroughAllCache<Record<string, t.ParsedServerConfig>>;
   private readonly pendingGetAllPromises = new Map<
     string,
     Promise<Record<string, t.ParsedServerConfig>>
@@ -202,15 +203,17 @@ export class MCPServersRegistry {
 
     const ttl = cacheConfig.MCP_REGISTRY_CACHE_TTL;
 
-    this.readThroughCache = new Keyv<t.ParsedServerConfig>({
-      namespace: 'mcp-registry-read-through',
+    /** Redis-backed when configured, in-memory otherwise; per-server keys are
+     *  invalidated by targeted deletes, so a plain store suffices. */
+    this.readThroughCache = standardCache(
+      'mcp-registry-read-through',
       ttl,
-    });
+    ) as Keyv<t.ParsedServerConfig>;
 
-    this.readThroughCacheAll = new Keyv<Record<string, t.ParsedServerConfig>>({
-      namespace: 'mcp-registry-read-through-all',
+    this.readThroughCacheAll = new ReadThroughAllCache<Record<string, t.ParsedServerConfig>>(
+      'mcp-registry-read-through-all',
       ttl,
-    });
+    );
   }
 
   /** Creates and initializes the singleton MCPServersRegistry instance */
@@ -408,8 +411,9 @@ export class MCPServersRegistry {
   ): Promise<Record<string, t.ParsedServerConfig>> {
     const cacheKey = userId ?? '__no_user__';
 
-    if (await this.readThroughCacheAll.has(cacheKey)) {
-      return (await this.readThroughCacheAll.get(cacheKey)) ?? {};
+    const cached = await this.readThroughCacheAll.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
     }
 
     const pending = this.pendingGetAllPromises.get(cacheKey);
@@ -828,9 +832,9 @@ export class MCPServersRegistry {
 
     await Promise.all([
       this.configCacheRepo.reset(),
-      // Only clear readThroughCacheAll (merged results that may include stale config servers).
+      // Only invalidate readThroughCacheAll (merged results that may include stale config servers).
       // readThroughCache (individual YAML/user lookups) is unaffected by config mutations.
-      this.readThroughCacheAll.clear(),
+      this.readThroughCacheAll.invalidateAll(),
     ]);
 
     if (evictedNames.length > 0) {
@@ -855,7 +859,7 @@ export class MCPServersRegistry {
     await this.cacheConfigsRepo.reset();
     await this.configCacheRepo.reset();
     await this.readThroughCache.clear();
-    await this.readThroughCacheAll.clear();
+    await this.readThroughCacheAll.invalidateAll();
     this.resetYamlServerNamesMemo();
   }
 
@@ -892,7 +896,7 @@ export class MCPServersRegistry {
   private async invalidateServerReadCaches(serverName: string, userId?: string): Promise<void> {
     const deletes = [
       this.readThroughCache.delete(this.getReadThroughCacheKey(serverName)),
-      this.readThroughCacheAll.clear(),
+      this.readThroughCacheAll.invalidateAll(),
     ];
 
     if (userId) {

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
-import { logger } from '@librechat/data-schemas';
 import { isProcessMCPServerConfig } from 'librechat-data-provider';
+import { logger, encryptV2, decryptV2 } from '@librechat/data-schemas';
 import type { Keyv } from 'keyv';
 import type { IServerConfigsRepositoryInterface } from './ServerConfigsRepositoryInterface';
 import type * as t from '~/mcp/types';
@@ -213,6 +213,13 @@ export class MCPServersRegistry {
     this.readThroughCacheAll = new ReadThroughAllCache<Record<string, t.ParsedServerConfig>>(
       'mcp-registry-read-through-all',
       ttl,
+      {
+        /** The resolved map carries decrypted oauth/apiKey credentials, so the
+         *  shared store only ever sees ciphertext; plaintext stays in process
+         *  memory, exactly where it lived before this cache became shared. */
+        encode: async (value) => encryptV2(JSON.stringify(value)),
+        decode: async (raw) => JSON.parse(await decryptV2(raw)),
+      },
     );
   }
 

--- a/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts
@@ -29,6 +29,7 @@ jest.mock('@librechat/data-schemas', () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
+  scopedCacheKey: (baseKey: string) => baseKey,
 }));
 
 // Mock ServerConfigsDB to avoid mongoose dependency

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -67,6 +67,10 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
     process.env.REDIS_KEY_PREFIX =
       process.env.REDIS_KEY_PREFIX ??
       `MCPServersRegistry-IntegrationTest-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+    // The read-through caches encrypt entries before they reach the shared store
+    process.env.CREDS_KEY =
+      process.env.CREDS_KEY ?? '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    process.env.CREDS_IV = process.env.CREDS_IV ?? '0123456789abcdef0123456789abcdef';
 
     // Import modules after setting env vars
     const registryModule = await import('../MCPServersRegistry');

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -244,7 +244,7 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
       await registry.addServer('server2', testRawConfig, 'CACHE');
       await registry.addServer('server3', testRawConfig, 'CACHE');
 
-      await registry['readThroughCacheAll'].clear();
+      await registry['readThroughCacheAll'].invalidateAll();
 
       const cacheRepoGetAllSpy = jest.spyOn(registry['cacheConfigsRepo'], 'getAll');
 
@@ -268,7 +268,7 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
     it('should handle different userIds independently', async () => {
       await registry.addServer('shared_server', testRawConfig, 'CACHE');
 
-      await registry['readThroughCacheAll'].clear();
+      await registry['readThroughCacheAll'].invalidateAll();
 
       const cacheRepoGetAllSpy = jest.spyOn(registry['cacheConfigsRepo'], 'getAll');
 
@@ -290,7 +290,7 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
         await registry.addServer(`stress_server_${i}`, testRawConfig, 'CACHE');
       }
 
-      await registry['readThroughCacheAll'].clear();
+      await registry['readThroughCacheAll'].invalidateAll();
 
       const concurrentCalls = 50;
       const startTime = Date.now();
@@ -320,7 +320,7 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
         'CACHE',
       );
 
-      await registry['readThroughCacheAll'].clear();
+      await registry['readThroughCacheAll'].invalidateAll();
 
       const results = await Promise.all([
         registry.getAllServerConfigs(),

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
@@ -106,6 +106,36 @@ describe('MCPServersRegistry', () => {
       expect(configs).toHaveProperty('user_server');
     });
 
+    it('should partition read-through entries by tenant', async () => {
+      const { tenantStorage } = await import('@librechat/data-schemas');
+      const dbGetAll = jest.spyOn(registry['dbConfigsRepo'], 'getAll');
+      dbGetAll.mockResolvedValueOnce({ tenant_a_server: testParsedConfig });
+      dbGetAll.mockResolvedValueOnce({ tenant_b_server: testParsedConfig });
+
+      /** The DB read behind each miss is tenant-filtered, so the cached maps
+       *  must never cross tenants even for the same userId. */
+      const inA = await tenantStorage.run(
+        { tenantId: 'tenant-a' },
+        async () => await registry.getAllServerConfigs('user-1'),
+      );
+      const inB = await tenantStorage.run(
+        { tenantId: 'tenant-b' },
+        async () => await registry.getAllServerConfigs('user-1'),
+      );
+
+      expect(Object.keys(inA)).toEqual(['tenant_a_server']);
+      expect(Object.keys(inB)).toEqual(['tenant_b_server']);
+      expect(dbGetAll).toHaveBeenCalledTimes(2);
+
+      /** Within one tenant the entry is reused without a second DB read. */
+      const inAAgain = await tenantStorage.run(
+        { tenantId: 'tenant-a' },
+        async () => await registry.getAllServerConfigs('user-1'),
+      );
+      expect(Object.keys(inAAgain)).toEqual(['tenant_a_server']);
+      expect(dbGetAll).toHaveBeenCalledTimes(2);
+    });
+
     it('should keep YAML servers authoritative when a DB server has the same name', async () => {
       const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
       const yamlConfig = { ...testParsedConfig, source: 'yaml' as const, title: 'YAML Slack' };

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
@@ -1,3 +1,4 @@
+import './helpers/setupCredsEnv';
 import { logger } from '@librechat/data-schemas';
 import type * as t from '~/mcp/types';
 import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
@@ -136,6 +136,59 @@ describe('MCPServersRegistry', () => {
       expect(dbGetAll).toHaveBeenCalledTimes(2);
     });
 
+    it('does not join or erase a single-flight fetch from another generation', async () => {
+      let resolveOld!: (value: Record<string, t.ParsedServerConfig>) => void;
+      let resolveFresh!: (value: Record<string, t.ParsedServerConfig>) => void;
+      let signalOldStarted!: () => void;
+      let signalFreshStarted!: () => void;
+      const oldResult = new Promise<Record<string, t.ParsedServerConfig>>((resolve) => {
+        resolveOld = resolve;
+      });
+      const freshResult = new Promise<Record<string, t.ParsedServerConfig>>((resolve) => {
+        resolveFresh = resolve;
+      });
+      const oldStarted = new Promise<void>((resolve) => {
+        signalOldStarted = resolve;
+      });
+      const freshStarted = new Promise<void>((resolve) => {
+        signalFreshStarted = resolve;
+      });
+      const dbGetAll = jest
+        .spyOn(registry['dbConfigsRepo'], 'getAll')
+        .mockImplementationOnce(async () => {
+          signalOldStarted();
+          return oldResult;
+        })
+        .mockImplementationOnce(async () => {
+          signalFreshStarted();
+          return freshResult;
+        });
+
+      const oldRequest = registry.getAllServerConfigs('user-1');
+      await oldStarted;
+      expect(dbGetAll).toHaveBeenCalledTimes(1);
+
+      await registry['readThroughCacheAll'].invalidateAll();
+      const freshRequest = registry.getAllServerConfigs('user-1');
+      await freshStarted;
+      expect(dbGetAll).toHaveBeenCalledTimes(2);
+
+      resolveOld({ old_server: testParsedConfig });
+      await expect(oldRequest).resolves.toEqual({ old_server: testParsedConfig });
+
+      const joinedFreshRequest = registry.getAllServerConfigs('user-1');
+
+      resolveFresh({ fresh_server: testParsedConfig });
+      await expect(freshRequest).resolves.toEqual({ fresh_server: testParsedConfig });
+      await expect(joinedFreshRequest).resolves.toEqual({ fresh_server: testParsedConfig });
+      expect(dbGetAll).toHaveBeenCalledTimes(2);
+
+      await expect(registry.getAllServerConfigs('user-1')).resolves.toEqual({
+        fresh_server: testParsedConfig,
+      });
+      expect(dbGetAll).toHaveBeenCalledTimes(2);
+    });
+
     it('should keep YAML servers authoritative when a DB server has the same name', async () => {
       const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
       const yamlConfig = { ...testParsedConfig, source: 'yaml' as const, title: 'YAML Slack' };

--- a/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/ServerConfigsDB.test.ts
@@ -40,6 +40,13 @@ const createSSEConfig = (
 
 let dbMethods: ReturnType<CreateMethodsType>;
 
+/** `Model.find` overloads reduce the spy's inferred arguments to an empty tuple,
+ *  so the recorded calls are re-typed here and mapped to their filter. */
+function aclFindFilters(spy: jest.SpyInstance): Array<Record<string, unknown>> {
+  const calls = spy.mock.calls as unknown as Array<[Record<string, unknown>]>;
+  return calls.map(([filter]) => filter);
+}
+
 beforeAll(async () => {
   // Set encryption keys BEFORE importing modules that use crypto
   process.env.CREDS_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -1357,6 +1364,103 @@ describe('ServerConfigsDB', () => {
         expect(Object.keys(result)).toHaveLength(1);
         expect(result['agent-only-server']).toBeDefined();
         expect(result['agent-only-server'].consumeOnly).toBe(true);
+      });
+
+      it('should bound the agent ACL query to agents that reference MCP servers', async () => {
+        const config = createSSEConfig('Bounded Server');
+        const created = await serverConfigsDB.add('temp', config, userId);
+
+        const Agent = mongoose.models.Agent;
+        const referencingAgent = await Agent.create({
+          id: 'referencing-agent',
+          name: 'Referencing Agent',
+          provider: 'openai',
+          model: 'gpt-4',
+          author: new mongoose.Types.ObjectId(userId),
+          mcpServerNames: [created.serverName],
+        });
+        // Accessible to userId2 but references no MCP server: these must not
+        // inflate the agent-side ACL query (#14016)
+        const spectatorAgent = await Agent.create({
+          id: 'spectator-agent',
+          name: 'Spectator Agent',
+          provider: 'openai',
+          model: 'gpt-4',
+          author: new mongoose.Types.ObjectId(userId),
+        });
+
+        const agentRole = await mongoose.models.AccessRole.findOne({
+          accessRoleId: AccessRoleIds.AGENT_VIEWER,
+        });
+        for (const agent of [referencingAgent, spectatorAgent]) {
+          await mongoose.models.AclEntry.create({
+            principalType: PrincipalType.USER,
+            principalModel: PrincipalModel.USER,
+            principalId: new mongoose.Types.ObjectId(userId2),
+            resourceType: ResourceType.AGENT,
+            resourceId: agent._id,
+            permBits: PermissionBits.VIEW,
+            roleId: agentRole!._id,
+            grantedBy: new mongoose.Types.ObjectId(userId),
+          });
+        }
+
+        const findSpy = jest.spyOn(mongoose.models.AclEntry, 'find');
+        try {
+          const result = await serverConfigsDB.getAll(userId2);
+          expect(result['bounded-server']?.consumeOnly).toBe(true);
+
+          const agentSideFilters = aclFindFilters(findSpy).filter(
+            (filter) => filter.resourceType === ResourceType.AGENT,
+          );
+          expect(agentSideFilters).toHaveLength(1);
+          const boundIds = (agentSideFilters[0]?.resourceId as { $in?: unknown[] } | undefined)
+            ?.$in;
+          expect(boundIds).toHaveLength(1);
+          expect(String(boundIds?.[0])).toBe(referencingAgent._id.toString());
+        } finally {
+          findSpy.mockRestore();
+        }
+      });
+
+      it('should skip the agent ACL query entirely when no agent references MCP servers', async () => {
+        const config = createSSEConfig('Unreferenced Server');
+        await serverConfigsDB.add('temp', config, userId);
+
+        const Agent = mongoose.models.Agent;
+        const agent = await Agent.create({
+          id: 'plain-agent',
+          name: 'Plain Agent',
+          provider: 'openai',
+          model: 'gpt-4',
+          author: new mongoose.Types.ObjectId(userId),
+        });
+        const agentRole = await mongoose.models.AccessRole.findOne({
+          accessRoleId: AccessRoleIds.AGENT_VIEWER,
+        });
+        await mongoose.models.AclEntry.create({
+          principalType: PrincipalType.USER,
+          principalModel: PrincipalModel.USER,
+          principalId: new mongoose.Types.ObjectId(userId2),
+          resourceType: ResourceType.AGENT,
+          resourceId: agent._id,
+          permBits: PermissionBits.VIEW,
+          roleId: agentRole!._id,
+          grantedBy: new mongoose.Types.ObjectId(userId),
+        });
+
+        const findSpy = jest.spyOn(mongoose.models.AclEntry, 'find');
+        try {
+          const result = await serverConfigsDB.getAll(userId2);
+          expect(result['unreferenced-server']).toBeUndefined();
+
+          const agentSideFilters = aclFindFilters(findSpy).filter(
+            (filter) => filter.resourceType === ResourceType.AGENT,
+          );
+          expect(agentSideFilters).toHaveLength(0);
+        } finally {
+          findSpy.mockRestore();
+        }
       });
 
       it('should deduplicate servers with both direct and agent access', async () => {

--- a/packages/api/src/mcp/registry/__tests__/helpers/setupCredsEnv.ts
+++ b/packages/api/src/mcp/registry/__tests__/helpers/setupCredsEnv.ts
@@ -1,0 +1,7 @@
+/** The registry read-through caches encrypt entries before they reach the
+ *  shared store, and the crypto module captures CREDS_KEY/CREDS_IV at import
+ *  time. Importing this module first lets static-import suites provide them. */
+process.env.CREDS_KEY ??= '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+process.env.CREDS_IV ??= '0123456789abcdef0123456789abcdef';
+
+export {};

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -69,15 +69,17 @@ export class ReadThroughAllCache<T> {
     return `${generation}::${key}`;
   }
 
-  /** Never throws: an unreadable generation degrades the next store read to a
-   *  miss, so a Redis outage stays off the request failure path. */
-  private async readGeneration(): Promise<string> {
+  /** Never throws. Returns undefined when the generation cannot be read: that
+   *  must surface as a miss, not as generation "0", which is a real first
+   *  generation whose unexpired entries could otherwise be revived by a
+   *  transient read failure. */
+  private async readGeneration(): Promise<string | undefined> {
     let generation: unknown;
     try {
       generation = await this.generationCache.get(GENERATION_KEY);
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Generation read failed:', error);
-      return '0';
+      return undefined;
     }
     return typeof generation === 'string' ? generation : '0';
   }
@@ -109,6 +111,9 @@ export class ReadThroughAllCache<T> {
       this.memo.delete(key);
     }
     const generation = await this.readGeneration();
+    if (generation == null) {
+      return undefined;
+    }
     let raw: unknown;
     try {
       raw = await this.cache.get(this.entryKey(generation, key));
@@ -155,18 +160,20 @@ export class ReadThroughAllCache<T> {
       return;
     }
     const generation = await this.readGeneration();
-    try {
-      const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-      await this.cache.set(this.entryKey(generation, key), stored);
-    } catch (error) {
-      /** A failed store write degrades to the memo only; the caller's result
-       *  is already computed and must still be served. */
-      logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
-    }
-    /** Same recheck as get(): skip the memo when an invalidation landed while
-     *  this write was in flight, so the next read recomputes. */
-    if ((await this.readGeneration()) !== generation) {
-      return;
+    if (generation != null) {
+      try {
+        const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+        await this.cache.set(this.entryKey(generation, key), stored);
+      } catch (error) {
+        /** A failed store write degrades to the memo only; the caller's result
+         *  is already computed and must still be served. */
+        logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
+      }
+      /** Same recheck as get(): skip the memo when an invalidation landed while
+       *  this write was in flight, so the next read recomputes. */
+      if ((await this.readGeneration()) !== generation) {
+        return;
+      }
     }
     this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
     this.sweepMemo();

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -69,8 +69,16 @@ export class ReadThroughAllCache<T> {
     return `${generation}::${key}`;
   }
 
+  /** Never throws: an unreadable generation degrades the next store read to a
+   *  miss, so a Redis outage stays off the request failure path. */
   private async readGeneration(): Promise<string> {
-    const generation = await this.generationCache.get(GENERATION_KEY);
+    let generation: unknown;
+    try {
+      generation = await this.generationCache.get(GENERATION_KEY);
+    } catch (error) {
+      logger.warn('[ReadThroughAllCache] Generation read failed:', error);
+      return '0';
+    }
     return typeof generation === 'string' ? generation : '0';
   }
 
@@ -101,8 +109,19 @@ export class ReadThroughAllCache<T> {
       this.memo.delete(key);
     }
     const generation = await this.readGeneration();
-    const raw = await this.cache.get(this.entryKey(generation, key));
+    let raw: unknown;
+    try {
+      raw = await this.cache.get(this.entryKey(generation, key));
+    } catch (error) {
+      logger.warn('[ReadThroughAllCache] Store read failed; treating as a miss:', error);
+      return undefined;
+    }
     if (raw === undefined) {
+      return undefined;
+    }
+    /** Re-check after the fetch: an invalidation landing mid-read must not have
+     *  its pre-mutation value memoized for a full TTL window. */
+    if ((await this.readGeneration()) !== generation) {
       return undefined;
     }
     if (!this.transforms?.decode) {
@@ -140,6 +159,11 @@ export class ReadThroughAllCache<T> {
        *  is already computed and must still be served. */
       logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
     }
+    /** Same recheck as get(): skip the memo when an invalidation landed while
+     *  this write was in flight, so the next read recomputes. */
+    if ((await this.readGeneration()) !== generation) {
+      return;
+    }
     this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
     this.sweepMemo();
   }
@@ -150,8 +174,12 @@ export class ReadThroughAllCache<T> {
     if (!this.enabled) {
       return;
     }
-    /** A fresh UUID cannot regress: two racing invalidations may overwrite each
-     *  other's tag, but neither can resurrect a prior generation's entries. */
-    await this.generationCache.set(GENERATION_KEY, randomUUID());
+    try {
+      /** A fresh UUID cannot regress: two racing invalidations may overwrite each
+       *  other's tag, but neither can resurrect a prior generation's entries. */
+      await this.generationCache.set(GENERATION_KEY, randomUUID());
+    } catch (error) {
+      logger.warn('[ReadThroughAllCache] Generation write failed:', error);
+    }
   }
 }

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -137,16 +137,11 @@ export class ReadThroughAllCache<T> {
       raw = await this.cache.get(this.entryKey(generation, key));
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Store read failed; treating as a miss:', error);
+      this.recordPendingFill(key, generation);
       return undefined;
     }
     if (raw === undefined) {
-      /** Record the miss generation so the eventual fill can be fenced when an
-       *  invalidation completes while the caller is still computing. */
-      this.pendingFills.set(key, {
-        generation,
-        expiresAt: Date.now() + this.ttl,
-      });
-      this.sweepMemo();
+      this.recordPendingFill(key, generation);
       return undefined;
     }
     let value: T;
@@ -162,6 +157,7 @@ export class ReadThroughAllCache<T> {
           '[ReadThroughAllCache] Failed to decode cached entry; treating as a miss:',
           error,
         );
+        this.recordPendingFill(key, generation);
         return undefined;
       }
     }
@@ -178,6 +174,14 @@ export class ReadThroughAllCache<T> {
     this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
     this.sweepMemo();
     return value;
+  }
+
+  /** Records the generation a miss observed, whatever caused the miss, so the
+   *  eventual fill can be fenced when an invalidation completes while the
+   *  caller is still computing. */
+  private recordPendingFill(key: string, generation: string): void {
+    this.pendingFills.set(key, { generation, expiresAt: Date.now() + this.ttl });
+    this.sweepMemo();
   }
 
   async set(key: string, value: T): Promise<void> {

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -6,6 +6,7 @@ import { standardCache } from '~/cache';
 /** Base key holding the active generation tag; the effective key is
  *  tenant-scoped, so one tenant's mutations cannot orphan another's entries. */
 const GENERATION_KEY = '__generation__';
+const GLOBAL_GENERATION_KEY = '__global_generation__';
 
 interface MemoEntry<T> {
   value: T;
@@ -19,7 +20,7 @@ interface MemoEntry<T> {
  *  only that fill) can be fenced when an invalidation completed first. */
 export interface FillToken {
   key: string;
-  generation: string;
+  generation: string | null;
 }
 
 /** Result of one read: `hit` distinguishes a stored value from a miss, and
@@ -99,14 +100,20 @@ export class ReadThroughAllCache<T> {
    *  generation whose unexpired entries could otherwise be revived by a
    *  transient read failure. */
   private async readGeneration(): Promise<string | undefined> {
-    let generation: unknown;
+    let globalGeneration: unknown;
+    let tenantGeneration: unknown;
     try {
-      generation = await this.generationCache.get(scopedCacheKey(GENERATION_KEY));
+      [globalGeneration, tenantGeneration] = await Promise.all([
+        this.generationCache.get(GLOBAL_GENERATION_KEY),
+        this.generationCache.get(scopedCacheKey(GENERATION_KEY)),
+      ]);
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Generation read failed:', error);
       return undefined;
     }
-    return typeof generation === 'string' ? generation : '0';
+    const global = typeof globalGeneration === 'string' ? globalGeneration : '0';
+    const tenant = typeof tenantGeneration === 'string' ? tenantGeneration : '0';
+    return `${global}:${tenant}`;
   }
 
   /** Effective tenant for cache scoping, mirroring scopedCacheKey: the system
@@ -144,7 +151,7 @@ export class ReadThroughAllCache<T> {
     }
     const generation = await this.readGeneration();
     if (generation == null) {
-      return { hit: false, value: undefined };
+      return { hit: false, value: undefined, fill: { key, generation: null } };
     }
     let raw: unknown;
     try {
@@ -195,27 +202,31 @@ export class ReadThroughAllCache<T> {
     if (!this.enabled) {
       return;
     }
+    if (fill != null && fill.key === key && fill.generation == null) {
+      return;
+    }
     const current = await this.readGeneration();
-    if (fill != null && fill.key === key && current != null && current !== fill.generation) {
+    if (current == null) {
+      return;
+    }
+    if (fill != null && fill.key === key && current !== fill.generation) {
       /** Fenced: this value was computed before an invalidation completed, so
        *  writing it (store or memo) would resurrect the pre-mutation map. */
       return;
     }
-    const generation = current ?? (fill != null && fill.key === key ? fill.generation : undefined);
-    if (generation != null) {
-      try {
-        const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-        await this.cache.set(this.entryKey(generation, key), stored);
-      } catch (error) {
-        /** A failed store write degrades to the memo only; the caller's result
-         *  is already computed and must still be served. */
-        logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
-      }
-      /** Same recheck as get(): skip the memo when an invalidation landed while
-       *  this write was in flight, so the next read recomputes. */
-      if ((await this.readGeneration()) !== generation) {
-        return;
-      }
+    const generation = current;
+    try {
+      const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+      await this.cache.set(this.entryKey(generation, key), stored);
+    } catch (error) {
+      /** A failed store write degrades to the memo only; the caller's result
+       *  is already computed and must still be served. */
+      logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
+    }
+    /** Same recheck as get(): skip the memo when an invalidation landed while
+     *  this write was in flight, so the next read recomputes. */
+    if ((await this.readGeneration()) !== generation) {
+      return;
     }
     this.memo.set(key, {
       value,
@@ -229,15 +240,13 @@ export class ReadThroughAllCache<T> {
    * Orphans the calling tenant's entries without scanning the keyspace.
    * DB-backed MCP servers and ACL grants are tenant-scoped data, so one
    * tenant's mutation has no business evicting another tenant's entries, in
-   * the store or in the process-local memo.
+   * the store or in the process-local memo. Rejects when the shared generation
+   * cannot be rotated, so a persisted mutation is never reported as fully
+   * invalidated while stale shared entries remain addressable.
    */
   async invalidateAll(): Promise<void> {
     const tenantId = this.currentTenantId();
-    for (const [key, entry] of this.memo) {
-      if (entry.tenantId === tenantId) {
-        this.memo.delete(key);
-      }
-    }
+    this.evictTenantMemo(tenantId);
     if (!this.enabled) {
       return;
     }
@@ -247,13 +256,18 @@ export class ReadThroughAllCache<T> {
       await this.generationCache.set(scopedCacheKey(GENERATION_KEY), randomUUID());
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Generation write failed:', error);
+      throw error;
     }
+    /** A read that completed against the old generation while the write was in
+     *  flight may have repopulated the memo after the first eviction. */
+    this.evictTenantMemo(tenantId);
   }
 
   /**
    * Clears every entry across tenants by scanning the namespace. Reserved for
    * genuinely global events (operator config changes, lifecycle resets) where
-   * the SCAN cost is rare and cross-tenant eviction is the point.
+   * the SCAN cost is rare and cross-tenant eviction is the point. Rejects when
+   * the shared global fence cannot be rotated.
    */
   async invalidateAllGlobal(): Promise<void> {
     this.memo.clear();
@@ -261,9 +275,24 @@ export class ReadThroughAllCache<T> {
       return;
     }
     try {
+      await this.generationCache.set(GLOBAL_GENERATION_KEY, randomUUID());
+    } catch (error) {
+      logger.warn('[ReadThroughAllCache] Global generation write failed:', error);
+      throw error;
+    }
+    this.memo.clear();
+    try {
       await this.cache.clear();
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Global clear failed:', error);
+    }
+  }
+
+  private evictTenantMemo(tenantId: string | undefined): void {
+    for (const [key, entry] of this.memo) {
+      if (entry.tenantId === tenantId) {
+        this.memo.delete(key);
+      }
     }
   }
 }

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -1,13 +1,21 @@
 import { Keyv } from 'keyv';
 import { randomUUID } from 'crypto';
-import { logger } from '@librechat/data-schemas';
+import { logger, scopedCacheKey } from '@librechat/data-schemas';
 import { standardCache } from '~/cache';
 
-/** Namespace-internal key holding the active generation tag. */
+/** Base key holding the active generation tag; the effective key is
+ *  tenant-scoped, so one tenant's mutations cannot orphan another's entries. */
 const GENERATION_KEY = '__generation__';
 
 interface MemoEntry<T> {
   value: T;
+  expiresAt: number;
+}
+
+/** Generation observed when a miss started, used to fence fills that finish
+ *  after an invalidation has already completed. */
+interface PendingFill {
+  generation: string;
   expiresAt: number;
 }
 
@@ -22,13 +30,15 @@ export interface ReadThroughTransforms<T> {
  *
  * The backing store comes from {@link standardCache}, so entries live in Redis
  * when it is configured (shared across instances, see #14016) and in process
- * memory otherwise. Invalidation never scans the keyspace:
+ * memory otherwise. Hot-path invalidation never scans the keyspace:
  * {@link invalidateAll} swaps the active generation tag for a fresh UUID,
  * orphaning every entry written under a previous generation, and the store TTL
  * reclaims them. This mirrors the aggregate-key lesson from #11624/#12408,
  * where SCAN-based invalidation stalled large deployments. The generation tag
- * lives in its own store created without a TTL so it can never expire before
- * the entries written under it.
+ * is tenant-scoped (entries are too) and lives in its own store created
+ * without a TTL so it can never expire before the entries written under it;
+ * {@link invalidateAllGlobal} provides the scanning variant for genuinely
+ * cross-tenant resets.
  *
  * Values may carry secrets (decrypted MCP credentials), so the caller can
  * inject {@link ReadThroughTransforms} to keep the shared store ciphertext
@@ -39,6 +49,8 @@ export interface ReadThroughTransforms<T> {
  * pattern as the local snapshot in `ServerConfigsCacheRedisAggregateKey`, added
  * because the registry resolves all-server configs many times per chat request.
  * An opportunistic sweep bounds the memo so one-time users cannot accumulate.
+ * Fills are fenced by the generation observed at their miss, so a value
+ * computed before an invalidation cannot be written or memoized after it.
  * Cross-instance worst-case staleness is therefore bounded by the memo TTL,
  * matching the documented 2x MCP_REGISTRY_CACHE_TTL trade-off.
  *
@@ -52,6 +64,7 @@ export class ReadThroughAllCache<T> {
   private readonly ttl: number;
   private readonly transforms?: ReadThroughTransforms<T>;
   private readonly memo = new Map<string, MemoEntry<T>>();
+  private readonly pendingFills = new Map<string, PendingFill>();
   private lastSweepAt = 0;
 
   constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
@@ -76,7 +89,7 @@ export class ReadThroughAllCache<T> {
   private async readGeneration(): Promise<string | undefined> {
     let generation: unknown;
     try {
-      generation = await this.generationCache.get(GENERATION_KEY);
+      generation = await this.generationCache.get(scopedCacheKey(GENERATION_KEY));
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Generation read failed:', error);
       return undefined;
@@ -95,6 +108,11 @@ export class ReadThroughAllCache<T> {
     for (const [key, entry] of this.memo) {
       if (now >= entry.expiresAt) {
         this.memo.delete(key);
+      }
+    }
+    for (const [key, fill] of this.pendingFills) {
+      if (now >= fill.expiresAt) {
+        this.pendingFills.delete(key);
       }
     }
   }
@@ -122,6 +140,13 @@ export class ReadThroughAllCache<T> {
       return undefined;
     }
     if (raw === undefined) {
+      /** Record the miss generation so the eventual fill can be fenced when an
+       *  invalidation completes while the caller is still computing. */
+      this.pendingFills.set(key, {
+        generation,
+        expiresAt: Date.now() + this.ttl,
+      });
+      this.sweepMemo();
       return undefined;
     }
     let value: T;
@@ -159,27 +184,44 @@ export class ReadThroughAllCache<T> {
     if (!this.enabled) {
       return;
     }
-    const generation = await this.readGeneration();
-    if (generation != null) {
-      try {
-        const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-        await this.cache.set(this.entryKey(generation, key), stored);
-      } catch (error) {
-        /** A failed store write degrades to the memo only; the caller's result
-         *  is already computed and must still be served. */
-        logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
-      }
-      /** Same recheck as get(): skip the memo when an invalidation landed while
-       *  this write was in flight, so the next read recomputes. */
-      if ((await this.readGeneration()) !== generation) {
+    const fill = this.pendingFills.get(key);
+    try {
+      const current = await this.readGeneration();
+      if (fill != null && current != null && current !== fill.generation) {
+        /** Fenced: this value was computed before an invalidation completed, so
+         *  writing it (store or memo) would resurrect the pre-mutation map. */
         return;
       }
+      const generation = current ?? fill?.generation;
+      if (generation != null) {
+        try {
+          const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+          await this.cache.set(this.entryKey(generation, key), stored);
+        } catch (error) {
+          /** A failed store write degrades to the memo only; the caller's result
+           *  is already computed and must still be served. */
+          logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
+        }
+        /** Same recheck as get(): skip the memo when an invalidation landed while
+         *  this write was in flight, so the next read recomputes. */
+        if ((await this.readGeneration()) !== generation) {
+          return;
+        }
+      }
+      this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
+      this.sweepMemo();
+    } finally {
+      if (fill != null) {
+        this.pendingFills.delete(key);
+      }
     }
-    this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
-    this.sweepMemo();
   }
 
-  /** Orphans every entry written so far without scanning the keyspace. */
+  /**
+   * Orphans the calling tenant's entries without scanning the keyspace.
+   * DB-backed MCP servers and ACL grants are tenant-scoped data, so one
+   * tenant's mutation has no business evicting another tenant's entries.
+   */
   async invalidateAll(): Promise<void> {
     this.memo.clear();
     if (!this.enabled) {
@@ -188,9 +230,27 @@ export class ReadThroughAllCache<T> {
     try {
       /** A fresh UUID cannot regress: two racing invalidations may overwrite each
        *  other's tag, but neither can resurrect a prior generation's entries. */
-      await this.generationCache.set(GENERATION_KEY, randomUUID());
+      await this.generationCache.set(scopedCacheKey(GENERATION_KEY), randomUUID());
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Generation write failed:', error);
+    }
+  }
+
+  /**
+   * Clears every entry across tenants by scanning the namespace. Reserved for
+   * genuinely global events (operator config changes, lifecycle resets) where
+   * the SCAN cost is rare and cross-tenant eviction is the point.
+   */
+  async invalidateAllGlobal(): Promise<void> {
+    this.memo.clear();
+    this.pendingFills.clear();
+    if (!this.enabled) {
+      return;
+    }
+    try {
+      await this.cache.clear();
+    } catch (error) {
+      logger.warn('[ReadThroughAllCache] Global clear failed:', error);
     }
   }
 }

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -119,25 +119,29 @@ export class ReadThroughAllCache<T> {
     if (raw === undefined) {
       return undefined;
     }
-    /** Re-check after the fetch: an invalidation landing mid-read must not have
-     *  its pre-mutation value memoized for a full TTL window. */
+    let value: T;
+    if (!this.transforms?.decode) {
+      value = raw as T;
+    } else {
+      try {
+        value = await this.transforms.decode(raw as string);
+      } catch (error) {
+        /** Fail open to a miss: an undecodable entry is stale across a key
+         *  rotation, not a reason to break the request. */
+        logger.warn(
+          '[ReadThroughAllCache] Failed to decode cached entry; treating as a miss:',
+          error,
+        );
+        return undefined;
+      }
+    }
+    /** Re-check after the full read (decode included): an invalidation landing
+     *  mid-read must not have its pre-mutation value memoized for a full TTL
+     *  window. */
     if ((await this.readGeneration()) !== generation) {
       return undefined;
     }
-    if (!this.transforms?.decode) {
-      return this.memoize(key, raw as T);
-    }
-    try {
-      return this.memoize(key, await this.transforms.decode(raw as string));
-    } catch (error) {
-      /** Fail open to a miss: an undecodable entry is stale across a key
-       *  rotation, not a reason to break the request. */
-      logger.warn(
-        '[ReadThroughAllCache] Failed to decode cached entry; treating as a miss:',
-        error,
-      );
-      return undefined;
-    }
+    return this.memoize(key, value);
   }
 
   private memoize(key: string, value: T): T {

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -15,12 +15,19 @@ interface MemoEntry<T> {
   tenantId: string | undefined;
 }
 
-/** Generation observed when a miss started, used to fence fills that finish
- *  after an invalidation has already completed. No expiry: a fence is removed
- *  when its fill settles or overwritten by the next miss for the key, which
- *  bounds cardinality to the memo's own. */
-interface PendingFill {
+/** State a miss observed, handed back with the miss so the matching fill (and
+ *  only that fill) can be fenced when an invalidation completed first. */
+export interface FillToken {
+  key: string;
   generation: string;
+}
+
+/** Result of one read: `hit` distinguishes a stored value from a miss, and
+ *  `fill` is present exactly when the caller should thread it into set(). */
+export interface CacheRead<T> {
+  hit: boolean;
+  value: T | undefined;
+  fill?: FillToken;
 }
 
 /** Store-side value transforms; the shared store only ever sees `encode` output. */
@@ -53,8 +60,10 @@ export interface ReadThroughTransforms<T> {
  * pattern as the local snapshot in `ServerConfigsCacheRedisAggregateKey`, added
  * because the registry resolves all-server configs many times per chat request.
  * An opportunistic sweep bounds the memo so one-time users cannot accumulate.
- * Fills are fenced by the generation observed at their miss, so a value
- * computed before an invalidation cannot be written or memoized after it.
+ * Each miss returns a fill token capturing the generation it observed, and the
+ * matching set() is fenced by it, so a value computed before an invalidation
+ * cannot be written or memoized after it, even when concurrent fills for the
+ * same key straddle the invalidation.
  * Cross-instance worst-case staleness is therefore bounded by the memo TTL,
  * matching the documented 2x MCP_REGISTRY_CACHE_TTL trade-off.
  *
@@ -68,7 +77,6 @@ export class ReadThroughAllCache<T> {
   private readonly ttl: number;
   private readonly transforms?: ReadThroughTransforms<T>;
   private readonly memo = new Map<string, MemoEntry<T>>();
-  private readonly pendingFills = new Map<string, PendingFill>();
   private lastSweepAt = 0;
 
   constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
@@ -123,32 +131,30 @@ export class ReadThroughAllCache<T> {
     }
   }
 
-  async get(key: string): Promise<T | undefined> {
+  async get(key: string): Promise<CacheRead<T>> {
     if (!this.enabled) {
-      return undefined;
+      return { hit: false, value: undefined };
     }
     const memoized = this.memo.get(key);
     if (memoized != null) {
       if (Date.now() < memoized.expiresAt) {
-        return memoized.value;
+        return { hit: true, value: memoized.value };
       }
       this.memo.delete(key);
     }
     const generation = await this.readGeneration();
     if (generation == null) {
-      return undefined;
+      return { hit: false, value: undefined };
     }
     let raw: unknown;
     try {
       raw = await this.cache.get(this.entryKey(generation, key));
     } catch (error) {
       logger.warn('[ReadThroughAllCache] Store read failed; treating as a miss:', error);
-      this.recordPendingFill(key, generation);
-      return undefined;
+      return { hit: false, value: undefined, fill: { key, generation } };
     }
     if (raw === undefined) {
-      this.recordPendingFill(key, generation);
-      return undefined;
+      return { hit: false, value: undefined, fill: { key, generation } };
     }
     let value: T;
     if (!this.transforms?.decode) {
@@ -163,17 +169,16 @@ export class ReadThroughAllCache<T> {
           '[ReadThroughAllCache] Failed to decode cached entry; treating as a miss:',
           error,
         );
-        this.recordPendingFill(key, generation);
-        return undefined;
+        return { hit: false, value: undefined, fill: { key, generation } };
       }
     }
     /** Re-check after the full read (decode included): an invalidation landing
      *  mid-read must not have its pre-mutation value memoized for a full TTL
      *  window. */
     if ((await this.readGeneration()) !== generation) {
-      return undefined;
+      return { hit: false, value: undefined, fill: { key, generation } };
     }
-    return this.memoize(key, value);
+    return { hit: true, value: this.memoize(key, value) };
   }
 
   private memoize(key: string, value: T): T {
@@ -186,52 +191,38 @@ export class ReadThroughAllCache<T> {
     return value;
   }
 
-  /** Records the generation a miss observed, whatever caused the miss, so the
-   *  eventual fill can be fenced when an invalidation completes while the
-   *  caller is still computing. */
-  private recordPendingFill(key: string, generation: string): void {
-    this.pendingFills.set(key, { generation });
-  }
-
-  async set(key: string, value: T): Promise<void> {
+  async set(key: string, value: T, fill?: FillToken): Promise<void> {
     if (!this.enabled) {
       return;
     }
-    const fill = this.pendingFills.get(key);
-    try {
-      const current = await this.readGeneration();
-      if (fill != null && current != null && current !== fill.generation) {
-        /** Fenced: this value was computed before an invalidation completed, so
-         *  writing it (store or memo) would resurrect the pre-mutation map. */
+    const current = await this.readGeneration();
+    if (fill != null && fill.key === key && current != null && current !== fill.generation) {
+      /** Fenced: this value was computed before an invalidation completed, so
+       *  writing it (store or memo) would resurrect the pre-mutation map. */
+      return;
+    }
+    const generation = current ?? (fill != null && fill.key === key ? fill.generation : undefined);
+    if (generation != null) {
+      try {
+        const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+        await this.cache.set(this.entryKey(generation, key), stored);
+      } catch (error) {
+        /** A failed store write degrades to the memo only; the caller's result
+         *  is already computed and must still be served. */
+        logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
+      }
+      /** Same recheck as get(): skip the memo when an invalidation landed while
+       *  this write was in flight, so the next read recomputes. */
+      if ((await this.readGeneration()) !== generation) {
         return;
       }
-      const generation = current ?? fill?.generation;
-      if (generation != null) {
-        try {
-          const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-          await this.cache.set(this.entryKey(generation, key), stored);
-        } catch (error) {
-          /** A failed store write degrades to the memo only; the caller's result
-           *  is already computed and must still be served. */
-          logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
-        }
-        /** Same recheck as get(): skip the memo when an invalidation landed while
-         *  this write was in flight, so the next read recomputes. */
-        if ((await this.readGeneration()) !== generation) {
-          return;
-        }
-      }
-      this.memo.set(key, {
-        value,
-        expiresAt: Date.now() + this.ttl,
-        tenantId: this.currentTenantId(),
-      });
-      this.sweepMemo();
-    } finally {
-      if (fill != null) {
-        this.pendingFills.delete(key);
-      }
     }
+    this.memo.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttl,
+      tenantId: this.currentTenantId(),
+    });
+    this.sweepMemo();
   }
 
   /**
@@ -266,7 +257,6 @@ export class ReadThroughAllCache<T> {
    */
   async invalidateAllGlobal(): Promise<void> {
     this.memo.clear();
-    this.pendingFills.clear();
     if (!this.enabled) {
       return;
     }

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -1,6 +1,6 @@
 import { Keyv } from 'keyv';
 import { randomUUID } from 'crypto';
-import { logger, scopedCacheKey } from '@librechat/data-schemas';
+import { logger, scopedCacheKey, getTenantId, SYSTEM_TENANT_ID } from '@librechat/data-schemas';
 import { standardCache } from '~/cache';
 
 /** Base key holding the active generation tag; the effective key is
@@ -10,13 +10,17 @@ const GENERATION_KEY = '__generation__';
 interface MemoEntry<T> {
   value: T;
   expiresAt: number;
+  /** Tenant the entry was memoized under, so a tenant-scoped invalidation
+   *  evicts only that tenant's memo entries. */
+  tenantId: string | undefined;
 }
 
 /** Generation observed when a miss started, used to fence fills that finish
- *  after an invalidation has already completed. */
+ *  after an invalidation has already completed. No expiry: a fence is removed
+ *  when its fill settles or overwritten by the next miss for the key, which
+ *  bounds cardinality to the memo's own. */
 interface PendingFill {
   generation: string;
-  expiresAt: number;
 }
 
 /** Store-side value transforms; the shared store only ever sees `encode` output. */
@@ -97,6 +101,13 @@ export class ReadThroughAllCache<T> {
     return typeof generation === 'string' ? generation : '0';
   }
 
+  /** Effective tenant for cache scoping, mirroring scopedCacheKey: the system
+   *  context and absent context both address the unscoped partition. */
+  private currentTenantId(): string | undefined {
+    const tenantId = getTenantId();
+    return !tenantId || tenantId === SYSTEM_TENANT_ID ? undefined : tenantId;
+  }
+
   /** At most one pass per TTL window, so expired entries from one-time users
    *  cannot accumulate unboundedly between global invalidations. */
   private sweepMemo(): void {
@@ -108,11 +119,6 @@ export class ReadThroughAllCache<T> {
     for (const [key, entry] of this.memo) {
       if (now >= entry.expiresAt) {
         this.memo.delete(key);
-      }
-    }
-    for (const [key, fill] of this.pendingFills) {
-      if (now >= fill.expiresAt) {
-        this.pendingFills.delete(key);
       }
     }
   }
@@ -171,7 +177,11 @@ export class ReadThroughAllCache<T> {
   }
 
   private memoize(key: string, value: T): T {
-    this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
+    this.memo.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttl,
+      tenantId: this.currentTenantId(),
+    });
     this.sweepMemo();
     return value;
   }
@@ -180,8 +190,7 @@ export class ReadThroughAllCache<T> {
    *  eventual fill can be fenced when an invalidation completes while the
    *  caller is still computing. */
   private recordPendingFill(key: string, generation: string): void {
-    this.pendingFills.set(key, { generation, expiresAt: Date.now() + this.ttl });
-    this.sweepMemo();
+    this.pendingFills.set(key, { generation });
   }
 
   async set(key: string, value: T): Promise<void> {
@@ -212,7 +221,11 @@ export class ReadThroughAllCache<T> {
           return;
         }
       }
-      this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
+      this.memo.set(key, {
+        value,
+        expiresAt: Date.now() + this.ttl,
+        tenantId: this.currentTenantId(),
+      });
       this.sweepMemo();
     } finally {
       if (fill != null) {
@@ -224,10 +237,16 @@ export class ReadThroughAllCache<T> {
   /**
    * Orphans the calling tenant's entries without scanning the keyspace.
    * DB-backed MCP servers and ACL grants are tenant-scoped data, so one
-   * tenant's mutation has no business evicting another tenant's entries.
+   * tenant's mutation has no business evicting another tenant's entries, in
+   * the store or in the process-local memo.
    */
   async invalidateAll(): Promise<void> {
-    this.memo.clear();
+    const tenantId = this.currentTenantId();
+    for (const [key, entry] of this.memo) {
+      if (entry.tenantId === tenantId) {
+        this.memo.delete(key);
+      }
+    }
     if (!this.enabled) {
       return;
     }

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from 'crypto';
 import { Keyv } from 'keyv';
+import { randomUUID } from 'crypto';
 import { standardCache } from '~/cache';
 
 /** Namespace-internal key holding the active generation tag. */

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'crypto';
+import { Keyv } from 'keyv';
+import { standardCache } from '~/cache';
+
+/** Namespace-internal key holding the active generation tag. */
+const GENERATION_KEY = '__generation__';
+
+interface MemoEntry<T> {
+  generation: string;
+  value: T;
+  expiresAt: number;
+}
+
+/**
+ * Redis-capable read-through cache for per-user aggregate config maps.
+ *
+ * The backing store comes from {@link standardCache}, so entries live in Redis
+ * when it is configured (shared across instances, see #14016) and in process
+ * memory otherwise. Invalidation never scans the keyspace:
+ * {@link invalidateAll} swaps the active generation tag for a fresh UUID,
+ * orphaning every entry written under a previous generation, and the store TTL
+ * reclaims them. This mirrors the aggregate-key lesson from #11624/#12408,
+ * where SCAN-based invalidation stalled large deployments.
+ *
+ * A process-local memo absorbs repeated reads within one TTL window, the same
+ * pattern as the local snapshot in `ServerConfigsCacheRedisAggregateKey`, added
+ * because the registry resolves all-server configs many times per chat request.
+ * Cross-instance worst-case staleness is therefore bounded by the memo TTL,
+ * matching the documented 2x MCP_REGISTRY_CACHE_TTL trade-off.
+ */
+export class ReadThroughAllCache<T> {
+  private readonly cache: Keyv;
+  private readonly ttl: number;
+  private readonly memo = new Map<string, MemoEntry<T>>();
+
+  constructor(namespace: string, ttl: number) {
+    this.cache = standardCache(namespace, ttl);
+    this.ttl = ttl;
+  }
+
+  private entryKey(generation: string, key: string): string {
+    return `${generation}::${key}`;
+  }
+
+  private async readGeneration(): Promise<string> {
+    const generation = await this.cache.get(GENERATION_KEY);
+    return typeof generation === 'string' ? generation : '0';
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    const memoized = this.memo.get(key);
+    if (memoized != null && Date.now() < memoized.expiresAt) {
+      return memoized.value;
+    }
+    const generation = await this.readGeneration();
+    const value = (await this.cache.get(this.entryKey(generation, key))) as T | undefined;
+    if (value !== undefined && this.ttl > 0) {
+      this.memo.set(key, { generation, value, expiresAt: Date.now() + this.ttl });
+    } else {
+      this.memo.delete(key);
+    }
+    return value;
+  }
+
+  async set(key: string, value: T): Promise<void> {
+    const generation = await this.readGeneration();
+    await this.cache.set(this.entryKey(generation, key), value);
+    if (this.ttl > 0) {
+      this.memo.set(key, { generation, value, expiresAt: Date.now() + this.ttl });
+    }
+  }
+
+  /** Orphans every entry written so far without scanning the keyspace. */
+  async invalidateAll(): Promise<void> {
+    /** A fresh UUID cannot regress: two racing invalidations may overwrite each
+     *  other's tag, but neither can resurrect a prior generation's entries. */
+    await this.cache.set(GENERATION_KEY, randomUUID());
+    this.memo.clear();
+  }
+}

--- a/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughAllCache.ts
@@ -1,14 +1,20 @@
 import { Keyv } from 'keyv';
 import { randomUUID } from 'crypto';
+import { logger } from '@librechat/data-schemas';
 import { standardCache } from '~/cache';
 
 /** Namespace-internal key holding the active generation tag. */
 const GENERATION_KEY = '__generation__';
 
 interface MemoEntry<T> {
-  generation: string;
   value: T;
   expiresAt: number;
+}
+
+/** Store-side value transforms; the shared store only ever sees `encode` output. */
+export interface ReadThroughTransforms<T> {
+  encode?: (value: T) => Promise<string> | string;
+  decode?: (raw: string) => Promise<T> | T;
 }
 
 /**
@@ -20,22 +26,43 @@ interface MemoEntry<T> {
  * {@link invalidateAll} swaps the active generation tag for a fresh UUID,
  * orphaning every entry written under a previous generation, and the store TTL
  * reclaims them. This mirrors the aggregate-key lesson from #11624/#12408,
- * where SCAN-based invalidation stalled large deployments.
+ * where SCAN-based invalidation stalled large deployments. The generation tag
+ * lives in its own store created without a TTL so it can never expire before
+ * the entries written under it.
+ *
+ * Values may carry secrets (decrypted MCP credentials), so the caller can
+ * inject {@link ReadThroughTransforms} to keep the shared store ciphertext
+ * only; the process-local memo keeps working with plaintext, matching the
+ * pre-Redis status quo where these values never left the process.
  *
  * A process-local memo absorbs repeated reads within one TTL window, the same
  * pattern as the local snapshot in `ServerConfigsCacheRedisAggregateKey`, added
  * because the registry resolves all-server configs many times per chat request.
+ * An opportunistic sweep bounds the memo so one-time users cannot accumulate.
  * Cross-instance worst-case staleness is therefore bounded by the memo TTL,
  * matching the documented 2x MCP_REGISTRY_CACHE_TTL trade-off.
+ *
+ * A ttl of zero or less disables the cache entirely: entries derive from ACL
+ * access, and without a TTL there is no bound on how long a revoked user could
+ * keep receiving a stale map.
  */
 export class ReadThroughAllCache<T> {
   private readonly cache: Keyv;
+  private readonly generationCache: Keyv;
   private readonly ttl: number;
+  private readonly transforms?: ReadThroughTransforms<T>;
   private readonly memo = new Map<string, MemoEntry<T>>();
+  private lastSweepAt = 0;
 
-  constructor(namespace: string, ttl: number) {
+  constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
     this.cache = standardCache(namespace, ttl);
+    this.generationCache = standardCache(`${namespace}::generation`);
     this.ttl = ttl;
+    this.transforms = transforms;
+  }
+
+  private get enabled(): boolean {
+    return this.ttl > 0;
   }
 
   private entryKey(generation: string, key: string): string {
@@ -43,38 +70,88 @@ export class ReadThroughAllCache<T> {
   }
 
   private async readGeneration(): Promise<string> {
-    const generation = await this.cache.get(GENERATION_KEY);
+    const generation = await this.generationCache.get(GENERATION_KEY);
     return typeof generation === 'string' ? generation : '0';
   }
 
-  async get(key: string): Promise<T | undefined> {
-    const memoized = this.memo.get(key);
-    if (memoized != null && Date.now() < memoized.expiresAt) {
-      return memoized.value;
+  /** At most one pass per TTL window, so expired entries from one-time users
+   *  cannot accumulate unboundedly between global invalidations. */
+  private sweepMemo(): void {
+    const now = Date.now();
+    if (now - this.lastSweepAt < this.ttl) {
+      return;
     }
-    const generation = await this.readGeneration();
-    const value = (await this.cache.get(this.entryKey(generation, key))) as T | undefined;
-    if (value !== undefined && this.ttl > 0) {
-      this.memo.set(key, { generation, value, expiresAt: Date.now() + this.ttl });
-    } else {
+    this.lastSweepAt = now;
+    for (const [key, entry] of this.memo) {
+      if (now >= entry.expiresAt) {
+        this.memo.delete(key);
+      }
+    }
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    if (!this.enabled) {
+      return undefined;
+    }
+    const memoized = this.memo.get(key);
+    if (memoized != null) {
+      if (Date.now() < memoized.expiresAt) {
+        return memoized.value;
+      }
       this.memo.delete(key);
     }
+    const generation = await this.readGeneration();
+    const raw = await this.cache.get(this.entryKey(generation, key));
+    if (raw === undefined) {
+      return undefined;
+    }
+    if (!this.transforms?.decode) {
+      return this.memoize(key, raw as T);
+    }
+    try {
+      return this.memoize(key, await this.transforms.decode(raw as string));
+    } catch (error) {
+      /** Fail open to a miss: an undecodable entry is stale across a key
+       *  rotation, not a reason to break the request. */
+      logger.warn(
+        '[ReadThroughAllCache] Failed to decode cached entry; treating as a miss:',
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  private memoize(key: string, value: T): T {
+    this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
+    this.sweepMemo();
     return value;
   }
 
   async set(key: string, value: T): Promise<void> {
-    const generation = await this.readGeneration();
-    await this.cache.set(this.entryKey(generation, key), value);
-    if (this.ttl > 0) {
-      this.memo.set(key, { generation, value, expiresAt: Date.now() + this.ttl });
+    if (!this.enabled) {
+      return;
     }
+    const generation = await this.readGeneration();
+    try {
+      const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+      await this.cache.set(this.entryKey(generation, key), stored);
+    } catch (error) {
+      /** A failed store write degrades to the memo only; the caller's result
+       *  is already computed and must still be served. */
+      logger.warn('[ReadThroughAllCache] Failed to write cache entry:', error);
+    }
+    this.memo.set(key, { value, expiresAt: Date.now() + this.ttl });
+    this.sweepMemo();
   }
 
   /** Orphans every entry written so far without scanning the keyspace. */
   async invalidateAll(): Promise<void> {
+    this.memo.clear();
+    if (!this.enabled) {
+      return;
+    }
     /** A fresh UUID cannot regress: two racing invalidations may overwrite each
      *  other's tag, but neither can resurrect a prior generation's entries. */
-    await this.cache.set(GENERATION_KEY, randomUUID());
-    this.memo.clear();
+    await this.generationCache.set(GENERATION_KEY, randomUUID());
   }
 }

--- a/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
@@ -1,54 +1,77 @@
 import { Keyv } from 'keyv';
-import { logger } from '@librechat/data-schemas';
+import { randomUUID } from 'crypto';
+import { logger, scopedCacheKey } from '@librechat/data-schemas';
 import type { ReadThroughTransforms } from './ReadThroughAllCache';
 import { standardCache } from '~/cache';
+
+const GENERATION_KEY = '__generation__';
+const GLOBAL_GENERATION_KEY = '__global_generation__';
 
 /** Invalidation state a per-server miss observed, handed back with the miss so
  *  the matching fill (and only that fill) can be fenced when a targeted delete
  *  or namespace clear completed first. */
 export interface FillToken {
   key: string;
-  globalVersion: number;
-  keyVersion: number;
+  generation: string | null;
 }
 
 /**
  * Redis-capable read-through cache for per-server config entries, the
  * single-entry counterpart to {@link ReadThroughAllCache}.
  *
- * Invalidation is by targeted deletes, so no generation tag is needed; the
- * store comes from {@link standardCache} (Redis when configured, process memory
- * otherwise), values may be kept ciphertext via {@link ReadThroughTransforms},
- * and a ttl of zero or less disables the cache entirely because entries encode
- * ACL decisions that must not outlive a revocation without a TTL bound.
+ * The store comes from {@link standardCache} (Redis when configured, process
+ * memory otherwise), values may be kept ciphertext via
+ * {@link ReadThroughTransforms}, and a ttl of zero or less disables the cache
+ * entirely because entries encode ACL decisions that must not outlive a
+ * revocation without a TTL bound.
  *
- * Each miss returns a fill token capturing the invalidation versions it
- * observed, and the matching set() is fenced by it: when a mutation deletes the
- * key (or resets the namespace) while the caller is still fetching from
- * YAML/Mongo, the completed value is dropped rather than written back over the
- * invalidation for every replica to see, even when concurrent fills for the
- * same key straddle the invalidation.
+ * Each miss returns a fill token capturing the shared tenant and global
+ * generations it observed. A targeted mutation rotates the tenant generation,
+ * while a namespace reset rotates the global generation. The matching set() is
+ * fenced by that token, so a fill that straddles an invalidation remains under
+ * its old generation and cannot become visible again on any replica.
  *
- * Store failures never reject: a Redis outage degrades reads to a miss and
- * writes to a skip so the shared store stays an optimization, not a
- * dependency, on the request path.
+ * Read and fill-write failures never reject: a Redis outage degrades reads to a
+ * miss and writes to a skip so the shared store stays an optimization on the
+ * request path. Mutation invalidations reject when their shared generation
+ * cannot be rotated, rather than reporting stale data as invalidated.
  */
 export class ReadThroughCache<T> {
   private readonly cache: Keyv;
+  private readonly generationCache: Keyv;
   private readonly ttl: number;
   private readonly transforms?: ReadThroughTransforms<T>;
-  /** Bumped by {@link delete} per key and by {@link clear} for all keys. */
-  private readonly keyVersions = new Map<string, number>();
-  private globalVersion = 0;
 
   constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
     this.cache = standardCache(namespace, ttl);
+    this.generationCache = standardCache(`${namespace}::generation`);
     this.ttl = ttl;
     this.transforms = transforms;
   }
 
   private get enabled(): boolean {
     return this.ttl > 0;
+  }
+
+  private entryKey(generation: string, key: string): string {
+    return `${generation}::${key}`;
+  }
+
+  private async readGeneration(): Promise<string | undefined> {
+    let globalGeneration: unknown;
+    let tenantGeneration: unknown;
+    try {
+      [globalGeneration, tenantGeneration] = await Promise.all([
+        this.generationCache.get(GLOBAL_GENERATION_KEY),
+        this.generationCache.get(scopedCacheKey(GENERATION_KEY)),
+      ]);
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Generation read failed:', error);
+      return undefined;
+    }
+    const global = typeof globalGeneration === 'string' ? globalGeneration : '0';
+    const tenant = typeof tenantGeneration === 'string' ? tenantGeneration : '0';
+    return `${global}:${tenant}`;
   }
 
   /** Single decoded read: `hit` distinguishes a stored value (which may
@@ -63,73 +86,112 @@ export class ReadThroughCache<T> {
     if (!this.enabled) {
       return { hit: false, value: undefined };
     }
+    const generation = await this.readGeneration();
+    if (generation == null) {
+      return { hit: false, value: undefined, fill: { key, generation: null } };
+    }
+    const cacheKey = this.entryKey(generation, key);
     let raw: unknown;
     try {
-      raw = await this.cache.get(key);
+      raw = await this.cache.get(cacheKey);
     } catch (error) {
       logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
-      return { hit: false, value: undefined, fill: this.observeFill(key) };
+      return { hit: false, value: undefined, fill: { key, generation } };
     }
     if (raw === undefined) {
-      return { hit: false, value: undefined, fill: this.observeFill(key) };
+      return { hit: false, value: undefined, fill: { key, generation } };
     }
+    let value: T;
     if (!this.transforms?.decode) {
-      return { hit: true, value: raw as T };
+      value = raw as T;
+    } else {
+      try {
+        value = await this.transforms.decode(raw as string);
+      } catch (error) {
+        logger.warn(
+          '[ReadThroughCache] Failed to decode cached entry; deleting and missing:',
+          error,
+        );
+        try {
+          await this.cache.delete(cacheKey);
+        } catch (deleteError) {
+          logger.warn('[ReadThroughCache] Failed to delete undecodable cache entry:', deleteError);
+        }
+        return { hit: false, value: undefined, fill: { key, generation } };
+      }
     }
-    try {
-      return { hit: true, value: await this.transforms.decode(raw as string) };
-    } catch (error) {
-      logger.warn('[ReadThroughCache] Failed to decode cached entry; deleting and missing:', error);
-      await this.delete(key);
-      return { hit: false, value: undefined, fill: this.observeFill(key) };
+    const current = await this.readGeneration();
+    if (current !== generation) {
+      return { hit: false, value: undefined, fill: { key, generation: current ?? null } };
     }
-  }
-
-  private observeFill(key: string): FillToken {
-    return {
-      key,
-      globalVersion: this.globalVersion,
-      keyVersion: this.keyVersions.get(key) ?? 0,
-    };
+    return { hit: true, value };
   }
 
   async set(key: string, value: T, fill?: FillToken): Promise<void> {
     if (!this.enabled) {
       return;
     }
-    if (
-      fill != null &&
-      fill.key === key &&
-      (fill.globalVersion !== this.globalVersion ||
-        fill.keyVersion !== (this.keyVersions.get(key) ?? 0))
-    ) {
+    if (fill != null && fill.key === key && fill.generation == null) {
+      return;
+    }
+    const generation = await this.readGeneration();
+    if (generation == null) {
+      return;
+    }
+    if (fill != null && fill.key === key && fill.generation !== generation) {
       /** Fenced: an invalidation completed while this value was being computed;
        *  writing it would undo the mutation for every replica. */
       return;
     }
+    const cacheKey = this.entryKey(generation, key);
     try {
       const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-      await this.cache.set(key, stored);
+      await this.cache.set(cacheKey, stored);
     } catch (error) {
       logger.warn('[ReadThroughCache] Failed to write cache entry:', error);
+      return;
+    }
+    if ((await this.readGeneration()) !== generation) {
+      try {
+        await this.cache.delete(cacheKey);
+      } catch (error) {
+        logger.warn('[ReadThroughCache] Failed to delete stale cache write:', error);
+      }
     }
   }
 
   async delete(key: string): Promise<void> {
-    this.keyVersions.set(key, (this.keyVersions.get(key) ?? 0) + 1);
     if (!this.enabled) {
       return;
     }
+    const generation = await this.readGeneration();
     try {
-      await this.cache.delete(key);
+      await this.generationCache.set(scopedCacheKey(GENERATION_KEY), randomUUID());
     } catch (error) {
-      logger.warn('[ReadThroughCache] Failed to delete cache entry:', error);
+      logger.warn('[ReadThroughCache] Generation write failed during delete:', error);
+      throw error;
+    }
+    if (generation == null) {
+      return;
+    }
+    try {
+      await this.cache.delete(this.entryKey(generation, key));
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Failed to delete orphaned cache entry:', error);
     }
   }
 
   /** Lifecycle resets only; not a hot-path invalidation. */
   async clear(): Promise<void> {
-    this.globalVersion += 1;
+    if (!this.enabled) {
+      return;
+    }
+    try {
+      await this.generationCache.set(GLOBAL_GENERATION_KEY, randomUUID());
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Global generation write failed:', error);
+      throw error;
+    }
     try {
       await this.cache.clear();
     } catch (error) {

--- a/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
@@ -1,0 +1,105 @@
+import { Keyv } from 'keyv';
+import { logger } from '@librechat/data-schemas';
+import type { ReadThroughTransforms } from './ReadThroughAllCache';
+import { standardCache } from '~/cache';
+
+/**
+ * Redis-capable read-through cache for per-server config entries, the
+ * single-entry counterpart to {@link ReadThroughAllCache}.
+ *
+ * Invalidation is by targeted deletes, so no generation tag is needed; the
+ * store comes from {@link standardCache} (Redis when configured, process memory
+ * otherwise), values may be kept ciphertext via {@link ReadThroughTransforms},
+ * and a ttl of zero or less disables the cache entirely because entries encode
+ * ACL decisions that must not outlive a revocation without a TTL bound.
+ *
+ * Store failures never reject: a Redis outage degrades reads to a miss and
+ * writes to a skip so the shared store stays an optimization, not a
+ * dependency, on the request path.
+ */
+export class ReadThroughCache<T> {
+  private readonly cache: Keyv;
+  private readonly ttl: number;
+  private readonly transforms?: ReadThroughTransforms<T>;
+
+  constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
+    this.cache = standardCache(namespace, ttl);
+    this.ttl = ttl;
+    this.transforms = transforms;
+  }
+
+  private get enabled(): boolean {
+    return this.ttl > 0;
+  }
+
+  /** Whether the store holds an entry for `key`, including one that decodes to
+   *  an absent value; lets callers negative-cache lookups like Keyv did. */
+  async has(key: string): Promise<boolean> {
+    if (!this.enabled) {
+      return false;
+    }
+    try {
+      return (await this.cache.get(key)) !== undefined;
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
+      return false;
+    }
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    if (!this.enabled) {
+      return undefined;
+    }
+    let raw: unknown;
+    try {
+      raw = await this.cache.get(key);
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
+      return undefined;
+    }
+    if (raw === undefined) {
+      return undefined;
+    }
+    if (!this.transforms?.decode) {
+      return raw as T;
+    }
+    try {
+      return await this.transforms.decode(raw as string);
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Failed to decode cached entry; treating as a miss:', error);
+      return undefined;
+    }
+  }
+
+  async set(key: string, value: T): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    try {
+      const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+      await this.cache.set(key, stored);
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Failed to write cache entry:', error);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    try {
+      await this.cache.delete(key);
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Failed to delete cache entry:', error);
+    }
+  }
+
+  /** Lifecycle resets only; not a hot-path invalidation. */
+  async clear(): Promise<void> {
+    try {
+      await this.cache.clear();
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Failed to clear cache:', error);
+    }
+  }
+}

--- a/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
@@ -3,6 +3,15 @@ import { logger } from '@librechat/data-schemas';
 import type { ReadThroughTransforms } from './ReadThroughAllCache';
 import { standardCache } from '~/cache';
 
+/** Invalidation state a per-server miss observed, so a fill that finishes after
+ *  a targeted delete (or clear) can be fenced instead of repopulating the
+ *  entry with the pre-mutation value. No expiry: a fence is removed when its
+ *  fill settles or overwritten by the next miss for the key. */
+interface PendingFill {
+  globalVersion: number;
+  keyVersion: number;
+}
+
 /**
  * Redis-capable read-through cache for per-server config entries, the
  * single-entry counterpart to {@link ReadThroughAllCache}.
@@ -13,6 +22,11 @@ import { standardCache } from '~/cache';
  * and a ttl of zero or less disables the cache entirely because entries encode
  * ACL decisions that must not outlive a revocation without a TTL bound.
  *
+ * Fills are fenced by the invalidation versions observed at their miss: when a
+ * mutation deletes the key (or resets the namespace) while the caller is still
+ * fetching from YAML/Mongo, the completed value is dropped rather than written
+ * back over the invalidation for every replica to see.
+ *
  * Store failures never reject: a Redis outage degrades reads to a miss and
  * writes to a skip so the shared store stays an optimization, not a
  * dependency, on the request path.
@@ -21,6 +35,10 @@ export class ReadThroughCache<T> {
   private readonly cache: Keyv;
   private readonly ttl: number;
   private readonly transforms?: ReadThroughTransforms<T>;
+  /** Bumped by {@link delete} per key and by {@link clear} for all keys. */
+  private readonly keyVersions = new Map<string, number>();
+  private readonly pendingFills = new Map<string, PendingFill>();
+  private globalVersion = 0;
 
   constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
     this.cache = standardCache(namespace, ttl);
@@ -30,6 +48,25 @@ export class ReadThroughCache<T> {
 
   private get enabled(): boolean {
     return this.ttl > 0;
+  }
+
+  private recordPendingFill(key: string): void {
+    this.pendingFills.set(key, {
+      globalVersion: this.globalVersion,
+      keyVersion: this.keyVersions.get(key) ?? 0,
+    });
+  }
+
+  /** True when an invalidation landed since the recorded miss. */
+  private fillIsStale(key: string): boolean {
+    const fill = this.pendingFills.get(key);
+    if (fill == null) {
+      return false;
+    }
+    return (
+      fill.globalVersion !== this.globalVersion ||
+      fill.keyVersion !== (this.keyVersions.get(key) ?? 0)
+    );
   }
 
   /** Single decoded read: `hit` distinguishes a stored value (which may
@@ -45,9 +82,11 @@ export class ReadThroughCache<T> {
       raw = await this.cache.get(key);
     } catch (error) {
       logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
+      this.recordPendingFill(key);
       return { hit: false, value: undefined };
     }
     if (raw === undefined) {
+      this.recordPendingFill(key);
       return { hit: false, value: undefined };
     }
     if (!this.transforms?.decode) {
@@ -58,6 +97,7 @@ export class ReadThroughCache<T> {
     } catch (error) {
       logger.warn('[ReadThroughCache] Failed to decode cached entry; deleting and missing:', error);
       await this.delete(key);
+      this.recordPendingFill(key);
       return { hit: false, value: undefined };
     }
   }
@@ -67,14 +107,24 @@ export class ReadThroughCache<T> {
       return;
     }
     try {
-      const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-      await this.cache.set(key, stored);
-    } catch (error) {
-      logger.warn('[ReadThroughCache] Failed to write cache entry:', error);
+      if (this.fillIsStale(key)) {
+        /** Fenced: an invalidation completed while this value was being
+         *  computed; writing it would undo the mutation for every replica. */
+        return;
+      }
+      try {
+        const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+        await this.cache.set(key, stored);
+      } catch (error) {
+        logger.warn('[ReadThroughCache] Failed to write cache entry:', error);
+      }
+    } finally {
+      this.pendingFills.delete(key);
     }
   }
 
   async delete(key: string): Promise<void> {
+    this.keyVersions.set(key, (this.keyVersions.get(key) ?? 0) + 1);
     if (!this.enabled) {
       return;
     }
@@ -87,6 +137,7 @@ export class ReadThroughCache<T> {
 
   /** Lifecycle resets only; not a hot-path invalidation. */
   async clear(): Promise<void> {
+    this.globalVersion += 1;
     try {
       await this.cache.clear();
     } catch (error) {

--- a/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
@@ -32,42 +32,33 @@ export class ReadThroughCache<T> {
     return this.ttl > 0;
   }
 
-  /** Whether the store holds an entry for `key`, including one that decodes to
-   *  an absent value; lets callers negative-cache lookups like Keyv did. */
-  async has(key: string): Promise<boolean> {
+  /** Single decoded read: `hit` distinguishes a stored value (which may
+   *  legitimately be absent) from a miss, so callers can negative-cache. An
+   *  undecodable entry (e.g. after a credentials-key rotation) self-heals: it
+   *  is deleted and reported as a miss so the caller refetches. */
+  async getEntry(key: string): Promise<{ hit: boolean; value: T | undefined }> {
     if (!this.enabled) {
-      return false;
-    }
-    try {
-      return (await this.cache.get(key)) !== undefined;
-    } catch (error) {
-      logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
-      return false;
-    }
-  }
-
-  async get(key: string): Promise<T | undefined> {
-    if (!this.enabled) {
-      return undefined;
+      return { hit: false, value: undefined };
     }
     let raw: unknown;
     try {
       raw = await this.cache.get(key);
     } catch (error) {
       logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
-      return undefined;
+      return { hit: false, value: undefined };
     }
     if (raw === undefined) {
-      return undefined;
+      return { hit: false, value: undefined };
     }
     if (!this.transforms?.decode) {
-      return raw as T;
+      return { hit: true, value: raw as T };
     }
     try {
-      return await this.transforms.decode(raw as string);
+      return { hit: true, value: await this.transforms.decode(raw as string) };
     } catch (error) {
-      logger.warn('[ReadThroughCache] Failed to decode cached entry; treating as a miss:', error);
-      return undefined;
+      logger.warn('[ReadThroughCache] Failed to decode cached entry; deleting and missing:', error);
+      await this.delete(key);
+      return { hit: false, value: undefined };
     }
   }
 

--- a/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
+++ b/packages/api/src/mcp/registry/cache/ReadThroughCache.ts
@@ -3,11 +3,11 @@ import { logger } from '@librechat/data-schemas';
 import type { ReadThroughTransforms } from './ReadThroughAllCache';
 import { standardCache } from '~/cache';
 
-/** Invalidation state a per-server miss observed, so a fill that finishes after
- *  a targeted delete (or clear) can be fenced instead of repopulating the
- *  entry with the pre-mutation value. No expiry: a fence is removed when its
- *  fill settles or overwritten by the next miss for the key. */
-interface PendingFill {
+/** Invalidation state a per-server miss observed, handed back with the miss so
+ *  the matching fill (and only that fill) can be fenced when a targeted delete
+ *  or namespace clear completed first. */
+export interface FillToken {
+  key: string;
   globalVersion: number;
   keyVersion: number;
 }
@@ -22,10 +22,12 @@ interface PendingFill {
  * and a ttl of zero or less disables the cache entirely because entries encode
  * ACL decisions that must not outlive a revocation without a TTL bound.
  *
- * Fills are fenced by the invalidation versions observed at their miss: when a
- * mutation deletes the key (or resets the namespace) while the caller is still
- * fetching from YAML/Mongo, the completed value is dropped rather than written
- * back over the invalidation for every replica to see.
+ * Each miss returns a fill token capturing the invalidation versions it
+ * observed, and the matching set() is fenced by it: when a mutation deletes the
+ * key (or resets the namespace) while the caller is still fetching from
+ * YAML/Mongo, the completed value is dropped rather than written back over the
+ * invalidation for every replica to see, even when concurrent fills for the
+ * same key straddle the invalidation.
  *
  * Store failures never reject: a Redis outage degrades reads to a miss and
  * writes to a skip so the shared store stays an optimization, not a
@@ -37,7 +39,6 @@ export class ReadThroughCache<T> {
   private readonly transforms?: ReadThroughTransforms<T>;
   /** Bumped by {@link delete} per key and by {@link clear} for all keys. */
   private readonly keyVersions = new Map<string, number>();
-  private readonly pendingFills = new Map<string, PendingFill>();
   private globalVersion = 0;
 
   constructor(namespace: string, ttl: number, transforms?: ReadThroughTransforms<T>) {
@@ -50,30 +51,15 @@ export class ReadThroughCache<T> {
     return this.ttl > 0;
   }
 
-  private recordPendingFill(key: string): void {
-    this.pendingFills.set(key, {
-      globalVersion: this.globalVersion,
-      keyVersion: this.keyVersions.get(key) ?? 0,
-    });
-  }
-
-  /** True when an invalidation landed since the recorded miss. */
-  private fillIsStale(key: string): boolean {
-    const fill = this.pendingFills.get(key);
-    if (fill == null) {
-      return false;
-    }
-    return (
-      fill.globalVersion !== this.globalVersion ||
-      fill.keyVersion !== (this.keyVersions.get(key) ?? 0)
-    );
-  }
-
   /** Single decoded read: `hit` distinguishes a stored value (which may
    *  legitimately be absent) from a miss, so callers can negative-cache. An
    *  undecodable entry (e.g. after a credentials-key rotation) self-heals: it
    *  is deleted and reported as a miss so the caller refetches. */
-  async getEntry(key: string): Promise<{ hit: boolean; value: T | undefined }> {
+  async getEntry(key: string): Promise<{
+    hit: boolean;
+    value: T | undefined;
+    fill?: FillToken;
+  }> {
     if (!this.enabled) {
       return { hit: false, value: undefined };
     }
@@ -82,12 +68,10 @@ export class ReadThroughCache<T> {
       raw = await this.cache.get(key);
     } catch (error) {
       logger.warn('[ReadThroughCache] Store read failed; treating as a miss:', error);
-      this.recordPendingFill(key);
-      return { hit: false, value: undefined };
+      return { hit: false, value: undefined, fill: this.observeFill(key) };
     }
     if (raw === undefined) {
-      this.recordPendingFill(key);
-      return { hit: false, value: undefined };
+      return { hit: false, value: undefined, fill: this.observeFill(key) };
     }
     if (!this.transforms?.decode) {
       return { hit: true, value: raw as T };
@@ -97,29 +81,37 @@ export class ReadThroughCache<T> {
     } catch (error) {
       logger.warn('[ReadThroughCache] Failed to decode cached entry; deleting and missing:', error);
       await this.delete(key);
-      this.recordPendingFill(key);
-      return { hit: false, value: undefined };
+      return { hit: false, value: undefined, fill: this.observeFill(key) };
     }
   }
 
-  async set(key: string, value: T): Promise<void> {
+  private observeFill(key: string): FillToken {
+    return {
+      key,
+      globalVersion: this.globalVersion,
+      keyVersion: this.keyVersions.get(key) ?? 0,
+    };
+  }
+
+  async set(key: string, value: T, fill?: FillToken): Promise<void> {
     if (!this.enabled) {
       return;
     }
+    if (
+      fill != null &&
+      fill.key === key &&
+      (fill.globalVersion !== this.globalVersion ||
+        fill.keyVersion !== (this.keyVersions.get(key) ?? 0))
+    ) {
+      /** Fenced: an invalidation completed while this value was being computed;
+       *  writing it would undo the mutation for every replica. */
+      return;
+    }
     try {
-      if (this.fillIsStale(key)) {
-        /** Fenced: an invalidation completed while this value was being
-         *  computed; writing it would undo the mutation for every replica. */
-        return;
-      }
-      try {
-        const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
-        await this.cache.set(key, stored);
-      } catch (error) {
-        logger.warn('[ReadThroughCache] Failed to write cache entry:', error);
-      }
-    } finally {
-      this.pendingFills.delete(key);
+      const stored = this.transforms?.encode ? await this.transforms.encode(value) : value;
+      await this.cache.set(key, stored);
+    } catch (error) {
+      logger.warn('[ReadThroughCache] Failed to write cache entry:', error);
     }
   }
 

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.cache_integration.spec.ts
@@ -85,4 +85,26 @@ describe('ReadThroughAllCache (Redis backing)', () => {
     expect(keys.some((key) => key.includes('user-1'))).toBe(true);
     expect(keys.some((key) => key.includes('user-2'))).toBe(true);
   });
+
+  test('with transforms, the shared store only ever holds ciphertext', async () => {
+    const { ReadThroughAllCache } = await import('../ReadThroughAllCache');
+    const namespace = `rtac-redis-${randomUUID()}`;
+    const transforms = {
+      encode: (value: string) => `enc:${Buffer.from(value).toString('base64')}`,
+      decode: (raw: string) => Buffer.from(raw.slice(4), 'base64').toString('utf8'),
+    };
+    const writer = new ReadThroughAllCache<string>(namespace, 60_000, transforms);
+    const reader = new ReadThroughAllCache<string>(namespace, 60_000, transforms);
+    /** A reader without transforms returns whatever the shared store holds. */
+    const plainReader = new ReadThroughAllCache<string>(namespace, 60_000);
+
+    await writer.set('user-1', 'super-secret-credential');
+
+    await expect(reader.get('user-1')).resolves.toBe('super-secret-credential');
+
+    const stored = await plainReader.get('user-1');
+    expect(stored).toBeDefined();
+    expect(stored).not.toBe('super-secret-credential');
+    expect(stored).toContain('enc:');
+  });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.cache_integration.spec.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'crypto';
+import { closeRedisClients } from '~/cache/__tests__/redisClients.helper';
+
+/**
+ * Redis-backed integration tests for the registry read-through cache (#14016).
+ * Two instances over one namespace model two containers: they share entries
+ * through Redis, and a generation invalidation on one orphans the entries for
+ * the other without any keyspace scan.
+ */
+describe('ReadThroughAllCache (Redis backing)', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  const testPrefix = 'RTAC-Integration-Test';
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.REDIS_PING_INTERVAL = '0';
+    process.env.REDIS_KEY_PREFIX = testPrefix;
+    process.env.REDIS_RETRY_MAX_ATTEMPTS = '5';
+    process.env.USE_REDIS = 'true';
+    process.env.USE_REDIS_CLUSTER = 'false';
+    process.env.REDIS_URI = 'redis://127.0.0.1:6379';
+    jest.resetModules();
+  });
+
+  afterEach(async () => {
+    const redisClients = await import('~/cache/redisClients');
+    const { ioredisClient } = redisClients;
+    if (ioredisClient && ioredisClient.status === 'ready') {
+      try {
+        const keys = await ioredisClient.keys(`${testPrefix}*`);
+        if (keys.length > 0) {
+          await ioredisClient.del(...keys);
+        }
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.warn('Error cleaning up test keys:', error.message);
+        }
+      }
+    }
+    await closeRedisClients(redisClients);
+    process.env = originalEnv;
+  });
+
+  test('entries are shared across instances through Redis', async () => {
+    const { ReadThroughAllCache } = await import('../ReadThroughAllCache');
+    const namespace = `rtac-redis-${randomUUID()}`;
+    const writer = new ReadThroughAllCache<string>(namespace, 60_000);
+    const reader = new ReadThroughAllCache<string>(namespace, 60_000);
+
+    await writer.set('user-1', 'written-by-other-instance');
+
+    await expect(reader.get('user-1')).resolves.toBe('written-by-other-instance');
+  });
+
+  test('invalidateAll on one instance orphans entries for the other', async () => {
+    const { ReadThroughAllCache } = await import('../ReadThroughAllCache');
+    const namespace = `rtac-redis-${randomUUID()}`;
+    const writer = new ReadThroughAllCache<string>(namespace, 60_000);
+    const reader = new ReadThroughAllCache<string>(namespace, 60_000);
+
+    await writer.set('user-1', 'stale-soon');
+    await writer.invalidateAll();
+
+    /** The reader never memoized the pre-invalidation value, so its read must
+     *  miss through Redis under the new generation. */
+    await expect(reader.get('user-1')).resolves.toBeUndefined();
+
+    await writer.set('user-1', 'fresh');
+    await expect(reader.get('user-1')).resolves.toBe('fresh');
+  });
+
+  test('stores per-user entries under distinct keys in Redis', async () => {
+    const { ReadThroughAllCache } = await import('../ReadThroughAllCache');
+    const namespace = `rtac-redis-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+
+    await cache.set('user-1', 'a');
+    await cache.set('user-2', 'b');
+
+    const { ioredisClient } = await import('~/cache/redisClients');
+    if (!ioredisClient) {
+      throw new Error('ioredisClient is null');
+    }
+    const keys = await ioredisClient.keys(`${testPrefix}*${namespace}*`);
+    expect(keys.some((key) => key.includes('user-1'))).toBe(true);
+    expect(keys.some((key) => key.includes('user-2'))).toBe(true);
+  });
+});

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.cache_integration.spec.ts
@@ -49,7 +49,10 @@ describe('ReadThroughAllCache (Redis backing)', () => {
 
     await writer.set('user-1', 'written-by-other-instance');
 
-    await expect(reader.get('user-1')).resolves.toBe('written-by-other-instance');
+    await expect(reader.get('user-1')).resolves.toEqual({
+      hit: true,
+      value: 'written-by-other-instance',
+    });
   });
 
   test('invalidateAll on one instance orphans entries for the other', async () => {
@@ -63,10 +66,10 @@ describe('ReadThroughAllCache (Redis backing)', () => {
 
     /** The reader never memoized the pre-invalidation value, so its read must
      *  miss through Redis under the new generation. */
-    await expect(reader.get('user-1')).resolves.toBeUndefined();
+    await expect(reader.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
 
     await writer.set('user-1', 'fresh');
-    await expect(reader.get('user-1')).resolves.toBe('fresh');
+    await expect(reader.get('user-1')).resolves.toEqual({ hit: true, value: 'fresh' });
   });
 
   test('stores per-user entries under distinct keys in Redis', async () => {
@@ -100,11 +103,13 @@ describe('ReadThroughAllCache (Redis backing)', () => {
 
     await writer.set('user-1', 'super-secret-credential');
 
-    await expect(reader.get('user-1')).resolves.toBe('super-secret-credential');
+    await expect(reader.get('user-1')).resolves.toEqual({
+      hit: true,
+      value: 'super-secret-credential',
+    });
 
     const stored = await plainReader.get('user-1');
-    expect(stored).toBeDefined();
-    expect(stored).not.toBe('super-secret-credential');
-    expect(stored).toContain('enc:');
+    expect(stored).toEqual({ hit: true, value: expect.stringContaining('enc:') });
+    expect(stored.value).not.toBe('super-secret-credential');
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.spec.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'crypto';
+
+type CacheCtor = typeof import('../ReadThroughAllCache').ReadThroughAllCache;
+
+describe('ReadThroughAllCache (in-memory backing)', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  const load = async (): Promise<CacheCtor> =>
+    (await import('../ReadThroughAllCache')).ReadThroughAllCache;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.USE_REDIS = 'false';
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('stores and returns values per key', async () => {
+    const Cache = await load();
+    const cache = new Cache<Record<string, number>>(`rtac-${randomUUID()}`, 60_000);
+    await cache.set('user-1', { a: 1 });
+
+    await expect(cache.get('user-1')).resolves.toEqual({ a: 1 });
+    await expect(cache.get('user-2')).resolves.toBeUndefined();
+  });
+
+  test('shares entries across instances of the same namespace', async () => {
+    const Cache = await load();
+    const namespace = `rtac-${randomUUID()}`;
+    const writer = new Cache<string>(namespace, 60_000);
+    const reader = new Cache<string>(namespace, 60_000);
+
+    await writer.set('user-1', 'value-a');
+
+    await expect(reader.get('user-1')).resolves.toBe('value-a');
+  });
+
+  test('invalidateAll orphans every entry without a keyspace scan', async () => {
+    const Cache = await load();
+    const namespace = `rtac-${randomUUID()}`;
+    const writer = new Cache<string>(namespace, 60_000);
+    /** A reader with no memoized entries: its next read must observe the new
+     *  generation through the shared store, proving eviction comes from the
+     *  generation tag rather than a local clear. */
+    const reader = new Cache<string>(namespace, 60_000);
+
+    await writer.set('user-1', 'value-a');
+    await writer.set('user-2', 'value-b');
+    await writer.invalidateAll();
+
+    await expect(reader.get('user-1')).resolves.toBeUndefined();
+    await expect(reader.get('user-2')).resolves.toBeUndefined();
+  });
+
+  test('entries expire after the ttl', async () => {
+    const Cache = await load();
+    const cache = new Cache<string>(`rtac-${randomUUID()}`, 40);
+    await cache.set('user-1', 'ephemeral');
+    await expect(cache.get('user-1')).resolves.toBe('ephemeral');
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test('a value written after invalidateAll is served under the new generation', async () => {
+    const Cache = await load();
+    const cache = new Cache<string>(`rtac-${randomUUID()}`, 60_000);
+    await cache.set('user-1', 'before');
+    await cache.invalidateAll();
+    await cache.set('user-1', 'after');
+
+    await expect(cache.get('user-1')).resolves.toBe('after');
+  });
+
+  test('ttl of 0 disables the memo but keeps store semantics', async () => {
+    const Cache = await load();
+    const cache = new Cache<string>(`rtac-${randomUUID()}`, 0);
+    await cache.set('user-1', 'persistent');
+
+    await expect(cache.get('user-1')).resolves.toBe('persistent');
+    await cache.invalidateAll();
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.spec.ts
@@ -76,13 +76,62 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
     await expect(cache.get('user-1')).resolves.toBe('after');
   });
 
-  test('ttl of 0 disables the memo but keeps store semantics', async () => {
+  test('ttl of 0 disables the cache entirely', async () => {
+    /** Entries derive from ACL access, so without a TTL there is no bound on
+     *  how long a revoked user could keep receiving a stale map. */
     const Cache = await load();
     const cache = new Cache<string>(`rtac-${randomUUID()}`, 0);
-    await cache.set('user-1', 'persistent');
+    await cache.set('user-1', 'never-cached');
 
-    await expect(cache.get('user-1')).resolves.toBe('persistent');
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
     await cache.invalidateAll();
     await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test('transforms keep the shared store ciphertext while serving plaintext', async () => {
+    const Cache = await load();
+    const namespace = `rtac-${randomUUID()}`;
+    const writer = new Cache<Record<string, string>>(namespace, 60_000, {
+      encode: (value) => `enc:${JSON.stringify(value)}`,
+      decode: (raw) => JSON.parse(raw.slice(4)),
+    });
+    const reader = new Cache<Record<string, string>>(namespace, 60_000, {
+      encode: (value) => `enc:${JSON.stringify(value)}`,
+      decode: (raw) => JSON.parse(raw.slice(4)),
+    });
+
+    await writer.set('user-1', { secret: 'plaintext-value' });
+
+    await expect(reader.get('user-1')).resolves.toEqual({ secret: 'plaintext-value' });
+  });
+
+  test('an undecodable stored entry fails open to a miss', async () => {
+    const Cache = await load();
+    const namespace = `rtac-${randomUUID()}`;
+    /** Writer without transforms stores plaintext JSON-shaped data. */
+    const plainWriter = new Cache<Record<string, string>>(namespace, 60_000);
+    const decodingReader = new Cache<Record<string, string>>(namespace, 60_000, {
+      encode: (value) => JSON.stringify(value),
+      decode: () => {
+        throw new Error('key rotation');
+      },
+    });
+
+    await plainWriter.set('user-1', { secret: 'stale-across-rotation' });
+
+    await expect(decodingReader.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test('a failing encode degrades to the memo without failing the set', async () => {
+    const Cache = await load();
+    const cache = new Cache<string>(`rtac-${randomUUID()}`, 60_000, {
+      encode: () => {
+        throw new Error('no CREDS key');
+      },
+      decode: (raw) => raw,
+    });
+
+    await expect(cache.set('user-1', 'memo-only')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toBe('memo-only');
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughAllCache.spec.ts
@@ -23,8 +23,8 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
     const cache = new Cache<Record<string, number>>(`rtac-${randomUUID()}`, 60_000);
     await cache.set('user-1', { a: 1 });
 
-    await expect(cache.get('user-1')).resolves.toEqual({ a: 1 });
-    await expect(cache.get('user-2')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual({ hit: true, value: { a: 1 } });
+    await expect(cache.get('user-2')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('shares entries across instances of the same namespace', async () => {
@@ -35,7 +35,7 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
 
     await writer.set('user-1', 'value-a');
 
-    await expect(reader.get('user-1')).resolves.toBe('value-a');
+    await expect(reader.get('user-1')).resolves.toEqual({ hit: true, value: 'value-a' });
   });
 
   test('invalidateAll orphans every entry without a keyspace scan', async () => {
@@ -51,19 +51,19 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
     await writer.set('user-2', 'value-b');
     await writer.invalidateAll();
 
-    await expect(reader.get('user-1')).resolves.toBeUndefined();
-    await expect(reader.get('user-2')).resolves.toBeUndefined();
+    await expect(reader.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
+    await expect(reader.get('user-2')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('entries expire after the ttl', async () => {
     const Cache = await load();
     const cache = new Cache<string>(`rtac-${randomUUID()}`, 40);
     await cache.set('user-1', 'ephemeral');
-    await expect(cache.get('user-1')).resolves.toBe('ephemeral');
+    await expect(cache.get('user-1')).resolves.toEqual({ hit: true, value: 'ephemeral' });
 
     await new Promise((resolve) => setTimeout(resolve, 80));
 
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('a value written after invalidateAll is served under the new generation', async () => {
@@ -73,7 +73,7 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
     await cache.invalidateAll();
     await cache.set('user-1', 'after');
 
-    await expect(cache.get('user-1')).resolves.toBe('after');
+    await expect(cache.get('user-1')).resolves.toEqual({ hit: true, value: 'after' });
   });
 
   test('ttl of 0 disables the cache entirely', async () => {
@@ -83,9 +83,9 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
     const cache = new Cache<string>(`rtac-${randomUUID()}`, 0);
     await cache.set('user-1', 'never-cached');
 
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
     await cache.invalidateAll();
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('transforms keep the shared store ciphertext while serving plaintext', async () => {
@@ -102,7 +102,10 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
 
     await writer.set('user-1', { secret: 'plaintext-value' });
 
-    await expect(reader.get('user-1')).resolves.toEqual({ secret: 'plaintext-value' });
+    await expect(reader.get('user-1')).resolves.toEqual({
+      hit: true,
+      value: { secret: 'plaintext-value' },
+    });
   });
 
   test('an undecodable stored entry fails open to a miss', async () => {
@@ -119,7 +122,9 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
 
     await plainWriter.set('user-1', { secret: 'stale-across-rotation' });
 
-    await expect(decodingReader.get('user-1')).resolves.toBeUndefined();
+    await expect(decodingReader.get('user-1')).resolves.toEqual(
+      expect.objectContaining({ hit: false }),
+    );
   });
 
   test('a failing encode degrades to the memo without failing the set', async () => {
@@ -132,6 +137,6 @@ describe('ReadThroughAllCache (in-memory backing)', () => {
     });
 
     await expect(cache.set('user-1', 'memo-only')).resolves.toBeUndefined();
-    await expect(cache.get('user-1')).resolves.toBe('memo-only');
+    await expect(cache.get('user-1')).resolves.toEqual({ hit: true, value: 'memo-only' });
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -151,6 +151,23 @@ describe('read-through cache resilience', () => {
     await expect(cache.get('user-1')).resolves.toBeUndefined();
   });
 
+  test('a store-failure miss still fences its fill across an invalidation', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    /** The Redis read fails under g1 but recovers by the time the fill lands,
+     *  after an invalidation moved the generation: the fill is still stale. */
+    generation.get.mockResolvedValueOnce('g1');
+    entry.get.mockRejectedValueOnce(new Error('redis unavailable'));
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+
+    generation.get.mockResolvedValue('g2');
+    await cache.set('user-1', 'stale-computed');
+
+    expect(entry.set).not.toHaveBeenCalled();
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
   test("invalidation in one tenant does not orphan another tenant's entries", async () => {
     const { tenantStorage } = await import('@librechat/data-schemas');
     const namespace = `rtac-r-${randomUUID()}`;

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from 'crypto';
+import { ReadThroughAllCache } from '../ReadThroughAllCache';
+import { ReadThroughCache } from '../ReadThroughCache';
+
+interface MockStore {
+  get: jest.Mock;
+  set: jest.Mock;
+  delete: jest.Mock;
+  clear: jest.Mock;
+}
+
+/** Stores created by the mocked `standardCache`, keyed by namespace, so tests
+ *  can drive the exact boundary failures and interleavings the real Redis
+ *  client cannot be asked to produce deterministically. */
+const mockStores = new Map<string, MockStore>();
+
+jest.mock('~/cache', () => {
+  const actual = jest.requireActual('~/cache');
+  return {
+    ...actual,
+    standardCache: (namespace: string) => {
+      const store: MockStore = {
+        get: jest.fn(async () => undefined),
+        set: jest.fn(async () => true),
+        delete: jest.fn(async () => true),
+        clear: jest.fn(async () => undefined),
+      };
+      mockStores.set(namespace, store);
+      return store;
+    },
+  };
+});
+
+function storesFor(namespace: string): { entry: MockStore; generation: MockStore } {
+  const entry = mockStores.get(namespace);
+  const generation = mockStores.get(`${namespace}::generation`);
+  if (!entry || !generation) {
+    throw new Error(`stores not created for ${namespace}`);
+  }
+  return { entry, generation };
+}
+
+function storeFor(namespace: string): MockStore {
+  const store = mockStores.get(namespace);
+  if (!store) {
+    throw new Error(`store not created for ${namespace}`);
+  }
+  return store;
+}
+
+describe('read-through cache resilience', () => {
+  test('entry store failure on get degrades to a miss', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry } = storesFor(namespace);
+    entry.get.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test('generation store failure on get degrades to a miss', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { generation } = storesFor(namespace);
+    generation.get.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test('store failure on set never rejects and keeps the process-local memo', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    entry.set.mockRejectedValue(new Error('redis unavailable'));
+    generation.set.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(cache.set('user-1', 'computed')).resolves.toBeUndefined();
+    /** The memo still serves the caller's own computed value; only the
+     *  cross-instance sharing is lost while the store is unavailable. */
+    await expect(cache.get('user-1')).resolves.toBe('computed');
+  });
+
+  test('generation write failure on invalidateAll never rejects', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { generation } = storesFor(namespace);
+    generation.set.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(cache.invalidateAll()).resolves.toBeUndefined();
+  });
+
+  test('an invalidation landing mid-read is not memoized', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    entry.get.mockResolvedValue('pre-mutation-value');
+    /** First read sees g1; the recheck after the entry fetch observes the
+     *  invalidation that landed in between. */
+    generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
+
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+
+    /** The value was never memoized, so the next read recomputes from the
+     *  store under the new generation rather than replaying the stale hit. */
+    entry.get.mockClear();
+    generation.get.mockResolvedValueOnce('g2').mockResolvedValueOnce('g2');
+    await expect(cache.get('user-1')).resolves.toBe('pre-mutation-value');
+    expect(entry.get).toHaveBeenCalledWith('g2::user-1');
+  });
+
+  test('an invalidation landing mid-set skips the memo', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { generation } = storesFor(namespace);
+    generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
+
+    await cache.set('user-1', 'fresh');
+
+    /** Generation flipped while the write was in flight, so the memo must not
+     *  serve the just-written value for a full TTL window. */
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+});
+
+describe('per-server ReadThroughCache resilience', () => {
+  test('ttl of 0 disables the cache entirely', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 0);
+    const store = storeFor(namespace);
+
+    await cache.set('server::user', 'never-cached');
+    await expect(cache.get('server::user')).resolves.toBeUndefined();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  test('store failures degrade to misses and skipped writes', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000);
+    const store = storeFor(namespace);
+    store.get.mockRejectedValue(new Error('redis unavailable'));
+    store.set.mockRejectedValue(new Error('redis unavailable'));
+    store.delete.mockRejectedValue(new Error('redis unavailable'));
+
+    await expect(cache.get('server::user')).resolves.toBeUndefined();
+    await expect(cache.set('server::user', 'value')).resolves.toBeUndefined();
+    await expect(cache.delete('server::user')).resolves.toBeUndefined();
+  });
+
+  test('transforms keep the store ciphertext while serving plaintext', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000, {
+      encode: (value) => Buffer.from(value).toString('base64'),
+      decode: (raw) => Buffer.from(raw, 'base64').toString('utf8'),
+    });
+
+    await cache.set('server::user', 'secret-value');
+
+    const store = storeFor(namespace);
+    const [, stored] = store.set.mock.calls[0];
+    expect(String(stored)).not.toContain('secret-value');
+    store.get.mockResolvedValueOnce(stored);
+    await expect(cache.get('server::user')).resolves.toBe('secret-value');
+  });
+});

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -129,7 +129,10 @@ describe('per-server ReadThroughCache resilience', () => {
     const store = storeFor(namespace);
 
     await cache.set('server::user', 'never-cached');
-    await expect(cache.get('server::user')).resolves.toBeUndefined();
+    await expect(cache.getEntry('server::user')).resolves.toEqual({
+      hit: false,
+      value: undefined,
+    });
     expect(store.set).not.toHaveBeenCalled();
   });
 
@@ -141,7 +144,10 @@ describe('per-server ReadThroughCache resilience', () => {
     store.set.mockRejectedValue(new Error('redis unavailable'));
     store.delete.mockRejectedValue(new Error('redis unavailable'));
 
-    await expect(cache.get('server::user')).resolves.toBeUndefined();
+    await expect(cache.getEntry('server::user')).resolves.toEqual({
+      hit: false,
+      value: undefined,
+    });
     await expect(cache.set('server::user', 'value')).resolves.toBeUndefined();
     await expect(cache.delete('server::user')).resolves.toBeUndefined();
   });
@@ -159,6 +165,27 @@ describe('per-server ReadThroughCache resilience', () => {
     const [, stored] = store.set.mock.calls[0];
     expect(String(stored)).not.toContain('secret-value');
     store.get.mockResolvedValueOnce(stored);
-    await expect(cache.get('server::user')).resolves.toBe('secret-value');
+    await expect(cache.getEntry('server::user')).resolves.toEqual({
+      hit: true,
+      value: 'secret-value',
+    });
+  });
+
+  test('an undecodable entry is deleted and reported as a miss', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000, {
+      encode: (value) => value,
+      decode: () => {
+        throw new Error('key rotation');
+      },
+    });
+    const store = storeFor(namespace);
+    store.get.mockResolvedValueOnce('stale-ciphertext');
+
+    await expect(cache.getEntry('server::user')).resolves.toEqual({
+      hit: false,
+      value: undefined,
+    });
+    expect(store.delete).toHaveBeenCalledWith('server::user');
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -67,6 +67,19 @@ describe('read-through cache resilience', () => {
     await expect(cache.get('user-1')).resolves.toBeUndefined();
   });
 
+  test('a generation failure cannot revive generation-zero entries', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    entry.get.mockResolvedValue('stale-from-generation-0');
+    generation.get.mockRejectedValue(new Error('transient'));
+
+    /** The unreadable generation must be a miss, not a fallback to "0", or an
+     *  unexpired pre-invalidation entry could be served for another TTL. */
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    expect(entry.get).not.toHaveBeenCalled();
+  });
+
   test('store failure on set never rejects and keeps the process-local memo', async () => {
     const namespace = `rtac-r-${randomUUID()}`;
     const cache = new ReadThroughAllCache<string>(namespace, 60_000);

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -19,6 +19,10 @@ jest.mock('~/cache', () => {
   return {
     ...actual,
     standardCache: (namespace: string) => {
+      const existing = mockStores.get(namespace);
+      if (existing) {
+        return existing;
+      }
       const store: MockStore = {
         get: jest.fn(async () => undefined),
         set: jest.fn(async () => true),
@@ -48,6 +52,30 @@ function storeFor(namespace: string): MockStore {
   return store;
 }
 
+function installGenerationStore(
+  generation: MockStore,
+  initial: Record<string, string> = {},
+): Map<string, string> {
+  const values = new Map(Object.entries(initial));
+  generation.get.mockImplementation(async (key: string) => values.get(key));
+  generation.set.mockImplementation(async (key: string, value: string) => {
+    values.set(key, value);
+    return true;
+  });
+  return values;
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('read-through cache resilience', () => {
   test('entry store failure on get degrades to a miss', async () => {
     const namespace = `rtac-r-${randomUUID()}`;
@@ -65,6 +93,20 @@ describe('read-through cache resilience', () => {
     generation.get.mockRejectedValue(new Error('redis unavailable'));
 
     await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
+  });
+
+  test('a generation-read failure marks the fill as uncacheable', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    generation.get.mockRejectedValue(new Error('redis unavailable'));
+
+    const miss = await cache.get('user-1');
+    expect(miss.fill).toEqual({ key: 'user-1', generation: null });
+
+    generation.get.mockResolvedValue(undefined);
+    await cache.set('user-1', 'must-not-be-shared', miss.fill);
+    expect(entry.set).not.toHaveBeenCalled();
   });
 
   test('a generation failure cannot revive generation-zero entries', async () => {
@@ -95,13 +137,13 @@ describe('read-through cache resilience', () => {
     );
   });
 
-  test('generation write failure on invalidateAll never rejects', async () => {
+  test('generation write failure on invalidateAll is propagated', async () => {
     const namespace = `rtac-r-${randomUUID()}`;
     const cache = new ReadThroughAllCache<string>(namespace, 60_000);
     const { generation } = storesFor(namespace);
     generation.set.mockRejectedValue(new Error('redis unavailable'));
 
-    await expect(cache.invalidateAll()).resolves.toBeUndefined();
+    await expect(cache.invalidateAll()).rejects.toThrow('redis unavailable');
   });
 
   test('an invalidation landing mid-read is not memoized', async () => {
@@ -111,7 +153,15 @@ describe('read-through cache resilience', () => {
     entry.get.mockResolvedValue('pre-mutation-value');
     /** First read sees g1; the recheck after the entry fetch observes the
      *  invalidation that landed in between. */
-    generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
+    generation.get.mockImplementation(async (key: string) => {
+      if (key === '__global_generation__') {
+        return 'global';
+      }
+      return generation.get.mock.calls.filter(([calledKey]) => calledKey === '__generation__')
+        .length === 1
+        ? 'g1'
+        : 'g2';
+    });
 
     const raced = await cache.get('user-1');
     expect(raced.hit).toBe(false);
@@ -123,11 +173,10 @@ describe('read-through cache resilience', () => {
     /** The value was never memoized, so the next read recomputes from the
      *  store under the new generation rather than replaying the stale hit. */
     entry.get.mockClear();
-    generation.get.mockResolvedValueOnce('g2').mockResolvedValueOnce('g2');
     await expect(cache.get('user-1')).resolves.toEqual(
       expect.objectContaining({ hit: true, value: 'pre-mutation-value' }),
     );
-    expect(entry.get).toHaveBeenCalledWith('g2::user-1');
+    expect(entry.get).toHaveBeenCalledWith('global:g2::user-1');
   });
 
   test('a fill computed across an invalidation is fenced', async () => {
@@ -136,12 +185,15 @@ describe('read-through cache resilience', () => {
     const { entry, generation } = storesFor(namespace);
     /** The miss happens under g1; the caller is still computing when the
      *  generation moves to g2, so the fill must not be written or memoized. */
-    generation.get.mockResolvedValueOnce('g1');
+    const values = installGenerationStore(generation, {
+      __global_generation__: 'global',
+      __generation__: 'g1',
+    });
     entry.get.mockResolvedValueOnce(undefined);
     const miss = await cache.get('user-1');
-    expect(miss.fill).toEqual({ key: 'user-1', generation: 'g1' });
+    expect(miss.fill).toEqual({ key: 'user-1', generation: 'global:g1' });
 
-    generation.get.mockResolvedValue('g2');
+    values.set('__generation__', 'g2');
     await cache.set('user-1', 'stale-computed', miss.fill);
 
     expect(entry.set).not.toHaveBeenCalled();
@@ -154,12 +206,15 @@ describe('read-through cache resilience', () => {
     const { entry, generation } = storesFor(namespace);
     /** The Redis read fails under g1 but recovers by the time the fill lands,
      *  after an invalidation moved the generation: the fill is still stale. */
-    generation.get.mockResolvedValueOnce('g1');
+    const values = installGenerationStore(generation, {
+      __global_generation__: 'global',
+      __generation__: 'g1',
+    });
     entry.get.mockRejectedValueOnce(new Error('redis unavailable'));
     const miss = await cache.get('user-1');
     expect(miss.hit).toBe(false);
 
-    generation.get.mockResolvedValue('g2');
+    values.set('__generation__', 'g2');
     await cache.set('user-1', 'stale-computed', miss.fill);
 
     expect(entry.set).not.toHaveBeenCalled();
@@ -169,13 +224,16 @@ describe('read-through cache resilience', () => {
     const namespace = `rtac-r-${randomUUID()}`;
     const cache = new ReadThroughAllCache<string>(namespace, 40);
     const { entry, generation } = storesFor(namespace);
-    generation.get.mockResolvedValueOnce('g1');
+    const values = installGenerationStore(generation, {
+      __global_generation__: 'global',
+      __generation__: 'g1',
+    });
     entry.get.mockResolvedValueOnce(undefined);
     const miss = await cache.get('user-1');
     expect(miss.hit).toBe(false);
 
     await new Promise((resolve) => setTimeout(resolve, 80));
-    generation.get.mockResolvedValue('g2');
+    values.set('__generation__', 'g2');
 
     /** The miss generation travels with the fill, so a compute slower than the
      *  entry TTL is still fenced when it lands. */
@@ -190,19 +248,71 @@ describe('read-through cache resilience', () => {
     /** Fill A misses under g1; an invalidation moves to g2; fill B misses
      *  under g2. A's later set must stay fenced even though B's fence is
      *  current, which a shared per-key marker could not express. */
-    generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
+    const values = installGenerationStore(generation, {
+      __global_generation__: 'global',
+      __generation__: 'g1',
+    });
     entry.get.mockResolvedValueOnce(undefined);
     const missA = await cache.get('user-1');
 
+    values.set('__generation__', 'g2');
     entry.get.mockResolvedValueOnce(undefined);
     const missB = await cache.get('user-1');
-    expect(missB.fill).toEqual({ key: 'user-1', generation: 'g2' });
+    expect(missB.fill).toEqual({ key: 'user-1', generation: 'global:g2' });
 
     await cache.set('user-1', 'stale-from-A', missA.fill);
     expect(entry.set).not.toHaveBeenCalled();
 
     await cache.set('user-1', 'fresh-from-B', missB.fill);
-    expect(entry.set).toHaveBeenCalledWith('g2::user-1', 'fresh-from-B');
+    expect(entry.set).toHaveBeenCalledWith('global:g2::user-1', 'fresh-from-B');
+  });
+
+  test('invalidateAll evicts a memo repopulated while the generation write is pending', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    const values = installGenerationStore(generation, {
+      __global_generation__: 'global',
+      __generation__: 'g1',
+    });
+    const generationWrite = deferred<void>();
+    generation.set.mockImplementation(async (key: string, value: string) => {
+      await generationWrite.promise;
+      values.set(key, value);
+      return true;
+    });
+
+    await cache.set('user-1', 'memoized-old');
+    entry.get.mockResolvedValue('stored-old');
+
+    const invalidation = cache.invalidateAll();
+    const racedRead = await cache.get('user-1');
+    expect(racedRead).toEqual(expect.objectContaining({ hit: true, value: 'stored-old' }));
+
+    generationWrite.resolve();
+    await invalidation;
+
+    entry.get.mockClear();
+    await cache.get('user-1');
+    expect(entry.get).toHaveBeenCalled();
+  });
+
+  test('invalidateAllGlobal rotates the shared fence for in-flight fills', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    installGenerationStore(generation, {
+      __global_generation__: 'global-1',
+      __generation__: 'tenant-1',
+    });
+    entry.get.mockResolvedValueOnce(undefined);
+    const miss = await cache.get('user-1');
+
+    await cache.invalidateAllGlobal();
+    await cache.set('user-1', 'pre-reset-value', miss.fill);
+
+    expect(generation.set).toHaveBeenCalledWith('__global_generation__', expect.any(String));
+    expect(entry.set).not.toHaveBeenCalled();
   });
 
   test("invalidation in one tenant does not orphan another tenant's entries", async () => {
@@ -241,7 +351,8 @@ describe('read-through cache resilience', () => {
   test('invalidateAllGlobal clears the shared namespace across tenants', async () => {
     const namespace = `rtac-r-${randomUUID()}`;
     const cache = new ReadThroughAllCache<string>(namespace, 60_000);
-    const { entry } = storesFor(namespace);
+    const { entry, generation } = storesFor(namespace);
+    installGenerationStore(generation);
     entry.get.mockResolvedValue('stored-value');
     await cache.set('user-1', 'memoized');
 
@@ -251,7 +362,7 @@ describe('read-through cache resilience', () => {
      *  next read goes back to the shared store instead of replaying it. */
     expect(entry.clear).toHaveBeenCalled();
     await cache.get('user-1');
-    expect(entry.get).toHaveBeenCalledWith('0::user-1');
+    expect(entry.get).toHaveBeenCalledWith(expect.stringMatching(/^[^:]+:0::user-1$/));
   });
 });
 
@@ -315,13 +426,14 @@ describe('per-server ReadThroughCache resilience', () => {
     await expect(cache.getEntry('server::user')).resolves.toEqual(
       expect.objectContaining({ hit: false }),
     );
-    expect(store.delete).toHaveBeenCalledWith('server::user');
+    expect(store.delete).toHaveBeenCalledWith('0:0::server::user');
   });
 
   test('a fill finishing after a targeted delete is fenced', async () => {
     const namespace = `rtc-r-${randomUUID()}`;
     const cache = new ReadThroughCache<string>(namespace, 60_000);
-    const store = storeFor(namespace);
+    const { entry: store, generation } = storesFor(namespace);
+    installGenerationStore(generation);
     store.get.mockResolvedValueOnce(undefined);
     const miss = await cache.getEntry('server::user');
     expect(miss.hit).toBe(false);
@@ -337,7 +449,8 @@ describe('per-server ReadThroughCache resilience', () => {
   test('a fill finishing after a namespace clear is fenced', async () => {
     const namespace = `rtc-r-${randomUUID()}`;
     const cache = new ReadThroughCache<string>(namespace, 60_000);
-    const store = storeFor(namespace);
+    const { entry: store, generation } = storesFor(namespace);
+    installGenerationStore(generation);
     store.get.mockResolvedValueOnce(undefined);
     const miss = await cache.getEntry('server::user');
     expect(miss.hit).toBe(false);
@@ -358,13 +471,14 @@ describe('per-server ReadThroughCache resilience', () => {
 
     await cache.set('server::user', 'fresh', miss.fill);
 
-    expect(store.set).toHaveBeenCalledWith('server::user', 'fresh');
+    expect(store.set).toHaveBeenCalledWith('0:0::server::user', 'fresh');
   });
 
   test('concurrent fills for one key keep distinct fences', async () => {
     const namespace = `rtc-r-${randomUUID()}`;
     const cache = new ReadThroughCache<string>(namespace, 60_000);
-    const store = storeFor(namespace);
+    const { entry: store, generation } = storesFor(namespace);
+    installGenerationStore(generation);
     /** Fill A misses; a targeted delete lands; fill B misses. A's later write
      *  must stay fenced even though B's fence is current. */
     store.get.mockResolvedValue(undefined);
@@ -377,6 +491,59 @@ describe('per-server ReadThroughCache resilience', () => {
     expect(store.set).not.toHaveBeenCalled();
 
     await cache.set('server::user', 'fresh-from-B', missB.fill);
-    expect(store.set).toHaveBeenCalledWith('server::user', 'fresh-from-B');
+    expect(store.set).toHaveBeenCalledWith(
+      expect.stringContaining('::server::user'),
+      'fresh-from-B',
+    );
+  });
+
+  test('a cross-instance invalidation fences a write already awaiting encode', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const encodeStarted = deferred<void>();
+    const releaseEncode = deferred<void>();
+    const writer = new ReadThroughCache<string>(namespace, 60_000, {
+      encode: async (value) => {
+        encodeStarted.resolve();
+        await releaseEncode.promise;
+        return value;
+      },
+    });
+    const invalidator = new ReadThroughCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    installGenerationStore(generation, {
+      __global_generation__: 'global',
+      __generation__: 'tenant-1',
+    });
+    entry.get.mockResolvedValueOnce(undefined);
+    const miss = await writer.getEntry('server::user');
+
+    const write = writer.set('server::user', 'pre-mutation-value', miss.fill);
+    await encodeStarted.promise;
+    await invalidator.delete('server::user');
+    releaseEncode.resolve();
+    await write;
+
+    expect(entry.set).toHaveBeenCalledWith('global:tenant-1::server::user', 'pre-mutation-value');
+    expect(entry.delete).toHaveBeenLastCalledWith('global:tenant-1::server::user');
+
+    entry.get.mockClear();
+    await expect(invalidator.getEntry('server::user')).resolves.toEqual(
+      expect.objectContaining({ hit: false }),
+    );
+    expect(entry.get).toHaveBeenCalledWith(expect.not.stringContaining('tenant-1'));
+  });
+
+  test('targeted invalidations reuse one shared tenant generation key', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000);
+    const { generation } = storesFor(namespace);
+    installGenerationStore(generation);
+
+    await cache.delete('server-a::user');
+    await cache.delete('server-b::user');
+    await cache.delete('server-c::user');
+
+    expect(generation.set).toHaveBeenCalledTimes(3);
+    expect(generation.set.mock.calls.every(([key]) => key === '__generation__')).toBe(true);
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -55,7 +55,7 @@ describe('read-through cache resilience', () => {
     const { entry } = storesFor(namespace);
     entry.get.mockRejectedValueOnce(new Error('redis unavailable'));
 
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('generation store failure on get degrades to a miss', async () => {
@@ -64,7 +64,7 @@ describe('read-through cache resilience', () => {
     const { generation } = storesFor(namespace);
     generation.get.mockRejectedValue(new Error('redis unavailable'));
 
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('a generation failure cannot revive generation-zero entries', async () => {
@@ -76,7 +76,7 @@ describe('read-through cache resilience', () => {
 
     /** The unreadable generation must be a miss, not a fallback to "0", or an
      *  unexpired pre-invalidation entry could be served for another TTL. */
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
     expect(entry.get).not.toHaveBeenCalled();
   });
 
@@ -90,7 +90,9 @@ describe('read-through cache resilience', () => {
     await expect(cache.set('user-1', 'computed')).resolves.toBeUndefined();
     /** The memo still serves the caller's own computed value; only the
      *  cross-instance sharing is lost while the store is unavailable. */
-    await expect(cache.get('user-1')).resolves.toBe('computed');
+    await expect(cache.get('user-1')).resolves.toEqual(
+      expect.objectContaining({ hit: true, value: 'computed' }),
+    );
   });
 
   test('generation write failure on invalidateAll never rejects', async () => {
@@ -111,27 +113,21 @@ describe('read-through cache resilience', () => {
      *  invalidation that landed in between. */
     generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
 
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    const raced = await cache.get('user-1');
+    expect(raced.hit).toBe(false);
+    /** The racing fill observes g1 and the generation has moved, so it stays
+     *  fenced when its caller finishes computing. */
+    await cache.set('user-1', 'stale-computed', raced.fill);
+    expect(entry.set).not.toHaveBeenCalled();
 
     /** The value was never memoized, so the next read recomputes from the
      *  store under the new generation rather than replaying the stale hit. */
     entry.get.mockClear();
     generation.get.mockResolvedValueOnce('g2').mockResolvedValueOnce('g2');
-    await expect(cache.get('user-1')).resolves.toBe('pre-mutation-value');
+    await expect(cache.get('user-1')).resolves.toEqual(
+      expect.objectContaining({ hit: true, value: 'pre-mutation-value' }),
+    );
     expect(entry.get).toHaveBeenCalledWith('g2::user-1');
-  });
-
-  test('an invalidation landing mid-set skips the memo', async () => {
-    const namespace = `rtac-r-${randomUUID()}`;
-    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
-    const { generation } = storesFor(namespace);
-    generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
-
-    await cache.set('user-1', 'fresh');
-
-    /** Generation flipped while the write was in flight, so the memo must not
-     *  serve the just-written value for a full TTL window. */
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
   });
 
   test('a fill computed across an invalidation is fenced', async () => {
@@ -142,13 +138,14 @@ describe('read-through cache resilience', () => {
      *  generation moves to g2, so the fill must not be written or memoized. */
     generation.get.mockResolvedValueOnce('g1');
     entry.get.mockResolvedValueOnce(undefined);
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    const miss = await cache.get('user-1');
+    expect(miss.fill).toEqual({ key: 'user-1', generation: 'g1' });
 
     generation.get.mockResolvedValue('g2');
-    await cache.set('user-1', 'stale-computed');
+    await cache.set('user-1', 'stale-computed', miss.fill);
 
     expect(entry.set).not.toHaveBeenCalled();
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    await expect(cache.get('user-1')).resolves.toEqual(expect.objectContaining({ hit: false }));
   });
 
   test('a store-failure miss still fences its fill across an invalidation', async () => {
@@ -159,13 +156,53 @@ describe('read-through cache resilience', () => {
      *  after an invalidation moved the generation: the fill is still stale. */
     generation.get.mockResolvedValueOnce('g1');
     entry.get.mockRejectedValueOnce(new Error('redis unavailable'));
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+    const miss = await cache.get('user-1');
+    expect(miss.hit).toBe(false);
 
     generation.get.mockResolvedValue('g2');
-    await cache.set('user-1', 'stale-computed');
+    await cache.set('user-1', 'stale-computed', miss.fill);
 
     expect(entry.set).not.toHaveBeenCalled();
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test('a fence survives fills slower than one TTL window', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 40);
+    const { entry, generation } = storesFor(namespace);
+    generation.get.mockResolvedValueOnce('g1');
+    entry.get.mockResolvedValueOnce(undefined);
+    const miss = await cache.get('user-1');
+    expect(miss.hit).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    generation.get.mockResolvedValue('g2');
+
+    /** The miss generation travels with the fill, so a compute slower than the
+     *  entry TTL is still fenced when it lands. */
+    await cache.set('user-1', 'slow-stale-computed', miss.fill);
+    expect(entry.set).not.toHaveBeenCalled();
+  });
+
+  test('concurrent fills for one key keep distinct fences', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    /** Fill A misses under g1; an invalidation moves to g2; fill B misses
+     *  under g2. A's later set must stay fenced even though B's fence is
+     *  current, which a shared per-key marker could not express. */
+    generation.get.mockResolvedValueOnce('g1').mockResolvedValue('g2');
+    entry.get.mockResolvedValueOnce(undefined);
+    const missA = await cache.get('user-1');
+
+    entry.get.mockResolvedValueOnce(undefined);
+    const missB = await cache.get('user-1');
+    expect(missB.fill).toEqual({ key: 'user-1', generation: 'g2' });
+
+    await cache.set('user-1', 'stale-from-A', missA.fill);
+    expect(entry.set).not.toHaveBeenCalled();
+
+    await cache.set('user-1', 'fresh-from-B', missB.fill);
+    expect(entry.set).toHaveBeenCalledWith('g2::user-1', 'fresh-from-B');
   });
 
   test("invalidation in one tenant does not orphan another tenant's entries", async () => {
@@ -197,25 +234,8 @@ describe('read-through cache resilience', () => {
     const survived = await tenantStorage.run({ tenantId: 'tenant-a' }, () =>
       cache.get('user:tenant-a'),
     );
-    expect(survived).toBe('value-a');
+    expect(survived).toEqual(expect.objectContaining({ hit: true, value: 'value-a' }));
     expect(entry.get).not.toHaveBeenCalled();
-  });
-
-  test('a fence survives fills slower than one TTL window', async () => {
-    const namespace = `rtac-r-${randomUUID()}`;
-    const cache = new ReadThroughAllCache<string>(namespace, 40);
-    const { entry, generation } = storesFor(namespace);
-    generation.get.mockResolvedValueOnce('g1');
-    entry.get.mockResolvedValueOnce(undefined);
-    await expect(cache.get('user-1')).resolves.toBeUndefined();
-
-    await new Promise((resolve) => setTimeout(resolve, 80));
-    generation.get.mockResolvedValue('g2');
-
-    /** The miss generation is still remembered after the entry TTL elapsed,
-     *  so the late fill stays fenced. */
-    await cache.set('user-1', 'slow-stale-computed');
-    expect(entry.set).not.toHaveBeenCalled();
   });
 
   test('invalidateAllGlobal clears the shared namespace across tenants', async () => {
@@ -242,10 +262,9 @@ describe('per-server ReadThroughCache resilience', () => {
     const store = storeFor(namespace);
 
     await cache.set('server::user', 'never-cached');
-    await expect(cache.getEntry('server::user')).resolves.toEqual({
-      hit: false,
-      value: undefined,
-    });
+    await expect(cache.getEntry('server::user')).resolves.toEqual(
+      expect.objectContaining({ hit: false }),
+    );
     expect(store.set).not.toHaveBeenCalled();
   });
 
@@ -257,10 +276,9 @@ describe('per-server ReadThroughCache resilience', () => {
     store.set.mockRejectedValue(new Error('redis unavailable'));
     store.delete.mockRejectedValue(new Error('redis unavailable'));
 
-    await expect(cache.getEntry('server::user')).resolves.toEqual({
-      hit: false,
-      value: undefined,
-    });
+    await expect(cache.getEntry('server::user')).resolves.toEqual(
+      expect.objectContaining({ hit: false }),
+    );
     await expect(cache.set('server::user', 'value')).resolves.toBeUndefined();
     await expect(cache.delete('server::user')).resolves.toBeUndefined();
   });
@@ -278,10 +296,9 @@ describe('per-server ReadThroughCache resilience', () => {
     const [, stored] = store.set.mock.calls[0];
     expect(String(stored)).not.toContain('secret-value');
     store.get.mockResolvedValueOnce(stored);
-    await expect(cache.getEntry('server::user')).resolves.toEqual({
-      hit: true,
-      value: 'secret-value',
-    });
+    await expect(cache.getEntry('server::user')).resolves.toEqual(
+      expect.objectContaining({ hit: true, value: 'secret-value' }),
+    );
   });
 
   test('an undecodable entry is deleted and reported as a miss', async () => {
@@ -295,10 +312,9 @@ describe('per-server ReadThroughCache resilience', () => {
     const store = storeFor(namespace);
     store.get.mockResolvedValueOnce('stale-ciphertext');
 
-    await expect(cache.getEntry('server::user')).resolves.toEqual({
-      hit: false,
-      value: undefined,
-    });
+    await expect(cache.getEntry('server::user')).resolves.toEqual(
+      expect.objectContaining({ hit: false }),
+    );
     expect(store.delete).toHaveBeenCalledWith('server::user');
   });
 
@@ -307,15 +323,13 @@ describe('per-server ReadThroughCache resilience', () => {
     const cache = new ReadThroughCache<string>(namespace, 60_000);
     const store = storeFor(namespace);
     store.get.mockResolvedValueOnce(undefined);
-    await expect(cache.getEntry('server::user')).resolves.toEqual({
-      hit: false,
-      value: undefined,
-    });
+    const miss = await cache.getEntry('server::user');
+    expect(miss.hit).toBe(false);
 
     /** The server is updated and the cache key deleted while the original
      *  request was still fetching; its write must not undo the mutation. */
     await cache.delete('server::user');
-    await cache.set('server::user', 'pre-mutation-value');
+    await cache.set('server::user', 'pre-mutation-value', miss.fill);
 
     expect(store.set).not.toHaveBeenCalled();
   });
@@ -325,13 +339,11 @@ describe('per-server ReadThroughCache resilience', () => {
     const cache = new ReadThroughCache<string>(namespace, 60_000);
     const store = storeFor(namespace);
     store.get.mockResolvedValueOnce(undefined);
-    await expect(cache.getEntry('server::user')).resolves.toEqual({
-      hit: false,
-      value: undefined,
-    });
+    const miss = await cache.getEntry('server::user');
+    expect(miss.hit).toBe(false);
 
     await cache.clear();
-    await cache.set('server::user', 'pre-reset-value');
+    await cache.set('server::user', 'pre-reset-value', miss.fill);
 
     expect(store.set).not.toHaveBeenCalled();
   });
@@ -341,10 +353,30 @@ describe('per-server ReadThroughCache resilience', () => {
     const cache = new ReadThroughCache<string>(namespace, 60_000);
     const store = storeFor(namespace);
     store.get.mockResolvedValueOnce(undefined);
-    await cache.getEntry('server::user');
+    const miss = await cache.getEntry('server::user');
+    expect(miss.hit).toBe(false);
 
-    await cache.set('server::user', 'fresh');
+    await cache.set('server::user', 'fresh', miss.fill);
 
     expect(store.set).toHaveBeenCalledWith('server::user', 'fresh');
+  });
+
+  test('concurrent fills for one key keep distinct fences', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000);
+    const store = storeFor(namespace);
+    /** Fill A misses; a targeted delete lands; fill B misses. A's later write
+     *  must stay fenced even though B's fence is current. */
+    store.get.mockResolvedValue(undefined);
+    const missA = await cache.getEntry('server::user');
+
+    await cache.delete('server::user');
+    const missB = await cache.getEntry('server::user');
+
+    await cache.set('server::user', 'stale-from-A', missA.fill);
+    expect(store.set).not.toHaveBeenCalled();
+
+    await cache.set('server::user', 'fresh-from-B', missB.fill);
+    expect(store.set).toHaveBeenCalledWith('server::user', 'fresh-from-B');
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -191,12 +191,31 @@ describe('read-through cache resilience', () => {
     await tenantStorage.run({ tenantId: 'tenant-b' }, () => cache.invalidateAll());
     expect(generation.set).toHaveBeenCalledWith('__generation__:tenant-b', expect.any(String));
 
-    /** Tenant A's memo was cleared by the shared clear, but its store entry
-     *  survives: the read hits the shared store instead of recomputing. */
+    /** Tenant B's invalidation left tenant A's memo entry in place, so this
+     *  read never even reaches the shared store. */
+    entry.get.mockClear();
     const survived = await tenantStorage.run({ tenantId: 'tenant-a' }, () =>
       cache.get('user:tenant-a'),
     );
     expect(survived).toBe('value-a');
+    expect(entry.get).not.toHaveBeenCalled();
+  });
+
+  test('a fence survives fills slower than one TTL window', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 40);
+    const { entry, generation } = storesFor(namespace);
+    generation.get.mockResolvedValueOnce('g1');
+    entry.get.mockResolvedValueOnce(undefined);
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    generation.get.mockResolvedValue('g2');
+
+    /** The miss generation is still remembered after the entry TTL elapsed,
+     *  so the late fill stays fenced. */
+    await cache.set('user-1', 'slow-stale-computed');
+    expect(entry.set).not.toHaveBeenCalled();
   });
 
   test('invalidateAllGlobal clears the shared namespace across tenants', async () => {
@@ -281,5 +300,51 @@ describe('per-server ReadThroughCache resilience', () => {
       value: undefined,
     });
     expect(store.delete).toHaveBeenCalledWith('server::user');
+  });
+
+  test('a fill finishing after a targeted delete is fenced', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000);
+    const store = storeFor(namespace);
+    store.get.mockResolvedValueOnce(undefined);
+    await expect(cache.getEntry('server::user')).resolves.toEqual({
+      hit: false,
+      value: undefined,
+    });
+
+    /** The server is updated and the cache key deleted while the original
+     *  request was still fetching; its write must not undo the mutation. */
+    await cache.delete('server::user');
+    await cache.set('server::user', 'pre-mutation-value');
+
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  test('a fill finishing after a namespace clear is fenced', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000);
+    const store = storeFor(namespace);
+    store.get.mockResolvedValueOnce(undefined);
+    await expect(cache.getEntry('server::user')).resolves.toEqual({
+      hit: false,
+      value: undefined,
+    });
+
+    await cache.clear();
+    await cache.set('server::user', 'pre-reset-value');
+
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  test('a fill is allowed when no invalidation intervened', async () => {
+    const namespace = `rtc-r-${randomUUID()}`;
+    const cache = new ReadThroughCache<string>(namespace, 60_000);
+    const store = storeFor(namespace);
+    store.get.mockResolvedValueOnce(undefined);
+    await cache.getEntry('server::user');
+
+    await cache.set('server::user', 'fresh');
+
+    expect(store.set).toHaveBeenCalledWith('server::user', 'fresh');
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ReadThroughCache.resilience.spec.ts
@@ -133,6 +133,70 @@ describe('read-through cache resilience', () => {
      *  serve the just-written value for a full TTL window. */
     await expect(cache.get('user-1')).resolves.toBeUndefined();
   });
+
+  test('a fill computed across an invalidation is fenced', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    /** The miss happens under g1; the caller is still computing when the
+     *  generation moves to g2, so the fill must not be written or memoized. */
+    generation.get.mockResolvedValueOnce('g1');
+    entry.get.mockResolvedValueOnce(undefined);
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+
+    generation.get.mockResolvedValue('g2');
+    await cache.set('user-1', 'stale-computed');
+
+    expect(entry.set).not.toHaveBeenCalled();
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+
+  test("invalidation in one tenant does not orphan another tenant's entries", async () => {
+    const { tenantStorage } = await import('@librechat/data-schemas');
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry, generation } = storesFor(namespace);
+    generation.get.mockImplementation(async (key: string) => {
+      if (key === '__generation__:tenant-a') {
+        return 'ga1';
+      }
+      if (key === '__generation__:tenant-b') {
+        return 'gb1';
+      }
+      return 'g0';
+    });
+
+    await tenantStorage.run({ tenantId: 'tenant-a' }, () => cache.set('user:tenant-a', 'value-a'));
+    entry.get.mockImplementation(async (key: string) =>
+      key === 'ga1::user:tenant-a' ? 'value-a' : undefined,
+    );
+
+    await tenantStorage.run({ tenantId: 'tenant-b' }, () => cache.invalidateAll());
+    expect(generation.set).toHaveBeenCalledWith('__generation__:tenant-b', expect.any(String));
+
+    /** Tenant A's memo was cleared by the shared clear, but its store entry
+     *  survives: the read hits the shared store instead of recomputing. */
+    const survived = await tenantStorage.run({ tenantId: 'tenant-a' }, () =>
+      cache.get('user:tenant-a'),
+    );
+    expect(survived).toBe('value-a');
+  });
+
+  test('invalidateAllGlobal clears the shared namespace across tenants', async () => {
+    const namespace = `rtac-r-${randomUUID()}`;
+    const cache = new ReadThroughAllCache<string>(namespace, 60_000);
+    const { entry } = storesFor(namespace);
+    entry.get.mockResolvedValue('stored-value');
+    await cache.set('user-1', 'memoized');
+
+    await cache.invalidateAllGlobal();
+
+    /** The namespace-wide clear ran and the memo was evicted with it, so the
+     *  next read goes back to the shared store instead of replaying it. */
+    expect(entry.clear).toHaveBeenCalled();
+    await cache.get('user-1');
+    expect(entry.get).toHaveBeenCalledWith('0::user-1');
+  });
 });
 
 describe('per-server ReadThroughCache resilience', () => {

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -541,44 +541,47 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
     const principalsPromise: Promise<ResolvedPrincipal[]> | undefined = userId
       ? this._aclService.getUserPrincipals({ userId, role })
       : undefined;
+    const principalsResolved = principalsPromise ?? Promise.resolve([] as ResolvedPrincipal[]);
+
     /** Direct-server ids depend on principals only for the user path; chaining
-     *  off the principals promise attaches a rejection handler at creation for
-     *  both branches, and the public branch starts immediately. */
-    const directIdsPromise: Promise<Types.ObjectId[]> = principalsPromise
-      ? principalsPromise.then((principalsList) =>
-          this._aclService.findAccessibleResourcesForPrincipals({
-            principalsList,
-            requiredPermissions: PermissionBits.VIEW,
+     *  attaches a rejection handler at creation for both branches, and the
+     *  direct-server fetch follows the ids immediately. */
+    const directResultsPromise = (
+      principalsPromise
+        ? principalsPromise.then((principalsList) =>
+            this._aclService.findAccessibleResourcesForPrincipals({
+              principalsList,
+              requiredPermissions: PermissionBits.VIEW,
+              resourceType: ResourceType.MCPSERVER,
+            }),
+          )
+        : this._aclService.findPubliclyAccessibleResources({
             resourceType: ResourceType.MCPSERVER,
-          }),
-        )
-      : this._aclService.findPubliclyAccessibleResources({
-          resourceType: ResourceType.MCPSERVER,
-          requiredPermissions: PermissionBits.VIEW,
-        });
+            requiredPermissions: PermissionBits.VIEW,
+          })
+    ).then((ids) => this._dbMethods.getListMCPServersByIds({ ids }));
 
-    /** One settlement for the three started reads, so none of their rejections
-     *  can surface as unhandled. */
-    const [agentCandidates, principalsList, directlyAccessibleMCPIds] = await Promise.all([
-      candidatesPromise,
-      principalsPromise ?? Promise.resolve([]),
-      directIdsPromise,
-    ]);
-    const candidateIds = agentCandidates.map((agent) => agent._id);
-
-    logger.debug(
-      `[ServerConfigsDB.getAll] resolving access for ${userId ?? 'public'}; ${candidateIds.length} agent candidate(s) reference MCP servers`,
+    /** The agent-side ACL needs only candidates and principals; chaining it
+     *  from those keeps the independent direct-server path off its critical
+     *  path, and the outer settlement attaches handlers to everything else. */
+    const agentAccessPromise = Promise.all([candidatesPromise, principalsResolved]).then(
+      ([agentCandidates, principalsList]) =>
+        this.findAccessibleAgentIds(
+          agentCandidates.map((agent) => agent._id),
+          userId,
+          principalsList,
+        ),
     );
 
-    /** The direct-server fetch depends only on the ids already resolved above,
-     *  so it runs concurrently with the agent ACL query and both settle
-     *  together. */
-    const [accessibleAgentIds, directResults] = await Promise.all([
-      this.findAccessibleAgentIds(candidateIds, userId, principalsList),
-      this._dbMethods.getListMCPServersByIds({
-        ids: directlyAccessibleMCPIds,
-      }),
+    const [agentCandidates, accessibleAgentIds, directResults] = await Promise.all([
+      candidatesPromise,
+      agentAccessPromise,
+      directResultsPromise,
     ]);
+
+    logger.debug(
+      `[ServerConfigsDB.getAll] resolving access for ${userId ?? 'public'}; ${agentCandidates.length} agent candidate(s) reference MCP servers`,
+    );
 
     const agentMCPServerNames = unionMCPServerNames(agentCandidates, accessibleAgentIds);
 

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -537,32 +537,37 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
    * @returns record of parsed configs
    */
   public async getAll(userId?: string, role?: string): Promise<Record<string, ParsedServerConfig>> {
-    /** The candidates query and principals resolution are independent, so they
-     *  start together; the ACL pair below then runs against both results. */
+    /** The candidate scan, principals resolution, and the public direct-server
+     *  ACL read are independent, so they all start together; awaiting them
+     *  through one Promise.all attaches rejection handlers to each as created. */
     const candidatesPromise = this._dbMethods.getAgentsWithMCPServerNames();
-    const principalsPromise = userId
+    const principalsPromise: Promise<ResolvedPrincipal[]> | undefined = userId
       ? this._aclService.getUserPrincipals({ userId, role })
       : undefined;
+    const publicDirectIdsPromise = userId
+      ? undefined
+      : this._aclService.findPubliclyAccessibleResources({
+          resourceType: ResourceType.MCPSERVER,
+          requiredPermissions: PermissionBits.VIEW,
+        });
 
-    const agentCandidates = await candidatesPromise;
+    const [agentCandidates, principalsList] = await Promise.all([
+      candidatesPromise,
+      principalsPromise ?? Promise.resolve([]),
+    ]);
     const candidateIds = agentCandidates.map((agent) => agent._id);
-    const principalsList = (await principalsPromise) ?? [];
 
     logger.debug(
       `[ServerConfigsDB.getAll] resolving access for ${userId ?? 'public'}; ${candidateIds.length} agent candidate(s) reference MCP servers`,
     );
 
     const [directlyAccessibleMCPIds, accessibleAgentIds] = await Promise.all([
-      userId
-        ? this._aclService.findAccessibleResourcesForPrincipals({
-            principalsList,
-            requiredPermissions: PermissionBits.VIEW,
-            resourceType: ResourceType.MCPSERVER,
-          })
-        : this._aclService.findPubliclyAccessibleResources({
-            resourceType: ResourceType.MCPSERVER,
-            requiredPermissions: PermissionBits.VIEW,
-          }),
+      publicDirectIdsPromise ??
+        this._aclService.findAccessibleResourcesForPrincipals({
+          principalsList,
+          requiredPermissions: PermissionBits.VIEW,
+          resourceType: ResourceType.MCPSERVER,
+        }),
       this.findAccessibleAgentIds(candidateIds, userId, principalsList),
     ]);
 

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -537,23 +537,32 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
    * @returns record of parsed configs
    */
   public async getAll(userId?: string, role?: string): Promise<Record<string, ParsedServerConfig>> {
-    /** The candidate scan, principals resolution, and the public direct-server
-     *  ACL read are independent, so they all start together; awaiting them
-     *  through one Promise.all attaches rejection handlers to each as created. */
     const candidatesPromise = this._dbMethods.getAgentsWithMCPServerNames();
     const principalsPromise: Promise<ResolvedPrincipal[]> | undefined = userId
       ? this._aclService.getUserPrincipals({ userId, role })
       : undefined;
-    const publicDirectIdsPromise = userId
-      ? undefined
+    /** Direct-server ids depend on principals only for the user path; chaining
+     *  off the principals promise attaches a rejection handler at creation for
+     *  both branches, and the public branch starts immediately. */
+    const directIdsPromise: Promise<Types.ObjectId[]> = principalsPromise
+      ? principalsPromise.then((principalsList) =>
+          this._aclService.findAccessibleResourcesForPrincipals({
+            principalsList,
+            requiredPermissions: PermissionBits.VIEW,
+            resourceType: ResourceType.MCPSERVER,
+          }),
+        )
       : this._aclService.findPubliclyAccessibleResources({
           resourceType: ResourceType.MCPSERVER,
           requiredPermissions: PermissionBits.VIEW,
         });
 
-    const [agentCandidates, principalsList] = await Promise.all([
+    /** One settlement for the three started reads, so none of their rejections
+     *  can surface as unhandled. */
+    const [agentCandidates, principalsList, directlyAccessibleMCPIds] = await Promise.all([
       candidatesPromise,
       principalsPromise ?? Promise.resolve([]),
+      directIdsPromise,
     ]);
     const candidateIds = agentCandidates.map((agent) => agent._id);
 
@@ -561,15 +570,11 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
       `[ServerConfigsDB.getAll] resolving access for ${userId ?? 'public'}; ${candidateIds.length} agent candidate(s) reference MCP servers`,
     );
 
-    const [directlyAccessibleMCPIds, accessibleAgentIds] = await Promise.all([
-      publicDirectIdsPromise ??
-        this._aclService.findAccessibleResourcesForPrincipals({
-          principalsList,
-          requiredPermissions: PermissionBits.VIEW,
-          resourceType: ResourceType.MCPSERVER,
-        }),
-      this.findAccessibleAgentIds(candidateIds, userId, principalsList),
-    ]);
+    const accessibleAgentIds = await this.findAccessibleAgentIds(
+      candidateIds,
+      userId,
+      principalsList,
+    );
 
     const agentMCPServerNames = unionMCPServerNames(agentCandidates, accessibleAgentIds);
     const directResults = await this._dbMethods.getListMCPServersByIds({

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -6,10 +6,11 @@ import {
   PrincipalType,
   PermissionBits,
 } from 'librechat-data-provider';
-import type { AllMethods, MCPServerDocument } from '@librechat/data-schemas';
+import type { AllMethods, MCPServerDocument, IAgent } from '@librechat/data-schemas';
 
 import type { IServerConfigsRepositoryInterface } from '~/mcp/registry/ServerConfigsRepositoryInterface';
 import type { ParsedServerConfig, AddServerResult } from '~/mcp/types';
+import type { ResolvedPrincipal } from '~/types/principal';
 import { MCPOAuthSecretReentryRequiredError } from '~/mcp/errors';
 import { AccessControlService } from '~/acl/accessControlService';
 
@@ -201,6 +202,27 @@ function getChangedOAuthSecretBindingFields(
   return fields.filter(([, existing, updated]) => existing !== updated).map(([field]) => field);
 }
 
+/** Unions `mcpServerNames` over the candidate agents the caller can access. */
+function unionMCPServerNames(
+  candidates: Array<Pick<IAgent, '_id' | 'mcpServerNames'>>,
+  accessibleAgentIds: Types.ObjectId[],
+): string[] {
+  if (accessibleAgentIds.length === 0) {
+    return [];
+  }
+  const accessible = new Set(accessibleAgentIds.map((id) => id.toString()));
+  const serverNames = new Set<string>();
+  for (const agent of candidates) {
+    if (!accessible.has(agent._id.toString())) {
+      continue;
+    }
+    for (const serverName of agent.mcpServerNames ?? []) {
+      serverNames.add(serverName);
+    }
+  }
+  return Array.from(serverNames);
+}
+
 /**
  * DB backed config storage
  * Handles CRUD Methods of dynamic mcp servers
@@ -220,36 +242,33 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
 
   /**
    * Checks if user has access to an MCP server via an agent they can VIEW.
+   * Starts from the agents that reference `serverName` (typically few, and an
+   * index-covered lookup) and bounds the ACL query to those ids, instead of
+   * materializing every accessible agent and scanning it (#14016).
    * @param serverName - The MCP server name to check
    * @param userId - The user ID (optional - if not provided, checks publicly accessible agents)
    * @returns true if user has VIEW access to at least one agent that has this MCP server
    */
   private async hasAccessViaAgent(serverName: string, userId?: string): Promise<boolean> {
-    let accessibleAgentIds: Types.ObjectId[];
-
-    if (!userId) {
-      /** Publicly accessible agents */
-      accessibleAgentIds = await this._aclService.findPubliclyAccessibleResources({
-        resourceType: ResourceType.AGENT,
-        requiredPermissions: PermissionBits.VIEW,
-      });
-    } else {
-      /** User-accessible agents */
-      accessibleAgentIds = await this._aclService.findAccessibleResources({
-        userId,
-        requiredPermissions: PermissionBits.VIEW,
-        resourceType: ResourceType.AGENT,
-      });
-    }
-
-    if (accessibleAgentIds.length === 0) {
+    const candidateIds = await this._dbMethods.getAgentIdsByMCPServerName(serverName);
+    if (candidateIds.length === 0) {
       return false;
     }
 
-    return await this._dbMethods.hasAgentWithMCPServerName({
-      agentIds: accessibleAgentIds,
-      serverName,
-    });
+    const accessibleAgentIds = userId
+      ? await this._aclService.findAccessibleResources({
+          userId,
+          requiredPermissions: PermissionBits.VIEW,
+          resourceType: ResourceType.AGENT,
+          resourceIds: candidateIds,
+        })
+      : await this._aclService.findPubliclyAccessibleResources({
+          resourceType: ResourceType.AGENT,
+          requiredPermissions: PermissionBits.VIEW,
+          resourceIds: candidateIds,
+        });
+
+    return accessibleAgentIds.length > 0;
   }
 
   /**
@@ -485,56 +504,72 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
   }
 
   /**
+   * Agent-side access resolution bounded to the MCP-referencing candidate ids,
+   * so the ACL query cost scales with agents that use MCP servers instead of
+   * every accessible agent (#14016).
+   */
+  private findAccessibleAgentIds(
+    candidateIds: Types.ObjectId[],
+    userId?: string,
+    principalsList: ResolvedPrincipal[] = [],
+  ): Promise<Types.ObjectId[]> {
+    if (candidateIds.length === 0) {
+      return Promise.resolve([]);
+    }
+    if (userId) {
+      return this._aclService.findAccessibleResourcesForPrincipals({
+        principalsList,
+        requiredPermissions: PermissionBits.VIEW,
+        resourceType: ResourceType.AGENT,
+        resourceIds: candidateIds,
+      });
+    }
+    return this._aclService.findPubliclyAccessibleResources({
+      resourceType: ResourceType.AGENT,
+      requiredPermissions: PermissionBits.VIEW,
+      resourceIds: candidateIds,
+    });
+  }
+
+  /**
    * Return all DB stored configs (scoped by user Id if provided)
    * @param userId optional user id. if not provided only publicly shared mcp configs will be returned
    * @returns record of parsed configs
    */
   public async getAll(userId?: string, role?: string): Promise<Record<string, ParsedServerConfig>> {
-    let directlyAccessibleMCPIds: Types.ObjectId[] = [];
-    let accessibleAgentIds: Types.ObjectId[] = [];
+    /** The candidates query and principals resolution are independent, so they
+     *  start together; the ACL pair below then runs against both results. */
+    const candidatesPromise = this._dbMethods.getAgentsWithMCPServerNames();
+    const principalsPromise = userId
+      ? this._aclService.getUserPrincipals({ userId, role })
+      : undefined;
 
-    if (!userId) {
-      logger.debug(`[ServerConfigsDB.getAll] fetching all publicly shared mcp servers`);
-      [directlyAccessibleMCPIds, accessibleAgentIds] = await Promise.all([
-        this._aclService.findPubliclyAccessibleResources({
-          resourceType: ResourceType.MCPSERVER,
-          requiredPermissions: PermissionBits.VIEW,
-        }),
-        this._aclService.findPubliclyAccessibleResources({
-          resourceType: ResourceType.AGENT,
-          requiredPermissions: PermissionBits.VIEW,
-        }),
-      ]);
-    } else {
-      logger.debug(
-        `[ServerConfigsDB.getAll] fetching mcp servers directly shared with the user with ID: ${userId}`,
-      );
-      const principalsList = await this._aclService.getUserPrincipals({ userId, role });
-      [directlyAccessibleMCPIds, accessibleAgentIds] = await Promise.all([
-        this._aclService.findAccessibleResourcesForPrincipals({
-          principalsList,
-          requiredPermissions: PermissionBits.VIEW,
-          resourceType: ResourceType.MCPSERVER,
-        }),
-        this._aclService.findAccessibleResourcesForPrincipals({
-          principalsList,
-          requiredPermissions: PermissionBits.VIEW,
-          resourceType: ResourceType.AGENT,
-        }),
-      ]);
-    }
+    const agentCandidates = await candidatesPromise;
+    const candidateIds = agentCandidates.map((agent) => agent._id);
+    const principalsList = (await principalsPromise) ?? [];
 
-    const agentMCPServerNamesPromise: Promise<string[]> =
-      accessibleAgentIds.length > 0
-        ? this._dbMethods.getMCPServerNamesByAgentIds(accessibleAgentIds)
-        : Promise.resolve([]);
-    const directResultsPromise = this._dbMethods.getListMCPServersByIds({
+    logger.debug(
+      `[ServerConfigsDB.getAll] resolving access for ${userId ?? 'public'}; ${candidateIds.length} agent candidate(s) reference MCP servers`,
+    );
+
+    const [directlyAccessibleMCPIds, accessibleAgentIds] = await Promise.all([
+      userId
+        ? this._aclService.findAccessibleResourcesForPrincipals({
+            principalsList,
+            requiredPermissions: PermissionBits.VIEW,
+            resourceType: ResourceType.MCPSERVER,
+          })
+        : this._aclService.findPubliclyAccessibleResources({
+            resourceType: ResourceType.MCPSERVER,
+            requiredPermissions: PermissionBits.VIEW,
+          }),
+      this.findAccessibleAgentIds(candidateIds, userId, principalsList),
+    ]);
+
+    const agentMCPServerNames = unionMCPServerNames(agentCandidates, accessibleAgentIds);
+    const directResults = await this._dbMethods.getListMCPServersByIds({
       ids: directlyAccessibleMCPIds,
     });
-    const [agentMCPServerNames, directResults] = await Promise.all([
-      agentMCPServerNamesPromise,
-      directResultsPromise,
-    ]);
 
     const parsedConfigs: Record<string, ParsedServerConfig> = {};
     const directData = directResults.data || [];

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -570,16 +570,17 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
       `[ServerConfigsDB.getAll] resolving access for ${userId ?? 'public'}; ${candidateIds.length} agent candidate(s) reference MCP servers`,
     );
 
-    const accessibleAgentIds = await this.findAccessibleAgentIds(
-      candidateIds,
-      userId,
-      principalsList,
-    );
+    /** The direct-server fetch depends only on the ids already resolved above,
+     *  so it runs concurrently with the agent ACL query and both settle
+     *  together. */
+    const [accessibleAgentIds, directResults] = await Promise.all([
+      this.findAccessibleAgentIds(candidateIds, userId, principalsList),
+      this._dbMethods.getListMCPServersByIds({
+        ids: directlyAccessibleMCPIds,
+      }),
+    ]);
 
     const agentMCPServerNames = unionMCPServerNames(agentCandidates, accessibleAgentIds);
-    const directResults = await this._dbMethods.getListMCPServersByIds({
-      ids: directlyAccessibleMCPIds,
-    });
 
     const parsedConfigs: Record<string, ParsedServerConfig> = {};
     const directData = directResults.data || [];

--- a/packages/data-schemas/src/methods/aclEntry.spec.ts
+++ b/packages/data-schemas/src/methods/aclEntry.spec.ts
@@ -1411,6 +1411,68 @@ describe('AclEntry Model Tests', () => {
         expect(result).toHaveLength(1);
         expect(result[0].toString()).toBe(viewEdit.toString());
       });
+
+      describe('resourceIds bound', () => {
+        const otherResource = new mongoose.Types.ObjectId();
+        beforeEach(async () => {
+          await methods.grantPermission(
+            PrincipalType.USER,
+            userId,
+            ResourceType.AGENT,
+            resourceId,
+            PermissionBits.VIEW,
+            grantedById,
+          );
+          await methods.grantPermission(
+            PrincipalType.USER,
+            userId,
+            ResourceType.AGENT,
+            otherResource,
+            PermissionBits.VIEW,
+            grantedById,
+          );
+        });
+
+        test('intersects access with the bound candidate ids only', async () => {
+          const result = await methods.findAccessibleResources(
+            [{ principalType: PrincipalType.USER, principalId: userId }],
+            ResourceType.AGENT,
+            PermissionBits.VIEW,
+            [resourceId, new mongoose.Types.ObjectId()],
+          );
+          expect(result).toHaveLength(1);
+          expect(result[0].toString()).toBe(resourceId.toString());
+        });
+
+        test('returns nothing when every accessible resource is outside the bound', async () => {
+          const result = await methods.findAccessibleResources(
+            [{ principalType: PrincipalType.USER, principalId: userId }],
+            ResourceType.AGENT,
+            PermissionBits.VIEW,
+            [new mongoose.Types.ObjectId()],
+          );
+          expect(result).toHaveLength(0);
+        });
+
+        test('an empty bound matches nothing rather than lifting the filter', async () => {
+          const result = await methods.findAccessibleResources(
+            [{ principalType: PrincipalType.USER, principalId: userId }],
+            ResourceType.AGENT,
+            PermissionBits.VIEW,
+            [],
+          );
+          expect(result).toHaveLength(0);
+        });
+
+        test('an unbound call still returns every accessible resource', async () => {
+          const result = await methods.findAccessibleResources(
+            [{ principalType: PrincipalType.USER, principalId: userId }],
+            ResourceType.AGENT,
+            PermissionBits.VIEW,
+          );
+          expect(result).toHaveLength(2);
+        });
+      });
     });
 
     describe('findPublicResourceIds', () => {
@@ -1431,6 +1493,42 @@ describe('AclEntry Model Tests', () => {
         );
         expect(result).toHaveLength(1);
         expect(result[0].toString()).toBe(shared.toString());
+      });
+
+      test('with resourceIds bound, intersects public access with the candidate ids', async () => {
+        const shared = new mongoose.Types.ObjectId();
+        const unreachable = new mongoose.Types.ObjectId();
+        await methods.grantPermission(
+          PrincipalType.PUBLIC,
+          null,
+          ResourceType.AGENT,
+          shared,
+          PermissionBits.VIEW,
+          grantedById,
+        );
+        await methods.grantPermission(
+          PrincipalType.PUBLIC,
+          null,
+          ResourceType.AGENT,
+          unreachable,
+          PermissionBits.VIEW,
+          grantedById,
+        );
+
+        const result = await methods.findPublicResourceIds(
+          ResourceType.AGENT,
+          PermissionBits.VIEW,
+          [shared, new mongoose.Types.ObjectId()],
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0].toString()).toBe(shared.toString());
+
+        const emptyBound = await methods.findPublicResourceIds(
+          ResourceType.AGENT,
+          PermissionBits.VIEW,
+          [],
+        );
+        expect(emptyBound).toHaveLength(0);
       });
 
       test('deduplicates when duplicate public entries exist for the same resource', async () => {

--- a/packages/data-schemas/src/methods/aclEntry.ts
+++ b/packages/data-schemas/src/methods/aclEntry.ts
@@ -138,6 +138,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
     principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
     resourceType: string,
     requiredPermBit: number,
+    resourceIds?: Types.ObjectId[],
   ) => Promise<Types.ObjectId[]>;
   deleteAclEntries: (
     filter: Record<string, unknown>,
@@ -150,6 +151,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
   findPublicResourceIds: (
     resourceType: string,
     requiredPermissions: number,
+    resourceIds?: Types.ObjectId[],
   ) => Promise<Types.ObjectId[]>;
   aggregateAclEntries: (pipeline: PipelineStage[]) => Promise<unknown[]>;
   getSoleOwnedResourceIds: (
@@ -486,12 +488,17 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
    * @param principalsList - List of principals, each containing { principalType, principalId }
    * @param resourceType - The type of resource
    * @param requiredPermBit - Required permission bit (use PermissionBits enum)
+   * @param resourceIds - Optional candidate bound. When provided, only these
+   *   resources are considered, so the query cost scales with the candidate set
+   *   instead of every accessible resource of the type. An empty array matches
+   *   nothing rather than lifting the bound.
    * @returns Array of resource IDs
    */
   async function findAccessibleResources(
     principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
     resourceType: string,
     requiredPermBit: number,
+    resourceIds?: Types.ObjectId[],
   ): Promise<Types.ObjectId[]> {
     const AclEntry = mongoose.models.AclEntry as Model<IAclEntry>;
     const principalsQuery = principalsList.map((p) => ({
@@ -501,6 +508,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
 
     return await AclEntry.find({
       $or: principalsQuery,
+      ...(resourceIds !== undefined && { resourceId: { $in: resourceIds } }),
       resourceType,
       permBits: { $in: permissionBitSupersets(requiredPermBit) },
     }).distinct('resourceId');
@@ -537,14 +545,17 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
    * See {@link permissionBitSupersets} for the Cosmos-compatible bit filter.
    * @param resourceType - The type of resource
    * @param requiredPermissions - Required permission bits
+   * @param resourceIds - Optional candidate bound; see {@link findAccessibleResources}
    */
   async function findPublicResourceIds(
     resourceType: string,
     requiredPermissions: number,
+    resourceIds?: Types.ObjectId[],
   ): Promise<Types.ObjectId[]> {
     const AclEntry = mongoose.models.AclEntry as Model<IAclEntry>;
     return await AclEntry.find({
       principalType: PrincipalType.PUBLIC,
+      ...(resourceIds !== undefined && { resourceId: { $in: resourceIds } }),
       resourceType,
       permBits: { $in: permissionBitSupersets(requiredPermissions) },
     }).distinct('resourceId');

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -550,6 +550,93 @@ describe('Agent Methods', () => {
       expect(newAgent.mcpServerNames).toEqual(['authorizedServer']);
     });
 
+    describe('MCP server name candidate lookups', () => {
+      test('getAgentsWithMCPServerNames returns only agents with a non-empty list, projected', async () => {
+        const { agentId, authorId } = createTestIds();
+        await createAgent({
+          id: agentId,
+          name: 'MCP Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+          mcpServerNames: ['server-a', 'server-b'],
+        });
+        await createAgent({
+          id: `no-mcp-${agentId}`,
+          name: 'Plain Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+        });
+
+        const candidates = await methods.getAgentsWithMCPServerNames();
+
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0].mcpServerNames).toEqual(['server-a', 'server-b']);
+        expect(Object.keys(candidates[0]).sort()).toEqual(['_id', 'mcpServerNames']);
+      });
+
+      test('getAgentsWithMCPServerNames returns empty when no agent references MCP servers', async () => {
+        const { agentId, authorId } = createTestIds();
+        await createAgent({
+          id: agentId,
+          name: 'Plain Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+        });
+
+        expect(await methods.getAgentsWithMCPServerNames()).toEqual([]);
+      });
+
+      test('getAgentIdsByMCPServerName returns ids of agents referencing the server', async () => {
+        const { agentId, authorId } = createTestIds();
+        const withServer = await createAgent({
+          id: agentId,
+          name: 'Gitlab Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+          mcpServerNames: ['gitlab', 'other'],
+        });
+        await createAgent({
+          id: `second-${agentId}`,
+          name: 'Second Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+          mcpServerNames: ['gitlab'],
+        });
+        await createAgent({
+          id: `unrelated-${agentId}`,
+          name: 'Unrelated Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+          mcpServerNames: ['not-gitlab'],
+        });
+
+        const ids = (await methods.getAgentIdsByMCPServerName('gitlab')).map((id) => id.toString());
+
+        expect(ids).toHaveLength(2);
+        expect(ids).toContain(withServer._id.toString());
+      });
+
+      test('getAgentIdsByMCPServerName returns empty when no agent references the server', async () => {
+        const { agentId, authorId } = createTestIds();
+        await createAgent({
+          id: agentId,
+          name: 'Agent',
+          provider: 'test',
+          model: 'test-model',
+          author: authorId,
+          mcpServerNames: ['other-server'],
+        });
+
+        expect(await methods.getAgentIdsByMCPServerName('gitlab')).toEqual([]);
+      });
+    });
+
     test('should derive the server from a key whose raw tool name contains the delimiter', async () => {
       const { agentId, authorId } = createTestIds();
       /** DB server names are slugs and cannot contain the delimiter, so the trailing

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -20,6 +20,7 @@ import type {
 } from 'mongoose';
 import type { IAgent, IAclEntry, IUser, IAccessRole } from '..';
 import { createAgentMethods, type AgentMethods } from './agent';
+import { tenantStorage } from '~/config/tenantContext';
 import { createAclEntryMethods } from './aclEntry';
 import { createModels } from '~/models';
 
@@ -587,6 +588,42 @@ describe('Agent Methods', () => {
         });
 
         expect(await methods.getAgentsWithMCPServerNames()).toEqual([]);
+      });
+
+      test('getAgentsWithMCPServerNames stays within the active tenant', async () => {
+        const tenantA = `tenant-a-${uuidv4()}`;
+        const tenantB = `tenant-b-${uuidv4()}`;
+        const { agentId, authorId } = createTestIds();
+        const agentA = await tenantStorage.run({ tenantId: tenantA }, async () =>
+          createAgent({
+            id: agentId,
+            name: 'Tenant A MCP Agent',
+            provider: 'test',
+            model: 'test-model',
+            author: authorId,
+            mcpServerNames: ['server-a'],
+          }),
+        );
+        const agentB = await tenantStorage.run({ tenantId: tenantB }, async () =>
+          createAgent({
+            id: agentId,
+            name: 'Tenant B MCP Agent',
+            provider: 'test',
+            model: 'test-model',
+            author: authorId,
+            mcpServerNames: ['server-b'],
+          }),
+        );
+
+        const inA = await tenantStorage.run({ tenantId: tenantA }, () =>
+          methods.getAgentsWithMCPServerNames(),
+        );
+        const inB = await tenantStorage.run({ tenantId: tenantB }, () =>
+          methods.getAgentsWithMCPServerNames(),
+        );
+
+        expect(inA.map((agent) => agent._id.toString())).toEqual([agentA._id.toString()]);
+        expect(inB.map((agent) => agent._id.toString())).toEqual([agentB._id.toString()]);
       });
 
       test('getAgentIdsByMCPServerName returns ids of agents referencing the server', async () => {

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -447,14 +447,8 @@ export function createAgentMethods(
   ) => Promise<(IAgent & { version: number }) | null>;
   getAgents: (searchParameter: FilterQuery<IAgent>) => Promise<IAgent[]>;
   createAgent: (agentData: Record<string, unknown>) => Promise<IAgent>;
-  hasAgentWithMCPServerName: ({
-    agentIds,
-    serverName,
-  }: {
-    agentIds: Types.ObjectId[];
-    serverName: string;
-  }) => Promise<boolean>;
-  getMCPServerNamesByAgentIds: (agentIds: Types.ObjectId[]) => Promise<string[]>;
+  getAgentIdsByMCPServerName: (serverName: string) => Promise<Types.ObjectId[]>;
+  getAgentsWithMCPServerNames: () => Promise<Array<Pick<IAgent, '_id' | 'mcpServerNames'>>>;
   updateAgent: (
     searchParameter: FilterQuery<IAgent>,
     updateData: Record<string, unknown>,
@@ -609,48 +603,27 @@ export function createAgentMethods(
     return await Agent.find(searchParameter).lean<IAgent[]>();
   }
 
-  async function hasAgentWithMCPServerName({
-    agentIds,
-    serverName,
-  }: {
-    agentIds: Types.ObjectId[];
-    serverName: string;
-  }): Promise<boolean> {
-    if (agentIds.length === 0) {
-      return false;
-    }
-
+  /** Returns the ids of every agent referencing `serverName`, the candidate set
+   *  for agent-mediated MCP access checks. Index-covered by `mcpServerNames`. */
+  async function getAgentIdsByMCPServerName(serverName: string): Promise<Types.ObjectId[]> {
     const Agent = mongoose.models.Agent as Model<IAgent>;
-    const agent = await Agent.exists({
-      _id: { $in: agentIds },
-      mcpServerNames: serverName,
-    });
-
-    return agent !== null;
+    const agents = await Agent.find({ mcpServerNames: serverName }, { _id: 1 }).lean<
+      Array<Pick<IAgent, '_id'>>
+    >();
+    return agents.map((agent) => agent._id);
   }
 
-  async function getMCPServerNamesByAgentIds(agentIds: Types.ObjectId[]): Promise<string[]> {
-    if (agentIds.length === 0) {
-      return [];
-    }
-
+  /** Returns every agent with a non-empty `mcpServerNames`, so access
+   *  calculations can start from the (typically small) set of agents that
+   *  actually reference MCP servers instead of every accessible agent. */
+  async function getAgentsWithMCPServerNames(): Promise<
+    Array<Pick<IAgent, '_id' | 'mcpServerNames'>>
+  > {
     const Agent = mongoose.models.Agent as Model<IAgent>;
-    const agents = await Agent.find(
-      {
-        _id: { $in: agentIds },
-        mcpServerNames: { $exists: true, $not: { $size: 0 } },
-      },
+    return await Agent.find(
+      { mcpServerNames: { $exists: true, $not: { $size: 0 } } },
       { mcpServerNames: 1 },
-    ).lean<Array<Pick<IAgent, 'mcpServerNames'>>>();
-
-    const serverNames = new Set<string>();
-    for (const agent of agents) {
-      for (const serverName of agent.mcpServerNames ?? []) {
-        serverNames.add(serverName);
-      }
-    }
-
-    return Array.from(serverNames);
+    ).lean<Array<Pick<IAgent, '_id' | 'mcpServerNames'>>>();
   }
 
   /**
@@ -1264,8 +1237,8 @@ export function createAgentMethods(
     getAgentWithVersionCount,
     getAgents,
     createAgent,
-    hasAgentWithMCPServerName,
-    getMCPServerNamesByAgentIds,
+    getAgentIdsByMCPServerName,
+    getAgentsWithMCPServerNames,
     updateAgent,
     deleteAgent,
     deleteUserAgents,

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -620,10 +620,9 @@ export function createAgentMethods(
     Array<Pick<IAgent, '_id' | 'mcpServerNames'>>
   > {
     const Agent = mongoose.models.Agent as Model<IAgent>;
-    return await Agent.find(
-      { mcpServerNames: { $exists: true, $not: { $size: 0 } } },
-      { mcpServerNames: 1 },
-    ).lean<Array<Pick<IAgent, '_id' | 'mcpServerNames'>>>();
+    return await Agent.find({ mcpServerNames: { $type: 'string' } }, { mcpServerNames: 1 }).lean<
+      Array<Pick<IAgent, '_id' | 'mcpServerNames'>>
+    >();
   }
 
   /**


### PR DESCRIPTION
## Summary

`GET /api/mcp/servers` resolves MCP access by starting from the full set of agents a user can VIEW. In deployments where one user can access 400+ agents but only a few reference MCP servers, the agent-side ACL `distinct` materialized every accessible agent id and then shipped the whole list back as an `$in` filter to fetch `mcpServerNames`, so the cost scaled with accessible agents rather than with agents that actually use MCP servers (#14016). On top of that, the registry's per-user read-through cache was a process-local Keyv, so every container recomputed access and invalidation never crossed instances.

Two changes:

- **Candidate-first agent scan.** `ServerConfigsDB.getAll` and `hasAccessViaAgent` now start from the agents whose `mcpServerNames` array is non-empty (covered by the existing `mcpServerNames_1_tenantId_1` index) and bound the ACL query to those candidate ids via a new optional `resourceIds` filter on `findAccessibleResources`/`findPublicResourceIds` (and the `AccessControlService` pass-throughs). When no agent references any MCP server, the agent-side ACL query is skipped entirely, and a server referenced by no agent skips the per-server check without touching ACL at all. The union of accessible `mcpServerNames` is now computed in memory from the candidates instead of a second Mongo pass over a giant `$in`. The old full-scan helpers (`hasAgentWithMCPServerName`, `getMCPServerNamesByAgentIds`) are removed; nothing else referenced them.
- **Shared, Redis-backed read-through cache.** The registry's `readThroughCacheAll` is now backed by `standardCache`, so the resolved per-user server map lives in Redis when `USE_REDIS=true` and in process memory otherwise. Invalidation swaps a generation tag (fresh UUID) instead of clearing the keyspace, so it is O(1) with no SCAN, following the same lesson as the aggregate-key cache work for #11624/#12408. A process-local memo absorbs repeated reads within the TTL window, keeping the many per-request `getAllServerConfigs` calls off the network; cross-instance worst-case staleness stays bounded by `MCP_REGISTRY_CACHE_TTL` (the same documented 2x TTL trade-off). The per-server `readThroughCache` also moves to `standardCache`, keeping its targeted O(1) deletes.

The access-control semantics are unchanged: the bounded query returns exactly the intersection the unbounded query produced, which the existing `getAll`/`get` suites plus the new intersection tests pin down.

## Change Type

- [x] Performance improvement (non-breaking change which improves efficiency)

## Testing

All suites run against real `mongodb-memory-server` instances and, for cache integration, a local Redis on `127.0.0.1:6379`; the ACL tests exercise real `AclEntry` queries, no permission-layer mocks.

New tests:

- `packages/data-schemas`: `findAccessibleResources`/`findPublicResourceIds` with a `resourceIds` bound (intersection, outside-bound, empty bound matches nothing, unbound unchanged); `getAgentsWithMCPServerNames` (non-empty only, projection) and `getAgentIdsByMCPServerName`.
- `packages/api`: `ServerConfigsDB.getAll` pins the agent-side `AclEntry.find` filter to `resourceId: { $in: <candidate ids> }` with a spy over the real query, and asserts no agent-side ACL query fires when no agent references MCP servers; `ReadThroughAllCache` unit tests (memo, TTL, generation orphaning across instances) and Redis integration tests (cross-instance sharing, invalidation orphans entries for the other instance, per-user keys present in Redis).

Commands run:

- `cd packages/data-schemas && npx jest src/methods/agent.spec.ts src/methods/aclEntry.spec.ts` (229 passed), `npx jest src/methods/aclEntry.parity.spec.ts src/methods/aclEntry.tenant.spec.ts` (16 passed)
- `cd packages/api && npx jest src/mcp/registry/` (262 passed; the 3 failing suites in that tree, `MCPReinitRecovery.integration`, `ServerConfigsCacheRedis.cache_integration`, `ServerConfigsCacheRedisAggregateKey.cache_integration`, fail identically on a pristine checkout due to a pre-existing babel parse error, unrelated to this change), `npx jest src/acl/` (60 passed), `npx jest src/mcp/assistants.spec.ts src/mcp/tools.spec.ts src/mcp/toolsChanged.spec.ts` (48 passed), `npx tsc --noEmit -p tsconfig.spec.json` (clean)
- `cd api && npx jest server/routes/__tests__/mcp.spec.js` (137 passed), `npx jest server/controllers/__tests__/mcp.servers.spec.js` (17 passed), `npx jest server/services/MCP.spec.js server/services/PermissionService.spec.js server/controllers/__tests__/PermissionsController.spec.js server/controllers/agents/filterAuthorizedTools.spec.js` (196 passed), `npx jest server/controllers/agents/v1.spec.js server/controllers/agents/__tests__/openai.spec.js server/controllers/agents/__tests__/responses.unit.spec.js server/controllers/agents/__tests__/v1.duplicate-actions.spec.js` (159 passed)
- `npx eslint` on every touched file (clean)

### **Test Configuration**:

- Node.js v24, Jest with `mongodb-memory-server`; Redis 7 on `127.0.0.1:6379` for the `.cache_integration` suites; no other external services.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
