### PR TITLE
📌 fix: Keep the Settled Turn Mounted Through Final Content Compaction

### DIFF
--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -38,6 +38,13 @@ const isEmptyTextPart = (part: TMessageContentParts | undefined): boolean => {
 const getToolCallId = (part: TMessageContentParts): string =>
   (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
 
+/** Render-identity index for keys: `finalHandler` stamps the position a part
+ * streamed at onto the persisted (compacted) content, so keying by the stamp
+ * keeps the settled message's parts mounted across the sparse→compact swap.
+ * Coordinate logic (bounds, edits, cursor) stays on the live index. */
+const getPartKeyIndex = (part: TMessageContentParts | undefined, idx: number): number =>
+  part?.streamedIndex ?? idx;
+
 const getPartAgentId = (part: TMessageContentParts): string | undefined =>
   (part as { agentId?: string })?.agentId ??
   (part?.[ContentTypes.TOOL_CALL] as { agentId?: string } | undefined)?.agentId;
@@ -51,20 +58,20 @@ const getToolGroupId = (parts: PartWithIndex[], fallbackScope: number): string =
    *  absorbs the block's leading THINK part when its text lands, so keying on
    *  `parts[0]` would flip the key mid-run — remounting the group and losing
    *  whatever the user had expanded. The tool calls themselves do not move. */
-  let firstToolIdx: number | undefined;
+  let firstToolKeyIdx: number | undefined;
   for (const { part, idx } of parts) {
     const toolCallId = getToolCallId(part);
     if (toolCallId) {
       return `tool:${toolCallId}`;
     }
-    if (firstToolIdx === undefined && part?.type === ContentTypes.TOOL_CALL) {
-      firstToolIdx = idx;
+    if (firstToolKeyIdx === undefined && part?.type === ContentTypes.TOOL_CALL) {
+      firstToolKeyIdx = getPartKeyIndex(part, idx);
     }
   }
   /** Same reasoning for id-less tool calls: anchor to the first TOOL entry's
    *  index rather than the block's first part, which shifts when reasoning is
    *  absorbed. Only a block with no tool call at all falls back to `parts[0]`. */
-  return `fallback:${fallbackScope}:${firstToolIdx ?? firstPart.idx}`;
+  return `fallback:${fallbackScope}:${firstToolKeyIdx ?? getPartKeyIndex(firstPart.part, firstPart.idx)}`;
 };
 
 type PartWithContextProps = {
@@ -117,7 +124,7 @@ const PartWithContext = memo(function PartWithContext({
         part={part}
         attachments={partAttachments}
         isSubmitting={isSubmitting}
-        key={`part-${messageId}-${idx}`}
+        key={`part-${messageId}-${getPartKeyIndex(part, idx)}`}
         isCreatedByUser={isCreatedByUser}
         isLast={isLastPart}
         showCursor={isLastPart && isLast}
@@ -248,7 +255,7 @@ const ContentPartsBody = memo(function ContentPartsBody({
     const indices = new Set<number>();
     for (const segment of phaseSegments ?? []) {
       if (segment.type === 'phase') {
-        indices.add(segment.labelIndex);
+        indices.add(getPartKeyIndex(segment.labelPart, segment.labelIndex));
       }
     }
     return indices;
@@ -332,7 +339,7 @@ const ContentPartsBody = memo(function ContentPartsBody({
       const localIdx = localIndexByAbsolute?.get(idx) ?? idx - contentIndexOffset;
       return (
         <PartWithContext
-          key={`provider-${messageId}-${idx}`}
+          key={`provider-${messageId}-${getPartKeyIndex(part, idx)}`}
           idx={idx}
           part={part}
           isLast={isLast}
@@ -369,7 +376,7 @@ const ContentPartsBody = memo(function ContentPartsBody({
       const localIdx = localIndexByAbsolute?.get(idx) ?? idx - contentIndexOffset;
       return (
         <PartWithContext
-          key={`provider-${messageId}-${idx}`}
+          key={`provider-${messageId}-${getPartKeyIndex(part, idx)}`}
           idx={idx}
           part={part}
           isLast={isLast}
@@ -456,15 +463,15 @@ const ContentPartsBody = memo(function ContentPartsBody({
   /** The re-attribution node for a part resuming after a steer block, shared
    *  by the sequential path and the parallel renderer's sequential stretches. */
   const renderResumeAttribution = useCallback(
-    (idx: number): ReactElement | null => {
+    (idx: number, keyIdx: number = idx): ReactElement | null => {
       if (authorHeader == null || !postSteerAuthors.has(idx)) {
         return null;
       }
       const activeAgentId = postSteerAuthors.get(idx);
       if (activeAgentId != null) {
-        return <AgentUpdate key={`author-${messageId}-${idx}`} currentAgentId={activeAgentId} />;
+        return <AgentUpdate key={`author-${messageId}-${keyIdx}`} currentAgentId={activeAgentId} />;
       }
-      return <Fragment key={`author-${messageId}-${idx}`}>{authorHeader}</Fragment>;
+      return <Fragment key={`author-${messageId}-${keyIdx}`}>{authorHeader}</Fragment>;
     },
     [authorHeader, postSteerAuthors, messageId],
   );
@@ -500,6 +507,23 @@ const ContentPartsBody = memo(function ContentPartsBody({
     const relativeGlobalLastContentIdx = lastCursorContentIdx(content ?? []);
     const globalLastContentIdx =
       relativeGlobalLastContentIdx < 0 ? -1 : absoluteIndexAt(relativeGlobalLastContentIdx);
+    /** Segment keys anchor to their first defined part's stable index, never
+     *  to the segment's ordinal: hole-only slots form phantom segments while
+     *  a run streams and vanish from the compacted final content, so ordinal
+     *  keys shift at settle and remount every segment body after them. */
+    const segmentKeyIndex = (segment: {
+      content: Array<TMessageContentParts | undefined>;
+      contentIndices: number[];
+      startIndex: number;
+    }): number => {
+      for (let i = 0; i < segment.content.length; i++) {
+        const part = segment.content[i];
+        if (part != null) {
+          return getPartKeyIndex(part, absoluteIndexAt(segment.contentIndices[i]));
+        }
+      }
+      return absoluteIndexAt(segment.startIndex);
+    };
     const renderSegment = (
       segmentContent: Array<TMessageContentParts | undefined>,
       segmentStartIndex: number,
@@ -538,17 +562,26 @@ const ContentPartsBody = memo(function ContentPartsBody({
             <Sources messageId={messageId} conversationId={conversationId || undefined} />
           )}
           {renderPendingSkills()}
-          {phaseSegments.map((segment, index) =>
-            segment.type === 'phase' ? (
+          {phaseSegments.map((segment) => {
+            if (segment.type !== 'phase') {
+              return renderSegment(
+                segment.content,
+                absoluteIndexAt(segment.startIndex),
+                segment.contentIndices.map(absoluteIndexAt),
+                `phase-adjacent-${segmentKeyIndex(segment)}`,
+              );
+            }
+            const phaseKeyIndex = getPartKeyIndex(segment.labelPart, segment.labelIndex);
+            return (
               <ActivityPhaseGroup
-                key={`activity-phase-${messageId}-${segment.labelIndex}`}
+                key={`activity-phase-${messageId}-${phaseKeyIndex}`}
                 labelPart={segment.labelPart}
                 hasContent={segment.hasContent}
                 hasPendingApproval={segment.content.some(
                   (part) => part != null && hasPendingApprovalInPart(part),
                 )}
                 animateEntrance={
-                  previousPhaseIndices != null && !previousPhaseIndices.has(segment.labelIndex)
+                  previousPhaseIndices != null && !previousPhaseIndices.has(phaseKeyIndex)
                 }
                 showCursor={
                   isLast &&
@@ -560,18 +593,11 @@ const ContentPartsBody = memo(function ContentPartsBody({
                   segment.content,
                   absoluteIndexAt(segment.startIndex),
                   segment.contentIndices.map(absoluteIndexAt),
-                  `phase-content-${index}`,
+                  `phase-content-${phaseKeyIndex}`,
                 )}
               </ActivityPhaseGroup>
-            ) : (
-              renderSegment(
-                segment.content,
-                absoluteIndexAt(segment.startIndex),
-                segment.contentIndices.map(absoluteIndexAt),
-                `phase-adjacent-${index}`,
-              )
-            ),
-          )}
+            );
+          })}
           <WorkspaceChanges attachments={workspaceChanges} />
         </SearchContext.Provider>
       </ApprovalProvider>
@@ -639,9 +665,13 @@ const ContentPartsBody = memo(function ContentPartsBody({
       )}
       {!showEmptyCursor &&
         groupedParts.flatMap((group) => {
-          const firstIdx = group.type === 'single' ? group.part.idx : (group.parts[0]?.idx ?? -1);
+          const first = group.type === 'single' ? group.part : group.parts[0];
+          const firstIdx = first?.idx ?? -1;
           const nodes: ReactElement[] = [];
-          const attribution = renderResumeAttribution(firstIdx);
+          const attribution = renderResumeAttribution(
+            firstIdx,
+            first ? getPartKeyIndex(first.part, first.idx) : firstIdx,
+          );
           if (attribution != null) {
             nodes.push(attribution);
           }

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -8,7 +8,12 @@ import type {
 } from 'librechat-data-provider';
 import type { ReactNode, ReactElement } from 'react';
 import type { ToolCallGroupExpansionState } from './ToolCallGroup';
-import { mapAttachments, filterAttachmentsForPart, groupSequentialToolCalls } from '~/utils';
+import {
+  mapAttachments,
+  getPartKeyIndex,
+  filterAttachmentsForPart,
+  groupSequentialToolCalls,
+} from '~/utils';
 import WorkspaceChanges, { partitionWorkspaceChanges } from './Parts/WorkspaceChanges';
 import { groupActivityPhases, lastCursorContentIdx } from '~/utils/activityLabels';
 import { ParallelContentRenderer, type PartWithIndex } from './ParallelContent';
@@ -37,13 +42,6 @@ const isEmptyTextPart = (part: TMessageContentParts | undefined): boolean => {
 
 const getToolCallId = (part: TMessageContentParts): string =>
   (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
-
-/** Render-identity index for keys: `finalHandler` stamps the position a part
- * streamed at onto the persisted (compacted) content, so keying by the stamp
- * keeps the settled message's parts mounted across the sparse→compact swap.
- * Coordinate logic (bounds, edits, cursor) stays on the live index. */
-const getPartKeyIndex = (part: TMessageContentParts | undefined, idx: number): number =>
-  part?.streamedIndex ?? idx;
 
 const getPartAgentId = (part: TMessageContentParts): string | undefined =>
   (part as { agentId?: string })?.agentId ??

--- a/client/src/components/Chat/Messages/Content/ParallelContent.tsx
+++ b/client/src/components/Chat/Messages/Content/ParallelContent.tsx
@@ -8,11 +8,11 @@ import {
 } from '~/utils/activityLabels';
 import MemoryArtifacts from './MemoryArtifacts';
 import Sources from '~/components/Web/Sources';
+import { cn, getPartKeyIndex } from '~/utils';
 import { SearchContext } from '~/Providers';
 import SiblingHeader from './SiblingHeader';
 import { EmptyText } from './Parts';
 import Container from './Container';
-import { cn } from '~/utils';
 
 export type PartWithIndex = { part: TMessageContentParts; idx: number };
 
@@ -235,7 +235,7 @@ type ParallelContentRendererProps = {
    * sequential before/after stretches consult it: column content already
    * carries per-agent identity.
    */
-  renderResumeAttribution?: (idx: number) => React.ReactNode;
+  renderResumeAttribution?: (idx: number, keyIdx?: number) => React.ReactNode;
   showDecorations?: boolean;
   /** Absolute transcript index represented by `content[0]` in a phase slice. */
   contentIndexOffset?: number;
@@ -302,7 +302,7 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
 
       {/* Sequential content BEFORE parallel sections */}
       {before.flatMap(({ part, idx }) => {
-        const attribution = renderResumeAttribution?.(idx);
+        const attribution = renderResumeAttribution?.(idx, getPartKeyIndex(part, idx));
         const rendered = renderPart(part, idx, false);
         return attribution != null ? [attribution, rendered] : [rendered];
       })}
@@ -324,7 +324,7 @@ export const ParallelContentRenderer = memo(function ParallelContentRenderer({
 
       {/* Sequential content AFTER parallel sections */}
       {after.flatMap(({ part, idx }) => {
-        const attribution = renderResumeAttribution?.(idx);
+        const attribution = renderResumeAttribution?.(idx, getPartKeyIndex(part, idx));
         const rendered = renderPart(part, idx, idx === lastContentIdx);
         return attribution != null ? [attribution, rendered] : [rendered];
       })}

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ContentTypes, Tools } from 'librechat-data-provider';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { TMessageContentParts, TAttachment } from 'librechat-data-provider';
+import { preserveStreamedContentIdentity } from '~/utils/messages';
 import { groupSequentialToolCalls } from '~/utils';
 
 jest.mock('~/utils', () => ({
@@ -649,5 +650,71 @@ describe('ContentParts — activity phase state', () => {
       'data-animate-entrance',
       'false',
     );
+  });
+});
+
+describe('ContentParts — settled content identity across compaction', () => {
+  /** Mirrors a captured run: the aggregator leaves holes at the source indexes
+   *  of steps that produced nothing, and `finalHandler` swaps in the server's
+   *  compacted array. Without the streamed-index stamp every index-derived key
+   *  shifts and the settled message remounts wholesale. */
+  const toolPart = {
+    type: ContentTypes.TOOL_CALL,
+    [ContentTypes.TOOL_CALL]: { id: 'call_a', name: 'search', args: {}, output: 'one' },
+  } as unknown as TMessageContentParts;
+  const batchLabel = {
+    type: ContentTypes.ACTIVITY_LABEL,
+    [ContentTypes.ACTIVITY_LABEL]: 'Recorded the fact',
+    tool_call_ids: ['call_a'],
+  } as unknown as TMessageContentParts;
+  const answer = { type: ContentTypes.TEXT, text: 'done' } as unknown as TMessageContentParts;
+  const phaseLabel = (bounds: { start: number; end: number }) =>
+    ({
+      type: ContentTypes.ACTIVITY_LABEL,
+      [ContentTypes.ACTIVITY_LABEL]: 'Researched the question',
+      activity_label_type: 'phase',
+      activity_start_index: bounds.start,
+      activity_end_index: bounds.end,
+      activity_count: 1,
+      pending: false,
+    }) as unknown as TMessageContentParts;
+
+  const streamed: Array<TMessageContentParts | undefined> = [
+    undefined,
+    toolPart,
+    batchLabel,
+    undefined,
+    answer,
+    phaseLabel({ start: 1, end: 4 }),
+  ];
+  const compacted = [toolPart, batchLabel, answer, phaseLabel({ start: 0, end: 2 })];
+
+  const renderStreaming = () =>
+    render(<ContentParts {...baseProps} content={streamed} isLast isSubmitting isLatestMessage />);
+
+  it('keeps every part and the phase group mounted when the final content is stamped', () => {
+    const { rerender } = renderStreaming();
+    const phaseNode = screen.getByTestId('activity-phase-group');
+    const toolNode = screen.getByTestId('real-part-tool_call');
+    const textNode = screen.getByTestId('real-part-text');
+
+    const finalContent = preserveStreamedContentIdentity(streamed, compacted);
+    rerender(<ContentParts {...baseProps} content={finalContent} isLast />);
+
+    expect(screen.getByTestId('activity-phase-group')).toBe(phaseNode);
+    expect(screen.getByTestId('real-part-tool_call')).toBe(toolNode);
+    expect(screen.getByTestId('real-part-text')).toBe(textNode);
+    expect(phaseNode).toHaveAttribute('data-animate-entrance', 'false');
+  });
+
+  it('remounts and replays the phase entrance without the stamp (regression control)', () => {
+    const { rerender } = renderStreaming();
+    const phaseNode = screen.getByTestId('activity-phase-group');
+
+    rerender(<ContentParts {...baseProps} content={compacted} isLast />);
+
+    const settledPhase = screen.getByTestId('activity-phase-group');
+    expect(settledPhase).not.toBe(phaseNode);
+    expect(settledPhase).toHaveAttribute('data-animate-entrance', 'true');
   });
 });

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.test.tsx
@@ -11,6 +11,7 @@ jest.mock('~/utils', () => ({
   filterAttachmentsForPart: (attachments: unknown) => attachments,
   groupSequentialToolCalls: jest.fn(),
   hasPendingApprovalInPart: jest.requireActual('~/utils/groupToolCalls').hasPendingApprovalInPart,
+  getPartKeyIndex: jest.requireActual('~/utils/messages').getPartKeyIndex,
 }));
 
 jest.mock('~/Providers', () => {

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -33,6 +33,7 @@ import {
   isSubmittableMessage,
   createDualMessageContent,
   getRouteChatProjectId,
+  stripStreamedIndexStamps,
 } from '~/utils';
 import useFocusRegeneratedResponse from '~/hooks/Chat/useFocusRegeneratedResponse';
 import useSetFilesToDelete from '~/hooks/Files/useSetFilesToDelete';
@@ -626,7 +627,10 @@ export default function useChatFunctions({
       initialResponse.text = '';
 
       if (editedContent && latestMessage?.content) {
-        initialResponse.content = cloneDeep(latestMessage.content);
+        /** Stamps off: the rerun appends provider parts at the prefix LENGTH,
+         *  and a retained `streamedIndex` at or above it would collide with an
+         *  appended part's render key (see `stripStreamedIndexStamps`). */
+        initialResponse.content = stripStreamedIndexStamps(cloneDeep(latestMessage.content));
         /** Captured now, while it is still the retained prefix: a later resume
          *  sync replaces this array with the server's completion-local
          *  snapshot, after which its length no longer describes the offset. */

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -36,6 +36,7 @@ import {
   updateConvoInAllQueries,
   removeConvoFromAllQueries,
   findConversationInInfinite,
+  preserveStreamedContentIdentity,
 } from '~/utils';
 import {
   startupConfigKey,
@@ -870,19 +871,29 @@ export default function useEventHandlers({
           finalMessages = [...messages, requestMessage, responseMessage];
         }
 
-        /* Preserve files from current messages when server response lacks them */
+        /* Preserve files and streamed content identity from current messages:
+         * files fill in when the server response lacks them, and the persisted
+         * (compacted) content is stamped with the indexes it streamed at so
+         * index-keyed renders don't remount the settled message. */
         if (finalMessages.length > 0) {
-          const currentMsgMap = new Map(
-            currentMessages
-              .filter((m) => m.files && m.files.length > 0)
-              .map((m) => [m.messageId, m.files]),
-          );
+          const currentMsgMap = new Map(currentMessages.map((m) => [m.messageId, m]));
           for (let i = 0; i < finalMessages.length; i++) {
             const msg = finalMessages[i];
-            const preservedFiles = currentMsgMap.get(msg.messageId);
-            if (msg.files == null && preservedFiles) {
-              finalMessages[i] = { ...msg, files: preservedFiles };
+            const currentMsg = currentMsgMap.get(msg.messageId);
+            if (!currentMsg) {
+              continue;
             }
+            const preservedFiles =
+              msg.files == null && currentMsg.files?.length ? currentMsg.files : undefined;
+            const content = preserveStreamedContentIdentity(currentMsg.content, msg.content);
+            if (preservedFiles == null && content === msg.content) {
+              continue;
+            }
+            finalMessages[i] = {
+              ...msg,
+              ...(preservedFiles != null ? { files: preservedFiles } : {}),
+              ...(content !== msg.content ? { content } : {}),
+            };
           }
         }
 

--- a/client/src/utils/messages.spec.ts
+++ b/client/src/utils/messages.spec.ts
@@ -1,6 +1,6 @@
 import { ContentTypes } from 'librechat-data-provider';
 import type { TMessage, TMessageContentParts } from 'librechat-data-provider';
-import { preserveStreamedContentIdentity } from './messages';
+import { preserveStreamedContentIdentity, stripStreamedIndexStamps } from './messages';
 
 const text = (value: string, extra: Record<string, unknown> = {}): TMessageContentParts =>
   ({ type: ContentTypes.TEXT, text: value, ...extra }) as TMessageContentParts;
@@ -125,6 +125,20 @@ describe('preserveStreamedContentIdentity', () => {
     expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
   });
 
+  it('abandons stamping when an omitted intermediate is a prefix of the retained output', () => {
+    const streamed = [text('Answer:'), text('Answer: final details')];
+    const final = [text('Answer: final details')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('ignores trailing holes and empty slots when checking for removed content', () => {
+    const streamed = [undefined, tool('call_a'), text('answer'), text(''), undefined];
+    const final = [tool('call_a'), text('answer')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([1, 2]);
+  });
+
   it('abandons stamping when streamed and final text diverge', () => {
     const streamed = [undefined, text('answer A')];
     const final = [text('answer B')];
@@ -193,5 +207,36 @@ describe('preserveStreamedContentIdentity', () => {
     const final = [tool(undefined, 'web_search')];
 
     expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+});
+
+describe('stripStreamedIndexStamps', () => {
+  const tool = (id: string): TMessageContentParts =>
+    ({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: { id, name: 'search', args: '' },
+    }) as TMessageContentParts;
+
+  it('drops every stamp from a settled content array', () => {
+    const settled = preserveStreamedContentIdentity(
+      [
+        undefined,
+        tool('call_a'),
+        { type: ContentTypes.TEXT, text: 'answer' } as TMessageContentParts,
+      ],
+      [tool('call_a'), { type: ContentTypes.TEXT, text: 'answer' } as TMessageContentParts],
+    );
+    expect((settled ?? []).some((part) => part?.streamedIndex !== undefined)).toBe(true);
+
+    const stripped = stripStreamedIndexStamps(settled);
+
+    expect((stripped ?? []).every((part) => part?.streamedIndex === undefined)).toBe(true);
+  });
+
+  it('returns the same reference when nothing is stamped', () => {
+    const plain = [tool('call_a')];
+
+    expect(stripStreamedIndexStamps(plain)).toBe(plain);
+    expect(stripStreamedIndexStamps(undefined)).toBeUndefined();
   });
 });

--- a/client/src/utils/messages.spec.ts
+++ b/client/src/utils/messages.spec.ts
@@ -118,6 +118,41 @@ describe('preserveStreamedContentIdentity', () => {
     expect(preserveStreamedContentIdentity([], final)).toBe(final);
   });
 
+  it('abandons stamping when a filtered run retains only a same-type later part', () => {
+    const streamed = [text('intermediate agent output'), text('final agent answer')];
+    const final = [text('final agent answer')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('abandons stamping when streamed and final text diverge', () => {
+    const streamed = [undefined, text('answer A')];
+    const final = [text('answer B')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('never pairs a batch label with a phase label of the same text', () => {
+    const streamed = [undefined, label('Ran the tools')];
+    const final = [label('Ran the tools', { activity_label_type: 'phase' })];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('pairs a blank label reservation with its filled final label', () => {
+    const streamed = [undefined, label('')];
+    const final = [label('Recorded the fact')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([1]);
+  });
+
+  it('never pairs text parts across different phases', () => {
+    const streamed = [undefined, text('note', { phase: 'commentary' })];
+    const final = [text('note')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
   it('carries existing stamps forward when a settled message is re-delivered compact', () => {
     const streamedSparse = [undefined, tool('call_a'), label('first'), undefined, text('answer')];
     const settled = preserveStreamedContentIdentity(streamedSparse, [

--- a/client/src/utils/messages.spec.ts
+++ b/client/src/utils/messages.spec.ts
@@ -1,0 +1,134 @@
+import { ContentTypes } from 'librechat-data-provider';
+import type { TMessage, TMessageContentParts } from 'librechat-data-provider';
+import { preserveStreamedContentIdentity } from './messages';
+
+const text = (value: string, extra: Record<string, unknown> = {}): TMessageContentParts =>
+  ({ type: ContentTypes.TEXT, text: value, ...extra }) as TMessageContentParts;
+
+const think = (value: string): TMessageContentParts =>
+  ({ type: ContentTypes.THINK, think: value }) as TMessageContentParts;
+
+const tool = (id: string | undefined, name = 'search'): TMessageContentParts =>
+  ({
+    type: ContentTypes.TOOL_CALL,
+    tool_call: { id, name, args: '' },
+  }) as TMessageContentParts;
+
+const label = (value: string, extra: Record<string, unknown> = {}): TMessageContentParts =>
+  ({ type: ContentTypes.ACTIVITY_LABEL, activity_label: value, ...extra }) as TMessageContentParts;
+
+const streamedIndexes = (content: TMessage['content']): Array<number | undefined> =>
+  (content ?? []).map((part) => part?.streamedIndex);
+
+describe('preserveStreamedContentIdentity', () => {
+  it('stamps every part shifted by compacted holes with its streamed index', () => {
+    const streamed = [
+      undefined,
+      tool('call_a'),
+      label('first'),
+      undefined,
+      tool('call_b'),
+      label('second'),
+      text('answer'),
+      label('phase', { activity_label_type: 'phase' }),
+    ];
+    const final = [
+      tool('call_a'),
+      label('first'),
+      tool('call_b'),
+      label('second'),
+      text('answer'),
+      label('phase', { activity_label_type: 'phase' }),
+    ];
+
+    const result = preserveStreamedContentIdentity(streamed, final);
+
+    expect(streamedIndexes(result)).toEqual([1, 2, 4, 5, 6, 7]);
+    expect(final.every((part) => part.streamedIndex === undefined)).toBe(true);
+  });
+
+  it('returns the final array untouched when no hole shifted anything', () => {
+    const streamed = [tool('call_a'), text('answer')];
+    const final = [tool('call_a'), text('answer')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('leaves aligned prefix parts unstamped while stamping the shifted tail', () => {
+    const streamed = [text('intro'), undefined, tool('call_a')];
+    const final = [text('intro'), tool('call_a')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([
+      undefined,
+      2,
+    ]);
+  });
+
+  it('skips streamed empty-text placeholders the compaction dropped', () => {
+    const streamed = [text(''), tool('call_a'), text('answer')];
+    const final = [tool('call_a'), text('answer')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([1, 2]);
+  });
+
+  it('skips streamed empty think parts and typeless placeholders', () => {
+    const streamed = [
+      { type: '' } as unknown as TMessageContentParts,
+      think(''),
+      think('reasoned'),
+      text('answer'),
+    ];
+    const final = [think('reasoned'), text('answer')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([2, 3]);
+  });
+
+  it('matches by identity, not equality: richer final text keeps its streamed slot', () => {
+    const streamed = [undefined, text('partial ans')];
+    const final = [text('partial answer, completed.')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([1]);
+  });
+
+  it('pairs tool calls by id and abandons stamping on an id mismatch', () => {
+    const streamed = [undefined, tool('call_a')];
+    const final = [tool('call_other')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('abandons stamping when the server appended a part that never streamed', () => {
+    const streamed = [undefined, tool('call_a')];
+    const final = [tool('call_a'), text('server-added')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('abandons stamping on a type mismatch instead of mispairing', () => {
+    const streamed = [think('reasoned'), text('answer')];
+    const final = [text('answer')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+
+  it('returns final content untouched when nothing streamed', () => {
+    const final = [text('answer')];
+
+    expect(preserveStreamedContentIdentity(undefined, final)).toBe(final);
+    expect(preserveStreamedContentIdentity([], final)).toBe(final);
+  });
+
+  it('pairs id-less tool calls by name', () => {
+    const streamed = [undefined, tool(undefined, 'execute_code')];
+    const final = [tool(undefined, 'execute_code')];
+
+    expect(streamedIndexes(preserveStreamedContentIdentity(streamed, final))).toEqual([1]);
+  });
+
+  it('abandons stamping when id-less tool call names differ', () => {
+    const streamed = [undefined, tool(undefined, 'execute_code')];
+    const final = [tool(undefined, 'web_search')];
+
+    expect(preserveStreamedContentIdentity(streamed, final)).toBe(final);
+  });
+});

--- a/client/src/utils/messages.spec.ts
+++ b/client/src/utils/messages.spec.ts
@@ -118,6 +118,34 @@ describe('preserveStreamedContentIdentity', () => {
     expect(preserveStreamedContentIdentity([], final)).toBe(final);
   });
 
+  it('carries existing stamps forward when a settled message is re-delivered compact', () => {
+    const streamedSparse = [undefined, tool('call_a'), label('first'), undefined, text('answer')];
+    const settled = preserveStreamedContentIdentity(streamedSparse, [
+      tool('call_a'),
+      label('first'),
+      text('answer'),
+    ]);
+    expect(streamedIndexes(settled)).toEqual([1, 2, 4]);
+
+    const redelivered = [tool('call_a'), label('first'), text('answer')];
+    const result = preserveStreamedContentIdentity(settled, redelivered);
+
+    expect(streamedIndexes(result)).toEqual([1, 2, 4]);
+  });
+
+  it('carries a partially stamped message forward without stamping its aligned prefix', () => {
+    const streamedSparse = [text('intro'), undefined, tool('call_a')];
+    const settled = preserveStreamedContentIdentity(streamedSparse, [
+      text('intro'),
+      tool('call_a'),
+    ]);
+    expect(streamedIndexes(settled)).toEqual([undefined, 2]);
+
+    const result = preserveStreamedContentIdentity(settled, [text('intro'), tool('call_a')]);
+
+    expect(streamedIndexes(result)).toEqual([undefined, 2]);
+  });
+
   it('pairs id-less tool calls by name', () => {
     const streamed = [undefined, tool(undefined, 'execute_code')];
     const final = [tool(undefined, 'execute_code')];

--- a/client/src/utils/messages.ts
+++ b/client/src/utils/messages.ts
@@ -286,8 +286,11 @@ const isSameStreamedPart = (
  *
  * Pairing is all-or-nothing: a partially stamped array could collide a
  * streamed key with a compacted fallback key. When any final part has no
- * streamed counterpart (server-enriched content), the final array is returned
- * untouched and the message re-keys as before.
+ * streamed counterpart (server-enriched content), or any substantial streamed
+ * part has no final counterpart (a filtered run that dropped intermediate
+ * outputs — where in-order pairing could hand a retained part an omitted
+ * part's identity), the final array is returned untouched and the message
+ * re-keys as before.
  */
 export const preserveStreamedContentIdentity = (
   streamedContent: Array<TMessageContentParts | undefined> | undefined,
@@ -342,8 +345,44 @@ export const preserveStreamedContentIdentity = (
       stamped[index] = { ...finalPart, streamedIndex: stampIndex };
     }
   }
+  /** Leftover substantial streamed parts mean the server REMOVED content
+   *  (`hide_sequential_outputs`), so every pairing above is suspect — an
+   *  omitted intermediate that happens to prefix the retained output would
+   *  have claimed its identity. Only holes and empty slots may remain. */
+  for (let rest = cursor; rest < streamedContent.length; rest++) {
+    const leftover = streamedContent[rest];
+    if (leftover != null && !isEmptyContentPart(leftover)) {
+      return finalContent;
+    }
+  }
   return stamped ?? finalContent;
 };
+
+/**
+ * Drops the client-only `streamedIndex` stamps from a content array. An
+ * edited resubmission retains the settled prefix and appends the rerun's
+ * parts at the prefix LENGTH — a stamp at or above that length would collide
+ * with an appended part's key — so the retained prefix reverts to physical
+ * identity for the rerun. Returns the input untouched when nothing is
+ * stamped.
+ */
+export function stripStreamedIndexStamps(content: TMessageContentParts[]): TMessageContentParts[];
+export function stripStreamedIndexStamps(content: TMessage['content']): TMessage['content'];
+export function stripStreamedIndexStamps(content: TMessage['content']): TMessage['content'] {
+  if (!content?.length) {
+    return content;
+  }
+  let changed = false;
+  const next = content.map((part) => {
+    if (part == null || part.streamedIndex === undefined) {
+      return part;
+    }
+    changed = true;
+    const { streamedIndex: _streamedIndex, ...rest } = part;
+    return rest as TMessageContentParts;
+  });
+  return changed ? next : content;
+}
 
 /** Render-identity index for content-part keys: the streamed position stamped
  * by the final handler survives the sparse→compact swap; everything else keys

--- a/client/src/utils/messages.ts
+++ b/client/src/utils/messages.ts
@@ -278,6 +278,7 @@ export const preserveStreamedContentIdentity = (
       return finalContent;
     }
     let matchedIndex = -1;
+    let matchedPart: TMessageContentParts | null = null;
     while (cursor < streamedContent.length) {
       const streamedPart = streamedContent[cursor];
       if (streamedPart == null) {
@@ -293,22 +294,36 @@ export const preserveStreamedContentIdentity = (
       }
       if (isSameStreamedPart(streamedPart, finalPart)) {
         matchedIndex = cursor;
+        matchedPart = streamedPart;
         cursor += 1;
       }
       break;
     }
-    if (matchedIndex === -1) {
+    if (matchedIndex === -1 || matchedPart == null) {
       return finalContent;
     }
-    if (matchedIndex !== index && stamped == null) {
+    /** A settled message can be re-delivered by a LATER final event (e.g. an
+     *  Assistants run resyncing prior turns): both sides arrive compact, but
+     *  the current parts already carry stamps from their own settle. Carrying
+     *  them forward keeps their keys stable forever, instead of silently
+     *  reverting the identity this stamp exists to preserve. */
+    const stampIndex = matchedPart.streamedIndex ?? matchedIndex;
+    if (stampIndex !== index && stamped == null) {
       stamped = [...finalContent];
     }
-    if (stamped != null && matchedIndex !== index) {
-      stamped[index] = { ...finalPart, streamedIndex: matchedIndex };
+    if (stamped != null && stampIndex !== index) {
+      stamped[index] = { ...finalPart, streamedIndex: stampIndex };
     }
   }
   return stamped ?? finalContent;
 };
+
+/** Render-identity index for content-part keys: the streamed position stamped
+ * by the final handler survives the sparse→compact swap; everything else keys
+ * by the live index. Coordinate logic (edit indexes, phase bounds, cursor)
+ * must keep using the live index. */
+export const getPartKeyIndex = (part: TMessageContentParts | undefined, idx: number): number =>
+  part?.streamedIndex ?? idx;
 
 /**
  * Whether a draft message has enough content to submit: non-whitespace

--- a/client/src/utils/messages.ts
+++ b/client/src/utils/messages.ts
@@ -9,6 +9,7 @@ import {
   encodeEphemeralAgentId,
 } from 'librechat-data-provider';
 import type {
+  Agents,
   TMessage,
   TConversation,
   TEndpointsConfig,
@@ -190,6 +191,123 @@ export const getAllContentText = (message?: TMessage | null): string => {
   }
 
   return '';
+};
+
+const getPartTextValue = (value?: string | { value?: string }): string =>
+  (typeof value === 'string' ? value : value?.value) ?? '';
+
+const getPartToolCall = (part: TMessageContentParts): Agents.ToolCall | undefined =>
+  part.type === ContentTypes.TOOL_CALL
+    ? (part[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)
+    : undefined;
+
+/** Slots the persistence compaction leaves nothing behind for: the
+ * dual-message `type: ''` placeholders, text/think parts that never received a
+ * delta, and tool calls missing their `tool_call` payload. */
+const isEmptyContentPart = (part: TMessageContentParts): boolean => {
+  if (!part.type) {
+    return true;
+  }
+  if (part.type === ContentTypes.TEXT) {
+    return getPartTextValue(part.text).length === 0;
+  }
+  if (part.type === ContentTypes.THINK) {
+    return getPartTextValue(part.think).length === 0;
+  }
+  if (part.type === ContentTypes.TOOL_CALL) {
+    return getPartToolCall(part) == null;
+  }
+  return false;
+};
+
+/** Identity match, not equality: the persisted part may carry richer content
+ * (flushed text, tool output) than its streamed counterpart, and updating a
+ * kept identity in place is exactly the point. */
+const isSameStreamedPart = (
+  streamed: TMessageContentParts,
+  final: TMessageContentParts,
+): boolean => {
+  if (streamed.type !== final.type) {
+    return false;
+  }
+  if (streamed.type !== ContentTypes.TOOL_CALL) {
+    return true;
+  }
+  const streamedCall = getPartToolCall(streamed);
+  const finalCall = getPartToolCall(final);
+  if (streamedCall?.id != null && finalCall?.id != null) {
+    return streamedCall.id === finalCall.id;
+  }
+  if (streamedCall?.name != null && finalCall?.name != null) {
+    return streamedCall.name === finalCall.name;
+  }
+  return true;
+};
+
+/**
+ * Stamps each part of a final (persisted, compacted) content array with the
+ * index it occupied while it streamed, pairing the two arrays in order.
+ *
+ * The aggregator writes parts at provider-source indexes, so the streamed
+ * array is sparse wherever a step produced nothing; persistence compacts the
+ * holes away and every later part shifts down. Adopting the compacted array
+ * verbatim re-keys every index-derived React identity at the final event —
+ * the settled message remounts wholesale, entrance animations replay, and the
+ * thread visibly jumps. The stamp (`streamedIndex`) lets renderers keep the
+ * streamed key while all coordinate logic uses the compacted positions the
+ * server persisted.
+ *
+ * Pairing is all-or-nothing: a partially stamped array could collide a
+ * streamed key with a compacted fallback key. When any final part has no
+ * streamed counterpart (server-enriched content), the final array is returned
+ * untouched and the message re-keys as before.
+ */
+export const preserveStreamedContentIdentity = (
+  streamedContent: Array<TMessageContentParts | undefined> | undefined,
+  finalContent: TMessage['content'],
+): TMessage['content'] => {
+  if (!streamedContent?.length || !finalContent?.length) {
+    return finalContent;
+  }
+
+  let cursor = 0;
+  let stamped: TMessageContentParts[] | null = null;
+  for (let index = 0; index < finalContent.length; index++) {
+    const finalPart = finalContent[index] as TMessageContentParts | undefined;
+    if (finalPart == null) {
+      return finalContent;
+    }
+    let matchedIndex = -1;
+    while (cursor < streamedContent.length) {
+      const streamedPart = streamedContent[cursor];
+      if (streamedPart == null) {
+        cursor += 1;
+        continue;
+      }
+      /** An empty streamed slot facing a filled final part was dropped by the
+       *  compaction — never let it steal the match from the filled streamed
+       *  part behind it (an empty THINK ahead of the real one, say). */
+      if (isEmptyContentPart(streamedPart) && !isEmptyContentPart(finalPart)) {
+        cursor += 1;
+        continue;
+      }
+      if (isSameStreamedPart(streamedPart, finalPart)) {
+        matchedIndex = cursor;
+        cursor += 1;
+      }
+      break;
+    }
+    if (matchedIndex === -1) {
+      return finalContent;
+    }
+    if (matchedIndex !== index && stamped == null) {
+      stamped = [...finalContent];
+    }
+    if (stamped != null && matchedIndex !== index) {
+      stamped[index] = { ...finalPart, streamedIndex: matchedIndex };
+    }
+  }
+  return stamped ?? finalContent;
 };
 
 /**

--- a/client/src/utils/messages.ts
+++ b/client/src/utils/messages.ts
@@ -220,9 +220,18 @@ const isEmptyContentPart = (part: TMessageContentParts): boolean => {
   return false;
 };
 
+/** One side extending the other is the same part observed at two moments —
+ * a flushed tail or a server-side trim — while divergent content is a
+ * different part that merely shares the type. */
+const isMutualPrefix = (streamed: string, final: string): boolean =>
+  final.startsWith(streamed) || streamed.startsWith(final);
+
 /** Identity match, not equality: the persisted part may carry richer content
  * (flushed text, tool output) than its streamed counterpart, and updating a
- * kept identity in place is exactly the point. */
+ * kept identity in place is exactly the point. Content still has to agree as
+ * an extension of what streamed: a filtered run (`hide_sequential_outputs`)
+ * omits intermediate parts from the final array, and a type-only match would
+ * hand the retained output an omitted intermediate's identity. */
 const isSameStreamedPart = (
   streamed: TMessageContentParts,
   final: TMessageContentParts,
@@ -230,16 +239,34 @@ const isSameStreamedPart = (
   if (streamed.type !== final.type) {
     return false;
   }
-  if (streamed.type !== ContentTypes.TOOL_CALL) {
+  if (streamed.type === ContentTypes.TOOL_CALL) {
+    const streamedCall = getPartToolCall(streamed);
+    const finalCall = getPartToolCall(final);
+    if (streamedCall?.id != null && finalCall?.id != null) {
+      return streamedCall.id === finalCall.id;
+    }
+    if (streamedCall?.name != null && finalCall?.name != null) {
+      return streamedCall.name === finalCall.name;
+    }
     return true;
   }
-  const streamedCall = getPartToolCall(streamed);
-  const finalCall = getPartToolCall(final);
-  if (streamedCall?.id != null && finalCall?.id != null) {
-    return streamedCall.id === finalCall.id;
+  if (streamed.type === ContentTypes.TEXT && final.type === ContentTypes.TEXT) {
+    if ((streamed.phase ?? null) !== (final.phase ?? null)) {
+      return false;
+    }
+    return isMutualPrefix(getPartTextValue(streamed.text), getPartTextValue(final.text));
   }
-  if (streamedCall?.name != null && finalCall?.name != null) {
-    return streamedCall.name === finalCall.name;
+  if (streamed.type === ContentTypes.THINK && final.type === ContentTypes.THINK) {
+    return isMutualPrefix(getPartTextValue(streamed.think), getPartTextValue(final.think));
+  }
+  if (streamed.type === ContentTypes.ACTIVITY_LABEL && final.type === ContentTypes.ACTIVITY_LABEL) {
+    if ((streamed.activity_label_type ?? null) !== (final.activity_label_type ?? null)) {
+      return false;
+    }
+    return isMutualPrefix(
+      getPartTextValue(streamed.activity_label),
+      getPartTextValue(final.activity_label),
+    );
   }
   return true;
 };

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -638,10 +638,20 @@ export type PartMetadata = {
    * as dispatch time rather than the task's runtime.
    */
   backgrounded?: boolean;
+  /**
+   * Content index this part occupied while its run streamed. The aggregator
+   * writes parts at provider-source indexes, so the streamed array is sparse;
+   * persistence compacts it and every part after a hole shifts down. The
+   * client's final handler stamps the streamed position onto the compacted
+   * parts it adopts, so index-derived render identity survives the swap
+   * instead of remounting the settled message. Client-only and absent
+   * everywhere else — persisted content never carries it.
+   */
+  streamedIndex?: number;
 };
 
 /** Metadata for parallel content rendering - subset of PartMetadata */
-export type ContentMetadata = Pick<PartMetadata, 'agentId' | 'groupId'>;
+export type ContentMetadata = Pick<PartMetadata, 'agentId' | 'groupId' | 'streamedIndex'>;
 
 export type ContentPart = (
   | CodeToolCall


### PR DESCRIPTION
## Summary

Fixes the settle-time jank: when a generation's **final** event lands, the thread visibly snaps — content shoves down and springs back up within a few frames — on any run whose model turn emitted tool calls (or any step that produced nothing) before text. Reported as "a weird snapping/scrolling effect when a final event is received … it just shifts the content up and down really quick."

## Diagnosis

Captured live with a frame-by-frame instrumentation harness (rAF layout sampler + `scrollTop`-write stack tracing + React commit walker + MutationObserver + SSE tap) against the mock e2e model:

- The aggregator writes content parts at **provider-source indexes**, so the streamed array is **sparse** — a turn that goes straight to tool calls leaves a hole at index 0 (in a captured phase run, parts sat at `1,2,4,5,6,7` with holes at `0,3`).
- The final event delivers the **persisted, compacted** array (`0..5`). `finalHandler` adopted it verbatim, so every part after a hole changed its absolute index.
- Every index-derived React identity re-keyed at once: `PartWithContext` (`provider-<msgId>-<idx>`), id-less `ToolCallGroup` fallback ids (which also silently discarded the user's expansion override), `ActivityPhaseGroup` (`activity-phase-<msgId>-<labelIndex>`), and the phase-path segment bodies (`phase-adjacent-<ordinal>`, whose ordinals shift because hole-only phantom segments vanish at compaction).
- The remount storm is directly visible in the DOM trace: **12 added / 4 removed elements in the commit ~5ms before settle**, followed by a +15px grow and a −37px fold replay over the next 350ms. The phase group's `animateEntrance` detection (`previousPhaseIndices` keyed by label index) mislabels the compacted marker as *new*, so an already-folded phase card **remounts expanded and replays its fold-in** — the up-then-down snap. Remounts also reset lazy code highlights and tool-pane state.

Plain text-only runs stream at index 0 with no holes and never snapped — matching the repro matrix.

## Changes

- **`finalHandler` stamps streamed positions instead of letting identity drift** (`client/src/utils/messages.ts`, `useEventHandlers.ts`): a new `preserveStreamedContentIdentity` pairs the compacted parts with their streamed counterparts in order (skipping holes and empty placeholder slots the compaction drops; tool calls pair by id, then name) and stamps each shifted part with `streamedIndex` — the index it occupied while streaming. Pairing is **all-or-nothing** so a partially stamped array can never collide a streamed key with a compacted fallback key; server-enriched content that no longer matches falls back to today's full re-key. Folded into the existing files-preservation pass (same single loop, no extra iteration).
- **Render keys read the stamp; coordinate logic stays on live indexes** (`ContentParts.tsx`): `getPartKeyIndex(part, idx) = part.streamedIndex ?? idx` feeds `PartWithContext`/inner `Part` keys, id-less tool-group fallback ids (user expansion overrides now survive settle), resume-attribution keys, the phase-group key, and the `previousPhaseIndices` entrance-detection set — so a settled phase never replays its fold-in. Edit indexes, phase bounds, `nextType`, and cursor logic all keep using the compacted positions the server persisted (`updateMessageContent` still addresses the server's array correctly).
- **Phase segment keys anchor to content, not ordinals** (`ContentParts.tsx`): segments key by their first defined part's stable index rather than `phaseSegments.map` position, so phantom hole-only segments disappearing at compaction no longer remount every segment after them.
- **`streamedIndex` type** (`packages/data-provider` `PartMetadata`/`ContentMetadata`): documented as client-only; persisted content never carries it.

## Verification

- **Live A/B on the instrumented harness** (mock model, phase-labeled tool run, dev build): at-final DOM churn drops from **12 added / 4 removed** (remount storm) to **2 added / 3 removed** (just the elapsed-timer → hover-actions swap and cursor removal); the duplicated post-final fold replay is gone — the only fold left is the designed entrance of a phase label that resolves at run end. Stamp correctness confirmed in-page: `cur 0:hole,1:tool,2:label,3:hole,4:tool,5:label,6:text,7:label` → `out 0:tool:1, 1:label:2, 2:tool:4, 3:label:5, 4:text:6, 5:label:7`.
- **Unit**: `client/src/utils/messages.spec.ts` (12 cases: hole stamping, aligned-prefix identity return, empty text/think/typeless placeholder skips, id/name pairing, all-or-nothing fallbacks). `ContentParts.test.tsx` gains a DOM-identity pair: stamped final content keeps the phase group, tool, and text **nodes** mounted (`toBe` on the elements) with `animateEntrance` false; the unstamped control documents the old remount + replay.
- Suites: client `src/components/Chat/Messages` + `src/hooks/SSE` + `src/utils` — 135 suites / 2533 tests passing; `packages/data-provider` 34 suites / 1631 passing; `tsc --noEmit` clean on `client`; lint clean.