### PR TITLE
📦 chore: bump `@librechat/agents` to v3.6.12

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.11",
+    "@librechat/agents": "^3.6.12",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.11",
+        "@librechat/agents": "^3.6.12",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10630,9 +10630,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.11.tgz",
-      "integrity": "sha512-/VK9BpP5BHtWUQWJ34gMv+cOvfd9qoJepaolAm3/GXLQWBmQKHPMHUsN8C6JWUdQTWSRgtvHCGCaxzjV9hNCyQ==",
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.12.tgz",
+      "integrity": "sha512-S73bRfCJ4bklASObib7gpSn9Vm0IkJ9ZmVgtzcKzUYju8lkb18vU9FcK1ZFcyZl7/FZAQbHIHRYBDKHMqEn7xg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42822,7 +42822,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.11",
+        "@librechat/agents": "^3.6.12",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.11",
+    "@librechat/agents": "^3.6.12",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

- bump `@librechat/agents` from `3.6.11` to `3.6.12` in both LibreChat consumers
- refresh the root lockfile to the published `3.6.12` artifact
- pick up incremental context-pressure measurement and provider-request preparation improvements

## Verification

- confirmed `@librechat/agents@3.6.12` is published on npm
- regenerated the package lock with npm workspaces
- `git diff --check`
- npm audit during lockfile refresh: 0 vulnerabilities