### PR TITLE
🛰️ test: Prove Cross-Replica Subagent Delivery

### DIFF
--- a/.github/workflows/agents-integration-tests.yml
+++ b/.github/workflows/agents-integration-tests.yml
@@ -1,7 +1,7 @@
 name: Agents Integration Tests
 
 # Runs the packages/api `src/agents/**` integration specs (e.g. the durable HITL
-# checkpointer against a real in-process MongoDB via mongodb-memory-server). These
+# checkpointer and cross-replica subagent delivery against real MongoDB and Redis). These
 # are `*.integration.spec.ts`, which `test:ci` deliberately excludes — without this
 # job they run nowhere and their regressions guard nothing.
 on:
@@ -33,9 +33,20 @@ concurrency:
 
 jobs:
   agents_integration_tests:
-    name: Integration Tests that use in-process MongoDB
+    name: Integration Tests (MongoDB and Redis)
     timeout-minutes: 20
     runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout repository
@@ -95,8 +106,9 @@ jobs:
         if: steps.cache-api.outputs.cache-hit != 'true'
         run: npm run build:api
 
-      - name: Run agents integration tests (in-process MongoDB)
+      - name: Run agents integration tests
         working-directory: packages/api
         env:
           NODE_ENV: test
+          REDIS_URI: redis://127.0.0.1:6379
         run: npm run test:agents-integration

--- a/packages/api/src/agents/subagentCrossReplica.integration.spec.ts
+++ b/packages/api/src/agents/subagentCrossReplica.integration.spec.ts
@@ -1,0 +1,382 @@
+import mongoose from 'mongoose';
+import IoRedis from 'ioredis';
+import { randomUUID } from 'node:crypto';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { Constants, EModelEndpoint } from 'librechat-data-provider';
+import { createMethods, createModels, tenantStorage } from '@librechat/data-schemas';
+import type {
+  SubagentTaskRuntime,
+  SubagentTaskStartRequest,
+  SubagentTaskStartResult,
+} from '@librechat/agents';
+import type { AllMethods } from '@librechat/data-schemas';
+import type { AgentTriggerDeliveryPersistence, AgentTriggerService } from './triggers/service';
+import type { AgentTriggerFetch } from './triggers/host';
+import type { SubagentTaskWakeupRegistration } from './subagentThreads';
+import { __resetShutdownStateForTests } from '../app/shutdown';
+import { buildSubagentThreadTaskConfig, SubagentThreadTaskStore } from './subagentThreads';
+import {
+  RedisSubagentTaskControlTransport,
+  SubagentTaskOwnerUnavailableError,
+} from './subagentTaskRouting';
+import {
+  createSubagentCompletionWakeupHandler,
+  createSubagentCompletionWakeupResolver,
+} from './subagentCompletionWakeup';
+import { createAgentTriggerService } from './triggers/service';
+
+const DB_SETUP_TIMEOUT_MS = 60_000;
+const REDIS_URI = process.env.REDIS_URI;
+const describeWithRedis = REDIS_URI == null ? describe.skip : describe;
+
+let mongod: MongoMemoryServer;
+let methods: AllMethods;
+let triggerService: AgentTriggerService | undefined;
+const redisClients: IoRedis[] = [];
+const taskStores: SubagentThreadTaskStore[] = [];
+
+function accepted(
+  started: SubagentTaskStartResult,
+): Extract<SubagentTaskStartResult, { accepted: true }> {
+  if (!started.accepted) {
+    throw new Error('Expected the child task to be accepted.');
+  }
+  return started;
+}
+
+async function waitUntil<T>(read: () => T | undefined | Promise<T | undefined>): Promise<T> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (value !== undefined) {
+      return value;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for the cross-replica integration condition.');
+}
+
+function redisClient(): IoRedis {
+  const client = new IoRedis(REDIS_URI!, {
+    enableOfflineQueue: false,
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  redisClients.push(client);
+  return client;
+}
+
+async function connectedRedisClient(): Promise<IoRedis> {
+  const client = redisClient();
+  await client.connect();
+  return client;
+}
+
+async function createRoutingTransport(instanceId: string, namespace: string) {
+  const [publisher, subscriber] = await Promise.all([
+    connectedRedisClient(),
+    connectedRedisClient(),
+  ]);
+  return new RedisSubagentTaskControlTransport(publisher, subscriber, {
+    instanceId,
+    namespace,
+    registrationHeartbeatMs: 25,
+    requestTimeoutMs: 200,
+    retryDelayMs: 10,
+  });
+}
+
+function taskRequest(
+  scopeId: string,
+  input: string,
+  subagentType: string,
+  run: SubagentTaskStartRequest['run'],
+): SubagentTaskStartRequest {
+  return {
+    scopeId,
+    idempotencyKey: randomUUID(),
+    parentRunId: 'parent-response',
+    parentAgentId: 'agent_parent',
+    parentToolCallId: randomUUID(),
+    input,
+    subagentKind: 'agent',
+    subagentType,
+    run,
+  };
+}
+
+async function saveParent(userId: string, tenantId: string, conversationId: string): Promise<void> {
+  await tenantStorage.run({ tenantId, userId }, async () => {
+    await methods.saveConvo(
+      { userId },
+      {
+        conversationId,
+        tenantId,
+        endpoint: EModelEndpoint.agents,
+        title: 'Cross-replica parent',
+        agent_id: 'agent_parent',
+      },
+    );
+    await methods.saveMessage(
+      { userId },
+      {
+        messageId: 'parent-response',
+        conversationId,
+        parentMessageId: String(Constants.NO_PARENT),
+        sender: 'Director',
+        text: 'I dispatched two child tasks.',
+        endpoint: EModelEndpoint.agents,
+        isCreatedByUser: false,
+      },
+    );
+  });
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  createModels(mongoose);
+  methods = createMethods(mongoose);
+  await mongoose.connect(mongod.getUri(), { autoIndex: false });
+}, DB_SETUP_TIMEOUT_MS);
+
+afterEach(async () => {
+  await triggerService?.stop();
+  triggerService = undefined;
+  __resetShutdownStateForTests();
+  await Promise.all(
+    taskStores.splice(0).map((store) => store.destroyTaskControlTransport().catch(() => undefined)),
+  );
+  await Promise.all(redisClients.splice(0).map((client) => client.quit().catch(() => undefined)));
+  await mongoose.connection.db?.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+}, DB_SETUP_TIMEOUT_MS);
+
+describeWithRedis('subagent cross-replica orchestration', () => {
+  it('routes controls to the execution owner and delivers two sibling wakeups once after owner loss', async () => {
+    const userId = new mongoose.Types.ObjectId().toString();
+    const tenantId = 'tenant-cross-replica';
+    const parentConversationId = randomUUID();
+    await saveParent(userId, tenantId, parentConversationId);
+
+    const continuationEffects = new Map<string, { input: string; parentMessageId: string }>();
+    let dropFirstReceipt = true;
+    const fetcher = jest.fn<ReturnType<AgentTriggerFetch>, Parameters<AgentTriggerFetch>>(
+      async (_input, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          text: string;
+          parentMessageId: string;
+          conversationId: string;
+          clientRequestId: string;
+        };
+        if (!continuationEffects.has(body.clientRequestId)) {
+          const userMessageId = `${body.clientRequestId}:user`;
+          const assistantMessageId = `${body.clientRequestId}:assistant`;
+          await tenantStorage.run({ tenantId, userId }, async () => {
+            await methods.saveMessage(
+              { userId },
+              {
+                messageId: userMessageId,
+                conversationId: body.conversationId,
+                parentMessageId: body.parentMessageId,
+                sender: 'User',
+                text: body.text,
+                endpoint: EModelEndpoint.agents,
+                isCreatedByUser: true,
+              },
+            );
+            await methods.saveMessage(
+              { userId },
+              {
+                messageId: assistantMessageId,
+                conversationId: body.conversationId,
+                parentMessageId: userMessageId,
+                sender: 'Director',
+                text: 'Accepted the child result.',
+                endpoint: EModelEndpoint.agents,
+                isCreatedByUser: false,
+              },
+            );
+          });
+          continuationEffects.set(body.clientRequestId, {
+            input: body.text,
+            parentMessageId: body.parentMessageId,
+          });
+          /** The parent continuation committed, but its HTTP receipt was lost. The
+           * durable delivery must retry with the same client request identity. */
+          if (dropFirstReceipt) {
+            dropFirstReceipt = false;
+            throw new Error('response lost after admission');
+          }
+        }
+        return new Response(
+          JSON.stringify({
+            status: 'started',
+            streamId: body.conversationId,
+            conversationId: body.conversationId,
+            generationCreatedAt: Date.now(),
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      },
+    );
+
+    const resolver = createSubagentCompletionWakeupResolver({
+      methods,
+      getGenerationJob: async () => null,
+    });
+    triggerService = createAgentTriggerService({
+      methods: methods as AllMethods & AgentTriggerDeliveryPersistence,
+      fetch: fetcher,
+      mintToken: () => 'trigger-token',
+      prepareContinue: resolver,
+      deliveryOptions: { concurrency: 2, tickMs: 1_000, retryBaseMs: 5, retryCapMs: 20 },
+    });
+    await triggerService.initialize({
+      address: { address: '127.0.0.1', family: 'IPv4', port: 3080 },
+    });
+
+    const receipts: Array<{ deliveryKey: string; replayed: boolean }> = [];
+    const registrations: SubagentTaskWakeupRegistration[] = [];
+    const wakeup = createSubagentCompletionWakeupHandler(async (envelope, options) => {
+      const receipt = await triggerService!.enqueue(envelope, options);
+      receipts.push(receipt);
+      return receipt;
+    });
+    const ownerStore = new SubagentThreadTaskStore(methods, {
+      onTaskPrepared: async (registration) => {
+        registrations.push(registration);
+        /** A crash-retried preparation can invoke the producer again; enqueueing the
+         * same task identity must retain one durable delivery. */
+        await wakeup(registration);
+        await wakeup(registration);
+      },
+    });
+    const requesterStore = new SubagentThreadTaskStore(methods);
+    taskStores.push(ownerStore, requesterStore);
+    const namespace = `subagent-integration-${randomUUID()}`;
+    await ownerStore.configureTaskControlTransport(
+      await createRoutingTransport('execution-owner', namespace),
+    );
+    await requesterStore.configureTaskControlTransport(
+      await createRoutingTransport('delivery-owner', namespace),
+    );
+    const config = buildSubagentThreadTaskConfig(ownerStore, {
+      userId,
+      tenantId,
+      parentConversationId,
+    });
+
+    const releases: Array<() => void> = [];
+    const entered: Promise<void>[] = [];
+    const childRun = (result: string) => {
+      let markEntered = (): void => undefined;
+      entered.push(new Promise<void>((resolve) => (markEntered = resolve)));
+      return async (_runtime: SubagentTaskRuntime) => {
+        markEntered();
+        return new Promise<{ content: string }>((resolve) =>
+          releases.push(() => resolve({ content: result })),
+        );
+      };
+    };
+    const first = ownerStore.start(
+      taskRequest(
+        config.scopeId,
+        'first child task',
+        'researcher',
+        childRun('First durable result.'),
+      ),
+    );
+    const second = ownerStore.start(
+      taskRequest(
+        config.scopeId,
+        'second child task',
+        'reviewer',
+        childRun('Second durable result.'),
+      ),
+    );
+    await Promise.all(entered);
+
+    const firstTaskId = accepted(first).task.taskId;
+    const secondTaskId = accepted(second).task.taskId;
+    await expect(requesterStore.listTasks(config.scopeId)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ taskId: firstTaskId, status: 'running' }),
+        expect.objectContaining({ taskId: secondTaskId, status: 'running' }),
+      ]),
+    );
+    await expect(
+      requesterStore.controlTask(
+        config.scopeId,
+        firstTaskId,
+        { action: 'queue', message: 'Include the primary source.' },
+        'cross-replica-steer',
+      ),
+    ).resolves.toMatchObject({ status: 'accepted' });
+
+    releases.forEach((release) => release());
+    await waitUntil(() => {
+      const tasks = [
+        ownerStore.get(config.scopeId, firstTaskId),
+        ownerStore.get(config.scopeId, secondTaskId),
+      ];
+      return tasks.every((task) => task?.status === 'completed') ? true : undefined;
+    });
+    await ownerStore.destroyTaskControlTransport();
+
+    await expect(
+      requesterStore.controlTask(
+        config.scopeId,
+        firstTaskId,
+        { action: 'cancel' },
+        'owner-gone-control',
+      ),
+    ).rejects.toBeInstanceOf(SubagentTaskOwnerUnavailableError);
+
+    const uniqueReceipts = new Map(receipts.map((receipt) => [receipt.deliveryKey, receipt]));
+    expect(registrations).toHaveLength(2);
+    expect(receipts).toHaveLength(4);
+    expect(uniqueReceipts.size).toBe(2);
+    expect(receipts.filter((receipt) => receipt.replayed)).toHaveLength(2);
+
+    const deliveries = await waitUntil(async () => {
+      const deliveries = await Promise.all(
+        [...uniqueReceipts.keys()].map((key) => triggerService!.getDelivery(key)),
+      );
+      const dead = deliveries.find((delivery) => delivery?.status === 'dead');
+      if (dead != null) {
+        throw new Error(`Wakeup dead-lettered: ${JSON.stringify(dead.lastError)}`);
+      }
+      return deliveries.every((delivery) => delivery?.status === 'succeeded')
+        ? deliveries
+        : undefined;
+    });
+
+    expect(continuationEffects.size).toBe(2);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(deliveries.map((delivery) => delivery?.attempts).sort()).toEqual([1, 2]);
+    expect([...continuationEffects.values()].map(({ input }) => input)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('First durable result.'),
+        expect.stringContaining('Second durable result.'),
+      ]),
+    );
+    expect([...continuationEffects.values()].map(({ parentMessageId }) => parentMessageId)).toEqual(
+      expect.arrayContaining([
+        'parent-response',
+        expect.stringMatching(/^trigger_[a-f0-9]{64}:assistant$/),
+      ]),
+    );
+    const parentMessages = await methods.getMessages({
+      user: userId,
+      conversationId: parentConversationId,
+    });
+    expect(parentMessages.filter((message) => message.isCreatedByUser)).toHaveLength(2);
+    expect(parentMessages.filter((message) => !message.isCreatedByUser)).toHaveLength(3);
+
+    await requesterStore.destroyTaskControlTransport();
+  });
+});

--- a/packages/api/src/agents/subagentCrossReplica.integration.spec.ts
+++ b/packages/api/src/agents/subagentCrossReplica.integration.spec.ts
@@ -1,5 +1,5 @@
-import mongoose from 'mongoose';
 import IoRedis from 'ioredis';
+import mongoose from 'mongoose';
 import { randomUUID } from 'node:crypto';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { Constants, EModelEndpoint } from 'librechat-data-provider';
@@ -11,18 +11,18 @@ import type {
 } from '@librechat/agents';
 import type { AllMethods } from '@librechat/data-schemas';
 import type { AgentTriggerDeliveryPersistence, AgentTriggerService } from './triggers/service';
-import type { AgentTriggerFetch } from './triggers/host';
 import type { SubagentTaskWakeupRegistration } from './subagentThreads';
-import { __resetShutdownStateForTests } from '../app/shutdown';
-import { buildSubagentThreadTaskConfig, SubagentThreadTaskStore } from './subagentThreads';
-import {
-  RedisSubagentTaskControlTransport,
-  SubagentTaskOwnerUnavailableError,
-} from './subagentTaskRouting';
+import type { AgentTriggerFetch } from './triggers/host';
 import {
   createSubagentCompletionWakeupHandler,
   createSubagentCompletionWakeupResolver,
 } from './subagentCompletionWakeup';
+import {
+  RedisSubagentTaskControlTransport,
+  SubagentTaskOwnerUnavailableError,
+} from './subagentTaskRouting';
+import { buildSubagentThreadTaskConfig, SubagentThreadTaskStore } from './subagentThreads';
+import { __resetShutdownStateForTests } from '../app/shutdown';
 import { createAgentTriggerService } from './triggers/service';
 
 const DB_SETUP_TIMEOUT_MS = 60_000;

--- a/packages/api/src/agents/subagentCrossReplica.integration.spec.ts
+++ b/packages/api/src/agents/subagentCrossReplica.integration.spec.ts
@@ -80,9 +80,9 @@ async function createRoutingTransport(instanceId: string, namespace: string) {
   return new RedisSubagentTaskControlTransport(publisher, subscriber, {
     instanceId,
     namespace,
-    registrationHeartbeatMs: 25,
-    requestTimeoutMs: 200,
-    retryDelayMs: 10,
+    registrationHeartbeatMs: 1_000,
+    requestTimeoutMs: 1_000,
+    retryDelayMs: 25,
   });
 }
 


### PR DESCRIPTION
## Summary

I added a focused integration proof that composes the existing subagent execution-owner routing and durable completion-wakeup paths without changing production interfaces.

- Exercise two logical API owners with separate `SubagentThreadTaskStore` and `RedisSubagentTaskControlTransport` instances over a real Redis server.
- Persist the parent, child threads, terminal child results, result claims, and trigger deliveries through a real in-process MongoDB.
- Start two sibling children on the execution owner, then list and steer them from the second owner.
- Enqueue each wakeup twice and verify the stable task identity collapses each pair into one durable delivery.
- Inject an ambiguous lost HTTP receipt after one parent continuation is admitted and verify its retry produces one observable continuation effect.
- Verify ordered sibling wakeups chain the second continuation onto the first continuation's assistant branch.
- Remove the execution owner's Redis address after both terminal results persist, verify live control fails as owner-unavailable, and verify the second owner still consumes both durable results.
- Add Redis 7 to the existing Agents integration workflow so this proof runs in CI.

This proves composition through the real Redis routing adapter, Mongo persistence methods, trigger delivery engine, completion resolver, and result-claim protocol. It deliberately does not claim a live multi-process deployment test: both logical owners run in one Jest process, and the HTTP admission endpoint is represented by a boundary fake that enforces `clientRequestId` idempotency. It also proves owner loss only after terminal persistence; an execution process lost before settlement is not migrated or resumed by this design.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the focused real Redis/Mongo integration scenario: 1/1 passed.
- Ran the complete Agents integration suite: 30/30 passed.
- Ran adjacent subagent routing and completion-wakeup suites: 40/40 passed.
- Ran ESLint and Prettier on the changed test and workflow.
- Ran a targeted TypeScript compile against current-worktree data-provider and data-schema builds.

### **Test Configuration**:

- Node.js 24.16.0
- Redis server on `REDIS_URI=redis://127.0.0.1:6389`
- `mongodb-memory-server`
- Jest in band

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules
