### PR TITLE
👔 fix: Route Flux Finetuned Endpoints Regardless of Action

### DIFF
--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -91,6 +91,9 @@ const fluxApiJsonSchema = {
 const displayMessage =
   "Flux displayed an image. All generated images are already plainly visible, so don't repeat the descriptions in detail. Do not list download links as they are available in the UI already. The user may download the images by clicking on them, but do not mention anything about downloading to the user.";
 
+/** Endpoints that require a `finetune_id`, regardless of which `action` the caller selected. */
+const FINETUNED_ENDPOINTS = ['/v1/flux-pro-finetuned', '/v1/flux-pro-1.1-ultra-finetuned'];
+
 /**
  * FluxAPI - A tool for generating high-quality images from text prompts using the Flux API.
  * Each call generates one image. If multiple images are needed, make multiple consecutive calls with the same or varied prompts.
@@ -200,8 +203,9 @@ class FluxAPI extends Tool {
       return this.getMyFinetunes(requestApiKey);
     }
 
-    // Handle finetuned generation
-    if (action === 'generate_finetuned') {
+    // Handle finetuned generation. Route by endpoint too, since a finetuned
+    // endpoint requires finetune_id regardless of which action was selected.
+    if (action === 'generate_finetuned' || FINETUNED_ENDPOINTS.includes(imageData.endpoint)) {
       return this.generateFinetunedImage(imageData, requestApiKey);
     }
 
@@ -434,12 +438,11 @@ class FluxAPI extends Tool {
     }
 
     // Validate endpoint is appropriate for finetuned generation
-    const validFinetunedEndpoints = ['/v1/flux-pro-finetuned', '/v1/flux-pro-1.1-ultra-finetuned'];
     const endpoint = imageData.endpoint || '/v1/flux-pro-finetuned';
 
-    if (!validFinetunedEndpoints.includes(endpoint)) {
+    if (!FINETUNED_ENDPOINTS.includes(endpoint)) {
       throw new Error(
-        `Invalid endpoint for finetuned generation. Must be one of: ${validFinetunedEndpoints.join(', ')}`,
+        `Invalid endpoint for finetuned generation. Must be one of: ${FINETUNED_ENDPOINTS.join(', ')}`,
       );
     }
 

--- a/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
+++ b/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
@@ -338,6 +338,51 @@ describe('image tools - agent mode ToolMessage format', () => {
       expect(contentStr).toContain('Something went wrong');
       expect(result.artifact).toBeDefined();
     });
+
+    it('routes a finetuned endpoint through generateFinetunedImage even when action is left as "generate"', async () => {
+      const flux = new FluxAPI({ isAgent: true });
+      const invokePromise = flux.invoke(
+        makeToolCall('flux', {
+          prompt: 'a box',
+          endpoint: '/v1/flux-pro-finetuned',
+          finetune_id: 'ft-abc123',
+          finetune_strength: 0.8,
+          guidance: 3,
+        }),
+      );
+      await jest.runAllTimersAsync();
+      const result = await invokePromise;
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining('/v1/flux-pro-finetuned'),
+        expect.objectContaining({
+          finetune_id: 'ft-abc123',
+          finetune_strength: 0.8,
+          guidance: 3,
+        }),
+        expect.anything(),
+      );
+
+      expect(result).toBeInstanceOf(ToolMessage);
+      expect(result.artifact).toBeDefined();
+      const artifactContent = result.artifact?.content;
+      expect(Array.isArray(artifactContent)).toBe(true);
+      expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
+      expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+
+    it('rejects a finetuned endpoint without finetune_id even when action is left as "generate"', async () => {
+      const flux = new FluxAPI({ isAgent: true });
+
+      await expect(
+        flux.invoke(
+          makeToolCall('flux', {
+            prompt: 'a box',
+            endpoint: '/v1/flux-pro-finetuned',
+          }),
+        ),
+      ).rejects.toThrow(/finetune_id/);
+    });
   });
 
   describe('StableDiffusion', () => {


### PR DESCRIPTION
## Summary

- `FluxAPI._call()` only dispatched to `generateFinetunedImage()` when `action` was explicitly `"generate_finetuned"`. The tool's schema exposes `endpoint`, `finetune_id`, `finetune_strength`, and `guidance` as top-level parameters regardless of `action`, so a model could set `endpoint: '/v1/flux-pro-finetuned'` (or the ultra variant) while leaving `action` at its default (`"generate"`).
- In that case the request went through the plain `generate` payload path, which never reads `finetune_id`/`finetune_strength`/`guidance`. The finetune was silently dropped, and a finetuned endpoint got called without its required `finetune_id`.
- This PR routes by `endpoint` as well as `action`, so a finetuned endpoint always goes through `generateFinetunedImage()`'s existing validation (which already requires `finetune_id` and forwards `finetune_strength`/`guidance` correctly). The finetuned-endpoint list is now a single shared constant instead of being duplicated.
- Fixes #15335.

This is a different bug from #6953 (which was about finetuned images not being displayed to agents at all, due to a missing `isAgent` branch in `generateFinetunedImage()`; that one was already fixed by #12310 and is covered by the existing regression tests in `imageTools-agent.spec.js`). While investigating #6953 I found this separate parameter-forwarding gap in the same file and filed #15335 for it.

## Test plan

- [x] Added two tests to `api/app/clients/tools/structured/specs/imageTools-agent.spec.js`:
  - a finetuned endpoint plus `finetune_id` with `action` left as the default `"generate"` is routed through `generateFinetunedImage()` and forwards `finetune_id`/`finetune_strength`/`guidance` in the outgoing payload.
  - a finetuned endpoint without `finetune_id` (again with default `action`) rejects with the existing "Missing required field: finetune_id" error.
- [x] `cd api && npx jest app/clients/tools`: 108/108 passing (no regressions in existing DALLE3/StableDiffusion/Flux/handleTools coverage).
- [x] `npx eslint` and `npx prettier --check` on both changed files: clean.