### PR TITLE
📎 fix: Keep SharePoint Picker Selections While Navigating

### DIFF
--- a/client/src/hooks/Files/useSharePointPicker.ts
+++ b/client/src/hooks/Files/useSharePointPicker.ts
@@ -285,6 +285,10 @@ export default function useSharePointPicker({
         },
         selection: {
           mode: 'multiple',
+          /** Without this the picker drops the current selection every time the user
+           * opens another folder or switches pivot, so a selection can only ever be
+           * assembled from one location. */
+          enablePersistence: true,
           maximumCount: maxSelectionCount,
         },
         title: localize('com_files_sharepoint_picker_title'),


### PR DESCRIPTION
Fixes the selection half of #15237.

**This PR was reduced from ~1,000 lines to 4.** See "What changed and why" below — the rest was new capability, not a fix, and is parked on `feat/sharepoint-folder-selection`.

## The fix

The picker never set `selection.enablePersistence`, so it discarded the current selection every time the user opened another folder or switched pivot. Selecting three files and then navigating anywhere loses all three — a selection can only ever be assembled from a single location.

```diff
 selection: {
   mode: 'multiple',
+  enablePersistence: true,
   maximumCount: maxSelectionCount,
 },
```

One option on the picker configuration. Nothing changes about what LibreChat does with the result — the same array of picked files arrives at the same handler.

## What changed and why

The original version of this PR also added folder selection (`typesAndSources.mode: 'all'` plus ~900 lines of Graph folder-expansion, screening and truncation), a compact list layout, a taller dialog, a selection-editor tray, and six new toasts.

Audited against the issues, that split as:

| | |
|---|---|
| **Bug fix** | `enablePersistence` — 1 line |
| **New capability** | folder selection and everything supporting it |
| **UX change** | list layout, dialog height, tray prompt, toast copy |

#15237 asks for two things. "Loses multi-file selections when navigating" is a defect, and it is what this PR now fixes. "Cannot select folders" is a feature request written in a bug report — it needs a product decision and testing against a live tenant, not a bug-fix merge.

#15238 is not addressed here at all. It has a competing interpretation in #15245 (which reads it as the Agent File Search side panel rather than the picker), and that ambiguity should be settled before either lands.

## The parked work

`feat/sharepoint-folder-selection` holds the full folder-selection implementation at `aa213b7`: Graph `children` traversal with pagination, per-page request budget, duplicate screening against existing attachments, aggregate byte budget, share-only identity handling, and 26 tests. It went through six codex review rounds. If folder selection is wanted, that branch is the starting point — it should not be resurrected without a decision on the behaviour change first.

## Testing

`client/src/hooks/Files` and `AttachFileMenu` — 157 passed, 8 suites. Client typecheck, ESLint, Prettier, import-sort clean.
