### PR TITLE
⛩️ ci: Gate Backend Jest on Codegraph Selection (Stage 1)

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -1,5 +1,20 @@
 name: Backend Unit Tests
 on:
+  # push-to-dev runs are the post-merge safety net: gating only ever narrows pull_request
+  # synchronize runs, so every merged state still gets the full suite — which is also what
+  # keeps ground-truth recall telemetry alive for the codegraph shadow evaluator once
+  # selection hides skipped tests from PR runs.
+  push:
+    branches:
+      - dev
+    paths:
+      - 'api/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'config/circular-deps.mjs'
+      - '.github/workflows/backend-review.yml'
+      - '!**.md'
   pull_request:
     paths:
       - 'api/**'
@@ -104,6 +119,104 @@ jobs:
           path: packages/api/dist
           retention-days: 2
 
+
+  # Codegraph test selection — the GATE (stage 1: backend jest only).
+  #
+  # Paranoia policy: FULL on opened/reopened PRs and on every push to dev (see the push
+  # trigger above); SELECTED only on pull_request synchronize. Fork PRs carry no secrets, so
+  # the curl fails and everything falls back to FULL. Kill switch: set repo variable
+  # CODEGRAPH_GATING=off and this job skips, which makes every output empty and every test
+  # job behave exactly as before this workflow change. The server itself fails open (stale
+  # graph, unclassifiable change, root/lockfile floors => mode FULL per workspace), and this
+  # job emits nothing unless the response parses end to end — the worst case at every layer
+  # is "CI runs everything", which is the pre-gating behavior.
+  codegraph_select:
+    name: Codegraph select
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'synchronize' &&
+      vars.CODEGRAPH_GATING != 'off'
+    outputs:
+      decided: ${{ steps.sel.outputs.decided }}
+      api_run: ${{ steps.sel.outputs.api_run }}
+      api_files: ${{ steps.sel.outputs.api_files }}
+      pkgapi_run: ${{ steps.sel.outputs.pkgapi_run }}
+      pkgapi_files: ${{ steps.sel.outputs.pkgapi_files }}
+      dataprovider_run: ${{ steps.sel.outputs.dataprovider_run }}
+      dataprovider_files: ${{ steps.sel.outputs.dataprovider_files }}
+      dataschemas_run: ${{ steps.sel.outputs.dataschemas_run }}
+      dataschemas_files: ${{ steps.sel.outputs.dataschemas_files }}
+    steps:
+      - name: Select tests, fail open on any doubt
+        id: sel
+        env:
+          URL: ${{ secrets.CODEGRAPH_URL }}
+          TOKEN: ${{ secrets.CODEGRAPH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set +e
+          note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+          note "### Codegraph select — GATING (backend jest)"
+          if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_no codegraph config; running FULL_"; exit 0; fi
+          gh api "repos/$REPO/pulls/$PR/files" --paginate             --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
+          if [ ! -s files.json ]; then note "_could not fetch changed files; running FULL_"; exit 0; fi
+          jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA"             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
+          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN"             -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
+          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.selected.api.mode' >/dev/null 2>&1; then
+            note "_codegraph unavailable (${RESP:0:120}); running FULL_"
+            exit 0
+          fi
+          # Emit per-workspace run flag + workspace-relative file list. A workspace emits
+          # run=false ONLY on an explicit NONE; FULL and FILES both run (FILES filtered).
+          # Any selected path containing a space forces that workspace FULL (paths are
+          # server-validated to exclude quotes/backslashes/control chars, so plain
+          # interpolation into the test command below is safe; spaces are the one shape
+          # that would split — refuse to filter rather than risk it).
+          emit() {
+            key="$1"; ws="$2"; ignore="$3"
+            mode=$(echo "$RESP" | jq -r --arg w "$ws" '.selected[$w].mode')
+            files=""
+            if [ "$mode" = "FILES" ]; then
+              files=$(echo "$RESP" | jq -r --arg w "$ws" --arg p "$ws/" --arg ig "$ignore"                 '.selected[$w].files // [] | map(select((test(" ") | not) and (($ig == "") or (test($ig) | not)))) | map(ltrimstr($p)) | join(" ")')
+              spaced=$(echo "$RESP" | jq -r --arg w "$ws" '[.selected[$w].files // [] | .[] | select(test(" "))] | length')
+              if [ "$spaced" != "0" ]; then mode="FULL"; files=""; fi
+              if [ "$mode" = "FILES" ] && [ -z "$files" ]; then mode="NONE"; fi
+            fi
+            if [ "$mode" = "NONE" ]; then
+              echo "${key}_run=false" >> "$GITHUB_OUTPUT"
+              note "| $ws | skip (no reachable tests) |"
+            elif [ "$mode" = "FILES" ]; then
+              n=$(echo "$files" | wc -w | tr -d ' ')
+              echo "${key}_run=true" >> "$GITHUB_OUTPUT"
+              echo "${key}_files=$files" >> "$GITHUB_OUTPUT"
+              note "| $ws | $n selected files |"
+            else
+              echo "${key}_run=true" >> "$GITHUB_OUTPUT"
+              note "| $ws | FULL |"
+            fi
+          }
+          note "| workspace | decision |"
+          note "|---|---|"
+          # Ignore regexes mirror what each workspace's own jest run excludes, because
+          # --runTestsByPath BYPASSES testPathIgnorePatterns (verified empirically) — without
+          # this, selection would newly run integration/manual/misc suites that full CI skips.
+          # Character classes instead of backslashes: these strings cross YAML->bash->jq and
+          # every escape layer is a chance to ship a filter that silently matches nothing.
+          emit api api ""
+          emit pkgapi packages/api 'integration|helper|__tests__/helpers/|manual[.]spec[.]'
+          emit dataprovider packages/data-provider ""
+          emit dataschemas packages/data-schemas 'misc/|dist/|node_modules/'
+          echo "decided=true" >> "$GITHUB_OUTPUT"
+          note ""
+          note "kill switch: repo variable \`CODEGRAPH_GATING=off\`; full runs remain on PR open and on every dev push"
+          exit 0
+
   typecheck:
     name: TypeScript type checks
     needs: build
@@ -196,7 +309,8 @@ jobs:
 
   test-api:
     name: 'Tests: api (shard ${{ matrix.shard }}/3)'
-    needs: build
+    needs: [build, codegraph_select]
+    if: always() && needs.build.result == 'success' && needs.codegraph_select.outputs.api_run != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -276,11 +390,21 @@ jobs:
           restore-keys: |
             mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests (shard ${{ matrix.shard }}/3)
-        run: cd api && npm run test:ci -- --shard=${{ matrix.shard }}/3
+        env:
+          SELECTED: ${{ needs.codegraph_select.outputs.api_files }}
+        run: |
+          cd api
+          if [ -n "$SELECTED" ]; then
+            echo "codegraph: $(echo $SELECTED | wc -w) selected test files (safe mode)"
+            npm run test:ci -- --shard=${{ matrix.shard }}/3 --passWithNoTests --runTestsByPath $SELECTED
+          else
+            npm run test:ci -- --shard=${{ matrix.shard }}/3
+          fi
 
   test-data-provider:
     name: 'Tests: data-provider'
-    needs: build
+    needs: [build, codegraph_select]
+    if: always() && needs.build.result == 'success' && needs.codegraph_select.outputs.dataprovider_run != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -327,11 +451,21 @@ jobs:
           restore-keys: |
             mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests
-        run: cd packages/data-provider && npm run test:ci
+        env:
+          SELECTED: ${{ needs.codegraph_select.outputs.dataprovider_files }}
+        run: |
+          cd packages/data-provider
+          if [ -n "$SELECTED" ]; then
+            echo "codegraph: $(echo $SELECTED | wc -w) selected test files (safe mode)"
+            npm run test:ci -- --passWithNoTests --runTestsByPath $SELECTED
+          else
+            npm run test:ci
+          fi
 
   test-data-schemas:
     name: 'Tests: data-schemas'
-    needs: build
+    needs: [build, codegraph_select]
+    if: always() && needs.build.result == 'success' && needs.codegraph_select.outputs.dataschemas_run != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -384,11 +518,21 @@ jobs:
           restore-keys: |
             mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests
-        run: cd packages/data-schemas && npm run test:ci
+        env:
+          SELECTED: ${{ needs.codegraph_select.outputs.dataschemas_files }}
+        run: |
+          cd packages/data-schemas
+          if [ -n "$SELECTED" ]; then
+            echo "codegraph: $(echo $SELECTED | wc -w) selected test files (safe mode)"
+            npm run test:ci -- --passWithNoTests --runTestsByPath $SELECTED
+          else
+            npm run test:ci
+          fi
 
   test-packages-api:
     name: 'Tests: @librechat/api (shard ${{ matrix.shard }}/4)'
-    needs: build
+    needs: [build, codegraph_select]
+    if: always() && needs.build.result == 'success' && needs.codegraph_select.outputs.pkgapi_run != 'false'
     runs-on: ubuntu-latest
     # Suite typically completes in ~5 min on a warm runner, but tail-latency
     # cancellations have started showing up: tests are actively passing right
@@ -455,4 +599,13 @@ jobs:
           restore-keys: |
             mongodb-binaries-${{ runner.os }}-
       - name: Run unit tests (shard ${{ matrix.shard }}/4)
-        run: cd packages/api && npm run test:ci -- --shard=${{ matrix.shard }}/4
+        env:
+          SELECTED: ${{ needs.codegraph_select.outputs.pkgapi_files }}
+        run: |
+          cd packages/api
+          if [ -n "$SELECTED" ]; then
+            echo "codegraph: $(echo $SELECTED | wc -w) selected test files (safe mode)"
+            npm run test:ci -- --shard=${{ matrix.shard }}/4 --passWithNoTests --runTestsByPath $SELECTED
+          else
+            npm run test:ci -- --shard=${{ matrix.shard }}/4
+          fi


### PR DESCRIPTION
The first workflow that **acts** on codegraph selection instead of observing it. Scope is deliberately stage 1: the four backend jest jobs (9 runners) only — frontend, Playwright and docker stay untouched.

## The policy

| Event | Behavior |
|---|---|
| PR **opened / reopened** | full suite |
| PR **synchronize** (every subsequent push) | selected tests (safe mode) |
| **push to dev** (new trigger) | full suite — the post-merge safety net |
| fork PR / API down / stale graph / root-config or lockfile floor | full suite (fail-open at every layer) |

The new dev-push trigger matters twice over: every merged state still gets the complete suite, and it keeps ground-truth recall telemetry flowing to the shadow evaluator once selection hides skipped tests from PR runs.

**Kill switch:** set repo variable `CODEGRAPH_GATING=off` — the select job skips, every output is empty, and all four jobs behave exactly as before this PR. No re-merge needed.

## Mechanics, each verified empirically before this PR

- Selection comes from `POST /v1/select` in **safe mode** (file-granular, mirrors jest's own dependency semantics — the mode the week of shadow verdicts is graded against). Per workspace: `NONE` skips the job, `FILES` runs `--runTestsByPath` with the list, `FULL`/any-doubt runs everything.
- **`--runTestsByPath` bypasses `testPathIgnorePatterns`** (tested): the select job mirrors each workspace's own exclusions (packages/api's integration/helper/manual flags, data-schemas' `/misc/`) using character-class regexes — no backslashes survive the YAML→bash→jq escape chain, which is exactly how the first draft's filter silently matched nothing.
- Plain positional args were tried first and **do not narrow** in this repo's jest setup (two paths → 404 files listed) — hence runTestsByPath + mirrored filters.
- `--passWithNoTests` on filtered runs; any selected path containing a space forces that workspace FULL rather than risking word-splitting (the server already rejects quotes/backslashes/control characters in paths).
- The exact select script was executed locally against the live API: a backend PR (#15089) selects 201/360/24/57 files across the four workspaces — first file selected is `chat.contentFilter.spec.js`, the regression the full suite caught last week; a client-only PR (#14979) emits `run=false` for **all four jobs**.

## Evidence base

One week of shadow soak: 717 decisions, 578 finalized against real CI receipts, **zero unadjudicated selection misses** (every MISSED ever recorded was the mongodb-memory-server download, fixed in #15131, or a stale-graph infra incident, since gated). Expected effect: scoped backend PRs trim most of their jest minutes; client-only PRs drop ~9 runner-jobs per push.

Playwright/e2e is untouched — its skip election runs separately and nothing here reads e2e tiers.