### PR TITLE
🧩 chore: Bump Agents SDK to v3.6.16

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.15",
+    "@librechat/agents": "^3.6.16",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.15",
+        "@librechat/agents": "^3.6.16",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10630,9 +10630,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.15",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.15.tgz",
-      "integrity": "sha512-AgQPT5i0APKP4pQz4ajEhfkrK0GqpD0YFnE55xcuEd/fPGsSags1jw++WISpyuU8tFsO9fuYHUIe1U2RNmPO5g==",
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.16.tgz",
+      "integrity": "sha512-V8WQTC4gwoUdej9Xg5slaw2QgypVhTkosNp8UL/ANh9OlS7zSKgyu5/iDz8ZXQBywKNdt7y6k7+cO9W+I6kezA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42822,7 +42822,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.15",
+        "@librechat/agents": "^3.6.16",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.15",
+    "@librechat/agents": "^3.6.16",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

I bumped @librechat/agents from 3.6.15 to 3.6.16 so LibreChat can consume runtime provider registration without waiting for a new SDK release for each host provider.

- Update the backend and shared API dependency ranges to ^3.6.16.
- Refresh the npm workspace lock to the published 3.6.16 artifact.
- Enable process-local host provider registration with provider-family request behavior and lifecycle safeguards.
- Expose the @librechat/agents/provider-registration subpath for stable host option declaration merging and runtime registration.
- Preserve existing built-in provider behavior while allowing registered providers to participate in graph, streaming, fallback, summarization, and context-overflow paths.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Confirmed @librechat/agents@3.6.16 is published and tagged latest on npm.
- Confirmed the agents publication workflow completed successfully.
- Regenerated package-lock.json with npm install --package-lock-only --ignore-scripts.
- Verified both LibreChat consumers request ^3.6.16 and npm resolves exactly 3.6.16.
- Verified the lockfile integrity matches the published npm artifact.
- Ran git diff --check.
- Confirmed the lock refresh changes only the expected agents version, URL, integrity, and consumer ranges.
- Observed 8 existing npm audit findings (6 low, 2 moderate); this bump adds no dependency-tree churn.

### **Test Configuration**:

- Node.js 24.16.0
- npm 11.16.0
- macOS arm64
- @librechat/agents 3.6.16 from npm

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] The agents SDK release validation and publication workflow passed
- [x] The required agents SDK release has been merged and published

