### PR TITLE
🛂 fix: Preserve Legacy Assistant Attribution

### DIFF
--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -3211,6 +3211,52 @@ describe('AgentClient - titleConvo', () => {
       ).toThrow(expect.objectContaining({ code: 'content_filter_block' }));
     });
 
+    it('preserves persisted assistant attribution at the final agent provider boundary', async () => {
+      const marker = 'E2E-PERSISTED-UNATTRIBUTED-ASSISTANT';
+      mockReq.config.filters = {
+        messages: {
+          pii: {
+            fields: ['text'],
+            starterPatterns: [],
+            customPatterns: [
+              {
+                id: 'persisted-unattributed-assistant',
+                label: 'persisted unattributed assistant content',
+                regex: `^${marker}$`,
+              },
+            ],
+          },
+          unattributedAssistantContent: 'inspect',
+        },
+      };
+      const storedMessage = {
+        messageId: 'legacy-assistant',
+        parentMessageId: null,
+        sender: 'Assistant',
+        text: marker,
+        isCreatedByUser: false,
+      };
+      client.setModelBoundStoredMessages([storedMessage]);
+
+      const result = await client.buildMessages([storedMessage], 'legacy-assistant', {}, {});
+      const { messages: providerMessages } = jest
+        .requireActual('@librechat/agents')
+        .formatAgentMessages(result.prompt);
+
+      expect(() =>
+        client
+          .createModelBoundChatModelCallback()
+          .handleChatModelStart(undefined, [providerMessages]),
+      ).toThrow(expect.objectContaining({ code: 'content_filter_block' }));
+
+      client.setModelBoundStoredMessages([{ ...storedMessage, isUserSubmitted: false }]);
+      expect(() =>
+        client
+          .createModelBoundChatModelCallback()
+          .handleChatModelStart(undefined, [providerMessages]),
+      ).not.toThrow();
+    });
+
     it('ignores historical file refs when this agent does not replay files', async () => {
       mockReq.config.filters = {
         files: {

--- a/packages/api/src/middleware/modelBoundContent.ts
+++ b/packages/api/src/middleware/modelBoundContent.ts
@@ -1986,7 +1986,9 @@ function projectStoredMessageForProvider(
     role: message.role,
     isCreatedByUser: message.isCreatedByUser,
     isUserSubmitted: message.isUserSubmitted,
-    ...(selectedContentPartIndices == null && messageContentCandidate == null && storedText != null
+    ...(messageContentCandidate == null &&
+    storedText != null &&
+    (selectedContentPartIndices == null || selectedContentPartIndices.has(0))
       ? { text: storedText }
       : {}),
     ...(attribution === 'user' && {


### PR DESCRIPTION
## Summary

I fixed the persisted-content-filter regression that was independently failing the Playwright E2E suite on `dev` in both memory and Redis modes.

Agent formatting normalizes a legacy assistant stored as top-level `text` into provider `content[0]`. The final provider-boundary filter then used that typed part index against the original persisted row, which has no `content` array, so it projected no text and incorrectly allowed the continuation. The canonical projection now maps selected part `0` back to the retained top-level text.

Explicitly attributed model output (`isUserSubmitted: false`) remains allowed.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `packages/api`: `modelBoundContent.spec.ts` — 193/193 passed
- `api`: `server/controllers/agents/client.test.js` — 156/156 passed
- Added an AgentClient regression that exercises the real two-pass agent formatting path and verifies both legacy-unattributed blocking and explicit-model allowance
- `npx tsc --noEmit -p packages/api/tsconfig.json`
- ESLint, Prettier, and `git diff --check`

### Test Configuration

- Node.js 24
- Current `origin/dev` at branch creation: `fc7d56dff`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes