### PR TITLE
fix: compact agent file search results

### DIFF
--- a/client/src/components/Chat/Input/Files/FileRow.tsx
+++ b/client/src/components/Chat/Input/Files/FileRow.tsx
@@ -1,6 +1,14 @@
 import { useEffect } from 'react';
-import { useToastContext } from '@librechat/client';
+import { X } from 'lucide-react';
 import { EToolResources } from 'librechat-data-provider';
+import {
+  OGDialog,
+  OGDialogClose,
+  OGDialogContent,
+  OGDialogTitle,
+  OGDialogTrigger,
+  useToastContext,
+} from '@librechat/client';
 import type { ExtendedFile } from '~/common';
 import { useDeleteFilesMutation } from '~/data-provider';
 import { logger, getCachedPreview } from '~/utils';
@@ -29,6 +37,7 @@ export default function FileRow({
   fileFilter,
   isRTL = false,
   Wrapper,
+  visibleFileLimit,
 }: {
   files: Map<string, ExtendedFile> | undefined;
   abortUpload?: (fileId?: string) => void;
@@ -40,12 +49,26 @@ export default function FileRow({
   tool_resource?: EToolResources;
   isRTL?: boolean;
   Wrapper?: React.FC<{ children: React.ReactNode }>;
+  visibleFileLimit?: number;
 }) {
   const localize = useLocalize();
   const { showToast } = useToastContext();
   const files = Array.from(_files?.values() ?? []).filter((file) =>
     fileFilter ? fileFilter(file) : true,
   );
+  const fileIds = new Set<string>();
+  const uniqueFiles = files.filter((file) => {
+    if (fileIds.has(file.file_id)) {
+      return false;
+    }
+    fileIds.add(file.file_id);
+    return true;
+  });
+  const hasValidFileLimit = visibleFileLimit != null && visibleFileLimit > 0;
+  const shouldShowAll = !hasValidFileLimit || uniqueFiles.length <= visibleFileLimit + 1;
+  const appliedFileLimit = shouldShowAll ? uniqueFiles.length : visibleFileLimit;
+  const visibleFiles = uniqueFiles.slice(0, appliedFileLimit);
+  const remainingFileCount = uniqueFiles.length - visibleFiles.length;
 
   const { mutateAsync } = useDeleteFilesMutation({
     onMutate: async () =>
@@ -88,7 +111,45 @@ export default function FileRow({
     return null;
   }
 
-  const renderFiles = () => {
+  const renderFile = (file: ExtendedFile) => {
+    const handleDelete = () => {
+      if (abortUpload && file.progress < 1) {
+        abortUpload(file.file_id);
+      }
+      if (file.progress >= 1 && !file.attached) {
+        showToast({
+          message: localize('com_ui_deleting_file'),
+          status: 'info',
+        });
+      }
+      deleteFile({ file, setFiles });
+    };
+    const isImage = file.type?.startsWith('image') ?? false;
+
+    return (
+      <div
+        key={file.file_id}
+        style={{
+          flexBasis: '70px',
+          flexGrow: 0,
+          flexShrink: 0,
+        }}
+      >
+        {isImage ? (
+          <Image
+            url={getCachedPreview(file.file_id) ?? file.preview ?? file.filepath}
+            onDelete={handleDelete}
+            progress={file.progress}
+            source={file.source}
+          />
+        ) : (
+          <FileContainer file={file} onDelete={handleDelete} />
+        )}
+      </div>
+    );
+  };
+
+  const renderFiles = (filesToRender: ExtendedFile[], showMore = false) => {
     const rowStyle = isRTL
       ? {
           display: 'flex',
@@ -108,61 +169,53 @@ export default function FileRow({
 
     return (
       <div style={rowStyle as React.CSSProperties}>
-        {files
-          .reduce(
-            (acc, current) => {
-              if (!acc.map.has(current.file_id)) {
-                acc.map.set(current.file_id, true);
-                acc.uniqueFiles.push(current);
-              }
-              return acc;
-            },
-            { map: new Map(), uniqueFiles: [] as ExtendedFile[] },
-          )
-          .uniqueFiles.map((file: ExtendedFile, index: number) => {
-            const handleDelete = () => {
-              if (abortUpload && file.progress < 1) {
-                abortUpload(file.file_id);
-              }
-              if (file.progress >= 1 && !file.attached) {
-                showToast({
-                  message: localize('com_ui_deleting_file'),
-                  status: 'info',
-                });
-              }
-              deleteFile({ file, setFiles });
-            };
-            const isImage = file.type?.startsWith('image') ?? false;
-
-            return (
-              <div
-                key={index}
-                style={{
-                  flexBasis: '70px',
-                  flexGrow: 0,
-                  flexShrink: 0,
-                }}
-              >
-                {isImage ? (
-                  <Image
-                    url={getCachedPreview(file.file_id) ?? file.preview ?? file.filepath}
-                    onDelete={handleDelete}
-                    progress={file.progress}
-                    source={file.source}
-                  />
-                ) : (
-                  <FileContainer file={file} onDelete={handleDelete} />
-                )}
-              </div>
-            );
-          })}
+        {filesToRender.map(renderFile)}
+        {showMore && (
+          <div
+            style={{
+              flexBasis: '70px',
+              flexGrow: 0,
+              flexShrink: 0,
+            }}
+          >
+            <OGDialogTrigger className="h-[52px] w-56 rounded-2xl border border-border-light bg-surface-hover-alt px-3 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary">
+              {localize('com_sources_more_files', { count: remainingFileCount })}
+            </OGDialogTrigger>
+          </div>
+        )}
       </div>
     );
   };
 
+  const content =
+    remainingFileCount > 0 ? (
+      <OGDialog>
+        {renderFiles(visibleFiles, true)}
+        <OGDialogContent
+          showCloseButton={false}
+          className="flex max-h-[80vh] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-lg bg-surface-dialog p-0 sm:max-w-[600px]"
+        >
+          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-border-light bg-surface-dialog px-3 py-2">
+            <OGDialogTitle className="text-base font-medium">
+              {localize('com_sources_agent_files')}
+            </OGDialogTitle>
+            <OGDialogClose
+              className="rounded-full p-1 text-text-secondary hover:bg-surface-tertiary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary"
+              aria-label={localize('com_ui_close')}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </OGDialogClose>
+          </div>
+          <div className="flex-1 overflow-y-auto px-3 py-2">{renderFiles(uniqueFiles)}</div>
+        </OGDialogContent>
+      </OGDialog>
+    ) : (
+      renderFiles(uniqueFiles)
+    );
+
   if (Wrapper) {
-    return <Wrapper>{renderFiles()}</Wrapper>;
+    return <Wrapper>{content}</Wrapper>;
   }
 
-  return renderFiles();
+  return content;
 }

--- a/client/src/components/Chat/Input/Files/FileRow.tsx
+++ b/client/src/components/Chat/Input/Files/FileRow.tsx
@@ -178,7 +178,7 @@ export default function FileRow({
               flexShrink: 0,
             }}
           >
-            <OGDialogTrigger className="h-[52px] w-56 rounded-2xl border border-border-light bg-surface-hover-alt px-3 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary">
+            <OGDialogTrigger className="h-[52px] w-full rounded-2xl border border-border-light bg-surface-hover-alt px-3 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary">
               {localize('com_sources_more_files', { count: remainingFileCount })}
             </OGDialogTrigger>
           </div>

--- a/client/src/components/Chat/Input/Files/__tests__/FileRow.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/FileRow.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FileSources } from 'librechat-data-provider';
 import type { ExtendedFile } from '~/common';
-import FileRow from '../FileRow';
+import FileRow, { FileRowWrapper } from '../FileRow';
 
 jest.mock('~/hooks', () => ({
   useLocalize: jest.fn(),
@@ -58,10 +58,14 @@ describe('FileRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseLocalize.mockReturnValue((key: string) => {
+    mockUseLocalize.mockReturnValue((key: string, options?: { count?: number }) => {
       const translations: Record<string, string> = {
         com_ui_deleting_file: 'Deleting file...',
+        com_sources_agent_files: 'Agent Files',
       };
+      if (key === 'com_sources_more_files') {
+        return `+${options?.count} files`;
+      }
       return translations[key] || key;
     });
 
@@ -300,6 +304,87 @@ describe('FileRow', () => {
 
       const images = screen.getAllByTestId('mock-image');
       expect(images).toHaveLength(1);
+    });
+
+    it('limits the inline list and opens all files in a dialog', () => {
+      const filesMap = new Map<string, ExtendedFile>();
+      for (let index = 1; index <= 7; index++) {
+        const file = createMockFile({
+          file_id: `file-${index}`,
+          type: 'application/pdf',
+          filename: `document-${index}.pdf`,
+        });
+        filesMap.set(file.file_id, file);
+      }
+
+      render(
+        <FileRow
+          files={filesMap}
+          setFiles={mockSetFiles}
+          setFilesLoading={mockSetFilesLoading}
+          visibleFileLimit={4}
+          Wrapper={FileRowWrapper}
+        />,
+      );
+
+      expect(screen.getAllByTestId('mock-file-container')).toHaveLength(4);
+
+      fireEvent.click(screen.getByRole('button', { name: '+3 files' }));
+
+      const dialog = screen.getByRole('dialog', { name: 'Agent Files' });
+      expect(within(dialog).getAllByTestId('mock-file-container')).toHaveLength(7);
+      expect(within(dialog).getByText('document-7.pdf')).toBeInTheDocument();
+    });
+
+    it('renders all files inline when the list does not exceed the limit', () => {
+      const filesMap = new Map<string, ExtendedFile>();
+      for (let index = 1; index <= 4; index++) {
+        const file = createMockFile({
+          file_id: `file-${index}`,
+          type: 'application/pdf',
+          filename: `document-${index}.pdf`,
+        });
+        filesMap.set(file.file_id, file);
+      }
+
+      render(<FileRow files={filesMap} setFiles={mockSetFiles} visibleFileLimit={4} />);
+
+      expect(screen.getAllByTestId('mock-file-container')).toHaveLength(4);
+      expect(screen.queryByRole('button', { name: /files$/ })).not.toBeInTheDocument();
+    });
+
+    it('renders one extra file inline when a dialog would not shorten the list', () => {
+      const filesMap = new Map<string, ExtendedFile>();
+      for (let index = 1; index <= 5; index++) {
+        const file = createMockFile({
+          file_id: `file-${index}`,
+          type: 'application/pdf',
+          filename: `document-${index}.pdf`,
+        });
+        filesMap.set(file.file_id, file);
+      }
+
+      render(<FileRow files={filesMap} setFiles={mockSetFiles} visibleFileLimit={4} />);
+
+      expect(screen.getAllByTestId('mock-file-container')).toHaveLength(5);
+      expect(screen.queryByRole('button', { name: '+1 files' })).not.toBeInTheDocument();
+    });
+
+    it('calculates the remaining count after deduplicating files', () => {
+      const filesMap = new Map<string, ExtendedFile>();
+      for (let index = 1; index <= 6; index++) {
+        const file = createMockFile({
+          file_id: `file-${index}`,
+          type: 'application/pdf',
+          filename: `document-${index}.pdf`,
+        });
+        filesMap.set(file.file_id, file);
+      }
+      filesMap.set('duplicate-key', createMockFile({ file_id: 'file-6' }));
+
+      render(<FileRow files={filesMap} setFiles={mockSetFiles} visibleFileLimit={4} />);
+
+      expect(screen.getByRole('button', { name: '+2 files' })).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/SidePanel/Agents/FileSearch.tsx
+++ b/client/src/components/SidePanel/Agents/FileSearch.tsx
@@ -15,6 +15,8 @@ import { useGetStartupConfig } from '~/data-provider';
 import SectionHeader from './SectionHeader';
 import { isEphemeralAgent } from '~/common';
 
+const VISIBLE_FILE_LIMIT = 4;
+
 function FileSearch({
   agent_id,
   files: _files,
@@ -143,6 +145,7 @@ function FileSearch({
           agent_id={agent_id}
           tool_resource={EToolResources.file_search}
           Wrapper={FileRowWrapper}
+          visibleFileLimit={VISIBLE_FILE_LIMIT}
         />
         <div>
           {sharePointEnabled ? (

--- a/client/src/components/SidePanel/Agents/__tests__/FileSearch.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/FileSearch.spec.tsx
@@ -47,7 +47,13 @@ jest.mock('~/components/SharePoint', () => ({
   SharePointPickerDialog: () => null,
 }));
 
-jest.mock('~/components/Chat/Input/Files/FileRow', () => () => null);
+jest.mock('~/components/Chat/Input/Files/FileRow', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+  FileRowWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const mockFileRow = jest.requireMock('~/components/Chat/Input/Files/FileRow').default;
 
 jest.mock('@ariakit/react', () => ({
   MenuButton: ({ children, ...props }: { children: React.ReactNode }) => (
@@ -73,6 +79,10 @@ function Wrapper({ provider, children }: { provider?: string; children: React.Re
 }
 
 describe('FileSearch', () => {
+  beforeEach(() => {
+    mockFileRow.mockClear();
+  });
+
   it('renders upload UI when file uploads are not disabled', () => {
     mockFileConfig = mergeFileConfig({ endpoints: { default: { fileLimit: 10 } } });
     render(
@@ -146,5 +156,17 @@ describe('FileSearch', () => {
       </Wrapper>,
     );
     expect(screen.getByText('com_assistants_file_search')).toBeInTheDocument();
+  });
+
+  it('limits the number of files rendered inline', () => {
+    render(
+      <Wrapper>
+        <FileSearch agent_id="agent-1" />
+      </Wrapper>,
+    );
+
+    const fileRowProps = mockFileRow.mock.calls[0][0];
+    expect(fileRowProps.visibleFileLimit).toBe(4);
+    expect(fileRowProps.Wrapper).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Limit Agent File Search to four inline file chips when a larger result set would otherwise overwhelm the side panel.
- Add a localized `+N files` trigger that opens the complete, deduplicated file list in an accessible, scrollable dialog.
- Preserve the existing unlimited `FileRow` behavior for chat attachments, context files, and code-interpreter files.

Closes #15238

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/components/Chat/Input/Files/__tests__/FileRow.spec.tsx src/components/SidePanel/Agents/__tests__/FileSearch.spec.tsx --runInBand --coverage=false --forceExit` — 27 tests passed
- `npm run typecheck` in `client`
- ESLint, Prettier, and import-order checks on all touched files
- `npm run build:data-provider`
- `npm run build:client-package`
- `npm run build` in `client`

### Test Configuration

- Node.js 24.16.0
- npm 11.13.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local focused unit tests pass with my changes
