### PR TITLE
🛃 feat: Route File Writes Through the Quota Ledger

### DIFF
--- a/api/app/clients/tools/structured/DALLE3.js
+++ b/api/app/clients/tools/structured/DALLE3.js
@@ -236,7 +236,6 @@ Error Message: ${error.message}`);
         fileName: imageName,
         fileStrategy: this.fileStrategy,
         context: FileContext.image_generation,
-        tenantId: this.tenantId,
         req: this.retentionRequest,
       });
 

--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -349,7 +349,6 @@ class FluxAPI extends Tool {
         fileName: imageName,
         basePath: 'images',
         context: FileContext.image_generation,
-        tenantId: this.tenantId,
         req: this.retentionRequest,
       });
 
@@ -581,7 +580,6 @@ class FluxAPI extends Tool {
         fileName: imageName,
         basePath: 'images',
         context: FileContext.image_generation,
-        tenantId: this.tenantId,
         req: this.retentionRequest,
       });
 

--- a/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
+++ b/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
@@ -111,6 +111,9 @@ describe('image tools - agent mode ToolMessage format', () => {
       expect(dalle.tenantId).toBe('tenant-a');
       expect(dalle.req).toBeUndefined();
       expect(dalle.retentionRequest).toEqual({
+        /* Carried so the later image write is charged to the request's tenant rather
+         * than whatever a rebuilt snapshot could infer from the fields it kept. */
+        storageScope: expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-a' }),
         user: { id: 'user-1', tenantId: 'tenant-a' },
         body: { conversationId: 'convo-1', isTemporary: 'true' },
         config: { interfaceConfig: { retentionMode: 'all' } },
@@ -202,6 +205,9 @@ describe('image tools - agent mode ToolMessage format', () => {
       expect(flux.tenantId).toBe('tenant-a');
       expect(flux.req).toBeUndefined();
       expect(flux.retentionRequest).toEqual({
+        /* Carried so the later image write is charged to the request's tenant rather
+         * than whatever a rebuilt snapshot could infer from the fields it kept. */
+        storageScope: expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-a' }),
         user: { id: 'user-1', tenantId: 'tenant-a' },
         body: { conversationId: 'convo-1', isTemporary: 'true' },
         config: { interfaceConfig: { retentionMode: 'all' } },
@@ -231,11 +237,14 @@ describe('image tools - agent mode ToolMessage format', () => {
 
       expect(processFileURL).toHaveBeenCalledWith(
         expect.objectContaining({
-          req: {
+          /* The snapshot carries the resolved storage scope so the later image write is
+           * charged to the same tenant and cap the live request would have used. */
+          req: expect.objectContaining({
+            storageScope: expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-a' }),
             user: { id: 'user-1', tenantId: 'tenant-a' },
             body: { conversationId: 'convo-1', isTemporary: 'true' },
             config: { interfaceConfig: { retentionMode: 'all' } },
-          },
+          }),
         }),
       );
     });
@@ -268,11 +277,14 @@ describe('image tools - agent mode ToolMessage format', () => {
 
       expect(processFileURL).toHaveBeenCalledWith(
         expect.objectContaining({
-          req: {
+          /* The snapshot carries the resolved storage scope so the later image write is
+           * charged to the same tenant and cap the live request would have used. */
+          req: expect.objectContaining({
+            storageScope: expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-a' }),
             user: { id: 'user-1', tenantId: 'tenant-a' },
             body: { conversationId: 'convo-1', isTemporary: 'true' },
             config: { interfaceConfig: { retentionMode: 'all' } },
-          },
+          }),
         }),
       );
     });

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -26,7 +26,7 @@ const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } =
  * @param {string} params.fileName - The name of the file.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
- * @returns {Promise<string>} The URL of the uploaded blob.
+ * @returns {Promise<{filepath: string, bytes: number}>} The uploaded blob metadata.
  */
 async function saveBufferToAzure({
   userId,
@@ -83,7 +83,14 @@ async function saveURLToAzure({
       throw new Error(`Remote file response too large: ${buffer.length} bytes`);
     }
 
-    return await saveBufferToAzure({ userId, buffer, fileName, basePath, containerName });
+    const filepath = await saveBufferToAzure({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      containerName,
+    });
+    return { filepath, bytes: buffer.length };
   } catch (error) {
     logger.error('[saveURLToAzure] Error uploading file from URL:', error);
     throw error;

--- a/api/server/services/Files/process.integration.spec.js
+++ b/api/server/services/Files/process.integration.spec.js
@@ -33,6 +33,15 @@ jest.mock('@librechat/api', () => ({
   sanitizeFilename: jest.fn((n) => n),
   parseText: jest.fn().mockResolvedValue({ text: '', bytes: 0 }),
   processAudioFile: jest.fn(),
+  resolveStorageScope: (req) => ({
+    userId: req.user?.id,
+    tenantId: req.tenantId ?? req.user?.tenantId,
+  }),
+  createFileQuotaPersistence: ({ createFile, getDeleteFile }) => ({
+    persistFile: (_req, row, _rollback, options = {}) =>
+      createFile(row, options.disableTTL ?? true),
+    deleteStoredFile: (req, row) => getDeleteFile(row.source)?.(req, row),
+  }),
 }));
 
 jest.mock('~/server/controllers/assistants/v2', () => ({

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -42,7 +42,7 @@ const {
   sendUploadSuccess,
   getStorageMetadata,
   resolveStorageScope,
-  persistFileWithQuota,
+  createFileQuotaPersistence,
   contentFilterBlockResponse,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
@@ -65,44 +65,18 @@ const { LB_QueueAsyncCall } = require('~/server/utils/queue');
 const { getRetentionExpiry, getAgentFileRetentionExpiry } = require('./retention');
 const { getStrategyFunctions } = require('./strategies');
 
-/** Removes a blob written before the row was offered to the ledger. */
-const deleteStoredBlob = async (req, { source, filepath, storageKey, storageRegion, tenantId }) => {
-  const { deleteFile } = getStrategyFunctions(source ?? FileSources.local);
-  if (!deleteFile) {
-    return;
-  }
-  await deleteFile(req, {
-    filepath,
-    storageKey,
-    storageRegion,
-    user: req.user.id,
-    tenantId: tenantId ?? req.user.tenantId,
-  });
-};
-
-/**
- * The one quota-checked path to the `File` ledger in this service.
- *
- * `rollback` is positional and required — `null` is how a caller states that nothing
- * was written before this point. Defaulting it would let a path that *does* leave a
- * blob behind reach the write by omission, which is the leak class this seam exists
- * to close.
- */
-const persistFile = (req, row, rollback, { disableTTL = true } = {}) =>
-  persistFileWithQuota(
-    {
-      scope: resolveStorageScope(req),
-      row,
-      write: (scopedRow) => db.createFile(scopedRow, disableTTL),
-      rollback,
-      getUserStorageUsage: db.getUserStorageUsage,
-    },
-    (error) => logger.error('[persistFile] Cleanup after a quota rejection failed:', error),
-  );
-
 const { determineFileType } = require('~/server/utils');
 const { STTService } = require('./Audio/STTService');
 const db = require('~/models');
+
+const { deleteStoredFile: deleteStoredBlob, persistFile } = createFileQuotaPersistence({
+  resolveScope: resolveStorageScope,
+  createFile: db.createFile,
+  getUserStorageUsage: db.getUserStorageUsage,
+  getDeleteFile: (source) => getStrategyFunctions(source ?? FileSources.local).deleteFile,
+  onCleanupError: (error) =>
+    logger.error('[persistFile] Cleanup after a quota rejection failed:', error),
+});
 
 /**
  * Creates a modular file upload wrapper that ensures filename sanitization
@@ -613,6 +587,7 @@ const processImageFile = async ({ req, res, metadata, returnFile = false, sseStr
  * @returns {Promise<{ filepath: string, filename: string, source: string, type: string}>}
  */
 const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true }) => {
+  const storageScope = resolveStorageScope(req);
   const retentionExpiryPromise = getRetentionExpiry(req);
   const appConfig = req.config;
   const source = getFileStrategy(appConfig, { isImage: true });
@@ -634,7 +609,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     userId: req.user.id,
     fileName,
     buffer,
-    tenantId: req.user.tenantId,
+    tenantId: storageScope.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
   return await persistFile(
@@ -652,7 +627,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
       width,
       ...(await retentionExpiryPromise),
       height,
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
     },
     () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
   );
@@ -1473,7 +1448,13 @@ const processOpenAIFile = async ({
   if (saveFile) {
     /* The bytes live on the provider and were not written by this request, so a
      * rejection just declines to record them — there is nothing local to undo. */
-    await persistFile(openai.req, file, null);
+    const [existing] =
+      (await db.getFiles({
+        file_id,
+        user: userId,
+        tenantId: resolveStorageScope(openai.req).tenantId ?? null,
+      })) ?? [];
+    await persistFile(openai.req, file, null, { replacedBytes: existing?.bytes });
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({
@@ -1651,6 +1632,7 @@ async function saveBase64Image(
   url,
   { req, file_id: _file_id, filename: _filename, endpoint, context, resolution },
 ) {
+  const storageScope = resolveStorageScope(req);
   const retentionExpiryPromise = getRetentionExpiry(req);
   const appConfig = req.config;
   const effectiveResolution = resolution ?? appConfig.fileConfig?.imageGeneration ?? 'high';
@@ -1678,7 +1660,7 @@ async function saveBase64Image(
     userId: req.user.id,
     fileName: filename,
     buffer: image.buffer,
-    tenantId: req.user.tenantId,
+    tenantId: storageScope.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
   return await persistFile(
@@ -1696,7 +1678,7 @@ async function saveBase64Image(
       width: image.width,
       ...(await retentionExpiryPromise),
       height: image.height,
-      tenantId: req.user.tenantId,
+      tenantId: storageScope.tenantId,
     },
     () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
   );

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -463,30 +463,32 @@ const processFileURL = async ({
       storageRegion: typeof savedFile === 'string' ? undefined : savedFile.storageRegion,
     });
 
-    return await persistFile(
-      req,
-      {
-        user: userId,
-        file_id: v4(),
-        bytes,
+    const fileInfo = {
+      user: userId,
+      file_id: v4(),
+      bytes,
+      filepath,
+      ...storageMetadata,
+      filename: fileName,
+      source: fileStrategy,
+      type,
+      context,
+      ...(await retentionExpiryPromise),
+      tenantId: effectiveTenantId,
+      width: dimensions.width,
+      height: dimensions.height,
+    };
+    if (!req) {
+      return await db.createFile(fileInfo, true);
+    }
+
+    return await persistFile(req, fileInfo, () =>
+      deleteStoredBlob(req, {
+        source: fileStrategy,
         filepath,
         ...storageMetadata,
-        filename: fileName,
-        source: fileStrategy,
-        type,
-        context,
-        ...(await retentionExpiryPromise),
         tenantId: effectiveTenantId,
-        width: dimensions.width,
-        height: dimensions.height,
-      },
-      () =>
-        deleteStoredBlob(req, {
-          source: fileStrategy,
-          filepath,
-          ...storageMetadata,
-          tenantId: effectiveTenantId,
-        }),
+      }),
     );
   } catch (error) {
     logger.error(`Error while processing the image with ${fileStrategy}:`, error);
@@ -1068,7 +1070,10 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
         await Promise.all([
           deleteStoredBlob(req, { source, filepath }),
           addedAgentResource
-            ? db.removeAgentResourceFiles({ agent_id, files: [{ file_id }] })
+            ? db.removeAgentResourceFiles({
+                agent_id,
+                files: [{ file_id, tool_resource: effectiveToolResource }],
+              })
             : Promise.resolve(),
         ]);
       });
@@ -1469,7 +1474,10 @@ const processOpenAIFile = async ({
         user: userId,
         tenantId: resolveStorageScope(openai.req).tenantId ?? null,
       })) ?? [];
-    await persistFile(openai.req, file, null, { replacedBytes: existing?.bytes });
+    await persistFile(openai.req, file, null, {
+      replacedBytes: existing?.bytes,
+      replacing: existing,
+    });
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -404,21 +404,11 @@ function startExpiredFileSweep(options = {}) {
  * @param {string} params.fileName - The name that will be used to save the file (including extension)
  * @param {string} params.basePath - The base path or directory where the file will be saved or retrieved from.
  * @param {FileContext} params.context - The context of the file (e.g., 'avatar', 'image_generation', etc.)
- * @param {string} [params.tenantId] - Optional tenant identifier for tenant-prefixed storage paths.
  * @param {ServerRequest} params.req - Authenticated request context used for quota and retention.
  * @returns {Promise<MongoFile>} A promise that resolves to the DB representation (MongoFile)
  *  of the processed file. It throws an error if the file processing fails at any stage.
  */
-const processFileURL = async ({
-  fileStrategy,
-  userId,
-  URL,
-  fileName,
-  basePath,
-  context,
-  tenantId,
-  req,
-}) => {
+const processFileURL = async ({ fileStrategy, userId, URL, fileName, basePath, context, req }) => {
   if (!req) {
     throw new Error('processFileURL requires an authenticated request');
   }

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -671,7 +671,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
   const sanitizedUploadFn = createSanitizedUploadWrapper(handleFileUpload);
   const {
     id,
-    bytes,
+    bytes: providerBytes,
     filename,
     filepath: _filepath,
     storageKey: _storageKey,
@@ -685,6 +685,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
     file_id,
     openai,
   });
+  let bytes = providerBytes;
 
   if (isAssistantUpload && !metadata.message_file && !metadata.tool_resource) {
     /** Authorized at the route before any bytes are sent — see
@@ -703,6 +704,7 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
   }
 
   let filepath = isAssistantUpload ? `${openai.baseURL}/files/${id}` : _filepath;
+  let secondaryStoredFile;
   let storageMetadata = getStorageMetadata({
     filepath,
     source,
@@ -716,6 +718,8 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
       metadata: { file_id: v4() },
       returnFile: true,
     });
+    secondaryStoredFile = result;
+    bytes = providerBytes + (result.bytes ?? 0);
     filepath = result.filepath;
     storageMetadata = getStorageMetadata({
       filepath,
@@ -725,6 +729,12 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
     });
   }
 
+  let rollbackStoredFile = null;
+  if (secondaryStoredFile) {
+    rollbackStoredFile = () => deleteStoredBlob(req, secondaryStoredFile);
+  } else if (!isAssistantUpload) {
+    rollbackStoredFile = () => deleteStoredBlob(req, { source, filepath, ...storageMetadata });
+  }
   const result = await persistFile(
     req,
     {
@@ -745,13 +755,10 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
       width,
       tenantId: req.user.tenantId,
     },
-    /* An assistant upload's row points at the provider copy, or — for images — at a
-     * blob `processImageFile` already persisted under its own quota-checked row.
-     * Neither is exclusively owned by this write, so there is nothing here to undo;
-     * detaching the provider-side file is tracked separately. */
-    isAssistantUpload
-      ? null
-      : () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
+    /* The converted image is a distinct app-storage object. The provider-side
+     * cleanup is completed by the final enforcement PR, while this scoped write
+     * owns and removes the converted copy when admission rejects it. */
+    rollbackStoredFile,
   );
   sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
@@ -819,6 +826,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
   const { file } = req;
   const appConfig = req.config;
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
+  const storageScope = resolveStorageScope(req);
 
   let messageAttachment = isMessageFileUpload(metadata.message_file);
 
@@ -1019,6 +1027,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
         file_id,
         basePath,
         entity_id,
+        tenantId: storageScope.tenantId,
       });
       const { bytes, filename, filepath, embedded, height, width } = storageResult;
 
@@ -1046,7 +1055,8 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
         ...retentionExpiry,
       };
 
-      if (!messageAttachment && effectiveToolResource) {
+      const addedAgentResource = !messageAttachment && effectiveToolResource;
+      if (addedAgentResource) {
         await db.addAgentResourceFile({
           file_id,
           agent_id,
@@ -1054,9 +1064,14 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
           updatingUserId: req?.user?.id,
         });
       }
-      /* `FileSources.text` rows carry the extracted text inline; the temporary upload
-       * is cleaned up by the caller's `finally`, so there is nothing here to undo. */
-      const result = await persistFile(req, fileInfo, null);
+      const result = await persistFile(req, fileInfo, async () => {
+        await Promise.all([
+          deleteStoredBlob(req, { source, filepath }),
+          addedAgentResource
+            ? db.removeAgentResourceFiles({ agent_id, files: [{ file_id }] })
+            : Promise.resolve(),
+        ]);
+      });
       sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
     };
 
@@ -1210,6 +1225,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       file_id,
       basePath,
       entity_id,
+      tenantId: storageScope.tenantId,
     });
 
     // SECOND: Upload to Vector DB
@@ -1245,6 +1261,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       storageRegion: converted.storageRegion,
       height: converted.height,
       width: converted.width,
+      source: converted.source,
     };
   } else {
     // Standard single storage for non-RAG files
@@ -1256,6 +1273,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       file_id,
       basePath,
       entity_id,
+      tenantId: storageScope.tenantId,
     });
   }
 
@@ -1344,9 +1362,10 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
   }
 
   let filepath = _filepath;
+  const storedSource = storageResult.source ?? source;
   let storageMetadata = getStorageMetadata({
     filepath,
-    source,
+    source: storedSource,
     storageKey: _storageKey,
     storageRegion: _storageRegion,
   });
@@ -1382,7 +1401,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       },
       type: storedType,
       embedded,
-      source,
+      source: storedSource,
       height,
       width,
       tenantId: req.user.tenantId,
@@ -1391,12 +1410,8 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     ...retentionExpiry,
   };
 
-  /* An image row points at a blob `processImageFile` already persisted under its own
-   * quota-checked row, so only the non-image storage write is ours to undo. */
-  const result = await persistFile(
-    req,
-    fileInfo,
-    isImage ? null : () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
+  const result = await persistFile(req, fileInfo, () =>
+    deleteStoredBlob(req, { source: storedSource, filepath, ...storageMetadata }),
   );
 
   sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -446,9 +446,16 @@ const processFileURL = async ({
   req,
 }) => {
   const retentionExpiryPromise = getRetentionExpiry(req);
+  const effectiveTenantId = req ? resolveStorageScope(req).tenantId : tenantId;
   const { saveURL, getFileURL } = getStrategyFunctions(fileStrategy);
   try {
-    const savedFile = await saveURL({ userId, URL, fileName, basePath, tenantId });
+    const savedFile = await saveURL({
+      userId,
+      URL,
+      fileName,
+      basePath,
+      tenantId: effectiveTenantId,
+    });
     if (!savedFile) {
       throw new Error(`Strategy "${fileStrategy}" did not save "${fileName}"`);
     }
@@ -466,7 +473,12 @@ const processFileURL = async ({
       typeof savedFile === 'string'
         ? savedFile
         : (savedFile.filepath ??
-          (await getFileURL({ userId, fileName: fallbackFileName, basePath, tenantId })));
+          (await getFileURL({
+            userId,
+            fileName: fallbackFileName,
+            basePath,
+            tenantId: effectiveTenantId,
+          })));
     if (!filepath) {
       throw new Error(`Strategy "${fileStrategy}" did not return a file URL for "${fileName}"`);
     }
@@ -490,11 +502,17 @@ const processFileURL = async ({
         type,
         context,
         ...(await retentionExpiryPromise),
-        tenantId,
+        tenantId: effectiveTenantId,
         width: dimensions.width,
         height: dimensions.height,
       },
-      () => deleteStoredBlob(req, { source: fileStrategy, filepath, ...storageMetadata, tenantId }),
+      () =>
+        deleteStoredBlob(req, {
+          source: fileStrategy,
+          filepath,
+          ...storageMetadata,
+          tenantId: effectiveTenantId,
+        }),
     );
   } catch (error) {
     logger.error(`Error while processing the image with ${fileStrategy}:`, error);
@@ -577,10 +595,8 @@ const processImageFile = async ({ req, res, metadata, returnFile = false, sseStr
     return fileInfo;
   }
 
-  const result = await persistFile(
-    req,
-    fileInfo,
-    () => deleteStoredBlob(req, { source, filepath, storageKey, storageRegion }),
+  const result = await persistFile(req, fileInfo, () =>
+    deleteStoredBlob(req, { source, filepath, storageKey, storageRegion }),
   );
   sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
@@ -1035,10 +1051,7 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       const fileInfo = {
         ...removeNullishValues({
           text,
-          /* Extractors may report a conservative estimate (Mistral OCR returns
-           * `text.length * 4`). The ledger charges what it writes, so the row has to
-           * record the size actually persisted. */
-          bytes: Buffer.byteLength(text, 'utf8'),
+          bytes,
           file_id,
           temp_file_id,
           user: req.user.id,
@@ -1508,13 +1521,9 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     ...(await retentionExpiryPromise),
     tenantId: req.user.tenantId,
   };
-  try {
-    await persistFile(req, file, () =>
-      deleteStoredBlob(req, { source: file.source, filepath: file.filepath }),
-    );
-  } catch (error) {
-    logger.warn('Error saving OpenAI image output file metadata', error);
-  }
+  await persistFile(req, file, () =>
+    deleteStoredBlob(req, { source: file.source, filepath: file.filepath }),
+  );
   return file;
 };
 

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -405,7 +405,7 @@ function startExpiredFileSweep(options = {}) {
  * @param {string} params.basePath - The base path or directory where the file will be saved or retrieved from.
  * @param {FileContext} params.context - The context of the file (e.g., 'avatar', 'image_generation', etc.)
  * @param {string} [params.tenantId] - Optional tenant identifier for tenant-prefixed storage paths.
- * @param {ServerRequest} [params.req] - Request context used to apply data retention metadata.
+ * @param {ServerRequest} params.req - Authenticated request context used for quota and retention.
  * @returns {Promise<MongoFile>} A promise that resolves to the DB representation (MongoFile)
  *  of the processed file. It throws an error if the file processing fails at any stage.
  */
@@ -419,8 +419,11 @@ const processFileURL = async ({
   tenantId,
   req,
 }) => {
+  if (!req) {
+    throw new Error('processFileURL requires an authenticated request');
+  }
   const retentionExpiryPromise = getRetentionExpiry(req);
-  const effectiveTenantId = req ? resolveStorageScope(req).tenantId : tenantId;
+  const effectiveTenantId = resolveStorageScope(req).tenantId;
   const { saveURL, getFileURL } = getStrategyFunctions(fileStrategy);
   try {
     const savedFile = await saveURL({
@@ -478,10 +481,6 @@ const processFileURL = async ({
       width: dimensions.width,
       height: dimensions.height,
     };
-    if (!req) {
-      return await db.createFile(fileInfo, true);
-    }
-
     return await persistFile(req, fileInfo, () =>
       deleteStoredBlob(req, {
         source: fileStrategy,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -41,6 +41,8 @@ const {
   hasActiveFileFieldPolicy,
   sendUploadSuccess,
   getStorageMetadata,
+  resolveStorageScope,
+  persistFileWithQuota,
   contentFilterBlockResponse,
   sweepExpiredFiles: sweepExpiredFilesWithDeps,
   startExpiredFileSweep: startExpiredFileSweepWithDeps,
@@ -62,6 +64,42 @@ const { checkCapability } = require('~/server/services/Config');
 const { LB_QueueAsyncCall } = require('~/server/utils/queue');
 const { getRetentionExpiry, getAgentFileRetentionExpiry } = require('./retention');
 const { getStrategyFunctions } = require('./strategies');
+
+/** Removes a blob written before the row was offered to the ledger. */
+const deleteStoredBlob = async (req, { source, filepath, storageKey, storageRegion, tenantId }) => {
+  const { deleteFile } = getStrategyFunctions(source ?? FileSources.local);
+  if (!deleteFile) {
+    return;
+  }
+  await deleteFile(req, {
+    filepath,
+    storageKey,
+    storageRegion,
+    user: req.user.id,
+    tenantId: tenantId ?? req.user.tenantId,
+  });
+};
+
+/**
+ * The one quota-checked path to the `File` ledger in this service.
+ *
+ * `rollback` is positional and required — `null` is how a caller states that nothing
+ * was written before this point. Defaulting it would let a path that *does* leave a
+ * blob behind reach the write by omission, which is the leak class this seam exists
+ * to close.
+ */
+const persistFile = (req, row, rollback, { disableTTL = true } = {}) =>
+  persistFileWithQuota(
+    {
+      scope: resolveStorageScope(req),
+      row,
+      write: (scopedRow) => db.createFile(scopedRow, disableTTL),
+      rollback,
+      getUserStorageUsage: db.getUserStorageUsage,
+    },
+    (error) => logger.error('[persistFile] Cleanup after a quota rejection failed:', error),
+  );
+
 const { determineFileType } = require('~/server/utils');
 const { STTService } = require('./Audio/STTService');
 const db = require('~/models');
@@ -439,7 +477,8 @@ const processFileURL = async ({
       storageRegion: typeof savedFile === 'string' ? undefined : savedFile.storageRegion,
     });
 
-    return await db.createFile(
+    return await persistFile(
+      req,
       {
         user: userId,
         file_id: v4(),
@@ -455,7 +494,7 @@ const processFileURL = async ({
         width: dimensions.width,
         height: dimensions.height,
       },
-      true,
+      () => deleteStoredBlob(req, { source: fileStrategy, filepath, ...storageMetadata, tenantId }),
     );
   } catch (error) {
     logger.error(`Error while processing the image with ${fileStrategy}:`, error);
@@ -538,7 +577,11 @@ const processImageFile = async ({ req, res, metadata, returnFile = false, sseStr
     return fileInfo;
   }
 
-  const result = await db.createFile(fileInfo, true);
+  const result = await persistFile(
+    req,
+    fileInfo,
+    () => deleteStoredBlob(req, { source, filepath, storageKey, storageRegion }),
+  );
   sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
 
@@ -578,7 +621,8 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
     tenantId: req.user.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
-  return await db.createFile(
+  return await persistFile(
+    req,
     {
       user: req.user.id,
       file_id,
@@ -594,7 +638,7 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
       height,
       tenantId: req.user.tenantId,
     },
-    true,
+    () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
   );
 };
 
@@ -690,7 +734,8 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
     });
   }
 
-  const result = await db.createFile(
+  const result = await persistFile(
+    req,
     {
       user: req.user.id,
       file_id: id ?? file_id,
@@ -709,7 +754,13 @@ const processFileUpload = async ({ req, res, metadata, sseStream, openai: provid
       width,
       tenantId: req.user.tenantId,
     },
-    true,
+    /* An assistant upload's row points at the provider copy, or — for images — at a
+     * blob `processImageFile` already persisted under its own quota-checked row.
+     * Neither is exclusively owned by this write, so there is nothing here to undo;
+     * detaching the provider-side file is tracked separately. */
+    isAssistantUpload
+      ? null
+      : () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
   );
   sendUploadSuccess(res, sseStream, 'File uploaded and processed successfully', result);
 };
@@ -984,7 +1035,10 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
       const fileInfo = {
         ...removeNullishValues({
           text,
-          bytes,
+          /* Extractors may report a conservative estimate (Mistral OCR returns
+           * `text.length * 4`). The ledger charges what it writes, so the row has to
+           * record the size actually persisted. */
+          bytes: Buffer.byteLength(text, 'utf8'),
           file_id,
           temp_file_id,
           user: req.user.id,
@@ -1012,7 +1066,9 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
           updatingUserId: req?.user?.id,
         });
       }
-      const result = await db.createFile(fileInfo, true);
+      /* `FileSources.text` rows carry the extracted text inline; the temporary upload
+       * is cleaned up by the caller's `finally`, so there is nothing here to undo. */
+      const result = await persistFile(req, fileInfo, null);
       sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
     };
 
@@ -1347,7 +1403,13 @@ const processAgentFileUpload = async ({ req, res, metadata, sseStream }) => {
     ...retentionExpiry,
   };
 
-  const result = await db.createFile(fileInfo, true);
+  /* An image row points at a blob `processImageFile` already persisted under its own
+   * quota-checked row, so only the non-image storage write is ours to undo. */
+  const result = await persistFile(
+    req,
+    fileInfo,
+    isImage ? null : () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
+  );
 
   sendUploadSuccess(res, sseStream, 'Agent file uploaded and processed successfully', result);
 };
@@ -1396,7 +1458,9 @@ const processOpenAIFile = async ({
   };
 
   if (saveFile) {
-    await db.createFile(file, true);
+    /* The bytes live on the provider and were not written by this request, so a
+     * rejection just declines to record them — there is nothing local to undo. */
+    await persistFile(openai.req, file, null);
   } else if (updateUsage) {
     try {
       await db.updateFileUsage({
@@ -1445,7 +1509,9 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     tenantId: req.user.tenantId,
   };
   try {
-    await db.createFile(file, true);
+    await persistFile(req, file, () =>
+      deleteStoredBlob(req, { source: file.source, filepath: file.filepath }),
+    );
   } catch (error) {
     logger.warn('Error saving OpenAI image output file metadata', error);
   }
@@ -1606,7 +1672,8 @@ async function saveBase64Image(
     tenantId: req.user.tenantId,
   });
   const storageMetadata = getStorageMetadata({ filepath, source });
-  return await db.createFile(
+  return await persistFile(
+    req,
     {
       type,
       source,
@@ -1622,7 +1689,7 @@ async function saveBase64Image(
       height: image.height,
       tenantId: req.user.tenantId,
     },
-    true,
+    () => deleteStoredBlob(req, { source, filepath, ...storageMetadata }),
   );
 }
 

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -2447,6 +2447,7 @@ describe('processFileURL', () => {
         basePath: 'images',
         context: FileContext.image_generation,
         tenantId: 'tenant-a',
+        req: makeReq(),
       }),
     ).rejects.toThrow('Strategy "local" did not save "image.png"');
 
@@ -2454,7 +2455,7 @@ describe('processFileURL', () => {
     expect(db.createFile).not.toHaveBeenCalled();
   });
 
-  it('preserves direct persistence for callers without a request', async () => {
+  it('rejects a missing request before writing storage', async () => {
     const saveURL = jest.fn().mockResolvedValue({
       filepath: '/images/user-123/image.png',
       bytes: 512,
@@ -2462,24 +2463,20 @@ describe('processFileURL', () => {
     });
     getStrategyFunctions.mockReturnValue({ saveURL, getFileURL: jest.fn() });
 
-    await processFileURL({
-      fileStrategy: FileSources.local,
-      userId: 'user-123',
-      URL: 'https://example.com/image.png',
-      fileName: 'image.png',
-      basePath: 'images',
-      context: FileContext.image_generation,
-      tenantId: 'tenant-a',
-    });
-
-    expect(db.createFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user: 'user-123',
-        filepath: '/images/user-123/image.png',
+    await expect(
+      processFileURL({
+        fileStrategy: FileSources.local,
+        userId: 'user-123',
+        URL: 'https://example.com/image.png',
+        fileName: 'image.png',
+        basePath: 'images',
+        context: FileContext.image_generation,
         tenantId: 'tenant-a',
       }),
-      true,
-    );
+    ).rejects.toThrow('processFileURL requires an authenticated request');
+
+    expect(saveURL).not.toHaveBeenCalled();
+    expect(db.createFile).not.toHaveBeenCalled();
   });
 
   it('persists tenantId and strategy-returned filepath metadata', async () => {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -2209,7 +2209,7 @@ describe('processAgentFileUpload', () => {
       );
       expect(db.removeAgentResourceFiles).toHaveBeenCalledWith({
         agent_id: 'agent-abc',
-        files: [{ file_id: 'file-uuid-123' }],
+        files: [{ file_id: 'file-uuid-123', tool_resource: 'context' }],
       });
     });
 
@@ -2452,6 +2452,34 @@ describe('processFileURL', () => {
 
     expect(getFileURL).not.toHaveBeenCalled();
     expect(db.createFile).not.toHaveBeenCalled();
+  });
+
+  it('preserves direct persistence for callers without a request', async () => {
+    const saveURL = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/image.png',
+      bytes: 512,
+      type: 'image/png',
+    });
+    getStrategyFunctions.mockReturnValue({ saveURL, getFileURL: jest.fn() });
+
+    await processFileURL({
+      fileStrategy: FileSources.local,
+      userId: 'user-123',
+      URL: 'https://example.com/image.png',
+      fileName: 'image.png',
+      basePath: 'images',
+      context: FileContext.image_generation,
+      tenantId: 'tenant-a',
+    });
+
+    expect(db.createFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: 'user-123',
+        filepath: '/images/user-123/image.png',
+        tenantId: 'tenant-a',
+      }),
+      true,
+    );
   });
 
   it('persists tenantId and strategy-returned filepath metadata', async () => {

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -169,6 +169,7 @@ jest.mock('@librechat/api', () => {
       },
       persistFile: async (req, row, rollback, options = {}) => {
         const scopedRow = { ...row, tenantId: resolveScope(req).tenantId };
+        global.__captureQuotaRow?.(scopedRow);
         if (!global.__mockQuotaRejection) {
           return createFile(scopedRow, options.disableTTL ?? true);
         }
@@ -484,6 +485,68 @@ describe('upload retention scheduling', () => {
       await pending;
     },
   );
+
+  it('charges and rolls back an assistant image secondary copy on quota rejection', async () => {
+    const quotaError = new Error('quota exceeded');
+    const capturedRows = [];
+    global.__mockQuotaRejection = quotaError;
+    global.__captureQuotaRow = (row) => capturedRows.push(row);
+    const providerUpload = jest.fn().mockResolvedValue({
+      id: 'provider-file-id',
+      bytes: 42,
+      filename: 'upload.png',
+      filepath: 'https://api.openai.test/files/provider-file-id',
+    });
+    const imageUpload = jest.fn().mockResolvedValue({
+      filepath: '/images/user-123/upload.webp',
+      source: FileSources.local,
+      bytes: 58,
+      width: 10,
+      height: 10,
+    });
+    const deleteImage = jest.fn().mockResolvedValue(undefined);
+    getStrategyFunctions.mockImplementation((source) =>
+      source === FileSources.openai
+        ? { handleFileUpload: providerUpload }
+        : { handleImageUpload: imageUpload, deleteFile: deleteImage },
+    );
+    const req = makeReq({ mimetype: 'image/png', body: { endpoint: 'assistants' } });
+    const openai = {
+      baseURL: 'https://api.openai.test',
+      files: { del: jest.fn() },
+      beta: { assistants: { files: { create: jest.fn() } } },
+    };
+
+    try {
+      await expect(
+        processFileUpload({
+          req,
+          res: mockRes,
+          metadata: {
+            endpoint: 'assistants',
+            assistant_id: 'assistant-1',
+            file_id: 'temp-file-id',
+          },
+          openai,
+        }),
+      ).rejects.toBe(quotaError);
+    } finally {
+      delete global.__mockQuotaRejection;
+      delete global.__captureQuotaRow;
+    }
+
+    expect(capturedRows).toEqual([
+      expect.objectContaining({
+        file_id: 'provider-file-id',
+        bytes: 100,
+        filepath: '/images/user-123/upload.webp',
+      }),
+    ]);
+    expect(deleteImage).toHaveBeenCalledWith(
+      req,
+      expect.objectContaining({ filepath: '/images/user-123/upload.webp' }),
+    );
+  });
 });
 
 describe('processAgentFileUpload', () => {
@@ -2085,6 +2148,106 @@ describe('processAgentFileUpload', () => {
           llmDeliveryPath: 'text',
         }),
         true,
+      );
+    });
+
+    test('passes the resolved request tenant to durable context storage', async () => {
+      const { parseText } = require('@librechat/api');
+      parseText.mockResolvedValueOnce({ text: 'tenant text', bytes: 11 });
+      const storageUpload = jest.fn().mockResolvedValue({
+        filepath: '/t/request-tenant/uploads/user-123/upload.bin',
+        bytes: 128,
+        filename: 'upload.bin',
+      });
+      getStrategyFunctions.mockReturnValue({ handleFileUpload: storageUpload });
+      mergeFileConfig.mockReturnValue(
+        makeFileConfig({ textSupportedMimeTypes: ['text/markdown'] }),
+      );
+      const req = makeReq({ mimetype: 'text/markdown', ocrConfig: null });
+      req.tenantId = 'request-tenant';
+      req.user.tenantId = null;
+
+      await processAgentFileUpload({
+        req,
+        res: mockRes,
+        metadata: { ...makeMetadata(), message_file: 'true' },
+      });
+
+      expect(storageUpload).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'request-tenant' }),
+      );
+    });
+
+    test('removes durable text storage and its agent reference when quota rejects it', async () => {
+      const quotaError = new Error('quota exceeded');
+      global.__mockQuotaRejection = quotaError;
+      const { parseText } = require('@librechat/api');
+      parseText.mockResolvedValueOnce({ text: 'stored text', bytes: 11 });
+      const deleteFile = jest.fn().mockResolvedValue(undefined);
+      const storageUpload = jest.fn().mockResolvedValue({
+        filepath: '/uploads/user-123/upload.bin',
+        bytes: 128,
+        filename: 'upload.bin',
+      });
+      getStrategyFunctions.mockReturnValue({ handleFileUpload: storageUpload, deleteFile });
+      mergeFileConfig.mockReturnValue(
+        makeFileConfig({ textSupportedMimeTypes: ['text/markdown'] }),
+      );
+      const req = makeReq({ mimetype: 'text/markdown', ocrConfig: null });
+
+      try {
+        await expect(
+          processAgentFileUpload({ req, res: mockRes, metadata: makeMetadata() }),
+        ).rejects.toBe(quotaError);
+      } finally {
+        delete global.__mockQuotaRejection;
+      }
+
+      expect(deleteFile).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({ filepath: '/uploads/user-123/upload.bin' }),
+      );
+      expect(db.removeAgentResourceFiles).toHaveBeenCalledWith({
+        agent_id: 'agent-abc',
+        files: [{ file_id: 'file-uuid-123' }],
+      });
+    });
+
+    test('removes a converted agent image when quota rejects its only row', async () => {
+      const quotaError = new Error('quota exceeded');
+      global.__mockQuotaRejection = quotaError;
+      const deleteFile = jest.fn().mockResolvedValue(undefined);
+      const handleImageUpload = jest.fn().mockResolvedValue({
+        filepath: '/images/user-123/upload.webp',
+        source: FileSources.local,
+        bytes: 64,
+        type: 'image/webp',
+      });
+      getStrategyFunctions.mockReturnValue({ handleImageUpload, deleteFile });
+      const req = makeReq({ mimetype: 'image/png' });
+
+      try {
+        await expect(
+          processAgentFileUpload({
+            req,
+            res: mockRes,
+            metadata: {
+              agent_id: 'agent-abc',
+              message_file: 'true',
+              file_id: 'file-uuid-123',
+            },
+          }),
+        ).rejects.toBe(quotaError);
+      } finally {
+        delete global.__mockQuotaRejection;
+      }
+
+      expect(deleteFile).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({
+          source: FileSources.local,
+          filepath: '/images/user-123/upload.webp',
+        }),
       );
     });
 

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -158,20 +158,30 @@ jest.mock('@librechat/api', () => {
       userId: req.user?.id,
       tenantId: req.tenantId ?? req.user?.tenantId,
     }),
-    persistFileWithQuota: async ({ scope, row, write, rollback }, onRollbackError) => {
-      const scopedRow = { ...row, tenantId: scope.tenantId };
-      if (!global.__mockQuotaRejection) {
-        return write(scopedRow);
-      }
-      if (rollback) {
-        try {
-          await rollback();
-        } catch (error) {
-          onRollbackError(error);
+    createFileQuotaPersistence: ({ resolveScope, createFile, getDeleteFile, onCleanupError }) => ({
+      deleteStoredFile: async (req, row) => {
+        const scope = resolveScope(req);
+        return getDeleteFile(row.source)?.(req, {
+          ...row,
+          user: scope.userId,
+          tenantId: row.tenantId ?? scope.tenantId,
+        });
+      },
+      persistFile: async (req, row, rollback, options = {}) => {
+        const scopedRow = { ...row, tenantId: resolveScope(req).tenantId };
+        if (!global.__mockQuotaRejection) {
+          return createFile(scopedRow, options.disableTTL ?? true);
         }
-      }
-      throw global.__mockQuotaRejection;
-    },
+        if (rollback) {
+          try {
+            await rollback();
+          } catch (error) {
+            onCleanupError(error);
+          }
+        }
+        throw global.__mockQuotaRejection;
+      },
+    }),
     getRetentionExpiry,
     createCodeApiRateLimitBudget,
     getCodeApiUploadOptions,
@@ -214,6 +224,7 @@ jest.mock('~/server/services/Tools/credentials', () => ({
 
 jest.mock('~/models', () => ({
   createFile: jest.fn().mockResolvedValue({ file_id: 'created-file-id' }),
+  getFiles: jest.fn().mockResolvedValue([]),
   updateFileUsage: jest.fn(),
   deleteFiles: jest.fn(),
   findFileById: jest.fn(),

--- a/api/server/services/Files/process.spec.js
+++ b/api/server/services/Files/process.spec.js
@@ -150,6 +150,28 @@ jest.mock('@librechat/api', () => {
       res.status(200).json({ message, ...result });
     }),
     getStorageMetadata: jest.fn(() => ({})),
+    /* Seam stand-in. It keeps the two properties these upload paths are asserted on —
+     * the row is written with the scope's tenant, and a rejection runs the caller's
+     * rollback — while the quota arithmetic itself is covered against the real module
+     * in `packages/api/src/files/quota.spec.ts`. */
+    resolveStorageScope: (req) => ({
+      userId: req.user?.id,
+      tenantId: req.tenantId ?? req.user?.tenantId,
+    }),
+    persistFileWithQuota: async ({ scope, row, write, rollback }, onRollbackError) => {
+      const scopedRow = { ...row, tenantId: scope.tenantId };
+      if (!global.__mockQuotaRejection) {
+        return write(scopedRow);
+      }
+      if (rollback) {
+        try {
+          await rollback();
+        } catch (error) {
+          onRollbackError(error);
+        }
+      }
+      throw global.__mockQuotaRejection;
+    },
     getRetentionExpiry,
     createCodeApiRateLimitBudget,
     getCodeApiUploadOptions,
@@ -2276,6 +2298,7 @@ describe('processFileURL', () => {
       basePath: 'images',
       context: FileContext.image_generation,
       tenantId: 'tenant-a',
+      req: { user: { id: 'user-123', tenantId: 'tenant-a' } },
     });
 
     expect(getFileURL).not.toHaveBeenCalled();
@@ -2418,6 +2441,7 @@ describe('processFileURL', () => {
       basePath: 'images',
       context: FileContext.image_generation,
       tenantId: 'tenant-a',
+      req: { user: { id: 'user-123', tenantId: 'tenant-a' } },
     });
 
     expect(getFileURL).toHaveBeenCalledWith({
@@ -2451,6 +2475,7 @@ describe('processFileURL', () => {
       basePath: 'images',
       context: FileContext.image_generation,
       tenantId: 'tenant-a',
+      req: { user: { id: 'user-123', tenantId: 'tenant-a' } },
     });
 
     expect(getFileURL).toHaveBeenCalledWith({

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -468,7 +468,7 @@ export type FileQuotaPersistence<TRequest, TResult> = {
     options?: {
       disableTTL?: boolean;
       replacedBytes?: number | null;
-      replacing?: { user?: unknown; tenantId?: string | null } | null;
+      replacing?: { file_id?: string; user?: unknown; tenantId?: string | null } | null;
     },
   ) => Promise<TResult>;
 };
@@ -501,7 +501,7 @@ export function createFileQuotaPersistence<TRequest, TResult>(
     options: {
       disableTTL?: boolean;
       replacedBytes?: number | null;
-      replacing?: { user?: unknown; tenantId?: string | null } | null;
+      replacing?: { file_id?: string; user?: unknown; tenantId?: string | null } | null;
     } = {},
   ): Promise<TResult> =>
     persistFileWithQuota(

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -442,6 +442,75 @@ export type FileRow = LedgerRow & {
   user?: string;
 };
 
+type StoredFileRow = FileRow & {
+  source?: string;
+  filepath?: string;
+  storageKey?: string;
+  storageRegion?: string;
+};
+
+export type FileQuotaPersistenceDependencies<TRequest, TResult> = {
+  resolveScope: (req: TRequest) => StorageScope;
+  createFile: (row: FileRow, disableTTL?: boolean) => Promise<TResult>;
+  getUserStorageUsage: GetUserStorageUsage;
+  getDeleteFile: (
+    source?: string,
+  ) => ((req: TRequest, row: StoredFileRow) => Promise<void>) | undefined;
+  onCleanupError: (error: unknown) => void;
+};
+
+export type FileQuotaPersistence<TRequest, TResult> = {
+  deleteStoredFile: (req: TRequest, row: StoredFileRow) => Promise<void>;
+  persistFile: <TRow extends FileRow>(
+    req: TRequest,
+    row: TRow,
+    rollback: StorageRollback,
+    options?: { disableTTL?: boolean; replacedBytes?: number | null },
+  ) => Promise<TResult>;
+};
+
+/**
+ * Builds the application-facing File persistence boundary. The legacy service only
+ * supplies database and storage-strategy dependencies; tenant stamping, quota
+ * accounting, and cleanup behavior stay owned by this package.
+ */
+export function createFileQuotaPersistence<TRequest, TResult>(
+  dependencies: FileQuotaPersistenceDependencies<TRequest, TResult>,
+): FileQuotaPersistence<TRequest, TResult> {
+  const deleteStoredFile = async (req: TRequest, row: StoredFileRow): Promise<void> => {
+    const scope = dependencies.resolveScope(req);
+    const deleteFile = dependencies.getDeleteFile(row.source);
+    if (!deleteFile) {
+      return;
+    }
+    await deleteFile(req, {
+      ...row,
+      user: scope.userId,
+      tenantId: row.tenantId ?? scope.tenantId,
+    });
+  };
+
+  const persistFile = <TRow extends FileRow>(
+    req: TRequest,
+    row: TRow,
+    rollback: StorageRollback,
+    options: { disableTTL?: boolean; replacedBytes?: number | null } = {},
+  ): Promise<TResult> =>
+    persistFileWithQuota(
+      {
+        scope: dependencies.resolveScope(req),
+        row,
+        write: (scopedRow) => dependencies.createFile(scopedRow, options.disableTTL ?? true),
+        rollback,
+        getUserStorageUsage: dependencies.getUserStorageUsage,
+        replacedBytes: options.replacedBytes,
+      },
+      dependencies.onCleanupError,
+    );
+
+  return { deleteStoredFile, persistFile };
+}
+
 export type SkillFileRow = LedgerRow & {
   skillId?: { toString(): string } | string;
   relativePath?: string;

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -465,7 +465,11 @@ export type FileQuotaPersistence<TRequest, TResult> = {
     req: TRequest,
     row: TRow,
     rollback: StorageRollback,
-    options?: { disableTTL?: boolean; replacedBytes?: number | null },
+    options?: {
+      disableTTL?: boolean;
+      replacedBytes?: number | null;
+      replacing?: { user?: unknown; tenantId?: string | null } | null;
+    },
   ) => Promise<TResult>;
 };
 
@@ -494,7 +498,11 @@ export function createFileQuotaPersistence<TRequest, TResult>(
     req: TRequest,
     row: TRow,
     rollback: StorageRollback,
-    options: { disableTTL?: boolean; replacedBytes?: number | null } = {},
+    options: {
+      disableTTL?: boolean;
+      replacedBytes?: number | null;
+      replacing?: { user?: unknown; tenantId?: string | null } | null;
+    } = {},
   ): Promise<TResult> =>
     persistFileWithQuota(
       {
@@ -504,6 +512,7 @@ export function createFileQuotaPersistence<TRequest, TResult>(
         rollback,
         getUserStorageUsage: dependencies.getUserStorageUsage,
         replacedBytes: options.replacedBytes,
+        replacing: options.replacing,
       },
       dependencies.onCleanupError,
     );

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -63,26 +63,32 @@ export type StorageScope = {
   replacementLocks?: Map<string, Promise<void>>;
 };
 
-type ScopeSource = {
+type ScopeIdentity = {
   tenantId?: string;
   user?: { id?: string; tenantId?: string };
-  /**
-   * Resolved app config. Required, because it is what distinguishes a real request
-   * from a reduced copy of one: without it there is no way to tell "no cap is
-   * configured" from "this object never carried the cap", and the second silently
-   * disables the quota.
-   */
-  config: {
-    fileConfig?: Parameters<typeof mergeFileConfig>[0] & { storageLimit?: number };
-  };
-  /**
-   * Already-resolved scope, carried by request snapshots. Image-generation tools hold a
-   * reduced copy of the request rather than the live one; carrying the branded scope is
-   * how such a copy stays chargeable, and it is honoured before the config requirement
-   * above because a snapshot that carries a real scope needs nothing further.
-   */
-  storageScope?: StorageScope;
 };
+
+type ScopeSource = ScopeIdentity &
+  (
+    | {
+        storageScope: StorageScope;
+        config?: {
+          fileConfig?: Parameters<typeof mergeFileConfig>[0] & { storageLimit?: number };
+        };
+      }
+    | {
+        storageScope?: never;
+        /**
+         * Resolved app config. Required, because it is what distinguishes a real request
+         * from a reduced copy of one: without it there is no way to tell "no cap is
+         * configured" from "this object never carried the cap", and the second silently
+         * disables the quota.
+         */
+        config: {
+          fileConfig?: Parameters<typeof mergeFileConfig>[0] & { storageLimit?: number };
+        };
+      }
+  );
 
 /** Keyed by request identity so the scope neither mutates the request nor outlives it. */
 const scopesByRequest: WeakMap<ScopeSource, StorageScope> = new WeakMap();

--- a/packages/api/src/files/quota.ts
+++ b/packages/api/src/files/quota.ts
@@ -75,6 +75,13 @@ type ScopeSource = {
   config: {
     fileConfig?: Parameters<typeof mergeFileConfig>[0] & { storageLimit?: number };
   };
+  /**
+   * Already-resolved scope, carried by request snapshots. Image-generation tools hold a
+   * reduced copy of the request rather than the live one; carrying the branded scope is
+   * how such a copy stays chargeable, and it is honoured before the config requirement
+   * above because a snapshot that carries a real scope needs nothing further.
+   */
+  storageScope?: StorageScope;
 };
 
 /** Keyed by request identity so the scope neither mutates the request nor outlives it. */
@@ -155,6 +162,10 @@ function assertChargeableBytes(bytes: number | null | undefined, label: string):
  * authenticates users that carry no tenant of their own and supplies it per request.
  */
 export function resolveStorageScope(req: ScopeSource): StorageScope {
+  if (req.storageScope) {
+    return req.storageScope;
+  }
+
   const cached = scopesByRequest.get(req);
   if (cached) {
     return cached;

--- a/packages/api/src/files/retention.spec.ts
+++ b/packages/api/src/files/retention.spec.ts
@@ -509,6 +509,7 @@ describe('retention helpers', () => {
         tenantId: 'request-tenant',
         user: { id: 'user-1' },
         body: { conversationId: 'convo-1' },
+        config: {},
       })?.storageScope,
     ).toEqual(expect.objectContaining({ userId: 'user-1', tenantId: 'request-tenant' }));
 

--- a/packages/api/src/files/retention.spec.ts
+++ b/packages/api/src/files/retention.spec.ts
@@ -493,12 +493,27 @@ describe('retention helpers', () => {
         config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY } },
       }),
     ).toEqual({
+      /* The snapshot carries the resolved scope so a later write is charged to the
+       * same tenant and cap the live request would have used. */
+      storageScope: expect.objectContaining({ userId: 'user-1', tenantId: 'tenant-1' }),
       user: { id: 'user-1', tenantId: 'tenant-1' },
       body: { conversationId: 'convo-1', isTemporary: 'true' },
       config: { interfaceConfig: { retentionMode: RetentionMode.TEMPORARY } },
     });
 
+    /* Remote-agent auth puts the tenant only on `req.tenantId`. Re-deriving it from the
+     * fields a snapshot happened to keep is what billed generated images to a second,
+     * null-tenant ledger; carrying the resolved scope removes that possibility. */
+    expect(
+      createMinimalRetentionRequest({
+        tenantId: 'request-tenant',
+        user: { id: 'user-1' },
+        body: { conversationId: 'convo-1' },
+      })?.storageScope,
+    ).toEqual(expect.objectContaining({ userId: 'user-1', tenantId: 'request-tenant' }));
+
     expect(createMinimalRetentionRequest()).toBeUndefined();
+    expect(createMinimalRetentionRequest({ body: {} })).toBeUndefined();
   });
 
   describe('getSharedLinkExpiration', () => {

--- a/packages/api/src/files/retention.ts
+++ b/packages/api/src/files/retention.ts
@@ -6,6 +6,7 @@ import { resolveStorageScope } from './quota';
 
 type InterfaceConfig = AppConfig['interfaceConfig'];
 type FileConfig = NonNullable<AppConfig['fileConfig']>;
+type AppPaths = AppConfig['paths'];
 
 const retentionExpiryCache = new WeakMap<
   RetentionRequest,
@@ -36,6 +37,8 @@ export type RetentionRequest = {
     interfaceConfig?: InterfaceConfig;
     /** Carries the storage cap so a snapshot can resolve the same scope the live request would. */
     fileConfig?: FileConfig;
+    /** Carries the filesystem roots needed to undo rejected local generated-image writes. */
+    paths?: AppPaths;
   };
 };
 
@@ -300,9 +303,13 @@ export const createMinimalRetentionRequest = (
     return undefined;
   }
 
+  const storageScope = req.storageScope
+    ? resolveStorageScope({ user: req.user, storageScope: req.storageScope })
+    : resolveStorageScope({ tenantId: req.tenantId, user: req.user, config: req.config ?? {} });
+
   return {
     fileRetentionSource: req.fileRetentionSource,
-    storageScope: resolveStorageScope(req),
+    storageScope,
     user: req.user
       ? {
           id: req.user.id,
@@ -316,6 +323,7 @@ export const createMinimalRetentionRequest = (
     config: {
       interfaceConfig: req.config?.interfaceConfig,
       ...(req.config?.fileConfig ? { fileConfig: req.config.fileConfig } : {}),
+      ...(req.config?.paths ? { paths: req.config.paths } : {}),
     },
   };
 };

--- a/packages/api/src/files/retention.ts
+++ b/packages/api/src/files/retention.ts
@@ -1,8 +1,11 @@
 import { RetentionMode } from 'librechat-data-provider';
 import { createFallbackRetentionDate } from '@librechat/data-schemas';
 import type { AppConfig } from '@librechat/data-schemas';
+import type { StorageScope } from './quota';
+import { resolveStorageScope } from './quota';
 
 type InterfaceConfig = AppConfig['interfaceConfig'];
+type FileConfig = NonNullable<AppConfig['fileConfig']>;
 
 const retentionExpiryCache = new WeakMap<
   RetentionRequest,
@@ -20,6 +23,7 @@ export type RetentionConversation = {
 export type RetentionRequest = {
   /** Owner-authenticated source row for operations attached to an existing message. */
   fileRetentionSource?: RetentionConversation;
+  tenantId?: string;
   user?: {
     id?: string;
     tenantId?: string;
@@ -30,6 +34,8 @@ export type RetentionRequest = {
   };
   config?: {
     interfaceConfig?: InterfaceConfig;
+    /** Carries the storage cap so a snapshot can resolve the same scope the live request would. */
+    fileConfig?: FileConfig;
   };
 };
 
@@ -276,15 +282,27 @@ export async function getSharedLinkExpiration(
   }
 }
 
+/**
+ * Snapshot of the request that image-generation tools keep for later writes.
+ *
+ * `storageScope` is required, so a snapshot cannot be assembled from whichever fields
+ * happen to be at hand — the resolved tenant and cap travel with it. Rebuilding a
+ * request without them is what silently billed generated images to a second ledger.
+ */
+export type MinimalFileRequest = RetentionRequest & { storageScope: StorageScope };
+
 export const createMinimalRetentionRequest = (
-  req?: RetentionRequest | null,
-): RetentionRequest | undefined => {
-  if (!req) {
+  req?: (RetentionRequest & { storageScope?: StorageScope }) | null,
+): MinimalFileRequest | undefined => {
+  /* No authenticated user means no ledger to charge, so there is no snapshot to make;
+   * callers already treat `undefined` as "no retention/persistence context". */
+  if (!req?.user?.id) {
     return undefined;
   }
 
   return {
     fileRetentionSource: req.fileRetentionSource,
+    storageScope: resolveStorageScope(req),
     user: req.user
       ? {
           id: req.user.id,
@@ -297,6 +315,7 @@ export const createMinimalRetentionRequest = (
     },
     config: {
       interfaceConfig: req.config?.interfaceConfig,
+      ...(req.config?.fileConfig ? { fileConfig: req.config.fileConfig } : {}),
     },
   };
 };

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -1978,6 +1978,11 @@ describe('defaultLLMDeliveryPath config merging', () => {
 });
 
 describe('agent attachment context limits', () => {
+  it('validates and merges the per-user storage limit in MB', () => {
+    expect(fileConfigSchema.safeParse({ storageLimit: 64 }).success).toBe(true);
+    expect(mergeFileConfig({ storageLimit: 64 }).storageLimit).toBe(64 * 1024 * 1024);
+  });
+
   it('keeps the turn-memory ceiling separate from agent upload storage', () => {
     expect(baseFileConfig.fileContextSizeLimit).toBe(128 * 1024 * 1024);
     expect(baseFileConfig.endpoints[EModelEndpoint.agents].totalSizeLimit).toBe(512 * 1024 * 1024);

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -593,6 +593,7 @@ export const fileConfigSchema = z.object({
   endpoints: z.record(endpointFileConfigSchema).optional(),
   skills: skillFileConfigSchema.optional(),
   serverFileSizeLimit: z.number().min(0).optional(),
+  storageLimit: z.number().min(0).optional(),
   avatarSizeLimit: z.number().min(0).optional(),
   fileTokenLimit: z.number().min(0).optional(),
   fileContextSizeLimit: z.number().min(0).optional(),
@@ -1167,6 +1168,10 @@ export function mergeFileConfig(dynamic: z.infer<typeof fileConfigSchema> | unde
 
   if (dynamic.serverFileSizeLimit !== undefined) {
     mergedConfig.serverFileSizeLimit = mbToBytes(dynamic.serverFileSizeLimit);
+  }
+
+  if (dynamic.storageLimit !== undefined) {
+    mergedConfig.storageLimit = mbToBytes(dynamic.storageLimit);
   }
 
   if (dynamic.avatarSizeLimit !== undefined) {


### PR DESCRIPTION
## Summary

This PR routes the ten core `File` creation paths through the storage-quota ledger introduced by #15220 while preserving upload routing and retention behavior.

- Route all ten `File` writes in `api/server/services/Files/process.js` through one quota-checked persistence seam.
- Expose storage-limit configuration to the runtime.
- Authorize before provider writes and roll back request-owned blobs when enforcement rejects or fails before persistence.
- Preserve tenant and storage scope in generated-image request snapshots.
- Carry local paths needed to clean up rejected generated images.
- Report Azure URL-upload byte counts so generated images cannot bypass quota.
- Propagate failed OpenAI image-output persistence instead of returning a deleted attachment.
- Charge uploaded text files by stored bytes rather than extracted-text length.
- Pass tenant identity into durable agent storage and roll back extracted-text and converted-image blobs on rejection.
- Charge retained assistant-image provider and converted copies together.

Depends on #15220. SkillFile routing and final Code-output/413/provider-cleanup enforcement remain scoped to #15788 and #15789.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Final top-of-stack focused run: package API 4 suites / 253 tests, data schemas 2 suites / 113 tests, server API 12 suites / 439 tests.
- TypeScript and package builds pass across data-provider, data-schemas, packages API, server API, and client.
- Targeted lint/format/import checks and `git diff --check` pass.
- Restacked on current #15220 after rebasing the full chain onto `origin/dev` at `ac2307b2ef`.
- Required CI is the authoritative broad matrix.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
