### PR TITLE
🎭 ci: Gate Playwright Lanes and Docker Smokes on Codegraph Selection (Stage 2)

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -178,9 +178,13 @@ jobs:
             note "_changed-file list incomplete ($N of ${CHANGED:-?}); running FULL_"; exit 0
           fi
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA"             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
-          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN"             -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
-          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.selected.api.mode' >/dev/null 2>&1; then
-            note "_codegraph unavailable (${RESP:0:120}); running FULL_"
+          # curl's status is checked explicitly: a transfer that times out or truncates after a
+          # parseable body must fail open, not be honoured (Codex P1, #15136). --fail-with-body
+          # also turns HTTP errors into a failure while keeping the error text for the summary.
+          RESP=$(curl -sS --fail-with-body -m 45 -H "Authorization: Bearer $TOKEN" \
+            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select"); RC=$?
+          if [ "$RC" -ne 0 ] || [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.selected.api.mode' >/dev/null 2>&1; then
+            note "_codegraph unavailable (curl exit $RC: ${RESP:0:120}); running FULL_"
             exit 0
           fi
           # Emit per-workspace run flag + workspace-relative file list. A workspace emits

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -159,13 +159,24 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED: ${{ github.event.pull_request.changed_files }}
         run: |
           set +e
           note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           note "### Codegraph select — GATING (backend jest)"
           if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_no codegraph config; running FULL_"; exit 0; fi
-          gh api "repos/$REPO/pulls/$PR/files" --paginate             --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
-          if [ ! -s files.json ]; then note "_could not fetch changed files; running FULL_"; exit 0; fi
+          # A failed or truncated page must not become a shorter file list: the pipeline would hide
+          # gh's exit status behind jq, and a partial list can turn a required lane off. Check the
+          # fetch status AND the count against the PR's own changed_files (Codex P1, #15136).
+          if ! gh api "repos/$REPO/pulls/$PR/files" --paginate \
+              --jq '.[] | {path: .filename, status, patch}' > files.ndjson; then
+            note "_could not fetch changed files; running FULL_"; exit 0
+          fi
+          jq -s . files.ndjson > files.json
+          N=$(jq 'length' files.json)
+          if [ "$N" -eq 0 ] || { [ -n "$CHANGED" ] && [ "$N" -ne "$CHANGED" ]; }; then
+            note "_changed-file list incomplete ($N of ${CHANGED:-?}); running FULL_"; exit 0
+          fi
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA"             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
           RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN"             -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
           if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.selected.api.mode' >/dev/null 2>&1; then

--- a/.github/workflows/codegraph-select.yml
+++ b/.github/workflows/codegraph-select.yml
@@ -53,10 +53,13 @@ jobs:
 
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
             '{files: ., lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
-          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
-            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
-          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e .selected >/dev/null 2>&1; then
-            note "_codegraph unavailable (${RESP:0:120}); skipped — full CI runs as always_"
+          # curl's status is checked explicitly: a transfer that times out or truncates after a
+          # parseable body must fail open, not be honoured (Codex P1, #15136). --fail-with-body
+          # also turns HTTP errors into a failure while keeping the error text for the summary.
+          RESP=$(curl -sS --fail-with-body -m 45 -H "Authorization: Bearer $TOKEN" \
+            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select"); RC=$?
+          if [ "$RC" -ne 0 ] || [ -z "$RESP" ] || ! echo "$RESP" | jq -e .selected >/dev/null 2>&1; then
+            note "_codegraph unavailable (curl exit $RC: ${RESP:0:120}); skipped — full CI runs as always_"
             exit 0
           fi
 

--- a/.github/workflows/codegraph-select.yml
+++ b/.github/workflows/codegraph-select.yml
@@ -31,15 +31,25 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED: ${{ github.event.pull_request.changed_files }}
         run: |
           set +e
           note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           note "### Codegraph select — observe-only"
           if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_secrets not configured; skipped_"; exit 0; fi
 
-          gh api "repos/$REPO/pulls/$PR/files" --paginate \
-            --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
-          if [ ! -s files.json ]; then note "_could not fetch changed files; skipped_"; exit 0; fi
+          # A failed or truncated page must not become a shorter file list: the pipeline would hide
+          # gh's exit status behind jq, and a partial list can turn a required lane off. Check the
+          # fetch status AND the count against the PR's own changed_files (Codex P1, #15136).
+          if ! gh api "repos/$REPO/pulls/$PR/files" --paginate \
+              --jq '.[] | {path: .filename, status, patch}' > files.ndjson; then
+            note "_could not fetch changed files; skipped_"; exit 0
+          fi
+          jq -s . files.ndjson > files.json
+          N=$(jq 'length' files.json)
+          if [ "$N" -eq 0 ] || { [ -n "$CHANGED" ] && [ "$N" -ne "$CHANGED" ]; }; then
+            note "_changed-file list incomplete ($N of ${CHANGED:-?}); skipped_"; exit 0
+          fi
 
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
             '{files: ., lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -94,6 +94,7 @@ jobs:
           }
           emit client client_package_target "client package build"
           emit api api_runtime_smoke "api runtime smoke"
+          echo "codegraph-select: $(echo "$RESP" | jq -c '.matrix["docker-smoke"]')"
           echo "decided=true" >> "$GITHUB_OUTPUT"
           note ""
           note "node image smoke keeps its own path filter · kill switch: repo variable \`CODEGRAPH_GATING=off\` · everything runs on PR open"

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -29,8 +29,77 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Stage 2 of codegraph gating (stage 1 = backend jest in backend-review.yml). Two of the three
+  # smokes are graph-decidable: the client package build only matters when the change reaches the
+  # client build context, and the production-image boot only when it reaches the api image's build
+  # context (Dockerfile.multi's api-build stage never builds client). Monotone and fail-open: a
+  # smoke is dropped ONLY on an explicit `false`; unavailable/unconfigured/non-synchronize events
+  # run everything. Lock attribution rides along so a dependency bump keeps the image smoke.
+  # Kill switch: repo variable CODEGRAPH_GATING=off.
+  codegraph_select:
+    name: Codegraph select
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'synchronize' &&
+      vars.CODEGRAPH_GATING != 'off'
+    outputs:
+      decided: ${{ steps.sel.outputs.decided }}
+      client_run: ${{ steps.sel.outputs.client_run }}
+      api_run: ${{ steps.sel.outputs.api_run }}
+    steps:
+      - name: Select smokes, fail open on any doubt
+        id: sel
+        env:
+          URL: ${{ secrets.CODEGRAPH_URL }}
+          TOKEN: ${{ secrets.CODEGRAPH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set +e
+          note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+          note "### Codegraph select — GATING (docker smokes)"
+          if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_no codegraph config; running FULL_"; exit 0; fi
+          gh api "repos/$REPO/pulls/$PR/files" --paginate \
+            --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
+          if [ ! -s files.json ]; then note "_could not fetch changed files; running FULL_"; exit 0; fi
+          jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
+            '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
+          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
+            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
+          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.matrix["docker-smoke"]' >/dev/null 2>&1; then
+            note "_codegraph unavailable (${RESP:0:120}); running FULL_"
+            exit 0
+          fi
+          # A smoke is skipped only on a literal false; anything else (true, null, missing) runs.
+          note "| smoke | decision |"
+          note "|---|---|"
+          emit() {
+            key="$1"; hint="$2"; label="$3"
+            v=$(echo "$RESP" | jq -r --arg h "$hint" '.matrix["docker-smoke"][$h]')
+            if [ "$v" = "false" ]; then
+              echo "${key}_run=false" >> "$GITHUB_OUTPUT"
+              note "| $label | skip (no reach into its build context) |"
+            else
+              echo "${key}_run=true" >> "$GITHUB_OUTPUT"
+              note "| $label | run |"
+            fi
+          }
+          emit client client_package_target "client package build"
+          emit api api_runtime_smoke "api runtime smoke"
+          echo "decided=true" >> "$GITHUB_OUTPUT"
+          note ""
+          note "node image smoke keeps its own path filter · kill switch: repo variable \`CODEGRAPH_GATING=off\` · everything runs on PR open"
+          exit 0
+
   client-package-target:
     name: Build Docker client package target
+    needs: [codegraph_select]
+    if: ${{ !cancelled() && needs.codegraph_select.outputs.client_run != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -88,6 +157,8 @@ jobs:
 
   api-runtime-smoke:
     name: API runtime smoke (production image boots)
+    needs: [codegraph_select]
+    if: ${{ !cancelled() && needs.codegraph_select.outputs.api_run != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -79,10 +79,13 @@ jobs:
           fi
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
-          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
-            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
-          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.matrix["docker-smoke"]' >/dev/null 2>&1; then
-            note "_codegraph unavailable (${RESP:0:120}); running FULL_"
+          # curl's status is checked explicitly: a transfer that times out or truncates after a
+          # parseable body must fail open, not be honoured (Codex P1, #15136). --fail-with-body
+          # also turns HTTP errors into a failure while keeping the error text for the summary.
+          RESP=$(curl -sS --fail-with-body -m 45 -H "Authorization: Bearer $TOKEN" \
+            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select"); RC=$?
+          if [ "$RC" -ne 0 ] || [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.matrix["docker-smoke"]' >/dev/null 2>&1; then
+            note "_codegraph unavailable (curl exit $RC: ${RESP:0:120}); running FULL_"
             exit 0
           fi
           # A smoke is skipped only on the JSON boolean false — tested inside jq, because `jq -r`

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -59,14 +59,24 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED: ${{ github.event.pull_request.changed_files }}
         run: |
           set +e
           note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           note "### Codegraph select — GATING (docker smokes)"
           if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_no codegraph config; running FULL_"; exit 0; fi
-          gh api "repos/$REPO/pulls/$PR/files" --paginate \
-            --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
-          if [ ! -s files.json ]; then note "_could not fetch changed files; running FULL_"; exit 0; fi
+          # A failed or truncated page must not become a shorter file list: the pipeline would hide
+          # gh's exit status behind jq, and a partial list can turn a required lane off. Check the
+          # fetch status AND the count against the PR's own changed_files (Codex P1, #15136).
+          if ! gh api "repos/$REPO/pulls/$PR/files" --paginate \
+              --jq '.[] | {path: .filename, status, patch}' > files.ndjson; then
+            note "_could not fetch changed files; running FULL_"; exit 0
+          fi
+          jq -s . files.ndjson > files.json
+          N=$(jq 'length' files.json)
+          if [ "$N" -eq 0 ] || { [ -n "$CHANGED" ] && [ "$N" -ne "$CHANGED" ]; }; then
+            note "_changed-file list incomplete ($N of ${CHANGED:-?}); running FULL_"; exit 0
+          fi
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
           RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
@@ -75,16 +85,17 @@ jobs:
             note "_codegraph unavailable (${RESP:0:120}); running FULL_"
             exit 0
           fi
-          # A smoke is skipped only on a literal false; anything else (true, null, missing) runs.
-          if [ "$(echo "$RESP" | jq -r '.e2e.fail_open // false')" = "true" ]; then
+          # A smoke is skipped only on the JSON boolean false — tested inside jq, because `jq -r`
+          # prints the string "false" and the boolean identically (Codex P1, #15136). Anything
+          # else (true, null, a string, missing) runs.
+          if echo "$RESP" | jq -e '.e2e.fail_open == true' >/dev/null 2>&1; then
             note "_fail-open decision (root/workflow/lockfile change or stale graph): everything runs_"
           fi
           note "| smoke | decision |"
           note "|---|---|"
           emit() {
             key="$1"; hint="$2"; label="$3"
-            v=$(echo "$RESP" | jq -r --arg h "$hint" '.matrix["docker-smoke"][$h]')
-            if [ "$v" = "false" ]; then
+            if echo "$RESP" | jq -e --arg h "$hint" '.matrix["docker-smoke"][$h] == false' >/dev/null 2>&1; then
               echo "${key}_run=false" >> "$GITHUB_OUTPUT"
               note "| $label | skip (no reach into its build context) |"
             else

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -76,6 +76,9 @@ jobs:
             exit 0
           fi
           # A smoke is skipped only on a literal false; anything else (true, null, missing) runs.
+          if [ "$(echo "$RESP" | jq -r '.e2e.fail_open // false')" = "true" ]; then
+            note "_fail-open decision (root/workflow/lockfile change or stale graph): everything runs_"
+          fi
           note "| smoke | decision |"
           note "|---|---|"
           emit() {

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -60,15 +60,25 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED: ${{ github.event.pull_request.changed_files }}
           FULL_INCLUDE: '{"include":[{"name":"memory, shard 1/3","stream_store":"memory","redis_image":"","suite":"full","shard":"1/3","artifact":"memory-1-of-3"},{"name":"memory, shard 2/3","stream_store":"memory","redis_image":"","suite":"full","shard":"2/3","artifact":"memory-2-of-3"},{"name":"memory, shard 3/3","stream_store":"memory","redis_image":"","suite":"full","shard":"3/3","artifact":"memory-3-of-3"},{"name":"redis transport","stream_store":"redis","redis_image":"redis:7-alpine","suite":"transport","shard":"","artifact":"redis-transport"}]}'
         run: |
           set +e
           note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           note "### Codegraph select — GATING (Playwright matrix lanes)"
           if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_no codegraph config; running FULL_"; exit 0; fi
-          gh api "repos/$REPO/pulls/$PR/files" --paginate \
-            --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
-          if [ ! -s files.json ]; then note "_could not fetch changed files; running FULL_"; exit 0; fi
+          # A failed or truncated page must not become a shorter file list: the pipeline would hide
+          # gh's exit status behind jq, and a partial list can turn a required lane off. Check the
+          # fetch status AND the count against the PR's own changed_files (Codex P1, #15136).
+          if ! gh api "repos/$REPO/pulls/$PR/files" --paginate \
+              --jq '.[] | {path: .filename, status, patch}' > files.ndjson; then
+            note "_could not fetch changed files; running FULL_"; exit 0
+          fi
+          jq -s . files.ndjson > files.json
+          N=$(jq 'length' files.json)
+          if [ "$N" -eq 0 ] || { [ -n "$CHANGED" ] && [ "$N" -ne "$CHANGED" ]; }; then
+            note "_changed-file list incomplete ($N of ${CHANGED:-?}); running FULL_"; exit 0
+          fi
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
           RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
@@ -77,15 +87,20 @@ jobs:
             note "_codegraph unavailable (${RESP:0:120}); running FULL_"
             exit 0
           fi
-          # A lane is skipped only on a literal false; anything else (true, null, missing) runs.
-          if [ "$(echo "$RESP" | jq -r '.e2e.fail_open // false')" = "true" ]; then
+          # A lane is skipped only on the JSON boolean false — tested inside jq, because `jq -r`
+          # prints the string "false" and the boolean identically (Codex P1, #15136). Anything
+          # else (true, null, a string, missing) runs.
+          if echo "$RESP" | jq -e '.e2e.fail_open == true' >/dev/null 2>&1; then
             note "_fail-open decision (root/workflow/lockfile change or stale graph): everything runs_"
           fi
-          REDIS=$(echo "$RESP" | jq -r '.matrix["playwright-mock"].redis_transport')
-          MCP=$(echo "$RESP" | jq -r '.matrix["playwright-mock"].mcp_tool_list_changed')
+          REDIS=$(echo "$RESP" | jq -c '.matrix["playwright-mock"].redis_transport')
+          MCP=$(echo "$RESP" | jq -c '.matrix["playwright-mock"].mcp_tool_list_changed')
+          REDIS_SKIP=0; MCP_SKIP=0
+          echo "$RESP" | jq -e '.matrix["playwright-mock"].redis_transport == false' >/dev/null 2>&1 && REDIS_SKIP=1
+          echo "$RESP" | jq -e '.matrix["playwright-mock"].mcp_tool_list_changed == false' >/dev/null 2>&1 && MCP_SKIP=1
           note "| lane | decision |"
           note "|---|---|"
-          if [ "$REDIS" = "false" ]; then
+          if [ "$REDIS_SKIP" = 1 ]; then
             INCLUDE=$(echo "$FULL_INCLUDE" | jq -c '.include |= map(select(.suite != "transport"))')
             note "| redis transport | skip (no reach into the stream boundary) |"
           else
@@ -98,7 +113,7 @@ jobs:
           fi
           echo "e2e_include=$INCLUDE" >> "$GITHUB_OUTPUT"
           echo "codegraph-select: redis_transport=$REDIS mcp_tool_list_changed=$MCP matrix_entries=$(echo "$INCLUDE" | jq '.include | length')"
-          if [ "$MCP" = "false" ]; then
+          if [ "$MCP_SKIP" = 1 ]; then
             echo "mcp_run=false" >> "$GITHUB_OUTPUT"
             note "| MCP list_changed | skip (no reach into MCP) |"
           else

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -28,22 +28,104 @@ env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 jobs:
+  # Stage 2 of codegraph gating (stage 1 = backend jest in backend-review.yml). The graph decides
+  # two matrix lanes whose relevance is a reachability question: the redis-transport lane (the ten
+  # stream-boundary specs under a real Redis round-trip) and the MCP list_changed lanes. Memory
+  # shards always run. Monotone and fail-open: a lane is dropped ONLY on an explicit `false` from
+  # the service; unavailable/unconfigured/non-synchronize events keep the full matrix. Lock
+  # attribution rides along so a backend dependency bump (reaches nothing in the graph) still
+  # earns both lanes. Kill switch: repo variable CODEGRAPH_GATING=off.
+  codegraph_select:
+    name: Codegraph select
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'synchronize' &&
+      vars.CODEGRAPH_GATING != 'off' &&
+      github.event.pull_request != null &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    outputs:
+      decided: ${{ steps.sel.outputs.decided }}
+      e2e_include: ${{ steps.sel.outputs.e2e_include }}
+      mcp_run: ${{ steps.sel.outputs.mcp_run }}
+    steps:
+      - name: Select matrix lanes, fail open on any doubt
+        id: sel
+        env:
+          URL: ${{ secrets.CODEGRAPH_URL }}
+          TOKEN: ${{ secrets.CODEGRAPH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FULL_INCLUDE: '{"include":[{"name":"memory, shard 1/3","stream_store":"memory","redis_image":"","suite":"full","shard":"1/3","artifact":"memory-1-of-3"},{"name":"memory, shard 2/3","stream_store":"memory","redis_image":"","suite":"full","shard":"2/3","artifact":"memory-2-of-3"},{"name":"memory, shard 3/3","stream_store":"memory","redis_image":"","suite":"full","shard":"3/3","artifact":"memory-3-of-3"},{"name":"redis transport","stream_store":"redis","redis_image":"redis:7-alpine","suite":"transport","shard":"","artifact":"redis-transport"}]}'
+        run: |
+          set +e
+          note() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+          note "### Codegraph select — GATING (Playwright matrix lanes)"
+          if [ -z "$URL" ] || [ -z "$TOKEN" ]; then note "_no codegraph config; running FULL_"; exit 0; fi
+          gh api "repos/$REPO/pulls/$PR/files" --paginate \
+            --jq '.[] | {path: .filename, status, patch}' | jq -s . > files.json
+          if [ ! -s files.json ]; then note "_could not fetch changed files; running FULL_"; exit 0; fi
+          jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
+            '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
+          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
+            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
+          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.matrix["playwright-mock"]' >/dev/null 2>&1; then
+            note "_codegraph unavailable (${RESP:0:120}); running FULL_"
+            exit 0
+          fi
+          # A lane is skipped only on a literal false; anything else (true, null, missing) runs.
+          REDIS=$(echo "$RESP" | jq -r '.matrix["playwright-mock"].redis_transport')
+          MCP=$(echo "$RESP" | jq -r '.matrix["playwright-mock"].mcp_tool_list_changed')
+          note "| lane | decision |"
+          note "|---|---|"
+          if [ "$REDIS" = "false" ]; then
+            INCLUDE=$(echo "$FULL_INCLUDE" | jq -c '.include |= map(select(.suite != "transport"))')
+            note "| redis transport | skip (no reach into the stream boundary) |"
+          else
+            INCLUDE="$FULL_INCLUDE"
+            note "| redis transport | run |"
+          fi
+          if ! echo "$INCLUDE" | jq -e '.include | length >= 3' >/dev/null 2>&1; then
+            note "_matrix assembly failed; running FULL_"
+            exit 0
+          fi
+          echo "e2e_include=$INCLUDE" >> "$GITHUB_OUTPUT"
+          if [ "$MCP" = "false" ]; then
+            echo "mcp_run=false" >> "$GITHUB_OUTPUT"
+            note "| MCP list_changed | skip (no reach into MCP) |"
+          else
+            echo "mcp_run=true" >> "$GITHUB_OUTPUT"
+            note "| MCP list_changed | run |"
+          fi
+          echo "decided=true" >> "$GITHUB_OUTPUT"
+          note ""
+          note "memory shards always run · kill switch: repo variable \`CODEGRAPH_GATING=off\` · full matrix on PR open and nightly"
+          exit 0
+
   e2e_shards:
     name: e2e (${{ matrix.name }})
+    needs: [codegraph_select]
     if: >-
-      github.event_name == 'schedule' ||
+      !cancelled() &&
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
       github.event.pull_request != null &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: >-
         ${{
-          github.event_name == 'pull_request' &&
-          fromJSON('{"include":[{"name":"memory, shard 1/3","stream_store":"memory","redis_image":"","suite":"full","shard":"1/3","artifact":"memory-1-of-3"},{"name":"memory, shard 2/3","stream_store":"memory","redis_image":"","suite":"full","shard":"2/3","artifact":"memory-2-of-3"},{"name":"memory, shard 3/3","stream_store":"memory","redis_image":"","suite":"full","shard":"3/3","artifact":"memory-3-of-3"},{"name":"redis transport","stream_store":"redis","redis_image":"redis:7-alpine","suite":"transport","shard":"","artifact":"redis-transport"}]}') ||
+          (github.event_name == 'pull_request' && needs.codegraph_select.outputs.e2e_include != '' &&
+          fromJSON(needs.codegraph_select.outputs.e2e_include)) ||
+          (github.event_name == 'pull_request' &&
+          fromJSON('{"include":[{"name":"memory, shard 1/3","stream_store":"memory","redis_image":"","suite":"full","shard":"1/3","artifact":"memory-1-of-3"},{"name":"memory, shard 2/3","stream_store":"memory","redis_image":"","suite":"full","shard":"2/3","artifact":"memory-2-of-3"},{"name":"memory, shard 3/3","stream_store":"memory","redis_image":"","suite":"full","shard":"3/3","artifact":"memory-3-of-3"},{"name":"redis transport","stream_store":"redis","redis_image":"redis:7-alpine","suite":"transport","shard":"","artifact":"redis-transport"}]}')) ||
           fromJSON('{"include":[{"name":"memory, shard 1/2","stream_store":"memory","redis_image":"","suite":"full","shard":"1/2","artifact":"memory-1-of-2"},{"name":"memory, shard 2/2","stream_store":"memory","redis_image":"","suite":"full","shard":"2/2","artifact":"memory-2-of-2"},{"name":"redis, shard 1/2","stream_store":"redis","redis_image":"redis:7-alpine","suite":"full","shard":"1/2","artifact":"redis-1-of-2"},{"name":"redis, shard 2/2","stream_store":"redis","redis_image":"redis:7-alpine","suite":"full","shard":"2/2","artifact":"redis-2-of-2"}]}')
         }}
     services:
@@ -231,12 +313,15 @@ jobs:
 
   mcp_tool_list_changed:
     name: MCP list_changed (replica count ${{ matrix.replicas }})
+    needs: [codegraph_select]
     if: >-
-      github.event_name == 'schedule' ||
+      !cancelled() &&
+      needs.codegraph_select.outputs.mcp_run != 'false' &&
+      (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
       github.event.pull_request != null &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -387,11 +472,13 @@ jobs:
       (github.event_name == 'pull_request' &&
       github.event.pull_request != null &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)))
-    needs: [e2e_shards, mcp_tool_list_changed]
+    needs: [codegraph_select, e2e_shards, mcp_tool_list_changed]
     runs-on: ubuntu-latest
     steps:
+      # A codegraph-skipped MCP lane reports `skipped`; that is a decision, not a failure.
       - name: Verify every Playwright job passed
         if: >-
           needs.e2e_shards.result != 'success' ||
-          needs.mcp_tool_list_changed.result != 'success'
+          (needs.mcp_tool_list_changed.result != 'success' &&
+          !(needs.mcp_tool_list_changed.result == 'skipped' && needs.codegraph_select.outputs.mcp_run == 'false'))
         run: exit 1

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -81,10 +81,13 @@ jobs:
           fi
           jq -c --arg b "$BASE_SHA" --arg h "$HEAD_SHA" \
             '{files: ., mode: "safe", lockBaseSha: $b, lockHeadSha: $h}' files.json > body.json
-          RESP=$(curl -sS -m 45 -H "Authorization: Bearer $TOKEN" \
-            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select")
-          if [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.matrix["playwright-mock"]' >/dev/null 2>&1; then
-            note "_codegraph unavailable (${RESP:0:120}); running FULL_"
+          # curl's status is checked explicitly: a transfer that times out or truncates after a
+          # parseable body must fail open, not be honoured (Codex P1, #15136). --fail-with-body
+          # also turns HTTP errors into a failure while keeping the error text for the summary.
+          RESP=$(curl -sS --fail-with-body -m 45 -H "Authorization: Bearer $TOKEN" \
+            -H 'content-type: application/json' --data-binary @body.json "$URL/v1/select"); RC=$?
+          if [ "$RC" -ne 0 ] || [ -z "$RESP" ] || ! echo "$RESP" | jq -e '.matrix["playwright-mock"]' >/dev/null 2>&1; then
+            note "_codegraph unavailable (curl exit $RC: ${RESP:0:120}); running FULL_"
             exit 0
           fi
           # A lane is skipped only on the JSON boolean false — tested inside jq, because `jq -r`

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -97,6 +97,7 @@ jobs:
             exit 0
           fi
           echo "e2e_include=$INCLUDE" >> "$GITHUB_OUTPUT"
+          echo "codegraph-select: redis_transport=$REDIS mcp_tool_list_changed=$MCP matrix_entries=$(echo "$INCLUDE" | jq '.include | length')"
           if [ "$MCP" = "false" ]; then
             echo "mcp_run=false" >> "$GITHUB_OUTPUT"
             note "| MCP list_changed | skip (no reach into MCP) |"

--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -78,6 +78,9 @@ jobs:
             exit 0
           fi
           # A lane is skipped only on a literal false; anything else (true, null, missing) runs.
+          if [ "$(echo "$RESP" | jq -r '.e2e.fail_open // false')" = "true" ]; then
+            note "_fail-open decision (root/workflow/lockfile change or stale graph): everything runs_"
+          fi
           REDIS=$(echo "$RESP" | jq -r '.matrix["playwright-mock"].redis_transport')
           MCP=$(echo "$RESP" | jq -r '.matrix["playwright-mock"].mcp_tool_list_changed')
           note "| lane | decision |"


### PR DESCRIPTION
## Summary

Stage 2 of codegraph gating (stage 1 = backend jest, #15132). The graph now decides the four matrix jobs whose relevance is a reachability question, on `synchronize` pushes only:

| workflow | job | skipped when the graph shows zero reach into… |
|---|---|---|
| Playwright E2E Tests | `e2e (redis transport)` | the stream boundary (`packages/api/src/{stream,cache,cluster,mcp}`, `redis-config/`, `api/cache/`, `e2e/`) **or** the agent runtime |
| Playwright E2E Tests | `MCP list_changed (1, 2 replicas)` | anything MCP-named, `e2e/` |
| Docker Build Smoke Tests | `Build Docker client package target` | the client build context (`client/`, `packages/client/`, `packages/data-provider/`) |
| Docker Build Smoke Tests | `API runtime smoke` | the production image's build inputs — `api/`, `packages/*`, `client/`, `config/`, `skill/`, Dockerfile, manifests (the image builds the client too; only e2e/docs/workflow-only changes skip it) |

Memory shards always run. `node-image-smoke` keeps its own path filter. Everything runs in full on PR open/reopen, nightly, and `workflow_dispatch`.

## Safety

- **Monotone and fail-open.** A job is dropped only on a literal `false` from the service; unavailable, unconfigured, timed-out, malformed, or non-`synchronize` → full matrix. The select job exits 0 on every path; dependents use `!cancelled()` so a failed select still runs everything.
- **Kill switch:** repo variable `CODEGRAPH_GATING=off` (same switch as stage 1).
- **Lock attribution rides along.** A backend dependency bump changes zero source files and reaches nothing in the graph; the service now maps `package-lock.json` attribution (workspace-granular, same as the jest floors) onto the lanes — backend deps → redis/MCP/api-image, client deps → client image. This was the one gap the pre-gating audit found (below).
- The `e2e` aggregate treats a codegraph-skipped MCP lane (`skipped`) as a decision, not a failure. Any other non-success still fails the aggregate.

## Pre-gating audit

Across 638 finalized shadow events (08-17 → 08-23), 346 jobs the matrix would have skipped actually ran; 5 failed. None was a unique miss: three were the chronic `tool-approvals` flake (27 PRs), one an unparsed infra failure, and #15038's two `usage.spec` failures were also caught by memory shard 3/3, which always runs. #15012 (agents 3.6.7→3.6.8) exposed the lockfile gap: redis/MCP skipped on a backend dependency bump. Fixed service-side (`matrixHints` consumes lock attribution + the agent-runtime scopes that already floor the agent-flow specs; guard tests added). Re-scored history under the fixed rule: 25 skips flip to run, 1,831 of 2,027 would-skip minutes survive.

## Receipts (same window)

| job | avg | skippable | minutes on the table |
|---|---|---|---|
| redis transport | 9.6 min | 17% of runs | 953 |
| API runtime smoke | 5.4 min | ~0% after the Codex correction (the image builds client) | 0 |
| client package build | 1.7 min | 17% | 170 |
| MCP list_changed ×2 | 4.0–4.5 min | 3% | 84 |

Select job overhead ≈ 20 s per run (no checkout; `gh api` + one `curl`). Stage-2 total under the corrected rules: 1,218 would-skip minutes over 644 events.

## Verification

- Both workflows strict-parsed with js-yaml (the votes-workflow lesson).
- The exact `run:` blocks were extracted and executed verbatim against the live service for #15038, #15012, #15047, #15089: decisions match the graph's known answers, including the fail-open path (empty shas → `bad sha` → FULL, exit 0, no outputs).
- First gated run on this PR's own `synchronize` push will show the decision under the `Codegraph select` job summary in each workflow.
- **Live on this PR:** the `opened` run built the full matrix through the fallback path and went green end-to-end (aggregate included). The `synchronize` runs executed both select jobs (~3 s each): Playwright logged `codegraph-select: redis_transport=true mcp_tool_list_changed=true matrix_entries=4` and `e2e_shards` expanded from the `fromJSON(select output)` path; docker logged `{"client_package_target":true,"api_runtime_smoke":true}`. All lanes run here on purpose — this PR edits workflow files, which is a fail-open class — so the first skip will appear on the first post-merge PR whose change reaches none of a lane's scope.

## Codex round 1 (all three addressed, 5934578)

- **P1 fetch failure hidden by the pipeline** → `if ! gh api … > files.ndjson` plus a count check against `pull_request.changed_files`; mismatch or empty → FULL. Applied to both stage-2 jobs, the stage-1 job in backend-review.yml (same pipeline, already merged) and the observe probe.
- **P1 string `"false"`** → decisions tested inside jq with `== false`; only the JSON boolean skips.
- **P2 api-smoke scope** → Codex was right and the service-side comment was wrong: `Dockerfile.multi:118` copies `client/dist` from `client-build`. Scope widened to `client/`, `packages/client/`, `skill/` (deployed); the api smoke now skips only for changes outside every image input. Re-scored: its savings go to 0, the rest stand.

## Codex round 2 (addressed, 71877cab8d)

- **P1 curl exit status ignored** → `RESP=$(curl --fail-with-body -m 45 …); RC=$?`; a selection is honoured only when curl succeeded and the body parses. Same fix in stage 1 and the probe. Verified: unreachable host → exit 28 → FULL; HTTP 401 → exit 22 with body → FULL.

## Codex round 3 — clean at 71877cab8d; CI 26/26 green on that head.
