### PR TITLE
🕶️ fix: Unhide Event Subagent Names on the Dark Surface

### DIFF
--- a/client/src/components/Chat/Subagents/EventSubagentActivityGroup.test.tsx
+++ b/client/src/components/Chat/Subagents/EventSubagentActivityGroup.test.tsx
@@ -118,6 +118,21 @@ describe('EventSubagentActivityGroup', () => {
     );
   });
 
+  it('themes the group root so raw child-row buttons never inherit the unthemed body color', () => {
+    render(
+      <RecoilRoot>
+        <EventSubagentActivityGroup
+          conversationId="parent-conversation"
+          parentMessageIds={['parent-message']}
+        />
+      </RecoilRoot>,
+    );
+
+    expect(screen.getByRole('region', { name: 'com_ui_subagent_activity' })).toHaveClass(
+      'text-text-primary',
+    );
+  });
+
   it('matches the width of a parallel assistant response', () => {
     render(
       <RecoilRoot>

--- a/client/src/components/Chat/Subagents/EventSubagentActivityGroup.tsx
+++ b/client/src/components/Chat/Subagents/EventSubagentActivityGroup.tsx
@@ -155,7 +155,11 @@ function EventSubagentRows({
   return (
     <section
       aria-label={localize('com_ui_subagent_activity')}
-      className="my-2 overflow-hidden rounded-lg border border-border-light bg-surface-secondary/40"
+      /** `text-text-primary` on the root, like `SubagentActivity` and
+       *  `SubagentThreadPanel`: the child rows are raw buttons that inherit
+       *  their label color, and without a themed ancestor they bottom out at
+       *  the unthemed black body color — invisible on the dark surface. */
+      className="my-2 overflow-hidden rounded-lg border border-border-light bg-surface-secondary/40 text-text-primary"
       data-event-subagent-group={eventChildren[0]?.parentMessageId}
     >
       <Button


### PR DESCRIPTION
## Summary

In the in-chat event subagent group ("N agents · X completed · Y dispatched"), the agent **name** on each row renders near-invisible in dark mode while the slug and status stay readable — the reported background-subagent theming bug.

## Diagnosis

The child rows are raw `<button>`s with no text color of their own, and the group's `<section>` root sets none either. With the CSS reset giving buttons `color: inherit`, the labels inherit all the way to the **unthemed black body color**: measured against the live cascade, the label computes `rgb(0, 0, 0)` in *both* themes — invisible on the dark surface, and silently off-token in light mode (pure black where `--text-primary` is `33 33 33`). The slug and status lines carry explicit `text-text-primary`-family roles (`text-text-secondary`), which is exactly why only the names vanished.

## Change

One class: `text-text-primary` on the section root, matching how the sibling subagent surfaces already do it (`SubagentActivity` and `SubagentThreadPanel` both theme their roots). Every descendant inherits the semantic role; the rows' secondary lines keep their explicit overrides, and the header button keeps its `text-text-secondary hover:text-text-primary`.

Verified against the running app's real cascade (probe injected the exact section/row markup, toggling the `dark` class): label goes from `rgb(0,0,0)` in both modes to the token color — `rgb(236,236,236)` dark / `rgb(33,33,33)` light — with the root themed, confirming the raw buttons do inherit through it.

## Testing

- New regression test asserts the group root carries the semantic text role (the condition that lets raw child rows inherit correctly).
- `client` Subagents suites: 6 suites / 82 tests passing; `tsc --noEmit` and lint clean.