### PR TITLE
🫆 feat: Fingerprint Agent Context for Zero-Read Warm Continuation

### DIFF
--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -86,8 +86,6 @@ const mockResolveAgentTurnExecutionPlan = jest.fn((input) => {
     input.event?.expectedAction != null &&
     input.checkpointerType !== 'memory' &&
     !input.canPause &&
-    !input.hasSkillPrimes &&
-    !input.hasMemoryContext &&
     !input.expectedActionMayDetach;
   let strategy = 'history';
   if (input.isNewConversation) {
@@ -4478,27 +4476,6 @@ describe('ResumableAgentController resume metadata', () => {
       undefined,
     ],
     [
-      'always-apply skill prime',
-      { toolDefinitions: [], alwaysApplySkillPrimes: [{ name: 'playbook', body: '# playbook' }] },
-      {},
-      undefined,
-      undefined,
-    ],
-    [
-      'manual skill prime',
-      { toolDefinitions: [], manualSkillPrimes: [{ name: 'playbook', body: '# playbook' }] },
-      {},
-      undefined,
-      undefined,
-    ],
-    [
-      'skills-capable (history-derived re-priming)',
-      { toolDefinitions: [] },
-      {},
-      undefined,
-      { primeInvokedSkills: async () => undefined },
-    ],
-    [
       'background-capable expected action',
       { toolDefinitions: [], backgroundToolNames: ['submit_move_mcp_chess'] },
       {},
@@ -4614,7 +4591,7 @@ describe('ResumableAgentController resume metadata', () => {
       options: {
         agent: {
           toolDefinitions: [],
-          manualSkillPrimes: [{ name: 'playbook', body: '# playbook' }],
+          backgroundToolNames: ['submit_move'],
         },
       },
       sendMessage: jest.fn(),
@@ -4689,7 +4666,7 @@ describe('ResumableAgentController resume metadata', () => {
       options: {
         agent: {
           toolDefinitions: [],
-          manualSkillPrimes: [{ name: 'playbook', body: '# playbook' }],
+          backgroundToolNames: ['submit_move'],
         },
       },
       sendMessage: jest.fn(async () => ({ messageId: 'must-not-run' })),
@@ -4758,7 +4735,7 @@ describe('ResumableAgentController resume metadata', () => {
       options: {
         agent: {
           toolDefinitions: [],
-          manualSkillPrimes: [{ name: 'playbook', body: '# playbook' }],
+          backgroundToolNames: ['submit_move'],
         },
       },
       sendMessage: jest.fn(async () => {
@@ -4840,7 +4817,7 @@ describe('ResumableAgentController resume metadata', () => {
       options: {
         agent: {
           toolDefinitions: [],
-          manualSkillPrimes: [{ name: 'playbook', body: '# playbook' }],
+          backgroundToolNames: ['submit_move'],
         },
       },
       sendMessage: jest.fn(async () => {

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -296,21 +296,26 @@ class AgentClient extends BaseClient {
       usageEmitSink?.filter((event) => event?.usage_type === 'subagent').length ?? 0;
     /** @type {AgentClientOptions} */
     this.options = Object.assign({ endpoint: options.endpoint }, clientOptions);
-    /** Preserve initialization-time semantic inputs before buildMessages
-     * decorates live agent instructions with request memory/MCP context. */
-    this.eventActorAgentContextSources = this.getEventActorAgents().map((agent) => ({
-      id: agent.id,
-      version: agent.version,
-      provider: agent.provider,
-      model: agent.model ?? agent.model_parameters?.model,
-      instructions: agent.instructions,
-      additional_instructions: agent.additional_instructions,
-      model_parameters: JSON.parse(JSON.stringify(agent.model_parameters ?? {})),
-      toolDefinitions: JSON.parse(JSON.stringify(agent.toolDefinitions ?? [])),
-      tool_options: JSON.parse(JSON.stringify(agent.tool_options ?? {})),
-      manualSkillPrimes: agent.manualSkillPrimes,
-      alwaysApplySkillPrimes: agent.alwaysApplySkillPrimes,
-    }));
+    if (
+      this.options.req?._isAgentTrigger === true &&
+      this.options.req?._agentEventBindingParentConversationId != null
+    ) {
+      /** Preserve initialization-time semantic inputs before buildMessages
+       * decorates live agent instructions with request memory/MCP context. */
+      this.eventActorAgentContextSources = this.getEventActorAgents().map((agent) => ({
+        id: agent.id,
+        version: agent.version,
+        provider: agent.provider,
+        model: agent.model ?? agent.model_parameters?.model,
+        instructions: agent.instructions,
+        additional_instructions: agent.additional_instructions,
+        model_parameters: JSON.parse(JSON.stringify(agent.model_parameters ?? {})),
+        toolDefinitions: JSON.parse(JSON.stringify(agent.toolDefinitions ?? [])),
+        tool_options: JSON.parse(JSON.stringify(agent.tool_options ?? {})),
+        manualSkillPrimes: agent.manualSkillPrimes,
+        alwaysApplySkillPrimes: agent.alwaysApplySkillPrimes,
+      }));
+    }
     /** @type {string} */
     this.model = this.options.agent.model_parameters.model;
     /** The key for the usage object's input tokens

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1570,7 +1570,10 @@ class AgentClient extends BaseClient {
   }
 
   getEventActorAgents() {
-    return [this.options.agent, ...(this.agentConfigs?.values() ?? [])].filter(Boolean);
+    return collectReachableAgents([
+      this.options.agent,
+      ...(this.agentConfigs?.values() ?? []),
+    ]).filter(Boolean);
   }
 
   /**
@@ -1620,6 +1623,18 @@ class AgentClient extends BaseClient {
    */
   async getEventActorContext(baseManifest = []) {
     const manifest = new Map(baseManifest.map((skill) => [skill.id, skill]));
+    for (const agent of this.eventActorAgentContextSources ?? []) {
+      for (const skill of agent.manualSkillPrimes ?? []) {
+        if (!Number.isInteger(skill.version) || skill.version < 1) {
+          throw new Error('Manual Skill is missing its semantic version');
+        }
+        manifest.set(skill._id.toString(), {
+          id: skill._id.toString(),
+          name: skill.name,
+          version: skill.version,
+        });
+      }
+    }
     for (const skill of this.eventActorSkillPrimeResult?.skillManifest ?? []) {
       manifest.set(skill.id, skill);
     }
@@ -3567,7 +3582,7 @@ class AgentClient extends BaseClient {
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */
       let skillPrimeResult = this.eventActorSkillPrimeResult;
-      if (this.eventActorContinuation !== 'warm' || skillPrimeResult == null) {
+      if (skillPrimeResult == null) {
         skillPrimeResult = this.options.primeInvokedSkills
           ? await this.options.primeInvokedSkills(payload)
           : undefined;

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1726,14 +1726,13 @@ class AgentClient extends BaseClient {
     this.contextMeta = contextMeta;
     const context = await this.getEventActorContext(storedManifest, discoveredToolNames);
     const skillBodies = new Map(skillPrimeResult?.skills ?? []);
-    for (const agent of this.eventActorAgentContextSources ?? []) {
-      for (const skill of [
-        ...(agent.manualSkillPrimes ?? []),
-        ...(agent.alwaysApplySkillPrimes ?? []),
-      ]) {
-        if (typeof skill.name === 'string' && typeof skill.body === 'string') {
-          skillBodies.set(skill.name, skill.body);
-        }
+    const rootAgentContext = this.eventActorAgentContextSources?.[0];
+    for (const skill of [
+      ...(rootAgentContext?.manualSkillPrimes ?? []),
+      ...(rootAgentContext?.alwaysApplySkillPrimes ?? []),
+    ]) {
+      if (typeof skill.name === 'string' && typeof skill.body === 'string') {
+        skillBodies.set(skill.name, skill.body);
       }
     }
     return {
@@ -1750,22 +1749,16 @@ class AgentClient extends BaseClient {
    */
   async getEventActorContext(baseManifest = [], baseDiscoveredToolNames) {
     const manifest = new Map(baseManifest.map((skill) => [skill.id, skill]));
-    for (const agent of this.eventActorAgentContextSources ?? []) {
-      for (const skill of agent.manualSkillPrimes ?? []) {
-        if (
-          !Number.isInteger(skill.version) ||
-          skill.version < 1 ||
-          typeof skill.body !== 'string'
-        ) {
-          throw new Error('Manual Skill is missing semantic identity');
-        }
-        manifest.set(skill._id.toString(), {
-          id: skill._id.toString(),
-          name: skill.name,
-          version: skill.version,
-          contentDigest: createSkillContentDigest(skill.body),
-        });
+    for (const skill of this.eventActorAgentContextSources?.[0]?.manualSkillPrimes ?? []) {
+      if (!Number.isInteger(skill.version) || skill.version < 1 || typeof skill.body !== 'string') {
+        throw new Error('Manual Skill is missing semantic identity');
       }
+      manifest.set(skill._id.toString(), {
+        id: skill._id.toString(),
+        name: skill.name,
+        version: skill.version,
+        contentDigest: createSkillContentDigest(skill.body),
+      });
     }
     for (const skill of this.eventActorSkillPrimeResult?.skillManifest ?? []) {
       manifest.set(skill.id, skill);

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -312,6 +312,25 @@ class AgentClient extends BaseClient {
         model_parameters: JSON.parse(JSON.stringify(agent.model_parameters ?? {})),
         toolDefinitions: JSON.parse(JSON.stringify(agent.toolDefinitions ?? [])),
         tool_options: JSON.parse(JSON.stringify(agent.tool_options ?? {})),
+        execution: JSON.parse(
+          JSON.stringify({
+            endpoint: agent.endpoint,
+            tool_kwargs: agent.tool_kwargs,
+            edges: agent.edges,
+            end_after_tools: agent.end_after_tools,
+            hide_sequential_outputs: agent.hide_sequential_outputs,
+            stateful_code_sessions: agent.stateful_code_sessions,
+            stateful_code_environment: agent.stateful_code_environment,
+            artifacts: agent.artifacts,
+            recursion_limit: agent.recursion_limit,
+            subagents: agent.subagents,
+            memory_scope: agent.memory_scope,
+            skills_enabled: agent.skills_enabled,
+            skills: agent.skills,
+            backgroundToolNames: agent.backgroundToolNames,
+            intentToolNames: agent.intentToolNames,
+          }),
+        ),
         manualSkillPrimes: agent.manualSkillPrimes,
         alwaysApplySkillPrimes: agent.alwaysApplySkillPrimes,
       }));
@@ -1575,10 +1594,22 @@ class AgentClient extends BaseClient {
   }
 
   getEventActorAgents() {
-    return collectReachableAgents([
-      this.options.agent,
-      ...(this.agentConfigs?.values() ?? []),
-    ]).filter(Boolean);
+    const agents = [];
+    const visited = new Set();
+    const pending = [this.options.agent, ...(this.agentConfigs?.values() ?? [])];
+    for (let index = 0; index < pending.length; index++) {
+      const agent = pending[index];
+      if (!agent || visited.has(agent)) {
+        continue;
+      }
+      visited.add(agent);
+      agents.push(agent);
+      pending.push(...(agent.subagentAgentConfigs?.values?.() ?? []));
+      for (const graph of agent.subagentGraphConfigs ?? []) {
+        pending.push(...(graph.memberConfigs ?? []));
+      }
+    }
+    return agents;
   }
 
   /**

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1,5 +1,9 @@
 require('events').EventEmitter.defaultMaxListeners = 100;
-const { logger } = require('@librechat/data-schemas');
+const {
+  logger,
+  MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH,
+} = require('@librechat/data-schemas');
 const { getBufferString, HumanMessage } = require('@librechat/agents/langchain/messages');
 const {
   createRun,
@@ -98,6 +102,7 @@ const {
   applyAttachmentOnlyText,
   hydrateMissingIndexTokenCounts,
   injectSkillPrimes,
+  buildAgentEventActorSkillMessages,
   collectFreshSkillPrimeNames,
   isSkillPrimeMessage,
   collectFileIds,
@@ -123,6 +128,7 @@ const {
   getSafeErrorMetadata,
   createInitializedAgentContextFingerprint,
   createSkillContentDigest,
+  normalizeAgentEventActorDiscoveredTools,
   MAX_AGENT_CONTEXT_SKILLS,
 } = require('@librechat/api');
 const {
@@ -164,6 +170,65 @@ const db = require('~/models');
 const loadAgent = (params) => loadAgentFn(params, { getAgent: db.getAgent, getMCPServerTools });
 
 const MEMORY_INPUT_CHARS_PER_TOKEN = 8;
+
+function normalizeEventActorSummary(summary) {
+  if (summary == null) {
+    return undefined;
+  }
+  if (
+    typeof summary.text !== 'string' ||
+    summary.text.length === 0 ||
+    summary.text.length > MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH ||
+    !Number.isFinite(summary.tokenCount) ||
+    summary.tokenCount < 0
+  ) {
+    throw new RangeError('Event actor summary state is invalid');
+  }
+  return { text: summary.text, tokenCount: summary.tokenCount };
+}
+
+function normalizeEventActorContextMeta(contextMeta) {
+  if (contextMeta == null) {
+    return undefined;
+  }
+  const { calibrationRatio, encoding } = contextMeta;
+  if (
+    !Number.isFinite(calibrationRatio) ||
+    calibrationRatio < 0.5 ||
+    calibrationRatio > 5 ||
+    (encoding != null &&
+      (typeof encoding !== 'string' ||
+        encoding.length === 0 ||
+        encoding.length > MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH))
+  ) {
+    throw new RangeError('Event actor context calibration is invalid');
+  }
+  return { calibrationRatio, ...(encoding == null ? {} : { encoding }) };
+}
+
+function getLatestEventActorSummary(contentParts) {
+  if (!Array.isArray(contentParts)) {
+    return undefined;
+  }
+  for (let index = contentParts.length - 1; index >= 0; index -= 1) {
+    const part = contentParts[index];
+    if (part?.type !== ContentTypes.SUMMARY || !Array.isArray(part.content)) {
+      continue;
+    }
+    const text = part.content
+      .map((block) => (typeof block?.text === 'string' ? block.text : ''))
+      .join('')
+      .trim();
+    if (text.length === 0) {
+      continue;
+    }
+    return normalizeEventActorSummary({
+      text,
+      tokenCount: Number.isFinite(part.tokenCount) && part.tokenCount >= 0 ? part.tokenCount : 0,
+    });
+  }
+  return undefined;
+}
 
 function getUserFacingRequestError(baseMessage, error, appConfig) {
   const protectionEnabled = hasModelBoundContentProtection(
@@ -220,6 +285,8 @@ class AgentClient extends BaseClient {
     this.eventActorInvocationId = undefined;
     this.eventActorContinuation = undefined;
     this.eventActorSkillPrimeResult = undefined;
+    this.eventActorDiscoveredToolNames = undefined;
+    this.eventActorSummary = undefined;
 
     /** @type {AgentRun} */
     this.run;
@@ -312,6 +379,13 @@ class AgentClient extends BaseClient {
         additional_instructions: agent.additional_instructions,
         model_parameters: JSON.parse(JSON.stringify(agent.model_parameters ?? {})),
         toolDefinitions: JSON.parse(JSON.stringify(agent.toolDefinitions ?? [])),
+        toolRegistryDefinitions: JSON.parse(
+          JSON.stringify(
+            [...(agent.toolRegistry?.values() ?? [])].sort((left, right) =>
+              left.name.localeCompare(right.name),
+            ),
+          ),
+        ),
         tool_options: JSON.parse(JSON.stringify(agent.tool_options ?? {})),
         execution: JSON.parse(
           JSON.stringify({
@@ -1596,23 +1670,7 @@ class AgentClient extends BaseClient {
   }
 
   getEventActorAgents() {
-    const agents = [];
-    const visited = new Set();
-    const pending = [this.options.agent, ...(this.agentConfigs?.values() ?? [])];
-    for (let index = 0; index < pending.length; index++) {
-      const agent = pending[index];
-      if (!agent || visited.has(agent)) {
-        continue;
-      }
-      visited.add(agent);
-      agents.push(agent);
-      pending.push(...(agent.subagentAgentConfigs?.values?.() ?? []));
-      pending.push(...(agent.lazySubagentConfigs?.values?.() ?? []));
-      for (const graph of agent.subagentGraphConfigs ?? []) {
-        pending.push(...(graph.memberConfigs ?? []));
-      }
-    }
-    return agents;
+    return collectReachableAgents([this.options.agent, ...(this.agentConfigs?.values() ?? [])]);
   }
 
   /**
@@ -1630,6 +1688,16 @@ class AgentClient extends BaseClient {
     }
     const storedManifest = Array.isArray(state.skillManifest) ? state.skillManifest : [];
     if (storedManifest.length > MAX_AGENT_CONTEXT_SKILLS) {
+      return undefined;
+    }
+    let discoveredToolNames;
+    let summary;
+    let contextMeta;
+    try {
+      discoveredToolNames = normalizeAgentEventActorDiscoveredTools(state.discoveredToolNames);
+      summary = normalizeEventActorSummary(state.summary);
+      contextMeta = normalizeEventActorContextMeta(state.contextMeta);
+    } catch {
       return undefined;
     }
 
@@ -1653,14 +1721,34 @@ class AgentClient extends BaseClient {
       }
     }
     this.eventActorSkillPrimeResult = skillPrimeResult;
-    const context = await this.getEventActorContext(storedManifest);
-    return context;
+    this.eventActorDiscoveredToolNames = discoveredToolNames;
+    this.eventActorSummary = summary;
+    this.contextMeta = contextMeta;
+    const context = await this.getEventActorContext(storedManifest, discoveredToolNames);
+    const skillBodies = new Map(skillPrimeResult?.skills ?? []);
+    for (const agent of this.eventActorAgentContextSources ?? []) {
+      for (const skill of [
+        ...(agent.manualSkillPrimes ?? []),
+        ...(agent.alwaysApplySkillPrimes ?? []),
+      ]) {
+        if (typeof skill.name === 'string' && typeof skill.body === 'string') {
+          skillBodies.set(skill.name, skill.body);
+        }
+      }
+    }
+    return {
+      ...context,
+      checkpointMessageOverlay: {
+        source: 'skill',
+        messages: buildAgentEventActorSkillMessages(skillBodies),
+      },
+    };
   }
 
   /**
    * @param {Array<{id: string, name: string, version: number}>} [baseManifest]
    */
-  async getEventActorContext(baseManifest = []) {
+  async getEventActorContext(baseManifest = [], baseDiscoveredToolNames) {
     const manifest = new Map(baseManifest.map((skill) => [skill.id, skill]));
     for (const agent of this.eventActorAgentContextSources ?? []) {
       for (const skill of agent.manualSkillPrimes ?? []) {
@@ -1694,15 +1782,26 @@ class AgentClient extends BaseClient {
     const agents = this.getEventActorAgents();
     const memory = await this.getEventActorMemorySnapshots(agents);
     const agentsConfig = this.options.req.config?.endpoints?.[EModelEndpoint.agents];
+    const discoveredToolNames = normalizeAgentEventActorDiscoveredTools([
+      ...(baseDiscoveredToolNames ??
+        (this.eventActorContinuation === 'warm' ? (this.eventActorDiscoveredToolNames ?? []) : [])),
+      ...(this.run == null ? [] : getRunDiscoveredTools(this.run)),
+    ]);
+    const summary = getLatestEventActorSummary(this.contentParts) ?? this.eventActorSummary;
+    this.eventActorSummary = summary;
     return {
       fingerprint: createInitializedAgentContextFingerprint({
         agents: this.eventActorAgentContextSources ?? agents,
         invokedSkills: skillManifest,
         approvalPolicy: agentsConfig?.toolApproval,
         memory,
+        discoveredToolNames,
         checkpointerType: agentsConfig?.checkpointer?.type,
       }),
       skillManifest,
+      discoveredToolNames,
+      ...(summary == null ? {} : { summary }),
+      ...(this.contextMeta == null ? {} : { contextMeta: this.contextMeta }),
     };
   }
 
@@ -1717,6 +1816,12 @@ class AgentClient extends BaseClient {
   }
 
   async buildMessages(messages, parentMessageId, _buildOptions, opts) {
+    if (this.eventActorContinuation === 'cold') {
+      /** Compatibility was rejected after warm state preparation. Rebuild all
+       * non-checkpointed state from durable history, never from that stale head. */
+      this.eventActorSummary = undefined;
+      this.contextMeta = undefined;
+    }
     /** Always pass mapMethod; getMessagesForConversation applies it only to messages with addedConvo flag */
     const orderedMessages = this.constructor.getMessagesForConversation({
       messages,
@@ -3628,6 +3733,10 @@ class AgentClient extends BaseClient {
       const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */
+      if (this.eventActorContinuation === 'cold') {
+        this.eventActorSkillPrimeResult = undefined;
+        this.eventActorDiscoveredToolNames = undefined;
+      }
       let skillPrimeResult = this.eventActorSkillPrimeResult;
       if (skillPrimeResult == null) {
         skillPrimeResult = this.options.primeInvokedSkills
@@ -3691,6 +3800,11 @@ class AgentClient extends BaseClient {
         skillPrimeResult?.skills,
         formatOptions,
       );
+      if (this.eventActorContinuation !== 'warm') {
+        this.eventActorSummary = initialSummary;
+      }
+      const continuationSummary =
+        this.eventActorContinuation === 'warm' ? this.eventActorSummary : initialSummary;
       if (boundaryTokenAdjustment) {
         logger.debug(
           `[AgentClient] Boundary token adjustment: ${boundaryTokenAdjustment.original} → ${boundaryTokenAdjustment.adjusted} (${boundaryTokenAdjustment.remainingChars}/${boundaryTokenAdjustment.totalChars} chars)`,
@@ -3916,6 +4030,8 @@ class AgentClient extends BaseClient {
           // carries no messages, so history cannot identify the conversation.
           conversationId: this.conversationId,
           messages,
+          discoveredToolNames:
+            this.eventActorContinuation === 'warm' ? this.eventActorDiscoveredToolNames : undefined,
           modelCallbacks: [modelBoundCallback],
           // This controller implements the full HITL pause/resume lifecycle (handleRunInterrupt
           // persists the pending action; the /resume route rebuilds + continues the run), so it
@@ -3936,11 +4052,11 @@ class AgentClient extends BaseClient {
           // plus the one new event), so those indices address different
           // messages and the pruner would never recount them. Hand it an empty
           // map so every count is derived from the messages actually in state.
-          // `initialSummary` deliberately stays: it rides the system tail, and
-          // the pre-boundary turns it summarizes were excluded from the very
-          // history the committed checkpoint was built from.
+          // The active summary lives in AgentContext rather than checkpointed
+          // graph messages, so warm turns restore the actor-head copy while
+          // rebuilt turns use the summary reconstructed from durable history.
           indexTokenCountMap: this.eventActorContinuation === 'warm' ? {} : indexTokenCountMap,
-          initialSummary,
+          initialSummary: continuationSummary,
           initialSessions,
           calibrationRatio,
           runId: this.responseMessageId,
@@ -4085,6 +4201,10 @@ class AgentClient extends BaseClient {
         this.contentParts.unshift(...manualParts);
       }
 
+      /** Summaries are run state, even when sequential-output reshaping hides
+       * their display block from the persisted response content. */
+      this.eventActorSummary =
+        getLatestEventActorSummary(this.contentParts) ?? this.eventActorSummary;
       this.applyHideSequentialOutputsFilter();
       this.rebaseActivityPhaseBounds(contentBeforeReshape);
     } catch (err) {
@@ -4135,6 +4255,10 @@ class AgentClient extends BaseClient {
         });
       }
     } finally {
+      /** An aborted/erroring run can still have completed compaction before
+       * the failure; retain that model-visible state for actor reconciliation. */
+      this.eventActorSummary =
+        getLatestEventActorSummary(this.contentParts) ?? this.eventActorSummary;
       /** Capture calibration state from the run for persistence on the response message.
        *  Runs in finally so values are captured even on abort. */
       const ratio = this.run?.getCalibrationRatio() ?? 0;
@@ -4523,6 +4647,8 @@ class AgentClient extends BaseClient {
       // before resume finalize/re-pause persistence reads `this.contentParts`, so a
       // resumed sequential chain doesn't persist/emit outputs hide_sequential_outputs
       // is meant to hide.
+      this.eventActorSummary =
+        getLatestEventActorSummary(this.contentParts) ?? this.eventActorSummary;
       const contentBeforeReshape = [...this.contentParts];
       this.applyHideSequentialOutputsFilter();
       this.rebaseActivityPhaseBounds(contentBeforeReshape);
@@ -4561,6 +4687,8 @@ class AgentClient extends BaseClient {
         });
       }
     } finally {
+      this.eventActorSummary =
+        getLatestEventActorSummary(this.contentParts) ?? this.eventActorSummary;
       const ratio = this.run?.getCalibrationRatio() ?? 0;
       if (ratio > 0 && ratio !== 1) {
         this.contextMeta = {

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -2674,6 +2674,9 @@ class AgentClient extends BaseClient {
     const scopes = new Map([[primaryScope ?? '', primary]]);
     await Promise.all(
       agents.map(async (agent) => {
+        if (agent !== this.options.agent && !agentHasInlineMemoryTools(agent)) {
+          return;
+        }
         const agentId = getMemoryAgentId(agent);
         const scope = agentId ?? '';
         if (scopes.has(scope)) {

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -121,6 +121,8 @@ const {
   collectReachableAgents,
   getDynamicToolContexts,
   getSafeErrorMetadata,
+  createInitializedAgentContextFingerprint,
+  MAX_AGENT_CONTEXT_SKILLS,
 } = require('@librechat/api');
 const {
   Run,
@@ -216,6 +218,7 @@ class AgentClient extends BaseClient {
     this.eventActorCheckpointId = undefined;
     this.eventActorInvocationId = undefined;
     this.eventActorContinuation = undefined;
+    this.eventActorSkillPrimeResult = undefined;
 
     /** @type {AgentRun} */
     this.run;
@@ -293,6 +296,21 @@ class AgentClient extends BaseClient {
       usageEmitSink?.filter((event) => event?.usage_type === 'subagent').length ?? 0;
     /** @type {AgentClientOptions} */
     this.options = Object.assign({ endpoint: options.endpoint }, clientOptions);
+    /** Preserve initialization-time semantic inputs before buildMessages
+     * decorates live agent instructions with request memory/MCP context. */
+    this.eventActorAgentContextSources = this.getEventActorAgents().map((agent) => ({
+      id: agent.id,
+      version: agent.version,
+      provider: agent.provider,
+      model: agent.model ?? agent.model_parameters?.model,
+      instructions: agent.instructions,
+      additional_instructions: agent.additional_instructions,
+      model_parameters: JSON.parse(JSON.stringify(agent.model_parameters ?? {})),
+      toolDefinitions: JSON.parse(JSON.stringify(agent.toolDefinitions ?? [])),
+      tool_options: JSON.parse(JSON.stringify(agent.tool_options ?? {})),
+      manualSkillPrimes: agent.manualSkillPrimes,
+      alwaysApplySkillPrimes: agent.alwaysApplySkillPrimes,
+    }));
     /** @type {string} */
     this.model = this.options.agent.model_parameters.model;
     /** The key for the usage object's input tokens
@@ -1551,6 +1569,94 @@ class AgentClient extends BaseClient {
     return files;
   }
 
+  getEventActorAgents() {
+    return [this.options.agent, ...(this.agentConfigs?.values() ?? [])].filter(Boolean);
+  }
+
+  /**
+   * Resolves the committed Skill manifest and request-cached memory before the
+   * actor chooses warm versus rebuilt continuation. No message history is read.
+   *
+   * @param {import('@librechat/data-schemas').IAgentEventActorState | null} state
+   */
+  async prepareEventActorContext(state) {
+    if (state?.contextFingerprint == null) {
+      return undefined;
+    }
+    if (isMemoryAgentEnabled(this.options.req.config?.memory)) {
+      return undefined;
+    }
+    const storedManifest = Array.isArray(state.skillManifest) ? state.skillManifest : [];
+    if (storedManifest.length > MAX_AGENT_CONTEXT_SKILLS) {
+      return undefined;
+    }
+
+    let skillPrimeResult = {};
+    if (storedManifest.length > 0) {
+      if (typeof this.options.primeInvokedSkills !== 'function') {
+        return undefined;
+      }
+      skillPrimeResult = await this.options.primeInvokedSkills(
+        [],
+        storedManifest.map((skill) => skill.name),
+      );
+      const resolvedManifest = [...(skillPrimeResult?.skillManifest ?? [])].sort((left, right) =>
+        left.id.localeCompare(right.id),
+      );
+      const expectedManifest = [...storedManifest].sort((left, right) =>
+        left.id.localeCompare(right.id),
+      );
+      if (JSON.stringify(resolvedManifest) !== JSON.stringify(expectedManifest)) {
+        return undefined;
+      }
+    }
+    this.eventActorSkillPrimeResult = skillPrimeResult;
+    const context = await this.getEventActorContext(storedManifest);
+    return context;
+  }
+
+  /**
+   * @param {Array<{id: string, name: string, version: number}>} [baseManifest]
+   */
+  async getEventActorContext(baseManifest = []) {
+    const manifest = new Map(baseManifest.map((skill) => [skill.id, skill]));
+    for (const skill of this.eventActorSkillPrimeResult?.skillManifest ?? []) {
+      manifest.set(skill.id, skill);
+    }
+    for (const skill of this.options.invokedSkillIdentities?.values?.() ?? []) {
+      manifest.set(skill.id, skill);
+    }
+    if (manifest.size > MAX_AGENT_CONTEXT_SKILLS) {
+      throw new RangeError(`Event actor exceeds ${MAX_AGENT_CONTEXT_SKILLS} durable Skills`);
+    }
+    const skillManifest = [...manifest.values()].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    );
+    const agents = this.getEventActorAgents();
+    const memory = await this.getEventActorMemorySnapshots(agents);
+    const agentsConfig = this.options.req.config?.endpoints?.[EModelEndpoint.agents];
+    return {
+      fingerprint: createInitializedAgentContextFingerprint({
+        agents: this.eventActorAgentContextSources ?? agents,
+        invokedSkills: skillManifest,
+        approvalPolicy: agentsConfig?.toolApproval,
+        memory,
+        checkpointerType: agentsConfig?.checkpointer?.type,
+      }),
+      skillManifest,
+    };
+  }
+
+  async loadHistory(conversationId, parentMessageId = null) {
+    if (this.eventActorContinuation === 'warm') {
+      logger.debug('[AgentClient] Skipping durable history for compatible event actor', {
+        conversationId,
+      });
+      return [];
+    }
+    return super.loadHistory(conversationId, parentMessageId);
+  }
+
   async buildMessages(messages, parentMessageId, _buildOptions, opts) {
     /** Always pass mapMethod; getMessagesForConversation applies it only to messages with addedConvo flag */
     const orderedMessages = this.constructor.getMessagesForConversation({
@@ -1616,7 +1722,7 @@ class AgentClient extends BaseClient {
      * original promise later still propagates either error.
      */
     const earlySharedContextPromise = Promise.all([
-      this.useMemory(),
+      this.getSharedMemoryContext(),
       resolveConfigServers(this.options.req),
     ]);
     void earlySharedContextPromise.catch(() => {});
@@ -2484,6 +2590,52 @@ class AgentClient extends BaseClient {
       );
     }
     return { withKeys, withoutKeys };
+  }
+
+  /** Reuses the exact memory authorization/load promise for planning and prompt construction. */
+  getSharedMemoryContext() {
+    this.memoryContextPromise ??= this.useMemory();
+    return this.memoryContextPromise;
+  }
+
+  /**
+   * Returns the model-bound memory snapshots needed for event-actor compatibility.
+   * The request-scoped memory cache makes this the same read used by buildMessages.
+   *
+   * @param {Array<import('@librechat/api').InitializedAgent>} agents
+   * @returns {Promise<Array<{scope: string, withKeys?: string, withoutKeys?: string}>>}
+   */
+  async getEventActorMemorySnapshots(agents) {
+    const primary = await this.getSharedMemoryContext();
+    if (!primary) {
+      return [];
+    }
+    const userId = this.options.req.user.id + '';
+    const primaryScope = getMemoryAgentId(this.options.agent);
+    const scopes = new Map([[primaryScope ?? '', primary]]);
+    await Promise.all(
+      agents.map(async (agent) => {
+        const agentId = getMemoryAgentId(agent);
+        const scope = agentId ?? '';
+        if (scopes.has(scope)) {
+          return;
+        }
+        const snapshot = await getRequestMemories({
+          req: this.options.req,
+          userId,
+          agentId,
+          getFormattedMemories: db.getFormattedMemories,
+        });
+        scopes.set(scope, snapshot);
+      }),
+    );
+    return [...scopes]
+      .map(([scope, snapshot]) => ({
+        scope: scope || 'shared',
+        ...(snapshot.withKeys ? { withKeys: snapshot.withKeys } : {}),
+        ...(snapshot.withoutKeys ? { withoutKeys: snapshot.withoutKeys } : {}),
+      }))
+      .sort((left, right) => left.scope.localeCompare(right.scope));
   }
 
   /**
@@ -3414,9 +3566,13 @@ class AgentClient extends BaseClient {
       const tokenCounter = await createCachedTokenCounter(this.getEncoding());
 
       /** Pre-resolve invoked skill bodies + re-prime files before formatting messages */
-      const skillPrimeResult = this.options.primeInvokedSkills
-        ? await this.options.primeInvokedSkills(payload)
-        : undefined;
+      let skillPrimeResult = this.eventActorSkillPrimeResult;
+      if (this.eventActorContinuation !== 'warm' || skillPrimeResult == null) {
+        skillPrimeResult = this.options.primeInvokedSkills
+          ? await this.options.primeInvokedSkills(payload)
+          : undefined;
+      }
+      this.eventActorSkillPrimeResult = skillPrimeResult;
 
       /** Seed each reachable agent's trusted code-session partition. */
       const initialSessions = buildInitialToolSessions({

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -122,6 +122,7 @@ const {
   getDynamicToolContexts,
   getSafeErrorMetadata,
   createInitializedAgentContextFingerprint,
+  createSkillContentDigest,
   MAX_AGENT_CONTEXT_SKILLS,
 } = require('@librechat/api');
 const {
@@ -315,6 +316,7 @@ class AgentClient extends BaseClient {
         execution: JSON.parse(
           JSON.stringify({
             endpoint: agent.endpoint,
+            configId: agent.configId,
             tool_kwargs: agent.tool_kwargs,
             edges: agent.edges,
             end_after_tools: agent.end_after_tools,
@@ -1605,6 +1607,7 @@ class AgentClient extends BaseClient {
       visited.add(agent);
       agents.push(agent);
       pending.push(...(agent.subagentAgentConfigs?.values?.() ?? []));
+      pending.push(...(agent.lazySubagentConfigs?.values?.() ?? []));
       for (const graph of agent.subagentGraphConfigs ?? []) {
         pending.push(...(graph.memberConfigs ?? []));
       }
@@ -1661,13 +1664,18 @@ class AgentClient extends BaseClient {
     const manifest = new Map(baseManifest.map((skill) => [skill.id, skill]));
     for (const agent of this.eventActorAgentContextSources ?? []) {
       for (const skill of agent.manualSkillPrimes ?? []) {
-        if (!Number.isInteger(skill.version) || skill.version < 1) {
-          throw new Error('Manual Skill is missing its semantic version');
+        if (
+          !Number.isInteger(skill.version) ||
+          skill.version < 1 ||
+          typeof skill.body !== 'string'
+        ) {
+          throw new Error('Manual Skill is missing semantic identity');
         }
         manifest.set(skill._id.toString(), {
           id: skill._id.toString(),
           name: skill.name,
           version: skill.version,
+          contentDigest: createSkillContentDigest(skill.body),
         });
       }
     }

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -61,6 +61,7 @@ jest.mock('@librechat/api', () => ({
     version: 1,
     digest: 'context',
   })),
+  createSkillContentDigest: jest.fn((body) => `digest:${body}`),
   MAX_AGENT_CONTEXT_SKILLS: 64,
   createDetachedSubagentUsageRecorder: (...args) =>
     mockCreateDetachedSubagentUsageRecorder(...args),
@@ -152,20 +153,34 @@ describe('AgentClient - event actor history adapter', () => {
     client.eventActorAgentContextSources = [
       {
         id: 'agent-1',
-        manualSkillPrimes: [{ _id: 'skill-1', name: 'analysis', version: 3 }],
+        manualSkillPrimes: [
+          { _id: 'skill-1', name: 'analysis', version: 3, body: 'Analyze carefully.' },
+        ],
       },
     ];
     client.getEventActorAgents = jest.fn(() => []);
     client.getEventActorMemorySnapshots = jest.fn().mockResolvedValue([]);
 
     await expect(client.getEventActorContext()).resolves.toMatchObject({
-      skillManifest: [{ id: 'skill-1', name: 'analysis', version: 3 }],
+      skillManifest: [
+        {
+          id: 'skill-1',
+          name: 'analysis',
+          version: 3,
+          contentDigest: 'digest:Analyze carefully.',
+        },
+      ],
     });
   });
 
   it('fingerprints agents reachable only through nested subagent graphs', () => {
     const graphMember = { id: 'graph-member' };
-    const nested = { id: 'nested', subagentGraphConfigs: [{ memberConfigs: [graphMember] }] };
+    const lazy = { id: 'lazy', configId: 'lazy-config-v2' };
+    const nested = {
+      id: 'nested',
+      lazySubagentConfigs: [lazy],
+      subagentGraphConfigs: [{ memberConfigs: [graphMember] }],
+    };
     const client = Object.create(AgentClient.prototype);
     client.options = { agent: { id: 'primary', subagentAgentConfigs: [nested] } };
     client.agentConfigs = new Map([['parallel', { id: 'parallel' }]]);
@@ -174,6 +189,7 @@ describe('AgentClient - event actor history adapter', () => {
       'primary',
       'parallel',
       'nested',
+      'lazy',
       'graph-member',
     ]);
   });

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -113,19 +113,60 @@ describe('AgentClient - event actor history adapter', () => {
 
   it('resolves and caches the exact durable Skill manifest before warming', async () => {
     const skillManifest = [{ id: 'skill-1', name: 'analysis', version: 3 }];
-    const primeInvokedSkills = jest.fn().mockResolvedValue({ skillManifest });
+    const skillPrimeResult = {
+      skillManifest,
+      skills: new Map([['analysis', 'Analyze carefully.']]),
+    };
+    const primeInvokedSkills = jest.fn().mockResolvedValue(skillPrimeResult);
     const client = Object.create(AgentClient.prototype);
     client.options = {
       req: { config: {} },
       primeInvokedSkills,
     };
-    client.getEventActorContext = jest.fn().mockResolvedValue({ fingerprint, skillManifest });
+    client.getEventActorContext = jest.fn().mockResolvedValue({
+      fingerprint,
+      skillManifest,
+      discoveredToolNames: ['deferred_tool'],
+      summary: { text: 'Earlier compacted context.', tokenCount: 12 },
+      contextMeta: { calibrationRatio: 1.25, encoding: 'o200k_base' },
+    });
 
     await expect(
-      client.prepareEventActorContext({ contextFingerprint: fingerprint, skillManifest }),
-    ).resolves.toEqual({ fingerprint, skillManifest });
+      client.prepareEventActorContext({
+        contextFingerprint: fingerprint,
+        skillManifest,
+        discoveredToolNames: ['deferred_tool'],
+        summary: { text: 'Earlier compacted context.', tokenCount: 12 },
+        contextMeta: { calibrationRatio: 1.25, encoding: 'o200k_base' },
+      }),
+    ).resolves.toMatchObject({
+      fingerprint,
+      skillManifest,
+      discoveredToolNames: ['deferred_tool'],
+      summary: { text: 'Earlier compacted context.', tokenCount: 12 },
+      contextMeta: { calibrationRatio: 1.25, encoding: 'o200k_base' },
+      checkpointMessageOverlay: {
+        source: 'skill',
+        messages: [
+          expect.objectContaining({
+            content: 'Analyze carefully.',
+            additional_kwargs: expect.objectContaining({
+              source: 'skill',
+              skillName: 'analysis',
+            }),
+          }),
+        ],
+      },
+    });
     expect(primeInvokedSkills).toHaveBeenCalledWith([], ['analysis']);
-    expect(client.eventActorSkillPrimeResult).toEqual({ skillManifest });
+    expect(client.getEventActorContext).toHaveBeenCalledWith(skillManifest, ['deferred_tool']);
+    expect(client.eventActorSkillPrimeResult).toEqual(skillPrimeResult);
+    expect(client.eventActorDiscoveredToolNames).toEqual(['deferred_tool']);
+    expect(client.eventActorSummary).toEqual({
+      text: 'Earlier compacted context.',
+      tokenCount: 12,
+    });
+    expect(client.contextMeta).toEqual({ calibrationRatio: 1.25, encoding: 'o200k_base' });
   });
 
   it('falls back when a durable Skill resolves to a different revision', async () => {
@@ -173,9 +214,35 @@ describe('AgentClient - event actor history adapter', () => {
     });
   });
 
+  it('captures the latest run summary and pruning calibration in continuation state', async () => {
+    const client = Object.create(AgentClient.prototype);
+    client.options = { req: { config: { endpoints: { agents: {} } } } };
+    client.eventActorAgentContextSources = [];
+    client.contentParts = [
+      {
+        type: ContentTypes.SUMMARY,
+        content: [{ type: ContentTypes.TEXT, text: 'Fresh compacted context.' }],
+        tokenCount: 18,
+      },
+    ];
+    client.contextMeta = { calibrationRatio: 1.3, encoding: 'o200k_base' };
+    client.getEventActorAgents = jest.fn(() => []);
+    client.getEventActorMemorySnapshots = jest.fn().mockResolvedValue([]);
+
+    await expect(client.getEventActorContext()).resolves.toMatchObject({
+      summary: { text: 'Fresh compacted context.', tokenCount: 18 },
+      contextMeta: { calibrationRatio: 1.3, encoding: 'o200k_base' },
+    });
+  });
+
   it('fingerprints agents reachable only through nested subagent graphs', () => {
     const graphMember = { id: 'graph-member' };
-    const lazy = { id: 'lazy', configId: 'lazy-config-v2' };
+    const graphMetadata = { id: 'graph-metadata', configId: 'graph-metadata-v2' };
+    const lazy = {
+      id: 'lazy',
+      configId: 'lazy-config-v2',
+      subagentGraphMemberMetadata: [graphMetadata],
+    };
     const nested = {
       id: 'nested',
       lazySubagentConfigs: [lazy],
@@ -191,6 +258,7 @@ describe('AgentClient - event actor history adapter', () => {
       'nested',
       'lazy',
       'graph-member',
+      'graph-metadata',
     ]);
   });
 
@@ -1584,16 +1652,26 @@ describe('AgentClient - startup telemetry', () => {
     mockFormatAgentMessages.mockReturnValueOnce({
       messages: [history, currentEvent],
       indexTokenCountMap: { 0: 11, 1: 22 },
-      summary: { text: 'summary of earlier turns', tokenCount: 40 },
+      summary: undefined,
       boundaryTokenAdjustment: undefined,
     });
-    const processStream = jest.fn().mockResolvedValue();
+    let client;
+    const processStream = jest.fn(async () => {
+      client.contentParts.push(
+        {
+          type: ContentTypes.SUMMARY,
+          content: [{ type: ContentTypes.TEXT, text: 'Fresh compacted context.' }],
+          tokenCount: 18,
+        },
+        { type: ContentTypes.TEXT, text: 'Done.' },
+      );
+    });
     mockCreateRun.mockResolvedValue({
       Graph: null,
       processStream,
       getCalibrationRatio: jest.fn(() => 0),
     });
-    const client = new AgentClient({
+    client = new AgentClient({
       req: {
         user: { id: 'user-123' },
         body: {},
@@ -1606,7 +1684,7 @@ describe('AgentClient - startup telemetry', () => {
         endpoint: EModelEndpoint.openAI,
         provider: EModelEndpoint.openAI,
         model_parameters: { model: 'gpt-4' },
-        hide_sequential_outputs: false,
+        hide_sequential_outputs: true,
       },
       endpointTokenConfig: {},
       eventHandlers: {},
@@ -1621,6 +1699,9 @@ describe('AgentClient - startup telemetry', () => {
     client.eventActorCheckpointId = 'checkpoint-base';
     client.eventActorInvocationId = 'event-2';
     client.eventActorContinuation = 'warm';
+    client.eventActorDiscoveredToolNames = ['deferred_tool'];
+    client.eventActorSummary = { text: 'summary of earlier turns', tokenCount: 40 };
+    client.contextMeta = { calibrationRatio: 1.25, encoding: client.getEncoding() };
     client.recordCollectedUsage = jest.fn().mockResolvedValue();
 
     await client.chatCompletion({ payload: [] });
@@ -1628,6 +1709,7 @@ describe('AgentClient - startup telemetry', () => {
     expect(mockCreateRun).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [history, currentEvent],
+        discoveredToolNames: ['deferred_tool'],
         eventActorCheckpointing: true,
         /** The DB-derived token map is positional over full history, which a
          * checkpoint-restored graph state no longer matches. It must be blank
@@ -1636,6 +1718,7 @@ describe('AgentClient - startup telemetry', () => {
          * excluded from the history the committed checkpoint was built from. */
         indexTokenCountMap: {},
         initialSummary: { text: 'summary of earlier turns', tokenCount: 40 },
+        calibrationRatio: 1.25,
       }),
     );
     expect(processStream).toHaveBeenCalledWith(
@@ -1653,6 +1736,13 @@ describe('AgentClient - startup telemetry', () => {
       expect.anything(),
     );
     expect(mockDeleteAgentCheckpoint).not.toHaveBeenCalled();
+    expect(client.eventActorSummary).toEqual({
+      text: 'Fresh compacted context.',
+      tokenCount: 18,
+    });
+    expect(client.contentParts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: ContentTypes.SUMMARY })]),
+    );
   });
 
   it('does not expose or process a fresh graph when strict checkpoint pruning fails', async () => {

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -193,6 +193,38 @@ describe('AgentClient - event actor history adapter', () => {
       'graph-member',
     ]);
   });
+
+  it('snapshots only memory partitions that can reach model context', async () => {
+    const getFormattedMemories = require('~/models').getFormattedMemories;
+    getFormattedMemories.mockClear();
+    getFormattedMemories.mockResolvedValue({ withKeys: 'private memory' });
+    const primary = { id: 'primary' };
+    const inertChild = {
+      id: 'inert-child',
+      memory_scope: 'agent',
+      memoryToolsRegistered: false,
+    };
+    const memoryChild = {
+      id: 'memory-child',
+      memory_scope: 'agent',
+      memoryToolsRegistered: true,
+    };
+    const client = Object.create(AgentClient.prototype);
+    client.options = { agent: primary, req: { user: { id: 'user-1' } } };
+    client.getSharedMemoryContext = jest.fn().mockResolvedValue({ withoutKeys: 'shared memory' });
+
+    await expect(
+      client.getEventActorMemorySnapshots([primary, inertChild, memoryChild]),
+    ).resolves.toEqual([
+      { scope: 'memory-child', withKeys: 'private memory' },
+      { scope: 'shared', withoutKeys: 'shared memory' },
+    ]);
+    expect(getFormattedMemories).toHaveBeenCalledTimes(1);
+    expect(getFormattedMemories).toHaveBeenCalledWith({
+      userId: 'user-1',
+      agentId: 'memory-child',
+    });
+  });
 });
 
 describe('AgentClient - final model-bound content protection', () => {

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -214,6 +214,60 @@ describe('AgentClient - event actor history adapter', () => {
     });
   });
 
+  it('replays only root Skill primes into the global checkpoint overlay', async () => {
+    const client = Object.create(AgentClient.prototype);
+    client.options = { req: { config: {} } };
+    client.eventActorAgentContextSources = [
+      {
+        id: 'root-agent',
+        alwaysApplySkillPrimes: [
+          { _id: 'root-skill', name: 'root-skill', version: 1, body: 'Root instructions.' },
+        ],
+      },
+      {
+        id: 'child-agent',
+        alwaysApplySkillPrimes: [
+          { _id: 'child-skill', name: 'child-skill', version: 1, body: 'Child instructions.' },
+        ],
+      },
+    ];
+    client.getEventActorContext = jest.fn().mockResolvedValue({ fingerprint });
+
+    const context = await client.prepareEventActorContext({ contextFingerprint: fingerprint });
+
+    expect(context.checkpointMessageOverlay.messages).toEqual([
+      expect.objectContaining({
+        content: 'Root instructions.',
+        additional_kwargs: expect.objectContaining({ skillName: 'root-skill' }),
+      }),
+    ]);
+    expect(context.checkpointMessageOverlay.messages).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          additional_kwargs: expect.objectContaining({ skillName: 'child-skill' }),
+        }),
+      ]),
+    );
+  });
+
+  it('keeps child manual Skills out of the root durable manifest', async () => {
+    const client = Object.create(AgentClient.prototype);
+    client.options = { req: { config: { endpoints: { agents: {} } } } };
+    client.eventActorAgentContextSources = [
+      { id: 'root-agent', manualSkillPrimes: [] },
+      {
+        id: 'child-agent',
+        manualSkillPrimes: [
+          { _id: 'child-skill', name: 'child-skill', version: 1, body: 'Child instructions.' },
+        ],
+      },
+    ];
+    client.getEventActorAgents = jest.fn(() => []);
+    client.getEventActorMemorySnapshots = jest.fn().mockResolvedValue([]);
+
+    await expect(client.getEventActorContext()).resolves.toMatchObject({ skillManifest: [] });
+  });
+
   it('captures the latest run summary and pruning calibration in continuation state', async () => {
     const client = Object.create(AgentClient.prototype);
     client.options = { req: { config: { endpoints: { agents: {} } } } };

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -162,6 +162,21 @@ describe('AgentClient - event actor history adapter', () => {
       skillManifest: [{ id: 'skill-1', name: 'analysis', version: 3 }],
     });
   });
+
+  it('fingerprints agents reachable only through nested subagent graphs', () => {
+    const graphMember = { id: 'graph-member' };
+    const nested = { id: 'nested', subagentGraphConfigs: [{ memberConfigs: [graphMember] }] };
+    const client = Object.create(AgentClient.prototype);
+    client.options = { agent: { id: 'primary', subagentAgentConfigs: [nested] } };
+    client.agentConfigs = new Map([['parallel', { id: 'parallel' }]]);
+
+    expect(client.getEventActorAgents().map((agent) => agent.id)).toEqual([
+      'primary',
+      'parallel',
+      'nested',
+      'graph-member',
+    ]);
+  });
 });
 
 describe('AgentClient - final model-bound content protection', () => {

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -56,6 +56,12 @@ jest.mock('@librechat/api', () => ({
   countFormattedMessageTokens: jest.fn(() => 42),
   countTokens: jest.fn((text) => Math.ceil(String(text ?? '').length / 4)),
   createCachedTokenCounter: jest.fn(async () => jest.fn(() => 0)),
+  createInitializedAgentContextFingerprint: jest.fn(() => ({
+    algorithm: 'sha256',
+    version: 1,
+    digest: 'context',
+  })),
+  MAX_AGENT_CONTEXT_SKILLS: 64,
   createDetachedSubagentUsageRecorder: (...args) =>
     mockCreateDetachedSubagentUsageRecorder(...args),
   captureAgentCheckpointGeneration: (...args) => mockCaptureAgentCheckpointGeneration(...args),
@@ -138,6 +144,23 @@ describe('AgentClient - event actor history adapter', () => {
       }),
     ).resolves.toBeUndefined();
     expect(client.getEventActorContext).not.toHaveBeenCalled();
+  });
+
+  it('carries a freshly manual-primed Skill into the durable manifest', async () => {
+    const client = Object.create(AgentClient.prototype);
+    client.options = { req: { config: { endpoints: { agents: {} } } } };
+    client.eventActorAgentContextSources = [
+      {
+        id: 'agent-1',
+        manualSkillPrimes: [{ _id: 'skill-1', name: 'analysis', version: 3 }],
+      },
+    ];
+    client.getEventActorAgents = jest.fn(() => []);
+    client.getEventActorMemorySnapshots = jest.fn().mockResolvedValue([]);
+
+    await expect(client.getEventActorContext()).resolves.toMatchObject({
+      skillManifest: [{ id: 'skill-1', name: 'analysis', version: 3 }],
+    });
   });
 });
 

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -77,6 +77,70 @@ jest.mock('@librechat/api', () => ({
   hasDurableAgentInterruptCheckpoint: (...args) => mockHasDurableAgentInterruptCheckpoint(...args),
 }));
 
+describe('AgentClient - event actor history adapter', () => {
+  const fingerprint = { algorithm: 'sha256', version: 1, digest: 'context' };
+
+  it('loads no durable history after compatibility selected a warm continuation', async () => {
+    const loadHistory = jest.spyOn(BaseClient.prototype, 'loadHistory');
+    const client = Object.create(AgentClient.prototype);
+    client.eventActorContinuation = 'warm';
+
+    await expect(client.loadHistory('conversation-1', 'message-1')).resolves.toEqual([]);
+    expect(loadHistory).not.toHaveBeenCalled();
+    loadHistory.mockRestore();
+  });
+
+  it('delegates rebuilt continuation to the existing durable history loader', async () => {
+    const loadHistory = jest
+      .spyOn(BaseClient.prototype, 'loadHistory')
+      .mockResolvedValue([{ messageId: 'message-1' }]);
+    const client = Object.create(AgentClient.prototype);
+    client.eventActorContinuation = 'cold';
+
+    await expect(client.loadHistory('conversation-1', 'message-1')).resolves.toEqual([
+      { messageId: 'message-1' },
+    ]);
+    expect(loadHistory).toHaveBeenCalledWith('conversation-1', 'message-1');
+    loadHistory.mockRestore();
+  });
+
+  it('resolves and caches the exact durable Skill manifest before warming', async () => {
+    const skillManifest = [{ id: 'skill-1', name: 'analysis', version: 3 }];
+    const primeInvokedSkills = jest.fn().mockResolvedValue({ skillManifest });
+    const client = Object.create(AgentClient.prototype);
+    client.options = {
+      req: { config: {} },
+      primeInvokedSkills,
+    };
+    client.getEventActorContext = jest.fn().mockResolvedValue({ fingerprint, skillManifest });
+
+    await expect(
+      client.prepareEventActorContext({ contextFingerprint: fingerprint, skillManifest }),
+    ).resolves.toEqual({ fingerprint, skillManifest });
+    expect(primeInvokedSkills).toHaveBeenCalledWith([], ['analysis']);
+    expect(client.eventActorSkillPrimeResult).toEqual({ skillManifest });
+  });
+
+  it('falls back when a durable Skill resolves to a different revision', async () => {
+    const client = Object.create(AgentClient.prototype);
+    client.options = {
+      req: { config: {} },
+      primeInvokedSkills: jest.fn().mockResolvedValue({
+        skillManifest: [{ id: 'skill-1', name: 'analysis', version: 4 }],
+      }),
+    };
+    client.getEventActorContext = jest.fn();
+
+    await expect(
+      client.prepareEventActorContext({
+        contextFingerprint: fingerprint,
+        skillManifest: [{ id: 'skill-1', name: 'analysis', version: 3 }],
+      }),
+    ).resolves.toBeUndefined();
+    expect(client.getEventActorContext).not.toHaveBeenCalled();
+  });
+});
+
 describe('AgentClient - final model-bound content protection', () => {
   const filters = {
     messages: {

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1690,10 +1690,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
     const eventActorMayPause =
       isHITLEnabled(agentsConfig?.toolApproval) ||
       eventActorAgents.some(agentRequestsAskUserQuestion);
-    const eventActorHasSkillPrimes =
-      client?.options?.primeInvokedSkills != null ||
-      (client?.options?.agent?.alwaysApplySkillPrimes?.length ?? 0) > 0 ||
-      (client?.options?.agent?.manualSkillPrimes?.length ?? 0) > 0;
     const expectedActionToolName = agentEventDelivery?.expectedAction?.toolName;
     const eventActorActionMayDetach =
       typeof expectedActionToolName === 'string' &&
@@ -1730,8 +1726,6 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
           : undefined,
       canPause: eventActorMayPause,
       checkpointerType: agentsConfig?.checkpointer?.type,
-      hasSkillPrimes: eventActorHasSkillPrimes,
-      hasMemoryContext: req.config?.memory != null && req.config.memory.disabled !== true,
       expectedActionMayDetach: eventActorActionMayDetach,
     });
 
@@ -2077,6 +2071,8 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
                 expectedAction: turnExecutionPlan.expectedAction,
                 signal: job.abortController.signal,
                 checkpointer: req.config?.endpoints?.[EModelEndpoint.agents]?.checkpointer,
+                resolveContext: (state) => client.prepareEventActorContext(state),
+                readResultContext: () => client.getEventActorContext(),
                 invoke: async (actorContext) => {
                   client.checkpointNamespace = actorContext.checkpointNamespace;
                   client.eventActorCheckpointId = actorContext.checkpointId;

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -345,6 +345,7 @@ const initializeClient = async ({
   /** @type {Map<string, import('@librechat/api').EndpointTokenConfig | undefined>} */
   const endpointTokenConfigByAgentId = new Map();
 
+  const invokedSkillIdentities = new Map();
   const toolExecuteOptions = {
     loadTools: async (toolNames, agentId, _configurable, callerCapabilityProjection) => {
       const ctx = agentToolContexts.get(agentId) ?? {};
@@ -392,6 +393,7 @@ const initializeClient = async ({
     }),
     emitAttachment: createAttachmentEmitter({ res, streamId, jobCreatedAt }),
     emitPtcProgress: createPtcProgressEmitter({ res, streamId, jobCreatedAt }),
+    onSkillResolved: (skill) => invokedSkillIdentities.set(skill.id, skill),
     ...getSkillToolDeps(),
   };
 
@@ -1355,10 +1357,11 @@ const initializeClient = async ({
     },
   );
   const handlePrimeInvokedSkills = skillsCapabilityEnabled
-    ? (payload) =>
+    ? (payload, skillNames) =>
         primeInvokedSkillsForProfiles({
           req,
           payload,
+          skillNames,
           accessibleSkillIds,
           executionProfiles: codeExecutionProfiles,
           ...getSkillToolDeps(),
@@ -1438,6 +1441,7 @@ const initializeClient = async ({
     aggregateContent,
     artifactPromises,
     primeInvokedSkills: handlePrimeInvokedSkills,
+    invokedSkillIdentities,
     agent: primaryConfig,
     spec: endpointOption.spec,
     iconURL: endpointOption.iconURL,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -860,6 +860,8 @@ const initializeClient = async ({
       model_parameters: { model: agent.model_parameters?.model },
       recursion_limit: agent.recursion_limit,
       memory_scope: agent.memory_scope,
+      memoryToolsRegistered:
+        memoryAvailable === true && agent.tools?.includes(Tools.memory) === true,
       subagents: agent.subagents,
       configId: getLazySubagentConfigId(agent),
       codeEnvAvailable:
@@ -1091,6 +1093,7 @@ const initializeClient = async ({
         model_parameters: metadata.model_parameters,
         recursion_limit: metadata.recursion_limit,
         memory_scope: metadata.memory_scope,
+        memoryToolsRegistered: metadata.memoryToolsRegistered,
         subagents: metadata.subagents,
         configId: metadata.configId,
         codeEnvAvailable: metadata.codeEnvAvailable,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -394,7 +394,11 @@ const initializeClient = async ({
     }),
     emitAttachment: createAttachmentEmitter({ res, streamId, jobCreatedAt }),
     emitPtcProgress: createPtcProgressEmitter({ res, streamId, jobCreatedAt }),
-    onSkillResolved: (skill) => invokedSkillIdentities.set(skill.id, skill),
+    onSkillResolved: (skill, { agentId }) => {
+      if (agentId === primaryConfig.id) {
+        invokedSkillIdentities.set(skill.id, skill);
+      }
+    },
     ...getSkillToolDeps(),
   };
 
@@ -729,6 +733,8 @@ const initializeClient = async ({
   const skippedAgentIds = new Set(discoveredSkippedIds ?? []);
 
   const lazyMetadataByAgentId = new Map();
+  const eventActorContextRequested =
+    req._isAgentTrigger === true && req._agentEventBindingParentConversationId != null;
   /** Request-scoped cache: lazy descriptors sharing the same Skill ACL scope
    * reuse one metadata-only always-apply lookup without initializing tools,
    * files, model clients, or MCP connections. */
@@ -844,6 +850,9 @@ const initializeClient = async ({
     );
 
   const resolveLazyAlwaysApplySkillPrimes = (agent) => {
+    if (!eventActorContextRequested) {
+      return Promise.resolve([]);
+    }
     const scopedSkillIds = resolveAgentScopedSkillIds({
       agent,
       accessibleSkillIds,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -859,6 +859,7 @@ const initializeClient = async ({
       model: agent.model,
       model_parameters: { model: agent.model_parameters?.model },
       recursion_limit: agent.recursion_limit,
+      memory_scope: agent.memory_scope,
       subagents: agent.subagents,
       configId: getLazySubagentConfigId(agent),
       codeEnvAvailable:
@@ -1089,6 +1090,7 @@ const initializeClient = async ({
         model: metadata.model,
         model_parameters: metadata.model_parameters,
         recursion_limit: metadata.recursion_limit,
+        memory_scope: metadata.memory_scope,
         subagents: metadata.subagents,
         configId: metadata.configId,
         codeEnvAvailable: metadata.codeEnvAvailable,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -14,6 +14,7 @@ const {
   discoverConnectedAgents,
   resolveAgentTokenConfig,
   resolveAgentScopedSkillIds,
+  resolveAlwaysApplySkills,
   resolveModelSpecSkillIds,
   getAgentStartupTelemetry,
   isContentFilterError,
@@ -728,6 +729,10 @@ const initializeClient = async ({
   const skippedAgentIds = new Set(discoveredSkippedIds ?? []);
 
   const lazyMetadataByAgentId = new Map();
+  /** Request-scoped cache: lazy descriptors sharing the same Skill ACL scope
+   * reuse one metadata-only always-apply lookup without initializing tools,
+   * files, model clients, or MCP connections. */
+  const lazyAlwaysApplySkillsByScope = new Map();
   const subagentGraphIds = new Set();
   const expandedSubagentDescriptorState = { configCount: 0, rootAgentIds: [] };
 
@@ -838,7 +843,35 @@ const initializeClient = async ({
       ),
     );
 
-  const toLazySubagentMetadata = (agent) => {
+  const resolveLazyAlwaysApplySkillPrimes = (agent) => {
+    const scopedSkillIds = resolveAgentScopedSkillIds({
+      agent,
+      accessibleSkillIds,
+      skillsCapabilityEnabled,
+      ephemeralSkillsToggle,
+    });
+    if (scopedSkillIds.length === 0 || typeof skillDbMethods.listAlwaysApplySkills !== 'function') {
+      return Promise.resolve([]);
+    }
+    const scopeKey = scopedSkillIds
+      .map((skillId) => skillId.toString())
+      .sort()
+      .join(':');
+    let resolution = lazyAlwaysApplySkillsByScope.get(scopeKey);
+    if (resolution == null) {
+      resolution = resolveAlwaysApplySkills({
+        listAlwaysApplySkills: skillDbMethods.listAlwaysApplySkills,
+        accessibleSkillIds: scopedSkillIds,
+        userId,
+        skillStates,
+        defaultActiveOnShare,
+      });
+      lazyAlwaysApplySkillsByScope.set(scopeKey, resolution);
+    }
+    return resolution;
+  };
+
+  const toLazySubagentMetadata = async (agent) => {
     const statefulCodeSessions =
       statefulSessionsAvailable === true &&
       codeEnvAvailable === true &&
@@ -869,6 +902,7 @@ const initializeClient = async ({
       statefulCodeSessions,
       statefulCodeEnvironment,
       includeReasoningHistory: getIncludeReasoningHistory(agent),
+      alwaysApplySkillPrimes: await resolveLazyAlwaysApplySkillPrimes(agent),
     };
   };
 
@@ -882,7 +916,7 @@ const initializeClient = async ({
         skippedAgentIds.add(agentId);
         return null;
       }
-      const metadata = toLazySubagentMetadata(agent);
+      const metadata = await toLazySubagentMetadata(agent);
       lazyMetadataByAgentId.set(agentId, metadata);
       return metadata;
     } catch (error) {
@@ -1100,6 +1134,7 @@ const initializeClient = async ({
         statefulCodeSessions: metadata.statefulCodeSessions,
         statefulCodeEnvironment: metadata.statefulCodeEnvironment,
         includeReasoningHistory: metadata.includeReasoningHistory,
+        alwaysApplySkillPrimes: metadata.alwaysApplySkillPrimes,
         lazySubagentConfigs: lazyChildren,
         subagentAgentConfigs: eagerChildren,
         subagentGraphMemberMetadata,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -986,6 +986,7 @@ describe('initializeClient — subagent loading', () => {
       author: new mongoose.Types.ObjectId(),
       tools: ['web'],
       stateful_code_environment: 'agent-user',
+      memory_scope: 'agent',
     });
     await grantView(subAgent);
 
@@ -1019,6 +1020,7 @@ describe('initializeClient — subagent loading', () => {
         id: SUBAGENT_ID,
         configId: expect.any(String),
         statefulCodeEnvironment: 'agent-user',
+        memory_scope: 'agent',
       }),
     );
     expect(agentClientArgs.agent.lazySubagentConfigs[0]).not.toHaveProperty('tools');

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -816,6 +816,33 @@ describe('initializeClient — subagent loading', () => {
     );
   });
 
+  it('retains only root-attributed model-invoked Skills for durable replay', async () => {
+    mockInitializeAgent.mockResolvedValue(makePrimaryConfig({}));
+    await initializeClient({
+      req: makeSubagentReq(),
+      res: {},
+      signal: new AbortController().signal,
+      endpointOption: makeEndpointOption(),
+    });
+    const rootSkill = {
+      id: 'root-skill',
+      name: 'root-skill',
+      version: 1,
+      contentDigest: 'root-digest',
+    };
+    const childSkill = {
+      id: 'child-skill',
+      name: 'child-skill',
+      version: 1,
+      contentDigest: 'child-digest',
+    };
+
+    capturedToolExecuteOptions.onSkillResolved(childSkill, { agentId: SUBAGENT_ID });
+    capturedToolExecuteOptions.onSkillResolved(rootSkill, { agentId: PRIMARY_ID });
+
+    expect([...agentClientArgs.invokedSkillIdentities.values()]).toEqual([rootSkill]);
+  });
+
   it('keeps an existing detached task controllable after subagent config is disabled', async () => {
     mockInitializeAgent.mockResolvedValue(
       makePrimaryConfig({
@@ -1107,6 +1134,23 @@ describe('initializeClient — subagent loading', () => {
       });
 
       expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+      expect(listAlwaysApplySkillsSpy).not.toHaveBeenCalled();
+      for (const descriptor of agentClientArgs.agent.lazySubagentConfigs) {
+        expect(descriptor.alwaysApplySkillPrimes).toEqual([]);
+      }
+
+      const eventReq = makeSubagentReq();
+      eventReq.config.endpoints.agents.capabilities.push('skills');
+      eventReq._isAgentTrigger = true;
+      eventReq._agentEventBindingParentConversationId = 'parent-conversation';
+      await initializeClient({
+        req: eventReq,
+        res: {},
+        signal: new AbortController().signal,
+        endpointOption: makeEndpointOption(),
+      });
+
+      expect(mockInitializeAgent).toHaveBeenCalledTimes(2);
       expect(listAlwaysApplySkillsSpy).toHaveBeenCalledTimes(1);
       expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(2);
       for (const descriptor of agentClientArgs.agent.lazySubagentConfigs) {

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1044,6 +1044,86 @@ describe('initializeClient — subagent loading', () => {
     expect(agentClientArgs.agentConfigs.has(SUBAGENT_ID)).toBe(false);
   });
 
+  it('includes current always-apply Skill revisions in lazy descriptor metadata', async () => {
+    const secondSubagentId = 'agent_subagent_skill_2';
+    const { skill } = await createSkill({
+      name: 'lazy-specialist',
+      description: 'Prime a lazy specialist.',
+      body: '# Lazy specialist v1\n',
+      alwaysApply: true,
+      author: testUser._id,
+      authorName: testUser.name,
+    });
+    await AclEntry.create({
+      principalType: PrincipalType.USER,
+      principalId: testUser._id,
+      principalModel: PrincipalModel.USER,
+      resourceType: ResourceType.SKILL,
+      resourceId: skill._id,
+      permBits: PermissionBits.VIEW,
+      grantedBy: testUser._id,
+    });
+    const subAgent = await createAgent({
+      id: SUBAGENT_ID,
+      name: 'Skill Subagent',
+      provider: 'openai',
+      model: 'gpt-4',
+      author: testUser._id,
+      tools: [],
+      skills_enabled: true,
+      skills: [skill._id.toString()],
+    });
+    await grantView(subAgent);
+    const secondSubAgent = await createAgent({
+      id: secondSubagentId,
+      name: 'Second Skill Subagent',
+      provider: 'openai',
+      model: 'gpt-4',
+      author: testUser._id,
+      tools: [],
+      skills_enabled: true,
+      skills: [skill._id.toString()],
+    });
+    await grantView(secondSubAgent);
+    mockInitializeAgent.mockResolvedValue(
+      makePrimaryConfig({
+        subagents: {
+          enabled: true,
+          allowSelf: true,
+          agent_ids: [SUBAGENT_ID, secondSubagentId],
+        },
+      }),
+    );
+    const req = makeSubagentReq();
+    req.config.endpoints.agents.capabilities.push('skills');
+    const listAlwaysApplySkillsSpy = jest.spyOn(getSkillDbMethods(), 'listAlwaysApplySkills');
+
+    try {
+      await initializeClient({
+        req,
+        res: {},
+        signal: new AbortController().signal,
+        endpointOption: makeEndpointOption(),
+      });
+
+      expect(mockInitializeAgent).toHaveBeenCalledTimes(1);
+      expect(listAlwaysApplySkillsSpy).toHaveBeenCalledTimes(1);
+      expect(agentClientArgs.agent.lazySubagentConfigs).toHaveLength(2);
+      for (const descriptor of agentClientArgs.agent.lazySubagentConfigs) {
+        expect(descriptor.alwaysApplySkillPrimes).toEqual([
+          expect.objectContaining({
+            _id: skill._id,
+            name: 'lazy-specialist',
+            version: 1,
+            body: '# Lazy specialist v1\n',
+          }),
+        ]);
+      }
+    } finally {
+      listAlwaysApplySkillsSpy.mockRestore();
+    }
+  });
+
   it('rejects a disallowed lazy subagent scope before exposing it for prewarm', async () => {
     const subAgent = await createAgent({
       id: SUBAGENT_ID,

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -1021,6 +1021,7 @@ describe('initializeClient — subagent loading', () => {
         configId: expect.any(String),
         statefulCodeEnvironment: 'agent-user',
         memory_scope: 'agent',
+        memoryToolsRegistered: false,
       }),
     );
     expect(agentClientArgs.agent.lazySubagentConfigs[0]).not.toHaveProperty('tools');

--- a/packages/api/src/agents/checkpointer.integration.spec.ts
+++ b/packages/api/src/agents/checkpointer.integration.spec.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import { logger } from '@librechat/data-schemas';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import { HumanMessage } from '@librechat/agents/langchain/messages';
 import { MongoDBSaver } from '@langchain/langgraph-checkpoint-mongodb';
 import { emptyCheckpoint, ERROR, INTERRUPT } from '@langchain/langgraph-checkpoint';
 import {
@@ -214,6 +215,70 @@ describe('checkpointer (mongodb-memory-server integration)', () => {
         .db!.collection('agent_checkpoints')
         .countDocuments({ thread_id: threadId }),
     ).toBe(2);
+  });
+
+  it('replaces checkpoint-carried Skill context while preserving the committed base', async () => {
+    const saver = await getAgentCheckpointer(MONGO_CFG);
+    const threadId = `actor-${new mongoose.Types.ObjectId().toString()}`;
+    const checkpoint = emptyCheckpoint();
+    checkpoint.channel_values.messages = [
+      new HumanMessage({ content: 'ordinary history' }),
+      new HumanMessage({
+        content: 'old skill body',
+        additional_kwargs: { isMeta: true, source: 'skill', skillName: 'analysis' },
+      }),
+    ];
+    checkpoint.channel_versions.messages = 1;
+    const sourceConfig = {
+      configurable: {
+        thread_id: threadId,
+        checkpoint_ns: '',
+        [LIBRECHAT_CHECKPOINT_NAMESPACE_KEY]: 'event-actor/base',
+        [LIBRECHAT_EVENT_ACTOR_INVOCATION_KEY]: 'event-1',
+      },
+    };
+    await saver!.put(sourceConfig, checkpoint, {
+      source: 'input',
+      step: -1,
+      parents: {},
+    });
+
+    await forkAgentEventCheckpoint(
+      { threadId, checkpointId: checkpoint.id, checkpointNs: 'event-actor/base' },
+      'event-actor/fork',
+      'event-2',
+      MONGO_CFG,
+      {
+        source: 'skill',
+        messages: [
+          new HumanMessage({
+            content: 'current skill body',
+            additional_kwargs: { isMeta: true, source: 'skill', skillName: 'analysis' },
+          }),
+        ],
+      },
+    );
+
+    const source = await saver!.getTuple(sourceConfig);
+    const fork = await saver!.getTuple({
+      configurable: {
+        thread_id: threadId,
+        checkpoint_ns: '',
+        checkpoint_id: checkpoint.id,
+        [LIBRECHAT_CHECKPOINT_NAMESPACE_KEY]: 'event-actor/fork',
+        [LIBRECHAT_EVENT_ACTOR_INVOCATION_KEY]: 'event-2',
+      },
+    });
+    expect(
+      (source?.checkpoint.channel_values.messages as HumanMessage[]).map(
+        (message) => message.content,
+      ),
+    ).toEqual(['ordinary history', 'old skill body']);
+    expect(
+      (fork?.checkpoint.channel_values.messages as HumanMessage[]).map(
+        (message) => message.content,
+      ),
+    ).toEqual(['ordinary history', 'current skill body']);
   });
 
   it('warm-continues from a copied actor head without mutating the committed base', async () => {

--- a/packages/api/src/agents/checkpointer.ts
+++ b/packages/api/src/agents/checkpointer.ts
@@ -9,6 +9,7 @@ import type {
   CheckpointTuple,
   PendingWrite,
 } from '@langchain/langgraph-checkpoint';
+import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { TCheckpointerConfig } from 'librechat-data-provider';
 import type { RunnableConfig } from '@langchain/core/runnables';
 
@@ -696,6 +697,47 @@ export interface AgentEventCheckpointReference {
   checkpointNs: string;
 }
 
+export interface AgentEventCheckpointMessageOverlay {
+  source: string;
+  messages: readonly BaseMessage[];
+}
+
+function applyAgentEventCheckpointMessageOverlay(
+  checkpoint: Checkpoint,
+  overlay: AgentEventCheckpointMessageOverlay | undefined,
+): Checkpoint {
+  if (overlay == null) {
+    return checkpoint;
+  }
+  const channelValues = checkpoint.channel_values;
+  const messages = Array.isArray(channelValues.messages) ? channelValues.messages : [];
+  const retainedMessages = messages.filter((message) => {
+    if (message == null || typeof message !== 'object') {
+      return true;
+    }
+    const kwargs = (message as { additional_kwargs?: { source?: unknown } }).additional_kwargs;
+    return kwargs?.source !== overlay.source;
+  });
+  const agentMessages = channelValues.agentMessages;
+  const retainedAgentMessages = Array.isArray(agentMessages)
+    ? agentMessages.filter((message) => {
+        if (message == null || typeof message !== 'object') {
+          return true;
+        }
+        const kwargs = (message as { additional_kwargs?: { source?: unknown } }).additional_kwargs;
+        return kwargs?.source !== overlay.source;
+      })
+    : agentMessages;
+  return {
+    ...checkpoint,
+    channel_values: {
+      ...channelValues,
+      messages: [...retainedMessages, ...overlay.messages],
+      ...(retainedAgentMessages === undefined ? {} : { agentMessages: retainedAgentMessages }),
+    },
+  };
+}
+
 function eventActorRunnableConfig(
   reference: Pick<AgentEventCheckpointReference, 'threadId' | 'checkpointNs'>,
   invocationId: string,
@@ -718,6 +760,7 @@ export async function forkAgentEventCheckpoint(
   checkpointNs: string,
   invocationId: string,
   cfg?: TCheckpointerConfig,
+  messageOverlay?: AgentEventCheckpointMessageOverlay,
 ): Promise<AgentEventCheckpointReference | null> {
   const saver = await getAgentCheckpointer(cfg);
   if (!saver || checkpointNs.length === 0 || invocationId.length === 0) {
@@ -732,7 +775,7 @@ export async function forkAgentEventCheckpoint(
   const target = { threadId: source.threadId, checkpointNs };
   const persisted = await saver.put(
     eventActorRunnableConfig(target, invocationId),
-    tuple.checkpoint,
+    applyAgentEventCheckpointMessageOverlay(tuple.checkpoint, messageOverlay),
     tuple.metadata,
   );
   const checkpointId = persisted.configurable?.checkpoint_id;

--- a/packages/api/src/agents/compatibility.spec.ts
+++ b/packages/api/src/agents/compatibility.spec.ts
@@ -125,4 +125,22 @@ describe('agent context compatibility', () => {
 
     expect(changed.digest).not.toBe(fingerprint.digest);
   });
+
+  it('invalidates a constant-version deployment Skill when its body changes', () => {
+    const fingerprint = (body: string) =>
+      createInitializedAgentContextFingerprint({
+        agents: [
+          {
+            id: 'agent-1',
+            alwaysApplySkillPrimes: [
+              { _id: 'deployment:analysis', name: 'analysis', version: 1, body },
+            ],
+          },
+        ],
+      });
+
+    expect(fingerprint('First instructions').digest).not.toBe(
+      fingerprint('Updated instructions').digest,
+    );
+  });
 });

--- a/packages/api/src/agents/compatibility.spec.ts
+++ b/packages/api/src/agents/compatibility.spec.ts
@@ -17,6 +17,7 @@ const context = (): AgentTurnSemanticContext => ({
       instructions: 'Help carefully.',
       modelParameters: { temperature: 0.2 },
       toolDefinitions: [{ name: 'search', schema: { type: 'object' } }],
+      execution: { edges: [{ from: 'agent-1', to: 'agent-2' }], recursionLimit: 25 },
       skills: [
         { id: 'skill-b', name: 'beta', version: 2 },
         { id: 'skill-a', name: 'alpha', version: 1 },
@@ -45,6 +46,14 @@ describe('agent context compatibility', () => {
       'tool definition',
       (value: AgentTurnSemanticContext) =>
         (value.agents[0].toolDefinitions = [{ name: 'submit', schema: { type: 'object' } }]),
+    ],
+    [
+      'graph topology',
+      (value: AgentTurnSemanticContext) =>
+        (value.agents[0].execution = {
+          edges: [{ from: 'agent-1', to: 'agent-3' }],
+          recursionLimit: 25,
+        }),
     ],
     [
       'Skill version',

--- a/packages/api/src/agents/compatibility.spec.ts
+++ b/packages/api/src/agents/compatibility.spec.ts
@@ -2,6 +2,7 @@ import {
   agentContextFingerprintsMatch,
   createAgentContextFingerprint,
   createInitializedAgentContextFingerprint,
+  normalizeAgentEventActorDiscoveredTools,
   type AgentTurnSemanticContext,
 } from './compatibility';
 
@@ -142,5 +143,42 @@ describe('agent context compatibility', () => {
     expect(fingerprint('First instructions').digest).not.toBe(
       fingerprint('Updated instructions').digest,
     );
+  });
+
+  it('normalizes bounded tool discoveries and fingerprints the active set', () => {
+    expect(normalizeAgentEventActorDiscoveredTools(['zeta', 'alpha', 'zeta'])).toEqual([
+      'alpha',
+      'zeta',
+    ]);
+    const left = context();
+    const reordered = context();
+    const changed = context();
+    left.discoveredToolNames = ['zeta', 'alpha'];
+    reordered.discoveredToolNames = ['alpha', 'zeta', 'alpha'];
+    changed.discoveredToolNames = ['alpha', 'gamma'];
+
+    expect(createAgentContextFingerprint(left)).toEqual(createAgentContextFingerprint(reordered));
+    expect(createAgentContextFingerprint(left).digest).not.toBe(
+      createAgentContextFingerprint(changed).digest,
+    );
+    expect(() =>
+      normalizeAgentEventActorDiscoveredTools(
+        Array.from({ length: 129 }, (_, index) => `tool-${index}`),
+      ),
+    ).toThrow('exceeds 128');
+  });
+
+  it('invalidates a deferred tool when its registry definition changes', () => {
+    const fingerprint = (description: string) =>
+      createInitializedAgentContextFingerprint({
+        agents: [
+          {
+            id: 'agent-1',
+            toolRegistryDefinitions: [{ name: 'deferred_tool', description, defer_loading: true }],
+          },
+        ],
+      });
+
+    expect(fingerprint('First schema').digest).not.toBe(fingerprint('Updated schema').digest);
   });
 });

--- a/packages/api/src/agents/compatibility.spec.ts
+++ b/packages/api/src/agents/compatibility.spec.ts
@@ -93,6 +93,27 @@ describe('agent context compatibility', () => {
     expect(createAgentContextFingerprint(left)).toEqual(createAgentContextFingerprint(right));
   });
 
+  it('preserves credential-named JSON Schema fields in semantic tool definitions', () => {
+    const left = context();
+    const right = context();
+    left.agents[0].toolDefinitions = [
+      {
+        name: 'login',
+        schema: { type: 'object', properties: { password: { type: 'string' } } },
+      },
+    ];
+    right.agents[0].toolDefinitions = [
+      {
+        name: 'login',
+        schema: { type: 'object', properties: { password: { type: 'number' } } },
+      },
+    ];
+
+    expect(createAgentContextFingerprint(left).digest).not.toBe(
+      createAgentContextFingerprint(right).digest,
+    );
+  });
+
   it('fails compatibility closed for a missing or unknown stored version', () => {
     const current = createAgentContextFingerprint(context());
 

--- a/packages/api/src/agents/compatibility.spec.ts
+++ b/packages/api/src/agents/compatibility.spec.ts
@@ -1,0 +1,119 @@
+import {
+  agentContextFingerprintsMatch,
+  createAgentContextFingerprint,
+  createInitializedAgentContextFingerprint,
+  type AgentTurnSemanticContext,
+} from './compatibility';
+
+const context = (): AgentTurnSemanticContext => ({
+  checkpointerType: 'mongodb',
+  approvalPolicy: { enabled: false },
+  agents: [
+    {
+      id: 'agent-1',
+      version: 3,
+      provider: 'openai',
+      model: 'gpt-5',
+      instructions: 'Help carefully.',
+      modelParameters: { temperature: 0.2 },
+      toolDefinitions: [{ name: 'search', schema: { type: 'object' } }],
+      skills: [
+        { id: 'skill-b', name: 'beta', version: 2 },
+        { id: 'skill-a', name: 'alpha', version: 1 },
+      ],
+    },
+  ],
+  memory: [{ scope: 'shared', withoutKeys: 'Prefers concise answers.' }],
+});
+
+describe('agent context compatibility', () => {
+  it('is deterministic across object-key and set-like Skill ordering', () => {
+    const left = context();
+    const right = context();
+    right.approvalPolicy = { enabled: false };
+    right.agents[0].modelParameters = { temperature: 0.2 };
+    right.agents[0].skills = [...(right.agents[0].skills ?? [])].reverse();
+
+    expect(createAgentContextFingerprint(left)).toEqual(createAgentContextFingerprint(right));
+  });
+
+  it.each([
+    ['agent revision', (value: AgentTurnSemanticContext) => (value.agents[0].version = 4)],
+    ['instructions', (value: AgentTurnSemanticContext) => (value.agents[0].instructions = 'New')],
+    ['model', (value: AgentTurnSemanticContext) => (value.agents[0].model = 'gpt-6')],
+    [
+      'tool definition',
+      (value: AgentTurnSemanticContext) =>
+        (value.agents[0].toolDefinitions = [{ name: 'submit', schema: { type: 'object' } }]),
+    ],
+    [
+      'Skill version',
+      (value: AgentTurnSemanticContext) =>
+        (value.agents[0].skills = [{ id: 'skill-a', name: 'alpha', version: 2 }]),
+    ],
+    [
+      'memory snapshot',
+      (value: AgentTurnSemanticContext) =>
+        (value.memory = [{ scope: 'shared', withoutKeys: 'Prefers detailed answers.' }]),
+    ],
+  ])('changes when %s changes', (_label, mutate) => {
+    const original = context();
+    const changed = context();
+    mutate(changed);
+
+    expect(createAgentContextFingerprint(changed).digest).not.toBe(
+      createAgentContextFingerprint(original).digest,
+    );
+  });
+
+  it('excludes credential values from compatibility', () => {
+    const left = context();
+    const right = context();
+    left.agents[0].modelParameters = {
+      temperature: 0.2,
+      apiKey: 'first',
+      headers: { 'x-api-key': 'first-header-secret' },
+    };
+    right.agents[0].modelParameters = {
+      apiKey: 'second',
+      temperature: 0.2,
+      headers: { 'x-api-key': 'second-header-secret' },
+    };
+
+    expect(createAgentContextFingerprint(left)).toEqual(createAgentContextFingerprint(right));
+  });
+
+  it('fails compatibility closed for a missing or unknown stored version', () => {
+    const current = createAgentContextFingerprint(context());
+
+    expect(agentContextFingerprintsMatch(undefined, current)).toBe(false);
+    expect(
+      agentContextFingerprintsMatch({ ...current, version: current.version + 1 }, current),
+    ).toBe(false);
+    expect(agentContextFingerprintsMatch(current, current)).toBe(true);
+  });
+
+  it('projects initialized Skill identities without duplicate reads', () => {
+    const fingerprint = createInitializedAgentContextFingerprint({
+      agents: [
+        {
+          id: 'agent-1',
+          manualSkillPrimes: [
+            { _id: 'skill-1', name: 'analysis', version: 4 },
+            { _id: 'skill-1', name: 'analysis', version: 4 },
+          ],
+        },
+      ],
+    });
+    const changed = createInitializedAgentContextFingerprint({
+      agents: [
+        {
+          id: 'agent-1',
+          manualSkillPrimes: [{ _id: 'skill-1', name: 'analysis', version: 5 }],
+        },
+      ],
+    });
+
+    expect(changed.digest).not.toBe(fingerprint.digest);
+  });
+});

--- a/packages/api/src/agents/compatibility.ts
+++ b/packages/api/src/agents/compatibility.ts
@@ -1,0 +1,203 @@
+import { createHash } from 'node:crypto';
+
+export const AGENT_CONTEXT_FINGERPRINT_VERSION = 1;
+export const AGENT_GRAPH_SCHEMA_VERSION = 1;
+export const AGENT_CHECKPOINT_FORMAT_VERSION = 1;
+
+export interface AgentContextFingerprint {
+  algorithm: 'sha256';
+  version: number;
+  digest: string;
+}
+
+export interface AgentContextSkillIdentity {
+  id: string;
+  name: string;
+  version: number;
+}
+
+export interface AgentContextMemorySnapshot {
+  scope: string;
+  withKeys?: string;
+  withoutKeys?: string;
+}
+
+export interface AgentContextDefinition {
+  id: string;
+  version?: number | string;
+  provider?: string;
+  model?: string;
+  instructions?: string;
+  additionalInstructions?: string;
+  modelParameters?: object;
+  toolDefinitions?: readonly object[];
+  toolOptions?: object;
+  skills?: readonly AgentContextSkillIdentity[];
+}
+
+export interface AgentTurnSemanticContext {
+  agents: readonly AgentContextDefinition[];
+  approvalPolicy?: object;
+  memory?: readonly AgentContextMemorySnapshot[];
+  checkpointerType?: string;
+  checkpointFormatVersion?: number;
+  graphSchemaVersion?: number;
+}
+
+export interface InitializedAgentContextSource {
+  id: string;
+  version?: number | string;
+  provider?: string;
+  model?: string;
+  instructions?: string;
+  additional_instructions?: string;
+  model_parameters?: object;
+  toolDefinitions?: readonly object[];
+  tool_options?: object;
+  manualSkillPrimes?: readonly {
+    _id: { toString(): string } | string;
+    name: string;
+    version?: number;
+  }[];
+  alwaysApplySkillPrimes?: readonly {
+    _id: { toString(): string } | string;
+    name: string;
+    version?: number;
+  }[];
+}
+
+export const MAX_AGENT_CONTEXT_SKILLS = 64;
+
+const SECRET_KEY_PATTERN =
+  /^(?:authorization|password|secret)$|(?:^|[-_])(?:api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret)$/i;
+
+function canonicalize(value: unknown, seen: WeakSet<object>): unknown {
+  if (value == null || typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item, seen)).filter((item) => item !== undefined);
+  }
+  if (typeof value !== 'object') {
+    return undefined;
+  }
+  if (seen.has(value)) {
+    throw new TypeError('Agent semantic context cannot contain circular references');
+  }
+  seen.add(value);
+  const record = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      continue;
+    }
+    const item = canonicalize(record[key], seen);
+    if (item !== undefined) {
+      normalized[key] = item;
+    }
+  }
+  seen.delete(value);
+  return normalized;
+}
+
+function sortSkillIdentities(
+  skills: readonly AgentContextSkillIdentity[] | undefined,
+): AgentContextSkillIdentity[] | undefined {
+  if (skills == null) {
+    return undefined;
+  }
+  const unique = new Map<string, AgentContextSkillIdentity>();
+  for (const skill of skills) {
+    unique.set(skill.id, skill);
+  }
+  if (unique.size > MAX_AGENT_CONTEXT_SKILLS) {
+    throw new RangeError(`Agent context exceeds ${MAX_AGENT_CONTEXT_SKILLS} Skills`);
+  }
+  return [...unique.values()].sort(
+    (left, right) =>
+      left.id.localeCompare(right.id) ||
+      left.name.localeCompare(right.name) ||
+      left.version - right.version,
+  );
+}
+
+/** Hashes only semantic, model-bound context; request and delivery metadata never enter this module. */
+export function createAgentContextFingerprint(
+  input: AgentTurnSemanticContext,
+): AgentContextFingerprint {
+  const semanticContext = {
+    version: AGENT_CONTEXT_FINGERPRINT_VERSION,
+    graphSchemaVersion: input.graphSchemaVersion ?? AGENT_GRAPH_SCHEMA_VERSION,
+    checkpointFormatVersion: input.checkpointFormatVersion ?? AGENT_CHECKPOINT_FORMAT_VERSION,
+    checkpointerType: input.checkpointerType,
+    approvalPolicy: input.approvalPolicy,
+    agents: input.agents.map((agent) => ({
+      ...agent,
+      skills: sortSkillIdentities(agent.skills),
+    })),
+    memory:
+      input.memory == null
+        ? undefined
+        : [...input.memory].sort((left, right) => left.scope.localeCompare(right.scope)),
+  };
+  const canonical = JSON.stringify(canonicalize(semanticContext, new WeakSet()));
+  return Object.freeze({
+    algorithm: 'sha256' as const,
+    version: AGENT_CONTEXT_FINGERPRINT_VERSION,
+    digest: createHash('sha256').update(canonical).digest('base64url'),
+  });
+}
+
+export function agentContextFingerprintsMatch(
+  stored: AgentContextFingerprint | undefined,
+  current: AgentContextFingerprint,
+): boolean {
+  return (
+    stored?.algorithm === current.algorithm &&
+    stored.version === current.version &&
+    stored.digest === current.digest
+  );
+}
+
+function skillIdentities(agent: InitializedAgentContextSource): AgentContextSkillIdentity[] {
+  const skills = [...(agent.manualSkillPrimes ?? []), ...(agent.alwaysApplySkillPrimes ?? [])];
+  const unique = new Map<string, AgentContextSkillIdentity>();
+  for (const skill of skills) {
+    const id = skill._id.toString();
+    unique.set(id, { id, name: skill.name, version: skill.version ?? 0 });
+  }
+  return [...unique.values()];
+}
+
+/** Projects initialized runtime facts into the single semantic compatibility module. */
+export function createInitializedAgentContextFingerprint(input: {
+  agents: readonly InitializedAgentContextSource[];
+  invokedSkills?: readonly AgentContextSkillIdentity[];
+  approvalPolicy?: object;
+  memory?: readonly AgentContextMemorySnapshot[];
+  checkpointerType?: string;
+}): AgentContextFingerprint {
+  return createAgentContextFingerprint({
+    checkpointerType: input.checkpointerType,
+    approvalPolicy: input.approvalPolicy,
+    memory: input.memory,
+    agents: input.agents.map((agent, index) => ({
+      id: agent.id,
+      version: agent.version,
+      provider: agent.provider,
+      model: agent.model,
+      instructions: agent.instructions,
+      additionalInstructions: agent.additional_instructions,
+      modelParameters: agent.model_parameters,
+      toolDefinitions: agent.toolDefinitions,
+      toolOptions: agent.tool_options,
+      skills:
+        index === 0
+          ? [...skillIdentities(agent), ...(input.invokedSkills ?? [])]
+          : skillIdentities(agent),
+    })),
+  });
+}

--- a/packages/api/src/agents/compatibility.ts
+++ b/packages/api/src/agents/compatibility.ts
@@ -32,6 +32,7 @@ export interface AgentContextDefinition {
   modelParameters?: object;
   toolDefinitions?: readonly object[];
   toolOptions?: object;
+  execution?: object;
   skills?: readonly AgentContextSkillIdentity[];
 }
 
@@ -54,6 +55,7 @@ export interface InitializedAgentContextSource {
   model_parameters?: object;
   toolDefinitions?: readonly object[];
   tool_options?: object;
+  execution?: object;
   manualSkillPrimes?: readonly {
     _id: { toString(): string } | string;
     name: string;
@@ -194,6 +196,7 @@ export function createInitializedAgentContextFingerprint(input: {
       modelParameters: agent.model_parameters,
       toolDefinitions: agent.toolDefinitions,
       toolOptions: agent.tool_options,
+      execution: agent.execution,
       skills:
         index === 0
           ? [...skillIdentities(agent), ...(input.invokedSkills ?? [])]

--- a/packages/api/src/agents/compatibility.ts
+++ b/packages/api/src/agents/compatibility.ts
@@ -14,6 +14,7 @@ export interface AgentContextSkillIdentity {
   id: string;
   name: string;
   version: number;
+  contentDigest?: string;
 }
 
 export interface AgentContextMemorySnapshot {
@@ -60,15 +61,21 @@ export interface InitializedAgentContextSource {
     _id: { toString(): string } | string;
     name: string;
     version?: number;
+    body?: string;
   }[];
   alwaysApplySkillPrimes?: readonly {
     _id: { toString(): string } | string;
     name: string;
     version?: number;
+    body?: string;
   }[];
 }
 
 export const MAX_AGENT_CONTEXT_SKILLS = 64;
+
+export function createSkillContentDigest(body: string): string {
+  return createHash('sha256').update(body).digest('base64url');
+}
 
 const SECRET_KEY_PATTERN =
   /^(?:authorization|password|secret)$|(?:^|[-_])(?:api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret)$/i;
@@ -169,7 +176,12 @@ function skillIdentities(agent: InitializedAgentContextSource): AgentContextSkil
   const unique = new Map<string, AgentContextSkillIdentity>();
   for (const skill of skills) {
     const id = skill._id.toString();
-    unique.set(id, { id, name: skill.name, version: skill.version ?? 0 });
+    unique.set(id, {
+      id,
+      name: skill.name,
+      version: skill.version ?? 0,
+      ...(skill.body == null ? {} : { contentDigest: createSkillContentDigest(skill.body) }),
+    });
   }
   return [...unique.values()];
 }

--- a/packages/api/src/agents/compatibility.ts
+++ b/packages/api/src/agents/compatibility.ts
@@ -1,4 +1,8 @@
 import { createHash } from 'node:crypto';
+import {
+  MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS,
+  MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH,
+} from '@librechat/data-schemas';
 
 export const AGENT_CONTEXT_FINGERPRINT_VERSION = 1;
 export const AGENT_GRAPH_SCHEMA_VERSION = 1;
@@ -32,6 +36,7 @@ export interface AgentContextDefinition {
   additionalInstructions?: string;
   modelParameters?: object;
   toolDefinitions?: readonly object[];
+  toolRegistryDefinitions?: readonly object[];
   toolOptions?: object;
   execution?: object;
   skills?: readonly AgentContextSkillIdentity[];
@@ -42,6 +47,7 @@ export interface AgentTurnSemanticContext {
   approvalPolicy?: object;
   memory?: readonly AgentContextMemorySnapshot[];
   checkpointerType?: string;
+  discoveredToolNames?: readonly string[];
   checkpointFormatVersion?: number;
   graphSchemaVersion?: number;
 }
@@ -55,6 +61,7 @@ export interface InitializedAgentContextSource {
   additional_instructions?: string;
   model_parameters?: object;
   toolDefinitions?: readonly object[];
+  toolRegistryDefinitions?: readonly object[];
   tool_options?: object;
   execution?: object;
   manualSkillPrimes?: readonly {
@@ -72,6 +79,31 @@ export interface InitializedAgentContextSource {
 }
 
 export const MAX_AGENT_CONTEXT_SKILLS = 64;
+
+export function normalizeAgentEventActorDiscoveredTools(
+  names: readonly string[] | undefined,
+): string[] {
+  if (names == null) {
+    return [];
+  }
+  const normalized = new Set<string>();
+  for (const name of names) {
+    if (
+      typeof name !== 'string' ||
+      name.length === 0 ||
+      name.length > MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH
+    ) {
+      throw new RangeError('Event actor discovered-tool state is invalid');
+    }
+    normalized.add(name);
+  }
+  if (normalized.size > MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS) {
+    throw new RangeError(
+      `Event actor discovered-tool state exceeds ${MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS}`,
+    );
+  }
+  return [...normalized].sort((left, right) => left.localeCompare(right));
+}
 
 export function createSkillContentDigest(body: string): string {
   return createHash('sha256').update(body).digest('base64url');
@@ -142,6 +174,7 @@ export function createAgentContextFingerprint(
     graphSchemaVersion: input.graphSchemaVersion ?? AGENT_GRAPH_SCHEMA_VERSION,
     checkpointFormatVersion: input.checkpointFormatVersion ?? AGENT_CHECKPOINT_FORMAT_VERSION,
     checkpointerType: input.checkpointerType,
+    discoveredToolNames: normalizeAgentEventActorDiscoveredTools(input.discoveredToolNames),
     approvalPolicy: input.approvalPolicy,
     agents: input.agents.map((agent) => ({
       ...agent,
@@ -193,11 +226,13 @@ export function createInitializedAgentContextFingerprint(input: {
   approvalPolicy?: object;
   memory?: readonly AgentContextMemorySnapshot[];
   checkpointerType?: string;
+  discoveredToolNames?: readonly string[];
 }): AgentContextFingerprint {
   return createAgentContextFingerprint({
     checkpointerType: input.checkpointerType,
     approvalPolicy: input.approvalPolicy,
     memory: input.memory,
+    discoveredToolNames: input.discoveredToolNames,
     agents: input.agents.map((agent, index) => ({
       id: agent.id,
       version: agent.version,
@@ -207,6 +242,7 @@ export function createInitializedAgentContextFingerprint(input: {
       additionalInstructions: agent.additional_instructions,
       modelParameters: agent.model_parameters,
       toolDefinitions: agent.toolDefinitions,
+      toolRegistryDefinitions: agent.toolRegistryDefinitions,
       toolOptions: agent.tool_options,
       execution: agent.execution,
       skills:

--- a/packages/api/src/agents/compatibility.ts
+++ b/packages/api/src/agents/compatibility.ts
@@ -109,8 +109,34 @@ export function createSkillContentDigest(body: string): string {
   return createHash('sha256').update(body).digest('base64url');
 }
 
-const SECRET_KEY_PATTERN =
+const CREDENTIAL_KEY_PATTERN =
   /^(?:authorization|password|secret)$|(?:^|[-_])(?:api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret)$/i;
+
+const REDACTED_CREDENTIAL = '[credential]';
+
+function redactModelParameterCredentials(value: object | undefined): object | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const redacted: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (CREDENTIAL_KEY_PATTERN.test(key)) {
+      redacted[key] = REDACTED_CREDENTIAL;
+      continue;
+    }
+    if (key.toLowerCase() === 'headers' && item != null && typeof item === 'object') {
+      redacted[key] = Object.fromEntries(
+        Object.entries(item).map(([header, headerValue]) => [
+          header,
+          CREDENTIAL_KEY_PATTERN.test(header) ? REDACTED_CREDENTIAL : headerValue,
+        ]),
+      );
+      continue;
+    }
+    redacted[key] = item;
+  }
+  return redacted;
+}
 
 function canonicalize(value: unknown, seen: WeakSet<object>): unknown {
   if (value == null || typeof value === 'string' || typeof value === 'boolean') {
@@ -132,9 +158,6 @@ function canonicalize(value: unknown, seen: WeakSet<object>): unknown {
   const record = value as Record<string, unknown>;
   const normalized: Record<string, unknown> = {};
   for (const key of Object.keys(record).sort()) {
-    if (SECRET_KEY_PATTERN.test(key)) {
-      continue;
-    }
     const item = canonicalize(record[key], seen);
     if (item !== undefined) {
       normalized[key] = item;
@@ -178,6 +201,7 @@ export function createAgentContextFingerprint(
     approvalPolicy: input.approvalPolicy,
     agents: input.agents.map((agent) => ({
       ...agent,
+      modelParameters: redactModelParameterCredentials(agent.modelParameters),
       skills: sortSkillIdentities(agent.skills),
     })),
     memory:

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -1427,6 +1427,7 @@ describe('createToolExecuteHandler', () => {
     function createSkillHandler(
       getSkillByName: ToolExecuteOptions['getSkillByName'],
       filters?: Record<string, unknown>,
+      onSkillResolved?: ToolExecuteOptions['onSkillResolved'],
     ) {
       const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
         loadedTools: [],
@@ -1435,7 +1436,7 @@ describe('createToolExecuteHandler', () => {
           ...(filters != null ? { req: { config: { filters } } } : {}),
         },
       }));
-      return createToolExecuteHandler({ loadTools, getSkillByName });
+      return createToolExecuteHandler({ loadTools, getSkillByName, onSkillResolved });
     }
 
     /** Skill with one bundled file plus every dep the priming gate requires,
@@ -1502,6 +1503,29 @@ describe('createToolExecuteHandler', () => {
       expect(result.status).toBe('error');
       expect(result.errorMessage).toContain('cannot be invoked by the model');
       expect(result.errorMessage).toContain('pii-redactor');
+    });
+
+    it('captures the exact identity of a successfully model-invoked Skill', async () => {
+      const onSkillResolved = jest.fn();
+      const getSkillByName = jest.fn(async () => ({
+        _id: { toString: () => 'skill-id' } as never,
+        name: 'analysis',
+        body: 'Analyze the position.',
+        fileCount: 0,
+        version: 4,
+      }));
+      const handler = createSkillHandler(getSkillByName, undefined, onSkillResolved);
+
+      const [result] = await invokeHandler(handler, [
+        { id: 'call_skill_identity', name: Constants.SKILL_TOOL, args: { skillName: 'analysis' } },
+      ]);
+
+      expect(result.status).toBe('success');
+      expect(onSkillResolved).toHaveBeenCalledWith({
+        id: 'skill-id',
+        name: 'analysis',
+        version: 4,
+      });
     });
 
     it('blocks stored skill instructions before injecting them into model context', async () => {

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -56,10 +56,12 @@ function invokeHandler(
     directOnlyToolNames: string[];
     codeExecutionOnlyToolNames: string[];
   },
+  agentId?: string,
 ): Promise<ToolExecuteResult[]> {
   return new Promise((resolve, reject) => {
     const request = {
       toolCalls,
+      agentId,
       callerCapabilityProjection,
       resolve,
       reject,
@@ -1516,17 +1518,29 @@ describe('createToolExecuteHandler', () => {
       }));
       const handler = createSkillHandler(getSkillByName, undefined, onSkillResolved);
 
-      const [result] = await invokeHandler(handler, [
-        { id: 'call_skill_identity', name: Constants.SKILL_TOOL, args: { skillName: 'analysis' } },
-      ]);
+      const [result] = await invokeHandler(
+        handler,
+        [
+          {
+            id: 'call_skill_identity',
+            name: Constants.SKILL_TOOL,
+            args: { skillName: 'analysis' },
+          },
+        ],
+        undefined,
+        'agent-child',
+      );
 
       expect(result.status).toBe('success');
-      expect(onSkillResolved).toHaveBeenCalledWith({
-        id: 'skill-id',
-        name: 'analysis',
-        version: 4,
-        contentDigest: expect.any(String),
-      });
+      expect(onSkillResolved).toHaveBeenCalledWith(
+        {
+          id: 'skill-id',
+          name: 'analysis',
+          version: 4,
+          contentDigest: expect.any(String),
+        },
+        { agentId: 'agent-child' },
+      );
     });
 
     it('blocks stored skill instructions before injecting them into model context', async () => {

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -1525,6 +1525,7 @@ describe('createToolExecuteHandler', () => {
         id: 'skill-id',
         name: 'analysis',
         version: 4,
+        contentDigest: expect.any(String),
       });
     });
 

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -201,12 +201,15 @@ export interface ToolExecuteOptions {
     disableModelInvocation?: boolean;
   } | null>;
   /** Captures a successfully resolved model-invoked Skill for durable continuation context. */
-  onSkillResolved?: (skill: {
-    id: string;
-    name: string;
-    version: number;
-    contentDigest: string;
-  }) => void;
+  onSkillResolved?: (
+    skill: {
+      id: string;
+      name: string;
+      version: number;
+      contentDigest: string;
+    },
+    context: { agentId?: string },
+  ) => void;
   /**
    * Loads a skill by name when the current user is the author. This is a
    * narrow recovery path for freshly-authored skills whose runtime catalog
@@ -3893,6 +3896,7 @@ async function handleSkillToolCall(
   tc: ToolCallRequest,
   mergedConfigurable: Record<string, unknown>,
   options: ToolExecuteOptions,
+  agentId?: string,
   req?: ServerRequest,
 ): Promise<ToolExecuteResult> {
   const {
@@ -4065,12 +4069,15 @@ async function handleSkillToolCall(
     }
   }
 
-  options.onSkillResolved?.({
-    id: skill._id.toString(),
-    name: skill.name,
-    version: skill.version,
-    contentDigest: createSkillContentDigest(skill.body),
-  });
+  options.onSkillResolved?.(
+    {
+      id: skill._id.toString(),
+      name: skill.name,
+      version: skill.version,
+      contentDigest: createSkillContentDigest(skill.body),
+    },
+    { agentId },
+  );
 
   return {
     toolCallId: tc.id,
@@ -4861,6 +4868,7 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                           tc,
                           mergedConfigurable,
                           options,
+                          agentId,
                           req,
                         );
                       } else if (tc.name === Constants.READ_FILE) {

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -199,6 +199,8 @@ export interface ToolExecuteOptions {
      */
     disableModelInvocation?: boolean;
   } | null>;
+  /** Captures a successfully resolved model-invoked Skill for durable continuation context. */
+  onSkillResolved?: (skill: { id: string; name: string; version: number }) => void;
   /**
    * Loads a skill by name when the current user is the author. This is a
    * narrow recovery path for freshly-authored skills whose runtime catalog
@@ -4056,6 +4058,12 @@ async function handleSkillToolCall(
         `are NOT available to bash or code execution this turn. Use the read_file tool to view bundled files instead.`;
     }
   }
+
+  options.onSkillResolved?.({
+    id: skill._id.toString(),
+    name: skill.name,
+    version: skill.version,
+  });
 
   return {
     toolCallId: tc.id,

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -68,6 +68,7 @@ import {
 } from './intent';
 import { getSafeErrorMetadata, logAxiosError, runOutsideTracing, truncateMiddle } from '~/utils';
 import { resolveCallerCapabilityProjectionSnapshot } from './callerCapabilities';
+import { createSkillContentDigest } from './compatibility';
 import { buildSkillPrimeMessage, SKILL_FILE_PREFIX } from './skills';
 import { parseFrontmatter } from '../skills/import';
 import { cleanCodeToolOutput } from './cleanup';
@@ -200,7 +201,12 @@ export interface ToolExecuteOptions {
     disableModelInvocation?: boolean;
   } | null>;
   /** Captures a successfully resolved model-invoked Skill for durable continuation context. */
-  onSkillResolved?: (skill: { id: string; name: string; version: number }) => void;
+  onSkillResolved?: (skill: {
+    id: string;
+    name: string;
+    version: number;
+    contentDigest: string;
+  }) => void;
   /**
    * Loads a skill by name when the current user is the author. This is a
    * narrow recovery path for freshly-authored skills whose runtime catalog
@@ -4063,6 +4069,7 @@ async function handleSkillToolCall(
     id: skill._id.toString(),
     name: skill.name,
     version: skill.version,
+    contentDigest: createSkillContentDigest(skill.body),
   });
 
   return {

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -68,8 +68,8 @@ import {
 } from './intent';
 import { getSafeErrorMetadata, logAxiosError, runOutsideTracing, truncateMiddle } from '~/utils';
 import { resolveCallerCapabilityProjectionSnapshot } from './callerCapabilities';
-import { createSkillContentDigest } from './compatibility';
 import { buildSkillPrimeMessage, SKILL_FILE_PREFIX } from './skills';
+import { createSkillContentDigest } from './compatibility';
 import { parseFrontmatter } from '../skills/import';
 import { cleanCodeToolOutput } from './cleanup';
 import { primeSkillFiles } from './skillFiles';

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -5,6 +5,7 @@ export * from './callerCapabilities';
 export * from './client';
 export * from './config';
 export * from './checkpointer';
+export * from './compatibility';
 export * from './contact';
 export * from './context';
 export * from './control';

--- a/packages/api/src/agents/plan.spec.ts
+++ b/packages/api/src/agents/plan.spec.ts
@@ -6,8 +6,6 @@ const baseInput = (): ResolveAgentTurnExecutionPlanInput => ({
   parentMessageId: 'message-1',
   isNewConversation: false,
   canPause: false,
-  hasSkillPrimes: false,
-  hasMemoryContext: false,
   expectedActionMayDetach: false,
 });
 
@@ -58,8 +56,6 @@ describe('resolveAgentTurnExecutionPlan', () => {
     ['no expected action', { event: { ...boundEvent(), expectedAction: undefined } }],
     ['memory checkpointer', { event: boundEvent(), checkpointerType: 'memory' }],
     ['pause-capable run', { event: boundEvent(), canPause: true }],
-    ['Skill primes', { event: boundEvent(), hasSkillPrimes: true }],
-    ['memory context', { event: boundEvent(), hasMemoryContext: true }],
     ['detachable action', { event: boundEvent(), expectedActionMayDetach: true }],
   ] as const)('falls back to history for %s', (_label, overrides) => {
     expect(resolveAgentTurnExecutionPlan({ ...baseInput(), ...overrides }).strategy).toBe(

--- a/packages/api/src/agents/plan.ts
+++ b/packages/api/src/agents/plan.ts
@@ -35,8 +35,6 @@ export interface ResolveAgentTurnExecutionPlanInput {
   };
   canPause: boolean;
   checkpointerType?: TCheckpointerType;
-  hasSkillPrimes: boolean;
-  hasMemoryContext: boolean;
   expectedActionMayDetach: boolean;
 }
 
@@ -73,8 +71,6 @@ export function resolveAgentTurnExecutionPlan(
     expectedAction != null &&
     input.checkpointerType !== 'memory' &&
     !input.canPause &&
-    !input.hasSkillPrimes &&
-    !input.hasMemoryContext &&
     !input.expectedActionMayDetach;
   let strategy: AgentTurnContinuationStrategy = 'history';
   if (input.isNewConversation) {

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -65,6 +65,18 @@ describe('primeInvokedSkills — execute_code capability gate', () => {
     expect(deps.batchUploadCodeEnvFiles).not.toHaveBeenCalled();
   });
 
+  it('resolves explicit actor-head names without scanning message history', async () => {
+    mockExtract.mockReturnValue(new Set());
+    const deps = makeDeps({ payload: undefined, skillNames: ['brand-guidelines'] });
+
+    const result = await primeInvokedSkills(deps);
+
+    expect(deps.getSkillByName).toHaveBeenCalledWith('brand-guidelines', [SKILL_ID]);
+    expect(result.skillManifest).toEqual([
+      { id: SKILL_ID.toString(), name: 'brand-guidelines', version: SKILL_VERSION },
+    ]);
+  });
+
   it('enters the batch-upload path when codeEnvAvailable is true', async () => {
     const deps = makeDeps({ codeEnvAvailable: true });
 

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -73,7 +73,12 @@ describe('primeInvokedSkills — execute_code capability gate', () => {
 
     expect(deps.getSkillByName).toHaveBeenCalledWith('brand-guidelines', [SKILL_ID]);
     expect(result.skillManifest).toEqual([
-      { id: SKILL_ID.toString(), name: 'brand-guidelines', version: SKILL_VERSION },
+      {
+        id: SKILL_ID.toString(),
+        name: 'brand-guidelines',
+        version: SKILL_VERSION,
+        contentDigest: expect.any(String),
+      },
     ]);
   });
 

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -631,6 +631,60 @@ describe('primeInvokedSkillsForProfiles', () => {
         .sort(),
     ).toEqual(['default', 'stateful']);
   });
+
+  it('keeps a successful profile Skill body and identity after another profile lookup fails', async () => {
+    const {
+      codeEnvAvailable: _codeEnvAvailable,
+      codeExecutionContext: _codeExecutionContext,
+      ...baseDeps
+    } = makeDeps({
+      getSkillByName: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('transient lookup failure'))
+        .mockResolvedValueOnce({
+          _id: SKILL_ID,
+          name: 'brand-guidelines',
+          body: 'skill body',
+          version: SKILL_VERSION,
+          fileCount: 0,
+        }),
+    });
+    const deps: PrimeInvokedSkillsForProfilesDeps = {
+      ...baseDeps,
+      executionProfiles: [
+        {
+          codeExecutionContext: {
+            baseUrl: 'https://code.example.com/v1',
+            codeSessionKey: 'execute_code',
+            executionProfile: 'default',
+            statefulSessions: false,
+          },
+          codeSessionKeys: ['execute_code'],
+        },
+        {
+          codeExecutionContext: {
+            baseUrl: 'https://stateful.example.com/v1',
+            codeSessionKey: 'execute_code:stateful:v2:user:abc',
+            executionProfile: 'stateful',
+            statefulSessions: true,
+          },
+          codeSessionKeys: ['execute_code:stateful:v2:user:abc'],
+        },
+      ],
+    };
+
+    const result = await primeInvokedSkillsForProfiles(deps);
+
+    expect(result.skills).toEqual(new Map([['brand-guidelines', 'skill body']]));
+    expect(result.skillManifest).toEqual([
+      {
+        id: SKILL_ID.toString(),
+        name: 'brand-guidelines',
+        version: SKILL_VERSION,
+        contentDigest: expect.any(String),
+      },
+    ]);
+  });
 });
 
 /* The tool-invoked skill loader (`handle_skill` -> `primeSkillFiles`)

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -24,9 +24,9 @@ import { seedCodeFilesIntoSessions, type CodeExecutionProfileRoute } from './cod
 import { ContentFilterError, isContentFilterError } from '~/middleware/contentFilter';
 import { createConcurrencyLimiter, getSafeErrorMetadata } from '~/utils';
 import { assertSkillFileContentAllowed } from '~/skills/protection';
+import { createSkillContentDigest } from './compatibility';
 import { extractInvokedSkillsFromPayload } from './run';
 import { SKILL_FILE_PREFIX } from './skills';
-import { createSkillContentDigest } from './compatibility';
 
 const MAX_INSPECTABLE_SKILL_FILE_BYTES = 10 * 1024 * 1024;
 const SKILL_FILE_CONTENT_FIELDS = ['file_text'] as const;

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -917,11 +917,30 @@ export async function primeInvokedSkillsForProfiles(
 
   let initialSessions: ToolSessionMap | undefined;
   const skills = new Map<string, string>();
-  let skillManifest: PrimeInvokedSkillsResult['skillManifest'];
+  const skillManifestByName = new Map<
+    string,
+    NonNullable<PrimeInvokedSkillsResult['skillManifest']>[number]
+  >();
   for (const { profile, result } of profileResults) {
-    skillManifest ??= result.skillManifest;
+    const resultManifestByName = new Map(
+      (result.skillManifest ?? []).map((skill) => [skill.name, skill]),
+    );
     for (const [name, body] of result.skills ?? []) {
+      const identity = resultManifestByName.get(name);
+      if (identity == null) {
+        throw new Error(`Skill "${name}" resolved without a semantic identity`);
+      }
+      const existingIdentity = skillManifestByName.get(name);
+      const existingBody = skills.get(name);
+      if (
+        (existingIdentity != null &&
+          JSON.stringify(existingIdentity) !== JSON.stringify(identity)) ||
+        (existingBody != null && existingBody !== body)
+      ) {
+        throw new Error(`Skill "${name}" changed while execution profiles were initialized`);
+      }
       skills.set(name, body);
+      skillManifestByName.set(name, identity);
     }
     const skillFiles = result.initialSessions?.get(Constants.EXECUTE_CODE)?.files;
     if (!skillFiles?.length) {
@@ -939,6 +958,9 @@ export async function primeInvokedSkillsForProfiles(
   return {
     initialSessions,
     skills: skills.size > 0 ? skills : undefined,
-    skillManifest,
+    skillManifest:
+      skillManifestByName.size > 0
+        ? [...skillManifestByName.values()].sort((left, right) => left.id.localeCompare(right.id))
+        : undefined,
   };
 }

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -604,7 +604,9 @@ async function executePrimeSkillFiles(
 export interface PrimeInvokedSkillsDeps {
   req: ServerRequest;
   /** Raw message payload (before formatAgentMessages). Used to extract invoked skill names. */
-  payload: Array<Partial<{ role: string; content: unknown }>>;
+  payload?: Array<Partial<{ role: string; content: unknown }>>;
+  /** Explicit durable names used by a validated event-actor preflight. */
+  skillNames?: readonly string[];
   accessibleSkillIds: Types.ObjectId[];
   /** `execute_code` capability flag for the run. When false, the batch-upload
    *  path is skipped entirely — skill bodies still reconstruct for history
@@ -635,6 +637,8 @@ export interface PrimeInvokedSkillsResult {
   /** Pre-resolved skill bodies keyed by skill name. Passed to formatAgentMessages
    *  so it can reconstruct HumanMessages at the right position in the message sequence. */
   skills?: Map<string, string>;
+  /** Exact records resolved under the current request's ACL. */
+  skillManifest?: Array<{ id: string; name: string; version: number }>;
 }
 
 export interface PrimeInvokedSkillsForProfilesDeps
@@ -653,11 +657,14 @@ export interface PrimeInvokedSkillsForProfilesDeps
 export async function primeInvokedSkills(
   deps: PrimeInvokedSkillsDeps,
 ): Promise<PrimeInvokedSkillsResult> {
-  if (!deps.payload?.length || !deps.accessibleSkillIds?.length) {
+  if ((!deps.payload?.length && !deps.skillNames?.length) || !deps.accessibleSkillIds?.length) {
     return {};
   }
 
-  const invokedSkills = extractInvokedSkillsFromPayload(deps.payload);
+  const invokedSkills = new Set(deps.skillNames ?? []);
+  for (const name of extractInvokedSkillsFromPayload(deps.payload ?? [])) {
+    invokedSkills.add(name);
+  }
   if (invokedSkills.size === 0) {
     return {};
   }
@@ -689,6 +696,11 @@ export async function primeInvokedSkills(
       logger.warn('[primeInvokedSkills] Skill resolution failed:', getSafeErrorMetadata(r.reason));
     }
   }
+  const skillManifest = resolvedSkills.map((skill) => ({
+    id: skill._id.toString(),
+    name: skill.name,
+    version: skill.version,
+  }));
 
   // Phase 2: Single batch upload for ALL skills' files (shared session)
   let sessions: ToolSessionMap | undefined;
@@ -784,7 +796,11 @@ export async function primeInvokedSkills(
               files: cachedFiles,
               lastUpdated: Date.now(),
             } satisfies CodeSessionContext);
-            return { initialSessions: sessions, skills: skills.size > 0 ? skills : undefined };
+            return {
+              initialSessions: sessions,
+              skills: skills.size > 0 ? skills : undefined,
+              skillManifest,
+            };
           }
         }
       }
@@ -867,6 +883,7 @@ export async function primeInvokedSkills(
   return {
     initialSessions: sessions,
     skills: skills.size > 0 ? skills : undefined,
+    skillManifest,
   };
 }
 
@@ -893,7 +910,9 @@ export async function primeInvokedSkillsForProfiles(
 
   let initialSessions: ToolSessionMap | undefined;
   const skills = new Map<string, string>();
+  let skillManifest: PrimeInvokedSkillsResult['skillManifest'];
   for (const { profile, result } of profileResults) {
+    skillManifest ??= result.skillManifest;
     for (const [name, body] of result.skills ?? []) {
       skills.set(name, body);
     }
@@ -913,5 +932,6 @@ export async function primeInvokedSkillsForProfiles(
   return {
     initialSessions,
     skills: skills.size > 0 ? skills : undefined,
+    skillManifest,
   };
 }

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -26,6 +26,7 @@ import { createConcurrencyLimiter, getSafeErrorMetadata } from '~/utils';
 import { assertSkillFileContentAllowed } from '~/skills/protection';
 import { extractInvokedSkillsFromPayload } from './run';
 import { SKILL_FILE_PREFIX } from './skills';
+import { createSkillContentDigest } from './compatibility';
 
 const MAX_INSPECTABLE_SKILL_FILE_BYTES = 10 * 1024 * 1024;
 const SKILL_FILE_CONTENT_FIELDS = ['file_text'] as const;
@@ -638,7 +639,12 @@ export interface PrimeInvokedSkillsResult {
    *  so it can reconstruct HumanMessages at the right position in the message sequence. */
   skills?: Map<string, string>;
   /** Exact records resolved under the current request's ACL. */
-  skillManifest?: Array<{ id: string; name: string; version: number }>;
+  skillManifest?: Array<{
+    id: string;
+    name: string;
+    version: number;
+    contentDigest: string;
+  }>;
 }
 
 export interface PrimeInvokedSkillsForProfilesDeps
@@ -700,6 +706,7 @@ export async function primeInvokedSkills(
     id: skill._id.toString(),
     name: skill.name,
     version: skill.version,
+    contentDigest: createSkillContentDigest(skill.body),
   }));
 
   // Phase 2: Single batch upload for ALL skills' files (shared session)

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -6,6 +6,7 @@ import type { LCToolRegistry, LCTool, InjectedMessage } from '@librechat/agents'
 import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { Agent } from 'librechat-data-provider';
 import type { Types } from 'mongoose';
+import { createSkillContentDigest } from './compatibility';
 import { registerCodeExecutionTools } from './tools';
 import { logAxiosError } from '~/utils';
 
@@ -780,6 +781,27 @@ export function buildSkillPrimeMessage(skill: { name: string; body: string }): I
     source: SKILL_MESSAGE_SOURCE,
     skillName: skill.name,
   };
+}
+
+/** Builds the exact live Skill overlay placed at the tail of an event actor checkpoint fork. */
+export function buildAgentEventActorSkillMessages(
+  skills: ReadonlyMap<string, string>,
+): HumanMessage[] {
+  return [...skills.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([name, body]) =>
+        new HumanMessage({
+          id: `event-actor-skill:${createSkillContentDigest(`${name}\0${body}`)}`,
+          content: body,
+          additional_kwargs: {
+            isMeta: true,
+            source: SKILL_MESSAGE_SOURCE,
+            trigger: SKILL_TRIGGER_MODEL,
+            skillName: name,
+          },
+        }),
+    );
 }
 
 export interface ResolveManualSkillsParams {

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -30,6 +30,8 @@ export type TGetSkillByName = (
   _id: Types.ObjectId;
   name: string;
   body: string;
+  /** Monotonic Skill document version used by checkpoint context compatibility. */
+  version?: number;
   author: Types.ObjectId;
   /** Structured SKILL.md metadata retained for model-bound policy checks. */
   frontmatter?: Record<string, unknown>;
@@ -798,6 +800,7 @@ export interface ResolveManualSkillsParams {
     _id: Types.ObjectId;
     name: string;
     body: string;
+    version?: number;
     author: Types.ObjectId | string;
     deployment?: boolean;
     /** Structured SKILL.md metadata retained for model-bound policy checks. */
@@ -846,6 +849,8 @@ export interface ResolvedSkillPrime {
   _id: Types.ObjectId;
   name: string;
   body: string;
+  /** Monotonic Skill revision used by checkpoint compatibility. */
+  version?: number;
   /** Structured SKILL.md metadata retained for model-bound policy checks. */
   frontmatter?: Record<string, unknown>;
   /**
@@ -980,6 +985,7 @@ export async function resolveManualSkills(
           _id: skill._id,
           name: skill.name,
           body: skill.body,
+          version: skill.version,
           frontmatter: skill.frontmatter,
         };
         if (skill.allowedTools !== undefined) {
@@ -1016,6 +1022,7 @@ export interface ResolveAlwaysApplySkillsParams {
       author: Types.ObjectId | string;
       frontmatter?: Record<string, unknown>;
       allowedTools?: string[];
+      version?: number;
       deployment?: boolean;
     }>;
     has_more?: boolean;
@@ -1140,6 +1147,7 @@ export async function resolveAlwaysApplySkills(
         _id: skill._id,
         name: skill.name,
         body: skill.body,
+        version: skill.version,
         frontmatter: skill.frontmatter,
       };
       if (skill.allowedTools !== undefined) {

--- a/packages/api/src/agents/traversal.spec.ts
+++ b/packages/api/src/agents/traversal.spec.ts
@@ -3,6 +3,9 @@ import { collectReachableAgents } from './traversal';
 interface TestAgent {
   id: string;
   subagentAgentConfigs?: Array<TestAgent | null>;
+  lazySubagentConfigs?: Array<TestAgent | null>;
+  subagentGraphMemberMetadata?: Array<TestAgent | null>;
+  subagentGraphConfigs?: Array<{ memberConfigs: Array<TestAgent | null> }>;
 }
 
 describe('collectReachableAgents', () => {
@@ -22,5 +25,21 @@ describe('collectReachableAgents', () => {
     second.subagentAgentConfigs = [first, null];
 
     expect(collectReachableAgents([first])).toEqual([first, second]);
+  });
+
+  it('collects every effective topology route exactly once', () => {
+    const eager: TestAgent = { id: 'eager' };
+    const lazy: TestAgent = { id: 'lazy' };
+    const graphMember: TestAgent = { id: 'graph-member' };
+    const graphMetadata: TestAgent = { id: 'graph-metadata' };
+    const root: TestAgent = {
+      id: 'root',
+      subagentAgentConfigs: [eager],
+      lazySubagentConfigs: [lazy],
+      subagentGraphMemberMetadata: [graphMetadata],
+      subagentGraphConfigs: [{ memberConfigs: [graphMember, eager] }],
+    };
+
+    expect(collectReachableAgents([root])).toEqual([root, eager, lazy, graphMetadata, graphMember]);
   });
 });

--- a/packages/api/src/agents/traversal.ts
+++ b/packages/api/src/agents/traversal.ts
@@ -1,5 +1,10 @@
 export interface ReachableAgent<TAgent> {
   readonly subagentAgentConfigs?: readonly (TAgent | null | undefined)[];
+  readonly lazySubagentConfigs?: readonly (TAgent | null | undefined)[];
+  readonly subagentGraphMemberMetadata?: readonly (TAgent | null | undefined)[];
+  readonly subagentGraphConfigs?: readonly {
+    readonly memberConfigs?: readonly (TAgent | null | undefined)[];
+  }[];
 }
 
 /**
@@ -21,7 +26,14 @@ export function collectReachableAgents<T extends ReachableAgent<T>>(
     }
     visited.add(agent);
     agents.push(agent);
-    pending.push(...(agent.subagentAgentConfigs ?? []));
+    pending.push(
+      ...(agent.subagentAgentConfigs ?? []),
+      ...(agent.lazySubagentConfigs ?? []),
+      ...(agent.subagentGraphMemberMetadata ?? []),
+    );
+    for (const graph of agent.subagentGraphConfigs ?? []) {
+      pending.push(...(graph.memberConfigs ?? []));
+    }
   }
 
   return agents;

--- a/packages/api/src/agents/triggers/actor.spec.ts
+++ b/packages/api/src/agents/triggers/actor.spec.ts
@@ -545,6 +545,41 @@ describe('event actor host adapter', () => {
     expect(mockedDelete).not.toHaveBeenCalled();
   });
 
+  it('retains applied-action evidence when result context capture fails', async () => {
+    const dependencies = deps();
+    let toolExecutions = 0;
+    await expect(
+      executeAgentEventActor(
+        {
+          user: 'user-1',
+          conversationId,
+          invocationId: 'event-context-indeterminate',
+          event: { id: 'event-context-indeterminate' },
+          signal: new AbortController().signal,
+          invoke: async () => {
+            toolExecutions += 1;
+            return 'response';
+          },
+          readAppliedAction: () => ({ toolName: 'submit_move' }),
+          readResultContext: async () => {
+            throw new Error('memory partition unavailable');
+          },
+        },
+        dependencies,
+      ),
+    ).rejects.toThrow('requires commit_indeterminate reconciliation');
+
+    expect(toolExecutions).toBe(1);
+    expect(dependencies.commitState).not.toHaveBeenCalled();
+    expect(dependencies.recordReconciliation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reconciliation: expect.objectContaining({ status: 'commit_indeterminate' }),
+      }),
+    );
+    expect(mockedCapture).not.toHaveBeenCalled();
+    expect(mockedDelete).not.toHaveBeenCalled();
+  });
+
   it('recovers an indeterminate cleanup after the actor head was committed', async () => {
     state = {
       generation: 2,

--- a/packages/api/src/agents/triggers/actor.spec.ts
+++ b/packages/api/src/agents/triggers/actor.spec.ts
@@ -60,7 +60,16 @@ describe('event actor host adapter', () => {
       epoch,
     })),
     commitState: jest.fn(
-      async ({ expected, expectedEpoch, checkpoint, contextFingerprint, skillManifest }) => {
+      async ({
+        expected,
+        expectedEpoch,
+        checkpoint,
+        contextFingerprint,
+        skillManifest,
+        discoveredToolNames,
+        summary,
+        contextMeta,
+      }) => {
         if (
           expectedEpoch !== epoch ||
           (state == null && expected != null) ||
@@ -68,6 +77,11 @@ describe('event actor host adapter', () => {
             (expected == null ||
               expected.generation !== state.generation ||
               expected.checkpoint.checkpointId !== state.checkpoint.checkpointId ||
+              JSON.stringify(expected.skillManifest) !== JSON.stringify(state.skillManifest) ||
+              JSON.stringify(expected.discoveredToolNames) !==
+                JSON.stringify(state.discoveredToolNames) ||
+              JSON.stringify(expected.summary) !== JSON.stringify(state.summary) ||
+              JSON.stringify(expected.contextMeta) !== JSON.stringify(state.contextMeta) ||
               (expected.requiresColdStart === true) !== (state.requiresColdStart === true)))
         ) {
           return { status: 'stale' as const, ...(state == null ? {} : { state }) };
@@ -78,6 +92,9 @@ describe('event actor host adapter', () => {
           checkpoint,
           ...(contextFingerprint == null ? {} : { contextFingerprint }),
           ...(skillManifest == null ? {} : { skillManifest }),
+          ...(discoveredToolNames == null ? {} : { discoveredToolNames }),
+          ...(summary == null ? {} : { summary }),
+          ...(contextMeta == null ? {} : { contextMeta }),
           ...(previous == null ? {} : { previousCheckpoint: previous }),
         };
         return { status: 'committed' as const, state };
@@ -127,6 +144,7 @@ describe('event actor host adapter', () => {
       expect.objectContaining({ checkpointId: 'checkpoint-1' }),
       expect.stringMatching(/^event-actor\//),
       'event-2',
+      undefined,
       undefined,
     );
     expect(state).toMatchObject({ generation: 2, checkpoint: { checkpointId: 'checkpoint-2' } });
@@ -180,8 +198,12 @@ describe('event actor host adapter', () => {
       },
       contextFingerprint: current,
       skillManifest: [storedSkill],
+      discoveredToolNames: ['deferred_lookup'],
+      summary: { text: 'Earlier compacted context.', tokenCount: 12 },
+      contextMeta: { calibrationRatio: 1.25, encoding: 'o200k_base' },
     };
     let continuation: 'warm' | 'cold' | undefined;
+    const checkpointMessageOverlay = { source: 'skill', messages: [] };
 
     await executeAgentEventActor(
       {
@@ -193,10 +215,17 @@ describe('event actor host adapter', () => {
         resolveContext: async (observed) => ({
           fingerprint: current,
           skillManifest: observed.skillManifest ?? [],
+          discoveredToolNames: observed.discoveredToolNames ?? [],
+          summary: observed.summary,
+          contextMeta: observed.contextMeta,
+          checkpointMessageOverlay,
         }),
         readResultContext: async () => ({
           fingerprint: current,
           skillManifest: [storedSkill, invokedSkill],
+          discoveredToolNames: ['deferred_lookup', 'deferred_write'],
+          summary: { text: 'Updated compacted context.', tokenCount: 15 },
+          contextMeta: { calibrationRatio: 1.3, encoding: 'o200k_base' },
         }),
         invoke: async (context) => {
           continuation = context.continuation;
@@ -209,6 +238,16 @@ describe('event actor host adapter', () => {
 
     expect(continuation).toBe('warm');
     expect(state?.skillManifest).toEqual([storedSkill, invokedSkill]);
+    expect(state?.discoveredToolNames).toEqual(['deferred_lookup', 'deferred_write']);
+    expect(state?.summary).toEqual({ text: 'Updated compacted context.', tokenCount: 15 });
+    expect(state?.contextMeta).toEqual({ calibrationRatio: 1.3, encoding: 'o200k_base' });
+    expect(mockedFork).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      'event-skill-context',
+      undefined,
+      checkpointMessageOverlay,
+    );
   });
 
   it('commits from the execution-time receipt when run steps lag sendMessage', async () => {

--- a/packages/api/src/agents/triggers/actor.spec.ts
+++ b/packages/api/src/agents/triggers/actor.spec.ts
@@ -8,8 +8,8 @@ import {
   forkAgentEventCheckpoint,
   getAgentCheckpointer,
 } from '../checkpointer';
-import { createAgentContextFingerprint } from '../compatibility';
 import { createAgentEventActionRecorder, findAgentEventAppliedAction } from './outcome';
+import { createAgentContextFingerprint } from '../compatibility';
 import { executeAgentEventActor } from './actor';
 
 jest.mock('../checkpointer', () => ({

--- a/packages/api/src/agents/triggers/actor.spec.ts
+++ b/packages/api/src/agents/triggers/actor.spec.ts
@@ -8,6 +8,7 @@ import {
   forkAgentEventCheckpoint,
   getAgentCheckpointer,
 } from '../checkpointer';
+import { createAgentContextFingerprint } from '../compatibility';
 import { createAgentEventActionRecorder, findAgentEventAppliedAction } from './outcome';
 import { executeAgentEventActor } from './actor';
 
@@ -58,26 +59,30 @@ describe('event actor host adapter', () => {
       legacyTurn,
       epoch,
     })),
-    commitState: jest.fn(async ({ expected, expectedEpoch, checkpoint }) => {
-      if (
-        expectedEpoch !== epoch ||
-        (state == null && expected != null) ||
-        (state != null &&
-          (expected == null ||
-            expected.generation !== state.generation ||
-            expected.checkpoint.checkpointId !== state.checkpoint.checkpointId ||
-            (expected.requiresColdStart === true) !== (state.requiresColdStart === true)))
-      ) {
-        return { status: 'stale' as const, ...(state == null ? {} : { state }) };
-      }
-      const previous = state?.checkpoint;
-      state = {
-        generation: (state?.generation ?? 0) + 1,
-        checkpoint,
-        ...(previous == null ? {} : { previousCheckpoint: previous }),
-      };
-      return { status: 'committed' as const, state };
-    }),
+    commitState: jest.fn(
+      async ({ expected, expectedEpoch, checkpoint, contextFingerprint, skillManifest }) => {
+        if (
+          expectedEpoch !== epoch ||
+          (state == null && expected != null) ||
+          (state != null &&
+            (expected == null ||
+              expected.generation !== state.generation ||
+              expected.checkpoint.checkpointId !== state.checkpoint.checkpointId ||
+              (expected.requiresColdStart === true) !== (state.requiresColdStart === true)))
+        ) {
+          return { status: 'stale' as const, ...(state == null ? {} : { state }) };
+        }
+        const previous = state?.checkpoint;
+        state = {
+          generation: (state?.generation ?? 0) + 1,
+          checkpoint,
+          ...(contextFingerprint == null ? {} : { contextFingerprint }),
+          ...(skillManifest == null ? {} : { skillManifest }),
+          ...(previous == null ? {} : { previousCheckpoint: previous }),
+        };
+        return { status: 'committed' as const, state };
+      },
+    ),
     recordReconciliation: jest.fn(async () => true),
     resolveReconciliation: jest.fn(async () => true),
     admitAction: jest.fn(async () => true),
@@ -125,6 +130,85 @@ describe('event actor host adapter', () => {
       undefined,
     );
     expect(state).toMatchObject({ generation: 2, checkpoint: { checkpointId: 'checkpoint-2' } });
+  });
+
+  it('rebuilds on a missing or changed context fingerprint and stamps the new head', async () => {
+    const current = createAgentContextFingerprint({ agents: [{ id: 'agent-1', version: 2 }] });
+    state = {
+      generation: 1,
+      checkpoint: {
+        threadId: conversationId,
+        checkpointId: 'checkpoint-old-context',
+        checkpointNs: 'event-actor/old-context',
+      },
+    };
+    const dependencies = deps();
+    let continuation: 'warm' | 'cold' | undefined;
+
+    await executeAgentEventActor(
+      {
+        user: 'user-1',
+        conversationId,
+        invocationId: 'event-new-context',
+        event: { id: 'event-new-context', type: 'turn' },
+        signal: new AbortController().signal,
+        contextFingerprint: current,
+        invoke: async (context) => {
+          continuation = context.continuation;
+          return 'response';
+        },
+        readAppliedAction: () => ({ toolName: 'submit_move' }),
+      },
+      dependencies,
+    );
+
+    expect(continuation).toBe('cold');
+    expect(mockedFork).not.toHaveBeenCalled();
+    expect(state?.contextFingerprint).toEqual(current);
+  });
+
+  it('validates the stored Skill manifest before warm continuation and commits additions', async () => {
+    const current = createAgentContextFingerprint({ agents: [{ id: 'agent-1', version: 2 }] });
+    const storedSkill = { id: 'skill-1', name: 'analysis', version: 3 };
+    const invokedSkill = { id: 'skill-2', name: 'reporting', version: 1 };
+    state = {
+      generation: 1,
+      checkpoint: {
+        threadId: conversationId,
+        checkpointId: 'checkpoint-compatible',
+        checkpointNs: 'event-actor/compatible',
+      },
+      contextFingerprint: current,
+      skillManifest: [storedSkill],
+    };
+    let continuation: 'warm' | 'cold' | undefined;
+
+    await executeAgentEventActor(
+      {
+        user: 'user-1',
+        conversationId,
+        invocationId: 'event-skill-context',
+        event: { id: 'event-skill-context', type: 'turn' },
+        signal: new AbortController().signal,
+        resolveContext: async (observed) => ({
+          fingerprint: current,
+          skillManifest: observed.skillManifest ?? [],
+        }),
+        readResultContext: async () => ({
+          fingerprint: current,
+          skillManifest: [storedSkill, invokedSkill],
+        }),
+        invoke: async (context) => {
+          continuation = context.continuation;
+          return 'response';
+        },
+        readAppliedAction: () => ({ toolName: 'submit_move' }),
+      },
+      deps(),
+    );
+
+    expect(continuation).toBe('warm');
+    expect(state?.skillManifest).toEqual([storedSkill, invokedSkill]);
   });
 
   it('commits from the execution-time receipt when run steps lag sendMessage', async () => {

--- a/packages/api/src/agents/triggers/actor.ts
+++ b/packages/api/src/agents/triggers/actor.ts
@@ -422,7 +422,18 @@ export async function executeAgentEventActor<T>(
         }
         return { status: 'completed_no_action' };
       }
-      resultContext = input.readResultContext ? await input.readResultContext() : preparedContext;
+      try {
+        resultContext = input.readResultContext ? await input.readResultContext() : preparedContext;
+      } catch (error) {
+        return {
+          status: 'applied',
+          result: {
+            action,
+            checkpointCaptureError: `Applied turn context could not be captured: ${asError(error).message}`,
+          },
+          checkpoint: invocation.fork,
+        };
+      }
       let checkpoint: Awaited<ReturnType<typeof captureAgentEventCheckpoint>>;
       try {
         checkpoint = await captureAgentEventCheckpoint(

--- a/packages/api/src/agents/triggers/actor.ts
+++ b/packages/api/src/agents/triggers/actor.ts
@@ -11,10 +11,13 @@ import type {
   AgentTriggerDeliveryMethods,
   ConversationMethods,
   IAgentEventActorState,
+  IAgentEventActorSkillIdentity,
 } from '@librechat/data-schemas';
 import type { TCheckpointerConfig } from 'librechat-data-provider';
 import type { AgentTriggerExpectedAction } from './envelope';
 import type { AgentEventAppliedAction } from './outcome';
+import type { AgentContextFingerprint } from '../compatibility';
+import { agentContextFingerprintsMatch } from '../compatibility';
 import {
   captureAgentEventCheckpoint,
   deleteAgentCheckpoint,
@@ -47,10 +50,18 @@ export interface ExecuteAgentEventActorInput<T> {
   expectedAction?: AgentTriggerExpectedAction;
   signal: AbortSignal;
   checkpointer?: TCheckpointerConfig;
+  contextFingerprint?: AgentContextFingerprint;
+  resolveContext?(state: IAgentEventActorState): Promise<AgentEventActorContext | undefined>;
+  readResultContext?(): Promise<AgentEventActorContext | undefined>;
   /** Deprecated compatibility input. Elapsed time never proves replay safety. */
   legacyTurnStaleMs?: number;
   invoke(context: AgentEventActorInvocationContext): Promise<T>;
   readAppliedAction(): AgentEventAppliedAction | undefined;
+}
+
+export interface AgentEventActorContext {
+  fingerprint: AgentContextFingerprint;
+  skillManifest: IAgentEventActorSkillIdentity[];
 }
 
 export interface ExecuteAgentEventActorResult<T> {
@@ -121,6 +132,8 @@ export async function executeAgentEventActor<T>(
   let ownedActionAdmissionId: string | undefined;
   let observedState: IAgentEventActorState | null | undefined;
   let observedEpoch: number | undefined;
+  let preparedContext: AgentEventActorContext | undefined;
+  let resultContext: AgentEventActorContext | undefined;
   const adapter: EventActorHostAdapter<EventActorEvent, EventActorResult> = {
     async prepare(request, context) {
       if (context.signal.aborted) {
@@ -244,6 +257,18 @@ export async function executeAgentEventActor<T>(
       const head = toHead(input.conversationId, state);
       if (state == null || state.requiresColdStart === true) {
         return { status: 'checkpoint_unavailable', head };
+      }
+      const validatesContext = input.resolveContext != null || input.contextFingerprint != null;
+      if (validatesContext) {
+        preparedContext = input.resolveContext
+          ? await input.resolveContext(state)
+          : { fingerprint: input.contextFingerprint!, skillManifest: [] };
+        if (
+          preparedContext == null ||
+          !agentContextFingerprintsMatch(state.contextFingerprint, preparedContext.fingerprint)
+        ) {
+          return { status: 'checkpoint_unavailable', head };
+        }
       }
       const fork = await forkAgentEventCheckpoint(
         state.checkpoint,
@@ -397,6 +422,7 @@ export async function executeAgentEventActor<T>(
         }
         return { status: 'completed_no_action' };
       }
+      resultContext = input.readResultContext ? await input.readResultContext() : preparedContext;
       let checkpoint: Awaited<ReturnType<typeof captureAgentEventCheckpoint>>;
       try {
         checkpoint = await captureAgentEventCheckpoint(
@@ -464,6 +490,12 @@ export async function executeAgentEventActor<T>(
                 checkpointNs: expectedHeadCheckpoint!.checkpointNs,
               },
               ...(observedState.requiresColdStart === true ? { requiresColdStart: true } : {}),
+              ...(observedState.contextFingerprint == null
+                ? {}
+                : { contextFingerprint: observedState.contextFingerprint }),
+              ...(observedState.skillManifest == null
+                ? {}
+                : { skillManifest: observedState.skillManifest }),
             };
       const committed = await deps.commitState({
         user: input.user,
@@ -481,6 +513,12 @@ export async function executeAgentEventActor<T>(
           checkpointId: appliedCheckpointId,
           checkpointNs: request.checkpoint.checkpointNs,
         },
+        ...(resultContext == null
+          ? {}
+          : {
+              contextFingerprint: resultContext.fingerprint,
+              skillManifest: resultContext.skillManifest,
+            }),
       });
       if (committed.status === 'stale') {
         /** A host-private cold marker can invalidate the CAS without advancing

--- a/packages/api/src/agents/triggers/actor.ts
+++ b/packages/api/src/agents/triggers/actor.ts
@@ -14,6 +14,7 @@ import type {
   IAgentEventActorSkillIdentity,
 } from '@librechat/data-schemas';
 import type { TCheckpointerConfig } from 'librechat-data-provider';
+import type { AgentEventCheckpointMessageOverlay } from '../checkpointer';
 import type { AgentContextFingerprint } from '../compatibility';
 import type { AgentTriggerExpectedAction } from './envelope';
 import type { AgentEventAppliedAction } from './outcome';
@@ -62,6 +63,10 @@ export interface ExecuteAgentEventActorInput<T> {
 export interface AgentEventActorContext {
   fingerprint: AgentContextFingerprint;
   skillManifest: IAgentEventActorSkillIdentity[];
+  discoveredToolNames?: string[];
+  summary?: IAgentEventActorState['summary'];
+  contextMeta?: IAgentEventActorState['contextMeta'];
+  checkpointMessageOverlay?: AgentEventCheckpointMessageOverlay;
 }
 
 export interface ExecuteAgentEventActorResult<T> {
@@ -262,7 +267,7 @@ export async function executeAgentEventActor<T>(
       if (validatesContext) {
         preparedContext = input.resolveContext
           ? await input.resolveContext(state)
-          : { fingerprint: input.contextFingerprint!, skillManifest: [] };
+          : { fingerprint: input.contextFingerprint!, skillManifest: [], discoveredToolNames: [] };
         if (
           preparedContext == null ||
           !agentContextFingerprintsMatch(state.contextFingerprint, preparedContext.fingerprint)
@@ -275,6 +280,7 @@ export async function executeAgentEventActor<T>(
         request.checkpointNs,
         request.invocationId,
         input.checkpointer,
+        preparedContext?.checkpointMessageOverlay,
       );
       if (fork == null) {
         return { status: 'checkpoint_unavailable', head };
@@ -507,6 +513,13 @@ export async function executeAgentEventActor<T>(
               ...(observedState.skillManifest == null
                 ? {}
                 : { skillManifest: observedState.skillManifest }),
+              ...(observedState.discoveredToolNames == null
+                ? {}
+                : { discoveredToolNames: observedState.discoveredToolNames }),
+              ...(observedState.summary == null ? {} : { summary: observedState.summary }),
+              ...(observedState.contextMeta == null
+                ? {}
+                : { contextMeta: observedState.contextMeta }),
             };
       const committed = await deps.commitState({
         user: input.user,
@@ -529,6 +542,11 @@ export async function executeAgentEventActor<T>(
           : {
               contextFingerprint: resultContext.fingerprint,
               skillManifest: resultContext.skillManifest,
+              discoveredToolNames: resultContext.discoveredToolNames ?? [],
+              ...(resultContext.summary == null ? {} : { summary: resultContext.summary }),
+              ...(resultContext.contextMeta == null
+                ? {}
+                : { contextMeta: resultContext.contextMeta }),
             }),
       });
       if (committed.status === 'stale') {

--- a/packages/api/src/agents/triggers/actor.ts
+++ b/packages/api/src/agents/triggers/actor.ts
@@ -14,10 +14,9 @@ import type {
   IAgentEventActorSkillIdentity,
 } from '@librechat/data-schemas';
 import type { TCheckpointerConfig } from 'librechat-data-provider';
+import type { AgentContextFingerprint } from '../compatibility';
 import type { AgentTriggerExpectedAction } from './envelope';
 import type { AgentEventAppliedAction } from './outcome';
-import type { AgentContextFingerprint } from '../compatibility';
-import { agentContextFingerprintsMatch } from '../compatibility';
 import {
   captureAgentEventCheckpoint,
   deleteAgentCheckpoint,
@@ -25,6 +24,7 @@ import {
   getAgentCheckpointer,
   getApprovalTtlMs,
 } from '../checkpointer';
+import { agentContextFingerprintsMatch } from '../compatibility';
 
 interface EventActorResult extends Record<string, EventActorEvent> {
   action: AgentEventAppliedAction;

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -46,6 +46,13 @@ export {
   digestMCPAuthorityValue,
 } from './methods';
 export { FAVORITE_ITEM_TYPES } from './types/favorite';
+export {
+  MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS,
+  MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_SKILLS,
+  MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH,
+} from './types/convo';
 export type * from './types';
 export type * from './methods';
 export {

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -4234,6 +4234,93 @@ describe('Conversation Operations', () => {
       );
     });
 
+    it('persists context fingerprints and Skill manifests with the actor head', async () => {
+      const conversationId = uuidv4();
+      const fingerprint = {
+        algorithm: 'sha256' as const,
+        version: 1,
+        digest: 'context-one',
+      };
+      const actorCheckpoint = {
+        threadId: conversationId,
+        checkpointId: 'checkpoint-context',
+        checkpointNs: 'event-actor/context',
+      };
+      const skillManifest = [{ id: 'skill-1', name: 'analysis', version: 3 }];
+      await Conversation.create({
+        conversationId,
+        user: 'actor-context-user',
+        endpoint: EModelEndpoint.agents,
+        agent_id: 'agent-player',
+        agentEventBinding: {
+          bindingId: `evtbind_${'f'.repeat(48)}`,
+          sourceKeyId: 'key-a',
+          actorId: 'player-a',
+        },
+        subagentThread: {
+          rootConversationId: 'parent',
+          parentConversationId: 'parent',
+          parentMessageId: 'parent-message',
+          parentToolCallId: 'event-binding',
+          parentAgentId: 'agent-director',
+          subagentType: 'agent-player',
+          subagentKind: 'agent',
+          depth: 1,
+        },
+      });
+      await methods.recordAgentEventActorReconciliation({
+        user: 'actor-context-user',
+        conversationId,
+        reconciliation: {
+          invocationId: 'context-one',
+          status: 'invocation_pending',
+          checkpoint: actorCheckpoint,
+          action: { toolName: 'submit_move' },
+          observedAt: new Date(),
+        },
+      });
+
+      const committed = await methods.commitAgentEventActorState({
+        user: 'actor-context-user',
+        conversationId,
+        invocationId: 'context-one',
+        expectedEpoch: 0,
+        action: { toolName: 'submit_move' },
+        checkpoint: actorCheckpoint,
+        contextFingerprint: fingerprint,
+        skillManifest,
+      });
+
+      expect(committed).toMatchObject({
+        status: 'committed',
+        state: {
+          generation: 1,
+          checkpoint: actorCheckpoint,
+          contextFingerprint: fingerprint,
+          skillManifest,
+        },
+      });
+      await expect(
+        methods.getAgentEventActorSnapshot({ user: 'actor-context-user', conversationId }),
+      ).resolves.toMatchObject({ state: { contextFingerprint: fingerprint, skillManifest } });
+
+      await expect(
+        methods.commitAgentEventActorState({
+          user: 'actor-context-user',
+          conversationId,
+          invocationId: 'too-many-skills',
+          expectedEpoch: 0,
+          action: { toolName: 'submit_move' },
+          checkpoint: actorCheckpoint,
+          skillManifest: Array.from({ length: 65 }, (_, index) => ({
+            id: `skill-${index}`,
+            name: `skill-${index}`,
+            version: 1,
+          })),
+        }),
+      ).rejects.toThrow('Event actor Skill manifest exceeds 64');
+    });
+
     it('retains exact legacy settled receipts until delivery-ledger migration', async () => {
       const conversationId = uuidv4();
       await Conversation.create({

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -4234,7 +4234,7 @@ describe('Conversation Operations', () => {
       );
     });
 
-    it('persists context fingerprints and Skill manifests with the actor head', async () => {
+    it('persists complete warm-continuation state with the actor head', async () => {
       const conversationId = uuidv4();
       const fingerprint = {
         algorithm: 'sha256' as const,
@@ -4247,6 +4247,9 @@ describe('Conversation Operations', () => {
         checkpointNs: 'event-actor/context',
       };
       const skillManifest = [{ id: 'skill-1', name: 'analysis', version: 3 }];
+      const discoveredToolNames = ['deferred_lookup', 'deferred_write'];
+      const summary = { text: 'Earlier compacted context.', tokenCount: 12 };
+      const contextMeta = { calibrationRatio: 1.25, encoding: 'o200k_base' };
       await Conversation.create({
         conversationId,
         user: 'actor-context-user',
@@ -4289,6 +4292,9 @@ describe('Conversation Operations', () => {
         checkpoint: actorCheckpoint,
         contextFingerprint: fingerprint,
         skillManifest,
+        discoveredToolNames,
+        summary,
+        contextMeta,
       });
 
       expect(committed).toMatchObject({
@@ -4298,11 +4304,22 @@ describe('Conversation Operations', () => {
           checkpoint: actorCheckpoint,
           contextFingerprint: fingerprint,
           skillManifest,
+          discoveredToolNames,
+          summary,
+          contextMeta,
         },
       });
       await expect(
         methods.getAgentEventActorSnapshot({ user: 'actor-context-user', conversationId }),
-      ).resolves.toMatchObject({ state: { contextFingerprint: fingerprint, skillManifest } });
+      ).resolves.toMatchObject({
+        state: {
+          contextFingerprint: fingerprint,
+          skillManifest,
+          discoveredToolNames,
+          summary,
+          contextMeta,
+        },
+      });
 
       await expect(
         methods.commitAgentEventActorState({
@@ -4319,6 +4336,42 @@ describe('Conversation Operations', () => {
           })),
         }),
       ).rejects.toThrow('Event actor Skill manifest exceeds 64');
+
+      await expect(
+        methods.commitAgentEventActorState({
+          user: 'actor-context-user',
+          conversationId,
+          invocationId: 'too-many-tools',
+          expectedEpoch: 0,
+          action: { toolName: 'submit_move' },
+          checkpoint: actorCheckpoint,
+          discoveredToolNames: Array.from({ length: 129 }, (_, index) => `tool-${index}`),
+        }),
+      ).rejects.toThrow('Event actor discovered-tool state is invalid');
+
+      await expect(
+        methods.commitAgentEventActorState({
+          user: 'actor-context-user',
+          conversationId,
+          invocationId: 'invalid-summary',
+          expectedEpoch: 0,
+          action: { toolName: 'submit_move' },
+          checkpoint: actorCheckpoint,
+          summary: { text: '', tokenCount: 1 },
+        }),
+      ).rejects.toThrow('Event actor summary state is invalid');
+
+      await expect(
+        methods.commitAgentEventActorState({
+          user: 'actor-context-user',
+          conversationId,
+          invocationId: 'invalid-calibration',
+          expectedEpoch: 0,
+          action: { toolName: 'submit_move' },
+          checkpoint: actorCheckpoint,
+          contextMeta: { calibrationRatio: 9, encoding: 'o200k_base' },
+        }),
+      ).rejects.toThrow('Event actor context calibration is invalid');
     });
 
     it('retains exact legacy settled receipts until delivery-ledger migration', async () => {

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -27,10 +27,10 @@ import {
 } from './chatProject';
 import { createTempChatExpirationDate } from '~/utils/tempChatRetention';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
+import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { decrementTagCounts } from './conversationTag';
 import logger from '~/config/winston';
-import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 
 const AGENT_EVENT_ACTOR_RECEIPT_RETENTION_MS = 90 * 24 * 60 * 60_000;
 

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -17,6 +17,13 @@ import type {
 } from '~/types';
 import type { MessageMethods } from './message';
 import {
+  MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS,
+  MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_SKILLS,
+  MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH,
+} from '~/types/convo';
+import {
   activeExpirationFilter,
   buildRetentionVisibilityFilter,
   createFallbackRetentionDate,
@@ -27,7 +34,6 @@ import {
 } from './chatProject';
 import { createTempChatExpirationDate } from '~/utils/tempChatRetention';
 import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
-import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { decrementTagCounts } from './conversationTag';
 import logger from '~/config/winston';
@@ -248,6 +254,9 @@ export interface ConversationMethods {
     checkpoint: IAgentEventActorCheckpoint;
     contextFingerprint?: IAgentEventActorState['contextFingerprint'];
     skillManifest?: IAgentEventActorState['skillManifest'];
+    discoveredToolNames?: IAgentEventActorState['discoveredToolNames'];
+    summary?: IAgentEventActorState['summary'];
+    contextMeta?: IAgentEventActorState['contextMeta'];
   }): Promise<AgentEventActorCommitResult>;
   beginAgentEventActorLegacyTurn(input: {
     user: string;
@@ -538,12 +547,43 @@ export function createConversationMethods(
     checkpoint: IAgentEventActorCheckpoint;
     contextFingerprint?: IAgentEventActorState['contextFingerprint'];
     skillManifest?: IAgentEventActorState['skillManifest'];
+    discoveredToolNames?: IAgentEventActorState['discoveredToolNames'];
+    summary?: IAgentEventActorState['summary'];
+    contextMeta?: IAgentEventActorState['contextMeta'];
   }): Promise<AgentEventActorCommitResult> {
     if (input.checkpoint.threadId !== input.conversationId) {
       throw new Error('Event actor checkpoint changed its logical thread');
     }
     if ((input.skillManifest?.length ?? 0) > MAX_AGENT_EVENT_ACTOR_SKILLS) {
       throw new RangeError(`Event actor Skill manifest exceeds ${MAX_AGENT_EVENT_ACTOR_SKILLS}`);
+    }
+    if (
+      (input.discoveredToolNames?.length ?? 0) > MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS ||
+      input.discoveredToolNames?.some(
+        (name) => name.length === 0 || name.length > MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH,
+      )
+    ) {
+      throw new RangeError('Event actor discovered-tool state is invalid');
+    }
+    if (
+      input.summary != null &&
+      (input.summary.text.length === 0 ||
+        input.summary.text.length > MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH ||
+        !Number.isFinite(input.summary.tokenCount) ||
+        input.summary.tokenCount < 0)
+    ) {
+      throw new RangeError('Event actor summary state is invalid');
+    }
+    if (
+      input.contextMeta != null &&
+      (!Number.isFinite(input.contextMeta.calibrationRatio) ||
+        input.contextMeta.calibrationRatio < 0.5 ||
+        input.contextMeta.calibrationRatio > 5 ||
+        (input.contextMeta.encoding != null &&
+          (input.contextMeta.encoding.length === 0 ||
+            input.contextMeta.encoding.length > MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH)))
+    ) {
+      throw new RangeError('Event actor context calibration is invalid');
     }
     const Conversation = mongoose.models.Conversation as Model<IConversation>;
     /** A legacy turn against a headless or already cold-marked actor leaves
@@ -576,6 +616,15 @@ export function createConversationMethods(
             ...(input.expected.skillManifest == null
               ? { 'agentEventActor.skillManifest': { $exists: false } }
               : { 'agentEventActor.skillManifest': input.expected.skillManifest }),
+            ...(input.expected.discoveredToolNames == null
+              ? { 'agentEventActor.discoveredToolNames': { $exists: false } }
+              : { 'agentEventActor.discoveredToolNames': input.expected.discoveredToolNames }),
+            ...(input.expected.summary == null
+              ? { 'agentEventActor.summary': { $exists: false } }
+              : { 'agentEventActor.summary': input.expected.summary }),
+            ...(input.expected.contextMeta == null
+              ? { 'agentEventActor.contextMeta': { $exists: false } }
+              : { 'agentEventActor.contextMeta': input.expected.contextMeta }),
             'agentEventActor.requiresColdStart':
               input.expected.requiresColdStart === true ? true : { $ne: true },
           }),
@@ -585,6 +634,11 @@ export function createConversationMethods(
       checkpoint: input.checkpoint,
       ...(input.contextFingerprint == null ? {} : { contextFingerprint: input.contextFingerprint }),
       ...(input.skillManifest == null ? {} : { skillManifest: input.skillManifest }),
+      ...(input.discoveredToolNames == null
+        ? {}
+        : { discoveredToolNames: input.discoveredToolNames }),
+      ...(input.summary == null ? {} : { summary: input.summary }),
+      ...(input.contextMeta == null ? {} : { contextMeta: input.contextMeta }),
       ...(input.expected == null ? {} : { previousCheckpoint: input.expected.checkpoint }),
     };
     const previous = await Conversation.findOneAndUpdate(

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -30,6 +30,7 @@ import { tenantSafeBulkWrite } from '~/utils/tenantBulkWrite';
 import { isValidObjectIdString } from '~/utils/objectId';
 import { decrementTagCounts } from './conversationTag';
 import logger from '~/config/winston';
+import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 
 const AGENT_EVENT_ACTOR_RECEIPT_RETENTION_MS = 90 * 24 * 60 * 60_000;
 
@@ -245,6 +246,8 @@ export interface ConversationMethods {
     expected?: IAgentEventActorState;
     expectedEpoch: number;
     checkpoint: IAgentEventActorCheckpoint;
+    contextFingerprint?: IAgentEventActorState['contextFingerprint'];
+    skillManifest?: IAgentEventActorState['skillManifest'];
   }): Promise<AgentEventActorCommitResult>;
   beginAgentEventActorLegacyTurn(input: {
     user: string;
@@ -533,9 +536,14 @@ export function createConversationMethods(
     expected?: IAgentEventActorState;
     expectedEpoch: number;
     checkpoint: IAgentEventActorCheckpoint;
+    contextFingerprint?: IAgentEventActorState['contextFingerprint'];
+    skillManifest?: IAgentEventActorState['skillManifest'];
   }): Promise<AgentEventActorCommitResult> {
     if (input.checkpoint.threadId !== input.conversationId) {
       throw new Error('Event actor checkpoint changed its logical thread');
+    }
+    if ((input.skillManifest?.length ?? 0) > MAX_AGENT_EVENT_ACTOR_SKILLS) {
+      throw new RangeError(`Event actor Skill manifest exceeds ${MAX_AGENT_EVENT_ACTOR_SKILLS}`);
     }
     const Conversation = mongoose.models.Conversation as Model<IConversation>;
     /** A legacy turn against a headless or already cold-marked actor leaves
@@ -555,6 +563,19 @@ export function createConversationMethods(
             'agentEventActor.checkpoint.threadId': input.expected.checkpoint.threadId,
             'agentEventActor.checkpoint.checkpointId': input.expected.checkpoint.checkpointId,
             'agentEventActor.checkpoint.checkpointNs': input.expected.checkpoint.checkpointNs,
+            ...(input.expected.contextFingerprint == null
+              ? { 'agentEventActor.contextFingerprint': { $exists: false } }
+              : {
+                  'agentEventActor.contextFingerprint.algorithm':
+                    input.expected.contextFingerprint.algorithm,
+                  'agentEventActor.contextFingerprint.version':
+                    input.expected.contextFingerprint.version,
+                  'agentEventActor.contextFingerprint.digest':
+                    input.expected.contextFingerprint.digest,
+                }),
+            ...(input.expected.skillManifest == null
+              ? { 'agentEventActor.skillManifest': { $exists: false } }
+              : { 'agentEventActor.skillManifest': input.expected.skillManifest }),
             'agentEventActor.requiresColdStart':
               input.expected.requiresColdStart === true ? true : { $ne: true },
           }),
@@ -562,6 +583,8 @@ export function createConversationMethods(
     const nextState: IAgentEventActorState = {
       generation: (input.expected?.generation ?? 0) + 1,
       checkpoint: input.checkpoint,
+      ...(input.contextFingerprint == null ? {} : { contextFingerprint: input.contextFingerprint }),
+      ...(input.skillManifest == null ? {} : { skillManifest: input.skillManifest }),
       ...(input.expected == null ? {} : { previousCheckpoint: input.expected.checkpoint }),
     };
     const previous = await Conversation.findOneAndUpdate(

--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -1337,6 +1337,7 @@ describe('Skill CRUD methods', () => {
     });
     const names = result.skills.map((s) => s.name).sort();
     expect(names).toEqual(['always-a', 'always-b']);
+    expect(result.skills.map((skill) => skill.version)).toEqual([1, 1]);
   });
 
   it('listAlwaysApplySkills excludes rows outside accessibleIds', async () => {

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -789,6 +789,7 @@ export type ListAlwaysApplySkillsResult = {
     author: Types.ObjectId;
     frontmatter?: Record<string, unknown>;
     allowedTools?: string[];
+    version: number;
   }>;
   /** `true` when another page exists beyond this one. */
   has_more: boolean;
@@ -1419,7 +1420,7 @@ export function createSkillMethods(
     const rows = await Skill.find(filter)
       .sort({ updatedAt: -1, _id: 1 })
       .limit(limit + 1)
-      .select('name body author frontmatter updatedAt allowedTools')
+      .select('name body author frontmatter updatedAt allowedTools version')
       .lean();
 
     const has_more = rows.length > limit;
@@ -1448,6 +1449,7 @@ export function createSkillMethods(
         name: row.name,
         body: row.body ?? '',
         author: row.author as Types.ObjectId,
+        version: row.version,
         frontmatter: row.frontmatter,
       };
       if (row.allowedTools !== undefined) {

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -1,5 +1,11 @@
 import { Schema } from 'mongoose';
-import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
+import {
+  MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS,
+  MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_SKILLS,
+  MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH,
+  MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH,
+} from '~/types/convo';
 import { conversationPreset } from './defaults';
 import { IConversation } from '~/types';
 
@@ -105,6 +111,38 @@ const convoSchema: Schema<IConversation> = new Schema(
             validator: (skills: unknown[]) => skills.length <= MAX_AGENT_EVENT_ACTOR_SKILLS,
             message: `Event actor Skill manifest exceeds ${MAX_AGENT_EVENT_ACTOR_SKILLS}`,
           },
+        },
+        discoveredToolNames: {
+          type: [{ type: String, maxlength: MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH }],
+          default: undefined,
+          validate: {
+            validator: (names: unknown[]) => names.length <= MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS,
+            message: `Event actor discovered-tool state exceeds ${MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS}`,
+          },
+        },
+        summary: {
+          type: {
+            text: {
+              type: String,
+              required: true,
+              maxlength: MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH,
+            },
+            tokenCount: { type: Number, min: 0, required: true },
+          },
+          _id: false,
+          default: undefined,
+        },
+        contextMeta: {
+          type: {
+            calibrationRatio: { type: Number, min: 0.5, max: 5, required: true },
+            encoding: {
+              type: String,
+              maxlength: MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH,
+              default: undefined,
+            },
+          },
+          _id: false,
+          default: undefined,
         },
         previousCheckpoint: {
           type: {

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -96,6 +96,7 @@ const convoSchema: Schema<IConversation> = new Schema(
               id: { type: String, required: true },
               name: { type: String, required: true },
               version: { type: Number, min: 1, required: true },
+              contentDigest: { type: String, default: undefined },
               _id: false,
             },
           ],

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'mongoose';
+import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 import { conversationPreset } from './defaults';
 import { IConversation } from '~/types';
-import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 
 const convoSchema: Schema<IConversation> = new Schema(
   {

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -1,6 +1,7 @@
 import { Schema } from 'mongoose';
 import { conversationPreset } from './defaults';
 import { IConversation } from '~/types';
+import { MAX_AGENT_EVENT_ACTOR_SKILLS } from '~/types/convo';
 
 const convoSchema: Schema<IConversation> = new Schema(
   {
@@ -79,6 +80,30 @@ const convoSchema: Schema<IConversation> = new Schema(
           },
           _id: false,
           required: true,
+        },
+        contextFingerprint: {
+          type: {
+            algorithm: { type: String, enum: ['sha256'], required: true },
+            version: { type: Number, min: 1, required: true },
+            digest: { type: String, required: true },
+          },
+          _id: false,
+          default: undefined,
+        },
+        skillManifest: {
+          type: [
+            {
+              id: { type: String, required: true },
+              name: { type: String, required: true },
+              version: { type: Number, min: 1, required: true },
+              _id: false,
+            },
+          ],
+          default: undefined,
+          validate: {
+            validator: (skills: unknown[]) => skills.length <= MAX_AGENT_EVENT_ACTOR_SKILLS,
+            message: `Event actor Skill manifest exceeds ${MAX_AGENT_EVENT_ACTOR_SKILLS}`,
+          },
         },
         previousCheckpoint: {
           type: {

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -32,6 +32,7 @@ export interface IAgentEventActorSkillIdentity {
   id: string;
   name: string;
   version: number;
+  contentDigest?: string;
 }
 
 /** Private committed checkpoint state for one event-bound child actor. */

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -2,6 +2,10 @@ import type { TSubagentThreadLineage } from 'librechat-data-provider';
 import type { Document, Types } from 'mongoose';
 
 export const MAX_AGENT_EVENT_ACTOR_SKILLS = 64;
+export const MAX_AGENT_EVENT_ACTOR_DISCOVERED_TOOLS = 128;
+export const MAX_AGENT_EVENT_ACTOR_TOOL_NAME_LENGTH = 512;
+export const MAX_AGENT_EVENT_ACTOR_SUMMARY_LENGTH = 1_000_000;
+export const MAX_AGENT_EVENT_ACTOR_ENCODING_LENGTH = 128;
 
 export interface ISubagentThreadLease {
   token: string;
@@ -35,6 +39,16 @@ export interface IAgentEventActorSkillIdentity {
   contentDigest?: string;
 }
 
+export interface IAgentEventActorSummary {
+  text: string;
+  tokenCount: number;
+}
+
+export interface IAgentEventActorContextMeta {
+  calibrationRatio: number;
+  encoding?: string;
+}
+
 /** Private committed checkpoint state for one event-bound child actor. */
 export interface IAgentEventActorState {
   generation: number;
@@ -42,6 +56,12 @@ export interface IAgentEventActorState {
   contextFingerprint?: IAgentEventActorContextFingerprint;
   /** Bounded semantic Skill set needed to validate a warm continuation without history. */
   skillManifest?: IAgentEventActorSkillIdentity[];
+  /** Bounded run-evolved tool-search state needed to rebuild the next model binding. */
+  discoveredToolNames?: string[];
+  /** Active compaction summary, which the SDK keeps outside checkpointed graph messages. */
+  summary?: IAgentEventActorSummary;
+  /** Pruner calibration carried by ordinary turns on the parent response message. */
+  contextMeta?: IAgentEventActorContextMeta;
   previousCheckpoint?: IAgentEventActorCheckpoint;
   /** Forces the next qualifying event to rebuild from durable message history. */
   requiresColdStart?: boolean;

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -1,6 +1,8 @@
 import type { TSubagentThreadLineage } from 'librechat-data-provider';
 import type { Document, Types } from 'mongoose';
 
+export const MAX_AGENT_EVENT_ACTOR_SKILLS = 64;
+
 export interface ISubagentThreadLease {
   token: string;
   taskId: string;
@@ -20,10 +22,25 @@ export interface IAgentEventActorCheckpoint {
   checkpointNs: string;
 }
 
+export interface IAgentEventActorContextFingerprint {
+  algorithm: 'sha256';
+  version: number;
+  digest: string;
+}
+
+export interface IAgentEventActorSkillIdentity {
+  id: string;
+  name: string;
+  version: number;
+}
+
 /** Private committed checkpoint state for one event-bound child actor. */
 export interface IAgentEventActorState {
   generation: number;
   checkpoint: IAgentEventActorCheckpoint;
+  contextFingerprint?: IAgentEventActorContextFingerprint;
+  /** Bounded semantic Skill set needed to validate a warm continuation without history. */
+  skillManifest?: IAgentEventActorSkillIdentity[];
   previousCheckpoint?: IAgentEventActorCheckpoint;
   /** Forces the next qualifying event to rebuild from durable message history. */
   requiresColdStart?: boolean;


### PR DESCRIPTION
## Summary

I added context-fingerprinted warm continuation for event-bound agents, stacked on #15296, and made the continuation contract fully reconstructable without relying on implicitly loaded conversation history.

- Compute a deterministic SHA-256 compatibility fingerprint over the complete effective agent topology, including eager and lazy subagents, graph-member metadata, full trusted tool registries, approval policy, Skills, memory, and checkpointer/runtime versions.
- Resolve the committed Skill manifest under the current request ACL and replace root checkpoint Skill messages with exact current root bodies on each isolated fork, preventing stale or duplicate primes after pruning without leaking child-only instructions.
- Project current always-apply Skill bodies and versions into lazy subagent and graph-member metadata only for bound event actors so nested Skill edits invalidate compatibility without adding queries to ordinary chats or eagerly initializing child tools, files, models, or MCP connections; cache identical Skill scopes per request.
- Attribute model-invoked Skills to their executing agent, retain only root invocations for root replay, preserve credential-named semantic schema fields during fingerprinting, and merge multi-profile Skill bodies and identities in lockstep.
- Capture bounded deferred-tool discoveries, the active compaction summary, and pruning calibration after each run; persist them atomically with the actor checkpoint head and restore them when constructing the next warm run.
- Include every continuation field in the actor compare-and-swap so a stale fork cannot commit over changed checkpoint, Skill, discovery, summary, or calibration state.
- Consolidate cycle-safe agent-topology traversal in one TypeScript utility shared by compatibility and AgentClient logic.
- Skip durable conversation-history loading only after exact compatibility succeeds; preserve the existing cold reconstruction path for missing, legacy, invalid, changed, or unrestorable state.
- Preserve post-action reconciliation when result-context capture or checkpoint persistence becomes uncertain.

Measured locally on Apple M4 Max / Node 24.16 with 9 rounds:

- Fingerprint, 1 agent × 20 tools: 0.0165 ms median; 0.0171 ms slowest-round average.
- Fingerprint, 16 agents × 20 tools: 0.2497 ms median; 0.3148 ms slowest-round average.
- Ordinary chats do not enter fingerprint preflight.
- A focused adapter test proves a compatible warm actor invokes zero durable-history loads.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran the full AgentClient suite: 180 tests passed.
- Ran the combined AgentClient and endpoint-initialization suites after the latest review fixes: 231 tests passed.
- Ran handler, Skill-file, and compatibility suites after the final ownership fixes: 196 tests passed.
- Ran focused actor, checkpointer integration, compatibility, and topology suites: 78 tests passed.
- Ran the full conversation data-method suite: 158 tests passed.
- Built `packages/data-schemas` and `packages/api` from the worktree with `tsdown@0.22.2`.
- Ran ESLint and Prettier over every changed file.
- Previously ran the focused planner, Skill, tool-handler, request-controller, and subagent-initialization regression suites on this PR stack; all passed.

### **Test Configuration**:

- macOS, Apple M4 Max
- Node.js 24.16
- Stacked base: `danny-avila/agent-turn-execution-plan` (`864397336`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
