### PR TITLE
🍃 fix: Send a Pure Inclusion Projection From the Legacy Receipt Sweep

### DIFF
--- a/packages/api/src/agents/triggers/service.delivery.spec.ts
+++ b/packages/api/src/agents/triggers/service.delivery.spec.ts
@@ -386,6 +386,31 @@ describe('durable agent trigger service', () => {
     await service.stop();
   });
 
+  it('reclaims lanes even when another maintenance step rejects', async () => {
+    /** A single broken cleanup (e.g. an engine-specific query rejection) used
+     * to fail the whole Promise.all and skip the sequenced lane reclamation on
+     * every pass; each step must fail alone. */
+    const expireLegacyAgentEventActorReceipts = jest
+      .fn()
+      .mockRejectedValue(new Error('Projections cannot have a mix of inclusion and exclusion'));
+    const reclaimInactiveAgentTriggerLanes = jest.fn(async () => 1);
+    const service = createAgentTriggerService({
+      methods: deliveryMethods({
+        expireLegacyAgentEventActorReceipts,
+        reclaimInactiveAgentTriggerLanes,
+      }),
+      purgeRecoveryIntervalMs: 60_000,
+      deliveryOptions: { concurrency: 1, tickMs: 60_000 },
+    });
+    await service.initialize({
+      address: { address: '127.0.0.1', family: 'IPv4', port: 3080 },
+    });
+
+    expect(expireLegacyAgentEventActorReceipts).toHaveBeenCalledTimes(1);
+    expect(reclaimInactiveAgentTriggerLanes).toHaveBeenCalledTimes(1);
+    await service.stop();
+  });
+
   it('settles interrupted batch receipts before reclaiming their lane', async () => {
     let finishBatchRecovery: ((count: number) => void) | undefined;
     const recoverAgentTriggerBatchReceipts = jest.fn(

--- a/packages/api/src/agents/triggers/service.delivery.spec.ts
+++ b/packages/api/src/agents/triggers/service.delivery.spec.ts
@@ -411,6 +411,31 @@ describe('durable agent trigger service', () => {
     await service.stop();
   });
 
+  it('holds lane reclamation while batch-receipt recovery fails', async () => {
+    /** Reclamation consumes the lane-cleanup markers; against a half-recovered
+     * batch it clears a request no later successful recovery can re-arm, so a
+     * failed batch pass must gate it — unlike the independent steps above. */
+    const recoverAgentTriggerBatchReceipts = jest
+      .fn()
+      .mockRejectedValue(new Error('transient settle failure'));
+    const reclaimInactiveAgentTriggerLanes = jest.fn(async () => 1);
+    const service = createAgentTriggerService({
+      methods: deliveryMethods({
+        recoverAgentTriggerBatchReceipts,
+        reclaimInactiveAgentTriggerLanes,
+      }),
+      purgeRecoveryIntervalMs: 60_000,
+      deliveryOptions: { concurrency: 1, tickMs: 60_000 },
+    });
+    await service.initialize({
+      address: { address: '127.0.0.1', family: 'IPv4', port: 3080 },
+    });
+
+    expect(recoverAgentTriggerBatchReceipts).toHaveBeenCalledTimes(1);
+    expect(reclaimInactiveAgentTriggerLanes).not.toHaveBeenCalled();
+    await service.stop();
+  });
+
   it('settles interrupted batch receipts before reclaiming their lane', async () => {
     let finishBatchRecovery: ((count: number) => void) | undefined;
     const recoverAgentTriggerBatchReceipts = jest.fn(

--- a/packages/api/src/agents/triggers/service.ts
+++ b/packages/api/src/agents/triggers/service.ts
@@ -348,11 +348,14 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
       return purgeRecoveryPromise;
     }
     const methods = deps.methods;
-    /** Each maintenance operation fails alone: a rejection is logged and
-     * counted as zero progress instead of aborting the pass, so one broken
+    /** Independent maintenance operations fail alone: a rejection is logged
+     * and counted as zero progress instead of aborting the pass, so one broken
      * cleanup (e.g. an engine-specific query rejection) can never starve the
-     * others — lane reclamation in particular runs after these and used to be
-     * skipped whenever any of them threw. */
+     * others. Batch-receipt recovery is NOT independent: lane reclamation
+     * consumes the lane-cleanup markers, and running it against a
+     * half-recovered batch clears a request that a later successful recovery
+     * can no longer re-arm, retaining the lane permanently — so reclamation
+     * still waits for a batch-recovery pass that did not fail. */
     const isolated = (label: string, run: () => Promise<number>): Promise<number> =>
       run().catch((error) => {
         logger.error(
@@ -362,14 +365,21 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
         return 0;
       });
     const current = runAsSystem(async () => {
-      const [purgedUsers, publishedLanes, recoveredBatches, expiredLegacyActorReceipts] =
+      const [purgedUsers, publishedLanes, batchRecovery, expiredLegacyActorReceipts] =
         await Promise.all([
           isolated('user purges', () => methods.recoverAgentTriggerUserPurges(purgeRecoveryLimit)),
           isolated('lane publications', () =>
             methods.recoverAgentTriggerLanePublications(purgeRecoveryLimit),
           ),
-          isolated('batch receipts', () =>
-            methods.recoverAgentTriggerBatchReceipts(purgeRecoveryLimit),
+          methods.recoverAgentTriggerBatchReceipts(purgeRecoveryLimit).then(
+            (count) => ({ succeeded: true as const, count }),
+            (error) => {
+              logger.error(
+                '[agent-triggers] durable delivery maintenance step failed (batch receipts):',
+                error,
+              );
+              return { succeeded: false as const, count: 0 };
+            },
           ),
           isolated(
             'legacy actor receipts',
@@ -378,9 +388,12 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
               Promise.resolve(0),
           ),
         ]);
-      const reclaimedLanes = await isolated('lane reclamation', () =>
-        methods.reclaimInactiveAgentTriggerLanes(purgeRecoveryLimit),
-      );
+      const recoveredBatches = batchRecovery.count;
+      const reclaimedLanes = batchRecovery.succeeded
+        ? await isolated('lane reclamation', () =>
+            methods.reclaimInactiveAgentTriggerLanes(purgeRecoveryLimit),
+          )
+        : 0;
       if (publishedLanes > 0) {
         deliveryEngine?.wake();
       }

--- a/packages/api/src/agents/triggers/service.ts
+++ b/packages/api/src/agents/triggers/service.ts
@@ -348,16 +348,39 @@ export function createAgentTriggerService(deps: AgentTriggerServiceDeps = {}): A
       return purgeRecoveryPromise;
     }
     const methods = deps.methods;
+    /** Each maintenance operation fails alone: a rejection is logged and
+     * counted as zero progress instead of aborting the pass, so one broken
+     * cleanup (e.g. an engine-specific query rejection) can never starve the
+     * others — lane reclamation in particular runs after these and used to be
+     * skipped whenever any of them threw. */
+    const isolated = (label: string, run: () => Promise<number>): Promise<number> =>
+      run().catch((error) => {
+        logger.error(
+          `[agent-triggers] durable delivery maintenance step failed (${label}):`,
+          error,
+        );
+        return 0;
+      });
     const current = runAsSystem(async () => {
       const [purgedUsers, publishedLanes, recoveredBatches, expiredLegacyActorReceipts] =
         await Promise.all([
-          methods.recoverAgentTriggerUserPurges(purgeRecoveryLimit),
-          methods.recoverAgentTriggerLanePublications(purgeRecoveryLimit),
-          methods.recoverAgentTriggerBatchReceipts(purgeRecoveryLimit),
-          methods.expireLegacyAgentEventActorReceipts?.(new Date(), purgeRecoveryLimit) ??
-            Promise.resolve(0),
+          isolated('user purges', () => methods.recoverAgentTriggerUserPurges(purgeRecoveryLimit)),
+          isolated('lane publications', () =>
+            methods.recoverAgentTriggerLanePublications(purgeRecoveryLimit),
+          ),
+          isolated('batch receipts', () =>
+            methods.recoverAgentTriggerBatchReceipts(purgeRecoveryLimit),
+          ),
+          isolated(
+            'legacy actor receipts',
+            () =>
+              methods.expireLegacyAgentEventActorReceipts?.(new Date(), purgeRecoveryLimit) ??
+              Promise.resolve(0),
+          ),
         ]);
-      const reclaimedLanes = await methods.reclaimInactiveAgentTriggerLanes(purgeRecoveryLimit);
+      const reclaimedLanes = await isolated('lane reclamation', () =>
+        methods.reclaimInactiveAgentTriggerLanes(purgeRecoveryLimit),
+      );
       if (publishedLanes > 0) {
         deliveryEngine?.wake();
       }

--- a/packages/data-schemas/misc/documentdb/audit.documentdb.spec.ts
+++ b/packages/data-schemas/misc/documentdb/audit.documentdb.spec.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import { randomUUID } from 'crypto';
 import type { ConnectOptions } from 'mongoose';
 import { createAgentTriggerDeliveryMethods } from '~/methods/triggerDelivery';
+import { createConversationMethods } from '~/methods/conversation';
 import { createMessageMethods } from '~/methods/message';
 import { createModels } from '~/models';
 
@@ -145,6 +146,20 @@ describeLive('Amazon DocumentDB - 2026-08-30 audit surface', () => {
   });
 
   describe('raw construct probes (isolates which primitive the engine refuses)', () => {
+    it('probes the mixed include and exclude projection', async () => {
+      /** `{ _id: 1, other: 0 }` is what Mongoose compiles `'_id +field'` to on
+       * a schema with hidden siblings. MongoDB tolerates it via the `_id`
+       * exception; DocumentDB rejects it, which broke the legacy actor-receipt
+       * sweep on every maintenance pass. */
+      const verdict = await probe('mixed projection { _id: 1, x: 0 }', () =>
+        getDb()
+          .collection(probeCollection)
+          .find({ probe: 1 }, { projection: { _id: 1, note: 0 } })
+          .toArray(),
+      );
+      expect(verdict).toBeTruthy();
+    });
+
     it('probes the pipeline-update form', async () => {
       const verdict = await probe('pipeline-form findOneAndUpdate', () =>
         getDb()
@@ -392,6 +407,14 @@ describeLive('Amazon DocumentDB - 2026-08-30 audit surface', () => {
         }),
       );
       expectShape('listSubagentTasksForThreads');
+    });
+
+    it('site 8 - expireLegacyAgentEventActorReceipts', async () => {
+      const verdict = await probe('expireLegacyAgentEventActorReceipts', () =>
+        createConversationMethods(mongoose).expireLegacyAgentEventActorReceipts(new Date(), 5),
+      );
+      expectShape('expireLegacyAgentEventActorReceipts');
+      expect(verdict).toBeTruthy();
     });
 
     it('site 7 - updateToolCallResult', async () => {

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -5652,12 +5652,12 @@ describe('Conversation Operations', () => {
           },
         ],
       });
-      const projections: Array<Record<string, unknown> | undefined> = [];
+      const projections: Array<Record<string, number> | undefined> = [];
       const originalFind = Conversation.collection.find.bind(Conversation.collection);
       const findSpy = jest
         .spyOn(Conversation.collection, 'find')
         .mockImplementation((filter, options) => {
-          projections.push(options?.projection as Record<string, unknown> | undefined);
+          projections.push(options?.projection);
           return originalFind(filter, options);
         });
       try {
@@ -5665,9 +5665,7 @@ describe('Conversation Operations', () => {
       } finally {
         findSpy.mockRestore();
       }
-      const candidateProjection = projections[0];
-      expect(candidateProjection).toBeDefined();
-      expect(Object.values(candidateProjection ?? {})).not.toContain(0);
+      expect(projections[0]).toEqual({ _id: 1, agentEventActorReconciliations: 1 });
     });
 
     it('retains an expired legacy receipt while its delivery handling is nonterminal', async () => {

--- a/packages/data-schemas/src/methods/conversation.spec.ts
+++ b/packages/data-schemas/src/methods/conversation.spec.ts
@@ -5626,6 +5626,50 @@ describe('Conversation Operations', () => {
       });
     });
 
+    it('sends a pure inclusion projection for the candidate read', async () => {
+      /** The string form `'_id +field'` compiles to `{ _id: 1 }` plus a `: 0`
+       * exclusion for every other `select: false` sibling — a mixed projection
+       * MongoDB tolerates but Amazon DocumentDB rejects, which failed this
+       * sweep on every maintenance pass. The candidate read must stay a pure
+       * inclusion AND still return the hidden reconciliations field. */
+      const conversationId = uuidv4();
+      const now = new Date();
+      await Conversation.create({
+        conversationId,
+        user: 'actor-projection-user',
+        endpoint: EModelEndpoint.agents,
+        agentEventActorReconciliations: [
+          {
+            invocationId: 'projection-probe',
+            status: 'settled',
+            resolution: 'action_compensated',
+            checkpoint: {
+              threadId: conversationId,
+              checkpointNs: 'event-actor/projection-probe',
+            },
+            action: { toolName: 'submit_move' },
+            observedAt: new Date(now.getTime() - 91 * 24 * 60 * 60_000),
+          },
+        ],
+      });
+      const projections: Array<Record<string, unknown> | undefined> = [];
+      const originalFind = Conversation.collection.find.bind(Conversation.collection);
+      const findSpy = jest
+        .spyOn(Conversation.collection, 'find')
+        .mockImplementation((filter, options) => {
+          projections.push(options?.projection as Record<string, unknown> | undefined);
+          return originalFind(filter, options);
+        });
+      try {
+        await expect(methods.expireLegacyAgentEventActorReceipts(now)).resolves.toBe(1);
+      } finally {
+        findSpy.mockRestore();
+      }
+      const candidateProjection = projections[0];
+      expect(candidateProjection).toBeDefined();
+      expect(Object.values(candidateProjection ?? {})).not.toContain(0);
+    });
+
     it('retains an expired legacy receipt while its delivery handling is nonterminal', async () => {
       const conversationId = uuidv4();
       const userId = new mongoose.Types.ObjectId();

--- a/packages/data-schemas/src/methods/conversation.ts
+++ b/packages/data-schemas/src/methods/conversation.ts
@@ -1722,7 +1722,16 @@ export function createConversationMethods(
     const candidates = await Conversation.find({
       ...(legacyReceiptExpiryCursor == null ? {} : { _id: { $gt: legacyReceiptExpiryCursor } }),
     })
-      .select('_id +agentEventActorReconciliations')
+      /** Pure inclusion, as an object. The string form
+       * `'_id +agentEventActorReconciliations'` compiles to `{ _id: 1 }` plus a
+       * `: 0` exclusion for every OTHER `select: false` sibling — the `+` token
+       * only un-hides its field and `_id` alone does not make the projection
+       * inclusive. MongoDB tolerates that mixed shape via the `_id` exception;
+       * Amazon DocumentDB rejects it, which failed this sweep on every pass and
+       * took the sequenced lane reclamation down with it. An explicit `1` for a
+       * `select: false` path overrides the schema default, so nothing hidden
+       * leaks and nothing extra is fetched. */
+      .select({ _id: 1, agentEventActorReconciliations: 1 })
       .sort({ _id: 1 })
       .limit(boundedLimit)
       .lean<

--- a/packages/data-schemas/src/methods/documentdb.spec.ts
+++ b/packages/data-schemas/src/methods/documentdb.spec.ts
@@ -176,6 +176,42 @@ function findForbiddenTokens(sourceFile: ts.SourceFile): string[] {
   return offenses;
 }
 
+/** Reports `.select('...')` string arguments that mix a bare inclusion token
+ * with a `+` token where the bare tokens are ONLY `_id`. `_id` alone does not
+ * make a Mongoose projection inclusive and a `+` token only un-hides its
+ * field, so this exact shape compiles to `{ _id: 1 }` plus a `: 0` exclusion
+ * for every OTHER `select: false` sibling — a mixed projection MongoDB
+ * tolerates via the `_id` exception but Amazon DocumentDB rejects:
+ * `Projections cannot have a mix of inclusion and exclusion`. Every related
+ * shape stays legal and is deliberately not flagged (verified empirically): a
+ * bare non-`_id` token makes the projection inclusive, turning `+` tokens
+ * into plain `field: 1` inclusions; pure-`+` strings compile to
+ * all-exclusion; object-form selects are sent verbatim. */
+function findMixedSelectStrings(sourceFile: ts.SourceFile): string[] {
+  const offenses: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'select' &&
+      node.arguments.length === 1
+    ) {
+      const argument = unwrapExpression(node.arguments[0]);
+      if (ts.isStringLiteralLike(argument)) {
+        const tokens = argument.text.split(/\s+/).filter((token) => token.length > 0);
+        const bare = tokens.filter((token) => !token.startsWith('+') && !token.startsWith('-'));
+        const hasUnhide = tokens.some((token) => token.startsWith('+'));
+        if (hasUnhide && bare.length > 0 && bare.every((token) => token === '_id')) {
+          offenses.push(offenseAt(sourceFile, node, `select('${argument.text}')`));
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return offenses;
+}
+
 describe('Amazon DocumentDB compatibility', () => {
   /** Each file is read and parsed once; both detectors walk the same tree. */
   const parsedSources = SCAN_ROOTS.flatMap((root) => collectSourceFiles(root)).map((file) =>
@@ -192,6 +228,10 @@ describe('Amazon DocumentDB compatibility', () => {
 
   it('uses no aggregation constructs the engine rejects', () => {
     expect(parsedSources.flatMap(findForbiddenTokens)).toEqual([]);
+  });
+
+  it('mixes no bare and un-hide tokens in select strings', () => {
+    expect(parsedSources.flatMap(findMixedSelectStrings)).toEqual([]);
   });
 
   /** A guard that cannot fail protects nothing, so every shape the detectors
@@ -230,6 +270,23 @@ describe('Amazon DocumentDB compatibility', () => {
       ['unrelated array variable', `const stages = [{ $match: {} }];\nModel.aggregate(stages);`],
     ])('accepts a supported shape: %s', (_shape, source) => {
       expect(findPipelineUpdates(parse('fixture.ts', source))).toEqual([]);
+    });
+
+    it.each([
+      ['_id with an un-hide token', `Model.find({}).select('_id +hiddenField');`],
+      ['regardless of token order', `Model.find({}).select('+hiddenField _id');`],
+    ])('flags a mixed select string: %s', (_shape, source) => {
+      expect(findMixedSelectStrings(parse('fixture.ts', source))).not.toEqual([]);
+    });
+
+    it.each([
+      ['pure un-hide tokens', `Model.find({}).select('+hiddenA +hiddenB');`],
+      ['pure inclusion string', `Model.find({}).select('_id title user');`],
+      ['bare non-_id token makes it inclusive', `Model.find({}).select('title +hiddenField');`],
+      ['object-form inclusion', `Model.find({}).select({ _id: 1, hiddenField: 1 });`],
+      ['bare with minus exclusion', `Model.find({}).select('-internal');`],
+    ])('accepts a supported select: %s', (_shape, source) => {
+      expect(findMixedSelectStrings(parse('fixture.ts', source))).toEqual([]);
     });
 
     it('flags forbidden operators in code but not in prose', () => {


### PR DESCRIPTION
## Summary

The legacy agent-event actor-receipt sweep added in #15265 fails on every
maintenance pass on Amazon DocumentDB, and its rejection takes the sequenced
lane reclamation down with it. Reported from a production DocumentDB deployment
(`Projections cannot have a mix of inclusion and exclusion`, every 30 seconds
per pod); root cause verified empirically against real Mongoose.

## Root cause

The candidate read used `.select('_id +agentEventActorReconciliations')`. In
Mongoose, `_id` alone does not make a projection inclusive, and a `+` token
only un-hides its `select: false` field — it never becomes an inclusion. The
compiled projection is therefore `{ _id: 1 }` plus a `: 0` exclusion for every
OTHER hidden sibling on the conversation schema:

```
{ _id: 1, agentEventBinding: 0, agentEventActor: 0, agentEventActorEpoch: 0,
  agentEventActorLegacyTurn: 0, agentEventActorSuspension: 0 }
```

MongoDB tolerates this mixed shape via the `_id` exception; DocumentDB rejects
it. Captured by spying on the driver call — not inferred.

The blast radius is worse than the query: the sweep runs inside the
maintenance `Promise.all`, and `reclaimInactiveAgentTriggerLanes` is sequenced
after it — so on DocumentDB, receipts never expired AND lane reclamation never
ran, on every pass, on every pod.

## Changes

- **The candidate read is a pure inclusion**:
  `.select({ _id: 1, agentEventActorReconciliations: 1 })`. An explicit `1`
  overrides the schema-level `select: false`, so the hidden field still comes
  back and nothing extra is fetched (deliberately NOT a bare `+field` select,
  which would compile to an all-exclusion projection returning entire
  documents). A regression test spies on the driver call and asserts the
  compiled projection contains no `0` values while the sweep still expires.
- **Each maintenance step fails alone**: a rejection is logged with its step
  name and counted as zero progress, and lane reclamation runs regardless.
  Covered by a test that rejects one step and asserts reclamation still runs.
- **The static guard catches the class**: a new detector flags
  `select('_id +field')` — with fixtures proving both directions. The shape is
  deliberately narrow: probing real Mongoose shows a bare non-`_id` token makes
  the projection inclusive and turns `+` tokens into plain `field: 1`
  inclusions, so the repo's nine other `+`-selects (verified one by one) are
  legal and stay unflagged.
- **The live audit suite** gains a raw mixed-projection probe and drives
  `expireLegacyAgentEventActorReceipts` itself as production shape #8, so the
  next cluster run adjudicates this path too.

## Testing

- `conversation.spec.ts`: 183 tests green including the new projection-shape
  assertion; `documentdb.spec.ts`: 21 green; `service.delivery.spec.ts`: 16
  green including the new isolation test.
- The compiled-projection claims were established by capturing the actual
  options Mongoose passes to `collection.find` for each select shape.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
