### PR TITLE
fix: Fetch serverInstructions from the First Live MCP Connection

### DIFF
--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -25,6 +25,7 @@ import { detectOAuthRequirement } from '~/mcp/oauth';
 import { isMCPDomainAllowed } from '~/auth/domain';
 import { MCPConnection } from './connection';
 import { mcpConfig } from './mcpConfig';
+import { isEnabled } from '~/utils';
 
 type PendingConnection = {
   promise: Promise<MCPConnection>;
@@ -634,7 +635,8 @@ export abstract class UserConnectionManager {
         this.userConnections.get(userId)?.set(serverName, connection);
       }
 
-      logger.info(`[MCP][User: ${userId}] Connection successfully established`);
+      logger.info(`[MCP][User: ${userId}][${serverName}] Connection successfully established`);
+      await this.backfillResolvedInstructions(serverName, config, connection, userId);
       if (!ephemeralConnection) {
         await this.updateUserLastActivity(userId);
         await this.assertToolPublicationLeaseCurrent(connection, userId, serverName, creationGuard);
@@ -657,6 +659,46 @@ export abstract class UserConnectionManager {
         this.removeUserConnection(userId, serverName);
       }
       throw error; // Re-throw the error to the caller
+    }
+  }
+
+  /**
+   * Startup inspection defers servers that need user/runtime context, including
+   * OAuth/OBO, custom variables, user API keys, and runtime placeholders. An
+   * enabled `serverInstructions` declaration therefore has no fetched text to
+   * resolve until the first live user connection. Persist the instructions from
+   * that connection so subsequent context builds include them. Best-effort: a
+   * failure here must never break connection creation.
+   */
+  protected async backfillResolvedInstructions(
+    serverName: string,
+    config: t.ParsedServerConfig | undefined,
+    connection: MCPConnection,
+    userId: string,
+  ): Promise<void> {
+    try {
+      if (!config || !isEnabled(config.serverInstructions) || config.resolvedInstructions != null) {
+        return;
+      }
+      const instructions = connection.client.getInstructions();
+      if (!instructions) {
+        return;
+      }
+      const updated = await MCPServersRegistry.getInstance().setResolvedInstructions(
+        serverName,
+        instructions,
+        userId,
+      );
+      if (updated) {
+        logger.info(
+          `[MCP][User: ${userId}][${serverName}] Stored server instructions from live connection`,
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        `[MCP][User: ${userId}][${serverName}] Failed to store server instructions from live connection`,
+        error,
+      );
     }
   }
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -560,6 +560,46 @@ export class MCPServersRegistry {
   }
 
   /**
+   * Backfills the inspector-derived `resolvedInstructions` for a server whose
+   * startup inspection was deferred because it needs user/runtime context. An
+   * enabled `serverInstructions` declaration has no fetched text to resolve in
+   * that case. Called once a live connection has delivered the instructions.
+   *
+   * YAML-tier servers only. Config-overlay servers are cached under
+   * config-hash keys and cannot be addressed by name here; DB-backed user
+   * servers need an identity-preserving write through mongoose timestamps and
+   * the credential-sanitization pipeline, which is its own change. Both are
+   * left untouched.
+   *
+   * The entry's `updatedAt` is deliberately preserved (the storage `patch`
+   * contract): the config identity did not change, and bumping it would mark
+   * every live connection for this server stale.
+   *
+   * @returns true when a stored config was updated.
+   */
+  public async setResolvedInstructions(
+    serverName: string,
+    instructions: string,
+    userId?: string,
+  ): Promise<boolean> {
+    if (!this.cacheConfigsRepo.patch) {
+      return false;
+    }
+    const yamlEntry = await this.cacheConfigsRepo.get(serverName);
+    if (!yamlEntry || yamlEntry.resolvedInstructions === instructions) {
+      return false;
+    }
+    const patched = await this.cacheConfigsRepo.patch(serverName, {
+      resolvedInstructions: instructions,
+    });
+    if (!patched) {
+      return false;
+    }
+    await this.invalidateServerReadCaches(serverName, userId, 'CACHE');
+    return true;
+  }
+
+  /**
    * Re-inspects a server that previously failed initialization.
    * Uses the stored stub config to attempt a full inspection and replaces the stub on success.
    */

--- a/packages/api/src/mcp/registry/ServerConfigsRepositoryInterface.ts
+++ b/packages/api/src/mcp/registry/ServerConfigsRepositoryInterface.ts
@@ -12,6 +12,16 @@ export interface IServerConfigsRepositoryInterface {
   /** Atomic add-or-update without requiring callers to inspect error messages. */
   upsert(serverName: string, config: ParsedServerConfig, userId?: string): Promise<void>;
 
+  /**
+   * Merges inspector-derived fields into an existing entry WITHOUT bumping
+   * `updatedAt`: the config identity is unchanged, and a bump would mark every
+   * live connection for the server stale. Returns false when the server is
+   * unknown. Optional: DB-backed storage does not implement it yet — an
+   * identity-preserving write there has to thread mongoose timestamps and the
+   * credential-sanitization pipeline, which is its own change.
+   */
+  patch?(serverName: string, fields: Partial<ParsedServerConfig>): Promise<boolean>;
+
   //ACL Entry check if remove is possible
   remove(serverName: string, userId?: string): Promise<void>;
 

--- a/packages/api/src/mcp/registry/__tests__/resolvedInstructionsBackfill.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/resolvedInstructionsBackfill.test.ts
@@ -1,0 +1,213 @@
+import './helpers/setupCredsEnv';
+import { tenantStorage } from '@librechat/data-schemas';
+import type { MCPConnection } from '~/mcp/connection';
+import type * as t from '~/mcp/types';
+import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
+import { UserConnectionManager } from '~/mcp/UserConnectionManager';
+import { resolveServerInstructions } from '~/mcp/utils';
+
+jest.mock('~/mcp/registry/db/ServerConfigsDB', () => ({
+  ServerConfigsDB: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(undefined),
+    getAll: jest.fn().mockResolvedValue({}),
+    add: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+    upsert: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn().mockResolvedValue(undefined),
+    reset: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+const mockMongoose = {} as typeof import('mongoose');
+const INSTRUCTIONS = 'Prefer $select on list operations. Never invent addresses.';
+const FIXED_TIME = 1699564800000;
+
+/** A YAML server whose startup inspection was deferred, leaving the enabled
+ * declaration without fetched text. */
+const startupDeferredYamlEntry: t.ParsedServerConfig = {
+  type: 'streamable-http',
+  url: 'https://mcp.example.com/mcp',
+  requiresOAuth: true,
+  serverInstructions: true,
+  source: 'yaml',
+  updatedAt: FIXED_TIME,
+};
+
+const runtimePlaceholderYamlEntry: t.ParsedServerConfig = {
+  ...startupDeferredYamlEntry,
+  requiresOAuth: false,
+  headers: { 'X-User-Id': '{{LIBRECHAT_USER_ID}}' },
+};
+
+describe('MCPServersRegistry.setResolvedInstructions', () => {
+  let registry: MCPServersRegistry;
+
+  beforeEach(async () => {
+    (MCPServersRegistry as unknown as { instance: undefined }).instance = undefined;
+    MCPServersRegistry.createInstance(mockMongoose);
+    registry = MCPServersRegistry.getInstance();
+    await registry.reset();
+  });
+
+  it('backfills a YAML-tier server and preserves its updatedAt', async () => {
+    const { config: stored } = await registry['cacheConfigsRepo'].add(
+      'deferred_server',
+      startupDeferredYamlEntry,
+    );
+
+    const updated = await registry.setResolvedInstructions('deferred_server', INSTRUCTIONS);
+
+    expect(updated).toBe(true);
+    const config = await registry.getServerConfig('deferred_server');
+    expect(config?.resolvedInstructions).toBe(INSTRUCTIONS);
+    expect(config?.serverInstructions).toBe(true);
+    expect(config?.updatedAt).toBe(stored.updatedAt);
+    expect(resolveServerInstructions(config!)).toBe(INSTRUCTIONS);
+  });
+
+  it('invalidates the read-through cache so a primed read sees the backfill', async () => {
+    await registry['cacheConfigsRepo'].add('deferred_server', startupDeferredYamlEntry);
+
+    const before = await registry.getServerConfig('deferred_server');
+    expect(before?.resolvedInstructions).toBeUndefined();
+
+    await registry.setResolvedInstructions('deferred_server', INSTRUCTIONS);
+
+    const after = await registry.getServerConfig('deferred_server');
+    expect(after?.resolvedInstructions).toBe(INSTRUCTIONS);
+  });
+
+  it('invalidates YAML read-through caches across tenants', async () => {
+    await registry['cacheConfigsRepo'].add('deferred_server', startupDeferredYamlEntry);
+    const getInTenant = (tenantId: string) =>
+      tenantStorage.run({ tenantId }, () => registry.getServerConfig('deferred_server'));
+
+    expect((await getInTenant('tenant-a'))?.resolvedInstructions).toBeUndefined();
+    expect((await getInTenant('tenant-b'))?.resolvedInstructions).toBeUndefined();
+
+    await tenantStorage.run({ tenantId: 'tenant-a' }, () =>
+      registry.setResolvedInstructions('deferred_server', INSTRUCTIONS, 'user-1'),
+    );
+
+    expect((await getInTenant('tenant-b'))?.resolvedInstructions).toBe(INSTRUCTIONS);
+  });
+
+  it('is a no-op when the stored instructions already match', async () => {
+    await registry['cacheConfigsRepo'].add('deferred_server', startupDeferredYamlEntry);
+
+    await registry.setResolvedInstructions('deferred_server', INSTRUCTIONS);
+    const updated = await registry.setResolvedInstructions('deferred_server', INSTRUCTIONS);
+
+    expect(updated).toBe(false);
+  });
+
+  it('returns false for an unknown server without a user', async () => {
+    const updated = await registry.setResolvedInstructions('missing_server', INSTRUCTIONS);
+    expect(updated).toBe(false);
+  });
+
+  it('leaves DB-tier user servers untouched (identity-preserving DB write is a follow-up)', async () => {
+    const dbRepo = registry['dbConfigsRepo'] as unknown as {
+      get: jest.Mock;
+      update: jest.Mock;
+    };
+    dbRepo.get.mockResolvedValue({ ...startupDeferredYamlEntry, source: 'user' });
+
+    const updated = await registry.setResolvedInstructions('db_server', INSTRUCTIONS, 'user-1');
+
+    expect(updated).toBe(false);
+    expect(dbRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('patch on the cache repo merges fields without bumping updatedAt', async () => {
+    const repo = registry['cacheConfigsRepo'];
+    await repo.add('deferred_server', startupDeferredYamlEntry);
+    const stored = await repo.get('deferred_server');
+
+    const patched = await repo.patch!('deferred_server', { resolvedInstructions: INSTRUCTIONS });
+
+    expect(patched).toBe(true);
+    const after = await repo.get('deferred_server');
+    expect(after?.resolvedInstructions).toBe(INSTRUCTIONS);
+    expect(after?.updatedAt).toBe(stored?.updatedAt);
+    expect(await repo.patch!('unknown_server', { resolvedInstructions: INSTRUCTIONS })).toBe(false);
+  });
+});
+
+describe('UserConnectionManager.backfillResolvedInstructions', () => {
+  class TestConnectionManager extends UserConnectionManager {}
+
+  let manager: TestConnectionManager;
+  let setResolvedInstructions: jest.Mock;
+
+  const connectionWith = (instructions?: string): MCPConnection =>
+    ({
+      client: { getInstructions: () => instructions },
+    }) as unknown as MCPConnection;
+
+  const backfill = (
+    config: t.ParsedServerConfig | undefined,
+    connection: MCPConnection,
+  ): Promise<void> =>
+    manager['backfillResolvedInstructions']('deferred_server', config, connection, 'user-1');
+
+  beforeEach(() => {
+    manager = new TestConnectionManager();
+    setResolvedInstructions = jest.fn().mockResolvedValue(true);
+    jest.spyOn(MCPServersRegistry, 'getInstance').mockReturnValue({
+      setResolvedInstructions,
+    } as unknown as MCPServersRegistry);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('persists instructions delivered by the live connection', async () => {
+    await backfill({ ...startupDeferredYamlEntry }, connectionWith(INSTRUCTIONS));
+
+    expect(setResolvedInstructions).toHaveBeenCalledWith('deferred_server', INSTRUCTIONS, 'user-1');
+  });
+
+  it('persists instructions for non-OAuth servers with runtime user placeholders', async () => {
+    await backfill({ ...runtimePlaceholderYamlEntry }, connectionWith(INSTRUCTIONS));
+
+    expect(setResolvedInstructions).toHaveBeenCalledWith('deferred_server', INSTRUCTIONS, 'user-1');
+  });
+
+  it('skips servers that do not enable serverInstructions', async () => {
+    await backfill(
+      { ...startupDeferredYamlEntry, serverInstructions: undefined },
+      connectionWith(INSTRUCTIONS),
+    );
+    expect(setResolvedInstructions).not.toHaveBeenCalled();
+  });
+
+  it('skips servers whose declaration is already a literal string', async () => {
+    await backfill(
+      { ...startupDeferredYamlEntry, serverInstructions: 'operator-provided text' },
+      connectionWith(INSTRUCTIONS),
+    );
+    expect(setResolvedInstructions).not.toHaveBeenCalled();
+  });
+
+  it('skips servers whose instructions were already resolved', async () => {
+    await backfill(
+      { ...startupDeferredYamlEntry, resolvedInstructions: INSTRUCTIONS },
+      connectionWith('newer text'),
+    );
+    expect(setResolvedInstructions).not.toHaveBeenCalled();
+  });
+
+  it('skips connections that advertise no instructions', async () => {
+    await backfill({ ...startupDeferredYamlEntry }, connectionWith(undefined));
+    expect(setResolvedInstructions).not.toHaveBeenCalled();
+  });
+
+  it('never propagates a persistence failure into connection creation', async () => {
+    setResolvedInstructions.mockRejectedValue(new Error('cache down'));
+    await expect(
+      backfill({ ...startupDeferredYamlEntry }, connectionWith(INSTRUCTIONS)),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheInMemory.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheInMemory.ts
@@ -32,6 +32,19 @@ export class ServerConfigsCacheInMemory {
     this.cache.set(serverName, { ...config, updatedAt: Date.now() });
   }
 
+  /** Merges derived fields into an existing entry without bumping `updatedAt` —
+   * see the interface doc: a bump would mark live connections stale. */
+  public async patch(serverName: string, fields: Partial<ParsedServerConfig>): Promise<boolean> {
+    const existing = this.cache.get(serverName);
+    if (!existing) {
+      return false;
+    }
+    /** Spreading a Partial over the transport-discriminated union widens it past the
+     * discriminant; the merge only touches shared inspector-derived fields. */
+    this.cache.set(serverName, { ...existing, ...fields } as ParsedServerConfig);
+    return true;
+  }
+
   public async remove(serverName: string): Promise<void> {
     if (!this.cache.delete(serverName)) {
       throw new Error(`Failed to remove server "${serverName}" in cache.`);

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedis.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedis.ts
@@ -58,6 +58,19 @@ export class ServerConfigsCacheRedis
     this.successCheck(`upsert ${this.namespace} server "${serverName}"`, success);
   }
 
+  /** Merges derived fields into an existing entry without bumping `updatedAt` —
+   * see the interface doc: a bump would mark live connections stale. */
+  public async patch(serverName: string, fields: Partial<ParsedServerConfig>): Promise<boolean> {
+    if (this.leaderOnly) await this.leaderCheck(`patch ${this.namespace} MCP servers`);
+    const existing = (await this.cache.get(serverName)) as ParsedServerConfig | undefined;
+    if (!existing) {
+      return false;
+    }
+    const success = await this.cache.set(serverName, { ...existing, ...fields });
+    this.successCheck(`patch ${this.namespace} server "${serverName}"`, success);
+    return true;
+  }
+
   public async remove(serverName: string): Promise<void> {
     if (this.leaderOnly) await this.leaderCheck(`remove ${this.namespace} MCP servers`);
     const success = await this.cache.delete(serverName);

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
@@ -160,6 +160,24 @@ export class ServerConfigsCacheRedisAggregateKey
     });
   }
 
+  /** Merges derived fields into an existing entry without bumping `updatedAt` —
+   * see the interface doc: a bump would mark live connections stale. */
+  public async patch(serverName: string, fields: Partial<ParsedServerConfig>): Promise<boolean> {
+    if (this.leaderOnly) await this.leaderCheck('patch MCP servers');
+    return this.withWriteLock(async () => {
+      this.invalidateLocalSnapshot(); // Force fresh Redis read (see add() comment)
+      const all = await this.getAll();
+      const existing = all[serverName];
+      if (!existing) {
+        return false;
+      }
+      const newAll = { ...all, [serverName]: { ...existing, ...fields } };
+      const success = await this.cache.set(AGGREGATE_KEY, newAll);
+      this.successCheck(`patch ${this.namespace} server "${serverName}"`, success);
+      return true;
+    });
+  }
+
   public async remove(serverName: string): Promise<void> {
     if (this.leaderOnly) await this.leaderCheck('remove MCP servers');
     return this.withWriteLock(async () => {


### PR DESCRIPTION
## Summary

Fixes #15081.

`serverInstructions: true` never resolves for any YAML-tier server whose startup connection is deferred because it needs user/runtime context. OAuth/OBO is one trigger, but the same path is skipped for custom user variables, user-provided API keys, runtime context placeholders, and `startup: false`.

The server instructions are already present on the first successful live connection through `connection.client.getInstructions()`; the existing fetch only ran inside the skipped startup-inspection block.

This PR backfills those instructions from the first live user connection, on the #14815 architecture:

- **`UserConnectionManager.backfillResolvedInstructions`** runs after any successful live connection; it is not keyed to OAuth. It runs only when the declaration is enabled (`true`/`"true"`) and `resolvedInstructions` is unset. Literal instruction strings keep winning, and persistence failures never break connection creation.
- **`MCPServersRegistry.setResolvedInstructions`** persists to the YAML tier and globally invalidates the tenant-scoped read-through caches, because YAML entries are shared across tenants. Concurrent first connections converge when the text already matches.
- **`patch` on the cache repositories** (in-memory, Redis, and Redis aggregate-key; optional on the interface) merges the derived field without bumping `updatedAt`. Bumping it would mark the new connection, and every other live connection for the server, stale—the failure mode #14815/#14798 removed.

Relationship to #11193: same goal, but that PR predates #14815, writes fetched text back into `serverInstructions`, and covers `requiresOAuth` but not the other startup-deferred paths.

**Scope**: YAML-tier servers. Config-overlay servers are cached under config-hash keys and are not addressable by server name; DB-backed user servers need a separate identity-preserving write through mongoose timestamps and credential sanitization.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New suite `packages/api/src/mcp/registry/__tests__/resolvedInstructionsBackfill.test.ts` (14 tests):

- backfills and resolves YAML instructions while preserving `updatedAt`
- invalidates primed read-through caches, including across tenants
- covers a non-OAuth server with `X-User-Id: "{{LIBRECHAT_USER_ID}}"`
- converges on identical text and leaves unknown/DB-tier servers untouched
- verifies cache `patch` identity preservation
- skips disabled, literal, already-resolved, and instruction-less cases
- keeps persistence failures out of connection creation

Verified after rebasing onto current `main`:

- `npx jest src/mcp --runInBand` with the repository's non-integration exclusions: **55 suites passed; 1,571 tests passed; 1 skipped**
- `npm run build:api`: passed
- Prettier and ESLint on all touched files: passed

### Test configuration

Node v24; in-memory cache configuration. Redis repository implementations are covered by the shared patch contract and existing repository tests.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that the change is effective
- [x] Local unit tests and build pass