### PR TITLE
🎨 style: Set Question Popover and Subagent Panel on the Sidebar Surface

### DIFF
--- a/client/src/components/Chat/Input/AskUserQuestionPopover.tsx
+++ b/client/src/components/Chat/Input/AskUserQuestionPopover.tsx
@@ -51,7 +51,7 @@ function AskUserQuestionsPopoverPanel({ ask }: { ask: ReturnType<typeof useAskAn
 
   return (
     <div className="absolute bottom-28 z-10 w-full">
-      <div className="popover border-token-border-light flex max-h-[70vh] flex-col rounded-2xl border bg-surface-secondary shadow-lg">
+      <div className="popover border-token-border-light flex max-h-[70vh] flex-col rounded-2xl border bg-surface-primary-alt shadow-lg">
         <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border-light px-3 py-2">
           <p className="text-sm font-medium text-text-primary">
             {localize(
@@ -156,7 +156,7 @@ function AskUserQuestionPopoverPanel({
           scroll region: the panel is absolutely positioned, so anything that
           overflows it is unreachable by page scroll. */}
       <div
-        className="popover border-token-border-light flex max-h-[60vh] flex-col rounded-2xl border bg-surface-secondary p-2 shadow-lg"
+        className="popover border-token-border-light flex max-h-[60vh] flex-col rounded-2xl border bg-surface-primary-alt p-2 shadow-lg"
         onKeyDown={handlePopoverKeyDown}
       >
         <div className="flex shrink-0 items-start justify-between gap-2 p-2">

--- a/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
+++ b/client/src/components/Chat/Subagents/SubagentThreadPanel.tsx
@@ -585,7 +585,7 @@ export default function SubagentThreadPanel({ selection }: { selection: ActiveSu
       role={isMobile ? 'dialog' : 'region'}
       aria-modal={isMobile || undefined}
       aria-label={localize('com_ui_subagent_thread_panel')}
-      className="flex h-full w-full flex-col overflow-hidden bg-surface-primary text-text-primary"
+      className="flex h-full w-full flex-col overflow-hidden bg-surface-primary-alt text-text-primary"
     >
       <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border-light px-4 py-3">
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-tertiary">


### PR DESCRIPTION
## Summary

The ask-user-question popover and the subagent thread panel both floated over the chat on surfaces one step too close to it — the popover on `surface-secondary`, the panel on the chat's own `surface-primary` — so neither read as its own layer. Both now sit on `surface-primary-alt`, the conversation-list sidebar's surface role: a touch darker than the chat in dark mode, and the same "chrome" layer the sidebar already establishes in both themes.

Verified in the running app (mock stack, computed styles): popover, panel, and a sidebar-token probe all resolve to the identical background — `rgb(23, 23, 23)` in dark, `rgb(247, 247, 248)` in light.

Deliberately unchanged: the inline question cards in the transcript keep `surface-secondary` — that is the tool-record family's surface (`ToolCall` uses it), and settled questions collapse into that family, so they should keep matching their siblings.

## Tests

- `Chat/Subagents` + `Chat/Input` suites green (365 tests); no spec pins either class.
- Computed-background equality checked live against the sidebar token in both themes, with screenshots.
