### PR TITLE
⚡ perf: Cut Serial Round Trips and a 100ms Admission Stall from Chat Turns

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1149,6 +1149,11 @@ class BaseClient {
   async loadHistory(conversationId, parentMessageId = null) {
     logger.debug('[BaseClient] Loading history:', { conversationId, parentMessageId });
 
+    /** No message has the root sentinel as its id, so the chain walk from it is empty. */
+    if (parentMessageId === Constants.NO_PARENT) {
+      return [];
+    }
+
     const messages = (await db.getMessages({ conversationId, user: this.user })) ?? [];
 
     if (messages.length === 0) {
@@ -1389,15 +1394,19 @@ class BaseClient {
     const orderedMessages = [];
     let currentMessageId = parentMessageId;
     const visitedMessageIds = new Set();
+    const messagesById = new Map();
+    for (const msg of messages) {
+      const messageId = msg.messageId ?? msg.id;
+      if (!messagesById.has(messageId)) {
+        messagesById.set(messageId, msg);
+      }
+    }
 
     while (currentMessageId) {
       if (visitedMessageIds.has(currentMessageId)) {
         break;
       }
-      const message = messages.find((msg) => {
-        const messageId = msg.messageId ?? msg.id;
-        return messageId === currentMessageId;
-      });
+      const message = messagesById.get(currentMessageId);
 
       visitedMessageIds.add(currentMessageId);
 

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1,4 +1,5 @@
 const { Constants, ContentTypes } = require('librechat-data-provider');
+const BaseClientClass = require('../BaseClient');
 const { ContentFilterError } = require('@librechat/api');
 const { FakeClient, initializeFakeClient } = require('./FakeClient');
 
@@ -224,6 +225,39 @@ describe('BaseClient', () => {
     expect(result.messagesToRefine.length - 1).toEqual(expectedIndex);
     expect(result.remainingContextTokens).toBe(expectedRemainingContextTokens);
     expect(result.messagesToRefine).toEqual(expectedMessagesToRefine);
+  });
+
+  describe('loadHistory', () => {
+    const receiver = Object.assign(Object.create(BaseClientClass.prototype), {
+      user: 'user-1',
+      getMessageMapMethod: null,
+      shouldSummarize: false,
+      addPreviousAttachments: async (messages) => messages,
+    });
+    const loadHistory = (parentMessageId) => receiver.loadHistory('convo-1', parentMessageId);
+
+    beforeEach(() => {
+      getMessages.mockClear();
+    });
+
+    test('skips the database when the parent is the root sentinel: no message can match it', async () => {
+      const result = await loadHistory(Constants.NO_PARENT);
+
+      expect(result).toEqual([]);
+      expect(getMessages).not.toHaveBeenCalled();
+    });
+
+    test('still loads and walks the chain for a real parent', async () => {
+      getMessages.mockResolvedValueOnce([
+        { messageId: 'root', parentMessageId: Constants.NO_PARENT, text: 'a' },
+        { messageId: 'reply', parentMessageId: 'root', text: 'b' },
+      ]);
+
+      const result = await loadHistory('reply');
+
+      expect(getMessages).toHaveBeenCalledTimes(1);
+      expect(result.map((m) => m.messageId)).toEqual(['root', 'reply']);
+    });
   });
 
   describe('getMessagesForConversation', () => {

--- a/api/server/middleware/validate/convoAccess.js
+++ b/api/server/middleware/validate/convoAccess.js
@@ -52,9 +52,10 @@ const validateConvoAccess = async (req, res, next) => {
       }
     }
 
-    /** Read the full document once: the subagent guard, agent initialization, and the
-     *  first save all consume `req.resolvedConversation` instead of re-reading it. */
-    const conversation = await searchConversation(conversationId, null);
+    /** One read serves the subagent guard, agent initialization, and the first save via
+     *  `req.resolvedConversation`. `messages` is the only unbounded field and no consumer
+     *  reads it, so it stays excluded — ownership is not yet known at this point. */
+    const conversation = await searchConversation(conversationId, '-messages');
 
     if (!conversation) {
       req.resolvedConversation = null;

--- a/api/server/middleware/validate/convoAccess.js
+++ b/api/server/middleware/validate/convoAccess.js
@@ -1,4 +1,5 @@
 const { isEnabled } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
 const { Constants, ViolationTypes, Time } = require('librechat-data-provider');
 const denyRequest = require('~/server/middleware/denyRequest');
 const { logViolation, getLogStores } = require('~/cache');
@@ -51,9 +52,12 @@ const validateConvoAccess = async (req, res, next) => {
       }
     }
 
-    const conversation = await searchConversation(conversationId);
+    /** Read the full document once: the subagent guard, agent initialization, and the
+     *  first save all consume `req.resolvedConversation` instead of re-reading it. */
+    const conversation = await searchConversation(conversationId, null);
 
     if (!conversation) {
+      req.resolvedConversation = null;
       return next();
     }
 
@@ -70,8 +74,13 @@ const validateConvoAccess = async (req, res, next) => {
     }
 
     if (cache) {
-      await cache.set(key, 'authorized', Time.TEN_MINUTES);
+      /** The marker only short-circuits the next check; the violations store is file-backed
+       *  without Redis and its debounced write takes ~100ms, so it must not gate this request. */
+      cache.set(key, 'authorized', Time.TEN_MINUTES).catch((error) => {
+        logger.warn('[validateConvoAccess] Failed to cache conversation access', error);
+      });
     }
+    req.resolvedConversation = conversation;
     next();
   } catch (error) {
     console.error('Error validating conversation access:', error);

--- a/api/server/middleware/validate/convoAccess.spec.js
+++ b/api/server/middleware/validate/convoAccess.spec.js
@@ -1,0 +1,124 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { ViolationTypes } = require('librechat-data-provider');
+
+const mockCache = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+
+jest.mock('~/cache', () => ({
+  getLogStores: jest.fn(() => mockCache),
+  logViolation: jest.fn(),
+}));
+
+jest.mock('~/server/middleware/denyRequest', () => jest.fn(async () => undefined));
+
+const denyRequest = require('~/server/middleware/denyRequest');
+const { Conversation } = require('~/db/models');
+const validateConvoAccess = require('./convoAccess');
+
+const OWNER_ID = new mongoose.Types.ObjectId().toString();
+const OTHER_ID = new mongoose.Types.ObjectId().toString();
+const CONVERSATION_ID = 'conversation-under-test';
+
+function createRequest(userId, conversationId) {
+  return {
+    user: { id: userId },
+    body: { conversationId, text: 'hello' },
+  };
+}
+
+describe('validateConvoAccess', () => {
+  let mongoServer;
+  let res;
+  let next;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    await Conversation.create({
+      conversationId: CONVERSATION_ID,
+      user: OWNER_ID,
+      endpoint: 'agents',
+      title: 'Owned conversation',
+      files: ['file-1', 'file-2'],
+    });
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(() => {
+    mockCache.get.mockReset().mockResolvedValue(undefined);
+    mockCache.set.mockReset().mockResolvedValue(true);
+    denyRequest.mockClear();
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    next = jest.fn();
+  });
+
+  it('stashes the full conversation document for downstream readers when access is granted', async () => {
+    const req = createRequest(OWNER_ID, CONVERSATION_ID);
+
+    await validateConvoAccess(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(denyRequest).not.toHaveBeenCalled();
+    expect(req.resolvedConversation).toMatchObject({
+      conversationId: CONVERSATION_ID,
+      user: OWNER_ID,
+      title: 'Owned conversation',
+      files: ['file-1', 'file-2'],
+    });
+  });
+
+  it('stashes null when the conversation does not exist so later readers skip their own lookup', async () => {
+    const req = createRequest(OWNER_ID, 'never-created');
+
+    await validateConvoAccess(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')).toBe(true);
+    expect(req.resolvedConversation).toBeNull();
+  });
+
+  it("denies another user's conversation without exposing the document on the request", async () => {
+    const req = createRequest(OTHER_ID, CONVERSATION_ID);
+
+    await validateConvoAccess(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(denyRequest).toHaveBeenCalledTimes(1);
+    expect(Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')).toBe(false);
+  });
+
+  it('does not wait for the access marker to be written before continuing', async () => {
+    mockCache.set.mockImplementation(() => new Promise(() => undefined));
+    const req = createRequest(OWNER_ID, CONVERSATION_ID);
+
+    await validateConvoAccess(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockCache.set).toHaveBeenCalledWith(
+      expect.stringContaining(`${OWNER_ID}:${CONVERSATION_ID}`),
+      'authorized',
+      expect.any(Number),
+    );
+  });
+
+  it('skips the database entirely when access is already cached', async () => {
+    mockCache.get.mockResolvedValue('authorized');
+    const findOne = jest.spyOn(Conversation, 'findOne');
+    const req = createRequest(OWNER_ID, CONVERSATION_ID);
+
+    await validateConvoAccess(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(findOne).not.toHaveBeenCalled();
+    expect(Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')).toBe(false);
+    expect(require('~/cache').getLogStores).toHaveBeenCalledWith(ViolationTypes.CONVO_ACCESS);
+    findOne.mockRestore();
+  });
+});

--- a/api/server/middleware/validate/convoAccess.spec.js
+++ b/api/server/middleware/validate/convoAccess.spec.js
@@ -43,6 +43,7 @@ describe('validateConvoAccess', () => {
       endpoint: 'agents',
       title: 'Owned conversation',
       files: ['file-1', 'file-2'],
+      messages: Array.from({ length: 50 }, () => new mongoose.Types.ObjectId()),
     });
   });
 
@@ -72,6 +73,7 @@ describe('validateConvoAccess', () => {
       title: 'Owned conversation',
       files: ['file-1', 'file-2'],
     });
+    expect(req.resolvedConversation).not.toHaveProperty('messages');
   });
 
   it('stashes null when the conversation does not exist so later readers skip their own lookup', async () => {

--- a/api/server/routes/agents/v1.js
+++ b/api/server/routes/agents/v1.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { generateCheckAccess } = require('@librechat/api');
 const { PermissionTypes, Permissions, PermissionBits } = require('librechat-data-provider');
-const { requireJwtAuth, configMiddleware, canAccessAgentResource } = require('~/server/middleware');
+const { configMiddleware, canAccessAgentResource } = require('~/server/middleware');
 const v1 = require('~/server/controllers/agents/v1');
 const { getRoleByName } = require('~/models');
 const actions = require('./actions');
@@ -20,8 +20,6 @@ const checkAgentCreate = generateCheckAccess({
   permissions: [Permissions.USE, Permissions.CREATE],
   getRoleByName,
 });
-
-router.use(requireJwtAuth);
 
 /**
  * Agent actions route.

--- a/packages/api/src/agents/guard.spec.ts
+++ b/packages/api/src/agents/guard.spec.ts
@@ -52,6 +52,7 @@ function createApp(
   store: SubagentThreadTaskStore,
   getEventBinding?: AllMethods['getAgentEventBinding'],
   isHumanResumeAllowed?: () => Promise<boolean>,
+  preResolved?: { conversation: IConversation | null },
 ) {
   const app = express();
   app.use(express.json());
@@ -59,6 +60,10 @@ function createApp(
     req.user = { id: 'user-1', tenantId: 'tenant-1' };
     (req as typeof req & { _isAgentTrigger?: boolean })._isAgentTrigger =
       req.get('x-test-trigger') === '1';
+    if (preResolved) {
+      (req as typeof req & { resolvedConversation?: IConversation | null }).resolvedConversation =
+        preResolved.conversation;
+    }
     next();
   });
   const guard = createSubagentThreadTurnGuard({
@@ -108,6 +113,39 @@ describe('subagent child-thread write policy', () => {
     });
     expect(fresh.status).toBe(200);
     expect(getConvo).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses a conversation an earlier middleware already read instead of re-reading it', async () => {
+    const getConvo = jest.fn();
+    const store = makeStore();
+
+    const ordinary = await request(
+      createApp(getConvo, store, undefined, undefined, {
+        conversation: {
+          conversationId: 'ordinary-conversation',
+          endpoint: 'agents',
+        } as IConversation,
+      }),
+    )
+      .post('/chat')
+      .send({ conversationId: 'ordinary-conversation' });
+    const child = await request(
+      createApp(getConvo, store, undefined, undefined, { conversation: childConversation() }),
+    )
+      .post('/chat')
+      .send({ conversationId: 'child-conversation', agent_id: 'child-agent' });
+    const absent = await request(
+      createApp(getConvo, store, undefined, undefined, { conversation: null }),
+    )
+      .post('/chat')
+      .send({ conversationId: 'missing-conversation' });
+
+    expect(ordinary.status).toBe(200);
+    expect(ordinary.body).toEqual({ ok: true, resolvedConversationId: 'ordinary-conversation' });
+    expect(child.status).toBe(409);
+    expect(child.body).toEqual({ error: CHILD_THREAD_READ_ONLY_ERROR });
+    expect(absent.status).toBe(200);
+    expect(getConvo).not.toHaveBeenCalled();
   });
 
   it('rejects every model-bound human turn against a durable child conversation', async () => {

--- a/packages/api/src/agents/guard.ts
+++ b/packages/api/src/agents/guard.ts
@@ -30,6 +30,8 @@ export interface SubagentThreadWriteTarget {
   userId: string;
   conversationId: string;
   tenantId?: string;
+  /** Conversation already read earlier in the request (`null` = looked up, absent). */
+  conversation?: IConversation | null;
 }
 
 interface SubagentThreadWriteResolution {
@@ -112,18 +114,23 @@ async function isBoundEventContinuation(
 
 async function resolveSubagentThreadWrite(
   { getConvo, store }: SubagentThreadWriteGuardDeps,
-  { userId, conversationId, tenantId }: SubagentThreadWriteTarget,
+  target: SubagentThreadWriteTarget,
 ): Promise<SubagentThreadWriteResolution> {
+  const { userId, conversationId, tenantId } = target;
+  const readConversation = (): Promise<IConversation | null> =>
+    target.conversation !== undefined
+      ? Promise.resolve(target.conversation)
+      : getConvo(userId, conversationId);
   /** New child IDs are returned synchronously by the SDK before Mongo creation can
    * finish. Their reserved UUID namespace closes that brief window on every replica. */
   if (isReservedSubagentThreadId(conversationId)) {
-    const conversation = await getConvo(userId, conversationId);
+    const conversation = await readConversation();
     return { blocked: true, conversation };
   }
   if (store.isThreadActiveForOwner(userId, conversationId, tenantId)) {
     return { blocked: true };
   }
-  const conversation = await getConvo(userId, conversationId);
+  const conversation = await readConversation();
   return { blocked: conversation?.subagentThread != null, conversation };
 }
 
@@ -159,10 +166,14 @@ export function createSubagentThreadTurnGuard(deps: SubagentThreadWriteGuardDeps
       typeof user?.tenantId === 'string' && user.tenantId !== '' ? user.tenantId : undefined;
 
     try {
+      const resolvedRequest = request as ResolvedConversationRequest;
       const resolved = await resolveSubagentThreadWrite(deps, {
         userId,
         conversationId: candidateConversationId,
         ...(tenantId == null ? {} : { tenantId }),
+        ...(Object.prototype.hasOwnProperty.call(request, 'resolvedConversation')
+          ? { conversation: resolvedRequest.resolvedConversation }
+          : {}),
       });
       if (resolved.conversation !== undefined) {
         (request as ResolvedConversationRequest).resolvedConversation = resolved.conversation;
@@ -171,7 +182,6 @@ export function createSubagentThreadTurnGuard(deps: SubagentThreadWriteGuardDeps
         next();
         return;
       }
-      const resolvedRequest = request as ResolvedConversationRequest;
       const resolvedConversation = resolved.conversation;
       const lineage = resolvedConversation?.subagentThread;
       const humanResume = deps.isHumanResumeAllowed;

--- a/packages/api/src/agents/initialize.files.spec.ts
+++ b/packages/api/src/agents/initialize.files.spec.ts
@@ -1,0 +1,45 @@
+import { readResolvedConversationFiles } from './initialize';
+
+describe('readResolvedConversationFiles', () => {
+  const conversationId = 'conversation-1';
+
+  it('leaves the database read in place when no middleware resolved the conversation', () => {
+    expect(readResolvedConversationFiles({}, conversationId)).toBeUndefined();
+  });
+
+  it('reports no files when the conversation was looked up and does not exist', () => {
+    expect(readResolvedConversationFiles({ resolvedConversation: null }, conversationId)).toEqual(
+      [],
+    );
+  });
+
+  it('uses the resolved document when it carries the files field', () => {
+    expect(
+      readResolvedConversationFiles(
+        { resolvedConversation: { conversationId, files: ['file-1'] } },
+        conversationId,
+      ),
+    ).toEqual(['file-1']);
+    expect(
+      readResolvedConversationFiles(
+        { resolvedConversation: { conversationId, files: [] } },
+        conversationId,
+      ),
+    ).toEqual([]);
+  });
+
+  it('falls back to the database when the resolved document omits files or is another conversation', () => {
+    expect(
+      readResolvedConversationFiles(
+        { resolvedConversation: { conversationId, agent_id: 'child-agent' } },
+        conversationId,
+      ),
+    ).toBeUndefined();
+    expect(
+      readResolvedConversationFiles(
+        { resolvedConversation: { conversationId: 'other', files: ['file-1'] } },
+        conversationId,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -188,6 +188,32 @@ function appendAdditionalInstructions(agent: Agent, text?: string | null): void 
     .join('\n\n');
 }
 
+/**
+ * The request middleware already read this conversation once (`null` = looked up, absent).
+ * Only a resolved document that actually carries `files` can stand in for the database:
+ * bound agent-event continuations stash a partial document built from lineage alone.
+ */
+export function readResolvedConversationFiles(
+  req: Pick<ServerRequest, 'resolvedConversation'>,
+  conversationId: string,
+): string[] | undefined {
+  if (!Object.prototype.hasOwnProperty.call(req, 'resolvedConversation')) {
+    return undefined;
+  }
+  const resolved = req.resolvedConversation;
+  if (resolved === null) {
+    return [];
+  }
+  if (
+    resolved == null ||
+    resolved.conversationId !== conversationId ||
+    !Object.prototype.hasOwnProperty.call(resolved, 'files')
+  ) {
+    return undefined;
+  }
+  return resolved.files ?? [];
+}
+
 function getMaxCatalogSkills(req: ServerRequest): number | undefined {
   const endpoints = req.config?.endpoints as
     | Record<string, { skills?: { maxCatalogSkills?: number } } | undefined>
@@ -987,7 +1013,7 @@ export async function initializeAgent(
      * every code-output ref.
      */
     const [convoFileIds, threadMessages] = await Promise.all([
-      db.getConvoFiles(conversationId),
+      readResolvedConversationFiles(req, conversationId) ?? db.getConvoFiles(conversationId),
       needsThreadWalk && getThreadMessages
         ? getThreadMessages({ conversationId }, 'messageId parentMessageId files attachments')
         : null,

--- a/packages/api/src/types/http.ts
+++ b/packages/api/src/types/http.ts
@@ -1,5 +1,5 @@
-import type { TConversation, TEndpointOption } from 'librechat-data-provider';
-import type { IUser, AppConfig } from '@librechat/data-schemas';
+import type { IUser, AppConfig, IConversation } from '@librechat/data-schemas';
+import type { TEndpointOption } from 'librechat-data-provider';
 import type { Request } from 'express';
 
 /**
@@ -25,8 +25,9 @@ export type ServerRequest = Request<unknown, unknown, RequestBody> & {
   config?: AppConfig;
   /** Server-captured conversation creation time used to anchor dynamic prompt variables. */
   conversationCreatedAt?: string;
-  /** Conversation loaded while resolving the prompt timestamp anchor, reused by save logic. */
-  resolvedConversation?: Partial<TConversation> | null;
+  /** Conversation read by request middleware (`null` = looked up, absent), reused by the
+   *  subagent guard, agent initialization, and the first save instead of re-reading it. */
+  resolvedConversation?: Partial<IConversation> | null;
   /** Passport strategy that populated req.user for this request. */
   authStrategy?: string;
 };

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -115,7 +115,10 @@ async function refreshChatProjectStatsInBatches(
 
 export interface ConversationMethods {
   getConvoFiles(conversationId: string): Promise<string[]>;
-  searchConversation(conversationId: string): Promise<IConversation | null>;
+  searchConversation(
+    conversationId: string,
+    fieldsToSelect?: string | null,
+  ): Promise<IConversation | null>;
   deleteNullOrEmptyConversations(): Promise<{
     conversations: { deletedCount?: number };
     messages: { deletedCount?: number };
@@ -259,13 +262,14 @@ export function createConversationMethods(
   /**
    * Searches for a conversation by conversationId and returns a lean document with only conversationId and user.
    */
-  async function searchConversation(conversationId: string) {
+  /** `fieldsToSelect: null` returns the full document so one read can serve the whole request. */
+  async function searchConversation(
+    conversationId: string,
+    fieldsToSelect: string | null = 'conversationId user',
+  ) {
     try {
       const Conversation = mongoose.models.Conversation as Model<IConversation>;
-      return await Conversation.findOne(
-        { conversationId },
-        'conversationId user',
-      ).lean<IConversation>();
+      return await Conversation.findOne({ conversationId }, fieldsToSelect).lean<IConversation>();
     } catch (error) {
       logger.error('[searchConversation] Error searching conversation', error);
       throw new Error('Error searching conversation');


### PR DESCRIPTION
## Summary

Four changes to the per-turn chat path, each removing work that a query trace and CPU profile showed was repeated or wasted. Together they take a chat turn from **19 Mongo round trips (15 serial) to 15**, and remove a **~100 ms stall before request admission** on the first message to any existing conversation.

All measurement was done on `main` at b40fcb4c5a with `@librechat/agents` 3.6.14, using a Mongoose query tracer that captures each query's call site, LibreChat's own `/metrics` milestones, and V8 CPU profiles.

### 1. Stop awaiting the conversation-access marker write (`convoAccess.js`)

Without Redis, the `CONVO_ACCESS` violations namespace is backed by `keyv-file` writing `./data/violations.json`. Its debounced `set` resolves after ~100 ms, and `validateConvoAccess` awaited it before `next()`. Measured with the server's `agent_startup_milestone` histogram:

| | `request_admitted` | ack |
|---|---|---|
| first turn on an existing conversation, before | **104–107 ms** | 105–109 ms |
| same, after | 3 ms | 4–5 ms |
| second turn / fresh conversation (unchanged) | 3 ms | 4–5 ms |

Independent of history length (20 and 300 messages behave the same). It recurs once per conversation per ten-minute cache window, on every deployment that doesn't run Redis. The marker only short-circuits the next check, so the write is now fire-and-forget with a logged failure.

### 2. Read the conversation once per turn (`convoAccess.js`, `guard.ts`, `initialize.ts`, `conversation.ts`)

One turn read the same conversation four times: `validateConvoAccess` (two fields), the subagent thread guard (full document), `initializeAgent` → `getConvoFiles` (one field), and the first save. The access check now reads the full document and leaves it on `req.resolvedConversation` (`null` when absent — the existing own-property convention the save path already uses). The guard accepts a pre-resolved document via `SubagentThreadWriteTarget.conversation`, and `initializeAgent` takes `files` from it. When the access check is served from cache, nothing is stashed and every consumer falls back to its own read exactly as before.

Tenant scoping is unchanged: the tenant-isolation plugin applies the request's tenant to both `searchConversation` and `getConvo`, and the access check still rejects another user's conversation before anything is stashed.

### 3. Remove the duplicate JWT authentication on agents routes (`v1.js`)

`routes/agents/index.js:124` applies `requireJwtAuth`, then mounts the `v1` router at `/` (line 1078), which applied its own `requireJwtAuth` at `v1.js:24`. Every request through the agents router ran the passport strategy twice — two verifies and two `User.findOne` — visible in the trace as two identical `JwtStrategy._verify` stacks 1.2 ms apart. `v1` is mounted nowhere else; its separately exported `avatar` router has its own auth in `files/index.js`.

### 4. Skip the history read for root-parent turns; walk the tree in O(n) (`BaseClient.js`)

`loadHistory` fetched every message in the conversation and then walked the parent chain from the request's head. For a new conversation — or a new branch from the root of an existing one — the head is `Constants.NO_PARENT`, which no message carries as its id, so the walk was empty by construction and the fetch was wasted. `getMessagesForConversation` also used `Array.find` inside the walk: O(n²) on a linear conversation, ~5 ms at 1000 messages. A `Map` by `messageId` makes it O(n) with the same first-match semantics.

## Per-turn query trace

New conversation, before → after (`✗` = removed):

```
 1  User.findOne               jwtStrategy (POST)
 2  User.findOne               jwtStrategy (POST, again)               ✗ #3
 3  SystemGrant.findOne        hasCapability
 4  Conversation.findOne       validateConvoAccess                      (now full doc)
 5  Conversation.findOne       resolveSubagentThreadWrite              ✗ #2
 6  Agent.findOne              loadAgent
 7  User.exists                isAgentTriggerPrincipalActive            (deliberate fence, kept)
 8  Conversation.findOne       getConvoFiles ← initializeAgent          ✗ #2
 9  Message.find               loadHistory (NO_PARENT)                  ✗ #4
10  Message.findOneAndUpdate   saveMessage (user)
11  User.findOne               jwtStrategy (GET /stream)
12  Message.find               saveConvo (messages[] maintenance)
13  Conversation.findOneAndUpdate  saveConvo
14  Message.findOneAndUpdate   saveMessage (assistant placeholder)
15  Conversation.findOne       saveMessageToDatabase (new convo only)
16  Message.find               saveConvo
17  Conversation.findOneAndUpdate  saveConvo
18  Message.findOneAndUpdate   saveMessage (assistant final)
19  Message.findOneAndUpdate   saveMessage (user tokens)
```

19 → 15 on a new conversation, 18 → 15 on a follow-up. Every removed read was serial, so on a deployment whose database is one network hop away each one is at least an RTT ahead of the ack. The two `saveConvo` → `Message.find` reads (12, 16) are left for a separate change; they maintain `Conversation.messages[]`, which the client still reads.

## Effect on the local benchmark

Node, local MongoDB, fake in-process model, median of 2 rounds — i.e. the setting that shows these changes *least*, since every removed round trip is sub-millisecond here:

| | ack p50 | first token p50 | throughput | CPU/turn |
|---|---|---|---|---|
| fresh conversation, c=32 | 137 → 102 ms (−26%) | 236 → 211 ms (−11%) | 53.8 → 58.5/s (+9%) | ±0 |
| 300-message history, c=32 | 332 → 233 ms (−30%) | 560 → 469 ms (−16%) | 28.4 → 28.8/s | ±0 |

Time-to-ack falls because the removed reads were serial and sat ahead of the ack; throughput is flat because at c=32 the limiter is per-turn CPU, not the database. The first-turn stall (#1) is amortized out of a closed-loop benchmark entirely and shows only in the milestone table above.

## Tests

- `convoAccess.spec.js` (new, real `mongodb-memory-server`): full document stashed on grant; `null` stashed on absent; nothing stashed on denial; `next()` called even when the cache `set` never resolves; cached access skips the database. Run against the previous middleware, the three behavioral cases fail (the non-blocking one hangs), the two invariants pass.
- `guard.spec.ts`: a pre-resolved conversation (ordinary / child / absent) is honored with `getConvo` never called.
- `BaseClient.test.js`: `loadHistory` skips the read on `NO_PARENT` and still walks a real chain; the existing 14 `getMessagesForConversation` cases now run against the `Map` walk.
- Existing suites touched: `api` 233 + 5, `packages/api` guard 9, `data-schemas` conversation 147 — all green.
- e2e mock subset (app-load, auth, chat, streaming, agents, message-tree, conversation-management): 28/28 on the modified server.

## Not in this PR

- `saveConvo`'s `messages[]` maintenance (two O(n) reads + array rewrite per turn) — touches client consumers.
- The second-save `getConvo` on brand-new conversations — feeds `unsetFields`; one read on first turns only.
- `initializeAgent`'s thread walk for `execute_code` agents re-reads the conversation's messages that `loadHistory` fetches moments later.
