### PR TITLE
📥 fix: Support Newer ChatGPT Export Format and Report Partial Imports

### DIFF
--- a/api/server/routes/__tests__/convos.spec.js
+++ b/api/server/routes/__tests__/convos.spec.js
@@ -248,6 +248,19 @@ describe('Convos Routes', () => {
       });
     });
 
+    it('reports how many conversations were imported and skipped', async () => {
+      importConversations.mockResolvedValue({ imported: 42, failed: 3 });
+
+      const response = await request(app).post('/api/convos/import');
+
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual({
+        message: 'Conversation(s) imported successfully',
+        imported: 42,
+        failed: 3,
+      });
+    });
+
     it('returns only metadata-safe filter details for a blocked import', async () => {
       const error = Object.assign(new Error('blocked'), {
         code: 'content_filter_block',

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -725,7 +725,7 @@ router.post(
   async (req, res) => {
     try {
       /* TODO: optimize to return imported conversations and add manually */
-      await importConversations({
+      const summary = await importConversations({
         filepath: req.file.path,
         requestUserId: req.user.id,
         userRole: req.user.role,
@@ -735,7 +735,7 @@ router.post(
           ? {}
           : { legacyPii: req.config.messageFilter.pii }),
       });
-      res.status(201).json({ message: 'Conversation(s) imported successfully' });
+      res.status(201).json({ message: 'Conversation(s) imported successfully', ...summary });
     } catch (error) {
       if (isContentFilterError(error)) {
         return res.status(error.statusCode).json(error.body);

--- a/api/server/utils/import/__data__/chatgpt-modern-export.json
+++ b/api/server/utils/import/__data__/chatgpt-modern-export.json
@@ -1,0 +1,178 @@
+[
+  {
+    "title": "Deploying the staging cluster",
+    "create_time": 1756000000.123456,
+    "update_time": 1756000400.654321,
+    "mapping": {
+      "client-created-root": {
+        "id": "client-created-root",
+        "message": null,
+        "parent": null,
+        "children": ["ctx-node"]
+      },
+      "ctx-node": {
+        "id": "ctx-node",
+        "message": {
+          "id": "ctx-node",
+          "author": { "role": "user", "name": null, "metadata": {} },
+          "create_time": null,
+          "update_time": null,
+          "content": {
+            "content_type": "user_editable_context",
+            "user_profile": "The user is an SRE.",
+            "user_instructions": "Answer concisely."
+          },
+          "status": "finished_successfully",
+          "weight": 0,
+          "metadata": {
+            "is_visually_hidden_from_conversation": true,
+            "is_user_system_message": true
+          },
+          "recipient": "all",
+          "channel": null
+        },
+        "parent": "client-created-root",
+        "children": ["user-1"]
+      },
+      "user-1": {
+        "id": "user-1",
+        "message": {
+          "id": "user-1",
+          "author": { "role": "user", "name": null, "metadata": {} },
+          "create_time": 1756000001.0,
+          "update_time": null,
+          "content": { "content_type": "text", "parts": ["How do I roll back the deploy?"] },
+          "status": "finished_successfully",
+          "weight": 1.0,
+          "metadata": { "request_id": "abc123", "timestamp_": "absolute" },
+          "recipient": "all",
+          "channel": null
+        },
+        "parent": "ctx-node",
+        "children": ["assistant-1"]
+      },
+      "assistant-1": {
+        "id": "assistant-1",
+        "message": {
+          "id": "assistant-1",
+          "author": { "role": "assistant", "name": null, "metadata": {} },
+          "create_time": 1756000002.0,
+          "update_time": null,
+          "content": { "content_type": "text", "parts": ["Run `helm rollback staging`."] },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": { "finish_details": { "type": "stop" }, "is_complete": true },
+          "recipient": "all",
+          "channel": "final"
+        },
+        "parent": "user-1",
+        "children": ["user-2"]
+      },
+      "user-2": {
+        "id": "user-2",
+        "message": {
+          "id": "user-2",
+          "author": { "role": "user", "name": null, "metadata": {} },
+          "create_time": 1756000003.0,
+          "update_time": null,
+          "content": { "content_type": "text", "parts": ["And if that fails?"] },
+          "status": "finished_successfully",
+          "weight": 1.0,
+          "metadata": {},
+          "recipient": "all",
+          "channel": null
+        },
+        "parent": "assistant-1",
+        "children": ["assistant-2"]
+      },
+      "assistant-2": {
+        "id": "assistant-2",
+        "message": {
+          "id": "assistant-2",
+          "author": { "role": "assistant", "name": null, "metadata": {} },
+          "create_time": 1756000004.0,
+          "update_time": null,
+          "content": {
+            "content_type": "text",
+            "parts": ["Restore from the last known-good chart."]
+          },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "weight": 1.0,
+          "metadata": { "model_slug": "o4-mini", "is_complete": true },
+          "recipient": "all",
+          "channel": "final"
+        },
+        "parent": "user-2",
+        "children": []
+      }
+    },
+    "moderation_results": [],
+    "current_node": "assistant-2",
+    "conversation_id": "6b0f0d9c-0000-4000-8000-000000000001",
+    "conversation_template_id": null,
+    "gizmo_id": null,
+    "is_archived": false,
+    "is_starred": null,
+    "safe_urls": [],
+    "blocked_urls": [],
+    "default_model_slug": "gpt-5-thinking",
+    "conversation_origin": null,
+    "voice": null,
+    "async_status": null,
+    "disabled_tool_ids": [],
+    "is_do_not_remember": false,
+    "memory_scope": "global_enabled",
+    "id": "6b0f0d9c-0000-4000-8000-000000000001"
+  },
+  {
+    "title": "Corrupted entry",
+    "create_time": 1756000500.0,
+    "update_time": 1756000500.0,
+    "conversation_id": "6b0f0d9c-0000-4000-8000-000000000002",
+    "default_model_slug": "gpt-5",
+    "id": "6b0f0d9c-0000-4000-8000-000000000002"
+  },
+  {
+    "title": "Weeknight pasta",
+    "create_time": 1756001000.0,
+    "update_time": 1756001100.0,
+    "mapping": {
+      "root-2": { "id": "root-2", "message": null, "parent": null, "children": ["user-3"] },
+      "user-3": {
+        "id": "user-3",
+        "message": {
+          "id": "user-3",
+          "author": { "role": "user", "name": null, "metadata": {} },
+          "create_time": 1756001001.0,
+          "content": { "content_type": "text", "parts": ["Something with anchovies?"] },
+          "status": "finished_successfully",
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "root-2",
+        "children": ["assistant-3"]
+      },
+      "assistant-3": {
+        "id": "assistant-3",
+        "message": {
+          "id": "assistant-3",
+          "author": { "role": "assistant", "name": null, "metadata": {} },
+          "create_time": 1756001002.0,
+          "content": { "content_type": "text", "parts": ["Puttanesca."] },
+          "status": "finished_successfully",
+          "end_turn": true,
+          "metadata": {},
+          "recipient": "all"
+        },
+        "parent": "user-3",
+        "children": []
+      }
+    },
+    "current_node": "assistant-3",
+    "conversation_id": "6b0f0d9c-0000-4000-8000-000000000003",
+    "default_model_slug": "gpt-5",
+    "id": "6b0f0d9c-0000-4000-8000-000000000003"
+  }
+]

--- a/api/server/utils/import/importBatchBuilder.js
+++ b/api/server/utils/import/importBatchBuilder.js
@@ -171,6 +171,25 @@ class ImportBatchBuilder {
   }
 
   /**
+   * Captures how much of the batch has been staged so far.
+   * @returns {{ conversations: number, messages: number }} A checkpoint token.
+   */
+  checkpoint() {
+    return { conversations: this.conversations.length, messages: this.messages.length };
+  }
+
+  /**
+   * Discards everything staged after the given checkpoint, so a conversation that
+   * fails partway through can be dropped without losing the ones before it.
+   * @param {{ conversations: number, messages: number }} checkpoint - Token from {@link checkpoint}.
+   * @returns {void}
+   */
+  rollback(checkpoint) {
+    this.conversations.length = checkpoint.conversations;
+    this.messages.length = checkpoint.messages;
+  }
+
+  /**
    * Saves the batch of conversations and messages to the DB.
    * Also increments tag counts for any existing tags.
    * @returns {Promise<void>} A promise that resolves when the batch is saved.

--- a/api/server/utils/import/importBatchBuilder.spec.js
+++ b/api/server/utils/import/importBatchBuilder.spec.js
@@ -891,3 +891,39 @@ describe('ImportBatchBuilder content filtering', () => {
     expect(error.body).not.toHaveProperty('fragmentPath');
   });
 });
+
+describe('ImportBatchBuilder checkpoint/rollback', () => {
+  it('discards only what was staged after the checkpoint', () => {
+    const builder = new ImportBatchBuilder('user-123');
+
+    builder.startConversation(EModelEndpoint.openAI);
+    builder.addUserMessage('kept question');
+    builder.addGptMessage('kept answer', 'gpt-4o');
+    builder.finishConversation('Kept', new Date());
+
+    const checkpoint = builder.checkpoint();
+
+    builder.startConversation(EModelEndpoint.openAI);
+    builder.addUserMessage('discarded question');
+    builder.rollback(checkpoint);
+
+    expect(builder.conversations).toHaveLength(1);
+    expect(builder.conversations[0].title).toBe('Kept');
+    expect(builder.messages).toHaveLength(2);
+    expect(builder.messages.map((msg) => msg.text)).toEqual(['kept question', 'kept answer']);
+  });
+
+  it('is a no-op when nothing was staged after the checkpoint', () => {
+    const builder = new ImportBatchBuilder('user-123');
+
+    builder.startConversation(EModelEndpoint.openAI);
+    builder.addUserMessage('only message');
+    builder.finishConversation('Only', new Date());
+
+    const checkpoint = builder.checkpoint();
+    builder.rollback(checkpoint);
+
+    expect(builder.conversations).toHaveLength(1);
+    expect(builder.messages).toHaveLength(1);
+  });
+});

--- a/api/server/utils/import/importConversations.js
+++ b/api/server/utils/import/importConversations.js
@@ -9,6 +9,7 @@ const maxFileSize = resolveImportMaxFileSize();
 /**
  * Job definition for importing a conversation.
  * @param {{ filepath: string, requestUserId: string, userRole?: string, interfaceConfig?: object, filters?: object, legacyPii?: object }} job
+ * @returns {Promise<{ imported: number, failed: number }>} Counts of imported and skipped conversations.
  */
 const importConversations = async (job) => {
   const { filepath, requestUserId, userRole, interfaceConfig, filters, legacyPii } = job;
@@ -25,7 +26,7 @@ const importConversations = async (job) => {
     const fileData = await fs.readFile(filepath, 'utf8');
     const jsonData = JSON.parse(fileData);
     const importer = getImporter(jsonData);
-    await importer(
+    const summary = await importer(
       jsonData,
       requestUserId,
       (userId) =>
@@ -35,6 +36,7 @@ const importConversations = async (job) => {
       userRole,
     );
     logger.debug(`user: ${requestUserId} | Finished importing conversations`);
+    return { imported: summary?.imported ?? 1, failed: summary?.failed ?? 0 };
   } catch (error) {
     logger.error(`user: ${requestUserId} | Failed to import conversation: `, error);
     throw error; // throw error all the way up so request does not return success

--- a/api/server/utils/import/importConversations.js
+++ b/api/server/utils/import/importConversations.js
@@ -36,7 +36,7 @@ const importConversations = async (job) => {
       userRole,
     );
     logger.debug(`user: ${requestUserId} | Finished importing conversations`);
-    return { imported: summary?.imported ?? 1, failed: summary?.failed ?? 0 };
+    return summary;
   } catch (error) {
     logger.error(`user: ${requestUserId} | Failed to import conversation: `, error);
     throw error; // throw error all the way up so request does not return success

--- a/api/server/utils/import/importers.js
+++ b/api/server/utils/import/importers.js
@@ -93,6 +93,20 @@ function describeConversation(conv) {
 }
 
 /**
+ * Coerces an exported timestamp into a usable Date. An unparseable value would
+ * otherwise persist as an Invalid Date and fail the whole batch at bulk-write time,
+ * which happens after per-conversation isolation and so cannot be attributed or
+ * skipped. Callers keep their own handling for a missing timestamp.
+ *
+ * @param {number|string|Date} value - Timestamp from the export, already in milliseconds.
+ * @returns {Date} The parsed date, or the current time when it cannot be parsed.
+ */
+function toImportedDate(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+/**
  * Identifies ChatGPT messages that never rendered in the source conversation:
  * system prompts, the reasoning summaries that get merged into their response, and
  * the hidden context blocks newer exports inject ahead of the first user turn
@@ -169,13 +183,24 @@ function importEachConversation({
 function getImporter(jsonData) {
   // For array-based formats (ChatGPT or Claude)
   if (Array.isArray(jsonData)) {
-    // Claude format has chat_messages array in each conversation
-    if (jsonData.length > 0 && jsonData[0]?.chat_messages) {
-      logger.info('Importing Claude conversation');
-      return importClaudeConvo;
+    /**
+     * Scan for the first recognizable entry rather than trusting index 0: a single
+     * malformed conversation at the head of an export would otherwise reject the
+     * whole file, while the same file imports fine when that entry appears later.
+     */
+    for (const conv of jsonData) {
+      // Claude format has chat_messages array in each conversation
+      if (conv?.chat_messages) {
+        logger.info('Importing Claude conversation');
+        return importClaudeConvo;
+      }
+      // ChatGPT format has mapping object in each conversation
+      if (conv?.mapping) {
+        logger.info('Importing ChatGPT conversation');
+        return importChatGptConvo;
+      }
     }
-    // ChatGPT format has mapping object in each conversation
-    if (jsonData.length === 0 || jsonData[0]?.mapping) {
+    if (jsonData.length === 0) {
       logger.info('Importing ChatGPT conversation');
       return importChatGptConvo;
     }
@@ -203,7 +228,7 @@ function getImporter(jsonData) {
  * @param {Object} jsonData - The JSON data containing the chatbot conversation.
  * @param {string} requestUserId - The ID of the user making the import request.
  * @param {Function} [builderFactory=createImportBatchBuilder] - The factory function to create an import batch builder.
- * @returns {Promise<void>} - A promise that resolves when the import is complete.
+ * @returns {Promise<ImportSummary>} Counts of imported and skipped conversations.
  * @throws {Error} - If there is an error creating the conversation from the JSON file.
  */
 async function importChatBotUiConvo(
@@ -222,19 +247,26 @@ async function importChatBotUiConvo(
       userRole,
     });
 
-    for (const historyItem of jsonData.history) {
-      importBatchBuilder.startConversation(EModelEndpoint.openAI);
-      for (const message of historyItem.messages) {
-        if (message.role === 'assistant') {
-          importBatchBuilder.addGptMessage(message.content, historyItem.model.id);
-        } else if (message.role === 'user') {
-          importBatchBuilder.addUserMessage(message.content);
+    const summary = importEachConversation({
+      conversations: jsonData.history,
+      importBatchBuilder,
+      requestUserId,
+      importConversation: (historyItem) => {
+        importBatchBuilder.startConversation(EModelEndpoint.openAI);
+        for (const message of historyItem.messages) {
+          if (message.role === 'assistant') {
+            importBatchBuilder.addGptMessage(message.content, historyItem.model.id);
+          } else if (message.role === 'user') {
+            importBatchBuilder.addUserMessage(message.content);
+          }
         }
-      }
-      importBatchBuilder.finishConversation(historyItem.name, new Date(), {}, defaultModel);
-    }
+        importBatchBuilder.finishConversation(historyItem.name, new Date(), {}, defaultModel);
+      },
+    });
+
     await importBatchBuilder.saveBatch();
     logger.info(`user: ${requestUserId} | ChatbotUI conversation imported`);
+    return summary;
   } catch (error) {
     logger.error(`user: ${requestUserId} | Error creating conversation from ChatbotUI file`, error);
     throw error;
@@ -291,8 +323,8 @@ async function importClaudeConvo(
 
     const importClaudeConversation = (conv) => {
       const chatMessages = conv?.chat_messages;
-      if (chatMessages != null && !Array.isArray(chatMessages)) {
-        throw new Error('Conversation has an invalid chat_messages list');
+      if (!Array.isArray(chatMessages)) {
+        throw new Error('Conversation has no chat_messages list');
       }
 
       importBatchBuilder.startConversation(EModelEndpoint.anthropic);
@@ -300,7 +332,7 @@ async function importClaudeConvo(
       let lastMessageId = Constants.NO_PARENT;
       let lastTimestamp = null;
 
-      for (const msg of chatMessages || []) {
+      for (const msg of chatMessages) {
         const isCreatedByUser = msg.sender === 'human';
         const messageId = uuidv4();
 
@@ -313,7 +345,7 @@ async function importClaudeConvo(
 
         // Parse timestamp, fallback to conversation create_time or current time
         const messageTime = msg.created_at || conv.created_at;
-        let createdAt = messageTime ? new Date(messageTime) : new Date();
+        let createdAt = messageTime ? toImportedDate(messageTime) : new Date();
 
         // Ensure timestamp is after the previous message.
         // Messages are sorted by createdAt and buildTree expects parents to appear before children.
@@ -347,7 +379,7 @@ async function importClaudeConvo(
         lastMessageId = messageId;
       }
 
-      const createdAt = conv.created_at ? new Date(conv.created_at) : new Date();
+      const createdAt = conv.created_at ? toImportedDate(conv.created_at) : new Date();
       importBatchBuilder.finishConversation(
         conv.name || 'Imported Claude Chat',
         createdAt,
@@ -378,7 +410,7 @@ async function importClaudeConvo(
  * @param {Object} jsonData - The JSON data representing the conversation.
  * @param {string} requestUserId - The ID of the user making the import request.
  * @param {Function} [builderFactory=createImportBatchBuilder] - The factory function to create an import batch builder.
- * @returns {Promise<void>} - A promise that resolves when the import is complete.
+ * @returns {Promise<ImportSummary>} Counts of imported and skipped conversations.
  */
 async function importLibreChatConvo(
   jsonData,
@@ -479,6 +511,7 @@ async function importLibreChatConvo(
     );
     await importBatchBuilder.saveBatch();
     logger.debug(`user: ${requestUserId} | Conversation "${jsonData.title}" imported`);
+    return { imported: 1, failed: 0 };
   } catch (error) {
     logger.error(`user: ${requestUserId} | Error creating conversation from LibreChat file`, error);
     throw error;
@@ -666,7 +699,7 @@ function processConversation(conv, importBatchBuilder, requestUserId, defaultMod
     // Use create_time from ChatGPT export to ensure proper message ordering
     // For null timestamps, use the conversation's create_time as fallback, or current time as last resort
     const messageTime = mapping.message.create_time || conv.create_time;
-    const createdAt = messageTime ? new Date(messageTime * 1000) : new Date();
+    const createdAt = messageTime ? toImportedDate(messageTime * 1000) : new Date();
 
     const message = {
       messageId: newMessageId,
@@ -704,8 +737,10 @@ function processConversation(conv, importBatchBuilder, requestUserId, defaultMod
 
   importBatchBuilder.finishConversation(
     conv.title,
-    new Date(conv.create_time * 1000),
-    {},
+    conv.create_time ? toImportedDate(conv.create_time * 1000) : new Date(),
+    /** Keeps the conversation on the model its messages were imported with, so the
+     * next turn is sent to the same model the chat is labeled with. */
+    conv.default_model_slug ? { model: conv.default_model_slug } : {},
     defaultModel,
   );
 }

--- a/api/server/utils/import/importers.js
+++ b/api/server/utils/import/importers.js
@@ -75,6 +75,91 @@ function sanitizeImportedMessage(message) {
 }
 
 /**
+ * Reports what a single import file actually produced, so a request that saved
+ * nothing (or only part of the file) is never reported to the user as a success.
+ * @typedef {object} ImportSummary
+ * @property {number} imported - Conversations written to the batch.
+ * @property {number} failed - Conversations skipped because they could not be read.
+ */
+
+/**
+ * Describes a conversation for logs when it cannot be imported. Falls back through
+ * the identifiers newer exports use before giving up on a name.
+ * @param {object} [conv] - The source conversation.
+ * @returns {string} A human-readable identifier.
+ */
+function describeConversation(conv) {
+  return conv?.title || conv?.name || conv?.conversation_id || conv?.uuid || 'Untitled';
+}
+
+/**
+ * Identifies ChatGPT messages that never rendered in the source conversation:
+ * system prompts, the reasoning summaries that get merged into their response, and
+ * the hidden context blocks newer exports inject ahead of the first user turn
+ * (user profile, custom instructions, model-editable memory). These are kept in the
+ * id map so replies can be re-parented through them, but are not imported themselves.
+ *
+ * @param {ChatGPTMessage} [message] - The message from a mapping node.
+ * @returns {boolean} Whether the message should be skipped.
+ */
+function isHiddenChatGptMessage(message) {
+  if (message?.author?.role === 'system') {
+    return true;
+  }
+  if (message?.metadata?.is_visually_hidden_from_conversation === true) {
+    return true;
+  }
+  const contentType = message?.content?.content_type;
+  return contentType === 'thoughts' || contentType === 'reasoning_recap';
+}
+
+/**
+ * Imports each conversation in isolation so one malformed entry cannot discard an
+ * entire export file. Newer ChatGPT exports ship tens of thousands of conversations
+ * split across many files, where a single unreadable entry used to abort everything.
+ *
+ * @param {object} params
+ * @param {object[]} params.conversations - The conversations to import.
+ * @param {ImportBatchBuilder} params.importBatchBuilder - The batch being built.
+ * @param {string} params.requestUserId - The ID of the importing user.
+ * @param {(conv: object) => void} params.importConversation - Stages a single conversation.
+ * @returns {ImportSummary} Counts of imported and skipped conversations.
+ */
+function importEachConversation({
+  conversations,
+  importBatchBuilder,
+  requestUserId,
+  importConversation,
+}) {
+  let imported = 0;
+  let failed = 0;
+
+  for (const conv of conversations) {
+    const checkpoint = importBatchBuilder.checkpoint();
+    try {
+      importConversation(conv);
+      imported++;
+    } catch (error) {
+      importBatchBuilder.rollback(checkpoint);
+      failed++;
+      logger.warn(
+        `user: ${requestUserId} | Skipped unreadable conversation "${describeConversation(conv)}": ${error.message}`,
+      );
+    }
+  }
+
+  if (imported === 0) {
+    throw new Error(
+      failed > 0
+        ? `None of the ${failed} conversation(s) in this file could be imported`
+        : 'No conversations found in this file',
+    );
+  }
+
+  return { imported, failed };
+}
+
+/**
  * Returns the appropriate importer function based on the provided JSON data.
  *
  * @param {Object} jsonData - The JSON data to import.
@@ -188,7 +273,7 @@ function extractClaudeContent(msg) {
  * @param {Array} jsonData - Array of Claude conversation objects to be imported.
  * @param {string} requestUserId - The ID of the user who initiated the import process.
  * @param {Function} builderFactory - Factory function to create a new import batch builder instance.
- * @returns {Promise<void>} Promise that resolves when all conversations have been imported.
+ * @returns {Promise<ImportSummary>} Counts of imported and skipped conversations.
  */
 async function importClaudeConvo(
   jsonData,
@@ -204,13 +289,18 @@ async function importClaudeConvo(
       userRole,
     });
 
-    for (const conv of jsonData) {
+    const importClaudeConversation = (conv) => {
+      const chatMessages = conv?.chat_messages;
+      if (chatMessages != null && !Array.isArray(chatMessages)) {
+        throw new Error('Conversation has an invalid chat_messages list');
+      }
+
       importBatchBuilder.startConversation(EModelEndpoint.anthropic);
 
       let lastMessageId = Constants.NO_PARENT;
       let lastTimestamp = null;
 
-      for (const msg of conv.chat_messages || []) {
+      for (const msg of chatMessages || []) {
         const isCreatedByUser = msg.sender === 'human';
         const messageId = uuidv4();
 
@@ -264,10 +354,18 @@ async function importClaudeConvo(
         {},
         defaultModel,
       );
-    }
+    };
+
+    const summary = importEachConversation({
+      conversations: jsonData,
+      importBatchBuilder,
+      requestUserId,
+      importConversation: importClaudeConversation,
+    });
 
     await importBatchBuilder.saveBatch();
     logger.info(`user: ${requestUserId} | Claude conversation imported`);
+    return summary;
   } catch (error) {
     logger.error(`user: ${requestUserId} | Error creating conversation from Claude file`, error);
     throw error;
@@ -394,7 +492,7 @@ async function importLibreChatConvo(
  * @param {ChatGPTConvo[]} jsonData - Array of conversation objects to be imported.
  * @param {string} requestUserId - The ID of the user who initiated the import process.
  * @param {Function} builderFactory - Factory function to create a new import batch builder instance, defaults to createImportBatchBuilder.
- * @returns {Promise<void>} Promise that resolves when all conversations have been imported.
+ * @returns {Promise<ImportSummary>} Counts of imported and skipped conversations.
  */
 async function importChatGptConvo(
   jsonData,
@@ -409,10 +507,15 @@ async function importChatGptConvo(
       requestUserId,
       userRole,
     });
-    for (const conv of jsonData) {
-      processConversation(conv, importBatchBuilder, requestUserId, defaultModel);
-    }
+    const summary = importEachConversation({
+      conversations: jsonData,
+      importBatchBuilder,
+      requestUserId,
+      importConversation: (conv) =>
+        processConversation(conv, importBatchBuilder, requestUserId, defaultModel),
+    });
     await importBatchBuilder.saveBatch();
+    return summary;
   } catch (error) {
     logger.error(`user: ${requestUserId} | Error creating conversation from imported file`, error);
     throw error;
@@ -430,6 +533,10 @@ async function importChatGptConvo(
  * @returns {void}
  */
 function processConversation(conv, importBatchBuilder, requestUserId, defaultModel) {
+  if (!conv?.mapping || typeof conv.mapping !== 'object') {
+    throw new Error('Conversation has no message mapping');
+  }
+
   importBatchBuilder.startConversation(EModelEndpoint.openAI);
 
   // Map all message IDs to new UUIDs
@@ -464,13 +571,7 @@ function processConversation(conv, importBatchBuilder, requestUserId, defaultMod
         return Constants.NO_PARENT;
       }
 
-      const contentType = parentMapping.message.content?.content_type;
-      const shouldSkip =
-        parentMapping.message.author?.role === 'system' ||
-        contentType === 'reasoning_recap' ||
-        contentType === 'thoughts';
-
-      if (!shouldSkip) {
+      if (!isHiddenChatGptMessage(parentMapping.message)) {
         return messageMap.get(parentId);
       }
 
@@ -529,20 +630,10 @@ function processConversation(conv, importBatchBuilder, requestUserId, defaultMod
     if (!mapping.message) {
       messageMap.delete(id);
       continue;
-    } else if (role === 'system') {
-      // Skip system messages but keep their ID in messageMap for parent references
-      continue;
     }
 
-    const contentType = mapping.message.content?.content_type;
-
-    // Skip thoughts messages - they will be merged into the response message
-    if (contentType === 'thoughts') {
-      continue;
-    }
-
-    // Skip reasoning_recap messages (just summaries like "Thought for 44s")
-    if (contentType === 'reasoning_recap') {
+    // Keep hidden messages in messageMap so replies can be re-parented through them
+    if (isHiddenChatGptMessage(mapping.message)) {
       continue;
     }
 
@@ -557,7 +648,10 @@ function processConversation(conv, importBatchBuilder, requestUserId, defaultMod
     const isCreatedByUser = role === 'user';
     let sender = isCreatedByUser ? 'user' : 'assistant';
     const model =
-      mapping.message.metadata?.model_slug || defaultModel || openAISettings.model.default;
+      mapping.message.metadata?.model_slug ||
+      conv.default_model_slug ||
+      defaultModel ||
+      openAISettings.model.default;
 
     if (!isCreatedByUser) {
       /** Extracted model name from model slug */

--- a/api/server/utils/import/importers.spec.js
+++ b/api/server/utils/import/importers.spec.js
@@ -850,6 +850,117 @@ describe('importChatGptConvo', () => {
       'db unavailable',
     );
   });
+
+  describe('newer ChatGPT export format', () => {
+    const modernExport = () =>
+      JSON.parse(
+        fs.readFileSync(path.join(__dirname, '__data__', 'chatgpt-modern-export.json'), 'utf8'),
+      );
+
+    const importModernExport = async (jsonData) => {
+      const requestUserId = 'user-123';
+      const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+      jest.spyOn(importBatchBuilder, 'saveMessage');
+      jest.spyOn(importBatchBuilder, 'finishConversation');
+
+      const importer = getImporter(jsonData);
+      const summary = await importer(jsonData, requestUserId, () => importBatchBuilder);
+      return {
+        summary,
+        importBatchBuilder,
+        savedMessages: importBatchBuilder.saveMessage.mock.calls.map((call) => call[0]),
+      };
+    };
+
+    it('should fall back to the conversation-level model when a message has no model_slug', async () => {
+      const { savedMessages } = await importModernExport(modernExport());
+
+      const firstReply = savedMessages.find((msg) => msg.text === 'Run `helm rollback staging`.');
+      expect(firstReply.model).toBe('gpt-5-thinking');
+      expect(firstReply.sender).toBe('GPT-5-thinking');
+    });
+
+    it('should prefer a per-message model_slug over the conversation-level model', async () => {
+      const { savedMessages } = await importModernExport(modernExport());
+
+      const secondReply = savedMessages.find(
+        (msg) => msg.text === 'Restore from the last known-good chart.',
+      );
+      expect(secondReply.model).toBe('o4-mini');
+    });
+
+    it('should skip hidden context messages and re-parent replies through them', async () => {
+      const { savedMessages } = await importModernExport(modernExport());
+
+      expect(savedMessages.some((msg) => msg.text.includes('user_editable_context'))).toBe(false);
+      expect(savedMessages.some((msg) => msg.text.includes('The user is an SRE.'))).toBe(false);
+
+      const firstQuestion = savedMessages.find(
+        (msg) => msg.text === 'How do I roll back the deploy?',
+      );
+      expect(firstQuestion.parentMessageId).toBe(Constants.NO_PARENT);
+    });
+
+    it('should import the readable conversations and skip only the malformed one', async () => {
+      const { summary, savedMessages, importBatchBuilder } =
+        await importModernExport(modernExport());
+
+      expect(summary).toEqual({ imported: 2, failed: 1 });
+      expect(importBatchBuilder.finishConversation).toHaveBeenCalledTimes(2);
+      expect(savedMessages).toHaveLength(6);
+      expect(savedMessages.some((msg) => msg.text === 'Puttanesca.')).toBe(true);
+    });
+
+    it('should not persist messages staged by a conversation that failed partway', async () => {
+      const jsonData = modernExport();
+      const requestUserId = 'user-123';
+      const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+      const realFinish = importBatchBuilder.finishConversation.bind(importBatchBuilder);
+      jest
+        .spyOn(importBatchBuilder, 'finishConversation')
+        .mockImplementationOnce(() => {
+          throw new Error('content policy rejected this conversation');
+        })
+        .mockImplementation(realFinish);
+
+      const importer = getImporter(jsonData);
+      const summary = await importer(jsonData, requestUserId, () => importBatchBuilder);
+
+      expect(summary).toEqual({ imported: 1, failed: 2 });
+      expect(importBatchBuilder.conversations).toHaveLength(1);
+      expect(importBatchBuilder.messages).toHaveLength(2);
+      expect(
+        importBatchBuilder.messages.every(
+          (msg) => msg.conversationId === importBatchBuilder.conversations[0].conversationId,
+        ),
+      ).toBe(true);
+    });
+
+    it('should throw when no conversation in the file could be imported', async () => {
+      const jsonData = [{ title: 'Corrupted entry', create_time: 1756000500, mapping: 'corrupt' }];
+      const requestUserId = 'user-123';
+      const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+      jest.spyOn(importBatchBuilder, 'saveBatch');
+
+      const importer = getImporter(jsonData);
+      await expect(importer(jsonData, requestUserId, () => importBatchBuilder)).rejects.toThrow(
+        'None of the 1 conversation(s) in this file could be imported',
+      );
+      expect(importBatchBuilder.saveBatch).not.toHaveBeenCalled();
+    });
+
+    it('should throw for an export file with no conversations instead of reporting success', async () => {
+      const requestUserId = 'user-123';
+      const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+      jest.spyOn(importBatchBuilder, 'saveBatch');
+
+      const importer = getImporter([]);
+      await expect(importer([], requestUserId, () => importBatchBuilder)).rejects.toThrow(
+        'No conversations found in this file',
+      );
+      expect(importBatchBuilder.saveBatch).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('importLibreChatConvo', () => {
@@ -2056,5 +2167,40 @@ describe('importClaudeConvo', () => {
       {},
       expect.any(String),
     );
+  });
+
+  it('should keep importing after an unreadable conversation', async () => {
+    const jsonData = [
+      {
+        uuid: 'conv-broken',
+        name: 'Broken',
+        created_at: '2025-01-15T10:00:00.000Z',
+        chat_messages: 'not-an-array',
+      },
+      {
+        uuid: 'conv-ok',
+        name: 'Readable',
+        created_at: '2025-01-15T11:00:00.000Z',
+        chat_messages: [
+          {
+            uuid: 'msg-1',
+            sender: 'human',
+            created_at: '2025-01-15T11:00:01.000Z',
+            content: [{ type: 'text', text: 'Still here' }],
+          },
+        ],
+      },
+    ];
+
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+    jest.spyOn(importBatchBuilder, 'saveMessage');
+
+    const importer = getImporter(jsonData);
+    const summary = await importer(jsonData, requestUserId, () => importBatchBuilder);
+
+    expect(summary).toEqual({ imported: 1, failed: 1 });
+    expect(importBatchBuilder.saveMessage).toHaveBeenCalledTimes(1);
+    expect(importBatchBuilder.conversations).toHaveLength(1);
   });
 });

--- a/api/server/utils/import/importers.spec.js
+++ b/api/server/utils/import/importers.spec.js
@@ -949,6 +949,37 @@ describe('importChatGptConvo', () => {
       expect(importBatchBuilder.saveBatch).not.toHaveBeenCalled();
     });
 
+    it('should skip a malformed first entry rather than rejecting the whole file', async () => {
+      const [readable, corrupt, alsoReadable] = modernExport();
+      const jsonData = [corrupt, readable, alsoReadable];
+
+      const { summary, savedMessages } = await importModernExport(jsonData);
+
+      expect(summary).toEqual({ imported: 2, failed: 1 });
+      expect(savedMessages.some((msg) => msg.text === 'Puttanesca.')).toBe(true);
+    });
+
+    it('should keep the conversation on the model its messages were imported with', async () => {
+      const { importBatchBuilder } = await importModernExport(modernExport());
+
+      const [conversation] = importBatchBuilder.conversations;
+      expect(conversation.title).toBe('Deploying the staging cluster');
+      expect(conversation.model).toBe('gpt-5-thinking');
+    });
+
+    it('should not persist an invalid date when create_time is unparseable', async () => {
+      const jsonData = modernExport().slice(0, 1);
+      jsonData[0].create_time = 'not-a-timestamp';
+      jsonData[0].mapping['user-1'].message.create_time = 'also-not-a-timestamp';
+
+      const { savedMessages, importBatchBuilder } = await importModernExport(jsonData);
+
+      for (const message of savedMessages) {
+        expect(Number.isNaN(message.createdAt.getTime())).toBe(false);
+      }
+      expect(Number.isNaN(importBatchBuilder.conversations[0].createdAt.getTime())).toBe(false);
+    });
+
     it('should throw for an export file with no conversations instead of reporting success', async () => {
       const requestUserId = 'user-123';
       const importBatchBuilder = new ImportBatchBuilder(requestUserId);
@@ -1488,6 +1519,33 @@ describe('importChatBotUiConvo', () => {
 
     expect(importBatchBuilder.saveBatch).toHaveBeenCalled();
   });
+
+  it('should report the number of conversations it actually imported', async () => {
+    const jsonData = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '__data__', 'chatbotui-export.json'), 'utf8'),
+    );
+    const requestUserId = 'custom-user-456';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    const importer = getImporter(jsonData);
+    const summary = await importer(jsonData, requestUserId, () => importBatchBuilder);
+
+    expect(summary).toEqual({ imported: jsonData.history.length, failed: 0 });
+    expect(summary.imported).toBeGreaterThan(1);
+  });
+
+  it('should throw for an export whose history is empty rather than reporting a success', async () => {
+    const jsonData = { version: 1, history: [], folders: [], prompts: [] };
+    const requestUserId = 'custom-user-456';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+    jest.spyOn(importBatchBuilder, 'saveBatch');
+
+    const importer = getImporter(jsonData);
+    await expect(importer(jsonData, requestUserId, () => importBatchBuilder)).rejects.toThrow(
+      'No conversations found in this file',
+    );
+    expect(importBatchBuilder.saveBatch).not.toHaveBeenCalled();
+  });
 });
 
 describe('getImporter', () => {
@@ -1505,6 +1563,18 @@ describe('getImporter', () => {
 
   it('should route empty arrays to the ChatGPT importer without throwing', () => {
     expect(() => getImporter([])).not.toThrow();
+  });
+
+  it('should recognize a ChatGPT export whose first entry is malformed', () => {
+    const jsonData = [{ title: 'Corrupted entry' }, { title: 'Readable', mapping: {} }];
+
+    expect(getImporter(jsonData)).toBe(getImporter([{ mapping: {} }]));
+  });
+
+  it('should recognize a Claude export whose first entry is malformed', () => {
+    const jsonData = [{ name: 'Corrupted entry' }, { name: 'Readable', chat_messages: [] }];
+
+    expect(getImporter(jsonData)).toBe(getImporter([{ chat_messages: [] }]));
   });
 });
 
@@ -2167,6 +2237,61 @@ describe('importClaudeConvo', () => {
       {},
       expect.any(String),
     );
+  });
+
+  it('should count a conversation with no chat_messages list as failed', async () => {
+    const jsonData = [
+      { uuid: 'conv-missing', name: 'Missing list', created_at: '2025-01-15T10:00:00.000Z' },
+      {
+        uuid: 'conv-ok',
+        name: 'Readable',
+        created_at: '2025-01-15T11:00:00.000Z',
+        chat_messages: [
+          {
+            uuid: 'msg-1',
+            sender: 'human',
+            created_at: '2025-01-15T11:00:01.000Z',
+            content: [{ type: 'text', text: 'Still here' }],
+          },
+        ],
+      },
+    ];
+
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    const importer = getImporter(jsonData);
+    const summary = await importer(jsonData, requestUserId, () => importBatchBuilder);
+
+    expect(summary).toEqual({ imported: 1, failed: 1 });
+    expect(importBatchBuilder.conversations).toHaveLength(1);
+  });
+
+  it('should not persist an invalid date when created_at is unparseable', async () => {
+    const jsonData = [
+      {
+        uuid: 'conv-bad-date',
+        name: 'Bad date',
+        created_at: 'not-a-date',
+        chat_messages: [
+          {
+            uuid: 'msg-1',
+            sender: 'human',
+            created_at: 'also-not-a-date',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+      },
+    ];
+
+    const requestUserId = 'user-123';
+    const importBatchBuilder = new ImportBatchBuilder(requestUserId);
+
+    const importer = getImporter(jsonData);
+    await importer(jsonData, requestUserId, () => importBatchBuilder);
+
+    expect(Number.isNaN(importBatchBuilder.messages[0].createdAt.getTime())).toBe(false);
+    expect(Number.isNaN(importBatchBuilder.conversations[0].createdAt.getTime())).toBe(false);
   });
 
   it('should keep importing after an unreadable conversation', async () => {

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useCallback } from 'react';
 import { Import } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
-import type { TStartupConfig } from 'librechat-data-provider';
 import { Spinner, useToastContext, Label, Button } from '@librechat/client';
+import type { TStartupConfig, TImportResponse } from 'librechat-data-provider';
 import { startupConfigKey, useUploadConversationsMutation } from '~/data-provider';
 import { NotificationSeverity } from '~/common';
 import { useLocalize } from '~/hooks';
@@ -15,13 +15,22 @@ function ImportConversations() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isUploading, setIsUploading] = useState(false);
 
-  const handleSuccess = useCallback(() => {
-    showToast({
-      message: localize('com_ui_import_conversation_success'),
-      status: NotificationSeverity.SUCCESS,
-    });
-    setIsUploading(false);
-  }, [localize, showToast]);
+  const handleSuccess = useCallback(
+    (data: TImportResponse) => {
+      const failed = data?.failed ?? 0;
+      showToast({
+        message: failed
+          ? localize('com_ui_import_conversation_partial', {
+              0: data?.imported ?? 0,
+              1: failed,
+            })
+          : localize('com_ui_import_conversation_success'),
+        status: failed ? NotificationSeverity.WARNING : NotificationSeverity.SUCCESS,
+      });
+      setIsUploading(false);
+    },
+    [localize, showToast],
+  );
 
   const handleError = useCallback(
     (error: unknown) => {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1414,6 +1414,7 @@
   "com_ui_import_conversation_error": "There was an error importing your conversations",
   "com_ui_import_conversation_file_type_error": "Unsupported import type",
   "com_ui_import_conversation_info": "Import conversations from a JSON file",
+  "com_ui_import_conversation_partial": "Imported {{0}} conversation(s). {{1}} could not be read and were skipped.",
   "com_ui_import_conversation_success": "Conversations imported successfully",
   "com_ui_import_conversation_upload_error": "Error uploading file. Please try again.",
   "com_ui_importing": "Importing",

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -717,6 +717,14 @@ export type TImportResponse = {
    * The message associated with the response.
    */
   message: string;
+  /**
+   * Number of conversations written to the database.
+   */
+  imported?: number;
+  /**
+   * Number of conversations in the file that could not be read and were skipped.
+   */
+  failed?: number;
 };
 
 /** Prompts */


### PR DESCRIPTION
Fixes #15229

## Summary

The crash pasted in #15229 (`Cannot read properties of undefined (reading 'model_slug')`) was already fixed by #13637, which shipped in v0.8.7 — the reporter was on v0.8.6. So this PR goes after what is still broken underneath, reproduced against `dev` with a fixture built from a current ChatGPT export.

### 1. The model is at the conversation level now

Newer exports carry `default_model_slug` on the conversation and omit `metadata.model_slug` from most messages. That fallback was missing, so every message landed on the deployment's resolved default: a `gpt-5-thinking` chat imported with `model: gpt-4o-mini` and assistant turns labelled `GPT-4o-mini`. The chain is now per-message slug → `conv.default_model_slug` → resolved default.

### 2. Hidden context imported as a chat message

Newer exports inject a `user_editable_context` node ahead of the first user turn, flagged `is_visually_hidden_from_conversation`. It was importing as a **user message containing a raw JSON dump of the user's profile and custom instructions**. It is now skipped, with replies re-parented through it — reusing the same predicate as the existing system/`thoughts`/`reasoning_recap` skips, which were three separate inline checks and are now one helper.

### 3. One bad conversation discarded the entire file

`processConversation` threw straight out of the loop, so a single unreadable entry aborted every conversation in the file — including the ones already staged. This matters much more now that an export is tens of thousands of conversations split across 50+ `conversations-0xx.json` files.

Each conversation now imports in isolation. Failures are logged with the conversation's title, rolled back off the batch (new `checkpoint()`/`rollback()` on `ImportBatchBuilder`, so a conversation that fails partway cannot leave orphan messages behind), and skipped.

### 4. "Conversations imported successfully" with nothing imported

This is the reporter's *"The UI indicated that the conversations had been imported, but nothing appeared."* `saveBatch()` with zero conversations succeeds, so the route returned 201 regardless.

The route now returns `{ imported, failed }`, the importer throws when nothing at all could be imported, and a partial import shows a warning toast naming both counts instead of a clean success.

Also guards the Claude importer against a non-array `chat_messages`, which previously iterated the string character by character and imported a silently empty conversation.

## Not included

Multi-file selection for the 50-file export. `IMPORT_USER_MAX` defaults to 50 requests per 15 minutes, so a 50-file loop sits exactly on the user limiter — that needs its own design rather than a `multiple` attribute on the input.

## Testing

- New `__data__/chatgpt-modern-export.json` fixture (conversation-level model, hidden context node, one deliberately corrupt entry) plus 7 cases covering model fallback precedence, hidden-message skipping and re-parenting, partial import, mid-conversation rollback, all-failed, and empty-file.
- Builder `checkpoint`/`rollback` unit tests, a Claude per-conversation isolation test, and a route test asserting the counts reach the client.
- `api/server/utils/import/` 203 passing; 283 including the convos route suite. Client typecheck and lint clean.
