### PR TITLE
🧭 feat: Choose a Schedule's Time Zone

### DIFF
--- a/client/src/components/SidePanel/Schedules/ScheduleDialog.tsx
+++ b/client/src/components/SidePanel/Schedules/ScheduleDialog.tsx
@@ -373,19 +373,22 @@ export default function ScheduleDialog({
       : undefined;
 
   /** Whether this submit carries a cadence at all: a pure rename does not, and the
-   *  API only validates a cadence it actually receives. Read by the interval floor
-   *  below as well as by the PATCH payload. */
+   *  API only validates a cadence it actually receives. Only touched cadence
+   *  CONTROLS count: a zone-only edit must not ship a cadence rebuilt from this
+   *  form, which would overwrite stored fields it cannot represent (an
+   *  API-created hourly cadence's nonzero hour, for one). */
   const cadenceTouched =
     dirtyFields.frequency === true ||
-    // The same expression is a different schedule in another zone, and the server
-    // recomputes the next run whenever the timezone changes, so this is a timing
-    // edit even when the cadence controls were never touched.
-    dirtyFields.timezone === true ||
     dirtyFields.hour12 === true ||
     dirtyFields.minute === true ||
     dirtyFields.meridiem === true ||
     dirtyFields.dayOfWeek === true ||
     dirtyFields.expression === true;
+  /** Whether this submit changes the schedule's TIMING. The zone alone re-times
+   *  every occurrence (the server recomputes the next run and re-measures the
+   *  interval floor against the effective cadence/zone pair), so the floor below
+   *  validates it even though no cadence travels with it. */
+  const timingTouched = cadenceTouched || dirtyFields.timezone === true;
 
   const onSubmit = (values: ScheduleFormValues) => {
     if (schedule) {
@@ -499,7 +502,7 @@ export default function ScheduleDialog({
    *  be submitted, and to any edit leaving the schedule enabled. Renaming a DISABLED
    *  schedule whose stored cadence predates a raised floor is a valid maintenance edit
    *  the API accepts, so the dialog must not hold it hostage to a timing change. */
-  const floorApplies = schedule == null || cadenceTouched || schedule.enabled;
+  const floorApplies = schedule == null || timingTouched || schedule.enabled;
 
   /** Checked against the SAME function the server enforces with, so the dialog never
    *  offers a submit the API would answer 400 to. Only meaningful once the expression

--- a/client/src/components/SidePanel/Schedules/ScheduleDialog.tsx
+++ b/client/src/components/SidePanel/Schedules/ScheduleDialog.tsx
@@ -34,19 +34,22 @@ import type {
 import type { TranslationKeys } from '~/hooks';
 import type { Meridiem } from './cadence';
 import {
+  to12Hour,
+  to24Hour,
+  describeCadence,
+  formatRunInstant,
+  formatScheduleDay,
+  resolveLocalTimezone,
+  buildTimezoneOptions,
+  formatTimezoneOffset,
+} from './cadence';
+import {
   useProjectQuery,
   useListAgentsQuery,
   useSchedulesQuery,
   useCreateScheduleMutation,
   useUpdateScheduleMutation,
 } from '~/data-provider';
-import {
-  to12Hour,
-  to24Hour,
-  describeCadence,
-  formatRunInstant,
-  formatScheduleDay,
-} from './cadence';
 import { useChatProjectPicker } from './useScheduleProjects';
 import { VariableEditor } from '~/components/Variables';
 import { useLocalize } from '~/hooks';
@@ -73,6 +76,7 @@ type ScheduleFormValues = {
   /** Only read when `frequency` is `cron`; held across a switch away and back so a
    *  user who tries a preset does not lose the expression they typed. */
   expression: string;
+  timezone: string;
 };
 
 const FREQUENCY_LABELS: Record<ScheduleFrequency, TranslationKeys> = {
@@ -98,6 +102,7 @@ const PREVIEW_RUN_COUNT = 3;
 const FORM_ID = 'schedule-form';
 
 const getDefaultValues = (schedule?: TSchedule): ScheduleFormValues => {
+  const localTimezone = resolveLocalTimezone();
   if (!schedule) {
     return {
       name: '',
@@ -110,6 +115,7 @@ const getDefaultValues = (schedule?: TSchedule): ScheduleFormValues => {
       meridiem: 'AM',
       dayOfWeek: 1,
       expression: DEFAULT_CRON,
+      timezone: localTimezone,
     };
   }
   const identity = {
@@ -117,6 +123,9 @@ const getDefaultValues = (schedule?: TSchedule): ScheduleFormValues => {
     prompt: schedule.prompt,
     agent_id: schedule.agent_id,
     chatProjectId: schedule.chatProjectId ?? '',
+    // A stored row always has one; the fallback only covers a legacy row written
+    // before the field existed, which would otherwise render an empty picker.
+    timezone: schedule.timezone || localTimezone,
   };
   const cadence = schedule.cadence;
   if (isCronCadence(cadence)) {
@@ -204,6 +213,7 @@ export default function ScheduleDialog({
   const meridiem = watch('meridiem');
   const dayOfWeek = watch('dayOfWeek');
   const expression = watch('expression');
+  const timezone = watch('timezone');
 
   const { data: agents } = useListAgentsQuery(
     { requiredPermission: PermissionBits.VIEW },
@@ -302,10 +312,13 @@ export default function ScheduleDialog({
     [locale],
   );
 
-  const timezone = useMemo(
-    () => schedule?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
-    [schedule],
-  );
+  const timezoneItems = useMemo(() => {
+    const zones = buildTimezoneOptions(resolveLocalTimezone(), schedule?.timezone);
+    return zones.map((zone) => {
+      const offset = formatTimezoneOffset(zone, locale);
+      return { value: zone, label: offset ? `${zone} (${offset})` : zone };
+    });
+  }, [schedule?.timezone, locale]);
 
   /** Idempotency key for the create being attempted. Held in a ref so every retry of
    *  the same intent reuses it, and rotated when the attempt SUCCEEDS or when the
@@ -364,6 +377,10 @@ export default function ScheduleDialog({
    *  below as well as by the PATCH payload. */
   const cadenceTouched =
     dirtyFields.frequency === true ||
+    // The same expression is a different schedule in another zone, and the server
+    // recomputes the next run whenever the timezone changes, so this is a timing
+    // edit even when the cadence controls were never touched.
+    dirtyFields.timezone === true ||
     dirtyFields.hour12 === true ||
     dirtyFields.minute === true ||
     dirtyFields.meridiem === true ||
@@ -391,6 +408,7 @@ export default function ScheduleDialog({
           ? { chatProjectId: values.chatProjectId || null }
           : {}),
         ...(cadenceTouched ? { cadence } : {}),
+        ...(dirtyFields.timezone === true ? { timezone: values.timezone } : {}),
       };
       // Nothing touched: a field-less PATCH is refused server-side (it would rotate
       // the schedule's fencing for a request that changes nothing), so just close.
@@ -421,7 +439,7 @@ export default function ScheduleDialog({
         ? { chatProjectId: values.chatProjectId }
         : {}),
       cadence: buildCadence(values),
-      timezone,
+      timezone: values.timezone,
       target: 'new' as const,
       enabled: true,
     };
@@ -506,7 +524,50 @@ export default function ScheduleDialog({
       : null;
   const canSubmit = cronIsValid && !belowFloor && !isLoading;
 
-  const summary = `${describeCadence(previewCadence, localize, locale)} · ${timezone}`;
+  /** The offset disambiguates two similar names, which matters now that the zone is
+   *  something the user picks rather than the browser's own. Memoized because it
+   *  builds an Intl formatter and the dialog re-renders per keystroke. */
+  const timezoneOffset = useMemo(() => formatTimezoneOffset(timezone, locale), [timezone, locale]);
+  const summary = `${describeCadence(previewCadence, localize, locale)} · ${
+    timezoneOffset ? `${timezone} (${timezoneOffset})` : timezone
+  }`;
+
+  /** A CELL in the cadence grid rather than a row of its own, in both modes. The
+   *  template's height budget is a contract (see its className below): scrolling is
+   *  off at `md`, so a full-width timezone row would push the footer's submit button
+   *  out of a 720px-tall viewport where it can never be scrolled back. */
+  const timezoneField = (
+    <fieldset className="space-y-2">
+      <legend>
+        <Label id="schedule-timezone-label" className="text-sm font-medium text-text-primary">
+          {localize('com_ui_schedule_timezone')}
+        </Label>
+      </legend>
+      <Controller
+        name="timezone"
+        control={control}
+        render={({ field }) => (
+          <ControlCombobox
+            selectedValue={field.value}
+            displayValue={field.value}
+            selectPlaceholder={localize('com_ui_schedule_timezone')}
+            searchPlaceholder={localize('com_ui_schedule_timezone_search')}
+            setValue={field.onChange}
+            items={timezoneItems}
+            ariaLabel={localize('com_ui_schedule_timezone')}
+            selectId="schedule-timezone"
+            isCollapsed={false}
+            showCarat={true}
+            placement="bottom-start"
+            /* Same focus-trap constraint as the agent picker above. */
+            portal={false}
+            matchTriggerWidth={true}
+            variant="field"
+          />
+        )}
+      />
+    </fieldset>
+  );
 
   return (
     <OGDialog open={open} onOpenChange={onOpenChange} triggerRef={triggerRef}>
@@ -730,40 +791,50 @@ export default function ScheduleDialog({
             </fieldset>
 
             {frequency === 'cron' ? (
-              <div className="space-y-2">
-                <Label htmlFor="schedule-cron" className="text-sm font-medium text-text-primary">
-                  {localize('com_ui_schedule_cron_expression')}
-                </Label>
-                <Input
-                  id="schedule-cron"
-                  className="w-full font-mono"
-                  spellCheck={false}
-                  autoComplete="off"
-                  placeholder={DEFAULT_CRON}
-                  maxLength={SCHEDULE_CRON_MAX_LENGTH}
-                  aria-invalid={!cronIsValid || belowFloor}
-                  aria-describedby={
-                    // The floor message renders under the summary as
-                    // `schedule-cadence-message`; a floor-violating expression must
-                    // still mark THIS input invalid and point at that message, or a
-                    // screen reader finds a disabled Create with no stated reason.
-                    belowFloor
-                      ? 'schedule-cron-hint schedule-cron-message schedule-cadence-message'
-                      : 'schedule-cron-hint schedule-cron-message'
-                  }
-                  data-testid="schedule-cron-input"
-                  {...register('expression')}
-                />
-                <p id="schedule-cron-hint" className="text-xs text-text-secondary">
-                  {localize('com_ui_schedule_cron_hint')}
-                </p>
-                <FieldMessage
-                  id="schedule-cron-message"
-                  message={cronIsValid ? undefined : localize('com_ui_schedule_cron_invalid')}
-                />
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="schedule-cron" className="text-sm font-medium text-text-primary">
+                    {localize('com_ui_schedule_cron_expression')}
+                  </Label>
+                  <Input
+                    id="schedule-cron"
+                    className="w-full font-mono"
+                    spellCheck={false}
+                    autoComplete="off"
+                    placeholder={DEFAULT_CRON}
+                    maxLength={SCHEDULE_CRON_MAX_LENGTH}
+                    aria-invalid={!cronIsValid || belowFloor}
+                    aria-describedby={
+                      // The floor message renders under the summary as
+                      // `schedule-cadence-message`; a floor-violating expression must
+                      // still mark THIS input invalid and point at that message, or a
+                      // screen reader finds a disabled Create with no stated reason.
+                      belowFloor
+                        ? 'schedule-cron-hint schedule-cron-message schedule-cadence-message'
+                        : 'schedule-cron-hint schedule-cron-message'
+                    }
+                    data-testid="schedule-cron-input"
+                    {...register('expression')}
+                  />
+                  <p id="schedule-cron-hint" className="text-xs text-text-secondary">
+                    {localize('com_ui_schedule_cron_hint')}
+                  </p>
+                  <FieldMessage
+                    id="schedule-cron-message"
+                    message={cronIsValid ? undefined : localize('com_ui_schedule_cron_invalid')}
+                  />
+                </div>
+                {timezoneField}
               </div>
             ) : (
-              <div className="grid gap-4 md:grid-cols-2">
+              <div
+                className={cn(
+                  'grid gap-4',
+                  // Three cells in weekly (day, time, zone) must still be ONE row at
+                  // md for the same height-budget reason the zone is a cell at all.
+                  frequency === 'weekly' ? 'md:grid-cols-3' : 'md:grid-cols-2',
+                )}
+              >
                 {frequency === 'weekly' && (
                   <fieldset className="space-y-2">
                     <legend>
@@ -861,6 +932,7 @@ export default function ScheduleDialog({
                     )}
                   </div>
                 </fieldset>
+                {timezoneField}
               </div>
             )}
 

--- a/client/src/components/SidePanel/Schedules/__tests__/ScheduleDialog.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/ScheduleDialog.spec.tsx
@@ -332,6 +332,76 @@ describe('ScheduleDialog', () => {
     });
   });
 
+  describe('timezone', () => {
+    it('defaults a new schedule to the browser zone and submits it', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await fillRequiredFields(user);
+
+      // Queried directly rather than scoped to role="dialog": the picker popovers
+      // render as dialogs of their own, so that scope goes ambiguous mid-file.
+      expect(screen.getByRole('combobox', { name: 'com_ui_schedule_timezone' })).toHaveTextContent(
+        Intl.DateTimeFormat().resolvedOptions().timeZone,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'com_ui_create' }));
+      await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+      expect(mockMutate.mock.calls[0][0].timezone).toBe(
+        Intl.DateTimeFormat().resolvedOptions().timeZone,
+      );
+    });
+
+    it('shows the stored zone rather than the browser one when editing', () => {
+      renderDialog(storedSchedule());
+
+      expect(screen.getByRole('combobox', { name: 'com_ui_schedule_timezone' })).toHaveTextContent(
+        'America/New_York',
+      );
+      expect(screen.getByTestId('schedule-summary')).toHaveTextContent('America/New_York');
+    });
+
+    it('sends a zone change on its own, without a cadence', async () => {
+      // The server recomputes the next run whenever the timezone changes, so a
+      // zone-only edit is a real timing edit and must reach it.
+      const user = userEvent.setup();
+      renderDialog(storedSchedule());
+
+      await user.click(screen.getByRole('combobox', { name: 'com_ui_schedule_timezone' }));
+      await user.type(screen.getByPlaceholderText('com_ui_schedule_timezone_search'), 'UTC');
+      await user.click(await screen.findByRole('option', { name: /^UTC/ }));
+
+      await user.click(screen.getByRole('button', { name: 'com_ui_save' }));
+      await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+      expect(mockMutate.mock.calls[0][0].payload.timezone).toBe('UTC');
+    });
+
+    it('validates a cron expression against the selected zone, not the browser one', async () => {
+      // `0 0,12 * * *` is a 12-hour gap nominally and an 11-hour one in New York on
+      // the day it springs forward, so a floor between the two accepts it in one zone
+      // and refuses it in the other.
+      mockLimits = { maxPerUser: 10, minIntervalMinutes: 700, requireProject: false };
+      const user = userEvent.setup();
+      renderDialog(
+        storedSchedule({
+          cadence: { frequency: 'cron', expression: '0 0,12 * * *' },
+          timezone: 'UTC',
+        }),
+      );
+
+      expect(screen.queryByText(/com_ui_schedule_min_interval/)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('combobox', { name: 'com_ui_schedule_timezone' }));
+      await user.type(
+        screen.getByPlaceholderText('com_ui_schedule_timezone_search'),
+        'America/New_York',
+      );
+      await user.click(await screen.findByRole('option', { name: /^America\/New_York/ }));
+
+      expect(screen.getByText(/com_ui_schedule_min_interval/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'com_ui_save' })).toBeDisabled();
+    });
+  });
+
   describe('project scope', () => {
     it('submits the chosen project so its runs are filed there', async () => {
       const user = userEvent.setup();

--- a/client/src/components/SidePanel/Schedules/__tests__/ScheduleDialog.spec.tsx
+++ b/client/src/components/SidePanel/Schedules/__tests__/ScheduleDialog.spec.tsx
@@ -373,6 +373,9 @@ describe('ScheduleDialog', () => {
       await user.click(screen.getByRole('button', { name: 'com_ui_save' }));
       await waitFor(() => expect(mockMutate).toHaveBeenCalled());
       expect(mockMutate.mock.calls[0][0].payload.timezone).toBe('UTC');
+      // And ONLY the zone: a cadence rebuilt from the form would overwrite stored
+      // fields the pickers cannot represent (an API-created hourly's nonzero hour).
+      expect(mockMutate.mock.calls[0][0].payload.cadence).toBeUndefined();
     });
 
     it('validates a cron expression against the selected zone, not the browser one', async () => {

--- a/client/src/components/SidePanel/Schedules/__tests__/cadence.spec.ts
+++ b/client/src/components/SidePanel/Schedules/__tests__/cadence.spec.ts
@@ -1,5 +1,5 @@
 import type { TScheduleCadence } from 'librechat-data-provider';
-import { describeCadence, formatRunInstant } from '../cadence';
+import { describeCadence, formatRunInstant, buildTimezoneOptions } from '../cadence';
 
 const localize = (key: string, vars?: Record<string, unknown>) =>
   vars ? `${key} ${JSON.stringify(vars)}` : key;
@@ -31,5 +31,31 @@ describe('formatRunInstant', () => {
     expect(formatRunInstant(instant, 'UTC', 'en-US')).toMatch(/9:05\s*PM/i);
     // Five hours behind UTC in January, so the same instant is a different clock time.
     expect(formatRunInstant(instant, 'America/New_York', 'en-US')).toMatch(/4:05\s*PM/i);
+  });
+});
+
+describe('buildTimezoneOptions', () => {
+  it('pins the local zone and UTC first, then browsable zones with no duplicates', () => {
+    const zones = buildTimezoneOptions('America/New_York');
+    expect(zones[0]).toBe('America/New_York');
+    expect(zones[1]).toBe('UTC');
+    expect(new Set(zones).size).toBe(zones.length);
+  });
+
+  it('includes modern IANA names the enumeration omits, wherever the engine accepts them', () => {
+    // `supportedValuesOf` reports CLDR's legacy canonical forms (Asia/Calcutta,
+    // Europe/Kiev); the names people search for must still find an option.
+    const zones = new Set(buildTimezoneOptions('America/New_York'));
+    for (const zone of ['Asia/Kolkata', 'Europe/Kyiv']) {
+      let accepted = true;
+      try {
+        new Intl.DateTimeFormat(undefined, { timeZone: zone });
+      } catch {
+        accepted = false;
+      }
+      if (accepted) {
+        expect(zones).toContain(zone);
+      }
+    }
   });
 });

--- a/client/src/components/SidePanel/Schedules/__tests__/cadence.spec.ts
+++ b/client/src/components/SidePanel/Schedules/__tests__/cadence.spec.ts
@@ -46,7 +46,7 @@ describe('buildTimezoneOptions', () => {
     // `supportedValuesOf` reports CLDR's legacy canonical forms (Asia/Calcutta,
     // Europe/Kiev); the names people search for must still find an option.
     const zones = new Set(buildTimezoneOptions('America/New_York'));
-    for (const zone of ['Asia/Kolkata', 'Europe/Kyiv']) {
+    for (const zone of ['Asia/Kolkata', 'Europe/Kyiv', 'America/Argentina/Buenos_Aires']) {
       let accepted = true;
       try {
         new Intl.DateTimeFormat(undefined, { timeZone: zone });

--- a/client/src/components/SidePanel/Schedules/cadence.ts
+++ b/client/src/components/SidePanel/Schedules/cadence.ts
@@ -80,22 +80,34 @@ export const formatRunInstant = (date: Date, timezone: string, locale?: string):
 export const resolveLocalTimezone = (): string =>
   Intl.DateTimeFormat().resolvedOptions().timeZone || UTC_TIMEZONE;
 
-/**
- * Every IANA zone the runtime knows, with the user's own zone and UTC pinned first.
- * `Intl.supportedValuesOf` is unavailable on older engines, so the pinned pair
- * doubles as the fallback list: a user who cannot browse zones can still keep the
- * one their schedule already uses.
- */
-/** Modern IANA names the runtime accepts but `supportedValuesOf` leaves out: that
- *  enumeration reports CLDR's legacy canonical forms (`Asia/Calcutta`,
+/** The modern IANA names the runtime accepts but `supportedValuesOf` leaves out:
+ *  that enumeration reports CLDR's legacy canonical forms (`Asia/Calcutta`,
  *  `Europe/Kiev`), so the name a user actually searches for would find nothing.
- *  Each entry is probed before inclusion, so an engine that rejects one drops it. */
+ *  This is tzdb's rename set, not every alias the runtime tolerates: deprecated
+ *  links (`US/Eastern`, `Etc/GMT+5`) point at zones already listed under their
+ *  canonical names, and offering them would duplicate each zone under a stale or
+ *  sign-inverted spelling. Each entry is probed before inclusion, so an engine
+ *  that rejects or already lists one simply drops it. */
 const MODERN_ZONE_NAMES = [
   'Asia/Kolkata',
   'Europe/Kyiv',
   'Asia/Ho_Chi_Minh',
   'Asia/Yangon',
+  'Asia/Kathmandu',
   'America/Nuuk',
+  'Africa/Asmara',
+  'Atlantic/Faroe',
+  'Pacific/Chuuk',
+  'Pacific/Pohnpei',
+  'Pacific/Kanton',
+  'America/Atikokan',
+  'America/Argentina/Buenos_Aires',
+  'America/Argentina/Catamarca',
+  'America/Argentina/Cordoba',
+  'America/Argentina/Jujuy',
+  'America/Argentina/Mendoza',
+  'America/Indiana/Indianapolis',
+  'America/Kentucky/Louisville',
 ];
 
 const zoneIsAccepted = (zone: string): boolean => {
@@ -107,6 +119,12 @@ const zoneIsAccepted = (zone: string): boolean => {
   }
 };
 
+/**
+ * Every IANA zone the runtime knows, with the user's own zone and UTC pinned first.
+ * `Intl.supportedValuesOf` is unavailable on older engines, so the pinned pair
+ * doubles as the fallback list: a user who cannot browse zones can still keep the
+ * one their schedule already uses.
+ */
 export const buildTimezoneOptions = (localTimezone: string, storedTimezone?: string): string[] => {
   const pinned = [localTimezone, UTC_TIMEZONE];
   if (storedTimezone != null && storedTimezone.length > 0) {
@@ -119,7 +137,7 @@ export const buildTimezoneOptions = (localTimezone: string, storedTimezone?: str
     new Set([
       ...listed,
       // Only when the engine could enumerate at all: the fallback list is the pinned
-      // pair by design, and five extra browsable names would not change that.
+      // pair by design, and extra browsable names would not change that.
       ...(listed.length > 0 ? MODERN_ZONE_NAMES.filter(zoneIsAccepted) : []),
     ]),
   )

--- a/client/src/components/SidePanel/Schedules/cadence.ts
+++ b/client/src/components/SidePanel/Schedules/cadence.ts
@@ -86,28 +86,70 @@ export const resolveLocalTimezone = (): string =>
  * doubles as the fallback list: a user who cannot browse zones can still keep the
  * one their schedule already uses.
  */
+/** Modern IANA names the runtime accepts but `supportedValuesOf` leaves out: that
+ *  enumeration reports CLDR's legacy canonical forms (`Asia/Calcutta`,
+ *  `Europe/Kiev`), so the name a user actually searches for would find nothing.
+ *  Each entry is probed before inclusion, so an engine that rejects one drops it. */
+const MODERN_ZONE_NAMES = [
+  'Asia/Kolkata',
+  'Europe/Kyiv',
+  'Asia/Ho_Chi_Minh',
+  'Asia/Yangon',
+  'America/Nuuk',
+];
+
+const zoneIsAccepted = (zone: string): boolean => {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export const buildTimezoneOptions = (localTimezone: string, storedTimezone?: string): string[] => {
   const pinned = [localTimezone, UTC_TIMEZONE];
   if (storedTimezone != null && storedTimezone.length > 0) {
     pinned.push(storedTimezone);
   }
   const seen = new Set(pinned);
-  const rest =
-    typeof Intl.supportedValuesOf === 'function'
-      ? Intl.supportedValuesOf('timeZone').filter((zone) => !seen.has(zone))
-      : [];
+  const listed =
+    typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : [];
+  const rest = Array.from(
+    new Set([
+      ...listed,
+      // Only when the engine could enumerate at all: the fallback list is the pinned
+      // pair by design, and five extra browsable names would not change that.
+      ...(listed.length > 0 ? MODERN_ZONE_NAMES.filter(zoneIsAccepted) : []),
+    ]),
+  )
+    .filter((zone) => !seen.has(zone))
+    .sort();
   return [...seen, ...rest];
 };
 
+/** Keyed by locale and zone. The offsets exist to tell two similar NAMES apart, so
+ *  serving one computed earlier in the session is fine even across a DST change,
+ *  and it saves rebuilding ~400 `Intl.DateTimeFormat`s on every dialog open. */
+const offsetCache = new Map<string, string>();
+
 /** The zone's current offset, e.g. `GMT+2`, so two similar names are tellable apart. */
 export const formatTimezoneOffset = (timezone: string, locale?: string): string => {
+  const cacheKey = `${locale ?? ''}|${timezone}`;
+  const cached = offsetCache.get(cacheKey);
+  if (cached != null) {
+    return cached;
+  }
+  let offset = '';
   try {
     const parts = new Intl.DateTimeFormat(locale, {
       timeZone: timezone,
       timeZoneName: 'shortOffset',
     }).formatToParts(new Date());
-    return parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+    offset = parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
   } catch {
-    return '';
+    offset = '';
   }
+  offsetCache.set(cacheKey, offset);
+  return offset;
 };

--- a/client/src/components/SidePanel/Schedules/cadence.ts
+++ b/client/src/components/SidePanel/Schedules/cadence.ts
@@ -13,6 +13,8 @@ const WEEKLY_DEFAULT_DAY = 1;
 /** August 1st, 2021 was a Sunday; anchors day-of-week indices 0-6 to real dates */
 const SUNDAY_UTC = Date.UTC(2021, 7, 1);
 
+export const UTC_TIMEZONE = 'UTC';
+
 export const to12Hour = (hour: number): { hour12: number; meridiem: Meridiem } => ({
   hour12: hour % 12 === 0 ? 12 : hour % 12,
   meridiem: hour >= 12 ? 'PM' : 'AM',
@@ -74,3 +76,38 @@ export const formatRunInstant = (date: Date, timezone: string, locale?: string):
     hour: 'numeric',
     minute: '2-digit',
   }).format(date);
+
+export const resolveLocalTimezone = (): string =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone || UTC_TIMEZONE;
+
+/**
+ * Every IANA zone the runtime knows, with the user's own zone and UTC pinned first.
+ * `Intl.supportedValuesOf` is unavailable on older engines, so the pinned pair
+ * doubles as the fallback list: a user who cannot browse zones can still keep the
+ * one their schedule already uses.
+ */
+export const buildTimezoneOptions = (localTimezone: string, storedTimezone?: string): string[] => {
+  const pinned = [localTimezone, UTC_TIMEZONE];
+  if (storedTimezone != null && storedTimezone.length > 0) {
+    pinned.push(storedTimezone);
+  }
+  const seen = new Set(pinned);
+  const rest =
+    typeof Intl.supportedValuesOf === 'function'
+      ? Intl.supportedValuesOf('timeZone').filter((zone) => !seen.has(zone))
+      : [];
+  return [...seen, ...rest];
+};
+
+/** The zone's current offset, e.g. `GMT+2`, so two similar names are tellable apart. */
+export const formatTimezoneOffset = (timezone: string, locale?: string): string => {
+  try {
+    const parts = new Intl.DateTimeFormat(locale, {
+      timeZone: timezone,
+      timeZoneName: 'shortOffset',
+    }).formatToParts(new Date());
+    return parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+  } catch {
+    return '';
+  }
+};

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1909,6 +1909,8 @@
   "com_ui_schedule_runs_weekly": "Runs weekly on {{days}} at {{time}}",
   "com_ui_schedule_target_new_chat": "Each run starts a new chat with this agent",
   "com_ui_schedule_time": "Time",
+  "com_ui_schedule_timezone": "Time zone",
+  "com_ui_schedule_timezone_search": "Search time zones",
   "com_ui_schedule_updated": "Schedule updated",
   "com_ui_schedule_weekdays": "Weekdays",
   "com_ui_schedule_weekly": "Weekly",


### PR DESCRIPTION
## Summary

A schedule's timezone was whatever zone the browser reported at creation, and nothing in the dialog could change it afterwards. That is wrong for anyone who travels, for a shared account, and for a team schedule that should follow an office rather than whoever happened to open the dialog.

The zone becomes a picker over every IANA zone the runtime knows, with the user's own zone and UTC pinned first. `Intl.supportedValuesOf` is unavailable on older engines, so that pinned pair doubles as the fallback list: a user who cannot browse zones can still keep the one their schedule already uses. Each option carries its current offset (`America/New_York (GMT-4)`), since a name alone does not tell two similar zones apart.

A zone change on its own is a timing edit and is submitted like one: the server recomputes the next run whenever the timezone changes and measures the interval floor against the effective cadence/zone pair. The dialog mirrors that, so the cron field validates against the selected zone and the floor is measured in it: `0 0,12 * * *` is a 12-hour gap in UTC and an 11-hour one in `America/New_York` on the day it springs forward, and a floor between the two must reject the move at edit time rather than after submit.

Stacked on #15084 (custom cron cadence); the base should be retargeted to `dev` when that merges.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Translation update

## Testing

- `cd client && npx jest src/components/SidePanel/Schedules`: new schedules default to the browser zone and submit it; editing shows the stored zone, not the browser one; a zone-only PATCH reaches the server without a cadence; a cron cadence re-validates against the newly selected zone and the floor blocks the DST-compressed case.
- `npx eslint`, `prettier --check`, `sort-imports --check`, and `tsc --noEmit` clean.

### **Test Configuration**:

- Node v24.16.0, Jest in `client/`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
