### PR TITLE
🧳 fix: Carry Stateful Environments Through Runtime Config

### DIFF
--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -266,24 +266,54 @@ describe('initializeAgent — execution context', () => {
 
   it('initializes without Express request or response objects', async () => {
     const { agent, loadTools, db } = createMocks();
-
-    await expect(
-      initializeAgent(
-        {
-          runtime: {
-            user: { id: 'user-1' } as never,
-            appConfig: {} as never,
-            requestBody: { timezone: 'America/New_York' },
+    const previousReqDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'req');
+    Object.defineProperty(globalThis, 'req', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const appConfig = {
+      endpoints: {
+        [EModelEndpoint.agents]: {
+          statefulCodeSessions: {
+            environments: [
+              {
+                id: 'request-free-stateful',
+                name: 'Request-free stateful',
+                type: 'attached',
+                baseURL: 'https://stateful.example.com/v1',
+              },
+            ],
           },
-          agent,
-          loadTools,
-          endpointOption: { endpoint: EModelEndpoint.agents },
-          allowedProviders: new Set([Providers.OPENAI]),
-          isInitialAgent: true,
         },
-        db,
-      ),
-    ).resolves.toBeDefined();
+      },
+    };
+
+    try {
+      await expect(
+        initializeAgent(
+          {
+            runtime: {
+              user: { id: 'user-1' } as never,
+              appConfig: appConfig as never,
+              requestBody: { timezone: 'America/New_York' },
+            },
+            agent,
+            loadTools,
+            endpointOption: { endpoint: EModelEndpoint.agents },
+            allowedProviders: new Set([Providers.OPENAI]),
+            isInitialAgent: true,
+          },
+          db,
+        ),
+      ).resolves.toBeDefined();
+    } finally {
+      if (previousReqDescriptor == null) {
+        delete (globalThis as typeof globalThis & { req?: unknown }).req;
+      } else {
+        Object.defineProperty(globalThis, 'req', previousReqDescriptor);
+      }
+    }
 
     expect(loadTools).toHaveBeenCalledWith(expect.not.objectContaining({ req: expect.anything() }));
     expect(loadTools).toHaveBeenCalledWith(expect.not.objectContaining({ res: expect.anything() }));

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -980,8 +980,7 @@ export async function initializeAgent(
     statefulSessions: effectiveStatefulSessions,
     environment: statefulCodeEnvironment,
     environmentId: agent.code_environment_id,
-    environments:
-      req.config?.endpoints?.[EModelEndpoint.agents]?.statefulCodeSessions?.environments,
+    environments: appConfig?.endpoints?.[EModelEndpoint.agents]?.statefulCodeSessions?.environments,
     userId: requestFileOwnerId,
     agentId: agent.id,
     conversationId,


### PR DESCRIPTION
## Summary

I fixed request-free agent initialization so event-bound child turns read stateful code-session environments from the supplied runtime configuration rather than an unavailable Express request object.

- Read `statefulCodeSessions.environments` from `runtime.appConfig` during agent initialization.
- Strengthen the existing request-free regression with an explicit stateful environment allowlist.
- Force the legacy global `req` symbol to be unavailable in the regression so the original failure cannot silently return.
- Preserve ordinary request-backed initialization behavior while unblocking API-triggered child turns.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/agents/__tests__/initialize.test.ts --runInBand --coverage=false` (88 passed)
- `npm run build` in `packages/api`
- Local event-driven Pong canary: eight alternating bound deliveries settled `applied`; each actor reused one child conversation and reached checkpoint generation 4.

### Test Configuration

- LibreChat on `localhost:3180`
- Redis-backed generation jobs
- MongoDB-backed trigger deliveries and checkpoints
- Azure Foundry `gpt-5.6-luna`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
