### PR TITLE
🔇 ci: Log Config-Blocked MCP Recovery at Debug

### DIFF
--- a/packages/api/src/mcp/catalog/recovery.spec.ts
+++ b/packages/api/src/mcp/catalog/recovery.spec.ts
@@ -1,7 +1,13 @@
+import { logger } from '@librechat/data-schemas';
 import { Constants } from 'librechat-data-provider';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
 import { loadMCPServerCatalogs, recoverMCPServerCatalogs } from './recovery';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
 
 const user = { id: 'user-1' } as IUser;
 const serverConfig = (name: string): ParsedServerConfig =>
@@ -92,6 +98,40 @@ describe('recoverMCPServerCatalogs', () => {
     expect(discoverServerTools).toHaveBeenCalledTimes(7);
     expect(maxActive).toBe(3);
     expect(result.size).toBe(7);
+  });
+
+  it('logs configuration-impossible discovery failures at debug, keeping error for the unexpected', async () => {
+    const servers = [
+      { serverName: 'policy-blocked', serverConfig: serverConfig('blocked') },
+      { serverName: 'crashed', serverConfig: serverConfig('crashed') },
+    ];
+
+    const result = await recoverMCPServerCatalogs(
+      { user, servers },
+      {
+        loadUserMCPAuthMap: jest.fn().mockResolvedValue({}),
+        discoverServerTools: jest.fn(async ({ serverName }: ToolDiscoveryOptions) => {
+          if (serverName === 'policy-blocked') {
+            throw new McpError(
+              ErrorCode.InvalidRequest,
+              'Resolved MCP server URL is not allowed by the configured domain policy.',
+            );
+          }
+          throw new Error('socket hang up');
+        }),
+        formatServerTools: jest.fn(),
+      },
+    );
+
+    expect(result.size).toBe(0);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('policy-blocked is not recoverable under current configuration'),
+    );
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('crashed'),
+      expect.any(Error),
+    );
   });
 
   it('keeps successful catalogs when another server fails or has no authoritative tools', async () => {

--- a/packages/api/src/mcp/catalog/recovery.ts
+++ b/packages/api/src/mcp/catalog/recovery.ts
@@ -1,4 +1,5 @@
 import { logger } from '@librechat/data-schemas';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { IUser } from '@librechat/data-schemas';
 import type { LCAvailableTools, ParsedServerConfig, ToolDiscoveryOptions } from '../types';
@@ -94,6 +95,16 @@ async function discoverCandidate(
       result.tools == null ? null : deps.formatServerTools(serverName, result.tools),
     ];
   } catch (error) {
+    /** Discovery raises `InvalidRequest` precisely when configuration makes the attempt
+     *  impossible — domain policy, unresolved placeholders, missing runtime fields. That
+     *  failure recurs on every request until an admin changes configuration, so it is
+     *  expected state, logged at the same level as this file's other config-proven skips. */
+    if (error instanceof McpError && error.code === ErrorCode.InvalidRequest) {
+      logger.debug(
+        `[MCP catalog recovery] ${serverName} is not recoverable under current configuration: ${error.message}`,
+      );
+      return [serverName, null];
+    }
     logger.error(`[MCP catalog recovery] Failed to discover tools for ${serverName}:`, error);
     return [serverName, null];
   }


### PR DESCRIPTION
## Summary

Passive MCP catalog recovery (#15323) attempts every cold server on each `GET /api/mcp/tools` request by design — recovered results cannot be retained, so there is no state to schedule around. When a server is blocked by the configured domain policy, that attempt fails **deterministically** on every request, and `discoverCandidate` logged each failure at `error` level.

The e2e suite makes the cost visible: `e2e-http` is *deliberately* policy-blocked in `e2e/config/librechat.e2e.yaml` (the allowlist-override spec depends on it booting `inspectionFailed`), so every marketplace fetch during any e2e run emitted

```
error: [MCP catalog recovery] Failed to discover tools for e2e-http: MCP error -32600: [MCP][Discovery] Resolved MCP server URL is not allowed by the configured domain policy.
```

— one line every few seconds, in every unrelated PR's CI logs. A production deployment with a policy-blocked server gets the same treatment.

Discovery raises `McpError` with `ErrorCode.InvalidRequest` (-32600) precisely for the config-impossible cases — domain policy, unresolved runtime placeholders, missing runtime fields. These are expected state that recurs until an admin changes configuration, not incidents. `discoverCandidate` now classifies that error and logs it at `debug` with a one-line reason, matching the level this file already uses for its other config-proven skips (config-tier retry, missing user variables). Genuinely unexpected failures — network faults, crashes — keep `error`.

The attempt itself is cheap and unchanged: the domain check throws before any socket is opened, and recovery stays stateless.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

One test added to `recovery.spec.ts`, mutation-verified (fails with the classification removed): a policy-blocked server and a crashed server recovered together produce exactly one `error` (the crash) and a `debug` line naming the blocked server as not recoverable under current configuration.

```text
packages/api recovery suite:  19 passed
tsc --noEmit:                 no new errors in src/mcp
eslint:                       clean
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xr1Dabvdn1mzzyYgpJgU5B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr1Dabvdn1mzzyYgpJgU5B)_