### PR TITLE
📭 fix: Drop Empty Summary Parts Before Persistence

### DIFF
--- a/packages/api/src/utils/content.spec.ts
+++ b/packages/api/src/utils/content.spec.ts
@@ -45,6 +45,41 @@ describe('filterMalformedContentParts', () => {
       expect(result).toEqual(parts);
     });
 
+    it('filters empty summary parts before persistence', () => {
+      const parts = [
+        { type: ContentTypes.SUMMARY },
+        { type: ContentTypes.SUMMARY, content: [] },
+        { type: ContentTypes.SUMMARY, content: [{ type: ContentTypes.TEXT, text: '   ' }] },
+        { type: ContentTypes.SUMMARY, text: '\n\t' },
+        { type: ContentTypes.TEXT, text: 'Final answer' },
+      ] as TMessageContentParts[];
+
+      expect(filterMalformedContentParts(parts)).toEqual([
+        { type: ContentTypes.TEXT, text: 'Final answer' },
+      ]);
+    });
+
+    it('keeps current and legacy summary parts that contain text', () => {
+      const current = {
+        type: ContentTypes.SUMMARY,
+        content: [{ type: ContentTypes.TEXT, text: 'Current summary' }],
+      };
+      const legacyContent = {
+        type: ContentTypes.SUMMARY,
+        content: 'Legacy content summary',
+      };
+      const legacyText = {
+        type: ContentTypes.SUMMARY,
+        text: 'Legacy text summary',
+      };
+
+      expect(filterMalformedContentParts([current, legacyContent, legacyText])).toEqual([
+        current,
+        legacyContent,
+        legacyText,
+      ]);
+    });
+
     it('should filter out null or undefined parts', () => {
       const parts = [
         { type: ContentTypes.TEXT, text: 'Valid' },

--- a/packages/api/src/utils/content.ts
+++ b/packages/api/src/utils/content.ts
@@ -2,6 +2,27 @@ import { ContentTypes } from 'librechat-data-provider';
 import type { TMessageContentParts } from 'librechat-data-provider';
 
 type ActivityLabelPart = Extract<TMessageContentParts, { type: ContentTypes.ACTIVITY_LABEL }>;
+type SummaryPart = Extract<TMessageContentParts, { type: ContentTypes.SUMMARY }>;
+type RuntimeSummaryPart = Omit<SummaryPart, 'content'> & {
+  content?: SummaryPart['content'] | string;
+  text?: string;
+};
+
+function hasSummaryText(part: RuntimeSummaryPart): boolean {
+  if (typeof part.content === 'string') {
+    return part.content.trim().length > 0;
+  }
+
+  if (Array.isArray(part.content)) {
+    for (const block of part.content) {
+      if (typeof block?.text === 'string' && block.text.trim().length > 0) {
+        return true;
+      }
+    }
+  }
+
+  return typeof part.text === 'string' && part.text.trim().length > 0;
+}
 
 function isRetainablePart(
   part: TMessageContentParts | null | undefined,
@@ -12,6 +33,10 @@ function isRetainablePart(
 
   if (part.type === ContentTypes.TOOL_CALL) {
     return 'tool_call' in part && part.tool_call != null && typeof part.tool_call === 'object';
+  }
+
+  if (part.type === ContentTypes.SUMMARY) {
+    return hasSummaryText(part);
   }
 
   return true;
@@ -35,8 +60,8 @@ function rebaseBound(bound: number, retainedBefore: number[], sourceLength: numb
 }
 
 /**
- * Removes malformed tool call parts and any empty slots, then rebases parent
- * activity-phase bounds onto the compacted coordinates.
+ * Removes malformed tool calls, empty summaries, and empty slots, then rebases
+ * parent activity-phase bounds onto the compacted coordinates.
  *
  * The source array is frequently sparse: the aggregator writes parts at
  * provider-source indexes, so a model turn that emits no text before its tool
@@ -95,9 +120,9 @@ function compactContentParts(contentParts: TMessageContentParts[]): TMessageCont
 }
 
 /**
- * Produces the durable content array: drops malformed tool call parts that lack the
- * required tool_call property, compacts away empty slots, and rebases parent
- * activity-phase bounds onto the resulting coordinates.
+ * Produces the durable content array: drops malformed tool calls and empty summaries,
+ * compacts away empty slots, and rebases parent activity-phase bounds onto the
+ * resulting coordinates.
  *
  * Compaction is not incidental — the source array is frequently sparse, because the
  * aggregator writes parts at provider-source indexes. Since that shifts positions, any


### PR DESCRIPTION
## Summary

Stacked on #15337.

Extends the existing single-pass durable-content compactor to discard summary parts that contain no non-whitespace text. The same seam serves normal agent completion and resumed persistence, so new empty blocks are not written and historical empty blocks are removed when resumed content is saved again.

The implementation preserves current and legacy non-empty summary shapes and reuses the compactor existing activity-index rebasing instead of adding another pass over message content.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run build:data-provider`
- `npm run build:data-schemas`
- `npm exec --workspace packages/api -- jest src/utils/content.spec.ts --runInBand --coverage=false`
- `npx eslint packages/api/src/utils/content.ts packages/api/src/utils/content.spec.ts`
- `npx tsc --noEmit -p packages/api/tsconfig.json`
- `git diff --check`

### **Test Configuration**:

- Node 24 / npm 11 on macOS

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.