### PR TITLE
🏎️ chore: Bump @librechat/agents to v3.6.15

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.14",
+    "@librechat/agents": "^3.6.15",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.14",
+        "@librechat/agents": "^3.6.15",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10630,9 +10630,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.14.tgz",
-      "integrity": "sha512-beN9SJtN3eRWwGhHXIzdok4TrZQqiTfMtC6cpwwoTodzW4BuAe7Z3yQsrPLDoUJ05gr7TcRZA6+2YvkVfeiitQ==",
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.15.tgz",
+      "integrity": "sha512-AgQPT5i0APKP4pQz4ajEhfkrK0GqpD0YFnE55xcuEd/fPGsSags1jw++WISpyuU8tFsO9fuYHUIe1U2RNmPO5g==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42822,7 +42822,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.14",
+        "@librechat/agents": "^3.6.15",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.14",
+    "@librechat/agents": "^3.6.15",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

I bumped @librechat/agents from 3.6.14 to 3.6.15 so LibreChat receives the measured token-count hot-path optimization.

- Update the API runtime dependency and the shared API peer dependency to ^3.6.15.
- Refresh the npm workspace lock to the published 3.6.15 artifact.
- Avoid exact token counts that LibreChat already supplies for retained messages.
- Replace exception-driven native Date and ArrayBuffer checks with native brand checks.
- Pick up measured improvements of 33% lower CPU per turn at 300 messages, 27% lower p50 latency at 1,000 messages, and 36% higher throughput.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Confirmed @librechat/agents@3.6.15 is published and tagged latest on npm.
- Regenerated package-lock.json with npm install --package-lock-only --ignore-scripts.
- Verified both LibreChat consumers request ^3.6.15 and the lock resolves exactly 3.6.15.
- Verified the lockfile integrity matches the published npm artifact.
- Ran git diff --check.
- Confirmed the lock refresh changes only the expected agents version, URL, integrity, and consumer ranges.
- Observed 8 existing npm audit findings (6 low, 2 moderate); this bump adds no dependency-tree churn.
- Confirmed all 13 agents release validation jobs passed before publication.

### **Test Configuration**:

- Node.js 24
- npm 11.16.0
- macOS arm64
- @librechat/agents 3.6.15 from npm

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] The agents SDK feature tests and CI passed before publication
- [x] The required agents SDK release has been merged and published
