### PR TITLE
📍 ci: Pin the Votes Ledger Results JSON to an Absolute Path

### DIFF
--- a/.github/workflows/codegraph-e2e-votes.yml
+++ b/.github/workflows/codegraph-e2e-votes.yml
@@ -174,7 +174,11 @@ jobs:
       - name: Vote — run the full mock suite (cannot fail the branch)
         continue-on-error: true
         env:
-          PLAYWRIGHT_JSON_OUTPUT_NAME: pw-results.json
+          # Absolute on purpose: Playwright resolves a relative PLAYWRIGHT_JSON_OUTPUT_NAME
+          # against the CONFIG directory (e2e/), not the working directory — the first live run
+          # wrote e2e/pw-results.json while the ledger looked in the repo root and logged zero
+          # trials (fail-safe, but a silent no-op).
+          PLAYWRIGHT_JSON_OUTPUT_NAME: ${{ github.workspace }}/pw-results.json
         run: npx playwright test --config=e2e/playwright.config.mock.ts --reporter=line,json
 
       - name: Ledger — log the specs that actually executed
@@ -187,8 +191,8 @@ jobs:
           # under this job's default env — counting them as covered would mint phantom trials,
           # the exact bug this workflow revision exists to kill (Codex P1 on #15162). A spec is
           # covered iff at least one of its tests reached a non-skipped outcome.
-          if jq -e '.suites' pw-results.json >/dev/null 2>&1; then
-            jq -r '[.suites[] | recurse(.suites[]?) | .specs[]? | select([.tests[]?.status] | any(. != "skipped")) | .file] | unique | .[]' pw-results.json \
+          if jq -e '.suites' "$GITHUB_WORKSPACE/pw-results.json" >/dev/null 2>&1; then
+            jq -r '[.suites[] | recurse(.suites[]?) | .specs[]? | select([.tests[]?.status] | any(. != "skipped")) | .file] | unique | .[]' "$GITHUB_WORKSPACE/pw-results.json" \
               | sed 's|^|specs/mock/|' > covered.txt
             N=$(wc -l < covered.txt | tr -d ' ')
             echo "codegraph-votes: running $N specs (executed, full suite)"


### PR DESCRIPTION
## What

One-line-class fix to the just-merged #15162: `PLAYWRIGHT_JSON_OUTPUT_NAME` becomes an absolute `${{ github.workspace }}` path, and the ledger step reads the same absolute path.

## Why

The first live full-suite vote run ([32731087273](https://github.com/danny-avila/LibreChat/actions/runs/32731087273), success, 198 passed / 3 skipped, 29 min) exercised the fail-safe instead of the ledger: **zero trials logged**. Playwright resolves a relative `PLAYWRIGHT_JSON_OUTPUT_NAME` against the **config directory** (`e2e/`), not the working directory — the reporter wrote `e2e/pw-results.json` while the ledger looked in the repo root. Reproduced synthetically (config in a subdirectory → file lands next to the config; absolute path → honored verbatim). My pre-merge validation ran config and cwd from the same directory, which is exactly why it couldn't catch this.

Degradation was the designed one — no phantom data, run green, just no trials — but it's a silent no-op that would have stalled graduation accrual.

## Verification

- Synthetic repro: relative name → file in config dir, cwd empty; absolute name → 3.4KB json at the absolute path; `--reporter=line,json` confirmed to override config reporters (no HTML-report hint in the live log).
- YAML parses; the jq/covered pipeline is unchanged and was already verified on both branches.