### PR TITLE
🎬 test: Cover Detached Subagent Activity Lifecycle

### DIFF
--- a/e2e/playwright.config.redis.ts
+++ b/e2e/playwright.config.redis.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     /steering\.spec\.ts/,
     /steering-escalation\.spec\.ts/,
     /streaming\.spec\.ts/,
+    /subagent-activity\.spec\.ts/,
     /thread-fold\.spec\.ts/,
     /tool-approvals\.spec\.ts/,
     /usage\.spec\.ts/,

--- a/e2e/setup/fake-model.js
+++ b/e2e/setup/fake-model.js
@@ -55,6 +55,8 @@ const DEFERRED_HITL_MARKER = 'E2E_DEFERRED_HITL:';
 const HANDOFF_MARKER = 'E2E_HANDOFF:';
 const SUBAGENT_RESULT_MARKER = 'E2E_SUBAGENT_RESULT:';
 const SUBAGENT_CHILD_MARKER = 'E2E_SUBAGENT_CHILD:';
+const SUBAGENT_ACTIVITY_MARKER = 'E2E_SUBAGENT_ACTIVITY:';
+const SUBAGENT_ACTIVITY_CHILD_MARKER = 'E2E_SUBAGENT_ACTIVITY_CHILD:';
 const SUBAGENT_MODEL_OVERRIDE_ERROR =
   '[e2e] Streamed subagent result coverage requires an @librechat/agents release with ' +
   'StandardGraph.setSubagentModelOverride';
@@ -685,10 +687,21 @@ function overrideModel({
   toolCalls,
   thrownError,
   overrideSubagentModel,
+  disableHumanInTheLoop,
   resolveInvocation,
   resolveOnStream,
   modelCallbacks,
 }) {
+  /** The shared mock profile enables approval HITL for its dedicated specs.
+   * Detached subagents reject that run-level mode before executing, so the
+   * credential-free activity scenario explicitly models a deployment with
+   * approval HITL disabled without weakening the shared profile. */
+  if (disableHumanInTheLoop) {
+    graph.humanInTheLoop = undefined;
+    for (const executor of graph._subagentExecutors ?? []) {
+      executor.humanInTheLoop = undefined;
+    }
+  }
   if (overrideSubagentModel && typeof graph.setSubagentModelOverride !== 'function') {
     overrideModel({
       graph,
@@ -1359,6 +1372,79 @@ function subagentResultResponses(text) {
             type: 'tool_call',
           },
         ],
+      };
+    },
+  };
+}
+
+function parseSubagentActivityMarker(text) {
+  const value = getMarkerValue(text, SUBAGENT_ACTIVITY_MARKER);
+  const separator = value.indexOf(':');
+  if (separator <= 0 || separator === value.length - 1) {
+    return null;
+  }
+
+  const childIds = value.slice(0, separator).split(',').filter(Boolean);
+  if (childIds.length !== 2) {
+    return null;
+  }
+
+  return {
+    childIds,
+    label: value.slice(separator + 1),
+  };
+}
+
+function subagentActivityResponses(text) {
+  const marker = parseSubagentActivityMarker(text);
+  if (!marker) {
+    return null;
+  }
+
+  return {
+    responses: [''],
+    sleep: 50,
+    overrideSubagentModel: true,
+    disableHumanInTheLoop: true,
+    resolveInvocation: (messages) => {
+      const latestUserText = getLatestUserText(messages);
+      for (const [index] of marker.childIds.entries()) {
+        const childPrompt = `${SUBAGENT_ACTIVITY_CHILD_MARKER}${marker.label}:${index + 1}`;
+        if (!latestUserText.includes(childPrompt)) {
+          continue;
+        }
+
+        const progress = Array.from(
+          { length: 100 },
+          (_, phase) => `child-${index + 1}-phase-${phase + 1}`,
+        ).join(' ');
+        return {
+          response: `E2E detached child ${index + 1} activity ${marker.label} ${progress} E2E detached child ${index + 1} complete ${marker.label}`,
+        };
+      }
+
+      const backgroundTaskResults = (messages ?? []).filter(
+        (message) =>
+          messageType(message) === 'tool' &&
+          typeof message?.tool_call_id === 'string' &&
+          message.tool_call_id.startsWith('call_e2e_subagent_activity_'),
+      );
+      if (backgroundTaskResults.length >= marker.childIds.length) {
+        return { response: `E2E detached subagents dispatched ${marker.label}` };
+      }
+
+      return {
+        response: '',
+        toolCalls: marker.childIds.map((childId, index) => ({
+          id: `call_e2e_subagent_activity_${marker.label}_${index + 1}`,
+          name: 'subagent',
+          args: {
+            description: `${SUBAGENT_ACTIVITY_CHILD_MARKER}${marker.label}:${index + 1}`,
+            subagent_type: childId,
+            run_in_background: true,
+          },
+          type: 'tool_call',
+        })),
       };
     },
   };
@@ -2129,6 +2215,11 @@ function buildHandoffResponses(graph, parsed) {
 }
 
 function resolveResponses({ graph, messages, text, toolNames }) {
+  const subagentActivity = subagentActivityResponses(text);
+  if (subagentActivity) {
+    return subagentActivity;
+  }
+
   const subagentResult = subagentResultResponses(text);
   if (subagentResult) {
     return subagentResult;
@@ -2310,6 +2401,7 @@ module.exports = function fakeModelHook(run, context) {
     toolCalls,
     thrownError,
     overrideSubagentModel,
+    disableHumanInTheLoop,
     resolveInvocation,
     resolveOnStream,
   } = handoffScript
@@ -2327,6 +2419,7 @@ module.exports = function fakeModelHook(run, context) {
     toolCalls,
     thrownError,
     overrideSubagentModel,
+    disableHumanInTheLoop,
     resolveInvocation: async (streamMessages, streamOptions, runManager) =>
       deferredHitlInvocationResponse({
         graph,

--- a/e2e/specs/mock/subagent-activity.spec.ts
+++ b/e2e/specs/mock/subagent-activity.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import type { AgentDetail } from './agents.helpers';
+import { cleanupAgent, openAgentBuilder, uniqueAgentName } from './agents.helpers';
+import { MOCK_ENDPOINTS, getAccessToken, requestJson, sendMessage } from './helpers';
+
+const DETACHED_ACTIVITY_MARKER = 'E2E_SUBAGENT_ACTIVITY:';
+
+async function createAgent(
+  page: Page,
+  token: string,
+  name: string,
+  subagents?: AgentDetail['subagents'],
+): Promise<AgentDetail> {
+  return requestJson<AgentDetail>(page, {
+    path: '/api/agents',
+    token,
+    method: 'POST',
+    body: {
+      name,
+      description: 'Playwright verification of detached child activity.',
+      instructions: 'Follow the deterministic end-to-end request exactly.',
+      provider: MOCK_ENDPOINTS[0].label,
+      model: MOCK_ENDPOINTS[0].model,
+      subagents,
+    },
+  });
+}
+
+async function selectAgent(page: Page, name: string): Promise<void> {
+  const form = await openAgentBuilder(page);
+  await form.getByRole('combobox', { name: 'Agent', exact: true }).click();
+  await page.getByRole('option', { name }).click();
+  await expect(form.getByLabel('Agent name')).toHaveValue(name);
+  await form.getByRole('button', { name: 'Select Agent' }).click();
+}
+
+test.describe('detached subagent activity', () => {
+  test('streams two child runs into the shared panel and restores terminal activity', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const label = `activity-${Date.now().toString(36)}`;
+    const childNames = [
+      uniqueAgentName('E2E Activity Child A'),
+      uniqueAgentName('E2E Activity Child B'),
+    ];
+    const parentName = uniqueAgentName('E2E Activity Parent');
+    const createdAgentIds: string[] = [];
+    const activityRequests: string[] = [];
+    page.on('request', (request) => {
+      const url = new URL(request.url());
+      if (/\/api\/convos\/[^/]+\/subagents\/[^/]+\/tasks\/[^/]+\/activity$/.test(url.pathname)) {
+        activityRequests.push(url.pathname);
+      }
+    });
+
+    try {
+      await page.goto('/c/new');
+      const token = await getAccessToken(page);
+      const children: AgentDetail[] = [];
+      for (const childName of childNames) {
+        const child = await createAgent(page, token, childName);
+        children.push(child);
+        createdAgentIds.push(child.id);
+      }
+      const parent = await createAgent(page, token, parentName, {
+        enabled: true,
+        allowSelf: false,
+        agent_ids: children.map((child) => child.id),
+      });
+      createdAgentIds.push(parent.id);
+
+      await selectAgent(page, parentName);
+      const response = await sendMessage(
+        page,
+        `${DETACHED_ACTIVITY_MARKER}${children.map((child) => child.id).join(',')}:${label}`,
+      );
+      expect(response.ok()).toBeTruthy();
+
+      await page.getByRole('button', { name: 'Ran 2 agents' }).click();
+      const cards = page.locator('[data-subagent-tool-call^="call_e2e_subagent_activity_"]');
+      await expect(cards).toHaveCount(2, { timeout: 30_000 });
+      await expect(cards.first()).toHaveAttribute('data-subagent-thread', /.+/);
+      await cards.first().click();
+
+      const panel = page.getByRole('region', { name: 'Child agent activity' });
+      await expect(panel).toBeVisible();
+      await expect(panel.getByText('Running', { exact: true })).toBeVisible();
+      await expect(panel.getByText('Writing', { exact: true })).toBeVisible();
+      await expect(panel).toContainText('child-1-phase-10');
+      await expect.poll(() => activityRequests.length).toBe(1);
+
+      await expect(panel.getByText('Completed', { exact: true })).toBeVisible({ timeout: 30_000 });
+      await expect(panel).toContainText(`E2E detached child 1 complete ${label}`);
+      await expect.poll(() => activityRequests.length).toBe(1);
+
+      await panel.getByRole('button', { name: 'Close' }).click();
+      await expect(panel).not.toBeVisible();
+      await cards.nth(1).click();
+      await expect(panel.getByText('Completed', { exact: true })).toBeVisible({ timeout: 30_000 });
+      await expect(panel).toContainText(`E2E detached child 2 complete ${label}`);
+
+      await panel.getByRole('button', { name: 'Close' }).click();
+      await page.reload();
+      await page.getByRole('button', { name: 'Ran 2 agents' }).click();
+      const restoredCards = page.locator(
+        '[data-subagent-tool-call^="call_e2e_subagent_activity_"]',
+      );
+      await expect(restoredCards).toHaveCount(2);
+      await restoredCards.first().click();
+      await expect(panel.getByText('Completed', { exact: true })).toBeVisible();
+      await expect(panel).toContainText(`E2E detached child 1 complete ${label}`);
+
+      await panel.getByRole('button', { name: 'Close' }).click();
+      await page.getByRole('button', { name: 'Chat History' }).click();
+      await expect(page.getByText(/Subagent:/)).toHaveCount(0);
+    } finally {
+      for (const agentId of createdAgentIds.reverse()) {
+        await cleanupAgent(page, agentId);
+      }
+    }
+  });
+});

--- a/e2e/specs/mock/subagent-activity.spec.ts
+++ b/e2e/specs/mock/subagent-activity.spec.ts
@@ -2,9 +2,17 @@ import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import type { AgentDetail } from './agents.helpers';
 import { cleanupAgent, openAgentBuilder, uniqueAgentName } from './agents.helpers';
-import { MOCK_ENDPOINTS, getAccessToken, requestJson, sendMessage } from './helpers';
+import {
+  MOCK_ENDPOINTS,
+  getAccessToken,
+  requestJson,
+  sendMessageAndWaitForCompletion,
+} from './helpers';
 
 const DETACHED_ACTIVITY_MARKER = 'E2E_SUBAGENT_ACTIVITY:';
+/** The activity hook's first reconnect is scheduled after 500 ms. */
+const ACTIVITY_RECONNECT_GUARD_MS = 1_000;
+const ACTIVITY_PATH = /\/api\/convos\/[^/]+\/subagents\/[^/]+\/tasks\/[^/]+\/activity$/;
 
 async function createAgent(
   page: Page,
@@ -48,10 +56,17 @@ test.describe('detached subagent activity', () => {
     const parentName = uniqueAgentName('E2E Activity Parent');
     const createdAgentIds: string[] = [];
     const activityRequests: string[] = [];
+    const finishedActivityRequests: string[] = [];
     page.on('request', (request) => {
       const url = new URL(request.url());
-      if (/\/api\/convos\/[^/]+\/subagents\/[^/]+\/tasks\/[^/]+\/activity$/.test(url.pathname)) {
+      if (ACTIVITY_PATH.test(url.pathname)) {
         activityRequests.push(url.pathname);
+      }
+    });
+    page.on('requestfinished', (request) => {
+      const url = new URL(request.url());
+      if (ACTIVITY_PATH.test(url.pathname)) {
+        finishedActivityRequests.push(url.pathname);
       }
     });
 
@@ -72,7 +87,7 @@ test.describe('detached subagent activity', () => {
       createdAgentIds.push(parent.id);
 
       await selectAgent(page, parentName);
-      const response = await sendMessage(
+      const response = await sendMessageAndWaitForCompletion(
         page,
         `${DETACHED_ACTIVITY_MARKER}${children.map((child) => child.id).join(',')}:${label}`,
       );
@@ -93,7 +108,9 @@ test.describe('detached subagent activity', () => {
 
       await expect(panel.getByText('Completed', { exact: true })).toBeVisible({ timeout: 30_000 });
       await expect(panel).toContainText(`E2E detached child 1 complete ${label}`);
-      await expect.poll(() => activityRequests.length).toBe(1);
+      await expect.poll(() => finishedActivityRequests.length).toBe(1);
+      await page.waitForTimeout(ACTIVITY_RECONNECT_GUARD_MS);
+      expect(activityRequests).toHaveLength(1);
 
       await panel.getByRole('button', { name: 'Close' }).click();
       await expect(panel).not.toBeVisible();
@@ -114,6 +131,8 @@ test.describe('detached subagent activity', () => {
 
       await panel.getByRole('button', { name: 'Close' }).click();
       await page.getByRole('button', { name: 'Chat History' }).click();
+      await expect(page.getByTestId('convo-item').first()).toBeVisible();
+      await expect(page.getByTestId('convo-item')).toHaveCount(1);
       await expect(page.getByText(/Subagent:/)).toHaveCount(0);
     } finally {
       for (const agentId of createdAgentIds.reverse()) {

--- a/e2e/specs/mock/subagent-activity.spec.ts
+++ b/e2e/specs/mock/subagent-activity.spec.ts
@@ -97,9 +97,14 @@ test.describe('detached subagent activity', () => {
       const cards = page.locator('[data-subagent-tool-call^="call_e2e_subagent_activity_"]');
       await expect(cards).toHaveCount(2, { timeout: 30_000 });
       await expect(cards.first()).toHaveAttribute('data-subagent-thread', /.+/);
+      const activityResponsePromise = page.waitForResponse((candidate) => {
+        const url = new URL(candidate.url());
+        return ACTIVITY_PATH.test(url.pathname);
+      });
       await cards.first().click();
 
       const panel = page.getByRole('region', { name: 'Child agent activity' });
+      const activityResponse = await activityResponsePromise;
       await expect(panel).toBeVisible();
       await expect(panel.getByText('Running', { exact: true })).toBeVisible();
       await expect(panel.getByText('Writing', { exact: true })).toBeVisible();
@@ -109,6 +114,9 @@ test.describe('detached subagent activity', () => {
       await expect(panel.getByText('Completed', { exact: true })).toBeVisible({ timeout: 30_000 });
       await expect(panel).toContainText(`E2E detached child 1 complete ${label}`);
       await expect.poll(() => finishedActivityRequests.length).toBe(1);
+      const activityStreamBody = await activityResponse.text();
+      expect(activityStreamBody).toContain('"event":"on_subagent_update"');
+      expect(activityStreamBody).toContain('"phase":"message_delta"');
       await page.waitForTimeout(ACTIVITY_RECONNECT_GUARD_MS);
       expect(activityRequests).toHaveLength(1);
 
@@ -131,9 +139,11 @@ test.describe('detached subagent activity', () => {
 
       await panel.getByRole('button', { name: 'Close' }).click();
       await page.getByRole('button', { name: 'Chat History' }).click();
-      await expect(page.getByTestId('convo-item').first()).toBeVisible();
-      await expect(page.getByTestId('convo-item')).toHaveCount(1);
-      await expect(page.getByText(/Subagent:/)).toHaveCount(0);
+      const conversationRows = page.getByTestId('convo-item');
+      await expect(conversationRows.locator('button[aria-current="page"]')).toBeVisible();
+      for (const child of children) {
+        await expect(conversationRows.filter({ hasText: `Subagent: ${child.id}` })).toHaveCount(0);
+      }
     } finally {
       for (const agentId of createdAgentIds.reverse()) {
         await cleanupAgent(page, agentId);


### PR DESCRIPTION
## Summary

I added deterministic browser coverage for the detached-subagent activity lifecycle through LibreChat's real agent route, durable child-thread store, authenticated activity SSE endpoint, and artifacts-style panel.

- Create two child agents and one parent agent with a credential-free fake-model fan-out fixture.
- Verify both detached siblings start and expose durable task/thread handles.
- Verify a selected child streams `Running` and `Writing` activity after the parent turn has completed.
- Verify the selected live panel opens only one activity stream, both children complete, and terminal output remains available after reload.
- Verify durable child conversations remain absent from Chat History.
- Run the scenario in the focused Redis Playwright lane in addition to the standard in-memory mock lane.
- Isolate the fixture from the shared mock profile's approval HITL switch, because detached subagents intentionally reject runs configured for approval pauses.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npx playwright test --config=e2e/playwright.config.mock.ts subagent-activity.spec.ts`
- `E2E_STREAM_STORE=redis npx playwright test --config=e2e/playwright.config.redis.ts subagent-activity.spec.ts`
- `npx eslint --max-warnings=0 e2e/specs/mock/subagent-activity.spec.ts e2e/setup/fake-model.js e2e/playwright.config.redis.ts`
- `node --check e2e/setup/fake-model.js`
- `npm run sort-imports:check -- e2e/specs/mock/subagent-activity.spec.ts e2e/playwright.config.redis.ts`
- `git diff --check`

### **Test Configuration**:

- Chromium
- Credential-free in-process fake model
- In-memory MongoDB
- In-memory and Redis stream stores

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
