### PR TITLE
⚡ perf: Plain-JSON Memory Cache and an Idle Backoff for the Trigger Poll

### DIFF
--- a/packages/api/src/agents/triggers/engine.spec.ts
+++ b/packages/api/src/agents/triggers/engine.spec.ts
@@ -524,6 +524,32 @@ describe('createAgentTriggerDeliveryEngine', () => {
     }
   });
 
+  it('keeps polling at the base cadence while claims are failing', async () => {
+    jest.useFakeTimers();
+    try {
+      const store = storeWith({
+        claimNext: jest.fn(async () => {
+          throw new Error('mongo unavailable');
+        }),
+      });
+      const dispatch = jest.fn(async () => successResult());
+      const engine = createAgentTriggerDeliveryEngine(
+        { store, dispatch, now: () => START, workerId: 'worker-1' },
+        { concurrency: 1, tickMs: 1_000, maxIdleTickMs: 8_000 },
+      );
+
+      engine.start();
+      /** A failed claim proves nothing about the queue, so recovery attempts stay
+       *  one second apart instead of stretching toward the idle ceiling. */
+      await jest.advanceTimersByTimeAsync(10_000);
+      expect((store.claimNext as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(10);
+
+      await engine.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('coalesces overlapping ticks into one claim pass', async () => {
     let releaseClaim: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {

--- a/packages/api/src/agents/triggers/engine.spec.ts
+++ b/packages/api/src/agents/triggers/engine.spec.ts
@@ -457,6 +457,73 @@ describe('createAgentTriggerDeliveryEngine', () => {
     await tick;
   });
 
+  it('backs off polling while idle and snaps back on a wake', async () => {
+    jest.useFakeTimers();
+    try {
+      const store = storeWith({ claimNext: jest.fn(async () => null) });
+      const dispatch = jest.fn(async () => successResult());
+      const engine = createAgentTriggerDeliveryEngine(
+        { store, dispatch, now: () => START, workerId: 'worker-1' },
+        { concurrency: 1, tickMs: 1_000, maxIdleTickMs: 8_000 },
+      );
+
+      engine.start();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(store.claimNext).toHaveBeenCalledTimes(1);
+
+      /** Idle polls land at +1s, +5s, +13s (doubling, capped at 8s): 3 more claims in 15s, not 15. */
+      await jest.advanceTimersByTimeAsync(15_000);
+      expect(store.claimNext).toHaveBeenCalledTimes(4);
+
+      /** A wake — an enqueue nudge or a finished delivery — claims immediately and
+       *  re-arms the base cadence, so the next idle poll is one second out again. */
+      engine.wake();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(store.claimNext).toHaveBeenCalledTimes(5);
+      await jest.advanceTimersByTimeAsync(1_000);
+      expect(store.claimNext).toHaveBeenCalledTimes(6);
+
+      await engine.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('returns to the base cadence after a claimed delivery interrupts an idle stretch', async () => {
+    jest.useFakeTimers();
+    try {
+      const responses: Array<AgentTriggerDeliveryRecord | null> = [
+        null,
+        null,
+        delivery(),
+        null,
+        null,
+      ];
+      const store = storeWith({
+        claimNext: jest.fn(async () => (responses.length > 0 ? (responses.shift() ?? null) : null)),
+      });
+      const dispatch = jest.fn(async () => successResult());
+      const engine = createAgentTriggerDeliveryEngine(
+        { store, dispatch, now: () => START, workerId: 'worker-1' },
+        { concurrency: 1, tickMs: 1_000, maxIdleTickMs: 8_000 },
+      );
+
+      engine.start();
+      /** start (null) -> +1s (null) -> +5s: the third claim finds work. */
+      await jest.advanceTimersByTimeAsync(5_000);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      const claimsAfterWork = (store.claimNext as jest.Mock).mock.calls.length;
+
+      /** The completed delivery wakes the engine, so polling resumes at one-second steps. */
+      await jest.advanceTimersByTimeAsync(1_000);
+      expect((store.claimNext as jest.Mock).mock.calls.length).toBeGreaterThan(claimsAfterWork);
+
+      await engine.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('coalesces overlapping ticks into one claim pass', async () => {
     let releaseClaim: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {

--- a/packages/api/src/agents/triggers/engine.spec.ts
+++ b/packages/api/src/agents/triggers/engine.spec.ts
@@ -603,6 +603,72 @@ describe('createAgentTriggerDeliveryEngine', () => {
     }
   });
 
+  it('tracks several eligibility deadlines and interrupts a capped idle sleep for a new earliest', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(START);
+    try {
+      const handed = new Set<string>();
+      const pendingAt = new Map<string, number>([
+        ['claim-1', 0],
+        ['claim-2', 0],
+        ['retry-1', START.getTime() + 5_000],
+        ['retry-2', START.getTime() + 23_000],
+      ]);
+      const store = storeWith({
+        claimNext: jest.fn(async () => {
+          for (const [token, at] of pendingAt) {
+            if (!handed.has(token) && Date.now() >= at) {
+              handed.add(token);
+              return delivery({ claimToken: token });
+            }
+          }
+          return null;
+        }),
+      });
+      const retryable = (retryAfter: string) =>
+        new AgentTriggerExecutionError('busy', {
+          mode: 'fire',
+          certainty: 'definite',
+          retryable: true,
+          code: 'RATE_LIMITED',
+          status: 429,
+          retryAfter,
+        });
+      const dispatch = jest
+        .fn()
+        .mockRejectedValueOnce(retryable('5'))
+        .mockRejectedValueOnce(retryable('23'))
+        .mockImplementation(async () => successResult());
+      const engine = createAgentTriggerDeliveryEngine(
+        { store, dispatch, now: () => new Date(), workerId: 'worker-1' },
+        { concurrency: 2, tickMs: 1_000, maxIdleTickMs: 60_000 },
+      );
+
+      engine.start();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(dispatch).toHaveBeenCalledTimes(2);
+
+      /** Both retry deadlines are tracked: the +5s one fires on time, and the +23s one
+       *  survives it — a single-slot tracker would discard it and idle to the cap. */
+      await jest.advanceTimersByTimeAsync(6_000);
+      expect(dispatch).toHaveBeenCalledTimes(3);
+      await jest.advanceTimersByTimeAsync(18_000);
+      expect(dispatch).toHaveBeenCalledTimes(4);
+
+      /** And a deadline learned while the timer already sleeps toward the idle cap
+       *  re-arms it: nothing new until the engine has idled well past base cadence. */
+      await jest.advanceTimersByTimeAsync(40_000);
+      pendingAt.set('late-arrival', Date.now() + 3_000);
+      engine.noteEligibleAt(new Date(Date.now() + 3_000));
+      await jest.advanceTimersByTimeAsync(4_000);
+      expect(dispatch).toHaveBeenCalledTimes(5);
+
+      await engine.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('coalesces overlapping ticks into one claim pass', async () => {
     let releaseClaim: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {

--- a/packages/api/src/agents/triggers/engine.spec.ts
+++ b/packages/api/src/agents/triggers/engine.spec.ts
@@ -550,6 +550,59 @@ describe('createAgentTriggerDeliveryEngine', () => {
     }
   });
 
+  it('claims a scheduled retry when it becomes eligible instead of waiting out the idle backoff', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(START);
+    try {
+      let handedFirst = false;
+      let handedRetry = false;
+      const store = storeWith({
+        claimNext: jest.fn(async () => {
+          if (!handedFirst) {
+            handedFirst = true;
+            return delivery();
+          }
+          if (!handedRetry && Date.now() >= START.getTime() + 20_000) {
+            handedRetry = true;
+            return delivery({ claimToken: 'claim-2', attempts: 1 });
+          }
+          return null;
+        }),
+      });
+      const retryable = new AgentTriggerExecutionError('busy', {
+        mode: 'fire',
+        certainty: 'definite',
+        retryable: true,
+        code: 'RATE_LIMITED',
+        status: 429,
+        retryAfter: '20',
+      });
+      const dispatch = jest
+        .fn()
+        .mockRejectedValueOnce(retryable)
+        .mockImplementation(async () => successResult());
+      const engine = createAgentTriggerDeliveryEngine(
+        { store, dispatch, now: () => new Date(), workerId: 'worker-1' },
+        { concurrency: 1, tickMs: 1_000, maxIdleTickMs: 60_000 },
+      );
+
+      engine.start();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(store.retry).toHaveBeenCalledWith(
+        expect.objectContaining({ availableAt: new Date(START.getTime() + 20_000) }),
+      );
+
+      /** The idle backoff alone would next poll at +31s; the recorded eligibility
+       *  caps the sleep so the retry is claimed on time. */
+      await jest.advanceTimersByTimeAsync(21_000);
+      expect(dispatch).toHaveBeenCalledTimes(2);
+
+      await engine.stop();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('coalesces overlapping ticks into one claim pass', async () => {
     let releaseClaim: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {

--- a/packages/api/src/agents/triggers/engine.ts
+++ b/packages/api/src/agents/triggers/engine.ts
@@ -247,10 +247,13 @@ export function createAgentTriggerDeliveryEngine(
   const workerId = deps.workerId ?? `${process.pid}-${randomUUID()}`;
   const controllers = new Map<AbortController, string>();
   let idleStreak = 0;
-  /** Earliest known future eligibility among deliveries this process has seen; the idle
-   *  timer never sleeps past it, so a retry or defer is claimed when due, not when the
-   *  backoff happens to wake. Cross-replica delays remain bounded by `maxIdleTickMs`. */
-  let nextEligibleAtMs: number | null = null;
+  /** Future eligibility times this process has seen (sorted, deduplicated, bounded); the
+   *  idle timer never sleeps past the earliest, so retries and defers are claimed when
+   *  due, not when the backoff happens to wake. On overflow the latest deadline is
+   *  dropped and that delivery degrades to idle-poll pickup, bounded by `maxIdleTickMs`
+   *  — the same bound that covers deliveries delayed by other replicas. */
+  const eligibleDeadlinesMs: number[] = [];
+  const MAX_TRACKED_DEADLINES = 64;
   const processing = new Set<Promise<void>>();
   const processingByUser = new Map<string, Set<Promise<void>>>();
   const cancelledUsers = new Set<string>();
@@ -584,11 +587,19 @@ export function createAgentTriggerDeliveryEngine(
     if (!Number.isFinite(eligibleAtMs) || stopped) {
       return;
     }
-    if (nextEligibleAtMs != null && eligibleAtMs >= nextEligibleAtMs) {
+    const insertAt = eligibleDeadlinesMs.findIndex((deadline) => deadline >= eligibleAtMs);
+    if (insertAt !== -1 && eligibleDeadlinesMs[insertAt] === eligibleAtMs) {
       return;
     }
-    nextEligibleAtMs = eligibleAtMs;
-    if (started) {
+    eligibleDeadlinesMs.splice(
+      insertAt === -1 ? eligibleDeadlinesMs.length : insertAt,
+      0,
+      eligibleAtMs,
+    );
+    if (eligibleDeadlinesMs.length > MAX_TRACKED_DEADLINES) {
+      eligibleDeadlinesMs.pop();
+    }
+    if (started && eligibleDeadlinesMs[0] === eligibleAtMs) {
       schedule();
     }
   }
@@ -614,15 +625,16 @@ export function createAgentTriggerDeliveryEngine(
       clearTimeout(timer);
     }
     let delay = Math.min(tickMs * 2 ** idleStreak, maxIdleTickMs);
-    if (nextEligibleAtMs != null) {
-      delay = Math.max(0, Math.min(delay, nextEligibleAtMs - now().getTime()));
+    if (eligibleDeadlinesMs.length > 0) {
+      delay = Math.max(0, Math.min(delay, eligibleDeadlinesMs[0] - now().getTime()));
     }
     timer = setTimeout(async () => {
       if (stopped) {
         return;
       }
-      if (nextEligibleAtMs != null && now().getTime() >= nextEligibleAtMs) {
-        nextEligibleAtMs = null;
+      const nowMs = now().getTime();
+      while (eligibleDeadlinesMs.length > 0 && eligibleDeadlinesMs[0] <= nowMs) {
+        eligibleDeadlinesMs.shift();
       }
       await claimAvailable().catch((error) =>
         logger.error('[agent-triggers] delivery claim pass failed:', error),

--- a/packages/api/src/agents/triggers/engine.ts
+++ b/packages/api/src/agents/triggers/engine.ts
@@ -138,6 +138,12 @@ export interface AgentTriggerDeliveryEngineDeps {
   workerId?: string;
 }
 
+interface ClaimPassResult {
+  count: number;
+  processing: Promise<void>[];
+  claimFailed?: boolean;
+}
+
 export interface AgentTriggerDeliveryEngine {
   start: () => void;
   stop: () => Promise<void>;
@@ -246,7 +252,7 @@ export function createAgentTriggerDeliveryEngine(
   let started = false;
   let repumpRequested = false;
   let timer: NodeJS.Timeout | undefined;
-  let activeClaim: Promise<{ count: number; processing: Promise<void>[] }> | undefined;
+  let activeClaim: Promise<ClaimPassResult> | undefined;
 
   const processDelivery = async (delivery: AgentTriggerDeliveryRecord): Promise<void> => {
     const userId = String(delivery.user);
@@ -465,7 +471,7 @@ export function createAgentTriggerDeliveryEngine(
     });
   };
 
-  const runClaimPass = async (): Promise<{ count: number; processing: Promise<void>[] }> => {
+  const runClaimPass = async (): Promise<ClaimPassResult> => {
     if (stopped) {
       return { count: 0, processing: [] };
     }
@@ -483,7 +489,7 @@ export function createAgentTriggerDeliveryEngine(
       deliveries.push(first);
     } catch (error) {
       logger.error('[agent-triggers] delivery claim failed:', error);
-      return { count: 0, processing: [] };
+      return { count: 0, processing: [], claimFailed: true };
     }
 
     if (openSlots > 1) {
@@ -525,13 +531,16 @@ export function createAgentTriggerDeliveryEngine(
     return { count: deliveries.length, processing: batch };
   };
 
-  const claimAvailable = (): Promise<{ count: number; processing: Promise<void>[] }> => {
+  const claimAvailable = (): Promise<ClaimPassResult> => {
     if (activeClaim != null) {
       return activeClaim;
     }
     activeClaim = runAsSystem(runClaimPass)
       .then((result) => {
-        idleStreak = result.count > 0 ? 0 : idleStreak + 1;
+        /** Only a pass that confirmed an empty queue may advance the idle backoff: work
+         *  resets it, and a failed claim proves nothing, so it polls on at the base
+         *  cadence — the pre-backoff status quo through an outage and at recovery. */
+        idleStreak = result.count === 0 && result.claimFailed !== true ? idleStreak + 1 : 0;
         return result;
       })
       .finally(() => {

--- a/packages/api/src/agents/triggers/engine.ts
+++ b/packages/api/src/agents/triggers/engine.ts
@@ -10,6 +10,7 @@ const DEFAULT_MAX_ATTEMPTS = 8;
 const DEFAULT_RETRY_BASE_MS = 1_000;
 const DEFAULT_RETRY_CAP_MS = 5 * 60_000;
 const DEFAULT_TICK_MS = 1_000;
+const DEFAULT_MAX_IDLE_TICK_MS = 15_000;
 const ORDERING_RECHECK_MS = 250;
 const DEFAULT_DEFER_MS = 5_000;
 const MAX_RETRY_AFTER_MS = 24 * 60 * 60_000;
@@ -121,6 +122,9 @@ export interface AgentTriggerDeliveryEngineOptions {
   retryBaseMs?: number;
   retryCapMs?: number;
   tickMs?: number;
+  /** Ceiling for the poll interval while the queue stays empty; any wake or claimed
+   *  delivery snaps polling back to `tickMs`, so only true idleness ever waits this long. */
+  maxIdleTickMs?: number;
 }
 
 export interface AgentTriggerDeliveryEngineDeps {
@@ -226,10 +230,15 @@ export function createAgentTriggerDeliveryEngine(
   const retryBaseMs = positiveInteger(options.retryBaseMs, DEFAULT_RETRY_BASE_MS, 'retryBaseMs');
   const retryCapMs = positiveInteger(options.retryCapMs, DEFAULT_RETRY_CAP_MS, 'retryCapMs');
   const tickMs = positiveInteger(options.tickMs, DEFAULT_TICK_MS, 'tickMs');
+  const maxIdleTickMs = Math.max(
+    tickMs,
+    positiveInteger(options.maxIdleTickMs, DEFAULT_MAX_IDLE_TICK_MS, 'maxIdleTickMs'),
+  );
   const now = deps.now ?? (() => new Date());
   const random = deps.random ?? Math.random;
   const workerId = deps.workerId ?? `${process.pid}-${randomUUID()}`;
   const controllers = new Map<AbortController, string>();
+  let idleStreak = 0;
   const processing = new Set<Promise<void>>();
   const processingByUser = new Map<string, Set<Promise<void>>>();
   const cancelledUsers = new Set<string>();
@@ -520,13 +529,18 @@ export function createAgentTriggerDeliveryEngine(
     if (activeClaim != null) {
       return activeClaim;
     }
-    activeClaim = runAsSystem(runClaimPass).finally(() => {
-      activeClaim = undefined;
-      if (repumpRequested && !stopped) {
-        repumpRequested = false;
-        queueMicrotask(wake);
-      }
-    });
+    activeClaim = runAsSystem(runClaimPass)
+      .then((result) => {
+        idleStreak = result.count > 0 ? 0 : idleStreak + 1;
+        return result;
+      })
+      .finally(() => {
+        activeClaim = undefined;
+        if (repumpRequested && !stopped) {
+          repumpRequested = false;
+          queueMicrotask(wake);
+        }
+      });
     return activeClaim;
   };
 
@@ -536,10 +550,7 @@ export function createAgentTriggerDeliveryEngine(
     return batch.count;
   };
 
-  function wake(): void {
-    if (stopped) {
-      return;
-    }
+  const claimOnce = (): void => {
     if (activeClaim != null) {
       repumpRequested = true;
       return;
@@ -547,16 +558,38 @@ export function createAgentTriggerDeliveryEngine(
     void claimAvailable().catch((error) =>
       logger.error('[agent-triggers] delivery claim pass failed:', error),
     );
+  };
+
+  /** A wake is evidence of work — an enqueue or a finished delivery — so it snaps the
+   *  idle backoff and the poll timer back to the base cadence before claiming. */
+  function wake(): void {
+    if (stopped) {
+      return;
+    }
+    idleStreak = 0;
+    if (started) {
+      schedule();
+    }
+    claimOnce();
   }
 
   const schedule = () => {
     if (stopped) {
       return;
     }
-    timer = setTimeout(() => {
-      wake();
+    if (timer != null) {
+      clearTimeout(timer);
+    }
+    const delay = Math.min(tickMs * 2 ** idleStreak, maxIdleTickMs);
+    timer = setTimeout(async () => {
+      if (stopped) {
+        return;
+      }
+      await claimAvailable().catch((error) =>
+        logger.error('[agent-triggers] delivery claim pass failed:', error),
+      );
       schedule();
-    }, tickMs);
+    }, delay);
     timer.unref();
   };
 
@@ -567,7 +600,6 @@ export function createAgentTriggerDeliveryEngine(
       }
       started = true;
       wake();
-      schedule();
     },
     stop: async () => {
       stopped = true;

--- a/packages/api/src/agents/triggers/engine.ts
+++ b/packages/api/src/agents/triggers/engine.ts
@@ -146,6 +146,8 @@ interface ClaimPassResult {
 
 export interface AgentTriggerDeliveryEngine {
   start: () => void;
+  /** Registers a future eligibility time so the idle poll never sleeps past it. */
+  noteEligibleAt: (at: Date) => void;
   stop: () => Promise<void>;
   cancelUser: (userId: string) => Promise<void>;
   releaseUserCancellation: (userId: string) => void;
@@ -245,6 +247,10 @@ export function createAgentTriggerDeliveryEngine(
   const workerId = deps.workerId ?? `${process.pid}-${randomUUID()}`;
   const controllers = new Map<AbortController, string>();
   let idleStreak = 0;
+  /** Earliest known future eligibility among deliveries this process has seen; the idle
+   *  timer never sleeps past it, so a retry or defer is claimed when due, not when the
+   *  backoff happens to wake. Cross-replica delays remain bounded by `maxIdleTickMs`. */
+  let nextEligibleAtMs: number | null = null;
   const processing = new Set<Promise<void>>();
   const processingByUser = new Map<string, Set<Promise<void>>>();
   const cancelledUsers = new Set<string>();
@@ -271,6 +277,7 @@ export function createAgentTriggerDeliveryEngine(
       const recheckAt = now().getTime() + ORDERING_RECHECK_MS;
       const nextCheck =
         block.leaseUntil == null ? Math.max(recheckAt, block.availableAt.getTime()) : recheckAt;
+      noteEligibleAt(new Date(nextCheck));
       await deps.store.release({
         id: delivery.id,
         workerId,
@@ -355,6 +362,7 @@ export function createAgentTriggerDeliveryEngine(
           const delayMs =
             error instanceof AgentTriggerDeliveryDeferredError ? error.delayMs : DEFAULT_DEFER_MS;
           const availableAt = new Date(attemptedAt.getTime() + delayMs);
+          noteEligibleAt(availableAt);
           const deferred = await deps.store.defer({
             id: delivery.id,
             workerId,
@@ -398,6 +406,7 @@ export function createAgentTriggerDeliveryEngine(
           return;
         }
         const availableAt = retryAt(error, attempt, attemptedAt, retryBaseMs, retryCapMs, random);
+        noteEligibleAt(availableAt);
         const retrying = await deps.store.retry({
           id: delivery.id,
           workerId,
@@ -437,6 +446,7 @@ export function createAgentTriggerDeliveryEngine(
           attemptedAt: settledAt,
         };
         const availableAt = retryAt(error, attempt, settledAt, retryBaseMs, retryCapMs, random);
+        noteEligibleAt(availableAt);
         const retrying = await deps.store.retry({
           id: delivery.id,
           workerId,
@@ -569,6 +579,20 @@ export function createAgentTriggerDeliveryEngine(
     );
   };
 
+  function noteEligibleAt(at: Date): void {
+    const eligibleAtMs = at.getTime();
+    if (!Number.isFinite(eligibleAtMs) || stopped) {
+      return;
+    }
+    if (nextEligibleAtMs != null && eligibleAtMs >= nextEligibleAtMs) {
+      return;
+    }
+    nextEligibleAtMs = eligibleAtMs;
+    if (started) {
+      schedule();
+    }
+  }
+
   /** A wake is evidence of work — an enqueue or a finished delivery — so it snaps the
    *  idle backoff and the poll timer back to the base cadence before claiming. */
   function wake(): void {
@@ -589,10 +613,16 @@ export function createAgentTriggerDeliveryEngine(
     if (timer != null) {
       clearTimeout(timer);
     }
-    const delay = Math.min(tickMs * 2 ** idleStreak, maxIdleTickMs);
+    let delay = Math.min(tickMs * 2 ** idleStreak, maxIdleTickMs);
+    if (nextEligibleAtMs != null) {
+      delay = Math.max(0, Math.min(delay, nextEligibleAtMs - now().getTime()));
+    }
     timer = setTimeout(async () => {
       if (stopped) {
         return;
+      }
+      if (nextEligibleAtMs != null && now().getTime() >= nextEligibleAtMs) {
+        nextEligibleAtMs = null;
       }
       await claimAvailable().catch((error) =>
         logger.error('[agent-triggers] delivery claim pass failed:', error),
@@ -638,6 +668,7 @@ export function createAgentTriggerDeliveryEngine(
       cancelledUsers.delete(userId);
     },
     wake,
+    noteEligibleAt,
     runTick,
   };
 }

--- a/packages/api/src/agents/triggers/service.delivery.spec.ts
+++ b/packages/api/src/agents/triggers/service.delivery.spec.ts
@@ -312,6 +312,39 @@ describe('durable agent trigger service', () => {
     await service.stop();
   });
 
+  it('wakes the delivery engine when a dead letter is requeued locally', async () => {
+    const claimNextAgentTriggerDelivery = jest.fn(async () => null);
+    const requeueAgentTriggerDelivery = jest
+      .fn()
+      .mockResolvedValueOnce(deliveryRecord())
+      .mockResolvedValueOnce(null);
+    const methods = deliveryMethods({
+      claimNextAgentTriggerDelivery,
+      requeueAgentTriggerDelivery,
+    });
+    const service = createAgentTriggerService({
+      methods,
+      deliveryOptions: { concurrency: 1, tickMs: 60_000 },
+    });
+    await service.initialize({
+      address: { address: '127.0.0.1', family: 'IPv4', port: 3080 },
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    const claimsBefore = claimNextAgentTriggerDelivery.mock.calls.length;
+
+    await service.requeue('delivery-row-1', START);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(claimNextAgentTriggerDelivery.mock.calls.length).toBeGreaterThan(claimsBefore);
+
+    /** A requeue that revived nothing must not wake anything. */
+    const claimsAfterWake = claimNextAgentTriggerDelivery.mock.calls.length;
+    await service.requeue('delivery-row-1', START);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(claimNextAgentTriggerDelivery.mock.calls.length).toBe(claimsAfterWake);
+
+    await service.stop();
+  });
+
   it('does not become ready when the required unique indexes fail', async () => {
     const methods = deliveryMethods({
       ensureAgentTriggerDeliveryIndexes: jest.fn(async () =>

--- a/packages/api/src/agents/triggers/service.ts
+++ b/packages/api/src/agents/triggers/service.ts
@@ -414,7 +414,13 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
     getDeadLetters: (limit) =>
       runAsSystem(async () => requireMethods().getAgentTriggerDeadLetters(limit)),
     requeue: (id, availableAt = new Date()) =>
-      runAsSystem(async () => requireMethods().requeueAgentTriggerDelivery(id, availableAt)),
+      runAsSystem(async () => {
+        const revived = await requireMethods().requeueAgentTriggerDelivery(id, availableAt);
+        if (revived != null) {
+          deliveryEngine?.wake();
+        }
+        return revived;
+      }),
     drainUser,
     prepareUserPurge: (userId, fenceStartedAt, tenantId) =>
       runAsSystem(async () =>

--- a/packages/api/src/agents/triggers/service.ts
+++ b/packages/api/src/agents/triggers/service.ts
@@ -396,7 +396,12 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
         await drainUser(String(prepared.user));
         throw error;
       }
-      deliveryEngine?.wake();
+      const eligibleAt = queued.delivery.availableAt;
+      if (eligibleAt instanceof Date && eligibleAt.getTime() > Date.now()) {
+        deliveryEngine?.noteEligibleAt(eligibleAt);
+      } else {
+        deliveryEngine?.wake();
+      }
       return {
         id: queued.delivery.id,
         deliveryKey: queued.delivery.deliveryKey,
@@ -417,7 +422,11 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
       runAsSystem(async () => {
         const revived = await requireMethods().requeueAgentTriggerDelivery(id, availableAt);
         if (revived != null) {
-          deliveryEngine?.wake();
+          if (availableAt.getTime() > Date.now()) {
+            deliveryEngine?.noteEligibleAt(availableAt);
+          } else {
+            deliveryEngine?.wake();
+          }
         }
         return revived;
       }),

--- a/packages/api/src/cache/__tests__/cacheFactory.memory.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory.memory.spec.ts
@@ -1,0 +1,37 @@
+import { standardCache } from '~/cache/cacheFactory';
+
+describe('standardCache in-memory serialization', () => {
+  it('returns copies, never references into the store', async () => {
+    const cache = standardCache('memory-serializer-copies');
+    const stored = { nested: { list: [1, 2, 3] } };
+    await cache.set('key', stored);
+
+    const first = await cache.get<typeof stored>('key');
+    expect(first).toEqual(stored);
+    expect(first).not.toBe(stored);
+    first!.nested.list.push(4);
+
+    const second = await cache.get<typeof stored>('key');
+    expect(second!.nested.list).toEqual([1, 2, 3]);
+  });
+
+  it('keeps the JSON semantics readers already rely on: dates come back as ISO strings', async () => {
+    const cache = standardCache('memory-serializer-dates');
+    await cache.set('key', { at: new Date('2026-08-23T12:00:00.000Z') });
+
+    const got = await cache.get<{ at: unknown }>('key');
+    expect(got!.at).toBe('2026-08-23T12:00:00.000Z');
+  });
+
+  it('does not revive Buffers: a plain JSON round trip is the documented contract', async () => {
+    /** The Buffer-aware reviver cost ~8x a plain JSON parse on every read, and an
+     *  instrumented e2e sweep found no namespace caching a Buffer. If one ever needs
+     *  to, it must not use the in-memory standardCache. */
+    const cache = standardCache('memory-serializer-buffers');
+    await cache.set('key', { blob: Buffer.from('hi') });
+
+    const got = await cache.get<{ blob: unknown }>('key');
+    expect(Buffer.isBuffer(got!.blob)).toBe(false);
+    expect(got!.blob).toEqual({ type: 'Buffer', data: [104, 105] });
+  });
+});

--- a/packages/api/src/cache/cacheFactory.ts
+++ b/packages/api/src/cache/cacheFactory.ts
@@ -98,7 +98,12 @@ export const standardCache = (namespace: string, ttl?: number, fallbackStore?: o
   if (existing) {
     return existing;
   }
-  const cache = new Keyv({ namespace, ttl });
+  /** The default serializer's Buffer-aware reviver costs ~8x a plain JSON round trip on
+   *  every read, and an instrumented sweep of the e2e suite found no namespace ever caching
+   *  a Buffer. Plain JSON keeps today's copy semantics (readers never share references with
+   *  the store, dates still come back as ISO strings); a Buffer would now round-trip as its
+   *  `{ type: 'Buffer', data }` JSON form instead of reviving. */
+  const cache = new Keyv({ namespace, ttl, serialize: JSON.stringify, deserialize: JSON.parse });
   inMemoryCacheMap.set(namespace, cache);
   return cache;
 };


### PR DESCRIPTION
## Summary

Two small hot-path costs from the [profiling round](https://github.com/danny-avila/LibreChat/pull/15138) that ships alongside #15138/#15141 — one paid on every cache read, one paid once a second forever.

### Plain JSON for the in-memory cache store

Every read from the in-memory Keyv fallback ran `@keyv/serialize`'s Buffer-aware reviver: **0.33 ms** for a 12 KB config-shaped value vs **0.038 ms** for plain `JSON.parse` (8.6×) — on every config, role, and model lookup a request makes (~1 ms/turn in the CPU profile, and every other cached read besides).

The reviver exists to round-trip Buffers, so before swapping I instrumented the serializer to flag any value carrying the `:base64:` Buffer marker and ran the e2e suite with the hook armed in all seven server and fixture processes: **zero namespaces ever cached a Buffer** (the hook self-test confirms it fires on a real one). Plain JSON preserves the semantics readers already rely on — values are copies, never references into the store; dates still come back as ISO strings. A Buffer would now round-trip as its `{ type: 'Buffer', data }` JSON form instead of reviving; the new spec pins that as the documented contract, and it fails against the old serializer. Redis and file-backed stores are untouched.

### Idle backoff for the trigger delivery poll

The delivery engine issued a claim `findOneAndUpdate` every second per replica whether or not any trigger existed — **~86,400 no-match queries a day per replica** on an idle deployment, visible as constant background chatter in the per-turn traces.

The poll now doubles its interval after each **confirmed-empty** claim pass, capped at a new `maxIdleTickMs` option (default 15 s, floored at `tickMs`), so an idle replica settles at one query per fifteen seconds (−93%).

The governing invariant, sharpened by four review findings (thanks, codex): **the engine never sleeps past work it can know about.**

- enqueues, finished deliveries, and now **successful requeues** call `wake()`, which resets the streak and re-arms the timer at base cadence before claiming;
- a **failed** claim pass proves nothing about the queue, so it resets the backoff rather than advancing it — outages keep the old one-second retry cadence and recovery catches up immediately;
- every future `availableAt` the engine itself schedules (retries, defers, ordering rechecks) and every future-dated enqueue/requeue is recorded in a sorted, deduplicated, **bounded deadline list**; the idle timer never sleeps past the earliest, entries are pruned as they come due, and a new earliest re-arms the timer even mid-sleep toward the cap;
- the next delay is computed after each claim settles, so the backoff is never a step behind;
- the residual latency is exactly one case: work enqueued or delayed **by another replica** while this one is fully idle — bounded by the cap (deadline-list overflow degrades to the same bound). If 15 s is too long there, `maxIdleTickMs` is the knob.

## Tests

- `cacheFactory.memory.spec.ts` (new): copy semantics, ISO-string dates, and the no-Buffer-revival contract — the last one fails against the old serializer.
- `engine.spec.ts` (+5, fake timers): the idle stretch (4 claims in 15 s, not 15), wake snap-back, streak reset on claimed work, base-cadence polling through claim failures, on-time pickup of a Retry-After retry the backoff alone would miss by 11 s, and two concurrent deadlines plus a deadline learned mid-cap-sleep. Every fix's test was verified to fail against the head it fixed.
- `service.delivery.spec.ts` (+1): a successful requeue wakes the engine; a no-op requeue doesn't.
- Full `packages/api` suite: 11,336 passed; the 7 failing suites (Redis-cluster/integration + libreoffice) fail identically on clean `dev` with no local cluster/soffice.
- e2e subset including `schedules` + `schedules-execution` — those ride the trigger-delivery machinery, exercising wake-on-enqueue against the backoff end to end.