### PR TITLE
🪪 fix: Reject ID Tokens as the OpenID Bearer Reuse Access Token

### DIFF
--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -16,6 +16,7 @@ const {
   invalidateCachedAuthUserDoc,
   setCachedAuthUserDoc,
   getHttpsProxyAgent,
+  isAccessTokenJwt,
   math,
 } = require('@librechat/api');
 const { updateUser, findUser, isAgentTriggerPrincipalActive } = require('~/models');
@@ -30,15 +31,23 @@ function decodeJwtExpiry(token) {
   }
 }
 
-const getOpenIdJwtAudience = () => {
-  const parsedAudience = (process.env.OPENID_AUDIENCE ?? '')
+const parseOpenIdAudiences = () =>
+  (process.env.OPENID_AUDIENCE ?? '')
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean);
-  const audiences = [process.env.OPENID_CLIENT_ID, ...parsedAudience].filter(Boolean);
+
+const getOpenIdJwtAudience = () => {
+  const audiences = [process.env.OPENID_CLIENT_ID, ...parseOpenIdAudiences()].filter(Boolean);
   const uniqueAudiences = [...new Set(audiences)];
 
   return uniqueAudiences.length > 1 ? uniqueAudiences : uniqueAudiences[0];
+};
+
+/** Audiences that name a protected resource rather than the OIDC client, so a token bearing one cannot be an ID token */
+const getOpenIdResourceAudiences = () => {
+  const clientId = process.env.OPENID_CLIENT_ID;
+  return new Set(parseOpenIdAudiences().filter((audience) => audience !== clientId));
 };
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -117,6 +126,8 @@ const openIdJwtLogin = (openIdConfig) => {
   if (requestAgent) {
     jwksRsaOptions.requestAgent = requestAgent;
   }
+
+  const resourceAudiences = getOpenIdResourceAudiences();
 
   return new JwtStrategy(
     {
@@ -233,7 +244,26 @@ const openIdJwtLogin = (openIdConfig) => {
             refreshToken = refreshToken || parsedCookies.refreshToken;
           }
 
-          const resolvedAccessToken = accessToken || rawToken;
+          /**
+           * The raw bearer only stands in for a missing stored access token when it is
+           * identifiable as one. It cleared this strategy's audience check, but an ID token
+           * clears the same check, and an ID token used as the OBO assertion is rejected by the
+           * IdP (Entra answers `AADSTS240002`). An unrecognised token is left unset so
+           * `isOpenIDTokenValid` fails closed with an actionable error instead.
+           */
+          let reusableRawToken;
+          if (!accessToken) {
+            reusableRawToken = isAccessTokenJwt(rawToken, payload, resourceAudiences)
+              ? rawToken
+              : undefined;
+            if (!reusableRawToken) {
+              logger.warn(
+                '[openIdJwtLogin] No stored OpenID access token, and the request bearer is not identifiable as one. Leaving it unset; downstream OBO exchanges will report that re-authentication is required.',
+              );
+            }
+          }
+
+          const resolvedAccessToken = accessToken || reusableRawToken;
           user.federatedTokens = {
             access_token: resolvedAccessToken,
             id_token: idToken,

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -44,10 +44,13 @@ const getOpenIdJwtAudience = () => {
   return uniqueAudiences.length > 1 ? uniqueAudiences : uniqueAudiences[0];
 };
 
-/** Audiences that name a protected resource rather than the OIDC client, so a token bearing one cannot be an ID token */
-const getOpenIdResourceAudiences = () => {
+/** The configured audiences a reused bearer is weighed against when deciding whether it is an access token */
+const getOpenIdAudienceConfig = () => {
   const clientId = process.env.OPENID_CLIENT_ID;
-  return new Set(parseOpenIdAudiences().filter((audience) => audience !== clientId));
+  return {
+    clientId,
+    resources: new Set(parseOpenIdAudiences().filter((audience) => audience !== clientId)),
+  };
 };
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -127,7 +130,7 @@ const openIdJwtLogin = (openIdConfig) => {
     jwksRsaOptions.requestAgent = requestAgent;
   }
 
-  const resourceAudiences = getOpenIdResourceAudiences();
+  const audienceConfig = getOpenIdAudienceConfig();
 
   return new JwtStrategy(
     {
@@ -253,12 +256,13 @@ const openIdJwtLogin = (openIdConfig) => {
            */
           let reusableRawToken;
           if (!accessToken) {
-            reusableRawToken = isAccessTokenJwt(rawToken, payload, resourceAudiences)
+            reusableRawToken = isAccessTokenJwt(rawToken, payload, audienceConfig)
               ? rawToken
               : undefined;
             if (!reusableRawToken) {
-              logger.warn(
-                '[openIdJwtLogin] No stored OpenID access token, and the request bearer is not identifiable as one. Leaving it unset; downstream OBO exchanges will report that re-authentication is required.',
+              /** Per-request on the reuse path, so the actionable warning is left to the consumer that actually needs the credential */
+              logger.debug(
+                '[openIdJwtLogin] No stored OpenID access token, and the request bearer is not identifiable as one; leaving it unset',
               );
             }
           }

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -349,6 +349,8 @@ describe('openIdJwtStrategy – token source handling', () => {
   const makeJwt = (claims, header = { alg: 'RS256' }) =>
     `${encodeSegment(header)}.${encodeSegment(claims)}.signature`;
 
+  const resourceEnv = { OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'api://resource-app' };
+
   it('should decline the raw Bearer token when nothing identifies it as an access token', async () => {
     const req = {
       headers: {
@@ -366,16 +368,9 @@ describe('openIdJwtStrategy – token source handling', () => {
   });
 
   it('should decline an Entra-shaped ID token rather than reuse it as the OBO assertion', async () => {
-    const idTokenClaims = { ...payload, aud: 'client-id', nonce: 'n-0S6_WzA2Mj', tid: 'tenant-1' };
-    const req = { headers: { authorization: `Bearer ${makeJwt(idTokenClaims)}` } };
+    withEnv(resourceEnv, () => openIdJwtLogin(mockOpenIdConfig));
 
-    const { user } = await invokeVerify(req, idTokenClaims);
-
-    expect(user.federatedTokens.access_token).toBeUndefined();
-  });
-
-  it('should decline a raw Bearer token carrying the ID-token-only at_hash claim', async () => {
-    const claims = { ...payload, scp: 'User.Read', at_hash: 'HK6E_P6Dh8Y93mRNtsDB1Q' };
+    const claims = { ...payload, aud: 'client-id', nonce: 'n-0S6_WzA2Mj', tid: 'tenant-1' };
     const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
 
     const { user } = await invokeVerify(req, claims);
@@ -383,8 +378,43 @@ describe('openIdJwtStrategy – token source handling', () => {
     expect(user.federatedTokens.access_token).toBeUndefined();
   });
 
-  it('should reuse a raw Bearer token bearing an OAuth `scp` claim', async () => {
-    const claims = { ...payload, scp: 'User.Read Files.Read' };
+  it('should decline a multi-audience ID token that also names a configured resource', async () => {
+    withEnv(resourceEnv, () => openIdJwtLogin(mockOpenIdConfig));
+
+    const claims = { ...payload, aud: ['client-id', 'api://resource-app'], nonce: 'n-0S6' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
+  });
+
+  it('should decline an ID token carrying a provider-added scope claim', async () => {
+    withEnv(resourceEnv, () => openIdJwtLogin(mockOpenIdConfig));
+
+    const claims = { ...payload, aud: 'client-id', scope: 'openid email profile' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
+  });
+
+  it('should decline a raw Bearer token carrying the ID-token-only at_hash claim', async () => {
+    withEnv(resourceEnv, () => openIdJwtLogin(mockOpenIdConfig));
+
+    const claims = { ...payload, aud: 'api://resource-app', at_hash: 'HK6E_P6Dh8Y93mRN' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
+  });
+
+  it('should reuse a raw Bearer token whose audience names a configured resource', async () => {
+    withEnv(resourceEnv, () => openIdJwtLogin(mockOpenIdConfig));
+
+    const claims = { ...payload, aud: 'api://resource-app' };
     const rawToken = makeJwt(claims);
     const req = { headers: { authorization: `Bearer ${rawToken}` } };
 
@@ -394,48 +424,13 @@ describe('openIdJwtStrategy – token source handling', () => {
     expect(user.federatedTokens.expires_at).toBe(payload.exp);
   });
 
-  it('should reuse a raw Bearer token bearing an OAuth `scope` claim', async () => {
-    const claims = { ...payload, scope: 'openid profile api.read' };
-    const rawToken = makeJwt(claims);
-    const req = { headers: { authorization: `Bearer ${rawToken}` } };
-
-    const { user } = await invokeVerify(req, claims);
-
-    expect(user.federatedTokens.access_token).toBe(rawToken);
-  });
-
   it('should reuse a raw Bearer token declaring the RFC 9068 `at+jwt` header type', async () => {
+    withEnv(resourceEnv, () => openIdJwtLogin(mockOpenIdConfig));
+
     const rawToken = makeJwt(payload, { alg: 'RS256', typ: 'at+JWT' });
     const req = { headers: { authorization: `Bearer ${rawToken}` } };
 
     const { user } = await invokeVerify(req, payload);
-
-    expect(user.federatedTokens.access_token).toBe(rawToken);
-  });
-
-  it('should decline a multi-audience ID token that also names a configured resource', async () => {
-    withEnv({ OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'api://resource-app' }, () => {
-      openIdJwtLogin(mockOpenIdConfig);
-    });
-
-    const claims = { ...payload, aud: ['client-id', 'api://resource-app'], nonce: 'n-0S6_WzA2Mj' };
-    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
-
-    const { user } = await invokeVerify(req, claims);
-
-    expect(user.federatedTokens.access_token).toBeUndefined();
-  });
-
-  it('should reuse a raw Bearer token whose audience names a configured resource', async () => {
-    withEnv({ OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'api://resource-app' }, () => {
-      openIdJwtLogin(mockOpenIdConfig);
-    });
-
-    const claims = { ...payload, aud: 'api://resource-app' };
-    const rawToken = makeJwt(claims);
-    const req = { headers: { authorization: `Bearer ${rawToken}` } };
-
-    const { user } = await invokeVerify(req, claims);
 
     expect(user.federatedTokens.access_token).toBe(rawToken);
   });
@@ -445,7 +440,7 @@ describe('openIdJwtStrategy – token source handling', () => {
       openIdJwtLogin(mockOpenIdConfig);
     });
 
-    const claims = { ...payload, aud: 'client-id' };
+    const claims = { ...payload, aud: 'client-id', scp: 'User.Read' };
     const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
 
     const { user } = await invokeVerify(req, claims);

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -413,6 +413,19 @@ describe('openIdJwtStrategy – token source handling', () => {
     expect(user.federatedTokens.access_token).toBe(rawToken);
   });
 
+  it('should decline a multi-audience ID token that also names a configured resource', async () => {
+    withEnv({ OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'api://resource-app' }, () => {
+      openIdJwtLogin(mockOpenIdConfig);
+    });
+
+    const claims = { ...payload, aud: ['client-id', 'api://resource-app'], nonce: 'n-0S6_WzA2Mj' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
+  });
+
   it('should reuse a raw Bearer token whose audience names a configured resource', async () => {
     withEnv({ OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'api://resource-app' }, () => {
       openIdJwtLogin(mockOpenIdConfig);

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -45,6 +45,7 @@ jest.mock('@librechat/api', () => ({
   invalidateCachedAuthUserDoc: jest.fn(),
   setCachedAuthUserDoc: jest.fn(),
   getHttpsProxyAgent: jest.fn(() => undefined),
+  isAccessTokenJwt: jest.requireActual('@librechat/api').isAccessTokenJwt,
   math: jest.fn((val, fallback) => fallback),
 }));
 jest.mock('~/models', () => ({
@@ -344,7 +345,11 @@ describe('openIdJwtStrategy – token source handling', () => {
     });
   });
 
-  it('should use raw Bearer token as access_token fallback when neither session nor cookie has one', async () => {
+  const encodeSegment = (value) => Buffer.from(JSON.stringify(value)).toString('base64');
+  const makeJwt = (claims, header = { alg: 'RS256' }) =>
+    `${encodeSegment(header)}.${encodeSegment(claims)}.signature`;
+
+  it('should decline the raw Bearer token when nothing identifies it as an access token', async () => {
     const req = {
       headers: {
         authorization: 'Bearer raw-bearer-token',
@@ -354,10 +359,85 @@ describe('openIdJwtStrategy – token source handling', () => {
 
     const { user } = await invokeVerify(req, payload);
 
-    expect(user.federatedTokens.access_token).toBe('raw-bearer-token');
+    expect(user.federatedTokens.access_token).toBeUndefined();
     expect(user.federatedTokens.id_token).toBe('cookie-id');
     expect(user.federatedTokens.refresh_token).toBe('cookie-refresh');
+    expect(user.federatedTokens.expires_at).toBeUndefined();
+  });
+
+  it('should decline an Entra-shaped ID token rather than reuse it as the OBO assertion', async () => {
+    const idTokenClaims = { ...payload, aud: 'client-id', nonce: 'n-0S6_WzA2Mj', tid: 'tenant-1' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(idTokenClaims)}` } };
+
+    const { user } = await invokeVerify(req, idTokenClaims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
+  });
+
+  it('should decline a raw Bearer token carrying the ID-token-only at_hash claim', async () => {
+    const claims = { ...payload, scp: 'User.Read', at_hash: 'HK6E_P6Dh8Y93mRNtsDB1Q' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
+  });
+
+  it('should reuse a raw Bearer token bearing an OAuth `scp` claim', async () => {
+    const claims = { ...payload, scp: 'User.Read Files.Read' };
+    const rawToken = makeJwt(claims);
+    const req = { headers: { authorization: `Bearer ${rawToken}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBe(rawToken);
     expect(user.federatedTokens.expires_at).toBe(payload.exp);
+  });
+
+  it('should reuse a raw Bearer token bearing an OAuth `scope` claim', async () => {
+    const claims = { ...payload, scope: 'openid profile api.read' };
+    const rawToken = makeJwt(claims);
+    const req = { headers: { authorization: `Bearer ${rawToken}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBe(rawToken);
+  });
+
+  it('should reuse a raw Bearer token declaring the RFC 9068 `at+jwt` header type', async () => {
+    const rawToken = makeJwt(payload, { alg: 'RS256', typ: 'at+JWT' });
+    const req = { headers: { authorization: `Bearer ${rawToken}` } };
+
+    const { user } = await invokeVerify(req, payload);
+
+    expect(user.federatedTokens.access_token).toBe(rawToken);
+  });
+
+  it('should reuse a raw Bearer token whose audience names a configured resource', async () => {
+    withEnv({ OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'api://resource-app' }, () => {
+      openIdJwtLogin(mockOpenIdConfig);
+    });
+
+    const claims = { ...payload, aud: 'api://resource-app' };
+    const rawToken = makeJwt(claims);
+    const req = { headers: { authorization: `Bearer ${rawToken}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBe(rawToken);
+  });
+
+  it('should decline a raw Bearer token whose only audience is the OIDC client id', async () => {
+    withEnv({ OPENID_CLIENT_ID: 'client-id', OPENID_AUDIENCE: 'client-id' }, () => {
+      openIdJwtLogin(mockOpenIdConfig);
+    });
+
+    const claims = { ...payload, aud: 'client-id' };
+    const req = { headers: { authorization: `Bearer ${makeJwt(claims)}` } };
+
+    const { user } = await invokeVerify(req, claims);
+
+    expect(user.federatedTokens.access_token).toBeUndefined();
   });
 
   it('should decode expires_at from a session access token that is itself a JWT', async () => {

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -2431,7 +2431,7 @@ describe('processMCPEnv OpenID re-authentication signalling', () => {
     }
   });
 
-  it('should raise re-auth from resolveHeaders when the token set is expired', () => {
+  it('should raise re-auth from resolveHeaders when the ID token is expired', () => {
     expect(() =>
       resolveHeaders({
         headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
@@ -2439,8 +2439,55 @@ describe('processMCPEnv OpenID re-authentication signalling', () => {
         stripUnresolved: true,
       }),
     ).toThrow(
-      'OpenID token is expired or unavailable; re-authentication is required to resolve {{LIBRECHAT_OPENID_ID_TOKEN}}',
+      'OpenID ID token is expired or unavailable; re-authentication is required to resolve {{LIBRECHAT_OPENID_ID_TOKEN}}',
     );
+  });
+
+  /** The OpenID JWT strategy leaves `access_token` unset when it cannot identify the request bearer as one */
+  function accessTokenlessOpenIDUser(idTokenExp: number): { user: IUser; idToken: string } {
+    const idToken = `header.${Buffer.from(
+      JSON.stringify({ sub: 'oidc-sub-456', exp: idTokenExp }),
+    ).toString('base64')}.signature`;
+    const user = {
+      ...createTestUser({ id: 'user-123', provider: 'openid' }),
+      openidId: 'oidc-sub-456',
+      federatedTokens: { id_token: idToken, refresh_token: 'stored-refresh-token' },
+    } as IUser;
+    return { user, idToken };
+  }
+
+  it('should resolve an ID token placeholder while no access token is stored', () => {
+    const { user, idToken } = accessTokenlessOpenIDUser(validSeconds);
+
+    const resolved = resolveHeaders({
+      headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ID_TOKEN}}' },
+      user,
+      stripUnresolved: true,
+    });
+
+    expect(resolved.Authorization).toBe(`Bearer ${idToken}`);
+  });
+
+  it('should keep identity metadata literal while no access token is stored', () => {
+    const { user } = accessTokenlessOpenIDUser(validSeconds);
+
+    const resolved = resolveHeaders({
+      headers: { 'X-User-Id': '{{LIBRECHAT_OPENID_USER_ID}}' },
+      user,
+    });
+
+    expect(resolved['X-User-Id']).toBe('{{LIBRECHAT_OPENID_USER_ID}}');
+  });
+
+  it('should still raise re-auth for an access token placeholder while no access token is stored', () => {
+    const { user } = accessTokenlessOpenIDUser(validSeconds);
+
+    expect(() =>
+      resolveHeaders({
+        headers: { Authorization: 'Bearer {{LIBRECHAT_OPENID_ACCESS_TOKEN}}' },
+        user,
+      }),
+    ).toThrow('re-authentication is required to resolve {{LIBRECHAT_OPENID_ACCESS_TOKEN}}');
   });
 
   it('should leave identity metadata placeholders literal for an OpenID user with no stored tokens', () => {

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -178,6 +178,15 @@ const OPENID_CREDENTIAL_PLACEHOLDER_PATTERN =
   /\{\{LIBRECHAT_OPENID_(?:ACCESS_TOKEN|ID_TOKEN|TOKEN)\}\}/;
 
 /**
+ * The credential placeholders that specifically need a usable *access* token, which is all
+ * `isOpenIDTokenValid` reports on. `ID_TOKEN` is absent because `processOpenIDPlaceholders`
+ * validates the ID token's own expiry, so an ID-token header still resolves while no access
+ * token is stored. Non-global so `exec` stays stateless.
+ */
+const OPENID_ACCESS_CREDENTIAL_PLACEHOLDER_PATTERN =
+  /\{\{LIBRECHAT_OPENID_(?:ACCESS_TOKEN|TOKEN)\}\}/;
+
+/**
  * Replaces resolvable-but-unresolved placeholders with an empty string so
  * LibreChat's internal template syntax is never sent upstream as if it were
  * real user data (e.g. a gateway trusting a literal
@@ -336,7 +345,7 @@ function processSingleValue({
   if (openidTokenInfo && isOpenIDTokenValid(openidTokenInfo)) {
     value = processOpenIDPlaceholders(value, openidTokenInfo);
   } else if (openidTokenInfo) {
-    const unresolvable = OPENID_CREDENTIAL_PLACEHOLDER_PATTERN.exec(value);
+    const unresolvable = OPENID_ACCESS_CREDENTIAL_PLACEHOLDER_PATTERN.exec(value);
     if (unresolvable) {
       logger.warn(
         `OpenID token is expired or unavailable; cannot resolve ${unresolvable[0]} for the current request`,
@@ -345,6 +354,12 @@ function processSingleValue({
         `OpenID token is expired or unavailable; re-authentication is required to resolve ${unresolvable[0]}`,
       );
     }
+    /**
+     * `isOpenIDTokenValid` reports on the access token alone, so an ID token placeholder is not
+     * its to refuse: `processOpenIDPlaceholders` validates the ID token's own expiry and raises
+     * if it is stale. Every other placeholder keeps its literal-then-strip behaviour here.
+     */
+    value = processOpenIDPlaceholders(value, openidTokenInfo, ['ID_TOKEN']);
   }
 
   if (body) {

--- a/packages/api/src/utils/oidc.spec.ts
+++ b/packages/api/src/utils/oidc.spec.ts
@@ -4,6 +4,7 @@ import {
   extractOpenIDTokenInfo,
   isOpenIDTokenValid,
   processOpenIDPlaceholders,
+  isAccessTokenJwt,
 } from './oidc';
 
 describe('OpenID Token Utilities', () => {
@@ -763,6 +764,73 @@ describe('OpenID Token Utilities', () => {
 
       const tokenInfo = extractOpenIDTokenInfo(user);
       expect(tokenInfo).toBeNull();
+    });
+  });
+
+  describe('isAccessTokenJwt', () => {
+    const encodeSegment = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64');
+    const makeJwt = (claims: object, header: object = { alg: 'RS256' }) =>
+      `${encodeSegment(header)}.${encodeSegment(claims)}.signature`;
+
+    it('accepts a token carrying the Entra `scp` scope claim', () => {
+      const claims = { aud: 'client-id', scp: 'User.Read Files.Read' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(true);
+    });
+
+    it('accepts a token carrying the `scope` claim', () => {
+      const claims = { aud: 'client-id', scope: 'openid api.read' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(true);
+    });
+
+    it('accepts an RFC 9068 `at+jwt` header type regardless of case', () => {
+      const claims = { aud: 'client-id' };
+      expect(isAccessTokenJwt(makeJwt(claims, { alg: 'RS256', typ: 'at+JWT' }), claims)).toBe(true);
+      expect(
+        isAccessTokenJwt(makeJwt(claims, { alg: 'RS256', typ: 'application/at+jwt' }), claims),
+      ).toBe(true);
+    });
+
+    it('accepts a token whose audience names a configured resource', () => {
+      const claims = { aud: 'api://resource-app' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, new Set(['api://resource-app']))).toBe(true);
+    });
+
+    it('accepts a resource audience listed among several', () => {
+      const claims = { aud: ['api://resource-app', 'client-id'] };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, new Set(['api://resource-app']))).toBe(true);
+    });
+
+    it('rejects an Entra-shaped ID token', () => {
+      const claims = { aud: 'client-id', nonce: 'n-0S6_WzA2Mj', tid: 'tenant-1', oid: 'object-1' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+    });
+
+    it('rejects a token bearing the ID-token-only `at_hash` claim even when scoped', () => {
+      const claims = { aud: 'client-id', scp: 'User.Read', at_hash: 'HK6E_P6Dh8Y93mRNtsDB1Q' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+    });
+
+    it('rejects a token bearing the ID-token-only `c_hash` claim', () => {
+      const claims = { aud: 'client-id', scope: 'api.read', c_hash: 'LDktKdoQak3Pk0cnXxCltA' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+    });
+
+    it('rejects a token whose audience is only the OIDC client id', () => {
+      const claims = { aud: 'client-id' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, new Set(['api://resource-app']))).toBe(
+        false,
+      );
+    });
+
+    it('does not treat `nonce` or `auth_time` as disqualifying on a scoped token', () => {
+      const claims = { aud: 'client-id', scope: 'api.read', nonce: 'abc', auth_time: 1700000000 };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(true);
+    });
+
+    it('rejects a missing token, missing claims, or an unparseable header', () => {
+      expect(isAccessTokenJwt(undefined, { aud: 'client-id' })).toBe(false);
+      expect(isAccessTokenJwt('a.b.c', undefined)).toBe(false);
+      expect(isAccessTokenJwt('not-a-jwt', { aud: 'client-id' })).toBe(false);
     });
   });
 });

--- a/packages/api/src/utils/oidc.spec.ts
+++ b/packages/api/src/utils/oidc.spec.ts
@@ -771,6 +771,7 @@ describe('OpenID Token Utilities', () => {
     const encodeSegment = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64');
     const makeJwt = (claims: object, header: object = { alg: 'RS256' }) =>
       `${encodeSegment(header)}.${encodeSegment(claims)}.signature`;
+    const audiences = { resources: new Set(['api://resource-app']), clientId: 'client-id' };
 
     it('accepts a token carrying the Entra `scp` scope claim', () => {
       const claims = { aud: 'client-id', scp: 'User.Read Files.Read' };
@@ -792,12 +793,17 @@ describe('OpenID Token Utilities', () => {
 
     it('accepts a token whose audience names a configured resource', () => {
       const claims = { aud: 'api://resource-app' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims, new Set(['api://resource-app']))).toBe(true);
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(true);
     });
 
-    it('accepts a resource audience listed among several', () => {
-      const claims = { aud: ['api://resource-app', 'client-id'] };
-      expect(isAccessTokenJwt(makeJwt(claims), claims, new Set(['api://resource-app']))).toBe(true);
+    it('accepts a resource audience listed among several non-client audiences', () => {
+      const claims = { aud: ['api://resource-app', 'api://other-app'] };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(true);
+    });
+
+    it('rejects a multi-audience ID token that also names a configured resource', () => {
+      const claims = { aud: ['client-id', 'api://resource-app'], nonce: 'n-0S6_WzA2Mj' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
     it('rejects an Entra-shaped ID token', () => {
@@ -817,9 +823,7 @@ describe('OpenID Token Utilities', () => {
 
     it('rejects a token whose audience is only the OIDC client id', () => {
       const claims = { aud: 'client-id' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims, new Set(['api://resource-app']))).toBe(
-        false,
-      );
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
     it('does not treat `nonce` or `auth_time` as disqualifying on a scoped token', () => {

--- a/packages/api/src/utils/oidc.spec.ts
+++ b/packages/api/src/utils/oidc.spec.ts
@@ -773,16 +773,6 @@ describe('OpenID Token Utilities', () => {
       `${encodeSegment(header)}.${encodeSegment(claims)}.signature`;
     const audiences = { resources: new Set(['api://resource-app']), clientId: 'client-id' };
 
-    it('accepts a token carrying the Entra `scp` scope claim', () => {
-      const claims = { aud: 'client-id', scp: 'User.Read Files.Read' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(true);
-    });
-
-    it('accepts a token carrying the `scope` claim', () => {
-      const claims = { aud: 'client-id', scope: 'openid api.read' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(true);
-    });
-
     it('accepts an RFC 9068 `at+jwt` header type regardless of case', () => {
       const claims = { aud: 'client-id' };
       expect(isAccessTokenJwt(makeJwt(claims, { alg: 'RS256', typ: 'at+JWT' }), claims)).toBe(true);
@@ -796,9 +786,31 @@ describe('OpenID Token Utilities', () => {
       expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(true);
     });
 
-    it('accepts a resource audience listed among several non-client audiences', () => {
-      const claims = { aud: ['api://resource-app', 'api://other-app'] };
+    it('accepts a scope claim once the audience has ruled out an ID token', () => {
+      const scp = { aud: 'api://other-app', scp: 'User.Read Files.Read' };
+      const scope = { aud: 'api://other-app', scope: 'openid api.read' };
+      expect(isAccessTokenJwt(makeJwt(scp), scp, audiences)).toBe(true);
+      expect(isAccessTokenJwt(makeJwt(scope), scope, audiences)).toBe(true);
+    });
+
+    it('does not treat `nonce` or `auth_time` as disqualifying once the audience has ruled out an ID token', () => {
+      const claims = {
+        aud: 'api://resource-app',
+        scope: 'api.read',
+        nonce: 'abc',
+        auth_time: 1700000000,
+      };
       expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(true);
+    });
+
+    it('rejects a scope claim while the client id is still an audience', () => {
+      const claims = { aud: 'client-id', scp: 'User.Read' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
+    });
+
+    it('rejects an ID token carrying a provider-added scope claim', () => {
+      const claims = { aud: 'client-id', scope: 'openid email profile', nonce: 'n-0S6_WzA2Mj' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
     it('rejects a multi-audience ID token that also names a configured resource', () => {
@@ -808,17 +820,17 @@ describe('OpenID Token Utilities', () => {
 
     it('rejects an Entra-shaped ID token', () => {
       const claims = { aud: 'client-id', nonce: 'n-0S6_WzA2Mj', tid: 'tenant-1', oid: 'object-1' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
     it('rejects a token bearing the ID-token-only `at_hash` claim even when scoped', () => {
-      const claims = { aud: 'client-id', scp: 'User.Read', at_hash: 'HK6E_P6Dh8Y93mRNtsDB1Q' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+      const claims = { aud: 'api://resource-app', scp: 'User.Read', at_hash: 'HK6E_P6Dh8Y93mRN' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
     it('rejects a token bearing the ID-token-only `c_hash` claim', () => {
-      const claims = { aud: 'client-id', scope: 'api.read', c_hash: 'LDktKdoQak3Pk0cnXxCltA' };
-      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+      const claims = { aud: 'api://resource-app', scope: 'api.read', c_hash: 'LDktKdoQak3Pk0cn' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
     it('rejects a token whose audience is only the OIDC client id', () => {
@@ -826,15 +838,16 @@ describe('OpenID Token Utilities', () => {
       expect(isAccessTokenJwt(makeJwt(claims), claims, audiences)).toBe(false);
     });
 
-    it('does not treat `nonce` or `auth_time` as disqualifying on a scoped token', () => {
-      const claims = { aud: 'client-id', scope: 'api.read', nonce: 'abc', auth_time: 1700000000 };
-      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(true);
+    it('qualifies nothing but `at+jwt` when no client id is configured', () => {
+      const claims = { aud: 'api://resource-app', scp: 'User.Read' };
+      expect(isAccessTokenJwt(makeJwt(claims), claims)).toBe(false);
+      expect(isAccessTokenJwt(makeJwt(claims, { alg: 'RS256', typ: 'at+jwt' }), claims)).toBe(true);
     });
 
     it('rejects a missing token, missing claims, or an unparseable header', () => {
-      expect(isAccessTokenJwt(undefined, { aud: 'client-id' })).toBe(false);
-      expect(isAccessTokenJwt('a.b.c', undefined)).toBe(false);
-      expect(isAccessTokenJwt('not-a-jwt', { aud: 'client-id' })).toBe(false);
+      expect(isAccessTokenJwt(undefined, { aud: 'api://resource-app' }, audiences)).toBe(false);
+      expect(isAccessTokenJwt('a.b.c', undefined, audiences)).toBe(false);
+      expect(isAccessTokenJwt('not-a-jwt', { aud: 'client-id' }, audiences)).toBe(false);
     });
   });
 });

--- a/packages/api/src/utils/oidc.ts
+++ b/packages/api/src/utils/oidc.ts
@@ -44,6 +44,79 @@ export const DEFAULT_GRAPH_SCOPES = 'https://graph.microsoft.com/.default';
 /** Shared with AuthController's OpenID session reuse check: a token within the buffer would expire in transit and 401 downstream */
 export const OPENID_EXPIRY_BUFFER_SECONDS = 30;
 
+/** Claims consulted when deciding whether a verified JWT is an access token rather than an ID token. */
+export interface JwtTypeClaims {
+  aud?: string | string[];
+  scp?: unknown;
+  scope?: unknown;
+  at_hash?: unknown;
+  c_hash?: unknown;
+}
+
+/** RFC 9068 media type for a JWT access token, as it appears in the `typ` header (compared case-insensitively). */
+const ACCESS_TOKEN_JWT_TYPES = new Set(['at+jwt', 'application/at+jwt']);
+
+function decodeJwtHeaderType(token: string): string | undefined {
+  try {
+    const header = JSON.parse(Buffer.from(token.split('.')[0], 'base64').toString());
+    return typeof header?.typ === 'string' ? header.typ.toLowerCase() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function audienceList(aud: string | string[] | undefined): string[] {
+  if (typeof aud === 'string') {
+    return [aud];
+  }
+  return Array.isArray(aud) ? aud : [];
+}
+
+/**
+ * Decides whether a verified bearer JWT is an OAuth 2.0 access token, so it may stand in for a
+ * stored access token. Passing this strategy's audience check does not settle the question: an
+ * OIDC ID token is minted for the client id and satisfies the same check, and using one as the
+ * On-Behalf-Of assertion is rejected by the IdP (Entra answers `AADSTS240002`).
+ *
+ * Only positive evidence qualifies a token, so an unrecognised shape fails closed rather than
+ * risking a mis-typed assertion:
+ * - an RFC 9068 `at+jwt` header type,
+ * - an OAuth scope claim (`scp` or `scope`), which OIDC does not define for an ID token,
+ * - an audience naming a protected resource rather than the OIDC client.
+ *
+ * `at_hash` and `c_hash` veto regardless, since they exist only to bind an ID token to its
+ * companion access token or code. `nonce` and `auth_time` are deliberately not vetoes: some
+ * providers (Keycloak) have emitted them in genuine access tokens.
+ */
+export function isAccessTokenJwt(
+  token: string | undefined,
+  claims: JwtTypeClaims | undefined,
+  resourceAudiences?: ReadonlySet<string>,
+): boolean {
+  if (!token || !claims) {
+    return false;
+  }
+
+  if (claims.at_hash != null || claims.c_hash != null) {
+    return false;
+  }
+
+  if (claims.scp != null || claims.scope != null) {
+    return true;
+  }
+
+  const headerType = decodeJwtHeaderType(token);
+  if (headerType != null && ACCESS_TOKEN_JWT_TYPES.has(headerType)) {
+    return true;
+  }
+
+  if (!resourceAudiences?.size) {
+    return false;
+  }
+
+  return audienceList(claims.aud).some((audience) => resourceAudiences.has(audience));
+}
+
 /**
  * Signals that the stored OpenID credentials cannot satisfy a placeholder, so the user must
  * re-authenticate. `ErrorController` maps this to a 401, and `statusCode` additionally lets

--- a/packages/api/src/utils/oidc.ts
+++ b/packages/api/src/utils/oidc.ts
@@ -88,15 +88,18 @@ function audienceList(aud: string | string[] | undefined): string[] {
  * OIDC ID token is minted for the client id and satisfies the same check, and using one as the
  * On-Behalf-Of assertion is rejected by the IdP (Entra answers `AADSTS240002`).
  *
- * Only positive evidence qualifies a token, so an unrecognised shape fails closed rather than
- * risking a mis-typed assertion:
- * - an RFC 9068 `at+jwt` header type,
- * - an OAuth scope claim (`scp` or `scope`), which OIDC does not define for an ID token,
- * - an audience naming a protected resource and not also the OIDC client.
+ * Only two signals distinguish the two by specification rather than by provider convention:
+ * - an RFC 9068 `at+jwt` header type, which is defined for access tokens alone;
+ * - an `aud` that omits the OIDC client id, which OIDC Core §2 requires every ID token to carry,
+ *   so a token without it cannot be an ID token for this deployment.
+ *
+ * Claim presence is deliberately not proof on its own. Providers add claims freely in both
+ * directions — Keycloak has emitted `nonce` and `auth_time` in access tokens, and maps `scope`
+ * into ID tokens — so `scp`/`scope` only qualifies a token whose audience has already ruled out
+ * an ID token. While the client id is in `aud` the token may be either, and it fails closed.
  *
  * `at_hash` and `c_hash` veto regardless, since they exist only to bind an ID token to its
- * companion access token or code. `nonce` and `auth_time` are deliberately not vetoes: some
- * providers (Keycloak) have emitted them in genuine access tokens.
+ * companion access token or code.
  */
 export function isAccessTokenJwt(
   token: string | undefined,
@@ -111,30 +114,28 @@ export function isAccessTokenJwt(
     return false;
   }
 
-  if (claims.scp != null || claims.scope != null) {
-    return true;
-  }
-
   const headerType = decodeJwtHeaderType(token);
   if (headerType != null && ACCESS_TOKEN_JWT_TYPES.has(headerType)) {
     return true;
   }
 
-  if (!audiences?.resources?.size) {
+  /** Without a configured client id the audience can rule nothing out, so nothing but `at+jwt` qualifies */
+  if (audiences?.clientId == null) {
     return false;
   }
 
-  /**
-   * OIDC permits an ID token to carry several audiences, and this strategy's own check admits
-   * the token as soon as one of them is the client id. A resource audience is therefore only
-   * evidence of an access token while the client id is absent from the list.
-   */
   const tokenAudiences = audienceList(claims.aud);
-  if (audiences.clientId != null && tokenAudiences.includes(audiences.clientId)) {
+  if (tokenAudiences.includes(audiences.clientId)) {
     return false;
   }
 
-  return tokenAudiences.some((audience) => audiences.resources!.has(audience));
+  if (audiences.resources?.size) {
+    if (tokenAudiences.some((audience) => audiences.resources!.has(audience))) {
+      return true;
+    }
+  }
+
+  return claims.scp != null || claims.scope != null;
 }
 
 /**

--- a/packages/api/src/utils/oidc.ts
+++ b/packages/api/src/utils/oidc.ts
@@ -28,6 +28,8 @@ export const OPENID_TOKEN_FIELDS = [
   'EXPIRES_AT',
 ] as const;
 
+export type OpenIDTokenField = (typeof OPENID_TOKEN_FIELDS)[number];
+
 /**
  * Placeholder for Microsoft Graph API access token.
  * This placeholder is resolved asynchronously via OBO (On-Behalf-Of) flow
@@ -51,6 +53,14 @@ export interface JwtTypeClaims {
   scope?: unknown;
   at_hash?: unknown;
   c_hash?: unknown;
+}
+
+/** The configured audiences a verified JWT is weighed against. */
+export interface AccessTokenAudiences {
+  /** Audiences that name a protected resource rather than the OIDC client. */
+  resources?: ReadonlySet<string>;
+  /** The OIDC client id, so an `aud` that still names it is not read as resource-bound. */
+  clientId?: string;
 }
 
 /** RFC 9068 media type for a JWT access token, as it appears in the `typ` header (compared case-insensitively). */
@@ -82,7 +92,7 @@ function audienceList(aud: string | string[] | undefined): string[] {
  * risking a mis-typed assertion:
  * - an RFC 9068 `at+jwt` header type,
  * - an OAuth scope claim (`scp` or `scope`), which OIDC does not define for an ID token,
- * - an audience naming a protected resource rather than the OIDC client.
+ * - an audience naming a protected resource and not also the OIDC client.
  *
  * `at_hash` and `c_hash` veto regardless, since they exist only to bind an ID token to its
  * companion access token or code. `nonce` and `auth_time` are deliberately not vetoes: some
@@ -91,7 +101,7 @@ function audienceList(aud: string | string[] | undefined): string[] {
 export function isAccessTokenJwt(
   token: string | undefined,
   claims: JwtTypeClaims | undefined,
-  resourceAudiences?: ReadonlySet<string>,
+  audiences?: AccessTokenAudiences,
 ): boolean {
   if (!token || !claims) {
     return false;
@@ -110,11 +120,21 @@ export function isAccessTokenJwt(
     return true;
   }
 
-  if (!resourceAudiences?.size) {
+  if (!audiences?.resources?.size) {
     return false;
   }
 
-  return audienceList(claims.aud).some((audience) => resourceAudiences.has(audience));
+  /**
+   * OIDC permits an ID token to carry several audiences, and this strategy's own check admits
+   * the token as soon as one of them is the client id. A resource audience is therefore only
+   * evidence of an access token while the client id is absent from the list.
+   */
+  const tokenAudiences = audienceList(claims.aud);
+  if (audiences.clientId != null && tokenAudiences.includes(audiences.clientId)) {
+    return false;
+  }
+
+  return tokenAudiences.some((audience) => audiences.resources!.has(audience));
 }
 
 /**
@@ -221,9 +241,15 @@ export function isOpenIDTokenValid(tokenInfo: OpenIDTokenInfo | null): boolean {
   return true;
 }
 
+/**
+ * @param fields Restricts which placeholders may resolve. Callers holding a token set whose
+ * access token is unusable pass `['ID_TOKEN']`, so the ID token resolves on its own expiry while
+ * every other placeholder keeps its literal-then-strip behaviour.
+ */
 export function processOpenIDPlaceholders(
   value: string,
   tokenInfo: OpenIDTokenInfo | null,
+  fields: readonly OpenIDTokenField[] = OPENID_TOKEN_FIELDS,
 ): string {
   if (!tokenInfo || typeof value !== 'string') {
     return value;
@@ -231,7 +257,7 @@ export function processOpenIDPlaceholders(
 
   let processedValue = value;
 
-  for (const field of OPENID_TOKEN_FIELDS) {
+  for (const field of fields) {
     const placeholder = `{{LIBRECHAT_OPENID_${field}}}`;
     if (!processedValue.includes(placeholder)) {
       continue;
@@ -271,7 +297,7 @@ export function processOpenIDPlaceholders(
   }
 
   const genericPlaceholder = '{{LIBRECHAT_OPENID_TOKEN}}';
-  if (processedValue.includes(genericPlaceholder)) {
+  if (fields.includes('ACCESS_TOKEN') && processedValue.includes(genericPlaceholder)) {
     const replacementValue = tokenInfo.accessToken || '';
     processedValue = processedValue.replace(new RegExp(genericPlaceholder, 'g'), replacementValue);
   }


### PR DESCRIPTION
## Summary

Fixes #15315.

When the `openidJwt` reuse strategy could not find a stored access token in the session or cookies, it substituted the raw incoming Authorization bearer as one:

```js
const resolvedAccessToken = accessToken || rawToken;
```

Clearing this strategy's audience check does not make a token an access token. An OIDC ID token is minted for the client id and satisfies the very same check, so the fallback could store an ID token as `federatedTokens.access_token`. That value is used verbatim as the On-Behalf-Of assertion in `resolveOboToken`, and Entra rejects an ID token there:

```
AADSTS240002: Input id_token cannot be used as jwt-bearer grant
```

This is easy to reach whenever the OpenID session store is not persistent. With no Redis configured, `express-session` falls back to `MemoryStore`, so every restart wipes the stored access tokens for active sessions and subsequent OBO attempts hit the fallback.

## Approach

The issue suggests deleting `|| rawToken` outright. That would also break the case the fallback legitimately serves: with a resource-bound provider (`OPENID_AUDIENCE` set), the incoming bearer genuinely *is* an access token, and those deployments would regress from working to the "no valid token" error of #13899. So the fallback is kept but gated on the token being identifiable as an access token.

A new `isAccessTokenJwt` helper in `packages/api/src/utils/oidc.ts` rests on the two signals that separate the token types **by specification** rather than by provider convention:

1. an RFC 9068 `at+jwt` header type, which is defined for access tokens alone;
2. an `aud` that omits the OIDC client id — OIDC Core §2 requires every ID token to carry the client id as an audience, so a token without it cannot be an ID token for this deployment.

A `scp`/`scope` claim is only a *supporting* signal, applying once the audience has already ruled out an ID token. Claim presence is not proof on its own in either direction: Keycloak has emitted `nonce` and `auth_time` in genuine access tokens, and maps `scope` into its ID tokens. `at_hash` and `c_hash` veto regardless, since they exist only to bind an ID token to its companion access token or code. With no client id configured the audience can rule nothing out, so nothing but `at+jwt` qualifies.

An unrecognised token is left unset rather than guessed at, so `isOpenIDTokenValid` fails closed and the OBO path raises its actionable error instead of attempting a Graph exchange with a token of the wrong type — the behaviour the issue asks for.

### What this means per provider

| Provider | Bearer | Outcome |
|---|---|---|
| Entra | ID token (`aud` = client id) | declined, fails closed ✅ |
| Entra / Okta / Auth0 | access token with `OPENID_AUDIENCE` naming the resource | reused ✅ |
| any | access token declaring `typ: at+jwt` | reused ✅ |
| any | bearer audienced to the client id | declined, fails closed |

The last row is the deliberate behaviour change. Reuse now requires either an `at+jwt` provider or `OPENID_AUDIENCE` naming a resource distinct from the client id; a bearer audienced only to the client id cannot be told apart from an ID token and is no longer guessed at. This applies solely on the degraded path where no access token was stored in the session or cookies to begin with — normal operation reads the stored token and is untouched — and `OPENID_AUDIENCE` is the documented way back to reuse.

### Also fixed here

`processSingleValue` gated *every* credential placeholder on `isOpenIDTokenValid`, which reports on the access token alone. Leaving `access_token` unset therefore made a header configured with only `{{LIBRECHAT_OPENID_ID_TOKEN}}` raise re-authentication even with a present, current ID token. Validity now depends on the credential actually requested: an access-token-specific pattern gates the raise, and the ID token resolves through `processOpenIDPlaceholders`, which already validates its own expiry. `processOpenIDPlaceholders` gained a `fields` allowlist so that path resolves the ID token alone and identity metadata keeps its literal-then-strip behaviour.

## Why this was missed

Worth recording, since three prior reports never reached code:

- [#11711](https://github.com/danny-avila/LibreChat/pull/11711) — titled "Distinguish ID Tokens from Access Tokens in OIDC Federated Auth" — fixed `id_token: rawToken` and left `access_token: accessToken || rawToken` on the line directly above it, then added a test pinning the survivor in place (`'should use raw Bearer token as access_token fallback…'`). That test is replaced here.
- [#14982](https://github.com/danny-avila/LibreChat/pull/14982) edited this exact expression, but through an expiry lens; it hoisted the fallback into `resolvedAccessToken` and made it load-bearing for `expires_at`.
- [#11857](https://github.com/danny-avila/LibreChat/issues/11857) closed with no linked change; [#12057](https://github.com/danny-avila/LibreChat/issues/12057) and [#12517](https://github.com/danny-avila/LibreChat/issues/12517) were converted to discussions. GitHub reports converted issues as `stateReason: COMPLETED`, so both read as *fixed* in any issue search — including #12517, whose body correctly names the root cause.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `cd packages/api && npx jest src/utils/oidc.spec.ts` — 59 passed (11 new, covering each accept/veto path and the Entra ID-token shape)
- `cd api && npx jest strategies/openIdJwtStrategy.spec.js` — 43 passed (8 new in `token source handling`, incl. the AADSTS240002 regression)
- `cd api && npx jest strategies/ server/middleware/__tests__/requireJwtAuth.spec.js server/services/MCP.spec.js server/controllers/AuthController.spec.js` — 12 suites, 434 passed
- `cd packages/api && npx jest src/utils src/mcp/oauth` — 44 suites, 1008 passed
- `npx tsc --noEmit` in `packages/api` — no new errors
- `npx eslint` + `npx prettier --check` on all changed files — clean
- `npm run sort-imports` — changed files already sorted

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
