### PR TITLE
fix: allow toast duration=0 to stay until manually dismissed

### DIFF
--- a/packages/client/src/hooks/useToast.ts
+++ b/packages/client/src/hooks/useToast.ts
@@ -47,10 +47,12 @@ export default function useToast(showDelay = 100): {
         severity: (status as NotificationSeverity) ?? severity,
         showIcon,
       });
-      // Hides the toast after the specified duration
-      hideTimerRef.current = window.setTimeout(() => {
-        setToast((prevToast: ToastState) => ({ ...prevToast, open: false }));
-      }, duration);
+      // Hides the toast after the specified duration (0 = stay until manually dismissed)
+      if (duration > 0) {
+        hideTimerRef.current = window.setTimeout(() => {
+          setToast((prevToast: ToastState) => ({ ...prevToast, open: false }));
+        }, duration);
+      }
     }, showDelay);
   };
 


### PR DESCRIPTION
Fixes #15048. When duration=0, the hide timer fires immediately (setTimeout(hide, 0)). Fix: skip setting hide timer when duration <= 0, allowing toast to stay until manually dismissed.