### PR TITLE
🪪 fix: Support MCP Server Titles With Hyphens

### DIFF
--- a/client/src/components/SidePanel/MCPBuilder/MCPServerDialog/sections/BasicInfoSection.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerDialog/sections/BasicInfoSection.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 import { Input, Label, Textarea } from '@librechat/client';
+import { MCP_SERVER_TITLE_PATTERN } from 'librechat-data-provider';
 import type { MCPServerFormData } from '../hooks/useMCPServerForm';
 import MCPIcon from '~/components/SidePanel/Agents/MCPIcon';
 import { useLocalize } from '~/hooks';
@@ -52,7 +53,7 @@ export default function BasicInfoSection() {
             {...register('title', {
               required: localize('com_ui_field_required'),
               pattern: {
-                value: /^[a-zA-Z0-9 ]+$/,
+                value: MCP_SERVER_TITLE_PATTERN,
                 message: localize('com_ui_mcp_title_invalid'),
               },
             })}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1527,7 +1527,7 @@
   "com_ui_mcp_servers_allow_share": "Allow users to share MCP servers",
   "com_ui_mcp_servers_allow_share_public": "Allow users to share MCP servers publicly",
   "com_ui_mcp_servers_allow_use": "Allow users to use MCP servers",
-  "com_ui_mcp_title_invalid": "Title can only contain letters, numbers, and spaces",
+  "com_ui_mcp_title_invalid": "Title must start with a letter or number and can include spaces, hyphens, and apostrophes",
   "com_ui_mcp_tool_options": "Tool Options",
   "com_ui_mcp_transport": "Transport",
   "com_ui_mcp_type_sse": "SSE",

--- a/packages/data-provider/specs/mcp.spec.ts
+++ b/packages/data-provider/specs/mcp.spec.ts
@@ -6,6 +6,48 @@ import {
   MCP_USER_INPUT_FIELDS,
 } from '../src/mcp';
 
+describe('MCP server title validation', () => {
+  const titleCases = [
+    ['hyphenated ASCII title', 'Read-Only Tools'],
+    ['accented title', "Générateur d'images"],
+    ['Unicode title', '画像ツール'],
+    ['typographic apostrophe', 'Today’s Tools'],
+  ];
+
+  it.each(titleCases)('accepts a %s in configured MCP servers', (_label, title) => {
+    const result = MCPOptionsSchema.safeParse({
+      type: 'sse',
+      url: 'https://mcp-server.com/sse',
+      title,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(titleCases)('accepts a %s from the MCP Builder', (_label, title) => {
+    const result = MCPServerUserInputSchema.safeParse({
+      type: 'sse',
+      url: 'https://mcp-server.com/sse',
+      title,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['', '   ', '-Tools', "'Tools", 'Tools@Home'])(
+    'rejects an invalid MCP server title: %p',
+    (title) => {
+      const result = MCPServerUserInputSchema.safeParse({
+        type: 'sse',
+        url: 'https://mcp-server.com/sse',
+        title,
+      });
+
+      expect(result.success).toBe(false);
+    },
+  );
+});
+
 describe('MCPOptionsSchema', () => {
   describe('OBO transport support', () => {
     it('should accept obo on SSE transport', () => {

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -154,11 +154,15 @@ const OboOptionsSchema = z.object({
   scopes: z.string().min(1),
 });
 
+export const MCP_SERVER_TITLE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}'’ -]*$/u;
+export const MCP_SERVER_TITLE_ERROR =
+  'Title must start with a letter or number and can include spaces, hyphens, and apostrophes';
+
 const BaseOptionsSchema = z.object({
-  /** Display name for the MCP server - only letters, numbers, and spaces allowed */
+  /** Display name for the MCP server */
   title: z
     .string()
-    .regex(/^[a-zA-Z0-9 ]+$/, 'Title can only contain letters, numbers, and spaces')
+    .regex(MCP_SERVER_TITLE_PATTERN, MCP_SERVER_TITLE_ERROR)
     .optional(),
   /** Description of the MCP server */
   description: z.string().optional(),

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -154,16 +154,16 @@ const OboOptionsSchema = z.object({
   scopes: z.string().min(1),
 });
 
-export const MCP_SERVER_TITLE_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\p{M}'’ -]*$/u;
+export const MCP_SERVER_TITLE_PATTERN = new RegExp(
+  "^[\\p{L}\\p{N}][\\p{L}\\p{N}\\p{M}'’ -]*$",
+  'u',
+);
 export const MCP_SERVER_TITLE_ERROR =
   'Title must start with a letter or number and can include spaces, hyphens, and apostrophes';
 
 const BaseOptionsSchema = z.object({
   /** Display name for the MCP server */
-  title: z
-    .string()
-    .regex(MCP_SERVER_TITLE_PATTERN, MCP_SERVER_TITLE_ERROR)
-    .optional(),
+  title: z.string().regex(MCP_SERVER_TITLE_PATTERN, MCP_SERVER_TITLE_ERROR).optional(),
   /** Description of the MCP server */
   description: z.string().optional(),
   /**


### PR DESCRIPTION
## Summary

I aligned MCP server title validation across the shared schema and Builder so human-readable titles can use hyphens, apostrophes, and Unicode letters without permitting blank display names.

- Centralized the title pattern in `librechat-data-provider` and applied it to API and configuration validation.
- Reused the shared pattern in the MCP Builder so browser validation cannot drift from the server.
- Updated the English validation message and added schema coverage for accepted and rejected title forms.
- Preserved compatibility with the data-provider package's legacy TypeScript target by constructing the Unicode pattern at runtime.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/data-provider && npm run build`
- `cd packages/data-provider && npx jest specs/mcp.spec.ts --runInBand --coverage=false` (70 passed)
- `npx eslint packages/data-provider/src/mcp.ts packages/data-provider/specs/mcp.spec.ts client/src/components/SidePanel/MCPBuilder/MCPServerDialog/sections/BasicInfoSection.tsx`
- `git diff --check`

The full client typecheck is currently blocked by unrelated stale local workspace package builds; the focused data-provider build verifies this export and its declarations.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes