### PR TITLE
🧹 chore: Sort Client Imports Left Behind by the Import Order Gate

### DIFF
--- a/client/src/Providers/AgentsContext.tsx
+++ b/client/src/Providers/AgentsContext.tsx
@@ -1,5 +1,5 @@
-import { useForm, FormProvider } from 'react-hook-form';
 import { createContext, useContext } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
 import type { UseFormReturn } from 'react-hook-form';
 import type { AgentForm } from '~/common';
 import { getDefaultAgentFormValues } from '~/utils';

--- a/client/src/Providers/AssistantsContext.tsx
+++ b/client/src/Providers/AssistantsContext.tsx
@@ -1,5 +1,5 @@
-import { useForm, FormProvider } from 'react-hook-form';
 import { createContext, useContext } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
 import { defaultAssistantFormValues } from 'librechat-data-provider';
 import type { UseFormReturn } from 'react-hook-form';
 import type { AssistantForm } from '~/common';

--- a/client/src/components/Agents/SmartLoader.tsx
+++ b/client/src/components/Agents/SmartLoader.tsx
@@ -1,5 +1,5 @@
-import { AgentListResponse } from 'librechat-data-provider';
 import React, { useState, useEffect } from 'react';
+import { AgentListResponse } from 'librechat-data-provider';
 
 interface SmartLoaderProps {
   /** Whether the content is currently loading */

--- a/client/src/components/Agents/tests/Accessibility.spec.tsx
+++ b/client/src/components/Agents/tests/Accessibility.spec.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
+import * as t from 'librechat-data-provider';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CategoryTabs from '../CategoryTabs';
+import ErrorDisplay from '../ErrorDisplay';
 import AgentGrid from '../AgentGrid';
 import AgentCard from '../AgentCard';
 import SearchBar from '../SearchBar';
-import ErrorDisplay from '../ErrorDisplay';
-import * as t from 'librechat-data-provider';
 
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {

--- a/client/src/components/Agents/tests/CategoryTabs.spec.tsx
+++ b/client/src/components/Agents/tests/CategoryTabs.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import CategoryTabs from '../CategoryTabs';
 import type t from 'librechat-data-provider';
+import CategoryTabs from '../CategoryTabs';
 
 // Mock useLocalize hook
 jest.mock('~/hooks/useLocalize', () => () => (key: string) => {

--- a/client/src/components/Agents/tests/SearchBar.spec.tsx
+++ b/client/src/components/Agents/tests/SearchBar.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SearchBar from '../SearchBar';
 

--- a/client/src/components/Audio/TTS.tsx
+++ b/client/src/components/Audio/TTS.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 import { useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
-import type { TMessageAudio } from '~/common';
 import { VolumeIcon, VolumeMuteIcon, Spinner } from '@librechat/client';
+import type { TMessageAudio } from '~/common';
 import { useLocalize, useTTSBrowser, useTTSExternal } from '~/hooks';
 import { logger } from '~/utils';
 import store from '~/store';

--- a/client/src/components/Auth/ApiErrorWatcher.tsx
+++ b/client/src/components/Auth/ApiErrorWatcher.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useApiErrorBoundary } from '~/hooks/ApiErrorBoundaryContext';
 import { useNavigate } from 'react-router-dom';
+import { useApiErrorBoundary } from '~/hooks/ApiErrorBoundaryContext';
 
 const ApiErrorWatcher = () => {
   const { error } = useApiErrorBoundary();

--- a/client/src/components/Chat/Input/Files/FileContainer.tsx
+++ b/client/src/components/Chat/Input/Files/FileContainer.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
 import type { TFile } from 'librechat-data-provider';
+import type { ReactNode } from 'react';
 import type { ExtendedFile } from '~/common';
 import { getFileType, cn } from '~/utils';
 import FilePreview from './FilePreview';

--- a/client/src/components/Chat/Input/Files/Table/Columns.tsx
+++ b/client/src/components/Chat/Input/Files/Table/Columns.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { ArrowUpDown, ArrowUp, ArrowDown, Database } from 'lucide-react';
 import { FileSources, FileContext } from 'librechat-data-provider';
+import { ArrowUpDown, ArrowUp, ArrowDown, Database } from 'lucide-react';
 import {
   Button,
   Checkbox,

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
+import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EModelEndpoint, mergeFileConfig } from 'librechat-data-provider';
 import type { TEndpointsConfig, Agent } from 'librechat-data-provider';

--- a/client/src/components/Chat/Input/StreamAudio.tsx
+++ b/client/src/components/Chat/Input/StreamAudio.tsx
@@ -1,5 +1,5 @@
-import { useParams } from 'react-router-dom';
 import { useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';

--- a/client/src/components/Chat/Input/TextareaHeader.tsx
+++ b/client/src/components/Chat/Input/TextareaHeader.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
-import AddedConvo from './AddedConvo';
 import type { TConversation } from 'librechat-data-provider';
 import type { SetterOrUpdater } from 'recoil';
+import AddedConvo from './AddedConvo';
 
 export default memo(function TextareaHeader({
   addedConvo,

--- a/client/src/components/Chat/Input/__tests__/PendingManualSkillsChips.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/PendingManualSkillsChips.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { RecoilRoot, MutableSnapshot } from 'recoil';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string, params?: Record<string, unknown>) =>

--- a/client/src/components/Chat/Menus/Endpoints/components/CustomGroup.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/CustomGroup.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import type { TModelSpec } from 'librechat-data-provider';
+import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenu as Menu } from '../CustomMenu';
 import { ModelSpecItem } from './ModelSpecItem';
-import { useModelSelectorContext } from '../ModelSelectorContext';
 import GroupIcon from './GroupIcon';
 
 interface CustomGroupProps {

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { Loader2, AlertCircle, Download, ChevronDown, Files as FilesIcon } from 'lucide-react';
 import { Tools } from 'librechat-data-provider';
+import { Loader2, AlertCircle, Download, ChevronDown, Files as FilesIcon } from 'lucide-react';
 import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
 import type { ToolArtifactType } from '~/utils/artifacts';
 import {
@@ -13,14 +13,14 @@ import {
   isTextAttachment,
   renderAttachmentKey,
 } from './attachmentTypes';
-import FilePreview from '~/components/Chat/Input/Files/FilePreview';
+import { useLocalize, useAttachmentPreviewSync, useExpandCollapse } from '~/hooks';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import { fileToArtifact, TOOL_ARTIFACT_TYPES } from '~/utils/artifacts';
+import FilePreview from '~/components/Chat/Input/Files/FilePreview';
 import Image from '~/components/Chat/Messages/Content/Image';
 import ToolMermaidArtifact from './ToolMermaidArtifact';
 import ToolArtifactCard from './ToolArtifactCard';
 import { useAttachmentLink } from './LogLink';
-import { useLocalize, useAttachmentPreviewSync, useExpandCollapse } from '~/hooks';
 import { cn, getFileType } from '~/utils';
 
 const COLLAPSED_MAX_HEIGHT = 320;

--- a/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
@@ -1,5 +1,5 @@
-import { isAfter } from 'date-fns';
 import React, { useMemo } from 'react';
+import { isAfter } from 'date-fns';
 import { imageExtRegex } from 'librechat-data-provider';
 import type { TFile, TAttachment, TAttachmentMetadata } from 'librechat-data-provider';
 import type { Artifact } from '~/common';

--- a/client/src/components/Chat/Messages/Content/Parts/ToolArtifactCard.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ToolArtifactCard.tsx
@@ -13,8 +13,8 @@ import FilePreview from '~/components/Chat/Input/Files/FilePreview';
 import { isCodeOnlyArtifact } from '~/utils/artifacts';
 import { displayFilename } from './attachmentTypes';
 import { useAttachmentLink } from './LogLink';
-import { useLocalize } from '~/hooks';
 import { cn, getFileType } from '~/utils';
+import { useLocalize } from '~/hooks';
 import store from '~/store';
 
 interface ToolArtifactCardProps {

--- a/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import Markdown from '../Markdown';
-import MarkdownLite from '../MarkdownLite';
 import { RecoilRoot } from 'recoil';
-import { UI_RESOURCE_MARKER } from '~/components/MCPUIResource/plugin';
+import { render, screen } from '@testing-library/react';
 import {
   useMessageContext,
   useOptionalMessagesConversation,
   useOptionalMessagesOperations,
 } from '~/Providers';
+import { UI_RESOURCE_MARKER } from '~/components/MCPUIResource/plugin';
 import { useGetMessagesByConvoId } from '~/data-provider';
+import MarkdownLite from '../MarkdownLite';
 import { useLocalize } from '~/hooks';
+import Markdown from '../Markdown';
 
 // Mocks for hooks used by MCPUIResource when rendered inside Markdown.
 // Keep Provider components intact while mocking only the hooks we use.

--- a/client/src/components/Chat/Messages/MessageIcon.tsx
+++ b/client/src/components/Chat/Messages/MessageIcon.tsx
@@ -4,9 +4,9 @@ import type { Assistant, Agent } from 'librechat-data-provider';
 import type { TMessageIcon } from '~/common';
 import ConvoIconURL from '~/components/Endpoints/ConvoIconURL';
 import { useGetEndpointsQuery } from '~/data-provider';
-import { getIconEndpoint } from '~/utils';
-import { isImageURL } from '~/utils/icons';
 import Icon from '~/components/Endpoints/Icon';
+import { isImageURL } from '~/utils/icons';
+import { getIconEndpoint } from '~/utils';
 
 type MessageIconProps = {
   iconData?: TMessageIcon;

--- a/client/src/components/Endpoints/Settings/Anthropic.tsx
+++ b/client/src/components/Endpoints/Settings/Anthropic.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
+import { presetSettings } from 'librechat-data-provider';
 import { getSettingsKeys } from 'librechat-data-provider';
 import type { SettingDefinition } from 'librechat-data-provider';
 import type { TModelSelectProps } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
-import { presetSettings } from 'librechat-data-provider';
 
 export default function AnthropicSettings({
   conversation,


### PR DESCRIPTION
## Summary

`scripts/sort-imports.mts` runs as a pre-commit gate and as its own CI check, but 21 client files predate it and have never been touched since, so they sit permanently unsorted. Anyone who edits one of them gets the whole file's imports reordered by lint-staged and ends up carrying unrelated churn in their diff.

This sorts those files once so the reordering stops leaking into feature branches. Import statements only: no runtime code, no behavior, no reordering of anything with side effects at import time.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `node scripts/sort-imports.mts --check <21 files>` — `All 21 files already sorted.`
- `npx eslint <21 files>` — clean
- `npx prettier --check <21 files>` — clean

### **Test Configuration**:

Node v24.16.0, local worktree branched from `dev`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
