### PR TITLE
🪪 fix: Prefer a Declared Custom Endpoint Over a Case-Folded Provider

### DIFF
--- a/packages/api/src/endpoints/config/providers.spec.ts
+++ b/packages/api/src/endpoints/config/providers.spec.ts
@@ -124,6 +124,86 @@ describe('getProviderConfig', () => {
     expect(result.customEndpointConfig?.name).toBe('My-LLM');
   });
 
+  describe('a declared custom endpoint outranks a case-folded builtin', () => {
+    /** `providerConfigMap` maps the known custom providers to `initializeCustom`. */
+    const initializeCustom = providerConfigMap[Providers.XAI];
+
+    it.each([
+      ['Anthropic', EModelEndpoint.anthropic],
+      ['Google', EModelEndpoint.google],
+      ['Bedrock', EModelEndpoint.bedrock],
+      ['VertexAI', EModelEndpoint.google],
+    ])('routes a custom endpoint named %s to the custom client', (name, nativeKey) => {
+      const appConfig = buildAppConfig([
+        { name, baseURL: 'https://gateway.example.com/v1', apiKey: 'sk-gateway' },
+      ]);
+
+      const result = getProviderConfig({ provider: name, appConfig });
+
+      expect(result.getOptions).toBe(initializeCustom);
+      expect(result.getOptions).not.toBe(providerConfigMap[nativeKey]);
+      expect(result.overrideProvider).toBe(Providers.OPENAI);
+      expect(result.customEndpointConfig?.baseURL).toBe('https://gateway.example.com/v1');
+    });
+
+    it('still routes a genuine native provider to its own initializer', () => {
+      const result = getProviderConfig({
+        provider: EModelEndpoint.anthropic,
+        appConfig: buildAppConfig([]),
+      });
+
+      expect(result.getOptions).toBe(providerConfigMap[EModelEndpoint.anthropic]);
+      expect(result.customEndpointConfig).toBeUndefined();
+    });
+
+    it('keeps the native provider on an exact-case request even when a custom endpoint shares its name', () => {
+      const appConfig = buildAppConfig([
+        { name: 'Anthropic', baseURL: 'https://gateway.example.com/v1', apiKey: 'sk-gateway' },
+      ]);
+
+      const result = getProviderConfig({ provider: EModelEndpoint.anthropic, appConfig });
+
+      expect(result.getOptions).toBe(providerConfigMap[EModelEndpoint.anthropic]);
+      expect(result.overrideProvider).toBe(EModelEndpoint.anthropic);
+    });
+
+    it('falls back to the case-folded builtin when no custom endpoint claims the name', () => {
+      const result = getProviderConfig({ provider: 'Anthropic', appConfig: buildAppConfig([]) });
+
+      expect(result.getOptions).toBe(providerConfigMap[EModelEndpoint.anthropic]);
+      expect(result.overrideProvider).toBe(EModelEndpoint.anthropic);
+    });
+
+    it('honours provider:anthropic on a custom endpoint named Anthropic', () => {
+      const appConfig = buildAppConfig([
+        {
+          name: 'Anthropic',
+          baseURL: 'https://gateway.example.com/v1',
+          apiKey: 'sk-gateway',
+          provider: EModelEndpoint.anthropic,
+        },
+      ]);
+
+      const result = getProviderConfig({ provider: 'Anthropic', appConfig });
+
+      expect(result.getOptions).toBe(initializeCustom);
+      expect(result.overrideProvider).toBe(Providers.ANTHROPIC);
+      expect(result.customEndpointConfig?.baseURL).toBe('https://gateway.example.com/v1');
+    });
+
+    it('keeps a CamelCase known custom provider on its own normalized name', () => {
+      const appConfig = buildAppConfig([
+        { name: 'OpenRouter', baseURL: 'https://openrouter.ai/api/v1', apiKey: 'sk-test' },
+      ]);
+
+      const result = getProviderConfig({ provider: 'OpenRouter', appConfig });
+
+      expect(result.getOptions).toBe(initializeCustom);
+      expect(result.overrideProvider).toBe(Providers.OPENROUTER);
+      expect(result.customEndpointConfig?.name).toBe('OpenRouter');
+    });
+  });
+
   it('applies provider:anthropic even when the endpoint name collides with a known custom provider', () => {
     // `openrouter` resolves via `providerConfigMap` first (skipping the generic
     // custom branch); the override must still be re-applied from the config so

--- a/packages/api/src/endpoints/config/providers.ts
+++ b/packages/api/src/endpoints/config/providers.ts
@@ -145,16 +145,32 @@ export function getProviderConfig({
   let overrideProvider = provider;
   let customEndpointConfig: Partial<TEndpoint> | undefined;
 
-  if (!getOptions && providerConfigMap[provider.toLowerCase()] != null) {
-    overrideProvider = provider.toLowerCase();
-    getOptions = providerConfigMap[overrideProvider];
-  } else if (!getOptions) {
+  if (!getOptions) {
+    /**
+     * A declared custom endpoint outranks a case-folded builtin. Without this an
+     * endpoint named `Anthropic` case-folds onto the native `anthropic` provider
+     * and is initialized from the environment, never reading its own `baseURL`,
+     * `apiKey` or headers — `initializeAnthropic` then throws on the missing
+     * `ANTHROPIC_API_KEY`. `Google`, `Bedrock` and `VertexAI` misroute the same
+     * way. The exact-case lookup above still gives a genuine native provider
+     * priority, since the agent flow re-enters here with enum values.
+     */
     customEndpointConfig = getCustomEndpointConfig({ endpoint: provider, appConfig });
-    if (!customEndpointConfig) {
+    const nativeOptions = providerConfigMap[provider.toLowerCase()];
+
+    if (customEndpointConfig) {
+      getOptions = initializeCustom;
+      /* A known custom provider keeps its own normalized name: it selects the
+         token and context-window maps. */
+      overrideProvider = isKnownCustomProvider(provider)
+        ? provider.toLowerCase()
+        : Providers.OPENAI;
+    } else if (nativeOptions != null) {
+      overrideProvider = provider.toLowerCase();
+      getOptions = nativeOptions;
+    } else {
       throw new Error(`Provider ${provider} not supported`);
     }
-    getOptions = initializeCustom;
-    overrideProvider = Providers.OPENAI;
   }
 
   if (isKnownCustomProvider(overrideProvider) && !customEndpointConfig) {


### PR DESCRIPTION
A custom endpoint whose name case-folds onto a built-in provider is silently ignored — its `baseURL`, `apiKey` and headers are never read, and the native provider initializes from the environment instead.

Hit in a deployment that fronts several providers through one OpenAI-compatible gateway, where one endpoint per parameter dialect is the only way to send each provider the parameters it needs.

## Reproduction

```yaml
endpoints:
  custom:
    - name: 'Anthropic'
      apiKey: '${GATEWAY_API_KEY}'
      baseURL: 'https://gateway.example.com/v1'
      models:
        default: ['claude-sonnet-4-5']
```

Select a model on that endpoint and send a message. It fails instantly, before any upstream call:

> Anthropic API key not provided. Please provide it again.

That string is thrown by the **native** Anthropic initializer (`packages/api/src/endpoints/anthropic/initialize.ts:57`), which reads `ANTHROPIC_API_KEY` — a variable such a deployment has no reason to set.

## Cause

`packages/api/src/endpoints/config/providers.ts` — the case-insensitive native lookup runs first, and the custom lookup is in its `else`:

```ts
let getOptions = providerConfigMap[provider];              // "Anthropic" → miss

if (!getOptions && providerConfigMap[provider.toLowerCase()] != null) {
  overrideProvider = provider.toLowerCase();               // "anthropic" → HIT
  getOptions = providerConfigMap[overrideProvider];        // initializeAnthropic
} else if (!getOptions) {
  customEndpointConfig = getCustomEndpointConfig(...);     // unreachable
  ...
}
```

Custom endpoints run as ephemeral agents whose provider is the endpoint's literal name (`agents/load.ts:136` → `provider: endpoint`), so the endpoint name *is* the routing identity.

This also affects `memory.agent.provider`, which reaches the same function.

## Affected names

| lowercased name | native initializer | affected |
|---|---|---|
| `anthropic` | `initializeAnthropic` | **yes** — throws |
| `google` | `initializeGoogle` | **yes** — builds empty credentials, fails downstream |
| `bedrock` | `initializeBedrock` | **yes** |
| `vertexai` | `initializeGoogle` | **yes** |
| `xai`, `deepseek`, `moonshot`, `openrouter` | `initializeCustom` | no — recovered by the known-custom-provider branch |

`openAI` and `azureOpenAI` never collide: the map keys are camelCase, so no lowercased name equals them.

## Fix

The custom lookup runs first when the exact-case lookup misses; the case-folded native lookup becomes the fallback. Three properties preserved, each covered by a test:

- **An exact-case hit still wins outright** — the agent flow re-enters this function with normalized lowercase enum values, so a genuine native provider is unaffected, including when a custom endpoint shares its name.
- **A CamelCase known custom provider keeps its own normalized `overrideProvider`** rather than collapsing to `openai`, since that value selects the token and context-window maps.
- **`provider: anthropic` still routes to the native `/v1/messages` client** — now reachable for an endpoint named `Anthropic` too.

## Behaviour change

Naming a custom endpoint `Google` and expecting it to inherit the native Google client now yields the custom client instead. Flagging it explicitly rather than burying it — an explicitly declared endpoint shouldn't be silently discarded, and `provider:` is the supported way to request a native wire format.

## Tests

`providers.spec.ts`, 11 added, 31 total green. The four collision names route to `initializeCustom` with their own config; a genuine native provider still routes natively; an exact-case request wins even with a same-named custom endpoint; no custom endpoint claiming the name still falls back to the builtin; `provider: anthropic` honoured on an endpoint named `Anthropic`; and a CamelCase `OpenRouter` keeps `overrideProvider: 'openrouter'`.
