### PR TITLE
🔔 fix: Honor Toast Duration and Support Persistent Toasts

### DIFF
--- a/packages/client/src/components/Toast.tsx
+++ b/packages/client/src/components/Toast.tsx
@@ -17,8 +17,9 @@ export function Toast(): JSX.Element {
 
   return (
     <RadixToast.Root
+      key={toast.id}
       open={toast.open}
-      onOpenChange={onOpenChange}
+      onOpenChange={(open) => onOpenChange(open, toast.id)}
       duration={toast.duration}
       className="toast-root"
       style={{

--- a/packages/client/src/components/Toast.tsx
+++ b/packages/client/src/components/Toast.tsx
@@ -1,10 +1,13 @@
+import { X } from 'lucide-react';
 import { JSX } from 'react/jsx-runtime';
 import * as RadixToast from '@radix-ui/react-toast';
 import { NotificationSeverity } from '~/common';
-import { useToast } from '~/hooks';
+import { useToast, useLocalize } from '~/hooks';
 
 export function Toast(): JSX.Element {
   const { toast, onOpenChange } = useToast();
+  const localize = useLocalize();
+  const persistent = toast.duration === Infinity;
   const severityClassName = {
     [NotificationSeverity.INFO]: 'border-status-info-strong bg-status-info-strong',
     [NotificationSeverity.SUCCESS]: 'border-status-success-strong bg-status-success-strong',
@@ -16,9 +19,10 @@ export function Toast(): JSX.Element {
     <RadixToast.Root
       open={toast.open}
       onOpenChange={onOpenChange}
+      duration={toast.duration}
       className="toast-root"
       style={{
-        height: '74px',
+        minHeight: '74px',
         marginBottom: '0px',
       }}
     >
@@ -51,6 +55,14 @@ export function Toast(): JSX.Element {
           <RadixToast.Description className="flex-1 justify-center gap-2">
             <div className="whitespace-pre-wrap text-left">{toast.message}</div>
           </RadixToast.Description>
+          {persistent && (
+            <RadixToast.Close
+              aria-label={localize('com_ui_close')}
+              className="mt-1 flex-shrink-0 flex-grow-0 rounded-sm opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+            >
+              <X className="icon-sm" />
+            </RadixToast.Close>
+          )}
         </div>
       </div>
     </RadixToast.Root>

--- a/packages/client/src/components/Toast.tsx
+++ b/packages/client/src/components/Toast.tsx
@@ -59,9 +59,9 @@ export function Toast(): JSX.Element {
           {persistent && (
             <RadixToast.Close
               aria-label={localize('com_ui_close')}
-              className="mt-1 flex-shrink-0 flex-grow-0 rounded-sm opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+              className="ml-2 inline-flex flex-shrink-0 flex-grow-0 items-center justify-center self-center rounded-sm opacity-80 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
             >
-              <X className="icon-sm" />
+              <X className="h-4 w-4" strokeWidth={3} />
             </RadixToast.Close>
           )}
         </div>

--- a/packages/client/src/components/__tests__/Toast.spec.tsx
+++ b/packages/client/src/components/__tests__/Toast.spec.tsx
@@ -10,8 +10,10 @@ const MESSAGE = 'The file is too large.';
 function ShowOnMount({ duration }: { duration?: number }): null {
   const { showToast } = useToast(0);
 
+  /** One toast per mount — re-running on a changed identity would reset the timers under test. */
   useEffect(() => {
     showToast({ message: MESSAGE, duration });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return null;

--- a/packages/client/src/components/__tests__/Toast.spec.tsx
+++ b/packages/client/src/components/__tests__/Toast.spec.tsx
@@ -2,10 +2,12 @@ import { useEffect } from 'react';
 import { Provider } from 'jotai';
 import * as RadixToast from '@radix-ui/react-toast';
 import { render, act, fireEvent } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import { useToast } from '~/hooks';
 import { Toast } from '../Toast';
 
 const MESSAGE = 'The file is too large.';
+const REPLACEMENT = 'The upload finished.';
 
 function ShowOnMount({ duration }: { duration?: number }): null {
   const { showToast } = useToast(0);
@@ -19,11 +21,25 @@ function ShowOnMount({ duration }: { duration?: number }): null {
   return null;
 }
 
-function setup(duration?: number): void {
+function ShowTwice({ duration, gap }: { duration: number; gap: number }): null {
+  const { showToast } = useToast(0);
+
+  /** One pair per mount, for the same reason ShowOnMount runs once. */
+  useEffect(() => {
+    showToast({ message: MESSAGE, duration });
+    const timer = window.setTimeout(() => showToast({ message: REPLACEMENT, duration }), gap);
+    return () => window.clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}
+
+function renderToast(trigger: ReactElement): void {
   render(
     <Provider>
       <RadixToast.Provider>
-        <ShowOnMount duration={duration} />
+        {trigger}
         <Toast />
         <RadixToast.Viewport />
       </RadixToast.Provider>
@@ -31,10 +47,18 @@ function setup(duration?: number): void {
   );
 }
 
+function setup(duration?: number): void {
+  renderToast(<ShowOnMount duration={duration} />);
+}
+
 /** Radix removes the root once it has closed, so an absent node and a node
  *  marked closed are the same observable outcome. */
 function state(): string {
   return document.querySelector('.toast-root')?.getAttribute('data-state') ?? 'unmounted';
+}
+
+function message(): string {
+  return document.querySelector('.toast-root')?.textContent ?? '';
 }
 
 function advance(ms: number): void {
@@ -101,5 +125,21 @@ describe('Toast duration', () => {
     advance(0);
 
     expect(document.querySelector('[aria-label="com_ui_close"]')).toBeNull();
+  });
+
+  test('restarts the deadline when a toast replaces one that is still open', () => {
+    renderToast(<ShowTwice duration={3000} gap={2000} />);
+    advance(0);
+    expect(state()).toBe('open');
+
+    advance(2001);
+    expect(message()).toContain(REPLACEMENT);
+
+    /** Past the first toast's deadline: the replacement keeps its own full duration. */
+    advance(1200);
+    expect(state()).toBe('open');
+
+    advance(2000);
+    expect(state()).not.toBe('open');
   });
 });

--- a/packages/client/src/components/__tests__/Toast.spec.tsx
+++ b/packages/client/src/components/__tests__/Toast.spec.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from 'react';
+import { Provider } from 'jotai';
+import * as RadixToast from '@radix-ui/react-toast';
+import { render, act, fireEvent } from '@testing-library/react';
+import { useToast } from '~/hooks';
+import { Toast } from '../Toast';
+
+const MESSAGE = 'The file is too large.';
+
+function ShowOnMount({ duration }: { duration?: number }): null {
+  const { showToast } = useToast(0);
+
+  useEffect(() => {
+    showToast({ message: MESSAGE, duration });
+  }, []);
+
+  return null;
+}
+
+function setup(duration?: number): void {
+  render(
+    <Provider>
+      <RadixToast.Provider>
+        <ShowOnMount duration={duration} />
+        <Toast />
+        <RadixToast.Viewport />
+      </RadixToast.Provider>
+    </Provider>,
+  );
+}
+
+/** Radix removes the root once it has closed, so an absent node and a node
+ *  marked closed are the same observable outcome. */
+function state(): string {
+  return document.querySelector('.toast-root')?.getAttribute('data-state') ?? 'unmounted';
+}
+
+function advance(ms: number): void {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+}
+
+describe('Toast duration', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('honors a duration shorter than the Radix default', () => {
+    setup(3000);
+    advance(0);
+    expect(state()).toBe('open');
+
+    advance(2900);
+    expect(state()).toBe('open');
+
+    advance(200);
+    expect(state()).not.toBe('open');
+  });
+
+  test('honors a duration longer than the Radix default', () => {
+    setup(10000);
+    advance(0);
+    expect(state()).toBe('open');
+
+    advance(5500);
+    expect(state()).toBe('open');
+  });
+
+  test('treats a duration of 0 as persistent', () => {
+    setup(0);
+    advance(0);
+    expect(state()).toBe('open');
+
+    advance(60000);
+    expect(state()).toBe('open');
+  });
+
+  test('offers a dismissal only for a persistent toast', () => {
+    setup(0);
+    advance(0);
+
+    const close = document.querySelector('[aria-label="com_ui_close"]');
+    expect(close).not.toBeNull();
+
+    act(() => {
+      fireEvent.click(close as Element);
+    });
+
+    expect(state()).not.toBe('open');
+  });
+
+  test('leaves a self-dismissing toast without a close control', () => {
+    setup(3000);
+    advance(0);
+
+    expect(document.querySelector('[aria-label="com_ui_close"]')).toBeNull();
+  });
+});

--- a/packages/client/src/hooks/useToast.ts
+++ b/packages/client/src/hooks/useToast.ts
@@ -6,20 +6,16 @@ import { NotificationSeverity } from '~/common';
 
 export default function useToast(showDelay = 100): {
   toast: ToastState;
-  onOpenChange: (open: boolean) => void;
+  onOpenChange: (open: boolean, id: number) => void;
   showToast: ({ message, severity, showIcon, duration, status }: TShowToast) => void;
 } {
   const [toast, setToast] = useAtom(toastState);
   const showTimerRef = useRef<number | null>(null);
-  const hideTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
       if (showTimerRef.current !== null) {
         clearTimeout(showTimerRef.current);
-      }
-      if (hideTimerRef.current !== null) {
-        clearTimeout(hideTimerRef.current);
       }
     };
   }, []);
@@ -31,40 +27,36 @@ export default function useToast(showDelay = 100): {
     duration = 3000, // default duration for the toast to be visible
     status,
   }: TShowToast): void => {
-    // Clear existing timeouts
+    // Clear a pending show that has not fired yet
     if (showTimerRef.current !== null) {
       clearTimeout(showTimerRef.current);
-    }
-    if (hideTimerRef.current !== null) {
-      clearTimeout(hideTimerRef.current);
     }
 
     const closeAfter = Number.isFinite(duration) && duration > 0 ? duration : Infinity;
 
     // Timeout to show the toast
     showTimerRef.current = window.setTimeout(() => {
-      setToast({
+      /** A new `id` gives the toast its own Radix lifecycle, so its close deadline
+       *  starts now even when it replaces a toast that is still open. */
+      setToast((prevToast: ToastState) => ({
         open: true,
         message,
         severity: (status as NotificationSeverity) ?? severity,
         showIcon,
         duration: closeAfter,
-      });
-
-      if (closeAfter === Infinity) {
-        return;
-      }
-
-      // Hides the toast after the specified duration
-      hideTimerRef.current = window.setTimeout(() => {
-        setToast((prevToast: ToastState) => ({ ...prevToast, open: false }));
-      }, closeAfter);
+        id: prevToast.id + 1,
+      }));
     }, showDelay);
   };
 
   return {
     toast,
-    onOpenChange: (open: boolean): void => setToast({ ...toast, open }),
+    /** Radix keeps a superseded toast's close timer alive past unmount, so it can
+     *  otherwise close the toast that replaced it; the id makes that a no-op. */
+    onOpenChange: (open: boolean, id: number): void =>
+      setToast((prevToast: ToastState) =>
+        prevToast.id === id ? { ...prevToast, open } : prevToast,
+      ),
     showToast,
   };
 }

--- a/packages/client/src/hooks/useToast.ts
+++ b/packages/client/src/hooks/useToast.ts
@@ -39,6 +39,8 @@ export default function useToast(showDelay = 100): {
       clearTimeout(hideTimerRef.current);
     }
 
+    const closeAfter = Number.isFinite(duration) && duration > 0 ? duration : Infinity;
+
     // Timeout to show the toast
     showTimerRef.current = window.setTimeout(() => {
       setToast({
@@ -46,11 +48,17 @@ export default function useToast(showDelay = 100): {
         message,
         severity: (status as NotificationSeverity) ?? severity,
         showIcon,
+        duration: closeAfter,
       });
+
+      if (closeAfter === Infinity) {
+        return;
+      }
+
       // Hides the toast after the specified duration
       hideTimerRef.current = window.setTimeout(() => {
         setToast((prevToast: ToastState) => ({ ...prevToast, open: false }));
-      }, duration);
+      }, closeAfter);
     }, showDelay);
   };
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -13,6 +13,8 @@ export type ToastState = {
   message: string;
   severity: NotificationSeverity;
   showIcon: boolean;
+  /** Milliseconds until the toast closes itself, or `Infinity` to require a dismissal. */
+  duration: number;
 };
 
 export const toastState: PrimitiveAtom<ToastState> & {
@@ -22,4 +24,5 @@ export const toastState: PrimitiveAtom<ToastState> & {
   message: '',
   severity: NotificationSeverity.SUCCESS,
   showIcon: true,
+  duration: 3000,
 });

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -15,6 +15,8 @@ export type ToastState = {
   showIcon: boolean;
   /** Milliseconds until the toast closes itself, or `Infinity` to require a dismissal. */
   duration: number;
+  /** Increments per shown toast, so each one gets its own close deadline. */
+  id: number;
 };
 
 export const toastState: PrimitiveAtom<ToastState> & {
@@ -25,4 +27,5 @@ export const toastState: PrimitiveAtom<ToastState> & {
   severity: NotificationSeverity.SUCCESS,
   showIcon: true,
   duration: 3000,
+  id: 0,
 });


### PR DESCRIPTION
## Summary

Fixes #15048.

`showToast`'s `duration` is only honored below 5 seconds. Above 5 seconds it is silently discarded, and `duration: 0` closes the toast on the next tick, so there is no way to show a toast that stays until the user dismisses it.

Two timers are in play on `dev`:

1. `useToast` arms its hide timer unconditionally, so `duration: 0` becomes `setTimeout(hide, 0)`.
2. `Toast.tsx` never forwards `duration` to `RadixToast.Root`, so Radix falls back to the `Provider` default of 5000ms and closes the toast itself.

Durations under 5s only appear to work because the hook's timer fires first. `useDelayedUploadToast` requests `10000` today and has been getting 5000.

Radix already supports what is being asked for, so the change is wiring rather than new machinery: `Toast.Root` takes a `duration`, and its close timer bails on `if (!duration || duration === Infinity) return;`. Because `durationProp || context.duration` treats `0` as absent, `Infinity` is the sentinel that has to reach Radix — so `useToast` normalizes any non-positive or non-finite `duration` to `Infinity` once and writes it into the toast atom. `Toast.tsx` forwards that value and renders a `RadixToast.Close` only when the toast is persistent, since a toast that never closes on its own needs a way out.

Rather than keep two timers racing, `useToast` drops its own hide timer entirely and Radix owns dismissal timing. That leaves one deadline per toast instead of two, and pause-on-hover now applies — it could not while an unpausable `setTimeout` was also running.

That single owner needs one piece of state to be correct across a replacement. Radix restarts its deadline only when `open` or `duration` changes, so a toast replacing one that is still open at the same duration inherits the earlier deadline and closes early. `ToastImpl`'s duration effect also has no cleanup, so the superseded toast's close timer survives unmount and still drives the shared open state — a distinct lifecycle alone is therefore not sufficient. Each shown toast now carries an incrementing `id`, which both keys `RadixToast.Root` (fresh deadline) and is passed to `onOpenChange`, which ignores a close arriving for an `id` that is no longer current (stale timer becomes a no-op).

`style.height` on the root becomes `minHeight` so a persistent multi-line message is readable rather than overflowing a fixed 74px box.

No call sites change. `TShowToast` already declared `duration?: number`, and every existing caller keeps its current behavior — the only difference is that a value above 5000 is now respected instead of capped.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `packages/client/src/components/__tests__/Toast.spec.tsx`, which renders the shared `Toast` inside a `RadixToast.Provider` and drives it with fake timers:

- a duration shorter than the Radix default is honored (passes before and after — regression guard)
- a duration longer than the Radix default is honored (fails on `dev`: closes at 5s)
- `duration: 0` is persistent (fails on `dev`: closes immediately)
- a persistent toast renders a dismiss control and closing it works
- a self-dismissing toast renders no dismiss control
- a toast replacing one that is still open gets its own full duration (fails on `dev`: closes on the earlier toast's deadline)

Control run with `Toast.tsx`, `useToast.ts` and `store.ts` reverted and the spec kept: exactly the three affected cases red, the others green — the spec catches the defects rather than passing vacuously.

### **Test Configuration**:

`cd packages/client && npx jest src/components/__tests__/Toast.spec.tsx`

Full `packages/client` suite: 278 passing. One suite fails to load in my environment — `ControlCombobox.spec.tsx`, `Cannot find module '@ariakit/react-components/select/select-renderer'` — which is a dependency resolution problem in a file this change does not touch.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
