### PR TITLE
🎛️ fix: Treat Model Spec Tools as Defaults, Not Mandates

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -156,6 +156,7 @@ const {
   isAgentsEndpoint,
   isEphemeralAgentId,
   removeNullishValues,
+  resolveSpecUserToggles,
   DEFAULT_MEMORY_MAX_INPUT_TOKENS,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
@@ -2379,7 +2380,20 @@ class AgentClient extends BaseClient {
      * NOTE: This intentionally mutates agent objects in place. The agentConfigs Map
      * holds references to config objects that will be passed to the graph runtime.
      */
-    const ephemeralAgent = this.options.req.body.ephemeralAgent;
+    /** Apply the same authority the loaders applied when equipping tools: for a
+     *  spec that hides the badge row, its own MCP servers decide. Without this
+     *  the model can be primed with instructions for servers it was not given
+     *  and left without instructions for the servers it was. */
+    const requestModelSpecs = this.options.req.config?.modelSpecs?.list;
+    const requestSpecName = this.options.req.body?.spec;
+    const selectedModelSpec =
+      requestSpecName && Array.isArray(requestModelSpecs)
+        ? requestModelSpecs.find((modelSpec) => modelSpec.name === requestSpecName)
+        : null;
+    const ephemeralAgent = resolveSpecUserToggles(
+      this.options.req.body.ephemeralAgent,
+      selectedModelSpec,
+    );
     const mcpManager = getMCPManager();
 
     const prepareRuntimeAgent = async (

--- a/api/server/routes/__tests__/config.spec.js
+++ b/api/server/routes/__tests__/config.spec.js
@@ -374,7 +374,10 @@ describe('GET /api/config', () => {
         model: 'gpt-4o',
         greeting: 'Hello',
       });
-      expect(response.body.modelSpecs.list[0]).not.toHaveProperty('skills');
+      /** Narrowed to the boolean the chat badge seeds from — an absent field is
+       *  indistinguishable from `skills: false` — while the names stay server-side. */
+      expect(response.body.modelSpecs.list[0].skills).toBe(true);
+      expect(JSON.stringify(response.body.modelSpecs.list[0])).not.toContain('private-skill');
     });
 
     it('should include full interface config', async () => {

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -9,7 +9,7 @@ const {
 } = require('@librechat/api');
 const {
   isEphemeralAgentId,
-  resolveSpecUserToggles,
+  resolveSpecUserToggle,
   resolveSpecSkillsEnabled,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
@@ -141,9 +141,10 @@ const processAddedConvo = async ({
       /** Mirrors the primary agent: the spec's `skills` config is a default the
        *  added conversation's own toggle overrides (`false` stays a hard opt-out). */
       const specSkillsEnabled = resolveSpecSkillsEnabled(
-        resolveSpecUserToggles(
+        resolveSpecUserToggle(
           addedConvo.ephemeralAgent?.skills ?? req.body?.ephemeralAgent?.skills,
           selectedModelSpec,
+          'skills',
         ),
         selectedModelSpec.skills,
       );

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -7,7 +7,11 @@ const {
   resolveModelSpecSkillIds,
   loadAddedAgent: loadAddedAgentFn,
 } = require('@librechat/api');
-const { isEphemeralAgentId, resolveSpecSkillsEnabled } = require('librechat-data-provider');
+const {
+  isEphemeralAgentId,
+  resolveSpecUserToggles,
+  resolveSpecSkillsEnabled,
+} = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { getMCPServerTools } = require('~/server/services/Config');
 const { getAccessibleMcpServerNames } = require('~/server/services/MCP');
@@ -137,7 +141,10 @@ const processAddedConvo = async ({
       /** Mirrors the primary agent: the spec's `skills` config is a default the
        *  added conversation's own toggle overrides (`false` stays a hard opt-out). */
       const specSkillsEnabled = resolveSpecSkillsEnabled(
-        addedConvo.ephemeralAgent?.skills ?? req.body?.ephemeralAgent?.skills,
+        resolveSpecUserToggles(
+          addedConvo.ephemeralAgent?.skills ?? req.body?.ephemeralAgent?.skills,
+          selectedModelSpec,
+        ),
         selectedModelSpec.skills,
       );
       if (!specSkillsEnabled) {

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -7,7 +7,7 @@ const {
   resolveModelSpecSkillIds,
   loadAddedAgent: loadAddedAgentFn,
 } = require('@librechat/api');
-const { isEphemeralAgentId } = require('librechat-data-provider');
+const { isEphemeralAgentId, resolveSpecSkillsEnabled } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { getMCPServerTools } = require('~/server/services/Config');
 const { getAccessibleMcpServerNames } = require('~/server/services/MCP');
@@ -134,10 +134,13 @@ const processAddedConvo = async ({
       selectedModelSpec &&
       Object.hasOwn(selectedModelSpec, 'skills')
     ) {
-      if (selectedModelSpec.skills === true) {
-        addedAgent.skills_enabled = true;
-        delete addedAgent.skills;
-      } else if (selectedModelSpec.skills === false) {
+      /** Mirrors the primary agent: the spec's `skills` config is a default the
+       *  added conversation's own toggle overrides (`false` stays a hard opt-out). */
+      const specSkillsEnabled = resolveSpecSkillsEnabled(
+        addedConvo.ephemeralAgent?.skills,
+        selectedModelSpec.skills,
+      );
+      if (!specSkillsEnabled) {
         addedAgent.skills_enabled = false;
         addedAgent.skills = [];
       } else if (Array.isArray(selectedModelSpec.skills)) {
@@ -148,6 +151,9 @@ const processAddedConvo = async ({
         });
         addedAgent.skills_enabled = true;
         addedAgent.skills = resolvedSkillIds.map((id) => id.toString());
+      } else {
+        addedAgent.skills_enabled = true;
+        delete addedAgent.skills;
       }
     }
 

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -137,7 +137,7 @@ const processAddedConvo = async ({
       /** Mirrors the primary agent: the spec's `skills` config is a default the
        *  added conversation's own toggle overrides (`false` stays a hard opt-out). */
       const specSkillsEnabled = resolveSpecSkillsEnabled(
-        addedConvo.ephemeralAgent?.skills,
+        addedConvo.ephemeralAgent?.skills ?? req.body?.ephemeralAgent?.skills,
         selectedModelSpec.skills,
       );
       if (!specSkillsEnabled) {

--- a/api/server/services/Endpoints/agents/addedConvo.spec.js
+++ b/api/server/services/Endpoints/agents/addedConvo.spec.js
@@ -329,4 +329,53 @@ describe('processAddedConvo', () => {
     );
     expect(mockGetSkillDbMethods).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ['honors the shared skills opt-out for an ordinary added spec', undefined, false],
+    ['ignores it when the added spec hides its badge row', true, true],
+  ])('%s', async (_label, hideBadgeRow, expectedEnabled) => {
+    mockResolveAgentScopedSkillIds.mockReturnValue([]);
+    mockCanAuthorSkillFiles.mockReturnValue(false);
+
+    /** The added pane has no badge row of its own; when its spec hides one,
+     *  the other pane's toggle must not strip what that spec configured. */
+    await processAddedConvo(
+      baseParams({
+        req: {
+          user: { id: 'u1', role: 'USER' },
+          body: { ephemeralAgent: { skills: false } },
+          config: {
+            modelSpecs: {
+              list: [
+                {
+                  name: 'added-spec',
+                  skills: true,
+                  ...(hideBadgeRow ? { hideBadgeRow } : {}),
+                },
+              ],
+            },
+          },
+        },
+        endpointOption: {
+          spec: 'primary-spec',
+          addedConvo: {
+            endpoint: 'openai',
+            model: 'gpt-4o',
+            spec: 'added-spec',
+          },
+        },
+        accessibleSkillIds: [],
+        editableSkillIds: [],
+        skillsCapabilityEnabled: true,
+        ephemeralSkillsToggle: false,
+        skillCreateAllowed: false,
+      }),
+    );
+
+    expect(mockResolveAgentScopedSkillIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({ skills_enabled: expectedEnabled }),
+      }),
+    );
+  });
 });

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -36,7 +36,7 @@ const {
   MAX_SUBAGENT_GRAPH_NODES,
   MAX_SUBAGENT_RUN_CONFIGS,
   isEphemeralAgentId,
-  resolveSpecUserToggles,
+  resolveSpecUserToggle,
   resolveSpecSkillsEnabled,
   resolveAllowedStatefulCodeEnvironments,
 } = require('librechat-data-provider');
@@ -505,7 +505,7 @@ const initializeClient = async ({
     /** The spec's `skills` config is the default the badge is seeded from; the
      *  request's explicit toggle decides (`skills: false` stays a hard opt-out). */
     const specSkillsEnabled = resolveSpecSkillsEnabled(
-      resolveSpecUserToggles(req.body?.ephemeralAgent?.skills, selectedModelSpec),
+      resolveSpecUserToggle(req.body?.ephemeralAgent?.skills, selectedModelSpec, 'skills'),
       selectedModelSpec.skills,
     );
     if (!specSkillsEnabled) {

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -36,6 +36,7 @@ const {
   MAX_SUBAGENT_GRAPH_NODES,
   MAX_SUBAGENT_RUN_CONFIGS,
   isEphemeralAgentId,
+  resolveSpecUserToggles,
   resolveSpecSkillsEnabled,
   resolveAllowedStatefulCodeEnvironments,
 } = require('librechat-data-provider');
@@ -504,7 +505,7 @@ const initializeClient = async ({
     /** The spec's `skills` config is the default the badge is seeded from; the
      *  request's explicit toggle decides (`skills: false` stays a hard opt-out). */
     const specSkillsEnabled = resolveSpecSkillsEnabled(
-      req.body?.ephemeralAgent?.skills,
+      resolveSpecUserToggles(req.body?.ephemeralAgent?.skills, selectedModelSpec),
       selectedModelSpec.skills,
     );
     if (!specSkillsEnabled) {

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -36,6 +36,7 @@ const {
   MAX_SUBAGENT_GRAPH_NODES,
   MAX_SUBAGENT_RUN_CONFIGS,
   isEphemeralAgentId,
+  resolveSpecSkillsEnabled,
   resolveAllowedStatefulCodeEnvironments,
 } = require('librechat-data-provider');
 const {
@@ -500,10 +501,13 @@ const initializeClient = async ({
     selectedModelSpec &&
     Object.hasOwn(selectedModelSpec, 'skills')
   ) {
-    if (selectedModelSpec.skills === true) {
-      primaryAgent.skills_enabled = true;
-      delete primaryAgent.skills;
-    } else if (selectedModelSpec.skills === false) {
+    /** The spec's `skills` config is the default the badge is seeded from; the
+     *  request's explicit toggle decides (`skills: false` stays a hard opt-out). */
+    const specSkillsEnabled = resolveSpecSkillsEnabled(
+      req.body?.ephemeralAgent?.skills,
+      selectedModelSpec.skills,
+    );
+    if (!specSkillsEnabled) {
       primaryAgent.skills_enabled = false;
       primaryAgent.skills = [];
     } else if (Array.isArray(selectedModelSpec.skills)) {
@@ -514,6 +518,9 @@ const initializeClient = async ({
       });
       primaryAgent.skills_enabled = true;
       primaryAgent.skills = resolvedSkillIds.map((id) => id.toString());
+    } else {
+      primaryAgent.skills_enabled = true;
+      delete primaryAgent.skills;
     }
   }
 

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -549,6 +549,40 @@ describe('initializeClient — processAgent ACL gate', () => {
     expect(initializeParams.skillAuthoringAvailable).toBe(true);
   });
 
+  it.each([
+    ['honors a skills opt-out against an ordinary spec', false, false],
+    ['ignores a skills opt-out against a spec that hides the badge row', true, true],
+  ])('%s', async (_label, hideBadgeRow, expectedEnabled) => {
+    const endpointOption = makeEndpointOption();
+    endpointOption.spec = 'spec-skills';
+    endpointOption.agent = Promise.resolve({
+      id: Constants.EPHEMERAL_AGENT_ID,
+      name: 'Ephemeral Primary',
+      provider: 'openai',
+      model: 'gpt-4',
+      tools: [],
+    });
+    mockInitializeAgent.mockResolvedValue(makePrimaryConfig([]));
+    const req = makeReq();
+    req.config.endpoints.agents = { capabilities: ['skills'] };
+    req.config.modelSpecs = {
+      list: [{ name: 'spec-skills', skills: true, ...(hideBadgeRow ? { hideBadgeRow } : {}) }],
+    };
+    /** Only an API caller can post this against a hidden badge row, so the
+     *  spec's own configuration stays authoritative there. */
+    req.body.ephemeralAgent = { skills: false };
+
+    await initializeClient({
+      req,
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption,
+    });
+
+    const initializeParams = mockInitializeAgent.mock.calls[0][0];
+    expect(initializeParams.agent.skills_enabled).toBe(expectedEnabled);
+  });
+
   it('loads model validation and skill permissions without serial waits', async () => {
     const models = deferred();
     const createPermission = deferred();

--- a/client/src/hooks/Agents/__tests__/useApplyModelSpecAgents.spec.tsx
+++ b/client/src/hooks/Agents/__tests__/useApplyModelSpecAgents.spec.tsx
@@ -206,6 +206,29 @@ describe('useApplyAgentTemplate spec merge (#15277)', () => {
     expect(result.current.ephemeralAgent?.mcp).toEqual(['clickhouse']);
   });
 
+  it("re-pins a hidden spec's capabilities rather than trusting what was submitted", () => {
+    const { result } = renderHook(() => useTemplateHarness(targetId), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.applyAgentTemplate({
+        targetId,
+        sourceId: NEW_CONVO,
+        ephemeralAgent: { web_search: false, mcp: [], memory: false },
+        specName: 'test-spec',
+        startupConfig: specWithTools({
+          hideBadgeRow: true,
+          webSearch: true,
+          mcpServers: ['clickhouse'],
+        }),
+      });
+    });
+
+    expect(result.current.ephemeralAgent?.web_search).toBe(true);
+    expect(result.current.ephemeralAgent?.mcp).toEqual(['clickhouse']);
+    /** The spec is silent on memory, so the submitted value still stands. */
+    expect(result.current.ephemeralAgent?.memory).toBe(false);
+  });
+
   it('carries an explicit tool opt-out through the merge', () => {
     const { result } = renderHook(() => useTemplateHarness(targetId), { wrapper: Wrapper });
 

--- a/client/src/hooks/Agents/__tests__/useApplyModelSpecAgents.spec.tsx
+++ b/client/src/hooks/Agents/__tests__/useApplyModelSpecAgents.spec.tsx
@@ -3,8 +3,8 @@ import { RecoilRoot, useRecoilValue } from 'recoil';
 import { renderHook, act } from '@testing-library/react';
 import { Constants, EModelEndpoint } from 'librechat-data-provider';
 import type { TEphemeralAgent, TStartupConfig, TModelSpec } from 'librechat-data-provider';
+import { useApplyModelSpecEffects, useApplyAgentTemplate } from '../useApplyModelSpecAgents';
 import { ephemeralAgentByConvoId, useUpdateEphemeralAgent } from '~/store/agents';
-import { useApplyModelSpecEffects } from '../useApplyModelSpecAgents';
 
 const NEW_CONVO = Constants.NEW_CONVO as string;
 
@@ -143,5 +143,83 @@ describe('useApplyModelSpecEffects', () => {
     });
 
     expect(result.current.ephemeralAgent).toEqual(agent);
+  });
+});
+
+const useTemplateHarness = (targetId: string) => {
+  const applyAgentTemplate = useApplyAgentTemplate();
+  const ephemeralAgent = useRecoilValue(ephemeralAgentByConvoId(targetId));
+  return { applyAgentTemplate, ephemeralAgent };
+};
+
+describe('useApplyAgentTemplate spec merge (#15277)', () => {
+  const targetId = 'convo-saved';
+
+  const specWithTools = (overrides: Partial<TModelSpec>): TStartupConfig =>
+    createStartupConfig([{ ...createModelSpec('test-spec'), ...overrides } as TModelSpec]);
+
+  it('does not re-add an MCP server the user deselected before submitting', () => {
+    const { result } = renderHook(() => useTemplateHarness(targetId), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.applyAgentTemplate({
+        targetId,
+        sourceId: NEW_CONVO,
+        ephemeralAgent: { mcp: [] },
+        specName: 'test-spec',
+        startupConfig: specWithTools({ mcpServers: ['clickhouse'] }),
+      });
+    });
+
+    expect(result.current.ephemeralAgent?.mcp).toEqual([]);
+  });
+
+  it('keeps the submitted selection rather than unioning it with the spec list', () => {
+    const { result } = renderHook(() => useTemplateHarness(targetId), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.applyAgentTemplate({
+        targetId,
+        sourceId: NEW_CONVO,
+        ephemeralAgent: { mcp: ['github'] },
+        specName: 'test-spec',
+        startupConfig: specWithTools({ mcpServers: ['clickhouse'] }),
+      });
+    });
+
+    expect(result.current.ephemeralAgent?.mcp).toEqual(['github']);
+  });
+
+  it('applies the spec MCP list when the submission carries no selection', () => {
+    const { result } = renderHook(() => useTemplateHarness(targetId), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.applyAgentTemplate({
+        targetId,
+        sourceId: NEW_CONVO,
+        ephemeralAgent: {},
+        specName: 'test-spec',
+        startupConfig: specWithTools({ mcpServers: ['clickhouse'] }),
+      });
+    });
+
+    expect(result.current.ephemeralAgent?.mcp).toEqual(['clickhouse']);
+  });
+
+  it('carries an explicit tool opt-out through the merge', () => {
+    const { result } = renderHook(() => useTemplateHarness(targetId), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.applyAgentTemplate({
+        targetId,
+        sourceId: NEW_CONVO,
+        ephemeralAgent: { web_search: false, skills: false },
+        specName: 'test-spec',
+        startupConfig: specWithTools({ webSearch: true, skills: true }),
+      });
+    });
+
+    expect(result.current.ephemeralAgent?.web_search).toBe(false);
+    expect(result.current.ephemeralAgent?.skills).toBe(false);
   });
 });

--- a/client/src/hooks/Agents/useApplyModelSpecAgents.ts
+++ b/client/src/hooks/Agents/useApplyModelSpecAgents.ts
@@ -3,6 +3,7 @@ import {
   Constants,
   resolveSpecArtifacts,
   resolveSpecMcpServers,
+  resolveSpecUserToggles,
   resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
 import type { TStartupConfig, TSubmission } from 'librechat-data-provider';
@@ -103,15 +104,19 @@ export function useApplyAgentTemplate() {
         return;
       }
 
+      /** Drop toggles the spec holds authority over before propagating them to
+       *  the saved conversation, so the pinned state is re-derived here rather
+       *  than inherited from whatever was submitted. */
+      const submitted = resolveSpecUserToggles(ephemeralAgent, modelSpec);
       const mergedAgent = {
-        ...ephemeralAgent,
-        mcp: [...new Set(resolveSpecMcpServers(ephemeralAgent?.mcp, modelSpec.mcpServers))],
-        web_search: ephemeralAgent?.web_search ?? modelSpec.webSearch ?? false,
-        file_search: ephemeralAgent?.file_search ?? modelSpec.fileSearch ?? false,
-        execute_code: ephemeralAgent?.execute_code ?? modelSpec.executeCode ?? false,
-        memory: ephemeralAgent?.memory ?? modelSpec.memory ?? false,
-        skills: resolveSpecSkillsEnabled(ephemeralAgent?.skills, modelSpec.skills),
-        artifacts: resolveSpecArtifacts(ephemeralAgent?.artifacts, modelSpec.artifacts) ?? '',
+        ...submitted,
+        mcp: [...new Set(resolveSpecMcpServers(submitted?.mcp, modelSpec.mcpServers))],
+        web_search: submitted?.web_search ?? modelSpec.webSearch ?? false,
+        file_search: submitted?.file_search ?? modelSpec.fileSearch ?? false,
+        execute_code: submitted?.execute_code ?? modelSpec.executeCode ?? false,
+        memory: submitted?.memory ?? modelSpec.memory ?? false,
+        skills: resolveSpecSkillsEnabled(submitted?.skills, modelSpec.skills),
+        artifacts: resolveSpecArtifacts(submitted?.artifacts, modelSpec.artifacts) ?? '',
       };
 
       applyAgentTemplate(targetId, sourceId, mergedAgent);

--- a/client/src/hooks/Agents/useApplyModelSpecAgents.ts
+++ b/client/src/hooks/Agents/useApplyModelSpecAgents.ts
@@ -1,5 +1,9 @@
 import { useCallback } from 'react';
-import { Constants } from 'librechat-data-provider';
+import {
+  Constants,
+  resolveSpecMcpServers,
+  resolveSpecSkillsEnabled,
+} from 'librechat-data-provider';
 import type { TStartupConfig, TSubmission } from 'librechat-data-provider';
 import { useUpdateEphemeralAgent, useApplyNewAgentTemplate } from '~/store/agents';
 import { getModelSpec, applyModelSpecEphemeralAgent } from '~/utils';
@@ -8,7 +12,9 @@ import { getModelSpec, applyModelSpecEphemeralAgent } from '~/utils';
  * Hook that applies a model spec from a preset to an ephemeral agent.
  * This is used when initializing a new conversation with a preset that has a spec.
  *
- * When a spec is provided, its tool settings are applied to the ephemeral agent.
+ * When a spec is provided, its tool settings seed the ephemeral agent as
+ * defaults — an explicit user toggle, including a cleared MCP selection, always
+ * survives the merge.
  * When no spec is provided but specs are configured, the ephemeral agent is reset
  * to null on context transitions (leaving a spec, or moving to a different
  * conversation key) so BadgeRowContext refills values from localStorage — both
@@ -98,16 +104,16 @@ export function useApplyAgentTemplate() {
 
       const mergedAgent = {
         ...ephemeralAgent,
-        mcp: [...(ephemeralAgent?.mcp ?? []), ...(modelSpec.mcpServers ?? [])],
+        mcp: [...new Set(resolveSpecMcpServers(ephemeralAgent?.mcp, modelSpec.mcpServers))],
         web_search: ephemeralAgent?.web_search ?? modelSpec.webSearch ?? false,
         file_search: ephemeralAgent?.file_search ?? modelSpec.fileSearch ?? false,
         execute_code: ephemeralAgent?.execute_code ?? modelSpec.executeCode ?? false,
+        memory: ephemeralAgent?.memory ?? modelSpec.memory ?? false,
+        skills: resolveSpecSkillsEnabled(ephemeralAgent?.skills, modelSpec.skills),
         artifacts:
           ephemeralAgent?.artifacts ??
           (modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || ''),
       };
-
-      mergedAgent.mcp = [...new Set(mergedAgent.mcp)];
 
       applyAgentTemplate(targetId, sourceId, mergedAgent);
     },

--- a/client/src/hooks/Agents/useApplyModelSpecAgents.ts
+++ b/client/src/hooks/Agents/useApplyModelSpecAgents.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import {
   Constants,
+  resolveSpecArtifacts,
   resolveSpecMcpServers,
   resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
@@ -110,9 +111,7 @@ export function useApplyAgentTemplate() {
         execute_code: ephemeralAgent?.execute_code ?? modelSpec.executeCode ?? false,
         memory: ephemeralAgent?.memory ?? modelSpec.memory ?? false,
         skills: resolveSpecSkillsEnabled(ephemeralAgent?.skills, modelSpec.skills),
-        artifacts:
-          ephemeralAgent?.artifacts ??
-          (modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || ''),
+        artifacts: resolveSpecArtifacts(ephemeralAgent?.artifacts, modelSpec.artifacts) ?? '',
       };
 
       applyAgentTemplate(targetId, sourceId, mergedAgent);

--- a/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
+++ b/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
@@ -65,6 +65,7 @@ describe('applyModelSpecEphemeralAgent', () => {
         web_search: false,
         file_search: true,
         memory: false,
+        skills: false,
         artifacts: 'default',
       });
     });
@@ -241,6 +242,7 @@ describe('applyModelSpecEphemeralAgent', () => {
         web_search: false,
         file_search: true,
         memory: false,
+        skills: false,
         artifacts: 'default',
       });
     });
@@ -293,6 +295,39 @@ describe('applyModelSpecEphemeralAgent', () => {
       });
 
       expect(updateEphemeralAgent).toHaveBeenCalledWith(Constants.NEW_CONVO, expect.any(Object));
+    });
+  });
+
+  describe('skills badge reflects the spec (#15277)', () => {
+    it.each([
+      ['skills: true', true, true],
+      ['a skill allowlist', ['research'], true],
+      ['skills: false', false, false],
+      ['no skills config', undefined, false],
+    ])('seeds the badge from %s', (_label, specSkills, expected) => {
+      const modelSpec = createModelSpec(
+        specSkills === undefined ? {} : { skills: specSkills as TModelSpec['skills'] },
+      );
+
+      applyModelSpecEphemeralAgent({ convoId: null, modelSpec, updateEphemeralAgent });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        Constants.NEW_CONVO,
+        expect.objectContaining({ skills: expected }),
+      );
+    });
+
+    it('layers a per-conversation skills opt-out over a spec that enables them', () => {
+      const convoId = 'convo-abc';
+      writeToolToggle(LocalStorageKeys.LAST_SKILLS_TOGGLE_, convoId, false);
+      const modelSpec = createModelSpec({ skills: true });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        convoId,
+        expect.objectContaining({ skills: false }),
+      );
     });
   });
 });

--- a/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
+++ b/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
@@ -330,4 +330,66 @@ describe('applyModelSpecEphemeralAgent', () => {
       );
     });
   });
+
+  describe('spec safeguards restored after review (#15292)', () => {
+    it('ignores stored overrides for a spec that hides the badge row', () => {
+      const convoId = 'convo-hidden';
+      writeToolToggle(LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, convoId, false);
+      writeToolToggle(LocalStorageKeys.LAST_CODE_TOGGLE_, convoId, false);
+      localStorage.setItem(`${LocalStorageKeys.LAST_MCP_}${convoId}`, JSON.stringify([]));
+      const modelSpec = createModelSpec({ hideBadgeRow: true, webSearch: true });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      /** No badge exists to inspect or restore these, so a value stored under an
+       *  earlier configuration must not silently disable a spec-enabled tool. */
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        convoId,
+        expect.objectContaining({
+          web_search: true,
+          execute_code: true,
+          mcp: ['spec-server1'],
+        }),
+      );
+    });
+
+    it('still layers stored overrides when the badge row is visible', () => {
+      const convoId = 'convo-visible';
+      writeToolToggle(LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, convoId, false);
+      const modelSpec = createModelSpec({ webSearch: true });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        convoId,
+        expect.objectContaining({ web_search: false }),
+      );
+    });
+
+    it('does not let a stored skills toggle lift a spec hard opt-out', () => {
+      const convoId = 'convo-skills-off';
+      writeToolToggle(LocalStorageKeys.LAST_SKILLS_TOGGLE_, convoId, true);
+      const modelSpec = createModelSpec({ skills: false });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        convoId,
+        expect.objectContaining({ skills: false }),
+      );
+    });
+
+    it('honors a stored skills opt-out against a spec that enables them', () => {
+      const convoId = 'convo-skills-user-off';
+      writeToolToggle(LocalStorageKeys.LAST_SKILLS_TOGGLE_, convoId, false);
+      const modelSpec = createModelSpec({ skills: true });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        convoId,
+        expect.objectContaining({ skills: false }),
+      );
+    });
+  });
 });

--- a/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
+++ b/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
@@ -332,6 +332,23 @@ describe('applyModelSpecEphemeralAgent', () => {
   });
 
   describe('spec safeguards restored after review (#15292)', () => {
+    it('restores stored toggles a hidden spec does not configure', () => {
+      const convoId = 'convo-hidden-partial';
+      writeToolToggle(LocalStorageKeys.LAST_MEMORY_TOGGLE_, convoId, true);
+      writeToolToggle(LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, convoId, false);
+      const modelSpec = createModelSpec({ hideBadgeRow: true, webSearch: true });
+      delete (modelSpec as { memory?: unknown }).memory;
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      /** The spec pins web search; it says nothing about memory, so erasing the
+       *  stored value here would be a divergence the server cannot repair. */
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(
+        convoId,
+        expect.objectContaining({ web_search: true, memory: true }),
+      );
+    });
+
     it('ignores stored overrides for a spec that hides the badge row', () => {
       const convoId = 'convo-hidden';
       writeToolToggle(LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, convoId, false);

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -357,10 +357,14 @@ export function applyModelSpecEphemeralAgent({
     artifacts: modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '',
   };
 
-  // For existing conversations, layer per-conversation localStorage overrides
-  // on top of spec defaults so user modifications persist across navigation.
-  // If localStorage is empty (e.g., cleared), spec values stand alone.
-  if (key !== Constants.NEW_CONVO) {
+  /** For existing conversations, layer per-conversation localStorage overrides on
+   *  top of spec defaults so user modifications persist across navigation. If
+   *  localStorage is empty (e.g. cleared), spec values stand alone.
+   *
+   *  A spec that hides the badge row is skipped entirely: with no badge to
+   *  inspect or restore a tool, a value stored under an earlier configuration
+   *  would silently disable a spec-enabled tool the user cannot see. */
+  if (key !== Constants.NEW_CONVO && modelSpec.hideBadgeRow !== true) {
     const toolStorageMap: Array<[keyof t.TEphemeralAgent, string]> = [
       ['execute_code', LocalStorageKeys.LAST_CODE_TOGGLE_],
       ['web_search', LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_],
@@ -372,12 +376,20 @@ export function applyModelSpecEphemeralAgent({
 
     for (const [toolKey, storagePrefix] of toolStorageMap) {
       const raw = getTimestampedValue(`${storagePrefix}${key}`);
-      if (raw !== null) {
-        try {
-          agent[toolKey] = JSON.parse(raw) as never;
-        } catch {
-          // ignore parse errors
-        }
+      if (raw === null) {
+        continue;
+      }
+      try {
+        const stored = JSON.parse(raw);
+        /** Skills route back through the spec rule so a stored `true` cannot
+         *  lift a spec's `skills: false`, which every server writer enforces. */
+        agent[toolKey] = (
+          toolKey === 'skills'
+            ? resolveSpecSkillsEnabled(stored as boolean | undefined, modelSpec.skills)
+            : stored
+        ) as never;
+      } catch {
+        // ignore parse errors
       }
     }
 

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -9,6 +9,7 @@ import {
   isEphemeralAgentId,
   isAssistantsEndpoint,
   resolveModelSpecEndpoint,
+  resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { LocalizeFunction } from '~/common';
@@ -352,6 +353,7 @@ export function applyModelSpecEphemeralAgent({
     file_search: modelSpec.fileSearch ?? false,
     execute_code: modelSpec.executeCode ?? false,
     memory: modelSpec.memory ?? false,
+    skills: resolveSpecSkillsEnabled(undefined, modelSpec.skills),
     artifacts: modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '',
   };
 
@@ -365,6 +367,7 @@ export function applyModelSpecEphemeralAgent({
       ['file_search', LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_],
       ['artifacts', LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_],
       ['memory', LocalStorageKeys.LAST_MEMORY_TOGGLE_],
+      ['skills', LocalStorageKeys.LAST_SKILLS_TOGGLE_],
     ];
 
     for (const [toolKey, storagePrefix] of toolStorageMap) {

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -8,6 +8,7 @@ import {
   isAgentsEndpoint,
   isEphemeralAgentId,
   isAssistantsEndpoint,
+  resolveSpecArtifacts,
   resolveModelSpecEndpoint,
   resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
@@ -354,7 +355,7 @@ export function applyModelSpecEphemeralAgent({
     execute_code: modelSpec.executeCode ?? false,
     memory: modelSpec.memory ?? false,
     skills: resolveSpecSkillsEnabled(undefined, modelSpec.skills),
-    artifacts: modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '',
+    artifacts: resolveSpecArtifacts(undefined, modelSpec.artifacts) ?? '',
   };
 
   /** For existing conversations, layer per-conversation localStorage overrides on

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -11,6 +11,7 @@ import {
   resolveSpecArtifacts,
   resolveModelSpecEndpoint,
   resolveSpecSkillsEnabled,
+  specOverridesUserToggle,
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { LocalizeFunction } from '~/common';
@@ -362,10 +363,13 @@ export function applyModelSpecEphemeralAgent({
    *  top of spec defaults so user modifications persist across navigation. If
    *  localStorage is empty (e.g. cleared), spec values stand alone.
    *
-   *  A spec that hides the badge row is skipped entirely: with no badge to
-   *  inspect or restore a tool, a value stored under an earlier configuration
-   *  would silently disable a spec-enabled tool the user cannot see. */
-  if (key !== Constants.NEW_CONVO && modelSpec.hideBadgeRow !== true) {
+   *  Capabilities a hidden-badge spec configures are pinned: with no badge to
+   *  inspect or restore one, a value stored under an earlier configuration
+   *  would silently disable a tool the user cannot see. The pinning is per
+   *  capability, matching the server — a hidden spec silent on a capability
+   *  holds nothing over it, and erasing that stored value here is the one
+   *  divergence the server could not repair. */
+  if (key !== Constants.NEW_CONVO) {
     const toolStorageMap: Array<[keyof t.TEphemeralAgent, string]> = [
       ['execute_code', LocalStorageKeys.LAST_CODE_TOGGLE_],
       ['web_search', LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_],
@@ -376,6 +380,9 @@ export function applyModelSpecEphemeralAgent({
     ];
 
     for (const [toolKey, storagePrefix] of toolStorageMap) {
+      if (specOverridesUserToggle(modelSpec, toolKey)) {
+        continue;
+      }
       const raw = getTimestampedValue(`${storagePrefix}${key}`);
       if (raw === null) {
         continue;
@@ -394,7 +401,9 @@ export function applyModelSpecEphemeralAgent({
       }
     }
 
-    const mcpRaw = localStorage.getItem(`${LocalStorageKeys.LAST_MCP_}${key}`);
+    const mcpRaw = specOverridesUserToggle(modelSpec, 'mcp')
+      ? null
+      : localStorage.getItem(`${LocalStorageKeys.LAST_MCP_}${key}`);
     if (mcpRaw !== null) {
       try {
         const parsed = JSON.parse(mcpRaw);

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -955,6 +955,135 @@ describe('loadAgent', () => {
     }
   });
 
+  describe('model spec tool flags are defaults, not mandates (#15277)', () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+
+    const buildReq = (
+      ephemeralAgent: TEphemeralAgent | undefined,
+      spec: Record<string, unknown>,
+    ): LoadAgentParams['req'] =>
+      ({
+        user: { id: 'user123' },
+        body: ephemeralAgent ? { ephemeralAgent } : {},
+        config: {
+          config: {},
+          fileStrategy: FileSources.local,
+          imageOutputType: 'png',
+          modelSpecs: {
+            list: [
+              {
+                name: 'spec-under-test',
+                label: 'spec-under-test',
+                preset: { endpoint: 'openai', model: 'gpt-4' },
+                ...spec,
+              },
+            ],
+          },
+        },
+      }) as unknown as LoadAgentParams['req'];
+
+    const load = (ephemeralAgent: TEphemeralAgent | undefined, spec: Record<string, unknown>) =>
+      loadAgent(
+        {
+          req: buildReq(ephemeralAgent, spec),
+          spec: 'spec-under-test',
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+    test('an explicit user "off" disables every spec-enabled tool', async () => {
+      const result = await load(
+        {
+          web_search: false,
+          file_search: false,
+          execute_code: false,
+          memory: false,
+          ask_user_question: false,
+        },
+        {
+          webSearch: true,
+          fileSearch: true,
+          executeCode: true,
+          memory: true,
+          askUserQuestion: true,
+        },
+      );
+
+      expect(result?.tools).toEqual([]);
+    });
+
+    test('a spec flag still applies when the request carries no toggle for it', async () => {
+      const result = await load({ web_search: false }, { webSearch: true, fileSearch: true });
+
+      expect(result?.tools).toEqual(['file_search']);
+    });
+
+    test('a spec flag applies when no ephemeral agent accompanies the request', async () => {
+      const result = await load(undefined, { webSearch: true, executeCode: true });
+
+      expect(result?.tools).toEqual(['execute_code', 'web_search']);
+    });
+
+    test('a user "on" still equips a tool the spec leaves off', async () => {
+      const result = await load({ web_search: true }, { webSearch: false });
+
+      expect(result?.tools).toEqual(['web_search']);
+    });
+
+    test('a deselected MCP server is not re-added by the spec', async () => {
+      mockGetMCPServerTools.mockResolvedValue({ crm_lookup: { name: 'crm_lookup' } });
+
+      const result = await load({ mcp: [] }, { mcpServers: ['crm'] });
+
+      expect(result?.tools).toEqual([]);
+      expect(mockGetMCPServerTools).not.toHaveBeenCalled();
+    });
+
+    test('an MCP selection replaces the spec list rather than unioning with it', async () => {
+      mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
+        [`lookup_mcp_${server}`]: { name: `lookup_mcp_${server}` },
+      }));
+
+      const result = await load({ mcp: ['jira'] }, { mcpServers: ['crm'] });
+
+      expect(result?.tools).toEqual(['lookup_mcp_jira']);
+    });
+
+    test('the spec MCP list applies when the request sends no selection', async () => {
+      mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
+        [`lookup_mcp_${server}`]: { name: `lookup_mcp_${server}` },
+      }));
+
+      const result = await load({ web_search: false }, { mcpServers: ['crm'] });
+
+      expect(result?.tools).toEqual(['lookup_mcp_crm']);
+    });
+
+    test('an explicit skills "off" overrides a spec that enables skills', async () => {
+      const result = await load({ skills: false }, { skills: true });
+
+      expect(result?.skills_enabled).toBe(false);
+      expect(result?.skills).toEqual([]);
+    });
+
+    test('a spec skill allowlist still narrows the catalog when skills stay on', async () => {
+      const result = await load({ skills: true }, { skills: ['research'] });
+
+      expect(result?.skills_enabled).toBe(true);
+      expect(result?.skills).toEqual([]);
+    });
+
+    test('a spec `skills: false` remains a hard opt-out the badge cannot lift', async () => {
+      const result = await load({ skills: true }, { skills: false });
+
+      expect(result?.skills_enabled).toBe(false);
+      expect(result?.skills).toEqual([]);
+    });
+  });
+
   describe('Edge Cases', () => {
     test('should handle loadAgent with malformed req object', async () => {
       const result = await loadAgent(

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1084,6 +1084,109 @@ describe('loadAgent', () => {
     });
   });
 
+  describe('added conversations inherit the composer toggles (#15277)', () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+
+    const addedReq = (ephemeralAgent?: TEphemeralAgent, spec?: Record<string, unknown>) =>
+      ({
+        user: { id: 'user123' },
+        body: ephemeralAgent ? { ephemeralAgent } : {},
+        config: {
+          config: {},
+          fileStrategy: FileSources.local,
+          imageOutputType: 'png',
+          modelSpecs: {
+            list: [
+              {
+                name: 'added-spec',
+                label: 'Added Spec',
+                preset: { endpoint: 'openai', model: 'gpt-4' },
+                ...spec,
+              },
+            ],
+          },
+        },
+      }) as unknown as Parameters<typeof loadAddedAgent>[0]['req'];
+
+    const addedConversation = {
+      endpoint: 'openai',
+      model: 'gpt-4',
+      spec: 'added-spec',
+    } as unknown as TConversation;
+
+    /** The added pane never carries an `ephemeralAgent` of its own — one badge
+     *  row submits one toggle set — so the request's state must reach it. */
+    test('a composer opt-out disables a spec tool on the added pane', async () => {
+      const result = await loadAddedAgent(
+        {
+          req: addedReq({ web_search: false }, { webSearch: true }),
+          conversation: addedConversation,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual([]);
+    });
+
+    test('a composer skills opt-out reaches the added pane', async () => {
+      const result = await loadAddedAgent(
+        {
+          req: addedReq({ skills: false }, { skills: true }),
+          conversation: addedConversation,
+        },
+        deps,
+      );
+
+      expect(result?.skills_enabled).toBe(false);
+      expect(result?.skills).toEqual([]);
+    });
+
+    test('a composer skills opt-out reaches the mirrored-tools branch too', async () => {
+      const result = await loadAddedAgent(
+        {
+          req: addedReq({ skills: false }, { skills: ['brand-writer'] }),
+          conversation: addedConversation,
+          primaryAgent: {
+            id: EPHEMERAL_AGENT_ID as string,
+            tools: ['web_search'],
+          } as LibreChatAgent,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['web_search']);
+      expect(result?.skills_enabled).toBe(false);
+    });
+
+    test('a spec still applies to the added pane when the composer is silent', async () => {
+      const result = await loadAddedAgent(
+        {
+          req: addedReq(undefined, { webSearch: true, skills: true }),
+          conversation: addedConversation,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['web_search']);
+      expect(result?.skills_enabled).toBe(true);
+    });
+
+    test("the added pane's own toggles still outrank the request when present", async () => {
+      const result = await loadAddedAgent(
+        {
+          req: addedReq({ web_search: false }, { webSearch: true }),
+          conversation: {
+            ...addedConversation,
+            ephemeralAgent: { web_search: true },
+          } as unknown as TConversation,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['web_search']);
+    });
+  });
+
   describe('Edge Cases', () => {
     test('should handle loadAgent with malformed req object', async () => {
       const result = await loadAgent(

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1171,6 +1171,47 @@ describe('loadAgent', () => {
       expect(result?.skills_enabled).toBe(true);
     });
 
+    test('a partial pane object still inherits the toggles it omits', async () => {
+      mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
+        [`lookup_mcp_${server}`]: { name: `lookup_mcp_${server}` },
+      }));
+
+      const result = await loadAddedAgent(
+        {
+          req: addedReq({ web_search: true, mcp: ['jira'] }, {}),
+          conversation: {
+            ...addedConversation,
+            ephemeralAgent: { skills: false },
+          } as unknown as TConversation,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['web_search', 'lookup_mcp_jira']);
+    });
+
+    test('a pane whose spec hides the badge row keeps its spec capabilities', async () => {
+      mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
+        [`lookup_mcp_${server}`]: { name: `lookup_mcp_${server}` },
+      }));
+
+      /** Those toggles were never offered for this pane, so the other pane's
+       *  choices must not strip what its own spec configured. */
+      const result = await loadAddedAgent(
+        {
+          req: addedReq(
+            { web_search: false, skills: false, mcp: [] },
+            { hideBadgeRow: true, webSearch: true, skills: true, mcpServers: ['crm'] },
+          ),
+          conversation: addedConversation,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['web_search', 'lookup_mcp_crm']);
+      expect(result?.skills_enabled).toBe(true);
+    });
+
     test("the added pane's own toggles still outrank the request when present", async () => {
       const result = await loadAddedAgent(
         {

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1292,6 +1292,33 @@ describe('loadAgent', () => {
       expect(result?.skills_enabled).toBe(false);
     });
 
+    test("records the pane's own skills choice when no spec configures skills", async () => {
+      /** Otherwise the pane falls back to the run-level toggle, which belongs to
+       *  the PRIMARY request — the other pane's badge scoping this one. */
+      const offResult = await loadAddedAgent(
+        { req: addedReq({ skills: false }, {}), conversation: addedConversation },
+        deps,
+      );
+      expect(offResult?.skills_enabled).toBe(false);
+      expect(offResult?.skills).toEqual([]);
+
+      const onResult = await loadAddedAgent(
+        { req: addedReq({ skills: true }, {}), conversation: addedConversation },
+        deps,
+      );
+      expect(onResult?.skills_enabled).toBe(true);
+      expect(onResult?.skills).toBeUndefined();
+    });
+
+    test('leaves skills unset when neither the spec nor the request decides', async () => {
+      const result = await loadAddedAgent(
+        { req: addedReq({ web_search: true }, {}), conversation: addedConversation },
+        deps,
+      );
+
+      expect(result?.skills_enabled).toBeUndefined();
+    });
+
     test('a spec still applies to the added pane when the composer is silent', async () => {
       const result = await loadAddedAgent(
         {

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1084,6 +1084,78 @@ describe('loadAgent', () => {
     });
   });
 
+  describe('a hidden badge row makes the spec unconditional (#15277)', () => {
+    const { EPHEMERAL_AGENT_ID } = Constants;
+
+    const hiddenReq = (ephemeralAgent: TEphemeralAgent) =>
+      ({
+        user: { id: 'user123' },
+        body: { ephemeralAgent },
+        config: {
+          config: {},
+          fileStrategy: FileSources.local,
+          imageOutputType: 'png',
+          modelSpecs: {
+            list: [
+              {
+                name: 'hidden-spec',
+                label: 'Hidden Spec',
+                preset: { endpoint: 'openai', model: 'gpt-4' },
+                hideBadgeRow: true,
+                webSearch: true,
+                executeCode: true,
+                skills: true,
+                mcpServers: ['crm'],
+              },
+            ],
+          },
+        },
+      }) as unknown as LoadAgentParams['req'];
+
+    /** No badge exists to express an override with, so a toggle posted against
+     *  such a spec — only an API caller can produce one — is dropped. */
+    test('request toggles cannot strip a hidden spec of its tools', async () => {
+      mockGetMCPServerTools.mockImplementation(async (_userId: string, server: string) => ({
+        [`lookup_mcp_${server}`]: { name: `lookup_mcp_${server}` },
+      }));
+
+      const result = await loadAgent(
+        {
+          req: hiddenReq({ web_search: false, execute_code: false, skills: false, mcp: [] }),
+          spec: 'hidden-spec',
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['execute_code', 'web_search', 'lookup_mcp_crm']);
+      expect(result?.skills_enabled).toBe(true);
+    });
+
+    test('an ordinary spec still honors the same toggles', async () => {
+      const req = hiddenReq({ web_search: false, execute_code: false, skills: false, mcp: [] });
+      const spec = (req.config as unknown as { modelSpecs: { list: Record<string, unknown>[] } })
+        .modelSpecs.list[0];
+      delete spec.hideBadgeRow;
+
+      const result = await loadAgent(
+        {
+          req,
+          spec: 'hidden-spec',
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual([]);
+      expect(result?.skills_enabled).toBe(false);
+    });
+  });
+
   describe('added conversations inherit the composer toggles (#15277)', () => {
     const { EPHEMERAL_AGENT_ID } = Constants;
 

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1256,6 +1256,25 @@ describe('loadAgent', () => {
       expect(result?.skills).toEqual([]);
     });
 
+    test('the mirrored-tools branch applies the spec artifacts too', async () => {
+      const { EPHEMERAL_AGENT_ID: EID } = Constants;
+      const req = addedReq(undefined, { artifacts: true });
+
+      /** This branch returns early, so every spec-configured capability has to
+       *  be resolved before it, not after. */
+      const result = await loadAddedAgent(
+        {
+          req,
+          conversation: addedConversation,
+          primaryAgent: { id: EID as string, tools: ['web_search'] } as LibreChatAgent,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['web_search']);
+      expect(result?.artifacts).toBe('default');
+    });
+
     test('a composer skills opt-out reaches the mirrored-tools branch too', async () => {
       const result = await loadAddedAgent(
         {

--- a/packages/api/src/agents/__tests__/load.spec.ts
+++ b/packages/api/src/agents/__tests__/load.spec.ts
@@ -1134,6 +1134,49 @@ describe('loadAgent', () => {
       expect(result?.skills_enabled).toBe(true);
     });
 
+    test('a hidden spec still applies the artifacts it configures', async () => {
+      const req = hiddenReq({ web_search: false });
+      const spec = (req.config as unknown as { modelSpecs: { list: Record<string, unknown>[] } })
+        .modelSpecs.list[0];
+      spec.artifacts = true;
+
+      const result = await loadAgent(
+        {
+          req,
+          spec: 'hidden-spec',
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+      expect(result?.artifacts).toBe('default');
+    });
+
+    test('a hidden spec leaves capabilities it does not configure to the request', async () => {
+      const req = hiddenReq({ file_search: true });
+      const spec = (req.config as unknown as { modelSpecs: { list: Record<string, unknown>[] } })
+        .modelSpecs.list[0];
+      /** Silent on file search, so it holds no authority over that toggle. */
+      delete spec.fileSearch;
+      delete spec.mcpServers;
+      delete spec.skills;
+
+      const result = await loadAgent(
+        {
+          req,
+          spec: 'hidden-spec',
+          agent_id: EPHEMERAL_AGENT_ID as string,
+          endpoint: 'openai',
+          model_parameters: { model: 'gpt-4' } as unknown as AgentModelParameters,
+        },
+        deps,
+      );
+
+      expect(result?.tools).toEqual(['execute_code', 'file_search', 'web_search']);
+    });
+
     test('an ordinary spec still honors the same toggles', async () => {
       const req = hiddenReq({ web_search: false, execute_code: false, skills: false, mcp: [] });
       const spec = (req.config as unknown as { modelSpecs: { list: Record<string, unknown>[] } })

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -5,6 +5,7 @@ import {
   isEphemeralAgentId,
   getEphemeralSender,
   appendAgentIdSuffix,
+  resolveSpecArtifacts,
   resolveSpecMcpServers,
   encodeEphemeralAgentId,
   resolveSpecUserToggles,
@@ -267,8 +268,9 @@ export async function loadAddedAgent(
     tools,
   };
 
-  if (ephemeralAgent?.artifacts != null && ephemeralAgent.artifacts) {
-    result.artifacts = ephemeralAgent.artifacts;
+  const artifacts = resolveSpecArtifacts(ephemeralAgent?.artifacts, modelSpec?.artifacts);
+  if (artifacts != null) {
+    result.artifacts = artifacts;
   }
   applyModelSpecSubagents(result, modelSpec);
   applyModelSpecSkills(result, modelSpec, ephemeralAgent?.skills);

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -7,6 +7,7 @@ import {
   appendAgentIdSuffix,
   resolveSpecMcpServers,
   encodeEphemeralAgentId,
+  resolveSpecUserToggles,
   resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
 import type {
@@ -131,8 +132,8 @@ export async function loadAddedAgent(
    *  A pane whose spec hides the badge row is exempt: those toggles were never
    *  offered for it, so the other pane's choices must not silently strip the
    *  capabilities its spec configured. */
-  const requestAgent = modelSpec?.hideBadgeRow === true ? undefined : req.body?.ephemeralAgent;
-  const paneAgent = rest.ephemeralAgent;
+  const requestAgent = resolveSpecUserToggles(req.body?.ephemeralAgent, modelSpec);
+  const paneAgent = resolveSpecUserToggles(rest.ephemeralAgent, modelSpec);
   const ephemeralAgent: TEphemeralAgent | undefined =
     requestAgent || paneAgent ? { ...requestAgent, ...paneAgent } : undefined;
 

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -118,12 +118,23 @@ export async function loadAddedAgent(
   }
 
   const appConfig = req.config as AppConfig | undefined;
-  /** An added conversation carries no toggles of its own — the composer's badge
-   *  row is shared by both panes and submits one `ephemeralAgent` — so the
-   *  request's state is the only expression of user intent for this pane. */
-  const ephemeralAgent = (rest.ephemeralAgent ?? req.body?.ephemeralAgent) as
-    | TEphemeralAgent
-    | undefined;
+  const modelSpecs = (appConfig?.modelSpecs as { list?: TModelSpec[] })?.list;
+  const modelSpec: TModelSpec | null =
+    spec != null && spec !== '' ? (modelSpecs?.find((s) => s.name === spec) ?? null) : null;
+
+  /** An added pane carries no toggles of its own — one badge row is shared by
+   *  both panes and submits a single `ephemeralAgent` — so the request's state
+   *  stands in, field by field, for whatever the pane leaves unset. Merged
+   *  rather than substituted so a pane that does carry a partial object still
+   *  inherits the toggles it omits.
+   *
+   *  A pane whose spec hides the badge row is exempt: those toggles were never
+   *  offered for it, so the other pane's choices must not silently strip the
+   *  capabilities its spec configured. */
+  const requestAgent = modelSpec?.hideBadgeRow === true ? undefined : req.body?.ephemeralAgent;
+  const paneAgent = rest.ephemeralAgent;
+  const ephemeralAgent: TEphemeralAgent | undefined =
+    requestAgent || paneAgent ? { ...requestAgent, ...paneAgent } : undefined;
 
   const primaryIsEphemeral = primaryAgent && isEphemeralAgentId(primaryAgent.id);
   if (primaryIsEphemeral && Array.isArray(primaryAgent.tools)) {
@@ -140,8 +151,6 @@ export async function loadAddedAgent(
       }
     }
 
-    const modelSpecs = (appConfig?.modelSpecs as { list?: TModelSpec[] })?.list;
-    const modelSpec = spec != null && spec !== '' ? modelSpecs?.find((s) => s.name === spec) : null;
     const sender = getEphemeralSender({
       modelLabel: rest.modelLabel,
       specLabel: modelSpec?.label,
@@ -179,11 +188,6 @@ export async function loadAddedAgent(
 
   const userId = req.user?.id ?? '';
 
-  const modelSpecs = (appConfig?.modelSpecs as { list?: TModelSpec[] })?.list;
-  let modelSpec: (typeof modelSpecs extends Array<infer T> | undefined ? T : never) | null = null;
-  if (spec != null && spec !== '') {
-    modelSpec = modelSpecs?.find((s) => s.name === spec) ?? null;
-  }
   const mcpServers = new Set<string>(
     resolveSpecMcpServers(ephemeralAgent?.mcp, modelSpec?.mcpServers),
   );

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -65,7 +65,11 @@ export interface LoadAddedAgentDeps {
 }
 
 interface LoadAddedAgentParams {
-  req: { user?: { id?: string }; config?: Record<string, unknown> };
+  req: {
+    user?: { id?: string };
+    config?: Record<string, unknown>;
+    body?: { ephemeralAgent?: TEphemeralAgent };
+  };
   conversation: TConversation | null;
   primaryAgent?: Agent | null;
 }
@@ -114,7 +118,12 @@ export async function loadAddedAgent(
   }
 
   const appConfig = req.config as AppConfig | undefined;
-  const ephemeralAgent = rest.ephemeralAgent as TEphemeralAgent | undefined;
+  /** An added conversation carries no toggles of its own — the composer's badge
+   *  row is shared by both panes and submits one `ephemeralAgent` — so the
+   *  request's state is the only expression of user intent for this pane. */
+  const ephemeralAgent = (rest.ephemeralAgent ?? req.body?.ephemeralAgent) as
+    | TEphemeralAgent
+    | undefined;
 
   const primaryIsEphemeral = primaryAgent && isEphemeralAgentId(primaryAgent.id);
   if (primaryIsEphemeral && Array.isArray(primaryAgent.tools)) {

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -1,21 +1,28 @@
 import { logger } from '@librechat/data-schemas';
 import {
-  Tools,
   Constants,
   isAgentsEndpoint,
   isEphemeralAgentId,
   getEphemeralSender,
   appendAgentIdSuffix,
+  resolveSpecMcpServers,
   encodeEphemeralAgentId,
+  resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
-import type { Agent, AgentToolOptions, TConversation, TModelSpec } from 'librechat-data-provider';
+import type {
+  Agent,
+  TModelSpec,
+  TConversation,
+  AgentToolOptions,
+  TEphemeralAgent,
+} from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ParsedServerConfig } from '~/mcp/types';
 import { requiresEphemeralUserConnection, validateMCPServerConfig } from '~/mcp/utils';
-import { ASK_USER_QUESTION_TOOL_NAME } from '~/agents/hitl/askUserQuestionTool';
 import { synthesizeBackgroundToolOptions } from '~/agents/background';
 import { mergeSynthesizedToolOptions } from '~/agents/selection';
 import { synthesizeIntentToolOptions } from '~/agents/intent';
+import { resolveEphemeralTools } from '~/agents/toggles';
 import { getCustomEndpointConfig } from '~/app/config';
 
 const { mcp_all, mcp_delimiter } = Constants;
@@ -25,20 +32,18 @@ export const ADDED_AGENT_ID = 'added_agent';
 function applyModelSpecSkills(
   result: Record<string, unknown>,
   modelSpec: Pick<TModelSpec, 'skills'> | null | undefined,
+  ephemeralSkills: boolean | undefined,
 ): void {
   if (!modelSpec || !Object.prototype.hasOwnProperty.call(modelSpec, 'skills')) {
     return;
   }
-  if (modelSpec.skills === true) {
-    result.skills_enabled = true;
-    delete result.skills;
-  } else if (modelSpec.skills === false) {
-    result.skills_enabled = false;
+  const skillsEnabled = resolveSpecSkillsEnabled(ephemeralSkills, modelSpec.skills);
+  result.skills_enabled = skillsEnabled;
+  if (!skillsEnabled || Array.isArray(modelSpec.skills)) {
     result.skills = [];
-  } else if (Array.isArray(modelSpec.skills)) {
-    result.skills_enabled = true;
-    result.skills = [];
+    return;
   }
+  delete result.skills;
 }
 
 function applyModelSpecSubagents(
@@ -99,14 +104,7 @@ export async function loadAddedAgent(
     promptPrefix?: string;
     spec?: string;
     modelLabel?: string;
-    ephemeralAgent?: {
-      mcp?: string[];
-      execute_code?: boolean;
-      file_search?: boolean;
-      web_search?: boolean;
-      artifacts?: unknown;
-      memory?: boolean;
-    };
+    ephemeralAgent?: TEphemeralAgent;
     [key: string]: unknown;
   };
 
@@ -116,19 +114,7 @@ export async function loadAddedAgent(
   }
 
   const appConfig = req.config as AppConfig | undefined;
-  const ephemeralAgent = rest.ephemeralAgent as
-    | {
-        mcp?: string[];
-        execute_code?: boolean;
-        file_search?: boolean;
-        web_search?: boolean;
-        artifacts?: unknown;
-        memory?: boolean;
-        ask_user_question?: boolean;
-        run_in_background?: boolean;
-        describe_intent?: boolean;
-      }
-    | undefined;
+  const ephemeralAgent = rest.ephemeralAgent as TEphemeralAgent | undefined;
 
   const primaryIsEphemeral = primaryAgent && isEphemeralAgentId(primaryAgent.id);
   if (primaryIsEphemeral && Array.isArray(primaryAgent.tools)) {
@@ -162,7 +148,7 @@ export async function loadAddedAgent(
       model,
       tools: [...primaryAgent.tools],
     };
-    applyModelSpecSkills(result, modelSpec);
+    applyModelSpecSkills(result, modelSpec, ephemeralAgent?.skills);
     applyModelSpecSubagents(result, modelSpec);
     const primaryBackgroundToolOptions: AgentToolOptions | undefined =
       synthesizeBackgroundToolOptions({ ephemeralAgent, modelSpec });
@@ -182,7 +168,6 @@ export async function loadAddedAgent(
     return result as unknown as Agent;
   }
 
-  const mcpServers = new Set<string>(ephemeralAgent?.mcp);
   const userId = req.user?.id ?? '';
 
   const modelSpecs = (appConfig?.modelSpecs as { list?: TModelSpec[] })?.list;
@@ -190,31 +175,14 @@ export async function loadAddedAgent(
   if (spec != null && spec !== '') {
     modelSpec = modelSpecs?.find((s) => s.name === spec) ?? null;
   }
-  if (modelSpec?.mcpServers) {
-    for (const mcpServer of modelSpec.mcpServers) {
-      mcpServers.add(mcpServer);
-    }
-  }
+  const mcpServers = new Set<string>(
+    resolveSpecMcpServers(ephemeralAgent?.mcp, modelSpec?.mcpServers),
+  );
 
-  const tools: string[] = [];
-  if (ephemeralAgent?.execute_code === true || modelSpec?.executeCode === true) {
-    tools.push(Tools.execute_code);
-  }
-  if (ephemeralAgent?.file_search === true || modelSpec?.fileSearch === true) {
-    tools.push(Tools.file_search);
-  }
-  if (ephemeralAgent?.web_search === true || modelSpec?.webSearch === true) {
-    tools.push(Tools.web_search);
-  }
-  if (ephemeralAgent?.memory === true || modelSpec?.memory === true) {
-    tools.push(Tools.memory);
-  }
-  /** Mirror the primary ephemeral loader (`loadEphemeralAgent`) so a model
-   *  spec's Ask User flag equips the added top-level agent too; downstream
+  /** Mirror the primary ephemeral loader (`loadEphemeralAgent`): spec flags are
+   *  defaults an explicit conversation toggle overrides, and downstream
    *  `createRun` gating (hitlCapable, non-subagent, admin filter) is uniform. */
-  if (ephemeralAgent?.ask_user_question === true || modelSpec?.askUserQuestion === true) {
-    tools.push(ASK_USER_QUESTION_TOOL_NAME);
-  }
+  const tools: string[] = resolveEphemeralTools(ephemeralAgent, modelSpec);
 
   const addedServers = new Set<string>();
   for (const mcpServer of mcpServers) {
@@ -289,7 +257,7 @@ export async function loadAddedAgent(
     result.artifacts = ephemeralAgent.artifacts;
   }
   applyModelSpecSubagents(result, modelSpec);
-  applyModelSpecSkills(result, modelSpec);
+  applyModelSpecSkills(result, modelSpec, ephemeralAgent?.skills);
 
   const backgroundToolOptions: AgentToolOptions | undefined = synthesizeBackgroundToolOptions({
     ephemeralAgent,

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -170,6 +170,10 @@ export async function loadAddedAgent(
     };
     applyModelSpecSkills(result, modelSpec, ephemeralAgent?.skills);
     applyModelSpecSubagents(result, modelSpec);
+    const mirroredArtifacts = resolveSpecArtifacts(ephemeralAgent?.artifacts, modelSpec?.artifacts);
+    if (mirroredArtifacts != null) {
+      result.artifacts = mirroredArtifacts;
+    }
     const primaryBackgroundToolOptions: AgentToolOptions | undefined =
       synthesizeBackgroundToolOptions({ ephemeralAgent, modelSpec });
     if (primaryBackgroundToolOptions) {

--- a/packages/api/src/agents/added.ts
+++ b/packages/api/src/agents/added.ts
@@ -37,6 +37,16 @@ function applyModelSpecSkills(
   ephemeralSkills: boolean | undefined,
 ): void {
   if (!modelSpec || !Object.prototype.hasOwnProperty.call(modelSpec, 'skills')) {
+    /** With no spec default to resolve against there is still a decision to
+     *  record: the run-level `ephemeralSkillsToggle` this pane would otherwise
+     *  fall back to belongs to the PRIMARY request, so leaving `skills_enabled`
+     *  unset lets the other pane's badge scope this one. */
+    if (typeof ephemeralSkills === 'boolean') {
+      result.skills_enabled = ephemeralSkills;
+      if (!ephemeralSkills) {
+        result.skills = [];
+      }
+    }
     return;
   }
   const skillsEnabled = resolveSpecSkillsEnabled(ephemeralSkills, modelSpec.skills);

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -36,6 +36,7 @@ export * from './usage';
 export * from './resources';
 export * from './responses';
 export * from './skills';
+export * from './toggles';
 export * from './phases';
 export * from './startup';
 export * from './subagentThreads';

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -4,6 +4,7 @@ import {
   isAgentsEndpoint,
   isEphemeralAgentId,
   getEphemeralSender,
+  resolveSpecArtifacts,
   resolveSpecMcpServers,
   encodeEphemeralAgentId,
   resolveSpecUserToggles,
@@ -164,8 +165,9 @@ export async function loadEphemeralAgent(
     result.tool_options = mergeSynthesizedToolOptions(result.tool_options, intentToolOptions);
   }
 
-  if (ephemeralAgent?.artifacts) {
-    result.artifacts = ephemeralAgent.artifacts;
+  const artifacts = resolveSpecArtifacts(ephemeralAgent?.artifacts, modelSpec?.artifacts);
+  if (artifacts != null) {
+    result.artifacts = artifacts;
   }
   if (modelSpec?.subagents) {
     result.subagents = modelSpec.subagents;

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -6,6 +6,7 @@ import {
   getEphemeralSender,
   resolveSpecMcpServers,
   encodeEphemeralAgentId,
+  resolveSpecUserToggles,
   resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
 import type {
@@ -64,7 +65,13 @@ export async function loadEphemeralAgent(
   if (spec != null && spec !== '') {
     modelSpec = modelSpecs?.list?.find((s) => s.name === spec) ?? null;
   }
-  const ephemeralAgent: TEphemeralAgent | undefined = req.body?.ephemeralAgent;
+  /** A spec that hides the badge row makes its tool configuration
+   *  unconditional — there is no control to express an override with, so a
+   *  request toggle against one is dropped rather than obeyed. */
+  const ephemeralAgent: TEphemeralAgent | undefined = resolveSpecUserToggles(
+    req.body?.ephemeralAgent,
+    modelSpec,
+  );
   const userId = req.user?.id ?? '';
   const mcpServers = new Set<string>(
     resolveSpecMcpServers(ephemeralAgent?.mcp, modelSpec?.mcpServers),

--- a/packages/api/src/agents/load.ts
+++ b/packages/api/src/agents/load.ts
@@ -1,11 +1,12 @@
 import { logger } from '@librechat/data-schemas';
 import {
-  Tools,
   Constants,
   isAgentsEndpoint,
   isEphemeralAgentId,
   getEphemeralSender,
+  resolveSpecMcpServers,
   encodeEphemeralAgentId,
+  resolveSpecSkillsEnabled,
 } from 'librechat-data-provider';
 import type {
   AgentModelParameters,
@@ -17,10 +18,10 @@ import type {
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ParsedServerConfig } from '~/mcp/types';
 import { requiresEphemeralUserConnection, validateMCPServerConfig } from '~/mcp/utils';
-import { ASK_USER_QUESTION_TOOL_NAME } from '~/agents/hitl/askUserQuestionTool';
 import { synthesizeBackgroundToolOptions } from '~/agents/background';
 import { mergeSynthesizedToolOptions } from '~/agents/selection';
 import { synthesizeIntentToolOptions } from '~/agents/intent';
+import { resolveEphemeralTools } from '~/agents/toggles';
 import { getCustomEndpointConfig } from '~/app/config';
 
 const { mcp_all, mcp_delimiter } = Constants;
@@ -64,32 +65,15 @@ export async function loadEphemeralAgent(
     modelSpec = modelSpecs?.list?.find((s) => s.name === spec) ?? null;
   }
   const ephemeralAgent: TEphemeralAgent | undefined = req.body?.ephemeralAgent;
-  const mcpServers = new Set<string>(ephemeralAgent?.mcp);
   const userId = req.user?.id ?? '';
-  if (modelSpec?.mcpServers) {
-    for (const mcpServer of modelSpec.mcpServers) {
-      mcpServers.add(mcpServer);
-    }
-  }
-  const tools: string[] = [];
-  if (ephemeralAgent?.execute_code === true || modelSpec?.executeCode === true) {
-    tools.push(Tools.execute_code);
-  }
-  if (ephemeralAgent?.file_search === true || modelSpec?.fileSearch === true) {
-    tools.push(Tools.file_search);
-  }
-  if (ephemeralAgent?.web_search === true || modelSpec?.webSearch === true) {
-    tools.push(Tools.web_search);
-  }
-  if (ephemeralAgent?.memory === true || modelSpec?.memory === true) {
-    tools.push(Tools.memory);
-  }
-  /** Same downstream gating as persisted agents applies: `createRun` only
-   *  equips the tool when the request is HITL-capable, the agent is not a
-   *  subagent, and the admin hasn't excluded it (filteredTools/includedTools). */
-  if (ephemeralAgent?.ask_user_question === true || modelSpec?.askUserQuestion === true) {
-    tools.push(ASK_USER_QUESTION_TOOL_NAME);
-  }
+  const mcpServers = new Set<string>(
+    resolveSpecMcpServers(ephemeralAgent?.mcp, modelSpec?.mcpServers),
+  );
+  /** Spec flags are defaults an explicit request toggle overrides. Same
+   *  downstream gating as persisted agents still applies: `createRun` only
+   *  equips `ask_user_question` when the request is HITL-capable, the agent is
+   *  not a subagent, and the admin hasn't excluded it. */
+  const tools: string[] = resolveEphemeralTools(ephemeralAgent, modelSpec);
 
   const addedServers = new Set<string>();
   if (mcpServers.size > 0) {
@@ -180,13 +164,9 @@ export async function loadEphemeralAgent(
     result.subagents = modelSpec.subagents;
   }
   if (modelSpec && Object.prototype.hasOwnProperty.call(modelSpec, 'skills')) {
-    if (modelSpec.skills === true) {
-      result.skills_enabled = true;
-    } else if (modelSpec.skills === false) {
-      result.skills_enabled = false;
-      result.skills = [];
-    } else if (Array.isArray(modelSpec.skills)) {
-      result.skills_enabled = true;
+    const skillsEnabled = resolveSpecSkillsEnabled(ephemeralAgent?.skills, modelSpec.skills);
+    result.skills_enabled = skillsEnabled;
+    if (!skillsEnabled || Array.isArray(modelSpec.skills)) {
       result.skills = [];
     }
   }

--- a/packages/api/src/agents/toggles.ts
+++ b/packages/api/src/agents/toggles.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Model-spec ↔ user-toggle reconciliation for ephemeral agents.
+ *
+ * A model spec's tool flags (`webSearch`, `executeCode`, `mcpServers`, …) are
+ * DEFAULTS the chat badge row is seeded from, not mandatory additions: once
+ * the client sends an explicit toggle for a capability, that toggle decides.
+ * Specs that must equip a tool unconditionally suppress the badge row
+ * (`hideBadgeRow`), leaving the seeded spec values as the only ones sent.
+ *
+ * Shared by both ephemeral loaders — `loadEphemeralAgent` (primary) and
+ * `loadAddedAgent` (multi-convo) — so the two resolve identically.
+ *
+ * @module packages/api/src/agents/toggles
+ */
+
+import { Tools, SPEC_TOOL_TOGGLES, resolveSpecToolFlag } from 'librechat-data-provider';
+import type { TEphemeralAgent, TModelSpec } from 'librechat-data-provider';
+import { ASK_USER_QUESTION_TOOL_NAME } from '~/agents/hitl/askUserQuestionTool';
+
+/** Tool id equipped for each spec-configurable capability. */
+const TOOL_NAMES: Record<string, string> = {
+  web_search: Tools.web_search,
+  file_search: Tools.file_search,
+  execute_code: Tools.execute_code,
+  memory: Tools.memory,
+  ask_user_question: ASK_USER_QUESTION_TOOL_NAME,
+};
+
+export type EphemeralToolSource = Pick<
+  TEphemeralAgent,
+  'web_search' | 'file_search' | 'execute_code' | 'memory' | 'ask_user_question'
+>;
+
+export type SpecToolSource = Pick<
+  TModelSpec,
+  'webSearch' | 'fileSearch' | 'executeCode' | 'memory' | 'askUserQuestion'
+>;
+
+/**
+ * Resolves the tool ids an ephemeral agent is equipped with, taking the model
+ * spec as the default for each capability and the request's explicit toggle as
+ * the decision. Downstream gating (admin capabilities, `createRun`'s HITL and
+ * subagent filters) still applies to every id returned here.
+ */
+export function resolveEphemeralTools(
+  ephemeralAgent: EphemeralToolSource | null | undefined,
+  modelSpec: SpecToolSource | null | undefined,
+): string[] {
+  const tools: string[] = [];
+  for (const [toggleKey, specKey] of SPEC_TOOL_TOGGLES) {
+    if (resolveSpecToolFlag(ephemeralAgent?.[toggleKey], modelSpec?.[specKey])) {
+      tools.push(TOOL_NAMES[toggleKey]);
+    }
+  }
+  return tools;
+}

--- a/packages/api/src/modelSpecs/index.ts
+++ b/packages/api/src/modelSpecs/index.ts
@@ -2,6 +2,7 @@ import {
   parseCompactConvo,
   replaceSpecialVars,
   resolveModelSpecEndpoint,
+  resolveSpecSkillsEnabled,
   type EModelEndpoint,
   type TConversation,
   type TModelSpec,
@@ -255,10 +256,16 @@ export function sanitizeModelSpecs<T extends Partial<TSpecsConfig> | null | unde
       /** Skill NAMES reveal the catalog, so they never reach a client — but the
        *  fact that a spec enables skills does, because the chat badge is seeded
        *  from it and an absent field is indistinguishable from `skills: false`.
-       *  Narrowed like `subagents` below rather than deleted. */
-      const specSkills = (sanitizedModelSpec as { skills?: unknown }).skills;
+       *  Narrowed like `subagents` below rather than deleted, and narrowed
+       *  through the same predicate the loaders resolve with so the badge and
+       *  the server can never disagree — an empty allowlist included, which
+       *  scopes to no skills yet still permits skill authoring. */
+      const specSkills = (sanitizedModelSpec as { skills?: TModelSpec['skills'] }).skills;
       if (Array.isArray(specSkills)) {
-        (sanitizedModelSpec as { skills?: unknown }).skills = specSkills.length > 0;
+        (sanitizedModelSpec as { skills?: TModelSpec['skills'] }).skills = resolveSpecSkillsEnabled(
+          undefined,
+          specSkills,
+        );
       }
       const subagents = sanitizedModelSpec.subagents;
       if (subagents && typeof subagents === 'object') {

--- a/packages/api/src/modelSpecs/index.ts
+++ b/packages/api/src/modelSpecs/index.ts
@@ -252,7 +252,14 @@ export function sanitizeModelSpecs<T extends Partial<TSpecsConfig> | null | unde
 
       const preset = modelSpec?.preset;
       const sanitizedModelSpec = { ...modelSpec };
-      delete (sanitizedModelSpec as { skills?: unknown }).skills;
+      /** Skill NAMES reveal the catalog, so they never reach a client — but the
+       *  fact that a spec enables skills does, because the chat badge is seeded
+       *  from it and an absent field is indistinguishable from `skills: false`.
+       *  Narrowed like `subagents` below rather than deleted. */
+      const specSkills = (sanitizedModelSpec as { skills?: unknown }).skills;
+      if (Array.isArray(specSkills)) {
+        (sanitizedModelSpec as { skills?: unknown }).skills = specSkills.length > 0;
+      }
       const subagents = sanitizedModelSpec.subagents;
       if (subagents && typeof subagents === 'object') {
         const sanitizedSubagents: TModelSpec['subagents'] = {};

--- a/packages/api/src/modelSpecs/modelSpecs.test.ts
+++ b/packages/api/src/modelSpecs/modelSpecs.test.ts
@@ -68,7 +68,10 @@ describe('modelSpecs helpers', () => {
     /** The client seeds its skills badge from this field, so an enabled spec has
      *  to stay distinguishable from `skills: false` and from no config at all. */
     expect(sanitizeModelSpecs(build(['a', 'b'])).list[0].skills).toBe(true);
-    expect(sanitizeModelSpecs(build([])).list[0].skills).toBe(false);
+    /** An empty allowlist scopes to no skills but keeps `skills_enabled` true,
+     *  which still permits skill authoring — so it must narrow to `true`, the
+     *  same answer `resolveSpecSkillsEnabled` gives the loaders. */
+    expect(sanitizeModelSpecs(build([])).list[0].skills).toBe(true);
     expect(sanitizeModelSpecs(build(true)).list[0].skills).toBe(true);
     expect(sanitizeModelSpecs(build(false)).list[0].skills).toBe(false);
     expect(sanitizeModelSpecs(build()).list[0]).not.toHaveProperty('skills');

--- a/packages/api/src/modelSpecs/modelSpecs.test.ts
+++ b/packages/api/src/modelSpecs/modelSpecs.test.ts
@@ -45,7 +45,36 @@ describe('modelSpecs helpers', () => {
       model: 'gpt-4o',
       greeting: 'Hello',
     });
-    expect(sanitizedModelSpecs.list[0]).not.toHaveProperty('skills');
+    /** Narrowed to the boolean the chat badge needs; the names never leave the server. */
+    expect(sanitizedModelSpecs.list[0].skills).toBe(true);
+    expect(JSON.stringify(sanitizedModelSpecs.list[0])).not.toContain('private-skill');
+  });
+
+  it('should narrow model spec skills to a boolean without leaking names', () => {
+    const build = (skills?: TModelSpec['skills']) =>
+      ({
+        enforce: false,
+        prioritize: true,
+        list: [
+          {
+            name: 'skills-spec',
+            label: 'Skills Spec',
+            ...(skills === undefined ? {} : { skills }),
+            preset: { endpoint: EModelEndpoint.openAI, model: 'gpt-4o' },
+          },
+        ],
+      }) as { enforce: boolean; prioritize: boolean; list: TModelSpec[] };
+
+    /** The client seeds its skills badge from this field, so an enabled spec has
+     *  to stay distinguishable from `skills: false` and from no config at all. */
+    expect(sanitizeModelSpecs(build(['a', 'b'])).list[0].skills).toBe(true);
+    expect(sanitizeModelSpecs(build([])).list[0].skills).toBe(false);
+    expect(sanitizeModelSpecs(build(true)).list[0].skills).toBe(true);
+    expect(sanitizeModelSpecs(build(false)).list[0].skills).toBe(false);
+    expect(sanitizeModelSpecs(build()).list[0]).not.toHaveProperty('skills');
+    expect(JSON.stringify(sanitizeModelSpecs(build(['secret-skill'])))).not.toContain(
+      'secret-skill',
+    );
   });
 
   it('should preserve conversation starters on model specs', () => {

--- a/packages/data-provider/src/models.spec.ts
+++ b/packages/data-provider/src/models.spec.ts
@@ -1,0 +1,61 @@
+import { resolveSpecToolFlag, resolveSpecMcpServers, resolveSpecSkillsEnabled } from './models';
+
+/**
+ * A model spec's tool configuration seeds the chat badge row; it does not
+ * override what the user then sends back. See #15277 — every one of these
+ * cases held before the fix except the "spec on, user off" rows.
+ */
+describe('model spec defaults vs. explicit user toggles', () => {
+  describe('resolveSpecToolFlag', () => {
+    it.each([
+      ['spec on, user off', false, true, false],
+      ['spec on, user on', true, true, true],
+      ['spec on, user silent', undefined, true, true],
+      ['spec off, user on', true, false, true],
+      ['spec off, user off', false, false, false],
+      ['spec off, user silent', undefined, false, false],
+      ['spec absent, user on', true, undefined, true],
+      ['spec absent, user silent', undefined, undefined, false],
+    ])('%s', (_label, userValue, specValue, expected) => {
+      expect(resolveSpecToolFlag(userValue, specValue)).toBe(expected);
+    });
+  });
+
+  describe('resolveSpecMcpServers', () => {
+    it('treats a cleared selection as a deselection, not an absent value', () => {
+      expect(resolveSpecMcpServers([], ['crm'])).toEqual([]);
+    });
+
+    it('replaces the spec list with the selection rather than unioning them', () => {
+      expect(resolveSpecMcpServers(['jira'], ['crm'])).toEqual(['jira']);
+    });
+
+    it('falls back to the spec list when no selection accompanies the request', () => {
+      expect(resolveSpecMcpServers(undefined, ['crm'])).toEqual(['crm']);
+    });
+
+    it('yields an empty list when neither side names a server', () => {
+      expect(resolveSpecMcpServers(undefined, undefined)).toEqual([]);
+    });
+  });
+
+  describe('resolveSpecSkillsEnabled', () => {
+    it.each([
+      ['spec true, user off', false, true, false],
+      ['spec true, user silent', undefined, true, true],
+      ['allowlist, user off', false, ['research'], false],
+      ['allowlist, user silent', undefined, ['research'], true],
+      ['spec absent, user on', true, undefined, true],
+      ['spec absent, user silent', undefined, undefined, false],
+    ])('%s', (_label, userValue, specValue, expected) => {
+      expect(resolveSpecSkillsEnabled(userValue, specValue as boolean | string[] | undefined)).toBe(
+        expected,
+      );
+    });
+
+    it('keeps `skills: false` a hard opt-out the badge cannot lift', () => {
+      expect(resolveSpecSkillsEnabled(true, false)).toBe(false);
+      expect(resolveSpecSkillsEnabled(undefined, false)).toBe(false);
+    });
+  });
+});

--- a/packages/data-provider/src/models.spec.ts
+++ b/packages/data-provider/src/models.spec.ts
@@ -1,4 +1,9 @@
-import { resolveSpecToolFlag, resolveSpecMcpServers, resolveSpecSkillsEnabled } from './models';
+import {
+  resolveSpecToolFlag,
+  resolveSpecMcpServers,
+  resolveSpecUserToggles,
+  resolveSpecSkillsEnabled,
+} from './models';
 
 /**
  * A model spec's tool configuration seeds the chat badge row; it does not
@@ -56,6 +61,21 @@ describe('model spec defaults vs. explicit user toggles', () => {
     it('keeps `skills: false` a hard opt-out the badge cannot lift', () => {
       expect(resolveSpecSkillsEnabled(true, false)).toBe(false);
       expect(resolveSpecSkillsEnabled(undefined, false)).toBe(false);
+    });
+  });
+
+  describe('resolveSpecUserToggles', () => {
+    it('drops request toggles for a spec that hides the badge row', () => {
+      expect(resolveSpecUserToggles({ web_search: false }, { hideBadgeRow: true })).toBeUndefined();
+      expect(resolveSpecUserToggles(false, { hideBadgeRow: true })).toBeUndefined();
+    });
+
+    it('passes toggles through for every ordinary spec', () => {
+      const toggles = { web_search: false };
+      expect(resolveSpecUserToggles(toggles, { hideBadgeRow: false })).toBe(toggles);
+      expect(resolveSpecUserToggles(toggles, {})).toBe(toggles);
+      expect(resolveSpecUserToggles(toggles, null)).toBe(toggles);
+      expect(resolveSpecUserToggles(toggles, undefined)).toBe(toggles);
     });
   });
 });

--- a/packages/data-provider/src/models.spec.ts
+++ b/packages/data-provider/src/models.spec.ts
@@ -1,6 +1,9 @@
+import type { TModelSpec } from './models';
 import {
   resolveSpecToolFlag,
+  resolveSpecArtifacts,
   resolveSpecMcpServers,
+  resolveSpecUserToggle,
   resolveSpecUserToggles,
   resolveSpecSkillsEnabled,
 } from './models';
@@ -65,17 +68,78 @@ describe('model spec defaults vs. explicit user toggles', () => {
   });
 
   describe('resolveSpecUserToggles', () => {
-    it('drops request toggles for a spec that hides the badge row', () => {
-      expect(resolveSpecUserToggles({ web_search: false }, { hideBadgeRow: true })).toBeUndefined();
-      expect(resolveSpecUserToggles(false, { hideBadgeRow: true })).toBeUndefined();
+    const hidden = (spec: Partial<TModelSpec>) => ({ hideBadgeRow: true, ...spec }) as TModelSpec;
+
+    it('drops only the toggles whose capability the hidden spec configures', () => {
+      /** Authority follows configuration: a hidden spec silent on a capability
+       *  has nothing to protect, so the request still decides there. */
+      expect(
+        resolveSpecUserToggles(
+          { web_search: false, file_search: false, run_in_background: true },
+          hidden({ webSearch: true }),
+        ),
+      ).toEqual({ file_search: false, run_in_background: true });
     });
 
-    it('passes toggles through for every ordinary spec', () => {
+    it('drops the object entirely when the spec governs every toggle sent', () => {
+      expect(
+        resolveSpecUserToggles({ web_search: false }, hidden({ webSearch: true })),
+      ).toBeUndefined();
+    });
+
+    it('preserves fields with no spec counterpart', () => {
+      expect(
+        resolveSpecUserToggles(
+          { unknown_future_toggle: true } as never,
+          hidden({ webSearch: true }),
+        ),
+      ).toEqual({ unknown_future_toggle: true });
+    });
+
+    it('passes toggles through untouched for every ordinary spec', () => {
       const toggles = { web_search: false };
-      expect(resolveSpecUserToggles(toggles, { hideBadgeRow: false })).toBe(toggles);
-      expect(resolveSpecUserToggles(toggles, {})).toBe(toggles);
+      expect(resolveSpecUserToggles(toggles, { webSearch: true } as TModelSpec)).toBe(toggles);
       expect(resolveSpecUserToggles(toggles, null)).toBe(toggles);
       expect(resolveSpecUserToggles(toggles, undefined)).toBe(toggles);
+    });
+
+    it('treats a spec value of false as configured', () => {
+      expect(
+        resolveSpecUserToggles({ web_search: true }, hidden({ webSearch: false })),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('resolveSpecUserToggle', () => {
+    it('drops a single field the hidden spec configures', () => {
+      expect(
+        resolveSpecUserToggle(false, { hideBadgeRow: true, skills: true } as TModelSpec, 'skills'),
+      ).toBeUndefined();
+    });
+
+    it('keeps it when the hidden spec is silent on that capability', () => {
+      expect(resolveSpecUserToggle(false, { hideBadgeRow: true } as TModelSpec, 'skills')).toBe(
+        false,
+      );
+    });
+
+    it('keeps it for an ordinary spec', () => {
+      expect(resolveSpecUserToggle(false, { skills: true } as TModelSpec, 'skills')).toBe(false);
+    });
+  });
+
+  describe('resolveSpecArtifacts', () => {
+    it.each([
+      ['spec true means the default renderer', undefined, true, 'default'],
+      ['a spec string passes through', undefined, 'shadcn', 'shadcn'],
+      ['a request value decides', 'custom', true, 'custom'],
+      ['an empty request value is the badge turned off', '', 'shadcn', undefined],
+      ['neither side asks', undefined, undefined, undefined],
+      ['an empty spec string is not a request', undefined, '', undefined],
+    ])('%s', (_label, userValue, specValue, expected) => {
+      expect(
+        resolveSpecArtifacts(userValue as string | undefined, specValue as TModelSpec['artifacts']),
+      ).toBe(expected);
     });
   });
 });

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -272,13 +272,22 @@ const SPEC_FIELD_BY_TOGGLE = new Map<string, keyof TModelSpec>(SPEC_CAPABILITY_F
  * Whether a spec holds authority over one capability: it hides the badge row —
  * so the user was never offered a control for it — AND it configures that
  * capability itself. A hidden spec silent on a capability has nothing to
- * protect, so the request still decides there.
+ * protect, so the user's own value still decides there.
+ *
+ * Shared with the client, which must filter its restored per-conversation
+ * toggles by the same rule: erasing a stored value the server would have
+ * honored puts the two out of step in the one direction the server cannot
+ * correct, because by then the value is already gone.
  */
-function specOverridesUser(
+export function specOverridesUserToggle(
   modelSpec: TModelSpec | null | undefined,
-  specField: keyof TModelSpec | undefined,
+  toggleField: keyof TEphemeralAgent,
 ): boolean {
-  return modelSpec?.hideBadgeRow === true && specField != null && modelSpec[specField] != null;
+  if (modelSpec?.hideBadgeRow !== true) {
+    return false;
+  }
+  const specField = SPEC_FIELD_BY_TOGGLE.get(toggleField);
+  return specField != null && modelSpec[specField] != null;
 }
 
 /**
@@ -289,9 +298,9 @@ function specOverridesUser(
 export function resolveSpecUserToggle<T>(
   userValue: T | undefined,
   modelSpec: TModelSpec | null | undefined,
-  specField: keyof TModelSpec,
+  toggleField: keyof TEphemeralAgent,
 ): T | undefined {
-  return specOverridesUser(modelSpec, specField) ? undefined : userValue;
+  return specOverridesUserToggle(modelSpec, toggleField) ? undefined : userValue;
 }
 
 /**
@@ -314,7 +323,7 @@ export function resolveSpecUserToggles(
   const preserved: Record<string, unknown> = {};
   let preservedCount = 0;
   for (const key of Object.keys(userToggles)) {
-    if (specOverridesUser(modelSpec, SPEC_FIELD_BY_TOGGLE.get(key))) {
+    if (specOverridesUserToggle(modelSpec, key as keyof TEphemeralAgent)) {
       continue;
     }
     preserved[key] = (userToggles as Record<string, unknown>)[key];

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -246,21 +246,100 @@ export function resolveSpecToolFlag(
 }
 
 /**
- * A spec that hides the chat badge row offers no control over the capabilities
- * it configures, which is how an admin makes them unconditional. Its own
- * configuration is therefore authoritative: request toggles are dropped before
- * any of the resolvers below see them, rather than each caller remembering the
- * check. Returns the toggles unchanged for every ordinary spec.
- *
- * Only the spec's OWN capabilities are governed — a spec with no `skills`
- * config has nothing to protect, so the per-conversation skills badge still
- * decides there.
+ * Every ephemeral toggle paired with the model-spec field that configures it.
+ * A superset of `SPEC_TOOL_TOGGLES`, which covers only the toggles that equip a
+ * tool; this one also carries the capabilities configured by other means
+ * (MCP servers, skills, artifacts, background execution, intent labels).
  */
-export function resolveSpecUserToggles<T>(
-  userToggles: T | undefined,
-  modelSpec: Pick<TModelSpec, 'hideBadgeRow'> | null | undefined,
+export const SPEC_CAPABILITY_FIELDS: ReadonlyArray<
+  readonly [keyof TEphemeralAgent, keyof TModelSpec]
+> = [
+  ['web_search', 'webSearch'],
+  ['file_search', 'fileSearch'],
+  ['execute_code', 'executeCode'],
+  ['memory', 'memory'],
+  ['ask_user_question', 'askUserQuestion'],
+  ['mcp', 'mcpServers'],
+  ['skills', 'skills'],
+  ['artifacts', 'artifacts'],
+  ['run_in_background', 'runInBackground'],
+  ['describe_intent', 'describeIntent'],
+];
+
+const SPEC_FIELD_BY_TOGGLE = new Map<string, keyof TModelSpec>(SPEC_CAPABILITY_FIELDS);
+
+/**
+ * Whether a spec holds authority over one capability: it hides the badge row —
+ * so the user was never offered a control for it — AND it configures that
+ * capability itself. A hidden spec silent on a capability has nothing to
+ * protect, so the request still decides there.
+ */
+function specOverridesUser(
+  modelSpec: TModelSpec | null | undefined,
+  specField: keyof TModelSpec | undefined,
+): boolean {
+  return modelSpec?.hideBadgeRow === true && specField != null && modelSpec[specField] != null;
+}
+
+/**
+ * Drops the request's toggle for one capability when the spec holds authority
+ * over it. For the sites that resolve a single field rather than a whole
+ * ephemeral agent.
+ */
+export function resolveSpecUserToggle<T>(
+  userValue: T | undefined,
+  modelSpec: TModelSpec | null | undefined,
+  specField: keyof TModelSpec,
 ): T | undefined {
-  return modelSpec?.hideBadgeRow === true ? undefined : userToggles;
+  return specOverridesUser(modelSpec, specField) ? undefined : userValue;
+}
+
+/**
+ * Strips from a request's ephemeral agent only the toggles whose capability the
+ * spec holds authority over, leaving the rest to decide as usual. Fields with no
+ * spec counterpart are always preserved, so a capability added later is not
+ * silently suppressed before it has a spec field to be governed by. Returns the
+ * object unchanged for every ordinary spec.
+ */
+export function resolveSpecUserToggles(
+  userToggles: TEphemeralAgent | null | undefined,
+  modelSpec: TModelSpec | null | undefined,
+): TEphemeralAgent | undefined {
+  if (userToggles == null) {
+    return undefined;
+  }
+  if (modelSpec?.hideBadgeRow !== true) {
+    return userToggles;
+  }
+  const preserved: Record<string, unknown> = {};
+  let preservedCount = 0;
+  for (const key of Object.keys(userToggles)) {
+    if (specOverridesUser(modelSpec, SPEC_FIELD_BY_TOGGLE.get(key))) {
+      continue;
+    }
+    preserved[key] = (userToggles as Record<string, unknown>)[key];
+    preservedCount++;
+  }
+  return preservedCount > 0 ? (preserved as TEphemeralAgent) : undefined;
+}
+
+/**
+ * The artifacts mode for an ephemeral agent. A spec's `artifacts` seeds it —
+ * `true` meaning the default renderer — and an explicit request value decides,
+ * matching every other spec-configured capability. Returns undefined when
+ * neither side asks for artifacts, so callers can leave the field unset.
+ */
+export function resolveSpecArtifacts(
+  userValue: string | undefined,
+  specValue: TModelSpec['artifacts'],
+): string | undefined {
+  if (typeof userValue === 'string') {
+    return userValue || undefined;
+  }
+  if (specValue === true) {
+    return 'default';
+  }
+  return typeof specValue === 'string' && specValue !== '' ? specValue : undefined;
 }
 
 /**

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -246,6 +246,24 @@ export function resolveSpecToolFlag(
 }
 
 /**
+ * A spec that hides the chat badge row offers no control over the capabilities
+ * it configures, which is how an admin makes them unconditional. Its own
+ * configuration is therefore authoritative: request toggles are dropped before
+ * any of the resolvers below see them, rather than each caller remembering the
+ * check. Returns the toggles unchanged for every ordinary spec.
+ *
+ * Only the spec's OWN capabilities are governed — a spec with no `skills`
+ * config has nothing to protect, so the per-conversation skills badge still
+ * decides there.
+ */
+export function resolveSpecUserToggles<T>(
+  userToggles: T | undefined,
+  modelSpec: Pick<TModelSpec, 'hideBadgeRow'> | null | undefined,
+): T | undefined {
+  return modelSpec?.hideBadgeRow === true ? undefined : userToggles;
+}
+
+/**
  * The user's MCP selection is authoritative whenever the client sends one — an
  * empty array is a deselection, not an absent value. A spec's `mcpServers`
  * seeds the picker, and applies only when no selection accompanies the request.

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { AgentSubagentsConfig } from './types/assistants';
 import type { TModelSpecPreset } from './schemas';
+import type { TEphemeralAgent } from './types';
 import {
   EModelEndpoint,
   tModelSpecPresetSchema,
@@ -83,6 +84,16 @@ export type TModelSpec = {
   skills?: boolean | string[];
   subagents?: ModelSpecSubagentsConfig;
 };
+
+type EphemeralToolToggles = Pick<
+  TEphemeralAgent,
+  'web_search' | 'file_search' | 'execute_code' | 'memory' | 'ask_user_question'
+>;
+
+type SpecToolToggles = Pick<
+  TModelSpec,
+  'webSearch' | 'fileSearch' | 'executeCode' | 'memory' | 'askUserQuestion'
+>;
 
 export const modelSpecSubagentsSchema = z
   .object({
@@ -205,6 +216,66 @@ export const tModelSpecSchema = z.object({
   skills: z.union([z.boolean(), z.array(z.string())]).optional(),
   subagents: modelSpecSubagentsSchema.optional(),
 });
+
+/**
+ * Ephemeral-agent toggle ↔ model-spec field pairs for the capabilities a spec
+ * can pre-enable and the chat badge row can toggle. Consumed by both the
+ * client (badge state) and the ephemeral agent loaders (tool equipping) so the
+ * two never drift.
+ */
+export const SPEC_TOOL_TOGGLES: ReadonlyArray<
+  readonly [keyof EphemeralToolToggles, keyof SpecToolToggles]
+> = [
+  ['execute_code', 'executeCode'],
+  ['file_search', 'fileSearch'],
+  ['web_search', 'webSearch'],
+  ['memory', 'memory'],
+  ['ask_user_question', 'askUserQuestion'],
+];
+
+/**
+ * A model spec pre-enables a capability as a DEFAULT, not a mandate: an
+ * explicit user toggle — `false` included — decides. Specs whose tools must
+ * not be overridden suppress the badge row entirely via `hideBadgeRow`.
+ */
+export function resolveSpecToolFlag(
+  userValue: boolean | undefined,
+  specValue: boolean | undefined,
+): boolean {
+  return typeof userValue === 'boolean' ? userValue : specValue === true;
+}
+
+/**
+ * The user's MCP selection is authoritative whenever the client sends one — an
+ * empty array is a deselection, not an absent value. A spec's `mcpServers`
+ * seeds the picker, and applies only when no selection accompanies the request.
+ */
+export function resolveSpecMcpServers(
+  userValue: string[] | undefined,
+  specValue: string[] | undefined,
+): string[] {
+  return Array.isArray(userValue) ? userValue : (specValue ?? []);
+}
+
+/**
+ * Skills follow the same default-not-mandate rule, with one exception kept
+ * from the original semantics: a spec's explicit `skills: false` remains a
+ * hard opt-out. Unlike the boolean tool flags — whose `false` has always been
+ * a mere default the badge could turn back on — `skills: false` has always
+ * pinned the agent off, and specs rely on it to keep a catalog out of reach.
+ */
+export function resolveSpecSkillsEnabled(
+  userValue: boolean | undefined,
+  specValue: TModelSpec['skills'],
+): boolean {
+  if (specValue === false) {
+    return false;
+  }
+  if (typeof userValue === 'boolean') {
+    return userValue;
+  }
+  return specValue === true || Array.isArray(specValue);
+}
 
 export const specsConfigSchema = z.object({
   enforce: z.boolean().default(false),


### PR DESCRIPTION
Fixes #15277

## Summary

A model spec's tool configuration seeds the chat badge row; it did not survive the round trip. Every merge site combined the spec with the request as `user === true || spec === true` (a `Set` union for MCP servers), so an explicit user `false` could never subtract. The badge read "off" while web search, code execution, file search, memory, and the deselected MCP servers stayed equipped for the turn.

This is not a permission escalation — `enabledCapabilities` and the per-user skill ACL still gate everything downstream — but it is silent egress against explicit user intent, in the common enterprise configuration, on an rc.

Spec flags are now defaults an explicit request toggle overrides.

**Not a regression — this shipped with the feature.** [#10272](https://github.com/danny-avila/LibreChat/pull/10272) (Oct 2025) introduced the spec tool flags and wrote the rule two ways in one commit: `??` on the client (spec as default) and `||` on the server (spec as mandate). The `skills` half came later, from [#13522](https://github.com/danny-avila/LibreChat/pull/13522), which strips `skills` from the client payload so the badge could never see it.

## Release note

**Model spec tool settings are now defaults a user can override.** If a spec enables web search, file search, code execution, memory, MCP servers, or skills, users can switch those off from the chat badge row and the choice is honored. Previously the badge showed the tool as off while it remained available to the model.

**No change to how specs are selected or presented.** `default`, `softDefault`, `prioritize`, `enforce`, `showInMenu`, `order`, `label`, `iconURL`, `group`, `description`, `conversation_starters`, and everything under `preset` behave exactly as before. `sanitizeModelSpecs` runs only on the `/api/config` client payload; server-side spec resolution and enforcement read the unsanitized config and are untouched.

**For admins who want a spec's tools to be non-negotiable:** set `hideBadgeRow: true`. That spec's configured capabilities then win over any request value, per capability — capabilities it does not configure remain the user's. Deployments already using `hideBadgeRow` see no behavioral change: those tools were previously enforced as a side effect of the old merge, and are now enforced deliberately.

Also fixed:

- Deselected MCP servers no longer reappear once a response completes
- The skills badge reflects a spec's skills configuration instead of always reading "off"
- In multi-conversation mode, the added pane honors the badge row instead of ignoring it
- A spec's `artifacts` setting applies to API clients that send no tool state, matching how its other capabilities already behaved

**Migration:** a deployment relying on users being *unable* to switch off spec-enabled tools should add `hideBadgeRow: true` to those specs.

## Scope of the behavior change

One truth-table cell per capability. A spec's `false` **already** acted as a mere default (`userValue || false` reduces to `userValue`), so only `spec on + user off` flips:

| spec | user | before | after |
|---|---|---|---|
| on | off | **on** | **off** ← the fix |
| on | on | on | on |
| on | silent | on | on |
| off / absent | on | on | on |
| off / absent | off / silent | off | off |

MCP moves from union to selection: an array on the request is the user's selection (`[]` is a deselection, not an absent value), and the spec's `mcpServers` applies only when no selection accompanies the request.

`hideBadgeRow` becomes the deliberate enforcement mechanism, applied per capability at every writer. Removing the old `||` removed the *incidental* enforcement those specs relied on, so this keeps them whole rather than granting anything new.

### `skills` keeps its asymmetry on purpose

Unlike the boolean tool flags, a spec's `skills: false` has always pinned `skills_enabled = false` past the badge, and specs rely on it to hold a catalog out of reach. It stays a hard opt-out, documented in `resolveSpecSkillsEnabled`. The inconsistency between `skills` and the tool flags is pre-existing and left for a separate decision rather than harmonized inside an rc fix.

## Changes

Resolvers live in `data-provider` beside `TModelSpec`, so badge state and the ephemeral loaders read one rule: `SPEC_TOOL_TOGGLES`, `SPEC_CAPABILITY_FIELDS`, `resolveSpecToolFlag`, `resolveSpecMcpServers`, `resolveSpecSkillsEnabled`, `resolveSpecArtifacts`, `resolveSpecUserToggle(s)`, `specOverridesUserToggle`. `packages/api/src/agents/toggles.ts` drives tool equipping from the shared pairs table.

Seven sites read a spec-configured capability, and all seven now share that rule:

- `agents/load.ts` and `agents/added.ts` — the two ephemeral loaders
- `Endpoints/agents/initialize.js` and `Endpoints/agents/addedConvo.js` — the skill recomputations that run afterwards
- `client/src/utils/endpoints.ts` — the badge seed, pinned per capability so a stored value cannot erase what the server would have honored
- `client/src/hooks/Agents/useApplyModelSpecAgents.ts` — the submission template, which re-derives rather than trusting its input
- `api/server/controllers/agents/client.js` — MCP instruction selection, so the model is primed for the servers it actually has

`sanitizeModelSpecs` narrows `skills` to a boolean instead of deleting it, exactly as it already narrows `subagents`. Skill names never leave the server; the one bit the badge needs does. Without this the client seeds `skills: false` for every spec, which the new resolver honors as an opt-out — caught by `model-spec-skills.spec.ts` in CI.

`added.ts` also drops two hand-maintained inline `ephemeralAgent` shapes in favour of `TEphemeralAgent`; one was already missing `skills`. Tool ordering within the equipped list is preserved exactly.

## Testing

~50 regression tests covering each truth-table cell, MCP selection vs. union vs. absent, the skills tri-state, artifacts normalization, and per-capability authority — each paired with an ordinary-spec case so the gate cannot silently become unconditional.

| Suite | Result |
|---|---|
| `/api` (full) | 4825 passed |
| `packages/api` agents + modelSpecs | 2853 passed |
| `client` hooks / utils / store / providers | 1207 passed |
| `data-provider` (full) | 1703 passed |
| e2e (mock-LLM, spec + badge + MCP + artifacts) | 15 passed |

`tsc --noEmit` and eslint clean in both workspaces. Rebased onto `dev` at `41c92dfd06`; six dev commits touched files in this diff and git merged all of them without conflict, so the reader inventory was re-run against the new base to confirm all seven sites survived and no eighth ungated reader appeared.

Reviewed by Codex over seven rounds — 11 findings, 10 accepted and fixed, one refuted with evidence ([the prior loaders compared strictly at all ten call sites](https://github.com/danny-avila/LibreChat/pull/15292#issuecomment-5442598800), so non-boolean values resolve identically before and after).
