### PR TITLE
🎽 fix: Commit Subagent Roster Selections to Form State

### DIFF
--- a/client/src/components/SidePanel/Agents/Advanced/AgentSubagents.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AgentSubagents.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Switch } from '@librechat/client';
 import { Network, Users } from 'lucide-react';
 import type { ControllerRenderProps } from 'react-hook-form';
@@ -16,7 +16,6 @@ interface AgentSubagentsProps {
 
 const AgentSubagents: React.FC<AgentSubagentsProps> = ({ field, currentAgentId, maxSubagents }) => {
   const localize = useLocalize();
-  const [newAgentId, setNewAgentId] = useState('');
 
   const fieldValue = field.value;
   const value = useMemo(() => fieldValue ?? {}, [fieldValue]);
@@ -65,14 +64,19 @@ const AgentSubagents: React.FC<AgentSubagentsProps> = ({ field, currentAgentId, 
     [field, value],
   );
 
-  useEffect(() => {
-    if (newAgentId && agentIds.length < maxSubagents && !agentIds.includes(newAgentId)) {
-      setAgentIds([...agentIds, newAgentId]);
-      setNewAgentId('');
-    } else if (newAgentId) {
-      setNewAgentId('');
-    }
-  }, [newAgentId, agentIds, maxSubagents, setAgentIds]);
+  const addAgent = useCallback(
+    (agentId: string) => {
+      if (!agentId || agentIds.length >= maxSubagents || agentIds.includes(agentId)) {
+        return;
+      }
+
+      /** Commit the selection directly to react-hook-form. Deferring this
+       * through component state and an effect allowed an immediate form submit
+       * to persist the enable toggles before the selected roster. */
+      setAgentIds([...agentIds, agentId]);
+    },
+    [agentIds, maxSubagents, setAgentIds],
+  );
 
   const removeAgentAt = (index: number) => {
     setAgentIds(agentIds.filter((_, i) => i !== index));
@@ -140,7 +144,7 @@ const AgentSubagents: React.FC<AgentSubagentsProps> = ({ field, currentAgentId, 
             {agentIds.length < maxSubagents && (
               <AddAgentSelect
                 options={options}
-                onSelect={setNewAgentId}
+                onSelect={addAgent}
                 placeholder={localize('com_ui_agent_subagents_add')}
                 ariaLabel={localize('com_ui_agent_subagents_add')}
               />

--- a/client/src/components/SidePanel/Agents/Advanced/__tests__/AgentSubagents.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/__tests__/AgentSubagents.spec.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import type { ControllerRenderProps } from 'react-hook-form';
+import type { ReactNode } from 'react';
+import type { AgentForm } from '~/common';
+import AgentSubagents from '../AgentSubagents';
+
+let selectAgent: ((agentId: string) => void) | undefined;
+
+jest.mock('@librechat/client', () => ({
+  Switch: () => null,
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('../AgentList', () => ({
+  AddAgentSelect: ({ onSelect }: { onSelect: (agentId: string) => void }) => {
+    selectAgent = onSelect;
+    return null;
+  },
+  ListMeta: () => null,
+  StaticAgentRow: () => null,
+  useSelectableAgents: () => ({ options: [], getAgent: () => undefined }),
+}));
+
+jest.mock('../OrchestrationPattern', () => ({
+  __esModule: true,
+  default: ({ children, trailing }: { children: ReactNode; trailing: ReactNode }) => (
+    <>
+      {trailing}
+      {children}
+    </>
+  ),
+}));
+
+jest.mock('../ui', () => ({
+  ToggleSetting: () => null,
+}));
+
+describe('AgentSubagents', () => {
+  beforeEach(() => {
+    selectAgent = undefined;
+  });
+
+  it('commits a selected agent to form state synchronously', () => {
+    let persistedValue: NonNullable<AgentForm['subagents']> = {
+      enabled: true,
+      allowSelf: false,
+      agent_ids: [] as string[],
+    };
+    const field = {
+      name: 'subagents',
+      value: persistedValue,
+      onBlur: jest.fn(),
+      onChange: jest.fn((value: NonNullable<AgentForm['subagents']>) => {
+        persistedValue = value;
+      }),
+      ref: jest.fn(),
+    } as unknown as ControllerRenderProps<AgentForm, 'subagents'>;
+
+    render(<AgentSubagents field={field} currentAgentId="parent" maxSubagents={10} />);
+
+    selectAgent?.('child');
+
+    expect(field.onChange).toHaveBeenCalledWith({
+      enabled: true,
+      allowSelf: false,
+      agent_ids: ['child'],
+    });
+    expect(persistedValue.agent_ids).toEqual(['child']);
+  });
+});

--- a/client/src/components/SidePanel/Agents/Advanced/__tests__/AgentSubagents.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/__tests__/AgentSubagents.spec.tsx
@@ -1,8 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Controller, useForm } from 'react-hook-form';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { ReactNode } from 'react';
 import type { AgentForm } from '~/common';

--- a/client/src/components/SidePanel/Agents/Advanced/__tests__/AgentSubagents.spec.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/__tests__/AgentSubagents.spec.tsx
@@ -1,13 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
-import type { ControllerRenderProps } from 'react-hook-form';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Controller, useForm } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import type { ReactNode } from 'react';
 import type { AgentForm } from '~/common';
 import AgentSubagents from '../AgentSubagents';
 
-let selectAgent: ((agentId: string) => void) | undefined;
+let mockSelectAgent: ((agentId: string) => void) | undefined;
+let mockGetValues: UseFormReturn<AgentForm>['getValues'] | undefined;
+const mockSubmit = jest.fn();
 
 jest.mock('@librechat/client', () => ({
   Switch: () => null,
@@ -19,7 +22,7 @@ jest.mock('~/hooks', () => ({
 
 jest.mock('../AgentList', () => ({
   AddAgentSelect: ({ onSelect }: { onSelect: (agentId: string) => void }) => {
-    selectAgent = onSelect;
+    mockSelectAgent = onSelect;
     return null;
   },
   ListMeta: () => null,
@@ -43,34 +46,60 @@ jest.mock('../ui', () => ({
 
 describe('AgentSubagents', () => {
   beforeEach(() => {
-    selectAgent = undefined;
+    mockSelectAgent = undefined;
+    mockGetValues = undefined;
+    mockSubmit.mockReset();
   });
 
-  it('commits a selected agent to form state synchronously', () => {
-    let persistedValue: NonNullable<AgentForm['subagents']> = {
-      enabled: true,
-      allowSelf: false,
-      agent_ids: [] as string[],
-    };
-    const field = {
-      name: 'subagents',
-      value: persistedValue,
-      onBlur: jest.fn(),
-      onChange: jest.fn((value: NonNullable<AgentForm['subagents']>) => {
-        persistedValue = value;
-      }),
-      ref: jest.fn(),
-    } as unknown as ControllerRenderProps<AgentForm, 'subagents'>;
+  function Harness() {
+    const methods = useForm<AgentForm>({
+      defaultValues: {
+        subagents: {
+          enabled: true,
+          allowSelf: false,
+          agent_ids: [],
+        },
+      },
+    });
+    mockGetValues = methods.getValues;
 
-    render(<AgentSubagents field={field} currentAgentId="parent" maxSubagents={10} />);
+    return (
+      <form aria-label="agent form" onSubmit={methods.handleSubmit(mockSubmit)}>
+        <Controller
+          name="subagents"
+          control={methods.control}
+          render={({ field }) => (
+            <AgentSubagents field={field} currentAgentId="parent" maxSubagents={10} />
+          )}
+        />
+      </form>
+    );
+  }
 
-    selectAgent?.('child');
+  it('commits a selected agent before an immediate form submit', async () => {
+    render(<Harness />);
 
-    expect(field.onChange).toHaveBeenCalledWith({
+    act(() => {
+      mockSelectAgent?.('child');
+      fireEvent.submit(screen.getByRole('form', { name: 'agent form' }));
+    });
+
+    expect(mockGetValues?.('subagents')).toEqual({
       enabled: true,
       allowSelf: false,
       agent_ids: ['child'],
     });
-    expect(persistedValue.agent_ids).toEqual(['child']);
+    await waitFor(() =>
+      expect(mockSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subagents: {
+            enabled: true,
+            allowSelf: false,
+            agent_ids: ['child'],
+          },
+        }),
+        expect.anything(),
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- commit Agent Builder subagent selections directly to react-hook-form
- remove the deferred component-state/effect write that could lose the roster on an immediate save
- add a regression test proving the selected child is present synchronously

## Context

A live Agent document persisted `subagents.enabled` and `allowSelf` while saving an empty `agent_ids` roster. Version history confirmed the intended eight IDs were never persisted. The API schema and update payload already preserve `subagents.agent_ids`; the remaining delayed write was in the Agent Builder control.

## Verification

- focused Jest regression: 1/1 passed
- Prettier check passed
- ESLint on changed files passed
- `git diff --check` passed