### PR TITLE
🗳️ ci: Log the Exact Spec List in Codegraph E2E Votes

### DIFF
--- a/.github/workflows/codegraph-e2e-votes.yml
+++ b/.github/workflows/codegraph-e2e-votes.yml
@@ -79,6 +79,11 @@ jobs:
             echo "no codegraph config; skipping"
           fi
           echo "codegraph-votes: running $N skippable specs"
+          # The exact list, one log line: the shadow's per-spec graduation ledger counts a clean
+          # trial for every spec a green vote run covered, and until this line existed it had to
+          # approximate coverage from the decision event's tier (drift: the tier is recomputed
+          # here at the merge commit against a possibly newer graph head).
+          if [ "$N" != "0" ]; then echo "codegraph-votes-specs: $(tr '\n' ' ' < skippable.txt)"; fi
           echo "count=$N" >> "$GITHUB_OUTPUT"
           exit 0
 


### PR DESCRIPTION
One log line: `codegraph-votes-specs: <list>` after the existing count marker. The shadow's per-spec graduation ledger (pre-registered tonight: 15 consecutive clean trials to skip, 30 when history-coupled, chronic never graduates) counts a clean trial for every spec a green vote run covered — until now it approximated coverage from the merged PR's decision event, which can drift from the tier this workflow recomputes at the merge commit. ~1.5 KB of log on a ~34-spec tier; no behavioral change; the tier step still exits 0 on every path.