### PR TITLE
🐛 fix: serialize MCP structuredContent when tool result content is empty

### DIFF
--- a/packages/api/src/mcp/__tests__/parsers.test.ts
+++ b/packages/api/src/mcp/__tests__/parsers.test.ts
@@ -503,6 +503,60 @@ describe('formatToolContent', () => {
       expect(content).toBe('Response with metadata');
       expect(artifacts).toBeUndefined();
     });
+
+    it('should fall back to structuredContent when content is empty', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [],
+        isError: false,
+        structuredContent: {
+          id: 10491,
+          deviceId: 1,
+          latitude: 50.996575,
+          longitude: 12.9628766,
+        },
+      };
+
+      const [content, artifacts] = formatToolContent(result, 'openai');
+      expect(content).toContain('"id": 10491');
+      expect(content).toContain('"latitude": 50.996575');
+      expect(artifacts).toBeUndefined();
+    });
+
+    it('should prefer content over structuredContent when both are present', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [{ type: 'text', text: 'Text from content' }],
+        structuredContent: { id: 10491 },
+      };
+
+      const [content, artifacts] = formatToolContent(result, 'openai');
+      expect(content).toBe('Text from content');
+      expect(artifacts).toBeUndefined();
+    });
+  });
+
+  describe('structuredContent fallback (unrecognized providers)', () => {
+    it('should serialize structuredContent when content is empty for unrecognized provider', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [],
+        structuredContent: { status: 'ok', nodes: ['node-1', 'node-2'] },
+      };
+
+      const [content, artifacts] = formatToolContent(result, 'unknown' as t.Provider);
+      expect(content).toContain('"status": "ok"');
+      expect(content).toContain('"node-1"');
+      expect(artifacts).toBeUndefined();
+    });
+
+    it('should still return "(No response)" when neither content nor structuredContent is present', () => {
+      const result: t.MCPToolCallResponse = { content: [] };
+      const [content, artifacts] = formatToolContent(result, 'unknown' as t.Provider);
+      expect(content).toBe('(No response)');
+      expect(artifacts).toBeUndefined();
+
+      const undefinedResult: t.MCPToolCallResponse = undefined;
+      const [undefinedContent] = formatToolContent(undefinedResult, 'unknown' as t.Provider);
+      expect(undefinedContent).toBe('(No response)');
+    });
   });
 
   describe('blob resource contents', () => {

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -170,10 +170,22 @@ function describeResourceLink(item: t.ResourceLink): string[] {
   return lines;
 }
 
+/**
+ * Serializes `structuredContent` (MCP 2025-06-18 spec) for tools that return
+ * structured output without any `content` entries.
+ */
+function getStructuredContentText(result: t.MCPToolCallResponse): string | undefined {
+  const structured = result?.structuredContent;
+  if (structured != null && typeof structured === 'object') {
+    return JSON.stringify(structured, null, 2);
+  }
+  return undefined;
+}
+
 function parseAsString(result: t.MCPToolCallResponse): string {
   const content = result?.content ?? [];
   if (!content.length) {
-    return '(No response)';
+    return getStructuredContentText(result) ?? '(No response)';
   }
 
   const text = content
@@ -233,7 +245,7 @@ export function formatToolContent(
 
   const content = result?.content ?? [];
   if (!content.length) {
-    return ['(No response)', undefined];
+    return [getStructuredContentText(result) ?? '(No response)', undefined];
   }
 
   const imageUrls: t.FormattedContent[] = [];

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -93,6 +93,8 @@ export type MCPToolCallResponse =
       _meta?: Record<string, unknown>;
       content?: Array<ToolContentPart>;
       isError?: boolean;
+      /** Structured tool output (MCP 2025-06-18 spec); used as a fallback when `content` is empty */
+      structuredContent?: Record<string, unknown>;
     };
 
 export type Provider =


### PR DESCRIPTION
## Summary

Fixes #15198.

Per the MCP 2025-06-18 spec, a `CallToolResult` may carry its actual payload in `structuredContent` while leaving `content` empty. LibreChat's MCP parsers only inspected `content`, so any tool returning structured output without a text block was reported to the agent as `(No response)` — e.g. a Traccar `device-position` tool returning:

```json
{ "content": [], "isError": false, "structuredContent": { "id": 10491, "latitude": 50.99, "longitude": 12.96 } }
```

This adds a fallback: when `content` is absent or empty, serialize `structuredContent` (pretty-printed JSON) for both the unrecognized-provider string path (`parseAsString`) and the recognized-provider path (`formatToolContent`). When both are present, `content` keeps priority, and results with neither still return `(No response)`. `MCPToolCallResponse` gains the optional `structuredContent?: Record<string, unknown>` field.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New cases in `packages/api/src/mcp/__tests__/parsers.test.ts`:

- structuredContent is serialized when content is empty (recognized provider)
- same for unrecognized providers (`parseAsString` path)
- `content` still takes precedence when non-empty
- `(No response)` unchanged when neither field carries data

```
npx jest src/mcp/__tests__/parsers.test.ts
→ Tests: 54 passed, 54 total
```

Reproduction of the original report: point an agent at any Streamable-HTTP MCP server exposing a tool that answers with `structuredContent` only; before this change the agent sees "(No response)", after it receives the serialized JSON.

### **Test Configuration**:
- Node v25.9.0, jest via `packages/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.