### PR TITLE
:telescope: fix: Map top_p to topP in getOpenAILLMConfig

### DIFF
--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -1556,13 +1556,14 @@ describe('getOpenAIConfig', () => {
           model: modelName,
           temperature: 0.7,
           maxTokens: 2048,
-          // topP is converted from top_p in modelOptions
+          topP: 0.9,
           frequencyPenalty: 0.1, // converted from frequency_penalty
           presencePenalty: 0.1, // converted from presence_penalty
           user: 'test-user-id',
           streaming: true, // default
           apiKey: mockApiKey,
         });
+        expect(result.llmConfig).not.toHaveProperty('top_p');
         expect(result.configOptions).toEqual({});
         expect(result.tools).toEqual([]);
       });

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -44,7 +44,7 @@ describe('getOpenAILLMConfig', () => {
       expect(result.llmConfig).toHaveProperty('presencePenalty', 0.3);
     });
 
-    it('should map top_p to topP for LangChain', () => {
+    it('should map top_p to topP', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',
         streaming: true,

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -44,6 +44,38 @@ describe('getOpenAILLMConfig', () => {
       expect(result.llmConfig).toHaveProperty('presencePenalty', 0.3);
     });
 
+    it('should map top_p to topP for LangChain', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        endpoint: 'custom',
+        modelOptions: {
+          model: 'provider/test-model',
+          temperature: 1,
+          top_p: 0.95,
+        } as Partial<t.OpenAIParameters>,
+      });
+
+      expect(result.llmConfig).toHaveProperty('topP', 0.95);
+      expect(result.llmConfig).not.toHaveProperty('top_p');
+      expect(result.llmConfig).toHaveProperty('temperature', 1);
+    });
+
+    it('should prefer topP over top_p when both are provided', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        modelOptions: {
+          model: 'provider/test-model',
+          top_p: 0.95,
+          topP: 0.8,
+        } as Partial<t.OpenAIParameters>,
+      });
+
+      expect(result.llmConfig).toHaveProperty('topP', 0.8);
+      expect(result.llmConfig).not.toHaveProperty('top_p');
+    });
+
     it('should handle max_tokens conversion to maxTokens', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -542,6 +542,7 @@ export function getOpenAILLMConfig({
     promptCacheTtl,
     frequency_penalty,
     presence_penalty,
+    top_p,
     ...modelOptions
   } = cleanedModelOptions as Partial<
     t.OpenAIParameters & { promptCache?: boolean; promptCacheTtl?: '5m' | '1h' }
@@ -560,6 +561,9 @@ export function getOpenAILLMConfig({
   }
   if (presence_penalty != null) {
     llmConfig.presencePenalty = presence_penalty;
+  }
+  if (top_p != null && llmConfig.topP == null) {
+    llmConfig.topP = top_p;
   }
 
   const modelKwargs: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

I fixed a bug where `top_p` set via modelSpecs presets or the parameters UI was not forwarded to custom OpenAI-compatible endpoints on the agents chat path.

* Mapped snake_case `top_p` to camelCase `topP` in `getOpenAILLMConfig`, matching the existing `frequency_penalty` / `presence_penalty` handling.
* LangChain's `knownOpenAIParams` recognizes `topP` only, so unmapped `top_p` on `llmConfig` was silently dropped before the upstream HTTP request; `temperature` was unaffected because it uses the same key on both sides.
* Added unit tests for the mapping, precedence when both `top_p` and `topP` are set, and updated the "OpenAI Initialize.js Simulation" test to assert `topP` instead of relying on a comment-only expectation.

Closes #15101

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

* `npm run test:api -- packages/api/src/endpoints/openai/llm.spec.ts`
* `npm run test:api -- packages/api/src/endpoints/openai/config.spec.ts`
* `npm run lint`
* `npm run build`
* Manual: custom endpoint + modelSpec with `top_p: 0.6` -> LiteLLM upstream logs show `top_p: 0.6` through config (modelSpec)
* Manual: custom endpoint + modelSpec with `top_p: 0.12` -> LiteLLM upstream logs show `top_p: 0.12` through settings UI

Updated tests verify:
* `top_p: 0.95` in `modelOptions` → `llmConfig.topP === 0.95`
* Explicit `topP` takes precedence over `top_p`
* Existing penalty mapping tests still pass

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

## Screenshots of testing
<img width="1917" height="965" alt="Screenshot 2026-08-22 002107" src="https://github.com/user-attachments/assets/49b44c12-bde2-437b-8c73-2f88c04ab259" />
<img width="1919" height="975" alt="Screenshot 2026-08-22 002128" src="https://github.com/user-attachments/assets/1cd8aada-9380-449c-8922-17f8fe80b021" />
<img width="1919" height="973" alt="Screenshot 2026-08-22 002232" src="https://github.com/user-attachments/assets/424f030b-efc8-42b1-a776-e1d41ace3338" />
<img width="1914" height="969" alt="Screenshot 2026-08-22 002245" src="https://github.com/user-attachments/assets/0a942aba-7939-4d34-80ee-8ea2055ff190" />