### PR TITLE
🪟 feat: Read Child Threads Through Their Parent

### DIFF
--- a/api/server/routes/__test-utils__/convos-route-mocks.js
+++ b/api/server/routes/__test-utils__/convos-route-mocks.js
@@ -32,6 +32,7 @@ module.exports = {
       });
       return archiveAllHandler;
     }),
+    createSubagentThreadViewHandler: jest.fn(() => (_req, res) => res.status(200).json({})),
     deleteConvoSharedLinksWithCleanup: jest.fn(),
     deleteAllSharedLinksWithCleanup: jest.fn(),
     deleteAgentCheckpoints: jest.fn(),

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -35,7 +35,7 @@ const assistantClients = {
 const router = express.Router();
 const archiveAllHandler = createArchiveAllHandler({ archiveAllConvos: db.archiveAllConvos });
 const subagentThreadViewHandler = createSubagentThreadViewHandler({
-  getConvo: db.getConvo,
+  getConvoOwnership: db.getConvoOwnership,
   getSubagentThreadForParent: db.getSubagentThreadForParent,
   getMessages: db.getMessages,
 });

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -5,6 +5,7 @@ const {
   isEnabled,
   deleteAgentCheckpoints,
   createArchiveAllHandler,
+  createSubagentThreadViewHandler,
   resolveImportMaxFileSize,
   restoreTenantContextFromReq,
   deleteAllSharedLinksWithCleanup,
@@ -33,6 +34,11 @@ const assistantClients = {
 
 const router = express.Router();
 const archiveAllHandler = createArchiveAllHandler({ archiveAllConvos: db.archiveAllConvos });
+const subagentThreadViewHandler = createSubagentThreadViewHandler({
+  getConvo: db.getConvo,
+  getSubagentThreadForParent: db.getSubagentThreadForParent,
+  getMessages: db.getMessages,
+});
 router.use(requireJwtAuth);
 
 const isValidProjectFilter = (projectId) =>
@@ -78,6 +84,8 @@ router.get('/', async (req, res) => {
     res.status(500).json({ error: 'Error fetching conversations' });
   }
 });
+
+router.get('/:parentConversationId/subagents/:threadId', subagentThreadViewHandler);
 
 router.get('/:conversationId', async (req, res) => {
   const { conversationId } = req.params;

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -37,7 +37,7 @@ const archiveAllHandler = createArchiveAllHandler({ archiveAllConvos: db.archive
 const subagentThreadViewHandler = createSubagentThreadViewHandler({
   getConvoOwnership: db.getConvoOwnership,
   getSubagentThreadForParent: db.getSubagentThreadForParent,
-  getMessages: db.getMessages,
+  getMessagesForSubagentThreadView: db.getMessagesForSubagentThreadView,
 });
 router.use(requireJwtAuth);
 

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -51,5 +51,6 @@ export * from './triggers';
 export * from './activityLabels';
 export * from './activityPhases';
 export * from './subagentDelivery';
+export * from './view';
 export * from './reasoningLabels';
 export * from './toolValidation';

--- a/packages/api/src/agents/view.spec.ts
+++ b/packages/api/src/agents/view.spec.ts
@@ -79,8 +79,11 @@ const createRequest = (params: Record<string, string> = {}): ServerRequest =>
 describe('subagent thread parent-scoped view', () => {
   it('returns a bounded public child projection through the owning parent', async () => {
     const getConvoOwnership = jest.fn().mockResolvedValue(parent);
-    const oversized = '🧵'.repeat(SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes);
-    const newest = { ...message('task-1:assistant', 'completed'), text: oversized } as IMessage;
+    const newest = {
+      ...message('task-1:assistant', 'completed'),
+      text: 'a'.repeat(SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes / 4),
+      textProjectionTruncated: true,
+    } as IMessage & { textProjectionTruncated: boolean };
     const getMessages = jest
       .fn()
       .mockResolvedValue([newest, message('task-1:user', 'running', true)]);
@@ -99,7 +102,7 @@ describe('subagent thread parent-scoped view', () => {
       user: 'user-1',
       tenantId: 'tenant-1',
       limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
-      textCodePointLimit: SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes,
+      textCodePointLimit: SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes / 4,
     });
     expect(getConvoOwnership).toHaveBeenCalledWith('user-1', parentConversationId, 'tenant-1');
     expect(json).toHaveBeenCalledWith({
@@ -179,7 +182,7 @@ describe('subagent thread parent-scoped view', () => {
       conversationId: threadId,
       user: 'user-1',
       limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
-      textCodePointLimit: SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes,
+      textCodePointLimit: SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes / 4,
     });
   });
 

--- a/packages/api/src/agents/view.spec.ts
+++ b/packages/api/src/agents/view.spec.ts
@@ -78,9 +78,7 @@ const createRequest = (params: Record<string, string> = {}): ServerRequest =>
 
 describe('subagent thread parent-scoped view', () => {
   it('returns a bounded public child projection through the owning parent', async () => {
-    const getConvo = jest.fn((_: string, conversationId: string) =>
-      Promise.resolve(conversationId === parentConversationId ? parent : child),
-    );
+    const getConvoOwnership = jest.fn().mockResolvedValue(parent);
     const oversized = '🧵'.repeat(SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes);
     const newest = { ...message('task-1:assistant', 'completed'), text: oversized } as IMessage;
     const getMessages = jest
@@ -88,7 +86,7 @@ describe('subagent thread parent-scoped view', () => {
       .mockResolvedValue([newest, message('task-1:user', 'running', true)]);
     const getSubagentThreadForParent = jest.fn().mockResolvedValue(child);
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent,
       getMessages,
     });
@@ -97,7 +95,7 @@ describe('subagent thread parent-scoped view', () => {
     await handler(createRequest(), response);
 
     expect(getMessages).toHaveBeenCalledWith(
-      { conversationId: threadId, user: 'user-1' },
+      { conversationId: threadId, user: 'user-1', tenantId: 'tenant-1' },
       expect.stringContaining('+subagentTask'),
       {
         limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
@@ -135,7 +133,7 @@ describe('subagent thread parent-scoped view', () => {
   });
 
   it('bounds the complete UTF-8 response while retaining the newest history', async () => {
-    const getConvo = jest.fn().mockResolvedValue(parent);
+    const getConvoOwnership = jest.fn().mockResolvedValue(parent);
     const messages = Array.from(
       { length: SUBAGENT_THREAD_VIEW_LIMITS.messages },
       (_, index) =>
@@ -145,7 +143,7 @@ describe('subagent thread parent-scoped view', () => {
         }) as IMessage,
     );
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
       getMessages: jest.fn().mockResolvedValue(messages),
     });
@@ -161,14 +159,39 @@ describe('subagent thread parent-scoped view', () => {
     expect(view.messages.at(-1).messageId).toBe('task-0:assistant');
   });
 
+  it('requires tenantless messages when the authenticated request has no tenant', async () => {
+    const getMessages = jest.fn().mockResolvedValue([]);
+    const handler = createSubagentThreadViewHandler({
+      getConvoOwnership: jest.fn().mockResolvedValue({ ...parent, tenantId: undefined }),
+      getSubagentThreadForParent: jest
+        .fn()
+        .mockResolvedValue({ ...child, tenantId: undefined, subagentThreadLease: undefined }),
+      getMessages,
+    });
+    const { response } = createResponse();
+
+    await handler(
+      { ...createRequest(), user: { id: 'user-1', tenantId: undefined } } as ServerRequest,
+      response,
+    );
+
+    expect(getMessages).toHaveBeenCalledWith(
+      {
+        conversationId: threadId,
+        user: 'user-1',
+        tenantId: { $exists: false },
+      },
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
+
   it.each([
     ['running', 'running'],
     ['error', 'failed'],
     ['cancelled', 'cancelled'],
   ] as const)('normalizes durable %s tasks as %s', async (durableStatus, publicStatus) => {
-    const getConvo = jest.fn((_: string, conversationId: string) =>
-      Promise.resolve(conversationId === parentConversationId ? parent : child),
-    );
+    const getConvoOwnership = jest.fn().mockResolvedValue(parent);
     const getMessages = jest
       .fn()
       .mockResolvedValue([
@@ -179,7 +202,7 @@ describe('subagent thread parent-scoped view', () => {
         ),
       ]);
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
       getMessages,
     });
@@ -191,11 +214,9 @@ describe('subagent thread parent-scoped view', () => {
   });
 
   it('reports a reserved child with no durable task messages as dispatched', async () => {
-    const getConvo = jest.fn((_: string, conversationId: string) =>
-      Promise.resolve(conversationId === parentConversationId ? parent : child),
-    );
+    const getConvoOwnership = jest.fn().mockResolvedValue(parent);
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent: jest
         .fn()
         .mockResolvedValue({ ...child, subagentThreadLease: undefined }),
@@ -212,7 +233,7 @@ describe('subagent thread parent-scoped view', () => {
 
   it('reports a child with an active preparation lease as running before its seed exists', async () => {
     const handler = createSubagentThreadViewHandler({
-      getConvo: jest.fn().mockResolvedValue(parent),
+      getConvoOwnership: jest.fn().mockResolvedValue(parent),
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
       getMessages: jest.fn().mockResolvedValue([]),
     });
@@ -231,7 +252,7 @@ describe('subagent thread parent-scoped view', () => {
       subagentThreadLease: { ...child.subagentThreadLease!, taskId: 'task-2' },
     } as IConversation;
     const handler = createSubagentThreadViewHandler({
-      getConvo: jest.fn().mockResolvedValue(parent),
+      getConvoOwnership: jest.fn().mockResolvedValue(parent),
       getSubagentThreadForParent: jest.fn().mockResolvedValue(activeChild),
       getMessages: jest.fn().mockResolvedValue([message('task-1:assistant', 'completed')]),
     });
@@ -243,14 +264,12 @@ describe('subagent thread parent-scoped view', () => {
   });
 
   it('keeps the newest bounded tail and marks older history as truncated', async () => {
-    const getConvo = jest.fn((_: string, conversationId: string) =>
-      Promise.resolve(conversationId === parentConversationId ? parent : child),
-    );
+    const getConvoOwnership = jest.fn().mockResolvedValue(parent);
     const messages = Array.from({ length: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1 }, (_, index) =>
       message(`task-${index}:assistant`, 'completed'),
     );
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
       getMessages: jest.fn().mockResolvedValue(messages),
     });
@@ -282,10 +301,10 @@ describe('subagent thread parent-scoped view', () => {
     ['parent tenant mismatch', { ...parent, tenantId: 'tenant-2' }, child, 'tenant-1'],
     ['child tenant mismatch', parent, { ...child, tenantId: 'tenant-2' }, 'tenant-1'],
   ])('returns the same 404 for %s', async (_, parentRecord, childRecord, tenantId) => {
-    const getConvo = jest.fn().mockResolvedValue(parentRecord);
+    const getConvoOwnership = jest.fn().mockResolvedValue(parentRecord);
     const getMessages = jest.fn().mockResolvedValue([message('task-1:assistant', 'completed')]);
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(childRecord),
       getMessages,
     });
@@ -305,11 +324,11 @@ describe('subagent thread parent-scoped view', () => {
   });
 
   it('rejects a child id used as its own parent before reading storage', async () => {
-    const getConvo = jest.fn();
+    const getConvoOwnership = jest.fn();
     const getSubagentThreadForParent = jest.fn();
     const getMessages = jest.fn();
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent,
       getMessages,
     });
@@ -318,17 +337,17 @@ describe('subagent thread parent-scoped view', () => {
     await handler(createRequest({ parentConversationId: threadId }), response);
 
     expect(status).toHaveBeenCalledWith(404);
-    expect(getConvo).not.toHaveBeenCalled();
+    expect(getConvoOwnership).not.toHaveBeenCalled();
     expect(getSubagentThreadForParent).not.toHaveBeenCalled();
     expect(getMessages).not.toHaveBeenCalled();
   });
 
   it('rejects oversized route identifiers before reading storage', async () => {
-    const getConvo = jest.fn();
+    const getConvoOwnership = jest.fn();
     const getSubagentThreadForParent = jest.fn();
     const getMessages = jest.fn();
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent,
       getMessages,
     });
@@ -337,15 +356,15 @@ describe('subagent thread parent-scoped view', () => {
     await handler(createRequest({ threadId: 'x'.repeat(257) }), response);
 
     expect(status).toHaveBeenCalledWith(404);
-    expect(getConvo).not.toHaveBeenCalled();
+    expect(getConvoOwnership).not.toHaveBeenCalled();
     expect(getSubagentThreadForParent).not.toHaveBeenCalled();
     expect(getMessages).not.toHaveBeenCalled();
   });
 
   it('marks an unleased running seed as interrupted', async () => {
-    const getConvo = jest.fn().mockResolvedValue(parent);
+    const getConvoOwnership = jest.fn().mockResolvedValue(parent);
     const handler = createSubagentThreadViewHandler({
-      getConvo,
+      getConvoOwnership,
       getSubagentThreadForParent: jest
         .fn()
         .mockResolvedValue({ ...child, subagentThreadLease: undefined }),

--- a/packages/api/src/agents/view.spec.ts
+++ b/packages/api/src/agents/view.spec.ts
@@ -96,7 +96,7 @@ describe('subagent thread parent-scoped view', () => {
 
     expect(getMessages).toHaveBeenCalledWith(
       { conversationId: threadId, user: 'user-1', tenantId: 'tenant-1' },
-      expect.stringContaining('+subagentTask'),
+      'messageId parentMessageId isCreatedByUser text createdAt error +subagentTask',
       {
         limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
         sort: { createdAt: -1, _id: -1 },

--- a/packages/api/src/agents/view.spec.ts
+++ b/packages/api/src/agents/view.spec.ts
@@ -1,0 +1,360 @@
+import type { IConversation, IMessage } from '@librechat/data-schemas';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types';
+import { createSubagentThreadViewHandler, SUBAGENT_THREAD_VIEW_LIMITS } from './view';
+
+jest.mock('@librechat/data-schemas', () => ({
+  CLIENT_MESSAGE_SELECT: '-_id -user',
+  logger: { error: jest.fn() },
+}));
+
+const parentConversationId = 'parent-conversation';
+const threadId = 'child-thread';
+
+const parent = {
+  conversationId: parentConversationId,
+  user: 'user-1',
+  tenantId: 'tenant-1',
+} as IConversation;
+
+const child = {
+  conversationId: threadId,
+  user: 'user-1',
+  tenantId: 'tenant-1',
+  title: 'Research child',
+  agent_id: 'agent-1',
+  updatedAt: new Date('2026-08-21T12:00:00.000Z'),
+  subagentThreadLease: {
+    token: 'lease-token',
+    taskId: 'task-1',
+    expiresAt: new Date('2099-08-21T12:00:00.000Z'),
+  },
+  subagentThread: {
+    rootConversationId: parentConversationId,
+    parentConversationId,
+    parentMessageId: 'parent-message',
+    parentToolCallId: 'parent-tool-call',
+    subagentType: 'researcher',
+    subagentKind: 'agent',
+    depth: 1,
+  },
+} as IConversation;
+
+const message = (
+  messageId: string,
+  status: NonNullable<IMessage['subagentTask']>['status'],
+  isCreatedByUser = false,
+): IMessage =>
+  ({
+    messageId,
+    conversationId: threadId,
+    user: 'user-1',
+    parentMessageId: isCreatedByUser ? '00000000-0000-0000-0000-000000000000' : 'task-1:user',
+    sender: isCreatedByUser ? 'User' : 'researcher',
+    text: isCreatedByUser ? 'Investigate this.' : 'Finished the research.',
+    isCreatedByUser,
+    createdAt: new Date(isCreatedByUser ? '2026-08-21T11:00:00.000Z' : '2026-08-21T11:01:00.000Z'),
+    subagentTask: {
+      attemptKey: 'attempt-1',
+      status,
+    },
+  }) as IMessage;
+
+const createResponse = () => {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  return {
+    response: { status } as Partial<Response> as Response,
+    status,
+    json,
+  };
+};
+
+const createRequest = (params: Record<string, string> = {}): ServerRequest =>
+  ({
+    params: { parentConversationId, threadId, ...params },
+    user: { id: 'user-1', tenantId: 'tenant-1' },
+  }) as ServerRequest;
+
+describe('subagent thread parent-scoped view', () => {
+  it('returns a bounded public child projection through the owning parent', async () => {
+    const getConvo = jest.fn((_: string, conversationId: string) =>
+      Promise.resolve(conversationId === parentConversationId ? parent : child),
+    );
+    const oversized = '🧵'.repeat(SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes);
+    const newest = { ...message('task-1:assistant', 'completed'), text: oversized } as IMessage;
+    const getMessages = jest
+      .fn()
+      .mockResolvedValue([newest, message('task-1:user', 'running', true)]);
+    const getSubagentThreadForParent = jest.fn().mockResolvedValue(child);
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent,
+      getMessages,
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(getMessages).toHaveBeenCalledWith(
+      { conversationId: threadId, user: 'user-1' },
+      expect.stringContaining('+subagentTask'),
+      {
+        limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
+        sort: { createdAt: -1, _id: -1 },
+      },
+    );
+    expect(json).toHaveBeenCalledWith({
+      threadId,
+      parentConversationId,
+      parentMessageId: 'parent-message',
+      parentToolCallId: 'parent-tool-call',
+      subagentType: 'researcher',
+      subagentKind: 'agent',
+      agentId: 'agent-1',
+      title: 'Research child',
+      status: 'completed',
+      messages: [
+        expect.objectContaining({ messageId: 'task-1:user', role: 'user' }),
+        expect.objectContaining({
+          messageId: 'task-1:assistant',
+          role: 'assistant',
+          textTruncated: true,
+        }),
+      ],
+      historyTruncated: false,
+      updatedAt: '2026-08-21T12:00:00.000Z',
+    });
+    expect(Buffer.byteLength(json.mock.calls[0][0].messages[1].text, 'utf8')).toBeLessThanOrEqual(
+      SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes,
+    );
+    expect(Buffer.byteLength(JSON.stringify(json.mock.calls[0][0]), 'utf8')).toBeLessThanOrEqual(
+      SUBAGENT_THREAD_VIEW_LIMITS.responseBytes,
+    );
+    expect(json.mock.calls[0][0].messages[1]).not.toHaveProperty('subagentTask');
+  });
+
+  it('bounds the complete UTF-8 response while retaining the newest history', async () => {
+    const getConvo = jest.fn().mockResolvedValue(parent);
+    const messages = Array.from(
+      { length: SUBAGENT_THREAD_VIEW_LIMITS.messages },
+      (_, index) =>
+        ({
+          ...message(`task-${index}:assistant`, 'completed'),
+          text: '🧵'.repeat(SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes),
+        }) as IMessage,
+    );
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
+      getMessages: jest.fn().mockResolvedValue(messages),
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    const view = json.mock.calls[0][0];
+    expect(Buffer.byteLength(JSON.stringify(view), 'utf8')).toBeLessThanOrEqual(
+      SUBAGENT_THREAD_VIEW_LIMITS.responseBytes,
+    );
+    expect(view.historyTruncated).toBe(true);
+    expect(view.messages.at(-1).messageId).toBe('task-0:assistant');
+  });
+
+  it.each([
+    ['running', 'running'],
+    ['error', 'failed'],
+    ['cancelled', 'cancelled'],
+  ] as const)('normalizes durable %s tasks as %s', async (durableStatus, publicStatus) => {
+    const getConvo = jest.fn((_: string, conversationId: string) =>
+      Promise.resolve(conversationId === parentConversationId ? parent : child),
+    );
+    const getMessages = jest
+      .fn()
+      .mockResolvedValue([
+        message(
+          durableStatus === 'running' ? 'task-1:user' : 'task-1:assistant',
+          durableStatus,
+          durableStatus === 'running',
+        ),
+      ]);
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
+      getMessages,
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(json.mock.calls[0][0]).toEqual(expect.objectContaining({ status: publicStatus }));
+  });
+
+  it('reports a reserved child with no durable task messages as dispatched', async () => {
+    const getConvo = jest.fn((_: string, conversationId: string) =>
+      Promise.resolve(conversationId === parentConversationId ? parent : child),
+    );
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent: jest
+        .fn()
+        .mockResolvedValue({ ...child, subagentThreadLease: undefined }),
+      getMessages: jest.fn().mockResolvedValue([]),
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(json.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ status: 'dispatched', messages: [] }),
+    );
+  });
+
+  it('reports a child with an active preparation lease as running before its seed exists', async () => {
+    const handler = createSubagentThreadViewHandler({
+      getConvo: jest.fn().mockResolvedValue(parent),
+      getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
+      getMessages: jest.fn().mockResolvedValue([]),
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(json.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ status: 'running', messages: [] }),
+    );
+  });
+
+  it('does not mistake an older completed turn for the active leased turn', async () => {
+    const activeChild = {
+      ...child,
+      subagentThreadLease: { ...child.subagentThreadLease!, taskId: 'task-2' },
+    } as IConversation;
+    const handler = createSubagentThreadViewHandler({
+      getConvo: jest.fn().mockResolvedValue(parent),
+      getSubagentThreadForParent: jest.fn().mockResolvedValue(activeChild),
+      getMessages: jest.fn().mockResolvedValue([message('task-1:assistant', 'completed')]),
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(json.mock.calls[0][0]).toEqual(expect.objectContaining({ status: 'running' }));
+  });
+
+  it('keeps the newest bounded tail and marks older history as truncated', async () => {
+    const getConvo = jest.fn((_: string, conversationId: string) =>
+      Promise.resolve(conversationId === parentConversationId ? parent : child),
+    );
+    const messages = Array.from({ length: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1 }, (_, index) =>
+      message(`task-${index}:assistant`, 'completed'),
+    );
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
+      getMessages: jest.fn().mockResolvedValue(messages),
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    const view = json.mock.calls[0][0];
+    expect(view.historyTruncated).toBe(true);
+    expect(view.messages).toHaveLength(SUBAGENT_THREAD_VIEW_LIMITS.messages);
+    expect(view.messages[0].messageId).toBe(
+      `task-${SUBAGENT_THREAD_VIEW_LIMITS.messages - 1}:assistant`,
+    );
+    expect(view.messages.at(-1).messageId).toBe('task-0:assistant');
+  });
+
+  it.each([
+    ['missing parent', null, child, 'tenant-1'],
+    ['missing child', parent, null, 'tenant-1'],
+    [
+      'unrelated child',
+      parent,
+      {
+        ...child,
+        subagentThread: { ...child.subagentThread, parentConversationId: 'another-parent' },
+      },
+      'tenant-1',
+    ],
+    ['parent tenant mismatch', { ...parent, tenantId: 'tenant-2' }, child, 'tenant-1'],
+    ['child tenant mismatch', parent, { ...child, tenantId: 'tenant-2' }, 'tenant-1'],
+  ])('returns the same 404 for %s', async (_, parentRecord, childRecord, tenantId) => {
+    const getConvo = jest.fn().mockResolvedValue(parentRecord);
+    const getMessages = jest.fn().mockResolvedValue([message('task-1:assistant', 'completed')]);
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent: jest.fn().mockResolvedValue(childRecord),
+      getMessages,
+    });
+    const { response, status, json } = createResponse();
+
+    await handler(
+      {
+        ...createRequest(),
+        user: { id: 'user-1', tenantId },
+      } as ServerRequest,
+      response,
+    );
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ error: 'Conversation not found' });
+    expect(getMessages).not.toHaveBeenCalled();
+  });
+
+  it('rejects a child id used as its own parent before reading storage', async () => {
+    const getConvo = jest.fn();
+    const getSubagentThreadForParent = jest.fn();
+    const getMessages = jest.fn();
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent,
+      getMessages,
+    });
+    const { response, status } = createResponse();
+
+    await handler(createRequest({ parentConversationId: threadId }), response);
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(getConvo).not.toHaveBeenCalled();
+    expect(getSubagentThreadForParent).not.toHaveBeenCalled();
+    expect(getMessages).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized route identifiers before reading storage', async () => {
+    const getConvo = jest.fn();
+    const getSubagentThreadForParent = jest.fn();
+    const getMessages = jest.fn();
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent,
+      getMessages,
+    });
+    const { response, status } = createResponse();
+
+    await handler(createRequest({ threadId: 'x'.repeat(257) }), response);
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(getConvo).not.toHaveBeenCalled();
+    expect(getSubagentThreadForParent).not.toHaveBeenCalled();
+    expect(getMessages).not.toHaveBeenCalled();
+  });
+
+  it('marks an unleased running seed as interrupted', async () => {
+    const getConvo = jest.fn().mockResolvedValue(parent);
+    const handler = createSubagentThreadViewHandler({
+      getConvo,
+      getSubagentThreadForParent: jest
+        .fn()
+        .mockResolvedValue({ ...child, subagentThreadLease: undefined }),
+      getMessages: jest.fn().mockResolvedValue([message('task-1:user', 'running', true)]),
+    });
+    const { response, json } = createResponse();
+
+    await handler(createRequest(), response);
+
+    expect(json.mock.calls[0][0]).toEqual(expect.objectContaining({ status: 'interrupted' }));
+  });
+});

--- a/packages/api/src/agents/view.spec.ts
+++ b/packages/api/src/agents/view.spec.ts
@@ -88,20 +88,20 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent,
-      getMessages,
+      getMessagesForSubagentThreadView: getMessages,
     });
     const { response, json } = createResponse();
 
     await handler(createRequest(), response);
 
-    expect(getMessages).toHaveBeenCalledWith(
-      { conversationId: threadId, user: 'user-1', tenantId: 'tenant-1' },
-      'messageId parentMessageId isCreatedByUser text createdAt error +subagentTask',
-      {
-        limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
-        sort: { createdAt: -1, _id: -1 },
-      },
-    );
+    expect(getMessages).toHaveBeenCalledWith({
+      conversationId: threadId,
+      user: 'user-1',
+      tenantId: 'tenant-1',
+      limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
+      textCodePointLimit: SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes,
+    });
+    expect(getConvoOwnership).toHaveBeenCalledWith('user-1', parentConversationId, 'tenant-1');
     expect(json).toHaveBeenCalledWith({
       threadId,
       parentConversationId,
@@ -145,7 +145,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
-      getMessages: jest.fn().mockResolvedValue(messages),
+      getMessagesForSubagentThreadView: jest.fn().mockResolvedValue(messages),
     });
     const { response, json } = createResponse();
 
@@ -166,7 +166,7 @@ describe('subagent thread parent-scoped view', () => {
       getSubagentThreadForParent: jest
         .fn()
         .mockResolvedValue({ ...child, tenantId: undefined, subagentThreadLease: undefined }),
-      getMessages,
+      getMessagesForSubagentThreadView: getMessages,
     });
     const { response } = createResponse();
 
@@ -175,15 +175,12 @@ describe('subagent thread parent-scoped view', () => {
       response,
     );
 
-    expect(getMessages).toHaveBeenCalledWith(
-      {
-        conversationId: threadId,
-        user: 'user-1',
-        tenantId: { $exists: false },
-      },
-      expect.any(String),
-      expect.any(Object),
-    );
+    expect(getMessages).toHaveBeenCalledWith({
+      conversationId: threadId,
+      user: 'user-1',
+      limit: SUBAGENT_THREAD_VIEW_LIMITS.messages + 1,
+      textCodePointLimit: SUBAGENT_THREAD_VIEW_LIMITS.messageTextBytes,
+    });
   });
 
   it.each([
@@ -204,7 +201,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
-      getMessages,
+      getMessagesForSubagentThreadView: getMessages,
     });
     const { response, json } = createResponse();
 
@@ -220,7 +217,7 @@ describe('subagent thread parent-scoped view', () => {
       getSubagentThreadForParent: jest
         .fn()
         .mockResolvedValue({ ...child, subagentThreadLease: undefined }),
-      getMessages: jest.fn().mockResolvedValue([]),
+      getMessagesForSubagentThreadView: jest.fn().mockResolvedValue([]),
     });
     const { response, json } = createResponse();
 
@@ -235,7 +232,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership: jest.fn().mockResolvedValue(parent),
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
-      getMessages: jest.fn().mockResolvedValue([]),
+      getMessagesForSubagentThreadView: jest.fn().mockResolvedValue([]),
     });
     const { response, json } = createResponse();
 
@@ -254,7 +251,9 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership: jest.fn().mockResolvedValue(parent),
       getSubagentThreadForParent: jest.fn().mockResolvedValue(activeChild),
-      getMessages: jest.fn().mockResolvedValue([message('task-1:assistant', 'completed')]),
+      getMessagesForSubagentThreadView: jest
+        .fn()
+        .mockResolvedValue([message('task-1:assistant', 'completed')]),
     });
     const { response, json } = createResponse();
 
@@ -271,7 +270,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(child),
-      getMessages: jest.fn().mockResolvedValue(messages),
+      getMessagesForSubagentThreadView: jest.fn().mockResolvedValue(messages),
     });
     const { response, json } = createResponse();
 
@@ -306,7 +305,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent: jest.fn().mockResolvedValue(childRecord),
-      getMessages,
+      getMessagesForSubagentThreadView: getMessages,
     });
     const { response, status, json } = createResponse();
 
@@ -330,7 +329,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent,
-      getMessages,
+      getMessagesForSubagentThreadView: getMessages,
     });
     const { response, status } = createResponse();
 
@@ -349,7 +348,7 @@ describe('subagent thread parent-scoped view', () => {
     const handler = createSubagentThreadViewHandler({
       getConvoOwnership,
       getSubagentThreadForParent,
-      getMessages,
+      getMessagesForSubagentThreadView: getMessages,
     });
     const { response, status } = createResponse();
 
@@ -368,7 +367,9 @@ describe('subagent thread parent-scoped view', () => {
       getSubagentThreadForParent: jest
         .fn()
         .mockResolvedValue({ ...child, subagentThreadLease: undefined }),
-      getMessages: jest.fn().mockResolvedValue([message('task-1:user', 'running', true)]),
+      getMessagesForSubagentThreadView: jest
+        .fn()
+        .mockResolvedValue([message('task-1:user', 'running', true)]),
     });
     const { response, json } = createResponse();
 

--- a/packages/api/src/agents/view.spec.ts
+++ b/packages/api/src/agents/view.spec.ts
@@ -64,7 +64,7 @@ const createResponse = () => {
   const json = jest.fn();
   const status = jest.fn(() => ({ json }));
   return {
-    response: { status } as Partial<Response> as Response,
+    response: { status } as unknown as Response,
     status,
     json,
   };

--- a/packages/api/src/agents/view.ts
+++ b/packages/api/src/agents/view.ts
@@ -1,4 +1,4 @@
-import { CLIENT_MESSAGE_SELECT, logger } from '@librechat/data-schemas';
+import { logger } from '@librechat/data-schemas';
 import type {
   SubagentThreadMessage,
   SubagentThreadStatus,
@@ -14,7 +14,8 @@ const MAX_RESPONSE_TEXT_BYTES = 128 * 1024;
 const MAX_RESPONSE_BYTES = 160 * 1024;
 const MAX_PUBLIC_ID_BYTES = 512;
 const MAX_TITLE_BYTES = 1024;
-const SUBAGENT_TASK_SELECT = `${CLIENT_MESSAGE_SELECT} +subagentTask`;
+const SUBAGENT_TASK_SELECT =
+  'messageId parentMessageId isCreatedByUser text createdAt error +subagentTask';
 
 type SubagentThreadViewDependencies = Pick<
   ConversationMethods,

--- a/packages/api/src/agents/view.ts
+++ b/packages/api/src/agents/view.ts
@@ -1,0 +1,228 @@
+import { CLIENT_MESSAGE_SELECT, logger } from '@librechat/data-schemas';
+import type {
+  SubagentThreadMessage,
+  SubagentThreadStatus,
+  SubagentThreadView,
+} from 'librechat-data-provider';
+import type { ConversationMethods, IMessage, MessageMethods } from '@librechat/data-schemas';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types';
+
+const MAX_THREAD_MESSAGES = 50;
+const MAX_MESSAGE_TEXT_BYTES = 32 * 1024;
+const MAX_RESPONSE_TEXT_BYTES = 128 * 1024;
+const MAX_RESPONSE_BYTES = 160 * 1024;
+const MAX_PUBLIC_ID_BYTES = 512;
+const MAX_TITLE_BYTES = 1024;
+const SUBAGENT_TASK_SELECT = `${CLIENT_MESSAGE_SELECT} +subagentTask`;
+
+type SubagentThreadViewDependencies = Pick<
+  ConversationMethods,
+  'getConvo' | 'getSubagentThreadForParent'
+> &
+  Pick<MessageMethods, 'getMessages'>;
+
+type SubagentThreadViewParams = {
+  parentConversationId?: string;
+  threadId?: string;
+};
+
+const validConversationId = (value: string | undefined): value is string =>
+  value != null && value.trim() !== '' && value.length <= 256;
+
+const tenantMatches = (recordTenantId: string | undefined, requestTenantId: string | undefined) =>
+  recordTenantId === requestTenantId;
+
+const isoDate = (value: Date | string | undefined): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+  return value instanceof Date ? value.toISOString() : value;
+};
+
+const truncateUtf8 = (
+  input: string,
+  byteLimit: number,
+): { text: string; truncated: boolean; bytes: number } => {
+  const inputBytes = Buffer.byteLength(input, 'utf8');
+  if (inputBytes <= byteLimit) {
+    return { text: input, truncated: false, bytes: inputBytes };
+  }
+  let low = 0;
+  let high = input.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(input.slice(0, middle), 'utf8') <= byteLimit) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  let end = low;
+  if (end > 0 && /[\uD800-\uDBFF]/.test(input[end - 1])) {
+    end -= 1;
+  }
+  const text = input.slice(0, end);
+  return { text, truncated: true, bytes: Buffer.byteLength(text, 'utf8') };
+};
+
+const publicMessage = (
+  message: IMessage,
+  byteLimit: number,
+): { message: SubagentThreadMessage; bytes: number } => {
+  const text = message.text ?? '';
+  const projected = truncateUtf8(text, Math.min(MAX_MESSAGE_TEXT_BYTES, byteLimit));
+  return {
+    message: {
+      messageId: truncateUtf8(message.messageId, MAX_PUBLIC_ID_BYTES).text,
+      parentMessageId:
+        message.parentMessageId == null
+          ? null
+          : truncateUtf8(message.parentMessageId, MAX_PUBLIC_ID_BYTES).text,
+      role: message.isCreatedByUser ? 'user' : 'assistant',
+      text: projected.text,
+      ...(isoDate(message.createdAt) == null ? {} : { createdAt: isoDate(message.createdAt) }),
+      ...(message.error === true ? { error: true } : {}),
+      ...(projected.truncated ? { textTruncated: true } : {}),
+    },
+    bytes: projected.bytes,
+  };
+};
+
+const publicStatus = (
+  messages: IMessage[],
+  activeLeaseTaskId: string | undefined,
+): SubagentThreadStatus => {
+  if (activeLeaseTaskId != null) {
+    const activeTaskMessage = messages.find(
+      (message) =>
+        message.messageId === `${activeLeaseTaskId}:user` ||
+        message.messageId === `${activeLeaseTaskId}:assistant`,
+    );
+    if (
+      activeTaskMessage?.subagentTask?.status == null ||
+      activeTaskMessage.subagentTask.status === 'running'
+    ) {
+      return 'running';
+    }
+    return publicStatus([activeTaskMessage], undefined);
+  }
+  const message = messages.find((candidate) => candidate.subagentTask != null);
+  switch (message?.subagentTask?.status) {
+    case 'running':
+      return 'interrupted';
+    case 'completed':
+      return 'completed';
+    case 'error':
+      return 'failed';
+    case 'cancelled':
+      return 'cancelled';
+    default:
+      return 'dispatched';
+  }
+};
+
+const notFound = (res: Response): void => {
+  res.status(404).json({ error: 'Conversation not found' });
+};
+
+/** Reads one durable child through its parent without reopening ordinary conversation reads. */
+export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependencies) {
+  return async (req: ServerRequest, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const tenantId = req.user?.tenantId || undefined;
+    const { parentConversationId, threadId } = req.params as SubagentThreadViewParams;
+    if (
+      !userId ||
+      !validConversationId(parentConversationId) ||
+      !validConversationId(threadId) ||
+      parentConversationId === threadId
+    ) {
+      notFound(res);
+      return;
+    }
+
+    try {
+      const now = new Date();
+      const [parent, child] = await Promise.all([
+        deps.getConvo(userId, parentConversationId),
+        deps.getSubagentThreadForParent({
+          user: userId,
+          parentConversationId,
+          conversationId: threadId,
+          ...(tenantId == null ? {} : { tenantId }),
+        }),
+      ]);
+      const lineage = child?.subagentThread;
+      const authorized =
+        parent != null &&
+        child != null &&
+        lineage != null &&
+        lineage.parentConversationId === parentConversationId &&
+        tenantMatches(parent.tenantId, tenantId) &&
+        tenantMatches(child.tenantId, tenantId);
+      if (!authorized || lineage == null || child == null) {
+        notFound(res);
+        return;
+      }
+
+      const messages = await deps.getMessages(
+        { conversationId: threadId, user: userId },
+        SUBAGENT_TASK_SELECT,
+        { limit: MAX_THREAD_MESSAGES + 1, sort: { createdAt: -1, _id: -1 } },
+      );
+
+      const historyTruncated = messages.length > MAX_THREAD_MESSAGES;
+      const newestFirst = historyTruncated ? messages.slice(0, MAX_THREAD_MESSAGES) : messages;
+      const activeLeaseTaskId =
+        child.subagentThreadLease != null && child.subagentThreadLease.expiresAt > now
+          ? child.subagentThreadLease.taskId
+          : undefined;
+      const projectedNewestFirst: SubagentThreadMessage[] = [];
+      let remainingTextBytes = MAX_RESPONSE_TEXT_BYTES;
+      for (const message of newestFirst) {
+        if (remainingTextBytes === 0) {
+          break;
+        }
+        const projected = publicMessage(message, remainingTextBytes);
+        projectedNewestFirst.push(projected.message);
+        remainingTextBytes -= projected.bytes;
+      }
+      const view: SubagentThreadView = {
+        threadId,
+        parentConversationId,
+        parentMessageId: truncateUtf8(lineage.parentMessageId, MAX_PUBLIC_ID_BYTES).text,
+        parentToolCallId: truncateUtf8(lineage.parentToolCallId, MAX_PUBLIC_ID_BYTES).text,
+        subagentType: truncateUtf8(lineage.subagentType, MAX_PUBLIC_ID_BYTES).text,
+        subagentKind: lineage.subagentKind,
+        ...(child.agent_id == null
+          ? {}
+          : { agentId: truncateUtf8(child.agent_id, MAX_PUBLIC_ID_BYTES).text }),
+        title: truncateUtf8(child.title ?? `Subagent: ${lineage.subagentType}`, MAX_TITLE_BYTES)
+          .text,
+        status: publicStatus(newestFirst, activeLeaseTaskId),
+        messages: projectedNewestFirst.reverse(),
+        historyTruncated: historyTruncated || projectedNewestFirst.length < newestFirst.length,
+        ...(isoDate(child.updatedAt) == null ? {} : { updatedAt: isoDate(child.updatedAt) }),
+      };
+      while (Buffer.byteLength(JSON.stringify(view), 'utf8') > MAX_RESPONSE_BYTES) {
+        if (view.messages.length === 0) {
+          throw new Error('Subagent thread projection exceeded its response limit');
+        }
+        view.messages.shift();
+        view.historyTruncated = true;
+      }
+      res.status(200).json(view);
+    } catch (error) {
+      logger.error('[subagentThreads] Failed to read child thread through parent', error);
+      res.status(500).json({ error: 'Failed to load subagent thread' });
+    }
+  };
+}
+
+export const SUBAGENT_THREAD_VIEW_LIMITS = {
+  messages: MAX_THREAD_MESSAGES,
+  messageTextBytes: MAX_MESSAGE_TEXT_BYTES,
+  responseTextBytes: MAX_RESPONSE_TEXT_BYTES,
+  responseBytes: MAX_RESPONSE_BYTES,
+} as const;

--- a/packages/api/src/agents/view.ts
+++ b/packages/api/src/agents/view.ts
@@ -14,6 +14,9 @@ import type { ServerRequest } from '~/types';
 
 const MAX_THREAD_MESSAGES = 50;
 const MAX_MESSAGE_TEXT_BYTES = 32 * 1024;
+// MongoDB slices by Unicode code points, so reserve the UTF-8 worst case and
+// keep the storage projection at or below the public byte ceiling.
+const MAX_MESSAGE_TEXT_PROJECTION_CODE_POINTS = Math.floor(MAX_MESSAGE_TEXT_BYTES / 4);
 const MAX_RESPONSE_TEXT_BYTES = 128 * 1024;
 const MAX_RESPONSE_BYTES = 160 * 1024;
 const MAX_PUBLIC_ID_BYTES = 512;
@@ -85,7 +88,9 @@ const publicMessage = (
       text: projected.text,
       ...(isoDate(message.createdAt) == null ? {} : { createdAt: isoDate(message.createdAt) }),
       ...(message.error === true ? { error: true } : {}),
-      ...(projected.truncated ? { textTruncated: true } : {}),
+      ...(message.textProjectionTruncated === true || projected.truncated
+        ? { textTruncated: true }
+        : {}),
     },
     bytes: projected.bytes,
   };
@@ -173,7 +178,7 @@ export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependen
         user: userId,
         ...(tenantId == null ? {} : { tenantId }),
         limit: MAX_THREAD_MESSAGES + 1,
-        textCodePointLimit: MAX_MESSAGE_TEXT_BYTES,
+        textCodePointLimit: MAX_MESSAGE_TEXT_PROJECTION_CODE_POINTS,
       });
 
       const historyTruncated = messages.length > MAX_THREAD_MESSAGES;

--- a/packages/api/src/agents/view.ts
+++ b/packages/api/src/agents/view.ts
@@ -4,7 +4,11 @@ import type {
   SubagentThreadStatus,
   SubagentThreadView,
 } from 'librechat-data-provider';
-import type { ConversationMethods, IMessage, MessageMethods } from '@librechat/data-schemas';
+import type {
+  ConversationMethods,
+  MessageMethods,
+  SubagentThreadViewMessageRecord,
+} from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types';
 
@@ -14,14 +18,11 @@ const MAX_RESPONSE_TEXT_BYTES = 128 * 1024;
 const MAX_RESPONSE_BYTES = 160 * 1024;
 const MAX_PUBLIC_ID_BYTES = 512;
 const MAX_TITLE_BYTES = 1024;
-const SUBAGENT_TASK_SELECT =
-  'messageId parentMessageId isCreatedByUser text createdAt error +subagentTask';
-
 type SubagentThreadViewDependencies = Pick<
   ConversationMethods,
   'getConvoOwnership' | 'getSubagentThreadForParent'
 > &
-  Pick<MessageMethods, 'getMessages'>;
+  Pick<MessageMethods, 'getMessagesForSubagentThreadView'>;
 
 type SubagentThreadViewParams = {
   parentConversationId?: string;
@@ -68,7 +69,7 @@ const truncateUtf8 = (
 };
 
 const publicMessage = (
-  message: IMessage,
+  message: SubagentThreadViewMessageRecord,
   byteLimit: number,
 ): { message: SubagentThreadMessage; bytes: number } => {
   const text = message.text ?? '';
@@ -91,7 +92,7 @@ const publicMessage = (
 };
 
 const publicStatus = (
-  messages: IMessage[],
+  messages: SubagentThreadViewMessageRecord[],
   activeLeaseTaskId: string | undefined,
 ): SubagentThreadStatus => {
   if (activeLeaseTaskId != null) {
@@ -146,7 +147,7 @@ export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependen
     try {
       const now = new Date();
       const [parent, child] = await Promise.all([
-        deps.getConvoOwnership(userId, parentConversationId),
+        deps.getConvoOwnership(userId, parentConversationId, tenantId ?? null),
         deps.getSubagentThreadForParent({
           user: userId,
           parentConversationId,
@@ -167,15 +168,13 @@ export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependen
         return;
       }
 
-      const messages = await deps.getMessages(
-        {
-          conversationId: threadId,
-          user: userId,
-          ...(tenantId == null ? { tenantId: { $exists: false } } : { tenantId }),
-        },
-        SUBAGENT_TASK_SELECT,
-        { limit: MAX_THREAD_MESSAGES + 1, sort: { createdAt: -1, _id: -1 } },
-      );
+      const messages = await deps.getMessagesForSubagentThreadView({
+        conversationId: threadId,
+        user: userId,
+        ...(tenantId == null ? {} : { tenantId }),
+        limit: MAX_THREAD_MESSAGES + 1,
+        textCodePointLimit: MAX_MESSAGE_TEXT_BYTES,
+      });
 
       const historyTruncated = messages.length > MAX_THREAD_MESSAGES;
       const newestFirst = historyTruncated ? messages.slice(0, MAX_THREAD_MESSAGES) : messages;

--- a/packages/api/src/agents/view.ts
+++ b/packages/api/src/agents/view.ts
@@ -1,14 +1,14 @@
 import { logger } from '@librechat/data-schemas';
 import type {
-  SubagentThreadMessage,
-  SubagentThreadStatus,
-  SubagentThreadView,
-} from 'librechat-data-provider';
-import type {
   ConversationMethods,
   MessageMethods,
   SubagentThreadViewMessageRecord,
 } from '@librechat/data-schemas';
+import type {
+  SubagentThreadMessage,
+  SubagentThreadStatus,
+  SubagentThreadView,
+} from 'librechat-data-provider';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types';
 

--- a/packages/api/src/agents/view.ts
+++ b/packages/api/src/agents/view.ts
@@ -18,7 +18,7 @@ const SUBAGENT_TASK_SELECT = `${CLIENT_MESSAGE_SELECT} +subagentTask`;
 
 type SubagentThreadViewDependencies = Pick<
   ConversationMethods,
-  'getConvo' | 'getSubagentThreadForParent'
+  'getConvoOwnership' | 'getSubagentThreadForParent'
 > &
   Pick<MessageMethods, 'getMessages'>;
 
@@ -145,7 +145,7 @@ export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependen
     try {
       const now = new Date();
       const [parent, child] = await Promise.all([
-        deps.getConvo(userId, parentConversationId),
+        deps.getConvoOwnership(userId, parentConversationId),
         deps.getSubagentThreadForParent({
           user: userId,
           parentConversationId,
@@ -167,7 +167,11 @@ export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependen
       }
 
       const messages = await deps.getMessages(
-        { conversationId: threadId, user: userId },
+        {
+          conversationId: threadId,
+          user: userId,
+          ...(tenantId == null ? { tenantId: { $exists: false } } : { tenantId }),
+        },
         SUBAGENT_TASK_SELECT,
         { limit: MAX_THREAD_MESSAGES + 1, sort: { createdAt: -1, _id: -1 } },
       );
@@ -220,9 +224,14 @@ export function createSubagentThreadViewHandler(deps: SubagentThreadViewDependen
   };
 }
 
-export const SUBAGENT_THREAD_VIEW_LIMITS = {
+export const SUBAGENT_THREAD_VIEW_LIMITS: Readonly<{
+  messages: number;
+  messageTextBytes: number;
+  responseTextBytes: number;
+  responseBytes: number;
+}> = {
   messages: MAX_THREAD_MESSAGES,
   messageTextBytes: MAX_MESSAGE_TEXT_BYTES,
   responseTextBytes: MAX_RESPONSE_TEXT_BYTES,
   responseBytes: MAX_RESPONSE_BYTES,
-} as const;
+};

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -116,6 +116,9 @@ export const conversations = (params: q.ConversationListParams) => {
 
 export const conversationById = (id: string) => `${conversationsRoot}/${id}`;
 
+export const subagentThread = (parentConversationId: string, threadId: string) =>
+  `${conversationsRoot}/${encodeURIComponent(parentConversationId)}/subagents/${encodeURIComponent(threadId)}`;
+
 export const genTitle = (conversationId: string) =>
   `${conversationsRoot}/gen_title/${encodeURIComponent(conversationId)}`;
 

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -1002,6 +1002,13 @@ export function getMessagesByConvoId(conversationId: string): Promise<s.TMessage
   return request.get(endpoints.messages({ conversationId }));
 }
 
+export function getSubagentThread(
+  parentConversationId: string,
+  threadId: string,
+): Promise<t.SubagentThreadView> {
+  return request.get(endpoints.subagentThread(parentConversationId, threadId));
+}
+
 export function getPrompt(id: string): Promise<{ prompt: t.TPrompt }> {
   return request.get(endpoints.getPrompt(id));
 }

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -34,6 +34,7 @@ export * from './types/runs';
 export * from './types/web';
 export * from './types/graph';
 export * from './types/insights';
+export * from './types/subagents';
 /* access permissions */
 export * from './accessPermissions';
 /* query/mutation keys */

--- a/packages/data-provider/src/keys.ts
+++ b/packages/data-provider/src/keys.ts
@@ -93,6 +93,7 @@ export enum QueryKeys {
   /* Scheduled chats */
   schedules = 'schedules',
   schedule = 'schedule',
+  subagentThread = 'subagentThread',
 }
 
 // Dynamic query keys that require parameters

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -17,6 +17,7 @@ import type { TMinimalFeedback } from './feedback';
 import type { ContentTypes } from './types/runs';
 
 export * from './schemas';
+export * from './types/subagents';
 
 export type TMessages = TMessage[];
 

--- a/packages/data-provider/src/types/index.ts
+++ b/packages/data-provider/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './queries';
 export * from './mcpServers';
+export * from './subagents';

--- a/packages/data-provider/src/types/subagents.ts
+++ b/packages/data-provider/src/types/subagents.ts
@@ -1,0 +1,32 @@
+export type SubagentThreadStatus =
+  | 'dispatched'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'interrupted'
+  | 'cancelled';
+
+export type SubagentThreadMessage = {
+  messageId: string;
+  parentMessageId: string | null;
+  role: 'user' | 'assistant';
+  text: string;
+  createdAt?: string;
+  error?: boolean;
+  textTruncated?: boolean;
+};
+
+export type SubagentThreadView = {
+  threadId: string;
+  parentConversationId: string;
+  parentMessageId: string;
+  parentToolCallId: string;
+  subagentType: string;
+  subagentKind: 'agent' | 'graph';
+  agentId?: string;
+  title: string;
+  status: SubagentThreadStatus;
+  messages: SubagentThreadMessage[];
+  historyTruncated: boolean;
+  updatedAt?: string;
+};

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -3406,6 +3406,7 @@ describe('Conversation Operations', () => {
           conversationId: parentConversationId,
           user: 'view-user',
           tenantId: 'tenant-a',
+          endpoint: EModelEndpoint.agents,
         },
         {
           conversationId,

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -3396,6 +3396,71 @@ describe('Conversation Operations', () => {
       expect(saved?.subagentThread).toEqual(lineage);
     });
 
+    it('reads a child only through its exact parent and tenant with the private lease', async () => {
+      const parentConversationId = uuidv4();
+      const conversationId = uuidv4();
+      await Conversation.create([
+        {
+          conversationId: parentConversationId,
+          user: 'view-user',
+          tenantId: 'tenant-a',
+        },
+        {
+          conversationId,
+          user: 'view-user',
+          tenantId: 'tenant-a',
+          endpoint: EModelEndpoint.agents,
+          subagentThread: {
+            rootConversationId: parentConversationId,
+            parentConversationId,
+            parentMessageId: 'parent-message',
+            parentToolCallId: 'parent-tool',
+            subagentType: 'researcher',
+            subagentKind: 'agent',
+            depth: 1,
+          },
+          subagentThreadLease: {
+            token: 'private-token',
+            taskId: 'task-1',
+            expiresAt: new Date('2099-08-21T12:00:00.000Z'),
+          },
+        },
+      ]);
+
+      await expect(
+        methods.getSubagentThreadForParent({
+          user: 'view-user',
+          parentConversationId,
+          conversationId,
+          tenantId: 'tenant-a',
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          conversationId,
+          subagentThreadLease: expect.objectContaining({ taskId: 'task-1' }),
+        }),
+      );
+      await expect(
+        methods.getSubagentThreadForParent({
+          user: 'view-user',
+          parentConversationId: 'another-parent',
+          conversationId,
+          tenantId: 'tenant-a',
+        }),
+      ).resolves.toBeNull();
+      await expect(
+        methods.getSubagentThreadForParent({
+          user: 'view-user',
+          parentConversationId,
+          conversationId,
+          tenantId: 'tenant-b',
+        }),
+      ).resolves.toBeNull();
+      expect(await methods.getConvo('view-user', conversationId)).not.toHaveProperty(
+        'subagentThreadLease',
+      );
+    });
+
     it('admits one cross-replica owner and fences renewal and release by token', async () => {
       const conversationId = uuidv4();
       await Conversation.create({

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -1490,6 +1490,7 @@ describe('Conversation Operations', () => {
       await Conversation.create({
         conversationId: mockConversationData.conversationId,
         user: 'user123',
+        tenantId: 'tenant-a',
         title: 'Test Conversation',
         endpoint: EModelEndpoint.openAI,
       });
@@ -1500,6 +1501,7 @@ describe('Conversation Operations', () => {
       );
 
       expect(result?.user).toBe('user123');
+      expect(result?.tenantId).toBe('tenant-a');
       expect(result).not.toHaveProperty('title');
       expect(result).not.toHaveProperty('messages');
       expect(result).not.toHaveProperty('endpoint');

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -1546,6 +1546,36 @@ describe('Conversation Operations', () => {
       });
       expect(result).not.toHaveProperty('title');
     });
+
+    it('selects the exact tenant when conversation identifiers collide', async () => {
+      await runAsSystem(async () => {
+        await Conversation.create([
+          {
+            conversationId: 'shared-conversation-id',
+            user: 'user123',
+            title: 'Tenantless parent',
+            endpoint: EModelEndpoint.agents,
+          },
+          {
+            conversationId: 'shared-conversation-id',
+            user: 'user123',
+            tenantId: 'tenant-a',
+            title: 'Tenant parent',
+            endpoint: EModelEndpoint.agents,
+          },
+        ]);
+      });
+
+      const tenantless = await methods.getConvoOwnership('user123', 'shared-conversation-id', null);
+      const tenant = await methods.getConvoOwnership(
+        'user123',
+        'shared-conversation-id',
+        'tenant-a',
+      );
+
+      expect(tenantless?.tenantId).toBeUndefined();
+      expect(tenant?.tenantId).toBe('tenant-a');
+    });
   });
 
   describe('getConvoRetention', () => {

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -38,6 +38,17 @@ type ConversationUpdateResult = {
   };
 };
 
+export type SubagentThreadReadRecord = Pick<
+  IConversation,
+  | 'conversationId'
+  | 'tenantId'
+  | 'title'
+  | 'agent_id'
+  | 'updatedAt'
+  | 'subagentThread'
+  | 'subagentThreadLease'
+>;
+
 const ARCHIVE_CONVERSATION_BATCH_SIZE = 500;
 const PROJECT_STATS_REFRESH_CONCURRENCY = 10;
 const PROJECT_STATS_REFRESH_MAX_PASSES = 2;
@@ -155,7 +166,7 @@ export interface ConversationMethods {
     parentConversationId: string;
     conversationId: string;
     tenantId?: string;
-  }): Promise<IConversation | null>;
+  }): Promise<SubagentThreadReadRecord | null>;
   reserveSubagentThread(input: {
     user: string;
     conversationId: string;
@@ -198,7 +209,7 @@ export interface ConversationMethods {
   getConvoOwnership(
     user: string,
     conversationId: string,
-  ): Promise<Pick<IConversation, 'user' | 'subagentThread'> | null>;
+  ): Promise<Pick<IConversation, 'user' | 'tenantId' | 'subagentThread'> | null>;
   getConvoRetention(
     user: string,
     conversationId: string,
@@ -266,7 +277,7 @@ export function createConversationMethods(
     parentConversationId: string;
     conversationId: string;
     tenantId?: string;
-  }): Promise<IConversation | null> {
+  }): Promise<SubagentThreadReadRecord | null> {
     try {
       const Conversation = mongoose.models.Conversation as Model<IConversation>;
       return await Conversation.findOne({
@@ -275,8 +286,10 @@ export function createConversationMethods(
         'subagentThread.parentConversationId': input.parentConversationId,
         ...subagentLeaseTenantFilter(input.tenantId),
       })
-        .select('+subagentThreadLease')
-        .lean<IConversation>();
+        .select(
+          'conversationId tenantId title agent_id updatedAt subagentThread +subagentThreadLease',
+        )
+        .lean<SubagentThreadReadRecord>();
     } catch (error) {
       logger.error('[getSubagentThreadForParent] Error getting child conversation', error);
       throw new Error('Error getting child conversation');
@@ -468,9 +481,10 @@ export function createConversationMethods(
   async function getConvoOwnership(user: string, conversationId: string) {
     try {
       const Conversation = mongoose.models.Conversation as Model<IConversation>;
-      return await Conversation.findOne({ user, conversationId }, 'user subagentThread').lean<
-        Pick<IConversation, 'user' | 'subagentThread'>
-      >();
+      return await Conversation.findOne(
+        { user, conversationId },
+        'user tenantId subagentThread',
+      ).lean<Pick<IConversation, 'user' | 'tenantId' | 'subagentThread'>>();
     } catch (error) {
       logger.error('[getConvoOwnership] Error checking conversation ownership', error);
       throw new Error('Error checking conversation ownership');

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -209,6 +209,7 @@ export interface ConversationMethods {
   getConvoOwnership(
     user: string,
     conversationId: string,
+    tenantId?: string | null,
   ): Promise<Pick<IConversation, 'user' | 'tenantId' | 'subagentThread'> | null>;
   getConvoRetention(
     user: string,
@@ -478,11 +479,17 @@ export function createConversationMethods(
    * without materializing the full conversation document (preset spread +
    * message ObjectId array).
    */
-  async function getConvoOwnership(user: string, conversationId: string) {
+  async function getConvoOwnership(user: string, conversationId: string, tenantId?: string | null) {
     try {
       const Conversation = mongoose.models.Conversation as Model<IConversation>;
+      const tenantFilter =
+        tenantId === undefined ? {} : subagentLeaseTenantFilter(tenantId ?? undefined);
       return await Conversation.findOne(
-        { user, conversationId },
+        {
+          user,
+          conversationId,
+          ...tenantFilter,
+        },
         'user tenantId subagentThread',
       ).lean<Pick<IConversation, 'user' | 'tenantId' | 'subagentThread'>>();
     } catch (error) {

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -150,6 +150,12 @@ export interface ConversationMethods {
     convoMap: Record<string, unknown>;
   }>;
   getConvo(user: string, conversationId: string): Promise<IConversation | null>;
+  getSubagentThreadForParent(input: {
+    user: string;
+    parentConversationId: string;
+    conversationId: string;
+    tenantId?: string;
+  }): Promise<IConversation | null>;
   reserveSubagentThread(input: {
     user: string;
     conversationId: string;
@@ -251,6 +257,29 @@ export function createConversationMethods(
     } catch (error) {
       logger.error('[getConvo] Error getting single conversation', error);
       throw new Error('Error getting single conversation');
+    }
+  }
+
+  /** Resolves a child only through its owning parent and includes its private live lease. */
+  async function getSubagentThreadForParent(input: {
+    user: string;
+    parentConversationId: string;
+    conversationId: string;
+    tenantId?: string;
+  }): Promise<IConversation | null> {
+    try {
+      const Conversation = mongoose.models.Conversation as Model<IConversation>;
+      return await Conversation.findOne({
+        user: input.user,
+        conversationId: input.conversationId,
+        'subagentThread.parentConversationId': input.parentConversationId,
+        ...subagentLeaseTenantFilter(input.tenantId),
+      })
+        .select('+subagentThreadLease')
+        .lean<IConversation>();
+    } catch (error) {
+      logger.error('[getSubagentThreadForParent] Error getting child conversation', error);
+      throw new Error('Error getting child conversation');
     }
   }
 
@@ -1566,6 +1595,7 @@ export function createConversationMethods(
     getConvosByCursor,
     getConvosQueried,
     getConvo,
+    getSubagentThreadForParent,
     reserveSubagentThread,
     acquireSubagentThreadLease,
     renewSubagentThreadLease,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -48,6 +48,7 @@ import {
   createMessageMethods,
   CLIENT_MESSAGE_SELECT,
   type MessageMethods,
+  type SubagentThreadViewMessageRecord,
   type SubagentTaskResultClaim,
 } from './message';
 import { createConversationMethods, type ConversationMethods } from './conversation';
@@ -376,6 +377,7 @@ export type {
   PresetMethods,
   ConversationTagMethods,
   MessageMethods,
+  SubagentThreadViewMessageRecord,
   SubagentTaskResultClaim,
   ConversationMethods,
   ChatProjectMethods,

--- a/packages/data-schemas/src/methods/message.spec.ts
+++ b/packages/data-schemas/src/methods/message.spec.ts
@@ -625,7 +625,7 @@ describe('Message Operations', () => {
     it('declares the compound index that serves the conversation fetch and its sort', () => {
       const indexes = Message.schema.indexes() as Array<[Record<string, number>, unknown]>;
       expect(indexes).toContainEqual([
-        { conversationId: 1, user: 1, createdAt: 1 },
+        { conversationId: 1, user: 1, createdAt: 1, _id: 1 },
         expect.anything(),
       ]);
     });
@@ -707,6 +707,8 @@ describe('Message Operations', () => {
 
       expect(messages).toHaveLength(1);
       expect(Array.from(messages[0].text ?? '')).toHaveLength(8_192);
+      expect(Buffer.byteLength(messages[0].text ?? '', 'utf8')).toBeLessThanOrEqual(32 * 1024);
+      expect(messages[0].textProjectionTruncated).toBe(true);
       expect(messages[0]).not.toHaveProperty('user');
       expect(messages[0]).not.toHaveProperty('conversationId');
     });

--- a/packages/data-schemas/src/methods/message.spec.ts
+++ b/packages/data-schemas/src/methods/message.spec.ts
@@ -21,6 +21,9 @@ let mongoServer: InstanceType<typeof MongoMemoryServer>;
 let Message: mongoose.Model<IMessage>;
 let saveMessage: ReturnType<typeof createMessageMethods>['saveMessage'];
 let getMessages: ReturnType<typeof createMessageMethods>['getMessages'];
+let getMessagesForSubagentThreadView: ReturnType<
+  typeof createMessageMethods
+>['getMessagesForSubagentThreadView'];
 let updateMessage: ReturnType<typeof createMessageMethods>['updateMessage'];
 let updateToolCallResult: ReturnType<typeof createMessageMethods>['updateToolCallResult'];
 let deleteMessages: ReturnType<typeof createMessageMethods>['deleteMessages'];
@@ -44,6 +47,7 @@ beforeAll(async () => {
   const methods = createMessageMethods(mongoose);
   saveMessage = methods.saveMessage;
   getMessages = methods.getMessages;
+  getMessagesForSubagentThreadView = methods.getMessagesForSubagentThreadView;
   updateMessage = methods.updateMessage;
   updateToolCallResult = methods.updateToolCallResult;
   deleteMessages = methods.deleteMessages;
@@ -681,6 +685,30 @@ describe('Message Operations', () => {
       expect(messages).toHaveLength(2);
       expect(messages[0].text).toBe('First message');
       expect(messages[1].text).toBe('Second message');
+    });
+  });
+
+  describe('getMessagesForSubagentThreadView', () => {
+    it('bounds text in MongoDB before returning the public projection', async () => {
+      const conversationId = uuidv4();
+      await saveMessage(mockCtx, {
+        messageId: 'bounded-message',
+        conversationId,
+        text: '🧵'.repeat(20_000),
+        user: 'user123',
+      });
+
+      const messages = await getMessagesForSubagentThreadView({
+        user: 'user123',
+        conversationId,
+        limit: 1,
+        textCodePointLimit: 8_192,
+      });
+
+      expect(messages).toHaveLength(1);
+      expect(Array.from(messages[0].text ?? '')).toHaveLength(8_192);
+      expect(messages[0]).not.toHaveProperty('user');
+      expect(messages[0]).not.toHaveProperty('conversationId');
     });
   });
 

--- a/packages/data-schemas/src/methods/message.ts
+++ b/packages/data-schemas/src/methods/message.ts
@@ -62,7 +62,7 @@ export type SubagentThreadViewMessageRecord = Pick<
   | 'createdAt'
   | 'error'
   | 'subagentTask'
->;
+> & { textProjectionTruncated?: boolean };
 
 export interface MessageMethods {
   saveMessage(
@@ -768,6 +768,9 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
             isCreatedByUser: 1,
             text: {
               $substrCP: [{ $ifNull: ['$text', ''] }, 0, input.textCodePointLimit],
+            },
+            textProjectionTruncated: {
+              $gt: [{ $strLenCP: { $ifNull: ['$text', ''] } }, input.textCodePointLimit],
             },
             createdAt: 1,
             error: 1,

--- a/packages/data-schemas/src/methods/message.ts
+++ b/packages/data-schemas/src/methods/message.ts
@@ -53,6 +53,17 @@ export type SubagentTaskResultClaim =
   | { status: 'claimed'; message: IMessage }
   | { status: 'acquired'; message: IMessage };
 
+export type SubagentThreadViewMessageRecord = Pick<
+  IMessage,
+  | 'messageId'
+  | 'parentMessageId'
+  | 'isCreatedByUser'
+  | 'text'
+  | 'createdAt'
+  | 'error'
+  | 'subagentTask'
+>;
+
 export interface MessageMethods {
   saveMessage(
     ctx: { userId: string; isTemporary?: boolean; interfaceConfig?: AppConfig['interfaceConfig'] },
@@ -110,6 +121,13 @@ export interface MessageMethods {
     select?: string,
     options?: MessageQueryOptions,
   ): Promise<IMessage[]>;
+  getMessagesForSubagentThreadView(input: {
+    user: string;
+    conversationId: string;
+    tenantId?: string;
+    limit: number;
+    textCodePointLimit: number;
+  }): Promise<SubagentThreadViewMessageRecord[]>;
   getMessage(params: { user: string; messageId: string }): Promise<IMessage | null>;
   getMessagesByCursor(
     filter: FilterQuery<IMessage>,
@@ -718,6 +736,52 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
   }
 
   /**
+   * Reads the fixed public child-thread projection and truncates text inside
+   * MongoDB so oversized persisted messages are never materialized by the API.
+   */
+  async function getMessagesForSubagentThreadView(input: {
+    user: string;
+    conversationId: string;
+    tenantId?: string;
+    limit: number;
+    textCodePointLimit: number;
+  }): Promise<SubagentThreadViewMessageRecord[]> {
+    try {
+      const Message = mongoose.models.Message as Model<IMessage>;
+      return await Message.aggregate<SubagentThreadViewMessageRecord>([
+        {
+          $match: {
+            user: input.user,
+            conversationId: input.conversationId,
+            ...(input.tenantId == null
+              ? { tenantId: { $exists: false } }
+              : { tenantId: input.tenantId }),
+          },
+        },
+        { $sort: { createdAt: -1, _id: -1 } },
+        { $limit: input.limit },
+        {
+          $project: {
+            _id: 0,
+            messageId: 1,
+            parentMessageId: 1,
+            isCreatedByUser: 1,
+            text: {
+              $substrCP: [{ $ifNull: ['$text', ''] }, 0, input.textCodePointLimit],
+            },
+            createdAt: 1,
+            error: 1,
+            subagentTask: 1,
+          },
+        },
+      ]);
+    } catch (err) {
+      logger.error('Error getting bounded subagent thread messages:', err);
+      throw err;
+    }
+  }
+
+  /**
    * Retrieves a single message from the database.
    */
   async function getMessage({ user, messageId }: { user: string; messageId: string }) {
@@ -806,6 +870,7 @@ export function createMessageMethods(mongoose: typeof import('mongoose')): Messa
     releaseSubagentTaskResultClaim,
     deleteMessagesSince,
     getMessages,
+    getMessagesForSubagentThreadView,
     getMessage,
     getMessagesByCursor,
     searchMessages,

--- a/packages/data-schemas/src/schema/message.ts
+++ b/packages/data-schemas/src/schema/message.ts
@@ -245,12 +245,13 @@ messageSchema.index({
 
 /**
  * Serves the conversation fetch ({conversationId, user} filter + createdAt
- * sort) from the index alone; without it Mongo fetches every full document in
- * the conversation and sorts them in memory. tenantId is deliberately not in
- * the middle: untenanted deployments issue no tenantId predicate, and a gap in
- * the prefix would push the sort back into memory for them.
+ * sort) and the deterministic child-thread view sort from the index alone;
+ * without it Mongo fetches every full document in the conversation and sorts
+ * them in memory. tenantId is deliberately not in the middle: untenanted
+ * deployments issue no tenantId predicate, and a gap in the prefix would push
+ * the sort back into memory for them.
  */
-messageSchema.index({ conversationId: 1, user: 1, createdAt: 1 });
+messageSchema.index({ conversationId: 1, user: 1, createdAt: 1, _id: 1 });
 
 /** Bounds parent-run completion snapshots without scanning a user's message history. */
 messageSchema.index(


### PR DESCRIPTION
## Summary

I added a bounded, parent-authorized read boundary for durable subagent threads so the client can inspect child activity without reopening hidden child conversations as normal chats.

- Verify exact user, tenant, and direct-parent lineage before reading child messages.
- Interpret active leases and durable task markers into public dispatched, running, completed, failed, interrupted, or cancelled states.
- Return only a bounded public message projection while excluding task metadata, transcripts, tool payloads, and internal fields.
- Preserve indistinguishable not-found responses for missing and unauthorized records.
- Expose a typed data-provider endpoint for the upcoming read-only child activity panel.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npm exec --workspace=packages/api -- jest src/agents/view.spec.ts --runInBand` (17/17)
- Touched-file ESLint with zero warnings
- Touched-file Prettier and import-order checks
- Data-provider and data-schema declaration TypeScript builds
- Mongo-backed data-schema coverage added for CI; the local runner lacks one existing optional test dependency

### **Test Configuration**:

- macOS arm64
- Node.js 24

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes