### PR TITLE
⏱️ test: Stabilize Meilisearch Retry Cleanup Assertion

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -55,23 +55,21 @@ const createDynamicMeiliModel = (modelName: string): DynamicMeiliModel => {
 
 const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-const waitForMock = async (mock: jest.Mock, timeoutMs = 2000): Promise<void> => {
+const waitForCondition = async (
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 2000,
+): Promise<void> => {
   const start = Date.now();
-  while (mock.mock.calls.length === 0 && Date.now() - start <= timeoutMs) {
+  while (!(await condition()) && Date.now() - start <= timeoutMs) {
     await wait(10);
   }
 };
 
-const waitForMockCalls = async (
-  mock: jest.Mock,
-  callCount: number,
-  timeoutMs = 2000,
-): Promise<void> => {
-  const start = Date.now();
-  while (mock.mock.calls.length < callCount && Date.now() - start <= timeoutMs) {
-    await wait(10);
-  }
-};
+const waitForMock = (mock: jest.Mock, timeoutMs = 2000): Promise<void> =>
+  waitForCondition(() => mock.mock.calls.length > 0, timeoutMs);
+
+const waitForMockCalls = (mock: jest.Mock, callCount: number, timeoutMs = 2000): Promise<void> =>
+  waitForCondition(() => mock.mock.calls.length >= callCount, timeoutMs);
 
 const mockAddDocuments = jest.fn();
 const mockAddDocumentsInBatches = jest.fn();
@@ -644,10 +642,16 @@ describe('Meilisearch Mongoose plugin', () => {
       subagentKind: 'agent',
       depth: 1,
     };
-    mockWaitForTask.mockResolvedValueOnce({ status: 'failed' });
+    mockWaitForTask.mockResolvedValueOnce({ status: 'failed' }).mockImplementationOnce(async () => {
+      await wait(50);
+      return { status: 'succeeded' };
+    });
     await conversation!.save();
     await waitForMockCalls(mockWaitForTask, 2);
-    await wait(25);
+    await waitForCondition(async () => {
+      const storedDoc = await conversationModel.collection.findOne({ conversationId });
+      return storedDoc?._meiliIndex === undefined && storedDoc?._meiliIndexAttempted === undefined;
+    });
     const storedDoc = await conversationModel.collection.findOne({ conversationId });
 
     expect(mockDeleteDocument).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
I stabilized the Meilisearch retry cleanup test so it observes the persisted asynchronous result instead of relying on a fixed sleep.

- Reused a bounded condition waiter for mock-call and persisted-state polling.
- Delayed the successful retry to exercise the asynchronous cleanup window deterministically.
- Asserted cleanup only after MongoDB removes both Meilisearch marker fields.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the changed test file with Prettier 3.5.3 using the repository formatting options.
- Verified the patch with git diff --check.
- Passed the GitHub Actions Tests: data-schemas full unit suite.

### **Test Configuration**:

- Node.js 24.16.0
- Ubuntu 24.04 GitHub Actions runner

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works