### PR TITLE
feat: add MEILI_NO_INDEX env var to skip index writes

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -226,6 +226,9 @@ const createMeiliMongooseModel = ({
      * incrementally indexing only non-temporary documents where `_meiliIndex` is not `true`.
      * */
     static async syncWithMeili(this: SchemaWithMeiliMethods): Promise<void> {
+      if (noIndex) {
+        return;
+      }
       const startTime = Date.now();
       const { batchSize, delayMs } = syncConfig;
 
@@ -305,7 +308,7 @@ const createMeiliMongooseModel = ({
       index: Index<MeiliIndexable>,
       documents: Array<Record<string, unknown>>,
     ): Promise<void> {
-      if (documents.length === 0) {
+      if (noIndex || documents.length === 0) {
         return;
       }
 
@@ -343,6 +346,9 @@ const createMeiliMongooseModel = ({
       batchSize: number,
       delayMs: number,
     ): Promise<void> {
+      if (noIndex) {
+        return;
+      }
       try {
         let offset = 0;
         let moreDocuments = true;
@@ -393,6 +399,9 @@ const createMeiliMongooseModel = ({
      * Updates settings for the MeiliSearch index
      */
     static async setMeiliIndexSettings(settings: Record<string, unknown>): Promise<unknown> {
+      if (noIndex) {
+        return;
+      }
       return await index.updateSettings(settings);
     }
 

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -84,6 +84,13 @@ const searchEnabled = process.env.SEARCH != null && process.env.SEARCH.toLowerCa
  */
 const meiliEnabled =
   process.env.MEILI_HOST != null && process.env.MEILI_MASTER_KEY != null && searchEnabled;
+/**
+ * Flag to indicate if writing to MeiliSearch index should be skipped.
+ * When true, search still works but documents are not added/updated/deleted in the index.
+ * Useful for read-only replicas or when index writes cause performance issues.
+ */
+const noIndex =
+  process.env.MEILI_NO_INDEX != null && process.env.MEILI_NO_INDEX.toLowerCase() === 'true';
 
 /**
  * Get sync configuration from environment variables
@@ -556,6 +563,9 @@ const createMeiliMongooseModel = ({
      * otherwise, it adds the document to the index.
      */
     postSaveHook(this: DocumentWithMeiliIndex, next: CallbackWithoutResultAndOptionalError): void {
+      if (noIndex) {
+        return next();
+      }
       if (this._meiliIndex) {
         this.updateObjectToMeili!(next);
       } else {
@@ -573,6 +583,9 @@ const createMeiliMongooseModel = ({
       this: DocumentWithMeiliIndex,
       next: CallbackWithoutResultAndOptionalError,
     ): void {
+      if (noIndex) {
+        return next();
+      }
       if (this._meiliIndex) {
         this.updateObjectToMeili!(next);
       } else {
@@ -590,6 +603,9 @@ const createMeiliMongooseModel = ({
       this: DocumentWithMeiliIndex,
       next: CallbackWithoutResultAndOptionalError,
     ): void {
+      if (noIndex) {
+        return next();
+      }
       if (this._meiliIndex) {
         this.deleteObjectFromMeili!(next);
       } else {
@@ -745,7 +761,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
 
   // Pre-deleteMany hook: remove corresponding documents from MeiliSearch when multiple documents are deleted.
   schema.pre('deleteMany', async function (next) {
-    if (!meiliEnabled) {
+    if (!meiliEnabled || noIndex) {
       return next();
     }
 
@@ -805,7 +821,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       res: DocumentWithMeiliIndex | { value: DocumentWithMeiliIndex | null } | null,
       next: CallbackWithoutResultAndOptionalError,
     ) {
-      if (!meiliEnabled) {
+      if (!meiliEnabled || noIndex) {
         return next();
       }
 


### PR DESCRIPTION
## What changed

Add a new environment variable `MEILI_NO_INDEX` that, when set to `true`, skips all write operations to MeiliSearch (add, update, delete) while keeping the search functionality intact.

## Why

Currently, there is no configuration that produces "search works, LibreChat does not write to the index". The existing `SEARCH=true` mode always writes to MeiliSearch. This feature is useful for:
- Read-only replicas
- When index writes cause performance issues
- Testing search without modifying the index

## How to verify

1. Set `SEARCH=true`, `MEILI_HOST`, `MEILI_MASTER_KEY`, and `MEILI_NO_INDEX=true`
2. Verify search works (documents already in index are searchable)
3. Create/update/delete conversations and verify no new documents appear in MeiliSearch index
4. Check logs for absence of `[addObjectToMeili]`, `[updateObjectToMeili]`, `[deleteObjectFromMeili]` messages

## Risk

Minimal - additive feature behind an opt-in env var. No existing behavior changes when `MEILI_NO_INDEX` is not set.

Fixes #14962