### PR TITLE
🎫 fix: Exclude System Tenant Sentinel from Code API JWT Claims

### DIFF
--- a/packages/api/src/auth/codeapi.spec.ts
+++ b/packages/api/src/auth/codeapi.spec.ts
@@ -7,6 +7,7 @@ jest.mock(
   '@librechat/data-schemas',
   () => ({
     getTenantId: jest.fn(),
+    SYSTEM_TENANT_ID: '__SYSTEM__',
   }),
   { virtual: true },
 );
@@ -240,6 +241,51 @@ describe('Code API JWT minting', () => {
   it('rejects minting without tenant context in strict tenant mode', async () => {
     process.env.TENANT_ISOLATION_STRICT = 'true';
     mockGetTenantId.mockReturnValue(undefined);
+
+    await expect(mintCodeApiToken(baseRequest({ tenantId: undefined }))).rejects.toThrow(
+      'Code API JWT auth requires tenant context',
+    );
+  });
+
+  it('treats the system tenant sentinel as absent tenant context', async () => {
+    mockGetTenantId.mockReturnValue('__SYSTEM__');
+
+    const token = await mintCodeApiToken(baseRequest({ tenantId: undefined }));
+    const { claims } = decodeToken(token);
+
+    expect(claims.tenant_id).toBe('legacy');
+    expect(claims.auth_context_hash).toBe(
+      expectedContextHash({
+        userId: 'user_123',
+        tenantId: 'legacy',
+        role: 'USER',
+        principalSource: 'librechat_jwt',
+      }),
+    );
+  });
+
+  it('honors the single-tenant override under the system tenant sentinel', async () => {
+    process.env.CODEAPI_JWT_SINGLE_TENANT_ID = 'local-single-tenant';
+    mockGetTenantId.mockReturnValue('__SYSTEM__');
+
+    const token = await mintCodeApiToken(baseRequest({ tenantId: undefined }));
+    const { claims } = decodeToken(token);
+
+    expect(claims.tenant_id).toBe('local-single-tenant');
+  });
+
+  it('treats a system tenant sentinel on the user document as absent', async () => {
+    mockGetTenantId.mockReturnValue(undefined);
+
+    const token = await mintCodeApiToken(baseRequest({ tenantId: '__SYSTEM__' }));
+    const { claims } = decodeToken(token);
+
+    expect(claims.tenant_id).toBe('legacy');
+  });
+
+  it('rejects minting under the system tenant sentinel in strict tenant mode', async () => {
+    process.env.TENANT_ISOLATION_STRICT = 'true';
+    mockGetTenantId.mockReturnValue('__SYSTEM__');
 
     await expect(mintCodeApiToken(baseRequest({ tenantId: undefined }))).rejects.toThrow(
       'Code API JWT auth requires tenant context',

--- a/packages/api/src/auth/codeapi.ts
+++ b/packages/api/src/auth/codeapi.ts
@@ -1,4 +1,4 @@
-import { getTenantId } from '@librechat/data-schemas';
+import { SYSTEM_TENANT_ID, getTenantId } from '@librechat/data-schemas';
 import { createHash, createPrivateKey, randomUUID, sign as cryptoSign } from 'crypto';
 import type { KeyObject, JsonWebKey } from 'crypto';
 import type { ServerRequest } from '~/types';
@@ -202,9 +202,14 @@ function resolveSingleTenantId(): string {
   return DEFAULT_SINGLE_TENANT_ID;
 }
 
+/**
+ * `SYSTEM_TENANT_ID` marks an ambient background context (e.g. the expired-file
+ * sweep) rather than a real tenant, so it is treated as absent: minting it into
+ * `tenant_id` would claim a tenant whose Code API sessions never existed.
+ */
 function resolveTenantId(user: CodeApiUserContext): string | undefined {
   const tenantId = stringifyClaimValue(user.tenantId) ?? getTenantId();
-  if (tenantId) {
+  if (tenantId && tenantId !== SYSTEM_TENANT_ID) {
     return tenantId;
   }
   if (isEnabled(process.env.TENANT_ISOLATION_STRICT)) {


### PR DESCRIPTION
Fixes #15313

## Summary

`resolveTenantId` in `packages/api/src/auth/codeapi.ts` accepted any truthy tenant value, including the `SYSTEM_TENANT_ID` (`'__SYSTEM__'`) sentinel that `runAsSystem()` installs for background work. The expired-file sweep runs entirely under `runAsSystem()`, so on any deployment without multi-tenant onboarding (`file.tenantId` undefined — the default for most self-hosted instances) it minted Code API tokens claiming `tenant_id: '__SYSTEM__'`.

## The failure chain

1. `startExpiredFileSweep` wraps the whole sweep in `runAsSystem()`, and fires immediately at boot as well as every `FILE_RETENTION_SWEEP_INTERVAL_MS`.
2. `createExpiredFileSweepRequest` sets `user.tenantId = file.tenantId`, which is `undefined`.
3. `resolveTenantId` therefore falls to `getTenantId()`, which returns the sentinel. It is truthy, so it returned immediately — never reaching `TENANT_ISOLATION_STRICT` or `resolveSingleTenantId()`, regardless of how either is configured.
4. The Code API does not validate `tenant_id` as a claim; it feeds the **storage namespace**, which prefixes the session key (`<namespace>:user:<userId>`). So `'__SYSTEM__'` silently derives a session key that cannot match the one cached at upload time, and `sessionAuth` rejects it with 403.
5. `deleteCodeEnvFile` only treats 404/405 as already-gone and rethrows everything else, so `expiredAt` is never cleared — the same files are retried identically on every subsequent sweep cycle and every process restart.

The reporter saw hundreds of doomed `DELETE` 403s against the Code API on every boot.

## Fix

Treat the sentinel as absent tenant context, matching every other identity-bearing `getTenantId()` consumer (`apiKeys/permissions.ts`, `shared-links/session.ts`, `mcp/registry/cache/ReadThroughAllCache.ts`, `stream/GenerationJobManager.ts`). Resolution now falls through to `CODEAPI_JWT_SINGLE_TENANT_ID`, or fails fast under `TENANT_ISOLATION_STRICT`.

I verified the fallback actually lands on the namespace the upload used rather than merely a different wrong one: both sides read the same `CODEAPI_JWT_SINGLE_TENANT_ID` env var and both default to `legacy` (LibreChat `DEFAULT_SINGLE_TENANT_ID`; Code API `DEFAULT_SINGLE_TENANT_NAMESPACE`).

Under `TENANT_ISOLATION_STRICT`, the sweep now throws `Code API JWT auth requires tenant context` locally instead of minting an impersonating token. That is still a failed delete, but it fails without hammering the Code API, and it mirrors the Code API's own strict-mode behavior.

## Tests

Four cases in `codeapi.spec.ts`, covering the sentinel arriving from ambient context and from the user document, the single-tenant override, and strict mode. All four fail against the unpatched `resolveTenantId` and pass with it — confirmed by reverting the guard and re-running.

Note the spec's virtual `@librechat/data-schemas` mock needed `SYSTEM_TENANT_ID` added; without it the constant would be `undefined` and the new guard would be inert under test while still appearing to pass.

## Deliberately not included

**403 is not treated as terminal in `deleteCodeEnvFile`.** That would close the retry loop for any residual cause, but the Code API's 403 is a `cachedSessionKey !== sessionKey` mismatch — byte-identical to a genuine cross-tenant access attempt. Making LibreChat give up on 403 would silently swallow real authorization failures alongside this one. Files that fail permanently for some other reason will still be retried; that is pre-existing behavior this bug exposed rather than caused, and worth handling separately if it proves to be a problem.

**Other unfiltered `getTenantId()` call sites left alone.** `app/service.ts`, `mcp/oauth/tokens.ts`, `MCPConnectionFactory.ts`, and `remoteAgentAuth.ts` also pass the sentinel through, but those use it for cache keys and connection scoping rather than minting an authorization claim, and changing them is out of scope here.

## Verification

- `packages/api`: `codeapi.spec.ts` 14/14; `src/auth` + `src/files` 1204 passed. The 2 failures in `libreoffice.spec.ts` are missing binary fixtures never committed to the repo, unrelated to this change.
- `tsc --noEmit`: 61 pre-existing errors both with and without this change (known agents SDK typing issue) — this change adds none.