### PR TITLE
🪪 feat: Forward the Active Agent Id in Request Header Placeholders

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -10,6 +10,7 @@ const {
   sanitizeTitle,
   payloadParser,
   createSafeUser,
+  createSafeAgent,
   initializeAgent,
   resolveConfigHeaders,
   countTokens,
@@ -2122,6 +2123,7 @@ class AgentClient extends BaseClient {
       },
       res: this.options.res,
       user: createSafeUser(this.options.req.user),
+      primaryAgent: createSafeAgent(this.options.agent),
     });
 
     this.processMemory = processMemory;
@@ -3985,6 +3987,7 @@ class AgentClient extends BaseClient {
         conversationId: this.conversationId,
         parentMessageId: this.parentMessageId,
       },
+      agent: createSafeAgent(this.options.agent),
     });
 
     try {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -567,11 +567,12 @@ endpoints:
   # (optional) Custom request headers for the built-in OpenAI / Google endpoints.
   # Forwarded on every request to the provider (or an AI gateway / reverse proxy
   # in front of it) while keeping provider-native request shaping intact. Values
-  # support env vars (${VAR}), user fields ({{LIBRECHAT_USER_*}}), and request-body
-  # fields ({{LIBRECHAT_BODY_CONVERSATIONID}}). Set the same `headers:` block under
-  # `endpoints.all` to apply globally across endpoints (endpoint values win on key
-  # collisions). NOTE: send metadata headers like these only behind a gateway that
-  # consumes them — native provider APIs ignore unknown headers.
+  # support env vars (${VAR}), user fields ({{LIBRECHAT_USER_*}}), request-body
+  # fields ({{LIBRECHAT_BODY_CONVERSATIONID}}), and the active agent id
+  # ({{LIBRECHAT_AGENT_ID}}). Set the same `headers:` block under `endpoints.all`
+  # to apply globally across endpoints (endpoint values win on key collisions).
+  # NOTE: send metadata headers like these only behind a gateway that consumes
+  # them — native provider APIs ignore unknown headers.
   # openAI:
   #   headers:
   #     cf-aig-metadata: '{"user_email":"{{LIBRECHAT_USER_EMAIL}}","app":"librechat"}'

--- a/packages/api/src/agents/__tests__/run-agentHeaders.test.ts
+++ b/packages/api/src/agents/__tests__/run-agentHeaders.test.ts
@@ -1,0 +1,160 @@
+import { createRun } from '~/agents/run';
+
+/**
+ * Guards `{{LIBRECHAT_AGENT_ID}}` resolution in `createRun`. The id must be the
+ * root agent's on every built input, subagents included, so a forwarded header
+ * matches the id persisted on the response message by
+ * `BaseClient.getResponseModel` — a gateway attributing spend per agent would
+ * otherwise bill a delegated step to a different agent than the database records.
+ * Ephemeral runs must resolve to nothing rather than leaking preset text.
+ */
+
+jest.mock('winston', () => ({
+  createLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  })),
+  format: Object.assign(
+    jest.fn((fn) => () => ({ transform: fn })),
+    {
+      combine: jest.fn(),
+      colorize: jest.fn(),
+      simple: jest.fn(),
+      label: jest.fn(),
+      timestamp: jest.fn(),
+      printf: jest.fn(),
+      errors: jest.fn(),
+      splat: jest.fn(),
+      json: jest.fn(),
+    },
+  ),
+  addColors: jest.fn(),
+  transports: { Console: jest.fn(), DailyRotateFile: jest.fn(), File: jest.fn() },
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock('@librechat/agents', () => {
+  const actual = jest.requireActual('@librechat/agents');
+  return {
+    ...actual,
+    Run: {
+      create: jest.fn().mockResolvedValue({
+        processStream: jest.fn().mockResolvedValue(undefined),
+      }),
+    },
+  };
+});
+
+jest.mock('~/agents/checkpointer', () => ({
+  getAgentCheckpointer: jest.fn().mockResolvedValue({}),
+}));
+
+import { Run } from '@librechat/agents';
+
+const AGENT_ID_HEADER = 'X-Agent-Id';
+
+/**
+ * Each agent gets its OWN `configuration.defaultHeaders` object. Sharing one
+ * reference would let the idempotency `WeakSet` in `resolveConfigHeaders` skip
+ * the second resolution and return the first agent's already-resolved map,
+ * which would pass the subagent assertion without ever resolving its headers.
+ */
+function makeAgent(overrides?: Record<string, unknown>) {
+  return {
+    id: 'agent_root',
+    provider: 'openAI',
+    endpoint: 'openAI',
+    model: 'gpt-4o',
+    tools: [],
+    model_parameters: {
+      model: 'gpt-4o',
+      configuration: {
+        defaultHeaders: { [AGENT_ID_HEADER]: '{{LIBRECHAT_AGENT_ID}}' },
+      },
+    },
+    maxContextTokens: 100_000,
+    toolContextMap: {},
+    ...overrides,
+  };
+}
+
+type CapturedInput = Record<string, unknown> & {
+  agentId?: string;
+  clientOptions?: { configuration?: { defaultHeaders?: Record<string, string> } };
+  subagentConfigs?: Array<{ type?: string; agentInputs?: CapturedInput }>;
+};
+
+async function captureAgentInputs(
+  agents: Array<Record<string, unknown>>,
+): Promise<CapturedInput[]> {
+  await createRun({
+    agents: agents as never,
+    signal: new AbortController().signal,
+    streaming: true,
+    streamUsage: true,
+  });
+  const createMock = Run.create as jest.Mock;
+  expect(createMock).toHaveBeenCalledTimes(1);
+  const callArgs = createMock.mock.calls[0][0] as {
+    graphConfig: { agents: CapturedInput[] };
+  };
+  return callArgs.graphConfig.agents;
+}
+
+function headerOf(input: CapturedInput | undefined): string | undefined {
+  return input?.clientOptions?.configuration?.defaultHeaders?.[AGENT_ID_HEADER];
+}
+
+describe('createRun agent-id header resolution', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('resolves the placeholder to the running agent id', async () => {
+    const [rootInput] = await captureAgentInputs([makeAgent()]);
+
+    expect(headerOf(rootInput)).toBe('agent_root');
+  });
+
+  it('resolves a subagent step to the ROOT agent id, not the subagent own id', async () => {
+    const child = makeAgent({ id: 'agent_child', name: 'Child' });
+    const root = makeAgent({
+      subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_child'] },
+      subagentAgentConfigs: [child],
+    });
+
+    const [rootInput] = await captureAgentInputs([root]);
+    const childInput = rootInput.subagentConfigs?.find(
+      (config) => config.type === 'agent_child',
+    )?.agentInputs;
+
+    /** The subagent really is a different agent... */
+    expect(childInput?.agentId).toBe('agent_child');
+    /** ...yet the forwarded header carries the id the turn is attributed to. */
+    expect(headerOf(childInput)).toBe('agent_root');
+    expect(headerOf(rootInput)).toBe('agent_root');
+  });
+
+  it('resolves to an empty value for an ephemeral (plain-chat) run', async () => {
+    const [rootInput] = await captureAgentInputs([makeAgent({ id: 'openAI__gpt-4o___My Preset' })]);
+
+    expect(headerOf(rootInput)).toBe('');
+  });
+
+  it('leaves headers without the placeholder untouched', async () => {
+    const [rootInput] = await captureAgentInputs([
+      makeAgent({
+        model_parameters: {
+          model: 'gpt-4o',
+          configuration: { defaultHeaders: { 'X-Static': 'value' } },
+        },
+      }),
+    ]);
+
+    expect(rootInput.clientOptions?.configuration?.defaultHeaders).toEqual({ 'X-Static': 'value' });
+  });
+});

--- a/packages/api/src/agents/activityLabels/host.ts
+++ b/packages/api/src/agents/activityLabels/host.ts
@@ -7,9 +7,9 @@ import type { ClientOptions } from '@librechat/agents';
 import type { EndpointDbMethods, OpenAIConfiguration, ServerRequest } from '~/types';
 import type { ActivityLabelLLM } from './runtime';
 import { getProviderConfig } from '~/endpoints/config/providers';
+import { createSafeUser, createSafeAgent } from '~/utils/env';
 import { resolveConfigHeaders } from '~/utils/headers';
 import { omitTitleOptions } from '~/agents/client';
-import { createSafeUser } from '~/utils/env';
 
 /** Additive label fields may precede the rebuilt data-provider artifact in a
  * package-local typecheck, so keep the endpoint view structural here. */
@@ -110,6 +110,7 @@ export function mapCollectedMetadataToUsage(
 
 /** The agent fields the label model resolution needs. */
 export interface ActivityLabelAgent {
+  id?: string;
   endpoint?: string;
   provider?: string;
   model?: string;
@@ -483,6 +484,7 @@ export async function resolveActivityLabelModel({
     llmConfig: clientOptions,
     user: createSafeUser(req.user as IUser | undefined),
     body: ids,
+    agent: createSafeAgent(agent),
   });
   return {
     provider,

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -31,8 +31,8 @@ import type {
   FormattedMemoriesResult,
 } from '@librechat/data-schemas';
 import type { BaseMessage, ToolMessage } from '@librechat/agents/langchain/messages';
+import type { Agent, TAttachment, MemoryArtifact } from 'librechat-data-provider';
 import type { DynamicStructuredTool } from '@librechat/agents/langchain/tools';
-import type { TAttachment, MemoryArtifact } from 'librechat-data-provider';
 import type { Response as ServerResponse } from 'express';
 import type { ServerRequest, RunLLMConfig } from '~/types';
 import { GenerationJobManager } from '~/stream/GenerationJobManager';
@@ -737,6 +737,7 @@ export async function processMemory({
   streamId = null,
   jobCreatedAt,
   user,
+  primaryAgent,
 }: {
   res: ServerResponse;
   setMemory: MemoryMethods['setMemory'];
@@ -744,6 +745,7 @@ export async function processMemory({
   userId: string | ObjectId;
   /** Agent partition; omit for the shared personal pool */
   agentId?: string;
+  primaryAgent?: Partial<Agent>;
   memory: string;
   messageId: string;
   conversationId: string;
@@ -859,6 +861,7 @@ ${memory ?? 'No existing memories'}`;
       llmConfig: finalLLMConfig as unknown as RunLLMConfig,
       user: user ? createSafeUser(user) : undefined,
       body: { conversationId, messageId },
+      agent: primaryAgent,
     });
 
     const artifactPromises: Promise<TAttachment | null>[] = [];
@@ -969,6 +972,7 @@ export async function createMemoryProcessor({
   streamId = null,
   jobCreatedAt,
   user,
+  primaryAgent,
 }: {
   res: ServerResponse;
   messageId: string;
@@ -976,6 +980,8 @@ export async function createMemoryProcessor({
   userId: string | ObjectId;
   /** Agent partition; omit for the shared personal pool */
   agentId?: string;
+  /** The primary agent whose turn triggered extraction — see {@link processMemory}. */
+  primaryAgent?: Partial<Agent>;
   memoryMethods: RequiredMemoryMethods;
   config?: MemoryConfig;
   streamId?: string | null;
@@ -1012,6 +1018,7 @@ export async function createMemoryProcessor({
           setMemory: memoryMethods.setMemory,
           deleteMemory: memoryMethods.deleteMemory,
           user,
+          primaryAgent,
         });
       } catch (error) {
         logger.error('Memory Agent failed to process memory', error);

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -63,11 +63,11 @@ import { stripIntentFromToolRegistry, stripIntentFromToolDefinitions } from '~/a
 import { isSteeringSupported, isSteerPreemptSupported } from '~/agents/steering/runtime';
 import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm';
 import { resolveStreamLimits, resolveSubagentMaxTurns } from '~/agents/config';
+import { resolveHeaders, createSafeUser, createSafeAgent } from '~/utils/env';
 import { CREATE_FILE_TOOL_NAME, EDIT_FILE_TOOL_NAME } from '~/agents/tools';
 import { buildAgentInitialToolSessions } from '~/agents/codeFilesSession';
 import { getProviderConfig } from '~/endpoints/config/providers';
 import { extractDefaultParams } from '~/endpoints/openai/llm';
-import { resolveHeaders, createSafeUser } from '~/utils/env';
 import { getAgentCheckpointer } from '~/agents/checkpointer';
 import { getPluginHookSource } from '~/agents/hooks/source';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
@@ -553,7 +553,7 @@ interface SummarizationClientOverrides {
 function resolveSummarizationProvider(
   rawProvider: string,
   appConfig: AppConfig | undefined,
-  headerContext: { user?: IUser; requestBody?: t.RequestBody },
+  headerContext: { user?: IUser; requestBody?: t.RequestBody; agent?: Partial<Agent> },
 ): {
   provider: string;
   clientOverrides?: SummarizationClientOverrides;
@@ -610,6 +610,7 @@ function resolveSummarizationProvider(
             headers: customEndpointConfig.headers as Record<string, string>,
             user: createSafeUser(headerContext.user),
             body: headerContext.requestBody,
+            agent: headerContext.agent,
             stripUnresolved: true,
           })
         : undefined;
@@ -701,7 +702,7 @@ function shapeSummarizationConfig(
   fallbackModel: string | undefined,
   appConfig: AppConfig | undefined,
   agentEndpoint: string | undefined,
-  headerContext: { user?: IUser; requestBody?: t.RequestBody },
+  headerContext: { user?: IUser; requestBody?: t.RequestBody; agent?: Partial<Agent> },
 ) {
   const rawProvider = config?.provider ?? fallbackProvider;
   /**
@@ -1389,6 +1390,9 @@ export async function createRun({
   /** Admin kill switch for the ask tool — see {@link isAskUserQuestionAdminDisabled}. */
   const askToolAdminDisabled = isAskUserQuestionAdminDisabled(appConfig);
 
+  /** Resolves `{{LIBRECHAT_AGENT_ID}}`; derived once so subagent steps share the turn's id. */
+  const safePrimaryAgent = createSafeAgent(agents[0]);
+
   const buildAgentInput = (agent: RunAgent, opts: { isSubagent?: boolean } = {}): AgentInputs => {
     const isSubagent = opts.isSubagent === true;
     const provider =
@@ -1403,7 +1407,7 @@ export async function createRun({
       selfModel,
       appConfig,
       agent.endpoint ?? undefined,
-      { user, requestBody },
+      { user, requestBody, agent: safePrimaryAgent },
     );
 
     const modelParameters = normalizeAgentModelParameters(agent.model_parameters);
@@ -1446,6 +1450,7 @@ export async function createRun({
       llmConfig,
       user: createSafeUser(user),
       body: requestBody,
+      agent: safePrimaryAgent,
     });
 
     /** Resolves issues with new OpenAI usage field */

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -1,12 +1,13 @@
 import { Types } from 'mongoose';
 import { TokenExchangeMethodEnum } from 'librechat-data-provider';
-import type { MCPOptions } from 'librechat-data-provider';
+import type { Agent, MCPOptions } from 'librechat-data-provider';
 import type { IUser } from '@librechat/data-schemas';
 import {
   resolveNestedObject,
   encodeHeaderValue,
   resolveHeaders,
   createSafeUser,
+  createSafeAgent,
   processMCPEnv,
 } from './env';
 
@@ -2503,5 +2504,163 @@ describe('processMCPEnv OpenID re-authentication signalling', () => {
     } else {
       throw new Error('Expected streamable-http options');
     }
+  });
+});
+
+describe('createSafeAgent', () => {
+  it('returns an empty object for null/undefined agents', () => {
+    expect(createSafeAgent(null)).toEqual({});
+    expect(createSafeAgent(undefined)).toEqual({});
+  });
+
+  it('projects only allowlisted fields, dropping everything else', () => {
+    const safeAgent = createSafeAgent({
+      id: 'agent_HTbJ5rDW0kOOK1a5MPBSt',
+      name: 'Support Bot',
+      instructions: 'internal system prompt',
+      author: 'user-123',
+    } as Partial<Agent>);
+
+    expect(safeAgent).toEqual({ id: 'agent_HTbJ5rDW0kOOK1a5MPBSt' });
+  });
+
+  it('omits an absent or null id rather than emitting a null value', () => {
+    expect(createSafeAgent({})).toEqual({});
+    expect(createSafeAgent({ id: null })).toEqual({});
+  });
+
+  it('passes an ephemeral id through — the gate belongs to resolution, not projection', () => {
+    expect(createSafeAgent({ id: 'openAI__gpt-4o___My Preset' })).toEqual({
+      id: 'openAI__gpt-4o___My Preset',
+    });
+  });
+});
+
+describe('resolveHeaders agent placeholders', () => {
+  const agentHeaders = { 'X-Agent-Id': '{{LIBRECHAT_AGENT_ID}}' };
+  const persistedAgent = { id: 'agent_HTbJ5rDW0kOOK1a5MPBSt' };
+
+  it('resolves the agent id for a persisted agent', () => {
+    const result = resolveHeaders({
+      headers: { ...agentHeaders },
+      agent: persistedAgent,
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Id']).toBe('agent_HTbJ5rDW0kOOK1a5MPBSt');
+  });
+
+  it('resolves alongside user and body placeholders without interfering', () => {
+    const result = resolveHeaders({
+      headers: {
+        'X-Agent-Id': '{{LIBRECHAT_AGENT_ID}}',
+        'X-User-Id': '{{LIBRECHAT_USER_ID}}',
+        'X-Convo': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+        'Content-Type': 'application/json',
+      },
+      user: { id: 'user-123' },
+      body: { conversationId: 'convo-abc' },
+      agent: persistedAgent,
+      stripUnresolved: true,
+    });
+
+    expect(result).toEqual({
+      'X-Agent-Id': 'agent_HTbJ5rDW0kOOK1a5MPBSt',
+      'X-User-Id': 'user-123',
+      'X-Convo': 'convo-abc',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('replaces every occurrence within a composite value', () => {
+    const result = resolveHeaders({
+      headers: { 'X-Meta': 'agent={{LIBRECHAT_AGENT_ID}};ref={{LIBRECHAT_AGENT_ID}}' },
+      agent: persistedAgent,
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Meta']).toBe(
+      'agent=agent_HTbJ5rDW0kOOK1a5MPBSt;ref=agent_HTbJ5rDW0kOOK1a5MPBSt',
+    );
+  });
+
+  it('strips the placeholder when no agent context is available', () => {
+    const result = resolveHeaders({
+      headers: { ...agentHeaders },
+      user: { id: 'user-123' },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Id']).toBe('');
+  });
+
+  it('strips the placeholder for an ephemeral agent id', () => {
+    const result = resolveHeaders({
+      headers: { ...agentHeaders },
+      agent: { id: 'openAI__gpt-4o___My Preset' },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Id']).toBe('');
+  });
+
+  it('never forwards user-authored preset text from an ephemeral id', () => {
+    const result = resolveHeaders({
+      headers: { ...agentHeaders },
+      agent: { id: 'openAI__gpt-4o___Marić\r\nX-Injected: 1' },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Id']).toBe('');
+  });
+
+  it('strips the placeholder when the agent id is empty', () => {
+    const result = resolveHeaders({
+      headers: { ...agentHeaders },
+      agent: { id: '' },
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Id']).toBe('');
+  });
+
+  it('preserves the placeholder by default so staged flows can resolve later', () => {
+    const result = resolveHeaders({ headers: { ...agentHeaders } });
+
+    expect(result['X-Agent-Id']).toBe('{{LIBRECHAT_AGENT_ID}}');
+  });
+
+  it('leaves headers without the placeholder untouched', () => {
+    const result = resolveHeaders({
+      headers: { 'Content-Type': 'application/json', 'X-Static': 'value' },
+      agent: persistedAgent,
+      stripUnresolved: true,
+    });
+
+    expect(result).toEqual({ 'Content-Type': 'application/json', 'X-Static': 'value' });
+  });
+
+  it('resolves from a full agent projected through createSafeAgent', () => {
+    const result = resolveHeaders({
+      headers: { ...agentHeaders },
+      agent: createSafeAgent({
+        id: 'agent_HTbJ5rDW0kOOK1a5MPBSt',
+        name: 'Support Bot',
+        instructions: 'internal system prompt',
+      } as Partial<Agent>),
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Id']).toBe('agent_HTbJ5rDW0kOOK1a5MPBSt');
+  });
+
+  it('does not resolve an unknown agent field', () => {
+    const result = resolveHeaders({
+      headers: { 'X-Agent-Name': '{{LIBRECHAT_AGENT_NAME}}' },
+      agent: persistedAgent,
+      stripUnresolved: true,
+    });
+
+    expect(result['X-Agent-Name']).toBe('{{LIBRECHAT_AGENT_NAME}}');
   });
 });

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -1,6 +1,6 @@
 import { logger } from '@librechat/data-schemas';
-import { extractEnvVariable } from 'librechat-data-provider';
-import type { MCPOptions } from 'librechat-data-provider';
+import { extractEnvVariable, isEphemeralAgentId } from 'librechat-data-provider';
+import type { Agent, MCPOptions } from 'librechat-data-provider';
 import type { IUser } from '@librechat/data-schemas';
 import type { RequestBody } from '~/types';
 import {
@@ -146,19 +146,62 @@ export function createSafeUser(
  */
 export const ALLOWED_BODY_FIELDS = ['conversationId', 'parentMessageId', 'messageId'] as const;
 
+/**
+ * List of allowed agent fields that can be used in header placeholders. Kept to
+ * identifiers the agent owns rather than user-authored content.
+ */
+const ALLOWED_AGENT_FIELDS = ['id'] as const;
+
+type AllowedAgentField = (typeof ALLOWED_AGENT_FIELDS)[number];
+type SafeAgent = Pick<Agent, AllowedAgentField>;
+
+/**
+ * Any object carrying agent identity fields, so the projection below accepts a
+ * full `Agent`, a run-shaped agent, or the narrower agent objects the auxiliary
+ * generation paths pass around, without those callers coupling to `Agent` itself.
+ */
+type AgentLike = { [K in AllowedAgentField]?: Agent[K] | null };
+
+/**
+ * Creates a safe agent object containing only allowed fields, mirroring
+ * `createSafeUser` — call sites project at the boundary rather than hand-building
+ * a literal, so the allowlist stays the one place that decides what an agent may
+ * contribute to a header.
+ *
+ * @param agent - The agent object to extract safe fields from
+ * @returns A new object containing only allowed fields
+ */
+export function createSafeAgent(agent?: AgentLike | null): Partial<SafeAgent> {
+  if (!agent) {
+    return {};
+  }
+
+  const safeAgent: Partial<SafeAgent> = {};
+  for (const field of ALLOWED_AGENT_FIELDS) {
+    const value = agent[field];
+    if (value != null) {
+      Object.assign(safeAgent, { [field]: value });
+    }
+  }
+
+  return safeAgent;
+}
+
 const OPENID_PLACEHOLDER_NAMES = `LIBRECHAT_OPENID_(?:${OPENID_TOKEN_FIELDS.join('|')}|TOKEN)`;
 
 /**
  * Matches every placeholder this module knows how to resolve: the enumerated
- * `{{LIBRECHAT_USER_*}}`, `{{LIBRECHAT_BODY_*}}`, and `{{LIBRECHAT_OPENID_*}}`
- * names. Deliberately excludes unknown names (a typo'd placeholder staying
- * literal is diagnosable) and `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}`, which is
- * resolved asynchronously via the OBO flow outside this pipeline.
+ * `{{LIBRECHAT_USER_*}}`, `{{LIBRECHAT_BODY_*}}`, `{{LIBRECHAT_AGENT_*}}`, and
+ * `{{LIBRECHAT_OPENID_*}}` names. Deliberately excludes unknown names (a typo'd
+ * placeholder staying literal is diagnosable) and
+ * `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}`, which is resolved asynchronously via the
+ * OBO flow outside this pipeline.
  */
 const RESOLVABLE_PLACEHOLDER_PATTERN = new RegExp(
   [
     `LIBRECHAT_USER_(?:${ALLOWED_USER_FIELDS.map((field) => field.toUpperCase()).join('|')})`,
     `LIBRECHAT_BODY_(?:${ALLOWED_BODY_FIELDS.map((field) => field.toUpperCase()).join('|')})`,
+    `LIBRECHAT_AGENT_(?:${ALLOWED_AGENT_FIELDS.map((field) => field.toUpperCase()).join('|')})`,
     OPENID_PLACEHOLDER_NAMES,
   ]
     .map((names) => `\\{\\{(?:${names})\\}\\}`)
@@ -274,12 +317,41 @@ function processBodyPlaceholders(value: string, body: RequestBody): string {
 }
 
 /**
+ * Replaces agent field placeholders within a string.
+ * Recognized placeholders: `{{LIBRECHAT_AGENT_<FIELD>}}` where `<FIELD>` ∈ ALLOWED_AGENT_FIELDS.
+ * Only persisted agents resolve; ephemeral ids are left for a final pass to strip.
+ *
+ * @param value - The string value to process
+ * @param agent - The agent serving the request
+ * @returns The processed string with placeholders replaced
+ */
+function processAgentPlaceholders(value: string, agent: Partial<Agent>): string {
+  if (typeof value !== 'string' || !agent.id || isEphemeralAgentId(agent.id)) {
+    return value;
+  }
+
+  for (const field of ALLOWED_AGENT_FIELDS) {
+    const placeholder = `{{LIBRECHAT_AGENT_${field.toUpperCase()}}}`;
+    if (!value.includes(placeholder)) {
+      continue;
+    }
+
+    const fieldValue = agent[field];
+    const replacementValue = fieldValue == null ? '' : String(fieldValue);
+    value = value.replace(new RegExp(placeholder, 'g'), replacementValue);
+  }
+
+  return value;
+}
+
+/**
  * Processes a single string value by replacing various types of placeholders
  *
  * @param originalValue - The original string value to process
  * @param customUserVars - Optional custom user variables to replace placeholders
  * @param user - Optional user object for replacing user field placeholders
  * @param body - Optional request body object for replacing body field placeholders
+ * @param agent - Optional agent object for replacing agent field placeholders
  * @param isHeader - Whether this value will be used in an HTTP header (enables encoding)
  * @returns The processed string with all placeholders replaced
  */
@@ -288,6 +360,7 @@ function processSingleValue({
   customUserVars,
   user,
   body = undefined,
+  agent = undefined,
   isHeader = false,
   dbSourced = false,
 }: {
@@ -295,6 +368,7 @@ function processSingleValue({
   customUserVars?: Record<string, string>;
   user?: Partial<IUser>;
   body?: RequestBody;
+  agent?: Partial<Agent>;
   isHeader?: boolean;
   /** When true, only resolve customUserVars — skip env vars, user/OpenID/body placeholders */
   dbSourced?: boolean;
@@ -349,6 +423,10 @@ function processSingleValue({
 
   if (body) {
     value = processBodyPlaceholders(value, body);
+  }
+
+  if (agent) {
+    value = processAgentPlaceholders(value, agent);
   }
 
   return value;
@@ -607,6 +685,8 @@ export function resolveNestedObject<T = unknown>(options?: {
  * @param options.headers - The headers object to process
  * @param options.user - Optional user object for replacing user field placeholders (can be partial with just id)
  * @param options.body - Optional request body object for replacing body field placeholders
+ * @param options.agent - Optional agent serving the request, for replacing agent field
+ *   placeholders. Only persisted agents resolve; see `processAgentPlaceholders`.
  * @param options.customUserVars - Optional custom user variables to replace placeholders
  * @param options.stripUnresolved - When true (final resolution passes only), replaces any
  *   remaining resolvable placeholders with an empty string so internal template syntax is
@@ -618,10 +698,11 @@ export function resolveHeaders(options?: {
   headers: Record<string, string> | undefined;
   user?: Partial<IUser> | { id: string };
   body?: RequestBody;
+  agent?: Partial<Agent>;
   customUserVars?: Record<string, string>;
   stripUnresolved?: boolean;
 }): Record<string, string> {
-  const { headers, user, body, customUserVars, stripUnresolved = false } = options ?? {};
+  const { headers, user, body, agent, customUserVars, stripUnresolved = false } = options ?? {};
   const inputHeaders = headers ?? {};
 
   const resolvedHeaders: Record<string, string> = { ...inputHeaders };
@@ -633,6 +714,7 @@ export function resolveHeaders(options?: {
         customUserVars,
         user: user as IUser,
         body,
+        agent,
         isHeader: true, // Important: Enable header encoding
       });
       if (!stripUnresolved) {

--- a/packages/api/src/utils/headers.ts
+++ b/packages/api/src/utils/headers.ts
@@ -1,4 +1,5 @@
 import type { AnthropicClientOptions } from '@librechat/agents';
+import type { Agent } from 'librechat-data-provider';
 import type { IUser } from '@librechat/data-schemas';
 import type { RequestBody, RunLLMConfig } from '~/types';
 import { resolveHeaders } from './env';
@@ -115,6 +116,7 @@ export function resolveConfigHeaders({
   llmConfig,
   user,
   body,
+  agent,
   customUserVars,
 }: {
   /** Partial: this only reads the three provider header carriers, so
@@ -124,6 +126,7 @@ export function resolveConfigHeaders({
   llmConfig?: Partial<RunLLMConfig> | null;
   user?: Partial<IUser> | { id: string };
   body?: RequestBody;
+  agent?: Partial<Agent>;
   customUserVars?: Record<string, string>;
 }): void {
   if (llmConfig == null) {
@@ -134,7 +137,14 @@ export function resolveConfigHeaders({
     if (resolvedHeaderMaps.has(headers)) {
       return headers;
     }
-    const resolved = resolveHeaders({ headers, user, body, customUserVars, stripUnresolved: true });
+    const resolved = resolveHeaders({
+      headers,
+      user,
+      body,
+      agent,
+      customUserVars,
+      stripUnresolved: true,
+    });
     resolvedHeaderMaps.add(resolved);
     return resolved;
   };


### PR DESCRIPTION
## Summary

Adds `{{LIBRECHAT_AGENT_ID}}` so a gateway in front of LibreChat can attribute spend per agent and apply per-agent limits — it currently sees the user, the conversation and the message, but not which agent is running.

```yaml
headers:
  x-agent-id: '{{LIBRECHAT_AGENT_ID}}'
```

- Resolve the placeholder as its own namespace beside the user / body / OpenID ones, inheriting the `stripUnresolved` pass from #14595; both the resolver and that pattern derive from `ALLOWED_AGENT_FIELDS`, so an unrecognised `{{LIBRECHAT_AGENT_NAME}}` stays literal rather than silently emptying.
- Forward the primary agent's id, derived once per run, so subagent steps carry the id of the turn they belong to.
- Forward it on auxiliary calls too: summarization, titles, activity labels, memory extraction.
- Project agents through `createSafeAgent`, mirroring `createSafeUser`, so one allowlist decides what reaches a header.
- Resolve persisted agents only — ephemeral ids embed user-set preset text that can make the outbound fetch throw.
- Strip to an empty value for ephemeral runs, non-agent requests and model-list fetches instead of forwarding template text.
- Change nothing unless the placeholder is configured.

Closes #15076.

Notes:

- `agentId` in `ALLOWED_BODY_FIELDS` would have reached MCP for free via #14780, scoping included; I kept the agent id out of a request-body allowlist. Happy to switch, or to rename.
- MCP (#14303) is not covered — the placeholder stays literal there and needs a follow-up.
- Memory extraction is attributed to the agent whose turn triggered it, not to a configured `memory.agent`.
- `langfuse.headers` now strips the placeholder instead of forwarding it literally, via the shared helper #14945 added.
- Docs PR to `librechat.ai` to follow once the name is settled.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Ran 19 new Jest tests covering projection, resolution, composition with user and body placeholders, stripping for missing/ephemeral/empty ids, and subagent constancy through the real `createRun` path.
- Mutation-checked the subagent case: resolving against the executing agent fails exactly that assertion.
- Ran the `packages/api` and `api/server/controllers/agents` suites — 4,654 passing, no new failures.
- Ran Prettier and ESLint against every touched file with zero findings.

### **Test Configuration**:

- macOS
- Node.js 26.5.0
- Jest per workspace

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes