### PR TITLE
🧮 perf: Enable Agent Context Count Reuse

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.12",
+    "@librechat/agents": "^3.6.13",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -17,7 +17,7 @@ const {
   omitTitleOptions,
   getProviderConfig,
   memoryInstructions,
-  createTokenCounter,
+  createCachedTokenCounter,
   applyContextToAgent,
   isMemoryAgentEnabled,
   recordCollectedUsage,
@@ -3249,7 +3249,7 @@ class AgentClient extends BaseClient {
       };
 
       const toolSet = buildToolSet(this.options.agent);
-      const tokenCounter = createTokenCounter(this.getEncoding());
+      const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */
       const skillPrimeResult = this.options.primeInvokedSkills
@@ -3889,7 +3889,7 @@ class AgentClient extends BaseClient {
         this.contentParts.push(...seedContent);
       }
 
-      const tokenCounter = createTokenCounter(this.getEncoding());
+      const tokenCounter = await createCachedTokenCounter(this.getEncoding());
       const agents = collectReachableAgents([
         this.options.agent,
         ...(this.agentConfigs?.size > 0 ? this.agentConfigs.values() : []),

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -47,7 +47,7 @@ jest.mock('@librechat/api', () => ({
   createRun: (...args) => mockCreateRun(...args),
   countFormattedMessageTokens: jest.fn(() => 42),
   countTokens: jest.fn((text) => Math.ceil(String(text ?? '').length / 4)),
-  createTokenCounter: jest.fn(() => jest.fn(() => 0)),
+  createCachedTokenCounter: jest.fn(async () => jest.fn(() => 0)),
   createDetachedSubagentUsageRecorder: (...args) =>
     mockCreateDetachedSubagentUsageRecorder(...args),
   captureAgentCheckpointGeneration: (...args) => mockCaptureAgentCheckpointGeneration(...args),

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.12",
+        "@librechat/agents": "^3.6.13",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10630,9 +10630,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.12",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.12.tgz",
-      "integrity": "sha512-S73bRfCJ4bklASObib7gpSn9Vm0IkJ9ZmVgtzcKzUYju8lkb18vU9FcK1ZFcyZl7/FZAQbHIHRYBDKHMqEn7xg==",
+      "version": "3.6.13",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.13.tgz",
+      "integrity": "sha512-nrcxEKwJDmIDsGf7txLqTgqqSKkJKl90xS5vqTtAoYSi4/EVPZ6ZFpJHLT3WMn2nWL5jjxdOmstet3JbSF1B+A==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42822,7 +42822,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.12",
+        "@librechat/agents": "^3.6.13",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.12",
+    "@librechat/agents": "^3.6.13",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",

--- a/packages/api/src/agents/client.spec.ts
+++ b/packages/api/src/agents/client.spec.ts
@@ -3,7 +3,7 @@ import { Providers, StandardGraph } from '@librechat/agents';
 import { HumanMessage } from '@librechat/agents/langchain/messages';
 import type { TMessage } from 'librechat-data-provider';
 import {
-  createTokenCounter,
+  createCachedTokenCounter,
   prependQuotes,
   prependFileContext,
   applyAttachmentOnlyText,
@@ -14,10 +14,11 @@ import Tokenizer from '~/utils/tokenizer';
 
 describe('createTokenCounter', () => {
   it('enables stable-message reuse in the agents runtime', async () => {
-    await Tokenizer.initEncoding('o200k_base');
+    const initEncoding = jest.spyOn(Tokenizer, 'initEncoding');
     const getTokenCount = jest.spyOn(Tokenizer, 'getTokenCount');
     try {
-      const tokenCounter = createTokenCounter('o200k_base');
+      const tokenCounter = await createCachedTokenCounter('o200k_base');
+      expect(initEncoding).toHaveBeenCalledWith('o200k_base');
       const graph = new StandardGraph({
         runId: 'token-cache-integration',
         agents: [
@@ -41,6 +42,7 @@ describe('createTokenCounter', () => {
       expect(callsAfterFirstCount).toBeGreaterThan(0);
       expect(getTokenCount).toHaveBeenCalledTimes(callsAfterFirstCount);
     } finally {
+      initEncoding.mockRestore();
       getTokenCount.mockRestore();
     }
   });

--- a/packages/api/src/agents/client.spec.ts
+++ b/packages/api/src/agents/client.spec.ts
@@ -1,4 +1,5 @@
 import { ContentTypes } from 'librechat-data-provider';
+import { Tokenizer as AiTokenizer } from 'ai-tokenizer';
 import { Providers, StandardGraph } from '@librechat/agents';
 import { HumanMessage } from '@librechat/agents/langchain/messages';
 import type { TMessage } from 'librechat-data-provider';
@@ -10,15 +11,12 @@ import {
   type FormattedMessageWithContent,
 } from './client';
 import { ATTACHMENT_ONLY_TEXT } from '~/files/context';
-import Tokenizer from '~/utils/tokenizer';
 
-describe('createTokenCounter', () => {
+describe('createCachedTokenCounter', () => {
   it('enables stable-message reuse in the agents runtime', async () => {
-    const initEncoding = jest.spyOn(Tokenizer, 'initEncoding');
-    const getTokenCount = jest.spyOn(Tokenizer, 'getTokenCount');
+    const getTokenCount = jest.spyOn(AiTokenizer.prototype, 'count');
     try {
       const tokenCounter = await createCachedTokenCounter('o200k_base');
-      expect(initEncoding).toHaveBeenCalledWith('o200k_base');
       const graph = new StandardGraph({
         runId: 'token-cache-integration',
         agents: [
@@ -42,7 +40,6 @@ describe('createTokenCounter', () => {
       expect(callsAfterFirstCount).toBeGreaterThan(0);
       expect(getTokenCount).toHaveBeenCalledTimes(callsAfterFirstCount);
     } finally {
-      initEncoding.mockRestore();
       getTokenCount.mockRestore();
     }
   });

--- a/packages/api/src/agents/client.spec.ts
+++ b/packages/api/src/agents/client.spec.ts
@@ -1,12 +1,50 @@
 import { ContentTypes } from 'librechat-data-provider';
+import { Providers, StandardGraph } from '@librechat/agents';
+import { HumanMessage } from '@librechat/agents/langchain/messages';
 import type { TMessage } from 'librechat-data-provider';
 import {
+  createTokenCounter,
   prependQuotes,
   prependFileContext,
   applyAttachmentOnlyText,
   type FormattedMessageWithContent,
 } from './client';
 import { ATTACHMENT_ONLY_TEXT } from '~/files/context';
+import Tokenizer from '~/utils/tokenizer';
+
+describe('createTokenCounter', () => {
+  it('enables stable-message reuse in the agents runtime', async () => {
+    await Tokenizer.initEncoding('o200k_base');
+    const getTokenCount = jest.spyOn(Tokenizer, 'getTokenCount');
+    try {
+      const tokenCounter = createTokenCounter('o200k_base');
+      const graph = new StandardGraph({
+        runId: 'token-cache-integration',
+        agents: [
+          {
+            agentId: 'primary',
+            provider: Providers.OPENAI,
+            instructions: 'Test instructions',
+          },
+        ],
+        tokenCounter,
+      });
+      const agentContext = graph.agentContexts.get('primary');
+      await agentContext?.tokenCalculationPromise;
+      getTokenCount.mockClear();
+      const message = new HumanMessage('Stable retained context');
+
+      agentContext?.contextPressureTokenCounts?.count(message);
+      const callsAfterFirstCount = getTokenCount.mock.calls.length;
+      agentContext?.contextPressureTokenCounts?.count(message);
+
+      expect(callsAfterFirstCount).toBeGreaterThan(0);
+      expect(getTokenCount).toHaveBeenCalledTimes(callsAfterFirstCount);
+    } finally {
+      getTokenCount.mockRestore();
+    }
+  });
+});
 
 describe('prependFileContext', () => {
   it('prepends file context to string content', () => {

--- a/packages/api/src/agents/client.ts
+++ b/packages/api/src/agents/client.ts
@@ -8,8 +8,8 @@ import {
   estimateAnthropicImageTokens,
   markTokenCounterCacheCompatible,
 } from '@librechat/agents';
-import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { MessageContentComplex, TokenCounter } from '@librechat/agents';
+import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { Agent, TMessage } from 'librechat-data-provider';
 import type { ServerRequest } from '~/types';
 import { getSafeErrorMetadata, mergeQuotedText, formatQuotesAsMarkdown } from '~/utils';

--- a/packages/api/src/agents/client.ts
+++ b/packages/api/src/agents/client.ts
@@ -9,7 +9,7 @@ import {
   markTokenCounterCacheCompatible,
 } from '@librechat/agents';
 import type { BaseMessage } from '@librechat/agents/langchain/messages';
-import type { MessageContentComplex } from '@librechat/agents';
+import type { MessageContentComplex, TokenCounter } from '@librechat/agents';
 import type { Agent, TMessage } from 'librechat-data-provider';
 import type { ServerRequest } from '~/types';
 import { getSafeErrorMetadata, mergeQuotedText, formatQuotesAsMarkdown } from '~/utils';
@@ -381,17 +381,24 @@ export function countFormattedMessageTokens(
 
 export function createTokenCounter(
   encoding: Parameters<typeof Tokenizer.getTokenCount>[1],
-): (message: BaseMessage) => number {
+): TokenCounter {
   const isClaude = encoding === 'claude';
   const countTokens = (text: string) => Tokenizer.getTokenCount(text, encoding);
-  return markTokenCounterCacheCompatible(function (message: BaseMessage): number {
+  return function (message: BaseMessage): number {
     const count = getTokenCountForMessage(
       message,
       countTokens,
       encoding as 'claude' | 'o200k_base',
     );
     return isClaude ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION) : count;
-  });
+  };
+}
+
+export async function createCachedTokenCounter(
+  encoding: Parameters<typeof Tokenizer.getTokenCount>[1],
+): Promise<TokenCounter> {
+  await Tokenizer.initEncoding(encoding ?? 'o200k_base');
+  return markTokenCounterCacheCompatible(createTokenCounter(encoding));
 }
 
 export function logToolError(_graph: unknown, error: unknown, toolId: string): void {

--- a/packages/api/src/agents/client.ts
+++ b/packages/api/src/agents/client.ts
@@ -382,8 +382,16 @@ export function countFormattedMessageTokens(
 export function createTokenCounter(
   encoding: Parameters<typeof Tokenizer.getTokenCount>[1],
 ): TokenCounter {
+  return createMessageTokenCounter(encoding, (text: string) =>
+    Tokenizer.getTokenCount(text, encoding),
+  );
+}
+
+function createMessageTokenCounter(
+  encoding: Parameters<typeof Tokenizer.getTokenCount>[1],
+  countTokens: (text: string) => number,
+): TokenCounter {
   const isClaude = encoding === 'claude';
-  const countTokens = (text: string) => Tokenizer.getTokenCount(text, encoding);
   return function (message: BaseMessage): number {
     const count = getTokenCountForMessage(
       message,
@@ -397,8 +405,8 @@ export function createTokenCounter(
 export async function createCachedTokenCounter(
   encoding: Parameters<typeof Tokenizer.getTokenCount>[1],
 ): Promise<TokenCounter> {
-  await Tokenizer.initEncoding(encoding ?? 'o200k_base');
-  return markTokenCounterCacheCompatible(createTokenCounter(encoding));
+  const countTokens = await Tokenizer.createExactTokenCounter(encoding ?? 'o200k_base');
+  return markTokenCounterCacheCompatible(createMessageTokenCounter(encoding, countTokens));
 }
 
 export function logToolError(_graph: unknown, error: unknown, toolId: string): void {

--- a/packages/api/src/agents/client.ts
+++ b/packages/api/src/agents/client.ts
@@ -379,7 +379,9 @@ export function countFormattedMessageTokens(
   return isClaude ? Math.ceil(numTokens * CLAUDE_TOKEN_CORRECTION) : numTokens;
 }
 
-export function createTokenCounter(encoding: Parameters<typeof Tokenizer.getTokenCount>[1]) {
+export function createTokenCounter(
+  encoding: Parameters<typeof Tokenizer.getTokenCount>[1],
+): (message: BaseMessage) => number {
   const isClaude = encoding === 'claude';
   const countTokens = (text: string) => Tokenizer.getTokenCount(text, encoding);
   return markTokenCounterCacheCompatible(function (message: BaseMessage): number {

--- a/packages/api/src/agents/client.ts
+++ b/packages/api/src/agents/client.ts
@@ -6,6 +6,7 @@ import {
   getTokenCountForMessage,
   estimateOpenAIImageTokens,
   estimateAnthropicImageTokens,
+  markTokenCounterCacheCompatible,
 } from '@librechat/agents';
 import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { MessageContentComplex } from '@librechat/agents';
@@ -381,14 +382,14 @@ export function countFormattedMessageTokens(
 export function createTokenCounter(encoding: Parameters<typeof Tokenizer.getTokenCount>[1]) {
   const isClaude = encoding === 'claude';
   const countTokens = (text: string) => Tokenizer.getTokenCount(text, encoding);
-  return function (message: BaseMessage): number {
+  return markTokenCounterCacheCompatible(function (message: BaseMessage): number {
     const count = getTokenCountForMessage(
       message,
       countTokens,
       encoding as 'claude' | 'o200k_base',
     );
     return isClaude ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION) : count;
-  };
+  });
 }
 
 export function logToolError(_graph: unknown, error: unknown, toolId: string): void {

--- a/packages/api/src/utils/tokenizer.spec.ts
+++ b/packages/api/src/utils/tokenizer.spec.ts
@@ -1,3 +1,4 @@
+import { Tokenizer as AiTokenizer } from 'ai-tokenizer';
 import Tokenizer from './tokenizer';
 
 jest.mock('@librechat/data-schemas', () => ({
@@ -51,6 +52,21 @@ describe('Tokenizer', () => {
     it('should count tokens using claude encoding', () => {
       const count = Tokenizer.getTokenCount('Hello, world!', 'claude');
       expect(count).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createExactTokenCounter', () => {
+    it('throws instead of returning a fallback estimate after a tokenizer failure', async () => {
+      const counter = await Tokenizer.createExactTokenCounter('o200k_base');
+      const count = jest.spyOn(AiTokenizer.prototype, 'count').mockImplementationOnce(() => {
+        throw new Error('tokenizer failed');
+      });
+      try {
+        expect(() => counter('Stable cached context')).toThrow('tokenizer failed');
+      } finally {
+        count.mockRestore();
+        await Tokenizer.initEncoding('o200k_base');
+      }
     });
   });
 });

--- a/packages/api/src/utils/tokenizer.ts
+++ b/packages/api/src/utils/tokenizer.ts
@@ -27,6 +27,23 @@ class Tokenizer {
     return this.loadingPromises[encoding];
   }
 
+  /** Returns a counter that never substitutes an estimate for tokenizer errors. */
+  async createExactTokenCounter(encoding: EncodingName): Promise<(text: string) => number> {
+    await this.initEncoding(encoding);
+    const tokenizer = this.tokenizersCache[encoding];
+    if (!tokenizer) {
+      throw new Error(`Tokenizer encoding failed to initialize: ${encoding}`);
+    }
+    return (text: string): number => {
+      try {
+        return tokenizer.count(text);
+      } catch (error) {
+        this.handleCountError(encoding, tokenizer, error);
+        throw error;
+      }
+    };
+  }
+
   getTokenCount(text: string, encoding: EncodingName = 'o200k_base'): number {
     const tokenizer = this.tokenizersCache[encoding];
     if (!tokenizer) {
@@ -36,12 +53,21 @@ class Tokenizer {
     try {
       return tokenizer.count(text);
     } catch (error) {
-      logger.error('[Tokenizer] Error getting token count:', error);
-      delete this.tokenizersCache[encoding];
-      delete this.loadingPromises[encoding];
-      this.initEncoding(encoding);
+      this.handleCountError(encoding, tokenizer, error);
       return Math.ceil(text.length / 4);
     }
+  }
+
+  private handleCountError(encoding: EncodingName, tokenizer: AiTokenizer, error: unknown): void {
+    logger.error('[Tokenizer] Error getting token count:', error);
+    if (this.tokenizersCache[encoding] !== tokenizer) {
+      return;
+    }
+    delete this.tokenizersCache[encoding];
+    delete this.loadingPromises[encoding];
+    void this.initEncoding(encoding).catch((initError: unknown) => {
+      logger.error(`[Tokenizer] Error reloading ${encoding} encoding:`, initError);
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

I enabled LibreChat's deterministic token-counter wrapper to reuse exact stable-message counts in `@librechat/agents` and upgraded the agents dependency to 3.6.13.

- Add an awaited cache-compatible counter constructor that initializes the tokenizer encoding before opting into the agents runtime's conservative exact-count cache.
- Preserve the existing synchronous fallback counter without a cache marker so temporary startup estimates are never retained.
- Switch both new-run and resume agent paths to await the initialized counter.
- Preserve exact recount behavior for mutable, structured, proxy-backed, tool-call, and otherwise ambiguous messages through the agents-side safety boundary.
- Upgrade both API dependency manifests and the root lockfile to the published `@librechat/agents@3.6.13` artifact.
- Add a real `StandardGraph` integration test proving initialization precedes reuse and a second count of the same stable message does not invoke LibreChat's tokenizer again.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Built `librechat-data-provider` and `@librechat/data-schemas` for workspace test resolution.
- Ran `npm run build` from `packages/api` (including isolated declaration generation).
- Ran `npx jest --config jest.config.mjs src/agents/client.spec.ts --runInBand` from `packages/api` (15 tests passed).
- Ran `NODE_ENV=test npx jest --config api/jest.config.js api/server/controllers/agents/client.test.js --runInBand` (157 tests passed).
- Ran scoped ESLint for both modified TypeScript and JavaScript production/test files.
- Ran `npx tsc -p packages/api/tsconfig.json --noEmit`.
- Ran `git diff --check`.
- Regenerated `package-lock.json` from the published npm package with `npm install --package-lock-only --ignore-scripts`.

### **Test Configuration**:

- Node.js 24
- npm 10
- `@librechat/agents` 3.6.13 from npm
- Tokenizer encoding: `o200k_base`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
