### PR TITLE
fix: use abortResult.success for scheduled resume abort check

### DIFF
--- a/api/server/controllers/agents/resume.js
+++ b/api/server/controllers/agents/resume.js
@@ -608,7 +608,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
         expectedCreatedAt: job.createdAt,
         awaitProviderDrain: true,
       });
-      stopped = abortResult != null && abortResult.failureReason == null;
+      stopped = abortResult?.success === true;
     } catch (error) {
       logger.warn('[ResumeAgentController] Failed to stop inactive scheduled run', error);
     }
@@ -979,7 +979,7 @@ const ResumeAgentController = async (req, res, next, initializeClient, addTitle)
           expectedCreatedAt: job.createdAt,
           awaitProviderDrain: true,
         });
-        stopped = abortResult != null && abortResult.failureReason == null;
+        stopped = abortResult?.success === true;
       } catch (error) {
         logger.warn('[ResumeAgentController] Failed to stop stale scheduled resume', error);
       }


### PR DESCRIPTION
## What

Gate the scheduled resume abort check on `abortResult.success` instead of `failureReason == null`.

## Why

Fixes #15042 - Scheduled resume treats a failed abort as a confirmed stop.

The previous implementation used `failureReason == null` to determine if a scheduled run was stopped, but `AbortResult` carries an explicit `success` flag. When `success: false` is returned without a `failureReason`, the old check treated it as a successful stop, causing the handler to record `interrupted` and prune the checkpoint even though the abort was not confirmed.

## Changes

- Changed both inactive and stale scheduled resume paths to use `abortResult?.success === true`
- Matches the abort route's own check in `api/server/routes/agents/index.js`

## Testing

- Verified the fix aligns with the abort route's behavior
- No breaking changes; the fix is a one-line change in two places

Fixes #15042