### PR TITLE
📏 fix: Size Agent Builder Tool and Skill Rows

### DIFF
--- a/client/src/components/SidePanel/Agents/Tools/ToolRow.tsx
+++ b/client/src/components/SidePanel/Agents/Tools/ToolRow.tsx
@@ -81,12 +81,13 @@ function ToolRowImpl({ item, onInfo, onRemove }: Props) {
       >
         <Button
           variant="ghost"
+          size="icon-xs"
           onClick={() => onInfo(item)}
           aria-label={
             configurable ? localize('com_ui_tools_configure') : localize('com_ui_tools_info')
           }
           className={cn(
-            'size-6 rounded-md p-0 text-text-secondary',
+            'rounded-md text-text-secondary',
             'hover:text-text-secondary focus-visible:opacity-100',
           )}
         >
@@ -94,10 +95,11 @@ function ToolRowImpl({ item, onInfo, onRemove }: Props) {
         </Button>
         <Button
           variant="ghost"
+          size="icon-xs"
           onClick={() => onRemove(item)}
           aria-label={localize('com_ui_tools_remove')}
           className={cn(
-            'size-6 rounded-md p-0 text-text-secondary',
+            'rounded-md text-text-secondary',
             'hover:text-text-secondary focus-visible:opacity-100',
           )}
         >


### PR DESCRIPTION
## Summary

The Tools and Skills rows in the agent builder side panel render 52px tall when their content only needs 40px, so the list reads as a column of widely spaced items with a lot of empty padding.

The cause is the two hover actions on each row (`Tool details` and `Remove from agent`) in `ToolRow.tsx`. They pass `size-6 p-0` through `className` but never set the `size` prop, so `buttonVariants` still applies its `default` size of `h-10 px-4 py-2`. This project is on `tailwind-merge` 1.14.0, which has no `size-*` group, so `size-6` and `h-10` are not treated as conflicting and both survive the merge. `h-10` wins on stylesheet order and the buttons lay out at 40px, which sets the row height. Because the actions sit at `opacity-0` until hover, nothing on screen explains where the extra 12px comes from.

Passing `size="icon-xs"` makes the recipe replace the default size outright, so the buttons are 28px and the row collapses to the 40px its content needs. The remaining `rounded-md text-text-secondary` classes are unchanged.

Same crop, same content (2 tools, 3 skills). Three skill rows now fit in the space that previously held two:

| Before | After |
| --- | --- |
| 52px rows | 40px rows |

No other component hits this: a scan of every `<Button>` in `client/src` and `packages/client/src` found no other call site that sets a `size-*` class without a `size` prop. The other 12 hits all use `h-8`/`h-9`, which do share a group with `h-10` and therefore merge correctly.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified in the browser against a local dev build, in both light and dark mode. Measured the rendered geometry rather than eyeballing it:

- Row height, `form ul > li` in the agent builder panel: 52px before, 40px after.
- Action buttons: 40x40 before, 28x28 after, comfortably inside the row and still above the 24px minimum target size.
- Hover and keyboard focus still reveal both actions, and both remain clickable.

Commands run:

- `npx jest src/components/SidePanel/Agents/Tools` in `client/` - 21 suites, 194 tests passed
- `npx tsc --noEmit -p tsconfig.json` in `client/` - clean
- `npx eslint client/src/components/SidePanel/Agents/Tools/ToolRow.tsx` - clean
- `npx prettier --check` and `node scripts/sort-imports.mts --check` on the same file - clean

### **Test Configuration**:

Node v24, local backend and Vite dev server, Chromium, light and dark theme.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
