### PR TITLE
fix: allow hyphens in MCP server titles

### DIFF
--- a/client/src/components/SidePanel/MCPBuilder/MCPServerDialog/sections/BasicInfoSection.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerDialog/sections/BasicInfoSection.tsx
@@ -52,7 +52,7 @@ export default function BasicInfoSection() {
             {...register('title', {
               required: localize('com_ui_field_required'),
               pattern: {
-                value: /^[a-zA-Z0-9 ]+$/,
+                value: /^[a-zA-Z0-9 -]+$/,
                 message: localize('com_ui_mcp_title_invalid'),
               },
             })}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1527,7 +1527,7 @@
   "com_ui_mcp_servers_allow_share": "Allow users to share MCP servers",
   "com_ui_mcp_servers_allow_share_public": "Allow users to share MCP servers publicly",
   "com_ui_mcp_servers_allow_use": "Allow users to use MCP servers",
-  "com_ui_mcp_title_invalid": "Title can only contain letters, numbers, and spaces",
+  "com_ui_mcp_title_invalid": "Title can only contain letters, numbers, spaces, and hyphens",
   "com_ui_mcp_tool_options": "Tool Options",
   "com_ui_mcp_transport": "Transport",
   "com_ui_mcp_type_sse": "SSE",

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -155,10 +155,10 @@ const OboOptionsSchema = z.object({
 });
 
 const BaseOptionsSchema = z.object({
-  /** Display name for the MCP server - only letters, numbers, and spaces allowed */
+  /** Display name for the MCP server - only letters, numbers, spaces, and hyphens allowed */
   title: z
     .string()
-    .regex(/^[a-zA-Z0-9 ]+$/, 'Title can only contain letters, numbers, and spaces')
+    .regex(/^[a-zA-Z0-9 -]+$/, 'Title can only contain letters, numbers, spaces, and hyphens')
     .optional(),
   /** Description of the MCP server */
   description: z.string().optional(),


### PR DESCRIPTION
## Summary
Fixes #15090 by allowing hyphens in MCP server titles. Internal server names already use hyphens; the title field was stricter than that.

## Change Type
Bug fix (non-breaking)

## Testing
1. Create an MCP server titled `my-server`
2. Confirm it saves
3. Confirm a name with `@` still shows the invalid-title message