### PR TITLE
🍃 ci: Cache MongoDB Memory-Server Binaries in Backend Test Jobs

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -262,6 +262,19 @@ jobs:
       - name: Prepare .env.test file
         run: cp api/test/.env.test.example api/test/.env.test
 
+      # mongodb-memory-server cold-downloads a ~122MB MongoDB binary into
+      # ~/.cache/mongodb-binaries on first use — inside a 15s beforeAll hook, which is a
+      # timeout on a slow mirror day. Every MISSED verdict the codegraph shadow evaluator has
+      # ever recorded (9 across 6 PRs) plus several chronically flaky suites trace to exactly
+      # this download. restore-keys keeps the previous binary warm across lockfile churn; a
+      # genuinely new binary version downloads once and re-saves.
+      - name: Cache MongoDB memory-server binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests (shard ${{ matrix.shard }}/3)
         run: cd api && npm run test:ci -- --shard=${{ matrix.shard }}/3
 
@@ -300,6 +313,19 @@ jobs:
           name: build-data-provider
           path: packages/data-provider/dist
 
+      # mongodb-memory-server cold-downloads a ~122MB MongoDB binary into
+      # ~/.cache/mongodb-binaries on first use — inside a 15s beforeAll hook, which is a
+      # timeout on a slow mirror day. Every MISSED verdict the codegraph shadow evaluator has
+      # ever recorded (9 across 6 PRs) plus several chronically flaky suites trace to exactly
+      # this download. restore-keys keeps the previous binary warm across lockfile churn; a
+      # genuinely new binary version downloads once and re-saves.
+      - name: Cache MongoDB memory-server binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests
         run: cd packages/data-provider && npm run test:ci
 
@@ -344,6 +370,19 @@ jobs:
           name: build-data-schemas
           path: packages/data-schemas/dist
 
+      # mongodb-memory-server cold-downloads a ~122MB MongoDB binary into
+      # ~/.cache/mongodb-binaries on first use — inside a 15s beforeAll hook, which is a
+      # timeout on a slow mirror day. Every MISSED verdict the codegraph shadow evaluator has
+      # ever recorded (9 across 6 PRs) plus several chronically flaky suites trace to exactly
+      # this download. restore-keys keeps the previous binary warm across lockfile churn; a
+      # genuinely new binary version downloads once and re-saves.
+      - name: Cache MongoDB memory-server binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests
         run: cd packages/data-schemas && npm run test:ci
 
@@ -402,5 +441,18 @@ jobs:
           name: build-api
           path: packages/api/dist
 
+      # mongodb-memory-server cold-downloads a ~122MB MongoDB binary into
+      # ~/.cache/mongodb-binaries on first use — inside a 15s beforeAll hook, which is a
+      # timeout on a slow mirror day. Every MISSED verdict the codegraph shadow evaluator has
+      # ever recorded (9 across 6 PRs) plus several chronically flaky suites trace to exactly
+      # this download. restore-keys keeps the previous binary warm across lockfile churn; a
+      # genuinely new binary version downloads once and re-saves.
+      - name: Cache MongoDB memory-server binaries
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests (shard ${{ matrix.shard }}/4)
         run: cd packages/api && npm run test:ci -- --shard=${{ matrix.shard }}/4


### PR DESCRIPTION
## Problem

`mongodb-memory-server` cold-downloads a **~122MB** MongoDB binary into `~/.cache/mongodb-binaries` on first use — inside each suite's `beforeAll`, which has a 15s hook timeout. On a slow mirror day the hook times out and the suite fails before running a single test.

This is not hypothetical noise: the codegraph shadow evaluator has been scoring every real CI failure for a week, and **every MISSED verdict it ever recorded (9 failures across 6 unrelated PRs) traces to exactly this download** — `agent.spec`, `conversation.spec`, `share.test`, `openid.spec`, `userGroup.spec`, `mongoMeili.spec`. Several of those are also chronic flakes in its ledger. Nine runners (api ×3 shards, @librechat/api ×4 shards, data-provider, data-schemas) each pay the download per run.

## Fix

One `actions/cache` step per jest job for `~/.cache/mongodb-binaries`, keyed on OS + lockfile hash with an OS-prefix `restore-keys` — lockfile churn still restores the previous binary, and a genuinely new MongoDB version downloads once and re-saves. No test or config changes; the 15s hook is generous once the download is warm.

Validated with a strict YAML parse; each of the four jobs carries exactly one cache step.