### PR TITLE
fix: subtract stored memory tokens on set_memory rewrite

### DIFF
--- a/packages/api/src/agents/memory.spec.ts
+++ b/packages/api/src/agents/memory.spec.ts
@@ -712,6 +712,60 @@ describe('createMemoryTool tokenLimit enforcement', () => {
     expect(setMemory).toHaveBeenCalledTimes(2);
   });
 
+  it('treats the first rewrite of a stored key as a replacement, not an addition', async () => {
+    const setMemory = jest.fn().mockResolvedValue({ ok: true });
+    /** totalTokens already includes k1 (100). Without priming the per-key map,
+     *  rewriting k1 with ~100 tokens would look like 200 and hit would_exceed. */
+    const value = 'word '.repeat(100).trim();
+    const tool = createMemoryTool({
+      userId: 'user-1',
+      setMemory,
+      tokenLimit: 150,
+      totalTokens: 100,
+      existingTokensByKey: { k1: 100 },
+    });
+
+    await tool.invoke({ key: 'k1', value });
+
+    expect(setMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects a stored-key rewrite that exceeds remaining capacity after subtracting the old value', async () => {
+    const setMemory = jest.fn().mockResolvedValue({ ok: true });
+    /** Same setup as the replacement case, but the new value (~200) is larger
+     *  than tokenLimit even after k1's stored 100 is subtracted. */
+    const value = 'word '.repeat(200).trim();
+    const tool = createMemoryTool({
+      userId: 'user-1',
+      setMemory,
+      tokenLimit: 150,
+      totalTokens: 100,
+      existingTokensByKey: { k1: 100 },
+    });
+
+    await tool.invoke({ key: 'k1', value });
+
+    expect(setMemory).not.toHaveBeenCalled();
+  });
+
+  it('still adds a new key on top of totalTokens from other stored keys', async () => {
+    const setMemory = jest.fn().mockResolvedValue({ ok: true });
+    /** k1 already accounts for the full total; writing a new key k2 must not
+     *  subtract k1 and therefore exceeds the 150 cap. */
+    const value = 'word '.repeat(100).trim();
+    const tool = createMemoryTool({
+      userId: 'user-1',
+      setMemory,
+      tokenLimit: 150,
+      totalTokens: 100,
+      existingTokensByKey: { k1: 100 },
+    });
+
+    await tool.invoke({ key: 'k2', value });
+
+    expect(setMemory).not.toHaveBeenCalled();
+  });
+
   it('fires onWrite after a successful set, but not when the write fails', async () => {
     const onWrite = jest.fn();
     const okTool = createMemoryTool({
@@ -804,6 +858,55 @@ describe('buildInlineMemoryTool content filtering', () => {
         value: 'Keep ORG-SECRET',
       }),
     );
+  });
+
+  it('seeds stored key tokens so rewriting an existing key does not double-count', async () => {
+    const setMemory = jest.fn().mockResolvedValue({ ok: true });
+    const value = 'word '.repeat(100).trim();
+    const req = {
+      config: {
+        endpoints: {
+          [EModelEndpoint.agents]: {
+            capabilities: [AgentCapabilities.memory],
+          },
+        },
+        memory: {
+          disabled: false,
+          tokenLimit: 150,
+        },
+      },
+      user: {
+        id: 'user-1',
+        personalization: {
+          memories: true,
+        },
+      },
+    } as ServerRequest;
+
+    const memoryTool = await buildInlineMemoryTool({
+      toolName: 'set_memory',
+      req,
+      agent: {
+        tools: [AgentCapabilities.memory],
+      },
+      userId: 'user-1',
+      memoryMethods: {
+        setMemory,
+        deleteMemory: jest.fn(),
+        getFormattedMemories: jest.fn().mockResolvedValue({
+          withKeys: '',
+          withoutKeys: '',
+          totalTokens: 100,
+          tokensByKey: { k1: 100 },
+        }),
+      },
+      getRoleByName: jest.fn(),
+    });
+
+    expect(memoryTool).not.toBeNull();
+    await memoryTool?.func({ key: 'k1', value });
+
+    expect(setMemory).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -130,6 +130,7 @@ export const createMemoryTool = ({
   charLimit,
   tokenLimit,
   totalTokens = 0,
+  existingTokensByKey,
   filters,
   onWrite,
 }: {
@@ -141,6 +142,9 @@ export const createMemoryTool = ({
   charLimit?: number;
   tokenLimit?: number;
   totalTokens?: number;
+  /** Stored token count per key. Primed into the in-instance map so the first
+   *  rewrite of a pre-existing key is measured as a replacement, not an add. */
+  existingTokensByKey?: Record<string, number>;
   filters?: FiltersConfig;
   onWrite?: () => void;
 }): DynamicStructuredTool => {
@@ -150,10 +154,10 @@ export const createMemoryTool = ({
    *  check against the same stale total and collectively exceed `tokenLimit`. */
   let currentTotalTokens = totalTokens;
   let writeChain: Promise<unknown> = Promise.resolve();
-  /** Tokens this instance has already committed per key. `set_memory` upserts,
-   *  so a repeat write to the same key REPLACES its value — the running total
-   *  must swap the prior contribution for the new one, not add both. */
-  const writtenTokensByKey = new Map<string, number>();
+  /** Tokens already attributed to each key: stored entries at construction,
+   *  then this instance's successful writes. `set_memory` upserts, so a
+   *  rewrite must swap the prior contribution rather than add both. */
+  const writtenTokensByKey = new Map<string, number>(Object.entries(existingTokensByKey ?? {}));
 
   return tool(
     async ({ key, value }) => {
@@ -188,8 +192,8 @@ export const createMemoryTool = ({
           }
 
           const tokenCount = Tokenizer.getTokenCount(value, 'o200k_base');
-          /** Total excluding this key's prior in-instance write, so a same-key
-           *  rewrite is measured as a replacement rather than an addition. */
+          /** Total excluding this key's stored or in-instance contribution, so a
+           *  same-key rewrite is measured as a replacement rather than an addition. */
           const baseTotalTokens = currentTotalTokens - (writtenTokensByKey.get(key) ?? 0);
           const remainingTokens = tokenLimit ? tokenLimit - baseTotalTokens : Infinity;
 
@@ -680,6 +684,7 @@ export async function buildInlineMemoryTool({
   const charLimit = memoryConfig?.charLimit as number | undefined;
   const tokenLimit = memoryConfig?.tokenLimit as number | undefined;
   let totalTokens = 0;
+  let existingTokensByKey: Record<string, number> | undefined;
   if (tokenLimit) {
     try {
       const formatted = await getRequestMemories({
@@ -689,6 +694,7 @@ export async function buildInlineMemoryTool({
         getFormattedMemories: memoryMethods.getFormattedMemories,
       });
       totalTokens = formatted?.totalTokens ?? 0;
+      existingTokensByKey = formatted?.tokensByKey;
     } catch (error) {
       logger.error(
         '[memory] Failed to load memory token count for set_memory',
@@ -708,6 +714,7 @@ export async function buildInlineMemoryTool({
     charLimit,
     tokenLimit,
     totalTokens,
+    existingTokensByKey,
     filters: req.config?.filters,
     onWrite: () => invalidateRequestMemories(req, memoryAgentId),
   });
@@ -754,6 +761,7 @@ export async function processMemory({
   llmConfig,
   tokenLimit,
   totalTokens = 0,
+  existingTokensByKey,
   filters,
   streamId = null,
   jobCreatedAt,
@@ -780,6 +788,7 @@ export async function processMemory({
   }[];
   tokenLimit?: number;
   totalTokens?: number;
+  existingTokensByKey?: Record<string, number>;
   filters?: FiltersConfig;
   llmConfig?: Partial<LLMConfig>;
   streamId?: string | null;
@@ -813,6 +822,7 @@ export async function processMemory({
       setMemory,
       validKeys,
       totalTokens,
+      existingTokensByKey,
       filters,
     });
     const deleteMemoryTool = createDeleteMemoryTool({
@@ -1044,7 +1054,7 @@ export async function createMemoryProcessor({
   const { validKeys, instructions, llmConfig, tokenLimit } = config;
   const finalInstructions = instructions || getDefaultInstructions(validKeys, tokenLimit);
 
-  const [{ withKeys, withoutKeys, totalTokens }, memoryEntries] = await Promise.all([
+  const [{ withKeys, withoutKeys, totalTokens, tokensByKey }, memoryEntries] = await Promise.all([
     memoryMethods.getFormattedMemories({
       userId,
       agentId,
@@ -1077,6 +1087,7 @@ export async function createMemoryProcessor({
           memory: withKeys,
           memoryEntries,
           totalTokens: totalTokens || 0,
+          existingTokensByKey: tokensByKey,
           filters,
           instructions: finalInstructions,
           setMemory: memoryMethods.setMemory,

--- a/packages/data-schemas/src/methods/memory.spec.ts
+++ b/packages/data-schemas/src/methods/memory.spec.ts
@@ -245,11 +245,13 @@ describe('memory partitions', () => {
 
     const personal = await methods.getFormattedMemories({ userId });
     expect(personal.totalTokens).toBe(5);
+    expect(personal.tokensByKey).toEqual({ one: 5 });
     expect(personal.withoutKeys).toContain('personal one');
     expect(personal.withoutKeys).not.toContain('agent two');
 
     const partitionA = await methods.getFormattedMemories({ userId, agentId });
     expect(partitionA.totalTokens).toBe(7);
+    expect(partitionA.tokensByKey).toEqual({ two: 7 });
     expect(partitionA.withKeys).toContain('"key": "two"');
     expect(partitionA.withKeys).not.toContain('personal one');
   });

--- a/packages/data-schemas/src/methods/memory.ts
+++ b/packages/data-schemas/src/methods/memory.ts
@@ -271,15 +271,18 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
       const memories = await getUserMemories({ userId, agentId });
 
       if (!memories || memories.length === 0) {
-        return { withKeys: '', withoutKeys: '', totalTokens: 0 };
+        return { withKeys: '', withoutKeys: '', totalTokens: 0, tokensByKey: {} };
       }
 
       const sortedMemories = memories.sort(
         (a, b) => new Date(a.updated_at!).getTime() - new Date(b.updated_at!).getTime(),
       );
 
+      const tokensByKey: Record<string, number> = {};
       const totalTokens = sortedMemories.reduce((sum, memory) => {
-        return sum + (memory.tokenCount || 0);
+        const count = memory.tokenCount || 0;
+        tokensByKey[memory.key] = count;
+        return sum + count;
       }, 0);
 
       const withKeys = sortedMemories
@@ -297,10 +300,10 @@ export function createMemoryMethods(mongoose: typeof import('mongoose')): {
         })
         .join('\n\n');
 
-      return { withKeys, withoutKeys, totalTokens };
+      return { withKeys, withoutKeys, totalTokens, tokensByKey };
     } catch (error) {
       logger.error('Failed to get formatted memories:', error);
-      return { withKeys: '', withoutKeys: '', totalTokens: 0 };
+      return { withKeys: '', withoutKeys: '', totalTokens: 0, tokensByKey: {} };
     }
   }
 

--- a/packages/data-schemas/src/types/memory.ts
+++ b/packages/data-schemas/src/types/memory.ts
@@ -76,4 +76,6 @@ export interface FormattedMemoriesResult {
   withKeys: string;
   withoutKeys: string;
   totalTokens?: number;
+  /** Stored token count per key; used so `set_memory` rewrites replace, not add. */
+  tokensByKey?: Record<string, number>;
 }


### PR DESCRIPTION
# Pull Request Template

## Summary

Fixes #15217

`set_memory` is an upsert, but the token-limit check only subtracted tokens written in this tool instance. `totalTokens` already includes the stored copy of that key, so the first rewrite double-counted it. Once `total + largest entry` exceeded the limit, that entry could never be updated.

I primed the per-key map from stored token counts (`tokensByKey` on `getFormattedMemories`) so a rewrite is measured as a replacement. New keys still add on top.

Thanks for the clear write-up on the issue.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `packages/api` Jest: first rewrite of a stored key is allowed, a rewrite that still exceeds is rejected, a new key still adds on top, `buildInlineMemoryTool` seeds `tokensByKey`

- `packages/data-schemas` Jest: `getFormattedMemories` returns `tokensByKey`

### **Test Configuration**:

Local Jest on the cloud agent VM: 57/57 api, 11/11 data-schemas.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
