### PR TITLE
fix: apply in-transit expiry buffer to exchanged-token cache TTLs (#15320)

### DIFF
--- a/packages/api/src/oauth/expiry.spec.ts
+++ b/packages/api/src/oauth/expiry.spec.ts
@@ -74,8 +74,14 @@ describe('normalizeExpiresIn', () => {
 });
 
 describe('getTokenCacheTtlMs', () => {
-  it('converts a declared lifetime to milliseconds', () => {
-    expect(getTokenCacheTtlMs(1800, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1_800_000);
+  it('converts a declared lifetime to milliseconds, minus the in-transit expiry buffer', () => {
+    expect(getTokenCacheTtlMs(1800, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1_770_000);
+  });
+
+  it('never caches a credential past its expiry buffer margin', () => {
+    const declared = 60;
+    const ttl = getTokenCacheTtlMs(declared, DEFAULT_OAUTH_TOKEN_TTL_SECONDS);
+    expect(ttl).toBeLessThan(declared * 1000);
   });
 
   it('falls back rather than returning NaN when the provider omits `expires_in`', () => {
@@ -87,6 +93,8 @@ describe('getTokenCacheTtlMs', () => {
   it('floors an elapsed lifetime to the shortest positive TTL, never 0', () => {
     expect(getTokenCacheTtlMs(0, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1);
     expect(getTokenCacheTtlMs(-60, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1);
+    /** buffer larger than the lifetime still lands on the floor, not 0 */
+    expect(getTokenCacheTtlMs(10, DEFAULT_OAUTH_TOKEN_TTL_SECONDS)).toBe(1);
   });
 
   it('does not hand an elapsed lifetime the fallback, which would revive a dead credential', () => {

--- a/packages/api/src/oauth/expiry.ts
+++ b/packages/api/src/oauth/expiry.ts
@@ -11,6 +11,7 @@
  *
  * Every lifetime derived from a token response goes through here so the rule has one home.
  */
+import { OPENID_EXPIRY_BUFFER_SECONDS } from '../utils/oidc';
 
 /**
  * Fallback lifetime for a token response that declares none. One hour matches every hand-written
@@ -68,13 +69,18 @@ export function normalizeExpiresIn(expiresIn: unknown): number | undefined {
  * Cache TTL in milliseconds for a token response. A provider that omits `expires_in` gets
  * `fallbackSeconds` rather than an entry that outlives the credential it holds; one that declares
  * an elapsed lifetime gets the shortest positive TTL rather than `0`, which Keyv reads as no expiry.
+ *
+ * The `OPENID_EXPIRY_BUFFER_SECONDS` margin is subtracted so a cached credential is never served
+ * in its final seconds, where it would expire in transit and 401 downstream. The buffer is applied
+ * to every exchanged-token cache (OBO, Graph, OpenID strategy), matching the federated-token check
+ * in `isOpenIDTokenValid` / `isIdTokenCurrent` (#15320).
  */
 export function getTokenCacheTtlMs(expiresIn: unknown, fallbackSeconds: number): number {
   const seconds = normalizeExpiresIn(expiresIn);
   if (seconds == null) {
     return fallbackSeconds * 1000;
   }
-  return Math.max(seconds * 1000, EXPIRED_CACHE_TTL_MS);
+  return Math.max(seconds * 1000 - OPENID_EXPIRY_BUFFER_SECONDS * 1000, EXPIRED_CACHE_TTL_MS);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #15320 — exchanged OBO / Graph / OpenID tokens were cached for their **full** `expires_in`, so a credential could expire in transit and 401 downstream (the intermittent "works on retry" shape reported in #13899).

**Fix:** `getTokenCacheTtlMs` now subtracts `OPENID_EXPIRY_BUFFER_SECONDS` (30s) — the same margin already used by `isOpenIDTokenValid` / `isIdTokenCurrent` for the user's federated token — from the derived cache TTL. All three exchanged-token caches (`OboTokenService.js`, `GraphApiService.js`, `openidStrategy.js`) call this single helper, so one change covers every path.

Edge cases preserved:
- Provider omits `expires_in` → fallback lifetime, no buffer subtraction (unknown lifetime stays conservative)
- Lifetime shorter than the buffer (e.g. 10s) → floors to the shortest positive TTL (1ms), never 0 (Keyv reads 0 as "no expiry")
- Already-elapsed lifetime → 1ms, not the fallback (dead credential stays dead)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Logic verified: 1800s → 1,770,000ms; undefined → 3,600,000ms (fallback); 0s → 1ms; 10s (buffer > ttl) → 1ms
- Spec updated: `getTokenCacheTtlMs(1800) → 1_770_000`, added buffer-margin and floor cases
- All three callers confirmed to route through `getTokenCacheTtlMs` (no direct `expires_in * 1000` caches remain)
- Prettier (repo `.prettierrc`) passes

### **Test Configuration**:
- No behavioral change for tokens with >30s remaining lifetime (only the final 30s window is no longer served from cache)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
