### PR TITLE
fix: terminate startup when OpenID initialization fails

### DIFF
--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -60,8 +60,10 @@ async function configureOpenId(app) {
 
   const config = await setupOpenId();
   if (!config) {
-    logger.error('OpenID Connect configuration failed - strategy not registered.');
-    return;
+    logger.error(
+      'OpenID Connect initialization failed - strategy not registered. Server startup will terminate.',
+    );
+    throw new Error('OpenID Connect initialization failed - strategy not registered.');
   }
 
   if (isEnabled(process.env.OPENID_REUSE_TOKENS)) {

--- a/api/server/socialLogins.spec.js
+++ b/api/server/socialLogins.spec.js
@@ -9,6 +9,7 @@ const mockSetupOpenId = jest.fn();
 const mockSetupSaml = jest.fn();
 const mockIsEnabled = jest.fn();
 const mockShouldUseSecureCookie = jest.fn(() => true);
+const mockLogger = { error: jest.fn(), info: jest.fn() };
 const mockMath = jest.fn((value, fallback) => {
   if (value == null || value === '') {
     return fallback;
@@ -45,7 +46,7 @@ jest.mock('@librechat/api', () => ({
 }));
 jest.mock('@librechat/data-schemas', () => ({
   DEFAULT_SESSION_EXPIRY: 900000,
-  logger: { error: jest.fn(), info: jest.fn() },
+  logger: mockLogger,
 }));
 jest.mock('~/cache', () => ({ getLogStores: (...args) => mockGetLogStores(...args) }));
 jest.mock('~/strategies', () => ({
@@ -137,6 +138,19 @@ describe('configureSocialLogins OpenID session expiry', () => {
       expect.objectContaining({
         cookie: expect.objectContaining({ maxAge: 900000 }),
       }),
+    );
+    expect(mockPassportUse).not.toHaveBeenCalled();
+  });
+
+  it('rejects startup when OpenID initialization fails', async () => {
+    mockSetupOpenId.mockResolvedValue(null);
+    const app = { use: jest.fn() };
+
+    await expect(configureSocialLogins(app)).rejects.toThrow(
+      'OpenID Connect initialization failed - strategy not registered.',
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'OpenID Connect initialization failed - strategy not registered. Server startup will terminate.',
     );
     expect(mockPassportUse).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Fail server startup when OpenID Connect initialization does not produce a valid configuration.

Previously, an OpenID discovery or initialization failure was logged but swallowed. The server continued starting without registering the OpenID strategy and could report itself as ready despite authentication being unavailable.

## Changes

- Log that OpenID initialization failed and startup will terminate.
- Throw an error instead of continuing without an OpenID strategy.
- Add regression coverage for the failure and log message.

## Result

The error reaches the existing top-level startup handler, which terminates the process with exit code 1. Container orchestrators can then restart the instance and retry initialization instead of routing traffic to a server with broken OpenID authentication.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested in prod

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes


Peter Rothlaender [ginkgo.rothlaender@external.daimlertruck.com](mailto:ginkgo.rothlaender@external.daimlertruck.com) on behalf of Daimler Truck AG.
[Provider & Legal Notice | Daimler Truck](https://www.daimlertruck.com/en/provider-legal-notice)
Copyright (c) {2026} Daimler Truck AG