### PR TITLE
Logo and favicon configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1121,6 +1121,9 @@ ALLOW_SHARED_LINKS_PUBLIC=false
 #===================================================#
 
 APP_TITLE=LibreChat
+APP_LOGO=logo.svg
+APP_FAVICON_16=assets/favicon-16x16.png
+APP_FAVICON_32=assets/favicon-32x32.png
 # CUSTOM_FOOTER="My custom footer"
 HELP_AND_FAQ_URL=https://librechat.ai
 

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -70,6 +70,10 @@ function buildPreLoginPayload() {
   /** @type {Partial<TStartupConfig>} */
   const payload = {
     appTitle: process.env.APP_TITLE || 'LibreChat',
+    appLogo: process.env.APP_LOGO || 'logo.svg',
+    appFavicon16: process.env.APP_FAVICON_16 || 'assets/favicon-16x16.png',
+    appFavicon32: process.env.APP_FAVICON_32 || 'assets/favicon-32x32.png',
+    helpAndFaqURL: process.env.HELP_AND_FAQ_URL || 'https://librechat.ai',
     discordLoginEnabled: !!process.env.DISCORD_CLIENT_ID && !!process.env.DISCORD_CLIENT_SECRET,
     facebookLoginEnabled: !!process.env.FACEBOOK_CLIENT_ID && !!process.env.FACEBOOK_CLIENT_SECRET,
     githubLoginEnabled: !!process.env.GITHUB_CLIENT_ID && !!process.env.GITHUB_CLIENT_SECRET,

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -63,12 +63,19 @@ function AuthLayout({
     <div className="relative flex min-h-screen flex-col bg-surface-primary">
       <Banner />
       <BlinkAnimation active={isFetching}>
-        <div className="mt-6 h-10 w-full bg-cover">
-          <img
-            src="assets/logo.svg"
-            className="h-full w-full object-contain"
-            alt={localize('com_ui_logo', { 0: startupConfig?.appTitle ?? 'LibreChat' })}
-          />
+        <div className="mt-6 flex h-24 w-full items-center justify-center overflow-visible">
+          <a
+            href={startupConfig?.helpAndFaqURL ?? 'https://librechat.ai'}
+            target="_blank"
+            rel="noreferrer"
+            className="flex h-full items-center justify-center overflow-visible"
+          >
+            <img
+              src={`assets/${startupConfig?.appLogo ?? 'logo.svg'}`}
+              className="h-full w-auto object-contain overflow-visible"
+              alt={localize('com_ui_logo', { 0: startupConfig?.appTitle ?? 'LibreChat' })}
+            />
+          </a>
         </div>
       </BlinkAnimation>
       <DisplayError />

--- a/client/src/routes/Layouts/Startup.tsx
+++ b/client/src/routes/Layouts/Startup.tsx
@@ -45,6 +45,29 @@ export default function StartupLayout({ isAuthenticated }: { isAuthenticated?: b
 
   useEffect(() => {
     document.title = startupConfig?.appTitle || 'LibreChat';
+
+    // Method to replace favicon link/href value
+    const updateFavicon = (size: '16x16' | '32x32', filename: string) => {
+      const faviconLink = document.querySelector(`link[rel="icon"][sizes="${size}"]`) as HTMLLinkElement;
+
+      if (faviconLink) {
+        faviconLink.href = filename;
+      } else {
+        // Optional: If no favicon link exists, then create one
+        const newLink = document.createElement('link');
+        newLink.rel = 'icon';
+        newLink.type = 'image/png';
+        newLink.sizes = size;
+        newLink.href = filename;
+        document.head.appendChild(newLink);
+      }
+    };
+
+    const favicon_16 = startupConfig?.appFavicon16 || 'assets/favicon-16x16.png';
+    updateFavicon('16x16', favicon_16);
+
+    const favicon_32 = startupConfig?.appFavicon32 || 'assets/favicon-32x32.png';
+    updateFavicon('32x32', favicon_32);
   }, [startupConfig?.appTitle]);
 
   useEffect(() => {


### PR DESCRIPTION
# Pull Request: Logo and favicon configurable

## Summary

We use multiple instances of LibreChat and for instance we would like to use a particular logo and favicon, such that it is clear for users which instance they are using or bookmarking.

## Change Type

Please delete any irrelevant options.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Add your custom logo and favicon to

client/public/assets

and configure it inside .env

APP_LOGO=logo.svg
APP_FAVICON_16=assets/favicon-16x16.png
APP_FAVICON_32=assets/favicon-32x32.png

and build / run LibreChat

npm run build
npm run backend

We have also tested it successfully with Docker

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes

