### PR TITLE
fix: Add print styles for clean, paginated document output

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,7 +6,7 @@ import * as RadixToast from '@radix-ui/react-toast';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query';
 import { Toast, ThemeProvider, ToastProvider, useInputModality } from '@librechat/client';
-import { ScreenshotProvider, useApiErrorBoundary } from './hooks';
+import { ScreenshotProvider, useApiErrorBoundary, completeProgressiveRowMounts } from './hooks';
 import WakeLockManager from '~/components/System/WakeLockManager';
 import QueryDevtoolsGate from '~/components/QueryDevtoolsGate';
 import LanguageSync from '~/components/System/LanguageSync';
@@ -41,6 +41,16 @@ const App = () => {
 
   useEffect(() => {
     initializeFontSize();
+  }, []);
+
+  useEffect(() => {
+    /** Force any windowed-out message rows to mount before the browser's
+     *  print pipeline reads the DOM, so long threads never print truncated. */
+    const handleBeforePrint = () => {
+      completeProgressiveRowMounts();
+    };
+    window.addEventListener('beforeprint', handleBeforePrint);
+    return () => window.removeEventListener('beforeprint', handleBeforePrint);
   }, []);
 
   // Load theme from environment variables if available

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,7 +6,7 @@ import * as RadixToast from '@radix-ui/react-toast';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query';
 import { Toast, ThemeProvider, ToastProvider, useInputModality } from '@librechat/client';
-import { ScreenshotProvider, useApiErrorBoundary, completeProgressiveRowMounts } from './hooks';
+import { ScreenshotProvider, useApiErrorBoundary, flushProgressiveRowMounts } from './hooks';
 import WakeLockManager from '~/components/System/WakeLockManager';
 import QueryDevtoolsGate from '~/components/QueryDevtoolsGate';
 import LanguageSync from '~/components/System/LanguageSync';
@@ -45,9 +45,12 @@ const App = () => {
 
   useEffect(() => {
     /** Force any windowed-out message rows to mount before the browser's
-     *  print pipeline reads the DOM, so long threads never print truncated. */
+     *  print pipeline reads the DOM, so long threads never print truncated.
+     *  Synchronous: `beforeprint` is dispatched synchronously and the
+     *  browser never waits on a handler's return value, so an async
+     *  completion (as screenshot export uses) would run too late. */
     const handleBeforePrint = () => {
-      completeProgressiveRowMounts();
+      flushProgressiveRowMounts();
     };
     window.addEventListener('beforeprint', handleBeforePrint);
     return () => window.removeEventListener('beforeprint', handleBeforePrint);

--- a/client/src/components/Messages/Content/Mermaid/Mermaid.tsx
+++ b/client/src/components/Messages/Content/Mermaid/Mermaid.tsx
@@ -318,7 +318,7 @@ export const MermaidRenderer = memo(function MermaidRenderer({
               ref={containerRef}
               hidden={showCode}
               className={cn(
-                'relative overflow-hidden rounded-md p-4 transition-colors duration-200',
+                'mermaid-viewport relative overflow-hidden rounded-md p-4 transition-colors duration-200',
                 fillContainer && 'h-full rounded-lg',
                 'bg-surface-primary-alt',
                 isPanning ? 'cursor-grabbing' : 'cursor-grab',
@@ -331,7 +331,7 @@ export const MermaidRenderer = memo(function MermaidRenderer({
                 <Spinner className="h-3 w-3" />
               </div>
               <div
-                className="absolute inset-0 flex items-center justify-center"
+                className="mermaid-pan-zoom absolute inset-0 flex items-center justify-center"
                 style={{
                   transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
                   transition: isPanning ? 'none' : 'transform 0.1s ease-out',
@@ -491,7 +491,7 @@ export const MermaidRenderer = memo(function MermaidRenderer({
           ref={containerRef}
           hidden={showCode}
           className={cn(
-            'relative overflow-hidden p-4 transition-colors duration-200',
+            'mermaid-viewport relative overflow-hidden p-4 transition-colors duration-200',
             fillContainer && 'h-full rounded-lg',
             'bg-surface-primary-alt',
             isPanning ? 'cursor-grabbing' : 'cursor-grab',
@@ -501,7 +501,7 @@ export const MermaidRenderer = memo(function MermaidRenderer({
           onMouseDown={handleMouseDown}
         >
           <div
-            className="absolute inset-0 flex items-center justify-center"
+            className="mermaid-pan-zoom absolute inset-0 flex items-center justify-center"
             style={{
               transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
               transition: isPanning ? 'none' : 'transform 0.1s ease-out',

--- a/client/src/components/Messages/Content/Mermaid/Mermaid.tsx
+++ b/client/src/components/Messages/Content/Mermaid/Mermaid.tsx
@@ -280,7 +280,7 @@ export const MermaidRenderer = memo(function MermaidRenderer({
           )}
           <div
             className={cn(
-              'relative w-full overflow-hidden rounded-lg border transition-all duration-200',
+              'mermaid-card relative w-full overflow-hidden rounded-lg border transition-all duration-200',
               fillContainer && 'h-full rounded-xl',
               showControls ? 'border-border-light' : 'border-transparent',
             )}
@@ -458,7 +458,7 @@ export const MermaidRenderer = memo(function MermaidRenderer({
       )}
       <div
         className={cn(
-          'relative w-full overflow-hidden rounded-lg border border-border-light transition-all duration-200',
+          'mermaid-card relative w-full overflow-hidden rounded-lg border border-border-light transition-all duration-200',
           fillContainer && 'h-full rounded-xl',
         )}
         {...hoverHandlers}

--- a/client/src/hooks/Messages/index.ts
+++ b/client/src/hooks/Messages/index.ts
@@ -17,6 +17,7 @@ export {
   useRowMountWindow,
   useProgressiveRowMount,
   completeProgressiveRowMounts,
+  flushProgressiveRowMounts,
 } from './useProgressiveRowMount';
 export type { RowMountWindow } from './useProgressiveRowMount';
 export { default as useMessageActions } from './useMessageActions';

--- a/client/src/hooks/Messages/useProgressiveRowMount.tsx
+++ b/client/src/hooks/Messages/useProgressiveRowMount.tsx
@@ -222,7 +222,7 @@ export async function completeProgressiveRowMounts(): Promise<void> {
  * before this function returns.
  */
 export function flushProgressiveRowMounts(): void {
-  for (const flush of activeFlushers) {
+  for (const flush of [...activeFlushers]) {
     flush();
   }
 }

--- a/client/src/hooks/Messages/useProgressiveRowMount.tsx
+++ b/client/src/hooks/Messages/useProgressiveRowMount.tsx
@@ -8,7 +8,11 @@ import {
   useLayoutEffect,
   startTransition,
 } from 'react';
+import { flushSync } from 'react-dom';
 import type { ReactNode, RefObject } from 'react';
+
+const activeCompleters = new Set<() => Promise<void>>();
+const activeFlushers = new Set<() => void>();
 
 /**
  * Depth range (inclusive) of visible-path rows allowed to mount; `null` means
@@ -178,15 +182,23 @@ export function useProgressiveRowMount({
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       });
     activeCompleters.add(complete);
+    /** Synchronous counterpart for callers that cannot await — namely the
+     *  `beforeprint` listener, since the browser never waits on a handler's
+     *  returned promise. `flushSync` forces the commit before returning, so
+     *  by the time the (unawaited) call site regains control the full
+     *  thread is already in the DOM. Kept as a separate registration so
+     *  `completeProgressiveRowMounts` and its async/rAF behavior for the
+     *  screenshot path are untouched. */
+    const flush = () => flushSync(() => setMountWindow(null));
+    activeFlushers.add(flush);
     return () => {
       activeCompleters.delete(complete);
+      activeFlushers.delete(flush);
     };
   }, [isWindowActive]);
 
   return mountWindow;
 }
-
-const activeCompleters = new Set<() => Promise<void>>();
 
 /**
  * Forces every in-flight progressive mount to completion and resolves after
@@ -199,4 +211,18 @@ export async function completeProgressiveRowMounts(): Promise<void> {
     return;
   }
   await Promise.all([...activeCompleters].map((complete) => complete()));
+}
+
+/**
+ * Synchronous counterpart to `completeProgressiveRowMounts`, for callers
+ * that cannot await a promise — the `beforeprint` listener, since the
+ * browser dispatches that event synchronously and never waits on a
+ * handler's return value. Forces every in-flight progressive mount to
+ * completion via `flushSync`, so the full thread is committed to the DOM
+ * before this function returns.
+ */
+export function flushProgressiveRowMounts(): void {
+  for (const flush of activeFlushers) {
+    flush();
+  }
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -5,6 +5,7 @@ import App from './App';
 import '@librechat/client/style.css';
 import './style.css';
 import './mobile.css';
+import './print.css';
 import { ApiErrorBoundaryProvider } from './hooks/ApiErrorBoundaryContext';
 import 'katex/dist/katex.min.css';
 import 'katex/dist/contrib/copy-tex.js';

--- a/client/src/print.css
+++ b/client/src/print.css
@@ -7,6 +7,7 @@
  * (client/src/components/Chat/Messages/MessagesView.tsx); reused here
  */
 @media print {
+
   /*
    * `:has()` gates this rule to routes that actually render the print
    * target. Without it, a route lacking `[data-testid='screenshot-target']`
@@ -91,6 +92,21 @@
    */
   .mermaid-pan-zoom {
     transform: none !important;
+  }
+
+  /*
+   * Keeps the whole diagram card — header toolbar plus diagram body —
+   * together rather than letting the page break fall between them or
+   * mid-diagram. Targets `.mermaid-card` (the outer wrapper that contains
+   * both `MermaidHeader` and `.mermaid-viewport`), not `.mermaid-viewport`
+   * alone: `break-inside: avoid` only protects the element it's applied to,
+   * so scoping it to just the diagram body let the header get stranded on
+   * the previous page while the diagram moved to the next. Only takes
+   * effect when the whole card fits within one page — a diagram taller
+   * than a page still has to split somewhere.
+   */
+  .mermaid-card {
+    break-inside: avoid;
   }
 
   [data-testid='screenshot-target'] svg {

--- a/client/src/print.css
+++ b/client/src/print.css
@@ -1,0 +1,85 @@
+/**
+ * Ctrl/Cmd+P prints the full conversation thread as a clean, paginated
+ * document (users can choose "Save as PDF" as the print destination).
+ *
+ * `[data-testid="screenshot-target"]` is the wrapper already used by the
+ * screenshot export feature to scope its capture to the message tree
+ * (client/src/components/Chat/Messages/MessagesView.tsx); reused here
+ */
+@media print {
+  body * {
+    visibility: hidden;
+  }
+
+  [data-testid='screenshot-target'],
+  [data-testid='screenshot-target'] * {
+    visibility: visible;
+  }
+
+  /*
+   * The transcript lives inside several nested scroll/clip containers
+   * (overflow-hidden / overflow-y-auto paired with h-full or an explicit
+   * height), none of which expand for print by default — a fixed-height,
+   * clipped box stays clipped to one page's worth of content instead of
+   * flowing across pages. Reset overflow/height site-wide within print
+   * media so the transcript can paginate naturally; this is safe globally
+   * because every other such container in the app (menus, dialogs, other
+   * scroll regions) is already invisible from the rule above.
+   */
+  html,
+  body,
+  #root,
+  #root * {
+    overflow: visible !important;
+    height: auto !important;
+    max-height: none !important;
+  }
+
+  [data-testid='screenshot-target'] {
+    width: 100% !important;
+  }
+
+  /*
+   * `visibility: hidden` above removes paint but not layout — the sidebar
+   * and the artifacts/subagent side panel are flex/resizable siblings of
+   * the transcript pane and would still reserve their on-screen width,
+   * squeezing the printed column into a narrow strip with blank space on
+   * either side. Collapse them outright using structural hooks that
+   * already exist for other purposes — `#messages-view`
+   * (client/src/components/SidePanel/SidePanelGroup.tsx) and the semantic
+   * `<aside>` sidebar landmark (client/src/components/UnifiedSidebar/UnifiedSidebar.tsx)
+   * — rather than adding new markup just for print.
+   */
+  div:has(> aside):has(#messages-view)>aside {
+    display: none !important;
+  }
+
+  #messages-view~* {
+    display: none !important;
+  }
+
+  #messages-view {
+    width: 100% !important;
+    flex: 1 1 100% !important;
+    max-width: none !important;
+  }
+
+  /*
+   * Transforms are reset for print so no ancestor's `transform` creates a
+   * containing block that could re-introduce clipping, and so a
+   * panned/zoomed Mermaid diagram falls back to its default view, which is
+   * what we want on paper.
+   */
+  * {
+    transform: none !important;
+  }
+
+  [data-testid='screenshot-target'] svg {
+    max-width: 100%;
+    height: auto;
+  }
+
+  @page {
+    margin: 12mm;
+  }
+}

--- a/client/src/print.css
+++ b/client/src/print.css
@@ -7,7 +7,16 @@
  * (client/src/components/Chat/Messages/MessagesView.tsx); reused here
  */
 @media print {
-  body * {
+  /*
+   * `:has()` gates this rule to routes that actually render the print
+   * target. Without it, a route lacking `[data-testid='screenshot-target']`
+   * (e.g. the read-only Share view, which uses `data-testid="messages-view"`
+   * instead) would hide the whole page here with nothing left to reveal,
+   * printing blank. Wrapped in `:where()` so the gate adds no specificity —
+   * otherwise this rule would outrank (and defeat) the plain attribute
+   * selector below that un-hides the target itself.
+   */
+  :where(body:has([data-testid='screenshot-target'])) * {
     visibility: hidden;
   }
 
@@ -25,11 +34,19 @@
    * media so the transcript can paginate naturally; this is safe globally
    * because every other such container in the app (menus, dialogs, other
    * scroll regions) is already invisible from the rule above.
+   *
+   * `.mermaid-viewport` and everything inside it
+   * (client/src/components/Messages/Content/Mermaid/Mermaid.tsx) are
+   * excluded: the viewport's inline height and `overflow-hidden` are
+   * load-bearing, and the rendered diagram `<img>` beneath it is sized by
+   * an inline pixel height — forcing `height: auto` on either collapses
+   * the diagram to zero height, and it disappears from the printed page
+   * entirely.
    */
   html,
   body,
   #root,
-  #root * {
+  #root *:not(.mermaid-viewport, .mermaid-viewport *) {
     overflow: visible !important;
     height: auto !important;
     max-height: none !important;
@@ -65,12 +82,14 @@
   }
 
   /*
-   * Transforms are reset for print so no ancestor's `transform` creates a
-   * containing block that could re-introduce clipping, and so a
-   * panned/zoomed Mermaid diagram falls back to its default view, which is
-   * what we want on paper.
+   * Resets a panned/zoomed Mermaid diagram to its default view for print.
+   * Scoped to the pan/zoom wrapper itself (`.mermaid-pan-zoom`, applied in
+   * client/src/components/Messages/Content/Mermaid/Mermaid.tsx) rather than
+   * every element, so it can't also strip `transform` off unrelated inline
+   * SVG content elsewhere in a message (e.g. KaTeX renders some glyphs as
+   * SVG with internally `transform`-positioned paths).
    */
-  * {
+  .mermaid-pan-zoom {
     transform: none !important;
   }
 

--- a/client/src/print.css
+++ b/client/src/print.css
@@ -43,14 +43,28 @@
    * an inline pixel height — forcing `height: auto` on either collapses
    * the diagram to zero height, and it disappears from the printed page
    * entirely.
+   *
+   * The `overflow` reset is split into its own rule with one more
+   * exclusion, `.mermaid-card` (the diagram's outer wrapper): it relies on
+   * its own `overflow-hidden` to clip `MermaidHeader`'s square corners to
+   * the card's rounded border. Forcing `overflow: visible` there doesn't
+   * clip anything taller (the card has no fixed height), it only lets
+   * those square corners show past the rounded clip in print — so `height`
+   * still resets for it, but `overflow` doesn't.
    */
   html,
   body,
   #root,
   #root *:not(.mermaid-viewport, .mermaid-viewport *) {
-    overflow: visible !important;
     height: auto !important;
     max-height: none !important;
+  }
+
+  html,
+  body,
+  #root,
+  #root *:not(.mermaid-card, .mermaid-viewport, .mermaid-viewport *) {
+    overflow: visible !important;
   }
 
   [data-testid='screenshot-target'] {


### PR DESCRIPTION
## Summary

This is primarily a CSS change to fix the print option in browser.  
Earlier the PDF created would only have the first few messages in chat.

I have kept changes **_minimal_** to make it easy to review.

| Old print | New print |
| :-------: | :-------: |
| [LibreChat-old-print.pdf](https://github.com/user-attachments/files/31450400/LibreChat-old-print.pdf) | [LibreChat-new-print.pdf](https://github.com/user-attachments/files/31450399/LibreChat-new-print.pdf) |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

Changes are:
1. New stylesheet with `@media print` style
2. A `useEffect()` hook to load the complete conversation before printing

## Testing

Manually tested:

1. Run librechat locally.
3. Open a chat thread.
4. Ctrl+P (Cmd+P on Mac)

[Screen Recording 2026-08-26 at 11.20.39 AM.webm](https://github.com/user-attachments/assets/f072e9e4-2d55-42f9-89a4-f75d9dda71a1)

### **Test Configuration**:

No change.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
