### PR TITLE
🩹 fix: Restore Provider Typing Against the Agents SDK Declarations

### DIFF
--- a/packages/api/src/agents/memory.spec.ts
+++ b/packages/api/src/agents/memory.spec.ts
@@ -3,6 +3,7 @@ import { Run, Providers, GraphEvents } from '@librechat/agents';
 import { AIMessage, HumanMessage } from '@librechat/agents/langchain/messages';
 import { Tools, MemoryScope, EModelEndpoint, AgentCapabilities } from 'librechat-data-provider';
 import type { FiltersConfig } from 'librechat-data-provider';
+import type { RuntimeProviderName } from '@librechat/agents';
 import type { IUser } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types';
@@ -223,7 +224,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should resolve environment variables in custom endpoint headers', async () => {
     const llmConfig = {
-      provider: 'custom',
+      provider: 'custom' as RuntimeProviderName,
       model: 'gpt-4o-mini',
       configuration: {
         defaultHeaders: {
@@ -258,7 +259,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should resolve user placeholders in custom endpoint headers', async () => {
     const llmConfig = {
-      provider: 'custom',
+      provider: 'custom' as RuntimeProviderName,
       model: 'gpt-4o-mini',
       configuration: {
         defaultHeaders: {
@@ -293,7 +294,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should handle mixed environment variables and user placeholders', async () => {
     const llmConfig = {
-      provider: 'custom',
+      provider: 'custom' as RuntimeProviderName,
       model: 'gpt-4o-mini',
       configuration: {
         defaultHeaders: {
@@ -330,7 +331,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should resolve env vars when user is undefined', async () => {
     const llmConfig = {
-      provider: 'custom',
+      provider: 'custom' as RuntimeProviderName,
       model: 'gpt-4o-mini',
       configuration: {
         defaultHeaders: {

--- a/packages/api/src/types/agents.d.ts
+++ b/packages/api/src/types/agents.d.ts
@@ -1,0 +1,16 @@
+/**
+ * `@librechat/agents` publishes its declaration files with its internal `@/*` path aliases
+ * unrewritten, so a consumer cannot resolve them. `types/llm.d.ts` imports `Providers` that
+ * way, which leaves `ProviderOptionsMap`'s computed keys unresolved and collapses
+ * `keyof ProviderOptionsMap` to `number`. Until v3.6.16 that only degraded `LLMConfig`
+ * silently; v3.6.16 made `SharedLLMConfig` generic over that key union, so `provider` became
+ * `number | RuntimeProviderName` and no real provider was assignable to it.
+ *
+ * Declaring the one alias `llm.d.ts` needs restores the enum, and with it the provider key
+ * union. Remove this once the SDK ships declarations with its aliases resolved — note that
+ * mapping every `@/*` alias instead unmasks a large backlog of latent errors elsewhere in
+ * this package, so widening it is a separate cleanup rather than a drop-in improvement.
+ */
+declare module '@/common' {
+  export { Providers } from '@librechat/agents';
+}


### PR DESCRIPTION
## Summary

`Type check @librechat/api` is red on `dev` as of 9cee6f9 (Agents SDK v3.6.16). It is not caused by anything in that bump's diff — it exposed a latent packaging defect.

`@librechat/agents` publishes its declaration files with its internal `@/*` path aliases **unrewritten**, across 112 files. `types/llm.d.ts` imports `Providers` that way:

```ts
import { Providers } from '@/common';
```

A consumer cannot resolve `@/common`, so `Providers` is unresolved, `ProviderOptionsMap`'s computed keys (`[Providers.AZURE]`, …) go unresolved with it, and `keyof ProviderOptionsMap` collapses to `number`.

Through v3.6.15 that only degraded `LLMConfig` silently — `provider` was typed as the unresolved `Providers`, so everything assigned and nothing complained:

```ts
export type SharedLLMConfig = { provider: Providers; ... };
```

v3.6.16 made it generic over that key union:

```ts
export type SharedLLMConfig<P extends keyof ProviderOptionsMap | CustomProviderName | RuntimeProviderName = keyof ProviderOptionsMap> = { provider: P; ... };
```

`provider` therefore resolves to `number | RuntimeProviderName`, and no real provider is assignable to it. That is the entire failure.

### The fix

Declaring the one alias `llm.d.ts` needs restores the enum, and with it the provider key union. That takes `packages/api` from 20 errors to 4.

The remaining 4 were genuine, and are fixed here rather than papered over: custom-endpoint specs pass `provider: 'custom'`, which widens to `string`. The SDK models a provider outside `ProviderOptionsMap` as `RuntimeProviderName`, so that is what those sites now say.

### What was deliberately not done

Mapping *every* `@/*` alias via `tsconfig` `paths` was tried and rejected. It works, but it restores real checking against the SDK's whole type surface and unmasks a backlog of roughly **114** latent errors elsewhere in `packages/api` (`activityPhases/runtime.spec.ts`, `graph-subagent.e2e.test.ts`, and others). That is a worthwhile cleanup, but a separate one — not a prerequisite for getting `dev` green.

The real fix belongs upstream, in what the SDK ships. This is the consumer-side unblock until then.

The shim sits beside `proxy-from-env.d.ts` and `es2024-string.d.ts`, the two existing ambient declaration shims in `packages/api/src/types/`, and like them is tracked past the `*.d.ts` line in `.gitignore`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```
cd packages/api           && npx tsc --noEmit        0 errors  (was 20)
cd packages/api           && npm run build           ✔ 9 files
cd packages/api           && npx jest agents/memory  2 suites, 53 passed
cd packages/data-provider && npx tsc --noEmit        exit 0
cd packages/data-schemas  && npx tsc --noEmit        exit 0

node scripts/sort-imports.mts --check                sorted
npx prettier --check                                 clean
npx eslint                                           exit 0
```

Both `memory` suites pass, so the `RuntimeProviderName` annotations changed types only and left the specs' behavior intact.

### **Test Configuration**:

Node v22.22.2. `xlsx` resolves from `https://cdn.sheetjs.com`, which this environment's egress policy blocks, so the six `Cannot find module 'xlsx'` resolution errors it causes were excluded from the counts above; nothing else in `packages/api` was affected, and CI has the dependency.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWvn6ezgLmN8D5GDmFVnwv)_