### PR TITLE
⚡ perf: Append Saved Message Ids Instead of Rebuilding the Conversation Array

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1315,6 +1315,7 @@ class BaseClient {
       unsetFields,
       noUpsert: req?._agentEventBindingParentConversationId != null,
       createdAtOnInsert: shouldSetCreatedAtOnInsert ? validCreatedAtOnInsert : undefined,
+      ...(savedMessage?._id != null ? { appendMessageIds: [savedMessage._id] } : {}),
     });
 
     return { message: savedMessage, conversation };

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1871,6 +1871,36 @@ describe('BaseClient', () => {
       );
     });
 
+    test('saveMessageToDatabase appends the saved message id instead of rebuilding the array', async () => {
+      const savedId = new (require('mongoose').Types.ObjectId)();
+      saveMessage.mockResolvedValueOnce({ _id: savedId, messageId: 'saved-1' });
+      saveConvo.mockResolvedValueOnce({ conversationId });
+
+      await TestClient.saveMessageToDatabase(
+        { messageId: 'saved-1', conversationId, text: 'hi' },
+        TestClient.getSaveOptions(),
+      );
+
+      expect(saveConvo).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ appendMessageIds: [savedId] }),
+      );
+    });
+
+    test('saveMessageToDatabase rebuilds the array when the saved message has no _id', async () => {
+      saveMessage.mockResolvedValueOnce({ messageId: 'saved-2' });
+      saveConvo.mockResolvedValueOnce({ conversationId });
+
+      await TestClient.saveMessageToDatabase(
+        { messageId: 'saved-2', conversationId, text: 'hi' },
+        TestClient.getSaveOptions(),
+      );
+
+      const metadata = saveConvo.mock.calls[saveConvo.mock.calls.length - 1][2];
+      expect(metadata).not.toHaveProperty('appendMessageIds');
+    });
+
     test('saveMessageToDatabase returns early when this.options is null (client disposed)', async () => {
       const savedOptions = TestClient.options;
       TestClient.options = null;

--- a/api/server/routes/__tests__/messages-get.spec.js
+++ b/api/server/routes/__tests__/messages-get.spec.js
@@ -443,7 +443,10 @@ describe('message route conversation ownership filters', () => {
         model: savedMessage.model,
         iconURL: savedMessage.iconURL,
       },
-      { context: 'POST /api/messages/:conversationId' },
+      {
+        context: 'POST /api/messages/:conversationId',
+        appendMessageIds: [savedMessage._id],
+      },
     );
   });
 

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -504,6 +504,7 @@ router.post('/:conversationId', storedMessageMutationMiddleware, async (req, res
     };
     await db.saveConvo(reqCtx, conversationUpdate, {
       context: 'POST /api/messages/:conversationId',
+      ...(savedMessage._id != null ? { appendMessageIds: [savedMessage._id] } : {}),
     });
     res.status(201).json(savedMessage);
   } catch (error) {

--- a/packages/api/src/agents/guard.ts
+++ b/packages/api/src/agents/guard.ts
@@ -51,6 +51,15 @@ interface ResolvedConversationRequest extends Request {
   _agentEventBindingTenantId?: string;
 }
 
+/**
+ * Brands the lineage-only conversation `isBoundEventContinuation` synthesizes: it stands in
+ * for binding checks but carries none of the stored document's optional fields, so readers
+ * of `req.resolvedConversation` must not treat its absent fields as authoritative.
+ */
+export const PARTIAL_RESOLVED_CONVERSATION: unique symbol = Symbol.for(
+  'librechat.resolvedConversation.partial',
+);
+
 function applyEventBindingContext(
   request: ResolvedConversationRequest,
   conversation: IConversation,
@@ -102,6 +111,7 @@ async function isBoundEventContinuation(
     return null;
   }
   return {
+    [PARTIAL_RESOLVED_CONVERSATION]: true,
     conversationId: binding.conversationId,
     agent_id: binding.agentId,
     ...(binding.tenantId == null ? {} : { tenantId: binding.tenantId }),

--- a/packages/api/src/agents/initialize.files.spec.ts
+++ b/packages/api/src/agents/initialize.files.spec.ts
@@ -1,4 +1,6 @@
+import type { IConversation } from '@librechat/data-schemas';
 import { readResolvedConversationFiles } from './initialize';
+import { PARTIAL_RESOLVED_CONVERSATION } from './guard';
 
 describe('readResolvedConversationFiles', () => {
   const conversationId = 'conversation-1';
@@ -28,12 +30,23 @@ describe('readResolvedConversationFiles', () => {
     ).toEqual([]);
   });
 
-  it('falls back to the database when the resolved document omits files or is another conversation', () => {
+  it('treats a stored document without files as having none', () => {
     expect(
       readResolvedConversationFiles(
-        { resolvedConversation: { conversationId, agent_id: 'child-agent' } },
+        { resolvedConversation: { conversationId, title: 'no uploads yet' } },
         conversationId,
       ),
+    ).toEqual([]);
+  });
+
+  it('falls back to the database for a branded lineage-only partial or another conversation', () => {
+    const lineageOnly = {
+      [PARTIAL_RESOLVED_CONVERSATION]: true,
+      conversationId,
+      agent_id: 'child-agent',
+    } as unknown as IConversation;
+    expect(
+      readResolvedConversationFiles({ resolvedConversation: lineageOnly }, conversationId),
     ).toBeUndefined();
     expect(
       readResolvedConversationFiles(

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -94,6 +94,7 @@ import { assertModelBoundContent } from '../middleware/modelBoundContent';
 import { registerMemoryTools, memoryToolUsageGuard } from './memory';
 import { applyIntentLabels, sanitizeIntentLabels } from './intent';
 import { ContentFilterError } from '../middleware/contentFilter';
+import { PARTIAL_RESOLVED_CONVERSATION } from './guard';
 import { applyBackgroundToolCalls } from './background';
 import { filterFilesByEndpointConfig } from '~/files';
 import { generateArtifactsPrompt } from '~/prompts';
@@ -190,8 +191,8 @@ function appendAdditionalInstructions(agent: Agent, text?: string | null): void 
 
 /**
  * The request middleware already read this conversation once (`null` = looked up, absent).
- * Only a resolved document that actually carries `files` can stand in for the database:
- * bound agent-event continuations stash a partial document built from lineage alone.
+ * A stored document without `files` genuinely has none; only the branded lineage-only
+ * partial from a bound agent-event continuation cannot speak for the database.
  */
 export function readResolvedConversationFiles(
   req: Pick<ServerRequest, 'resolvedConversation'>,
@@ -207,7 +208,7 @@ export function readResolvedConversationFiles(
   if (
     resolved == null ||
     resolved.conversationId !== conversationId ||
-    !Object.prototype.hasOwnProperty.call(resolved, 'files')
+    (resolved as Record<symbol, unknown>)[PARTIAL_RESOLVED_CONVERSATION] === true
   ) {
     return undefined;
   }

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -961,6 +961,85 @@ describe('Conversation Operations', () => {
     });
   });
 
+  describe('saveConvo appendMessageIds', () => {
+    const ctx = { userId: 'append-user' };
+    const conversationId = 'append-conversation';
+
+    beforeEach(async () => {
+      await Conversation.deleteMany({ user: ctx.userId });
+      getMessages.mockClear();
+    });
+
+    it('appends the provided ids without reading the messages collection', async () => {
+      const seeded = [new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId()];
+      getMessages.mockResolvedValueOnce(seeded.map((_id) => ({ _id })));
+      await saveConvo(ctx, { conversationId, title: 'seeded' });
+      expect(getMessages).toHaveBeenCalledTimes(1);
+
+      const appended = new mongoose.Types.ObjectId();
+      const result = await saveConvo(
+        ctx,
+        { conversationId, title: 'appended' },
+        { appendMessageIds: [appended] },
+      );
+
+      expect(getMessages).toHaveBeenCalledTimes(1);
+      expect(result?.title).toBe('appended');
+      const stored = await Conversation.findOne({ conversationId }).lean();
+      expect(stored?.messages?.map(String)).toEqual([...seeded, appended].map(String));
+    });
+
+    it('does not duplicate an id that is already recorded', async () => {
+      const id = new mongoose.Types.ObjectId();
+      await saveConvo(ctx, { conversationId }, { appendMessageIds: [id] });
+      await saveConvo(ctx, { conversationId }, { appendMessageIds: [id] });
+
+      const stored = await Conversation.findOne({ conversationId }).lean();
+      expect(stored?.messages?.map(String)).toEqual([String(id)]);
+      expect(getMessages).not.toHaveBeenCalled();
+    });
+
+    it('creates the conversation with the appended id when it does not exist yet', async () => {
+      const id = new mongoose.Types.ObjectId();
+      const result = await saveConvo(
+        ctx,
+        { conversationId, title: 'first turn' },
+        { appendMessageIds: [id] },
+      );
+
+      expect(result?.conversationId).toBe(conversationId);
+      const stored = await Conversation.findOne({ conversationId }).lean();
+      expect(stored?.messages?.map(String)).toEqual([String(id)]);
+      expect(getMessages).not.toHaveBeenCalled();
+    });
+
+    it('ignores a caller-supplied messages field so $set cannot conflict with the append', async () => {
+      const kept = new mongoose.Types.ObjectId();
+      await saveConvo(ctx, { conversationId }, { appendMessageIds: [kept] });
+
+      const appended = new mongoose.Types.ObjectId();
+      await saveConvo(
+        ctx,
+        { conversationId, messages: [new mongoose.Types.ObjectId()] },
+        { appendMessageIds: [appended] },
+      );
+
+      const stored = await Conversation.findOne({ conversationId }).lean();
+      expect(stored?.messages?.map(String)).toEqual([kept, appended].map(String));
+    });
+
+    it('still rebuilds the array from the database when the option is absent', async () => {
+      const rebuilt = [new mongoose.Types.ObjectId()];
+      getMessages.mockResolvedValueOnce(rebuilt.map((_id) => ({ _id })));
+
+      await saveConvo(ctx, { conversationId, title: 'rebuild' });
+
+      expect(getMessages).toHaveBeenCalledWith({ conversationId, user: ctx.userId }, '_id');
+      const stored = await Conversation.findOne({ conversationId }).lean();
+      expect(stored?.messages?.map(String)).toEqual(rebuilt.map(String));
+    });
+  });
+
   describe('isTemporary conversation handling', () => {
     it('should save a conversation with expiredAt when isTemporary is true', async () => {
       mockCtx.interfaceConfig = { temporaryChatRetention: 24 };

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -137,6 +137,10 @@ export interface ConversationMethods {
       noUpsert?: boolean;
       createdAtOnInsert?: Date;
       preserveUpdatedAt?: boolean;
+      /** `_id`s of messages this save just wrote. When present, they are appended with
+       *  `$addToSet` and the O(n) read-and-rewrite of the `messages` array is skipped;
+       *  every save without this option still rebuilds the array from the database. */
+      appendMessageIds?: Types.ObjectId[];
     },
   ): Promise<IConversation | { message: string } | null>;
   setConvoPinned(
@@ -649,6 +653,7 @@ export function createConversationMethods(
       noUpsert?: boolean;
       createdAtOnInsert?: Date;
       preserveUpdatedAt?: boolean;
+      appendMessageIds?: Types.ObjectId[];
     },
   ) {
     try {
@@ -659,8 +664,13 @@ export function createConversationMethods(
         logger.debug(`[saveConvo] ${metadata.context}`);
       }
 
-      const messages = await getMessages({ conversationId, user: userId }, '_id');
-      const update: Record<string, unknown> = { ...convo, messages, user: userId };
+      const appendMessageIds = metadata?.appendMessageIds;
+      const update: Record<string, unknown> = { ...convo, user: userId };
+      if (appendMessageIds == null) {
+        update.messages = await getMessages({ conversationId, user: userId }, '_id');
+      } else {
+        delete update.messages;
+      }
       const unsetFields: Record<string, number> = { ...(metadata?.unsetFields ?? {}) };
 
       if (Object.prototype.hasOwnProperty.call(update, 'chatProjectId') && update.chatProjectId) {
@@ -750,6 +760,9 @@ export function createConversationMethods(
 
       const buildOperation = (setFields: Record<string, unknown>) => {
         const operation: Record<string, unknown> = { $set: setFields };
+        if (appendMessageIds != null && appendMessageIds.length > 0) {
+          operation.$addToSet = { messages: { $each: appendMessageIds } };
+        }
         if (Object.keys(unsetFields).length > 0) {
           operation.$unset = unsetFields;
         }


### PR DESCRIPTION
## Summary

Follow-up to #15138, taking the next item from the same per-turn query trace: `saveConvo` read **every message id in the conversation** (sorted by `createdAt`) and wrote the array back onto the Conversation document — twice per chat turn, O(n) in conversation length, from a write path.

### Append instead of rebuild

The turn's two savers know exactly which message they just wrote, so `saveConvo` gains `metadata.appendMessageIds`: the ids are `$addToSet`-ed and the read + full-array rewrite are skipped. Only `BaseClient.saveMessageToDatabase` and `POST /api/messages/:conversationId` pass it. Every other caller — title generation, archive, rename, fork, import, thread management — still rebuilds the array from the database.

That rebuild remains the heal point for drift, and the drift is not new: message deletion has never run `saveConvo`, so the array has always been eventually-consistent, healed by the next rebuild. The consumers tolerate that by construction — four read `messages.length >= 1`, one uses the array as an optimistic React Query placeholder that the next real fetch replaces. On traced turns the appended array stays **exactly equal** to the messages collection.

`$addToSet` composes with the existing `$set`/`$unset`/`$setOnInsert` operation (a caller-supplied `messages` field is dropped in append mode so the same path can never appear in both `$set` and `$addToSet`), works on the upsert-insert path, and cannot duplicate ids.

### Brand the lineage-only partial (refines a #15138 codex fix)

Measuring this change exposed a blind spot in the previous PR's hardening: the files fast path treated an *absent* `files` property on `req.resolvedConversation` as "unresolved", to protect against the lineage-only partial that a bound agent-event continuation stashes. But MongoDB never stores an empty `files` array, so nearly every real conversation also lacks the property — the fast path never fired, and follow-up turns on upload-free conversations still paid the `getConvoFiles` round trip.

The synthesized partial is the one object that cannot speak for the database, so it now carries an explicit brand — `PARTIAL_RESOLVED_CONVERSATION`, a symbol key that never serializes and is invisible to `for...in` — and a stored document without `files` means what it means in Mongo: no files.

## Per-turn query trace

Same tracer as #15138, on `dev` (which already includes #15138):

| turn | before this PR | after |
|---|---|---|
| new conversation | 15 | **13** |
| follow-up, 300 messages | 15 | **13** |

The two removed reads per turn were the `saveConvo` → `Message.find` pair; the branding recovers the `getConvoFiles` read that #15138 intended to remove. The only remaining O(conversation) read per turn is `loadHistory` itself. Cumulatively from `main` two days ago: **19 → 13** on a new conversation, plus the ~100 ms admission stall.

Beyond the round trips, the O(n) cost this removes scales with conversation length: at 300 messages each turn was reading 300 ids and writing a 300-element array back — twice.

## Tests

- `conversation.spec.ts` (+5, real `mongodb-memory-server`): append without reading (the injected `getMessages` is never called), no duplicate ids, upsert-insert with append, caller-supplied `messages` cannot conflict with the append, and the rebuild path is unchanged when the option is absent.
- `BaseClient.test.js` (+2): the saved message's `_id` is passed through; no option when the save returns no `_id`.
- `initialize.files.spec.ts`: reworked for the brand — a stored document without `files` yields `[]`; the branded partial and foreign conversations fall back to the database.
- Touched suites: data-schemas conversation 152, packages/api agents 2475, api BaseClient 110 — green; `tsc --noEmit` clean in both TS packages.
- e2e mock subset (app-load, auth, chat, streaming, agents, message-tree, conversation-management) on the modified server.

## Not in this PR

- `$pull`-ing deleted ids from the array on the single-message DELETE route (would make the array *tighter* than today; the route only has the message UUID, not the `_id`).
- Replacing the array outright with a `messageCount` — five client consumers, coordinated change.
