### PR TITLE
Add Gandr TTS provider

### DIFF
--- a/api/server/services/Files/Audio/TTSService.js
+++ b/api/server/services/Files/Audio/TTSService.js
@@ -25,6 +25,7 @@ class TTSService {
       [TTSProviders.AZURE_OPENAI]: this.azureOpenAIProvider.bind(this),
       [TTSProviders.ELEVENLABS]: this.elevenLabsProvider.bind(this),
       [TTSProviders.LOCALAI]: this.localAIProvider.bind(this),
+      [TTSProviders.GANDR]: this.gandrProvider.bind(this),
     };
   }
 
@@ -236,6 +237,42 @@ class TTSService {
       input,
       model: ttsSchema?.voices && ttsSchema.voices.length > 0 ? voice : undefined,
       backend: ttsSchema?.backend,
+    };
+
+    const apiKey = resolveConfigSecret(ttsSchema?.apiKey) || '';
+    const headers = {
+      'Content-Type': 'application/json',
+      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+    };
+
+    return [url, data, headers];
+  }
+
+  /**
+   * Prepares the request for Gandr TTS provider.
+   * @param {Object} ttsSchema - The TTS schema for Gandr.
+   * @param {string} input - The input text.
+   * @param {string} voice - The selected voice.
+   * @returns {Array} An array containing the URL, data, and headers for the request.
+   * @throws {Error} If the selected voice is not available.
+   */
+  gandrProvider(ttsSchema, input, voice) {
+    const url = ttsSchema?.url || 'https://tts.gandr.ai/v1/audio/speech';
+
+    if (
+      ttsSchema?.voices &&
+      ttsSchema.voices.length > 0 &&
+      !ttsSchema.voices.includes(voice) &&
+      !ttsSchema.voices.includes('ALL')
+    ) {
+      throw new Error(`Voice ${voice} is not available.`);
+    }
+
+    const data = {
+      model: ttsSchema?.model,
+      input,
+      voice: ttsSchema?.voices && ttsSchema.voices.length > 0 ? voice : undefined,
+      response_format: 'mp3',
     };
 
     const apiKey = resolveConfigSecret(ttsSchema?.apiKey) || '';

--- a/api/server/services/Files/Audio/TTSService.spec.js
+++ b/api/server/services/Files/Audio/TTSService.spec.js
@@ -13,6 +13,7 @@ jest.mock('librechat-data-provider', () => ({
     AZURE_OPENAI: 'azureOpenAI',
     ELEVENLABS: 'elevenlabs',
     LOCALAI: 'localai',
+    GANDR: 'gandr',
   },
 }));
 jest.mock('./streamAudio', () => ({
@@ -68,6 +69,30 @@ describe('TTSService provider header construction with an undecryptable apiKey',
       'voice1',
     );
     expect(headers).not.toHaveProperty('Authorization');
+  });
+
+  it('omits the Authorization header for gandrProvider with an undecryptable apiKey', () => {
+    resolveConfigSecret.mockReturnValue(undefined);
+    const [, , headers] = service.gandrProvider(
+      { apiKey: 'v3:corrupted', voices: [] },
+      'hi',
+      'voice1',
+    );
+    expect(headers).not.toHaveProperty('Authorization');
+  });
+
+  it('sets the Authorization header for gandrProvider when the key resolves', () => {
+    resolveConfigSecret.mockReturnValue('gnd-real-key');
+    const [, data, headers] = service.gandrProvider(
+      { apiKey: 'v3:ok', model: 'gandr-1', voices: ['gandr-ava'] },
+      'hi',
+      'gandr-ava',
+    );
+    expect(headers.Authorization).toBe('Bearer gnd-real-key');
+    expect(data.model).toBe('gandr-1');
+    expect(data.input).toBe('hi');
+    expect(data.voice).toBe('gandr-ava');
+    expect(data.response_format).toBe('mp3');
   });
 });
 

--- a/api/server/services/Files/Audio/getCustomConfigSpeech.js
+++ b/api/server/services/Files/Audio/getCustomConfigSpeech.js
@@ -2,7 +2,13 @@ const { logger } = require('@librechat/data-schemas');
 const { getAppConfig } = require('~/server/services/Config');
 
 const LEGACY_EXTERNAL_STT_ENGINES = new Set(['openai', 'azureOpenAI']);
-const LEGACY_EXTERNAL_TTS_ENGINES = new Set(['openai', 'azureOpenAI', 'elevenlabs', 'localai']);
+const LEGACY_EXTERNAL_TTS_ENGINES = new Set([
+  'openai',
+  'azureOpenAI',
+  'elevenlabs',
+  'localai',
+  'gandr',
+]);
 
 function normalizeSpeechEngine(key, value) {
   if (key === 'engineSTT' && LEGACY_EXTERNAL_STT_ENGINES.has(value)) {

--- a/api/server/services/Files/Audio/getCustomConfigSpeech.spec.js
+++ b/api/server/services/Files/Audio/getCustomConfigSpeech.spec.js
@@ -53,7 +53,7 @@ describe('getCustomConfigSpeech', () => {
     expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ engineSTT }));
   });
 
-  it.each(['openai', 'azureOpenAI', 'elevenlabs', 'localai'])(
+  it.each(['openai', 'azureOpenAI', 'elevenlabs', 'localai', 'gandr'])(
     'normalizes the legacy TTS provider "%s" to the external engine',
     async (engineTTS) => {
       const req = {

--- a/api/server/services/Files/Audio/getVoices.js
+++ b/api/server/services/Files/Audio/getVoices.js
@@ -43,6 +43,9 @@ async function getVoices(req, res) {
       case TTSProviders.LOCALAI:
         voices = ttsSchema.localai?.voices;
         break;
+      case TTSProviders.GANDR:
+        voices = ttsSchema.gandr?.voices;
+        break;
       default:
         throw new Error('Invalid provider');
     }

--- a/client/src/hooks/Config/__tests__/useSpeechSettingsInit.spec.tsx
+++ b/client/src/hooks/Config/__tests__/useSpeechSettingsInit.spec.tsx
@@ -49,7 +49,7 @@ describe('useSpeechSettingsInit', () => {
     },
   );
 
-  it.each(['openai', 'azureOpenAI', 'elevenlabs', 'localai'])(
+  it.each(['openai', 'azureOpenAI', 'elevenlabs', 'localai', 'gandr'])(
     'migrates the persisted TTS provider "%s" to the external engine',
     async (engineTTS) => {
       localStorage.setItem('engineTTS', JSON.stringify(engineTTS));

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -12,6 +12,7 @@ const LEGACY_EXTERNAL_TTS_ENGINES = new Set<string>([
   'azureOpenAI',
   'elevenlabs',
   'localai',
+  'gandr',
 ]);
 
 const normalizeSavedSpeechEngine = (

--- a/packages/api/src/admin/secrets.integration.spec.ts
+++ b/packages/api/src/admin/secrets.integration.spec.ts
@@ -80,6 +80,14 @@ const SECRET_FIELD_CASES: SecretFieldCase[] = [
     siblingValue: 'http://localai:8081',
   },
   {
+    path: 'speech.tts.gandr.apiKey',
+    previewPath: 'speech.tts.gandr.apiKeyPreview',
+    section: 'speech',
+    object: { tts: { gandr: { apiKey: SECRET, model: 'gandr-1', voices: ['gandr-ava'] } } },
+    siblingPath: 'speech.tts.gandr.model',
+    siblingValue: 'gandr-1',
+  },
+  {
     path: 'speech.stt.openai.apiKey',
     previewPath: 'speech.stt.openai.apiKeyPreview',
     section: 'speech',

--- a/packages/api/src/admin/secrets.ts
+++ b/packages/api/src/admin/secrets.ts
@@ -34,6 +34,7 @@ const CONFIG_SECRET_FIELDS: readonly ConfigSecretField[] = (
     { path: 'speech.tts.azureOpenAI.apiKey', allowEnvPlaceholder: true },
     { path: 'speech.tts.elevenlabs.apiKey', allowEnvPlaceholder: true },
     { path: 'speech.tts.localai.apiKey', allowEnvPlaceholder: true },
+    { path: 'speech.tts.gandr.apiKey', allowEnvPlaceholder: true },
     { path: 'speech.stt.openai.apiKey', allowEnvPlaceholder: true },
     { path: 'speech.stt.azureOpenAI.apiKey', allowEnvPlaceholder: true },
     { path: 'webSearch.serperApiKey', allowEnvPlaceholder: true },

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -171,7 +171,7 @@ describe('speechTab schema', () => {
     expect(result.success).toBe(false);
   });
 
-  it.each(['browser', 'external', 'openai', 'azureOpenAI', 'elevenlabs', 'localai'])(
+  it.each(['browser', 'external', 'openai', 'azureOpenAI', 'elevenlabs', 'localai', 'gandr'])(
     'accepts the text-to-speech engine "%s"',
     (engineTTS) => {
       const result = configSchema.safeParse({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1441,12 +1441,21 @@ const ttsLocalaiSchema = z.object({
   backend: z.string(),
 });
 
+const ttsGandrSchema = z.object({
+  url: z.string().optional(),
+  apiKey: z.string(),
+  apiKeyPreview: apiKeyPreviewSchema,
+  model: z.string(),
+  voices: z.array(z.string()),
+});
+
 const ttsSchema = z.object({
   allowedAddresses: allowedAddressesSchema,
   openai: ttsOpenaiSchema.optional(),
   azureOpenAI: ttsAzureOpenAISchema.optional(),
   elevenlabs: ttsElevenLabsSchema.optional(),
   localai: ttsLocalaiSchema.optional(),
+  gandr: ttsGandrSchema.optional(),
 });
 
 const sttOpenaiSchema = z.object({
@@ -1495,7 +1504,15 @@ const speechTab = z
         z.object({
           /** Provider names remain valid for backward compatibility and are normalized for clients. */
           engineTTS: z
-            .enum(['browser', 'external', 'openai', 'azureOpenAI', 'elevenlabs', 'localai'])
+            .enum([
+              'browser',
+              'external',
+              'openai',
+              'azureOpenAI',
+              'elevenlabs',
+              'localai',
+              'gandr',
+            ])
             .optional(),
           voice: z.string().optional(),
           languageTTS: z.string().optional(),
@@ -2465,6 +2482,7 @@ export type TProviderSchema =
   | z.infer<typeof ttsOpenaiSchema>
   | z.infer<typeof ttsElevenLabsSchema>
   | z.infer<typeof ttsLocalaiSchema>
+  | z.infer<typeof ttsGandrSchema>
   | undefined;
 
 export enum KnownEndpoints {
@@ -3210,6 +3228,10 @@ export enum TTSProviders {
    * Provider for LocalAI TTS
    */
   LOCALAI = 'localai',
+  /**
+   * Provider for Gandr TTS
+   */
+  GANDR = 'gandr',
 }
 
 /** Enum for app-wide constants */


### PR DESCRIPTION
## Summary

Adds Gandr as a built-in TTS provider, wired like the existing external TTS providers: a speech.tts.gandr config schema (apiKey, model, voices, optional url), a gandrProvider branch in TTSService, the voice-list case in getVoices, a TTSProviders enum entry, engine normalization entries, and the admin secrets registry so the apiKey is encrypted at rest and redacted on reads.

Requests go to POST https://tts.gandr.ai/v1/audio/speech with a Bearer key (a gnd_ key from gandr.ai) and a JSON body of {model, input, voice, response_format}. Formats are mp3 (default), wav, and pcm, where pcm is raw s16le mono audio. The model id is gandr-1 and the voices are gandr-ava, gandr-dane, gandr-jenny, gandr-leo, gandr-lewis, and gandr-mia. Input is capped at 2000 characters per request.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Extended TTSService.spec.js with gandrProvider header tests and added gandr to the provider enumeration cases in config.spec.ts, getCustomConfigSpeech.spec.js, useSpeechSettingsInit.spec.tsx, and secrets.integration.spec.ts.

    speech:
      tts:
        gandr:
          apiKey: '${GANDR_API_KEY}'
          model: 'gandr-1'
          voices: ['gandr-ava', 'gandr-dane', 'gandr-jenny', 'gandr-leo', 'gandr-lewis', 'gandr-mia']

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have written tests demonstrating that my changes are effective or that my feature works
