### PR TITLE
📈 chore: Bump Agents SDK to v3.7.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.16",
+    "@librechat/agents": "^3.7.0",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.16",
+        "@librechat/agents": "^3.7.0",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10630,9 +10630,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.6.16.tgz",
-      "integrity": "sha512-V8WQTC4gwoUdej9Xg5slaw2QgypVhTkosNp8UL/ANh9OlS7zSKgyu5/iDz8ZXQBywKNdt7y6k7+cO9W+I6kezA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.0.tgz",
+      "integrity": "sha512-U/OewG2fUyrzqT18pz054Aq56GlH9mLJDL7+eGgWchxhLM5T8N+CDMEvev7O3CiSvvkX7e5F1MCAHQNOlCgZBQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42822,7 +42822,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.6.16",
+        "@librechat/agents": "^3.7.0",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.6.16",
+    "@librechat/agents": "^3.7.0",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

I bumped @librechat/agents from v3.6.16 to v3.7.0 so LibreChat receives runtime provider registration and the latest provider-message/runtime loading performance improvements.

- Updated both backend workspace manifests to require ^3.7.0.
- Refreshed package-lock.json against the published npm artifact.
- Confirmed both backend workspaces resolve @librechat/agents@3.7.0.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran npm@11.13.0 install --package-lock-only --ignore-scripts.
- Ran npm ls @librechat/agents --package-lock-only --all.
- Ran git diff --check.

### **Test Configuration**:

- Node.js v24.16.0
- npm v11.13.0 for lockfile generation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.