### PR TITLE
🍱 feat: Guide Compaction With a Bounded Semantic Index

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -3868,10 +3868,17 @@ class AgentClient extends BaseClient {
       let semanticIntentToolNames;
       if (deriveCompactionSemanticIndex) {
         semanticIntentToolNames = new Set();
+        const semanticIntentBlockedToolNames = new Set();
         for (const agent of reachableAgents) {
           for (const toolName of agent.semanticIntentToolNames ?? []) {
             semanticIntentToolNames.add(toolName);
           }
+          for (const toolName of agent.semanticIntentBlockedToolNames ?? []) {
+            semanticIntentBlockedToolNames.add(toolName);
+          }
+        }
+        for (const toolName of semanticIntentBlockedToolNames) {
+          semanticIntentToolNames.delete(toolName);
         }
       }
       const hasMessageFormatOptions =

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -3855,14 +3855,34 @@ class AgentClient extends BaseClient {
         alwaysApplySkillPrimes,
       });
       const useLegacyContent = this.options.agent?.useLegacyContent === true;
+      const reachableAgents = collectReachableAgents([
+        this.options.agent,
+        ...(this.agentConfigs?.values() ?? []),
+      ]);
+      const deriveCompactionSemanticIndex = this.eventActorContinuation !== 'warm';
+      const messageFormatOptions = {
+        ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
+        ...(freshSkillPrimeNames.size > 0 ? { skipSkillBodyNames: freshSkillPrimeNames } : {}),
+        ...(useLegacyContent ? { legacyContent: true } : {}),
+      };
+      let semanticIntentToolNames;
+      if (deriveCompactionSemanticIndex) {
+        semanticIntentToolNames = new Set();
+        for (const agent of reachableAgents) {
+          for (const toolName of agent.semanticIntentToolNames ?? []) {
+            semanticIntentToolNames.add(toolName);
+          }
+        }
+      }
+      const hasMessageFormatOptions =
+        needsReasoningContentFormat || freshSkillPrimeNames.size > 0 || useLegacyContent;
       const formatOptions =
-        needsReasoningContentFormat || freshSkillPrimeNames.size > 0 || useLegacyContent
+        hasMessageFormatOptions || deriveCompactionSemanticIndex
           ? {
-              ...(needsReasoningContentFormat ? { preserveReasoningContent: true } : {}),
-              ...(freshSkillPrimeNames.size > 0
-                ? { skipSkillBodyNames: freshSkillPrimeNames }
+              ...messageFormatOptions,
+              ...(deriveCompactionSemanticIndex
+                ? { compactionSemanticIndex: { intentToolNames: semanticIntentToolNames } }
                 : {}),
-              ...(useLegacyContent ? { legacyContent: true } : {}),
             }
           : undefined;
       let {
@@ -3870,8 +3890,9 @@ class AgentClient extends BaseClient {
         indexTokenCountMap,
         summary: initialSummary,
         boundaryTokenAdjustment,
+        compactionSemanticIndex,
       } = formatAgentMessages(
-        stripActivityLabelParts(payload),
+        deriveCompactionSemanticIndex ? payload : stripActivityLabelParts(payload),
         this.indexTokenCountMap,
         toolSet,
         skillPrimeResult?.skills,
@@ -3932,10 +3953,7 @@ class AgentClient extends BaseClient {
       assertModelBoundContent({
         filters: appConfig?.filters,
         legacyPii: appConfig?.messageFilter?.pii,
-        agents: collectReachableAgents([
-          this.options.agent,
-          ...(this.agentConfigs?.values() ?? []),
-        ]),
+        agents: reachableAgents,
         skills: [...(manualSkillPrimes ?? []), ...(alwaysApplySkillPrimes ?? [])],
         memories: this.modelBoundMemoryContexts,
         files: this.modelBoundFileContexts,
@@ -3965,7 +3983,7 @@ class AgentClient extends BaseClient {
               undefined,
               toolSet,
               skillPrimeResult?.skills,
-              formatOptions,
+              hasMessageFormatOptions ? messageFormatOptions : undefined,
             ).messages
           : initialMessages;
 
@@ -4134,6 +4152,7 @@ class AgentClient extends BaseClient {
           // rebuilt turns use the summary reconstructed from durable history.
           indexTokenCountMap: this.eventActorContinuation === 'warm' ? {} : indexTokenCountMap,
           initialSummary: continuationSummary,
+          ...(deriveCompactionSemanticIndex ? { compactionSemanticIndex } : {}),
           initialSessions,
           calibrationRatio,
           runId: this.responseMessageId,

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -1772,6 +1772,7 @@ describe('AgentClient - startup telemetry', () => {
         model_parameters: { model: 'gpt-4' },
         hide_sequential_outputs: false,
         semanticIntentToolNames: ['web_search'],
+        semanticIntentBlockedToolNames: ['create_record'],
       },
       agentConfigs: new Map([
         [
@@ -1781,7 +1782,7 @@ describe('AgentClient - startup telemetry', () => {
             endpoint: EModelEndpoint.openAI,
             provider: EModelEndpoint.openAI,
             model_parameters: { model: 'gpt-4' },
-            semanticIntentToolNames: ['read_file'],
+            semanticIntentToolNames: ['read_file', 'create_record'],
           },
         ],
       ]),

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -16,6 +16,9 @@ const mockFormatAgentMessages = jest.fn(() => ({
   summary: undefined,
   boundaryTokenAdjustment: undefined,
 }));
+const mockStripActivityLabelParts = jest.fn((payload) =>
+  jest.requireActual('@librechat/api').stripActivityLabelParts(payload),
+);
 
 const { Providers } = require('@librechat/agents');
 const { Constants, ContentTypes, EModelEndpoint } = require('librechat-data-provider');
@@ -82,6 +85,7 @@ jest.mock('@librechat/api', () => ({
   recordCollectedUsage: (...args) => mockRecordCollectedUsage(...args),
   getAgentCheckpointer: mockGetAgentCheckpointer,
   hasDurableAgentInterruptCheckpoint: (...args) => mockHasDurableAgentInterruptCheckpoint(...args),
+  stripActivityLabelParts: (...args) => mockStripActivityLabelParts(...args),
 }));
 
 describe('AgentClient - event actor history adapter', () => {
@@ -1713,6 +1717,185 @@ describe('AgentClient - startup telemetry', () => {
     expect(processStream.mock.calls[0][1]).not.toHaveProperty('callbacks');
   });
 
+  it('derives and forwards compaction guidance without stripping activity labels', async () => {
+    jest.clearAllMocks();
+    mockIsHITLEnabled.mockReturnValue(false);
+    const compactionSemanticIndex = [
+      {
+        type: 'activity_phase',
+        sourceMessageId: 'assistant-history',
+        sourceContentIndex: 1,
+        revision: 1,
+        status: 'committed',
+        text: 'Verified the release state',
+      },
+    ];
+    const payload = [
+      {
+        messageId: 'assistant-history',
+        content: [
+          { type: ContentTypes.TEXT, text: 'Details' },
+          {
+            type: ContentTypes.ACTIVITY_LABEL,
+            activity_label: 'Verified the release state',
+            activity_label_type: 'phase',
+          },
+        ],
+      },
+    ];
+    mockFormatAgentMessages.mockReturnValueOnce({
+      messages: [],
+      indexTokenCountMap: {},
+      summary: undefined,
+      boundaryTokenAdjustment: undefined,
+      compactionSemanticIndex,
+    });
+    const processStream = jest.fn().mockResolvedValue();
+    mockCreateRun.mockResolvedValueOnce({
+      Graph: null,
+      processStream,
+      getCalibrationRatio: jest.fn(() => 0),
+      getInterrupt: jest.fn(() => undefined),
+    });
+    const client = new AgentClient({
+      req: {
+        user: { id: 'user-123' },
+        body: {},
+        config: { endpoints: { [EModelEndpoint.agents]: {} } },
+        _resumableStreamId: 'semantic-index-conversation',
+      },
+      res: {},
+      agent: {
+        id: 'agent-primary',
+        endpoint: EModelEndpoint.openAI,
+        provider: EModelEndpoint.openAI,
+        model_parameters: { model: 'gpt-4' },
+        hide_sequential_outputs: false,
+        semanticIntentToolNames: ['web_search'],
+      },
+      agentConfigs: new Map([
+        [
+          'agent-secondary',
+          {
+            id: 'agent-secondary',
+            endpoint: EModelEndpoint.openAI,
+            provider: EModelEndpoint.openAI,
+            model_parameters: { model: 'gpt-4' },
+            semanticIntentToolNames: ['read_file'],
+          },
+        ],
+      ]),
+      endpointTokenConfig: {},
+      eventHandlers: {},
+      contentParts: [],
+      collectedUsage: [],
+      artifactPromises: [],
+    });
+    client.conversationId = 'semantic-index-conversation';
+    client.responseMessageId = 'semantic-index-response';
+    client.parentMessageId = 'semantic-index-parent';
+    client.recordCollectedUsage = jest.fn().mockResolvedValue();
+
+    await client.chatCompletion({ payload });
+
+    expect(mockFormatAgentMessages).toHaveBeenCalledTimes(1);
+    const [formattedPayload, , , , formatOptions] = mockFormatAgentMessages.mock.calls[0];
+    expect(formattedPayload).toBe(payload);
+    expect(formattedPayload[0].content).toContainEqual(
+      expect.objectContaining({ type: ContentTypes.ACTIVITY_LABEL }),
+    );
+    expect(mockStripActivityLabelParts).not.toHaveBeenCalled();
+    expect(formatOptions.compactionSemanticIndex.intentToolNames).toEqual(
+      new Set(['web_search', 'read_file']),
+    );
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.objectContaining({ compactionSemanticIndex }),
+    );
+    expect(processStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves provider messages while deriving the full semantic index', () => {
+    const { formatAgentMessages } = jest.requireActual('@librechat/agents');
+    const { stripActivityLabelParts } = jest.requireActual('@librechat/api');
+    const payload = [
+      {
+        role: 'assistant',
+        messageId: 'semantic-history',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'search-1',
+              name: 'search_docs',
+              args: JSON.stringify({ intent: 'Locate the cache implementation', query: 'cache' }),
+              output: 'Found the implementation.',
+              outcome: 'Located the cache implementation',
+            },
+          },
+          {
+            type: ContentTypes.THINK,
+            think: 'Private reasoning stays out of compaction guidance.',
+            reasoning_label: 'Checking cache ownership',
+            reasoning_label_step_id: 'reasoning-1',
+            reasoning_label_revision: 2,
+            reasoning_label_status: 'complete',
+          },
+          {
+            type: ContentTypes.ACTIVITY_LABEL,
+            activity_label: 'Mapped the cache request path',
+            activity_label_type: 'phase',
+            activity_start_index: 0,
+            pending: false,
+          },
+          { type: ContentTypes.TEXT, text: 'The cache is initialized in the request adapter.' },
+        ],
+      },
+    ];
+
+    const legacyProjection = formatAgentMessages(
+      stripActivityLabelParts(payload),
+      undefined,
+      undefined,
+      undefined,
+      { preserveReasoningContent: true },
+    );
+    const baseline = formatAgentMessages(payload, undefined, undefined, undefined, {
+      preserveReasoningContent: true,
+    });
+    const derived = formatAgentMessages(payload, undefined, undefined, undefined, {
+      preserveReasoningContent: true,
+      compactionSemanticIndex: { intentToolNames: new Set(['search_docs']) },
+    });
+
+    expect(derived.messages.map((message) => message.toDict())).toEqual(
+      baseline.messages.map((message) => message.toDict()),
+    );
+    const providerShape = (messages) =>
+      messages.map((message) => {
+        const serialized = message.toDict();
+        const {
+          sourceMessageId: _sourceMessageId,
+          sourceMessageIds: _sourceMessageIds,
+          provenance: _provenance,
+          ...additional_kwargs
+        } = serialized.data.additional_kwargs;
+        const { response_metadata: _responseMetadata, ...data } = serialized.data;
+        return { ...serialized, data: { ...data, additional_kwargs } };
+      });
+    expect(providerShape(derived.messages)).toEqual(providerShape(legacyProjection.messages));
+    expect(derived.compactionSemanticIndex).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'tool_intent', text: 'Locate the cache implementation' }),
+        expect.objectContaining({
+          type: 'tool_outcome',
+          text: 'Located the cache implementation',
+        }),
+        expect.objectContaining({ type: 'reasoning_label', text: 'Checking cache ownership' }),
+        expect.objectContaining({ type: 'activity_phase', text: 'Mapped the cache request path' }),
+      ]),
+    );
+  });
+
   it('propagates final model callback policy errors instead of persisting a generic error part', async () => {
     jest.clearAllMocks();
     let policyError;
@@ -1849,6 +2032,9 @@ describe('AgentClient - startup telemetry', () => {
         calibrationRatio: 1.25,
       }),
     );
+    expect(mockCreateRun.mock.calls[0][0]).not.toHaveProperty('compactionSemanticIndex');
+    expect(mockFormatAgentMessages.mock.calls[0][4]).toBeUndefined();
+    expect(mockStripActivityLabelParts).toHaveBeenCalledTimes(1);
     expect(processStream).toHaveBeenCalledWith(
       { messages: [currentEvent] },
       expect.objectContaining({

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -6,9 +6,9 @@ import {
   MAX_SUBAGENT_DEPTH,
   MAX_SUBAGENT_RUN_CONFIGS,
 } from 'librechat-data-provider';
+import type { CompactionSemanticIndex, SubagentTaskConfig } from '@librechat/agents';
 import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { CompactionSemanticIndex, SubagentTaskConfig } from '@librechat/agents';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ModelBoundChatModelCallback } from '~/middleware/modelBoundContent';
 import { createRun, isAskUserQuestionAdminDisabled } from '~/agents/run';

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -8,7 +8,7 @@ import {
 } from 'librechat-data-provider';
 import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { SubagentTaskConfig } from '@librechat/agents';
+import type { CompactionSemanticIndex, SubagentTaskConfig } from '@librechat/agents';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { ModelBoundChatModelCallback } from '~/middleware/modelBoundContent';
 import { createRun, isAskUserQuestionAdminDisabled } from '~/agents/run';
@@ -182,6 +182,7 @@ async function callAndCapture(
     appConfig?: AppConfig;
     messages?: BaseMessage[];
     discoveredToolNames?: string[];
+    compactionSemanticIndex?: CompactionSemanticIndex;
     subagentTasks?: SubagentTaskConfig;
     modelCallbacks?: readonly ModelBoundChatModelCallback[];
   } = {},
@@ -197,6 +198,7 @@ async function callAndCapture(
     appConfig: opts.appConfig,
     messages: opts.messages,
     discoveredToolNames: opts.discoveredToolNames,
+    compactionSemanticIndex: opts.compactionSemanticIndex,
     subagentTasks: opts.subagentTasks,
     modelCallbacks: opts.modelCallbacks,
     streaming: true,
@@ -258,6 +260,57 @@ beforeEach(() => {
   delete process.env.LANGFUSE_TRACING_ENABLED;
   delete process.env.LANGFUSE_SAMPLE_RATE;
   process.env.TENANT_ISOLATION_STRICT = 'true';
+});
+
+describe('compaction semantic index forwarding', () => {
+  it('forwards one host-derived snapshot to every top-level agent input', async () => {
+    const compactionSemanticIndex = [
+      {
+        type: 'activity_phase',
+        sourceMessageId: 'message-1',
+        sourceContentIndex: 3,
+        revision: 2,
+        status: 'committed',
+        text: 'Verified the release state',
+      },
+    ] satisfies CompactionSemanticIndex;
+
+    const agents = await callAndCapture({
+      agents: [makeAgent({ id: 'agent_1' }), makeAgent({ id: 'agent_2' })],
+      compactionSemanticIndex,
+    });
+
+    expect(agents).toHaveLength(2);
+    expect(agents[0].compactionSemanticIndex).toBe(compactionSemanticIndex);
+    expect(agents[1].compactionSemanticIndex).toBe(compactionSemanticIndex);
+  });
+
+  it('does not leak the parent history index into an isolated subagent', async () => {
+    const compactionSemanticIndex = [
+      {
+        type: 'activity_phase',
+        sourceMessageId: 'message-1',
+        sourceContentIndex: 3,
+        revision: 2,
+        status: 'committed',
+        text: 'Verified the release state',
+      },
+    ] satisfies CompactionSemanticIndex;
+    const child = makeAgent({ id: 'agent_child' });
+    const [root] = await callAndCapture({
+      agents: [
+        makeAgent({
+          subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_child'] },
+          subagentAgentConfigs: [child],
+        }),
+      ],
+      compactionSemanticIndex,
+    });
+    const [childConfig] = root.subagentConfigs as Array<Record<string, unknown>>;
+
+    expect(root.compactionSemanticIndex).toBe(compactionSemanticIndex);
+    expect(childConfig.agentInputs).not.toHaveProperty('compactionSemanticIndex');
+  });
 });
 
 afterAll(() => {

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -405,6 +405,8 @@ export type InitializedAgent = Agent & {
   intentToolNames?: string[];
   /** Marker-verified tool names whose model-authored intent labels are safe compaction guidance. */
   semanticIntentToolNames?: string[];
+  /** Tool names whose unverified schemas veto global semantic-intent trust for same-name calls. */
+  semanticIntentBlockedToolNames?: string[];
   /** Whether the inline memory tools (`set_memory`/`delete_memory`) were
    *  registered for this agent. Authoritative LibreChat-only signal of the
    *  inline memory opt-in for the execution path, since some contexts hold the
@@ -1524,6 +1526,7 @@ export async function initializeAgent(
 
   let intentToolNames: string[] | undefined;
   let semanticIntentToolNames: string[] | undefined;
+  let semanticIntentBlockedToolNames: string[] | undefined;
 
   /**
    * Inject the `run_in_background` param into eligible opted-in tools and
@@ -1707,6 +1710,9 @@ export async function initializeAgent(
   if (intentSanitized.semanticIntentToolNames.length > 0) {
     semanticIntentToolNames = intentSanitized.semanticIntentToolNames;
   }
+  if (intentSanitized.semanticIntentBlockedToolNames.length > 0) {
+    semanticIntentBlockedToolNames = intentSanitized.semanticIntentBlockedToolNames;
+  }
 
   const hasFinalAgentTools =
     (structuredTools?.length ?? 0) > 0 || (toolDefinitions?.length ?? 0) > 0;
@@ -1771,6 +1777,7 @@ export async function initializeAgent(
     backgroundToolNames,
     intentToolNames,
     semanticIntentToolNames,
+    semanticIntentBlockedToolNames,
     actionsEnabled,
     accessibleMcpServerNames: resolvedAuditNames,
     baseContextTokens,

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -403,6 +403,8 @@ export type InitializedAgent = Agent & {
    * own and are never listed here.
    */
   intentToolNames?: string[];
+  /** Marker-verified tool names whose model-authored intent labels are safe compaction guidance. */
+  semanticIntentToolNames?: string[];
   /** Whether the inline memory tools (`set_memory`/`delete_memory`) were
    *  registered for this agent. Authoritative LibreChat-only signal of the
    *  inline memory opt-in for the execution path, since some contexts hold the
@@ -1521,6 +1523,7 @@ export async function initializeAgent(
   }
 
   let intentToolNames: string[] | undefined;
+  let semanticIntentToolNames: string[] | undefined;
 
   /**
    * Inject the `run_in_background` param into eligible opted-in tools and
@@ -1701,6 +1704,9 @@ export async function initializeAgent(
     capabilityToolNames,
   });
   toolDefinitions = intentSanitized.toolDefinitions;
+  if (intentSanitized.semanticIntentToolNames.length > 0) {
+    semanticIntentToolNames = intentSanitized.semanticIntentToolNames;
+  }
 
   const hasFinalAgentTools =
     (structuredTools?.length ?? 0) > 0 || (toolDefinitions?.length ?? 0) > 0;
@@ -1764,6 +1770,7 @@ export async function initializeAgent(
     mcpToolAliases,
     backgroundToolNames,
     intentToolNames,
+    semanticIntentToolNames,
     actionsEnabled,
     accessibleMcpServerNames: resolvedAuditNames,
     baseContextTokens,

--- a/packages/api/src/agents/intent.spec.ts
+++ b/packages/api/src/agents/intent.spec.ts
@@ -525,13 +525,51 @@ describe('sanitizeIntentLabels', () => {
   it('leaves defs untouched when the capability is on and nothing opted out', () => {
     const skill = sdkNativeDef('skill');
     const defs = [skill];
-    const { toolDefinitions } = sanitizeIntentLabels({
+    const { toolDefinitions, semanticIntentToolNames } = sanitizeIntentLabels({
       toolDefinitions: defs,
       toolRegistry: undefined,
       toolOptions: undefined,
       capabilityEnabled: true,
     });
     expect(toolDefinitions).toBe(defs);
+    expect(semanticIntentToolNames).toEqual(['skill']);
+  });
+
+  it('projects only surviving marker-verified intent schemas for compaction', () => {
+    const skill = sdkNativeDef('skill');
+    const hostInjected = injectIntentParam(mcpDef('web_search'));
+    const optedOut = sdkNativeDef('read_file');
+    const businessIntent = {
+      name: 'create_record',
+      parameters: {
+        type: 'object',
+        properties: {
+          intent: { type: 'string', description: 'CRM intent category for the record' },
+        },
+      },
+    } as unknown as LCTool;
+    const registryOnly = sdkNativeDef('tool_search');
+    const toolRegistry: LCToolRegistry = new Map([['tool_search', registryOnly]]);
+
+    const { semanticIntentToolNames } = sanitizeIntentLabels({
+      toolDefinitions: [skill, hostInjected, optedOut, businessIntent],
+      toolRegistry,
+      toolOptions: { read_file: { describe_intent: false } },
+      capabilityEnabled: true,
+    });
+
+    expect(semanticIntentToolNames).toEqual(['skill', 'web_search', 'tool_search']);
+  });
+
+  it('projects no semantic intent names when the capability is disabled', () => {
+    const { semanticIntentToolNames } = sanitizeIntentLabels({
+      toolDefinitions: [sdkNativeDef('skill')],
+      toolRegistry: undefined,
+      toolOptions: undefined,
+      capabilityEnabled: false,
+    });
+
+    expect(semanticIntentToolNames).toEqual([]);
   });
 
   it('enforces explicit opt-outs on late-registered defs when the capability is on', () => {

--- a/packages/api/src/agents/intent.spec.ts
+++ b/packages/api/src/agents/intent.spec.ts
@@ -551,7 +551,7 @@ describe('sanitizeIntentLabels', () => {
     const registryOnly = sdkNativeDef('tool_search');
     const toolRegistry: LCToolRegistry = new Map([['tool_search', registryOnly]]);
 
-    const { semanticIntentToolNames } = sanitizeIntentLabels({
+    const { semanticIntentToolNames, semanticIntentBlockedToolNames } = sanitizeIntentLabels({
       toolDefinitions: [skill, hostInjected, optedOut, businessIntent],
       toolRegistry,
       toolOptions: { read_file: { describe_intent: false } },
@@ -559,10 +559,11 @@ describe('sanitizeIntentLabels', () => {
     });
 
     expect(semanticIntentToolNames).toEqual(['skill', 'web_search', 'tool_search']);
+    expect(semanticIntentBlockedToolNames).toEqual(['read_file', 'create_record']);
   });
 
   it('projects no semantic intent names when the capability is disabled', () => {
-    const { semanticIntentToolNames } = sanitizeIntentLabels({
+    const { semanticIntentToolNames, semanticIntentBlockedToolNames } = sanitizeIntentLabels({
       toolDefinitions: [sdkNativeDef('skill')],
       toolRegistry: undefined,
       toolOptions: undefined,
@@ -570,6 +571,7 @@ describe('sanitizeIntentLabels', () => {
     });
 
     expect(semanticIntentToolNames).toEqual([]);
+    expect(semanticIntentBlockedToolNames).toEqual(['skill']);
   });
 
   it('enforces explicit opt-outs on late-registered defs when the capability is on', () => {

--- a/packages/api/src/agents/intent.ts
+++ b/packages/api/src/agents/intent.ts
@@ -412,7 +412,11 @@ export function sanitizeIntentLabels(params: {
   capabilityEnabled: boolean;
   /** Capability marker → registered definition names, from `initializeAgent`. */
   capabilityToolNames?: CapabilityToolNames;
-}): { toolDefinitions: LCTool[]; semanticIntentToolNames: string[] } {
+}): {
+  toolDefinitions: LCTool[];
+  semanticIntentToolNames: string[];
+  semanticIntentBlockedToolNames: string[];
+} {
   const { toolRegistry, toolOptions, capabilityEnabled, capabilityToolNames } = params;
   const defs = params.toolDefinitions ?? [];
   const shouldStrip = (name: string): boolean =>
@@ -423,14 +427,21 @@ export function sanitizeIntentLabels(params: {
 
   let changed = false;
   const semanticIntentToolNames = new Set<string>();
+  const semanticIntentBlockedToolNames = new Set<string>();
+  const projectSemanticTrust = (def: LCTool): void => {
+    if (isIntentLabelProperty(def.parameters?.properties?.[INTENT_ARG])) {
+      semanticIntentToolNames.add(def.name);
+      return;
+    }
+    semanticIntentBlockedToolNames.add(def.name);
+  };
   const nextDefs = defs.map((def) => {
     if (!shouldStrip(def.name)) {
-      if (isIntentLabelProperty(def.parameters?.properties?.[INTENT_ARG])) {
-        semanticIntentToolNames.add(def.name);
-      }
+      projectSemanticTrust(def);
       return def;
     }
     const stripped = removeIntentParam(def);
+    projectSemanticTrust(stripped);
     if (stripped !== def) {
       changed = true;
       const registryEntry = toolRegistry?.get(def.name);
@@ -443,12 +454,11 @@ export function sanitizeIntentLabels(params: {
   if (toolRegistry) {
     for (const [name, entry] of toolRegistry) {
       if (!shouldStrip(name)) {
-        if (isIntentLabelProperty(entry.parameters?.properties?.[INTENT_ARG])) {
-          semanticIntentToolNames.add(name);
-        }
+        projectSemanticTrust(entry);
         continue;
       }
       const stripped = removeIntentParam(entry);
+      projectSemanticTrust(stripped);
       if (stripped !== entry) {
         toolRegistry.set(name, stripped);
       }
@@ -457,6 +467,7 @@ export function sanitizeIntentLabels(params: {
   return {
     toolDefinitions: changed ? nextDefs : defs,
     semanticIntentToolNames: Array.from(semanticIntentToolNames),
+    semanticIntentBlockedToolNames: Array.from(semanticIntentBlockedToolNames),
   };
 }
 

--- a/packages/api/src/agents/intent.ts
+++ b/packages/api/src/agents/intent.ts
@@ -412,7 +412,7 @@ export function sanitizeIntentLabels(params: {
   capabilityEnabled: boolean;
   /** Capability marker → registered definition names, from `initializeAgent`. */
   capabilityToolNames?: CapabilityToolNames;
-}): { toolDefinitions: LCTool[] } {
+}): { toolDefinitions: LCTool[]; semanticIntentToolNames: string[] } {
   const { toolRegistry, toolOptions, capabilityEnabled, capabilityToolNames } = params;
   const defs = params.toolDefinitions ?? [];
   const shouldStrip = (name: string): boolean =>
@@ -422,8 +422,12 @@ export function sanitizeIntentLabels(params: {
       : true;
 
   let changed = false;
+  const semanticIntentToolNames = new Set<string>();
   const nextDefs = defs.map((def) => {
     if (!shouldStrip(def.name)) {
+      if (isIntentLabelProperty(def.parameters?.properties?.[INTENT_ARG])) {
+        semanticIntentToolNames.add(def.name);
+      }
       return def;
     }
     const stripped = removeIntentParam(def);
@@ -439,6 +443,9 @@ export function sanitizeIntentLabels(params: {
   if (toolRegistry) {
     for (const [name, entry] of toolRegistry) {
       if (!shouldStrip(name)) {
+        if (isIntentLabelProperty(entry.parameters?.properties?.[INTENT_ARG])) {
+          semanticIntentToolNames.add(name);
+        }
         continue;
       }
       const stripped = removeIntentParam(entry);
@@ -447,7 +454,10 @@ export function sanitizeIntentLabels(params: {
       }
     }
   }
-  return { toolDefinitions: changed ? nextDefs : defs };
+  return {
+    toolDefinitions: changed ? nextDefs : defs,
+    semanticIntentToolNames: Array.from(semanticIntentToolNames),
+  };
 }
 
 /**

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -15,6 +15,7 @@ import type {
   SummarizationConfig as AgentSummarizationConfig,
   MultiAgentGraphConfig,
   ContextPruningConfig,
+  CompactionSemanticIndex,
   OpenAIClientOptions,
   StandardGraphConfig,
   StreamPreemption,
@@ -397,6 +398,8 @@ type RunAgent = Omit<Agent, 'tools'> & {
   backgroundToolNames?: string[];
   /** Names of tools with the host-injected `intent` param (stripped from self-spawn inputs). */
   intentToolNames?: string[];
+  /** Marker-verified tool names whose intent labels are safe compaction guidance. */
+  semanticIntentToolNames?: string[];
   /**
    * Per-agent codeenv gate set by `initializeAgent`: admin-level
    * `execute_code` capability AND the agent actually requested
@@ -1383,6 +1386,7 @@ export async function createRun({
   indexTokenCountMap,
   initialSessions,
   summarizationConfig,
+  compactionSemanticIndex,
   initialSummary,
   modelCallbacks,
   calibrationRatio,
@@ -1429,6 +1433,8 @@ export async function createRun({
    */
   discoveredToolNames?: string[];
   summarizationConfig?: SummarizationConfig;
+  /** Bounded, source-addressed navigation guidance derived with provider messages. */
+  compactionSemanticIndex?: CompactionSemanticIndex;
   /** Cross-run summary from formatAgentMessages, forwarded to AgentContext */
   initialSummary?: { text: string; tokenCount: number };
   /** Model-level guards inherited by root, summary, fallback, and subagent clients. */
@@ -1730,6 +1736,7 @@ export async function createRun({
         !isSubagent && discoveredTools.size > 0 ? Array.from(discoveredTools) : undefined,
       summarizationEnabled: summarization.enabled,
       summarizationConfig: summarization.config,
+      ...(!isSubagent && compactionSemanticIndex != null ? { compactionSemanticIndex } : {}),
       initialSummary: isSubagent ? undefined : initialSummary,
       contextPruningConfig: summarization.contextPruning,
       maxToolResultChars: agent.maxToolResultChars,


### PR DESCRIPTION
## Summary

- enable the Agents 3.7.8 bounded Compaction Semantic Index for AgentClient's primary persisted-history projection
- derive activity phases, visible reasoning labels, settled tool outcomes, and marker-verified tool intents during the existing formatter pass
- forward one source-addressed snapshot to every top-level run agent while excluding isolated subagents
- retain existing compatibility behavior for memory formatting, OpenAI-compatible and Responses controllers, warm Event Actor continuations, and HITL resume rebuilds

This PR is stacked on #15337, which supplies @librechat/agents 3.7.8. It can be retargeted to dev once the bump merges.

## Architecture

The formatter remains the single derivation Module and the SDK's compactionSemanticIndex option remains the Interface. LibreChat acts only as the host Adapter: it supplies trusted intent-tool identity and forwards the bounded projection into AgentInputs.

Trusted intent names are projected in the existing final schema-sanitization pass. Only surviving SDK-marker-verified intent properties qualify. Capability-off tools, explicit opt-outs, and unrelated business parameters named intent fail closed.

## Safety and scope

- provider-facing message content, tool calls, and additional provider fields remain equivalent to the former pre-strip path
- activity labels retain original persisted content coordinates for provenance
- raw private reasoning never enters the semantic index
- warm checkpoint continuations and HITL resumes receive no stale history index
- memory and compatibility controllers keep stripping UI-only activity parts
- subagents do not inherit parent-history guidance
- semantic guidance adds no ordinary prompt tokens; the bounded appendix is rendered only when compaction runs

## Performance

Local median microbenchmark, Node with 100-message histories:

| workload | previous host path | semantic-index path | delta |
| --- | ---: | ---: | ---: |
| ordinary text | 0.1545 ms | 0.1522 ms | -1.5% |
| tool-rich, all four signals | 0.6054 ms | 0.6919 ms | +0.0864 ms |

The primary path deletes the separate activity-label map/filter pass. The worst-case semantic work remains in the existing formatter traversal and is bounded by the SDK's index limits.

## Tests

- `cd packages/api && npx jest src/agents/intent.spec.ts src/agents/__tests__/run-summarization.test.ts --runInBand --coverage=false` (199 tests)
- `cd api && npx jest server/controllers/agents/client.test.js --runInBand --coverage=false` (185 tests)
- `npx tsc --noEmit -p packages/api/tsconfig.json`
- focused ESLint on all seven changed files
- `npm run build:api`
