### PR TITLE
📦 chore: bump `@librechat/agents` to v3.7.8

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.7",
+    "@librechat/agents": "^3.7.8",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.7",
+        "@librechat/agents": "^3.7.8",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10633,9 +10633,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.7.tgz",
-      "integrity": "sha512-3gDBoZodm2CZnwCjiYMI3KzYYwvP2M8k/pumj72eAd6u777oydV1NTXa6gQx1MvwQVaWyXztMWeg64TT31XQVA==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.7.8.tgz",
+      "integrity": "sha512-XLUnZaGdPovtwXAc1SxSfUmQi/D4zu6hNRpEoqfLIF4QkA8DOV8wj6ruztuPR4bbMOP1dBze8wqmHEUNVM4zdw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
@@ -42838,7 +42838,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^2.8.0",
         "@keyv/redis": "5.1.6",
-        "@librechat/agents": "^3.7.7",
+        "@librechat/agents": "^3.7.8",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -113,7 +113,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^2.8.0",
     "@keyv/redis": "5.1.6",
-    "@librechat/agents": "^3.7.7",
+    "@librechat/agents": "^3.7.8",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary

Bumps `@librechat/agents` from 3.7.7 to 3.7.8 in both backend workspaces. This brings in the bounded compaction semantic index, suspended event-actor invocation serialization, the empty-summary-loop guard, and honest output-truncation halt signaling.

The package is published on npm and the lockfile resolves the exact 3.7.8 artifact.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm install --package-lock-only --ignore-scripts`
- `git diff --check`
- Confirmed npm reports `@librechat/agents` 3.7.8

### **Test Configuration**:

- Node/npm lockfile resolution on macOS

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.