### PR TITLE
⏱️ test: Make Active Item Observer Assertions Deterministic

### DIFF
--- a/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
+++ b/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @happy-dom/jest-environment
  */
 import React from 'react';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import useIsActiveItem from '../useIsActiveItem';
 
@@ -11,17 +11,24 @@ function Probe() {
   return <div ref={ref} data-testid="probe" data-active={isActive ? 'true' : 'false'} />;
 }
 
-/**
- * Observer delivery lands on the next microtask in this environment; the wait exists so the
- * test does not depend on that scheduling detail, with budget to ride out a stalled host.
- */
-const OBSERVER_WAIT = { timeout: 4000 };
-
-/** One test chains two OBSERVER_WAITs, whose budget exceeds Jest's 5s default. */
-jest.setTimeout(20_000);
-
 const getProbe = (container: HTMLElement) =>
   container.querySelector('[data-testid="probe"]') as HTMLDivElement;
+
+/**
+ * Resolves once a `data-active-item` mutation has been delivered to observers. The hook
+ * registers its observer on mount, so it is always ahead of this one in delivery order,
+ * which means the hook has already reacted by the time this resolves. Filtering matters:
+ * React writes `data-active` onto the same element when it re-renders, and an unfiltered
+ * observer would resolve on that write instead of on the attribute under test.
+ */
+const nextActiveItemMutation = (element: HTMLElement): Promise<void> =>
+  new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(element, { attributes: true, attributeFilter: ['data-active-item'] });
+  });
 
 /**
  * Resolves once an attribute mutation on `element` has been delivered to observers. The
@@ -48,26 +55,32 @@ describe('useIsActiveItem', () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);
 
-    act(() => {
+    const delivered = nextActiveItemMutation(probe);
+    await act(async () => {
       probe.setAttribute('data-active-item', '');
+      await delivered;
     });
 
-    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
+    expect(probe.getAttribute('data-active')).toBe('true');
   });
 
   it('flips isActive back to false when data-active-item is removed', async () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);
 
-    act(() => {
+    const added = nextActiveItemMutation(probe);
+    await act(async () => {
       probe.setAttribute('data-active-item', '');
+      await added;
     });
-    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('true'), OBSERVER_WAIT);
+    expect(probe.getAttribute('data-active')).toBe('true');
 
-    act(() => {
+    const removed = nextActiveItemMutation(probe);
+    await act(async () => {
       probe.removeAttribute('data-active-item');
+      await removed;
     });
-    await waitFor(() => expect(probe.getAttribute('data-active')).toBe('false'), OBSERVER_WAIT);
+    expect(probe.getAttribute('data-active')).toBe('false');
   });
 
   it('ignores unrelated attribute mutations', async () => {


### PR DESCRIPTION
## Summary

The two attribute-flip tests in `useIsActiveItem.spec.tsx` mutated the probe inside `act()` and then raced a 4 second `waitFor` against `MutationObserver` delivery. That budget only holds while the client workspace stays small enough that no Jest worker stalls past it, so the tests fail once the workspace gains a handful of additional suites, on a machine under load, with a timeout rather than a meaningful assertion.

This replaces the race with a wait on actual observer delivery. The hook registers its observer on mount, so it is always ahead of the test's observer in delivery order and has therefore already reacted by the time the promise resolves. The new helper filters on `data-active-item` deliberately: React writes `data-active` onto the same element when it re-renders, and an unfiltered observer would resolve on that write instead of on the attribute under test.

With the last wall-clock dependence gone, the file no longer needs its 20 second Jest timeout. The two converted tests drop from polling to deterministic, 12ms and 6ms down to 5ms and 3ms.

This follows the pattern already established in the same file by #14653, and the same pattern the neighboring "ignores unrelated attribute mutations" test uses, which is the one test in the file that never flaked.

No production code changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the spec in isolation and under the full client workspace suite, on a 16 core machine under load, which is the condition that surfaced the original failure.

```
cd client && npx jest src/hooks/__tests__/useIsActiveItem.spec.tsx --coverage=false
  5 passed, 5 total

cd client && npx jest --coverage=false
  448 passed, 449 total
```

The single remaining client failure is `Markdown.mcpui.test.tsx`, which fails identically on `dev` at d86459773 with this branch not applied. It is unrelated to this change.

### **Test Configuration**:

Node v24.16.0, jsdom for the workspace, `@happy-dom/jest-environment` for this spec, `maxWorkers: 50%`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
