### PR TITLE
🧪 fix: Mock the Parent Subagent Index Handler in Convos Route Tests

### DIFF
--- a/api/server/routes/__test-utils__/convos-route-mocks.js
+++ b/api/server/routes/__test-utils__/convos-route-mocks.js
@@ -40,6 +40,9 @@ module.exports = {
       return archiveAllHandler;
     }),
     createSubagentThreadViewHandler: jest.fn(() => (_req, res) => res.status(200).json({})),
+    createParentSubagentIndexHandler: jest.fn(
+      () => (_req, res) => res.status(200).json({ threads: [] }),
+    ),
     GenerationJobManager: generationJobManager,
     isStopConfirmed: jest.fn(
       (result) => result?.success === true || result?.failureReason === 'already_settled',


### PR DESCRIPTION
## Summary

dev's backend runs are red since #15142 merged: `convos.spec.js` dies at module load with `TypeError: createParentSubagentIndexHandler is not a function` (7 downstream assertion failures). #15142 added the handler to `@librechat/api` and wired it in `convos.js:51`, but the shared mock factory the route tests build `@librechat/api` from (`__test-utils__/convos-route-mocks.js`) was not taught the new export — so the destructured value is `undefined` in test-land only. One line adds the mock beside its sibling `createSubagentThreadViewHandler`.

## Receipts

- dev push run for fc2b8584c4 fails exactly this suite; d864597731's run — the commit before #15142 — was green.
- #15142's own last backend PR run (32671703366, 22:48Z) had the same failure and pattern-matched the familiar flaky reds at merge time (22:50Z); it is deterministic, not flaky.
- With this one line: `convos.spec.js` 62/62 locally. `convos-route-mocks.js` is consumed only by `convos.spec.js`, so the blast radius is this suite.