### PR TITLE
🐺 fix: Stop Routine MCP Teardowns From Failing Concurrent Tool Calls

### DIFF
--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -229,9 +229,10 @@ export abstract class UserConnectionManager {
    * against the config and connection state the teardown left behind, instead of failing.
    */
   public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
+    let attemptOptions = opts;
     for (let attempt = 0; ; attempt++) {
       try {
-        return await this.establishUserConnection(opts);
+        return await this.establishUserConnection(attemptOptions);
       } catch (error) {
         if (
           !(error instanceof ConnectionCreationCancelledError) ||
@@ -242,8 +243,36 @@ export abstract class UserConnectionManager {
         logger.info(
           `[MCP][User: ${opts.user?.id}][${opts.serverName}] Connection creation raced a teardown; re-establishing`,
         );
+        attemptOptions = await this.refreshFencedServerConfig(attemptOptions);
       }
     }
+  }
+
+  /**
+   * Callers hand in a config they resolved before the teardown, so a re-established attempt
+   * re-reads it: a registry-backed server picks up the committed update, and a deleted user
+   * server resolves to nothing and fails the attempt instead of reconnecting to the removed
+   * endpoint. A caller-supplied config the registry cannot resolve on its own — a config-source
+   * server not cached yet — is kept, since no user mutation removes it.
+   */
+  private async refreshFencedServerConfig(
+    opts: t.UserMCPConnectionOptions,
+  ): Promise<t.UserMCPConnectionOptions> {
+    const userId = opts.user?.id;
+    if (!userId) {
+      return opts;
+    }
+    const serverConfig = await MCPServersRegistry.getInstance().getServerConfig(
+      opts.serverName,
+      userId,
+    );
+    if (serverConfig) {
+      return { ...opts, serverConfig };
+    }
+    if (opts.serverConfig && !isUserSourced(opts.serverConfig)) {
+      return opts;
+    }
+    return { ...opts, serverConfig: undefined };
   }
 
   private async establishUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -34,6 +34,15 @@ type PendingConnection = {
 type ConnectionCreationGuard = { cancelled: boolean };
 
 /**
+ * Signals that a teardown fenced an in-flight creation. The attempt is discarded, not the
+ * caller: `getUserConnection` re-establishes it against the state the teardown left behind.
+ */
+class ConnectionCreationCancelledError extends Error {}
+
+/** Bounds re-establishment so back-to-back teardowns cannot spin a caller forever. */
+const MAX_TEARDOWN_RESTARTS = 3;
+
+/**
  * Abstract base class for managing user-specific MCP connections with lifecycle management.
  * Only meant to be extended by MCPManager.
  * Much of the logic was move here from the old MCPManager to make it more manageable.
@@ -108,6 +117,19 @@ export abstract class UserConnectionManager {
     if (guards?.size === 0) {
       this.activeConnectionCreations.delete(key);
     }
+  }
+
+  private assertCreationNotCancelled(
+    guard: ConnectionCreationGuard | undefined,
+    userId: string,
+    serverName: string,
+  ): void {
+    if (!guard?.cancelled) {
+      return;
+    }
+    throw new ConnectionCreationCancelledError(
+      `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
+    );
   }
 
   private cancelConnectionCreations(key: string, preserved?: ConnectionCreationGuard): void {
@@ -198,8 +220,33 @@ export abstract class UserConnectionManager {
     throw new Error(`[MCP][User: ${userId}][${serverName}] Publication lease is no longer current`);
   }
 
-  /** Gets or creates a connection for a specific user, coalescing concurrent attempts */
+  /**
+   * Gets or creates a connection for a specific user, coalescing concurrent attempts.
+   *
+   * A teardown fences every creation in flight for the same user and server, since those may
+   * install a connection built from the state it is removing. The caller behind one is next in
+   * line rather than stale, so a fenced attempt is discarded and re-established from scratch,
+   * against the config and connection state the teardown left behind, instead of failing.
+   */
   public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await this.establishUserConnection(opts);
+      } catch (error) {
+        if (
+          !(error instanceof ConnectionCreationCancelledError) ||
+          attempt >= MAX_TEARDOWN_RESTARTS
+        ) {
+          throw error;
+        }
+        logger.info(
+          `[MCP][User: ${opts.user?.id}][${opts.serverName}] Connection creation raced a teardown; re-establishing`,
+        );
+      }
+    }
+  }
+
+  private async establishUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
     const { serverName, forceNew, user } = opts;
     const userId = user?.id;
     if (!userId) {
@@ -387,11 +434,7 @@ export abstract class UserConnectionManager {
     clearCooldown: boolean,
     creationGuard?: ConnectionCreationGuard,
   ): Promise<MCPConnection> {
-    if (creationGuard?.cancelled) {
-      throw new Error(
-        `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
-      );
-    }
+    this.assertCreationNotCancelled(creationGuard, userId, serverName);
     if (await this.appConnections!.has(serverName)) {
       throw new McpError(
         ErrorCode.InvalidRequest,
@@ -500,11 +543,7 @@ export abstract class UserConnectionManager {
             serverName,
             creationGuard,
           );
-          if (creationGuard?.cancelled) {
-            throw new Error(
-              `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
-            );
-          }
+          this.assertCreationNotCancelled(creationGuard, userId, serverName);
           return connection;
         }
         logger.warn(`[MCP][User: ${userId}] Found disconnected connection object; cleaning up`);
@@ -593,11 +632,7 @@ export abstract class UserConnectionManager {
 
       connection = await MCPConnectionFactory.create(basic, connectionOptions);
 
-      if (creationGuard?.cancelled) {
-        throw new Error(
-          `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
-        );
-      }
+      this.assertCreationNotCancelled(creationGuard, userId, serverName);
 
       if (publicationGeneration) {
         this.toolPublicationGenerations.set(connection, publicationGeneration);
@@ -623,11 +658,7 @@ export abstract class UserConnectionManager {
 
       if (!ephemeralConnection) {
         await connection.refreshToolList();
-        if (creationGuard?.cancelled) {
-          throw new Error(
-            `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
-          );
-        }
+        this.assertCreationNotCancelled(creationGuard, userId, serverName);
         if (!this.userConnections.has(userId)) {
           this.userConnections.set(userId, new Map());
         }
@@ -639,11 +670,7 @@ export abstract class UserConnectionManager {
         await this.updateUserLastActivity(userId);
         await this.assertToolPublicationLeaseCurrent(connection, userId, serverName, creationGuard);
       }
-      if (creationGuard?.cancelled) {
-        throw new Error(
-          `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
-        );
-      }
+      this.assertCreationNotCancelled(creationGuard, userId, serverName);
       return connection;
     } catch (error) {
       logger.error(`[MCP][User: ${userId}] Failed to establish connection`);

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -31,13 +31,32 @@ type PendingConnection = {
   oauth: OAuthLifecycleRelay;
 };
 
-type ConnectionCreationGuard = { cancelled: boolean };
-
 /**
- * Signals that a teardown fenced an in-flight creation. The attempt is discarded, not the
- * caller: `getUserConnection` re-establishes it against the state the teardown left behind.
+ * Why a connection is being torn down. A `mutation` teardown follows a committed change to the
+ * server config or its credentials, so whatever an in-flight creation resolved before it may be
+ * stale and that creation cannot be re-established from the same inputs. A `lifecycle` teardown
+ * — an idle sweep, a forced replacement, a dead connection cleaned up — leaves those inputs
+ * exactly as valid as they were, and only the connection object itself goes away.
  */
-class ConnectionCreationCancelledError extends Error {}
+type ConnectionTeardownReason = 'mutation' | 'lifecycle';
+
+type ConnectionTeardownOptions = {
+  /** The creation that requested the teardown; it is fenced by its own replacement. */
+  preservedCreation?: ConnectionCreationGuard;
+  reason?: ConnectionTeardownReason;
+};
+
+type ConnectionCreationGuard = { cancelledBy: ConnectionTeardownReason | null };
+
+/** Signals that a teardown fenced an in-flight creation before it could finish. */
+class ConnectionCreationCancelledError extends Error {
+  constructor(
+    message: string,
+    public readonly reason: ConnectionTeardownReason,
+  ) {
+    super(message);
+  }
+}
 
 /** Bounds re-establishment so back-to-back teardowns cannot spin a caller forever. */
 const MAX_TEARDOWN_RESTARTS = 3;
@@ -124,18 +143,24 @@ export abstract class UserConnectionManager {
     userId: string,
     serverName: string,
   ): void {
-    if (!guard?.cancelled) {
+    if (!guard?.cancelledBy) {
       return;
     }
     throw new ConnectionCreationCancelledError(
       `[MCP][User: ${userId}][${serverName}] Connection creation was cancelled during teardown`,
+      guard.cancelledBy,
     );
   }
 
-  private cancelConnectionCreations(key: string, preserved?: ConnectionCreationGuard): void {
+  /** A mutation fence outranks a lifecycle one: the stale inputs stay stale either way. */
+  private cancelConnectionCreations(
+    key: string,
+    reason: ConnectionTeardownReason,
+    preserved?: ConnectionCreationGuard,
+  ): void {
     for (const guard of this.activeConnectionCreations.get(key) ?? []) {
-      if (guard !== preserved) {
-        guard.cancelled = true;
+      if (guard !== preserved && guard.cancelledBy !== 'mutation') {
+        guard.cancelledBy = reason;
       }
     }
   }
@@ -216,26 +241,29 @@ export abstract class UserConnectionManager {
     if (!this.lostToolPublicationLeases.has(connection)) {
       return;
     }
-    await this.disconnectUserConnection(userId, serverName, creationGuard);
+    await this.disconnectUserConnection(userId, serverName, { preservedCreation: creationGuard });
     throw new Error(`[MCP][User: ${userId}][${serverName}] Publication lease is no longer current`);
   }
 
   /**
    * Gets or creates a connection for a specific user, coalescing concurrent attempts.
    *
-   * A teardown fences every creation in flight for the same user and server, since those may
-   * install a connection built from the state it is removing. The caller behind one is next in
-   * line rather than stale, so a fenced attempt is discarded and re-established from scratch,
-   * against the config and connection state the teardown left behind, instead of failing.
+   * A teardown fences every creation in flight for the same user and server, since one of them
+   * may install the connection it is removing, or hand back the one it just disposed. What the
+   * fenced caller deserves depends on why the teardown ran. After a `lifecycle` teardown it is
+   * next in line rather than stale — nothing it resolved changed — so its attempt is discarded
+   * and re-established. After a `mutation` teardown the config and credentials it resolved may
+   * be the ones that were just replaced, and only the caller can resolve them again, so the
+   * fence stays fatal.
    */
   public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
-    let attemptOptions = opts;
     for (let attempt = 0; ; attempt++) {
       try {
-        return await this.establishUserConnection(attemptOptions);
+        return await this.establishUserConnection(opts);
       } catch (error) {
         if (
           !(error instanceof ConnectionCreationCancelledError) ||
+          error.reason !== 'lifecycle' ||
           attempt >= MAX_TEARDOWN_RESTARTS
         ) {
           throw error;
@@ -243,36 +271,8 @@ export abstract class UserConnectionManager {
         logger.info(
           `[MCP][User: ${opts.user?.id}][${opts.serverName}] Connection creation raced a teardown; re-establishing`,
         );
-        attemptOptions = await this.refreshFencedServerConfig(attemptOptions);
       }
     }
-  }
-
-  /**
-   * Callers hand in a config they resolved before the teardown, so a re-established attempt
-   * re-reads it: a registry-backed server picks up the committed update, and a deleted user
-   * server resolves to nothing and fails the attempt instead of reconnecting to the removed
-   * endpoint. A caller-supplied config the registry cannot resolve on its own — a config-source
-   * server not cached yet — is kept, since no user mutation removes it.
-   */
-  private async refreshFencedServerConfig(
-    opts: t.UserMCPConnectionOptions,
-  ): Promise<t.UserMCPConnectionOptions> {
-    const userId = opts.user?.id;
-    if (!userId) {
-      return opts;
-    }
-    const serverConfig = await MCPServersRegistry.getInstance().getServerConfig(
-      opts.serverName,
-      userId,
-    );
-    if (serverConfig) {
-      return { ...opts, serverConfig };
-    }
-    if (opts.serverConfig && !isUserSourced(opts.serverConfig)) {
-      return opts;
-    }
-    return { ...opts, serverConfig: undefined };
   }
 
   private async establishUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
@@ -399,7 +399,7 @@ export abstract class UserConnectionManager {
       oauthEnd: opts.oauthEnd,
       logPrefix: `[MCP][User: ${userId}][${serverName}]`,
     });
-    const creationGuard: ConnectionCreationGuard = { cancelled: false };
+    const creationGuard: ConnectionCreationGuard = { cancelledBy: null };
     this.registerConnectionCreation(lockKey, creationGuard);
     const createConnection = () =>
       this.createUserConnectionInternal(
@@ -487,7 +487,10 @@ export abstract class UserConnectionManager {
       logger.info(
         `[MCP][User: ${userId}][${serverName}] Disposing existing connection before forced replacement`,
       );
-      await this.disconnectUserConnection(userId, serverName, creationGuard);
+      await this.disconnectUserConnection(userId, serverName, {
+        preservedCreation: creationGuard,
+        reason: 'lifecycle',
+      });
       connection = undefined;
     } else if (forceNew) {
       connection = undefined;
@@ -513,7 +516,9 @@ export abstract class UserConnectionManager {
       logger.info(
         `[MCP][User: ${userId}][${serverName}] Config identity changed, disconnecting stale connection`,
       );
-      await this.disconnectUserConnection(userId, serverName, creationGuard);
+      await this.disconnectUserConnection(userId, serverName, {
+        preservedCreation: creationGuard,
+      });
       connection = undefined;
     }
     if (
@@ -525,7 +530,9 @@ export abstract class UserConnectionManager {
       logger.info(
         `[MCP][User: ${userId}][${serverName}] Cache generation changed, disconnecting stale connection`,
       );
-      await this.disconnectUserConnection(userId, serverName, creationGuard);
+      await this.disconnectUserConnection(userId, serverName, {
+        preservedCreation: creationGuard,
+      });
       connection = undefined;
     }
 
@@ -535,7 +542,10 @@ export abstract class UserConnectionManager {
       logger.info(`[MCP][User: ${userId}] User idle for too long. Disconnecting all connections.`);
       // Disconnect all user connections
       try {
-        await this.disconnectUserConnections(userId, creationGuard);
+        await this.disconnectUserConnections(userId, {
+          preservedCreation: creationGuard,
+          reason: 'lifecycle',
+        });
       } catch {
         logger.error(`[MCP][User: ${userId}] Error disconnecting idle connections`);
       }
@@ -547,7 +557,9 @@ export abstract class UserConnectionManager {
             `[MCP][User: ${userId}] Server configuration updated; disconnecting stale connection`,
           );
         }
-        await this.disconnectUserConnection(userId, serverName, creationGuard);
+        await this.disconnectUserConnection(userId, serverName, {
+          preservedCreation: creationGuard,
+        });
         connection = undefined;
       } else {
         const activeRecovery = this.getActiveConnectionRecovery(connection);
@@ -576,7 +588,10 @@ export abstract class UserConnectionManager {
           return connection;
         }
         logger.warn(`[MCP][User: ${userId}] Found disconnected connection object; cleaning up`);
-        await this.disconnectUserConnection(userId, serverName, creationGuard);
+        await this.disconnectUserConnection(userId, serverName, {
+          preservedCreation: creationGuard,
+          reason: 'lifecycle',
+        });
         connection = undefined;
       }
     }
@@ -994,15 +1009,18 @@ export abstract class UserConnectionManager {
     }
   }
 
-  /** Disconnects and removes a specific user connection */
+  /**
+   * Disconnects and removes a specific user connection. Teardowns default to `mutation`, the
+   * conservative reading for external callers, which all tear down after committing a change.
+   */
   public async disconnectUserConnection(
     userId: string,
     serverName: string,
-    preservedCreation?: ConnectionCreationGuard,
+    { preservedCreation, reason = 'mutation' }: ConnectionTeardownOptions = {},
   ): Promise<void> {
     const pendingKey = `${userId}:${serverName}`;
     const pending = this.pendingConnections.get(pendingKey);
-    this.cancelConnectionCreations(pendingKey, preservedCreation);
+    this.cancelConnectionCreations(pendingKey, reason, preservedCreation);
     if (pending && preservedCreation == null) {
       this.pendingConnections.delete(pendingKey);
     }
@@ -1024,11 +1042,11 @@ export abstract class UserConnectionManager {
   /** Disconnects and removes all connections for a specific user */
   public async disconnectUserConnections(
     userId: string,
-    preservedCreation?: ConnectionCreationGuard,
+    { preservedCreation, reason = 'mutation' }: ConnectionTeardownOptions = {},
   ): Promise<void> {
     for (const key of this.activeConnectionCreations.keys()) {
       if (key.startsWith(`${userId}:`)) {
-        this.cancelConnectionCreations(key, preservedCreation);
+        this.cancelConnectionCreations(key, reason, preservedCreation);
       }
     }
     if (preservedCreation == null) {
@@ -1045,9 +1063,11 @@ export abstract class UserConnectionManager {
       const userServers = Array.from(userMap.keys());
       for (const serverName of userServers) {
         disconnectPromises.push(
-          this.disconnectUserConnection(userId, serverName, preservedCreation).catch(() => {
-            logger.error(`[MCP][User: ${userId}] Error during server disconnection`);
-          }),
+          this.disconnectUserConnection(userId, serverName, { preservedCreation, reason }).catch(
+            () => {
+              logger.error(`[MCP][User: ${userId}] Error during server disconnection`);
+            },
+          ),
         );
       }
       await Promise.allSettled(disconnectPromises);
@@ -1077,7 +1097,7 @@ export abstract class UserConnectionManager {
           `[MCP][User: ${userId}] User idle for too long. Disconnecting all connections...`,
         );
         // Disconnect all user connections asynchronously (fire and forget)
-        this.disconnectUserConnections(userId).catch(() =>
+        this.disconnectUserConnections(userId, { reason: 'lifecycle' }).catch(() =>
           logger.error(`[MCP][User: ${userId}] Error disconnecting idle connections`),
         );
       }

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -246,38 +246,56 @@ export abstract class UserConnectionManager {
   }
 
   /**
-   * Gets or creates a connection for a specific user, coalescing concurrent attempts.
-   *
    * A teardown fences every creation in flight for the same user and server, since one of them
    * may install the connection it is removing, or hand back the one it just disposed. What the
-   * fenced caller deserves depends on why the teardown ran. After a `lifecycle` teardown it is
-   * next in line rather than stale — nothing it resolved changed — so its attempt is discarded
-   * and re-established. After a `mutation` teardown the config and credentials it resolved may
-   * be the ones that were just replaced, and only the caller can resolve them again, so the
-   * fence stays fatal. A caller that has since aborted gets neither: there is nobody left to
-   * hand the connection to.
+   * fenced attempt deserves depends on why the teardown ran. After a `lifecycle` teardown it is
+   * next in line rather than stale — nothing its caller resolved changed — so the attempt is
+   * discarded and re-established. After a `mutation` teardown the config and credentials that
+   * caller resolved may be the ones that were just replaced, and only the caller can resolve
+   * them again, so the fence stays fatal. A caller that has since aborted gets neither: there
+   * is nobody left to hand the connection to.
+   *
+   * Re-establishment happens inside the queue slot the attempt already holds, so a replacement
+   * queued behind another one keeps its position instead of moving to the tail and overwriting
+   * a newer connection later.
    */
-  public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
+  private async createUserConnectionWithLifecycleRestarts(
+    options: t.UserMCPConnectionOptions,
+    userId: string,
+    clearCooldown: boolean,
+    creationGuard: ConnectionCreationGuard,
+  ): Promise<MCPConnection> {
     for (let attempt = 0; ; attempt++) {
+      /** A lifecycle fence raised while this attempt waited its turn has nothing left to fence;
+       *  a mutation fence is kept, so the attempt below fails on it immediately. */
+      if (creationGuard.cancelledBy === 'lifecycle') {
+        creationGuard.cancelledBy = null;
+      }
       try {
-        return await this.establishUserConnection(opts);
+        return await this.createUserConnectionInternal(
+          options,
+          userId,
+          clearCooldown,
+          creationGuard,
+        );
       } catch (error) {
         if (
           !(error instanceof ConnectionCreationCancelledError) ||
           error.reason !== 'lifecycle' ||
           attempt >= MAX_TEARDOWN_RESTARTS ||
-          opts.signal?.aborted === true
+          options.signal?.aborted === true
         ) {
           throw error;
         }
         logger.info(
-          `[MCP][User: ${opts.user?.id}][${opts.serverName}] Connection creation raced a teardown; re-establishing`,
+          `[MCP][User: ${userId}][${options.serverName}] Connection creation raced a teardown; re-establishing`,
         );
       }
     }
   }
 
-  private async establishUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
+  /** Gets or creates a connection for a specific user, coalescing concurrent attempts */
+  public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
     const { serverName, forceNew, user } = opts;
     const userId = user?.id;
     if (!userId) {
@@ -404,7 +422,7 @@ export abstract class UserConnectionManager {
     const creationGuard: ConnectionCreationGuard = { cancelledBy: null };
     this.registerConnectionCreation(lockKey, creationGuard);
     const createConnection = () =>
-      this.createUserConnectionInternal(
+      this.createUserConnectionWithLifecycleRestarts(
         {
           ...opts,
           forceNew: forceNewConnection,
@@ -1028,16 +1046,26 @@ export abstract class UserConnectionManager {
     }
     const userMap = this.userConnections.get(userId);
     const connection = userMap?.get(serverName);
+    const logPrefix = `[MCP][User: ${userId}]`;
+    if (connection) {
+      logger.info(`${logPrefix} Disconnecting server connection`);
+      connection.removeAllListeners?.('toolsChanged');
+      this.removeUserConnection(userId, serverName);
+    }
+    /**
+     * Started in the same synchronous stretch as the fence: `cancelMCPToolsChanged` drops the
+     * pending publication before it awaits, so a creation re-established while this teardown
+     * is still disposing cannot have its own publication and retry timer cancelled by it.
+     */
+    const publicationCancelled = cancelMCPToolsChanged({ userId, serverName });
+    /** Observed here so a rejection cannot surface as unhandled while disposal is awaited. */
+    publicationCancelled.catch(() => undefined);
     try {
       if (connection) {
-        const logPrefix = `[MCP][User: ${userId}]`;
-        logger.info(`${logPrefix} Disconnecting server connection`);
-        connection.removeAllListeners?.('toolsChanged');
-        this.removeUserConnection(userId, serverName);
         await this.disposeEvictedConnection(connection, logPrefix);
       }
     } finally {
-      await cancelMCPToolsChanged({ userId, serverName });
+      await publicationCancelled;
     }
   }
 

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -254,7 +254,8 @@ export abstract class UserConnectionManager {
    * next in line rather than stale — nothing it resolved changed — so its attempt is discarded
    * and re-established. After a `mutation` teardown the config and credentials it resolved may
    * be the ones that were just replaced, and only the caller can resolve them again, so the
-   * fence stays fatal.
+   * fence stays fatal. A caller that has since aborted gets neither: there is nobody left to
+   * hand the connection to.
    */
   public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
     for (let attempt = 0; ; attempt++) {
@@ -264,7 +265,8 @@ export abstract class UserConnectionManager {
         if (
           !(error instanceof ConnectionCreationCancelledError) ||
           error.reason !== 'lifecycle' ||
-          attempt >= MAX_TEARDOWN_RESTARTS
+          attempt >= MAX_TEARDOWN_RESTARTS ||
+          opts.signal?.aborted === true
         ) {
           throw error;
         }
@@ -1082,7 +1084,7 @@ export abstract class UserConnectionManager {
      * timestamp: `checkIdleConnections` walks activity rather than connections, so clearing it
      * would hide that connection from every later idle sweep.
      */
-    if (!this.userConnections.has(userId)) {
+    if ((this.userConnections.get(userId)?.size ?? 0) === 0) {
       this.userLastActivity.delete(userId);
     }
   }

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -1074,13 +1074,17 @@ export abstract class UserConnectionManager {
       logger.info(`[MCP][User: ${userId}] All connections processed for disconnection.`);
     }
     /**
-     * Always clear the activity timestamp, even when userMap was missing.
-     * `updateUserLastActivity` can be called before a connection is established
-     * (e.g. in MCPManager.callTool prior to getConnection); if that connection
-     * attempt fails, the activity entry would otherwise leak and trigger the
-     * idle check repeatedly for the same userId.
+     * Clear the activity timestamp whenever nothing is left to track, including when userMap
+     * was missing. `updateUserLastActivity` can be called before a connection is established
+     * (e.g. in MCPManager.callTool prior to getConnection); if that connection attempt fails,
+     * the activity entry would otherwise leak and trigger the idle check repeatedly for the
+     * same userId. A connection installed while this teardown was disposing keeps its own
+     * timestamp: `checkIdleConnections` walks activity rather than connections, so clearing it
+     * would hide that connection from every later idle sweep.
      */
-    this.userLastActivity.delete(userId);
+    if (!this.userConnections.has(userId)) {
+      this.userLastActivity.delete(userId);
+    }
   }
 
   /** Check for and disconnect idle connections */

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3478,6 +3478,45 @@ describe('MCPManager', () => {
       expect(internals.userLastActivity.has(userId)).toBe(true);
     });
 
+    it('does not re-establish a lifecycle-fenced creation whose caller aborted', async () => {
+      const fencedConnection = newUserConnection();
+      const neverReached = newUserConnection();
+      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
+      const factoryResult = new Promise<MCPConnection>((resolve) => {
+        resolveConnection = resolve;
+      });
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      (MCPConnectionFactory.create as jest.Mock)
+        .mockReturnValueOnce(factoryResult)
+        .mockResolvedValue(neverReached);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const controller = new AbortController();
+      const creation = manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        signal: controller.signal,
+      });
+      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+
+      controller.abort();
+      await manager.disconnectUserConnection(userId, serverName, { reason: 'lifecycle' });
+      resolveConnection?.(fencedConnection);
+
+      await expect(creation).rejects.toThrow('Connection creation was cancelled during teardown');
+      expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
+      expect(MCPConnectionFactory.create).toHaveBeenCalledTimes(1);
+      expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
+    });
+
     it('fails a creation that a lifecycle teardown keeps cancelling on every attempt', async () => {
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3140,6 +3140,15 @@ describe('MCPManager', () => {
       refreshToolList: jest.fn().mockResolvedValue(undefined),
       on: jest.fn(),
     } as unknown as MCPConnection;
+    const newUserConnection = () =>
+      ({
+        isConnected: jest.fn().mockResolvedValue(true),
+        isStale: jest.fn().mockReturnValue(false),
+        refreshToolList: jest.fn().mockResolvedValue(undefined),
+        on: jest.fn(),
+        removeAllListeners: jest.fn(),
+        dispose: jest.fn().mockResolvedValue(undefined),
+      }) as unknown as MCPConnection;
 
     it('should pass useOAuth for servers with configured oauth and no requiresOAuth value', async () => {
       mockAppConnections({
@@ -3261,16 +3270,10 @@ describe('MCPManager', () => {
     });
 
     it.each([false, true])(
-      'cancels and disposes a pending connection during mutation teardown (forceNew=%s)',
+      'disposes a connection created during mutation teardown and re-establishes it (forceNew=%s)',
       async (forceNew) => {
-        const pendingConnection = {
-          isConnected: jest.fn().mockResolvedValue(true),
-          isStale: jest.fn().mockReturnValue(false),
-          refreshToolList: jest.fn().mockResolvedValue(undefined),
-          on: jest.fn(),
-          removeAllListeners: jest.fn(),
-          dispose: jest.fn().mockResolvedValue(undefined),
-        } as unknown as MCPConnection;
+        const cancelledConnection = newUserConnection();
+        const reestablishedConnection = newUserConnection();
         let resolveConnection: ((connection: MCPConnection) => void) | undefined;
         const factoryResult = new Promise<MCPConnection>((resolve) => {
           resolveConnection = resolve;
@@ -3282,7 +3285,9 @@ describe('MCPManager', () => {
           source: 'user',
           dbId: 'server-1',
         });
-        (MCPConnectionFactory.create as jest.Mock).mockReturnValue(factoryResult);
+        (MCPConnectionFactory.create as jest.Mock)
+          .mockReturnValueOnce(factoryResult)
+          .mockResolvedValue(reestablishedConnection);
 
         const manager = await MCPManager.createInstance(newMCPServersConfig());
         const creation = manager.getUserConnection({ serverName, user: mockUser, forceNew });
@@ -3291,27 +3296,141 @@ describe('MCPManager', () => {
         }
 
         await manager.disconnectUserConnection(userId, serverName);
-        resolveConnection?.(pendingConnection);
+        resolveConnection?.(cancelledConnection);
 
-        await expect(creation).rejects.toThrow('Connection creation was cancelled during teardown');
-        expect(pendingConnection.removeAllListeners).toHaveBeenCalledWith('toolsChanged');
-        expect(pendingConnection.dispose).toHaveBeenCalledTimes(1);
-        expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
+        await expect(creation).resolves.toBe(reestablishedConnection);
+        expect(cancelledConnection.removeAllListeners).toHaveBeenCalledWith('toolsChanged');
+        expect(cancelledConnection.dispose).toHaveBeenCalledTimes(1);
+        expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
       },
     );
 
+    it('resolves both callers when a forced replacement races a plain creation', async () => {
+      const original = newUserConnection();
+      const replacement = newUserConnection();
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(original);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({ serverName, user: mockUser });
+
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(replacement);
+      const results = await Promise.allSettled([
+        manager.getUserConnection({ serverName, user: mockUser, forceNew: true }),
+        manager.getUserConnection({ serverName, user: mockUser }),
+      ]);
+
+      expect(results.map((result) => result.status)).toEqual(['fulfilled', 'fulfilled']);
+      expect(manager.getUserConnections(userId)?.get(serverName)).toBe(replacement);
+      expect(original.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-establishes a creation cancelled by a user-wide idle teardown', async () => {
+      const cancelledConnection = newUserConnection();
+      const reestablishedConnection = newUserConnection();
+      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
+      const factoryResult = new Promise<MCPConnection>((resolve) => {
+        resolveConnection = resolve;
+      });
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      (MCPConnectionFactory.create as jest.Mock)
+        .mockReturnValueOnce(factoryResult)
+        .mockResolvedValue(reestablishedConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const creation = manager.getUserConnection({ serverName, user: mockUser });
+      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+
+      await manager.disconnectUserConnections(userId);
+      resolveConnection?.(cancelledConnection);
+
+      await expect(creation).resolves.toBe(reestablishedConnection);
+      expect(cancelledConnection.dispose).toHaveBeenCalledTimes(1);
+      expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
+    });
+
+    it('re-reads the server config when a teardown fences an in-flight creation', async () => {
+      const fencedConnection = newUserConnection();
+      const reestablishedConnection = newUserConnection();
+      const staleConfig: t.ParsedServerConfig = {
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/old',
+        source: 'user',
+        dbId: 'server-1',
+      };
+      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
+      const factoryResult = new Promise<MCPConnection>((resolve) => {
+        resolveConnection = resolve;
+      });
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(staleConfig);
+      (MCPConnectionFactory.create as jest.Mock)
+        .mockReturnValueOnce(factoryResult)
+        .mockResolvedValue(reestablishedConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const creation = manager.getUserConnection({ serverName, user: mockUser });
+      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        ...staleConfig,
+        url: 'https://mcp.example.com/new',
+      });
+      await manager.disconnectUserConnection(userId, serverName);
+      resolveConnection?.(fencedConnection);
+
+      await expect(creation).resolves.toBe(reestablishedConnection);
+      expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
+      expect(MCPConnectionFactory.create).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          serverConfig: expect.objectContaining({ url: 'https://mcp.example.com/new' }),
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('fails a creation that a teardown keeps cancelling on every attempt', async () => {
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      (MCPConnectionFactory.create as jest.Mock).mockReset();
+      (MCPConnectionFactory.create as jest.Mock).mockImplementation(async () => {
+        const connection = newUserConnection();
+        await manager.disconnectUserConnection(userId, serverName);
+        return connection;
+      });
+
+      await expect(manager.getUserConnection({ serverName, user: mockUser })).rejects.toThrow(
+        'Connection creation was cancelled during teardown',
+      );
+      expect(MCPConnectionFactory.create).toHaveBeenCalledTimes(4);
+      expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
+    });
+
     it('disposes the tracked durable connection before a forced replacement', async () => {
-      const createConnection = () =>
-        ({
-          isConnected: jest.fn().mockResolvedValue(true),
-          isStale: jest.fn().mockReturnValue(false),
-          refreshToolList: jest.fn().mockResolvedValue(undefined),
-          on: jest.fn(),
-          removeAllListeners: jest.fn(),
-          dispose: jest.fn().mockResolvedValue(undefined),
-        }) as unknown as MCPConnection;
-      const previousConnection = createConnection();
-      const replacementConnection = createConnection();
+      const previousConnection = newUserConnection();
+      const replacementConnection = newUserConnection();
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
         type: 'streamable-http',
@@ -3341,18 +3460,9 @@ describe('MCPManager', () => {
     });
 
     it('serializes an ordinary load with multiple queued forced replacements', async () => {
-      const createConnection = () =>
-        ({
-          isConnected: jest.fn().mockResolvedValue(true),
-          isStale: jest.fn().mockReturnValue(false),
-          refreshToolList: jest.fn().mockResolvedValue(undefined),
-          on: jest.fn(),
-          removeAllListeners: jest.fn(),
-          dispose: jest.fn().mockResolvedValue(undefined),
-        }) as unknown as MCPConnection;
-      const initial = createConnection();
-      const firstReplacement = createConnection();
-      const secondReplacement = createConnection();
+      const initial = newUserConnection();
+      const firstReplacement = newUserConnection();
+      const secondReplacement = newUserConnection();
       let resolveFirst: ((connection: MCPConnection) => void) | undefined;
       let resolveSecond: ((connection: MCPConnection) => void) | undefined;
       const firstFactoryResult = new Promise<MCPConnection>((resolve) => {
@@ -3702,7 +3812,7 @@ describe('MCPManager', () => {
       }
     });
 
-    it('does not return a reused connection cancelled while its lease renewal is pending', async () => {
+    it('re-establishes a reused connection cancelled while its lease renewal is pending', async () => {
       const generationSpy = jest
         .spyOn(toolsChanged, 'getMCPToolsChangedGeneration')
         .mockResolvedValue('generation-a');
@@ -3727,9 +3837,12 @@ describe('MCPManager', () => {
         source: 'yaml',
         startup: false,
       };
+      const reestablishedConnection = newUserConnection();
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(serverConfig);
-      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(connection);
+      (MCPConnectionFactory.create as jest.Mock)
+        .mockResolvedValueOnce(connection)
+        .mockResolvedValue(reestablishedConnection);
 
       try {
         const manager = await MCPManager.createInstance(newMCPServersConfig());
@@ -3748,8 +3861,9 @@ describe('MCPManager', () => {
         await manager.disconnectUserConnection(userId, serverName);
         resolveRenewal?.(true);
 
-        await expect(reuse).rejects.toThrow('Connection creation was cancelled during teardown');
+        await expect(reuse).resolves.toBe(reestablishedConnection);
         expect(connection.dispose).toHaveBeenCalled();
+        expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
       } finally {
         generationSpy.mockRestore();
         renewalSpy.mockRestore();

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3517,6 +3517,36 @@ describe('MCPManager', () => {
       expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
     });
 
+    it('cancels pending tool publications before it starts disposing', async () => {
+      const connection = newUserConnection();
+      const cancelSpy = jest.spyOn(toolsChanged, 'cancelMCPToolsChanged');
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(connection);
+
+      try {
+        const manager = await MCPManager.createInstance(newMCPServersConfig());
+        await manager.getUserConnection({ serverName, user: mockUser });
+        cancelSpy.mockClear();
+
+        await manager.disconnectUserConnection(userId, serverName);
+
+        /** A creation re-established while disposal is still awaited publishes its own catalog;
+         *  a cancellation issued after that point would drop the replacement's pending change. */
+        expect(cancelSpy).toHaveBeenCalledWith({ userId, serverName });
+        expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+          (connection.dispose as jest.Mock).mock.invocationCallOrder[0],
+        );
+      } finally {
+        cancelSpy.mockRestore();
+      }
+    });
+
     it('fails a creation that a lifecycle teardown keeps cancelling on every attempt', async () => {
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3363,7 +3363,7 @@ describe('MCPManager', () => {
       expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
     });
 
-    it('re-reads the server config when a teardown fences an in-flight creation', async () => {
+    it('re-reads the committed config when a teardown fences a caller-resolved creation', async () => {
       const fencedConnection = newUserConnection();
       const reestablishedConnection = newUserConnection();
       const staleConfig: t.ParsedServerConfig = {
@@ -3383,7 +3383,12 @@ describe('MCPManager', () => {
         .mockResolvedValue(reestablishedConnection);
 
       const manager = await MCPManager.createInstance(newMCPServersConfig());
-      const creation = manager.getUserConnection({ serverName, user: mockUser });
+      /** `MCPManager.getConnection` resolves the config once and hands it to every attempt. */
+      const creation = manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        serverConfig: staleConfig,
+      });
       while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
         await new Promise((resolve) => setImmediate(resolve));
       }
@@ -3401,6 +3406,81 @@ describe('MCPManager', () => {
         expect.objectContaining({
           serverConfig: expect.objectContaining({ url: 'https://mcp.example.com/new' }),
         }),
+        expect.anything(),
+      );
+    });
+
+    it('fails a fenced creation whose user server was deleted during the teardown', async () => {
+      const fencedConnection = newUserConnection();
+      const deletedConfig: t.ParsedServerConfig = {
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/deleted',
+        source: 'user',
+        dbId: 'server-1',
+      };
+      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
+      const factoryResult = new Promise<MCPConnection>((resolve) => {
+        resolveConnection = resolve;
+      });
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(deletedConfig);
+      (MCPConnectionFactory.create as jest.Mock).mockReturnValue(factoryResult);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const creation = manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        serverConfig: deletedConfig,
+      });
+      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(undefined);
+      await manager.disconnectUserConnection(userId, serverName);
+      resolveConnection?.(fencedConnection);
+
+      await expect(creation).rejects.toThrow(`Configuration for server "${serverName}" not found`);
+      expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
+      expect(MCPConnectionFactory.create).toHaveBeenCalledTimes(1);
+      expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
+    });
+
+    it('keeps a config-source config the registry cannot resolve when re-establishing', async () => {
+      const fencedConnection = newUserConnection();
+      const reestablishedConnection = newUserConnection();
+      const configSourced: t.ParsedServerConfig = {
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/config-sourced',
+        source: 'config',
+      };
+      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
+      const factoryResult = new Promise<MCPConnection>((resolve) => {
+        resolveConnection = resolve;
+      });
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(undefined);
+      (MCPConnectionFactory.create as jest.Mock)
+        .mockReturnValueOnce(factoryResult)
+        .mockResolvedValue(reestablishedConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      const creation = manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        serverConfig: configSourced,
+      });
+      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+
+      await manager.disconnectUserConnection(userId, serverName);
+      resolveConnection?.(fencedConnection);
+
+      await expect(creation).resolves.toBe(reestablishedConnection);
+      expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
+      expect(MCPConnectionFactory.create).toHaveBeenLastCalledWith(
+        expect.objectContaining({ serverConfig: expect.objectContaining(configSourced) }),
         expect.anything(),
       );
     });

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3432,6 +3432,52 @@ describe('MCPManager', () => {
       expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
     });
 
+    it('keeps the activity timestamp for a connection installed during a user-wide teardown', async () => {
+      const otherServer = 'other_server';
+      const installedConnection = newUserConnection();
+      let resolveDispose: (() => void) | undefined;
+      (installedConnection.dispose as jest.Mock).mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveDispose = () => resolve();
+        }),
+      );
+      const fencedConnection = newUserConnection();
+      const reestablishedConnection = newUserConnection();
+      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
+      const factoryResult = new Promise<MCPConnection>((resolve) => {
+        resolveConnection = resolve;
+      });
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      (MCPConnectionFactory.create as jest.Mock)
+        .mockResolvedValueOnce(installedConnection)
+        .mockReturnValueOnce(factoryResult)
+        .mockResolvedValue(reestablishedConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({ serverName, user: mockUser });
+      const creation = manager.getUserConnection({ serverName: otherServer, user: mockUser });
+      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length < 2) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+
+      /** The sweep is still disposing the first connection when the fenced one re-establishes. */
+      const teardown = manager.disconnectUserConnections(userId, { reason: 'lifecycle' });
+      resolveConnection?.(fencedConnection);
+      await expect(creation).resolves.toBe(reestablishedConnection);
+      resolveDispose?.();
+      await teardown;
+
+      const internals = manager as unknown as { userLastActivity: Map<string, number> };
+      expect(manager.getUserConnections(userId)?.get(otherServer)).toBe(reestablishedConnection);
+      expect(internals.userLastActivity.has(userId)).toBe(true);
+    });
+
     it('fails a creation that a lifecycle teardown keeps cancelling on every attempt', async () => {
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -3270,10 +3270,10 @@ describe('MCPManager', () => {
     });
 
     it.each([false, true])(
-      'disposes a connection created during mutation teardown and re-establishes it (forceNew=%s)',
+      'cancels and disposes a pending connection during mutation teardown (forceNew=%s)',
       async (forceNew) => {
-        const cancelledConnection = newUserConnection();
-        const reestablishedConnection = newUserConnection();
+        const pendingConnection = newUserConnection();
+        const neverReached = newUserConnection();
         let resolveConnection: ((connection: MCPConnection) => void) | undefined;
         const factoryResult = new Promise<MCPConnection>((resolve) => {
           resolveConnection = resolve;
@@ -3287,7 +3287,7 @@ describe('MCPManager', () => {
         });
         (MCPConnectionFactory.create as jest.Mock)
           .mockReturnValueOnce(factoryResult)
-          .mockResolvedValue(reestablishedConnection);
+          .mockResolvedValue(neverReached);
 
         const manager = await MCPManager.createInstance(newMCPServersConfig());
         const creation = manager.getUserConnection({ serverName, user: mockUser, forceNew });
@@ -3296,12 +3296,14 @@ describe('MCPManager', () => {
         }
 
         await manager.disconnectUserConnection(userId, serverName);
-        resolveConnection?.(cancelledConnection);
+        resolveConnection?.(pendingConnection);
 
-        await expect(creation).resolves.toBe(reestablishedConnection);
-        expect(cancelledConnection.removeAllListeners).toHaveBeenCalledWith('toolsChanged');
-        expect(cancelledConnection.dispose).toHaveBeenCalledTimes(1);
-        expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
+        await expect(creation).rejects.toThrow('Connection creation was cancelled during teardown');
+        expect(pendingConnection.removeAllListeners).toHaveBeenCalledWith('toolsChanged');
+        expect(pendingConnection.dispose).toHaveBeenCalledTimes(1);
+        expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
+        /** A committed mutation invalidates what the caller resolved, so nothing re-establishes. */
+        expect(MCPConnectionFactory.create).toHaveBeenCalledTimes(1);
       },
     );
 
@@ -3331,7 +3333,34 @@ describe('MCPManager', () => {
       expect(original.dispose).toHaveBeenCalledTimes(1);
     });
 
-    it('re-establishes a creation cancelled by a user-wide idle teardown', async () => {
+    it('tears down idle users with a lifecycle teardown', async () => {
+      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://mcp.example.com/mcp',
+        source: 'user',
+        dbId: 'server-1',
+      });
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(newUserConnection());
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({ serverName, user: mockUser });
+      const internals = manager as unknown as {
+        userLastActivity: Map<string, number>;
+        checkIdleConnections(currentUserId?: string): void;
+      };
+      internals.userLastActivity.set(userId, 0);
+      const disconnectSpy = jest
+        .spyOn(manager, 'disconnectUserConnections')
+        .mockResolvedValue(undefined);
+
+      internals.checkIdleConnections();
+
+      expect(disconnectSpy).toHaveBeenCalledWith(userId, { reason: 'lifecycle' });
+      disconnectSpy.mockRestore();
+    });
+
+    it('re-establishes a creation cancelled by a user-wide lifecycle teardown', async () => {
       const cancelledConnection = newUserConnection();
       const reestablishedConnection = newUserConnection();
       let resolveConnection: ((connection: MCPConnection) => void) | undefined;
@@ -3355,20 +3384,19 @@ describe('MCPManager', () => {
         await new Promise((resolve) => setImmediate(resolve));
       }
 
-      await manager.disconnectUserConnections(userId);
+      await manager.disconnectUserConnections(userId, { reason: 'lifecycle' });
       resolveConnection?.(cancelledConnection);
 
       await expect(creation).resolves.toBe(reestablishedConnection);
       expect(cancelledConnection.dispose).toHaveBeenCalledTimes(1);
       expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
     });
-
-    it('re-reads the committed config when a teardown fences a caller-resolved creation', async () => {
+    it('fails a caller-resolved creation fenced by a credential mutation', async () => {
       const fencedConnection = newUserConnection();
-      const reestablishedConnection = newUserConnection();
-      const staleConfig: t.ParsedServerConfig = {
+      const neverReached = newUserConnection();
+      const serverConfig: t.ParsedServerConfig = {
         type: 'streamable-http',
-        url: 'https://mcp.example.com/old',
+        url: 'https://mcp.example.com/mcp',
         source: 'user',
         dbId: 'server-1',
       };
@@ -3377,115 +3405,34 @@ describe('MCPManager', () => {
         resolveConnection = resolve;
       });
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
-      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(staleConfig);
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(serverConfig);
       (MCPConnectionFactory.create as jest.Mock)
         .mockReturnValueOnce(factoryResult)
-        .mockResolvedValue(reestablishedConnection);
+        .mockResolvedValue(neverReached);
 
       const manager = await MCPManager.createInstance(newMCPServersConfig());
-      /** `MCPManager.getConnection` resolves the config once and hands it to every attempt. */
+      /** Callers resolve the config and credentials per request and hand them in; a mutation
+       *  teardown invalidates both, and only the caller can resolve them again. */
       const creation = manager.getUserConnection({
         serverName,
         user: mockUser,
-        serverConfig: staleConfig,
+        serverConfig,
+        customUserVars: { API_KEY: 'revoked-key' },
       });
       while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
         await new Promise((resolve) => setImmediate(resolve));
       }
 
-      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
-        ...staleConfig,
-        url: 'https://mcp.example.com/new',
-      });
       await manager.disconnectUserConnection(userId, serverName);
       resolveConnection?.(fencedConnection);
 
-      await expect(creation).resolves.toBe(reestablishedConnection);
-      expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
-      expect(MCPConnectionFactory.create).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          serverConfig: expect.objectContaining({ url: 'https://mcp.example.com/new' }),
-        }),
-        expect.anything(),
-      );
-    });
-
-    it('fails a fenced creation whose user server was deleted during the teardown', async () => {
-      const fencedConnection = newUserConnection();
-      const deletedConfig: t.ParsedServerConfig = {
-        type: 'streamable-http',
-        url: 'https://mcp.example.com/deleted',
-        source: 'user',
-        dbId: 'server-1',
-      };
-      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
-      const factoryResult = new Promise<MCPConnection>((resolve) => {
-        resolveConnection = resolve;
-      });
-      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
-      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(deletedConfig);
-      (MCPConnectionFactory.create as jest.Mock).mockReturnValue(factoryResult);
-
-      const manager = await MCPManager.createInstance(newMCPServersConfig());
-      const creation = manager.getUserConnection({
-        serverName,
-        user: mockUser,
-        serverConfig: deletedConfig,
-      });
-      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
-        await new Promise((resolve) => setImmediate(resolve));
-      }
-
-      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(undefined);
-      await manager.disconnectUserConnection(userId, serverName);
-      resolveConnection?.(fencedConnection);
-
-      await expect(creation).rejects.toThrow(`Configuration for server "${serverName}" not found`);
+      await expect(creation).rejects.toThrow('Connection creation was cancelled during teardown');
       expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
       expect(MCPConnectionFactory.create).toHaveBeenCalledTimes(1);
       expect(manager.getUserConnections(userId)?.has(serverName) ?? false).toBe(false);
     });
 
-    it('keeps a config-source config the registry cannot resolve when re-establishing', async () => {
-      const fencedConnection = newUserConnection();
-      const reestablishedConnection = newUserConnection();
-      const configSourced: t.ParsedServerConfig = {
-        type: 'streamable-http',
-        url: 'https://mcp.example.com/config-sourced',
-        source: 'config',
-      };
-      let resolveConnection: ((connection: MCPConnection) => void) | undefined;
-      const factoryResult = new Promise<MCPConnection>((resolve) => {
-        resolveConnection = resolve;
-      });
-      mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
-      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(undefined);
-      (MCPConnectionFactory.create as jest.Mock)
-        .mockReturnValueOnce(factoryResult)
-        .mockResolvedValue(reestablishedConnection);
-
-      const manager = await MCPManager.createInstance(newMCPServersConfig());
-      const creation = manager.getUserConnection({
-        serverName,
-        user: mockUser,
-        serverConfig: configSourced,
-      });
-      while ((MCPConnectionFactory.create as jest.Mock).mock.calls.length === 0) {
-        await new Promise((resolve) => setImmediate(resolve));
-      }
-
-      await manager.disconnectUserConnection(userId, serverName);
-      resolveConnection?.(fencedConnection);
-
-      await expect(creation).resolves.toBe(reestablishedConnection);
-      expect(fencedConnection.dispose).toHaveBeenCalledTimes(1);
-      expect(MCPConnectionFactory.create).toHaveBeenLastCalledWith(
-        expect.objectContaining({ serverConfig: expect.objectContaining(configSourced) }),
-        expect.anything(),
-      );
-    });
-
-    it('fails a creation that a teardown keeps cancelling on every attempt', async () => {
+    it('fails a creation that a lifecycle teardown keeps cancelling on every attempt', async () => {
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
         type: 'streamable-http',
@@ -3497,7 +3444,7 @@ describe('MCPManager', () => {
       (MCPConnectionFactory.create as jest.Mock).mockReset();
       (MCPConnectionFactory.create as jest.Mock).mockImplementation(async () => {
         const connection = newUserConnection();
-        await manager.disconnectUserConnection(userId, serverName);
+        await manager.disconnectUserConnection(userId, serverName, { reason: 'lifecycle' });
         return connection;
       });
 
@@ -3892,7 +3839,7 @@ describe('MCPManager', () => {
       }
     });
 
-    it('re-establishes a reused connection cancelled while its lease renewal is pending', async () => {
+    it('does not return a reused connection cancelled while its lease renewal is pending', async () => {
       const generationSpy = jest
         .spyOn(toolsChanged, 'getMCPToolsChangedGeneration')
         .mockResolvedValue('generation-a');
@@ -3917,12 +3864,9 @@ describe('MCPManager', () => {
         source: 'yaml',
         startup: false,
       };
-      const reestablishedConnection = newUserConnection();
       mockAppConnections({ has: jest.fn().mockResolvedValue(false) });
       (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue(serverConfig);
-      (MCPConnectionFactory.create as jest.Mock)
-        .mockResolvedValueOnce(connection)
-        .mockResolvedValue(reestablishedConnection);
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(connection);
 
       try {
         const manager = await MCPManager.createInstance(newMCPServersConfig());
@@ -3941,9 +3885,8 @@ describe('MCPManager', () => {
         await manager.disconnectUserConnection(userId, serverName);
         resolveRenewal?.(true);
 
-        await expect(reuse).resolves.toBe(reestablishedConnection);
+        await expect(reuse).rejects.toThrow('Connection creation was cancelled during teardown');
         expect(connection.dispose).toHaveBeenCalled();
-        expect(manager.getUserConnections(userId)?.get(serverName)).toBe(reestablishedConnection);
       } finally {
         generationSpy.mockRestore();
         renewalSpy.mockRestore();

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.test.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.test.ts
@@ -255,7 +255,9 @@ describe('OAuthReconnectionManager', () => {
       // Verify failure handling
       expect(reconnectionTracker.isFailed(userId, 'server1')).toBe(true);
       expect(reconnectionTracker.isActive(userId, 'server1')).toBe(false);
-      expect(mockMCPManager.disconnectUserConnection).toHaveBeenCalledWith(userId, 'server1');
+      expect(mockMCPManager.disconnectUserConnection).toHaveBeenCalledWith(userId, 'server1', {
+        reason: 'lifecycle',
+      });
     });
 
     it('should not reconnect servers with expired tokens and no refresh token', async () => {
@@ -394,7 +396,9 @@ describe('OAuthReconnectionManager', () => {
       expect(mockConnection.disconnect).toHaveBeenCalled();
       expect(reconnectionTracker.isFailed(userId, 'server1')).toBe(true);
       expect(reconnectionTracker.isActive(userId, 'server1')).toBe(false);
-      expect(mockMCPManager.disconnectUserConnection).toHaveBeenCalledWith(userId, 'server1');
+      expect(mockMCPManager.disconnectUserConnection).toHaveBeenCalledWith(userId, 'server1', {
+        reason: 'lifecycle',
+      });
     });
 
     it('should handle MCPManager not available gracefully', async () => {
@@ -661,7 +665,9 @@ describe('OAuthReconnectionManager', () => {
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to reconnect'));
       expect(reconnectionTracker.isActive(userId, 'server1')).toBe(false);
       expect(reconnectionTracker.isFailed(userId, 'server1')).toBe(true);
-      expect(mockMCPManager.disconnectUserConnection).toHaveBeenCalledWith(userId, 'server1');
+      expect(mockMCPManager.disconnectUserConnection).toHaveBeenCalledWith(userId, 'server1', {
+        reason: 'lifecycle',
+      });
     });
   });
 

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
@@ -134,7 +134,7 @@ export class OAuthReconnectionManager {
   private cleanupOnFailedReconnect(userId: string, serverName: string): void {
     this.reconnectionsTracker.setFailed(userId, serverName);
     this.reconnectionsTracker.removeActive(userId, serverName);
-    this.mcpManager?.disconnectUserConnection(userId, serverName);
+    this.mcpManager?.disconnectUserConnection(userId, serverName, { reason: 'lifecycle' });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #15329. Concurrent MCP tool calls for the same user and server failed with `Connection creation was cancelled during teardown` whenever a teardown raced them, and an immediate manual retry always succeeded.

Every `getUserConnection` registers a `ConnectionCreationGuard` under `${userId}:${serverName}`, and any teardown of that key cancels every registered guard except the one that requested it. The registry that holds them is documented as "visible to mutation teardown" — and that is the bug: it is armed by *every* teardown, including routine lifecycle ones that invalidate nothing. A forced reconnect, the idle sweeper and a dead-connection cleanup all failed whatever else was in flight for that user, which is why retrying by hand worked every time.

The fence itself is right — an in-flight creation may install a connection the teardown is removing, or hand back the one it just disposed. What the fenced caller deserves depends on why the teardown ran, so the teardown now says so:

- **`mutation`** — the default, and what every external caller gets — follows a committed config or credential change (`updateMCPServerController`, `deleteMCPServerController`, `updateUserPluginsController`, `deleteUserMcpServers`, the disconnect route). Whatever the caller resolved before it may be the thing that was just replaced, and the config (with the request's `configServers` overlay) and credentials (`customUserVars`) are resolved in the api layer, so the manager cannot re-resolve them. The fence stays fatal exactly as it is today and the caller resolves again on its next request.
- **`lifecycle`** — a forced replacement, an idle sweep, a dead connection cleaned up, a failed OAuth reconnect — changes neither config nor credentials. The fenced attempt is discarded and re-established from the same options, bounded at 3 re-establishments so back-to-back teardowns cannot spin a caller forever.

That covers the triggers in the report: the forced reconnect from `reinitMCPServer({ forceNew: true })` and the idle sweeper's `disconnectUserConnections`, which between them account for the failures under concurrent tool use.

- Replaced the guard's `cancelled` boolean with `cancelledBy: ConnectionTeardownReason | null`, a mutation fence outranking a lifecycle one.
- Hoisted the five duplicated guard checks in `createUserConnectionInternal` into `assertCreationNotCancelled`, which throws a typed `ConnectionCreationCancelledError` carrying the reason.
- Gave `disconnectUserConnection` / `disconnectUserConnections` an options object (`preservedCreation`, `reason`), defaulting to `mutation`; external JS callers are unchanged.
- Classified the internal teardowns: forced replacement, in-creation idle sweep, dead-connection cleanup, `checkIdleConnections` and `OAuthReconnectionManager`'s failed-reconnect cleanup are `lifecycle`; stale config identity, rotated cache generation, updated/missing config and a lost publication lease stay `mutation`.

Re-establishment happens **inside the queue slot the attempt already holds**, so a replacement fenced while queued keeps its position instead of moving to the tail of `forceNewConnectionQueues` and later overwriting a newer connection with an older caller-resolved config. A lifecycle fence raised while an attempt waited its turn is cleared as it starts; a mutation fence is kept, so it still fails immediately. Callers that joined through `pendingConnections` ride the same shared promise and see the re-established result rather than a rejection.

Three ordering edges around that, each found while reviewing the change:

- `disconnectUserConnections` cleared the user's activity timestamp unconditionally, so a connection installed while the sweep was still disposing kept its map entry but lost its timestamp — invisible to `checkIdleConnections`, which walks activity rather than connections. It now clears only when the user has no connections left, which still drops an entry written before a failed attempt.
- `disconnectUserConnection` cancelled pending tool publications *after* awaiting disposal, so a creation re-established inside that window could have its own publication and retry timer dropped. `cancelMCPToolsChanged` deletes before its only await, so it is now issued in the teardown's synchronous stretch and awaited at the end.
- A caller that aborted while its creation was fenced no longer re-establishes; there is nobody left to hand the connection to.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added coverage in `packages/api/src/mcp/__tests__/MCPManager.test.ts`, including @sisve's repro from the issue verbatim:

- `resolves both callers when a forced replacement races a plain creation` — the reported repro; fails on `dev`, passes here.
- `re-establishes a creation cancelled by a user-wide lifecycle teardown` and `tears down idle users with a lifecycle teardown` — the idle-sweeper trigger, and the wiring that classifies it.
- `fails a creation that a lifecycle teardown keeps cancelling on every attempt` — pins the re-establishment bound at 4 attempts.
- `cancels and disposes a pending connection during mutation teardown (forceNew=false|true)` and `does not return a reused connection cancelled while its lease renewal is pending` — unchanged behavior for mutation teardowns, now also asserting that nothing is re-established behind them.
- `fails a caller-resolved creation fenced by a credential mutation` — a creation carrying `customUserVars` fenced by a credential mutation rejects rather than re-establishing with revoked credentials.
- `keeps the activity timestamp for a connection installed during a user-wide teardown` — holds the sweep open on a controlled `dispose()` and asserts the surviving timestamp.
- `cancels pending tool publications before it starts disposing` — pins the cancellation ordering on invocation order.
- `does not re-establish a lifecycle-fenced creation whose caller aborted`.

Each new test was verified to fail against the code without its fix.

### **Test Configuration**:

```bash
cd packages/api && npx jest src/mcp/__tests__/MCPManager.test.ts   # 119 passed
cd packages/api && npx jest src/mcp/__tests__ src/mcp/oauth        # 1274 passed
cd packages/api && npx tsc --noEmit -p tsconfig.json
npx eslint packages/api/src/mcp/UserConnectionManager.ts packages/api/src/mcp/__tests__/MCPManager.test.ts
```

Local caveat: the Redis- and Mongo-backed suites cannot run in this environment (no Redis, and the `mongodb-memory-server` binary download is blocked); they fail identically on a clean tree. Both `MCP list_changed` replica jobs pass in CI.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes