### PR TITLE
🙈 feat: Config Option to Hide Response Feedback Buttons

### DIFF
--- a/api/server/routes/__tests__/messages-content-edit.spec.js
+++ b/api/server/routes/__tests__/messages-content-edit.spec.js
@@ -14,6 +14,7 @@ jest.mock('@librechat/api', () => ({
   mergeQuotedTextForCount: jest.fn((text) => text),
   CHILD_THREAD_READ_ONLY_ERROR: 'Child thread is view-only.',
   isSubagentThreadWriteBlocked: jest.fn().mockResolvedValue(false),
+  requireFeedbackEnabled: (req, res, next) => next(),
 }));
 
 jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));

--- a/api/server/routes/__tests__/messages-delete.spec.js
+++ b/api/server/routes/__tests__/messages-delete.spec.js
@@ -15,6 +15,7 @@ jest.mock('@librechat/api', () => ({
   traceIdForMessage: jest.fn((messageId) => `trace-${messageId}`),
   CHILD_THREAD_READ_ONLY_ERROR: 'Child thread is view-only.',
   isSubagentThreadWriteBlocked: jest.fn().mockResolvedValue(false),
+  requireFeedbackEnabled: (req, res, next) => next(),
 }));
 
 jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));

--- a/api/server/routes/__tests__/messages-feedback.spec.js
+++ b/api/server/routes/__tests__/messages-feedback.spec.js
@@ -65,6 +65,7 @@ jest.mock('~/db/models', () => ({
 
 describe('PUT /:conversationId/:messageId/feedback', () => {
   let app;
+  let interfaceConfig;
   const { sendFeedbackScore } = require('@librechat/api');
   const { updateMessage } = require('~/models');
 
@@ -75,6 +76,7 @@ describe('PUT /:conversationId/:messageId/feedback', () => {
     app.use(express.json());
     app.use((req, res, next) => {
       req.user = { id: 'user-1' };
+      req.config = { interfaceConfig };
       next();
     });
     app.use('/api/messages', messagesRouter);
@@ -82,6 +84,7 @@ describe('PUT /:conversationId/:messageId/feedback', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    interfaceConfig = {};
     updateMessage.mockImplementation((userId, { messageId, feedback }) =>
       Promise.resolve({
         messageId,
@@ -143,6 +146,19 @@ describe('PUT /:conversationId/:messageId/feedback', () => {
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({ error: 'Invalid feedback' });
+    expect(updateMessage).not.toHaveBeenCalled();
+    expect(sendFeedbackScore).not.toHaveBeenCalled();
+  });
+
+  it('rejects feedback when the interface disables it', async () => {
+    interfaceConfig = { feedback: false };
+
+    const response = await request(app)
+      .put('/api/messages/conversation-1/message-1/feedback')
+      .send({ feedback: { rating: 'thumbsUp', tag: 'accurate' } });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'Feedback is disabled' });
     expect(updateMessage).not.toHaveBeenCalled();
     expect(sendFeedbackScore).not.toHaveBeenCalled();
   });

--- a/api/server/routes/__tests__/messages-feedback.spec.js
+++ b/api/server/routes/__tests__/messages-feedback.spec.js
@@ -12,6 +12,7 @@ jest.mock('@librechat/api', () => ({
   traceIdForMessage: jest.fn((messageId) => `trace-${messageId}`),
   CHILD_THREAD_READ_ONLY_ERROR: 'Child thread is view-only.',
   isSubagentThreadWriteBlocked: jest.fn().mockResolvedValue(false),
+  requireFeedbackEnabled: jest.fn((req, res, next) => next()),
 }));
 
 jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));
@@ -65,8 +66,7 @@ jest.mock('~/db/models', () => ({
 
 describe('PUT /:conversationId/:messageId/feedback', () => {
   let app;
-  let interfaceConfig;
-  const { sendFeedbackScore } = require('@librechat/api');
+  const { sendFeedbackScore, requireFeedbackEnabled } = require('@librechat/api');
   const { updateMessage } = require('~/models');
 
   beforeAll(() => {
@@ -76,7 +76,6 @@ describe('PUT /:conversationId/:messageId/feedback', () => {
     app.use(express.json());
     app.use((req, res, next) => {
       req.user = { id: 'user-1' };
-      req.config = { interfaceConfig };
       next();
     });
     app.use('/api/messages', messagesRouter);
@@ -84,7 +83,7 @@ describe('PUT /:conversationId/:messageId/feedback', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    interfaceConfig = {};
+    requireFeedbackEnabled.mockImplementation((req, res, next) => next());
     updateMessage.mockImplementation((userId, { messageId, feedback }) =>
       Promise.resolve({
         messageId,
@@ -150,12 +149,14 @@ describe('PUT /:conversationId/:messageId/feedback', () => {
     expect(sendFeedbackScore).not.toHaveBeenCalled();
   });
 
-  it('rejects feedback when the interface disables it', async () => {
-    interfaceConfig = { feedback: false };
+  it('gates the route on the shared feedback-enabled middleware', async () => {
+    requireFeedbackEnabled.mockImplementationOnce((req, res) =>
+      res.status(403).json({ error: 'Feedback is disabled' }),
+    );
 
     const response = await request(app)
       .put('/api/messages/conversation-1/message-1/feedback')
-      .send({ feedback: { rating: 'thumbsUp', tag: 'accurate' } });
+      .send({ feedback: { rating: 'thumbsUp', tag: 'accurate_reliable' } });
 
     expect(response.status).toBe(403);
     expect(response.body).toEqual({ error: 'Feedback is disabled' });

--- a/api/server/routes/__tests__/messages-get-real-validation.spec.js
+++ b/api/server/routes/__tests__/messages-get-real-validation.spec.js
@@ -34,6 +34,7 @@ jest.mock('@librechat/api', () => ({
   isPendingActionStale: jest.fn(() => false),
   CHILD_THREAD_READ_ONLY_ERROR: 'Child thread is view-only.',
   isSubagentThreadWriteBlocked: jest.fn().mockResolvedValue(false),
+  requireFeedbackEnabled: (req, res, next) => next(),
 }));
 
 jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));

--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -13,6 +13,7 @@ jest.mock('@librechat/api', () => ({
   traceIdForMessage: jest.fn((messageId) => `trace-${messageId}`),
   CHILD_THREAD_READ_ONLY_ERROR: 'Child thread is view-only.',
   isSubagentThreadWriteBlocked: jest.fn().mockResolvedValue(false),
+  requireFeedbackEnabled: (req, res, next) => next(),
 }));
 
 jest.mock('~/server/services/Endpoints/agents/subagentThreadStore', () => ({}));

--- a/api/server/routes/__tests__/messages-subagent-thread.spec.js
+++ b/api/server/routes/__tests__/messages-subagent-thread.spec.js
@@ -13,6 +13,7 @@ jest.mock('@librechat/api', () => ({
   mergeQuotedTextForCount: jest.fn((text) => text),
   CHILD_THREAD_READ_ONLY_ERROR: 'This subagent thread is view-only.',
   isSubagentThreadWriteBlocked: (...args) => mockIsSubagentThreadWriteBlocked(...args),
+  requireFeedbackEnabled: (req, res, next) => next(),
 }));
 
 jest.mock('@librechat/data-schemas', () => ({

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -518,6 +518,10 @@ router.put(
   configMiddleware,
   async (req, res) => {
     try {
+      if (req.config?.interfaceConfig?.feedback === false) {
+        return res.status(403).json({ error: 'Feedback is disabled' });
+      }
+
       const { conversationId, messageId } = req.params;
       const { feedback } = req.body;
       const feedbackResult = feedback == null ? null : feedbackSchema.safeParse(feedback);

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -13,6 +13,7 @@ const {
   sendFeedbackScore,
   traceIdForMessage,
   mergeQuotedTextForCount,
+  requireFeedbackEnabled,
   CHILD_THREAD_READ_ONLY_ERROR,
   isSubagentThreadWriteBlocked,
 } = require('@librechat/api');
@@ -516,12 +517,9 @@ router.put(
   '/:conversationId/:messageId/feedback',
   validateMessageReq,
   configMiddleware,
+  requireFeedbackEnabled,
   async (req, res) => {
     try {
-      if (req.config?.interfaceConfig?.feedback === false) {
-        return res.status(403).json({ error: 'Feedback is disabled' });
-      }
-
       const { conversationId, messageId } = req.params;
       const { feedback } = req.body;
       const feedbackResult = feedback == null ? null : feedbackSchema.safeParse(feedback);

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -409,6 +409,8 @@ export type TMessageChatContext = {
   latestMessageId: string | undefined;
   latestMessageDepth: number | undefined;
   handleContinue: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Resolved once per chat from `interface.feedback`; false until the config loads */
+  feedbackEnabled: boolean;
   /** Should be a getter backed by a ref — reads current value without triggering re-renders */
   readonly isSubmitting: boolean;
 };

--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -11,7 +11,6 @@ import {
 } from '@librechat/client';
 import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
-import { useGetStartupConfig } from '~/data-provider';
 import { Fork } from '~/components/Conversations';
 import { hoverButtonClasses } from './styles';
 import MessageAudio from './MessageAudio';
@@ -136,8 +135,6 @@ const HoverButtons = ({
   const localize = useLocalize();
   const [isCopied, setIsCopied] = useState(false);
   const [TextToSpeech] = useRecoilState<boolean>(store.textToSpeech);
-  const { data: startupConfig } = useGetStartupConfig();
-  const feedbackEnabled = startupConfig?.interface?.feedback !== false;
 
   const endpoint = useMemo(() => {
     if (!conversation) {
@@ -255,13 +252,9 @@ const HoverButtons = ({
       )}
 
       {/* Feedback Buttons */}
-      {feedbackEnabled &&
-        !error &&
-        !isActiveStreamingMessage &&
-        !isCreatedByUser &&
-        handleFeedback != null && (
-          <Feedback handleFeedback={handleFeedback} feedback={message.feedback} isLast={isLast} />
-        )}
+      {!error && !isActiveStreamingMessage && !isCreatedByUser && handleFeedback != null && (
+        <Feedback handleFeedback={handleFeedback} feedback={message.feedback} isLast={isLast} />
+      )}
 
       {/* Regenerate Button */}
       {!isSubagentThreadReadOnly && regenerateEnabled && (

--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -11,6 +11,7 @@ import {
 } from '@librechat/client';
 import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 import { Fork } from '~/components/Conversations';
 import { hoverButtonClasses } from './styles';
 import MessageAudio from './MessageAudio';
@@ -135,6 +136,8 @@ const HoverButtons = ({
   const localize = useLocalize();
   const [isCopied, setIsCopied] = useState(false);
   const [TextToSpeech] = useRecoilState<boolean>(store.textToSpeech);
+  const { data: startupConfig } = useGetStartupConfig();
+  const feedbackEnabled = startupConfig?.interface?.feedback !== false;
 
   const endpoint = useMemo(() => {
     if (!conversation) {
@@ -252,9 +255,13 @@ const HoverButtons = ({
       )}
 
       {/* Feedback Buttons */}
-      {!error && !isActiveStreamingMessage && !isCreatedByUser && handleFeedback != null && (
-        <Feedback handleFeedback={handleFeedback} feedback={message.feedback} isLast={isLast} />
-      )}
+      {feedbackEnabled &&
+        !error &&
+        !isActiveStreamingMessage &&
+        !isCreatedByUser &&
+        handleFeedback != null && (
+          <Feedback handleFeedback={handleFeedback} feedback={message.feedback} isLast={isLast} />
+        )}
 
       {/* Regenerate Button */}
       {!isSubagentThreadReadOnly && regenerateEnabled && (

--- a/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
@@ -10,6 +10,7 @@ import {
   type TMessage,
 } from 'librechat-data-provider';
 import { hasCopyableText } from '~/hooks/Messages/useCopyToClipboard';
+import { startupConfigKey } from '~/data-provider/Endpoints/queries';
 import HoverButtons from '~/components/Chat/Messages/HoverButtons';
 import store from '~/store';
 
@@ -34,6 +35,8 @@ function renderHoverButtons({
   isLast = false,
   latestMessageId = 'assistant-1',
   getCanCopy = () => hasCopyableText({ text: message.text, content: message.content }),
+  handleFeedback,
+  feedbackEnabled,
 }: {
   isSubmitting: boolean;
   message?: TMessage;
@@ -41,9 +44,15 @@ function renderHoverButtons({
   isLast?: boolean;
   latestMessageId?: string;
   getCanCopy?: () => boolean;
+  handleFeedback?: () => void;
+  feedbackEnabled?: boolean;
 }) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
+  });
+
+  queryClient.setQueryData(startupConfigKey(false), {
+    interface: feedbackEnabled === undefined ? {} : { feedback: feedbackEnabled },
   });
 
   const initializeState = ({ set }: MutableSnapshot) => set(store.textToSpeech, false);
@@ -65,6 +74,7 @@ function renderHoverButtons({
             copyToClipboard={jest.fn()}
             getCanCopy={getCanCopy}
             latestMessageId={latestMessageId}
+            handleFeedback={handleFeedback}
           />
         </MemoryRouter>
       </RecoilRoot>
@@ -210,5 +220,46 @@ describe('HoverButtons edit affordance', () => {
     expect(container.querySelector(`#edit-${assistantMessage.messageId}`)).toBeNull();
     expect(screen.queryByTestId('regenerate-generation-button')).toBeNull();
     expect(screen.queryByTestId('continue-generation-button')).toBeNull();
+  });
+});
+
+describe('HoverButtons feedback affordance', () => {
+  const assistantMessage = {
+    ...userMessage,
+    messageId: 'assistant-1',
+    isCreatedByUser: false,
+    text: 'Here is the answer',
+  } as TMessage;
+
+  const renderSettledResponse = (feedbackEnabled?: boolean) =>
+    renderHoverButtons({
+      isSubmitting: false,
+      message: assistantMessage,
+      isLast: true,
+      latestMessageId: 'assistant-2',
+      handleFeedback: jest.fn(),
+      feedbackEnabled,
+    });
+
+  it('offers feedback when the interface leaves it unconfigured', () => {
+    renderSettledResponse();
+
+    expect(screen.getByTitle('Love this')).toBeInTheDocument();
+    expect(screen.getByTitle('Needs improvement')).toBeInTheDocument();
+  });
+
+  it('offers feedback when the interface explicitly enables it', () => {
+    renderSettledResponse(true);
+
+    expect(screen.getByTitle('Love this')).toBeInTheDocument();
+    expect(screen.getByTitle('Needs improvement')).toBeInTheDocument();
+  });
+
+  it('hides feedback when the interface disables it', () => {
+    renderSettledResponse(false);
+
+    expect(screen.queryByTitle('Love this')).toBeNull();
+    expect(screen.queryByTitle('Needs improvement')).toBeNull();
+    expect(screen.getByTestId('copy-response-button')).toBeInTheDocument();
   });
 });

--- a/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/HoverButtons.spec.tsx
@@ -10,7 +10,6 @@ import {
   type TMessage,
 } from 'librechat-data-provider';
 import { hasCopyableText } from '~/hooks/Messages/useCopyToClipboard';
-import { startupConfigKey } from '~/data-provider/Endpoints/queries';
 import HoverButtons from '~/components/Chat/Messages/HoverButtons';
 import store from '~/store';
 
@@ -36,7 +35,6 @@ function renderHoverButtons({
   latestMessageId = 'assistant-1',
   getCanCopy = () => hasCopyableText({ text: message.text, content: message.content }),
   handleFeedback,
-  feedbackEnabled,
 }: {
   isSubmitting: boolean;
   message?: TMessage;
@@ -45,14 +43,9 @@ function renderHoverButtons({
   latestMessageId?: string;
   getCanCopy?: () => boolean;
   handleFeedback?: () => void;
-  feedbackEnabled?: boolean;
 }) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
-  });
-
-  queryClient.setQueryData(startupConfigKey(false), {
-    interface: feedbackEnabled === undefined ? {} : { feedback: feedbackEnabled },
   });
 
   const initializeState = ({ set }: MutableSnapshot) => set(store.textToSpeech, false);
@@ -231,32 +224,26 @@ describe('HoverButtons feedback affordance', () => {
     text: 'Here is the answer',
   } as TMessage;
 
-  const renderSettledResponse = (feedbackEnabled?: boolean) =>
+  const renderSettledResponse = (handleFeedback?: () => void) =>
     renderHoverButtons({
       isSubmitting: false,
       message: assistantMessage,
       isLast: true,
       latestMessageId: 'assistant-2',
-      handleFeedback: jest.fn(),
-      feedbackEnabled,
+      handleFeedback,
     });
 
-  it('offers feedback when the interface leaves it unconfigured', () => {
+  it('offers feedback on a settled response when a handler is supplied', () => {
+    renderSettledResponse(jest.fn());
+
+    expect(screen.getByTitle('Love this')).toBeInTheDocument();
+    expect(screen.getByTitle('Needs improvement')).toBeInTheDocument();
+  });
+
+  /** `useMessageActions` withholds the handler when `interface.feedback` is false, so
+   *  this is how a deployment that disabled feedback reaches the action row. */
+  it('hides feedback when no handler is supplied', () => {
     renderSettledResponse();
-
-    expect(screen.getByTitle('Love this')).toBeInTheDocument();
-    expect(screen.getByTitle('Needs improvement')).toBeInTheDocument();
-  });
-
-  it('offers feedback when the interface explicitly enables it', () => {
-    renderSettledResponse(true);
-
-    expect(screen.getByTitle('Love this')).toBeInTheDocument();
-    expect(screen.getByTitle('Needs improvement')).toBeInTheDocument();
-  });
-
-  it('hides feedback when the interface disables it', () => {
-    renderSettledResponse(false);
 
     expect(screen.queryByTitle('Love this')).toBeNull();
     expect(screen.queryByTitle('Needs improvement')).toBeNull();

--- a/client/src/hooks/Chat/__tests__/abort.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/abort.spec.tsx
@@ -13,6 +13,7 @@ const mockAbortMutateAsync = jest.fn();
 const mockConvertSteersToQueued = jest.fn();
 
 jest.mock('~/data-provider', () => ({
+  useGetStartupConfig: () => ({ data: undefined }),
   useAbortStreamMutation: () => ({ mutateAsync: mockAbortMutateAsync }),
   supportsGenerationProtocolV2: (value: unknown) =>
     value != null &&

--- a/client/src/hooks/Chat/__tests__/feedback.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/feedback.spec.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TStartupConfig } from 'librechat-data-provider';
+import useChatHelpers from '../useChatHelpers';
+
+let mockStartupConfig: Partial<TStartupConfig> | undefined;
+
+jest.mock('~/data-provider', () => ({
+  useGetStartupConfig: () => ({ data: mockStartupConfig }),
+  useAbortStreamMutation: () => ({ mutateAsync: jest.fn() }),
+  supportsGenerationProtocolV2: () => false,
+}));
+
+jest.mock('~/hooks/Messages/useLatestMessage', () => ({
+  useLatestMessage: () => null,
+  useLatestMessageId: () => null,
+}));
+
+jest.mock('~/hooks/Chat/useChatFunctions', () => ({
+  __esModule: true,
+  default: () => ({ ask: jest.fn(), regenerate: jest.fn() }),
+}));
+
+jest.mock('~/hooks/useNewConvo', () => ({
+  __esModule: true,
+  default: () => ({ newConversation: jest.fn() }),
+}));
+
+jest.mock('~/hooks/Chat/useSteerConvert', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+function renderChatHelpers() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>{children}</RecoilRoot>
+    </QueryClientProvider>
+  );
+  return renderHook(() => useChatHelpers(0), { wrapper });
+}
+
+describe('useChatHelpers feedbackEnabled', () => {
+  afterEach(() => {
+    mockStartupConfig = undefined;
+  });
+
+  /** Fail closed while loading: a `feedback: false` deployment must never flash controls
+   *  whose writes the server rejects with 403. */
+  it('withholds feedback until the startup config resolves', () => {
+    mockStartupConfig = undefined;
+
+    expect(renderChatHelpers().result.current.feedbackEnabled).toBe(false);
+  });
+
+  it('enables feedback when the interface leaves the flag unconfigured', () => {
+    mockStartupConfig = { interface: {} } as Partial<TStartupConfig>;
+
+    expect(renderChatHelpers().result.current.feedbackEnabled).toBe(true);
+  });
+
+  it('enables feedback when the interface explicitly enables it', () => {
+    mockStartupConfig = { interface: { feedback: true } } as Partial<TStartupConfig>;
+
+    expect(renderChatHelpers().result.current.feedbackEnabled).toBe(true);
+  });
+
+  it('disables feedback when the interface disables it', () => {
+    mockStartupConfig = { interface: { feedback: false } } as Partial<TStartupConfig>;
+
+    expect(renderChatHelpers().result.current.feedbackEnabled).toBe(false);
+  });
+});

--- a/client/src/hooks/Chat/useChatHelpers.ts
+++ b/client/src/hooks/Chat/useChatHelpers.ts
@@ -3,8 +3,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Constants, QueryKeys, isAssistantsEndpoint } from 'librechat-data-provider';
 import { useRecoilState, useRecoilValue, useSetRecoilState, useRecoilCallback } from 'recoil';
 import type { TMessage } from 'librechat-data-provider';
+import {
+  useGetStartupConfig,
+  useAbortStreamMutation,
+  supportsGenerationProtocolV2,
+} from '~/data-provider';
 import { useLatestMessage, useLatestMessageId } from '~/hooks/Messages/useLatestMessage';
-import { supportsGenerationProtocolV2, useAbortStreamMutation } from '~/data-provider';
 import useChatFunctions from '~/hooks/Chat/useChatFunctions';
 import useSteerConvert from '~/hooks/Chat/useSteerConvert';
 import { resolveAbortSteerTarget } from '~/utils';
@@ -377,6 +381,13 @@ export default function useChatHelpers(index = 0, paramId?: string) {
   const [abortScroll, setAbortScroll] = useRecoilState(store.abortScrollFamily(index));
   const [optionSettings, setOptionSettings] = useRecoilState(store.optionSettingsFamily(index));
 
+  /** Read once per chat rather than per message row: message rows never unmount, so a
+   *  per-row config observer would accumulate for the length of the conversation.
+   *  Stays disabled until the config resolves, so a `feedback: false` deployment never
+   *  flashes controls whose writes the server rejects. */
+  const { data: startupConfig } = useGetStartupConfig();
+  const feedbackEnabled = startupConfig != null && startupConfig.interface?.feedback !== false;
+
   return useMemo(
     () => ({
       newConversation,
@@ -408,6 +419,7 @@ export default function useChatHelpers(index = 0, paramId?: string) {
       setFiles,
       filesLoading,
       setFilesLoading,
+      feedbackEnabled,
     }),
     [
       newConversation,
@@ -439,6 +451,7 @@ export default function useChatHelpers(index = 0, paramId?: string) {
       setFiles,
       filesLoading,
       setFilesLoading,
+      feedbackEnabled,
     ],
   );
 }

--- a/client/src/hooks/Messages/useMemoizedChatContext.ts
+++ b/client/src/hooks/Messages/useMemoizedChatContext.ts
@@ -55,6 +55,7 @@ export default function useMemoizedChatContext(
       latestMessageId: chatCtx.latestMessageId,
       latestMessageDepth: chatCtx.latestMessageDepth,
       handleContinue: chatCtx.handleContinue,
+      feedbackEnabled: chatCtx.feedbackEnabled,
       get isSubmitting() {
         return isSubmittingRef.current;
       },
@@ -68,6 +69,7 @@ export default function useMemoizedChatContext(
       chatCtx.latestMessageId,
       chatCtx.latestMessageDepth,
       chatCtx.handleContinue,
+      chatCtx.feedbackEnabled,
       isSubmitting, // intentional: forces new reference on streaming start/end so HoverButtons re-renders
     ],
   );

--- a/client/src/hooks/Messages/useMessageActions.tsx
+++ b/client/src/hooks/Messages/useMessageActions.tsx
@@ -47,6 +47,7 @@ export default function useMessageActions(props: TMessageActions) {
     latestMessageId,
     latestMessageDepth,
     handleContinue,
+    feedbackEnabled,
     // NOTE: isSubmitting is intentionally NOT destructured here.
     // chatContext.isSubmitting is a getter backed by a ref — destructuring
     // would capture a one-time snapshot. Always access via chatContext.isSubmitting.
@@ -183,7 +184,9 @@ export default function useMessageActions(props: TMessageActions) {
     enterEdit,
     conversation,
     messageLabel,
-    handleFeedback,
+    /** Withholding the handler removes the controls: `HoverButtons` renders feedback
+     *  only when it has somewhere to send it. */
+    handleFeedback: feedbackEnabled ? handleFeedback : undefined,
     handleContinue,
     copyToClipboard,
     latestMessageId,

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -214,6 +214,8 @@ interface:
   marketplace:
     use: false
   fileCitations: true
+  # Show the thumbs up/thumbs down feedback buttons on responses (default: true)
+  feedback: true
   # Tools pinned to the prompt bar by default for all users.
   # Only seeds the initial state — once a user pins/unpins a tool, their choice is kept.
   # Valid tool keys: artifacts, execute_code, web_search, file_search, skills.

--- a/packages/api/src/middleware/feedback.spec.ts
+++ b/packages/api/src/middleware/feedback.spec.ts
@@ -1,0 +1,59 @@
+import type { NextFunction, Response } from 'express';
+import type { ServerRequest } from '~/types/http';
+import { requireFeedbackEnabled } from './feedback';
+
+function createResponse() {
+  const res = {
+    statusCode: undefined as number | undefined,
+    body: undefined as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+function run(req: Partial<ServerRequest>) {
+  const res = createResponse();
+  const next = jest.fn() as unknown as NextFunction;
+  requireFeedbackEnabled(req as ServerRequest, res as unknown as Response, next);
+  return { res, next };
+}
+
+describe('requireFeedbackEnabled', () => {
+  it('rejects the write when the interface disables feedback', () => {
+    const { res, next } = run({
+      config: { interfaceConfig: { feedback: false } },
+    } as Partial<ServerRequest>);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'Feedback is disabled' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows the write when the interface enables feedback', () => {
+    const { res, next } = run({
+      config: { interfaceConfig: { feedback: true } },
+    } as Partial<ServerRequest>);
+
+    expect(res.statusCode).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the write when the flag is unconfigured', () => {
+    const { next } = run({ config: { interfaceConfig: {} } } as Partial<ServerRequest>);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the write when no app config reached the request', () => {
+    const { next } = run({});
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/middleware/feedback.ts
+++ b/packages/api/src/middleware/feedback.ts
@@ -1,0 +1,19 @@
+import type { NextFunction, Response } from 'express';
+import type { ServerRequest } from '~/types/http';
+
+/**
+ * Rejects message feedback writes when the deployment set `interface.feedback: false`,
+ * so a deployment that hides the controls also stores no ratings. Requires the app
+ * config to already be resolved onto the request.
+ */
+export function requireFeedbackEnabled(
+  req: ServerRequest,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (req.config?.interfaceConfig?.feedback === false) {
+    res.status(403).json({ error: 'Feedback is disabled' });
+    return;
+  }
+  next();
+}

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -20,3 +20,4 @@ export * from './remoteAgentAuth';
 export * from './share';
 export * from './messageFilterPii';
 export * from './messageValidation';
+export * from './feedback';

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1509,6 +1509,7 @@ export const interfaceSchema = z
     webSearch: z.boolean().optional(),
     contextUsage: z.boolean().optional(),
     contextCost: z.boolean().optional(),
+    feedback: z.boolean().optional(),
     currency: z
       .object({
         code: z.string(),
@@ -1602,6 +1603,7 @@ export const interfaceSchema = z
     webSearch: true,
     contextUsage: true,
     contextCost: false,
+    feedback: true,
     peoplePicker: {
       users: true,
       groups: true,

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -66,6 +66,30 @@ describe('loadDefaultInterface', () => {
     expect(interfaceConfig?.buildInfo).toBe(true);
   });
 
+  it('enables response feedback by default', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.feedback).toBe(true);
+  });
+
+  it('preserves a disabled response feedback flag', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        feedback: false,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.feedback).toBe(false);
+  });
+
   it('disables context cost by default', async () => {
     const interfaceConfig = await loadDefaultInterface({
       config: {},

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -42,6 +42,7 @@ export async function loadDefaultInterface({
     buildInfo: interfaceConfig?.buildInfo ?? defaults.buildInfo,
     contextUsage: interfaceConfig?.contextUsage ?? defaults.contextUsage,
     contextCost: interfaceConfig?.contextCost ?? defaults.contextCost,
+    feedback: interfaceConfig?.feedback ?? defaults.feedback,
     currency: interfaceConfig?.currency ?? defaults.currency,
 
     // Permissions and related settings - only include if explicitly configured


### PR DESCRIPTION
## Summary

Closes #13818

Chat responses carry thumbs up / thumbs down buttons that write a rating into the message document. Unless Langfuse is configured, nothing consumes that data, and for privacy-conscious deployments the buttons read as if feedback is being sent back to the model provider. There was no way to turn them off.

This adds an `interface.feedback` flag to `librechat.yaml`:

```yaml
interface:
  feedback: false   # default: true
```

When it is `false`:

- The `<Feedback />` render is dropped from the message action row. Read aloud, copy, edit, fork and regenerate are untouched, and the row reflows with no gap.
- `PUT /api/messages/:conversationId/:messageId/feedback` returns `403 {"error":"Feedback is disabled"}` before any database write or Langfuse export.

The server-side guard is the point of the issue rather than an extra: hiding the button alone would leave the endpoint open, so an operator who disables the feature would still be storing ratings.

`feedback` is a plain UI flag alongside `buildInfo` and `contextUsage`, not a role permission. There is nothing per-role to grant here, and registering a `PermissionTypes` entry would persist permission documents that stay stuck once the flag is later removed.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Unit tests, all passing:

| Suite | Result |
|---|---|
| `packages/data-schemas` `src/app/interface.spec.ts` | 18 passed (2 new: schema default on, explicit `false` preserved) |
| `api` `messages-feedback.spec.js` + `config.spec.js` | 53 passed (1 new: 403 before `updateMessage` and `sendFeedbackScore`) |
| `client` `HoverButtons.spec.tsx` | 10 passed (3 new: unconfigured, explicit `true`, explicit `false`) |
| `packages/api` `permissions.spec.ts` | 40 passed, role defaults unchanged |

`npx eslint` clean on every touched file, `tsc --noEmit` clean in `client`.

Also ran the real stack against a local config file:

- `GET /api/config` (authenticated) served `"feedback": false`, then `true` after flipping the yaml
- `PUT .../feedback` returned `403 Feedback is disabled`; with the flag on, `200` with the tag persisted and `200` on clear
- Browser, light and dark: no thumbs buttons with the flag off, both present with it on

### **Test Configuration**:

Node 24, MongoDB, backend and Vite dev server, `interface.feedback` toggled between `false` and `true` in `librechat.yaml`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
