### PR TITLE
🔣 fix: Escape SPA Language Attribute

### DIFF
--- a/api/server/csp.spec.js
+++ b/api/server/csp.spec.js
@@ -195,6 +195,14 @@ describe('Content Security Policy', () => {
     expect(response.headers['content-security-policy']).toContain("script-src 'nonce-");
   });
 
+  it('keeps replacement patterns in the language cookie as literal attribute text', async () => {
+    const response = await request(app).get('/').set('Cookie', 'lang=$&');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('<html lang="$&amp;">');
+    expect(response.text).not.toContain('<html lang="lang="en-US"">');
+  });
+
   it('carries deployment-specific sources and the clickjacking default', async () => {
     const csp = (await request(app).get('/')).headers['content-security-policy'];
 

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -19,6 +19,7 @@ const {
   applyCspNonce,
   createCspPolicy,
   shellCacheHeaders,
+  escapeHtmlAttribute,
   ErrorController,
   QUERY_DEVTOOLS_HEADER,
   createSecurityHeaders,
@@ -434,8 +435,8 @@ if (cluster.isMaster) {
       res.vary(QUERY_DEVTOOLS_HEADER);
 
       const lang = req.cookies.lang || req.headers['accept-language']?.split(',')[0] || 'en-US';
-      const saneLang = lang.replace(/"/g, '&quot;');
-      let updatedIndexHtml = indexHTML.replace(/lang="en-US"/g, `lang="${saneLang}"`);
+      const saneLang = escapeHtmlAttribute(lang);
+      let updatedIndexHtml = indexHTML.replace(/lang="en-US"/g, () => `lang="${saneLang}"`);
       updatedIndexHtml = maybeInjectQueryDevtoolsBootstrap(updatedIndexHtml, req);
 
       /* Nonce last: every injected script above must be stamped too. */

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -20,6 +20,7 @@ const {
   applyCspNonce,
   createCspPolicy,
   shellCacheHeaders,
+  escapeHtmlAttribute,
   ErrorController,
   memoryDiagnostics,
   createSecurityHeaders,
@@ -252,8 +253,8 @@ const startServer = async () => {
     res.vary(QUERY_DEVTOOLS_HEADER);
 
     const lang = req.cookies.lang || req.headers['accept-language']?.split(',')[0] || 'en-US';
-    const saneLang = lang.replace(/"/g, '&quot;');
-    let updatedIndexHtml = indexHTML.replace(/lang="en-US"/g, `lang="${saneLang}"`);
+    const saneLang = escapeHtmlAttribute(lang);
+    let updatedIndexHtml = indexHTML.replace(/lang="en-US"/g, () => `lang="${saneLang}"`);
     updatedIndexHtml = maybeInjectQueryDevtoolsBootstrap(updatedIndexHtml, req);
 
     /* Nonce last: every injected script above must be stamped too. */

--- a/packages/api/src/security/html.spec.ts
+++ b/packages/api/src/security/html.spec.ts
@@ -1,0 +1,7 @@
+import { escapeHtmlAttribute } from './html';
+
+describe('escapeHtmlAttribute', () => {
+  it('escapes all characters that can alter a quoted attribute', () => {
+    expect(escapeHtmlAttribute(`$&<>'"`)).toBe('$&amp;&lt;&gt;&#39;&quot;');
+  });
+});

--- a/packages/api/src/security/html.ts
+++ b/packages/api/src/security/html.ts
@@ -1,0 +1,12 @@
+const HTML_ATTRIBUTE_ENTITIES: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/** Escapes text before interpolating it into a quoted HTML attribute. */
+export function escapeHtmlAttribute(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => HTML_ATTRIBUTE_ENTITIES[character]);
+}

--- a/packages/api/src/security/index.ts
+++ b/packages/api/src/security/index.ts
@@ -1,3 +1,4 @@
 export * from './env';
 export * from './headers';
 export * from './csp';
+export * from './html';


### PR DESCRIPTION
## Summary

I fixed reflected HTML injection in the SPA shell language attribute.

- Escape all attribute-sensitive characters before interpolating the language cookie or request header.
- Use function-based replacement so JavaScript replacement patterns such as `$&` remain literal text.
- Cover the escaping helper and a server response using a `$&` language cookie.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && NODE_PATH=/Users/danny/.codex/worktrees/ai-1716-librechat/node_modules /Users/danny/.codex/worktrees/ai-1716-librechat/node_modules/.bin/jest src/security/html.spec.ts --runInBand --coverage=false`
- `git diff --check`

## Checklist

- [x] My code adheres to this project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective