### PR TITLE
🪢 feat: show Langfuse session link in shared chats

### DIFF
--- a/api/server/middleware/roles/capabilities.js
+++ b/api/server/middleware/roles/capabilities.js
@@ -3,26 +3,28 @@ const {
   getUserPrincipals,
   hasAnyConfigReadAccess,
   hasCapabilityForPrincipals,
-  getHeldCapabilities,
+  getHeldCapabilities: getHeldCapabilitiesForPrincipals,
 } = require('~/models');
 
 const {
   hasCapability,
   requireCapability,
   hasConfigCapability,
+  getHeldCapabilities,
   hasAnyConfigReadAccess: checkAnyConfigReadAccess,
   getReadableConfigSections,
 } = generateCapabilityCheck({
   getUserPrincipals,
   hasAnyConfigReadAccess,
   hasCapabilityForPrincipals,
-  getHeldCapabilities,
+  getHeldCapabilities: getHeldCapabilitiesForPrincipals,
 });
 
 module.exports = {
   hasCapability,
   requireCapability,
   hasConfigCapability,
+  getHeldCapabilities,
   capabilityContextMiddleware,
   hasAnyConfigReadAccess: checkAnyConfigReadAccess,
   getReadableConfigSections,

--- a/api/server/routes/__tests__/share.spec.js
+++ b/api/server/routes/__tests__/share.spec.js
@@ -10,7 +10,7 @@ const mockSharedLinkConfigMiddleware = jest.fn((_req, _res, next) => next());
 let mockShareTenantId;
 const mockHasCapability = jest.fn();
 const mockHasConfigCapability = jest.fn();
-const mockResolveLangfuseSessionUrl = jest.fn();
+const mockGetSharedLangfuseSessionUrl = jest.fn();
 const mockBuildSharedLinkStartupPayload = jest.fn();
 const mockCanAccessSharedLink = jest.fn((req, _res, next) => {
   req.shareResourceId = 'resource-123';
@@ -98,7 +98,11 @@ jest.mock('@librechat/api', () => ({
   buildShareFileEtag: (file) =>
     `"share-${file.file_id}-${file.previewRevision ?? 0}-${file.bytes ?? 0}-${file.filepath ?? ''}"`,
   MAX_SHARED_LINK_SEARCH_LENGTH: 256,
-  resolveLangfuseSessionUrl: (...args) => mockResolveLangfuseSessionUrl(...args),
+  createSharedLangfuseSessionResolver: jest.fn(
+    () =>
+      (...args) =>
+        mockGetSharedLangfuseSessionUrl(...args),
+  ),
   isContentFilterError: jest.fn(
     (error) =>
       error?.code === 'content_filter_block' || error?.code === 'content_filter_uninspectable',
@@ -295,7 +299,7 @@ describe('share routes', () => {
     mockShareTenantId = undefined;
     mockHasCapability.mockResolvedValue(false);
     mockHasConfigCapability.mockResolvedValue(false);
-    mockResolveLangfuseSessionUrl.mockResolvedValue(null);
+    mockGetSharedLangfuseSessionUrl.mockResolvedValue(null);
     mockGetAppConfig.mockResolvedValue({
       interfaceConfig: {
         privacyPolicy: { externalUrl: 'https://example.com/privacy' },
@@ -373,9 +377,7 @@ describe('share routes', () => {
 
   it('includes the source conversation session for an admin in the share tenant', async () => {
     mockShareTenantId = 'tenant-abc';
-    mockHasCapability.mockResolvedValue(true);
-    mockHasConfigCapability.mockResolvedValue(true);
-    mockResolveLangfuseSessionUrl.mockResolvedValue(
+    mockGetSharedLangfuseSessionUrl.mockResolvedValue(
       'https://cloud.langfuse.com/project/project-1/sessions/conversation-owner-123',
     );
     mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
@@ -392,23 +394,16 @@ describe('share routes', () => {
     expect(response.body.langfuseSessionUrl).toBe(
       'https://cloud.langfuse.com/project/project-1/sessions/conversation-owner-123',
     );
-    expect(mockHasCapability).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
-      'access:admin',
-    );
-    expect(mockHasConfigCapability).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
-      'langfuse',
-    );
-    expect(mockResolveLangfuseSessionUrl).toHaveBeenCalledWith({
+    expect(mockGetSharedLangfuseSessionUrl).toHaveBeenCalledWith({
+      viewer: expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
+      shareTenantId: 'tenant-abc',
+      shareConversationId: 'conversation-owner-123',
+      shareOwnerId: 'owner-123',
       config: langfuse,
-      conversationId: 'conversation-owner-123',
-      userId: 'owner-123',
-      getMessages: expect.any(Function),
     });
   });
 
-  it('does not expose a session link to a non-admin in the share tenant', async () => {
+  it('omits the session link when the shared-session resolver denies access', async () => {
     mockShareTenantId = 'tenant-abc';
     mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
 
@@ -418,47 +413,11 @@ describe('share routes', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).not.toHaveProperty('langfuseSessionUrl');
-    expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
-  });
-
-  it('does not expose a session link to an admin without Langfuse config access', async () => {
-    mockShareTenantId = 'tenant-abc';
-    mockHasCapability.mockResolvedValue(true);
-    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
-
-    const response = await request(
-      buildApp({ user: { id: 'admin-123', role: 'ADMIN', tenantId: 'tenant-abc' } }),
-    ).get('/api/share/share-123');
-
-    expect(response.status).toBe(200);
-    expect(response.body).not.toHaveProperty('langfuseSessionUrl');
-    expect(mockHasConfigCapability).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
-      'langfuse',
-    );
-    expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
-  });
-
-  it('does not expose a session link to an admin from another tenant', async () => {
-    mockShareTenantId = 'tenant-owner';
-    mockHasCapability.mockResolvedValue(true);
-    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
-
-    const response = await request(
-      buildApp({ user: { id: 'admin-123', role: 'ADMIN', tenantId: 'tenant-viewer' } }),
-    ).get('/api/share/share-123');
-
-    expect(response.status).toBe(200);
-    expect(response.body).not.toHaveProperty('langfuseSessionUrl');
-    expect(mockHasCapability).not.toHaveBeenCalled();
-    expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
   });
 
   it('serves the shared chat when session-link resolution fails', async () => {
     mockShareTenantId = 'tenant-abc';
-    mockHasCapability.mockResolvedValue(true);
-    mockHasConfigCapability.mockResolvedValue(true);
-    mockResolveLangfuseSessionUrl.mockRejectedValue(new Error('Langfuse lookup failed'));
+    mockGetSharedLangfuseSessionUrl.mockRejectedValue(new Error('Langfuse lookup failed'));
     mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
 
     const response = await request(

--- a/api/server/routes/__tests__/share.spec.js
+++ b/api/server/routes/__tests__/share.spec.js
@@ -8,10 +8,14 @@ const mockUpdateSharedLinkPermissionsExpiration = jest.fn();
 const mockSharedLinksAccess = jest.fn((_req, _res, next) => next());
 const mockSharedLinkConfigMiddleware = jest.fn((_req, _res, next) => next());
 let mockShareTenantId;
+const mockHasCapability = jest.fn();
+const mockResolveLangfuseSessionUrl = jest.fn();
 const mockBuildSharedLinkStartupPayload = jest.fn();
 const mockCanAccessSharedLink = jest.fn((req, _res, next) => {
   req.shareResourceId = 'resource-123';
   req.shareTenantId = mockShareTenantId;
+  req.shareConversationId = 'conversation-owner-123';
+  req.shareOwnerId = 'owner-123';
   next();
 });
 const mockGetAppConfig = jest.fn();
@@ -93,6 +97,7 @@ jest.mock('@librechat/api', () => ({
   buildShareFileEtag: (file) =>
     `"share-${file.file_id}-${file.previewRevision ?? 0}-${file.bytes ?? 0}-${file.filepath ?? ''}"`,
   MAX_SHARED_LINK_SEARCH_LENGTH: 256,
+  resolveLangfuseSessionUrl: (...args) => mockResolveLangfuseSessionUrl(...args),
   isContentFilterError: jest.fn(
     (error) =>
       error?.code === 'content_filter_block' || error?.code === 'content_filter_uninspectable',
@@ -105,6 +110,7 @@ jest.mock('@librechat/data-schemas', () => ({
   runAsSystem: jest.fn((fn) => fn()),
   tenantStorage: { run: jest.fn((_ctx, fn) => fn()) },
   SYSTEM_TENANT_ID: '__SYSTEM__',
+  SystemCapabilities: { ACCESS_ADMIN: 'access:admin' },
 }));
 
 jest.mock('librechat-data-provider', () => ({
@@ -151,7 +157,12 @@ jest.mock('~/models', () => ({
   getSharedLink: jest.fn(),
   getSharedLinkFile: jest.fn(),
   backfillSharedLinkFiles: jest.fn(),
+  getMessages: jest.fn(),
   getRoleByName: jest.fn(),
+}));
+
+jest.mock('~/server/middleware/roles/capabilities', () => ({
+  hasCapability: (...args) => mockHasCapability(...args),
 }));
 
 const mockGetStrategyFunctions = jest.fn();
@@ -233,6 +244,7 @@ const buildApp = ({
   user = { id: 'user-123' },
   filters,
   messageFilter,
+  langfuse,
 } = {}) => {
   const app = express();
   app.use(express.json());
@@ -242,6 +254,7 @@ const buildApp = ({
       interfaceConfig: { retentionMode },
       ...(filters == null ? {} : { filters }),
       ...(messageFilter == null ? {} : { messageFilter }),
+      ...(langfuse == null ? {} : { langfuse }),
     };
     next();
   });
@@ -278,6 +291,8 @@ describe('share routes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockShareTenantId = undefined;
+    mockHasCapability.mockResolvedValue(false);
+    mockResolveLangfuseSessionUrl.mockResolvedValue(null);
     mockGetAppConfig.mockResolvedValue({
       interfaceConfig: {
         privacyPolicy: { externalUrl: 'https://example.com/privacy' },
@@ -351,6 +366,84 @@ describe('share routes', () => {
     expect(response.headers['cache-control']).toBe('private, no-store');
     expect(mockAssertConversationContentAllowed).not.toHaveBeenCalled();
     expect(mockAssertSharedFileMetadataAllowed).not.toHaveBeenCalled();
+  });
+
+  it('includes the source conversation session for an admin in the share tenant', async () => {
+    mockShareTenantId = 'tenant-abc';
+    mockHasCapability.mockResolvedValue(true);
+    mockResolveLangfuseSessionUrl.mockResolvedValue(
+      'https://cloud.langfuse.com/project/project-1/sessions/conversation-owner-123',
+    );
+    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
+    const langfuse = { enabled: true, destination: 'eu', projectId: 'project-1' };
+
+    const response = await request(
+      buildApp({
+        user: { id: 'admin-123', role: 'ADMIN', tenantId: 'tenant-abc' },
+        langfuse,
+      }),
+    ).get('/api/share/share-123');
+
+    expect(response.status).toBe(200);
+    expect(response.body.langfuseSessionUrl).toBe(
+      'https://cloud.langfuse.com/project/project-1/sessions/conversation-owner-123',
+    );
+    expect(mockHasCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
+      'access:admin',
+    );
+    expect(mockResolveLangfuseSessionUrl).toHaveBeenCalledWith({
+      config: langfuse,
+      conversationId: 'conversation-owner-123',
+      userId: 'owner-123',
+      getMessages: expect.any(Function),
+    });
+  });
+
+  it('does not expose a session link to a non-admin in the share tenant', async () => {
+    mockShareTenantId = 'tenant-abc';
+    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
+
+    const response = await request(
+      buildApp({ user: { id: 'user-123', role: 'USER', tenantId: 'tenant-abc' } }),
+    ).get('/api/share/share-123');
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toHaveProperty('langfuseSessionUrl');
+    expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not expose a session link to an admin from another tenant', async () => {
+    mockShareTenantId = 'tenant-owner';
+    mockHasCapability.mockResolvedValue(true);
+    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
+
+    const response = await request(
+      buildApp({ user: { id: 'admin-123', role: 'ADMIN', tenantId: 'tenant-viewer' } }),
+    ).get('/api/share/share-123');
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toHaveProperty('langfuseSessionUrl');
+    expect(mockHasCapability).not.toHaveBeenCalled();
+    expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
+  });
+
+  it('serves the shared chat when session-link resolution fails', async () => {
+    mockShareTenantId = 'tenant-abc';
+    mockHasCapability.mockResolvedValue(true);
+    mockResolveLangfuseSessionUrl.mockRejectedValue(new Error('Langfuse lookup failed'));
+    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
+
+    const response = await request(
+      buildApp({ user: { id: 'admin-123', role: 'ADMIN', tenantId: 'tenant-abc' } }),
+    ).get('/api/share/share-123');
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toHaveProperty('langfuseSessionUrl');
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[share] Failed to resolve Langfuse session link:',
+      expect.any(Error),
+    );
   });
 
   it('normalizes shared-link list parameters without double-decoding search text', async () => {

--- a/api/server/routes/__tests__/share.spec.js
+++ b/api/server/routes/__tests__/share.spec.js
@@ -432,6 +432,31 @@ describe('share routes', () => {
     );
   });
 
+  it('resolves the session link while loading the shared snapshot', async () => {
+    let resolveShare;
+    let markShareStarted;
+    const shareStarted = new Promise((resolve) => {
+      markShareStarted = resolve;
+    });
+    const pendingShare = new Promise((resolve) => {
+      resolveShare = resolve;
+    });
+    getSharedMessages.mockImplementationOnce(() => {
+      markShareStarted();
+      return pendingShare;
+    });
+    mockGetSharedLangfuseSessionUrl.mockResolvedValue(null);
+
+    const responsePromise = request(buildApp())
+      .get('/api/share/share-123')
+      .then((response) => response);
+    await shareStarted;
+
+    expect(mockGetSharedLangfuseSessionUrl).toHaveBeenCalledTimes(1);
+    resolveShare({ shareId: 'share-123', messages: [] });
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 });
+  });
+
   it('normalizes shared-link list parameters without double-decoding search text', async () => {
     getSharedLinks.mockResolvedValue({ links: [], hasNextPage: false });
     mockParseSharedLinksPageSize.mockReturnValueOnce(100);

--- a/api/server/routes/__tests__/share.spec.js
+++ b/api/server/routes/__tests__/share.spec.js
@@ -9,6 +9,7 @@ const mockSharedLinksAccess = jest.fn((_req, _res, next) => next());
 const mockSharedLinkConfigMiddleware = jest.fn((_req, _res, next) => next());
 let mockShareTenantId;
 const mockHasCapability = jest.fn();
+const mockHasConfigCapability = jest.fn();
 const mockResolveLangfuseSessionUrl = jest.fn();
 const mockBuildSharedLinkStartupPayload = jest.fn();
 const mockCanAccessSharedLink = jest.fn((req, _res, next) => {
@@ -163,6 +164,7 @@ jest.mock('~/models', () => ({
 
 jest.mock('~/server/middleware/roles/capabilities', () => ({
   hasCapability: (...args) => mockHasCapability(...args),
+  hasConfigCapability: (...args) => mockHasConfigCapability(...args),
 }));
 
 const mockGetStrategyFunctions = jest.fn();
@@ -292,6 +294,7 @@ describe('share routes', () => {
     jest.clearAllMocks();
     mockShareTenantId = undefined;
     mockHasCapability.mockResolvedValue(false);
+    mockHasConfigCapability.mockResolvedValue(false);
     mockResolveLangfuseSessionUrl.mockResolvedValue(null);
     mockGetAppConfig.mockResolvedValue({
       interfaceConfig: {
@@ -371,6 +374,7 @@ describe('share routes', () => {
   it('includes the source conversation session for an admin in the share tenant', async () => {
     mockShareTenantId = 'tenant-abc';
     mockHasCapability.mockResolvedValue(true);
+    mockHasConfigCapability.mockResolvedValue(true);
     mockResolveLangfuseSessionUrl.mockResolvedValue(
       'https://cloud.langfuse.com/project/project-1/sessions/conversation-owner-123',
     );
@@ -391,6 +395,10 @@ describe('share routes', () => {
     expect(mockHasCapability).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
       'access:admin',
+    );
+    expect(mockHasConfigCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
+      'langfuse',
     );
     expect(mockResolveLangfuseSessionUrl).toHaveBeenCalledWith({
       config: langfuse,
@@ -413,6 +421,24 @@ describe('share routes', () => {
     expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
   });
 
+  it('does not expose a session link to an admin without Langfuse config access', async () => {
+    mockShareTenantId = 'tenant-abc';
+    mockHasCapability.mockResolvedValue(true);
+    mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
+
+    const response = await request(
+      buildApp({ user: { id: 'admin-123', role: 'ADMIN', tenantId: 'tenant-abc' } }),
+    ).get('/api/share/share-123');
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toHaveProperty('langfuseSessionUrl');
+    expect(mockHasConfigCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin-123', tenantId: 'tenant-abc' }),
+      'langfuse',
+    );
+    expect(mockResolveLangfuseSessionUrl).not.toHaveBeenCalled();
+  });
+
   it('does not expose a session link to an admin from another tenant', async () => {
     mockShareTenantId = 'tenant-owner';
     mockHasCapability.mockResolvedValue(true);
@@ -431,6 +457,7 @@ describe('share routes', () => {
   it('serves the shared chat when session-link resolution fails', async () => {
     mockShareTenantId = 'tenant-abc';
     mockHasCapability.mockResolvedValue(true);
+    mockHasConfigCapability.mockResolvedValue(true);
     mockResolveLangfuseSessionUrl.mockRejectedValue(new Error('Langfuse lookup failed'));
     mockSharedMessagesResult({ shareId: 'share-123', messages: [] });
 

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -20,14 +20,12 @@ const {
   isValidSharedLinksCursor,
   MAX_SHARED_LINK_SEARCH_LENGTH,
   createSharedLinkConfigMiddleware,
-  resolveLangfuseSessionUrl,
+  createSharedLangfuseSessionResolver,
 } = require('@librechat/api');
 const {
   logger,
   runAsSystem,
   tenantStorage,
-  SYSTEM_TENANT_ID,
-  SystemCapabilities,
   createTempChatExpirationDate,
 } = require('@librechat/data-schemas');
 const { FileSources, PermissionTypes, Permissions } = require('librechat-data-provider');
@@ -58,41 +56,11 @@ const { getAppConfig } = require('~/server/services/Config/app');
 const router = express.Router();
 const sharedLinkConfigMiddleware = createSharedLinkConfigMiddleware({ getAppConfig });
 
-const normalizedTenantId = (tenantId) =>
-  tenantId && tenantId !== SYSTEM_TENANT_ID ? tenantId : undefined;
-
-const getSharedLangfuseSessionUrl = async (req) => {
-  const userId = req.user?.id ?? req.user?._id?.toString();
-  if (
-    !userId ||
-    normalizedTenantId(req.user?.tenantId) !== normalizedTenantId(req.shareTenantId) ||
-    !req.shareOwnerId ||
-    !req.shareConversationId
-  ) {
-    return null;
-  }
-
-  const capabilityUser = {
-    id: userId,
-    role: req.user.role ?? '',
-    tenantId: req.user.tenantId,
-    idOnTheSource: req.user.idOnTheSource ?? null,
-  };
-  const isAdmin = await hasCapability(capabilityUser, SystemCapabilities.ACCESS_ADMIN);
-  if (!isAdmin) {
-    return null;
-  }
-  if (!(await hasConfigCapability(capabilityUser, 'langfuse'))) {
-    return null;
-  }
-
-  return resolveLangfuseSessionUrl({
-    config: req.config?.langfuse,
-    conversationId: req.shareConversationId,
-    userId: req.shareOwnerId,
-    getMessages,
-  });
-};
+const getSharedLangfuseSessionUrl = createSharedLangfuseSessionResolver({
+  hasCapability,
+  hasConfigCapability,
+  getMessages,
+});
 
 const SHARE_SERVICE_ERROR_STATUS = {
   INVALID_PARAMS: 400,
@@ -385,7 +353,13 @@ if (allowSharedLinks) {
         if (share) {
           let langfuseSessionUrl = null;
           try {
-            langfuseSessionUrl = await getSharedLangfuseSessionUrl(req);
+            langfuseSessionUrl = await getSharedLangfuseSessionUrl({
+              viewer: req.user,
+              shareTenantId: req.shareTenantId,
+              shareConversationId: req.shareConversationId,
+              shareOwnerId: req.shareOwnerId,
+              config: req.config?.langfuse,
+            });
           } catch (error) {
             logger.warn('[share] Failed to resolve Langfuse session link:', error);
           }

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -52,7 +52,7 @@ const { createForkLimiters } = require('~/server/middleware/limiters');
 const optionalShareFileAuth = require('~/server/middleware/optionalShareFileAuth');
 const optionalJwtAuth = require('~/server/middleware/optionalJwtAuth');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
-const { hasCapability } = require('~/server/middleware/roles/capabilities');
+const { hasCapability, hasConfigCapability } = require('~/server/middleware/roles/capabilities');
 const configMiddleware = require('~/server/middleware/config/app');
 const { getAppConfig } = require('~/server/services/Config/app');
 const router = express.Router();
@@ -72,16 +72,17 @@ const getSharedLangfuseSessionUrl = async (req) => {
     return null;
   }
 
-  const isAdmin = await hasCapability(
-    {
-      id: userId,
-      role: req.user.role ?? '',
-      tenantId: req.user.tenantId,
-      idOnTheSource: req.user.idOnTheSource ?? null,
-    },
-    SystemCapabilities.ACCESS_ADMIN,
-  );
+  const capabilityUser = {
+    id: userId,
+    role: req.user.role ?? '',
+    tenantId: req.user.tenantId,
+    idOnTheSource: req.user.idOnTheSource ?? null,
+  };
+  const isAdmin = await hasCapability(capabilityUser, SystemCapabilities.ACCESS_ADMIN);
   if (!isAdmin) {
+    return null;
+  }
+  if (!(await hasConfigCapability(capabilityUser, 'langfuse'))) {
     return null;
   }
 

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -344,25 +344,27 @@ if (allowSharedLinks) {
           sharedFileMetadata: true,
           legacyPii: req.config?.messageFilter?.pii,
         });
-        const share = await getSharedMessages(req.params.shareId, req.shareResourceId, {
+        const sharePromise = getSharedMessages(req.params.shareId, req.shareResourceId, {
           // Viewer-independent: the per-link choice (stored on the share) decides
           // file inclusion; only a global env kill switch can force it off here.
           snapshotFiles: !isFileSnapshotKillSwitchActive(),
           preflight: contentPreflight,
         });
+        const langfuseSessionPromise = getSharedLangfuseSessionUrl({
+          viewer: req.user,
+          shareTenantId: req.shareTenantId,
+          shareConversationId: req.shareConversationId,
+          shareOwnerId: req.shareOwnerId,
+          config: req.config?.langfuse,
+        }).catch((error) => {
+          logger.warn('[share] Failed to resolve Langfuse session link:', error);
+          return null;
+        });
+        const [share, langfuseSessionUrl] = await Promise.all([
+          sharePromise,
+          langfuseSessionPromise,
+        ]);
         if (share) {
-          let langfuseSessionUrl = null;
-          try {
-            langfuseSessionUrl = await getSharedLangfuseSessionUrl({
-              viewer: req.user,
-              shareTenantId: req.shareTenantId,
-              shareConversationId: req.shareConversationId,
-              shareOwnerId: req.shareOwnerId,
-              config: req.config?.langfuse,
-            });
-          } catch (error) {
-            logger.warn('[share] Failed to resolve Langfuse session link:', error);
-          }
           res.set('Cache-Control', 'private, no-store');
           res
             .status(200)

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -50,15 +50,14 @@ const { createForkLimiters } = require('~/server/middleware/limiters');
 const optionalShareFileAuth = require('~/server/middleware/optionalShareFileAuth');
 const optionalJwtAuth = require('~/server/middleware/optionalJwtAuth');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
-const { hasCapability, hasConfigCapability } = require('~/server/middleware/roles/capabilities');
+const { getHeldCapabilities } = require('~/server/middleware/roles/capabilities');
 const configMiddleware = require('~/server/middleware/config/app');
 const { getAppConfig } = require('~/server/services/Config/app');
 const router = express.Router();
 const sharedLinkConfigMiddleware = createSharedLinkConfigMiddleware({ getAppConfig });
 
 const getSharedLangfuseSessionUrl = createSharedLangfuseSessionResolver({
-  hasCapability,
-  hasConfigCapability,
+  getHeldCapabilities,
   getMessages,
 });
 

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -20,11 +20,14 @@ const {
   isValidSharedLinksCursor,
   MAX_SHARED_LINK_SEARCH_LENGTH,
   createSharedLinkConfigMiddleware,
+  resolveLangfuseSessionUrl,
 } = require('@librechat/api');
 const {
   logger,
   runAsSystem,
   tenantStorage,
+  SYSTEM_TENANT_ID,
+  SystemCapabilities,
   createTempChatExpirationDate,
 } = require('@librechat/data-schemas');
 const { FileSources, PermissionTypes, Permissions } = require('librechat-data-provider');
@@ -38,6 +41,7 @@ const {
   getSharedLink,
   getSharedLinkFile,
   backfillSharedLinkFiles,
+  getMessages,
   getRoleByName,
 } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
@@ -48,10 +52,46 @@ const { createForkLimiters } = require('~/server/middleware/limiters');
 const optionalShareFileAuth = require('~/server/middleware/optionalShareFileAuth');
 const optionalJwtAuth = require('~/server/middleware/optionalJwtAuth');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
+const { hasCapability } = require('~/server/middleware/roles/capabilities');
 const configMiddleware = require('~/server/middleware/config/app');
 const { getAppConfig } = require('~/server/services/Config/app');
 const router = express.Router();
 const sharedLinkConfigMiddleware = createSharedLinkConfigMiddleware({ getAppConfig });
+
+const normalizedTenantId = (tenantId) =>
+  tenantId && tenantId !== SYSTEM_TENANT_ID ? tenantId : undefined;
+
+const getSharedLangfuseSessionUrl = async (req) => {
+  const userId = req.user?.id ?? req.user?._id?.toString();
+  if (
+    !userId ||
+    normalizedTenantId(req.user?.tenantId) !== normalizedTenantId(req.shareTenantId) ||
+    !req.shareOwnerId ||
+    !req.shareConversationId
+  ) {
+    return null;
+  }
+
+  const isAdmin = await hasCapability(
+    {
+      id: userId,
+      role: req.user.role ?? '',
+      tenantId: req.user.tenantId,
+      idOnTheSource: req.user.idOnTheSource ?? null,
+    },
+    SystemCapabilities.ACCESS_ADMIN,
+  );
+  if (!isAdmin) {
+    return null;
+  }
+
+  return resolveLangfuseSessionUrl({
+    config: req.config?.langfuse,
+    conversationId: req.shareConversationId,
+    userId: req.shareOwnerId,
+    getMessages,
+  });
+};
 
 const SHARE_SERVICE_ERROR_STATUS = {
   INVALID_PARAMS: 400,
@@ -342,8 +382,16 @@ if (allowSharedLinks) {
           preflight: contentPreflight,
         });
         if (share) {
+          let langfuseSessionUrl = null;
+          try {
+            langfuseSessionUrl = await getSharedLangfuseSessionUrl(req);
+          } catch (error) {
+            logger.warn('[share] Failed to resolve Langfuse session link:', error);
+          }
           res.set('Cache-Control', 'private, no-store');
-          res.status(200).json(share);
+          res
+            .status(200)
+            .json(langfuseSessionUrl == null ? share : { ...share, langfuseSessionUrl });
         } else {
           res.status(404).end();
         }

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -491,6 +491,7 @@ export type TAuthContext = {
   user: t.TUser | undefined;
   token: string | undefined;
   isAuthenticated: boolean;
+  isAuthReady: boolean;
   error: string | undefined;
   login: (data: t.TLoginUser) => void;
   logout: (redirect?: string) => void;
@@ -508,6 +509,7 @@ export type TUserContext = {
 export type TAuthConfig = {
   loginRedirect: string;
   test?: boolean;
+  optional?: boolean;
 };
 
 export type IconProps = Pick<t.TMessage, 'isCreatedByUser' | 'model'> &

--- a/client/src/components/Share/ShareView.spec.tsx
+++ b/client/src/components/Share/ShareView.spec.tsx
@@ -24,6 +24,7 @@ describe('ShareHeader', () => {
     const link = screen.getByRole('link', { name: 'View session in Langfuse' });
     expect(link).toHaveAttribute('href', url);
     expect(link).toHaveAttribute('target', '_blank');
+    expect(link.parentElement).toHaveClass('flex-wrap');
   });
 
   it('omits the Langfuse action when the server does not supply a session', () => {

--- a/client/src/components/Share/ShareView.spec.tsx
+++ b/client/src/components/Share/ShareView.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { ShareHeader } from './ShareView';
+
+const defaultProps = {
+  title: 'Shared conversation',
+  formattedDate: 'August 27, 2026',
+  theme: 'system',
+  langcode: 'en-US',
+  settingsLabel: 'Settings',
+  continueLabel: 'Continue chat',
+  langfuseSessionLabel: 'View session in Langfuse',
+  isContinuing: false,
+  onContinue: jest.fn(),
+  onThemeChange: jest.fn(),
+  onLangChange: jest.fn(),
+};
+
+describe('ShareHeader', () => {
+  it('shows the Langfuse session as an external link when supplied', () => {
+    const url = 'https://cloud.langfuse.com/project/project-1/sessions/conversation-1';
+
+    render(<ShareHeader {...defaultProps} langfuseSessionUrl={url} />);
+
+    const link = screen.getByRole('link', { name: 'View session in Langfuse' });
+    expect(link).toHaveAttribute('href', url);
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('omits the Langfuse action when the server does not supply a session', () => {
+    render(<ShareHeader {...defaultProps} />);
+
+    expect(
+      screen.queryByRole('link', { name: 'View session in Langfuse' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -327,7 +327,7 @@ export function ShareHeader({
             )}
           </div>
 
-          <div className="flex items-center gap-2 md:self-start">
+          <div className="flex flex-wrap items-center justify-end gap-2 md:flex-nowrap md:self-start">
             {langfuseSessionUrl && (
               <Button
                 asChild

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -42,7 +42,7 @@ function SharedView() {
   const { isAuthReady } = useAuthContext();
   const { theme, setTheme } = useContext(ThemeContext);
   const { shareId } = useParams();
-  const { data: config } = useGetSharedStartupConfig(shareId);
+  const { data: config } = useGetSharedStartupConfig(shareId, { enabled: isAuthReady });
   const { data, isLoading, refetch } = useGetSharedMessages(shareId ?? '', {
     enabled: isAuthReady,
   });

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -173,7 +173,7 @@ function SharedView() {
   );
 
   let content: JSX.Element;
-  if (isLoading) {
+  if (!isAuthReady || isLoading) {
     content = (
       <div className="flex h-screen items-center justify-center">
         <Spinner className="" />

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -2,9 +2,9 @@ import { memo, useState, useCallback, useContext } from 'react';
 import Cookies from 'js-cookie';
 import { buildTree } from 'librechat-data-provider';
 import { useParams, useNavigate } from 'react-router-dom';
-import { CalendarDays, Settings, MessageSquarePlus } from 'lucide-react';
 import { useRecoilState, useRecoilValue, useRecoilCallback } from 'recoil';
 import { useGetSharedMessages } from 'librechat-data-provider/react-query';
+import { CalendarDays, ExternalLink, Settings, MessageSquarePlus } from 'lucide-react';
 import {
   Spinner,
   Button,
@@ -21,12 +21,12 @@ import {
 } from '@librechat/client';
 import SharedSubagentActivityDialog from '~/components/Chat/Subagents/SharedSubagentActivityDialog';
 import { cn, DEFAULT_APP_TITLE, getResponseStatus, selectActiveBranchTail } from '~/utils';
+import { useLocalize, useDocumentTitle, useAuthContext } from '~/hooks';
 import { ThemeSelector, LangSelector } from '~/components/Appearance';
 import { ShareMessagesProvider } from './ShareMessagesProvider';
 import { useForkSharedConvoMutation } from '~/data-provider';
 import { useGetSharedStartupConfig } from '~/data-provider';
 import { ShareArtifactsContainer } from './ShareArtifacts';
-import { useLocalize, useDocumentTitle } from '~/hooks';
 import { ShareContext } from '~/Providers';
 import MessagesView from './MessagesView';
 import Footer from '../Chat/Footer';
@@ -39,10 +39,13 @@ function SharedView() {
   const localize = useLocalize();
   const navigate = useNavigate();
   const { showToast } = useToastContext();
+  const { isAuthReady } = useAuthContext();
   const { theme, setTheme } = useContext(ThemeContext);
   const { shareId } = useParams();
   const { data: config } = useGetSharedStartupConfig(shareId);
-  const { data, isLoading, refetch } = useGetSharedMessages(shareId ?? '');
+  const { data, isLoading, refetch } = useGetSharedMessages(shareId ?? '', {
+    enabled: isAuthReady,
+  });
   const dataTree = data && buildTree({ messages: data.messages });
   const messagesTree = dataTree?.length === 0 ? null : (dataTree ?? null);
 
@@ -188,6 +191,8 @@ function SharedView() {
           onLangChange={handleLangChange}
           settingsLabel={localize('com_nav_settings')}
           continueLabel={localize('com_ui_continue_chat')}
+          langfuseSessionLabel={localize('com_ui_langfuse_view_session')}
+          langfuseSessionUrl={data.langfuseSessionUrl}
           onContinue={handleContinue}
           isContinuing={forkShare.isLoading}
         />
@@ -275,19 +280,23 @@ interface ShareHeaderProps {
   langcode: string;
   settingsLabel: string;
   continueLabel: string;
+  langfuseSessionLabel: string;
+  langfuseSessionUrl?: string;
   isContinuing: boolean;
   onContinue: () => void;
   onThemeChange: (value: string) => void;
   onLangChange: (value: string) => void;
 }
 
-function ShareHeader({
+export function ShareHeader({
   title,
   formattedDate,
   theme,
   langcode,
   settingsLabel,
   continueLabel,
+  langfuseSessionLabel,
+  langfuseSessionUrl,
   isContinuing,
   onContinue,
   onThemeChange,
@@ -319,6 +328,18 @@ function ShareHeader({
           </div>
 
           <div className="flex items-center gap-2 md:self-start">
+            {langfuseSessionUrl && (
+              <Button
+                asChild
+                variant="outline"
+                className="gap-2 rounded-full border-border-medium px-4 py-2 text-sm text-text-primary"
+              >
+                <a href={langfuseSessionUrl} target="_blank" rel="noopener noreferrer">
+                  <span>{langfuseSessionLabel}</span>
+                  <ExternalLink className="size-4 shrink-0" aria-hidden="true" />
+                </a>
+              </Button>
+            )}
             <Button
               type="button"
               variant="submit"

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -68,7 +68,7 @@ const AuthContextProvider = ({
   const [token, setToken] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const [isAuthReady, setIsAuthReady] = useState<boolean>(false);
+  const [isAuthReady, setIsAuthReady] = useState<boolean>(authConfig?.test === true);
   const setQueriesEnabled = useSetRecoilState<boolean>(store.queriesEnabled);
 
   const userRoleName = user?.role ?? '';

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -68,6 +68,7 @@ const AuthContextProvider = ({
   const [token, setToken] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [isAuthReady, setIsAuthReady] = useState<boolean>(false);
   const setQueriesEnabled = useSetRecoilState<boolean>(store.queriesEnabled);
 
   const userRoleName = user?.role ?? '';
@@ -93,6 +94,7 @@ const AuthContextProvider = ({
         setToken(token);
         setTokenHeader(token);
         setIsAuthenticated(isAuthenticated);
+        setIsAuthReady(true);
         if (isAuthenticated) {
           setQueriesEnabled(true);
           /** The clear on the way out latches retention shut so a DELETE that settles afterwards
@@ -235,10 +237,13 @@ const AuthContextProvider = ({
         }
         console.log('Token is not present. User is not authenticated.');
         endSessionClientState();
+        setIsAuthReady(true);
         if (authConfig?.test === true) {
           return;
         }
-        navigate(buildLoginRedirectUrl());
+        if (authConfig?.optional !== true) {
+          navigate(buildLoginRedirectUrl());
+        }
       },
       onError: (error) => {
         if (isExternalRedirectRef.current) {
@@ -246,10 +251,13 @@ const AuthContextProvider = ({
         }
         console.log('refreshToken mutation error:', error);
         endSessionClientState();
+        setIsAuthReady(true);
         if (authConfig?.test === true) {
           return;
         }
-        navigate(buildLoginRedirectUrl());
+        if (authConfig?.optional !== true) {
+          navigate(buildLoginRedirectUrl());
+        }
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are stable at mount; adding refreshToken causes infinite re-fire
@@ -264,7 +272,10 @@ const AuthContextProvider = ({
     } else if (userQuery.isError) {
       endSessionClientState();
       doSetError((userQuery.error as Error).message);
-      navigate(buildLoginRedirectUrl(), { replace: true });
+      setIsAuthReady(true);
+      if (authConfig?.optional !== true) {
+        navigate(buildLoginRedirectUrl(), { replace: true });
+      }
     }
     if (error != null && error && isAuthenticated) {
       doSetError(undefined);
@@ -319,6 +330,7 @@ const AuthContextProvider = ({
         ...(isCustomRole && customRole ? { [userRoleName]: customRole } : {}),
       },
       isAuthenticated,
+      isAuthReady,
     }),
 
     /** `login` is a plain function rebuilt every render, so depending on it would rebuild this
@@ -328,6 +340,7 @@ const AuthContextProvider = ({
       user,
       error,
       isAuthenticated,
+      isAuthReady,
       token,
       userRole,
       adminRole,

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -2,13 +2,11 @@
  * @jest-environment @happy-dom/jest-environment
  */
 import React from 'react';
-import { render, act } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
-
+import { render, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { TAuthConfig } from '~/common';
-
 import { AuthContextProvider, useAuthContext } from '../AuthContext';
 import { SESSION_KEY } from '~/utils';
 
@@ -75,6 +73,7 @@ function TestConsumer() {
     <div
       data-testid="consumer"
       data-authenticated={ctx.isAuthenticated}
+      data-auth-ready={ctx.isAuthReady}
       data-roles={JSON.stringify(ctx.roles ?? {})}
     />
   );
@@ -109,6 +108,24 @@ function renderProviderLive() {
       <RecoilRoot>
         <MemoryRouter>
           <AuthContextProvider authConfig={{ loginRedirect: '/login' }}>
+            <TestConsumer />
+          </AuthContextProvider>
+        </MemoryRouter>
+      </RecoilRoot>
+    </QueryClientProvider>,
+  );
+}
+
+function renderOptionalProvider() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <MemoryRouter>
+          <AuthContextProvider authConfig={{ loginRedirect: '/login', optional: true }}>
             <TestConsumer />
           </AuthContextProvider>
         </MemoryRouter>
@@ -359,6 +376,53 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
     expect(mockNavigate).not.toHaveBeenCalledWith('https://evil.com/steal', expect.anything());
     expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
     jest.useRealTimers();
+  });
+});
+
+describe('AuthContextProvider — optional authentication', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.replaceState({}, '', '/share/share-1');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('keeps a public route visible when no refresh token exists', () => {
+    renderOptionalProvider();
+
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
+    act(() => {
+      refreshOptions.onSuccess(undefined);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="consumer"]')).toHaveAttribute(
+      'data-auth-ready',
+      'true',
+    );
+  });
+
+  it('keeps a public route visible when session refresh fails', () => {
+    renderOptionalProvider();
+
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onError: (error: unknown) => void },
+    ];
+    act(() => {
+      refreshOptions.onError(new Error('No session'));
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="consumer"]')).toHaveAttribute(
+      'data-auth-ready',
+      'true',
+    );
   });
 });
 

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -134,6 +134,19 @@ function renderOptionalProvider() {
   );
 }
 
+describe('AuthContextProvider — test mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is ready without starting silent refresh', () => {
+    const { getByTestId } = renderProvider();
+
+    expect(getByTestId('consumer')).toHaveAttribute('data-auth-ready', 'true');
+    expect(mockRefreshMutate).not.toHaveBeenCalled();
+  });
+});
+
 describe('AuthContextProvider — login onError redirect handling', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/client/src/routes/ShareRoute.tsx
+++ b/client/src/routes/ShareRoute.tsx
@@ -1,5 +1,10 @@
+import { AuthContextProvider } from '~/hooks/AuthContext';
 import ShareView from '~/components/Share/ShareView';
 
 export default function ShareRoute() {
-  return <ShareView />;
+  return (
+    <AuthContextProvider authConfig={{ loginRedirect: '/login', optional: true }}>
+      <ShareView />
+    </AuthContextProvider>
+  );
 }

--- a/packages/api/src/admin/index.ts
+++ b/packages/api/src/admin/index.ts
@@ -1,5 +1,5 @@
 export { createAdminConfigHandlers } from './config';
-export { createAdminLangfuseHandlers, resolveLangfuseSessionUrl } from './langfuse';
+export { createAdminLangfuseHandlers } from './langfuse';
 export { createAdminGrantsHandlers } from './grants';
 export { createAdminGroupsHandlers } from './groups';
 export { createAdminRolesHandlers } from './roles';
@@ -8,7 +8,7 @@ export { createAdminUsersHandlers } from './users';
 export { createAdminAuditLogHandlers } from './auditLog';
 export { resolveConfigSecret, redactConfigSecretMaps } from './secrets';
 export type { AdminConfigDeps } from './config';
-export type { AdminLangfuseDeps, LangfuseSessionLinkParams } from './langfuse';
+export type { AdminLangfuseDeps } from './langfuse';
 export type { AdminGrantsDeps, GrantPrincipalType } from './grants';
 export type { AdminGroupsDeps } from './groups';
 export type { AdminRolesDeps } from './roles';

--- a/packages/api/src/admin/index.ts
+++ b/packages/api/src/admin/index.ts
@@ -1,5 +1,5 @@
 export { createAdminConfigHandlers } from './config';
-export { createAdminLangfuseHandlers } from './langfuse';
+export { createAdminLangfuseHandlers, resolveLangfuseSessionUrl } from './langfuse';
 export { createAdminGrantsHandlers } from './grants';
 export { createAdminGroupsHandlers } from './groups';
 export { createAdminRolesHandlers } from './roles';
@@ -8,7 +8,7 @@ export { createAdminUsersHandlers } from './users';
 export { createAdminAuditLogHandlers } from './auditLog';
 export { resolveConfigSecret, redactConfigSecretMaps } from './secrets';
 export type { AdminConfigDeps } from './config';
-export type { AdminLangfuseDeps } from './langfuse';
+export type { AdminLangfuseDeps, LangfuseSessionLinkParams } from './langfuse';
 export type { AdminGrantsDeps, GrantPrincipalType } from './grants';
 export type { AdminGroupsDeps } from './groups';
 export type { AdminRolesDeps } from './roles';

--- a/packages/api/src/admin/langfuse.ts
+++ b/packages/api/src/admin/langfuse.ts
@@ -74,6 +74,13 @@ export interface AdminLangfuseDeps {
   recordConnectionUpdate?: (event: LangfuseConnectionEvent) => void;
 }
 
+export interface LangfuseSessionLinkParams {
+  config: TCustomConfig['langfuse'];
+  conversationId: string;
+  userId: string;
+  getMessages: MessageMethods['getMessages'];
+}
+
 function getTenantId(req: ServerRequest): string | undefined {
   return (req.user as { tenantId?: string } | undefined)?.tenantId;
 }
@@ -133,6 +140,43 @@ function rejectWhenConnectionUnavailable(res: Response): Response | undefined {
   }
 
   return res.status(404).json({ error: 'Langfuse connection settings are not available' });
+}
+
+export async function resolveLangfuseSessionUrl({
+  config,
+  conversationId,
+  userId,
+  getMessages,
+}: LangfuseSessionLinkParams): Promise<string | null> {
+  if (!isLangfuseConnectionAvailable()) {
+    return null;
+  }
+
+  const destination = resolveLangfuseTenantDestination(config?.destination);
+  const projectId = config?.projectId?.trim();
+  if (config?.enabled !== true || !destination || !projectId) {
+    return null;
+  }
+
+  const destinationId = getLangfuseDestinationId(destination.baseUrl, projectId);
+  const messages = await getMessages(
+    {
+      user: userId,
+      conversationId,
+      langfuseSampled: true,
+      langfuseDestinationIds: destinationId,
+    },
+    '_id',
+    { sort: false, limit: 1 },
+  );
+  if (messages.length === 0) {
+    return null;
+  }
+
+  const sessionUrl = new URL(destination.baseUrl);
+  const basePath = sessionUrl.pathname.replace(/\/+$/, '');
+  sessionUrl.pathname = `${basePath}/project/${encodeURIComponent(projectId)}/sessions/${encodeURIComponent(conversationId)}`;
+  return sessionUrl.toString();
 }
 
 type LangfuseVerificationFailure = {
@@ -332,34 +376,13 @@ export function createAdminLangfuseHandlers(deps: AdminLangfuseDeps): {
     }
 
     try {
-      const stored = readStoredLangfuse(await findBaseConfig());
-      const destination = resolveLangfuseTenantDestination(stored?.destination);
-      const projectId = stored?.projectId?.trim();
-      if (stored?.enabled !== true || !destination || !projectId) {
-        const response: TLangfuseSessionLinkResponse = { url: null };
-        return res.status(200).json(response);
-      }
-
-      const destinationId = getLangfuseDestinationId(destination.baseUrl, projectId);
-      const messages = await getMessages(
-        {
-          user: userId,
-          conversationId,
-          langfuseSampled: true,
-          langfuseDestinationIds: destinationId,
-        },
-        '_id',
-        { sort: false, limit: 1 },
-      );
-      if (messages.length === 0) {
-        const response: TLangfuseSessionLinkResponse = { url: null };
-        return res.status(200).json(response);
-      }
-
-      const sessionUrl = new URL(destination.baseUrl);
-      const basePath = sessionUrl.pathname.replace(/\/+$/, '');
-      sessionUrl.pathname = `${basePath}/project/${encodeURIComponent(projectId)}/sessions/${encodeURIComponent(conversationId)}`;
-      const response: TLangfuseSessionLinkResponse = { url: sessionUrl.toString() };
+      const url = await resolveLangfuseSessionUrl({
+        config: readStoredLangfuse(await findBaseConfig()),
+        conversationId,
+        userId,
+        getMessages,
+      });
+      const response: TLangfuseSessionLinkResponse = { url };
       return res.status(200).json(response);
     } catch (error) {
       logger.error('[adminLangfuse] getSessionLink error:', error);

--- a/packages/api/src/admin/langfuse.ts
+++ b/packages/api/src/admin/langfuse.ts
@@ -18,10 +18,11 @@ import {
   getLangfuseTenantDestinations,
   resolveLangfuseTenantDestination,
 } from '~/langfuse/tenantDestinations';
-import { getLangfuseDestinationId, scopeHeadersToDestination } from '~/langfuse/destinations';
 import { redirectPolicyFor, resolveLangfuseHeaders } from '~/langfuse/utils';
 import { decryptConfigSecret, encryptConfigSecretFields } from './secrets';
+import { scopeHeadersToDestination } from '~/langfuse/destinations';
 import { isLangfuseConnectionAvailable } from '~/langfuse/policy';
+import { resolveLangfuseSessionUrl } from '~/langfuse/session';
 import { mergeHeaders } from '~/utils/headers';
 
 const DEFAULT_PRIORITY = 10;
@@ -72,13 +73,6 @@ export interface AdminLangfuseDeps {
   getMessages: MessageMethods['getMessages'];
   invalidateConfigCaches?: (tenantId?: string) => Promise<void>;
   recordConnectionUpdate?: (event: LangfuseConnectionEvent) => void;
-}
-
-export interface LangfuseSessionLinkParams {
-  config: TCustomConfig['langfuse'];
-  conversationId: string;
-  userId: string;
-  getMessages: MessageMethods['getMessages'];
 }
 
 function getTenantId(req: ServerRequest): string | undefined {
@@ -140,43 +134,6 @@ function rejectWhenConnectionUnavailable(res: Response): Response | undefined {
   }
 
   return res.status(404).json({ error: 'Langfuse connection settings are not available' });
-}
-
-export async function resolveLangfuseSessionUrl({
-  config,
-  conversationId,
-  userId,
-  getMessages,
-}: LangfuseSessionLinkParams): Promise<string | null> {
-  if (!isLangfuseConnectionAvailable()) {
-    return null;
-  }
-
-  const destination = resolveLangfuseTenantDestination(config?.destination);
-  const projectId = config?.projectId?.trim();
-  if (config?.enabled !== true || !destination || !projectId) {
-    return null;
-  }
-
-  const destinationId = getLangfuseDestinationId(destination.baseUrl, projectId);
-  const messages = await getMessages(
-    {
-      user: userId,
-      conversationId,
-      langfuseSampled: true,
-      langfuseDestinationIds: destinationId,
-    },
-    '_id',
-    { sort: false, limit: 1 },
-  );
-  if (messages.length === 0) {
-    return null;
-  }
-
-  const sessionUrl = new URL(destination.baseUrl);
-  const basePath = sessionUrl.pathname.replace(/\/+$/, '');
-  sessionUrl.pathname = `${basePath}/project/${encodeURIComponent(projectId)}/sessions/${encodeURIComponent(conversationId)}`;
-  return sessionUrl.toString();
 }
 
 type LangfuseVerificationFailure = {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -96,6 +96,7 @@ export * from './shared-links/service';
 export * from './shared-links/config';
 export * from './shared-links/http';
 export * from './shared-links/protection';
+export * from './shared-links/session';
 /* Stream */
 export * from './stream';
 /* Diagnostics */

--- a/packages/api/src/langfuse/index.ts
+++ b/packages/api/src/langfuse/index.ts
@@ -2,3 +2,4 @@ export * from './destinations';
 export * from './feedback';
 export * from './policy';
 export * from './trace';
+export * from './session';

--- a/packages/api/src/langfuse/session.ts
+++ b/packages/api/src/langfuse/session.ts
@@ -1,0 +1,49 @@
+import type { MessageMethods } from '@librechat/data-schemas';
+import type { TCustomConfig } from 'librechat-data-provider';
+import { resolveLangfuseTenantDestination } from './tenantDestinations';
+import { getLangfuseDestinationId } from './destinations';
+import { isLangfuseConnectionAvailable } from './policy';
+
+export interface LangfuseSessionLinkParams {
+  config: TCustomConfig['langfuse'];
+  conversationId: string;
+  userId: string;
+  getMessages: MessageMethods['getMessages'];
+}
+
+export async function resolveLangfuseSessionUrl({
+  config,
+  conversationId,
+  userId,
+  getMessages,
+}: LangfuseSessionLinkParams): Promise<string | null> {
+  if (!isLangfuseConnectionAvailable()) {
+    return null;
+  }
+
+  const destination = resolveLangfuseTenantDestination(config?.destination);
+  const projectId = config?.projectId?.trim();
+  if (config?.enabled !== true || !destination || !projectId) {
+    return null;
+  }
+
+  const destinationId = getLangfuseDestinationId(destination.baseUrl, projectId);
+  const messages = await getMessages(
+    {
+      user: userId,
+      conversationId,
+      langfuseSampled: true,
+      langfuseDestinationIds: destinationId,
+    },
+    '_id',
+    { sort: false, limit: 1 },
+  );
+  if (messages.length === 0) {
+    return null;
+  }
+
+  const sessionUrl = new URL(destination.baseUrl);
+  const basePath = sessionUrl.pathname.replace(/\/+$/, '');
+  sessionUrl.pathname = `${basePath}/project/${encodeURIComponent(projectId)}/sessions/${encodeURIComponent(conversationId)}`;
+  return sessionUrl.toString();
+}

--- a/packages/api/src/middleware/capabilities.spec.ts
+++ b/packages/api/src/middleware/capabilities.spec.ts
@@ -31,15 +31,47 @@ const userPrincipals = [
 describe('generateCapabilityCheck', () => {
   const mockGetUserPrincipals = jest.fn();
   const mockHasCapabilityForPrincipals = jest.fn();
+  const mockGetHeldCapabilities = jest.fn();
 
-  const { hasCapability, requireCapability, hasConfigCapability } = generateCapabilityCheck({
-    getUserPrincipals: mockGetUserPrincipals,
-    hasCapabilityForPrincipals: mockHasCapabilityForPrincipals,
-  });
+  const { hasCapability, requireCapability, hasConfigCapability, getHeldCapabilities } =
+    generateCapabilityCheck({
+      getUserPrincipals: mockGetUserPrincipals,
+      hasCapabilityForPrincipals: mockHasCapabilityForPrincipals,
+      getHeldCapabilities: mockGetHeldCapabilities,
+    });
 
   beforeEach(() => {
     mockGetUserPrincipals.mockReset();
     mockHasCapabilityForPrincipals.mockReset();
+    mockGetHeldCapabilities.mockReset();
+  });
+
+  describe('getHeldCapabilities', () => {
+    it('resolves principals once and checks all requested capabilities in one batch', async () => {
+      const capabilities = [
+        SystemCapabilities.ACCESS_ADMIN,
+        SystemCapabilities.MANAGE_CONFIGS,
+        configCapability('langfuse'),
+      ];
+      const held = new Set([SystemCapabilities.ACCESS_ADMIN, configCapability('langfuse')]);
+      mockGetUserPrincipals.mockResolvedValue(adminPrincipals);
+      mockGetHeldCapabilities.mockResolvedValue(held);
+
+      const result = await getHeldCapabilities(
+        { id: 'user-123', role: 'ADMIN', tenantId: 'tenant-1' },
+        capabilities,
+      );
+
+      expect(result).toBe(held);
+      expect(mockGetUserPrincipals).toHaveBeenCalledTimes(1);
+      expect(mockGetHeldCapabilities).toHaveBeenCalledTimes(1);
+      expect(mockGetHeldCapabilities).toHaveBeenCalledWith({
+        principals: adminPrincipals,
+        capabilities,
+        tenantId: 'tenant-1',
+      });
+      expect(mockHasCapabilityForPrincipals).not.toHaveBeenCalled();
+    });
   });
 
   describe('hasCapability', () => {

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -69,6 +69,11 @@ export type HasConfigCapabilityFn = (
   verb?: 'manage' | 'read',
 ) => Promise<boolean>;
 
+export type GetHeldCapabilitiesFn = (
+  user: CapabilityUser,
+  capabilities: SystemCapability[],
+) => Promise<Set<SystemCapability>>;
+
 /**
  * Per-request store for caching resolved principals and capability check results.
  * When running inside an Express request (via `capabilityContextMiddleware`),
@@ -141,6 +146,7 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
   hasCapability: HasCapabilityFn;
   requireCapability: RequireCapabilityFn;
   hasConfigCapability: HasConfigCapabilityFn;
+  getHeldCapabilities: GetHeldCapabilitiesFn;
   hasAnyConfigReadAccess: (user: CapabilityUser) => Promise<boolean>;
   getReadableConfigSections: GetReadableConfigSectionsFn;
 } {
@@ -175,6 +181,14 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
     return checkAny({ principals, tenantId: user.tenantId });
   }
 
+  async function getHeldCapabilities(
+    user: CapabilityUser,
+    capabilities: SystemCapability[],
+  ): Promise<Set<SystemCapability>> {
+    const principals = await resolvePrincipals(user);
+    return getHeldCaps({ principals, capabilities, tenantId: user.tenantId });
+  }
+
   /**
    * Resolves which of `sections` the user can read in a single batched
    * query, instead of one `hasConfigCapability` round trip per section.
@@ -183,17 +197,12 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
     user: CapabilityUser,
     sections: ConfigSection[],
   ): Promise<{ broad: boolean; sections: Set<string> }> {
-    const principals = await resolvePrincipals(user);
     const capsToCheck = [
       SystemCapabilities.READ_CONFIGS,
       SystemCapabilities.MANAGE_CONFIGS,
       ...sections.map(readConfigCapability),
     ];
-    const held = await getHeldCaps({
-      principals,
-      capabilities: capsToCheck,
-      tenantId: user.tenantId,
-    });
+    const held = await getHeldCapabilities(user, capsToCheck);
     const broad =
       held.has(SystemCapabilities.READ_CONFIGS) || held.has(SystemCapabilities.MANAGE_CONFIGS);
     const readableSections = new Set(
@@ -298,6 +307,7 @@ export function generateCapabilityCheck(deps: CapabilityDeps): {
     hasCapability,
     requireCapability,
     hasConfigCapability,
+    getHeldCapabilities,
     hasAnyConfigReadAccess,
     getReadableConfigSections,
   };

--- a/packages/api/src/shared-links/access.test.ts
+++ b/packages/api/src/shared-links/access.test.ts
@@ -200,7 +200,11 @@ describe('canAccessSharedLink', () => {
       await canAccessSharedLink(req, res, next as unknown as NextFunction);
 
       expect(next).toHaveBeenCalled();
-      expect((req as unknown as Record<string, unknown>).shareResourceId).toBe(link._id.toString());
+      expect(req).toMatchObject({
+        shareResourceId: link._id.toString(),
+        shareConversationId: 'convo1',
+        shareOwnerId: userId.toString(),
+      });
     });
 
     test('returns 401 for anonymous access when ALLOW_SHARED_LINKS_PUBLIC is not set', async () => {

--- a/packages/api/src/shared-links/access.ts
+++ b/packages/api/src/shared-links/access.ts
@@ -26,6 +26,8 @@ interface RawSharedLink {
 interface SharedLinkAccessRequest extends Request {
   shareResourceId?: string;
   shareTenantId?: string;
+  shareConversationId?: string;
+  shareOwnerId?: string;
 }
 
 export interface SharedLinkAccessDeps {
@@ -94,6 +96,8 @@ export function createSharedLinkAccessMiddleware(deps: SharedLinkAccessDeps) {
       const sharedRequest = req as SharedLinkAccessRequest;
       sharedRequest.shareResourceId = resourceId;
       sharedRequest.shareTenantId = rawShare.tenantId;
+      sharedRequest.shareConversationId = rawShare.conversationId;
+      sharedRequest.shareOwnerId = rawShare.user;
       next();
     };
 

--- a/packages/api/src/shared-links/session.spec.ts
+++ b/packages/api/src/shared-links/session.spec.ts
@@ -1,8 +1,7 @@
-import type { MessageMethods } from '@librechat/data-schemas';
+import { configCapability, SystemCapabilities, type MessageMethods } from '@librechat/data-schemas';
 import { createSharedLangfuseSessionResolver } from './session';
 
-const hasCapability = jest.fn();
-const hasConfigCapability = jest.fn();
+const getHeldCapabilities = jest.fn();
 const getMessages = jest.fn() as unknown as MessageMethods['getMessages'];
 const resolveSessionUrl = jest.fn();
 
@@ -14,8 +13,7 @@ const config = {
 
 function createResolver() {
   return createSharedLangfuseSessionResolver({
-    hasCapability,
-    hasConfigCapability,
+    getHeldCapabilities,
     getMessages,
     resolveSessionUrl,
   });
@@ -32,8 +30,9 @@ const validParams = {
 describe('createSharedLangfuseSessionResolver', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    hasCapability.mockResolvedValue(true);
-    hasConfigCapability.mockResolvedValue(true);
+    getHeldCapabilities.mockResolvedValue(
+      new Set([SystemCapabilities.ACCESS_ADMIN, SystemCapabilities.MANAGE_CONFIGS]),
+    );
     resolveSessionUrl.mockResolvedValue('https://cloud.langfuse.com/session-1');
   });
 
@@ -41,13 +40,13 @@ describe('createSharedLangfuseSessionResolver', () => {
     const result = await createResolver()(validParams);
 
     expect(result).toBe('https://cloud.langfuse.com/session-1');
-    expect(hasCapability).toHaveBeenCalledWith(
+    expect(getHeldCapabilities).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'admin-1', tenantId: 'tenant-1' }),
-      'access:admin',
-    );
-    expect(hasConfigCapability).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'admin-1', tenantId: 'tenant-1' }),
-      'langfuse',
+      [
+        SystemCapabilities.ACCESS_ADMIN,
+        SystemCapabilities.MANAGE_CONFIGS,
+        configCapability('langfuse'),
+      ],
     );
     expect(resolveSessionUrl).toHaveBeenCalledWith({
       config,
@@ -64,27 +63,36 @@ describe('createSharedLangfuseSessionResolver', () => {
     });
 
     expect(result).toBeNull();
-    expect(hasCapability).not.toHaveBeenCalled();
+    expect(getHeldCapabilities).not.toHaveBeenCalled();
     expect(resolveSessionUrl).not.toHaveBeenCalled();
   });
 
   it('rejects a viewer without admin access', async () => {
-    hasCapability.mockResolvedValue(false);
+    getHeldCapabilities.mockResolvedValue(new Set([SystemCapabilities.MANAGE_CONFIGS]));
 
     const result = await createResolver()(validParams);
 
     expect(result).toBeNull();
-    expect(hasConfigCapability).not.toHaveBeenCalled();
     expect(resolveSessionUrl).not.toHaveBeenCalled();
   });
 
   it('rejects an admin without Langfuse config access', async () => {
-    hasConfigCapability.mockResolvedValue(false);
+    getHeldCapabilities.mockResolvedValue(new Set([SystemCapabilities.ACCESS_ADMIN]));
 
     const result = await createResolver()(validParams);
 
     expect(result).toBeNull();
     expect(resolveSessionUrl).not.toHaveBeenCalled();
+  });
+
+  it('accepts an admin with section-specific Langfuse config access', async () => {
+    getHeldCapabilities.mockResolvedValue(
+      new Set([SystemCapabilities.ACCESS_ADMIN, configCapability('langfuse')]),
+    );
+
+    const result = await createResolver()(validParams);
+
+    expect(result).toBe('https://cloud.langfuse.com/session-1');
   });
 
   it('treats the system tenant and an omitted tenant as the same deployment', async () => {

--- a/packages/api/src/shared-links/session.spec.ts
+++ b/packages/api/src/shared-links/session.spec.ts
@@ -1,0 +1,99 @@
+import type { MessageMethods } from '@librechat/data-schemas';
+import { createSharedLangfuseSessionResolver } from './session';
+
+const hasCapability = jest.fn();
+const hasConfigCapability = jest.fn();
+const getMessages = jest.fn() as unknown as MessageMethods['getMessages'];
+const resolveSessionUrl = jest.fn();
+
+const config = {
+  enabled: true,
+  destination: 'eu',
+  projectId: 'project-1',
+};
+
+function createResolver() {
+  return createSharedLangfuseSessionResolver({
+    hasCapability,
+    hasConfigCapability,
+    getMessages,
+    resolveSessionUrl,
+  });
+}
+
+const validParams = {
+  viewer: { id: 'admin-1', role: 'ADMIN', tenantId: 'tenant-1' },
+  shareTenantId: 'tenant-1',
+  shareConversationId: 'conversation-1',
+  shareOwnerId: 'owner-1',
+  config,
+};
+
+describe('createSharedLangfuseSessionResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasCapability.mockResolvedValue(true);
+    hasConfigCapability.mockResolvedValue(true);
+    resolveSessionUrl.mockResolvedValue('https://cloud.langfuse.com/session-1');
+  });
+
+  it('resolves the source session for an authorized same-tenant admin', async () => {
+    const result = await createResolver()(validParams);
+
+    expect(result).toBe('https://cloud.langfuse.com/session-1');
+    expect(hasCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin-1', tenantId: 'tenant-1' }),
+      'access:admin',
+    );
+    expect(hasConfigCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin-1', tenantId: 'tenant-1' }),
+      'langfuse',
+    );
+    expect(resolveSessionUrl).toHaveBeenCalledWith({
+      config,
+      conversationId: 'conversation-1',
+      userId: 'owner-1',
+      getMessages,
+    });
+  });
+
+  it('rejects a viewer from another tenant before capability checks', async () => {
+    const result = await createResolver()({
+      ...validParams,
+      viewer: { ...validParams.viewer, tenantId: 'tenant-2' },
+    });
+
+    expect(result).toBeNull();
+    expect(hasCapability).not.toHaveBeenCalled();
+    expect(resolveSessionUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a viewer without admin access', async () => {
+    hasCapability.mockResolvedValue(false);
+
+    const result = await createResolver()(validParams);
+
+    expect(result).toBeNull();
+    expect(hasConfigCapability).not.toHaveBeenCalled();
+    expect(resolveSessionUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects an admin without Langfuse config access', async () => {
+    hasConfigCapability.mockResolvedValue(false);
+
+    const result = await createResolver()(validParams);
+
+    expect(result).toBeNull();
+    expect(resolveSessionUrl).not.toHaveBeenCalled();
+  });
+
+  it('treats the system tenant and an omitted tenant as the same deployment', async () => {
+    const result = await createResolver()({
+      ...validParams,
+      viewer: { id: 'admin-1', role: 'ADMIN' },
+      shareTenantId: '__SYSTEM__',
+    });
+
+    expect(result).toBe('https://cloud.langfuse.com/session-1');
+  });
+});

--- a/packages/api/src/shared-links/session.ts
+++ b/packages/api/src/shared-links/session.ts
@@ -1,10 +1,6 @@
-import { SYSTEM_TENANT_ID, SystemCapabilities } from '@librechat/data-schemas';
+import { configCapability, SYSTEM_TENANT_ID, SystemCapabilities } from '@librechat/data-schemas';
 import type { TCustomConfig } from 'librechat-data-provider';
-import type {
-  CapabilityUser,
-  HasCapabilityFn,
-  HasConfigCapabilityFn,
-} from '~/middleware/capabilities';
+import type { CapabilityUser, GetHeldCapabilitiesFn } from '~/middleware/capabilities';
 import type { LangfuseSessionLinkParams } from '~/langfuse/session';
 import { resolveLangfuseSessionUrl } from '~/langfuse/session';
 
@@ -25,8 +21,7 @@ export interface SharedLangfuseSessionParams {
 }
 
 export interface SharedLangfuseSessionDeps {
-  hasCapability: HasCapabilityFn;
-  hasConfigCapability: HasConfigCapabilityFn;
+  getHeldCapabilities: GetHeldCapabilitiesFn;
   getMessages: LangfuseSessionLinkParams['getMessages'];
   resolveSessionUrl?: (params: LangfuseSessionLinkParams) => Promise<string | null>;
 }
@@ -62,10 +57,17 @@ export function createSharedLangfuseSessionResolver(deps: SharedLangfuseSessionD
       tenantId: viewer.tenantId,
       idOnTheSource: viewer.idOnTheSource ?? null,
     };
-    if (!(await deps.hasCapability(capabilityUser, SystemCapabilities.ACCESS_ADMIN))) {
-      return null;
-    }
-    if (!(await deps.hasConfigCapability(capabilityUser, 'langfuse'))) {
+    const langfuseConfigCapability = configCapability('langfuse');
+    const heldCapabilities = await deps.getHeldCapabilities(capabilityUser, [
+      SystemCapabilities.ACCESS_ADMIN,
+      SystemCapabilities.MANAGE_CONFIGS,
+      langfuseConfigCapability,
+    ]);
+    if (
+      !heldCapabilities.has(SystemCapabilities.ACCESS_ADMIN) ||
+      (!heldCapabilities.has(SystemCapabilities.MANAGE_CONFIGS) &&
+        !heldCapabilities.has(langfuseConfigCapability))
+    ) {
       return null;
     }
 

--- a/packages/api/src/shared-links/session.ts
+++ b/packages/api/src/shared-links/session.ts
@@ -1,0 +1,79 @@
+import { SYSTEM_TENANT_ID, SystemCapabilities } from '@librechat/data-schemas';
+import type { TCustomConfig } from 'librechat-data-provider';
+import type {
+  CapabilityUser,
+  HasCapabilityFn,
+  HasConfigCapabilityFn,
+} from '~/middleware/capabilities';
+import type { LangfuseSessionLinkParams } from '~/langfuse/session';
+import { resolveLangfuseSessionUrl } from '~/langfuse/session';
+
+interface SharedSessionViewer {
+  id?: string;
+  _id?: { toString(): string };
+  role?: string;
+  tenantId?: string;
+  idOnTheSource?: string | null;
+}
+
+export interface SharedLangfuseSessionParams {
+  viewer?: SharedSessionViewer;
+  shareTenantId?: string;
+  shareConversationId?: string;
+  shareOwnerId?: string;
+  config: TCustomConfig['langfuse'];
+}
+
+export interface SharedLangfuseSessionDeps {
+  hasCapability: HasCapabilityFn;
+  hasConfigCapability: HasConfigCapabilityFn;
+  getMessages: LangfuseSessionLinkParams['getMessages'];
+  resolveSessionUrl?: (params: LangfuseSessionLinkParams) => Promise<string | null>;
+}
+
+function normalizeTenantId(tenantId?: string): string | undefined {
+  return tenantId && tenantId !== SYSTEM_TENANT_ID ? tenantId : undefined;
+}
+
+export function createSharedLangfuseSessionResolver(deps: SharedLangfuseSessionDeps) {
+  const resolveSessionUrl = deps.resolveSessionUrl ?? resolveLangfuseSessionUrl;
+
+  return async function getSharedLangfuseSessionUrl({
+    viewer,
+    shareTenantId,
+    shareConversationId,
+    shareOwnerId,
+    config,
+  }: SharedLangfuseSessionParams): Promise<string | null> {
+    const userId = viewer?.id ?? viewer?._id?.toString();
+    if (
+      !viewer ||
+      !userId ||
+      normalizeTenantId(viewer?.tenantId) !== normalizeTenantId(shareTenantId) ||
+      !shareOwnerId ||
+      !shareConversationId
+    ) {
+      return null;
+    }
+
+    const capabilityUser: CapabilityUser = {
+      id: userId,
+      role: viewer.role ?? '',
+      tenantId: viewer.tenantId,
+      idOnTheSource: viewer.idOnTheSource ?? null,
+    };
+    if (!(await deps.hasCapability(capabilityUser, SystemCapabilities.ACCESS_ADMIN))) {
+      return null;
+    }
+    if (!(await deps.hasConfigCapability(capabilityUser, 'langfuse'))) {
+      return null;
+    }
+
+    return resolveSessionUrl({
+      config,
+      conversationId: shareConversationId,
+      userId: shareOwnerId,
+      getMessages: deps.getMessages,
+    });
+  };
+}

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -444,6 +444,7 @@ export type TPinConversationResponse = TConversation;
 
 export type TSharedMessagesResponse = Omit<TSharedLink, 'messages'> & {
   messages: TMessage[];
+  langfuseSessionUrl?: string;
 };
 
 export type TCreateShareLinkRequest = Pick<TConversation, 'conversationId'>;


### PR DESCRIPTION
## Summary

Extends the Langfuse session link from #14776 to shared conversations.

- Adds the session link to the existing shared-conversation response only for authenticated, same-tenant admins.
- Resolves the original conversation owner's sampled trace marker and current Langfuse destination before returning a URL.
- Keeps shared chats public by restoring authentication opportunistically without redirecting anonymous viewers.

No new endpoint is added, and anonymous, non-admin, and cross-tenant viewers never receive the Langfuse URL.

<img width="587" height="512" alt="Screenshot 2026-08-27 at 11 16 53" src="https://github.com/user-attachments/assets/fc430fe0-a982-4fb2-a58f-0a6b0766cf42" />

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- API route tests cover same-tenant admins, non-admins, cross-tenant admins, and resolver failures.
- Package tests cover source conversation identity and Langfuse session resolution.
- Client tests cover optional authentication and conditional link rendering.
- Local end-to-end validation created a conversation through the LibreChat agent API, shared it as the owner, and opened it as a same-tenant admin. The admin saw the original Langfuse session link; an anonymous viewer did not.

### **Test Configuration**:

- LibreChat API: local development server
- Database: isolated local MongoDB
- Langfuse: local API/OTLP-compatible test service

## Call Flow

`ShareRoute` restores an existing session through optional auth, then loads `ShareView`. `GET /api/share/:shareId` checks tenant equality and `ACCESS_ADMIN`, then calls `resolveLangfuseSessionUrl`, which verifies the active destination and a sampled source-message marker before returning the original conversation session URL.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
