### PR TITLE
fix: preserve tool-managed files through provider MIME filters

### DIFF
--- a/packages/api/src/files/filter.spec.ts
+++ b/packages/api/src/files/filter.spec.ts
@@ -847,6 +847,99 @@ describe('filterFilesByEndpointConfig', () => {
       expect(result).toEqual([pdfFile, pngFile]);
     });
 
+    it('should preserve code-environment files outside the provider MIME allowlist', () => {
+      const req = {
+        config: {
+          fileConfig: {
+            endpoints: {
+              OpenRouter: {
+                disabled: false,
+                supportedMimeTypes: ['^image/.*$', '^application/pdf$'],
+              },
+            },
+          },
+        },
+      } as unknown as ServerRequest;
+
+      const spreadsheet = {
+        ...createMockFile('sample.xlsx'),
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        metadata: {
+          codeEnvRef: {
+            kind: 'user',
+            id: 'user-1',
+            storage_session_id: 'session-1',
+            file_id: 'code-file-1',
+          },
+        },
+      } as IMongoFile;
+
+      const result = filterFilesByEndpointConfig(req, {
+        files: [spreadsheet],
+        endpoint: 'OpenRouter',
+        endpointType: EModelEndpoint.custom,
+      });
+
+      expect(result).toEqual([spreadsheet]);
+    });
+
+    it('should still reject a raw spreadsheet outside the provider MIME allowlist', () => {
+      const req = {
+        config: {
+          fileConfig: {
+            endpoints: {
+              OpenRouter: {
+                disabled: false,
+                supportedMimeTypes: ['^image/.*$', '^application/pdf$'],
+              },
+            },
+          },
+        },
+      } as unknown as ServerRequest;
+
+      const spreadsheet = {
+        ...createMockFile('sample.xlsx'),
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      } as IMongoFile;
+
+      const result = filterFilesByEndpointConfig(req, {
+        files: [spreadsheet],
+        endpoint: 'OpenRouter',
+        endpointType: EModelEndpoint.custom,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should preserve embedded retrieval files outside the provider MIME allowlist', () => {
+      const req = {
+        config: {
+          fileConfig: {
+            endpoints: {
+              OpenRouter: {
+                disabled: false,
+                supportedMimeTypes: ['^image/.*$', '^application/pdf$'],
+              },
+            },
+          },
+        },
+      } as unknown as ServerRequest;
+
+      const embeddedFile = {
+        ...createMockFile('knowledge.docx'),
+        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        embedded: true,
+      } as IMongoFile;
+
+      const result = filterFilesByEndpointConfig(req, {
+        files: [embeddedFile],
+        endpoint: 'OpenRouter',
+        endpointType: EModelEndpoint.custom,
+      });
+
+      expect(result).toEqual([embeddedFile]);
+    });
+
     it('should keep all files when supportedMimeTypes is not set', () => {
       const req = {
         config: {

--- a/packages/api/src/files/filter.ts
+++ b/packages/api/src/files/filter.ts
@@ -17,6 +17,15 @@ function isMimeTypeSupported(mimeType: string, supportedMimeTypes?: RegexLike[])
 }
 
 /**
+ * Files already routed to an internal tool are not serialized as raw provider
+ * attachments. Provider MIME allowlists therefore must not discard them before
+ * agent resource priming. Size/total limits still apply to these files.
+ */
+function isToolManagedFile(file: IMongoFile): boolean {
+  return file.embedded === true || file.metadata?.codeEnvRef != null;
+}
+
+/**
  * Filters out files based on endpoint configuration including:
  * - Disabled status
  * - File size limits
@@ -73,7 +82,7 @@ export function filterFilesByEndpointConfig(
   /** Filter by MIME type */
   if (supportedMimeTypes && supportedMimeTypes.length > 0) {
     filteredFiles = filteredFiles.filter((file) => {
-      return isMimeTypeSupported(file.type, supportedMimeTypes);
+      return isToolManagedFile(file) || isMimeTypeSupported(file.type, supportedMimeTypes);
     });
   }
 


### PR DESCRIPTION
## Summary

Provider MIME allowlists describe raw attachments sent to the model. They currently also discard files already routed to internal tools before agent resource priming. A spreadsheet uploaded to `execute_code`, for example, can be uploaded successfully and receive `metadata.codeEnvRef`, then disappear because the provider itself accepts only images/PDF.

This change preserves code-environment and embedded retrieval files during MIME filtering while continuing to enforce endpoint disabled, individual-size, and total-size limits. Raw unsupported provider attachments remain rejected.

## Reproduction

1. Configure a custom agent provider with an image/PDF-only `supportedMimeTypes` allowlist.
2. Upload an XLSX through **Upload to Code Environment**.
3. Submit a turn asking the agent to read it.
4. The file record and `codeEnvRef` exist, but the code tool receives no input file because `filterFilesByEndpointConfig` removes it before `primeResources`.

## Verification

The focused file-filter and agent-resource suite passes 80 tests on the v0.8.7 integration branch. Added coverage proves that code-environment and embedded files survive while the same raw XLSX remains filtered.