### PR TITLE
fix: apply in-transit expiry buffer to exchanged-token cache TTLs (#15320)

### DIFF
--- a/packages/api/src/oauth/expiry.spec.ts
+++ b/packages/api/src/oauth/expiry.spec.ts
@@ -1,0 +1,157 @@
+import {
+  DEFAULT_OAUTH_TOKEN_TTL_SECONDS,
+  getTokenCacheTtlMs,
+  getTokenExpiresAt,
+  normalizeExpiresIn,
+} from './expiry';
+
+describe('normalizeExpiresIn', () => {
+  it('accepts a positive finite number of seconds', () => {
+    expect(normalizeExpiresIn(3599)).toBe(3599);
+    expect(normalizeExpiresIn(1)).toBe(1);
+  });
+
+  it('accepts a numeric string, as some providers send', () => {
+    expect(normalizeExpiresIn('3599')).toBe(3599);
+  });
+
+  it('rejects an omitted lifetime', () => {
+    expect(normalizeExpiresIn(undefined)).toBeUndefined();
+    expect(normalizeExpiresIn(null)).toBeUndefined();
+  });
+
+  it('rejects NaN, which `undefined * 1000` produces and every naive guard admits', () => {
+    expect(normalizeExpiresIn(NaN)).toBeUndefined();
+    expect(normalizeExpiresIn('not-a-number')).toBeUndefined();
+  });
+
+  it('rejects a non-finite lifetime', () => {
+    expect(normalizeExpiresIn(Infinity)).toBeUndefined();
+    expect(normalizeExpiresIn(-Infinity)).toBeUndefined();
+  });
+
+  /**
+   * Parsing the complete string is what makes this reachable — `parseInt('1e13', 10)` was `1` and
+   * masked it. `1e13` seconds overruns the ECMAScript time range, so every derived timestamp would
+   * be an Invalid Date whose `toISOString()` throws: the very failure this module removes.
+   */
+  it('rejects a lifetime that would overflow the Date range', () => {
+    expect(normalizeExpiresIn('1e13')).toBeUndefined();
+    expect(normalizeExpiresIn(1e13)).toBeUndefined();
+    expect(normalizeExpiresIn(-1e13)).toBeUndefined();
+    expect(normalizeExpiresIn(Number.MAX_SAFE_INTEGER)).toBeUndefined();
+  });
+
+  it('still accepts lifetimes far longer than any real credential', () => {
+    const oneYear = 365 * 24 * 60 * 60;
+    expect(normalizeExpiresIn(oneYear)).toBe(oneYear);
+    expect(normalizeExpiresIn(oneYear * 100)).toBe(oneYear * 100);
+  });
+
+  /** An explicit non-positive value is the provider saying the credential is already dead, which is
+   *  information — collapsing it into "unknown" would hand it the fallback lifetime and revive it. */
+  it('preserves an explicitly elapsed lifetime rather than calling it unknown', () => {
+    expect(normalizeExpiresIn(0)).toBe(0);
+    expect(normalizeExpiresIn(-60)).toBe(-60);
+    expect(normalizeExpiresIn('0')).toBe(0);
+  });
+
+  it('parses a complete numeric string, which parseInt would truncate', () => {
+    expect(normalizeExpiresIn('3.6e3')).toBe(3600);
+    expect(normalizeExpiresIn(' 3600 ')).toBe(3600);
+  });
+
+  it('rejects an empty or blank string rather than reading it as zero', () => {
+    expect(normalizeExpiresIn('')).toBeUndefined();
+    expect(normalizeExpiresIn('   ')).toBeUndefined();
+  });
+
+  it('rejects shapes that are neither number nor string', () => {
+    expect(normalizeExpiresIn({})).toBeUndefined();
+    expect(normalizeExpiresIn([3600])).toBeUndefined();
+    expect(normalizeExpiresIn(true)).toBeUndefined();
+  });
+});
+
+describe('getTokenCacheTtlMs', () => {
+  it('converts a declared lifetime to milliseconds, minus the in-transit expiry buffer', () => {
+    expect(getTokenCacheTtlMs(1800, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1_770_000);
+  });
+
+  it('never caches a credential past its expiry buffer margin', () => {
+    const declared = 60;
+    const ttl = getTokenCacheTtlMs(declared, DEFAULT_OAUTH_TOKEN_TTL_SECONDS);
+    expect(ttl).toBeLessThan(declared * 1000);
+  });
+
+  it('falls back rather than returning NaN when the provider omits `expires_in`', () => {
+    expect(getTokenCacheTtlMs(undefined, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(3_600_000);
+    expect(getTokenCacheTtlMs(NaN, 60)).toBe(60_000);
+  });
+
+  /** Keyv reads a TTL of exactly 0 as "no expiry", so an elapsed lifetime must not pass through raw */
+  it('floors an elapsed lifetime to the shortest positive TTL, never 0', () => {
+    expect(getTokenCacheTtlMs(0, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1);
+    expect(getTokenCacheTtlMs(-60, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1);
+    /** buffer larger than the lifetime still lands on the floor, not 0 */
+    expect(getTokenCacheTtlMs(10, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1);
+  });
+
+  it('does not hand an elapsed lifetime the fallback, which would revive a dead credential', () => {
+    expect(getTokenCacheTtlMs(0, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).not.toBe(3_600_000);
+  });
+
+  it('never returns 0, which Keyv would store as no expiry', () => {
+    for (const value of [undefined, null, NaN, Infinity, 0, -1, '0', 'abc', {}, '1e13', 1e300]) {
+      const ttl = getTokenCacheTtlMs(value, DEFAULT_OAUTH_TOKEN_TTL_SECONDS);
+      expect(ttl).toBeGreaterThan(0);
+      expect(Number.isFinite(ttl)).toBe(true);
+    }
+  });
+
+  /**
+   * A NaN TTL is not a short TTL: `@keyv/redis` skips its `PX` branch because NaN is falsy, and
+   * Keyv's own expiry checks compare with `>`, always false against NaN. The result is an entry
+   * that outlives the credential it holds.
+   */
+  it('never returns NaN, whatever the provider sent', () => {
+    for (const value of [undefined, null, NaN, Infinity, 0, -1, 'abc', {}]) {
+      expect(Number.isFinite(getTokenCacheTtlMs(value, DEFAULT_OAUTH_TOKEN_TTL_SECONDS))).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe('getTokenExpiresAt', () => {
+  it('returns an absolute expiry for a declared lifetime', () => {
+    const before = Date.now();
+    const expiresAt = getTokenExpiresAt(600);
+
+    expect(expiresAt).toBeInstanceOf(Date);
+    expect(expiresAt!.getTime()).toBeGreaterThanOrEqual(before + 600_000);
+    expect(expiresAt!.getTime()).toBeLessThanOrEqual(Date.now() + 600_000);
+  });
+
+  it('returns undefined rather than an Invalid Date when the lifetime is unknown', () => {
+    for (const value of [undefined, null, NaN, Infinity, 'abc', '']) {
+      expect(getTokenExpiresAt(value)).toBeUndefined();
+    }
+  });
+
+  /** An elapsed lifetime must stay elapsed, so callers refresh instead of treating it as unknown */
+  it('returns a past timestamp for an explicitly elapsed lifetime', () => {
+    const expiresAt = getTokenExpiresAt(0);
+
+    expect(expiresAt).toBeInstanceOf(Date);
+    expect(expiresAt!.getTime()).toBeLessThanOrEqual(Date.now());
+    expect(getTokenExpiresAt(-60)!.getTime()).toBeLessThan(Date.now());
+  });
+
+  /** `new Date(NaN).toISOString()` throws `RangeError: Invalid time value`, which is the ActionService failure */
+  it('never yields a value whose toISOString throws', () => {
+    for (const value of [undefined, null, NaN, Infinity, 'abc', '', 0, -60, 3600, '1e13', 1e300]) {
+      expect(() => getTokenExpiresAt(value)?.toISOString()).not.toThrow();
+    }
+  });
+});

--- a/packages/api/src/oauth/expiry.ts
+++ b/packages/api/src/oauth/expiry.ts
@@ -1,0 +1,94 @@
+/**
+ * RFC 6749 §5.1 makes `expires_in` only RECOMMENDED, so a token response may legally omit it, and
+ * providers have been observed sending it as a string. Deriving a lifetime from the raw field is
+ * therefore unsafe: `undefined * 1000` is `NaN`, and `NaN` is neither an error nor a default.
+ *
+ * A `NaN` cache TTL means an entry that never expires. `@keyv/redis` writes the key without `PX`
+ * because `NaN` is falsy, and Keyv's own expiry checks compare with `>`, which is always false
+ * against `NaN`. The namespace default does not stand in either, since Keyv applies it with `??=`
+ * and `NaN` is neither `null` nor `undefined`. A `NaN` timestamp is just as sharp: `new Date(NaN)`
+ * is an Invalid Date and `toISOString()` on it throws `RangeError`.
+ *
+ * Every lifetime derived from a token response goes through here so the rule has one home.
+ */
+import { OPENID_EXPIRY_BUFFER_SECONDS } from '../utils/oidc';
+
+/**
+ * Fallback lifetime for a token response that declares none. One hour matches every hand-written
+ * default this helper replaces, and is short enough that a wrongly-guessed lifetime self-corrects.
+ */
+export const DEFAULT_OAUTH_TOKEN_TTL_SECONDS = 3600;
+
+/**
+ * Floor for a cache TTL derived from an already-elapsed lifetime. Keyv reads a TTL of exactly `0`
+ * as "no expiry" (`data.ttl === 0` becomes `undefined`), so a credential the provider declared
+ * expired must never be written as `0` — that is the very failure this module exists to prevent.
+ */
+const EXPIRED_CACHE_TTL_MS = 1;
+
+/**
+ * Longest lifetime that can still produce a valid `Date`. The ECMAScript time value range ends at
+ * ±8.64e15 ms, and every derived timestamp adds `Date.now()`, so the bound is halved to leave room
+ * for it. A provider sending something beyond this — `"1e13"` seconds is roughly 317,000 years — is
+ * not describing a credential lifetime, and accepting it would yield the Invalid Date this module
+ * exists to prevent. Such a value is reported as unusable so callers take their fallback.
+ */
+const MAX_EXPIRES_IN_SECONDS = 4_320_000_000_000;
+
+function parseExpiresIn(expiresIn: unknown): number | undefined {
+  if (typeof expiresIn === 'number') {
+    return expiresIn;
+  }
+
+  if (typeof expiresIn !== 'string') {
+    return undefined;
+  }
+
+  /** `Number` over `parseInt`, which truncates a complete numeric string such as `"3.6e3"` to `3` */
+  const trimmed = expiresIn.trim();
+  return trimmed.length === 0 ? undefined : Number(trimmed);
+}
+
+/**
+ * The lifetime a token response declares, in seconds, or `undefined` when it declares none usable.
+ *
+ * A non-positive value is preserved rather than discarded: the provider is stating the credential
+ * is already expired, which is information, and collapsing it into "unknown" would hand it the
+ * fallback lifetime and keep a dead credential alive.
+ */
+export function normalizeExpiresIn(expiresIn: unknown): number | undefined {
+  const parsed = parseExpiresIn(expiresIn);
+  if (parsed == null || !Number.isFinite(parsed)) {
+    return undefined;
+  }
+
+  return Math.abs(parsed) <= MAX_EXPIRES_IN_SECONDS ? parsed : undefined;
+}
+
+/**
+ * Cache TTL in milliseconds for a token response. A provider that omits `expires_in` gets
+ * `fallbackSeconds` rather than an entry that outlives the credential it holds; one that declares
+ * an elapsed lifetime gets the shortest positive TTL rather than `0`, which Keyv reads as no expiry.
+ *
+ * The `OPENID_EXPIRY_BUFFER_SECONDS` margin is subtracted so a cached credential is never served
+ * in its final seconds, where it would expire in transit and 401 downstream. The buffer is applied
+ * to every exchanged-token cache (OBO, Graph, OpenID strategy), matching the federated-token check
+ * in `isOpenIDTokenValid` / `isIdTokenCurrent` (#15320).
+ */
+export function getTokenCacheTtlMs(expiresIn: unknown, fallbackSeconds: number): number {
+  const seconds = normalizeExpiresIn(expiresIn);
+  if (seconds == null) {
+    return fallbackSeconds * 1000;
+  }
+  return Math.max(seconds * 1000 - OPENID_EXPIRY_BUFFER_SECONDS * 1000, EXPIRED_CACHE_TTL_MS);
+}
+
+/**
+ * Absolute expiry for a token response, or `undefined` when its lifetime is unknown. Callers store
+ * nothing rather than an Invalid Date, so an unknown expiry stays distinguishable from an elapsed
+ * one — an elapsed lifetime still yields a past timestamp, so callers refresh instead of guessing.
+ */
+export function getTokenExpiresAt(expiresIn: unknown): Date | undefined {
+  const seconds = normalizeExpiresIn(expiresIn);
+  return seconds == null ? undefined : new Date(Date.now() + seconds * 1000);
+}


### PR DESCRIPTION
## Summary

Fixes #15320 — exchanged OBO / Graph / OpenID tokens were cached for their **full** `expires_in`, so a credential could expire in transit and 401 downstream (the intermittent "works on retry" shape reported in #13899).

**Fix:** `getTokenCacheTtlMs` now subtracts `OPENID_EXPIRY_BUFFER_SECONDS` (30s) — the same margin already used by `isOpenIDTokenValid` / `isIdTokenCurrent` for the user's federated token — from the derived cache TTL. All three exchanged-token caches (`OboTokenService.js`, `GraphApiService.js`, `openidStrategy.js`) call this single helper, so one change covers every path.

Edge cases preserved:
- Provider omits `expires_in` → fallback lifetime, no buffer subtraction (unknown lifetime stays conservative)
- Lifetime shorter than the buffer (e.g. 10s) → floors to the shortest positive TTL (1ms), never 0 (Keyv reads 0 as "no expiry")
- Already-elapsed lifetime → 1ms, not the fallback (dead credential stays dead)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Logic verified: 1800s → 1,770,000ms; undefined → 3,600,000ms (fallback); 0s → 1ms; 10s (buffer > ttl) → 1ms
- Spec updated: `getTokenCacheTtlMs(1800) → 1_770_000`, added buffer-margin and floor cases
- All three callers confirmed to route through `getTokenCacheTtlMs` (no direct `expires_in * 1000` caches remain)
- Prettier (repo `.prettierrc`) passes

### **Test Configuration**:
- No behavioral change for tokens with >30s remaining lifetime (only the final 30s window is no longer served from cache)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
