### PR TITLE
📐 fix: Set the Elapsed Reading on the Column Its Neighbors Share

### DIFF
--- a/client/src/components/Chat/Messages/Elapsed.tsx
+++ b/client/src/components/Chat/Messages/Elapsed.tsx
@@ -59,8 +59,13 @@ const Elapsed = memo(function Elapsed({ index }: { index: number }) {
   }, [start]);
 
   const labels = getElapsedDurationLabels(seconds * 1000, i18n.language);
+  /** `ps-1.5` puts the reading on the column everything else in this slot
+   *  shares: the streaming dot pads the same 6px to center on the size-6
+   *  header icon's axis (see `EmptyTextPart`), and the hover-button glyphs
+   *  that replace the timer sit behind the same `p-1.5`. Inline-start, so
+   *  the alignment holds in RTL. */
   return (
-    <span className="flex items-center text-text-secondary">
+    <span className="flex items-center ps-1.5 text-text-secondary">
       <span aria-hidden="true" className="tabular-nums" data-testid="stream-elapsed">
         {localize(labels.key, labels.values)}
       </span>

--- a/client/src/components/Chat/Messages/__tests__/Elapsed.spec.tsx
+++ b/client/src/components/Chat/Messages/__tests__/Elapsed.spec.tsx
@@ -34,6 +34,9 @@ describe('Elapsed', () => {
     expect(screen.getByTestId('stream-elapsed')).toHaveTextContent(/^5s$/);
     expect(screen.getByTestId('stream-elapsed')).toHaveAttribute('aria-hidden', 'true');
     expect(screen.getByText('5 seconds elapsed')).toHaveClass('sr-only');
+    /** The 6px inline-start inset that lines the reading up with the
+     *  streaming dot and the hover-button glyphs that replace it. */
+    expect(screen.getByTestId('stream-elapsed').parentElement).toHaveClass('ps-1.5');
 
     advance(54_000);
     expect(screen.getByTestId('stream-elapsed')).toHaveTextContent(/^59s$/);


### PR DESCRIPTION
## Summary

Follow-up to #15167: the elapsed reading sat at the footer's flush left while everything around it is inset 6px — the streaming dot pads `(24 − 12) / 2` inline-start to center on the size-6 header icon's axis (`EmptyTextPart`), and the hover-button glyphs that replace the timer sit behind their own `p-1.5`. So the timer hung a touch left of the dot above it and of the glyphs that take its place at settle.

One class fixes it: the same `ps-1.5` inline-start inset on the timer's wrapper (logical property, so the column holds in RTL). The reading now stacks on the axis the dot and avatar share, and hands off in place to the first action glyph when the answer lands.

Measured in the live app (mock stack, Playwright bounding boxes): timer `x = 382`, dot origin `x = 382`, first settled action glyph `x = 382`.

## Tests

- `Elapsed.spec.tsx` (+1 assertion): pins the `ps-1.5` inset on the timer's wrapper, with the derivation in a comment beside it.
- `Elapsed` + `HoverActions.streaming` suites green on current `dev` (20 tests); the geometry was verified against the running app as above.
