### PR TITLE
fix: always use terminal mode in askSilentQuestion to hide password input

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -49,7 +49,12 @@ const askSilentQuestion = (query, input = process.stdin, destination = process.s
   const rl = readline.createInterface({
     input,
     output,
-    terminal: input.isTTY,
+    // Always use terminal mode so readline puts stdin in raw mode and
+    // prevents the terminal driver from echoing typed characters.
+    // Without this, passwords would be visible on terminals where
+    // input.isTTY is falsy or on platforms that echo before readline
+    // intercepts.
+    terminal: true,
   });
 
   destination.write(query);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #14922：`npm run reset-password` 的密码输入在终端中以明文显示。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：#14922
- 本 PR 包含：`config/helpers.js` 中 `askSilentQuestion` 函数的终端模式修复
- 用户可见变化：密码输入不再在终端中显示

## 怎么验证的

运行 `npm run reset-password`，确认输入密码时不再显示明文。

## 风险

- 无已知风险
- 向后兼容：仅改变终端模式设置，不影响功能逻辑

Fixes #14922