### PR TITLE
⏳ fix: Anchor Resumed Elapsed Time at the Generation's Real Start

### DIFF
--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -7,6 +7,7 @@ const {
   buildAbortedResponseMetadata,
   isPendingActionStale,
   toClientPendingAction,
+  getGenerationElapsedMs,
   isHITLEnabled,
   captureAgentCheckpointGeneration,
   deleteAgentCheckpoint,
@@ -524,9 +525,7 @@ router.get('/chat/status/:conversationId', async (req, res) => {
     status: job.status,
     aggregatedContent: resumeState?.aggregatedContent ?? [],
     createdAt: job.createdAt,
-    // Server-computed so a reattaching client can rebuild a clock-local
-    // elapsed baseline without comparing timestamps across machines.
-    elapsedMs: Math.max(0, Date.now() - job.createdAt),
+    elapsedMs: getGenerationElapsedMs(job),
     resumeState,
     // Surface the live pending approval so a client rebuilding from /chat/status
     // (reload / cross-replica) has the action id + payload to render and submit

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -524,6 +524,9 @@ router.get('/chat/status/:conversationId', async (req, res) => {
     status: job.status,
     aggregatedContent: resumeState?.aggregatedContent ?? [],
     createdAt: job.createdAt,
+    // Server-computed so a reattaching client can rebuild a clock-local
+    // elapsed baseline without comparing timestamps across machines.
+    elapsedMs: Math.max(0, Date.now() - job.createdAt),
     resumeState,
     // Surface the live pending approval so a client rebuilding from /chat/status
     // (reload / cross-replica) has the action id + payload to render and submit

--- a/client/src/data-provider/SSE/queries.ts
+++ b/client/src/data-provider/SSE/queries.ts
@@ -17,6 +17,9 @@ export interface StreamStatusResponse {
   status?: 'running' | 'complete' | 'error' | 'aborted' | 'requires_action';
   aggregatedContent?: Array<{ type: string; text?: string }>;
   createdAt?: number;
+  /** Generation age computed on the server's clock, so a reattaching client
+   *  can rebuild a clock-local elapsed baseline free of cross-machine skew. */
+  elapsedMs?: number;
   resumeState?: Agents.ResumeState;
   /** Live pending approval when `status === 'requires_action'`; mirrors
    *  `resumeState.pendingAction`, surfaced top-level for the resume-on-load path. */

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -306,7 +306,9 @@ describe('useResumeOnLoad', () => {
     /** The elapsed indicator's baseline must be the generation's real start:
      *  an attach with no surviving anchor (a reload, or a run another client
      *  started) rebuilds it clock-locally from the server-computed generation
-     *  age, so cross-machine clock skew never enters the reading. */
+     *  age, subtracted from the moment the status response ARRIVED — so
+     *  neither cross-machine clock skew nor a slow history fetch between
+     *  receipt and apply can distort the reading. */
     it('anchors the elapsed baseline via the server-computed generation age', async () => {
       const observedStarts: Array<number | null> = [];
       mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
@@ -326,18 +328,15 @@ describe('useResumeOnLoad', () => {
       });
       mockUseStreamStatus.mockReturnValue({
         ...ACTIVE_STATUS,
+        dataUpdatedAt: 1_000_000,
         data: { ...ACTIVE_STATUS.data, elapsedMs: 30_000 },
       });
-      const before = Date.now();
       rerender();
       await act(async () => {
         await Promise.resolve();
       });
-      const after = Date.now();
 
-      const anchored = observedStarts[observedStarts.length - 1];
-      expect(anchored).toBeGreaterThanOrEqual(before - 30_000);
-      expect(anchored).toBeLessThanOrEqual(after - 30_000);
+      expect(observedStarts[observedStarts.length - 1]).toBe(1_000_000 - 30_000);
     });
 
     /** An older server without `elapsedMs` still beats counting from attach:

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -75,6 +75,8 @@ function renderUseResumeOnLoad({
   pendingSteers,
   onPendingSteers,
   onQueuedMessages,
+  submissionStart,
+  onSubmissionStart,
 }: {
   messages?: TMessage[];
   getMessages?: () => TMessage[] | undefined;
@@ -87,6 +89,8 @@ function renderUseResumeOnLoad({
   pendingSteers?: PendingSteer[];
   onPendingSteers?: (steers: PendingSteer[]) => void;
   onQueuedMessages?: (queued: QueuedMessage[]) => void;
+  submissionStart?: number;
+  onSubmissionStart?: (submissionStart: number | null) => void;
 }) {
   const getMessages = jest.fn(getMessagesOverride ?? (() => messages));
   const queryClient = new QueryClient({
@@ -96,6 +100,9 @@ function renderUseResumeOnLoad({
   const initializeState = (snapshot: MutableSnapshot) => {
     snapshot.set(store.conversationByIndex(0), buildConversation(conversationId));
     snapshot.set(store.submissionByIndex(0), submission);
+    if (submissionStart != null) {
+      snapshot.set(store.submissionStartFamily(0), submissionStart);
+    }
     if (pendingSteers) {
       snapshot.set(store.pendingSteersByConvoId(conversationId), pendingSteers);
     }
@@ -105,6 +112,11 @@ function renderUseResumeOnLoad({
     const currentSubmission = useRecoilValue(store.submissionByIndex(0));
     setSubmissionState = useSetRecoilState(store.submissionByIndex(0));
     onSubmission?.(currentSubmission);
+    return null;
+  };
+  const SubmissionStartProbe = () => {
+    const currentStart = useRecoilValue(store.submissionStartFamily(0));
+    onSubmissionStart?.(currentStart);
     return null;
   };
   const PendingSteersProbe = () => {
@@ -129,6 +141,7 @@ function renderUseResumeOnLoad({
     <QueryClientProvider client={queryClient}>
       <RecoilRoot initializeState={initializeState}>
         <SubmissionProbe />
+        <SubmissionStartProbe />
         <SiblingIndexProbe />
         <PendingSteersProbe />
         <QueuedMessagesProbe />
@@ -288,6 +301,64 @@ describe('useResumeOnLoad', () => {
         | null;
       expect(attached?.resumeStreamId).toBe(CONVERSATION_ID);
       expect(attached?.resumeGenerationCreatedAt).toBe(4242);
+    });
+
+    /** The elapsed indicator's baseline must be the generation's real start:
+     *  an attach with no surviving anchor (a reload, or a run another client
+     *  started) adopts the server-recorded `createdAt` rather than counting
+     *  from the moment this pane happened to attach. */
+    it('anchors the elapsed baseline at the server-recorded generation start', async () => {
+      const observedStarts: Array<number | null> = [];
+      mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
+
+      const { rerender } = renderUseResumeOnLoad({
+        messages: [buildUserMessage(CONVERSATION_ID)],
+        onSubmissionStart: (start) => observedStarts.push(start),
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(observedStarts[observedStarts.length - 1]).toBeNull();
+
+      mockUseActiveJobs.mockReturnValue({
+        data: { activeJobIds: [CONVERSATION_ID] },
+        dataUpdatedAt: 2,
+      });
+      mockUseStreamStatus.mockReturnValue(ACTIVE_STATUS);
+      rerender();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(observedStarts[observedStarts.length - 1]).toBe(4242);
+    });
+
+    /** A reattach to the run this session already anchored must keep the ask
+     *  baseline — the atom deliberately outlives the submission it timed. */
+    it('preserves a surviving elapsed baseline over the server-recorded start', async () => {
+      const observedStarts: Array<number | null> = [];
+      mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
+
+      const { rerender } = renderUseResumeOnLoad({
+        messages: [buildUserMessage(CONVERSATION_ID)],
+        submissionStart: 1111,
+        onSubmissionStart: (start) => observedStarts.push(start),
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      mockUseActiveJobs.mockReturnValue({
+        data: { activeJobIds: [CONVERSATION_ID] },
+        dataUpdatedAt: 2,
+      });
+      mockUseStreamStatus.mockReturnValue(ACTIVE_STATUS);
+      rerender();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(observedStarts[observedStarts.length - 1]).toBe(1111);
     });
 
     it('restores an externally started regeneration after history refreshes', async () => {

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -305,9 +305,9 @@ describe('useResumeOnLoad', () => {
 
     /** The elapsed indicator's baseline must be the generation's real start:
      *  an attach with no surviving anchor (a reload, or a run another client
-     *  started) adopts the server-recorded `createdAt` rather than counting
-     *  from the moment this pane happened to attach. */
-    it('anchors the elapsed baseline at the server-recorded generation start', async () => {
+     *  started) rebuilds it clock-locally from the server-computed generation
+     *  age, so cross-machine clock skew never enters the reading. */
+    it('anchors the elapsed baseline via the server-computed generation age', async () => {
       const observedStarts: Array<number | null> = [];
       mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
 
@@ -319,6 +319,40 @@ describe('useResumeOnLoad', () => {
         await Promise.resolve();
       });
       expect(observedStarts[observedStarts.length - 1]).toBeNull();
+
+      mockUseActiveJobs.mockReturnValue({
+        data: { activeJobIds: [CONVERSATION_ID] },
+        dataUpdatedAt: 2,
+      });
+      mockUseStreamStatus.mockReturnValue({
+        ...ACTIVE_STATUS,
+        data: { ...ACTIVE_STATUS.data, elapsedMs: 30_000 },
+      });
+      const before = Date.now();
+      rerender();
+      await act(async () => {
+        await Promise.resolve();
+      });
+      const after = Date.now();
+
+      const anchored = observedStarts[observedStarts.length - 1];
+      expect(anchored).toBeGreaterThanOrEqual(before - 30_000);
+      expect(anchored).toBeLessThanOrEqual(after - 30_000);
+    });
+
+    /** An older server without `elapsedMs` still beats counting from attach:
+     *  the raw server start is adopted and the indicator clamps its skew. */
+    it('falls back to the server-recorded generation start without elapsedMs', async () => {
+      const observedStarts: Array<number | null> = [];
+      mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
+
+      const { rerender } = renderUseResumeOnLoad({
+        messages: [buildUserMessage(CONVERSATION_ID)],
+        onSubmissionStart: (start) => observedStarts.push(start),
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       mockUseActiveJobs.mockReturnValue({
         data: { activeJobIds: [CONVERSATION_ID] },

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -463,6 +463,7 @@ export default function useResumeOnLoad(
 
   const {
     data: streamStatus,
+    dataUpdatedAt: streamStatusUpdatedAt,
     isSuccess,
     isFetching,
   } = useStreamStatus(conversationId, shouldCheck);
@@ -612,15 +613,20 @@ export default function useResumeOnLoad(
      *  the submission). A run it never anchored — after a reload, or started by
      *  another client — rebuilds the real baseline from the server-computed
      *  generation age, which keeps both clocks comparing only to themselves.
-     *  Raw `createdAt` (an older server) still beats counting from attach; the
-     *  indicator clamps whatever skew that carries. */
-    setSubmissionStart(
-      (prev) =>
-        prev ??
-        (streamStatus.elapsedMs != null
-          ? Date.now() - streamStatus.elapsedMs
-          : (streamStatus.createdAt ?? Date.now())),
-    );
+     *  The age is subtracted from the moment the status RESPONSE arrived
+     *  (`dataUpdatedAt`), not from now: this effect trails the response behind
+     *  `messagesLoaded`, and a slow history fetch would silently shrink the
+     *  reading. Raw `createdAt` (an older server) still beats counting from
+     *  attach; the indicator clamps whatever skew that carries. */
+    setSubmissionStart((prev) => {
+      if (prev != null) {
+        return prev;
+      }
+      if (streamStatus.elapsedMs != null) {
+        return (streamStatusUpdatedAt || Date.now()) - streamStatus.elapsedMs;
+      }
+      return streamStatus.createdAt ?? Date.now();
+    });
 
     // Build submission from resume state if available
     if (streamStatus.resumeState) {
@@ -688,6 +694,7 @@ export default function useResumeOnLoad(
     isSuccess,
     isFetching,
     streamStatus,
+    streamStatusUpdatedAt,
     getMessages,
     setSubmission,
     setSubmissionStart,

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -610,9 +610,17 @@ export default function useResumeOnLoad(
     /** Fill the elapsed baseline only when none survives: a reattach to the run
      *  this session already anchored keeps its original start (the atom outlives
      *  the submission). A run it never anchored — after a reload, or started by
-     *  another client — anchors at the server-recorded generation start, so the
-     *  reading reports real elapsed time rather than time since this attach. */
-    setSubmissionStart((prev) => prev ?? streamStatus.createdAt ?? Date.now());
+     *  another client — rebuilds the real baseline from the server-computed
+     *  generation age, which keeps both clocks comparing only to themselves.
+     *  Raw `createdAt` (an older server) still beats counting from attach; the
+     *  indicator clamps whatever skew that carries. */
+    setSubmissionStart(
+      (prev) =>
+        prev ??
+        (streamStatus.elapsedMs != null
+          ? Date.now() - streamStatus.elapsedMs
+          : (streamStatus.createdAt ?? Date.now())),
+    );
 
     // Build submission from resume state if available
     if (streamStatus.resumeState) {

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -609,9 +609,10 @@ export default function useResumeOnLoad(
     const messages = getMessages() || [];
     /** Fill the elapsed baseline only when none survives: a reattach to the run
      *  this session already anchored keeps its original start (the atom outlives
-     *  the submission), while a run it never anchored — another client's, or any
-     *  attach after the previous run's terminal clear — counts from attach. */
-    setSubmissionStart((prev) => prev ?? Date.now());
+     *  the submission). A run it never anchored — after a reload, or started by
+     *  another client — anchors at the server-recorded generation start, so the
+     *  reading reports real elapsed time rather than time since this attach. */
+    setSubmissionStart((prev) => prev ?? streamStatus.createdAt ?? Date.now());
 
     // Build submission from resume state if available
     if (streamStatus.resumeState) {

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -42,9 +42,10 @@ const submissionByIndex = atomFamily<TSubmission | null, string | number>({
  * Epoch ms baseline for the streaming elapsed indicator at this chat index.
  * Stamped when this session submits a generation (every path through `ask`),
  * cleared by the terminal handlers when that generation ends, and only FILLED
- * — never overwritten — when resume-on-load attaches a run. The reading
- * therefore survives mid-stream remounts (new-conversation id hydration,
- * navigating away from a still-live run and back) without a later,
+ * — never overwritten — when resume-on-load attaches a run, preferring the
+ * server-recorded generation start so a reload reports real elapsed time.
+ * The reading therefore survives mid-stream remounts (new-conversation id
+ * hydration, navigating away from a still-live run and back) without a later,
  * externally-started generation inheriting a stale baseline. Known residual:
  * a run whose end this pane never observed (left mid-stream, finished
  * elsewhere) leaves its stamp for the next attach at this index to inherit.

--- a/packages/api/src/stream/__tests__/elapsed.spec.ts
+++ b/packages/api/src/stream/__tests__/elapsed.spec.ts
@@ -1,0 +1,13 @@
+import { getGenerationElapsedMs } from '../elapsed';
+
+describe('getGenerationElapsedMs', () => {
+  it('reports the age of the job on this clock', () => {
+    const elapsed = getGenerationElapsedMs({ createdAt: Date.now() - 5_000 });
+    expect(elapsed).toBeGreaterThanOrEqual(5_000);
+    expect(elapsed).toBeLessThan(6_000);
+  });
+
+  it('clamps a creator clock ahead of this replica to zero', () => {
+    expect(getGenerationElapsedMs({ createdAt: Date.now() + 60_000 })).toBe(0);
+  });
+});

--- a/packages/api/src/stream/elapsed.ts
+++ b/packages/api/src/stream/elapsed.ts
@@ -1,0 +1,9 @@
+/**
+ * Age of a generation computed entirely on this process's clock, for status
+ * responses whose clients rebuild a clock-local elapsed baseline instead of
+ * comparing timestamps across machines. Clamped: a job stamped by a replica
+ * whose clock ran ahead of this one must never report a negative age.
+ */
+export function getGenerationElapsedMs(job: { createdAt: number }): number {
+  return Math.max(0, Date.now() - job.createdAt);
+}

--- a/packages/api/src/stream/index.ts
+++ b/packages/api/src/stream/index.ts
@@ -54,6 +54,7 @@ export type { RecoveredSteerPayload } from './SteerRecovery';
 export { createStreamServices } from './createStreamServices';
 export type { StreamServicesConfig, StreamServices } from './createStreamServices';
 export { filterPersistableAbortContent, hasPersistableAbortContent } from './abortContent';
+export { getGenerationElapsedMs } from './elapsed';
 
 // Implementations (for advanced use cases)
 export { InMemoryJobStore } from './implementations/InMemoryJobStore';


### PR DESCRIPTION
## Summary

Refreshing mid-generation visibly reset the elapsed indicator to `0s`: the reload empties the Recoil anchor, and the timer fell back to counting from its own mount — the reattach moment — instead of the generation's real start.

The status route now also reports the generation's **age computed on the server's own clock** (`elapsedMs`), and the resume-on-load anchor fill rebuilds a clock-local baseline from it — each machine only ever compares to itself, so cross-machine skew never enters the reading (codex round 1):

```ts
setSubmissionStart(
  (prev) =>
    prev ??
    (streamStatus.elapsedMs != null
      ? Date.now() - streamStatus.elapsedMs
      : (streamStatus.createdAt ?? Date.now())),
);
```

- **Reload mid-run**: the timer resumes at the run's true elapsed time instead of `0s`.
- **A run another client started**: same — anchored at its real start, not this pane's attach.
- **Same-session reattach** (navigate away and back): unchanged — the fill is still fill-only, so the surviving ask-time baseline wins.
- **Clock skew**: none by construction on current servers — the anchor is `Date.now() − elapsedMs`, both on the client's clock. An older server mid-rolling-deploy falls back to raw `createdAt`, where the indicator's `Math.max(0, …)` clamp absorbs a server clock running ahead.

## Tests

- `useResumeOnLoad.spec.tsx` (+3, on the existing external-run harness): an attach with no surviving anchor rebuilds the baseline from `elapsedMs` (bounded around `Date.now() − 30 000`); an older server without `elapsedMs` falls back to `createdAt` (`4242`); a surviving anchor (`1111`) is preserved over both.
- `streamTenant.spec.js` (route suite): 48/48 with the new field.
- Full client suite green: 5,522 tests. Client `tsc --noEmit` and ESLint clean.
