### PR TITLE
📐 docs: Make CLAUDE.md Portable and Restore AGENTS.md Parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,8 @@ instead of copying classes into a feature. Keep genuine layout and behavior loca
 why any new custom CSS cannot be expressed by the shared system. See the detailed policy in
 `CLAUDE.md` under “Theming and styling.”
 
-When adding or changing code that mutates user documents, invalidate the auth user document cache for affected users. This includes single-user updates and bulk role/user mutations; otherwise OpenID JWT request burst caching can serve a stale `req.user` until its TTL expires.
+## Backend auth cache
+
+When adding or changing code that mutates user documents, invalidate the auth user document cache
+for affected users, including bulk role and user mutations. See the detailed policy in `CLAUDE.md`
+under “Auth cache invalidation”.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ LibreChat is a monorepo with the following key workspaces:
 | `/client` | TypeScript/React | Frontend | `packages/data-provider`, `packages/client` | Frontend SPA |
 | `/packages/client` | TypeScript | Frontend | `packages/data-provider` | Shared frontend utilities |
 
-The source code for `@librechat/agents` (major backend dependency, same team) is at `/home/danny/agentus`.
+The source code for `@librechat/agents` (major backend dependency, same team) lives at
+<https://github.com/danny-avila/agents>.
 
 ---
 
@@ -167,6 +168,16 @@ Multi-line imports count total character length across all lines. Consolidate va
 - Cursor pagination for large datasets.
 - Proper dependency arrays to avoid unnecessary re-renders.
 - Leverage React Query caching and background refetching.
+
+---
+
+## Backend Rules (`api/**`, `packages/api/**`)
+
+### Auth cache invalidation
+
+When adding or changing code that mutates user documents, invalidate the auth user document cache
+for the affected users. This covers single-user updates as well as bulk role and user mutations.
+Without it, OpenID JWT request burst caching can serve a stale `req.user` until its TTL expires.
 
 ---
 


### PR DESCRIPTION
Closes #15045.

Two small fixes to the repository's agent harness files. Documentation only, no runtime code touched.

## 1. `CLAUDE.md` pointed at a path that exists on one machine

```
The source code for `@librechat/agents` ... is at `/home/danny/agentus`
```

Harness files are reloaded into context on every turn of every session, for every contributor. This line therefore costs context permanently while resolving for exactly one person. `@librechat/agents` publishes its repository, so the same instruction works for everyone as a URL.

## 2. `AGENTS.md` held a rule that `CLAUDE.md` was missing

`AGENTS.md` opens with `See CLAUDE.md.`, which sets `CLAUDE.md` up as the source of truth. It then carried this, which appears nowhere in `CLAUDE.md`:

> invalidate the auth user document cache for affected users ... otherwise OpenID JWT request burst caching can serve a stale `req.user` until its TTL expires

Claude Code reads `CLAUDE.md` and does not read `AGENTS.md`, so contributors using it never received the rule. Given it concerns serving stale authentication state, reaching only some contributors is the wrong failure mode.

I moved it into a `## Backend Rules` section in `CLAUDE.md`, mirroring the existing `## Frontend Rules` section, and left `AGENTS.md` pointing at it exactly the way its theming paragraph already points at `### Theming and styling`. That keeps both files useful without letting them drift apart again.

The theming paragraph needed no change: its cross-reference to `CLAUDE.md:124` was already correct.

## Alternative worth considering

If you would rather remove this class of problem structurally, making `AGENTS.md` a symlink to `CLAUDE.md` means the two can never diverge again. I did not do that here because the current `AGENTS.md` is deliberately a short summary rather than a copy, and that seemed like your call rather than mine.

Placement of the new section is also easy to move if you would prefer it elsewhere in the file.

## Verification

```
grep -n "/home/" CLAUDE.md AGENTS.md          # no matches after the change
grep -n "auth user document cache" CLAUDE.md  # now present
```

Checked against `main` at `b4593f8`.
