### PR TITLE
🎛️ fix: Withhold the Seeded Model Catalogue Until Models Resolve

### DIFF
--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -227,6 +227,7 @@ export type AgentModelPanelProps = {
   agent_id?: string;
   providers: Option[];
   models: Record<string, string[] | undefined>;
+  modelsError: boolean;
   modelsReady: boolean;
   setActivePanel: React.Dispatch<React.SetStateAction<Panel>>;
 };

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -246,6 +246,8 @@ export type AgentModelPanelProps = {
   agent_id?: string;
   providers: Option[];
   models: Record<string, string[] | undefined>;
+  modelsError: boolean;
+  modelsLoaded: boolean;
   setActivePanel: React.Dispatch<React.SetStateAction<Panel>>;
 };
 

--- a/client/src/components/SidePanel/Agents/AgentCategorySelector.tsx
+++ b/client/src/components/SidePanel/Agents/AgentCategorySelector.tsx
@@ -77,6 +77,7 @@ const AgentCategorySelector: React.FC<{ className?: string }> = ({ className }) 
 
         return (
           <ControlCombobox
+            selectId="category-selector"
             selectedValue={field.value}
             displayValue={displayValue}
             searchPlaceholder={searchPlaceholder}

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -101,6 +101,7 @@ export default function AgentConfig() {
             {localize('com_ui_model')} <span className="text-red-500">*</span>
           </Label>
           <button
+            id="provider"
             type="button"
             onClick={() => setActivePanel(Panel.model)}
             title={model || undefined}

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -113,6 +113,7 @@ export default function AgentConfig() {
             {localize('com_ui_model')} <span className="text-red-500">*</span>
           </Label>
           <button
+            id="provider"
             type="button"
             onClick={() => setActivePanel(Panel.model)}
             title={model || undefined}

--- a/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
@@ -6,7 +6,7 @@ import { render, waitFor, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { UseFormReturn } from 'react-hook-form';
 import type { Agent } from 'librechat-data-provider';
-import type { AgentForm } from '~/common';
+import type { AgentForm, AgentModelPanelProps } from '~/common';
 
 // Mock toast context - define this after all mocks
 let mockShowToast: jest.Mock;
@@ -16,6 +16,11 @@ let mockModelsQuery: {
   isSuccess: boolean;
   isFetching?: boolean;
 } = { data: {}, isFetchedAfterMount: true, isSuccess: true };
+let mockModelPanelProps: Pick<
+  AgentModelPanelProps,
+  'models' | 'modelsError' | 'modelsReady'
+> | null = null;
+let mockFormDefaults: Partial<AgentForm> = {};
 let mockAgentPanelContext = {
   activePanel: 'builder',
   agentsConfig: { allowedProviders: [] as string[] },
@@ -50,6 +55,7 @@ jest.mock('librechat-data-provider', () => {
   return {
     ...actualModule,
     dataService: {
+      createAgent: jest.fn(),
       updateAgent: jest.fn(),
     },
     Tools: actualModule.Tools || {
@@ -163,7 +169,10 @@ jest.mock('./AgentSelect', () => ({
 
 jest.mock('./ModelPanel', () => ({
   __esModule: true,
-  default: () => <div>{`Model Panel`}</div>,
+  default: (props: Pick<AgentModelPanelProps, 'models' | 'modelsError' | 'modelsReady'>) => {
+    mockModelPanelProps = props;
+    return <div>{`Model Panel`}</div>;
+  },
 }));
 
 // Mock AgentFooter to provide a save button
@@ -196,6 +205,7 @@ jest.mock('react-hook-form', () => {
           execute_code: false,
           file_search: false,
           web_search: false,
+          ...mockFormDefaults,
         },
       });
 
@@ -308,6 +318,8 @@ describe('AgentPanel - Update Agent Toast Messages', () => {
     mockShowToast = jest.fn();
     mockFormSubmitHandler = null;
     capturedFormMethods = null;
+    mockModelPanelProps = null;
+    mockFormDefaults = {};
     mockModelsQuery = {
       data: { openai: ['gpt-4'] },
       isFetchedAfterMount: true,
@@ -389,6 +401,45 @@ describe('AgentPanel - Update Agent Toast Messages', () => {
         expect(capturedFormMethods?.getValues('model')).toBe('');
       });
       expect(localStorage.getItem('lastAgentModel')).toBeNull();
+    });
+
+    it('withholds the seeded catalogue until the mounted fetch resolves', async () => {
+      const { mockUseGetAgentByIdQuery } = setupMocks();
+      mockAgentQuery(mockUseGetAgentByIdQuery, {});
+      mockAgentPanelContext = { ...mockAgentPanelContext, activePanel: 'model' };
+      mockModelsQuery = {
+        data: { openai: ['seeded-fallback-model'] },
+        isFetchedAfterMount: false,
+        isSuccess: true,
+        isFetching: true,
+      };
+
+      const Wrapper = createWrapper();
+      render(<AgentPanel />, { wrapper: Wrapper });
+
+      await waitFor(() => expect(mockModelPanelProps).not.toBeNull());
+      expect(mockModelPanelProps?.models).toEqual({});
+      expect(mockModelPanelProps?.modelsReady).toBe(false);
+      expect(mockModelPanelProps?.modelsError).toBe(false);
+    });
+
+    it('withholds the seeded catalogue when the models request fails', async () => {
+      const { mockUseGetAgentByIdQuery } = setupMocks();
+      mockAgentQuery(mockUseGetAgentByIdQuery, {});
+      mockAgentPanelContext = { ...mockAgentPanelContext, activePanel: 'model' };
+      mockModelsQuery = {
+        data: { openai: ['seeded-fallback-model'] },
+        isFetchedAfterMount: true,
+        isSuccess: false,
+        isFetching: false,
+      };
+
+      const Wrapper = createWrapper();
+      render(<AgentPanel />, { wrapper: Wrapper });
+
+      await waitFor(() => expect(mockModelPanelProps).not.toBeNull());
+      expect(mockModelPanelProps?.models).toEqual({});
+      expect(mockModelPanelProps?.modelsError).toBe(true);
     });
 
     it("preserves an existing agent's configured model", async () => {
@@ -602,6 +653,88 @@ describe('AgentPanel - Update Agent Toast Messages', () => {
           message: 'com_assistants_update_success_name',
           status: undefined,
         });
+      });
+    });
+
+    describe('agent creation', () => {
+      /** Creation runs off the form's own `id`, and a provider/model the user picked keeps the
+       *  saved-defaults reconciliation from rewriting the pair before it reaches submission. */
+      const renderAndSubmitNewAgent = async () => {
+        const Wrapper = createWrapper();
+        const { container } = render(<AgentPanel />, { wrapper: Wrapper });
+
+        await act(async () => {
+          capturedFormMethods?.setValue('provider', 'openai', { shouldDirty: true });
+          capturedFormMethods?.setValue('model', 'gpt-4', { shouldDirty: true });
+        });
+
+        fireEvent.submit(container.querySelector('form')!);
+        if (mockFormSubmitHandler) {
+          await act(async () => {
+            mockFormSubmitHandler!();
+          });
+        }
+      };
+
+      beforeEach(() => {
+        mockFormDefaults = { id: '' };
+        mockAgentPanelContext = { ...mockAgentPanelContext, agent_id: undefined };
+      });
+
+      it('refuses to create an agent while the catalogue is unavailable', async () => {
+        const { mockUseGetAgentByIdQuery } = setupMocks();
+        mockAgentQuery(mockUseGetAgentByIdQuery, {});
+        mockModelsQuery = {
+          data: { openai: ['gpt-4'] },
+          isFetchedAfterMount: true,
+          isSuccess: false,
+          isFetching: false,
+        };
+
+        await renderAndSubmitNewAgent();
+
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'com_error_models_not_loaded' }),
+        );
+        expect(dataService.createAgent).not.toHaveBeenCalled();
+      });
+
+      it('refuses to create an agent with a model the catalogue no longer offers', async () => {
+        const { mockUseGetAgentByIdQuery } = setupMocks();
+        mockAgentQuery(mockUseGetAgentByIdQuery, {});
+        mockModelsQuery = {
+          data: { openai: ['gpt-4o'] },
+          isFetchedAfterMount: true,
+          isSuccess: true,
+          isFetching: false,
+        };
+
+        await renderAndSubmitNewAgent();
+
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'com_error_model_not_found' }),
+        );
+        expect(dataService.createAgent).not.toHaveBeenCalled();
+      });
+
+      it('creates the agent when the catalogue offers the selected model', async () => {
+        const { mockUseGetAgentByIdQuery } = setupMocks();
+        mockAgentQuery(mockUseGetAgentByIdQuery, {});
+        (dataService.createAgent as jest.Mock).mockResolvedValue(createMockAgent());
+        mockModelsQuery = {
+          data: { openai: ['gpt-4'] },
+          isFetchedAfterMount: true,
+          isSuccess: true,
+          isFetching: false,
+        };
+
+        await renderAndSubmitNewAgent();
+
+        await waitFor(() =>
+          expect(dataService.createAgent).toHaveBeenCalledWith(
+            expect.objectContaining({ model: 'gpt-4', provider: 'openai' }),
+          ),
+        );
       });
     });
 

--- a/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
@@ -4,12 +4,25 @@
 import * as React from 'react';
 import { render, waitFor, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Agent, TModelsConfig } from 'librechat-data-provider';
+import type { QueryObserverResult } from '@tanstack/react-query';
 import type { UseFormReturn } from 'react-hook-form';
-import type { Agent } from 'librechat-data-provider';
 import type { AgentForm } from '~/common';
 
 // Mock toast context - define this after all mocks
 let mockShowToast: jest.Mock;
+let mockActivePanel = 'builder';
+let mockModelPanelModels: TModelsConfig | undefined;
+let mockModelPanelModelsError: boolean | undefined;
+let mockModelPanelModelsLoaded: boolean | undefined;
+let mockModelsQuery: Pick<
+  QueryObserverResult<TModelsConfig>,
+  'data' | 'isFetchedAfterMount' | 'isSuccess'
+> = {
+  data: {},
+  isFetchedAfterMount: true,
+  isSuccess: true,
+};
 
 // Mock notification severity enum before other imports
 jest.mock('~/common/types', () => ({
@@ -77,7 +90,7 @@ jest.mock('@librechat/client', () => ({
 
 // Mock other dependencies
 jest.mock('librechat-data-provider/react-query', () => ({
-  useGetModelsQuery: () => ({ data: {} }),
+  useGetModelsQuery: () => mockModelsQuery,
   useGetEffectivePermissionsQuery: () => ({
     data: { permissionBits: 0xffffffff }, // All permissions
     isLoading: false,
@@ -111,7 +124,7 @@ jest.mock('~/hooks/useResourcePermissions', () => ({
 
 jest.mock('~/Providers/AgentPanelContext', () => ({
   useAgentPanelContext: () => ({
-    activePanel: 'builder',
+    activePanel: mockActivePanel,
     agentsConfig: { allowedProviders: [] },
     setActivePanel: jest.fn(),
     endpointsConfig: {},
@@ -154,7 +167,20 @@ jest.mock('./AgentSelect', () => ({
 
 jest.mock('./ModelPanel', () => ({
   __esModule: true,
-  default: () => <div>{`Model Panel`}</div>,
+  default: ({
+    models,
+    modelsError,
+    modelsLoaded,
+  }: {
+    models: TModelsConfig;
+    modelsError: boolean;
+    modelsLoaded: boolean;
+  }) => {
+    mockModelPanelModels = models;
+    mockModelPanelModelsError = modelsError;
+    mockModelPanelModelsLoaded = modelsLoaded;
+    return <div>{`Model Panel`}</div>;
+  },
 }));
 
 // Mock AgentFooter to provide a save button
@@ -294,9 +320,64 @@ const renderAndSubmitForm = async () => {
   return { container, rerender, form };
 };
 
+describe('AgentPanel - Model Availability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActivePanel = 'model';
+    mockModelPanelModels = undefined;
+    mockModelPanelModelsError = undefined;
+    mockModelPanelModelsLoaded = undefined;
+  });
+
+  it('withholds fallback models until the authoritative request succeeds', () => {
+    const { mockUseGetAgentByIdQuery } = setupMocks();
+    mockAgentQuery(mockUseGetAgentByIdQuery, createMockAgent());
+    mockModelsQuery = {
+      data: { openAI: ['fallback-model'] },
+      isFetchedAfterMount: false,
+      isSuccess: true,
+    };
+
+    const Wrapper = createWrapper();
+    const { rerender } = render(<AgentPanel />, { wrapper: Wrapper });
+
+    expect(mockModelPanelModels).toEqual({});
+    expect(mockModelPanelModelsError).toBe(false);
+    expect(mockModelPanelModelsLoaded).toBe(false);
+
+    mockModelsQuery = {
+      data: { openAI: ['configured-model'] },
+      isFetchedAfterMount: true,
+      isSuccess: true,
+    };
+    rerender(<AgentPanel />);
+
+    expect(mockModelPanelModels).toEqual({ openAI: ['configured-model'] });
+    expect(mockModelPanelModelsError).toBe(false);
+    expect(mockModelPanelModelsLoaded).toBe(true);
+
+    mockModelsQuery = {
+      data: { openAI: ['fallback-model'] },
+      isFetchedAfterMount: true,
+      isSuccess: false,
+    };
+    rerender(<AgentPanel />);
+
+    expect(mockModelPanelModels).toEqual({});
+    expect(mockModelPanelModelsError).toBe(true);
+    expect(mockModelPanelModelsLoaded).toBe(false);
+  });
+});
+
 describe('AgentPanel - Update Agent Toast Messages', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockActivePanel = 'builder';
+    mockModelsQuery = {
+      data: {},
+      isFetchedAfterMount: true,
+      isSuccess: true,
+    };
     mockShowToast = jest.fn();
     mockFormSubmitHandler = null;
     capturedFormMethods = null;

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -319,8 +319,15 @@ export default function AgentPanel() {
 
   const agentQuery = canEdit && expandedAgentQuery.data ? expandedAgentQuery : basicAgentQuery;
 
-  const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
   const modelsReady = modelsQuery.isFetchedAfterMount && !modelsQuery.isFetching;
+  const modelsError = modelsQuery.isFetchedAfterMount && !modelsQuery.isSuccess;
+  /** The models query is seeded with a static fallback config, so its entries only describe the
+   *  active server once the fetch issued on mount has resolved. Until then there is nothing
+   *  authoritative to offer, and an outright failure must not fall back to the seed either. */
+  const models = useMemo(
+    () => (modelsQuery.isFetchedAfterMount && !modelsError ? (modelsQuery.data ?? {}) : {}),
+    [modelsError, modelsQuery.isFetchedAfterMount, modelsQuery.data],
+  );
   const methods = useForm<AgentForm>({
     defaultValues: getDefaultAgentFormValues(defaultStatefulCodeEnvironment),
     mode: 'onChange',
@@ -600,6 +607,18 @@ export default function AgentPanel() {
           status: 'error',
         });
       }
+      if (!modelsReady || modelsError) {
+        return showToast({
+          message: localize('com_error_models_not_loaded'),
+          status: 'error',
+        });
+      }
+      if (!(models[provider] ?? []).includes(model)) {
+        return showToast({
+          message: localize('com_error_model_not_found'),
+          status: 'error',
+        });
+      }
       if (!data.name) {
         return showToast({
           message: localize('com_agents_missing_name'),
@@ -609,7 +628,18 @@ export default function AgentPanel() {
 
       create.mutate({ ...basePayload, model, tools, provider });
     },
-    [agent_id, create, dirtyFields, handleAvatarUpload, update, showToast, localize],
+    [
+      agent_id,
+      create,
+      dirtyFields,
+      handleAvatarUpload,
+      models,
+      modelsError,
+      modelsReady,
+      update,
+      showToast,
+      localize,
+    ],
   );
 
   const handleSelectAgent = useCallback(() => {
@@ -693,6 +723,7 @@ export default function AgentPanel() {
             <ModelPanel
               models={models}
               providers={providers}
+              modelsError={modelsError}
               modelsReady={modelsReady}
               setActivePanel={setActivePanel}
             />

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -314,7 +314,12 @@ export default function AgentPanel() {
 
   const agentQuery = canEdit && expandedAgentQuery.data ? expandedAgentQuery : basicAgentQuery;
 
-  const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
+  const modelsLoaded = modelsQuery.isSuccess && modelsQuery.isFetchedAfterMount;
+  const modelsError = !modelsQuery.isSuccess && modelsQuery.isFetchedAfterMount;
+  const models = useMemo(
+    () => (modelsLoaded ? (modelsQuery.data ?? {}) : {}),
+    [modelsLoaded, modelsQuery.data],
+  );
   const methods = useForm<AgentForm>({
     defaultValues: getDefaultAgentFormValues(defaultStatefulCodeEnvironment),
     mode: 'onChange',
@@ -633,7 +638,13 @@ export default function AgentPanel() {
             </div>
           )}
           {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.model && (
-            <ModelPanel models={models} providers={providers} setActivePanel={setActivePanel} />
+            <ModelPanel
+              models={models}
+              modelsError={modelsError}
+              modelsLoaded={modelsLoaded}
+              providers={providers}
+              setActivePanel={setActivePanel}
+            />
           )}
           {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.builder && (
             <AgentConfig />

--- a/client/src/components/SidePanel/Agents/ModelPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.test.tsx
@@ -8,6 +8,7 @@ import type { AgentForm } from '~/common';
 import ModelPanel from './ModelPanel';
 
 jest.mock('@librechat/client', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div role="alert">{children}</div>,
   Button: ({ children, onClick, type }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button type={type} onClick={onClick}>
       {children}
@@ -17,17 +18,25 @@ jest.mock('@librechat/client', () => ({
     ariaLabel,
     disabled,
     items,
+    selectId,
     selectedValue,
+    selectPlaceholder,
     setValue,
   }: {
     ariaLabel: string;
     disabled?: boolean;
     items: Array<{ label: string; value: string }>;
+    selectId?: string;
     selectedValue: string;
+    selectPlaceholder?: string;
     setValue: (value: string) => void;
   }) => (
     <div>
+      <button id={selectId} type="button" disabled={disabled} aria-label={ariaLabel}>
+        {selectedValue || selectPlaceholder}
+      </button>
       <span data-testid={`${ariaLabel}-selected`}>{selectedValue}</span>
+      <span data-testid={`${ariaLabel}-placeholder`}>{selectPlaceholder}</span>
       {items.map((item) => (
         <button
           key={item.value}
@@ -67,12 +76,14 @@ function TestForm({
   defaultModel = '',
   defaultProvider = '',
   models,
+  modelsError = false,
   modelsReady,
   providers = [{ label: 'Custom', value: 'custom' }],
 }: {
   defaultModel?: string;
   defaultProvider?: string;
   models: Record<string, string[]>;
+  modelsError?: boolean;
   modelsReady: boolean;
   providers?: Array<{ label: string; value: string }>;
 }) {
@@ -89,6 +100,7 @@ function TestForm({
       <ModelPanel
         providers={providers}
         models={models}
+        modelsError={modelsError}
         modelsReady={modelsReady}
         setActivePanel={jest.fn()}
       />
@@ -163,5 +175,38 @@ describe('ModelPanel', () => {
 
     expect(localStorage.getItem('lastAgentProvider')).toBe('custom');
     expect(localStorage.getItem('lastAgentModel')).toBe('second-model');
+  });
+
+  it('announces the pending catalogue instead of inviting a selection', () => {
+    const { getByTestId } = render(
+      <TestForm defaultProvider="custom" models={{}} modelsReady={false} />,
+    );
+
+    expect(getByTestId('com_ui_model-placeholder')).toHaveTextContent('com_ui_loading');
+  });
+
+  it('offers no models and explains the failure when the catalogue cannot be loaded', () => {
+    const { getByRole, getByTestId, queryByTestId } = render(
+      <TestForm defaultProvider="custom" models={{}} modelsError={true} modelsReady={true} />,
+    );
+
+    expect(getByRole('alert')).toHaveTextContent('com_error_models_not_loaded');
+    expect(queryByTestId('com_ui_model-placeholder')).toHaveTextContent('com_ui_select_model');
+    expect(getByTestId('com_ui_provider-custom')).toBeDisabled();
+  });
+
+  it('labels the provider and model controls', () => {
+    const { container } = render(
+      <TestForm
+        defaultProvider="custom"
+        models={{ custom: ['custom-model'] }}
+        modelsReady={true}
+      />,
+    );
+
+    expect(container.querySelector('label[for="provider"]')).not.toBeNull();
+    expect(container.querySelector('label[for="model"]')).not.toBeNull();
+    expect(container.querySelector('#provider')).not.toBeNull();
+    expect(container.querySelector('#model')).not.toBeNull();
   });
 });

--- a/client/src/components/SidePanel/Agents/ModelPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import type { AgentForm } from '~/common';
+import ModelPanel from './ModelPanel';
+
+jest.mock('@librechat/client', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div role="alert">{children}</div>,
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  ControlCombobox: ({
+    ariaLabel,
+    disabled,
+    selectId,
+    selectPlaceholder,
+  }: {
+    ariaLabel: string;
+    disabled?: boolean;
+    selectId?: string;
+    selectPlaceholder?: string;
+  }) => (
+    <button id={selectId} type="button" aria-label={ariaLabel} disabled={disabled}>
+      {selectPlaceholder}
+    </button>
+  ),
+}));
+
+jest.mock('~/components/SidePanel/Parameters/components', () => ({ componentMapping: {} }));
+jest.mock('~/data-provider', () => ({ useGetEndpointsQuery: () => ({ data: {} }) }));
+jest.mock('~/Providers', () => ({
+  useLiveAnnouncer: () => ({ announcePolite: jest.fn() }),
+}));
+jest.mock('~/hooks', () => ({ useLocalize: () => (key: string) => key }));
+jest.mock('~/common', () => ({ Panel: { builder: 'builder' } }));
+jest.mock('~/utils', () => ({
+  cn: (...values: Array<string | false | undefined>) => values.filter(Boolean).join(' '),
+}));
+
+function ModelPanelHarness({
+  models,
+  modelsError = false,
+  modelsLoaded,
+}: {
+  models: Record<string, string[]>;
+  modelsError?: boolean;
+  modelsLoaded: boolean;
+}) {
+  const methods = useForm<AgentForm>({
+    defaultValues: {
+      provider: 'openAI',
+      model: 'fallback-model',
+      model_parameters: {},
+    },
+  });
+  const selectedModel = useWatch({ control: methods.control, name: 'model' });
+
+  return (
+    <FormProvider {...methods}>
+      <span data-testid="selected-model">{selectedModel}</span>
+      <ModelPanel
+        models={models}
+        modelsError={modelsError}
+        modelsLoaded={modelsLoaded}
+        providers={[{ label: 'OpenAI', value: 'openAI' }]}
+        setActivePanel={jest.fn()}
+      />
+    </FormProvider>
+  );
+}
+
+describe('ModelPanel model availability', () => {
+  it('preserves the selected model until authoritative models load', async () => {
+    const { rerender } = render(<ModelPanelHarness models={{}} modelsLoaded={false} />);
+
+    expect(screen.getByTestId('selected-model')).toHaveTextContent('fallback-model');
+    expect(screen.getByRole('button', { name: 'com_ui_model' })).toBeDisabled();
+    expect(document.querySelector('label[for="provider"]')).toHaveAttribute('for', 'provider');
+    expect(document.querySelector('label[for="model"]')).toHaveAttribute('for', 'model');
+    expect(document.getElementById('provider')).toBeInTheDocument();
+    expect(document.getElementById('model')).toBeInTheDocument();
+
+    rerender(<ModelPanelHarness models={{}} modelsError={true} modelsLoaded={false} />);
+
+    expect(screen.getByTestId('selected-model')).toHaveTextContent('fallback-model');
+    expect(screen.getByRole('alert')).toHaveTextContent('com_error_models_not_loaded');
+    expect(screen.getByRole('button', { name: 'com_ui_model' })).toBeDisabled();
+
+    rerender(<ModelPanelHarness models={{ openAI: ['configured-model'] }} modelsLoaded={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('configured-model');
+    });
+    expect(screen.getByRole('button', { name: 'com_ui_model' })).toBeEnabled();
+  });
+});

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import keyBy from 'lodash/keyBy';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
-import { Button, ControlCombobox } from '@librechat/client';
+import { Alert, Button, ControlCombobox } from '@librechat/client';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
 import {
   alternateName,
@@ -21,12 +21,26 @@ import { useLocalize } from '~/hooks';
 import { Panel } from '~/common';
 import { cn } from '~/utils';
 
+function getModelPlaceholderKey(modelsPending: boolean, provider: string) {
+  if (modelsPending) {
+    return 'com_ui_loading';
+  }
+  if (provider) {
+    return 'com_ui_select_model';
+  }
+  return 'com_ui_select_provider_first';
+}
+
 export default function ModelPanel({
   providers,
+  modelsError,
   setActivePanel,
   models: modelsData,
   modelsReady,
-}: Pick<AgentModelPanelProps, 'models' | 'modelsReady' | 'providers' | 'setActivePanel'>) {
+}: Pick<
+  AgentModelPanelProps,
+  'models' | 'modelsError' | 'modelsReady' | 'providers' | 'setActivePanel'
+>) {
   const localize = useLocalize();
   const { announcePolite } = useLiveAnnouncer();
 
@@ -47,6 +61,8 @@ export default function ModelPanel({
     () => (provider ? (modelsData[provider] ?? []) : []),
     [modelsData, provider],
   );
+  const modelsPending = !modelsReady && !modelsError;
+  const selectionDisabled = !modelsReady || modelsError;
 
   const { data: endpointsConfig = {} } = useGetEndpointsQuery();
 
@@ -105,10 +121,13 @@ export default function ModelPanel({
       </header>
       <div>
         {/* Endpoint aka Provider for Agents */}
-        <div className="mb-3">
+        <div className="mb-3" aria-busy={modelsPending}>
           <label
             id="provider-label"
-            className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-text-secondary"
+            className={cn(
+              'mb-1 block text-[11px] font-medium uppercase tracking-wide text-text-secondary',
+              modelsPending && 'opacity-60',
+            )}
             htmlFor="provider"
           >
             {localize('com_ui_provider')} <span className="text-red-500">*</span>
@@ -130,6 +149,7 @@ export default function ModelPanel({
               return (
                 <>
                   <ControlCombobox
+                    selectId="provider"
                     selectedValue={value}
                     displayValue={alternateName[display] ?? display}
                     selectPlaceholder={localize('com_ui_select_provider')}
@@ -154,7 +174,7 @@ export default function ModelPanel({
                     }))}
                     className={cn(error ? 'border-2 border-red-500' : '')}
                     ariaLabel={localize('com_ui_provider')}
-                    disabled={!modelsReady}
+                    disabled={selectionDisabled}
                     isCollapsed={false}
                     showCarat={true}
                   />
@@ -169,12 +189,12 @@ export default function ModelPanel({
           />
         </div>
         {/* Model */}
-        <div className="mb-3">
+        <div className="mb-3" aria-busy={modelsPending}>
           <label
             id="model-label"
             className={cn(
               'mb-1 block text-[11px] font-medium uppercase tracking-wide text-text-secondary',
-              !provider && 'opacity-60',
+              (!provider || modelsPending) && 'opacity-60',
             )}
             htmlFor="model"
           >
@@ -188,12 +208,9 @@ export default function ModelPanel({
               return (
                 <>
                   <ControlCombobox
+                    selectId="model"
                     selectedValue={field.value || ''}
-                    selectPlaceholder={
-                      provider
-                        ? localize('com_ui_select_model')
-                        : localize('com_ui_select_provider_first')
-                    }
+                    selectPlaceholder={localize(getModelPlaceholderKey(modelsPending, provider))}
                     searchPlaceholder={localize('com_ui_select_model')}
                     setValue={(value) => {
                       field.onChange(value);
@@ -208,7 +225,7 @@ export default function ModelPanel({
                       label: model,
                       value: model,
                     }))}
-                    disabled={!provider || !modelsReady}
+                    disabled={!provider || selectionDisabled}
                     className={cn('disabled:opacity-50', error ? 'border-2 border-red-500' : '')}
                     ariaLabel={localize('com_ui_model')}
                     isCollapsed={false}
@@ -223,6 +240,11 @@ export default function ModelPanel({
               );
             }}
           />
+          {modelsError && (
+            <Alert variant="error" className="mt-1">
+              {localize('com_error_models_not_loaded')}
+            </Alert>
+          )}
         </div>
       </div>
       {/* Model Parameters */}

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect } from 'react';
 import keyBy from 'lodash/keyBy';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
-import { Button, ControlCombobox } from '@librechat/client';
+import { Alert, Button, ControlCombobox } from '@librechat/client';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
 import {
   alternateName,
@@ -23,9 +23,14 @@ import { cn } from '~/utils';
 
 export default function ModelPanel({
   providers,
+  modelsError,
+  modelsLoaded,
   setActivePanel,
   models: modelsData,
-}: Pick<AgentModelPanelProps, 'models' | 'providers' | 'setActivePanel'>) {
+}: Pick<
+  AgentModelPanelProps,
+  'models' | 'modelsError' | 'modelsLoaded' | 'providers' | 'setActivePanel'
+>) {
   const localize = useLocalize();
   const { announcePolite } = useLiveAnnouncer();
 
@@ -46,8 +51,18 @@ export default function ModelPanel({
     () => (provider ? (modelsData[provider] ?? []) : []),
     [modelsData, provider],
   );
+  let modelPlaceholder = localize('com_ui_select_provider_first');
+  if (!modelsLoaded && !modelsError) {
+    modelPlaceholder = localize('com_ui_loading');
+  } else if (provider) {
+    modelPlaceholder = localize('com_ui_select_model');
+  }
 
   useEffect(() => {
+    if (!modelsLoaded) {
+      return;
+    }
+
     const _model = model ?? '';
     if (provider && _model) {
       const modelExists = models.includes(_model);
@@ -62,7 +77,7 @@ export default function ModelPanel({
     if (provider && !_model) {
       setValue('model', models[0] ?? '');
     }
-  }, [provider, models, modelsData, setValue, model]);
+  }, [provider, models, modelsData, modelsLoaded, setValue, model]);
 
   const { data: endpointsConfig = {} } = useGetEndpointsQuery();
 
@@ -146,6 +161,7 @@ export default function ModelPanel({
               return (
                 <>
                   <ControlCombobox
+                    selectId="provider"
                     selectedValue={value}
                     displayValue={alternateName[display] ?? display}
                     selectPlaceholder={localize('com_ui_select_provider')}
@@ -171,7 +187,7 @@ export default function ModelPanel({
           />
         </div>
         {/* Model */}
-        <div className="mb-3">
+        <div className="mb-3" aria-busy={!modelsLoaded && !modelsError}>
           <label
             id="model-label"
             className={cn(
@@ -190,19 +206,16 @@ export default function ModelPanel({
               return (
                 <>
                   <ControlCombobox
+                    selectId="model"
                     selectedValue={field.value || ''}
-                    selectPlaceholder={
-                      provider
-                        ? localize('com_ui_select_model')
-                        : localize('com_ui_select_provider_first')
-                    }
+                    selectPlaceholder={modelPlaceholder}
                     searchPlaceholder={localize('com_ui_select_model')}
                     setValue={field.onChange}
                     items={models.map((model) => ({
                       label: model,
                       value: model,
                     }))}
-                    disabled={!provider}
+                    disabled={!provider || !modelsLoaded}
                     className={cn('disabled:opacity-50', error ? 'border-2 border-red-500' : '')}
                     ariaLabel={localize('com_ui_model')}
                     isCollapsed={false}
@@ -217,6 +230,11 @@ export default function ModelPanel({
               );
             }}
           />
+          {modelsError && (
+            <Alert variant="error" className="mt-1">
+              {localize('com_error_models_not_loaded')}
+            </Alert>
+          )}
         </div>
       </div>
       {/* Model Parameters */}


### PR DESCRIPTION
## Summary

Closes #15022. Rebased onto `dev` after #15179 landed, and reduced to the half that PR did not cover — #15179 fixed the `localStorage` seeding vector, this fixes the fetch-timing one the issue actually reports (Edge's cache behaviour changes when the mounted `/api/models` fetch resolves relative to first paint).

`useGetModelsQuery` is declared with `initialData: initialModelsConfig`, so `modelsQuery.data` holds a static fallback catalog both *before* the mounted `/api/models` fetch resolves and *after* that fetch fails — react-query keeps `data` and only flips `status` to error. #15179 removed the `localStorage` seeding of the form and gates the selectors on `modelsReady = isFetchedAfterMount && !isFetching`, but that flag goes **true** once a failed fetch settles, so the builder re-enables its selectors over the fallback catalog.

This change makes the seed non-authoritative:

- `models` is blanked to `{}` unless the mounted fetch actually succeeded, so fallback entries are never rendered as options.
- A new `modelsError` prop surfaces the failure as an `Alert` in the model panel and keeps both selectors disabled, instead of silently offering the seed.
- The model placeholder reads `com_ui_loading` while the fetch is in flight, and both fields carry `aria-busy`.
- Agent creation refuses a provider/model pair the resolved catalog does not offer. The guards are ordered after the existing `!provider || !model` check, so an empty field still reports `com_agents_missing_provider_model` rather than "model not found".
- `selectId` is wired on the provider, model, and category comboboxes. `dev` already had `htmlFor="provider"`, `htmlFor="model"`, and `htmlFor="category-selector"` pointing at elements that did not exist.

Prop surface converges on #15179's naming: `modelsReady` is kept as-is and only `modelsError` is added, rather than the three overlapping flags the original revision of this PR introduced.

### Screenshots

Not included. The steady-state layout is unchanged; this removes transient and post-failure unavailable options.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```bash
npx eslint client/src/common/types.ts client/src/components/SidePanel/Agents/AgentCategorySelector.tsx client/src/components/SidePanel/Agents/AgentConfig.tsx client/src/components/SidePanel/Agents/AgentPanel.test.tsx client/src/components/SidePanel/Agents/AgentPanel.tsx client/src/components/SidePanel/Agents/ModelPanel.tsx client/src/components/SidePanel/Agents/ModelPanel.test.tsx
```

```bash
cd client && npx jest src/components/SidePanel/Agents/ModelPanel.test.tsx src/components/SidePanel/Agents/AgentPanel.test.tsx --coverage=false
```

23/23 pass across the two suites.

The 7 new tests were run as a negative control against the pre-change source (source reverted, tests kept) and all 7 fail there, so they are not passing vacuously:

- `ModelPanel › announces the pending catalogue instead of inviting a selection`
- `ModelPanel › offers no models and explains the failure when the catalogue cannot be loaded`
- `ModelPanel › labels the provider and model controls`
- `AgentPanel › withholds the seeded catalogue until the mounted fetch resolves`
- `AgentPanel › withholds the seeded catalogue when the models request fails`
- `AgentPanel › agent creation › refuses to create an agent while the catalogue is unavailable`
- `AgentPanel › agent creation › refuses to create an agent with a model the catalogue no longer offers`

An eighth test, `agent creation › creates the agent when the catalogue offers the selected model`, passes both with and without the change — it guards against the new checks over-firing.

### **Test Configuration**

- Jest, 2 suites, 23 tests
- `tsc --noEmit` reports no errors in any file touched here

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes