### PR TITLE
💍 fix: Keep SAML Accounts Bound to Their Original NameID

### DIFF
--- a/api/strategies/samlStrategy.js
+++ b/api/strategies/samlStrategy.js
@@ -216,6 +216,15 @@ function createSamlCallback(existingUsersOnly = false) {
         });
       }
 
+      if (user?.samlId && user.samlId !== profile.nameID) {
+        logger.warn(
+          `[samlStrategy] Refused SAML login with a different NameID for user: ${user.email}`,
+        );
+        return done(null, false, {
+          message: ErrorTypes.AUTH_FAILED,
+        });
+      }
+
       const appConfig = user?.tenantId
         ? await resolveAppConfigForUser(getAppConfig, user)
         : baseConfig;

--- a/api/strategies/samlStrategy.spec.js
+++ b/api/strategies/samlStrategy.spec.js
@@ -7,6 +7,7 @@ jest.mock('@librechat/data-schemas', () => ({
   logger: {
     info: jest.fn(),
     debug: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn(),
   },
   hashToken: jest.fn().mockResolvedValue('hashed-token'),
@@ -424,6 +425,23 @@ u7wlOSk+oFzDIO/UILIA
     expect(user.username).toBe(baseProfile.username);
     expect(user.name).toBe(`${baseProfile.given_name} ${baseProfile.family_name}`);
     expect(user.email).toBe(baseProfile.email);
+  });
+
+  it('should reject an email match bound to a different NameID', async () => {
+    const { findUser, updateUser } = require('~/models');
+    const existingUser = {
+      _id: 'existing-user-id',
+      provider: 'saml',
+      email: baseProfile.email,
+      samlId: 'original-name-id',
+    };
+    findUser.mockResolvedValueOnce(null).mockResolvedValueOnce(existingUser);
+
+    const result = await validate(baseProfile);
+
+    expect(result.user).toBe(false);
+    expect(result.details.message).toBe(require('librechat-data-provider').ErrorTypes.AUTH_FAILED);
+    expect(updateUser).not.toHaveBeenCalled();
   });
 
   it('should block login when email exists with different provider', async () => {


### PR DESCRIPTION
## Summary

I prevent a SAML email fallback from rebinding an existing account to a different identity-provider NameID.

- Reject SAML authentication when an email-matched account is already bound to a different NameID.
- Preserve first-time NameID linking for legacy SAML accounts without a binding.
- Add a regression test that verifies no user update occurs on a mismatch.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran syntax validation and attempted the focused SAML test suite.

### **Test Configuration**:

- `node --check api/strategies/samlStrategy.js`
- `npm --prefix api exec -- jest strategies/samlStrategy.spec.js --runInBand` *(blocked before test execution because this worktree lacks the existing `node-fetch` dependency)*

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas where needed
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [ ] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.