### PR TITLE
⚡ perf: Avoid Parallel Full and Paged Prompt Loading on Startup

### DIFF
--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -11,7 +11,7 @@ const {
   registerShutdownTask,
 } = require('@librechat/api');
 
-/** No-op store registered when the user principals cache is disabled (TTL of 0). */
+/** No-op store for cache namespaces that are deliberately disabled. */
 const disabledCache = {
   get: async () => undefined,
   set: async () => undefined,
@@ -46,6 +46,8 @@ const namespaces = {
 
   [CacheKeys.ROLES]: standardCache(CacheKeys.ROLES),
   [CacheKeys.USER_PRINCIPALS]: userPrincipalsCache() ?? disabledCache,
+  /** Authorization IDs stay uncached because a failed shared invalidation cannot fail closed. */
+  [CacheKeys.PROMPT_GROUPS_ACCESS]: disabledCache,
   [CacheKeys.APP_CONFIG]: standardCache(CacheKeys.APP_CONFIG),
   [CacheKeys.CONFIG_STORE]: standardCache(CacheKeys.CONFIG_STORE),
   [CacheKeys.TOOL_CACHE]: standardCache(CacheKeys.TOOL_CACHE),

--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -46,6 +46,10 @@ const namespaces = {
 
   [CacheKeys.ROLES]: standardCache(CacheKeys.ROLES),
   [CacheKeys.USER_PRINCIPALS]: userPrincipalsCache() ?? disabledCache,
+  [CacheKeys.PROMPT_GROUPS_ACCESS]: standardCache(
+    CacheKeys.PROMPT_GROUPS_ACCESS,
+    Time.THIRTY_SECONDS,
+  ),
   [CacheKeys.APP_CONFIG]: standardCache(CacheKeys.APP_CONFIG),
   [CacheKeys.CONFIG_STORE]: standardCache(CacheKeys.CONFIG_STORE),
   [CacheKeys.TOOL_CACHE]: standardCache(CacheKeys.TOOL_CACHE),

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -30,6 +30,7 @@ const handlers = createAdminRolesHandlers({
   deleteAclEntries: db.deleteAclEntries,
   deleteGrantsForPrincipal: db.deleteGrantsForPrincipal,
   recordAuditEntry: db.recordAuditEntry,
+  invalidatePromptGroupAccessContext: db.invalidatePromptGroupAccessContext,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/api/server/routes/prompts.js
+++ b/api/server/routes/prompts.js
@@ -26,7 +26,7 @@ const {
 const { SystemCapabilities } = require('@librechat/data-schemas');
 const {
   getListPromptGroupsByAccess,
-  getOwnedPromptGroupIds,
+  getPromptGroupAccessContext,
   incrementPromptGroupUsage,
   makePromptProduction,
   updatePromptGroup,
@@ -46,12 +46,7 @@ const {
   requireJwtAuth,
   configMiddleware,
 } = require('~/server/middleware');
-const {
-  findPubliclyAccessibleResources,
-  getEffectivePermissions,
-  findAccessibleResources,
-  grantPermission,
-} = require('~/server/services/PermissionService');
+const { getEffectivePermissions, grantPermission } = require('~/server/services/PermissionService');
 const { hasCapability } = require('~/server/middleware/roles/capabilities');
 
 const router = express.Router();
@@ -130,19 +125,8 @@ router.get('/all', configMiddleware, async (req, res) => {
       category,
     });
 
-    const [accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
-      findAccessibleResources({
-        userId,
-        role: req.user.role,
-        resourceType: ResourceType.PROMPTGROUP,
-        requiredPermissions: PermissionBits.VIEW,
-      }),
-      findPubliclyAccessibleResources({
-        resourceType: ResourceType.PROMPTGROUP,
-        requiredPermissions: PermissionBits.VIEW,
-      }),
-      getOwnedPromptGroupIds(userId),
-    ]);
+    const { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds } =
+      await getPromptGroupAccessContext({ userId, role: req.user.role });
 
     const filteredAccessibleIds = await filterAccessibleIdsBySharedLogic({
       accessibleIds,
@@ -208,19 +192,8 @@ router.get('/groups', configMiddleware, async (req, res) => {
       actualCursor = null;
     }
 
-    const [accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
-      findAccessibleResources({
-        userId,
-        role: req.user.role,
-        resourceType: ResourceType.PROMPTGROUP,
-        requiredPermissions: PermissionBits.VIEW,
-      }),
-      findPubliclyAccessibleResources({
-        resourceType: ResourceType.PROMPTGROUP,
-        requiredPermissions: PermissionBits.VIEW,
-      }),
-      getOwnedPromptGroupIds(userId),
-    ]);
+    const { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds } =
+      await getPromptGroupAccessContext({ userId, role: req.user.role });
 
     const filteredAccessibleIds = await filterAccessibleIdsBySharedLogic({
       accessibleIds,

--- a/api/server/routes/prompts.js
+++ b/api/server/routes/prompts.js
@@ -21,7 +21,7 @@ const {
 const { SystemCapabilities } = require('@librechat/data-schemas');
 const {
   getListPromptGroupsByAccess,
-  getOwnedPromptGroupIds,
+  getPromptGroupAccessContext,
   incrementPromptGroupUsage,
   makePromptProduction,
   updatePromptGroup,
@@ -40,12 +40,7 @@ const {
   promptUsageLimiter,
   requireJwtAuth,
 } = require('~/server/middleware');
-const {
-  findPubliclyAccessibleResources,
-  getEffectivePermissions,
-  findAccessibleResources,
-  grantPermission,
-} = require('~/server/services/PermissionService');
+const { getEffectivePermissions, grantPermission } = require('~/server/services/PermissionService');
 const { hasCapability } = require('~/server/middleware/roles/capabilities');
 
 const router = express.Router();
@@ -110,20 +105,8 @@ router.get('/all', async (req, res) => {
       category,
     });
 
-    let accessibleIds = await findAccessibleResources({
-      userId,
-      role: req.user.role,
-      resourceType: ResourceType.PROMPTGROUP,
-      requiredPermissions: PermissionBits.VIEW,
-    });
-
-    const [publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
-      findPubliclyAccessibleResources({
-        resourceType: ResourceType.PROMPTGROUP,
-        requiredPermissions: PermissionBits.VIEW,
-      }),
-      getOwnedPromptGroupIds(userId),
-    ]);
+    const { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds } =
+      await getPromptGroupAccessContext({ userId, role: req.user.role });
 
     const filteredAccessibleIds = await filterAccessibleIdsBySharedLogic({
       accessibleIds,
@@ -183,20 +166,8 @@ router.get('/groups', async (req, res) => {
       actualCursor = null;
     }
 
-    let accessibleIds = await findAccessibleResources({
-      userId,
-      role: req.user.role,
-      resourceType: ResourceType.PROMPTGROUP,
-      requiredPermissions: PermissionBits.VIEW,
-    });
-
-    const [publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
-      findPubliclyAccessibleResources({
-        resourceType: ResourceType.PROMPTGROUP,
-        requiredPermissions: PermissionBits.VIEW,
-      }),
-      getOwnedPromptGroupIds(userId),
-    ]);
+    const { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds } =
+      await getPromptGroupAccessContext({ userId, role: req.user.role });
 
     const filteredAccessibleIds = await filterAccessibleIdsBySharedLogic({
       accessibleIds,

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -5,6 +5,7 @@ const {
   tenantStorage,
   getTenantId,
   logger,
+  runAfterTransaction,
 } = require('@librechat/data-schemas');
 const { ResourceType, PrincipalType, PrincipalModel } = require('librechat-data-provider');
 const {
@@ -114,7 +115,7 @@ const grantPermission = async ({
         `Role ${accessRoleId} is for ${role.resourceType} resources, not ${resourceType}`,
       );
     }
-    return await db.grantPermission(
+    const result = await db.grantPermission(
       principalType,
       principalId,
       resourceType,
@@ -124,6 +125,12 @@ const grantPermission = async ({
       session,
       role._id,
     );
+    if (resourceType === ResourceType.PROMPTGROUP) {
+      /** A caller-owned session may not have committed yet; invalidating early
+       * would let a concurrent read re-cache pre-commit IDs under the new generation. */
+      await runAfterTransaction(session, () => db.invalidatePromptGroupAccessContext());
+    }
+    return result;
   } catch (error) {
     logger.error(`[PermissionService.grantPermission] Error: ${error.message}`);
     throw error;
@@ -928,6 +935,11 @@ const bulkUpdateResourcePermissions = async ({
       await localSession.commitTransaction();
     }
 
+    if (resourceType === ResourceType.PROMPTGROUP) {
+      /** The caller's session may still be uncommitted; defer until it commits */
+      await runAfterTransaction(localSession, () => db.invalidatePromptGroupAccessContext());
+    }
+
     return results;
   } catch (error) {
     if (shouldEndSession && supportsTransactions) {
@@ -969,6 +981,10 @@ const removeAllPermissions = async ({ resourceType, resourceId }) => {
       resourceType,
       resourceId,
     });
+
+    if (resourceType === ResourceType.PROMPTGROUP) {
+      await db.invalidatePromptGroupAccessContext();
+    }
 
     return result;
   } catch (error) {

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -5,6 +5,7 @@ const {
   tenantStorage,
   getTenantId,
   logger,
+  runAfterTransaction,
 } = require('@librechat/data-schemas');
 const { ResourceType, PrincipalType, PrincipalModel } = require('librechat-data-provider');
 const {
@@ -125,7 +126,9 @@ const grantPermission = async ({
       role._id,
     );
     if (resourceType === ResourceType.PROMPTGROUP) {
-      await db.invalidatePromptGroupAccessContext();
+      /** A caller-owned session may not have committed yet; invalidating early
+       * would let a concurrent read re-cache pre-commit IDs under the new generation. */
+      await runAfterTransaction(session, () => db.invalidatePromptGroupAccessContext());
     }
     return result;
   } catch (error) {
@@ -933,7 +936,8 @@ const bulkUpdateResourcePermissions = async ({
     }
 
     if (resourceType === ResourceType.PROMPTGROUP) {
-      await db.invalidatePromptGroupAccessContext();
+      /** The caller's session may still be uncommitted; defer until it ends */
+      await runAfterTransaction(localSession, () => db.invalidatePromptGroupAccessContext());
     }
 
     return results;

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -114,7 +114,7 @@ const grantPermission = async ({
         `Role ${accessRoleId} is for ${role.resourceType} resources, not ${resourceType}`,
       );
     }
-    return await db.grantPermission(
+    const result = await db.grantPermission(
       principalType,
       principalId,
       resourceType,
@@ -124,6 +124,10 @@ const grantPermission = async ({
       session,
       role._id,
     );
+    if (resourceType === ResourceType.PROMPTGROUP) {
+      await db.invalidatePromptGroupAccessContext();
+    }
+    return result;
   } catch (error) {
     logger.error(`[PermissionService.grantPermission] Error: ${error.message}`);
     throw error;
@@ -928,6 +932,10 @@ const bulkUpdateResourcePermissions = async ({
       await localSession.commitTransaction();
     }
 
+    if (resourceType === ResourceType.PROMPTGROUP) {
+      await db.invalidatePromptGroupAccessContext();
+    }
+
     return results;
   } catch (error) {
     if (shouldEndSession && supportsTransactions) {
@@ -969,6 +977,10 @@ const removeAllPermissions = async ({ resourceType, resourceId }) => {
       resourceType,
       resourceId,
     });
+
+    if (resourceType === ResourceType.PROMPTGROUP) {
+      await db.invalidatePromptGroupAccessContext();
+    }
 
     return result;
   } catch (error) {

--- a/client/src/Providers/PromptGroupsContext.tsx
+++ b/client/src/Providers/PromptGroupsContext.tsx
@@ -1,8 +1,8 @@
-import React, { createContext, useContext, ReactNode, useMemo } from 'react';
+import React, { createContext, useContext, ReactNode, useCallback, useMemo, useState } from 'react';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { TPromptGroup } from 'librechat-data-provider';
 import type { PromptOption } from '~/common';
-import { usePromptGroupsNav, useHasAccess, useCatalogReady } from '~/hooks';
+import { usePromptGroupsNav, useHasAccess, useCatalogReady, activateCatalog } from '~/hooks';
 import { useGetAllPromptGroups } from '~/data-provider';
 import { CategoryIcon } from '~/components/Prompts';
 import { mapPromptGroups } from '~/utils';
@@ -21,6 +21,8 @@ type PromptGroupsContextType =
         isLoading: boolean;
       };
       hasAccess: boolean;
+      /** Opts the full prompt list query in; it stays idle until first requested. */
+      requestAllPromptGroups: () => void;
     })
   | null;
 
@@ -37,8 +39,20 @@ export const PromptGroupsProvider = ({ children }: { children: ReactNode }) => {
   const promptsEnabled = hasAccess && promptsReady;
 
   const promptGroupsNav = usePromptGroupsNav(promptsEnabled);
+
+  /**
+   * The full prompt list only serves the `/` command popover, so its query stays
+   * idle until requested instead of racing the paginated sidebar query on startup.
+   * Requesting it also releases the catalog, for a popover opened before warmup.
+   */
+  const [allPromptsActive, setAllPromptsActive] = useState(false);
+  const requestAllPromptGroups = useCallback(() => {
+    activateCatalog('prompts');
+    setAllPromptsActive(true);
+  }, []);
+
   const { data: allGroupsData, isLoading: isLoadingAll } = useGetAllPromptGroups(undefined, {
-    enabled: promptsEnabled,
+    enabled: promptsEnabled && allPromptsActive,
     select: (data) => {
       const mappedArray: PromptOption[] = data.map((group) => ({
         id: group._id ?? '',
@@ -68,11 +82,21 @@ export const PromptGroupsProvider = ({ children }: { children: ReactNode }) => {
       ...promptGroupsNav,
       allPromptGroups: {
         data: hasAccess ? allGroupsData : undefined,
-        isLoading: hasAccess ? isLoadingAll : false,
+        /** A never-fetched disabled query reports `isLoading` in React Query v4 */
+        isLoading: promptsEnabled && allPromptsActive ? isLoadingAll : false,
       },
       hasAccess,
+      requestAllPromptGroups,
     }),
-    [promptGroupsNav, allGroupsData, isLoadingAll, hasAccess],
+    [
+      promptGroupsNav,
+      allGroupsData,
+      isLoadingAll,
+      hasAccess,
+      promptsEnabled,
+      allPromptsActive,
+      requestAllPromptGroups,
+    ],
   );
 
   return (

--- a/client/src/Providers/PromptGroupsContext.tsx
+++ b/client/src/Providers/PromptGroupsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode, useMemo } from 'react';
+import React, { createContext, useContext, ReactNode, useCallback, useMemo, useState } from 'react';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { TPromptGroup } from 'librechat-data-provider';
 import type { PromptOption } from '~/common';
@@ -21,6 +21,8 @@ type PromptGroupsContextType =
         isLoading: boolean;
       };
       hasAccess: boolean;
+      /** Opts the full prompt list query in; it stays idle until first requested. */
+      requestAllPromptGroups: () => void;
     })
   | null;
 
@@ -33,8 +35,16 @@ export const PromptGroupsProvider = ({ children }: { children: ReactNode }) => {
   });
 
   const promptGroupsNav = usePromptGroupsNav(hasAccess);
+
+  /**
+   * The full prompt list only serves the `/` command popover, so its query stays
+   * idle until requested instead of racing the paginated sidebar query on startup.
+   */
+  const [allPromptsActive, setAllPromptsActive] = useState(false);
+  const requestAllPromptGroups = useCallback(() => setAllPromptsActive(true), []);
+
   const { data: allGroupsData, isLoading: isLoadingAll } = useGetAllPromptGroups(undefined, {
-    enabled: hasAccess,
+    enabled: hasAccess && allPromptsActive,
     select: (data) => {
       const mappedArray: PromptOption[] = data.map((group) => ({
         id: group._id ?? '',
@@ -64,11 +74,20 @@ export const PromptGroupsProvider = ({ children }: { children: ReactNode }) => {
       ...promptGroupsNav,
       allPromptGroups: {
         data: hasAccess ? allGroupsData : undefined,
-        isLoading: hasAccess ? isLoadingAll : false,
+        /** A never-fetched disabled query reports `isLoading` in React Query v4 */
+        isLoading: hasAccess && allPromptsActive ? isLoadingAll : false,
       },
       hasAccess,
+      requestAllPromptGroups,
     }),
-    [promptGroupsNav, allGroupsData, isLoadingAll, hasAccess],
+    [
+      promptGroupsNav,
+      allGroupsData,
+      isLoadingAll,
+      hasAccess,
+      allPromptsActive,
+      requestAllPromptGroups,
+    ],
   );
 
   return (

--- a/client/src/components/Chat/Input/PromptsCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsCommand.tsx
@@ -65,8 +65,9 @@ function PromptsCommand({
   const localize = useLocalize();
   const { mutate: recordUsage } = useRecordPromptUsage();
   const promptGroupsContext = usePromptGroupsContext();
-  const { allPromptGroups, hasAccess } = promptGroupsContext ?? {};
+  const { allPromptGroups, hasAccess, requestAllPromptGroups } = promptGroupsContext ?? {};
   const { data, isLoading } = allPromptGroups ?? {};
+  const showPromptsPopover = useRecoilValue(store.showPromptsPopoverFamily(index));
 
   const [activeIndex, setActiveIndex] = useState(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -146,6 +147,13 @@ function PromptsCommand({
       setVariableGroup(null);
     }
   }, [open, setSearchValue]);
+
+  /** The full prompt list is fetched on first popover open, not at app startup */
+  useEffect(() => {
+    if (showPromptsPopover) {
+      requestAllPromptGroups?.();
+    }
+  }, [showPromptsPopover, requestAllPromptGroups]);
 
   useEffect(() => {
     setActiveIndex((prev) => Math.min(prev, Math.max(matches.length - 1, 0)));

--- a/client/src/components/Chat/Input/PromptsCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsCommand.tsx
@@ -64,8 +64,9 @@ function PromptsCommand({
   const localize = useLocalize();
   const { mutate: recordUsage } = useRecordPromptUsage();
   const promptGroupsContext = usePromptGroupsContext();
-  const { allPromptGroups, hasAccess } = promptGroupsContext ?? {};
+  const { allPromptGroups, hasAccess, requestAllPromptGroups } = promptGroupsContext ?? {};
   const { data, isLoading } = allPromptGroups ?? {};
+  const showPromptsPopover = useRecoilValue(store.showPromptsPopoverFamily(index));
 
   const [activeIndex, setActiveIndex] = useState(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -143,6 +144,13 @@ function PromptsCommand({
       setVariableGroup(null);
     }
   }, [open, setSearchValue]);
+
+  /** The full prompt list is fetched on first popover open, not at app startup */
+  useEffect(() => {
+    if (showPromptsPopover) {
+      requestAllPromptGroups?.();
+    }
+  }, [showPromptsPopover, requestAllPromptGroups]);
 
   useEffect(() => {
     setActiveIndex((prev) => Math.min(prev, Math.max(matches.length - 1, 0)));

--- a/client/src/components/Chat/Input/__tests__/PromptsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/PromptsCommand.spec.tsx
@@ -14,6 +14,7 @@ const PLACEHOLDER = 'com_ui_command_usage_placeholder';
 
 const mockSetShowPromptsPopover = jest.fn();
 const mockShowPromptsPopover = { current: true };
+const mockRequestAllPromptGroups = jest.fn();
 
 jest.mock('recoil', () => {
   const actual = jest.requireActual('recoil');
@@ -126,6 +127,7 @@ beforeEach(() => {
       data: { promptGroups, promptsMap },
       isLoading: false,
     },
+    requestAllPromptGroups: mockRequestAllPromptGroups,
   });
 });
 
@@ -143,7 +145,6 @@ describe('PromptsCommand keyboard navigation', () => {
     const { container } = renderCommand();
     expect(container).toBeEmptyDOMElement();
   });
-
   it('moves the active highlight with ArrowDown/ArrowUp and wraps around', () => {
     renderCommand();
     const input = getInput();
@@ -217,5 +218,19 @@ describe('PromptsCommand keyboard navigation', () => {
        no-match query has to be cleared or the popover reopens still filtered. */
     fireEvent.keyDown(input, { key: 'Enter' });
     expect((getInput() as HTMLInputElement).value).toBe('');
+  });
+});
+
+describe('PromptsCommand lazy prompt loading', () => {
+  it('requests the full prompt list when the popover is shown', () => {
+    mockShowPromptsPopover.current = true;
+    renderCommand();
+    expect(mockRequestAllPromptGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request the full prompt list while the popover is hidden', () => {
+    mockShowPromptsPopover.current = false;
+    renderCommand();
+    expect(mockRequestAllPromptGroups).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/Chat/Input/__tests__/PromptsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/PromptsCommand.spec.tsx
@@ -14,6 +14,7 @@ const PLACEHOLDER = 'com_ui_command_usage_placeholder';
 
 const mockSetShowPromptsPopover = jest.fn();
 const mockShowPromptsPopover = { current: true };
+const mockRequestAllPromptGroups = jest.fn();
 
 jest.mock('recoil', () => {
   const actual = jest.requireActual('recoil');
@@ -125,6 +126,7 @@ beforeEach(() => {
       data: { promptGroups, promptsMap },
       isLoading: false,
     },
+    requestAllPromptGroups: mockRequestAllPromptGroups,
   });
 });
 
@@ -142,7 +144,6 @@ describe('PromptsCommand keyboard navigation', () => {
     const { container } = renderCommand();
     expect(container).toBeEmptyDOMElement();
   });
-
   it('moves the active highlight with ArrowDown/ArrowUp and wraps around', () => {
     renderCommand();
     const input = getInput();
@@ -216,5 +217,19 @@ describe('PromptsCommand keyboard navigation', () => {
        no-match query has to be cleared or the popover reopens still filtered. */
     fireEvent.keyDown(input, { key: 'Enter' });
     expect((getInput() as HTMLInputElement).value).toBe('');
+  });
+});
+
+describe('PromptsCommand lazy prompt loading', () => {
+  it('requests the full prompt list when the popover is shown', () => {
+    mockShowPromptsPopover.current = true;
+    renderCommand();
+    expect(mockRequestAllPromptGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request the full prompt list while the popover is hidden', () => {
+    mockShowPromptsPopover.current = false;
+    renderCommand();
+    expect(mockRequestAllPromptGroups).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/Conversations/ConvoOptions/__tests__/SharedLinkButton.test.tsx
+++ b/client/src/components/Conversations/ConvoOptions/__tests__/SharedLinkButton.test.tsx
@@ -132,7 +132,9 @@ describe('SharedLinkButton', () => {
         snapshotFiles: true,
       });
     });
-    expect(updateButton.querySelector('svg')).toHaveClass('animate-refresh-link-spin');
+    await waitFor(() =>
+      expect(updateButton.querySelector('svg')).toHaveClass('animate-refresh-link-spin'),
+    );
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     expect(setSharedLink).toHaveBeenCalledWith(expect.stringContaining('/share/share-old'));
   });

--- a/client/src/utils/__tests__/promptGroups.test.ts
+++ b/client/src/utils/__tests__/promptGroups.test.ts
@@ -1,11 +1,15 @@
-import { InfiniteCollections } from 'librechat-data-provider';
-import type { InfiniteData } from '@tanstack/react-query';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { InfiniteCollections, QueryKeys } from 'librechat-data-provider';
 import type { PromptGroupListResponse, TPromptGroup } from 'librechat-data-provider';
+import type { InfiniteData } from '@tanstack/react-query';
 import {
+  addGroupToAll,
   addPromptGroup,
   deletePromptGroup,
+  removeGroupFromAll,
   updateGroupFields,
   updateGroupFieldsInPlace,
+  updateGroupInAll,
   updatePromptGroup,
   getSnippet,
   findPromptGroup,
@@ -32,6 +36,34 @@ function makeInfiniteData(
     pages: pages as PromptGroupListResponse[],
     pageParams: pages.map((_, i) => i),
   };
+}
+
+async function expectFirstAllGroupsFetchRestart(
+  mutate: (queryClient: QueryClient) => void,
+  freshList: TPromptGroup[],
+) {
+  const queryClient = new QueryClient();
+  const queryKey = [QueryKeys.allPromptGroups];
+  const staleList = [makeGroup({ _id: 'stale', name: 'Stale Group' })];
+  const deferreds: Array<{ resolve: (value: TPromptGroup[]) => void }> = [];
+  const queryFn = () => new Promise<TPromptGroup[]>((resolve) => deferreds.push({ resolve }));
+  const observer = new QueryObserver<TPromptGroup[]>(queryClient, { queryKey, queryFn });
+  const unsubscribe = observer.subscribe(() => undefined);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(deferreds).toHaveLength(1);
+
+  mutate(queryClient);
+  deferreds[0].resolve(staleList);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(deferreds).toHaveLength(2);
+
+  deferreds[1].resolve(freshList);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(queryClient.getQueryData<TPromptGroup[]>(queryKey)).toEqual(freshList);
+
+  unsubscribe();
+  queryClient.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -324,5 +356,103 @@ describe('getSnippet', () => {
 
   it('handles an empty string without throwing', () => {
     expect(getSnippet('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addGroupToAll
+// ---------------------------------------------------------------------------
+
+describe('addGroupToAll', () => {
+  it('does not seed the all-prompt-groups list before its first fetch', () => {
+    const queryClient = new QueryClient();
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+    expect(queryClient.getQueryData([QueryKeys.allPromptGroups])).toBeUndefined();
+  });
+
+  it('appends to an already fetched list', () => {
+    const queryClient = new QueryClient();
+    const existing = [makeGroup({ _id: 'group-a' })];
+    queryClient.setQueryData([QueryKeys.allPromptGroups], existing);
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-b' }));
+    expect(queryClient.getQueryData<TPromptGroup[]>([QueryKeys.allPromptGroups])).toHaveLength(2);
+  });
+
+  it('restarts a first fetch already in flight so it settles with the created group', async () => {
+    const queryClient = new QueryClient();
+    const queryKey = [QueryKeys.allPromptGroups];
+    const newList = [makeGroup({ _id: 'group-new' })];
+    const deferreds: Array<{ resolve: (value: TPromptGroup[]) => void }> = [];
+    const queryFn = () => new Promise<TPromptGroup[]>((resolve) => deferreds.push({ resolve }));
+    const observer = new QueryObserver<TPromptGroup[]>(queryClient, { queryKey, queryFn });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(deferreds).toHaveLength(1);
+
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+    deferreds[0].resolve([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    /* The pre-creation read must not be allowed to stand: a restart has to
+       have started a second fetch that can settle with the created group. */
+    expect(deferreds).toHaveLength(2);
+    deferreds[1].resolve(newList);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryClient.getQueryData<TPromptGroup[]>(queryKey)).toEqual(newList);
+    unsubscribe();
+    queryClient.clear();
+  });
+
+  it('refetches an errored list after creation so the command appears', async () => {
+    const queryClient = new QueryClient();
+    const queryKey = [QueryKeys.allPromptGroups];
+    const newList = [makeGroup({ _id: 'group-new' })];
+    const deferreds: Array<{
+      resolve: (value: TPromptGroup[]) => void;
+      reject: (reason: Error) => void;
+    }> = [];
+    const queryFn = () =>
+      new Promise<TPromptGroup[]>((resolve, reject) => deferreds.push({ resolve, reject }));
+    const observer = new QueryObserver<TPromptGroup[]>(queryClient, {
+      queryKey,
+      queryFn,
+      retry: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    deferreds[0].reject(new Error('boom'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(queryClient.getQueryState(queryKey)?.status).toBe('error');
+
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(deferreds).toHaveLength(2);
+    deferreds[1].resolve(newList);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryClient.getQueryData<TPromptGroup[]>(queryKey)).toEqual(newList);
+    unsubscribe();
+    queryClient.clear();
+  });
+});
+
+describe('all-prompt-groups mutation reconciliation', () => {
+  it('restarts a first fetch that would overwrite a group update', async () => {
+    expect.assertions(3);
+    const updatedGroup = makeGroup({ _id: 'stale', name: 'Updated Group' });
+    await expectFirstAllGroupsFetchRestart(
+      (queryClient) => updateGroupInAll(queryClient, { _id: 'stale', name: 'Updated Group' }),
+      [updatedGroup],
+    );
+  });
+
+  it('restarts a first fetch that would restore a deleted group', async () => {
+    expect.assertions(3);
+    await expectFirstAllGroupsFetchRestart(
+      (queryClient) => removeGroupFromAll(queryClient, 'stale'),
+      [],
+    );
   });
 });

--- a/client/src/utils/__tests__/promptGroups.test.ts
+++ b/client/src/utils/__tests__/promptGroups.test.ts
@@ -347,4 +347,18 @@ describe('addGroupToAll', () => {
     addGroupToAll(queryClient, makeGroup({ _id: 'group-b' }));
     expect(queryClient.getQueryData<TPromptGroup[]>([QueryKeys.allPromptGroups])).toHaveLength(2);
   });
+
+  it('restarts a first fetch already in flight so it settles with the created group', () => {
+    const queryClient = new QueryClient();
+    const queryKey = [QueryKeys.allPromptGroups];
+    const pending = queryClient.fetchQuery(queryKey, () => new Promise<TPromptGroup[]>(() => {}), {
+      retry: false,
+    });
+    pending.catch(() => undefined);
+
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    queryClient.clear();
+  });
 });

--- a/client/src/utils/__tests__/promptGroups.test.ts
+++ b/client/src/utils/__tests__/promptGroups.test.ts
@@ -361,4 +361,21 @@ describe('addGroupToAll', () => {
     expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
     queryClient.clear();
   });
+
+  it('refetches an errored list after creation so the command appears', async () => {
+    const queryClient = new QueryClient();
+    const queryKey = [QueryKeys.allPromptGroups];
+    const failed = queryClient.fetchQuery(
+      queryKey,
+      () => Promise.reject(new Error('boom')) as Promise<TPromptGroup[]>,
+      { retry: false },
+    );
+    await failed.catch(() => undefined);
+    expect(queryClient.getQueryState(queryKey)?.status).toBe('error');
+
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    queryClient.clear();
+  });
 });

--- a/client/src/utils/__tests__/promptGroups.test.ts
+++ b/client/src/utils/__tests__/promptGroups.test.ts
@@ -1,7 +1,9 @@
-import { InfiniteCollections } from 'librechat-data-provider';
-import type { InfiniteData } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { InfiniteCollections, QueryKeys } from 'librechat-data-provider';
 import type { PromptGroupListResponse, TPromptGroup } from 'librechat-data-provider';
+import type { InfiniteData } from '@tanstack/react-query';
 import {
+  addGroupToAll,
   addPromptGroup,
   deletePromptGroup,
   updateGroupFields,
@@ -324,5 +326,25 @@ describe('getSnippet', () => {
 
   it('handles an empty string without throwing', () => {
     expect(getSnippet('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addGroupToAll
+// ---------------------------------------------------------------------------
+
+describe('addGroupToAll', () => {
+  it('does not seed the all-prompt-groups list before its first fetch', () => {
+    const queryClient = new QueryClient();
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+    expect(queryClient.getQueryData([QueryKeys.allPromptGroups])).toBeUndefined();
+  });
+
+  it('appends to an already fetched list', () => {
+    const queryClient = new QueryClient();
+    const existing = [makeGroup({ _id: 'group-a' })];
+    queryClient.setQueryData([QueryKeys.allPromptGroups], existing);
+    addGroupToAll(queryClient, makeGroup({ _id: 'group-b' }));
+    expect(queryClient.getQueryData<TPromptGroup[]>([QueryKeys.allPromptGroups])).toHaveLength(2);
   });
 });

--- a/client/src/utils/__tests__/promptGroups.test.ts
+++ b/client/src/utils/__tests__/promptGroups.test.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
 import { InfiniteCollections, QueryKeys } from 'librechat-data-provider';
 import type { PromptGroupListResponse, TPromptGroup } from 'librechat-data-provider';
 import type { InfiniteData } from '@tanstack/react-query';
@@ -348,34 +348,58 @@ describe('addGroupToAll', () => {
     expect(queryClient.getQueryData<TPromptGroup[]>([QueryKeys.allPromptGroups])).toHaveLength(2);
   });
 
-  it('restarts a first fetch already in flight so it settles with the created group', () => {
+  it('restarts a first fetch already in flight so it settles with the created group', async () => {
     const queryClient = new QueryClient();
     const queryKey = [QueryKeys.allPromptGroups];
-    const pending = queryClient.fetchQuery(queryKey, () => new Promise<TPromptGroup[]>(() => {}), {
-      retry: false,
-    });
-    pending.catch(() => undefined);
+    const newList = [makeGroup({ _id: 'group-new' })];
+    const deferreds: Array<{ resolve: (value: TPromptGroup[]) => void }> = [];
+    const queryFn = () => new Promise<TPromptGroup[]>((resolve) => deferreds.push({ resolve }));
+    const observer = new QueryObserver<TPromptGroup[]>(queryClient, { queryKey, queryFn });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(deferreds).toHaveLength(1);
 
     addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
+    deferreds[0].resolve([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    /* The pre-creation read must not be allowed to stand: a restart has to
+       have started a second fetch that can settle with the created group. */
+    expect(deferreds).toHaveLength(2);
+    deferreds[1].resolve(newList);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryClient.getQueryData<TPromptGroup[]>(queryKey)).toEqual(newList);
+    unsubscribe();
     queryClient.clear();
   });
 
   it('refetches an errored list after creation so the command appears', async () => {
     const queryClient = new QueryClient();
     const queryKey = [QueryKeys.allPromptGroups];
-    const failed = queryClient.fetchQuery(
+    const newList = [makeGroup({ _id: 'group-new' })];
+    const deferreds: Array<{ resolve: (value: TPromptGroup[]) => void }> = [];
+    const queryFn = () => new Promise<TPromptGroup[]>((resolve) => deferreds.push({ resolve }));
+    const observer = new QueryObserver<TPromptGroup[]>(queryClient, {
       queryKey,
-      () => Promise.reject(new Error('boom')) as Promise<TPromptGroup[]>,
-      { retry: false },
-    );
-    await failed.catch(() => undefined);
+      queryFn,
+      retry: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    deferreds[0].resolve(Promise.reject(new Error('boom')) as unknown as Promise<TPromptGroup[]>);
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(queryClient.getQueryState(queryKey)?.status).toBe('error');
 
     addGroupToAll(queryClient, makeGroup({ _id: 'group-new' }));
 
-    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(deferreds).toHaveLength(2);
+    deferreds[1].resolve(newList);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queryClient.getQueryData<TPromptGroup[]>(queryKey)).toEqual(newList);
+    unsubscribe();
     queryClient.clear();
   });
 });

--- a/client/src/utils/promptGroups.ts
+++ b/client/src/utils/promptGroups.ts
@@ -1,10 +1,10 @@
 import { InfiniteCollections, QueryKeys } from 'librechat-data-provider';
-import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 import type {
   PromptGroupListResponse,
   PromptGroupListData,
   TPromptGroup,
 } from 'librechat-data-provider';
+import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 import {
   addData,
   deleteData,
@@ -93,17 +93,46 @@ export const findPromptGroup = (
   );
 };
 
+const restartUnresolvedAllPromptGroups = (
+  queryClient: QueryClient,
+  queryKey: string[],
+): boolean => {
+  const state = queryClient.getQueryState(queryKey);
+  /**
+   * An idle, never-fetched list must not be seeded partial; its first fetch
+   * includes the mutation. A first fetch already in flight may have read the
+   * database before the mutation and settle stale (invalidating alone does not
+   * cancel a data-less fetch in React Query v4), and an errored fetch never
+   * retries on its own because retry and refetch triggers are off.
+   */
+  if (!state || state.data === undefined) {
+    if (state && (state.fetchStatus === 'fetching' || state.status === 'error')) {
+      void queryClient.cancelQueries(queryKey).then(() => queryClient.invalidateQueries(queryKey));
+    }
+    return true;
+  }
+  return false;
+};
+
 export const addGroupToAll = (queryClient: QueryClient, newGroup: TPromptGroup) => {
-  addToCacheList<TPromptGroup>(queryClient, [QueryKeys.allPromptGroups], newGroup);
+  const queryKey = [QueryKeys.allPromptGroups];
+  if (restartUnresolvedAllPromptGroups(queryClient, queryKey)) {
+    return;
+  }
+  addToCacheList<TPromptGroup>(queryClient, queryKey, newGroup);
 };
 
 export const updateGroupInAll = (
   queryClient: QueryClient,
   updatedGroup: Partial<TPromptGroup> & { _id: string },
 ) => {
+  const queryKey = [QueryKeys.allPromptGroups];
+  if (restartUnresolvedAllPromptGroups(queryClient, queryKey)) {
+    return;
+  }
   updateCacheList<TPromptGroup>({
     queryClient,
-    queryKey: [QueryKeys.allPromptGroups],
+    queryKey,
     searchProperty: '_id',
     updateData: updatedGroup,
     searchValue: updatedGroup._id,
@@ -111,5 +140,9 @@ export const updateGroupInAll = (
 };
 
 export const removeGroupFromAll = (queryClient: QueryClient, groupId: string) => {
-  removeFromCacheList<TPromptGroup>(queryClient, [QueryKeys.allPromptGroups], '_id', groupId);
+  const queryKey = [QueryKeys.allPromptGroups];
+  if (restartUnresolvedAllPromptGroups(queryClient, queryKey)) {
+    return;
+  }
+  removeFromCacheList<TPromptGroup>(queryClient, queryKey, '_id', groupId);
 };

--- a/client/src/utils/promptGroups.ts
+++ b/client/src/utils/promptGroups.ts
@@ -95,14 +95,16 @@ export const findPromptGroup = (
 
 export const addGroupToAll = (queryClient: QueryClient, newGroup: TPromptGroup) => {
   const queryKey = [QueryKeys.allPromptGroups];
+  const state = queryClient.getQueryState(queryKey);
   /**
    * An idle, never-fetched list must not be seeded partial; its first fetch
-   * includes the group. A first fetch already in flight, though, may have read
-   * the database before this creation and settle without it, so restart it.
+   * includes the group. A first fetch already in flight may have read the
+   * database before this creation and settle without it, and an errored fetch
+   * never retries on its own (retry and refetch triggers are off), so restart
+   * both to settle with the created group.
    */
-  if (!queryClient.getQueryData<TPromptGroup[]>(queryKey)) {
-    const state = queryClient.getQueryState(queryKey);
-    if (state?.fetchStatus === 'fetching') {
+  if (!state || state.data === undefined) {
+    if (state && (state.fetchStatus === 'fetching' || state.status === 'error')) {
       queryClient.invalidateQueries(queryKey);
     }
     return;

--- a/client/src/utils/promptGroups.ts
+++ b/client/src/utils/promptGroups.ts
@@ -94,11 +94,20 @@ export const findPromptGroup = (
 };
 
 export const addGroupToAll = (queryClient: QueryClient, newGroup: TPromptGroup) => {
-  /** An unfetched list must not be seeded partial; its first fetch includes the group */
-  if (!queryClient.getQueryData<TPromptGroup[]>([QueryKeys.allPromptGroups])) {
+  const queryKey = [QueryKeys.allPromptGroups];
+  /**
+   * An idle, never-fetched list must not be seeded partial; its first fetch
+   * includes the group. A first fetch already in flight, though, may have read
+   * the database before this creation and settle without it, so restart it.
+   */
+  if (!queryClient.getQueryData<TPromptGroup[]>(queryKey)) {
+    const state = queryClient.getQueryState(queryKey);
+    if (state?.fetchStatus === 'fetching') {
+      queryClient.invalidateQueries(queryKey);
+    }
     return;
   }
-  addToCacheList<TPromptGroup>(queryClient, [QueryKeys.allPromptGroups], newGroup);
+  addToCacheList<TPromptGroup>(queryClient, queryKey, newGroup);
 };
 
 export const updateGroupInAll = (

--- a/client/src/utils/promptGroups.ts
+++ b/client/src/utils/promptGroups.ts
@@ -93,18 +93,20 @@ export const findPromptGroup = (
   );
 };
 
-export const addGroupToAll = (queryClient: QueryClient, newGroup: TPromptGroup) => {
+export const addGroupToAll = async (queryClient: QueryClient, newGroup: TPromptGroup) => {
   const queryKey = [QueryKeys.allPromptGroups];
   const state = queryClient.getQueryState(queryKey);
   /**
    * An idle, never-fetched list must not be seeded partial; its first fetch
    * includes the group. A first fetch already in flight may have read the
-   * database before this creation and settle without it, and an errored fetch
-   * never retries on its own (retry and refetch triggers are off), so restart
-   * both to settle with the created group.
+   * database before this creation and settle without it (invalidating alone
+   * does not cancel a data-less fetch in React Query v4), and an errored fetch
+   * never retries on its own (retry and refetch triggers are off), so cancel
+   * and invalidate both to settle with the created group.
    */
   if (!state || state.data === undefined) {
     if (state && (state.fetchStatus === 'fetching' || state.status === 'error')) {
+      await queryClient.cancelQueries(queryKey);
       queryClient.invalidateQueries(queryKey);
     }
     return;

--- a/client/src/utils/promptGroups.ts
+++ b/client/src/utils/promptGroups.ts
@@ -1,10 +1,10 @@
 import { InfiniteCollections, QueryKeys } from 'librechat-data-provider';
-import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 import type {
   PromptGroupListResponse,
   PromptGroupListData,
   TPromptGroup,
 } from 'librechat-data-provider';
+import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 import {
   addData,
   deleteData,
@@ -94,6 +94,10 @@ export const findPromptGroup = (
 };
 
 export const addGroupToAll = (queryClient: QueryClient, newGroup: TPromptGroup) => {
+  /** An unfetched list must not be seeded partial; its first fetch includes the group */
+  if (!queryClient.getQueryData<TPromptGroup[]>([QueryKeys.allPromptGroups])) {
+    return;
+  }
   addToCacheList<TPromptGroup>(queryClient, [QueryKeys.allPromptGroups], newGroup);
 };
 

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -124,6 +124,8 @@ export interface AdminRolesDeps {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
   }) => Promise<void>;
+  /** Drops cached prompt group access IDs; role deletion can remove PROMPTGROUP grants. */
+  invalidatePromptGroupAccessContext?: () => Promise<void>;
   /** Removes all system capability grants held by this principal and returns
    * the removed grants so each can be audited. */
   deleteGrantsForPrincipal: (
@@ -169,6 +171,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps): {
     deleteAclEntries,
     deleteGrantsForPrincipal,
     recordAuditEntry,
+    invalidatePromptGroupAccessContext,
   } = deps;
 
   /** Emits a `grant.removed` audit entry for each grant the role-deletion cascade
@@ -460,6 +463,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps): {
         if (result.status === 'rejected') {
           logger.error('[adminRoles] cascade cleanup failed for role:', name, result.reason);
         }
+      }
+      if (aclResult.status === 'fulfilled') {
+        /** The removed entries can include PROMPTGROUP grants feeding the access cache */
+        await invalidatePromptGroupAccessContext?.();
       }
       if (grantsResult.status === 'fulfilled') {
         await emitGrantRemovals(req, name, grantsResult.value);

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2532,6 +2532,10 @@ export enum CacheKeys {
    */
   USER_PRINCIPALS = 'USER_PRINCIPALS',
   /**
+   * Key for cached prompt group access ID sets (accessible, public, owned).
+   */
+  PROMPT_GROUPS_ACCESS = 'PROMPT_GROUPS_ACCESS',
+  /**
    * Key for per-conversation stateful code sandbox prewarm/warm state.
    */
   SANDBOX_PREWARM = 'SANDBOX_PREWARM',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2698,6 +2698,10 @@ export enum CacheKeys {
    */
   USER_PRINCIPALS = 'USER_PRINCIPALS',
   /**
+   * Key for cached prompt group access ID sets (accessible, public, owned).
+   */
+  PROMPT_GROUPS_ACCESS = 'PROMPT_GROUPS_ACCESS',
+  /**
    * Key for per-conversation stateful code sandbox prewarm/warm state.
    */
   SANDBOX_PREWARM = 'SANDBOX_PREWARM',

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -28,6 +28,7 @@ export {
   normalizeSkillFrontmatterKeys,
   validateSkillDescription,
   deriveStructuredFrontmatterFields,
+  runAfterTransaction,
   AUDIT_SCHEMA_VERSION,
   MAX_AUDIT_EXPORT_ROWS,
   MAX_AUDIT_LOG_LIMIT,

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -27,6 +27,7 @@ export {
   normalizeSkillFrontmatterKeys,
   validateSkillDescription,
   deriveStructuredFrontmatterFields,
+  runAfterTransaction,
   AUDIT_SCHEMA_VERSION,
   MAX_AUDIT_EXPORT_ROWS,
   MAX_AUDIT_LOG_LIMIT,

--- a/packages/data-schemas/src/methods/aclEntry.ts
+++ b/packages/data-schemas/src/methods/aclEntry.ts
@@ -138,6 +138,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
     principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
     resourceType: string,
     requiredPermBit: number,
+    readPrimary?: boolean,
   ) => Promise<Types.ObjectId[]>;
   deleteAclEntries: (
     filter: Record<string, unknown>,
@@ -150,6 +151,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
   findPublicResourceIds: (
     resourceType: string,
     requiredPermissions: number,
+    readPrimary?: boolean,
   ) => Promise<Types.ObjectId[]>;
   aggregateAclEntries: (pipeline: PipelineStage[]) => Promise<unknown[]>;
   getSoleOwnedResourceIds: (
@@ -492,6 +494,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
     principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
     resourceType: string,
     requiredPermBit: number,
+    readPrimary = false,
   ): Promise<Types.ObjectId[]> {
     const AclEntry = mongoose.models.AclEntry as Model<IAclEntry>;
     const principalsQuery = principalsList.map((p) => ({
@@ -499,11 +502,16 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
       ...(p.principalType !== PrincipalType.PUBLIC && { principalId: p.principalId }),
     }));
 
-    return await AclEntry.find({
+    const query = AclEntry.find({
       $or: principalsQuery,
       resourceType,
       permBits: { $in: permissionBitSupersets(requiredPermBit) },
-    }).distinct('resourceId');
+    });
+    if (readPrimary) {
+      /** Cache builds must not capture a lagging secondary's pre-mutation state */
+      query.read('primary');
+    }
+    return await query.distinct('resourceId');
   }
 
   /**
@@ -541,13 +549,19 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
   async function findPublicResourceIds(
     resourceType: string,
     requiredPermissions: number,
+    readPrimary = false,
   ): Promise<Types.ObjectId[]> {
     const AclEntry = mongoose.models.AclEntry as Model<IAclEntry>;
-    return await AclEntry.find({
+    const query = AclEntry.find({
       principalType: PrincipalType.PUBLIC,
       resourceType,
       permBits: { $in: permissionBitSupersets(requiredPermissions) },
-    }).distinct('resourceId');
+    });
+    if (readPrimary) {
+      /** Cache builds must not capture a lagging secondary's pre-mutation state */
+      query.read('primary');
+    }
+    return await query.distinct('resourceId');
   }
 
   /**

--- a/packages/data-schemas/src/methods/aclEntry.ts
+++ b/packages/data-schemas/src/methods/aclEntry.ts
@@ -139,6 +139,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
     resourceType: string,
     requiredPermBit: number,
     resourceIds?: Types.ObjectId[],
+    readPrimary?: boolean,
   ) => Promise<Types.ObjectId[]>;
   deleteAclEntries: (
     filter: Record<string, unknown>,
@@ -152,6 +153,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
     resourceType: string,
     requiredPermissions: number,
     resourceIds?: Types.ObjectId[],
+    readPrimary?: boolean,
   ) => Promise<Types.ObjectId[]>;
   aggregateAclEntries: (pipeline: PipelineStage[]) => Promise<unknown[]>;
   getSoleOwnedResourceIds: (
@@ -492,6 +494,8 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
    *   resources are considered, so the query cost scales with the candidate set
    *   instead of every accessible resource of the type. An empty array matches
    *   nothing rather than lifting the bound.
+   * @param readPrimary - Read from the primary so a lagging secondary cannot
+   *   pin pre-mutation IDs into a caller's cache.
    * @returns Array of resource IDs
    */
   async function findAccessibleResources(
@@ -499,6 +503,7 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
     resourceType: string,
     requiredPermBit: number,
     resourceIds?: Types.ObjectId[],
+    readPrimary = false,
   ): Promise<Types.ObjectId[]> {
     const AclEntry = mongoose.models.AclEntry as Model<IAclEntry>;
     const principalsQuery = principalsList.map((p) => ({
@@ -506,12 +511,17 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
       ...(p.principalType !== PrincipalType.PUBLIC && { principalId: p.principalId }),
     }));
 
-    return await AclEntry.find({
+    const query = AclEntry.find({
       $or: principalsQuery,
       ...(resourceIds !== undefined && { resourceId: { $in: resourceIds } }),
       resourceType,
       permBits: { $in: permissionBitSupersets(requiredPermBit) },
-    }).distinct('resourceId');
+    });
+    if (readPrimary) {
+      /** Cache builds must not capture a lagging secondary's pre-mutation state */
+      query.read('primary');
+    }
+    return await query.distinct('resourceId');
   }
 
   /**
@@ -546,19 +556,26 @@ export function createAclEntryMethods(mongoose: typeof import('mongoose')): {
    * @param resourceType - The type of resource
    * @param requiredPermissions - Required permission bits
    * @param resourceIds - Optional candidate bound; see {@link findAccessibleResources}
+   * @param readPrimary - Read from the primary; see {@link findAccessibleResources}
    */
   async function findPublicResourceIds(
     resourceType: string,
     requiredPermissions: number,
     resourceIds?: Types.ObjectId[],
+    readPrimary = false,
   ): Promise<Types.ObjectId[]> {
     const AclEntry = mongoose.models.AclEntry as Model<IAclEntry>;
-    return await AclEntry.find({
+    const query = AclEntry.find({
       principalType: PrincipalType.PUBLIC,
       ...(resourceIds !== undefined && { resourceId: { $in: resourceIds } }),
       resourceType,
       permBits: { $in: permissionBitSupersets(requiredPermissions) },
-    }).distinct('resourceId');
+    });
+    if (readPrimary) {
+      /** Cache builds must not capture a lagging secondary's pre-mutation state */
+      query.read('primary');
+    }
+    return await query.distinct('resourceId');
   }
 
   /**

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -23,7 +23,12 @@ import { createMCPServerMethods, type MCPServerMethods } from './mcpServer';
 import { createPluginAuthMethods, type PluginAuthMethods } from './pluginAuth';
 /* Permissions */
 import { createAccessRoleMethods, type AccessRoleMethods } from './accessRole';
-import { createUserGroupMethods, type UserGroupMethods, type UserGroupDeps } from './userGroup';
+import {
+  createUserGroupMethods,
+  runAfterTransaction,
+  type UserGroupMethods,
+  type UserGroupDeps,
+} from './userGroup';
 import { createAclEntryMethods, permissionBitSupersets, type AclEntryMethods } from './aclEntry';
 import { createSystemGrantMethods, type SystemGrantMethods } from './systemGrant';
 import {
@@ -139,6 +144,7 @@ import {
 import { createInsightsMethods, type InsightsMethods } from './insights';
 
 export {
+  runAfterTransaction,
   RoleConflictError,
   MCPAuthorityProofError,
   MAX_MCP_AUTHORITY_TARGETS,
@@ -275,22 +281,34 @@ export function createMethods(
       await aclEntryMethods.deleteAclEntries({ resourceType, resourceId });
     });
 
+  // Role and user-group methods with optional cache injection; user-group methods
+  // are created before prompt methods so prompt methods can resolve ACL principals.
+  // The membership hook is late-bound: prompt methods do not exist yet here.
+  const promptAccessInvalidator: { current?: () => Promise<void> } = {};
+  const roleDeps: RoleDeps = { getCache: deps.getCache };
+  const userGroupDeps: UserGroupDeps = {
+    getCache: deps.getCache,
+    onMemberGroupsInvalidated: () => promptAccessInvalidator.current?.(),
+  };
+  const roleMethods = createRoleMethods(mongoose, roleDeps);
+  const userGroupMethods = createUserGroupMethods(mongoose, userGroupDeps);
+
   const promptDeps: PromptDeps = {
     removeAllPermissions,
     getSoleOwnedResourceIds: aclEntryMethods.getSoleOwnedResourceIds,
+    getCache: deps.getCache,
+    getUserPrincipals: userGroupMethods.getUserPrincipals,
+    findAccessibleResources: aclEntryMethods.findAccessibleResources,
+    findPublicResourceIds: aclEntryMethods.findPublicResourceIds,
   };
   const promptMethods = createPromptMethods(mongoose, promptDeps);
+  promptAccessInvalidator.current = promptMethods.invalidatePromptGroupAccessContext;
 
   const skillDeps: SkillDeps = {
     removeAllPermissions,
     getSoleOwnedResourceIds: aclEntryMethods.getSoleOwnedResourceIds,
   };
   const skillMethods = createSkillMethods(mongoose, skillDeps);
-
-  // Role methods with optional cache injection
-  const roleDeps: RoleDeps = { getCache: deps.getCache };
-  const userGroupDeps: UserGroupDeps = { getCache: deps.getCache };
-  const roleMethods = createRoleMethods(mongoose, roleDeps);
 
   // Tier 1: action methods (created as variable for agent dependency)
   const actionMethods = createActionMethods(mongoose);
@@ -317,7 +335,7 @@ export function createMethods(
     ...createAgentApiKeyMethods(mongoose),
     ...createMCPServerMethods(mongoose),
     ...createAccessRoleMethods(mongoose),
-    ...createUserGroupMethods(mongoose, userGroupDeps),
+    ...userGroupMethods,
     ...aclEntryMethods,
     ...systemGrantMethods,
     ...createAuditLogMethods(mongoose),

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -267,9 +267,14 @@ export function createMethods(
     });
 
   // Role and user-group methods with optional cache injection; user-group methods
-  // are created before prompt methods so prompt methods can resolve ACL principals
+  // are created before prompt methods so prompt methods can resolve ACL principals.
+  // The membership hook is late-bound: prompt methods do not exist yet here.
+  const promptAccessInvalidator: { current?: () => Promise<void> } = {};
   const roleDeps: RoleDeps = { getCache: deps.getCache };
-  const userGroupDeps: UserGroupDeps = { getCache: deps.getCache };
+  const userGroupDeps: UserGroupDeps = {
+    getCache: deps.getCache,
+    onMemberGroupsInvalidated: () => promptAccessInvalidator.current?.(),
+  };
   const roleMethods = createRoleMethods(mongoose, roleDeps);
   const userGroupMethods = createUserGroupMethods(mongoose, userGroupDeps);
 
@@ -282,6 +287,7 @@ export function createMethods(
     findPublicResourceIds: aclEntryMethods.findPublicResourceIds,
   };
   const promptMethods = createPromptMethods(mongoose, promptDeps);
+  promptAccessInvalidator.current = promptMethods.invalidatePromptGroupAccessContext;
 
   const skillDeps: SkillDeps = {
     removeAllPermissions,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -23,7 +23,12 @@ import { createMCPServerMethods, type MCPServerMethods } from './mcpServer';
 import { createPluginAuthMethods, type PluginAuthMethods } from './pluginAuth';
 /* Permissions */
 import { createAccessRoleMethods, type AccessRoleMethods } from './accessRole';
-import { createUserGroupMethods, type UserGroupMethods, type UserGroupDeps } from './userGroup';
+import {
+  createUserGroupMethods,
+  runAfterTransaction,
+  type UserGroupMethods,
+  type UserGroupDeps,
+} from './userGroup';
 import { createAclEntryMethods, permissionBitSupersets, type AclEntryMethods } from './aclEntry';
 import { createSystemGrantMethods, type SystemGrantMethods } from './systemGrant';
 import {
@@ -131,6 +136,7 @@ import {
 import { createInsightsMethods, type InsightsMethods } from './insights';
 
 export {
+  runAfterTransaction,
   RoleConflictError,
   MCPAuthorityProofError,
   MAX_MCP_AUTHORITY_TARGETS,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -266,9 +266,20 @@ export function createMethods(
       await aclEntryMethods.deleteAclEntries({ resourceType, resourceId });
     });
 
+  // Role and user-group methods with optional cache injection; user-group methods
+  // are created before prompt methods so prompt methods can resolve ACL principals
+  const roleDeps: RoleDeps = { getCache: deps.getCache };
+  const userGroupDeps: UserGroupDeps = { getCache: deps.getCache };
+  const roleMethods = createRoleMethods(mongoose, roleDeps);
+  const userGroupMethods = createUserGroupMethods(mongoose, userGroupDeps);
+
   const promptDeps: PromptDeps = {
     removeAllPermissions,
     getSoleOwnedResourceIds: aclEntryMethods.getSoleOwnedResourceIds,
+    getCache: deps.getCache,
+    getUserPrincipals: userGroupMethods.getUserPrincipals,
+    findAccessibleResources: aclEntryMethods.findAccessibleResources,
+    findPublicResourceIds: aclEntryMethods.findPublicResourceIds,
   };
   const promptMethods = createPromptMethods(mongoose, promptDeps);
 
@@ -277,11 +288,6 @@ export function createMethods(
     getSoleOwnedResourceIds: aclEntryMethods.getSoleOwnedResourceIds,
   };
   const skillMethods = createSkillMethods(mongoose, skillDeps);
-
-  // Role methods with optional cache injection
-  const roleDeps: RoleDeps = { getCache: deps.getCache };
-  const userGroupDeps: UserGroupDeps = { getCache: deps.getCache };
-  const roleMethods = createRoleMethods(mongoose, roleDeps);
 
   // Tier 1: action methods (created as variable for agent dependency)
   const actionMethods = createActionMethods(mongoose);
@@ -308,7 +314,7 @@ export function createMethods(
     ...createAgentApiKeyMethods(mongoose),
     ...createMCPServerMethods(mongoose),
     ...createAccessRoleMethods(mongoose),
-    ...createUserGroupMethods(mongoose, userGroupDeps),
+    ...userGroupMethods,
     ...aclEntryMethods,
     ...systemGrantMethods,
     ...createAuditLogMethods(mongoose),

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -1,0 +1,653 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createModels, logger, runAfterTransaction, tenantStorage } from '..';
+import {
+  PermissionBits,
+  PrincipalModel,
+  PrincipalType,
+  ResourceType,
+  Time,
+} from 'librechat-data-provider';
+import type { CacheStore } from '~/types';
+import { createMethods } from './index';
+
+logger.silent = true;
+
+type Methods = ReturnType<typeof createMethods>;
+type AclEntryDoc = { principalType: string; resourceId: unknown; permBits: number };
+
+let mongoServer: MongoMemoryServer;
+let methods: Methods;
+let AclEntry: mongoose.Model<unknown>;
+let Prompt: mongoose.Model<unknown>;
+let PromptGroup: mongoose.Model<unknown>;
+let cacheMap: Map<string, unknown>;
+let delaySets = false;
+let resolvePendingSets: Array<() => void> = [];
+let delayDeletes = false;
+let resolvePendingDeletes: Array<() => void> = [];
+let generationTtls: Array<number | undefined> = [];
+let failGenerationReads = false;
+let failGenerationWrites = false;
+let failGenerationDeletes = false;
+let notifyPendingSet: (() => void) | undefined;
+
+const cacheStore: CacheStore = {
+  get: async (key) => {
+    if (failGenerationReads && key.includes(':generation')) {
+      throw new Error('marker read failed');
+    }
+    return cacheMap.get(key);
+  },
+  set: async (key, value, ttl) => {
+    if (failGenerationWrites && key.includes(':generation')) {
+      return false;
+    }
+    /** The generation entry itself must never be held back by the test gate */
+    if (delaySets && !key.includes(':generation')) {
+      notifyPendingSet?.();
+      await new Promise<void>((resolve) => resolvePendingSets.push(resolve));
+    }
+    if (key.includes(':generation')) {
+      generationTtls.push(ttl);
+    }
+    cacheMap.set(key, value);
+  },
+  delete: async (key) => {
+    if (failGenerationDeletes && key.includes(':generation')) {
+      return false;
+    }
+    if (delayDeletes) {
+      await new Promise<void>((resolve) => resolvePendingDeletes.push(resolve));
+    }
+    cacheMap.delete(key);
+  },
+  clear: async () => {
+    cacheMap.clear();
+  },
+};
+
+const idStrings = (ids: Array<mongoose.Types.ObjectId>): string[] => ids.map((id) => id.toString());
+
+async function seedGroupAndPrompt(author: mongoose.Types.ObjectId) {
+  const prompt = await Prompt.create({
+    groupId: new mongoose.Types.ObjectId(),
+    author,
+    prompt: 'Hello {{name}}',
+    type: 'text',
+  });
+  const group = await PromptGroup.create({
+    name: `Group ${new mongoose.Types.ObjectId().toString().slice(-6)}`,
+    author,
+    authorName: 'Test Author',
+    productionId: prompt._id,
+  });
+  return group;
+}
+
+async function grantView(
+  principalType: string,
+  principalId: mongoose.Types.ObjectId | null,
+  resourceId: unknown,
+) {
+  const principalModels: Record<string, string> = {
+    [PrincipalType.USER]: PrincipalModel.USER,
+    [PrincipalType.GROUP]: PrincipalModel.GROUP,
+    [PrincipalType.ROLE]: PrincipalModel.ROLE,
+  };
+  await AclEntry.create({
+    principalType,
+    ...(principalId ? { principalId } : {}),
+    ...(principalModels[principalType] ? { principalModel: principalModels[principalType] } : {}),
+    resourceType: ResourceType.PROMPTGROUP,
+    resourceId,
+    permBits: PermissionBits.VIEW,
+  } as AclEntryDoc);
+}
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  AclEntry = mongoose.models.AclEntry;
+  Prompt = mongoose.models.Prompt;
+  PromptGroup = mongoose.models.PromptGroup;
+  cacheMap = new Map();
+  methods = createMethods(mongoose, { getCache: () => cacheStore });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  failGenerationWrites = false;
+  failGenerationDeletes = false;
+  await Promise.all([AclEntry.deleteMany({}), Prompt.deleteMany({}), PromptGroup.deleteMany({})]);
+  await methods.invalidatePromptGroupAccessContext();
+  delaySets = false;
+  resolvePendingSets.forEach((resolve) => resolve());
+  resolvePendingSets = [];
+  delayDeletes = false;
+  resolvePendingDeletes.forEach((resolve) => resolve());
+  resolvePendingDeletes = [];
+  failGenerationReads = false;
+  notifyPendingSet = undefined;
+});
+
+describe('getPromptGroupAccessContext', () => {
+  it('resolves user-accessible, public, and owned prompt group ID sets', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const otherId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    const publicGroup = await seedGroupAndPrompt(otherId);
+    const hiddenGroup = await seedGroupAndPrompt(otherId);
+
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+    await grantView(PrincipalType.PUBLIC, null, publicGroup._id);
+
+    const { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds } =
+      await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+
+    expect(idStrings(publiclyAccessibleIds)).toEqual([publicGroup._id.toString()]);
+    expect(idStrings(ownedPromptGroupIds)).toEqual([ownGroup._id.toString()]);
+
+    const accessible = idStrings(accessibleIds);
+    expect(accessible).toContain(ownGroup._id.toString());
+    expect(accessible).toContain(publicGroup._id.toString());
+    expect(accessible).not.toContain(hiddenGroup._id.toString());
+  });
+
+  it('serves repeat reads from the cache and refreshes after invalidation', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    const sharedGroup = await seedGroupAndPrompt(new mongoose.Types.ObjectId());
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+
+    await grantView(PrincipalType.USER, userId, sharedGroup._id);
+
+    const stale = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(stale.accessibleIds)).not.toContain(sharedGroup._id.toString());
+
+    await methods.invalidatePromptGroupAccessContext();
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).toContain(sharedGroup._id.toString());
+  });
+
+  it('shares the public set across users and invalidates it on group deletion', async () => {
+    const authorId = new mongoose.Types.ObjectId();
+    const publicGroup = await seedGroupAndPrompt(authorId);
+    await grantView(PrincipalType.PUBLIC, null, publicGroup._id);
+
+    const authorCtx = await methods.getPromptGroupAccessContext({
+      userId: authorId.toString(),
+      role: 'USER',
+    });
+    const otherCtx = await methods.getPromptGroupAccessContext({
+      userId: new mongoose.Types.ObjectId().toString(),
+      role: 'USER',
+    });
+
+    expect(idStrings(authorCtx.publiclyAccessibleIds)).toEqual([publicGroup._id.toString()]);
+    expect(idStrings(otherCtx.publiclyAccessibleIds)).toEqual([publicGroup._id.toString()]);
+
+    await methods.deletePromptGroup({ _id: publicGroup._id.toString() });
+
+    const afterDelete = await methods.getPromptGroupAccessContext({
+      userId: authorId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(afterDelete.publiclyAccessibleIds)).toEqual([]);
+  });
+
+  it('invalidates cached owned IDs when a prompt group is created', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const before = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(before.ownedPromptGroupIds).toHaveLength(0);
+
+    await methods.createPromptGroup({
+      prompt: { prompt: 'Created', type: 'text' },
+      group: { name: 'Created Group' },
+      author: userId.toString(),
+      authorName: 'Test Author',
+    });
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(after.ownedPromptGroupIds).toHaveLength(1);
+  });
+
+  it('drops access granted through a user group when the member is removed', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const userGroup = await methods.createGroup({
+      name: 'Editors',
+      memberIds: [userId.toString()],
+    });
+    const groupPrompt = await seedGroupAndPrompt(new mongoose.Types.ObjectId());
+    await grantView(PrincipalType.GROUP, userGroup._id, groupPrompt._id);
+
+    const before = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(before.accessibleIds)).toContain(groupPrompt._id.toString());
+
+    await methods.removeMemberById(userGroup._id, userId.toString());
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(after.accessibleIds)).not.toContain(groupPrompt._id.toString());
+  });
+
+  it('cannot read IDs written back by a build that was in flight across an invalidation', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    const pendingSet = new Promise<void>((resolve) => {
+      notifyPendingSet = resolve;
+    });
+    delaySets = true;
+    const firstResolve = methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    await pendingSet;
+
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    await methods.invalidatePromptGroupAccessContext();
+
+    delaySets = false;
+    resolvePendingSets.forEach((resolve) => resolve());
+    resolvePendingSets = [];
+    await firstResolve;
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('does not resurrect an old cache era when generation initializers overlap', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    const raceMap = new Map<string, unknown>();
+    let generationReadCount = 0;
+    let generationSetCount = 0;
+    let releaseFirstGenerationRead!: () => void;
+    let releaseSecondInitialization!: () => void;
+    let signalSecondInitialization!: () => void;
+    const firstGenerationRead = new Promise<void>((resolve) => {
+      releaseFirstGenerationRead = resolve;
+    });
+    const secondInitialization = new Promise<void>((resolve) => {
+      signalSecondInitialization = resolve;
+    });
+    const secondInitializationGate = new Promise<void>((resolve) => {
+      releaseSecondInitialization = resolve;
+    });
+    const raceStore: CacheStore = {
+      get: async (key) => {
+        if (key === 'access:generation' && generationReadCount < 2) {
+          generationReadCount += 1;
+          if (generationReadCount === 1) {
+            await firstGenerationRead;
+          } else {
+            releaseFirstGenerationRead();
+          }
+          return undefined;
+        }
+        return raceMap.get(key);
+      },
+      set: async (key, value) => {
+        if (key === 'access:generation') {
+          generationSetCount += 1;
+          if (generationSetCount === 2) {
+            signalSecondInitialization();
+            await secondInitializationGate;
+          }
+        }
+        raceMap.set(key, value);
+      },
+    };
+    const raceMethods = createMethods(mongoose, { getCache: () => raceStore });
+    const dateNow = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+    try {
+      const requestA = raceMethods.getPromptGroupAccessContext({
+        userId: userId.toString(),
+        role: 'USER',
+      });
+      const requestB = raceMethods.getPromptGroupAccessContext({
+        userId: userId.toString(),
+        role: 'USER',
+      });
+
+      await secondInitialization;
+      const beforeMutation = await Promise.race([requestA, requestB]);
+      expect(idStrings(beforeMutation.accessibleIds)).toContain(ownGroup._id.toString());
+
+      await AclEntry.deleteMany({ resourceId: ownGroup._id });
+      await raceMethods.invalidatePromptGroupAccessContext();
+      releaseSecondInitialization();
+      await Promise.all([requestA, requestB]);
+
+      const afterMutation = await raceMethods.getPromptGroupAccessContext({
+        userId: userId.toString(),
+        role: 'USER',
+      });
+      expect(idStrings(afterMutation.accessibleIds)).not.toContain(ownGroup._id.toString());
+    } finally {
+      dateNow.mockRestore();
+      releaseSecondInitialization();
+    }
+  });
+
+  it('only marks in-flight lookups stale for the active tenant', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    const pendingSet = new Promise<void>((resolve) => {
+      notifyPendingSet = resolve;
+    });
+    delaySets = true;
+    const tenantBResolve = tenantStorage.run({ tenantId: 'tenant-b' }, () =>
+      methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' }),
+    );
+    await pendingSet;
+
+    await tenantStorage.run({ tenantId: 'tenant-a' }, () =>
+      methods.invalidatePromptGroupAccessContext(),
+    );
+
+    delaySets = false;
+    resolvePendingSets.forEach((resolve) => resolve());
+    resolvePendingSets = [];
+    await tenantBResolve;
+
+    const userKey = `:user:${userId.toString()}:USER:tenant-b`;
+    expect([...cacheMap.keys()].some((key) => key.includes(userKey))).toBe(true);
+  });
+
+  it('does not reuse an expired generation value after the marker itself expires', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await methods.invalidatePromptGroupAccessContext();
+    const primed = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(primed.accessibleIds)).toContain(ownGroup._id.toString());
+
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    cacheMap.delete('access:generation');
+    await methods.invalidatePromptGroupAccessContext();
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('does not cache a failed ownership lookup as empty', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    const findSpy = jest.spyOn(PromptGroup, 'find');
+    findSpy.mockImplementationOnce(() => {
+      throw new Error('transient failure');
+    });
+
+    await expect(
+      methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' }),
+    ).rejects.toThrow('transient failure');
+    findSpy.mockRestore();
+
+    const recovered = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(recovered.ownedPromptGroupIds)).toEqual([ownGroup._id.toString()]);
+  });
+
+  it('reinitializes an evicted marker instead of reusing generation zero', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    await methods.invalidatePromptGroupAccessContext();
+    /** Simulate the marker being evicted while the pre-revocation entry is still alive */
+    cacheMap.delete('access:generation');
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(after.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('bypasses the cache instead of guessing a generation when the marker read fails', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    await methods.invalidatePromptGroupAccessContext();
+
+    failGenerationReads = true;
+    const bypassed = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(bypassed.accessibleIds)).not.toContain(ownGroup._id.toString());
+    failGenerationReads = false;
+  });
+
+  it('removes the old generation before a replacement write can fail', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+
+    failGenerationWrites = true;
+    await methods.invalidatePromptGroupAccessContext();
+    failGenerationWrites = false;
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('bypasses access caching when the old generation cannot be replaced or removed', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    const previousGeneration = cacheMap.get('access:generation');
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+
+    failGenerationDeletes = true;
+    failGenerationWrites = true;
+    await expect(methods.invalidatePromptGroupAccessContext()).rejects.toThrow(
+      'Prompt group access generation write failed',
+    );
+    failGenerationDeletes = false;
+    failGenerationWrites = false;
+    expect(cacheMap.get('access:generation')).toBe(previousGeneration);
+
+    const bypassed = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(bypassed.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('writes the generation marker with a ttl that outlives cached entries', async () => {
+    generationTtls = [];
+    await methods.invalidatePromptGroupAccessContext();
+    expect(generationTtls.length).toBeGreaterThan(0);
+    for (const ttl of generationTtls) {
+      expect(ttl).toBeGreaterThanOrEqual(Time.ONE_DAY);
+    }
+  });
+
+  it('does not cache access built from a stale membership while its eviction is pending', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const userGroup = await methods.createGroup({
+      name: 'Editors',
+      memberIds: [userId.toString()],
+    });
+    const groupPrompt = await seedGroupAndPrompt(new mongoose.Types.ObjectId());
+    await grantView(PrincipalType.GROUP, userGroup._id, groupPrompt._id);
+
+    const before = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(before.accessibleIds)).toContain(groupPrompt._id.toString());
+
+    delayDeletes = true;
+    const removal = methods.removeMemberById(userGroup._id, userId.toString());
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+
+    delayDeletes = false;
+    resolvePendingDeletes.forEach((resolve) => resolve());
+    resolvePendingDeletes = [];
+    await removal;
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(after.accessibleIds)).not.toContain(groupPrompt._id.toString());
+  });
+});
+
+describe('runAfterTransaction', () => {
+  function createSession(abortError?: Error) {
+    let active = true;
+    const endedHandlers: Array<() => void> = [];
+    const abortTransaction = jest.fn(async (_options?: { timeoutMS?: number }) => {
+      active = false;
+      if (abortError) {
+        throw abortError;
+      }
+    });
+    const rawSession = {
+      inTransaction: () => active,
+      commitTransaction: jest.fn(async () => {
+        active = false;
+      }),
+      abortTransaction,
+      once: (event: string, handler: () => void) => {
+        if (event === 'ended') {
+          endedHandlers.push(handler);
+        }
+      },
+    };
+    return {
+      abortTransaction,
+      endedHandlers,
+      session: rawSession as unknown as NonNullable<Parameters<typeof runAfterTransaction>[0]>,
+      startTransaction: () => {
+        active = true;
+      },
+    };
+  }
+
+  it('defers invalidation until a caller-owned session commits', async () => {
+    const { session } = createSession();
+    const invalidate = jest.fn().mockResolvedValue(undefined);
+
+    await runAfterTransaction(session, invalidate);
+    expect(invalidate).not.toHaveBeenCalled();
+
+    await session.commitTransaction();
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('discards deferred invalidation when the transaction aborts', async () => {
+    const { endedHandlers, session } = createSession();
+    const invalidate = jest.fn().mockResolvedValue(undefined);
+
+    await runAfterTransaction(session, invalidate);
+    await session.abortTransaction();
+    endedHandlers.forEach((fire) => fire());
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it('does not carry a failed abort queue into a reused session', async () => {
+    const abortError = new Error('abort failed');
+    const { abortTransaction, session, startTransaction } = createSession(abortError);
+    const abortedInvalidate = jest.fn().mockResolvedValue(undefined);
+    const committedInvalidate = jest.fn().mockResolvedValue(undefined);
+
+    await runAfterTransaction(session, abortedInvalidate);
+    await expect(session.abortTransaction({ timeoutMS: 25 })).rejects.toThrow(abortError);
+    expect(abortTransaction).toHaveBeenCalledWith({ timeoutMS: 25 });
+
+    startTransaction();
+    await runAfterTransaction(session, committedInvalidate);
+    await session.commitTransaction();
+
+    expect(abortedInvalidate).not.toHaveBeenCalled();
+    expect(committedInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains only the current queue when a session is reused', async () => {
+    const { session, startTransaction } = createSession();
+    const firstInvalidate = jest.fn().mockResolvedValue(undefined);
+    const secondInvalidate = jest.fn().mockResolvedValue(undefined);
+
+    await runAfterTransaction(session, firstInvalidate);
+    await session.commitTransaction();
+    startTransaction();
+    await runAfterTransaction(session, secondInvalidate);
+    await session.commitTransaction();
+
+    expect(firstInvalidate).toHaveBeenCalledTimes(1);
+    expect(secondInvalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs invalidation immediately without an active transaction', async () => {
+    const invalidate = jest.fn();
+    await runAfterTransaction(undefined, invalidate);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -27,9 +27,15 @@ let resolvePendingSets: Array<() => void> = [];
 let delayDeletes = false;
 let resolvePendingDeletes: Array<() => void> = [];
 let generationTtls: Array<number | undefined> = [];
+let failGenerationReads = false;
 
 const cacheStore: CacheStore = {
-  get: async (key) => cacheMap.get(key),
+  get: async (key) => {
+    if (failGenerationReads && key.includes(':generation')) {
+      throw new Error('marker read failed');
+    }
+    return cacheMap.get(key);
+  },
   set: async (key, value, ttl) => {
     /** The generation entry itself must never be held back by the test gate */
     if (delaySets && !key.includes(':generation')) {
@@ -114,6 +120,7 @@ afterEach(async () => {
   delayDeletes = false;
   resolvePendingDeletes.forEach((resolve) => resolve());
   resolvePendingDeletes = [];
+  failGenerationReads = false;
 });
 
 describe('getPromptGroupAccessContext', () => {
@@ -306,6 +313,24 @@ describe('getPromptGroupAccessContext', () => {
       role: 'USER',
     });
     expect(idStrings(recovered.ownedPromptGroupIds)).toEqual([ownGroup._id.toString()]);
+  });
+
+  it('bypasses the cache instead of guessing a generation when the marker read fails', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    await methods.invalidatePromptGroupAccessContext();
+
+    failGenerationReads = true;
+    const bypassed = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(bypassed.accessibleIds)).not.toContain(ownGroup._id.toString());
+    failGenerationReads = false;
   });
 
   it('writes the generation marker with a ttl that outlives cached entries', async () => {

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -1,0 +1,187 @@
+import mongoose from 'mongoose';
+import { createModels, logger } from '..';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import {
+  PermissionBits,
+  PrincipalModel,
+  PrincipalType,
+  ResourceType,
+} from 'librechat-data-provider';
+import type { CacheStore } from '~/types';
+import { createMethods } from './index';
+
+logger.silent = true;
+
+type Methods = ReturnType<typeof createMethods>;
+type AclEntryDoc = { principalType: string; resourceId: unknown; permBits: number };
+
+let mongoServer: MongoMemoryServer;
+let methods: Methods;
+let AclEntry: mongoose.Model<unknown>;
+let Prompt: mongoose.Model<unknown>;
+let PromptGroup: mongoose.Model<unknown>;
+let cacheMap: Map<string, unknown>;
+
+const cacheStore: CacheStore = {
+  get: async (key) => cacheMap.get(key),
+  set: async (key, value) => {
+    cacheMap.set(key, value);
+  },
+  delete: async (key) => {
+    cacheMap.delete(key);
+  },
+  clear: async () => {
+    cacheMap.clear();
+  },
+};
+
+const idStrings = (ids: Array<mongoose.Types.ObjectId>): string[] => ids.map((id) => id.toString());
+
+async function seedGroupAndPrompt(author: mongoose.Types.ObjectId) {
+  const prompt = await Prompt.create({
+    groupId: new mongoose.Types.ObjectId(),
+    author,
+    prompt: 'Hello {{name}}',
+    type: 'text',
+  });
+  const group = await PromptGroup.create({
+    name: `Group ${new mongoose.Types.ObjectId().toString().slice(-6)}`,
+    author,
+    authorName: 'Test Author',
+    productionId: prompt._id,
+  });
+  return group;
+}
+
+async function grantView(
+  principalType: string,
+  principalId: mongoose.Types.ObjectId | null,
+  resourceId: unknown,
+) {
+  await AclEntry.create({
+    principalType,
+    ...(principalId ? { principalId } : {}),
+    ...(principalType === PrincipalType.USER ? { principalModel: PrincipalModel.USER } : {}),
+    resourceType: ResourceType.PROMPTGROUP,
+    resourceId,
+    permBits: PermissionBits.VIEW,
+  } as AclEntryDoc);
+}
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  AclEntry = mongoose.models.AclEntry;
+  Prompt = mongoose.models.Prompt;
+  PromptGroup = mongoose.models.PromptGroup;
+  cacheMap = new Map();
+  methods = createMethods(mongoose, { getCache: () => cacheStore });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await Promise.all([AclEntry.deleteMany({}), Prompt.deleteMany({}), PromptGroup.deleteMany({})]);
+  await methods.invalidatePromptGroupAccessContext();
+});
+
+describe('getPromptGroupAccessContext', () => {
+  it('resolves user-accessible, public, and owned prompt group ID sets', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const otherId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    const publicGroup = await seedGroupAndPrompt(otherId);
+    const hiddenGroup = await seedGroupAndPrompt(otherId);
+
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+    await grantView(PrincipalType.PUBLIC, null, publicGroup._id);
+
+    const { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds } =
+      await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+
+    expect(idStrings(publiclyAccessibleIds)).toEqual([publicGroup._id.toString()]);
+    expect(idStrings(ownedPromptGroupIds)).toEqual([ownGroup._id.toString()]);
+
+    const accessible = idStrings(accessibleIds);
+    expect(accessible).toContain(ownGroup._id.toString());
+    expect(accessible).toContain(publicGroup._id.toString());
+    expect(accessible).not.toContain(hiddenGroup._id.toString());
+  });
+
+  it('serves repeat reads from the cache and refreshes after invalidation', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    const sharedGroup = await seedGroupAndPrompt(new mongoose.Types.ObjectId());
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+
+    await grantView(PrincipalType.USER, userId, sharedGroup._id);
+
+    const stale = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(stale.accessibleIds)).not.toContain(sharedGroup._id.toString());
+
+    await methods.invalidatePromptGroupAccessContext();
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).toContain(sharedGroup._id.toString());
+  });
+
+  it('shares the public set across users and invalidates it on group deletion', async () => {
+    const authorId = new mongoose.Types.ObjectId();
+    const publicGroup = await seedGroupAndPrompt(authorId);
+    await grantView(PrincipalType.PUBLIC, null, publicGroup._id);
+
+    const authorCtx = await methods.getPromptGroupAccessContext({
+      userId: authorId.toString(),
+      role: 'USER',
+    });
+    const otherCtx = await methods.getPromptGroupAccessContext({
+      userId: new mongoose.Types.ObjectId().toString(),
+      role: 'USER',
+    });
+
+    expect(idStrings(authorCtx.publiclyAccessibleIds)).toEqual([publicGroup._id.toString()]);
+    expect(idStrings(otherCtx.publiclyAccessibleIds)).toEqual([publicGroup._id.toString()]);
+
+    await methods.deletePromptGroup({ _id: publicGroup._id.toString() });
+
+    const afterDelete = await methods.getPromptGroupAccessContext({
+      userId: authorId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(afterDelete.publiclyAccessibleIds)).toEqual([]);
+  });
+
+  it('invalidates cached owned IDs when a prompt group is created', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const before = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(before.ownedPromptGroupIds).toHaveLength(0);
+
+    await methods.createPromptGroup({
+      prompt: { prompt: 'Created', type: 'text' },
+      group: { name: 'Created Group' },
+      author: userId.toString(),
+      authorName: 'Test Author',
+    });
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(after.ownedPromptGroupIds).toHaveLength(1);
+  });
+});

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -315,6 +315,24 @@ describe('getPromptGroupAccessContext', () => {
     expect(idStrings(recovered.ownedPromptGroupIds)).toEqual([ownGroup._id.toString()]);
   });
 
+  it('reinitializes an evicted marker instead of reusing generation zero', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    await methods.invalidatePromptGroupAccessContext();
+    /** Simulate the marker being evicted while the pre-revocation entry is still alive */
+    cacheMap.delete('access:generation');
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(after.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
   it('bypasses the cache instead of guessing a generation when the marker read fails', async () => {
     const userId = new mongoose.Types.ObjectId();
     const ownGroup = await seedGroupAndPrompt(userId);

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -23,6 +23,8 @@ let PromptGroup: mongoose.Model<unknown>;
 let cacheMap: Map<string, unknown>;
 let delaySets = false;
 let resolvePendingSets: Array<() => void> = [];
+let delayDeletes = false;
+let resolvePendingDeletes: Array<() => void> = [];
 
 const cacheStore: CacheStore = {
   get: async (key) => cacheMap.get(key),
@@ -34,6 +36,9 @@ const cacheStore: CacheStore = {
     cacheMap.set(key, value);
   },
   delete: async (key) => {
+    if (delayDeletes) {
+      await new Promise<void>((resolve) => resolvePendingDeletes.push(resolve));
+    }
     cacheMap.delete(key);
   },
   clear: async () => {
@@ -101,6 +106,9 @@ afterEach(async () => {
   delaySets = false;
   resolvePendingSets.forEach((resolve) => resolve());
   resolvePendingSets = [];
+  delayDeletes = false;
+  resolvePendingDeletes.forEach((resolve) => resolve());
+  resolvePendingDeletes = [];
 });
 
 describe('getPromptGroupAccessContext', () => {
@@ -247,5 +255,61 @@ describe('getPromptGroupAccessContext', () => {
       role: 'USER',
     });
     expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('does not reuse an expired generation value after the marker itself expires', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+    await methods.invalidatePromptGroupAccessContext();
+    const primed = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(primed.accessibleIds)).toContain(ownGroup._id.toString());
+
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    cacheMap.delete('access:generation');
+    await methods.invalidatePromptGroupAccessContext();
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('does not cache access built from a stale membership while its eviction is pending', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const userGroup = await methods.createGroup({
+      name: 'Editors',
+      memberIds: [userId.toString()],
+    });
+    const groupPrompt = await seedGroupAndPrompt(new mongoose.Types.ObjectId());
+    await grantView(PrincipalType.GROUP, userGroup._id, groupPrompt._id);
+
+    const before = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(before.accessibleIds)).toContain(groupPrompt._id.toString());
+
+    delayDeletes = true;
+    const removal = methods.removeMemberById(userGroup._id, userId.toString());
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    await methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' });
+
+    delayDeletes = false;
+    resolvePendingDeletes.forEach((resolve) => resolve());
+    resolvePendingDeletes = [];
+    await removal;
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(after.accessibleIds)).not.toContain(groupPrompt._id.toString());
   });
 });

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -6,6 +6,7 @@ import {
   PrincipalModel,
   PrincipalType,
   ResourceType,
+  Time,
 } from 'librechat-data-provider';
 import type { CacheStore } from '~/types';
 import { createMethods } from './index';
@@ -25,13 +26,17 @@ let delaySets = false;
 let resolvePendingSets: Array<() => void> = [];
 let delayDeletes = false;
 let resolvePendingDeletes: Array<() => void> = [];
+let generationTtls: Array<number | undefined> = [];
 
 const cacheStore: CacheStore = {
   get: async (key) => cacheMap.get(key),
-  set: async (key, value) => {
+  set: async (key, value, ttl) => {
     /** The generation entry itself must never be held back by the test gate */
     if (delaySets && !key.includes(':generation')) {
       await new Promise<void>((resolve) => resolvePendingSets.push(resolve));
+    }
+    if (key.includes(':generation')) {
+      generationTtls.push(ttl);
     }
     cacheMap.set(key, value);
   },
@@ -279,6 +284,15 @@ describe('getPromptGroupAccessContext', () => {
       role: 'USER',
     });
     expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
+  });
+
+  it('writes the generation marker with a ttl that outlives cached entries', async () => {
+    generationTtls = [];
+    await methods.invalidatePromptGroupAccessContext();
+    expect(generationTtls.length).toBeGreaterThan(0);
+    for (const ttl of generationTtls) {
+      expect(ttl).toBeGreaterThanOrEqual(Time.ONE_DAY);
+    }
   });
 
   it('does not cache access built from a stale membership while its eviction is pending', async () => {

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
-import { createModels, logger } from '..';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { createModels, logger, runAfterTransaction } from '..';
 import {
   PermissionBits,
   PrincipalModel,
@@ -286,6 +286,28 @@ describe('getPromptGroupAccessContext', () => {
     expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
   });
 
+  it('does not cache a failed ownership lookup as empty', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    const findSpy = jest.spyOn(PromptGroup, 'find');
+    findSpy.mockImplementationOnce(() => {
+      throw new Error('transient failure');
+    });
+
+    await expect(
+      methods.getPromptGroupAccessContext({ userId: userId.toString(), role: 'USER' }),
+    ).rejects.toThrow('transient failure');
+    findSpy.mockRestore();
+
+    const recovered = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(recovered.ownedPromptGroupIds)).toEqual([ownGroup._id.toString()]);
+  });
+
   it('writes the generation marker with a ttl that outlives cached entries', async () => {
     generationTtls = [];
     await methods.invalidatePromptGroupAccessContext();
@@ -325,5 +347,33 @@ describe('getPromptGroupAccessContext', () => {
       role: 'USER',
     });
     expect(idStrings(after.accessibleIds)).not.toContain(groupPrompt._id.toString());
+  });
+});
+
+describe('runAfterTransaction', () => {
+  it('defers invalidation until a caller-owned session ends', async () => {
+    const endedHandlers: Array<() => void> = [];
+    const session = {
+      inTransaction: () => true,
+      once: (event: string, handler: () => void) => {
+        if (event === 'ended') {
+          endedHandlers.push(handler);
+        }
+      },
+    } as unknown as Parameters<typeof runAfterTransaction>[0];
+    const invalidate = jest.fn().mockResolvedValue(undefined);
+
+    await runAfterTransaction(session, invalidate);
+    expect(invalidate).not.toHaveBeenCalled();
+
+    endedHandlers.forEach((fire) => fire());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs invalidation immediately without an active transaction', async () => {
+    const invalidate = jest.fn();
+    await runAfterTransaction(undefined, invalidate);
+    expect(invalidate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
+++ b/packages/data-schemas/src/methods/prompt.accessContext.spec.ts
@@ -21,10 +21,16 @@ let AclEntry: mongoose.Model<unknown>;
 let Prompt: mongoose.Model<unknown>;
 let PromptGroup: mongoose.Model<unknown>;
 let cacheMap: Map<string, unknown>;
+let delaySets = false;
+let resolvePendingSets: Array<() => void> = [];
 
 const cacheStore: CacheStore = {
   get: async (key) => cacheMap.get(key),
   set: async (key, value) => {
+    /** The generation entry itself must never be held back by the test gate */
+    if (delaySets && !key.includes(':generation')) {
+      await new Promise<void>((resolve) => resolvePendingSets.push(resolve));
+    }
     cacheMap.set(key, value);
   },
   delete: async (key) => {
@@ -58,10 +64,15 @@ async function grantView(
   principalId: mongoose.Types.ObjectId | null,
   resourceId: unknown,
 ) {
+  const principalModels: Record<string, string> = {
+    [PrincipalType.USER]: PrincipalModel.USER,
+    [PrincipalType.GROUP]: PrincipalModel.GROUP,
+    [PrincipalType.ROLE]: PrincipalModel.ROLE,
+  };
   await AclEntry.create({
     principalType,
     ...(principalId ? { principalId } : {}),
-    ...(principalType === PrincipalType.USER ? { principalModel: PrincipalModel.USER } : {}),
+    ...(principalModels[principalType] ? { principalModel: principalModels[principalType] } : {}),
     resourceType: ResourceType.PROMPTGROUP,
     resourceId,
     permBits: PermissionBits.VIEW,
@@ -87,6 +98,9 @@ afterAll(async () => {
 afterEach(async () => {
   await Promise.all([AclEntry.deleteMany({}), Prompt.deleteMany({}), PromptGroup.deleteMany({})]);
   await methods.invalidatePromptGroupAccessContext();
+  delaySets = false;
+  resolvePendingSets.forEach((resolve) => resolve());
+  resolvePendingSets = [];
 });
 
 describe('getPromptGroupAccessContext', () => {
@@ -183,5 +197,55 @@ describe('getPromptGroupAccessContext', () => {
       role: 'USER',
     });
     expect(after.ownedPromptGroupIds).toHaveLength(1);
+  });
+
+  it('drops access granted through a user group when the member is removed', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const userGroup = await methods.createGroup({
+      name: 'Editors',
+      memberIds: [userId.toString()],
+    });
+    const groupPrompt = await seedGroupAndPrompt(new mongoose.Types.ObjectId());
+    await grantView(PrincipalType.GROUP, userGroup._id, groupPrompt._id);
+
+    const before = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(before.accessibleIds)).toContain(groupPrompt._id.toString());
+
+    await methods.removeMemberById(userGroup._id, userId.toString());
+
+    const after = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(after.accessibleIds)).not.toContain(groupPrompt._id.toString());
+  });
+
+  it('cannot read IDs written back by a build that was in flight across an invalidation', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownGroup = await seedGroupAndPrompt(userId);
+    await grantView(PrincipalType.USER, userId, ownGroup._id);
+
+    delaySets = true;
+    const firstResolve = methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+
+    await AclEntry.deleteMany({ resourceId: ownGroup._id });
+    await methods.invalidatePromptGroupAccessContext();
+
+    delaySets = false;
+    resolvePendingSets.forEach((resolve) => resolve());
+    resolvePendingSets = [];
+    await firstResolve;
+
+    const fresh = await methods.getPromptGroupAccessContext({
+      userId: userId.toString(),
+      role: 'USER',
+    });
+    expect(idStrings(fresh.accessibleIds)).not.toContain(ownGroup._id.toString());
   });
 });

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -1,7 +1,14 @@
-import { ResourceType, SystemCategories } from 'librechat-data-provider';
+import { randomUUID } from 'crypto';
+import {
+  CacheKeys,
+  PermissionBits,
+  ResourceType,
+  SystemCategories,
+  Time,
+} from 'librechat-data-provider';
 import type { Model, Types } from 'mongoose';
-import type { IAclEntry, IPrompt, IPromptGroup, IPromptGroupDocument } from '~/types';
-import { getTenantId, SYSTEM_TENANT_ID } from '~/config/tenantContext';
+import type { IAclEntry, CacheStore, IPrompt, IPromptGroup, IPromptGroupDocument } from '~/types';
+import { getTenantId, scopedCacheKey, SYSTEM_TENANT_ID } from '~/config/tenantContext';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { escapeRegExp } from '~/utils/string';
 import logger from '~/config/winston';
@@ -14,6 +21,74 @@ export interface PromptDeps {
     userObjectId: Types.ObjectId,
     resourceTypes: string | string[],
   ) => Promise<Types.ObjectId[]>;
+  /** Returns a cache store for the given key. Injected from getLogStores. */
+  getCache?: (key: string) => CacheStore | undefined;
+  /** Resolves ACL principals for a user. From createUserGroupMethods. */
+  getUserPrincipals: (params: {
+    userId: string | Types.ObjectId;
+    role?: string | null;
+  }) => Promise<Array<{ principalType: string; principalId?: string | Types.ObjectId }>>;
+  /** Finds resource IDs accessible to a set of principals. From createAclEntryMethods. */
+  findAccessibleResources: (
+    principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
+    resourceType: string,
+    requiredPermBit: number,
+    resourceIds?: Types.ObjectId[],
+    readPrimary?: boolean,
+  ) => Promise<Types.ObjectId[]>;
+  /** Finds publicly accessible resource IDs. From createAclEntryMethods. */
+  findPublicResourceIds: (
+    resourceType: string,
+    requiredPermissions: number,
+    resourceIds?: Types.ObjectId[],
+    readPrimary?: boolean,
+  ) => Promise<Types.ObjectId[]>;
+}
+
+/** In-flight access ID builds, so concurrent same-process misses share one resolution. */
+const pendingAccessLookups = new Map<
+  string,
+  { generationKey: string; promise: Promise<string[]>; markStale: () => void }
+>();
+/** Tenant generation markers whose failed invalidation makes cache reads unsafe. */
+const bypassedAccessGenerationKeys = new Set<string>();
+
+const ACCESS_GENERATION_KEY = 'access:generation';
+
+function isCachedIdArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((id) => typeof id === 'string' && isValidObjectIdString(id))
+  );
+}
+
+/**
+ * Reads the tenant's invalidation generation. Cached entries are keyed by it, so a
+ * bump orphans every previous entry for this tenant without touching other tenants.
+ * A missing marker (fresh tenant, or evicted under a Redis eviction policy) is
+ * reinitialized to a fresh never-before-used value rather than falling back to
+ * zero, where an evicted era's orphaned entry could still be read. Resolves
+ * undefined when the marker cannot be read: guessing a generation then could
+ * serve an orphaned entry, so callers must bypass the cache.
+ */
+async function readAccessGeneration(cache: CacheStore): Promise<string | undefined> {
+  const generationKey = scopedCacheKey(ACCESS_GENERATION_KEY);
+  if (bypassedAccessGenerationKeys.has(generationKey)) {
+    return undefined;
+  }
+  try {
+    const value = await cache.get(generationKey);
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value.toString();
+    }
+    const initialized = randomUUID();
+    await cache.set(generationKey, initialized, Time.ONE_DAY);
+    return initialized;
+  } catch {
+    return undefined;
+  }
 }
 
 export interface PromptMethods {
@@ -68,7 +143,13 @@ export interface PromptMethods {
     filter: Record<string, unknown>,
   ): Promise<Record<string, unknown> | null | { message: string }>;
   getPromptGroup(filter: Record<string, unknown>): Promise<Record<string, unknown> | null>;
-  getOwnedPromptGroupIds(author: string): Promise<Types.ObjectId[]>;
+  getOwnedPromptGroupIds(author: string, readPrimary?: boolean): Promise<Types.ObjectId[]>;
+  getPromptGroupAccessContext(params: { userId: string; role?: string }): Promise<{
+    accessibleIds: Types.ObjectId[];
+    publiclyAccessibleIds: Types.ObjectId[];
+    ownedPromptGroupIds: Types.ObjectId[];
+  }>;
+  invalidatePromptGroupAccessContext(): Promise<void>;
   deletePrompt(params: {
     promptId: string | Types.ObjectId;
     groupId: string | Types.ObjectId;
@@ -274,6 +355,8 @@ export function createPromptMethods(
       logger.error('Error removing promptGroup permissions:', error);
     }
 
+    await invalidatePromptGroupAccessContext();
+
     return { message: 'Prompt group deleted successfully' };
   }
 
@@ -465,6 +548,8 @@ export function createPromptMethods(
         .select('-__v')
         .exec())!;
 
+      await invalidatePromptGroupAccessContext();
+
       return {
         prompt: newPrompt,
         group: {
@@ -647,18 +732,227 @@ export function createPromptMethods(
    * Used by the "Shared Prompts" and "My Prompts" filters to distinguish
    * owned prompts from prompts shared with the user.
    */
-  async function getOwnedPromptGroupIds(author: string) {
+  async function getOwnedPromptGroupIds(author: string, readPrimary = false) {
     try {
       const PromptGroup = mongoose.models.PromptGroup as Model<IPromptGroupDocument>;
       if (!author || !ObjectId.isValid(author)) {
         logger.warn('getOwnedPromptGroupIds called with invalid author', { author });
         return [];
       }
-      const groups = await PromptGroup.find({ author: new ObjectId(author) }, { _id: 1 }).lean();
+      const groupsQuery = PromptGroup.find({ author: new ObjectId(author) }, { _id: 1 });
+      if (readPrimary) {
+        /**
+         * Cache builds must not capture a lagging secondary's pre-mutation state
+         * for the full TTL (`secondaryPreferred` deployments).
+         */
+        groupsQuery.read('primary');
+      }
+      const groups = await groupsQuery.lean();
       return groups.map((g) => g._id);
     } catch (error) {
       logger.error('Error getting owned prompt group IDs', error);
-      return [];
+      /** A failed lookup must not be cached as an empty ownership set */
+      throw error;
+    }
+  }
+
+  /**
+   * Resolves one prompt group ID set from the PROMPT_GROUPS_ACCESS cache, building
+   * it on miss. Entries are stored as hex strings and revived to ObjectIds on read;
+   * concurrent same-process misses share a single build, which invalidation marks
+   * stale so a pre-mutation build never writes its IDs back into the cache.
+   */
+  async function resolveCachedIds(
+    cacheKey: string,
+    generationKey: string,
+    build: () => Promise<Types.ObjectId[]>,
+  ): Promise<Types.ObjectId[]> {
+    const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
+    if (!cache) {
+      return build();
+    }
+
+    try {
+      const cached = await cache.get(cacheKey);
+      if (isCachedIdArray(cached)) {
+        return cached.map((id) => new ObjectId(id));
+      }
+    } catch {
+      /** Cache failures must not block access resolution. */
+    }
+
+    const pending = pendingAccessLookups.get(cacheKey);
+    if (pending) {
+      const ids = await pending.promise;
+      return ids.map((id) => new ObjectId(id));
+    }
+
+    let stale = false;
+    const lookup = (async () => {
+      const ids = await build();
+      if (!stale) {
+        try {
+          await cache.set(
+            cacheKey,
+            ids.map((id) => id.toString()),
+          );
+        } catch {
+          /** Cache write failures only cost a rebuild on the next request. */
+        }
+      }
+      return ids.map((id) => id.toString());
+    })();
+
+    pendingAccessLookups.set(cacheKey, {
+      generationKey,
+      promise: lookup,
+      markStale: () => {
+        stale = true;
+      },
+    });
+    try {
+      const ids = await lookup;
+      return ids.map((id) => new ObjectId(id));
+    } finally {
+      if (pendingAccessLookups.get(cacheKey)?.promise === lookup) {
+        pendingAccessLookups.delete(cacheKey);
+      }
+    }
+  }
+
+  /**
+   * Resolves the prompt group access ID sets shared by the list endpoints:
+   * user-accessible, publicly accessible, and user-owned group IDs.
+   *
+   * The public set is identical for every user of a tenant and the per-user sets
+   * only change on prompt or permission mutations. Hosts may cache all three in
+   * the PROMPT_GROUPS_ACCESS namespace to spare overlapping requests the repeated
+   * ACL queries. Hosts that cannot guarantee shared invalidation can use a no-op
+   * store so authorization IDs are always rebuilt.
+   */
+  async function getPromptGroupAccessContext({
+    userId,
+    role,
+  }: {
+    userId: string;
+    role?: string;
+  }): Promise<{
+    accessibleIds: Types.ObjectId[];
+    publiclyAccessibleIds: Types.ObjectId[];
+    ownedPromptGroupIds: Types.ObjectId[];
+  }> {
+    const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
+    /**
+     * Keys carry the tenant's invalidation generation, so a bump orphans every
+     * cached set for this tenant, including late writes from in-flight builds,
+     * without clearing other tenants' entries in the shared namespace. Builds
+     * read the primary so a lagging secondary cannot pin pre-mutation IDs for
+     * the full TTL.
+     */
+    const generationKey = scopedCacheKey(ACCESS_GENERATION_KEY);
+    const generation = cache ? await readAccessGeneration(cache) : '0';
+    const buildAccessible = async (): Promise<Types.ObjectId[]> => {
+      const principalsList = await deps.getUserPrincipals({ userId, role });
+      if (principalsList.length === 0) {
+        return [];
+      }
+      return deps.findAccessibleResources(
+        principalsList,
+        ResourceType.PROMPTGROUP,
+        PermissionBits.VIEW,
+        undefined,
+        true,
+      );
+    };
+    const buildPublic = () =>
+      deps.findPublicResourceIds(ResourceType.PROMPTGROUP, PermissionBits.VIEW, undefined, true);
+    const buildOwned = () => getOwnedPromptGroupIds(userId, true);
+
+    if (generation === undefined) {
+      /** The marker could not be read; guessing a generation could serve an orphaned entry */
+      const [accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
+        buildAccessible(),
+        buildPublic(),
+        buildOwned(),
+      ]);
+      return { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds };
+    }
+
+    const scopedKey = (key: string) => scopedCacheKey(`access:${generation}:${key}`);
+
+    const accessibleIds = await resolveCachedIds(
+      scopedKey(`user:${userId}:${role ?? ''}`),
+      generationKey,
+      buildAccessible,
+    );
+
+    const [publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
+      resolveCachedIds(scopedKey('public'), generationKey, buildPublic),
+      resolveCachedIds(scopedKey(`owned:${userId}`), generationKey, buildOwned),
+    ]);
+
+    return { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds };
+  }
+
+  /**
+   * Invalidates all cached prompt group access ID sets for the active tenant after
+   * a mutation that can change them (group create/delete, permission grants/revokes,
+   * membership changes). Bumping the generation orphans cached entries and any
+   * writes still in flight from pre-mutation builds, including in other processes
+   * sharing the store, while other tenants' entries stay intact. In-flight builds
+   * in this process are additionally marked stale so they skip their cache write.
+   * The old generation marker is removed before its replacement is written. If
+   * neither operation succeeds, reads bypass this tenant's cache and the mutation
+   * rejects instead of allowing the old authorization era to remain authoritative.
+   */
+  async function invalidatePromptGroupAccessContext(): Promise<void> {
+    const generationKey = scopedCacheKey(ACCESS_GENERATION_KEY);
+    for (const [cacheKey, pending] of pendingAccessLookups) {
+      if (pending.generationKey !== generationKey) {
+        continue;
+      }
+      pending.markStale();
+      pendingAccessLookups.delete(cacheKey);
+    }
+    const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
+    if (!cache) {
+      return;
+    }
+    let markerRemoved = false;
+    if (cache.delete) {
+      try {
+        const deleteResult = await cache.delete(generationKey);
+        markerRemoved = deleteResult !== false;
+        if (!markerRemoved) {
+          logger.warn('The previous prompt group access generation was not removed');
+        }
+      } catch (error) {
+        logger.warn('Failed to remove the previous prompt group access generation', error);
+      }
+    }
+    try {
+      /**
+       * A collision-resistant token cannot repeat an evicted era or be restored
+       * by a delayed initializer that selected a different token before this write.
+       */
+      /**
+       * Keep the marker longer than derived entries so normal expiry does not
+       * orphan a warm cache era and force avoidable access-query rebuilds.
+       */
+      const setResult = await cache.set(generationKey, randomUUID(), Time.ONE_DAY);
+      if (setResult === false) {
+        throw new Error('Prompt group access generation write failed');
+      }
+      bypassedAccessGenerationKeys.delete(generationKey);
+    } catch (error) {
+      if (markerRemoved) {
+        bypassedAccessGenerationKeys.delete(generationKey);
+        logger.warn('Failed to restore the removed prompt group access generation', error);
+        return;
+      }
+      bypassedAccessGenerationKeys.add(generationKey);
+      logger.warn('Failed to invalidate prompt group access cache', error);
+      throw error;
     }
   }
 
@@ -701,6 +995,8 @@ export function createPromptMethods(
       }
 
       await PromptGroup.deleteOne({ _id: groupId });
+
+      await invalidatePromptGroupAccessContext();
 
       return {
         prompt: 'Prompt deleted successfully',
@@ -772,6 +1068,7 @@ export function createPromptMethods(
 
       await PromptGroup.deleteMany({ _id: { $in: allGroupIdsToDelete } });
       await Prompt.deleteMany({ groupId: { $in: allGroupIdsToDelete } });
+      await invalidatePromptGroupAccessContext();
     } catch (error) {
       logger.error('[deleteUserPrompts] General error:', error);
     }
@@ -866,6 +1163,8 @@ export function createPromptMethods(
     getPromptGroupsWithPrompts,
     getPromptGroup,
     getOwnedPromptGroupIds,
+    getPromptGroupAccessContext,
+    invalidatePromptGroupAccessContext,
     deletePrompt,
     deleteUserPrompts,
     updatePromptGroup,

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -867,7 +867,15 @@ export function createPromptMethods(
     try {
       const generationKey = scopedCacheKey(ACCESS_GENERATION_KEY);
       const current = await cache.get(generationKey);
-      const next = (typeof current === 'number' && Number.isFinite(current) ? current : 0) + 1;
+      /**
+       * Strictly increasing and never repeating, even when the marker itself
+       * expired out of the TTL cache: a repeated value could resurrect a
+       * pre-mutation entry that is still alive under that generation.
+       */
+      const next = Math.max(
+        Date.now(),
+        (typeof current === 'number' && Number.isFinite(current) ? current : 0) + 1,
+      );
       await cache.set(generationKey, next);
     } catch (error) {
       logger.warn('Failed to invalidate prompt group access cache', error);

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -1,7 +1,7 @@
-import { ResourceType, SystemCategories } from 'librechat-data-provider';
+import { CacheKeys, PermissionBits, ResourceType, SystemCategories } from 'librechat-data-provider';
 import type { Model, Types } from 'mongoose';
-import type { IAclEntry, IPrompt, IPromptGroup, IPromptGroupDocument } from '~/types';
-import { getTenantId, SYSTEM_TENANT_ID } from '~/config/tenantContext';
+import type { IAclEntry, CacheStore, IPrompt, IPromptGroup, IPromptGroupDocument } from '~/types';
+import { getTenantId, scopedCacheKey, SYSTEM_TENANT_ID } from '~/config/tenantContext';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { escapeRegExp } from '~/utils/string';
 import logger from '~/config/winston';
@@ -14,6 +14,33 @@ export interface PromptDeps {
     userObjectId: Types.ObjectId,
     resourceTypes: string | string[],
   ) => Promise<Types.ObjectId[]>;
+  /** Returns a cache store for the given key. Injected from getLogStores. */
+  getCache?: (key: string) => CacheStore | undefined;
+  /** Resolves ACL principals for a user. From createUserGroupMethods. */
+  getUserPrincipals: (params: {
+    userId: string | Types.ObjectId;
+    role?: string | null;
+  }) => Promise<Array<{ principalType: string; principalId?: string | Types.ObjectId }>>;
+  /** Finds resource IDs accessible to a set of principals. From createAclEntryMethods. */
+  findAccessibleResources: (
+    principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
+    resourceType: string,
+    requiredPermBit: number,
+  ) => Promise<Types.ObjectId[]>;
+  /** Finds publicly accessible resource IDs. From createAclEntryMethods. */
+  findPublicResourceIds: (
+    resourceType: string,
+    requiredPermissions: number,
+  ) => Promise<Types.ObjectId[]>;
+}
+
+/** In-flight access ID builds, so concurrent same-process misses share one resolution. */
+const pendingAccessLookups = new Map<string, Promise<string[]>>();
+
+function isCachedIdArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((id) => typeof id === 'string' && isValidObjectIdString(id))
+  );
 }
 
 export interface PromptMethods {
@@ -69,6 +96,12 @@ export interface PromptMethods {
   ): Promise<Record<string, unknown> | null | { message: string }>;
   getPromptGroup(filter: Record<string, unknown>): Promise<Record<string, unknown> | null>;
   getOwnedPromptGroupIds(author: string): Promise<Types.ObjectId[]>;
+  getPromptGroupAccessContext(params: { userId: string; role?: string }): Promise<{
+    accessibleIds: Types.ObjectId[];
+    publiclyAccessibleIds: Types.ObjectId[];
+    ownedPromptGroupIds: Types.ObjectId[];
+  }>;
+  invalidatePromptGroupAccessContext(): Promise<void>;
   deletePrompt(params: {
     promptId: string | Types.ObjectId;
     groupId: string | Types.ObjectId;
@@ -274,6 +307,8 @@ export function createPromptMethods(
       logger.error('Error removing promptGroup permissions:', error);
     }
 
+    await invalidatePromptGroupAccessContext();
+
     return { message: 'Prompt group deleted successfully' };
   }
 
@@ -464,6 +499,8 @@ export function createPromptMethods(
         .lean()
         .select('-__v')
         .exec())!;
+
+      await invalidatePromptGroupAccessContext();
 
       return {
         prompt: newPrompt,
@@ -663,6 +700,122 @@ export function createPromptMethods(
   }
 
   /**
+   * Resolves one prompt group ID set from the PROMPT_GROUPS_ACCESS cache, building
+   * it on miss. Entries are stored as hex strings and revived to ObjectIds on read;
+   * concurrent same-process misses share a single build.
+   */
+  async function resolveCachedIds(
+    cacheKey: string,
+    build: () => Promise<Types.ObjectId[]>,
+  ): Promise<Types.ObjectId[]> {
+    const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
+    if (!cache) {
+      return build();
+    }
+
+    try {
+      const cached = await cache.get(cacheKey);
+      if (isCachedIdArray(cached)) {
+        return cached.map((id) => new ObjectId(id));
+      }
+    } catch {
+      /** Cache failures must not block access resolution. */
+    }
+
+    const pending = pendingAccessLookups.get(cacheKey);
+    if (pending) {
+      const ids = await pending;
+      return ids.map((id) => new ObjectId(id));
+    }
+
+    const lookup = (async () => {
+      const ids = await build();
+      try {
+        await cache.set(
+          cacheKey,
+          ids.map((id) => id.toString()),
+        );
+      } catch {
+        /** Cache write failures only cost a rebuild on the next request. */
+      }
+      return ids.map((id) => id.toString());
+    })();
+
+    pendingAccessLookups.set(cacheKey, lookup);
+    try {
+      const ids = await lookup;
+      return ids.map((id) => new ObjectId(id));
+    } finally {
+      if (pendingAccessLookups.get(cacheKey) === lookup) {
+        pendingAccessLookups.delete(cacheKey);
+      }
+    }
+  }
+
+  /**
+   * Resolves the prompt group access ID sets shared by the list endpoints:
+   * user-accessible, publicly accessible, and user-owned group IDs.
+   *
+   * The public set is identical for every user of a tenant and the per-user sets
+   * only change on prompt or permission mutations, so all three are cached briefly
+   * (PROMPT_GROUPS_ACCESS namespace, TTL-bounded) to spare overlapping requests
+   * (startup, filter changes, reloads, multiple tabs) the repeated ACL queries.
+   */
+  async function getPromptGroupAccessContext({
+    userId,
+    role,
+  }: {
+    userId: string;
+    role?: string;
+  }): Promise<{
+    accessibleIds: Types.ObjectId[];
+    publiclyAccessibleIds: Types.ObjectId[];
+    ownedPromptGroupIds: Types.ObjectId[];
+  }> {
+    const accessibleIds = await resolveCachedIds(
+      scopedCacheKey(`user:${userId}:${role ?? ''}`),
+      async () => {
+        const principalsList = await deps.getUserPrincipals({ userId, role });
+        if (principalsList.length === 0) {
+          return [];
+        }
+        return deps.findAccessibleResources(
+          principalsList,
+          ResourceType.PROMPTGROUP,
+          PermissionBits.VIEW,
+        );
+      },
+    );
+
+    const [publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
+      resolveCachedIds(scopedCacheKey('public'), () =>
+        deps.findPublicResourceIds(ResourceType.PROMPTGROUP, PermissionBits.VIEW),
+      ),
+      resolveCachedIds(scopedCacheKey(`owned:${userId}`), () => getOwnedPromptGroupIds(userId)),
+    ]);
+
+    return { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds };
+  }
+
+  /**
+   * Clears all cached prompt group access ID sets after a mutation that can change
+   * them (group create/delete, permission grants/revokes). Failures are non-fatal;
+   * the cache TTL bounds any residual staleness.
+   */
+  async function invalidatePromptGroupAccessContext(): Promise<void> {
+    pendingAccessLookups.clear();
+    const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
+    if (!cache?.clear) {
+      return;
+    }
+    try {
+      await cache.clear();
+    } catch (error) {
+      logger.warn('Failed to invalidate prompt group access cache', error);
+    }
+  }
+
+  /**
    * Delete a prompt, potentially removing the group if it's the last prompt.
    *
    * **Authorization is enforced upstream.** This method performs no ownership
@@ -701,6 +854,8 @@ export function createPromptMethods(
       }
 
       await PromptGroup.deleteOne({ _id: groupId });
+
+      await invalidatePromptGroupAccessContext();
 
       return {
         prompt: 'Prompt deleted successfully',
@@ -772,6 +927,7 @@ export function createPromptMethods(
 
       await PromptGroup.deleteMany({ _id: { $in: allGroupIdsToDelete } });
       await Prompt.deleteMany({ groupId: { $in: allGroupIdsToDelete } });
+      await invalidatePromptGroupAccessContext();
     } catch (error) {
       logger.error('[deleteUserPrompts] General error:', error);
     }
@@ -866,6 +1022,8 @@ export function createPromptMethods(
     getPromptGroupsWithPrompts,
     getPromptGroup,
     getOwnedPromptGroupIds,
+    getPromptGroupAccessContext,
+    invalidatePromptGroupAccessContext,
     deletePrompt,
     deleteUserPrompts,
     updatePromptGroup,

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -1,4 +1,10 @@
-import { CacheKeys, PermissionBits, ResourceType, SystemCategories } from 'librechat-data-provider';
+import {
+  CacheKeys,
+  PermissionBits,
+  ResourceType,
+  SystemCategories,
+  Time,
+} from 'librechat-data-provider';
 import type { Model, Types } from 'mongoose';
 import type { IAclEntry, CacheStore, IPrompt, IPromptGroup, IPromptGroupDocument } from '~/types';
 import { getTenantId, scopedCacheKey, SYSTEM_TENANT_ID } from '~/config/tenantContext';
@@ -876,7 +882,13 @@ export function createPromptMethods(
         Date.now(),
         (typeof current === 'number' && Number.isFinite(current) ? current : 0) + 1,
       );
-      await cache.set(generationKey, next);
+      /**
+       * The marker must outlive every derived entry and in-flight build: with the
+       * namespace default it could expire first, and a reader would fall back to
+       * generation 0 while a late cross-process write from that era is still
+       * alive, briefly re-exposing revoked IDs.
+       */
+      await cache.set(generationKey, next, Time.ONE_DAY);
     } catch (error) {
       logger.warn('Failed to invalidate prompt group access cache', error);
     }

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -26,21 +26,41 @@ export interface PromptDeps {
     principalsList: Array<{ principalType: string; principalId?: string | Types.ObjectId }>,
     resourceType: string,
     requiredPermBit: number,
+    readPrimary?: boolean,
   ) => Promise<Types.ObjectId[]>;
   /** Finds publicly accessible resource IDs. From createAclEntryMethods. */
   findPublicResourceIds: (
     resourceType: string,
     requiredPermissions: number,
+    readPrimary?: boolean,
   ) => Promise<Types.ObjectId[]>;
 }
 
 /** In-flight access ID builds, so concurrent same-process misses share one resolution. */
-const pendingAccessLookups = new Map<string, Promise<string[]>>();
+const pendingAccessLookups = new Map<
+  string,
+  { promise: Promise<string[]>; markStale: () => void }
+>();
+
+const ACCESS_GENERATION_KEY = 'access:generation';
 
 function isCachedIdArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((id) => typeof id === 'string' && isValidObjectIdString(id))
   );
+}
+
+/**
+ * Reads the tenant's invalidation generation. Cached entries are keyed by it, so a
+ * bump orphans every previous entry for this tenant without touching other tenants.
+ */
+async function readAccessGeneration(cache: CacheStore): Promise<number> {
+  try {
+    const value = await cache.get(scopedCacheKey(ACCESS_GENERATION_KEY));
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+  } catch {
+    return 0;
+  }
 }
 
 export interface PromptMethods {
@@ -95,7 +115,7 @@ export interface PromptMethods {
     filter: Record<string, unknown>,
   ): Promise<Record<string, unknown> | null | { message: string }>;
   getPromptGroup(filter: Record<string, unknown>): Promise<Record<string, unknown> | null>;
-  getOwnedPromptGroupIds(author: string): Promise<Types.ObjectId[]>;
+  getOwnedPromptGroupIds(author: string, readPrimary?: boolean): Promise<Types.ObjectId[]>;
   getPromptGroupAccessContext(params: { userId: string; role?: string }): Promise<{
     accessibleIds: Types.ObjectId[];
     publiclyAccessibleIds: Types.ObjectId[];
@@ -684,14 +704,22 @@ export function createPromptMethods(
    * Used by the "Shared Prompts" and "My Prompts" filters to distinguish
    * owned prompts from prompts shared with the user.
    */
-  async function getOwnedPromptGroupIds(author: string) {
+  async function getOwnedPromptGroupIds(author: string, readPrimary = false) {
     try {
       const PromptGroup = mongoose.models.PromptGroup as Model<IPromptGroupDocument>;
       if (!author || !ObjectId.isValid(author)) {
         logger.warn('getOwnedPromptGroupIds called with invalid author', { author });
         return [];
       }
-      const groups = await PromptGroup.find({ author: new ObjectId(author) }, { _id: 1 }).lean();
+      const groupsQuery = PromptGroup.find({ author: new ObjectId(author) }, { _id: 1 });
+      if (readPrimary) {
+        /**
+         * Cache builds must not capture a lagging secondary's pre-mutation state
+         * for the full TTL (`secondaryPreferred` deployments).
+         */
+        groupsQuery.read('primary');
+      }
+      const groups = await groupsQuery.lean();
       return groups.map((g) => g._id);
     } catch (error) {
       logger.error('Error getting owned prompt group IDs', error);
@@ -702,7 +730,8 @@ export function createPromptMethods(
   /**
    * Resolves one prompt group ID set from the PROMPT_GROUPS_ACCESS cache, building
    * it on miss. Entries are stored as hex strings and revived to ObjectIds on read;
-   * concurrent same-process misses share a single build.
+   * concurrent same-process misses share a single build, which invalidation marks
+   * stale so a pre-mutation build never writes its IDs back into the cache.
    */
   async function resolveCachedIds(
     cacheKey: string,
@@ -724,29 +753,37 @@ export function createPromptMethods(
 
     const pending = pendingAccessLookups.get(cacheKey);
     if (pending) {
-      const ids = await pending;
+      const ids = await pending.promise;
       return ids.map((id) => new ObjectId(id));
     }
 
+    let stale = false;
     const lookup = (async () => {
       const ids = await build();
-      try {
-        await cache.set(
-          cacheKey,
-          ids.map((id) => id.toString()),
-        );
-      } catch {
-        /** Cache write failures only cost a rebuild on the next request. */
+      if (!stale) {
+        try {
+          await cache.set(
+            cacheKey,
+            ids.map((id) => id.toString()),
+          );
+        } catch {
+          /** Cache write failures only cost a rebuild on the next request. */
+        }
       }
       return ids.map((id) => id.toString());
     })();
 
-    pendingAccessLookups.set(cacheKey, lookup);
+    pendingAccessLookups.set(cacheKey, {
+      promise: lookup,
+      markStale: () => {
+        stale = true;
+      },
+    });
     try {
       const ids = await lookup;
       return ids.map((id) => new ObjectId(id));
     } finally {
-      if (pendingAccessLookups.get(cacheKey) === lookup) {
+      if (pendingAccessLookups.get(cacheKey)?.promise === lookup) {
         pendingAccessLookups.delete(cacheKey);
       }
     }
@@ -772,8 +809,19 @@ export function createPromptMethods(
     publiclyAccessibleIds: Types.ObjectId[];
     ownedPromptGroupIds: Types.ObjectId[];
   }> {
+    const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
+    /**
+     * Keys carry the tenant's invalidation generation, so a bump orphans every
+     * cached set for this tenant, including late writes from in-flight builds,
+     * without clearing other tenants' entries in the shared namespace. Builds
+     * read the primary so a lagging secondary cannot pin pre-mutation IDs for
+     * the full TTL.
+     */
+    const generation = cache ? await readAccessGeneration(cache) : 0;
+    const scopedKey = (key: string) => scopedCacheKey(`access:${generation}:${key}`);
+
     const accessibleIds = await resolveCachedIds(
-      scopedCacheKey(`user:${userId}:${role ?? ''}`),
+      scopedKey(`user:${userId}:${role ?? ''}`),
       async () => {
         const principalsList = await deps.getUserPrincipals({ userId, role });
         if (principalsList.length === 0) {
@@ -783,33 +831,44 @@ export function createPromptMethods(
           principalsList,
           ResourceType.PROMPTGROUP,
           PermissionBits.VIEW,
+          true,
         );
       },
     );
 
     const [publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
-      resolveCachedIds(scopedCacheKey('public'), () =>
-        deps.findPublicResourceIds(ResourceType.PROMPTGROUP, PermissionBits.VIEW),
+      resolveCachedIds(scopedKey('public'), () =>
+        deps.findPublicResourceIds(ResourceType.PROMPTGROUP, PermissionBits.VIEW, true),
       ),
-      resolveCachedIds(scopedCacheKey(`owned:${userId}`), () => getOwnedPromptGroupIds(userId)),
+      resolveCachedIds(scopedKey(`owned:${userId}`), () => getOwnedPromptGroupIds(userId, true)),
     ]);
 
     return { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds };
   }
 
   /**
-   * Clears all cached prompt group access ID sets after a mutation that can change
-   * them (group create/delete, permission grants/revokes). Failures are non-fatal;
-   * the cache TTL bounds any residual staleness.
+   * Invalidates all cached prompt group access ID sets for the active tenant after
+   * a mutation that can change them (group create/delete, permission grants/revokes,
+   * membership changes). Bumping the generation orphans cached entries and any
+   * writes still in flight from pre-mutation builds, including in other processes
+   * sharing the store, while other tenants' entries stay intact. In-flight builds
+   * in this process are additionally marked stale so they skip their cache write.
+   * Failures are non-fatal; the cache TTL bounds any residual staleness.
    */
   async function invalidatePromptGroupAccessContext(): Promise<void> {
+    for (const pending of pendingAccessLookups.values()) {
+      pending.markStale();
+    }
     pendingAccessLookups.clear();
     const cache = deps.getCache?.(CacheKeys.PROMPT_GROUPS_ACCESS);
-    if (!cache?.clear) {
+    if (!cache) {
       return;
     }
     try {
-      await cache.clear();
+      const generationKey = scopedCacheKey(ACCESS_GENERATION_KEY);
+      const current = await cache.get(generationKey);
+      const next = (typeof current === 'number' && Number.isFinite(current) ? current : 0) + 1;
+      await cache.set(generationKey, next);
     } catch (error) {
       logger.warn('Failed to invalidate prompt group access cache', error);
     }

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -729,7 +729,8 @@ export function createPromptMethods(
       return groups.map((g) => g._id);
     } catch (error) {
       logger.error('Error getting owned prompt group IDs', error);
-      return [];
+      /** A failed lookup must not be cached as an empty ownership set */
+      throw error;
     }
   }
 

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -59,13 +59,22 @@ function isCachedIdArray(value: unknown): value is string[] {
 /**
  * Reads the tenant's invalidation generation. Cached entries are keyed by it, so a
  * bump orphans every previous entry for this tenant without touching other tenants.
- * Resolves undefined when the marker cannot be read: guessing a generation then
- * could serve an orphaned pre-mutation entry, so callers must bypass the cache.
+ * A missing marker (fresh tenant, or evicted under a Redis eviction policy) is
+ * reinitialized to a fresh never-before-used value rather than falling back to
+ * zero, where an evicted era's orphaned entry could still be read. Resolves
+ * undefined when the marker cannot be read: guessing a generation then could
+ * serve an orphaned entry, so callers must bypass the cache.
  */
 async function readAccessGeneration(cache: CacheStore): Promise<number | undefined> {
+  const generationKey = scopedCacheKey(ACCESS_GENERATION_KEY);
   try {
-    const value = await cache.get(scopedCacheKey(ACCESS_GENERATION_KEY));
-    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+    const value = await cache.get(generationKey);
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    const initialized = Math.max(Date.now(), 1);
+    await cache.set(generationKey, initialized, Time.ONE_DAY);
+    return initialized;
   } catch {
     return undefined;
   }

--- a/packages/data-schemas/src/methods/prompt.ts
+++ b/packages/data-schemas/src/methods/prompt.ts
@@ -59,13 +59,15 @@ function isCachedIdArray(value: unknown): value is string[] {
 /**
  * Reads the tenant's invalidation generation. Cached entries are keyed by it, so a
  * bump orphans every previous entry for this tenant without touching other tenants.
+ * Resolves undefined when the marker cannot be read: guessing a generation then
+ * could serve an orphaned pre-mutation entry, so callers must bypass the cache.
  */
-async function readAccessGeneration(cache: CacheStore): Promise<number> {
+async function readAccessGeneration(cache: CacheStore): Promise<number | undefined> {
   try {
     const value = await cache.get(scopedCacheKey(ACCESS_GENERATION_KEY));
     return typeof value === 'number' && Number.isFinite(value) ? value : 0;
   } catch {
-    return 0;
+    return undefined;
   }
 }
 
@@ -825,29 +827,42 @@ export function createPromptMethods(
      * the full TTL.
      */
     const generation = cache ? await readAccessGeneration(cache) : 0;
+    const buildAccessible = async (): Promise<Types.ObjectId[]> => {
+      const principalsList = await deps.getUserPrincipals({ userId, role });
+      if (principalsList.length === 0) {
+        return [];
+      }
+      return deps.findAccessibleResources(
+        principalsList,
+        ResourceType.PROMPTGROUP,
+        PermissionBits.VIEW,
+        true,
+      );
+    };
+    const buildPublic = () =>
+      deps.findPublicResourceIds(ResourceType.PROMPTGROUP, PermissionBits.VIEW, true);
+    const buildOwned = () => getOwnedPromptGroupIds(userId, true);
+
+    if (generation === undefined) {
+      /** The marker could not be read; guessing a generation could serve an orphaned entry */
+      const [accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
+        buildAccessible(),
+        buildPublic(),
+        buildOwned(),
+      ]);
+      return { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds };
+    }
+
     const scopedKey = (key: string) => scopedCacheKey(`access:${generation}:${key}`);
 
     const accessibleIds = await resolveCachedIds(
       scopedKey(`user:${userId}:${role ?? ''}`),
-      async () => {
-        const principalsList = await deps.getUserPrincipals({ userId, role });
-        if (principalsList.length === 0) {
-          return [];
-        }
-        return deps.findAccessibleResources(
-          principalsList,
-          ResourceType.PROMPTGROUP,
-          PermissionBits.VIEW,
-          true,
-        );
-      },
+      buildAccessible,
     );
 
     const [publiclyAccessibleIds, ownedPromptGroupIds] = await Promise.all([
-      resolveCachedIds(scopedKey('public'), () =>
-        deps.findPublicResourceIds(ResourceType.PROMPTGROUP, PermissionBits.VIEW, true),
-      ),
-      resolveCachedIds(scopedKey(`owned:${userId}`), () => getOwnedPromptGroupIds(userId, true)),
+      resolveCachedIds(scopedKey('public'), buildPublic),
+      resolveCachedIds(scopedKey(`owned:${userId}`), buildOwned),
     ]);
 
     return { accessibleIds, publiclyAccessibleIds, ownedPromptGroupIds };

--- a/packages/data-schemas/src/methods/userGroup.spec.ts
+++ b/packages/data-schemas/src/methods/userGroup.spec.ts
@@ -957,7 +957,7 @@ describe('userGroup methods', () => {
       expect(groupPrincipalIds(await parkedRead)).toEqual([]);
     });
 
-    it('defers invalidation for transactional writes until the session ends', async () => {
+    it('defers invalidation for transactional writes until the session commits', async () => {
       const user = await createTestUser({ idOnTheSource: 'txn-ext-1' });
       const group = await Group.create({
         name: 'Transactional Team',
@@ -984,13 +984,12 @@ describe('userGroup methods', () => {
       expect(groupPrincipalIds(await cachedMethods.getUserPrincipals(params))).toEqual([]);
 
       await session.commitTransaction();
-      await session.endSession();
-      await new Promise((resolve) => setTimeout(resolve, 20));
 
       expect(cache.delete).toHaveBeenCalledWith('txn-ext-1');
       expect(groupPrincipalIds(await cachedMethods.getUserPrincipals(params))).toEqual([
         group._id.toString(),
       ]);
+      await session.endSession();
     });
 
     it('caches and invalidates under tenant-scoped keys within a tenant context', async () => {
@@ -1043,13 +1042,12 @@ describe('userGroup methods', () => {
       });
       expect(cache.delete).not.toHaveBeenCalled();
 
-      /** Session ends outside the tenant context; the snapshot must preserve it */
+      /** Commit runs outside the tenant context; the snapshot must preserve it */
       await session.commitTransaction();
-      await session.endSession();
-      await new Promise((resolve) => setTimeout(resolve, 20));
 
       expect(cache.delete).toHaveBeenCalledWith('txn-tenant-ext-1:tenant-b');
       expect(cache.delete).toHaveBeenCalledWith('txn-tenant-ext-1');
+      await session.endSession();
     });
 
     it('runs a delayed second invalidation to evict cross-process stale rewrites', async () => {

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -11,6 +11,11 @@ import { escapeRegExp } from '~/utils/string';
 export interface UserGroupDeps {
   /** Returns the USER_PRINCIPALS cache store when principal caching is enabled. From getLogStores. */
   getCache?: (key: string) => CacheStore | undefined;
+  /**
+   * Notified after membership caches are invalidated so access caches derived from
+   * memberships (e.g. prompt group access IDs) drop their stale entries too.
+   */
+  onMemberGroupsInvalidated?: () => void | Promise<void>;
 }
 
 type PendingGroupLookup = { promise: Promise<Types.ObjectId[]>; markStale: () => void };
@@ -32,17 +37,57 @@ type DeferredInvalidation = {
   invalidate: () => Promise<void>;
 };
 
-/** One queue (and one `ended` listener) per session, so many mutations in one transaction
- * cannot trip the emitter's max-listeners warning. Weak keys drop abandoned sessions. */
+/** One queue and one set of lifecycle hooks per session, so many mutations in one
+ * transaction cannot trip the emitter's max-listeners warning. */
 const sessionInvalidations = new WeakMap<ClientSession, DeferredInvalidation[]>();
+const hookedSessions = new WeakSet<ClientSession>();
+
+async function drainSessionInvalidations(session: ClientSession): Promise<void> {
+  const queue = sessionInvalidations.get(session);
+  if (!queue) {
+    return;
+  }
+  sessionInvalidations.delete(session);
+  await Promise.all(queue.map((entry) => entry.run(entry.invalidate).catch(() => undefined)));
+}
+
+function hookSessionLifecycle(session: ClientSession): void {
+  if (hookedSessions.has(session)) {
+    return;
+  }
+  hookedSessions.add(session);
+
+  const commitTransaction = session.commitTransaction.bind(session);
+  session.commitTransaction = async (
+    ...args: Parameters<ClientSession['commitTransaction']>
+  ): Promise<void> => {
+    await commitTransaction(...args);
+    await drainSessionInvalidations(session);
+  };
+
+  const abortTransaction = session.abortTransaction.bind(session);
+  session.abortTransaction = async (
+    ...args: Parameters<ClientSession['abortTransaction']>
+  ): Promise<void> => {
+    try {
+      await abortTransaction(...args);
+    } finally {
+      sessionInvalidations.delete(session);
+    }
+  };
+
+  session.once('ended', () => {
+    sessionInvalidations.delete(session);
+  });
+}
 
 /**
- * Runs cache invalidation immediately, or defers it to session end for transactional
+ * Runs cache invalidation immediately, or defers it to commit for transactional
  * writes. Mid-transaction invalidation would let concurrent readers re-cache pre-commit
  * state with no later correction; deferring keeps the existing entry serving the
- * still-committed old memberships until the transaction commits or aborts.
+ * still-committed old memberships until the transaction commits. Aborts discard the queue.
  */
-function runAfterTransaction(
+export function runAfterTransaction(
   session: ClientSession | undefined,
   invalidate: () => Promise<void>,
 ): Promise<void> {
@@ -57,12 +102,7 @@ function runAfterTransaction(
   }
   const newQueue: DeferredInvalidation[] = [deferred];
   sessionInvalidations.set(session, newQueue);
-  session.once('ended', () => {
-    sessionInvalidations.delete(session);
-    for (const entry of newQueue) {
-      entry.run(entry.invalidate).catch(() => undefined);
-    }
-  });
+  hookSessionLifecycle(session);
   return Promise.resolve();
 }
 
@@ -437,11 +477,26 @@ export function createUserGroupMethods(
    * non-fatal; the cache TTL bounds any residual staleness (e.g. mutations
    * running under a different tenant context than the member's reads).
    */
+  /**
+   * Notifies dependent access caches after memberships have been evicted, never
+   * before: a dependent rebuild that runs first would read the stale membership
+   * and cache its derived IDs under the freshly bumped generation, surviving
+   * the membership eviction that should have prevented them.
+   */
+  const notifyMemberGroupsInvalidated = async (): Promise<void> => {
+    try {
+      await deps.onMemberGroupsInvalidated?.();
+    } catch {
+      /** Dependent cache invalidation must not block membership updates. */
+    }
+  };
+
   async function invalidateMemberGroupsCache(
     memberIds: Array<string | Types.ObjectId | undefined | null>,
   ): Promise<void> {
     const cache = getPrincipalsCache();
     if (!cache?.delete) {
+      await notifyMemberGroupsInvalidated();
       return;
     }
     const cacheKeys = new Set<string>();
@@ -459,14 +514,19 @@ export function createUserGroupMethods(
     if (cacheKeys.size > INVALIDATION_CLEAR_THRESHOLD && cache.clear) {
       return clearMemberGroupsCache();
     }
-    await dropMemberKeys(cache, cacheKeys);
-    scheduleSecondInvalidation(cache, () => dropMemberKeys(cache, cacheKeys));
+    const evict = async (): Promise<void> => {
+      await dropMemberKeys(cache, cacheKeys);
+      await notifyMemberGroupsInvalidated();
+    };
+    await evict();
+    scheduleSecondInvalidation(cache, evict);
   }
 
   /** Clears the whole membership cache when affected members cannot be enumerated. */
   async function clearMemberGroupsCache(): Promise<void> {
     const cache = getPrincipalsCache();
     if (!cache?.clear) {
+      await notifyMemberGroupsInvalidated();
       return;
     }
     const clearAll = async (): Promise<void> => {
@@ -479,6 +539,7 @@ export function createUserGroupMethods(
       } catch {
         /** Cache failures must not block membership updates. */
       }
+      await notifyMemberGroupsInvalidated();
     };
     await clearAll();
     scheduleSecondInvalidation(cache, clearAll);

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -11,6 +11,11 @@ import { escapeRegExp } from '~/utils/string';
 export interface UserGroupDeps {
   /** Returns the USER_PRINCIPALS cache store when principal caching is enabled. From getLogStores. */
   getCache?: (key: string) => CacheStore | undefined;
+  /**
+   * Notified after membership caches are invalidated so access caches derived from
+   * memberships (e.g. prompt group access IDs) drop their stale entries too.
+   */
+  onMemberGroupsInvalidated?: () => void | Promise<void>;
 }
 
 type PendingGroupLookup = { promise: Promise<Types.ObjectId[]>; markStale: () => void };
@@ -440,6 +445,11 @@ export function createUserGroupMethods(
   async function invalidateMemberGroupsCache(
     memberIds: Array<string | Types.ObjectId | undefined | null>,
   ): Promise<void> {
+    try {
+      await deps.onMemberGroupsInvalidated?.();
+    } catch {
+      /** Dependent cache invalidation must not block membership updates. */
+    }
     const cache = getPrincipalsCache();
     if (!cache?.delete) {
       return;
@@ -465,6 +475,11 @@ export function createUserGroupMethods(
 
   /** Clears the whole membership cache when affected members cannot be enumerated. */
   async function clearMemberGroupsCache(): Promise<void> {
+    try {
+      await deps.onMemberGroupsInvalidated?.();
+    } catch {
+      /** Dependent cache invalidation must not block membership updates. */
+    }
     const cache = getPrincipalsCache();
     if (!cache?.clear) {
       return;

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -442,16 +442,26 @@ export function createUserGroupMethods(
    * non-fatal; the cache TTL bounds any residual staleness (e.g. mutations
    * running under a different tenant context than the member's reads).
    */
-  async function invalidateMemberGroupsCache(
-    memberIds: Array<string | Types.ObjectId | undefined | null>,
-  ): Promise<void> {
+  /**
+   * Notifies dependent access caches after memberships have been evicted, never
+   * before: a dependent rebuild that runs first would read the stale membership
+   * and cache its derived IDs under the freshly bumped generation, surviving
+   * the membership eviction that should have prevented them.
+   */
+  const notifyMemberGroupsInvalidated = async (): Promise<void> => {
     try {
       await deps.onMemberGroupsInvalidated?.();
     } catch {
       /** Dependent cache invalidation must not block membership updates. */
     }
+  };
+
+  async function invalidateMemberGroupsCache(
+    memberIds: Array<string | Types.ObjectId | undefined | null>,
+  ): Promise<void> {
     const cache = getPrincipalsCache();
     if (!cache?.delete) {
+      await notifyMemberGroupsInvalidated();
       return;
     }
     const cacheKeys = new Set<string>();
@@ -469,19 +479,19 @@ export function createUserGroupMethods(
     if (cacheKeys.size > INVALIDATION_CLEAR_THRESHOLD && cache.clear) {
       return clearMemberGroupsCache();
     }
-    await dropMemberKeys(cache, cacheKeys);
-    scheduleSecondInvalidation(cache, () => dropMemberKeys(cache, cacheKeys));
+    const evict = async (): Promise<void> => {
+      await dropMemberKeys(cache, cacheKeys);
+      await notifyMemberGroupsInvalidated();
+    };
+    await evict();
+    scheduleSecondInvalidation(cache, evict);
   }
 
   /** Clears the whole membership cache when affected members cannot be enumerated. */
   async function clearMemberGroupsCache(): Promise<void> {
-    try {
-      await deps.onMemberGroupsInvalidated?.();
-    } catch {
-      /** Dependent cache invalidation must not block membership updates. */
-    }
     const cache = getPrincipalsCache();
     if (!cache?.clear) {
+      await notifyMemberGroupsInvalidated();
       return;
     }
     const clearAll = async (): Promise<void> => {
@@ -494,6 +504,7 @@ export function createUserGroupMethods(
       } catch {
         /** Cache failures must not block membership updates. */
       }
+      await notifyMemberGroupsInvalidated();
     };
     await clearAll();
     scheduleSecondInvalidation(cache, clearAll);

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -47,7 +47,7 @@ const sessionInvalidations = new WeakMap<ClientSession, DeferredInvalidation[]>(
  * state with no later correction; deferring keeps the existing entry serving the
  * still-committed old memberships until the transaction commits or aborts.
  */
-function runAfterTransaction(
+export function runAfterTransaction(
   session: ClientSession | undefined,
   invalidate: () => Promise<void>,
 ): Promise<void> {

--- a/packages/data-schemas/src/types/cache.ts
+++ b/packages/data-schemas/src/types/cache.ts
@@ -5,7 +5,8 @@
  */
 export interface CacheStore {
   get: (key: string) => Promise<unknown>;
-  set: (key: string, value: unknown) => Promise<unknown>;
+  /** The optional ttl overrides the store's namespace default for this entry. */
+  set: (key: string, value: unknown, ttl?: number) => Promise<unknown>;
   delete?: (key: string) => Promise<unknown>;
   clear?: () => Promise<unknown>;
   /** True when the store is shared across processes (e.g. Redis-backed). */


### PR DESCRIPTION
## Summary

Startup currently fires two overlapping prompt requests for every user with prompt access: the paginated `/api/prompts/groups?limit=10` for the sidebar and the unpaginated `/api/prompts/all`, both from `PromptGroupsProvider`. They cannot be deduplicated client side, and both run the same ACL resolution on the backend before the actual group query.

Closes #14017.

Frontend:

- The `/api/prompts/all` query now stays idle until the `/` command popover first opens (its only consumer), so initial load fetches only the paginated sidebar query. The popover's existing loading spinner covers the first-open fetch, and selecting a command requires the loaded list, so the `promptsMap` submit path cannot race the fetch.
- `isLoading` from the context is gated on the query being active, because a never-fetched disabled query reports `isLoading: true` in React Query v4.
- `addGroupToAll` no longer seeds a never-fetched `[allPromptGroups]` cache with a single created group, which `refetchOnMount: false` would otherwise serve as a one-item list.

Backend:

- `GET /all` and `GET /groups` resolved accessible, public, and owned prompt group IDs through duplicated preambles. Both now call one shared `getPromptGroupAccessContext` method.
- The three ID sets are cached in a new `PROMPT_GROUPS_ACCESS` namespace (Redis-backed when configured, 30s TTL) with tenant-scoped keys and in-process in-flight dedup. The public set is shared across all users of a tenant, so concurrent startups reuse one AclEntry query instead of one per user.
- The cache is invalidated on prompt group create/delete (including last-prompt group removal and user prompt cleanup) and on prompt permission grants, revokes, and bulk permission updates, so newly created or shared groups appear immediately rather than after the TTL.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Backend behavior is covered by integration tests against a real in-memory MongoDB (`mongodb-memory-server`) with real ACL entries, no mocked DB layer:

- `prompt.accessContext.spec.ts` (new): resolves the accessible/public/owned sets, serves repeat reads from cache, refreshes after invalidation, shares the public set across users, and invalidates on group create and delete.
- `api/server/routes/prompts.test.js`: 25 existing route tests over `/all` and `/groups` (ACL visibility, sharing, cursor pagination) pass unchanged against the shared resolver.
- `accessPermissions` suite: 15/15 after the PermissionService invalidation hooks.
- Client: `PromptsCommand.spec.tsx` gains lazy-loading cases (requests the list when the popover shows, stays quiet while hidden), 8/8; `promptGroups.test.ts` gains cache-guard cases for `addGroupToAll`, 26/26; `tsc --noEmit` clean.

### **Test Configuration**:

- Node v24.16.0, in-memory MongoDB via `mongodb-memory-server`, Redis optional (cache falls back to in-memory store)
- `cd api && npx jest prompts.test.js`
- `cd packages/data-schemas && npx jest prompt.accessContext prompt.getPromptGroup`
- `cd client && npx jest PromptsCommand promptGroups.test && npm run typecheck`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
