### PR TITLE
🧪 fix: Align Detached Activity E2E With the Removed Running Chip

### DIFF
--- a/e2e/specs/mock/subagent-activity.spec.ts
+++ b/e2e/specs/mock/subagent-activity.spec.ts
@@ -106,8 +106,10 @@ test.describe('detached subagent activity', () => {
       const panel = page.getByRole('region', { name: 'Child agent activity' });
       const activityResponse = await activityResponsePromise;
       await expect(panel).toBeVisible();
-      await expect(panel.getByText('Running', { exact: true })).toBeVisible();
       await expect(panel).toContainText('child-1-phase-10');
+      /** An in-flight child reads through its streaming content like the main
+       *  chat view; the panel no longer stamps a "Running" status chip. */
+      await expect(panel.getByText('Running', { exact: true })).toHaveCount(0);
       await expect.poll(() => activityRequests.length).toBe(1);
 
       await expect(panel).toContainText(`E2E detached child 1 complete ${label}`, {

--- a/e2e/specs/mock/subagent-activity.spec.ts
+++ b/e2e/specs/mock/subagent-activity.spec.ts
@@ -107,8 +107,6 @@ test.describe('detached subagent activity', () => {
       const activityResponse = await activityResponsePromise;
       await expect(panel).toBeVisible();
       await expect(panel).toContainText('child-1-phase-10');
-      /** An in-flight child reads through its streaming content like the main
-       *  chat view; the panel no longer stamps a "Running" status chip. */
       await expect(panel.getByText('Running', { exact: true })).toHaveCount(0);
       await expect.poll(() => activityRequests.length).toBe(1);
 


### PR DESCRIPTION
## Summary

Follow-up to #15379, which merged while its `e2e (redis transport)` job was still running — that job then failed for a real reason: `e2e/specs/mock/subagent-activity.spec.ts` gated on the panel's `Running` status chip, which #15379 removed (an in-flight child now reads through its streaming content, like main chat).

The spec now asserts the streamed content directly and that the chip never renders, matching the merged contract. One-line behavior change, spec-only.