### PR TITLE
🧪 test: Mock the Parent Subagent Index Handler in the Convos Route Suites

### DIFF
--- a/api/server/routes/__test-utils__/convos-route-mocks.js
+++ b/api/server/routes/__test-utils__/convos-route-mocks.js
@@ -40,6 +40,7 @@ module.exports = {
       return archiveAllHandler;
     }),
     createSubagentThreadViewHandler: jest.fn(() => (_req, res) => res.status(200).json({})),
+    createParentSubagentIndexHandler: jest.fn(() => (_req, res) => res.status(200).json({})),
     GenerationJobManager: generationJobManager,
     isStopConfirmed: jest.fn(
       (result) => result?.success === true || result?.failureReason === 'already_settled',


### PR DESCRIPTION
dev is currently red for the convos route suites: #15142 added `createParentSubagentIndexHandler` to `routes/convos.js`, but the shared mock factory (`convos-route-mocks.js`) predates it, so `convos.spec.js` and `convos-duplicate-ratelimit.spec.js` fail at require time — 64 tests — and every PR merge-ref CI against dev inherits the failure (seen on #15144, whose own suites pass). The codegraph gate evidently did not select these shards for #15142's change set.

One line: the same passthrough stub as the sibling `createSubagentThreadViewHandler`. Both suites 68/68 locally with it.