### PR TITLE
♟️ fix: Settle First Bound Actor Events

### DIFF
--- a/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
+++ b/api/server/controllers/agents/__tests__/request.resumeMetadata.spec.js
@@ -3931,7 +3931,7 @@ describe('ResumableAgentController resume metadata', () => {
     );
   });
 
-  it('reports a temporary event-actor fence as retryable rather than ending the binding', async () => {
+  it('retains terminal metadata for the first event in an empty bound actor thread', async () => {
     const expiredAt = new Date(Date.now() + 60_000);
     mockGenerationJobManager.claimGeneration.mockResolvedValue(
       wonGenerationClaim({
@@ -3950,11 +3950,10 @@ describe('ResumableAgentController resume metadata', () => {
       body: {
         text: 'Continue from event.',
         messageId: 'user-msg',
-        parentMessageId: 'response-previous',
+        parentMessageId: '00000000-0000-0000-0000-000000000000',
         clientRequestId: 'req-event',
         agentEventDelivery: {
           deliveryKey: 'req-event',
-          target: { bindingId: 'binding-1' },
           expectedAction: {
             toolName: 'submit_move',
             argumentSubset: { gameId: 'game-1', expectedPly: 7 },
@@ -3965,6 +3964,7 @@ describe('ResumableAgentController resume metadata', () => {
       },
       config: {},
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',
@@ -3988,6 +3988,7 @@ describe('ResumableAgentController resume metadata', () => {
         responseMessageId: 'req-event:assistant',
         userMessage: expect.objectContaining({ messageId: 'req-event:user' }),
         agentEventDeliveryKey: 'req-event',
+        agentEventBindingId: 'binding-1',
         agentEventExpectedAction: {
           toolName: 'submit_move',
           argumentSubset: { gameId: 'game-1', expectedPly: 7 },
@@ -4044,6 +4045,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: undefined,
@@ -4138,6 +4140,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: undefined,
@@ -4228,6 +4231,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',
@@ -4340,6 +4344,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',
@@ -4505,6 +4510,7 @@ describe('ResumableAgentController resume metadata', () => {
         },
         config: { endpoints: { agents: config } },
         _isAgentTrigger: true,
+        _agentEventBindingId: 'binding-1',
         _agentEventBindingParentConversationId: 'parent-conversation',
         _agentEventBindingParentAgentId: 'parent-agent',
         _agentEventBindingTenantId: 'tenant-1',
@@ -4599,6 +4605,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',
@@ -4673,6 +4680,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',
@@ -4743,6 +4751,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',
@@ -4824,6 +4833,7 @@ describe('ResumableAgentController resume metadata', () => {
         endpoints: { agents: { eventDriven: { checkpointForks: true, durableReceipts: true } } },
       },
       _isAgentTrigger: true,
+      _agentEventBindingId: 'binding-1',
       _agentEventBindingParentConversationId: 'parent-conversation',
       _agentEventBindingParentAgentId: 'parent-agent',
       _agentEventBindingTenantId: 'tenant-1',

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -726,8 +726,22 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
       : undefined,
   });
 
+  /** A newly bound actor conversation has no child messages yet, so its first
+   * event legitimately uses the root parent id. The authenticated write guard
+   * supplies the binding identity before this controller; that durable binding,
+   * not the presence of an earlier child message, proves this is a continuation. */
+  const boundEventBindingId =
+    req._agentEventBindingId ?? req.resolvedConversation?.agentEventBinding?.bindingId;
+  const isBoundEventContinuation =
+    req._isAgentTrigger === true &&
+    !isNewConvo &&
+    req._agentEventBindingParentConversationId != null &&
+    typeof boundEventBindingId === 'string' &&
+    boundEventBindingId.length > 0;
   const isTriggerContinuation =
-    req._isAgentTrigger === true && !isNewConvo && parentMessageId !== Constants.NO_PARENT;
+    req._isAgentTrigger === true &&
+    !isNewConvo &&
+    (parentMessageId !== Constants.NO_PARENT || isBoundEventContinuation);
 
   if (
     await isUnpersistedPreliminaryParent({
@@ -1297,6 +1311,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
   const rawAgentEventDelivery = req.body?.agentEventDelivery;
   const agentEventDelivery =
     isTriggerContinuation &&
+    isBoundEventContinuation &&
     rawAgentEventDelivery != null &&
     typeof rawAgentEventDelivery === 'object' &&
     rawAgentEventDelivery.deliveryKey === clientRequestId
@@ -1351,7 +1366,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         isTemporary: req._agentEventBindingRetention?.isTemporary ?? req.body?.isTemporary,
         ...(agentEventDelivery != null && {
           agentEventDeliveryKey: agentEventDelivery.deliveryKey,
-          agentEventBindingId: agentEventDelivery.target.bindingId,
+          agentEventBindingId: boundEventBindingId,
           ...(agentEventDelivery.expectedAction != null && {
             agentEventExpectedAction: agentEventDelivery.expectedAction,
           }),
@@ -2060,7 +2075,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
                 user: userId,
                 ...(eventActorTenantId == null ? {} : { tenantId: eventActorTenantId }),
                 conversationId,
-                bindingId: agentEventDelivery.target.bindingId,
+                bindingId: boundEventBindingId,
                 invocationId: eventTaskId,
                 event: agentEventDelivery.event,
                 expectedAction: agentEventDelivery.expectedAction,

--- a/packages/api/src/agents/guard.spec.ts
+++ b/packages/api/src/agents/guard.spec.ts
@@ -82,6 +82,7 @@ function createApp(
       parentConversationId: (
         req as typeof req & { _agentEventBindingParentConversationId?: string }
       )._agentEventBindingParentConversationId,
+      bindingId: (req as typeof req & { _agentEventBindingId?: string })._agentEventBindingId,
       retention: (
         req as typeof req & {
           _agentEventBindingRetention?: { isTemporary?: boolean; expiredAt?: Date };
@@ -200,6 +201,7 @@ describe('subagent child-thread write policy', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
+      bindingId: `evtbind_${'a'.repeat(48)}`,
       parentConversationId: 'parent-conversation',
       retention: { isTemporary: true, expiredAt: '2099-08-22T00:00:00.000Z' },
     });

--- a/packages/api/src/agents/guard.ts
+++ b/packages/api/src/agents/guard.ts
@@ -46,6 +46,7 @@ interface ResolvedConversationRequest extends Request {
     isTemporary?: boolean;
     expiredAt?: Date;
   };
+  _agentEventBindingId?: string;
   _agentEventBindingParentConversationId?: string;
   _agentEventBindingParentAgentId?: string;
   _agentEventBindingTenantId?: string;
@@ -69,6 +70,7 @@ function applyEventBindingContext(
     ...(conversation.isTemporary == null ? {} : { isTemporary: conversation.isTemporary }),
     ...(conversation.expiredAt == null ? {} : { expiredAt: conversation.expiredAt }),
   };
+  request._agentEventBindingId = conversation.agentEventBinding?.bindingId;
   request._agentEventBindingParentConversationId =
     conversation.subagentThread?.parentConversationId;
   request._agentEventBindingParentAgentId = conversation.subagentThread?.parentAgentId;


### PR DESCRIPTION
## Summary

I fixed first-event handling for newly bound event-actor conversations so terminal metadata reaches the durable mailbox and receipt pipeline.

- Treat a root-parent event as a continuation when the authenticated child-thread write guard resolved a durable event binding.
- Propagate the authoritative binding ID from the resolved conversation instead of trusting an event payload field.
- Require authenticated bound-event context before attaching terminal-delivery metadata.
- Cover the production-shaped first event, where the child conversation is empty and the delivery payload has no target binding.
- Update existing event-actor controller fixtures to model the write-guard context.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the focused controller suite: 124/124 passed.
- Ran the child-thread write-guard suite: 9/9 passed.
- Ran a local browser-path Speed Chess canary with Mongo and Redis:
  - 28 deliveries across four resident child conversations.
  - 26 deliveries reached authoritative `handling.status=applied`; two were actively running at the final snapshot.
  - Zero deliveries remained pending.
  - Two simultaneous games advanced to ply 14 and 15.
  - The same child conversations processed 6-8 events each, proving subsequent mailbox work was admitted.

### **Test Configuration**:

- LibreChat API on port 3180
- MongoDB on port 27018
- Redis on port 6389 / DB 15
- Local Speed Chess MCP on port 3211
- Vertex AI `gemini-3.7-flash` actors

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
