### PR TITLE
✂️ fix: Unclip the Share Dialog's Public Role Menu

### DIFF
--- a/client/src/components/Sharing/PublicSharingToggle.tsx
+++ b/client/src/components/Sharing/PublicSharingToggle.tsx
@@ -85,7 +85,7 @@ export default function PublicSharingToggle({
         </div>
       </div>
 
-      <Collapse open={isPublic} className="pt-4">
+      <Collapse open={isPublic} overflowVisibleWhenOpen className="pt-4">
         <div className="flex items-center justify-between bg-transparent">
           <div className="flex items-center gap-3">
             <div className="text-status-info">

--- a/client/src/components/Sharing/__tests__/PublicSharingToggle.spec.tsx
+++ b/client/src/components/Sharing/__tests__/PublicSharingToggle.spec.tsx
@@ -26,6 +26,7 @@ describe('PublicSharingToggle', () => {
     const collapse = permissionLabel.closest('[aria-hidden="true"]');
 
     expect(collapse).toHaveClass('grid-rows-[0fr]');
+    expect(permissionLabel.closest('.overflow-hidden')).toBeInTheDocument();
 
     rerender(
       <PublicSharingToggle
@@ -38,5 +39,19 @@ describe('PublicSharingToggle', () => {
     expect(permissionLabel.closest('.bg-transparent')).toBeInTheDocument();
     expect(permissionLabel.closest('.bg-transparent')).not.toHaveClass('bg-surface-secondary/50');
     expect(permissionLabel.closest('.grid')).toHaveClass('grid-rows-[1fr]');
+  });
+
+  it('does not clip the open permission row, so the inline role menu can escape the box', () => {
+    render(
+      <PublicSharingToggle
+        isPublic={true}
+        onPublicToggle={jest.fn()}
+        onPublicRoleChange={jest.fn()}
+      />,
+    );
+
+    const permissionLabel = screen.getByText('com_ui_everyone_permission_level');
+    expect(permissionLabel.closest('.overflow-hidden')).toBeNull();
+    expect(permissionLabel.closest('.overflow-visible')).toBeInTheDocument();
   });
 });

--- a/client/src/components/ui/Collapse.tsx
+++ b/client/src/components/ui/Collapse.tsx
@@ -5,6 +5,7 @@ interface CollapseProps {
   open: boolean;
   children: ReactNode;
   className?: string;
+  overflowVisibleWhenOpen?: boolean;
 }
 
 /**
@@ -14,8 +15,19 @@ interface CollapseProps {
  * cross-fade smoothly without a measuring wrapper fighting nested reveals.
  * Content fades to soften the swap; while closed it is `inert` (removed from tab
  * order and the a11y tree) so collapsed form fields can't be focused or read.
+ *
+ * `overflowVisibleWhenOpen` lifts the clip while open so non-portaled popovers
+ * anchored inside (e.g. dropdown menus, which must stay in-tree within modal
+ * dialogs to remain inside the focus trap) aren't sheared at the box edge; the
+ * closed state and the closing tween still clip, and the opacity fade masks the
+ * un-clipped opening tween.
  */
-export default function Collapse({ open, children, className }: CollapseProps) {
+export default function Collapse({
+  open,
+  children,
+  className,
+  overflowVisibleWhenOpen = false,
+}: CollapseProps) {
   return (
     <div
       aria-hidden={!open || undefined}
@@ -25,7 +37,12 @@ export default function Collapse({ open, children, className }: CollapseProps) {
         open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
       )}
     >
-      <div className="min-h-0 overflow-hidden">
+      <div
+        className={cn(
+          'min-h-0',
+          open && overflowVisibleWhenOpen ? 'overflow-visible' : 'overflow-hidden',
+        )}
+      >
         <div
           className={cn(
             'transition-opacity duration-200 ease-out motion-reduce:transition-none',

--- a/client/src/components/ui/__tests__/Collapse.spec.tsx
+++ b/client/src/components/ui/__tests__/Collapse.spec.tsx
@@ -25,4 +25,33 @@ describe('Collapse', () => {
     expect(root).toHaveClass('grid-rows-[0fr]');
     expect(root).toHaveAttribute('aria-hidden', 'true');
   });
+
+  test('clips content while open by default', () => {
+    const { container } = render(
+      <Collapse open={true}>
+        <span data-testid="child" />
+      </Collapse>,
+    );
+    const clipWrapper = (container.firstChild as HTMLElement).firstElementChild as HTMLElement;
+    expect(clipWrapper).toHaveClass('overflow-hidden');
+  });
+
+  test('lifts the clip while open for popover-hosting content, restoring it when closed', () => {
+    const { container, rerender } = render(
+      <Collapse open={true} overflowVisibleWhenOpen>
+        <span data-testid="child" />
+      </Collapse>,
+    );
+    const clipWrapper = (container.firstChild as HTMLElement).firstElementChild as HTMLElement;
+    expect(clipWrapper).toHaveClass('overflow-visible');
+    expect(clipWrapper).not.toHaveClass('overflow-hidden');
+
+    rerender(
+      <Collapse open={false} overflowVisibleWhenOpen>
+        <span data-testid="child" />
+      </Collapse>,
+    );
+    expect(clipWrapper).toHaveClass('overflow-hidden');
+    expect(clipWrapper).not.toHaveClass('overflow-visible');
+  });
 });


### PR DESCRIPTION
## Summary

When sharing an agent (or any resource) with the whole organization, opening the **"Everyone's permission level"** dropdown in the share dialog rendered only a ~10px floating sliver of the menu instead of the role list — the "broken fragment" visible between the toggle row and the permission row.

**Root cause:** #14734 replaced `PublicSharingToggle`'s hand-rolled reveal — which deliberately set `overflow: isPublic ? 'visible' : 'hidden'` — with the shared `Collapse`, which always keeps `overflow-hidden` for its grid-rows height tween. The access-roles menu is intentionally rendered in-tree (non-portaled) so it stays inside the modal dialog's focus scope, so the ~212px menu can never fit inside the ~56px clipped row: floating-ui flips it upward and the clip shears it to a sliver.

**Fix:** an opt-in `overflowVisibleWhenOpen` prop on `Collapse` — still clipped while closed and during the closing tween, unclipped once open so in-tree popovers can escape the box (the content opacity fade masks the un-clipped opening tween, the same trade-off the pre-#14734 code shipped with). `PublicSharingToggle` opts in. All other `Collapse` consumers are unchanged.

**Why not portal the menu instead:** verified empirically (jsdom with real Radix + Ariakit): inside a modal `OGDialog`, a portaled `DropdownPopup` menu lands in a portal container that Radix's `hideOthers` marks `aria-hidden="true"` (invisible to assistive tech), and the dialog's focus trap yanks focus back on ArrowDown, closing the menu — keyboard-dead. Mouse clicks still land (via the #14487 `pointerEvents: auto` fix), which is why portaled menus elsewhere look fine casually. The existing `AccessRolesPicker` spec ("keeps its menu within the modal focus and pointer scope") guards exactly this and is untouched.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Unit: new `Collapse` specs cover the default (still clips while open) and the new prop (unclipped open → re-clipped closed); new `PublicSharingToggle` spec asserts the open permission row has no `overflow-hidden` ancestor — the structural condition that regressed (jsdom can't catch the visual shear itself). All 19 Sharing + Collapse tests pass.
- Real app: built this branch, booted the backend against an in-memory MongoDB, created an agent, and drove the share dialog with Playwright — the menu renders at full size (280×212) flipped above the trigger, mouse selection updates the trigger, ArrowDown/Enter keyboard selection works with focus staying inside the dialog, and toggling org-share off collapses the row cleanly.
- `npx tsc --noEmit` (client) and ESLint clean.

### **Test Configuration**:

- `cd client && npx jest src/components/ui/__tests__/Collapse.spec.tsx src/components/Sharing/__tests__`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
