### PR TITLE
Fix OpenRouter summarization reasoning override

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -84,7 +84,15 @@ jest.mock('~/agents/checkpointer', () => ({
   getAgentCheckpointer: jest.fn().mockResolvedValue({}),
 }));
 
-import { Run, buildChildInputs, InMemorySubagentTaskStore } from '@librechat/agents';
+import {
+  Run,
+  Providers,
+  ChatOpenRouter,
+  buildChildInputs,
+  InMemorySubagentTaskStore,
+} from '@librechat/agents';
+
+const LUNA_MODEL = 'openai/gpt-5.6-luna';
 
 /** Minimal RunAgent factory */
 function makeAgent(
@@ -462,6 +470,52 @@ describe('summarizationConfig field passthrough', () => {
     const config = agents[0].summarizationConfig as Record<string, unknown>;
     expect(config.trigger).toEqual({ type: 'token_ratio', value: 0 });
   });
+
+  it.each(['medium', 'low'])(
+    'overrides OpenRouter main max reasoning with %s for summarization only',
+    async (reasoningEffort) => {
+      const agents = await callAndCapture({
+        agents: [
+          makeAgent({
+            provider: Providers.OPENROUTER,
+            endpoint: 'OpenRouter',
+            model: LUNA_MODEL,
+            model_parameters: {
+              model: LUNA_MODEL,
+              modelKwargs: { reasoning: { effort: 'max' } },
+            },
+          }),
+        ],
+        summarizationConfig: {
+          provider: 'OpenRouter',
+          model: LUNA_MODEL,
+          parameters: { reasoning_effort: reasoningEffort },
+        },
+      });
+
+      const mainClientOptions = agents[0].clientOptions as {
+        modelKwargs: { reasoning: { effort: string } };
+      };
+      const summaryConfig = agents[0].summarizationConfig as {
+        model: string;
+        parameters: Record<string, unknown>;
+      };
+
+      expect(mainClientOptions.modelKwargs.reasoning).toEqual({ effort: 'max' });
+      expect(summaryConfig.parameters).toEqual({ reasoning: { effort: reasoningEffort } });
+
+      const summaryModel = new ChatOpenRouter({
+        ...mainClientOptions,
+        ...summaryConfig.parameters,
+        apiKey: 'test-key',
+        model: summaryConfig.model,
+      });
+      const request = summaryModel.invocationParams();
+
+      expect(request.reasoning).toEqual({ effort: reasoningEffort });
+      expect(request.reasoning_effort).toBeUndefined();
+    },
+  );
 
   it.each([
     ['remaining_tokens', 500],

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -525,6 +525,32 @@ function mergeParameters(
   return merged;
 }
 
+/** Converts LibreChat's scalar effort setting to the object OpenRouter consumes. */
+function normalizeSummarizationParameters(
+  provider: string,
+  parameters: SummarizationConfig['parameters'] | Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (provider.toLowerCase() !== Providers.OPENROUTER || parameters == null) {
+    return parameters;
+  }
+
+  const reasoningEffort = parameters.reasoning_effort;
+  if (!isNonEmptyString(reasoningEffort)) {
+    return parameters;
+  }
+
+  const normalized = { ...parameters };
+  delete normalized.reasoning_effort;
+  const reasoning = isPlainObject(normalized.reasoning) ? normalized.reasoning : {};
+  return {
+    ...normalized,
+    reasoning: {
+      ...reasoning,
+      effort: reasoningEffort,
+    },
+  };
+}
+
 /**
  * Mirrors `getOpenAIConfig`'s `llmConfig` shape (plus its `configOptions`
  * assigned to `configuration`). Index signature covers fields that the
@@ -736,10 +762,11 @@ function shapeSummarizationConfig(
    * adding e.g. `configuration.defaultQuery` keeps the resolved `baseURL`
    * and `defaultHeaders` rather than replacing the whole object.
    */
-  const parameters =
+  const mergedParameters =
     clientOverrides != null
       ? mergeParameters(clientOverrides, config?.parameters)
       : config?.parameters;
+  const parameters = normalizeSummarizationParameters(provider, mergedParameters);
 
   return {
     enabled: config?.enabled !== false && isNonEmptyString(provider) && isNonEmptyString(model),


### PR DESCRIPTION
## Summary

- translate summary-only `reasoning_effort` into OpenRouter’s nested `reasoning` option
- preserve the main agent reasoning configuration
- verify low and medium summary profiles with the actual OpenRouter client

## Why

A same-endpoint OpenRouter summarizer reuses the main agent client options. The scalar summarization parameter currently passes through without overriding the nested OpenRouter reasoning object, so a hidden summary configured for a lower effort can silently inherit the main agent’s higher effort.

## Verification

- `npm run build:packages`
- `npm test --workspace=packages/api -- --runTestsByPath src/agents/__tests__/run-summarization.test.ts --runInBand --coverage=false --watch=false` (127 passed)
- focused ESLint
- `git diff --check`