### PR TITLE
🥁 fix: Compare TOTP Codes in Constant Time

### DIFF
--- a/api/server/services/twoFactorService.js
+++ b/api/server/services/twoFactorService.js
@@ -1,4 +1,4 @@
-const { webcrypto } = require('node:crypto');
+const { webcrypto, timingSafeEqual } = require('node:crypto');
 const { hashBackupCode, decryptV3, decryptV2 } = require('@librechat/data-schemas');
 const { updateUser } = require('~/models');
 
@@ -103,6 +103,31 @@ const generateTOTP = async (secret, forTime = Date.now()) => {
 };
 
 /**
+ * Constant-time comparison of a candidate 2FA code against the expected value.
+ * A plain `===` comparison short-circuits at the first differing character, so
+ * an attacker submitting codes to the 2FA verification endpoint could, in
+ * principle, learn how many leading digits are correct from the response time.
+ * Codes are of a fixed, public length, so returning early on a length mismatch
+ * (or a non-string input) leaks nothing secret while keeping the match path
+ * timing-independent. Mirrors the `crypto.timingSafeEqual(Buffer.from(...))`
+ * pattern already used for CSRF token checks in `packages/api`.
+ * @param {string} expected
+ * @param {string} candidate
+ * @returns {boolean}
+ */
+const constantTimeEqual = (expected, candidate) => {
+  if (typeof expected !== 'string' || typeof candidate !== 'string') {
+    return false;
+  }
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const candidateBuffer = Buffer.from(candidate, 'utf8');
+  if (expectedBuffer.length !== candidateBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuffer, candidateBuffer);
+};
+
+/**
  * Verifies a TOTP token by checking a ±1 time step window.
  * @param {string} secret
  * @param {string} token
@@ -113,7 +138,7 @@ const verifyTOTP = async (secret, token) => {
   const currentTime = Date.now();
   for (let offset = -1; offset <= 1; offset++) {
     const expected = await generateTOTP(secret, currentTime + offset * timeStepMS);
-    if (expected === token) {
+    if (constantTimeEqual(expected, token)) {
       return true;
     }
   }

--- a/api/server/services/twoFactorService.spec.js
+++ b/api/server/services/twoFactorService.spec.js
@@ -1,0 +1,42 @@
+const crypto = require('node:crypto');
+
+jest.mock('node:crypto', () => {
+  const actual = jest.requireActual('node:crypto');
+  return {
+    ...actual,
+    timingSafeEqual: jest.fn((a, b) => actual.timingSafeEqual(a, b)),
+  };
+});
+
+jest.mock('@librechat/data-schemas', () => ({
+  hashBackupCode: jest.fn(),
+  decryptV3: jest.fn(),
+  decryptV2: jest.fn(),
+}));
+
+jest.mock('~/models', () => ({ updateUser: jest.fn() }));
+
+const { generateTOTP, verifyTOTP, generateTOTPSecret } = require('./twoFactorService');
+
+describe('verifyTOTP', () => {
+  it('accepts a valid current TOTP code', async () => {
+    const secret = generateTOTPSecret();
+    const code = await generateTOTP(secret);
+    await expect(verifyTOTP(secret, code)).resolves.toBe(true);
+  });
+
+  it('rejects an invalid code of the same length', async () => {
+    const secret = generateTOTPSecret();
+    const code = await generateTOTP(secret);
+    const wrong = code === '000000' ? '111111' : '000000';
+    await expect(verifyTOTP(secret, wrong)).resolves.toBe(false);
+  });
+
+  it('compares codes in constant time via crypto.timingSafeEqual', async () => {
+    const secret = generateTOTPSecret();
+    const code = await generateTOTP(secret);
+    crypto.timingSafeEqual.mockClear();
+    await verifyTOTP(secret, code);
+    expect(crypto.timingSafeEqual).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`verifyTOTP` in `api/server/services/twoFactorService.js` compared the expected TOTP code to the user-supplied candidate with `===`, which short-circuits on the first differing character and leaks match progress through response timing on the 2FA login endpoint (`verify2FAWithTempToken`). The submitted `token` comes straight from `req.body` of a user holding a temp token, so the sink is reachable by an unprivileged request.

This replaces the comparison with a length-guarded `crypto.timingSafeEqual` helper (the TOTP length is public and fixed, so it leaks no secret), matching the existing CSRF-token pattern in `packages/api/src/oauth/csrf.ts`.

## Change Type

- [x] Bug fix (non-breaking change which resolves an issue)

## Testing

Added unit tests in `twoFactorService.spec.js`: valid code accepted, invalid same-length code rejected, and the comparison routes through `timingSafeEqual`. Reverting the fix makes the constant-time test fail (0 calls). Jest: 3/3 pass with the fix.