### PR TITLE
fix: precache PWA icons during client build

### DIFF
--- a/client/scripts/post-build.cjs
+++ b/client/scripts/post-build.cjs
@@ -1,14 +1,24 @@
-const fs = require('fs-extra');
+const fs = require('fs');
+const path = require('path');
 
-async function postBuild() {
-  try {
-    await fs.copy('public/assets', 'dist/assets');
-    await fs.copy('public/robots.txt', 'dist/robots.txt');
-    console.log('✅ PWA icons and robots.txt copied successfully. Glob pattern warnings resolved.');
-  } catch (err) {
-    console.error('❌ Error copying files:', err);
-    process.exit(1);
-  }
+const distDir = path.resolve(__dirname, '../dist');
+const manifest = JSON.parse(fs.readFileSync(path.join(distDir, 'manifest.webmanifest'), 'utf8'));
+const serviceWorker = fs.readFileSync(path.join(distDir, 'sw.js'), 'utf8');
+const iconPaths = manifest.icons.map((icon) => icon.src);
+const missingFiles = iconPaths.filter((iconPath) => !fs.existsSync(path.join(distDir, iconPath)));
+const missingPrecacheEntries = iconPaths.filter((iconPath) => !serviceWorker.includes(iconPath));
+
+if (missingFiles.length || missingPrecacheEntries.length) {
+  console.error('❌ PWA build verification failed.', {
+    missingFiles,
+    missingPrecacheEntries,
+  });
+  process.exit(1);
 }
 
-postBuild();
+if (!fs.existsSync(path.join(distDir, 'robots.txt'))) {
+  console.error('❌ PWA build verification failed: robots.txt was not copied.');
+  process.exit(1);
+}
+
+console.log('✅ PWA icons are copied and precached, and robots.txt is present.');

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -88,6 +88,24 @@ export default defineConfig(({ command }) => ({
         });
       },
     },
+    {
+      name: 'copy-public-assets',
+      apply: 'build',
+      async writeBundle() {
+        const publicDir = path.resolve(__dirname, 'public');
+        const distDir = path.resolve(__dirname, 'dist');
+
+        await Promise.all([
+          fs.promises.cp(path.join(publicDir, 'assets'), path.join(distDir, 'assets'), {
+            recursive: true,
+          }),
+          fs.promises.copyFile(
+            path.join(publicDir, 'robots.txt'),
+            path.join(distDir, 'robots.txt'),
+          ),
+        ]);
+      },
+    },
     VitePWA({
       injectRegister: 'auto', // 'auto' | 'manual' | 'disabled'
       registerType: 'autoUpdate', // 'prompt' | 'autoUpdate'


### PR DESCRIPTION
## Summary

Fixes #15030.

- Copy PWA assets before Workbox generates the service worker.
- Verify manifest icons exist and are precached after the build.
- Keep `public/images` excluded and add no dependencies.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Commands and checks completed locally:

- `npm run build:packages`
- `cd client && npm run build` (53 precache entries; all five icons verified)
- `cd client && npm run typecheck`
- `npx eslint client/vite.config.ts client/scripts/post-build.cjs`
- `npx prettier --check client/vite.config.ts client/scripts/post-build.cjs`
- `git diff --check`

`npm run test:client`: 415/417 suites passed. Seven unrelated locale assertions expect en-US output on this zh-CN Windows environment. Full `npm run lint` produced no diagnostics before a five-minute timeout; changed-file lint passed.

### **Test Configuration**:

- Windows
- Node.js 24.14.0 (the contribution guide specifies 24.16.0)
- npm 11.9.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written automated build checks demonstrating that my changes are effective
- [ ] Local unit tests pass with my changes (see the locale-specific failures documented above)

