### PR TITLE
🕯️ fix: Decay Violation Scores With a Configurable TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -677,6 +677,9 @@ BAN_VIOLATIONS=true
 BAN_DURATION=1000 * 60 * 60 * 2
 BAN_INTERVAL=20
 
+# Violation scores expire after this long (in ms) without new violations; 0 = never expire
+VIOLATION_SCORE_TTL=1000 * 60 * 60
+
 LOGIN_VIOLATION_SCORE=1
 REGISTRATION_VIOLATION_SCORE=1
 CONCURRENT_VIOLATION_SCORE=1

--- a/packages/api/src/cache/__tests__/cacheConfig.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheConfig.spec.ts
@@ -15,6 +15,7 @@ describe('cacheConfig', () => {
     delete process.env.REDIS_CLUSTER_SAFE_DELETE;
     delete process.env.REDIS_PING_INTERVAL;
     delete process.env.FORCED_IN_MEMORY_CACHE_NAMESPACES;
+    delete process.env.VIOLATION_SCORE_TTL;
 
     // Clear module cache
     jest.resetModules();
@@ -261,6 +262,41 @@ describe('cacheConfig', () => {
 
       const { cacheConfig } = await import('../cacheConfig');
       expect(cacheConfig.FORCED_IN_MEMORY_CACHE_NAMESPACES).toEqual(['CONFIG_STORE', 'APP_CONFIG']);
+    });
+  });
+
+  describe('VIOLATION_SCORE_TTL configuration', () => {
+    test('should default to one hour when not set', async () => {
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.VIOLATION_SCORE_TTL).toBe(3600000);
+    });
+
+    test('should evaluate math expressions from the environment', async () => {
+      process.env.VIOLATION_SCORE_TTL = '1000 * 60 * 60 * 24';
+
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.VIOLATION_SCORE_TTL).toBe(86400000);
+    });
+
+    test('should disable expiry when set to 0', async () => {
+      process.env.VIOLATION_SCORE_TTL = '0';
+
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.VIOLATION_SCORE_TTL).toBeUndefined();
+    });
+
+    test('should disable expiry for negative values', async () => {
+      process.env.VIOLATION_SCORE_TTL = '-1000';
+
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.VIOLATION_SCORE_TTL).toBeUndefined();
+    });
+
+    test('should fall back to the default on invalid input', async () => {
+      process.env.VIOLATION_SCORE_TTL = 'not-a-duration';
+
+      const { cacheConfig } = await import('../cacheConfig');
+      expect(cacheConfig.VIOLATION_SCORE_TTL).toBe(3600000);
     });
   });
 });

--- a/packages/api/src/cache/__tests__/cacheFactory/violationCache.spec.ts
+++ b/packages/api/src/cache/__tests__/cacheFactory/violationCache.spec.ts
@@ -1,0 +1,56 @@
+describe('violationCache TTL defaults', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.USE_REDIS;
+    delete process.env.REDIS_URI;
+    delete process.env.VIOLATION_SCORE_TTL;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  test('applies the default violation score TTL when none is given', async () => {
+    const { violationCache } = await import('../../cacheFactory');
+    const cache = violationCache('logins');
+
+    expect(cache.opts.ttl).toBe(3600000);
+    expect(cache.opts.namespace).toBe('violations:logins');
+  });
+
+  test('an explicit TTL overrides the default', async () => {
+    const { violationCache } = await import('../../cacheFactory');
+    const cache = violationCache('logins', 60000);
+
+    expect(cache.opts.ttl).toBe(60000);
+  });
+
+  test('honors VIOLATION_SCORE_TTL from the environment', async () => {
+    process.env.VIOLATION_SCORE_TTL = '1000 * 60 * 5';
+
+    const { violationCache } = await import('../../cacheFactory');
+    expect(violationCache('concurrent').opts.ttl).toBe(300000);
+  });
+
+  test('VIOLATION_SCORE_TTL=0 disables expiry', async () => {
+    process.env.VIOLATION_SCORE_TTL = '0';
+
+    const { violationCache } = await import('../../cacheFactory');
+    expect(violationCache('concurrent').opts.ttl).toBeUndefined();
+  });
+
+  test('expires violation entries once the TTL elapses', async () => {
+    const { violationCache } = await import('../../cacheFactory');
+    const cache = violationCache('expiry-check', 500);
+
+    await cache.set('user-1', 3);
+    await expect(cache.get('user-1')).resolves.toBe(3);
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    await expect(cache.get('user-1')).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/cache/cacheConfig.ts
+++ b/packages/api/src/cache/cacheConfig.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync } from 'fs';
 import { logger } from '@librechat/data-schemas';
-import { CacheKeys } from 'librechat-data-provider';
+import { Time, CacheKeys } from 'librechat-data-provider';
 import { math, isEnabled } from '~/utils';
 
 // To ensure that different deployments do not interfere with each other's cache, we use a prefix for the Redis keys.
@@ -47,6 +47,12 @@ if (FORCED_IN_MEMORY_CACHE_NAMESPACES.length > 0) {
     );
   }
 }
+
+// Violation scores expire after this long without new violations; every violation write
+// restarts the countdown. Non-positive values disable expiry, restoring the legacy
+// accumulate-forever behavior.
+const VIOLATION_SCORE_TTL_MS = math(process.env.VIOLATION_SCORE_TTL, Time.ONE_HOUR);
+const VIOLATION_SCORE_TTL = VIOLATION_SCORE_TTL_MS > 0 ? VIOLATION_SCORE_TTL_MS : undefined;
 
 /** Helper function to safely read Redis CA certificate from file
  * @returns {string|null} The contents of the CA certificate file, or null if not set or on error
@@ -105,6 +111,13 @@ const cacheConfig: {
   CI: boolean;
   DEBUG_MEMORY_CACHE: boolean;
   BAN_DURATION: number; // 2 hours
+  /**
+   * TTL in ms for violation scores: a score expires after this long without new violations
+   * (each violation write restarts the countdown). `undefined` — from a non-positive
+   * setting — disables expiry so scores accumulate forever.
+   * @default 3600000 (1 hour)
+   */
+  VIOLATION_SCORE_TTL: number | undefined;
   /**
    * Number of keys to delete in each batch during Redis DEL operations.
    * In cluster mode, keys are deleted individually in parallel chunks to avoid CROSSSLOT errors.
@@ -176,6 +189,7 @@ const cacheConfig: {
   DEBUG_MEMORY_CACHE: isEnabled(process.env.DEBUG_MEMORY_CACHE),
 
   BAN_DURATION: math(process.env.BAN_DURATION, 7200000), // 2 hours
+  VIOLATION_SCORE_TTL,
 
   /**
    * Number of keys to delete in each batch during Redis DEL operations.

--- a/packages/api/src/cache/cacheFactory.ts
+++ b/packages/api/src/cache/cacheFactory.ts
@@ -116,10 +116,14 @@ export const tokenConfigCache = (): Keyv =>
  * Creates a cache instance for storing violation data.
  * Uses a file-based fallback store if Redis is not enabled.
  * @param namespace - The cache namespace for violations.
- * @param ttl - Time to live for cache entries.
+ * @param ttl - Time to live for cache entries. Defaults to `cacheConfig.VIOLATION_SCORE_TTL`
+ * so violation scores decay instead of accumulating forever; each write restarts the countdown.
  * @returns Cache instance for violations.
  */
-export const violationCache = (namespace: string, ttl?: number): Keyv => {
+export const violationCache = (
+  namespace: string,
+  ttl: number | undefined = cacheConfig.VIOLATION_SCORE_TTL,
+): Keyv => {
   return standardCache(`violations:${namespace}`, ttl, violationFile);
 };
 


### PR DESCRIPTION
## Summary

All 15 violation counter namespaces in `api/cache/getLogStores.js` call `violationCache(type)` with no TTL, so `standardCache` constructs Keyv with `ttl: undefined` and every violation score is written with **no expiry** (`ttl: -1` in Redis). The score is a lifetime tally rather than a rate: once a user crosses `BAN_INTERVAL`, each ban expiry is followed by an instant re-ban on their next violation, indefinitely, until someone manually deletes the key. Observed in production: `violations:concurrent:…` at `{"value":52}` with `ttl: -1` against `BAN_INTERVAL=20`.

This PR gives violation scores a decay window:

- **`cacheConfig.VIOLATION_SCORE_TTL`** (new): read from the `VIOLATION_SCORE_TTL` env var via `math()` (expression strings like `1000 * 60 * 60` work, same as `BAN_DURATION`). Defaults to **1 hour**; non-positive values disable expiry, restoring the legacy accumulate-forever behavior.
- **`violationCache()`** now defaults its `ttl` parameter to `cacheConfig.VIOLATION_SCORE_TTL`, so all 15 call sites pick up the decay window with zero changes to `/api`.
- `.env.example` documents the new variable.

Since `logViolation` re-`set`s the score on every violation, each write restarts the countdown: a score only expires after a full quiet period, so sustained abusers still accumulate toward `BAN_INTERVAL` while self-resolving bursts (e.g. `concurrent` double-sends) no longer haunt users forever.

Deliberately untouched: the `GENERAL` audit log (intentionally permanent) and the `BAN` store (already bounded by `BAN_DURATION`). Also verified while investigating: `BAN_DURATION` expression strings are correctly evaluated by `math()` — the suspected string-TTL bug there is a non-issue.

**Note for existing deployments:** keys written before this change carry no expiry until their next write refreshes them; ops can clear `violations:*` keys once after upgrading if immediate cleanup matters.

A follow-up PR to [librechat.ai](https://github.com/LibreChat-AI/librechat.ai) is needed to document `VIOLATION_SCORE_TTL`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

- `packages/api`: new `violationCache.spec.ts` — default TTL applied (`opts.ttl === 3600000`, namespace prefix intact), explicit TTL still wins, env override honored (`1000 * 60 * 5` → 300000), `0` disables expiry, and a real end-to-end expiry check through the KeyvFile fallback store (entry gone after TTL elapses).
- `packages/api`: `cacheConfig.spec.ts` — new `VIOLATION_SCORE_TTL` block: 1-hour default, math-expression evaluation, `0`/negative → `undefined`, invalid input falls back to default.
- `api`: `cache/banViolation.spec.js` passes unchanged (12/12) — interval threshold logic is untouched.
- `npx tsc --noEmit` introduces no new diagnostics in `src/cache/**`; `npm run build` (tsdown + dts) completes clean; ESLint clean on all changed files.
- Sweeper interaction checked: `clearExpiredFromCache`/`auditCache` guard on `store.entries`, which `KeyvFile` does not expose, so newly TTL'd violation stores remain no-ops there.

### **Test Configuration**:
- Node v24.16.0, Jest per-workspace (`packages/api`, `api`), no Redis required for the new unit specs (KeyvFile fallback path); Redis-mode TTL passthrough is already covered by `violationCache.cache_integration.spec.ts`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
