### PR TITLE
🧷 fix: Fence Server-Admitted Queue Boundaries

### DIFF
--- a/client/src/components/Chat/Input/PendingSteerChips.tsx
+++ b/client/src/components/Chat/Input/PendingSteerChips.tsx
@@ -103,8 +103,18 @@ function QueuedRow({
   const quoteCount = message.quotes?.length ?? 0;
   const isRecovered = message.recoverySteerId != null;
   const isRejected = message.server?.status === 'rejected';
+  const isIndeterminate = message.server?.status === 'indeterminate';
   const isUnconfirmed =
     message.server?.status === 'uncertain' && message.server.reconciliationExpired === true;
+  let statusLabel:
+    | 'com_ui_queued_turn_reconciliation_required'
+    | 'com_ui_steer_delivery_unconfirmed'
+    | 'com_ui_queued_turn_failed' = 'com_ui_queued_turn_failed';
+  if (isIndeterminate) {
+    statusLabel = 'com_ui_queued_turn_reconciliation_required';
+  } else if (isUnconfirmed) {
+    statusLabel = 'com_ui_steer_delivery_unconfirmed';
+  }
   const requiresDiscard = isRecovered || message.server?.id != null;
   const serverActionable =
     message.server == null ||
@@ -198,7 +208,7 @@ function QueuedRow({
 
   return (
     <div role="listitem" className={ROW_CLASS} data-testid="queued-message-row">
-      {isRejected || isUnconfirmed ? (
+      {isRejected || isUnconfirmed || isIndeterminate ? (
         <TriangleAlert className="h-4 w-4 shrink-0 text-text-warning" aria-hidden="true" />
       ) : (
         <Clock className="h-4 w-4 shrink-0 text-cyan-500" aria-hidden="true" />
@@ -216,12 +226,8 @@ function QueuedRow({
           0: String(fileCount),
         })}
       />
-      {(isRejected || isUnconfirmed) && (
-        <span className="shrink-0 text-xs text-text-warning">
-          {localize(
-            isUnconfirmed ? 'com_ui_steer_delivery_unconfirmed' : 'com_ui_queued_turn_failed',
-          )}
-        </span>
+      {(isRejected || isUnconfirmed || isIndeterminate) && (
+        <span className="shrink-0 text-xs text-text-warning">{localize(statusLabel)}</span>
       )}
       {showPrimary && (
         <button

--- a/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
+++ b/client/src/components/Chat/Input/__tests__/PendingSteerChips.test.tsx
@@ -181,6 +181,25 @@ describe('PendingSteerChips — terminal server state', () => {
     expect(screen.getByText('com_ui_queued_turn_failed')).toBeInTheDocument();
   });
 
+  it('shows indeterminate admission as non-actionable reconciliation work', () => {
+    renderChips([
+      {
+        id: 'indeterminate-turn',
+        text: 'external result unknown',
+        createdAt: 1,
+        server: {
+          id: 'server-indeterminate-1',
+          status: 'indeterminate',
+          errorCode: 'ADMISSION_INDETERMINATE',
+        },
+      },
+    ]);
+
+    expect(screen.getByText('com_ui_queued_turn_reconciliation_required')).toBeInTheDocument();
+    expect(screen.getByLabelText('com_ui_remove_queued')).toBeDisabled();
+    expect(screen.queryByText('com_ui_send_now')).toBeNull();
+  });
+
   it('dismisses an expired ambiguous receipt without restoring or resending it', () => {
     renderChips([
       {

--- a/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
+++ b/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
@@ -21,6 +21,7 @@ import {
   fetchAgentQueuedTurns,
   isDefiniteQueuedTurnRejection,
   isDefiniteQueuedTurnsUnsupported,
+  shouldPollAgentQueuedTurns,
 } from '../queuedTurns';
 
 describe('Agent queued-turn data adapter', () => {
@@ -116,4 +117,17 @@ describe('Agent queued-turn data adapter', () => {
       expect(isDefiniteQueuedTurnRejection(error)).toBe(false);
     },
   );
+
+  it('stops background polling for a fail-closed indeterminate claim', () => {
+    expect(
+      shouldPollAgentQueuedTurns([
+        {
+          status: 'claimed',
+          failure: { code: 'ADMISSION_INDETERMINATE' },
+        },
+      ]),
+    ).toBe(false);
+    expect(shouldPollAgentQueuedTurns([{ status: 'claimed' }])).toBe(true);
+    expect(shouldPollAgentQueuedTurns([{ status: 'queued' }])).toBe(true);
+  });
 });

--- a/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
+++ b/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
@@ -1,15 +1,17 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 const mockListAgentQueuedTurns = jest.fn();
 const mockEnqueueAgentQueuedTurn = jest.fn();
 const mockCancelAgentQueuedTurn = jest.fn();
 const mockRefetch = jest.fn();
+const mockCancelQueries = jest.fn().mockResolvedValue(undefined);
+const mockQueryClient = { cancelQueries: mockCancelQueries };
 const mockUseQuery = jest.fn((options: unknown) => ({ options, refetch: mockRefetch }));
 
 jest.mock('@tanstack/react-query', () => ({
   useQuery: (options: unknown) => mockUseQuery(options),
   useMutation: jest.fn(),
-  useQueryClient: jest.fn(),
+  useQueryClient: () => mockQueryClient,
 }));
 
 jest.mock('librechat-data-provider', () => ({
@@ -169,14 +171,46 @@ describe('Agent queued-turn data adapter', () => {
     rendered.rerender({ ids: [] });
 
     await waitFor(() =>
+      expect(mockCancelQueries).toHaveBeenCalledWith({
+        queryKey: ['agentQueuedTurns', 'conversation/one'],
+        exact: true,
+      }),
+    );
+    await waitFor(() =>
       expect(mockRefetch).toHaveBeenCalledWith({
         cancelRefetch: true,
       }),
+    );
+    expect(mockCancelQueries.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRefetch.mock.invocationCallOrder[0],
     );
     expect(mockUseQuery).toHaveBeenLastCalledWith(
       expect.objectContaining({
         queryKey: ['agentQueuedTurns', 'conversation/one'],
       }),
     );
+  });
+
+  it('lets only the newest identity projection refetch after cancellation', async () => {
+    let releaseFirstCancellation: (() => void) | undefined;
+    mockCancelQueries
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseFirstCancellation = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+    const rendered = renderHook(
+      ({ ids }: { ids: string[] }) => useAgentQueuedTurns('conversation/one', true, ids),
+      { initialProps: { ids: ['request-one'] } },
+    );
+
+    rendered.rerender({ ids: ['request-two'] });
+    rendered.rerender({ ids: ['request-three'] });
+
+    await waitFor(() => expect(mockRefetch).toHaveBeenCalledTimes(1));
+    await act(async () => releaseFirstCancellation?.());
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
+++ b/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
@@ -1,6 +1,13 @@
 const mockListAgentQueuedTurns = jest.fn();
 const mockEnqueueAgentQueuedTurn = jest.fn();
 const mockCancelAgentQueuedTurn = jest.fn();
+const mockUseQuery = jest.fn((options: unknown) => options);
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (options: unknown) => mockUseQuery(options),
+  useMutation: jest.fn(),
+  useQueryClient: jest.fn(),
+}));
 
 jest.mock('librechat-data-provider', () => ({
   QueryKeys: { agentQueuedTurns: 'agentQueuedTurns' },
@@ -22,6 +29,7 @@ import {
   isDefiniteQueuedTurnRejection,
   isDefiniteQueuedTurnsUnsupported,
   shouldPollAgentQueuedTurns,
+  useAgentQueuedTurns,
 } from '../queuedTurns';
 
 describe('Agent queued-turn data adapter', () => {
@@ -129,5 +137,16 @@ describe('Agent queued-turn data adapter', () => {
     ).toBe(false);
     expect(shouldPollAgentQueuedTurns([{ status: 'claimed' }])).toBe(true);
     expect(shouldPollAgentQueuedTurns([{ status: 'queued' }])).toBe(true);
+  });
+
+  it('refreshes stopped reconciliation work on every mount and focus', () => {
+    useAgentQueuedTurns('conversation/one', true);
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refetchOnMount: 'always',
+        refetchOnWindowFocus: 'always',
+      }),
+    );
   });
 });

--- a/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
+++ b/client/src/data-provider/SSE/__tests__/queuedTurns.test.ts
@@ -1,7 +1,10 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
 const mockListAgentQueuedTurns = jest.fn();
 const mockEnqueueAgentQueuedTurn = jest.fn();
 const mockCancelAgentQueuedTurn = jest.fn();
-const mockUseQuery = jest.fn((options: unknown) => options);
+const mockRefetch = jest.fn();
+const mockUseQuery = jest.fn((options: unknown) => ({ options, refetch: mockRefetch }));
 
 jest.mock('@tanstack/react-query', () => ({
   useQuery: (options: unknown) => mockUseQuery(options),
@@ -140,12 +143,39 @@ describe('Agent queued-turn data adapter', () => {
   });
 
   it('refreshes stopped reconciliation work on every mount and focus', () => {
-    useAgentQueuedTurns('conversation/one', true);
+    renderHook(() => useAgentQueuedTurns('conversation/one', true));
 
     expect(mockUseQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         refetchOnMount: 'always',
         refetchOnWindowFocus: 'always',
+      }),
+    );
+  });
+
+  it('keeps one cache authority and refetches when known receipt ids change', async () => {
+    const rendered = renderHook(
+      ({ ids }: { ids: string[] }) => useAgentQueuedTurns('conversation/one', true, ids),
+      { initialProps: { ids: ['request-one'] } },
+    );
+
+    expect(mockUseQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryKey: ['agentQueuedTurns', 'conversation/one'],
+      }),
+    );
+    expect(mockRefetch).not.toHaveBeenCalled();
+
+    rendered.rerender({ ids: [] });
+
+    await waitFor(() =>
+      expect(mockRefetch).toHaveBeenCalledWith({
+        cancelRefetch: true,
+      }),
+    );
+    expect(mockUseQuery).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryKey: ['agentQueuedTurns', 'conversation/one'],
       }),
     );
   });

--- a/client/src/data-provider/SSE/queuedTurns.ts
+++ b/client/src/data-provider/SSE/queuedTurns.ts
@@ -101,6 +101,7 @@ export function useAgentQueuedTurns(
   clientRequestIds: string[] = [],
   reconcileUntil?: number,
 ) {
+  const queryClient = useQueryClient();
   const knownIds = [...new Set(clientRequestIds)].sort();
   const knownIdsSignature = knownIds.join('\u0000');
   const previousRequest = useRef({ conversationId, knownIdsSignature });
@@ -132,11 +133,25 @@ export function useAgentQueuedTurns(
       return;
     }
 
-    /** The stable query key prevents old snapshots from becoming current
-     * again. Cancel/refetch also prevents an older in-flight projection from
-     * winning when receipt identities are added or retired. */
-    void refetch({ cancelRefetch: true });
-  }, [conversationId, enabled, knownIdsSignature, refetch]);
+    let superseded = false;
+    const refreshProjection = async () => {
+      /** React Query cannot replace an initial fetch that has no cached data
+       * through `refetch` alone. Cancel it explicitly so the next request
+       * captures the current reconciliation identities. */
+      await queryClient.cancelQueries({
+        queryKey: agentQueuedTurnsQueryKey(conversationId),
+        exact: true,
+      });
+      if (!superseded) {
+        await refetch({ cancelRefetch: true });
+      }
+    };
+    void refreshProjection();
+
+    return () => {
+      superseded = true;
+    };
+  }, [conversationId, enabled, knownIdsSignature, queryClient, refetch]);
 
   return query;
 }

--- a/client/src/data-provider/SSE/queuedTurns.ts
+++ b/client/src/data-provider/SSE/queuedTurns.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { dataService, MutationKeys, QueryKeys } from 'librechat-data-provider';
 import type {
@@ -8,10 +9,12 @@ import type {
 export type AgentQueuedTurnReceipt = TAgentQueuedTurnReceipt;
 export type EnqueueAgentQueuedTurnRequest = TEnqueueAgentQueuedTurnRequest;
 
-export const agentQueuedTurnsQueryKey = (
-  conversationId: string,
-  clientRequestIds: readonly string[] = [],
-) => [QueryKeys.agentQueuedTurns, conversationId, ...clientRequestIds] as const;
+/** Keep one cache authority for a conversation. Known receipt ids change the
+ * server projection, not the identity of the durable queue. Giving every id
+ * set its own key can resurrect an older cached projection after an id is
+ * retired. */
+export const agentQueuedTurnsQueryKey = (conversationId: string) =>
+  [QueryKeys.agentQueuedTurns, conversationId] as const;
 
 function queuedTurnErrorResponse(error: unknown): { status?: number; code?: string } {
   const response = (
@@ -99,8 +102,10 @@ export function useAgentQueuedTurns(
   reconcileUntil?: number,
 ) {
   const knownIds = [...new Set(clientRequestIds)].sort();
-  return useQuery({
-    queryKey: agentQueuedTurnsQueryKey(conversationId, knownIds),
+  const knownIdsSignature = knownIds.join('\u0000');
+  const previousRequest = useRef({ conversationId, knownIdsSignature });
+  const query = useQuery({
+    queryKey: agentQueuedTurnsQueryKey(conversationId),
     queryFn: () => fetchAgentQueuedTurns(conversationId, knownIds),
     enabled: enabled && conversationId.length > 0,
     staleTime: 1_000,
@@ -113,6 +118,27 @@ export function useAgentQueuedTurns(
       shouldPollAgentQueuedTurns(receipts, reconcileUntil) ? 2_000 : false,
     retry: false,
   });
+  const { refetch } = query;
+
+  useEffect(() => {
+    const previous = previousRequest.current;
+    previousRequest.current = { conversationId, knownIdsSignature };
+    if (
+      !enabled ||
+      conversationId.length === 0 ||
+      previous.conversationId !== conversationId ||
+      previous.knownIdsSignature === knownIdsSignature
+    ) {
+      return;
+    }
+
+    /** The stable query key prevents old snapshots from becoming current
+     * again. Cancel/refetch also prevents an older in-flight projection from
+     * winning when receipt identities are added or retired. */
+    void refetch({ cancelRefetch: true });
+  }, [conversationId, enabled, knownIdsSignature, refetch]);
+
+  return query;
 }
 
 export function useEnqueueAgentQueuedTurnMutation() {

--- a/client/src/data-provider/SSE/queuedTurns.ts
+++ b/client/src/data-provider/SSE/queuedTurns.ts
@@ -72,6 +72,26 @@ export async function cancelAgentQueuedTurn(input: {
   return response.receipt;
 }
 
+/** Indeterminate admission deliberately retains its durable claim until exact
+ * source evidence arrives. It can still be refreshed on mount/focus, but a
+ * two-second loop cannot resolve it and disguises permanent quarantine as
+ * ordinary progress. */
+export function shouldPollAgentQueuedTurns(
+  receipts: unknown,
+  reconcileUntil?: number,
+  observedAt = Date.now(),
+): boolean {
+  return (
+    (reconcileUntil != null && observedAt < reconcileUntil) ||
+    (Array.isArray(receipts) &&
+      receipts.some(
+        (item: AgentQueuedTurnReceipt) =>
+          item.status === 'queued' ||
+          (item.status === 'claimed' && item.failure?.code !== 'ADMISSION_INDETERMINATE'),
+      ))
+  );
+}
+
 export function useAgentQueuedTurns(
   conversationId: string,
   enabled: boolean,
@@ -86,13 +106,8 @@ export function useAgentQueuedTurns(
     staleTime: 1_000,
     refetchOnMount: true,
     refetchOnWindowFocus: true,
-    refetchInterval: (receipts) => {
-      return (reconcileUntil != null && Date.now() < reconcileUntil) ||
-        (Array.isArray(receipts) &&
-          receipts.some((item) => item.status === 'queued' || item.status === 'claimed'))
-        ? 2_000
-        : false;
-    },
+    refetchInterval: (receipts) =>
+      shouldPollAgentQueuedTurns(receipts, reconcileUntil) ? 2_000 : false,
     retry: false,
   });
 }

--- a/client/src/data-provider/SSE/queuedTurns.ts
+++ b/client/src/data-provider/SSE/queuedTurns.ts
@@ -104,8 +104,11 @@ export function useAgentQueuedTurns(
     queryFn: () => fetchAgentQueuedTurns(conversationId, knownIds),
     enabled: enabled && conversationId.length > 0,
     staleTime: 1_000,
-    refetchOnMount: true,
-    refetchOnWindowFocus: true,
+    /** A stopped indeterminate row can receive exact proof at any time. Its
+     * cache may still be inside `staleTime`, so mount/focus must bypass the
+     * ordinary freshness gate rather than waiting for another user cycle. */
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: 'always',
     refetchInterval: (receipts) =>
       shouldPollAgentQueuedTurns(receipts, reconcileUntil) ? 2_000 : false,
     retry: false,

--- a/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
@@ -31,6 +31,7 @@ function setup(
     setIsSubmitting?: (value: boolean) => void;
     setQueue?: (value: QueuedMessage[]) => void;
     setNewConvoQueue?: (value: QueuedMessage[]) => void;
+    setSettledReceipts?: (value: SettledQueuedTurnReceipt[]) => void;
     setInterruptFlag?: (value: DrainAfterAbort | false) => void;
     queue?: QueuedMessage[];
     newConvoQueue?: QueuedMessage[];
@@ -44,6 +45,9 @@ function setup(
     setters.setQueue = useSetRecoilState(store.queuedMessagesByConvoId(CONVO_ID));
     setters.setNewConvoQueue = useSetRecoilState(
       store.queuedMessagesByConvoId(Constants.NEW_CONVO),
+    );
+    setters.setSettledReceipts = useSetRecoilState(
+      store.settledQueuedTurnReceiptsByConvoId(CONVO_ID),
     );
     setters.setInterruptFlag = useSetRecoilState(store.drainAfterAbortByIndex(INDEX));
     setters.queue = useRecoilValue(store.queuedMessagesByConvoId(CONVO_ID));
@@ -160,6 +164,42 @@ describe('useQueueDrain', () => {
     });
     await waitFor(() => expect(ask).toHaveBeenCalledTimes(1));
     expect(ask).toHaveBeenCalledWith({ text: 'legacy successor' }, emptyOverrides);
+  });
+
+  it('reacts to a settled admission while another server row still owns the queue', async () => {
+    const admittedServer: QueuedMessage = {
+      ...queuedMessage('q-server-1', 'admitted server-owned turn'),
+      server: { id: 'server-queue-1', status: 'claimed', revision: 1 },
+    };
+    const remainingServer: QueuedMessage = {
+      ...queuedMessage('q-server-2', 'later server-owned turn'),
+      server: { id: 'server-queue-2', status: 'queued', revision: 2 },
+    };
+    const { ask, setters } = setup(({ set }) => {
+      set(store.queuedMessagesByConvoId(CONVO_ID), [admittedServer, remainingServer]);
+    });
+
+    act(() => {
+      setters.setRunEnd!(runEnd({ generationCreatedAt: 41 }));
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(setters.runEnd).not.toBeNull();
+
+    act(() => {
+      setters.setQueue!([remainingServer]);
+      setters.setSettledReceipts!([
+        {
+          clientRequestId: 'admitted-request-1',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+      ]);
+    });
+
+    await waitFor(() => expect(setters.runEnd).toBeNull());
+    expect(ask).not.toHaveBeenCalled();
+    expect(setters.settledReceipts).toEqual([]);
+    expect(setters.queue).toEqual([remainingServer]);
   });
 
   it('discards a predecessor boundary already consumed by server admission', async () => {

--- a/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
@@ -29,6 +29,7 @@ function setup(
     setInterruptFlag?: (value: DrainAfterAbort | false) => void;
     queue?: QueuedMessage[];
     newConvoQueue?: QueuedMessage[];
+    consumedPredecessors?: number[];
     runEnd?: RunEnd | null;
   } = {};
 
@@ -42,6 +43,9 @@ function setup(
     setters.setInterruptFlag = useSetRecoilState(store.drainAfterAbortByIndex(INDEX));
     setters.queue = useRecoilValue(store.queuedMessagesByConvoId(CONVO_ID));
     setters.newConvoQueue = useRecoilValue(store.queuedMessagesByConvoId(Constants.NEW_CONVO));
+    setters.consumedPredecessors = useRecoilValue(
+      store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID),
+    );
     setters.runEnd = useRecoilValue(store.runEndByIndex(INDEX));
     useQueueDrain(INDEX, activeConversationId, ask);
     return null;
@@ -160,7 +164,7 @@ describe('useQueueDrain', () => {
       set(store.queuedMessagesByConvoId(CONVO_ID), [
         queuedMessage('q-local', 'must wait for the admitted run'),
       ]);
-      set(store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID), 41);
+      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [41]);
     });
 
     act(() => {
@@ -169,6 +173,7 @@ describe('useQueueDrain', () => {
 
     await waitFor(() => expect(setters.runEnd).toBeNull());
     expect(ask).not.toHaveBeenCalled();
+    expect(setters.consumedPredecessors).toEqual([]);
   });
 
   it('migrates the NEW_CONVO queue before discarding a consumed predecessor boundary', async () => {
@@ -177,7 +182,7 @@ describe('useQueueDrain', () => {
     const { ask, setters } = setup(({ set }) => {
       set(store.queuedMessagesByConvoId(Constants.NEW_CONVO), [queuedBeforeResolution]);
       set(store.queuedMessagesByConvoId(CONVO_ID), [queuedAfterResolution]);
-      set(store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID), 41);
+      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [41]);
     });
 
     act(() => {
@@ -200,7 +205,7 @@ describe('useQueueDrain', () => {
       set(store.queuedMessagesByConvoId(CONVO_ID), [
         queuedMessage('q-local', 'send after the admitted run'),
       ]);
-      set(store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID), 41);
+      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [41]);
     });
 
     act(() => {
@@ -209,6 +214,26 @@ describe('useQueueDrain', () => {
 
     await waitFor(() => expect(ask).toHaveBeenCalledTimes(1));
     expect(ask).toHaveBeenCalledWith({ text: 'send after the admitted run' }, emptyOverrides);
+  });
+
+  it('does not interpret a consumed predecessor as a timestamp range', async () => {
+    const { ask, setters } = setup(({ set }) => {
+      set(store.queuedMessagesByConvoId(CONVO_ID), [
+        queuedMessage('q-local', 'send after the lower-clock successor'),
+      ]);
+      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [42]);
+    });
+
+    act(() => {
+      setters.setRunEnd!(runEnd({ generationCreatedAt: 41 }));
+    });
+
+    await waitFor(() => expect(ask).toHaveBeenCalledTimes(1));
+    expect(ask).toHaveBeenCalledWith(
+      { text: 'send after the lower-clock successor' },
+      emptyOverrides,
+    );
+    expect(setters.consumedPredecessors).toEqual([42]);
   });
 
   it('parks a mismatched signal instead of draining into the wrong conversation', async () => {

--- a/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
@@ -27,7 +27,8 @@ function setup(
     setQueue?: (value: QueuedMessage[]) => void;
     setNewConvoQueue?: (value: QueuedMessage[]) => void;
     setInterruptFlag?: (value: DrainAfterAbort | false) => void;
-    queueRef?: { current: QueuedMessage[] };
+    queue?: QueuedMessage[];
+    newConvoQueue?: QueuedMessage[];
     runEnd?: RunEnd | null;
   } = {};
 
@@ -39,6 +40,8 @@ function setup(
       store.queuedMessagesByConvoId(Constants.NEW_CONVO),
     );
     setters.setInterruptFlag = useSetRecoilState(store.drainAfterAbortByIndex(INDEX));
+    setters.queue = useRecoilValue(store.queuedMessagesByConvoId(CONVO_ID));
+    setters.newConvoQueue = useRecoilValue(store.queuedMessagesByConvoId(Constants.NEW_CONVO));
     setters.runEnd = useRecoilValue(store.runEndByIndex(INDEX));
     useQueueDrain(INDEX, activeConversationId, ask);
     return null;
@@ -166,6 +169,30 @@ describe('useQueueDrain', () => {
 
     await waitFor(() => expect(setters.runEnd).toBeNull());
     expect(ask).not.toHaveBeenCalled();
+  });
+
+  it('migrates the NEW_CONVO queue before discarding a consumed predecessor boundary', async () => {
+    const queuedBeforeResolution = queuedMessage('q-new', 'wait for the admitted successor');
+    const queuedAfterResolution = queuedMessage('q-resolved', 'still ordered after migration');
+    const { ask, setters } = setup(({ set }) => {
+      set(store.queuedMessagesByConvoId(Constants.NEW_CONVO), [queuedBeforeResolution]);
+      set(store.queuedMessagesByConvoId(CONVO_ID), [queuedAfterResolution]);
+      set(store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID), 41);
+    });
+
+    act(() => {
+      setters.setRunEnd!(
+        runEnd({
+          generationCreatedAt: 41,
+          startedAsNewConvo: true,
+        }),
+      );
+    });
+
+    await waitFor(() => expect(setters.runEnd).toBeNull());
+    expect(ask).not.toHaveBeenCalled();
+    expect(setters.newConvoQueue).toEqual([]);
+    expect(setters.queue).toEqual([queuedBeforeResolution, queuedAfterResolution]);
   });
 
   it('lets the admitted successor terminal boundary release the next turn', async () => {

--- a/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
@@ -3,7 +3,12 @@ import { Constants } from 'librechat-data-provider';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RecoilRoot, useRecoilValue, useSetRecoilState, type MutableSnapshot } from 'recoil';
-import type { DrainAfterAbort, RunEnd, QueuedMessage } from '~/store/families';
+import type {
+  DrainAfterAbort,
+  RunEnd,
+  QueuedMessage,
+  SettledQueuedTurnReceipt,
+} from '~/store/families';
 import useQueueDrain from '../useQueueDrain';
 import store from '~/store';
 
@@ -29,7 +34,7 @@ function setup(
     setInterruptFlag?: (value: DrainAfterAbort | false) => void;
     queue?: QueuedMessage[];
     newConvoQueue?: QueuedMessage[];
-    consumedPredecessors?: number[];
+    settledReceipts?: SettledQueuedTurnReceipt[];
     runEnd?: RunEnd | null;
   } = {};
 
@@ -43,9 +48,7 @@ function setup(
     setters.setInterruptFlag = useSetRecoilState(store.drainAfterAbortByIndex(INDEX));
     setters.queue = useRecoilValue(store.queuedMessagesByConvoId(CONVO_ID));
     setters.newConvoQueue = useRecoilValue(store.queuedMessagesByConvoId(Constants.NEW_CONVO));
-    setters.consumedPredecessors = useRecoilValue(
-      store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID),
-    );
+    setters.settledReceipts = useRecoilValue(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID));
     setters.runEnd = useRecoilValue(store.runEndByIndex(INDEX));
     useQueueDrain(INDEX, activeConversationId, ask);
     return null;
@@ -164,7 +167,13 @@ describe('useQueueDrain', () => {
       set(store.queuedMessagesByConvoId(CONVO_ID), [
         queuedMessage('q-local', 'must wait for the admitted run'),
       ]);
-      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [41]);
+      set(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID), [
+        {
+          clientRequestId: 'admission-1',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+      ]);
     });
 
     act(() => {
@@ -173,7 +182,57 @@ describe('useQueueDrain', () => {
 
     await waitFor(() => expect(setters.runEnd).toBeNull());
     expect(ask).not.toHaveBeenCalled();
-    expect(setters.consumedPredecessors).toEqual([]);
+    expect(setters.settledReceipts).toEqual([
+      expect.objectContaining({ clientRequestId: 'admission-1', boundaryConsumed: true }),
+    ]);
+  });
+
+  it('consumes one admission when separate receipts share the same predecessor epoch', async () => {
+    const { ask, setters } = setup(({ set }) => {
+      set(store.queuedMessagesByConvoId(CONVO_ID), [
+        queuedMessage('q-local', 'wait for both admitted runs'),
+      ]);
+      set(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID), [
+        {
+          clientRequestId: 'admission-1',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+        {
+          clientRequestId: 'admission-2',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+      ]);
+    });
+
+    act(() => {
+      setters.setRunEnd!(runEnd({ generationCreatedAt: 41 }));
+    });
+
+    await waitFor(() =>
+      expect(setters.settledReceipts).toEqual([
+        expect.objectContaining({ clientRequestId: 'admission-1', boundaryConsumed: true }),
+        {
+          clientRequestId: 'admission-2',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+      ]),
+    );
+    expect(ask).not.toHaveBeenCalled();
+
+    act(() => {
+      setters.setRunEnd!(runEnd({ generationCreatedAt: 41, endedAt: Date.now() + 1 }));
+    });
+
+    await waitFor(() =>
+      expect(setters.settledReceipts).toEqual([
+        expect.objectContaining({ clientRequestId: 'admission-1', boundaryConsumed: true }),
+        expect.objectContaining({ clientRequestId: 'admission-2', boundaryConsumed: true }),
+      ]),
+    );
+    expect(ask).not.toHaveBeenCalled();
   });
 
   it('migrates the NEW_CONVO queue before discarding a consumed predecessor boundary', async () => {
@@ -182,7 +241,13 @@ describe('useQueueDrain', () => {
     const { ask, setters } = setup(({ set }) => {
       set(store.queuedMessagesByConvoId(Constants.NEW_CONVO), [queuedBeforeResolution]);
       set(store.queuedMessagesByConvoId(CONVO_ID), [queuedAfterResolution]);
-      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [41]);
+      set(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID), [
+        {
+          clientRequestId: 'admission-1',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+      ]);
     });
 
     act(() => {
@@ -205,7 +270,13 @@ describe('useQueueDrain', () => {
       set(store.queuedMessagesByConvoId(CONVO_ID), [
         queuedMessage('q-local', 'send after the admitted run'),
       ]);
-      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [41]);
+      set(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID), [
+        {
+          clientRequestId: 'admission-1',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
+      ]);
     });
 
     act(() => {
@@ -221,7 +292,13 @@ describe('useQueueDrain', () => {
       set(store.queuedMessagesByConvoId(CONVO_ID), [
         queuedMessage('q-local', 'send after the lower-clock successor'),
       ]);
-      set(store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID), [42]);
+      set(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID), [
+        {
+          clientRequestId: 'admission-1',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 42,
+        },
+      ]);
     });
 
     act(() => {
@@ -233,7 +310,13 @@ describe('useQueueDrain', () => {
       { text: 'send after the lower-clock successor' },
       emptyOverrides,
     );
-    expect(setters.consumedPredecessors).toEqual([42]);
+    expect(setters.settledReceipts).toEqual([
+      {
+        clientRequestId: 'admission-1',
+        status: 'admitted',
+        effectivePredecessorCreatedAt: 42,
+      },
+    ]);
   });
 
   it('parks a mismatched signal instead of draining into the wrong conversation', async () => {

--- a/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
@@ -28,6 +28,7 @@ function setup(
     setNewConvoQueue?: (value: QueuedMessage[]) => void;
     setInterruptFlag?: (value: DrainAfterAbort | false) => void;
     queueRef?: { current: QueuedMessage[] };
+    runEnd?: RunEnd | null;
   } = {};
 
   function Harness() {
@@ -38,6 +39,7 @@ function setup(
       store.queuedMessagesByConvoId(Constants.NEW_CONVO),
     );
     setters.setInterruptFlag = useSetRecoilState(store.drainAfterAbortByIndex(INDEX));
+    setters.runEnd = useRecoilValue(store.runEndByIndex(INDEX));
     useQueueDrain(INDEX, activeConversationId, ask);
     return null;
   }
@@ -148,6 +150,38 @@ describe('useQueueDrain', () => {
     });
     await waitFor(() => expect(ask).toHaveBeenCalledTimes(1));
     expect(ask).toHaveBeenCalledWith({ text: 'legacy successor' }, emptyOverrides);
+  });
+
+  it('discards a predecessor boundary already consumed by server admission', async () => {
+    const { ask, setters } = setup(({ set }) => {
+      set(store.queuedMessagesByConvoId(CONVO_ID), [
+        queuedMessage('q-local', 'must wait for the admitted run'),
+      ]);
+      set(store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID), 41);
+    });
+
+    act(() => {
+      setters.setRunEnd!(runEnd({ generationCreatedAt: 41 }));
+    });
+
+    await waitFor(() => expect(setters.runEnd).toBeNull());
+    expect(ask).not.toHaveBeenCalled();
+  });
+
+  it('lets the admitted successor terminal boundary release the next turn', async () => {
+    const { ask, setters } = setup(({ set }) => {
+      set(store.queuedMessagesByConvoId(CONVO_ID), [
+        queuedMessage('q-local', 'send after the admitted run'),
+      ]);
+      set(store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID), 41);
+    });
+
+    act(() => {
+      setters.setRunEnd!(runEnd({ generationCreatedAt: 42 }));
+    });
+
+    await waitFor(() => expect(ask).toHaveBeenCalledTimes(1));
+    expect(ask).toHaveBeenCalledWith({ text: 'send after the admitted run' }, emptyOverrides);
   });
 
   it('parks a mismatched signal instead of draining into the wrong conversation', async () => {

--- a/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useQueueDrain.spec.tsx
@@ -182,9 +182,7 @@ describe('useQueueDrain', () => {
 
     await waitFor(() => expect(setters.runEnd).toBeNull());
     expect(ask).not.toHaveBeenCalled();
-    expect(setters.settledReceipts).toEqual([
-      expect.objectContaining({ clientRequestId: 'admission-1', boundaryConsumed: true }),
-    ]);
+    expect(setters.settledReceipts).toEqual([]);
   });
 
   it('consumes one admission when separate receipts share the same predecessor epoch', async () => {
@@ -212,7 +210,6 @@ describe('useQueueDrain', () => {
 
     await waitFor(() =>
       expect(setters.settledReceipts).toEqual([
-        expect.objectContaining({ clientRequestId: 'admission-1', boundaryConsumed: true }),
         {
           clientRequestId: 'admission-2',
           status: 'admitted',
@@ -226,12 +223,7 @@ describe('useQueueDrain', () => {
       setters.setRunEnd!(runEnd({ generationCreatedAt: 41, endedAt: Date.now() + 1 }));
     });
 
-    await waitFor(() =>
-      expect(setters.settledReceipts).toEqual([
-        expect.objectContaining({ clientRequestId: 'admission-1', boundaryConsumed: true }),
-        expect.objectContaining({ clientRequestId: 'admission-2', boundaryConsumed: true }),
-      ]),
-    );
+    await waitFor(() => expect(setters.settledReceipts).toEqual([]));
     expect(ask).not.toHaveBeenCalled();
   });
 

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -507,13 +507,14 @@ describe('useSteering', () => {
           status: 'admitted',
           revision: 4,
           expectedPredecessorCreatedAt: 41,
+          effectivePredecessorCreatedAt: 42,
           createdAt: new Date(200).toISOString(),
           updatedAt: new Date(300).toISOString(),
         },
       ];
       const { result } = setupServerQueue();
 
-      await waitFor(() => expect(result.current.admittedPredecessor).toBe(41));
+      await waitFor(() => expect(result.current.admittedPredecessor).toBe(42));
       expect(result.current.queue).toEqual([]);
     });
 

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -261,8 +261,8 @@ describe('useSteering', () => {
             stopGenerating: jest.fn(),
           }),
           queue: useQueue(CONVO_ID),
-          admittedPredecessor: useRecoilValue(
-            store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID),
+          consumedPredecessors: useRecoilValue(
+            store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID),
           ),
         }),
         { wrapper },
@@ -337,6 +337,43 @@ describe('useSteering', () => {
           }),
         ]),
       );
+    });
+
+    it('applies an admitted POST replay to the consumed predecessor set', async () => {
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        options.onSuccess({
+          ...input,
+          queuedTurnId: 'server-admitted-replay',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+          revision: 1,
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        });
+      });
+      const { result } = setupServerQueue(
+        withActiveGeneration(({ set }) => {
+          set(store.queuedMessagesByConvoId(CONVO_ID), [
+            {
+              id: 'unrelated-server-row',
+              clientRequestId: 'unrelated-request',
+              text: 'keep me',
+              createdAt: 50,
+              server: { id: 'unrelated-server-id', status: 'queued', revision: 1 },
+            },
+          ]);
+        }),
+      );
+
+      await act(async () => {
+        result.current.steering.queueFromComposer('already admitted');
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(result.current.consumedPredecessors).toEqual([41]));
+      expect(result.current.queue).toEqual([
+        expect.objectContaining({ id: 'unrelated-server-row', text: 'keep me' }),
+      ]);
     });
 
     it('anchors enqueue to the selected branch tail instead of a later hidden sibling', async () => {
@@ -514,7 +551,7 @@ describe('useSteering', () => {
       ];
       const { result } = setupServerQueue();
 
-      await waitFor(() => expect(result.current.admittedPredecessor).toBe(42));
+      await waitFor(() => expect(result.current.consumedPredecessors).toEqual([42]));
       expect(result.current.queue).toEqual([]);
     });
 

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -261,9 +261,7 @@ describe('useSteering', () => {
             stopGenerating: jest.fn(),
           }),
           queue: useQueue(CONVO_ID),
-          consumedPredecessors: useRecoilValue(
-            store.consumedQueuedTurnPredecessorsByConvoId(CONVO_ID),
-          ),
+          settledReceipts: useRecoilValue(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID)),
         }),
         { wrapper },
       );
@@ -370,9 +368,103 @@ describe('useSteering', () => {
         await Promise.resolve();
       });
 
-      await waitFor(() => expect(result.current.consumedPredecessors).toEqual([41]));
+      await waitFor(() =>
+        expect(result.current.settledReceipts).toEqual([
+          {
+            clientRequestId: expect.stringMatching(UUID_V4_PATTERN),
+            status: 'admitted',
+            effectivePredecessorCreatedAt: 41,
+          },
+        ]),
+      );
       expect(result.current.queue).toEqual([
         expect.objectContaining({ id: 'unrelated-server-row', text: 'keep me' }),
+      ]);
+    });
+
+    it('keeps an old-server admitted receipt uncertain until its exact boundary is known', async () => {
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        options.onSuccess({
+          ...input,
+          queuedTurnId: 'legacy-admitted-replay',
+          status: 'admitted',
+          revision: 1,
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        });
+      });
+      const { result } = setupServerQueue();
+
+      await act(async () => {
+        result.current.steering.queueFromComposer('await exact admission boundary');
+        await Promise.resolve();
+      });
+
+      await waitFor(() =>
+        expect(result.current.queue).toEqual([
+          expect.objectContaining({
+            text: 'await exact admission boundary',
+            clientRequestId: expect.stringMatching(UUID_V4_PATTERN),
+            server: expect.objectContaining({
+              id: 'legacy-admitted-replay',
+              status: 'uncertain',
+            }),
+          }),
+        ]),
+      );
+      expect(result.current.settledReceipts).toEqual([]);
+      expect(mockUseAgentQueuedTurns.mock.calls.at(-1)?.[2]).toEqual([
+        result.current.queue[0].clientRequestId,
+      ]);
+    });
+
+    it('does not let a stale queued POST response resurrect a terminal receipt', async () => {
+      let releaseQueuedPost = () => undefined;
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        releaseQueuedPost = () =>
+          options.onSuccess({
+            ...input,
+            queuedTurnId: 'server-stale-post',
+            status: 'queued',
+            revision: 1,
+            createdAt: new Date(100).toISOString(),
+            updatedAt: new Date(100).toISOString(),
+          });
+      });
+      const rendered = setupServerQueue();
+
+      await act(async () => {
+        rendered.result.current.steering.queueFromComposer('settle before POST returns');
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(mockEnqueueQueuedTurn).toHaveBeenCalledTimes(1));
+      const input = mockEnqueueQueuedTurn.mock.calls[0][0];
+      mockServerQueuedTurns = [
+        {
+          ...input,
+          queuedTurnId: 'server-terminal-get',
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+          revision: 2,
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        },
+      ];
+      rendered.rerender();
+
+      await waitFor(() => expect(rendered.result.current.queue).toEqual([]));
+      await act(async () => {
+        releaseQueuedPost();
+        await Promise.resolve();
+      });
+
+      expect(rendered.result.current.queue).toEqual([]);
+      expect(rendered.result.current.settledReceipts).toEqual([
+        {
+          clientRequestId: input.clientRequestId,
+          status: 'admitted',
+          effectivePredecessorCreatedAt: 41,
+        },
       ]);
     });
 
@@ -551,11 +643,19 @@ describe('useSteering', () => {
       ];
       const { result } = setupServerQueue();
 
-      await waitFor(() => expect(result.current.consumedPredecessors).toEqual([42]));
+      await waitFor(() =>
+        expect(result.current.settledReceipts).toEqual([
+          {
+            clientRequestId: 'client-admitted-1',
+            status: 'admitted',
+            effectivePredecessorCreatedAt: 42,
+          },
+        ]),
+      );
       expect(result.current.queue).toEqual([]);
     });
 
-    it('does not release a local successor when admission precedes SSE attachment', async () => {
+    it('keeps the terminal boundary when an old-server admission lacks its exact fence', async () => {
       mockServerQueuedTurns = [
         {
           queuedTurnId: 'server-admitted-race',
@@ -617,8 +717,17 @@ describe('useSteering', () => {
         { wrapper },
       );
 
-      await waitFor(() => expect(result.current.runEnd).toBeNull());
-      expect(result.current.queue.map((item) => item.id)).toEqual(['local-successor']);
+      await waitFor(() =>
+        expect(result.current.queue[0]).toMatchObject({
+          id: 'client-admitted-race',
+          server: { id: 'server-admitted-race', status: 'uncertain' },
+        }),
+      );
+      expect(result.current.runEnd).not.toBeNull();
+      expect(result.current.queue.map((item) => item.id)).toEqual([
+        'client-admitted-race',
+        'local-successor',
+      ]);
       expect(ask).not.toHaveBeenCalled();
       expect(sendNow).not.toHaveBeenCalled();
     });

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -1100,23 +1100,6 @@ describe('useSteering', () => {
         },
       });
       expect(rendered.result.current.settledReceipts).toEqual([]);
-
-      mockServerQueuedTurns = [
-        {
-          ...(mockServerQueuedTurns[0] as Record<string, unknown>),
-          status: 'queued',
-          revision: 3,
-          failure: undefined,
-        },
-      ];
-      rendered.rerender();
-
-      await waitFor(() =>
-        expect(rendered.result.current.queue[0].server).toMatchObject({
-          status: 'indeterminate',
-          revision: 4,
-        }),
-      );
     });
 
     it('cancels the durable copy before downgrading a row to local control', async () => {

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -4,6 +4,7 @@ import { RecoilRoot, useRecoilValue, useSetRecoilState, type MutableSnapshot } f
 import { Constants, ContentTypes, EModelEndpoint, LocalStorageKeys } from 'librechat-data-provider';
 import type { TConversation, TMessage } from 'librechat-data-provider';
 import type { QueuedMessage } from '~/store/families';
+import useQueueDrain from '../useQueueDrain';
 import useSteering from '../useSteering';
 import store from '~/store';
 
@@ -260,6 +261,9 @@ describe('useSteering', () => {
             stopGenerating: jest.fn(),
           }),
           queue: useQueue(CONVO_ID),
+          admittedPredecessor: useRecoilValue(
+            store.admittedQueuedTurnPredecessorByConvoId(CONVO_ID),
+          ),
         }),
         { wrapper },
       );
@@ -490,6 +494,95 @@ describe('useSteering', () => {
         text: 'restored after reload',
         server: { id: 'server-snapshot-1', status: 'queued', revision: 3 },
       });
+    });
+
+    it('fences the predecessor boundary when the server receipt is admitted', async () => {
+      mockServerQueuedTurns = [
+        {
+          queuedTurnId: 'server-admitted-1',
+          clientRequestId: 'client-admitted-1',
+          conversationId: CONVO_ID,
+          parentMessageId: 'visible-assistant-tail',
+          text: 'already started by the server',
+          status: 'admitted',
+          revision: 4,
+          expectedPredecessorCreatedAt: 41,
+          createdAt: new Date(200).toISOString(),
+          updatedAt: new Date(300).toISOString(),
+        },
+      ];
+      const { result } = setupServerQueue();
+
+      await waitFor(() => expect(result.current.admittedPredecessor).toBe(41));
+      expect(result.current.queue).toEqual([]);
+    });
+
+    it('does not release a local successor when admission precedes SSE attachment', async () => {
+      mockServerQueuedTurns = [
+        {
+          queuedTurnId: 'server-admitted-race',
+          clientRequestId: 'client-admitted-race',
+          conversationId: CONVO_ID,
+          parentMessageId: 'visible-assistant-tail',
+          text: 'server-owned successor',
+          status: 'admitted',
+          revision: 4,
+          expectedPredecessorCreatedAt: 41,
+          createdAt: new Date(200).toISOString(),
+          updatedAt: new Date(300).toISOString(),
+        },
+      ];
+      const ask = jest.fn();
+      const sendNow = jest.fn();
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <RecoilRoot
+          initializeState={withActiveGeneration(({ set }) => {
+            set(store.isSubmittingFamily(0), false);
+            set(store.runEndByIndex(0), {
+              conversationId: CONVO_ID,
+              outcome: 'completed',
+              endedAt: 200,
+              generationCreatedAt: 41,
+            });
+            set(store.queuedMessagesByConvoId(CONVO_ID), [
+              {
+                id: 'client-admitted-race',
+                clientRequestId: 'client-admitted-race',
+                text: 'server-owned successor',
+                createdAt: 100,
+                server: { id: 'server-admitted-race', status: 'claimed', revision: 3 },
+              },
+              { id: 'local-successor', text: 'must wait', createdAt: 101 },
+            ]);
+          })}
+        >
+          {children}
+        </RecoilRoot>
+      );
+      const { result } = renderHook(
+        () => {
+          useSteering({
+            index: 0,
+            conversationId: CONVO_ID,
+            conversation: agentsConversation,
+            isSubmitting: false,
+            answerModeActive: false,
+            sendNow,
+            stopGenerating: jest.fn(),
+          });
+          useQueueDrain(0, CONVO_ID, ask);
+          return {
+            queue: useQueue(CONVO_ID),
+            runEnd: useRecoilValue(store.runEndByIndex(0)),
+          };
+        },
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.runEnd).toBeNull());
+      expect(result.current.queue.map((item) => item.id)).toEqual(['local-successor']);
+      expect(ask).not.toHaveBeenCalled();
+      expect(sendNow).not.toHaveBeenCalled();
     });
 
     it('uses server sequence instead of Mongo timestamps for projected queue order', async () => {

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -262,6 +262,7 @@ describe('useSteering', () => {
           }),
           queue: useQueue(CONVO_ID),
           settledReceipts: useRecoilValue(store.settledQueuedTurnReceiptsByConvoId(CONVO_ID)),
+          pendingEnqueueIds: useRecoilValue(store.pendingQueuedTurnEnqueueIdsByConvoId(CONVO_ID)),
         }),
         { wrapper },
       );
@@ -418,6 +419,62 @@ describe('useSteering', () => {
       ]);
     });
 
+    it('does not let a stale queued POST erase incomplete admission evidence', async () => {
+      let releaseQueuedPost = () => undefined;
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        releaseQueuedPost = () =>
+          options.onSuccess({
+            ...input,
+            queuedTurnId: 'legacy-admitted-race',
+            status: 'queued',
+            revision: 1,
+            createdAt: new Date(100).toISOString(),
+            updatedAt: new Date(100).toISOString(),
+          });
+      });
+      const rendered = setupServerQueue();
+
+      await act(async () => {
+        rendered.result.current.steering.queueFromComposer('hold incomplete admission');
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(mockEnqueueQueuedTurn).toHaveBeenCalledTimes(1));
+      const input = mockEnqueueQueuedTurn.mock.calls[0][0];
+      mockServerQueuedTurns = [
+        {
+          ...input,
+          queuedTurnId: 'legacy-admitted-race',
+          status: 'admitted',
+          revision: 2,
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        },
+      ];
+      rendered.rerender();
+
+      await waitFor(() =>
+        expect(rendered.result.current.queue[0].server).toMatchObject({
+          id: 'legacy-admitted-race',
+          status: 'uncertain',
+        }),
+      );
+      expect(rendered.result.current.settledReceipts).toEqual([
+        { clientRequestId: input.clientRequestId, status: 'admitted_pending_boundary' },
+      ]);
+
+      await act(async () => {
+        releaseQueuedPost();
+        await Promise.resolve();
+      });
+      expect(rendered.result.current.queue).toHaveLength(1);
+      expect(rendered.result.current.queue[0].server).toMatchObject({
+        id: 'legacy-admitted-race',
+        status: 'uncertain',
+      });
+      expect(rendered.result.current.pendingEnqueueIds).toEqual([]);
+      expect(rendered.result.current.settledReceipts).toEqual([]);
+    });
+
     it('does not let a stale queued POST response resurrect a terminal receipt', async () => {
       let releaseQueuedPost = () => undefined;
       mockEnqueueQueuedTurn.mockImplementation((input, options) => {
@@ -466,6 +523,132 @@ describe('useSteering', () => {
           effectivePredecessorCreatedAt: 41,
         },
       ]);
+    });
+
+    it('does not let a stale queued POST response resurrect a cancelled row', async () => {
+      let releaseQueuedPost = () => undefined;
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        releaseQueuedPost = () =>
+          options.onSuccess({
+            ...input,
+            queuedTurnId: 'server-cancel-race',
+            status: 'queued',
+            revision: 1,
+            createdAt: new Date(100).toISOString(),
+            updatedAt: new Date(100).toISOString(),
+          });
+      });
+      const rendered = setupServerQueue();
+
+      await act(async () => {
+        rendered.result.current.steering.queueFromComposer('cancel before POST returns');
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(mockEnqueueQueuedTurn).toHaveBeenCalledTimes(1));
+      const input = mockEnqueueQueuedTurn.mock.calls[0][0];
+      mockServerQueuedTurns = [
+        {
+          ...input,
+          queuedTurnId: 'server-cancel-race',
+          status: 'queued',
+          revision: 2,
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        },
+      ];
+      rendered.rerender();
+      await waitFor(() =>
+        expect(rendered.result.current.queue[0].server?.id).toBe('server-cancel-race'),
+      );
+      mockCancelQueuedTurn.mockResolvedValueOnce({
+        ...input,
+        queuedTurnId: 'server-cancel-race',
+        status: 'cancelled',
+        revision: 3,
+        createdAt: new Date(100).toISOString(),
+        updatedAt: new Date(300).toISOString(),
+      });
+
+      await act(async () => {
+        await rendered.result.current.steering.discardQueued(rendered.result.current.queue[0]);
+      });
+      expect(rendered.result.current.queue[0].server).toBeUndefined();
+      expect(rendered.result.current.settledReceipts).toEqual([
+        { clientRequestId: input.clientRequestId, status: 'cancelled' },
+      ]);
+
+      await act(async () => {
+        releaseQueuedPost();
+        await Promise.resolve();
+      });
+      expect(rendered.result.current.queue).toEqual([
+        expect.objectContaining({
+          text: 'cancel before POST returns',
+          clientRequestId: input.clientRequestId,
+        }),
+      ]);
+      expect(rendered.result.current.queue[0].server).toBeUndefined();
+      expect(rendered.result.current.pendingEnqueueIds).toEqual([]);
+      expect(rendered.result.current.settledReceipts).toEqual([]);
+    });
+
+    it('does not let a stale queued POST response replace a definitive dead snapshot', async () => {
+      let releaseQueuedPost = () => undefined;
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        releaseQueuedPost = () =>
+          options.onSuccess({
+            ...input,
+            queuedTurnId: 'server-dead-race',
+            status: 'queued',
+            revision: 1,
+            createdAt: new Date(100).toISOString(),
+            updatedAt: new Date(100).toISOString(),
+          });
+      });
+      const rendered = setupServerQueue();
+
+      await act(async () => {
+        rendered.result.current.steering.queueFromComposer('fail before POST returns');
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(mockEnqueueQueuedTurn).toHaveBeenCalledTimes(1));
+      const input = mockEnqueueQueuedTurn.mock.calls[0][0];
+      mockServerQueuedTurns = [
+        {
+          ...input,
+          queuedTurnId: 'server-dead-race',
+          status: 'dead',
+          revision: 2,
+          failure: { code: 'PREDECESSOR_ABORTED', message: 'The predecessor aborted' },
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        },
+      ];
+      rendered.rerender();
+
+      await waitFor(() =>
+        expect(rendered.result.current.queue[0].server).toMatchObject({
+          id: 'server-dead-race',
+          status: 'rejected',
+          errorCode: 'PREDECESSOR_ABORTED',
+        }),
+      );
+      expect(rendered.result.current.settledReceipts).toEqual([
+        { clientRequestId: input.clientRequestId, status: 'dead' },
+      ]);
+
+      await act(async () => {
+        releaseQueuedPost();
+        await Promise.resolve();
+      });
+      expect(rendered.result.current.queue).toHaveLength(1);
+      expect(rendered.result.current.queue[0].server).toMatchObject({
+        id: 'server-dead-race',
+        status: 'rejected',
+        errorCode: 'PREDECESSOR_ABORTED',
+      });
+      expect(rendered.result.current.pendingEnqueueIds).toEqual([]);
+      expect(rendered.result.current.settledReceipts).toEqual([]);
     });
 
     it('anchors enqueue to the selected branch tail instead of a later hidden sibling', async () => {

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -1011,6 +1011,39 @@ describe('useSteering', () => {
       expect(result.current.queue[0].server).toBeUndefined();
     });
 
+    it('projects an indeterminate claim as non-progressing reconciliation work', async () => {
+      mockServerQueuedTurns = [
+        {
+          queuedTurnId: 'server-indeterminate-1',
+          clientRequestId: 'client-indeterminate-1',
+          conversationId: CONVO_ID,
+          parentMessageId: 'visible-assistant-tail',
+          text: 'external result is unknown',
+          status: 'claimed',
+          revision: 4,
+          failure: {
+            code: 'ADMISSION_INDETERMINATE',
+            message: 'Awaiting exact source evidence',
+          },
+          createdAt: new Date(250).toISOString(),
+          updatedAt: new Date(300).toISOString(),
+        },
+      ];
+      const { result } = setupServerQueue();
+
+      await waitFor(() => expect(result.current.queue).toHaveLength(1));
+      expect(result.current.queue[0]).toMatchObject({
+        text: 'external result is unknown',
+        server: {
+          id: 'server-indeterminate-1',
+          status: 'indeterminate',
+          errorCode: 'ADMISSION_INDETERMINATE',
+          errorMessage: 'Awaiting exact source evidence',
+        },
+      });
+      expect(result.current.settledReceipts).toEqual([]);
+    });
+
     it('cancels the durable copy before downgrading a row to local control', async () => {
       mockServerQueuedTurns = [
         {

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -838,6 +838,27 @@ describe('useSteering', () => {
       expect(result.current.queue).toEqual([]);
     });
 
+    it('settles an explicit root admission without waiting for a timestamp boundary', async () => {
+      mockServerQueuedTurns = [
+        {
+          queuedTurnId: 'server-root-admitted',
+          clientRequestId: 'client-root-admitted',
+          conversationId: CONVO_ID,
+          parentMessageId: 'visible-assistant-tail',
+          text: 'started from the conversation root',
+          status: 'admitted',
+          revision: 4,
+          rootPredecessor: true,
+          createdAt: new Date(200).toISOString(),
+          updatedAt: new Date(300).toISOString(),
+        },
+      ];
+      const { result } = setupServerQueue();
+
+      await waitFor(() => expect(result.current.queue).toEqual([]));
+      expect(result.current.settledReceipts).toEqual([]);
+    });
+
     it('keeps the terminal boundary when an old-server admission lacks its exact fence', async () => {
       mockServerQueuedTurns = [
         {

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -1103,7 +1103,7 @@ describe('useSteering', () => {
 
       mockServerQueuedTurns = [
         {
-          ...mockServerQueuedTurns[0],
+          ...(mockServerQueuedTurns[0] as Record<string, unknown>),
           status: 'queued',
           revision: 3,
           failure: undefined,

--- a/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
+++ b/client/src/hooks/Chat/__tests__/useSteering.spec.tsx
@@ -651,6 +651,64 @@ describe('useSteering', () => {
       expect(rendered.result.current.settledReceipts).toEqual([]);
     });
 
+    it('does not let a stale queued POST replace indeterminate GET evidence', async () => {
+      let releaseQueuedPost = () => undefined;
+      mockEnqueueQueuedTurn.mockImplementation((input, options) => {
+        releaseQueuedPost = () =>
+          options.onSuccess({
+            ...input,
+            queuedTurnId: 'server-indeterminate-race',
+            status: 'queued',
+            revision: 1,
+            createdAt: new Date(100).toISOString(),
+            updatedAt: new Date(100).toISOString(),
+          });
+      });
+      const rendered = setupServerQueue();
+
+      await act(async () => {
+        rendered.result.current.steering.queueFromComposer('unknown before POST returns');
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(mockEnqueueQueuedTurn).toHaveBeenCalledTimes(1));
+      const input = mockEnqueueQueuedTurn.mock.calls[0][0];
+      mockServerQueuedTurns = [
+        {
+          ...input,
+          queuedTurnId: 'server-indeterminate-race',
+          status: 'claimed',
+          revision: 2,
+          failure: { code: 'ADMISSION_INDETERMINATE' },
+          createdAt: new Date(100).toISOString(),
+          updatedAt: new Date(200).toISOString(),
+        },
+      ];
+      rendered.rerender();
+
+      await waitFor(() =>
+        expect(rendered.result.current.queue[0].server).toMatchObject({
+          id: 'server-indeterminate-race',
+          status: 'indeterminate',
+          revision: 2,
+        }),
+      );
+      expect(rendered.result.current.settledReceipts).toEqual([
+        { clientRequestId: input.clientRequestId, status: 'indeterminate' },
+      ]);
+
+      await act(async () => {
+        releaseQueuedPost();
+        await Promise.resolve();
+      });
+      expect(rendered.result.current.queue[0].server).toMatchObject({
+        id: 'server-indeterminate-race',
+        status: 'indeterminate',
+        revision: 2,
+      });
+      expect(rendered.result.current.pendingEnqueueIds).toEqual([]);
+      expect(rendered.result.current.settledReceipts).toEqual([]);
+    });
+
     it('anchors enqueue to the selected branch tail instead of a later hidden sibling', async () => {
       mockMessages = [
         {
@@ -798,10 +856,10 @@ describe('useSteering', () => {
           updatedAt: new Date(200).toISOString(),
         },
       ];
-      const { result } = setupServerQueue();
+      const rendered = setupServerQueue();
 
-      await waitFor(() => expect(result.current.queue).toHaveLength(1));
-      expect(result.current.queue[0]).toMatchObject({
+      await waitFor(() => expect(rendered.result.current.queue).toHaveLength(1));
+      expect(rendered.result.current.queue[0]).toMatchObject({
         id: 'client-snapshot-1',
         text: 'restored after reload',
         server: { id: 'server-snapshot-1', status: 'queued', revision: 3 },
@@ -986,10 +1044,10 @@ describe('useSteering', () => {
         },
       ];
       mockCancelQueuedTurn.mockResolvedValueOnce({ status: 'cancelled' });
-      const { result } = setupServerQueue();
+      const rendered = setupServerQueue();
 
-      await waitFor(() => expect(result.current.queue).toHaveLength(1));
-      expect(result.current.queue[0]).toMatchObject({
+      await waitFor(() => expect(rendered.result.current.queue).toHaveLength(1));
+      expect(rendered.result.current.queue[0]).toMatchObject({
         text: 'recover this failed turn',
         server: {
           id: 'server-dead-1',
@@ -1000,15 +1058,15 @@ describe('useSteering', () => {
       });
 
       await act(async () => {
-        await expect(result.current.steering.discardQueued(result.current.queue[0])).resolves.toBe(
-          true,
-        );
+        await expect(
+          rendered.result.current.steering.discardQueued(rendered.result.current.queue[0]),
+        ).resolves.toBe(true);
       });
       expect(mockCancelQueuedTurn).toHaveBeenCalledWith({
         conversationId: CONVO_ID,
         queuedTurnId: 'server-dead-1',
       });
-      expect(result.current.queue[0].server).toBeUndefined();
+      expect(rendered.result.current.queue[0].server).toBeUndefined();
     });
 
     it('projects an indeterminate claim as non-progressing reconciliation work', async () => {
@@ -1029,10 +1087,10 @@ describe('useSteering', () => {
           updatedAt: new Date(300).toISOString(),
         },
       ];
-      const { result } = setupServerQueue();
+      const rendered = setupServerQueue();
 
-      await waitFor(() => expect(result.current.queue).toHaveLength(1));
-      expect(result.current.queue[0]).toMatchObject({
+      await waitFor(() => expect(rendered.result.current.queue).toHaveLength(1));
+      expect(rendered.result.current.queue[0]).toMatchObject({
         text: 'external result is unknown',
         server: {
           id: 'server-indeterminate-1',
@@ -1041,7 +1099,24 @@ describe('useSteering', () => {
           errorMessage: 'Awaiting exact source evidence',
         },
       });
-      expect(result.current.settledReceipts).toEqual([]);
+      expect(rendered.result.current.settledReceipts).toEqual([]);
+
+      mockServerQueuedTurns = [
+        {
+          ...mockServerQueuedTurns[0],
+          status: 'queued',
+          revision: 3,
+          failure: undefined,
+        },
+      ];
+      rendered.rerender();
+
+      await waitFor(() =>
+        expect(rendered.result.current.queue[0].server).toMatchObject({
+          status: 'indeterminate',
+          revision: 4,
+        }),
+      );
     });
 
     it('cancels the durable copy before downgrading a row to local control', async () => {

--- a/client/src/hooks/Chat/useQueueDrain.ts
+++ b/client/src/hooks/Chat/useQueueDrain.ts
@@ -238,11 +238,17 @@ export default function useQueueDrain(
           : ownQueue;
 
         const shouldDrain = end.outcome === 'completed' || interruptArmed;
-        const consumedPredecessors = snapshot
-          .getLoadable(store.consumedQueuedTurnPredecessorsByConvoId(conversationId))
+        const settledReceipts = snapshot
+          .getLoadable(store.settledQueuedTurnReceiptsByConvoId(conversationId))
           .getValue();
-        const consumedByServerAdmission =
-          end.generationCreatedAt != null && consumedPredecessors.includes(end.generationCreatedAt);
+        const consumedReceiptIndex = settledReceipts.findIndex(
+          (receipt) =>
+            receipt.status === 'admitted' &&
+            receipt.boundaryConsumed !== true &&
+            end.generationCreatedAt != null &&
+            receipt.effectivePredecessorCreatedAt === end.generationCreatedAt,
+        );
+        const consumedByServerAdmission = consumedReceiptIndex >= 0;
         const consumeEnd = () => {
           if (fromParked && activeConversationId) {
             set(store.pendingRunEndByConvoId(activeConversationId), null);
@@ -260,9 +266,21 @@ export default function useQueueDrain(
             set(store.queuedMessagesByConvoId(Constants.NEW_CONVO), []);
             set(store.queuedMessagesByConvoId(conversationId), merged);
           }
-          set(store.consumedQueuedTurnPredecessorsByConvoId(conversationId), (previous) =>
-            previous.filter((predecessor) => predecessor !== end.generationCreatedAt),
-          );
+          set(store.settledQueuedTurnReceiptsByConvoId(conversationId), (previous) => {
+            let consumed = false;
+            return previous.map((receipt) => {
+              if (
+                !consumed &&
+                receipt.status === 'admitted' &&
+                receipt.boundaryConsumed !== true &&
+                receipt.effectivePredecessorCreatedAt === end.generationCreatedAt
+              ) {
+                consumed = true;
+                return { ...receipt, boundaryConsumed: true };
+              }
+              return receipt;
+            });
+          });
           consumeEnd();
           return null;
         }

--- a/client/src/hooks/Chat/useQueueDrain.ts
+++ b/client/src/hooks/Chat/useQueueDrain.ts
@@ -241,6 +241,9 @@ export default function useQueueDrain(
         const settledReceipts = snapshot
           .getLoadable(store.settledQueuedTurnReceiptsByConvoId(conversationId))
           .getValue();
+        const pendingEnqueueIds = snapshot
+          .getLoadable(store.pendingQueuedTurnEnqueueIdsByConvoId(conversationId))
+          .getValue();
         const consumedReceiptIndex = settledReceipts.findIndex(
           (receipt) =>
             receipt.status === 'admitted' &&
@@ -268,7 +271,7 @@ export default function useQueueDrain(
           }
           set(store.settledQueuedTurnReceiptsByConvoId(conversationId), (previous) => {
             let consumed = false;
-            return previous.map((receipt) => {
+            return previous.flatMap((receipt) => {
               if (
                 !consumed &&
                 receipt.status === 'admitted' &&
@@ -276,9 +279,11 @@ export default function useQueueDrain(
                 receipt.effectivePredecessorCreatedAt === end.generationCreatedAt
               ) {
                 consumed = true;
-                return { ...receipt, boundaryConsumed: true };
+                return pendingEnqueueIds.includes(receipt.clientRequestId)
+                  ? [{ ...receipt, boundaryConsumed: true }]
+                  : [];
               }
-              return receipt;
+              return [receipt];
             });
           });
           consumeEnd();

--- a/client/src/hooks/Chat/useQueueDrain.ts
+++ b/client/src/hooks/Chat/useQueueDrain.ts
@@ -238,6 +238,29 @@ export default function useQueueDrain(
           : ownQueue;
 
         const shouldDrain = end.outcome === 'completed' || interruptArmed;
+        const admittedPredecessor = snapshot
+          .getLoadable(store.admittedQueuedTurnPredecessorByConvoId(conversationId))
+          .getValue();
+        const supersededByServerAdmission =
+          end.generationCreatedAt != null &&
+          admittedPredecessor != null &&
+          end.generationCreatedAt <= admittedPredecessor;
+        const consumeEnd = () => {
+          if (fromParked && activeConversationId) {
+            set(store.pendingRunEndByConvoId(activeConversationId), null);
+          } else {
+            set(store.runEndByIndex(index), null);
+          }
+          if (matchingIndexArm) {
+            set(store.drainAfterAbortByIndex(index), false);
+          }
+        };
+        if (supersededByServerAdmission) {
+          /** Admission consumed this terminal boundary on the server. A late
+           * client terminal observation cannot authorize a second successor. */
+          consumeEnd();
+          return null;
+        }
         /** A server-owned Agent row means the backend owns the next fresh-turn
          * admission. Do not let a legacy/recovered local row race or overtake
          * it. Keep this terminal boundary available until the authoritative
@@ -253,14 +276,7 @@ export default function useQueueDrain(
 
         // Consume only after server authority has yielded the boundary — a
         // hard double-fire guard even if the effect re-runs before propagation.
-        if (fromParked && activeConversationId) {
-          set(store.pendingRunEndByConvoId(activeConversationId), null);
-        } else {
-          set(store.runEndByIndex(index), null);
-        }
-        if (matchingIndexArm) {
-          set(store.drainAfterAbortByIndex(index), false);
-        }
+        consumeEnd();
 
         const next = shouldDrain ? (merged[0] ?? null) : null;
         const remainder = next ? merged.slice(1) : merged;

--- a/client/src/hooks/Chat/useQueueDrain.ts
+++ b/client/src/hooks/Chat/useQueueDrain.ts
@@ -238,13 +238,11 @@ export default function useQueueDrain(
           : ownQueue;
 
         const shouldDrain = end.outcome === 'completed' || interruptArmed;
-        const admittedPredecessor = snapshot
-          .getLoadable(store.admittedQueuedTurnPredecessorByConvoId(conversationId))
+        const consumedPredecessors = snapshot
+          .getLoadable(store.consumedQueuedTurnPredecessorsByConvoId(conversationId))
           .getValue();
-        const supersededByServerAdmission =
-          end.generationCreatedAt != null &&
-          admittedPredecessor != null &&
-          end.generationCreatedAt <= admittedPredecessor;
+        const consumedByServerAdmission =
+          end.generationCreatedAt != null && consumedPredecessors.includes(end.generationCreatedAt);
         const consumeEnd = () => {
           if (fromParked && activeConversationId) {
             set(store.pendingRunEndByConvoId(activeConversationId), null);
@@ -255,14 +253,17 @@ export default function useQueueDrain(
             set(store.drainAfterAbortByIndex(index), false);
           }
         };
-        if (supersededByServerAdmission) {
+        if (consumedByServerAdmission) {
           /** Admission consumed this terminal boundary on the server. A late
            * client terminal observation cannot authorize a second successor. */
-          consumeEnd();
           if (shouldMigrate && newConvoQueue.length > 0) {
             set(store.queuedMessagesByConvoId(Constants.NEW_CONVO), []);
             set(store.queuedMessagesByConvoId(conversationId), merged);
           }
+          set(store.consumedQueuedTurnPredecessorsByConvoId(conversationId), (previous) =>
+            previous.filter((predecessor) => predecessor !== end.generationCreatedAt),
+          );
+          consumeEnd();
           return null;
         }
         /** A server-owned Agent row means the backend owns the next fresh-turn

--- a/client/src/hooks/Chat/useQueueDrain.ts
+++ b/client/src/hooks/Chat/useQueueDrain.ts
@@ -89,6 +89,13 @@ export default function useQueueDrain(
    *  during the first turn stay keyed here until that run ends. Renewing only
    *  the active id would skip them for the whole of that run. */
   const newConvoQueue = useRecoilValue(store.queuedMessagesByConvoId(Constants.NEW_CONVO));
+  /** Receipt settlement can consume the parked terminal boundary without
+   * changing whether another server-owned row remains. Subscribe here so the
+   * drain effect observes that durable transition instead of reading it only
+   * through a callback snapshot whose other dependencies stayed unchanged. */
+  const settledQueuedTurnReceipts = useRecoilValue(
+    store.settledQueuedTurnReceiptsByConvoId(activeConversationId ?? Constants.NEW_CONVO),
+  );
   const hasServerOwnedQueue = [...ownQueue, ...newConvoQueue].some((item) => item.server != null);
 
   /* Deduped because the two subscriptions are the same atom before migration.
@@ -406,6 +413,7 @@ export default function useQueueDrain(
     restoreQueued,
     markFilesUsage,
     hasServerOwnedQueue,
+    settledQueuedTurnReceipts,
     ask,
   ]);
 }

--- a/client/src/hooks/Chat/useQueueDrain.ts
+++ b/client/src/hooks/Chat/useQueueDrain.ts
@@ -259,6 +259,10 @@ export default function useQueueDrain(
           /** Admission consumed this terminal boundary on the server. A late
            * client terminal observation cannot authorize a second successor. */
           consumeEnd();
+          if (shouldMigrate && newConvoQueue.length > 0) {
+            set(store.queuedMessagesByConvoId(Constants.NEW_CONVO), []);
+            set(store.queuedMessagesByConvoId(conversationId), merged);
+          }
           return null;
         }
         /** A server-owned Agent row means the backend owns the next fresh-turn

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -363,12 +363,37 @@ export default function useSteering({
     store.activeGenerationProtocolVersionByConvoId(queueKey),
   );
 
+  const reconcileQueuedTurns = useRecoilCallback(
+    ({ set }) =>
+      (receipts: AgentQueuedTurnReceipt[]) => {
+        let admittedPredecessor: number | undefined;
+        for (const receipt of receipts) {
+          if (receipt.status !== 'admitted' || receipt.expectedPredecessorCreatedAt == null) {
+            continue;
+          }
+          admittedPredecessor = Math.max(
+            admittedPredecessor ?? receipt.expectedPredecessorCreatedAt,
+            receipt.expectedPredecessorCreatedAt,
+          );
+        }
+        if (admittedPredecessor != null) {
+          set(store.admittedQueuedTurnPredecessorByConvoId(queueKey), (previous) =>
+            Math.max(previous ?? admittedPredecessor, admittedPredecessor),
+          );
+        }
+        set(store.queuedMessagesByConvoId(queueKey), (previous) =>
+          reconcileServerQueuedTurns(previous, receipts),
+        );
+      },
+    [queueKey],
+  );
+
   useEffect(() => {
     if (!serverQueueEnabled || serverQueuedTurns == null) {
       return;
     }
-    setQueuedMessages((previous) => reconcileServerQueuedTurns(previous, serverQueuedTurns));
-  }, [serverQueueEnabled, serverQueuedTurns, setQueuedMessages]);
+    reconcileQueuedTurns(serverQueuedTurns);
+  }, [serverQueueEnabled, serverQueuedTurns, reconcileQueuedTurns]);
   useEffect(() => {
     if (!serverQueueEnabled || nextReconciliationExpiry == null) {
       return;

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -426,17 +426,23 @@ export default function useSteering({
             !(
               existing.status === 'admitted_pending_boundary' &&
               receipt.status === 'admitted' &&
-              receipt.effectivePredecessorCreatedAt != null
+              (receipt.effectivePredecessorCreatedAt != null || receipt.rootPredecessor === true)
             )
           ) {
             continue;
           }
           let settled: SettledQueuedTurnReceipt | undefined;
-          if (receipt.status === 'admitted' && receipt.effectivePredecessorCreatedAt != null) {
+          if (
+            receipt.status === 'admitted' &&
+            (receipt.effectivePredecessorCreatedAt != null || receipt.rootPredecessor === true)
+          ) {
             settled = {
               clientRequestId: receipt.clientRequestId,
               status: 'admitted',
-              effectivePredecessorCreatedAt: receipt.effectivePredecessorCreatedAt,
+              ...(receipt.effectivePredecessorCreatedAt != null && {
+                effectivePredecessorCreatedAt: receipt.effectivePredecessorCreatedAt,
+              }),
+              ...(receipt.rootPredecessor === true && { rootPredecessor: true }),
             };
           } else if (receipt.status === 'admitted') {
             settled = {
@@ -460,7 +466,9 @@ export default function useSteering({
         const pendingRequestIds = new Set(nextPending);
         const nextSettled = [...settledByRequestId.values()].filter(
           (receipt) =>
-            (receipt.status === 'admitted' && receipt.boundaryConsumed !== true) ||
+            (receipt.status === 'admitted' &&
+              receipt.rootPredecessor !== true &&
+              receipt.boundaryConsumed !== true) ||
             pendingRequestIds.has(receipt.clientRequestId),
         );
         if (source === 'enqueue') {

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -297,11 +297,6 @@ function reconcileServerQueuedTurns(
       return optimistic == null ? [] : [optimistic];
     }
     const boundaryPending = receipt.status === 'admitted';
-    /** Reordered requests may complete after a newer authoritative GET. The
-     * row revision is durable evidence; never regress its projection. */
-    if (optimistic?.server?.revision != null && optimistic.server.revision > receipt.revision) {
-      return [optimistic];
-    }
     let status: NonNullable<QueuedMessage['server']>['status'] = 'rejected';
     if (admissionIndeterminate) {
       status = 'indeterminate';

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -14,7 +14,13 @@ import type {
   TConversation,
   TMessageContentParts,
 } from 'librechat-data-provider';
-import type { RunEnd, PendingSteer, QueuedMessage, QueuedMessageOrigin } from '~/store/families';
+import type {
+  RunEnd,
+  PendingSteer,
+  QueuedMessage,
+  QueuedMessageOrigin,
+  SettledQueuedTurnReceipt,
+} from '~/store/families';
 import type { AgentQueuedTurnReceipt, GenerationProtocolVersion } from '~/data-provider';
 import type { ExtendedFile, FileSetter } from '~/common';
 import {
@@ -195,6 +201,7 @@ function toQueuedTurnFileRefs(files: TMessage['files']): TAgentQueuedTurnFileRef
 function reconcileServerQueuedTurns(
   previous: QueuedMessage[],
   receipts: AgentQueuedTurnReceipt[],
+  settledClientRequestIds: ReadonlySet<string>,
   authoritativeSnapshot = true,
 ): QueuedMessage[] {
   const previousByClientRequestId = new Map(
@@ -204,10 +211,17 @@ function reconcileServerQueuedTurns(
   );
   const observedClientRequestIds = new Set(receipts.map((receipt) => receipt.clientRequestId));
   const projected = receipts.flatMap((receipt): QueuedMessage[] => {
-    if (receipt.status === 'admitted' || receipt.status === 'cancelled') {
+    if (settledClientRequestIds.has(receipt.clientRequestId)) {
       return [];
     }
     const optimistic = previousByClientRequestId.get(receipt.clientRequestId);
+    const boundaryPending = receipt.status === 'admitted';
+    let status: NonNullable<QueuedMessage['server']>['status'] = receipt.status;
+    if (boundaryPending) {
+      status = 'uncertain';
+    } else if (receipt.status === 'dead') {
+      status = 'rejected';
+    }
     return [
       {
         id: optimistic?.id ?? receipt.clientRequestId,
@@ -227,8 +241,11 @@ function reconcileServerQueuedTurns(
         ...(receipt.priority === true && { priority: true }),
         server: {
           id: receipt.queuedTurnId,
-          status: receipt.status === 'dead' ? 'rejected' : receipt.status,
+          status,
           revision: receipt.revision,
+          ...(boundaryPending && {
+            uncertainSince: optimistic?.server?.uncertainSince ?? Date.now(),
+          }),
           ...(receipt.position != null && { position: receipt.position }),
           ...(receipt.failure?.code != null && { errorCode: receipt.failure.code }),
           ...(receipt.failure?.message != null && { errorMessage: receipt.failure.message }),
@@ -237,6 +254,9 @@ function reconcileServerQueuedTurns(
     ];
   });
   const retained = previous.filter((item) => {
+    if (item.clientRequestId != null && settledClientRequestIds.has(item.clientRequestId)) {
+      return false;
+    }
     if (item.server == null) {
       return true;
     }
@@ -368,31 +388,45 @@ export default function useSteering({
   );
 
   const applyQueuedTurnReceipts = useRecoilCallback(
-    ({ set }) =>
+    ({ snapshot, set }) =>
       (receipts: AgentQueuedTurnReceipt[], authoritativeSnapshot: boolean = true) => {
-        const consumedPredecessors: number[] = [];
+        const previousSettled = snapshot
+          .getLoadable(store.settledQueuedTurnReceiptsByConvoId(queueKey))
+          .getValue();
+        const settledByRequestId = new Map(
+          previousSettled.map((receipt) => [receipt.clientRequestId, receipt]),
+        );
         for (const receipt of receipts) {
-          if (receipt.status !== 'admitted') {
+          if (settledByRequestId.has(receipt.clientRequestId)) {
             continue;
           }
-          const effectivePredecessor =
-            receipt.effectivePredecessorCreatedAt ?? receipt.expectedPredecessorCreatedAt;
-          if (effectivePredecessor == null) {
+          let settled: SettledQueuedTurnReceipt | undefined;
+          if (receipt.status === 'admitted' && receipt.effectivePredecessorCreatedAt != null) {
+            settled = {
+              clientRequestId: receipt.clientRequestId,
+              status: 'admitted',
+              effectivePredecessorCreatedAt: receipt.effectivePredecessorCreatedAt,
+            };
+          } else if (receipt.status === 'cancelled') {
+            settled = { clientRequestId: receipt.clientRequestId, status: 'cancelled' };
+          }
+          if (settled == null) {
             continue;
           }
-          consumedPredecessors.push(effectivePredecessor);
+          settledByRequestId.set(receipt.clientRequestId, settled);
         }
-        if (consumedPredecessors.length > 0) {
-          set(store.consumedQueuedTurnPredecessorsByConvoId(queueKey), (previous) => {
-            const next = new Set(previous);
-            for (const predecessor of consumedPredecessors) {
-              next.add(predecessor);
-            }
-            return next.size === previous.length ? previous : [...next];
-          });
+        const nextSettled = [...settledByRequestId.values()];
+        const settledClientRequestIds = new Set(settledByRequestId.keys());
+        if (nextSettled.length !== previousSettled.length) {
+          set(store.settledQueuedTurnReceiptsByConvoId(queueKey), nextSettled);
         }
         set(store.queuedMessagesByConvoId(queueKey), (previous) =>
-          reconcileServerQueuedTurns(previous, receipts, authoritativeSnapshot),
+          reconcileServerQueuedTurns(
+            previous,
+            receipts,
+            settledClientRequestIds,
+            authoritativeSnapshot,
+          ),
         );
       },
     [queueKey],

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -195,6 +195,7 @@ function toQueuedTurnFileRefs(files: TMessage['files']): TAgentQueuedTurnFileRef
 function reconcileServerQueuedTurns(
   previous: QueuedMessage[],
   receipts: AgentQueuedTurnReceipt[],
+  authoritativeSnapshot = true,
 ): QueuedMessage[] {
   const previousByClientRequestId = new Map(
     previous.flatMap((item) =>
@@ -241,6 +242,9 @@ function reconcileServerQueuedTurns(
     }
     if (item.clientRequestId == null || observedClientRequestIds.has(item.clientRequestId)) {
       return false;
+    }
+    if (!authoritativeSnapshot) {
+      return true;
     }
     return (
       item.server.status === 'sending' ||
@@ -363,10 +367,10 @@ export default function useSteering({
     store.activeGenerationProtocolVersionByConvoId(queueKey),
   );
 
-  const reconcileQueuedTurns = useRecoilCallback(
+  const applyQueuedTurnReceipts = useRecoilCallback(
     ({ set }) =>
-      (receipts: AgentQueuedTurnReceipt[]) => {
-        let admittedPredecessor: number | undefined;
+      (receipts: AgentQueuedTurnReceipt[], authoritativeSnapshot: boolean = true) => {
+        const consumedPredecessors: number[] = [];
         for (const receipt of receipts) {
           if (receipt.status !== 'admitted') {
             continue;
@@ -376,18 +380,19 @@ export default function useSteering({
           if (effectivePredecessor == null) {
             continue;
           }
-          admittedPredecessor = Math.max(
-            admittedPredecessor ?? effectivePredecessor,
-            effectivePredecessor,
-          );
+          consumedPredecessors.push(effectivePredecessor);
         }
-        if (admittedPredecessor != null) {
-          set(store.admittedQueuedTurnPredecessorByConvoId(queueKey), (previous) =>
-            Math.max(previous ?? admittedPredecessor, admittedPredecessor),
-          );
+        if (consumedPredecessors.length > 0) {
+          set(store.consumedQueuedTurnPredecessorsByConvoId(queueKey), (previous) => {
+            const next = new Set(previous);
+            for (const predecessor of consumedPredecessors) {
+              next.add(predecessor);
+            }
+            return next.size === previous.length ? previous : [...next];
+          });
         }
         set(store.queuedMessagesByConvoId(queueKey), (previous) =>
-          reconcileServerQueuedTurns(previous, receipts),
+          reconcileServerQueuedTurns(previous, receipts, authoritativeSnapshot),
         );
       },
     [queueKey],
@@ -397,8 +402,8 @@ export default function useSteering({
     if (!serverQueueEnabled || serverQueuedTurns == null) {
       return;
     }
-    reconcileQueuedTurns(serverQueuedTurns);
-  }, [serverQueueEnabled, serverQueuedTurns, reconcileQueuedTurns]);
+    applyQueuedTurnReceipts(serverQueuedTurns);
+  }, [serverQueueEnabled, serverQueuedTurns, applyQueuedTurnReceipts]);
   useEffect(() => {
     if (!serverQueueEnabled || nextReconciliationExpiry == null) {
       return;
@@ -850,27 +855,7 @@ export default function useSteering({
             },
             {
               onSuccess: (receipt) => {
-                updateQueuedMessage(item.id, (current) => {
-                  if (receipt.status === 'admitted' || receipt.status === 'cancelled') {
-                    return null;
-                  }
-                  return {
-                    ...current,
-                    text: receipt.text,
-                    createdAt: queuedTurnCreatedAt(receipt),
-                    parentMessageId: receipt.parentMessageId,
-                    server: {
-                      id: receipt.queuedTurnId,
-                      status: receipt.status === 'dead' ? 'rejected' : receipt.status,
-                      revision: receipt.revision,
-                      ...(receipt.position != null && { position: receipt.position }),
-                      ...(receipt.failure?.code != null && { errorCode: receipt.failure.code }),
-                      ...(receipt.failure?.message != null && {
-                        errorMessage: receipt.failure.message,
-                      }),
-                    },
-                  };
-                });
+                applyQueuedTurnReceipts([receipt], false);
               },
               onError: (error) => {
                 updateQueuedMessage(item.id, (current) => {
@@ -921,6 +906,7 @@ export default function useSteering({
       markQueuedFilesUsage,
       activeGenerationCreatedAt,
       enqueueAgentQueuedTurn,
+      applyQueuedTurnReceipts,
       updateQueuedMessage,
     ],
   );

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -201,7 +201,7 @@ function toQueuedTurnFileRefs(files: TMessage['files']): TAgentQueuedTurnFileRef
 function reconcileServerQueuedTurns(
   previous: QueuedMessage[],
   receipts: AgentQueuedTurnReceipt[],
-  settledClientRequestIds: ReadonlySet<string>,
+  settledByRequestId: ReadonlyMap<string, SettledQueuedTurnReceipt>,
   authoritativeSnapshot = true,
 ): QueuedMessage[] {
   const previousByClientRequestId = new Map(
@@ -211,10 +211,18 @@ function reconcileServerQueuedTurns(
   );
   const observedClientRequestIds = new Set(receipts.map((receipt) => receipt.clientRequestId));
   const projected = receipts.flatMap((receipt): QueuedMessage[] => {
-    if (settledClientRequestIds.has(receipt.clientRequestId)) {
+    const settled = settledByRequestId.get(receipt.clientRequestId);
+    if (settled?.status === 'admitted' || settled?.status === 'cancelled') {
       return [];
     }
     const optimistic = previousByClientRequestId.get(receipt.clientRequestId);
+    if (
+      (settled?.status === 'dead' || settled?.status === 'admitted_pending_boundary') &&
+      receipt.status !== 'dead' &&
+      receipt.status !== 'admitted'
+    ) {
+      return optimistic == null ? [] : [optimistic];
+    }
     const boundaryPending = receipt.status === 'admitted';
     let status: NonNullable<QueuedMessage['server']>['status'] = 'rejected';
     if (boundaryPending) {
@@ -254,11 +262,16 @@ function reconcileServerQueuedTurns(
     ];
   });
   const retained = previous.filter((item) => {
-    if (item.clientRequestId != null && settledClientRequestIds.has(item.clientRequestId)) {
-      return false;
-    }
     if (item.server == null) {
       return true;
+    }
+    const settled =
+      item.clientRequestId == null ? undefined : settledByRequestId.get(item.clientRequestId);
+    if (settled?.status === 'admitted' || settled?.status === 'cancelled') {
+      return false;
+    }
+    if (settled?.status === 'dead' || settled?.status === 'admitted_pending_boundary') {
+      return item.clientRequestId == null || !observedClientRequestIds.has(item.clientRequestId);
     }
     if (item.clientRequestId == null || observedClientRequestIds.has(item.clientRequestId)) {
       return false;
@@ -389,15 +402,33 @@ export default function useSteering({
 
   const applyQueuedTurnReceipts = useRecoilCallback(
     ({ snapshot, set }) =>
-      (receipts: AgentQueuedTurnReceipt[], authoritativeSnapshot: boolean = true) => {
+      (
+        receipts: AgentQueuedTurnReceipt[],
+        source: 'snapshot' | 'enqueue' | 'direct' = 'snapshot',
+      ) => {
         const previousSettled = snapshot
           .getLoadable(store.settledQueuedTurnReceiptsByConvoId(queueKey))
           .getValue();
+        const previousPending = snapshot
+          .getLoadable(store.pendingQueuedTurnEnqueueIdsByConvoId(queueKey))
+          .getValue();
+        const completedRequestIds = new Set(
+          source === 'enqueue' ? receipts.map((receipt) => receipt.clientRequestId) : [],
+        );
+        const nextPending = previousPending.filter((id) => !completedRequestIds.has(id));
         const settledByRequestId = new Map(
           previousSettled.map((receipt) => [receipt.clientRequestId, receipt]),
         );
         for (const receipt of receipts) {
-          if (settledByRequestId.has(receipt.clientRequestId)) {
+          const existing = settledByRequestId.get(receipt.clientRequestId);
+          if (
+            existing != null &&
+            !(
+              existing.status === 'admitted_pending_boundary' &&
+              receipt.status === 'admitted' &&
+              receipt.effectivePredecessorCreatedAt != null
+            )
+          ) {
             continue;
           }
           let settled: SettledQueuedTurnReceipt | undefined;
@@ -407,27 +438,75 @@ export default function useSteering({
               status: 'admitted',
               effectivePredecessorCreatedAt: receipt.effectivePredecessorCreatedAt,
             };
+          } else if (receipt.status === 'admitted') {
+            settled = {
+              clientRequestId: receipt.clientRequestId,
+              status: 'admitted_pending_boundary',
+            };
           } else if (receipt.status === 'cancelled') {
             settled = { clientRequestId: receipt.clientRequestId, status: 'cancelled' };
+          } else if (
+            receipt.status === 'dead' &&
+            receipt.failure?.code !== 'ADMISSION_INDETERMINATE'
+          ) {
+            settled = { clientRequestId: receipt.clientRequestId, status: 'dead' };
           }
           if (settled == null) {
             continue;
           }
           settledByRequestId.set(receipt.clientRequestId, settled);
         }
-        const nextSettled = [...settledByRequestId.values()];
-        const settledClientRequestIds = new Set(settledByRequestId.keys());
-        if (nextSettled.length !== previousSettled.length) {
+        const terminalForReconciliation = new Map(settledByRequestId);
+        const pendingRequestIds = new Set(nextPending);
+        const nextSettled = [...settledByRequestId.values()].filter(
+          (receipt) =>
+            (receipt.status === 'admitted' && receipt.boundaryConsumed !== true) ||
+            pendingRequestIds.has(receipt.clientRequestId),
+        );
+        if (source === 'enqueue') {
+          set(store.pendingQueuedTurnEnqueueIdsByConvoId(queueKey), nextPending);
+        }
+        if (
+          nextSettled.length !== previousSettled.length ||
+          nextSettled.some((receipt, index) => receipt !== previousSettled[index])
+        ) {
           set(store.settledQueuedTurnReceiptsByConvoId(queueKey), nextSettled);
         }
-        set(store.queuedMessagesByConvoId(queueKey), (previous) =>
-          reconcileServerQueuedTurns(
-            previous,
-            receipts,
-            settledClientRequestIds,
-            authoritativeSnapshot,
-          ),
+        if (source !== 'direct') {
+          set(store.queuedMessagesByConvoId(queueKey), (previous) =>
+            reconcileServerQueuedTurns(
+              previous,
+              receipts,
+              terminalForReconciliation,
+              source === 'snapshot',
+            ),
+          );
+        }
+      },
+    [queueKey],
+  );
+
+  const finishQueuedTurnEnqueue = useRecoilCallback(
+    ({ snapshot, set }) =>
+      (clientRequestId: string): boolean => {
+        const settledReceipts = snapshot
+          .getLoadable(store.settledQueuedTurnReceiptsByConvoId(queueKey))
+          .getValue();
+        const settled = settledReceipts.find(
+          (receipt) => receipt.clientRequestId === clientRequestId,
         );
+        set(store.pendingQueuedTurnEnqueueIdsByConvoId(queueKey), (previous) =>
+          previous.filter((id) => id !== clientRequestId),
+        );
+        if (
+          settled != null &&
+          (settled.status !== 'admitted' || settled.boundaryConsumed === true)
+        ) {
+          set(store.settledQueuedTurnReceiptsByConvoId(queueKey), (previous) =>
+            previous.filter((receipt) => receipt.clientRequestId !== clientRequestId),
+          );
+        }
+        return settled != null;
       },
     [queueKey],
   );
@@ -865,6 +944,9 @@ export default function useSteering({
         if (!serverOwned || clientRequestId == null) {
           return;
         }
+        set(store.pendingQueuedTurnEnqueueIdsByConvoId(queueKey), (previous) =>
+          previous.includes(clientRequestId) ? previous : [...previous, clientRequestId],
+        );
         const serverFiles = toQueuedTurnFileRefs(item.files);
         /** Commit the optimistic Recoil row before mutation callbacks can
          * reconcile it. This also makes synchronous test/adaptor completions
@@ -889,9 +971,12 @@ export default function useSteering({
             },
             {
               onSuccess: (receipt) => {
-                applyQueuedTurnReceipts([receipt], false);
+                applyQueuedTurnReceipts([receipt], 'enqueue');
               },
               onError: (error) => {
+                if (finishQueuedTurnEnqueue(clientRequestId)) {
+                  return;
+                }
                 updateQueuedMessage(item.id, (current) => {
                   if (isDefiniteQueuedTurnsUnsupported(error)) {
                     const {
@@ -941,6 +1026,7 @@ export default function useSteering({
       activeGenerationCreatedAt,
       enqueueAgentQueuedTurn,
       applyQueuedTurnReceipts,
+      finishQueuedTurnEnqueue,
       updateQueuedMessage,
     ],
   );
@@ -1165,6 +1251,7 @@ export default function useSteering({
             });
             return false;
           }
+          applyQueuedTurnReceipts([receipt], 'direct');
           return downgradeServerQueuedTurn(item.id);
         } catch {
           showToast({
@@ -1209,6 +1296,7 @@ export default function useSteering({
     [
       cancelSteer,
       cancelAgentQueuedTurn,
+      applyQueuedTurnReceipts,
       conversationId,
       downgradeQueuedRecovery,
       downgradeServerQueuedTurn,

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -224,8 +224,13 @@ function reconcileServerQueuedTurns(
       return optimistic == null ? [] : [optimistic];
     }
     const boundaryPending = receipt.status === 'admitted';
+    const admissionIndeterminate =
+      receipt.failure?.code === 'ADMISSION_INDETERMINATE' &&
+      (receipt.status === 'claimed' || receipt.status === 'dead');
     let status: NonNullable<QueuedMessage['server']>['status'] = 'rejected';
-    if (boundaryPending) {
+    if (admissionIndeterminate) {
+      status = 'indeterminate';
+    } else if (boundaryPending) {
       status = 'uncertain';
     } else if (receipt.status === 'queued' || receipt.status === 'claimed') {
       status = receipt.status;
@@ -282,6 +287,7 @@ function reconcileServerQueuedTurns(
     return (
       item.server.status === 'sending' ||
       item.server.status === 'uncertain' ||
+      item.server.status === 'indeterminate' ||
       item.server.status === 'rejected'
     );
   });

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -178,6 +178,76 @@ function queuedTurnCreatedAt(receipt: AgentQueuedTurnReceipt): number {
   return Number.isFinite(createdAt) ? createdAt : 0;
 }
 
+type QueuedTurnReceiptSource = 'snapshot' | 'enqueue' | 'direct';
+
+function isAdmissionIndeterminateReceipt(receipt: AgentQueuedTurnReceipt): boolean {
+  return (
+    receipt.failure?.code === 'ADMISSION_INDETERMINATE' &&
+    (receipt.status === 'claimed' || receipt.status === 'dead')
+  );
+}
+
+function settledEvidenceForReceipt(
+  receipt: AgentQueuedTurnReceipt,
+): SettledQueuedTurnReceipt | undefined {
+  if (
+    receipt.status === 'admitted' &&
+    (receipt.effectivePredecessorCreatedAt != null || receipt.rootPredecessor === true)
+  ) {
+    return {
+      clientRequestId: receipt.clientRequestId,
+      status: 'admitted',
+      ...(receipt.effectivePredecessorCreatedAt != null && {
+        effectivePredecessorCreatedAt: receipt.effectivePredecessorCreatedAt,
+      }),
+      ...(receipt.rootPredecessor === true && { rootPredecessor: true }),
+    };
+  }
+  if (receipt.status === 'admitted') {
+    return {
+      clientRequestId: receipt.clientRequestId,
+      status: 'admitted_pending_boundary',
+    };
+  }
+  if (isAdmissionIndeterminateReceipt(receipt)) {
+    return { clientRequestId: receipt.clientRequestId, status: 'indeterminate' };
+  }
+  if (receipt.status === 'cancelled') {
+    return { clientRequestId: receipt.clientRequestId, status: 'cancelled' };
+  }
+  if (receipt.status === 'dead') {
+    return { clientRequestId: receipt.clientRequestId, status: 'dead' };
+  }
+  return undefined;
+}
+
+/** Client receipt knowledge is a monotonic evidence lattice. Enqueue is the
+ * only source that can carry a pre-scheduling snapshot, so it never weakens
+ * evidence already observed by GET/direct settlement. Indeterminate evidence
+ * can advance only through a later authoritative terminal observation. */
+function mergeSettledQueuedTurnEvidence(
+  existing: SettledQueuedTurnReceipt | undefined,
+  receipt: AgentQueuedTurnReceipt,
+  source: QueuedTurnReceiptSource,
+): SettledQueuedTurnReceipt | undefined {
+  const incoming = settledEvidenceForReceipt(receipt);
+  if (existing == null) {
+    return incoming;
+  }
+  if (existing.status === 'admitted_pending_boundary' && incoming?.status === 'admitted') {
+    return incoming;
+  }
+  if (
+    existing.status === 'indeterminate' &&
+    source !== 'enqueue' &&
+    incoming != null &&
+    incoming.status !== 'indeterminate'
+  ) {
+    return incoming;
+  }
+  return existing;
+}
+
 function toQueuedTurnFileRefs(files: TMessage['files']): TAgentQueuedTurnFileRef[] | undefined {
   const refs = (files ?? []).flatMap((file): TAgentQueuedTurnFileRef[] => {
     if (typeof file.file_id !== 'string' || file.file_id.length === 0) {
@@ -212,21 +282,26 @@ function reconcileServerQueuedTurns(
   const observedClientRequestIds = new Set(receipts.map((receipt) => receipt.clientRequestId));
   const projected = receipts.flatMap((receipt): QueuedMessage[] => {
     const settled = settledByRequestId.get(receipt.clientRequestId);
+    const admissionIndeterminate = isAdmissionIndeterminateReceipt(receipt);
     if (settled?.status === 'admitted' || settled?.status === 'cancelled') {
       return [];
     }
     const optimistic = previousByClientRequestId.get(receipt.clientRequestId);
     if (
-      (settled?.status === 'dead' || settled?.status === 'admitted_pending_boundary') &&
+      (settled?.status === 'dead' ||
+        settled?.status === 'admitted_pending_boundary' ||
+        (settled?.status === 'indeterminate' && !admissionIndeterminate)) &&
       receipt.status !== 'dead' &&
       receipt.status !== 'admitted'
     ) {
       return optimistic == null ? [] : [optimistic];
     }
     const boundaryPending = receipt.status === 'admitted';
-    const admissionIndeterminate =
-      receipt.failure?.code === 'ADMISSION_INDETERMINATE' &&
-      (receipt.status === 'claimed' || receipt.status === 'dead');
+    /** Reordered requests may complete after a newer authoritative GET. The
+     * row revision is durable evidence; never regress its projection. */
+    if (optimistic?.server?.revision != null && optimistic.server.revision > receipt.revision) {
+      return [optimistic];
+    }
     let status: NonNullable<QueuedMessage['server']>['status'] = 'rejected';
     if (admissionIndeterminate) {
       status = 'indeterminate';
@@ -408,10 +483,7 @@ export default function useSteering({
 
   const applyQueuedTurnReceipts = useRecoilCallback(
     ({ snapshot, set }) =>
-      (
-        receipts: AgentQueuedTurnReceipt[],
-        source: 'snapshot' | 'enqueue' | 'direct' = 'snapshot',
-      ) => {
+      (receipts: AgentQueuedTurnReceipt[], source: QueuedTurnReceiptSource = 'snapshot') => {
         const previousSettled = snapshot
           .getLoadable(store.settledQueuedTurnReceiptsByConvoId(queueKey))
           .getValue();
@@ -427,42 +499,7 @@ export default function useSteering({
         );
         for (const receipt of receipts) {
           const existing = settledByRequestId.get(receipt.clientRequestId);
-          if (
-            existing != null &&
-            !(
-              existing.status === 'admitted_pending_boundary' &&
-              receipt.status === 'admitted' &&
-              (receipt.effectivePredecessorCreatedAt != null || receipt.rootPredecessor === true)
-            )
-          ) {
-            continue;
-          }
-          let settled: SettledQueuedTurnReceipt | undefined;
-          if (
-            receipt.status === 'admitted' &&
-            (receipt.effectivePredecessorCreatedAt != null || receipt.rootPredecessor === true)
-          ) {
-            settled = {
-              clientRequestId: receipt.clientRequestId,
-              status: 'admitted',
-              ...(receipt.effectivePredecessorCreatedAt != null && {
-                effectivePredecessorCreatedAt: receipt.effectivePredecessorCreatedAt,
-              }),
-              ...(receipt.rootPredecessor === true && { rootPredecessor: true }),
-            };
-          } else if (receipt.status === 'admitted') {
-            settled = {
-              clientRequestId: receipt.clientRequestId,
-              status: 'admitted_pending_boundary',
-            };
-          } else if (receipt.status === 'cancelled') {
-            settled = { clientRequestId: receipt.clientRequestId, status: 'cancelled' };
-          } else if (
-            receipt.status === 'dead' &&
-            receipt.failure?.code !== 'ADMISSION_INDETERMINATE'
-          ) {
-            settled = { clientRequestId: receipt.clientRequestId, status: 'dead' };
-          }
+          const settled = mergeSettledQueuedTurnEvidence(existing, receipt, source);
           if (settled == null) {
             continue;
           }

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -368,12 +368,17 @@ export default function useSteering({
       (receipts: AgentQueuedTurnReceipt[]) => {
         let admittedPredecessor: number | undefined;
         for (const receipt of receipts) {
-          if (receipt.status !== 'admitted' || receipt.expectedPredecessorCreatedAt == null) {
+          if (receipt.status !== 'admitted') {
+            continue;
+          }
+          const effectivePredecessor =
+            receipt.effectivePredecessorCreatedAt ?? receipt.expectedPredecessorCreatedAt;
+          if (effectivePredecessor == null) {
             continue;
           }
           admittedPredecessor = Math.max(
-            admittedPredecessor ?? receipt.expectedPredecessorCreatedAt,
-            receipt.expectedPredecessorCreatedAt,
+            admittedPredecessor ?? effectivePredecessor,
+            effectivePredecessor,
           );
         }
         if (admittedPredecessor != null) {

--- a/client/src/hooks/Chat/useSteering.ts
+++ b/client/src/hooks/Chat/useSteering.ts
@@ -216,11 +216,11 @@ function reconcileServerQueuedTurns(
     }
     const optimistic = previousByClientRequestId.get(receipt.clientRequestId);
     const boundaryPending = receipt.status === 'admitted';
-    let status: NonNullable<QueuedMessage['server']>['status'] = receipt.status;
+    let status: NonNullable<QueuedMessage['server']>['status'] = 'rejected';
     if (boundaryPending) {
       status = 'uncertain';
-    } else if (receipt.status === 'dead') {
-      status = 'rejected';
+    } else if (receipt.status === 'queued' || receipt.status === 'claimed') {
+      status = receipt.status;
     }
     return [
       {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1791,6 +1791,7 @@
   "com_ui_queued_messages": "Queued messages",
   "com_ui_queued_quote_count": "{{0}} quoted excerpts included with this message",
   "com_ui_queued_turn_failed": "Queued message failed",
+  "com_ui_queued_turn_reconciliation_required": "Awaiting reconciliation",
   "com_ui_quote_selections": "{{0}} selections",
   "com_ui_quotes_queued": "Quotes added for your next message",
   "com_ui_ran_n_agents": "Ran {{0}} agents",

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -461,7 +461,7 @@ const queuedMessagesByConvoId = atomFamily<QueuedMessage[], string>({
 
 export type SettledQueuedTurnReceipt = {
   clientRequestId: string;
-  status: 'admitted' | 'admitted_pending_boundary' | 'cancelled' | 'dead';
+  status: 'admitted' | 'admitted_pending_boundary' | 'indeterminate' | 'cancelled' | 'dead';
   effectivePredecessorCreatedAt?: number;
   rootPredecessor?: true;
   boundaryConsumed?: boolean;

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -459,11 +459,18 @@ const queuedMessagesByConvoId = atomFamily<QueuedMessage[], string>({
   default: [],
 });
 
-/** Exact terminal generations whose queue boundary was consumed by a
- * server-admitted successor. Each delayed UI terminal event consumes only
- * its matching entry; replica clocks do not impose generation order. */
-const consumedQueuedTurnPredecessorsByConvoId = atomFamily<number[], string>({
-  key: 'consumedQueuedTurnPredecessorsByConvoId',
+export type SettledQueuedTurnReceipt = {
+  clientRequestId: string;
+  status: 'admitted' | 'cancelled';
+  effectivePredecessorCreatedAt?: number;
+  boundaryConsumed?: boolean;
+};
+
+/** Monotonic client knowledge of terminal server queue receipts. Admission
+ * records preserve boundary multiplicity by request identity and remain as
+ * tombstones after consumption so delayed POST responses cannot regress UI. */
+const settledQueuedTurnReceiptsByConvoId = atomFamily<SettledQueuedTurnReceipt[], string>({
+  key: 'settledQueuedTurnReceiptsByConvoId',
   default: [],
 });
 
@@ -796,7 +803,7 @@ export default {
   pendingQuotesByConvoId,
   pendingSteersByConvoId,
   queuedMessagesByConvoId,
-  consumedQueuedTurnPredecessorsByConvoId,
+  settledQueuedTurnReceiptsByConvoId,
   runEndByIndex,
   pendingRunEndByConvoId,
   drainAfterAbortByIndex,

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -459,12 +459,12 @@ const queuedMessagesByConvoId = atomFamily<QueuedMessage[], string>({
   default: [],
 });
 
-/** Highest terminal generation whose queue boundary was consumed by a
- * server-admitted successor. Delayed UI terminal events at or below this
- * watermark are observations, not fresh permission to drain another turn. */
-const admittedQueuedTurnPredecessorByConvoId = atomFamily<number | null, string>({
-  key: 'admittedQueuedTurnPredecessorByConvoId',
-  default: null,
+/** Exact terminal generations whose queue boundary was consumed by a
+ * server-admitted successor. Each delayed UI terminal event consumes only
+ * its matching entry; replica clocks do not impose generation order. */
+const consumedQueuedTurnPredecessorsByConvoId = atomFamily<number[], string>({
+  key: 'consumedQueuedTurnPredecessorsByConvoId',
+  default: [],
 });
 
 /**
@@ -796,7 +796,7 @@ export default {
   pendingQuotesByConvoId,
   pendingSteersByConvoId,
   queuedMessagesByConvoId,
-  admittedQueuedTurnPredecessorByConvoId,
+  consumedQueuedTurnPredecessorsByConvoId,
   runEndByIndex,
   pendingRunEndByConvoId,
   drainAfterAbortByIndex,

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -459,6 +459,14 @@ const queuedMessagesByConvoId = atomFamily<QueuedMessage[], string>({
   default: [],
 });
 
+/** Highest terminal generation whose queue boundary was consumed by a
+ * server-admitted successor. Delayed UI terminal events at or below this
+ * watermark are observations, not fresh permission to drain another turn. */
+const admittedQueuedTurnPredecessorByConvoId = atomFamily<number | null, string>({
+  key: 'admittedQueuedTurnPredecessorByConvoId',
+  default: null,
+});
+
 /**
  * One-shot run-termination signal written by the SSE final/error handlers and
  * consumed (reset to null) by `useQueueDrain`. Keyed by chat index like
@@ -788,6 +796,7 @@ export default {
   pendingQuotesByConvoId,
   pendingSteersByConvoId,
   queuedMessagesByConvoId,
+  admittedQueuedTurnPredecessorByConvoId,
   runEndByIndex,
   pendingRunEndByConvoId,
   drainAfterAbortByIndex,

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -402,7 +402,7 @@ export type QueuedMessage = {
    * after an ambiguous POST could submit the same words twice. */
   server?: {
     id?: string;
-    status: 'sending' | 'uncertain' | 'rejected' | 'queued' | 'claimed';
+    status: 'sending' | 'uncertain' | 'indeterminate' | 'rejected' | 'queued' | 'claimed';
     errorCode?: string;
     errorMessage?: string;
     /** Observation time for a transport-ambiguous enqueue. The logical item

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -461,16 +461,23 @@ const queuedMessagesByConvoId = atomFamily<QueuedMessage[], string>({
 
 export type SettledQueuedTurnReceipt = {
   clientRequestId: string;
-  status: 'admitted' | 'cancelled';
+  status: 'admitted' | 'admitted_pending_boundary' | 'cancelled' | 'dead';
   effectivePredecessorCreatedAt?: number;
   boundaryConsumed?: boolean;
 };
 
 /** Monotonic client knowledge of terminal server queue receipts. Admission
- * records preserve boundary multiplicity by request identity and remain as
- * tombstones after consumption so delayed POST responses cannot regress UI. */
+ * records preserve boundary multiplicity by request identity. Other terminal
+ * records exist only while their original enqueue callback is outstanding. */
 const settledQueuedTurnReceiptsByConvoId = atomFamily<SettledQueuedTurnReceipt[], string>({
   key: 'settledQueuedTurnReceiptsByConvoId',
+  default: [],
+});
+
+/** Enqueue callbacks that can still race newer GET/cancellation evidence.
+ * Entries retire as soon as that one callback settles. */
+const pendingQueuedTurnEnqueueIdsByConvoId = atomFamily<string[], string>({
+  key: 'pendingQueuedTurnEnqueueIdsByConvoId',
   default: [],
 });
 
@@ -804,6 +811,7 @@ export default {
   pendingSteersByConvoId,
   queuedMessagesByConvoId,
   settledQueuedTurnReceiptsByConvoId,
+  pendingQueuedTurnEnqueueIdsByConvoId,
   runEndByIndex,
   pendingRunEndByConvoId,
   drainAfterAbortByIndex,

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -463,6 +463,7 @@ export type SettledQueuedTurnReceipt = {
   clientRequestId: string;
   status: 'admitted' | 'admitted_pending_boundary' | 'cancelled' | 'dead';
   effectivePredecessorCreatedAt?: number;
+  rootPredecessor?: true;
   boundaryConsumed?: boolean;
 };
 

--- a/packages/api/src/agents/queuedTurnHttp.spec.ts
+++ b/packages/api/src/agents/queuedTurnHttp.spec.ts
@@ -67,10 +67,21 @@ describe('Agent queued-turn HTTP admission receipts', () => {
     const enqueueAgentQueuedTurn = jest
       .fn()
       .mockResolvedValueOnce({ turn: turn('queued'), replayed: false });
+    const admitted = {
+      ...turn('admitted'),
+      terminalReceipt: {
+        outcome: 'admitted' as const,
+        settledAt: new Date('2026-08-30T12:01:00Z'),
+        admissionId: 'client-request-1',
+        generationId: 'generation-1',
+        generationCreatedAt: 43,
+        effectivePredecessorCreatedAt: 42,
+      },
+    };
     const getAgentQueuedTurnByClientRequestId = jest
       .fn()
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(turn('admitted'));
+      .mockResolvedValueOnce(admitted);
     const schedule = jest.fn().mockRejectedValueOnce(new Error('scheduler unavailable'));
     const methods = {
       getConvo: jest.fn(async () => ({
@@ -104,6 +115,7 @@ describe('Agent queued-turn HTTP admission receipts', () => {
           queuedTurnId: 'queued-turn-1',
           clientRequestId: 'client-request-1',
           status: 'admitted',
+          effectivePredecessorCreatedAt: 42,
         },
       },
     });

--- a/packages/api/src/agents/queuedTurnHttp.spec.ts
+++ b/packages/api/src/agents/queuedTurnHttp.spec.ts
@@ -184,6 +184,47 @@ describe('Agent queued-turn HTTP admission receipts', () => {
     expect(cancel).toHaveBeenCalledWith(expect.objectContaining({ queuedTurnId: 'queued-turn-1' }));
   });
 
+  it('projects an explicit root admission without a timestamp boundary', async () => {
+    const admitted = {
+      ...turn('admitted'),
+      terminalReceipt: {
+        outcome: 'admitted' as const,
+        settledAt: new Date('2026-08-30T12:01:00Z'),
+        admissionId: 'client-request-1',
+        generationId: 'generation-root',
+        generationCreatedAt: 43,
+        lineagePredecessorId: 'root:message-identity',
+        rootPredecessor: true as const,
+      },
+    };
+    const methods = {
+      getConvo: jest.fn(async () => ({ agent_id: 'agent_1', endpoint: 'agents' })),
+      listAgentQueuedTurnReceipts: jest.fn(async () => [admitted]),
+    };
+    const deps = {
+      methods: methods as unknown as AgentQueuedTurnMethods & {
+        getConvo: typeof methods.getConvo;
+      },
+      lifecycle: { schedule: jest.fn(), cancel: jest.fn() },
+      checkAgentAccess: jest.fn(async () => true),
+    } satisfies AgentQueuedTurnHttpDeps;
+
+    await expect(
+      handleAgentQueuedTurnList({ id: USER_ID }, 'conversation-1', deps),
+    ).resolves.toMatchObject({
+      status: 200,
+      body: {
+        queuedTurns: [
+          {
+            queuedTurnId: 'queued-turn-1',
+            status: 'admitted',
+            rootPredecessor: true,
+          },
+        ],
+      },
+    });
+  });
+
   it('retires a cancelled source after its published delivery receipt expires', async () => {
     const cancelled = {
       ...turn('cancelled'),

--- a/packages/api/src/agents/queuedTurnHttp.ts
+++ b/packages/api/src/agents/queuedTurnHttp.ts
@@ -90,6 +90,10 @@ function receipt(
     ...(turn.expectedPredecessorCreatedAt != null && {
       expectedPredecessorCreatedAt: turn.expectedPredecessorCreatedAt,
     }),
+    ...(turn.terminalReceipt?.outcome === 'admitted' &&
+      turn.terminalReceipt.effectivePredecessorCreatedAt != null && {
+        effectivePredecessorCreatedAt: turn.terminalReceipt.effectivePredecessorCreatedAt,
+      }),
     status: turn.status,
     ...(position != null && { position }),
     revision: turn.sequence,

--- a/packages/api/src/agents/queuedTurnHttp.ts
+++ b/packages/api/src/agents/queuedTurnHttp.ts
@@ -94,6 +94,8 @@ function receipt(
       turn.terminalReceipt.effectivePredecessorCreatedAt != null && {
         effectivePredecessorCreatedAt: turn.terminalReceipt.effectivePredecessorCreatedAt,
       }),
+    ...(turn.terminalReceipt?.outcome === 'admitted' &&
+      turn.terminalReceipt.rootPredecessor === true && { rootPredecessor: true as const }),
     status: turn.status,
     ...(position != null && { position }),
     revision: turn.sequence,

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -107,7 +107,7 @@ function resolverMethods() {
     getEffectiveAgentQueuedTurnPredecessor: jest.fn(
       async (
         ..._args: Parameters<AgentQueuedTurnMethods['getEffectiveAgentQueuedTurnPredecessor']>
-      ): Promise<number | undefined> => undefined,
+      ): Promise<number | null | undefined> => undefined,
     ),
     markAgentQueuedTurnAdmitted: jest.fn(async () => ({
       outcome: 'admitted' as const,
@@ -494,7 +494,32 @@ describe('Agent queued-turn continuation', () => {
       conversationId: 'conversation-1',
       sequence: 1,
       expectedPredecessorCreatedAt: NOW,
+      allowLegacyPredecessorInference: true,
     });
+  });
+
+  it('dead-letters a legacy admission order that cannot be reconstructed safely', async () => {
+    const { methods, spies } = resolverMethods();
+    spies.getEffectiveAgentQueuedTurnPredecessor.mockResolvedValueOnce(null);
+    const resolve = createAgentQueuedTurnResolver({
+      methods,
+      getGenerationJob: async () => null,
+      now: () => NOW,
+      claimBy: 'worker-1',
+    });
+
+    await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toEqual({
+      status: 'settled',
+    });
+    expect(spies.releaseAgentQueuedTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disposition: 'dead',
+        failure: expect.objectContaining({
+          code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE',
+        }),
+      }),
+    );
+    expect(spies.beginAgentQueuedTurnAdmission).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -493,7 +493,11 @@ describe('Agent queued-turn continuation', () => {
 
   it('dead-letters a legacy admission order that cannot be reconstructed safely', async () => {
     const { methods, spies } = resolverMethods();
-    spies.beginAgentQueuedTurnAdmission.mockResolvedValueOnce({
+    (
+      spies.beginAgentQueuedTurnAdmission as unknown as jest.MockedFunction<
+        AgentQueuedTurnMethods['beginAgentQueuedTurnAdmission']
+      >
+    ).mockResolvedValueOnce({
       outcome: 'order_unavailable',
       turn: { ...claim(), status: 'dead' },
     });

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -51,6 +51,7 @@ function claim(): AgentQueuedTurnClaim {
     clientRequestId: 'client-1',
     fingerprint: 'fingerprint-1',
     sequence: 1,
+    admissionSlot: true,
     status: 'claimed',
     priority: false,
     text: 'queued words',
@@ -107,7 +108,7 @@ function resolverMethods() {
     getEffectiveAgentQueuedTurnPredecessor: jest.fn(
       async (
         ..._args: Parameters<AgentQueuedTurnMethods['getEffectiveAgentQueuedTurnPredecessor']>
-      ): Promise<number | null | undefined> => undefined,
+      ) => null,
     ),
     markAgentQueuedTurnAdmitted: jest.fn(async () => ({
       outcome: 'admitted' as const,

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -306,6 +306,7 @@ describe('Agent queued-turn continuation', () => {
           sourceId: 'queued-turn-1',
           claimId: 'trigger-1',
           claimBy: 'worker-1',
+          effectivePredecessorCreatedAt: NOW,
         },
         {
           userId: USER_ID,
@@ -325,6 +326,7 @@ describe('Agent queued-turn continuation', () => {
         admissionId: 'trigger-1',
         generationId: 'conversation-1',
         generationCreatedAt: NOW + 1,
+        effectivePredecessorCreatedAt: NOW,
       }),
     );
   });
@@ -342,6 +344,7 @@ describe('Agent queued-turn continuation', () => {
       sourceId: 'queued-turn-1',
       claimId: 'trigger-1',
       claimBy: 'worker-1',
+      effectivePredecessorCreatedAt: NOW,
     };
     const admission = {
       userId: USER_ID,
@@ -361,6 +364,7 @@ describe('Agent queued-turn continuation', () => {
       admissionId: 'trigger-1',
       generationId: 'conversation-1',
       generationCreatedAt: NOW + 1,
+      effectivePredecessorCreatedAt: NOW,
     });
 
     spies.hasAgentQueuedTurnAdmissionReceipt.mockResolvedValueOnce(false);
@@ -459,10 +463,28 @@ describe('Agent queued-turn continuation', () => {
       claimBy: 'worker-1',
     });
 
-    await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toMatchObject({
+    const prepared = await resolve(envelope(), { idempotencyKey: 'trigger-1' });
+    expect(prepared).toMatchObject({
       status: 'ready',
       expectedPredecessorCreatedAt: NOW + 250,
+      admissionSource: { effectivePredecessorCreatedAt: NOW + 250 },
     });
+    if (prepared?.status !== 'ready') {
+      throw new Error('Expected a ready queued turn');
+    }
+    await prepared.settleOnAdmission?.({
+      mode: 'continue',
+      status: 'started',
+      conversationId: 'conversation-1',
+      streamId: 'stream-2',
+      generationCreatedAt: NOW + 500,
+    });
+    expect(spies.markAgentQueuedTurnAdmitted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queuedTurnId: 'queued-turn-1',
+        effectivePredecessorCreatedAt: NOW + 250,
+      }),
+    );
     expect(spies.getEffectiveAgentQueuedTurnPredecessor).toHaveBeenCalledWith({
       user: new Types.ObjectId(USER_ID),
       tenantId: 'tenant-1',

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -469,6 +469,9 @@ describe('Agent queued-turn continuation', () => {
       expectedPredecessorCreatedAt: NOW + 250,
       admissionSource: { effectivePredecessorCreatedAt: NOW + 250 },
     });
+    expect(spies.beginAgentQueuedTurnAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({ effectivePredecessorCreatedAt: NOW + 250 }),
+    );
     if (prepared?.status !== 'ready') {
       throw new Error('Expected a ready queued turn');
     }

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -455,7 +455,10 @@ describe('Agent queued-turn continuation', () => {
     const claimed = claim();
     claimed.expectedPredecessorCreatedAt = NOW;
     spies.claimNextAgentQueuedTurn.mockResolvedValueOnce({ outcome: 'acquired', claim: claimed });
-    spies.getEffectiveAgentQueuedTurnPredecessor.mockResolvedValueOnce(NOW + 250);
+    spies.beginAgentQueuedTurnAdmission.mockResolvedValueOnce({
+      outcome: 'started',
+      turn: { ...claimed, admissionEffectivePredecessorCreatedAt: NOW + 250 },
+    });
     const resolve = createAgentQueuedTurnResolver({
       methods,
       getGenerationJob: async () => null,
@@ -469,9 +472,7 @@ describe('Agent queued-turn continuation', () => {
       expectedPredecessorCreatedAt: NOW + 250,
       admissionSource: { effectivePredecessorCreatedAt: NOW + 250 },
     });
-    expect(spies.beginAgentQueuedTurnAdmission).toHaveBeenCalledWith(
-      expect.objectContaining({ effectivePredecessorCreatedAt: NOW + 250 }),
-    );
+    expect(spies.beginAgentQueuedTurnAdmission).toHaveBeenCalledTimes(1);
     if (prepared?.status !== 'ready') {
       throw new Error('Expected a ready queued turn');
     }
@@ -488,19 +489,14 @@ describe('Agent queued-turn continuation', () => {
         effectivePredecessorCreatedAt: NOW + 250,
       }),
     );
-    expect(spies.getEffectiveAgentQueuedTurnPredecessor).toHaveBeenCalledWith({
-      user: new Types.ObjectId(USER_ID),
-      tenantId: 'tenant-1',
-      conversationId: 'conversation-1',
-      sequence: 1,
-      expectedPredecessorCreatedAt: NOW,
-      allowLegacyPredecessorInference: true,
-    });
   });
 
   it('dead-letters a legacy admission order that cannot be reconstructed safely', async () => {
     const { methods, spies } = resolverMethods();
-    spies.getEffectiveAgentQueuedTurnPredecessor.mockResolvedValueOnce(null);
+    spies.beginAgentQueuedTurnAdmission.mockResolvedValueOnce({
+      outcome: 'order_unavailable',
+      turn: { ...claim(), status: 'dead' },
+    });
     const resolve = createAgentQueuedTurnResolver({
       methods,
       getGenerationJob: async () => null,
@@ -511,15 +507,8 @@ describe('Agent queued-turn continuation', () => {
     await expect(resolve(envelope(), { idempotencyKey: 'trigger-1' })).resolves.toEqual({
       status: 'settled',
     });
-    expect(spies.releaseAgentQueuedTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        disposition: 'dead',
-        failure: expect.objectContaining({
-          code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE',
-        }),
-      }),
-    );
-    expect(spies.beginAgentQueuedTurnAdmission).not.toHaveBeenCalled();
+    expect(spies.releaseAgentQueuedTurn).not.toHaveBeenCalled();
+    expect(spies.beginAgentQueuedTurnAdmission).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/packages/api/src/agents/queuedTurns.spec.ts
+++ b/packages/api/src/agents/queuedTurns.spec.ts
@@ -820,10 +820,10 @@ describe('Agent queued-turn delivery scheduling', () => {
     );
   });
 
-  it('reconciles quarantined admission receipts during durable recovery', async () => {
+  it('reconciles a claimed indeterminate legacy admission during durable recovery', async () => {
     const turn = {
       ...queuedTurn('queued-turn-indeterminate', 1),
-      status: 'dead' as const,
+      status: 'claimed' as const,
       deliveryKey: 'delivery-indeterminate',
       deliveryState: 'published' as const,
       admissionId: 'delivery-indeterminate',
@@ -885,7 +885,7 @@ describe('Agent queued-turn delivery scheduling', () => {
   it('rotates source-fenced ambiguity without trusting transient job-store evidence', async () => {
     const turn = {
       ...queuedTurn('queued-turn-source-fenced', 1),
-      status: 'dead' as const,
+      status: 'claimed' as const,
       deliveryKey: 'delivery-source-fenced',
       deliveryState: 'published' as const,
       admissionId: 'delivery-source-fenced',

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -598,29 +598,6 @@ function createAgentQueuedTurnResolver({
       return { status: 'settled' };
     }
 
-    const resolvedPredecessorCreatedAt = await methods.getEffectiveAgentQueuedTurnPredecessor({
-      user: claim.user,
-      ...(claim.tenantId != null && { tenantId: claim.tenantId }),
-      conversationId: claim.conversationId,
-      sequence: claim.sequence,
-      ...(claim.expectedPredecessorCreatedAt != null && {
-        expectedPredecessorCreatedAt: claim.expectedPredecessorCreatedAt,
-      }),
-      allowLegacyPredecessorInference: true,
-    });
-    if (resolvedPredecessorCreatedAt === null) {
-      await deadClaim(
-        methods,
-        envelope,
-        claim,
-        'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE',
-        'The queued turn admission order could not be reconstructed safely. Review this turn before sending it.',
-      );
-      return { status: 'settled' };
-    }
-    const effectivePredecessorCreatedAt =
-      resolvedPredecessorCreatedAt ?? claim.expectedPredecessorCreatedAt;
-
     const admission = await methods.beginAgentQueuedTurnAdmission({
       user: claim.user,
       ...(claim.tenantId != null && { tenantId: claim.tenantId }),
@@ -630,7 +607,6 @@ function createAgentQueuedTurnResolver({
       claimBy: claim.claimBy,
       admissionId: context.idempotencyKey,
       startedAt: new Date(now()),
-      ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
       admissionProtocolVersion: 2,
     });
     if (admission.outcome === 'conflict') {
@@ -640,9 +616,10 @@ function createAgentQueuedTurnResolver({
         deferWithoutAttempt: true,
       });
     }
-    if (admission.outcome === 'retired') {
+    if (admission.outcome === 'retired' || admission.outcome === 'order_unavailable') {
       return { status: 'settled' };
     }
+    const effectivePredecessorCreatedAt = admission.turn.admissionEffectivePredecessorCreatedAt;
 
     return {
       status: 'ready',

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -598,16 +598,28 @@ function createAgentQueuedTurnResolver({
       return { status: 'settled' };
     }
 
+    const resolvedPredecessorCreatedAt = await methods.getEffectiveAgentQueuedTurnPredecessor({
+      user: claim.user,
+      ...(claim.tenantId != null && { tenantId: claim.tenantId }),
+      conversationId: claim.conversationId,
+      sequence: claim.sequence,
+      ...(claim.expectedPredecessorCreatedAt != null && {
+        expectedPredecessorCreatedAt: claim.expectedPredecessorCreatedAt,
+      }),
+      allowLegacyPredecessorInference: true,
+    });
+    if (resolvedPredecessorCreatedAt === null) {
+      await deadClaim(
+        methods,
+        envelope,
+        claim,
+        'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE',
+        'The queued turn admission order could not be reconstructed safely. Review this turn before sending it.',
+      );
+      return { status: 'settled' };
+    }
     const effectivePredecessorCreatedAt =
-      (await methods.getEffectiveAgentQueuedTurnPredecessor({
-        user: claim.user,
-        ...(claim.tenantId != null && { tenantId: claim.tenantId }),
-        conversationId: claim.conversationId,
-        sequence: claim.sequence,
-        ...(claim.expectedPredecessorCreatedAt != null && {
-          expectedPredecessorCreatedAt: claim.expectedPredecessorCreatedAt,
-        }),
-      })) ?? claim.expectedPredecessorCreatedAt;
+      resolvedPredecessorCreatedAt ?? claim.expectedPredecessorCreatedAt;
 
     const admission = await methods.beginAgentQueuedTurnAdmission({
       user: claim.user,

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -618,6 +618,7 @@ function createAgentQueuedTurnResolver({
       claimBy: claim.claimBy,
       admissionId: context.idempotencyKey,
       startedAt: new Date(now()),
+      ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
       admissionProtocolVersion: 2,
     });
     if (admission.outcome === 'conflict') {

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -153,6 +153,8 @@ function parseQueuedTurnAdmissionSource(raw: unknown): AgentContinuationAdmissio
   const sourceId = 'sourceId' in raw ? raw.sourceId : undefined;
   const claimId = 'claimId' in raw ? raw.claimId : undefined;
   const claimBy = 'claimBy' in raw ? raw.claimBy : undefined;
+  const effectivePredecessorCreatedAt =
+    'effectivePredecessorCreatedAt' in raw ? raw.effectivePredecessorCreatedAt : undefined;
   if (
     typeof sourceId !== 'string' ||
     sourceId.length === 0 ||
@@ -162,11 +164,23 @@ function parseQueuedTurnAdmissionSource(raw: unknown): AgentContinuationAdmissio
     claimId.length > 128 ||
     typeof claimBy !== 'string' ||
     claimBy.length === 0 ||
-    claimBy.length > 256
+    claimBy.length > 256 ||
+    (effectivePredecessorCreatedAt != null &&
+      (typeof effectivePredecessorCreatedAt !== 'number' ||
+        !Number.isSafeInteger(effectivePredecessorCreatedAt) ||
+        effectivePredecessorCreatedAt < 0))
   ) {
     throw new TypeError('Agent queued turn admission source is invalid');
   }
-  return { source: AGENT_QUEUED_TURN_SOURCE, sourceId, claimId, claimBy };
+  return {
+    source: AGENT_QUEUED_TURN_SOURCE,
+    sourceId,
+    claimId,
+    claimBy,
+    ...(typeof effectivePredecessorCreatedAt === 'number' && {
+      effectivePredecessorCreatedAt,
+    }),
+  };
 }
 
 /** Commits the source-owned admission receipt only after the controller has
@@ -195,6 +209,9 @@ async function settleAgentQueuedTurnExecutionAdmission(
     admissionMode: 'ordinary',
     generationId: input.generationId,
     generationCreatedAt: input.generationCreatedAt,
+    ...(source.effectivePredecessorCreatedAt != null && {
+      effectivePredecessorCreatedAt: source.effectivePredecessorCreatedAt,
+    }),
     settledAt: new Date(),
   });
   if (settled.outcome === 'conflict') {
@@ -226,6 +243,9 @@ async function verifyAgentQueuedTurnExecutionAdmission(
     admissionId: input.clientRequestId,
     generationId: input.generationId,
     generationCreatedAt: input.generationCreatedAt,
+    ...(source.effectivePredecessorCreatedAt != null && {
+      effectivePredecessorCreatedAt: source.effectivePredecessorCreatedAt,
+    }),
   });
   if (!confirmed) {
     throw new Error('The queued turn execution admission is not yet confirmed');
@@ -626,6 +646,7 @@ function createAgentQueuedTurnResolver({
         sourceId: claim.queuedTurnId,
         claimId: claim.claimId,
         claimBy: claim.claimBy,
+        ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
       },
       releaseOnDefiniteFailure: async (error) => {
         if (
@@ -659,6 +680,7 @@ function createAgentQueuedTurnResolver({
           ...(result.generationCreatedAt != null && {
             generationCreatedAt: result.generationCreatedAt,
           }),
+          ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
           settledAt: new Date(now()),
         });
         if (settled.outcome === 'conflict') {

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -155,6 +155,7 @@ function parseQueuedTurnAdmissionSource(raw: unknown): AgentContinuationAdmissio
   const claimBy = 'claimBy' in raw ? raw.claimBy : undefined;
   const effectivePredecessorCreatedAt =
     'effectivePredecessorCreatedAt' in raw ? raw.effectivePredecessorCreatedAt : undefined;
+  const lineagePredecessorId = 'lineagePredecessorId' in raw ? raw.lineagePredecessorId : undefined;
   if (
     typeof sourceId !== 'string' ||
     sourceId.length === 0 ||
@@ -168,7 +169,11 @@ function parseQueuedTurnAdmissionSource(raw: unknown): AgentContinuationAdmissio
     (effectivePredecessorCreatedAt != null &&
       (typeof effectivePredecessorCreatedAt !== 'number' ||
         !Number.isSafeInteger(effectivePredecessorCreatedAt) ||
-        effectivePredecessorCreatedAt < 0))
+        effectivePredecessorCreatedAt < 0)) ||
+    (lineagePredecessorId != null &&
+      (typeof lineagePredecessorId !== 'string' ||
+        lineagePredecessorId.length === 0 ||
+        lineagePredecessorId.length > 128))
   ) {
     throw new TypeError('Agent queued turn admission source is invalid');
   }
@@ -180,6 +185,7 @@ function parseQueuedTurnAdmissionSource(raw: unknown): AgentContinuationAdmissio
     ...(typeof effectivePredecessorCreatedAt === 'number' && {
       effectivePredecessorCreatedAt,
     }),
+    ...(typeof lineagePredecessorId === 'string' && { lineagePredecessorId }),
   };
 }
 
@@ -211,6 +217,9 @@ async function settleAgentQueuedTurnExecutionAdmission(
     generationCreatedAt: input.generationCreatedAt,
     ...(source.effectivePredecessorCreatedAt != null && {
       effectivePredecessorCreatedAt: source.effectivePredecessorCreatedAt,
+    }),
+    ...(source.lineagePredecessorId != null && {
+      lineagePredecessorId: source.lineagePredecessorId,
     }),
     settledAt: new Date(),
   });
@@ -245,6 +254,9 @@ async function verifyAgentQueuedTurnExecutionAdmission(
     generationCreatedAt: input.generationCreatedAt,
     ...(source.effectivePredecessorCreatedAt != null && {
       effectivePredecessorCreatedAt: source.effectivePredecessorCreatedAt,
+    }),
+    ...(source.lineagePredecessorId != null && {
+      lineagePredecessorId: source.lineagePredecessorId,
     }),
   });
   if (!confirmed) {
@@ -620,6 +632,7 @@ function createAgentQueuedTurnResolver({
       return { status: 'settled' };
     }
     const effectivePredecessorCreatedAt = admission.turn.admissionEffectivePredecessorCreatedAt;
+    const lineagePredecessorId = admission.turn.admissionLineagePredecessorId;
 
     return {
       status: 'ready',
@@ -637,6 +650,7 @@ function createAgentQueuedTurnResolver({
         claimId: claim.claimId,
         claimBy: claim.claimBy,
         ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
+        ...(lineagePredecessorId != null && { lineagePredecessorId }),
       },
       releaseOnDefiniteFailure: async (error) => {
         if (
@@ -671,6 +685,7 @@ function createAgentQueuedTurnResolver({
             generationCreatedAt: result.generationCreatedAt,
           }),
           ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
+          ...(lineagePredecessorId != null && { lineagePredecessorId }),
           settledAt: new Date(now()),
         });
         if (settled.outcome === 'conflict') {

--- a/packages/api/src/agents/queuedTurns.ts
+++ b/packages/api/src/agents/queuedTurns.ts
@@ -821,7 +821,10 @@ function createAgentQueuedTurnScheduler({
             }),
           );
         try {
-          if (turn.status === 'claimed') {
+          const isIndeterminate =
+            turn.terminalReceipt?.outcome === 'dead' &&
+            turn.terminalReceipt.failure?.code === 'ADMISSION_INDETERMINATE';
+          if (turn.status === 'claimed' && !isIndeterminate) {
             const result = await runAsSystem(() =>
               methods.deadLetterAgentQueuedTurn({
                 user: turn.user,

--- a/packages/api/src/agents/triggers/host.ts
+++ b/packages/api/src/agents/triggers/host.ts
@@ -44,6 +44,7 @@ export interface AgentContinuationAdmissionSource {
   claimId: string;
   claimBy: string;
   effectivePredecessorCreatedAt?: number;
+  lineagePredecessorId?: string;
 }
 
 export type AgentTriggerContinuePreparation =

--- a/packages/api/src/agents/triggers/host.ts
+++ b/packages/api/src/agents/triggers/host.ts
@@ -43,6 +43,7 @@ export interface AgentContinuationAdmissionSource {
   sourceId: string;
   claimId: string;
   claimBy: string;
+  effectivePredecessorCreatedAt?: number;
 }
 
 export type AgentTriggerContinuePreparation =

--- a/packages/data-provider/src/types/queuedTurns.spec.ts
+++ b/packages/data-provider/src/types/queuedTurns.spec.ts
@@ -108,6 +108,20 @@ describe('agent queued turn schemas', () => {
     expect(agentQueuedTurnReceiptSchema.parse(receipt)).toEqual(receipt);
   });
 
+  it('parses an explicit root admission without a synthetic timestamp', () => {
+    const receipt = {
+      ...request,
+      queuedTurnId: 'turn-root',
+      status: 'admitted',
+      rootPredecessor: true,
+      revision: 2,
+      createdAt: '2026-08-30T12:00:00.000Z',
+      updatedAt: '2026-08-30T12:01:00.000Z',
+    };
+
+    expect(agentQueuedTurnReceiptSchema.parse(receipt)).toEqual(receipt);
+  });
+
   it('requires durability only when the capability is supported', () => {
     expect(agentQueuedTurnCapabilitySchema.parse({ supported: false })).toEqual({
       supported: false,

--- a/packages/data-provider/src/types/queuedTurns.spec.ts
+++ b/packages/data-provider/src/types/queuedTurns.spec.ts
@@ -94,6 +94,20 @@ describe('agent queued turn schemas', () => {
     expect(agentQueuedTurnReceiptSchema.parse(receipt)).toEqual(receipt);
   });
 
+  it('parses the effective boundary consumed by an admitted turn', () => {
+    const receipt = {
+      ...request,
+      queuedTurnId: 'turn-1',
+      status: 'admitted',
+      effectivePredecessorCreatedAt: 84,
+      revision: 2,
+      createdAt: '2026-08-30T12:00:00.000Z',
+      updatedAt: '2026-08-30T12:01:00.000Z',
+    };
+
+    expect(agentQueuedTurnReceiptSchema.parse(receipt)).toEqual(receipt);
+  });
+
   it('requires durability only when the capability is supported', () => {
     expect(agentQueuedTurnCapabilitySchema.parse({ supported: false })).toEqual({
       supported: false,

--- a/packages/data-provider/src/types/queuedTurns.ts
+++ b/packages/data-provider/src/types/queuedTurns.ts
@@ -55,6 +55,8 @@ export const agentQueuedTurnReceiptSchema = enqueueAgentQueuedTurnSchema.extend(
   /** Effective generation boundary consumed by an admitted turn. This can
    * advance beyond the originally captured root as queued turns chain. */
   effectivePredecessorCreatedAt: z.number().int().nonnegative().optional(),
+  /** Explicitly proves that this admission consumed no predecessor boundary. */
+  rootPredecessor: z.literal(true).optional(),
   position: z.number().int().nonnegative().optional(),
   revision: z.number().int().nonnegative(),
   failure: z

--- a/packages/data-provider/src/types/queuedTurns.ts
+++ b/packages/data-provider/src/types/queuedTurns.ts
@@ -58,6 +58,7 @@ export const agentQueuedTurnReceiptSchema = enqueueAgentQueuedTurnSchema.extend(
   /** Explicitly proves that this admission consumed no predecessor boundary. */
   rootPredecessor: z.literal(true).optional(),
   position: z.number().int().nonnegative().optional(),
+  /** Immutable queue sequence retained as `revision` for wire compatibility. */
   revision: z.number().int().nonnegative(),
   failure: z
     .object({

--- a/packages/data-provider/src/types/queuedTurns.ts
+++ b/packages/data-provider/src/types/queuedTurns.ts
@@ -52,6 +52,9 @@ export type TCancelAgentQueuedTurnRequest = z.infer<typeof cancelAgentQueuedTurn
 export const agentQueuedTurnReceiptSchema = enqueueAgentQueuedTurnSchema.extend({
   queuedTurnId: z.string().trim().min(1),
   status: z.enum(agentQueuedTurnStatuses),
+  /** Effective generation boundary consumed by an admitted turn. This can
+   * advance beyond the originally captured root as queued turns chain. */
+  effectivePredecessorCreatedAt: z.number().int().nonnegative().optional(),
   position: z.number().int().nonnegative().optional(),
   revision: z.number().int().nonnegative(),
   failure: z

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { Model } from 'mongoose';
@@ -78,6 +79,10 @@ function claimInput(
     leaseUntil: LATER,
     ...overrides,
   };
+}
+
+function rootLineageId(parentMessageId = 'parent-1') {
+  return `root:${createHash('sha256').update(parentMessageId).digest('base64url')}`;
 }
 
 describe('agent queued turn methods', () => {
@@ -470,6 +475,41 @@ describe('agent queued turn methods', () => {
     await expect(Turn.countDocuments({ admissionSlot: true })).resolves.toBe(1);
   });
 
+  it('rejects a pre-slot replica claim through the legacy-written status shell', async () => {
+    const first = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'cross-version-first' }),
+    );
+    const second = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'cross-version-second', priority: true }),
+    );
+    await Turn.updateOne(
+      { _id: first.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'claimed',
+          admissionSlot: true,
+          claimId: 'new-replica-claim',
+          claimBy: 'new-replica',
+          claimUntil: LATER,
+        },
+      },
+    );
+
+    await expect(
+      Turn.updateOne(
+        { _id: second.turn.queuedTurnId },
+        {
+          $set: {
+            status: 'claimed',
+            claimId: 'legacy-replica-claim',
+            claimBy: 'legacy-replica',
+            claimUntil: LATER,
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 11000 });
+  });
+
   it('reclaims an expired exact lease but never replays a different claim identity', async () => {
     const queued = await methods.enqueueAgentQueuedTurn(enqueueInput());
     const first = await methods.claimNextAgentQueuedTurn(
@@ -745,7 +785,7 @@ describe('agent queued turn methods', () => {
       generationId: 'generation-1',
       generationCreatedAt: 84,
       effectivePredecessorCreatedAt: 83,
-      lineagePredecessorId: 'root',
+      lineagePredecessorId: rootLineageId(),
       settledAt: START,
     };
     await expect(
@@ -921,7 +961,7 @@ describe('agent queued turn methods', () => {
           terminalReceipt: {
             outcome: 'admitted',
             settledAt: START,
-            lineagePredecessorId: 'root',
+            lineagePredecessorId: rootLineageId(),
           },
         },
         $unset: { activeSlot: 1 },
@@ -971,12 +1011,23 @@ describe('agent queued turn methods', () => {
     ).resolves.toMatchObject({
       outcome: 'admission_indeterminate',
       turn: {
-        status: 'dead',
+        status: 'claimed',
         admissionId: 'delivery-ambiguous-admission',
         deliveryState: 'published',
         terminalReceipt: { failure: { code: 'ADMISSION_INDETERMINATE' } },
       },
     });
+    await expect(
+      methods.deadLetterAgentQueuedTurn({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        queuedTurnId: queued.turn.queuedTurnId,
+        deliveryKey: 'delivery-ambiguous-admission',
+        settledAt: new Date(LATER.getTime() + 1),
+        failure: { code: 'ATTEMPTS_EXHAUSTED', message: 'duplicate terminal callback' },
+      }),
+    ).resolves.toMatchObject({ outcome: 'already_terminal' });
     const priority = await methods.enqueueAgentQueuedTurn(
       enqueueInput({ clientRequestId: 'priority-behind-indeterminate', priority: true }),
     );
@@ -994,6 +1045,19 @@ describe('agent queued turn methods', () => {
       admissionSlot: true,
     });
     await expect(
+      Turn.updateOne(
+        { _id: priority.turn.queuedTurnId },
+        {
+          $set: {
+            status: 'claimed',
+            claimId: 'legacy-priority-claim',
+            claimBy: 'legacy-worker',
+            claimUntil: new Date(LATER.getTime() + 60_000),
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 11000 });
+    await expect(
       methods.cancelAgentQueuedTurn({
         user,
         tenantId: 'tenant-1',
@@ -1009,7 +1073,7 @@ describe('agent queued turn methods', () => {
           leaseUntil: new Date(LATER.getTime() + 60_000),
         }),
       ),
-    ).resolves.toMatchObject({ outcome: 'missing' });
+    ).resolves.toMatchObject({ outcome: 'blocked' });
     await expect(
       methods.prepareAgentQueuedTurnConversationDeletion({
         user,
@@ -1048,7 +1112,7 @@ describe('agent queued turn methods', () => {
       }),
     ).resolves.toMatchObject({
       outcome: 'started',
-      turn: { admissionLineagePredecessorId: 'root' },
+      turn: { admissionLineagePredecessorId: rootLineageId() },
     });
     await expect(
       methods.deadLetterAgentQueuedTurn({
@@ -1068,7 +1132,8 @@ describe('agent queued turn methods', () => {
         terminalReceipt: {
           generationId: 'root-generation',
           generationCreatedAt: 42,
-          lineagePredecessorId: 'root',
+          lineagePredecessorId: rootLineageId(),
+          rootPredecessor: true,
         },
       },
     });
@@ -1115,7 +1180,7 @@ describe('agent queued turn methods', () => {
       generationId: 'generation-predecessor',
       generationCreatedAt: 41,
       effectivePredecessorCreatedAt: 40,
-      lineagePredecessorId: 'root',
+      lineagePredecessorId: rootLineageId(),
       settledAt: START,
     });
     await methods.reserveAgentQueuedTurnDelivery({
@@ -1360,7 +1425,7 @@ describe('agent queued turn methods', () => {
         admissionMode: 'ordinary',
         generationId: 'generation-late-proof',
         generationCreatedAt: 44,
-        lineagePredecessorId: 'root',
+        lineagePredecessorId: rootLineageId(),
         settledAt: new Date(claimNow.getTime() + 1),
       }),
     ).resolves.toMatchObject({ outcome: 'admitted', turn: { status: 'admitted' } });
@@ -1374,7 +1439,11 @@ describe('agent queued turn methods', () => {
       enqueueInput({ clientRequestId: 'root-a-2', expectedPredecessorCreatedAt: 10 }),
     );
     const laterRoot = await methods.enqueueAgentQueuedTurn(
-      enqueueInput({ clientRequestId: 'root-b-1', expectedPredecessorCreatedAt: 20 }),
+      enqueueInput({
+        clientRequestId: 'root-b-1',
+        parentMessageId: 'parent-2',
+        expectedPredecessorCreatedAt: 10,
+      }),
     );
     await methods.reserveAgentQueuedTurnDelivery({
       user,
@@ -1403,7 +1472,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 11,
       effectivePredecessorCreatedAt: 10,
-      lineagePredecessorId: 'root',
+      lineagePredecessorId: rootLineageId(),
       settledAt: START,
     });
 
@@ -1413,6 +1482,7 @@ describe('agent queued turn methods', () => {
         tenantId: 'tenant-1',
         conversationId: 'conversation-1',
         sequence: sameRoot.turn.sequence,
+        rootParentMessageId: 'parent-1',
         expectedPredecessorCreatedAt: 10,
       }),
     ).resolves.toEqual({
@@ -1425,11 +1495,12 @@ describe('agent queued turn methods', () => {
         tenantId: 'tenant-1',
         conversationId: 'conversation-1',
         sequence: laterRoot.turn.sequence,
-        expectedPredecessorCreatedAt: 20,
+        rootParentMessageId: 'parent-2',
+        expectedPredecessorCreatedAt: 10,
       }),
     ).resolves.toEqual({
-      effectivePredecessorCreatedAt: 20,
-      lineagePredecessorId: 'root',
+      effectivePredecessorCreatedAt: 10,
+      lineagePredecessorId: rootLineageId('parent-2'),
     });
 
     await methods.reserveAgentQueuedTurnDelivery({
@@ -1513,7 +1584,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 10,
       effectivePredecessorCreatedAt: 10,
-      lineagePredecessorId: 'root',
+      lineagePredecessorId: rootLineageId(),
       settledAt: START,
     });
 
@@ -1573,7 +1644,7 @@ describe('agent queued turn methods', () => {
             outcome: 'admitted',
             settledAt: START,
             effectivePredecessorCreatedAt: 10,
-            lineagePredecessorId: 'root',
+            lineagePredecessorId: rootLineageId(),
           },
         },
         $unset: { activeSlot: 1 },
@@ -1658,7 +1729,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 11,
       effectivePredecessorCreatedAt: 10,
-      lineagePredecessorId: 'root',
+      lineagePredecessorId: rootLineageId(),
       settledAt: START,
     });
 
@@ -1677,6 +1748,7 @@ describe('agent queued turn methods', () => {
         tenantId: 'tenant-1',
         conversationId: 'conversation-1',
         sequence: normal.turn.sequence,
+        rootParentMessageId: 'parent-1',
         expectedPredecessorCreatedAt: 10,
         allowLegacyPredecessorInference: true,
       }),
@@ -1689,7 +1761,7 @@ describe('agent queued turn methods', () => {
       {
         $set: {
           'terminalReceipt.effectivePredecessorCreatedAt': 10,
-          'terminalReceipt.lineagePredecessorId': 'root',
+          'terminalReceipt.lineagePredecessorId': rootLineageId(),
         },
       },
     );
@@ -1762,6 +1834,7 @@ describe('agent queued turn methods', () => {
         tenantId: 'tenant-1',
         conversationId: 'conversation-1',
         sequence: ambiguous.turn.sequence,
+        rootParentMessageId: 'parent-1',
         expectedPredecessorCreatedAt: 10,
       }),
     ).resolves.toBeNull();
@@ -1813,6 +1886,7 @@ describe('agent queued turn methods', () => {
         tenantId: 'tenant-1',
         conversationId: 'conversation-1',
         sequence: target.turn.sequence,
+        rootParentMessageId: 'parent-1',
         expectedPredecessorCreatedAt: 10,
         allowLegacyPredecessorInference: true,
       }),
@@ -1919,7 +1993,7 @@ describe('agent queued turn methods', () => {
     ).resolves.toMatchObject({
       outcome: 'admission_indeterminate',
       turn: {
-        status: 'dead',
+        status: 'claimed',
         terminalReceipt: {
           failure: { code: 'ADMISSION_INDETERMINATE' },
         },
@@ -2218,7 +2292,7 @@ describe('agent queued turn methods', () => {
       admissionId: 'delivery-admission-during-delete',
       admissionMode: 'ordinary',
       generationCreatedAt: 42,
-      lineagePredecessorId: 'root',
+      lineagePredecessorId: rootLineageId(),
       settledAt: LATER,
     });
     await expect(

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -364,6 +364,73 @@ describe('agent queued turn methods', () => {
     ).resolves.toEqual({ outcome: 'blocked', claim: null });
   });
 
+  it('serializes competing claims across independent method instances', async () => {
+    const normal = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'concurrent-claim-normal' }),
+    );
+    const priority = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'concurrent-claim-priority', priority: true }),
+    );
+    const otherReplica = createAgentQueuedTurnMethods(mongoose);
+
+    const [normalResult, priorityResult] = await Promise.all([
+      methods.claimNextAgentQueuedTurn(
+        claimInput(normal.turn.queuedTurnId, { claimId: 'normal-claim' }),
+      ),
+      otherReplica.claimNextAgentQueuedTurn(
+        claimInput(priority.turn.queuedTurnId, {
+          claimId: 'priority-claim',
+          claimBy: 'worker-2',
+        }),
+      ),
+    ]);
+
+    expect(normalResult).toEqual({ outcome: 'blocked', claim: null });
+    expect(priorityResult).toMatchObject({
+      outcome: 'acquired',
+      claim: { queuedTurnId: priority.turn.queuedTurnId },
+    });
+    await expect(Turn.countDocuments({ status: 'claimed' })).resolves.toBe(1);
+  });
+
+  it('keeps priority work behind an existing admission-order claim', async () => {
+    const normal = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'claimed-before-priority' }),
+    );
+    const normalClaim = claimInput(normal.turn.queuedTurnId, { claimId: 'normal-owner' });
+    await expect(methods.claimNextAgentQueuedTurn(normalClaim)).resolves.toMatchObject({
+      outcome: 'acquired',
+    });
+    const priority = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'priority-after-claim', priority: true }),
+    );
+    const otherReplica = createAgentQueuedTurnMethods(mongoose);
+
+    await expect(
+      otherReplica.claimNextAgentQueuedTurn(
+        claimInput(priority.turn.queuedTurnId, {
+          claimId: 'priority-owner',
+          claimBy: 'worker-2',
+        }),
+      ),
+    ).resolves.toEqual({ outcome: 'blocked', claim: null });
+
+    await methods.releaseAgentQueuedTurn({
+      ...normalClaim,
+      disposition: 'dead',
+      settledAt: START,
+      failure: { code: 'TEST_SETTLED', message: 'Release the lane reservation' },
+    });
+    await expect(
+      otherReplica.claimNextAgentQueuedTurn(
+        claimInput(priority.turn.queuedTurnId, {
+          claimId: 'priority-owner',
+          claimBy: 'worker-2',
+        }),
+      ),
+    ).resolves.toMatchObject({ outcome: 'acquired' });
+  });
+
   it('reclaims an expired exact lease but never replays a different claim identity', async () => {
     const queued = await methods.enqueueAgentQueuedTurn(enqueueInput());
     const first = await methods.claimNextAgentQueuedTurn(
@@ -373,6 +440,9 @@ describe('agent queued turn methods', () => {
       }),
     );
     expect(first.outcome).toBe('acquired');
+    const priority = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'priority-after-expired-claim', priority: true }),
+    );
 
     const reclaimed = await methods.claimNextAgentQueuedTurn(
       claimInput(queued.turn.queuedTurnId, {
@@ -386,6 +456,16 @@ describe('agent queued turn methods', () => {
       outcome: 'acquired',
       claim: { attempts: 2 },
     });
+    await expect(
+      methods.claimNextAgentQueuedTurn(
+        claimInput(priority.turn.queuedTurnId, {
+          claimId: 'priority-claim',
+          claimBy: 'worker-3',
+          now: new Date(START.getTime() + 2),
+          leaseUntil: LATER,
+        }),
+      ),
+    ).resolves.toEqual({ outcome: 'blocked', claim: null });
   });
 
   it('repairs delivery scheduling idempotently and leaves unscheduled replays discoverable', async () => {
@@ -600,6 +680,7 @@ describe('agent queued turn methods', () => {
         clientRequestId: 'admitted',
         text: 'admitted',
         priority: true,
+        expectedPredecessorCreatedAt: 83,
       }),
     );
     await methods.reserveAgentQueuedTurnDelivery({
@@ -632,7 +713,6 @@ describe('agent queued turn methods', () => {
         ...claimInput(admitted.turn.queuedTurnId),
         admissionId: 'admission-1',
         startedAt: START,
-        effectivePredecessorCreatedAt: 83,
       }),
     ).resolves.toMatchObject({
       outcome: 'started',
@@ -901,6 +981,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationId: 'generation-predecessor',
       generationCreatedAt: 41,
+      effectivePredecessorCreatedAt: 40,
       settledAt: START,
     });
     await methods.reserveAgentQueuedTurnDelivery({
@@ -921,7 +1002,9 @@ describe('agent queued turn methods', () => {
     const admissionClaim = claimInput(queued.turn.queuedTurnId, {
       claimId: 'delivery-reconciled-admission',
     });
-    await methods.claimNextAgentQueuedTurn(admissionClaim);
+    await expect(methods.claimNextAgentQueuedTurn(admissionClaim)).resolves.toMatchObject({
+      outcome: 'acquired',
+    });
     await expect(
       methods.beginAgentQueuedTurnAdmission({
         ...admissionClaim,
@@ -963,10 +1046,16 @@ describe('agent queued turn methods', () => {
 
   it('reconciles a quarantined admission after exact evidence arrives and unblocks its successor', async () => {
     const first = await methods.enqueueAgentQueuedTurn(
-      enqueueInput({ clientRequestId: 'late-reconciled-admission' }),
+      enqueueInput({
+        clientRequestId: 'late-reconciled-admission',
+        expectedPredecessorCreatedAt: 41,
+      }),
     );
     const successor = await methods.enqueueAgentQueuedTurn(
-      enqueueInput({ clientRequestId: 'late-reconciled-successor' }),
+      enqueueInput({
+        clientRequestId: 'late-reconciled-successor',
+        expectedPredecessorCreatedAt: 41,
+      }),
     );
     const deliveryKey = 'delivery-late-reconciled-admission';
     await methods.reserveAgentQueuedTurnDelivery({
@@ -991,7 +1080,6 @@ describe('agent queued turn methods', () => {
       ...claimInput(first.turn.queuedTurnId, { claimId: deliveryKey }),
       admissionId: deliveryKey,
       startedAt: START,
-      effectivePredecessorCreatedAt: 41,
       admissionProtocolVersion: 2,
     });
     await methods.deadLetterAgentQueuedTurn({
@@ -1173,7 +1261,6 @@ describe('agent queued turn methods', () => {
       ...claimInput(first.turn.queuedTurnId),
       admissionId: 'admission-root-a',
       startedAt: START,
-      effectivePredecessorCreatedAt: 10,
     });
     await methods.markAgentQueuedTurnAdmitted({
       ...claimInput(first.turn.queuedTurnId),
@@ -1232,6 +1319,7 @@ describe('agent queued turn methods', () => {
       admissionId: 'admission-root-a-2',
       admissionMode: 'ordinary',
       generationCreatedAt: 12,
+      effectivePredecessorCreatedAt: 11,
       settledAt: START,
     });
     await expect(
@@ -1283,7 +1371,6 @@ describe('agent queued turn methods', () => {
       ...priorityClaim,
       admissionId: priorityDelivery,
       startedAt: START,
-      effectivePredecessorCreatedAt: 10,
     });
     await methods.markAgentQueuedTurnAdmitted({
       ...priorityClaim,
@@ -1337,7 +1424,6 @@ describe('agent queued turn methods', () => {
       ...normalClaim,
       admissionId: normalDelivery,
       startedAt: LATER,
-      effectivePredecessorCreatedAt: 11,
     });
     await methods.markAgentQueuedTurnAdmitted({
       ...normalClaim,
@@ -1379,6 +1465,165 @@ describe('agent queued turn methods', () => {
         expectedPredecessorCreatedAt: 10,
       }),
     ).resolves.toBeNull();
+  });
+
+  it('rejects an inferred legacy edge that reconnects to an exact-edge tail', async () => {
+    const exact = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'cycle-exact', expectedPredecessorCreatedAt: 10 }),
+    );
+    const legacy = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'cycle-legacy', expectedPredecessorCreatedAt: 10 }),
+    );
+    const target = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'cycle-target', expectedPredecessorCreatedAt: 10 }),
+    );
+    await Turn.updateOne(
+      { _id: exact.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: START,
+            generationCreatedAt: 11,
+            effectivePredecessorCreatedAt: 10,
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
+    await Turn.updateOne(
+      { _id: legacy.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: START,
+            generationCreatedAt: 11,
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
+
+    await expect(
+      methods.getEffectiveAgentQueuedTurnPredecessor({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        sequence: target.turn.sequence,
+        expectedPredecessorCreatedAt: 10,
+        allowLegacyPredecessorInference: true,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('does not repair a legacy receipt through its successor edge', async () => {
+    const target = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'repair-target', expectedPredecessorCreatedAt: 10 }),
+    );
+    const successor = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'repair-successor', expectedPredecessorCreatedAt: 10 }),
+    );
+    await Turn.updateOne(
+      { _id: target.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: START,
+            generationCreatedAt: 10,
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
+    await Turn.updateOne(
+      { _id: successor.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: LATER,
+            generationCreatedAt: 11,
+            effectivePredecessorCreatedAt: 10,
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
+
+    const repaired = await methods.getAgentQueuedTurnByClientRequestId({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      clientRequestId: 'repair-target',
+    });
+    expect(repaired?.terminalReceipt?.effectivePredecessorCreatedAt).toBeUndefined();
+  });
+
+  it('keeps exact late evidence quarantined when lineage crosses its successor', async () => {
+    const target = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'reconcile-target', expectedPredecessorCreatedAt: 10 }),
+    );
+    const successor = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'reconcile-successor', expectedPredecessorCreatedAt: 10 }),
+    );
+    const deliveryKey = 'reconcile-target-delivery';
+    await Turn.updateOne(
+      { _id: target.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'claimed',
+          deliveryKey,
+          deliveryState: 'published',
+          claimId: deliveryKey,
+          claimBy: 'worker-1',
+          claimUntil: LATER,
+          admissionId: deliveryKey,
+          admissionStartedAt: START,
+        },
+      },
+    );
+    await Turn.updateOne(
+      { _id: successor.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: LATER,
+            generationCreatedAt: 11,
+            effectivePredecessorCreatedAt: 10,
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
+
+    await expect(
+      methods.deadLetterAgentQueuedTurn({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        queuedTurnId: target.turn.queuedTurnId,
+        deliveryKey,
+        settledAt: LATER,
+        failure: { code: 'ATTEMPTS_EXHAUSTED', message: 'result unavailable' },
+        admissionEvidence: { generationCreatedAt: 10 },
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'admission_indeterminate',
+      turn: {
+        status: 'dead',
+        terminalReceipt: {
+          failure: { code: 'ADMISSION_INDETERMINATE' },
+        },
+      },
+    });
   });
 
   it('projects the newest failures when more than 100 dead receipts await dismissal', async () => {

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -634,7 +634,10 @@ describe('agent queued turn methods', () => {
         startedAt: START,
         effectivePredecessorCreatedAt: 83,
       }),
-    ).resolves.toMatchObject({ outcome: 'started' });
+    ).resolves.toMatchObject({
+      outcome: 'started',
+      turn: { admissionEffectivePredecessorCreatedAt: 83 },
+    });
     await expect(methods.markAgentQueuedTurnAdmitted(admissionInput)).resolves.toMatchObject({
       outcome: 'admitted',
       turn: {
@@ -756,7 +759,7 @@ describe('agent queued turn methods', () => {
     ).resolves.toEqual([]);
   });
 
-  it('keeps an ambiguous admission fenced when its delivery exhausts', async () => {
+  it('keeps an ambiguous admission fenced when its predecessor boundary is unavailable', async () => {
     const queued = await methods.enqueueAgentQueuedTurn(
       enqueueInput({ clientRequestId: 'ambiguous-admission' }),
     );
@@ -819,6 +822,10 @@ describe('agent queued turn methods', () => {
         deliveryKey: 'delivery-ambiguous-admission',
         settledAt: LATER,
         failure: { code: 'ATTEMPTS_EXHAUSTED', message: 'admission result unavailable' },
+        admissionEvidence: {
+          generationId: 'generation-without-predecessor-proof',
+          generationCreatedAt: 42,
+        },
       }),
     ).resolves.toMatchObject({
       outcome: 'admission_indeterminate',
@@ -854,10 +861,48 @@ describe('agent queued turn methods', () => {
     ).rejects.toThrow('admission must settle');
   });
 
-  it('reconciles an ambiguous admission from durable generation evidence', async () => {
-    const queued = await methods.enqueueAgentQueuedTurn(
-      enqueueInput({ clientRequestId: 'reconciled-admission' }),
+  it('reconstructs a pre-upgrade chained boundary during exact-evidence reconciliation', async () => {
+    const predecessor = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({
+        clientRequestId: 'reconciled-predecessor',
+        expectedPredecessorCreatedAt: 40,
+      }),
     );
+    const queued = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'reconciled-admission', expectedPredecessorCreatedAt: 40 }),
+    );
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: predecessor.turn.queuedTurnId,
+      deliveryKey: 'delivery-reconciled-predecessor',
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: predecessor.turn.queuedTurnId,
+      deliveryKey: 'delivery-reconciled-predecessor',
+      scheduledAt: START,
+    });
+    const predecessorClaim = claimInput(predecessor.turn.queuedTurnId, {
+      claimId: 'delivery-reconciled-predecessor',
+    });
+    await methods.claimNextAgentQueuedTurn(predecessorClaim);
+    await methods.beginAgentQueuedTurnAdmission({
+      ...predecessorClaim,
+      admissionId: 'delivery-reconciled-predecessor',
+      startedAt: START,
+    });
+    await methods.markAgentQueuedTurnAdmitted({
+      ...predecessorClaim,
+      admissionId: 'delivery-reconciled-predecessor',
+      admissionMode: 'ordinary',
+      generationId: 'generation-predecessor',
+      generationCreatedAt: 41,
+      settledAt: START,
+    });
     await methods.reserveAgentQueuedTurnDelivery({
       user,
       tenantId: 'tenant-1',
@@ -873,19 +918,19 @@ describe('agent queued turn methods', () => {
       deliveryKey: 'delivery-reconciled-admission',
       scheduledAt: START,
     });
-    await methods.claimNextAgentQueuedTurn(
-      claimInput(queued.turn.queuedTurnId, { claimId: 'delivery-reconciled-admission' }),
-    );
+    const admissionClaim = claimInput(queued.turn.queuedTurnId, {
+      claimId: 'delivery-reconciled-admission',
+    });
+    await methods.claimNextAgentQueuedTurn(admissionClaim);
     await expect(
       methods.beginAgentQueuedTurnAdmission({
-        ...claimInput(queued.turn.queuedTurnId, { claimId: 'delivery-reconciled-admission' }),
+        ...admissionClaim,
         admissionId: 'delivery-reconciled-admission',
         startedAt: START,
-        effectivePredecessorCreatedAt: 41,
       }),
     ).resolves.toMatchObject({
       outcome: 'started',
-      turn: { admissionEffectivePredecessorCreatedAt: 41 },
+      turn: { expectedPredecessorCreatedAt: 40 },
     });
 
     await expect(
@@ -946,6 +991,7 @@ describe('agent queued turn methods', () => {
       ...claimInput(first.turn.queuedTurnId, { claimId: deliveryKey }),
       admissionId: deliveryKey,
       startedAt: START,
+      effectivePredecessorCreatedAt: 41,
       admissionProtocolVersion: 2,
     });
     await methods.deadLetterAgentQueuedTurn({
@@ -1154,6 +1200,48 @@ describe('agent queued turn methods', () => {
         expectedPredecessorCreatedAt: 20,
       }),
     ).resolves.toBeUndefined();
+
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: sameRoot.turn.queuedTurnId,
+      deliveryKey: 'admission-root-a-2',
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: sameRoot.turn.queuedTurnId,
+      deliveryKey: 'admission-root-a-2',
+      scheduledAt: START,
+    });
+    const sameRootClaim = claimInput(sameRoot.turn.queuedTurnId, {
+      claimId: 'admission-root-a-2',
+    });
+    await methods.claimNextAgentQueuedTurn(sameRootClaim);
+    await methods.beginAgentQueuedTurnAdmission({
+      ...sameRootClaim,
+      admissionId: 'admission-root-a-2',
+      startedAt: START,
+    });
+    await methods.markAgentQueuedTurnAdmitted({
+      ...sameRootClaim,
+      admissionId: 'admission-root-a-2',
+      admissionMode: 'ordinary',
+      generationCreatedAt: 12,
+      settledAt: START,
+    });
+    await expect(
+      methods.getAgentQueuedTurnByClientRequestId({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        clientRequestId: 'root-a-2',
+      }),
+    ).resolves.toMatchObject({
+      terminalReceipt: { effectivePredecessorCreatedAt: 11 },
+    });
   });
 
   it('projects the newest failures when more than 100 dead receipts await dismissal', async () => {

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -632,6 +632,7 @@ describe('agent queued turn methods', () => {
         ...claimInput(admitted.turn.queuedTurnId),
         admissionId: 'admission-1',
         startedAt: START,
+        effectivePredecessorCreatedAt: 83,
       }),
     ).resolves.toMatchObject({ outcome: 'started' });
     await expect(methods.markAgentQueuedTurnAdmitted(admissionInput)).resolves.toMatchObject({
@@ -875,10 +876,16 @@ describe('agent queued turn methods', () => {
     await methods.claimNextAgentQueuedTurn(
       claimInput(queued.turn.queuedTurnId, { claimId: 'delivery-reconciled-admission' }),
     );
-    await methods.beginAgentQueuedTurnAdmission({
-      ...claimInput(queued.turn.queuedTurnId, { claimId: 'delivery-reconciled-admission' }),
-      admissionId: 'delivery-reconciled-admission',
-      startedAt: START,
+    await expect(
+      methods.beginAgentQueuedTurnAdmission({
+        ...claimInput(queued.turn.queuedTurnId, { claimId: 'delivery-reconciled-admission' }),
+        admissionId: 'delivery-reconciled-admission',
+        startedAt: START,
+        effectivePredecessorCreatedAt: 41,
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'started',
+      turn: { admissionEffectivePredecessorCreatedAt: 41 },
     });
 
     await expect(
@@ -903,6 +910,7 @@ describe('agent queued turn methods', () => {
           admissionId: 'delivery-reconciled-admission',
           generationId: 'generation-reconciled',
           generationCreatedAt: 42,
+          effectivePredecessorCreatedAt: 41,
         },
       },
     });

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -1244,6 +1244,119 @@ describe('agent queued turn methods', () => {
     });
   });
 
+  it('derives the predecessor from admission order when priority overtakes sequence', async () => {
+    const normal = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'priority-normal', expectedPredecessorCreatedAt: 10 }),
+    );
+    const priority = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({
+        clientRequestId: 'priority-overtake',
+        expectedPredecessorCreatedAt: 10,
+        priority: true,
+      }),
+    );
+    const priorityDelivery = 'admission-priority-overtake';
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: priority.turn.queuedTurnId,
+      deliveryKey: priorityDelivery,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: priority.turn.queuedTurnId,
+      deliveryKey: priorityDelivery,
+      scheduledAt: START,
+    });
+    const priorityClaim = claimInput(priority.turn.queuedTurnId, {
+      claimId: priorityDelivery,
+    });
+    await expect(methods.claimNextAgentQueuedTurn(priorityClaim)).resolves.toMatchObject({
+      outcome: 'acquired',
+    });
+    await methods.beginAgentQueuedTurnAdmission({
+      ...priorityClaim,
+      admissionId: priorityDelivery,
+      startedAt: START,
+      effectivePredecessorCreatedAt: 10,
+    });
+    await methods.markAgentQueuedTurnAdmitted({
+      ...priorityClaim,
+      admissionId: priorityDelivery,
+      admissionMode: 'ordinary',
+      generationCreatedAt: 11,
+      effectivePredecessorCreatedAt: 10,
+      settledAt: START,
+    });
+
+    await Turn.updateOne(
+      { _id: priority.turn.queuedTurnId },
+      { $unset: { 'terminalReceipt.effectivePredecessorCreatedAt': 1 } },
+    );
+    await expect(
+      methods.getEffectiveAgentQueuedTurnPredecessor({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        sequence: normal.turn.sequence,
+        expectedPredecessorCreatedAt: 10,
+      }),
+    ).resolves.toBe(11);
+
+    const normalDelivery = 'admission-priority-normal';
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: normal.turn.queuedTurnId,
+      deliveryKey: normalDelivery,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: normal.turn.queuedTurnId,
+      deliveryKey: normalDelivery,
+      scheduledAt: START,
+    });
+    const normalClaim = claimInput(normal.turn.queuedTurnId, { claimId: normalDelivery });
+    await expect(methods.claimNextAgentQueuedTurn(normalClaim)).resolves.toMatchObject({
+      outcome: 'acquired',
+    });
+    await methods.beginAgentQueuedTurnAdmission({
+      ...normalClaim,
+      admissionId: normalDelivery,
+      startedAt: LATER,
+      effectivePredecessorCreatedAt: 11,
+    });
+    await methods.markAgentQueuedTurnAdmitted({
+      ...normalClaim,
+      admissionId: normalDelivery,
+      admissionMode: 'ordinary',
+      generationCreatedAt: 12,
+      effectivePredecessorCreatedAt: 11,
+      settledAt: LATER,
+    });
+    await Turn.updateOne(
+      { _id: normal.turn.queuedTurnId },
+      { $unset: { 'terminalReceipt.effectivePredecessorCreatedAt': 1 } },
+    );
+
+    await expect(
+      methods.getAgentQueuedTurnByClientRequestId({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        clientRequestId: 'priority-normal',
+      }),
+    ).resolves.toMatchObject({
+      terminalReceipt: { effectivePredecessorCreatedAt: 11 },
+    });
+  });
+
   it('projects the newest failures when more than 100 dead receipts await dismissal', async () => {
     const deadIds: string[] = [];
     for (let index = 0; index < 101; index++) {

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -1173,12 +1173,14 @@ describe('agent queued turn methods', () => {
       ...claimInput(first.turn.queuedTurnId),
       admissionId: 'admission-root-a',
       startedAt: START,
+      effectivePredecessorCreatedAt: 10,
     });
     await methods.markAgentQueuedTurnAdmitted({
       ...claimInput(first.turn.queuedTurnId),
       admissionId: 'admission-root-a',
       admissionMode: 'ordinary',
       generationCreatedAt: 11,
+      effectivePredecessorCreatedAt: 10,
       settledAt: START,
     });
 
@@ -1303,8 +1305,13 @@ describe('agent queued turn methods', () => {
         conversationId: 'conversation-1',
         sequence: normal.turn.sequence,
         expectedPredecessorCreatedAt: 10,
+        allowLegacyPredecessorInference: true,
       }),
     ).resolves.toBe(11);
+    await Turn.updateOne(
+      { _id: priority.turn.queuedTurnId },
+      { $set: { 'terminalReceipt.effectivePredecessorCreatedAt': 10 } },
+    );
 
     const normalDelivery = 'admission-priority-normal';
     await methods.reserveAgentQueuedTurnDelivery({
@@ -1355,6 +1362,23 @@ describe('agent queued turn methods', () => {
     ).resolves.toMatchObject({
       terminalReceipt: { effectivePredecessorCreatedAt: 11 },
     });
+
+    await Turn.updateMany(
+      { _id: { $in: [priority.turn.queuedTurnId, normal.turn.queuedTurnId] } },
+      { $unset: { 'terminalReceipt.effectivePredecessorCreatedAt': 1 } },
+    );
+    const ambiguous = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'priority-ambiguous', expectedPredecessorCreatedAt: 10 }),
+    );
+    await expect(
+      methods.getEffectiveAgentQueuedTurnPredecessor({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        sequence: ambiguous.turn.sequence,
+        expectedPredecessorCreatedAt: 10,
+      }),
+    ).resolves.toBeNull();
   });
 
   it('projects the newest failures when more than 100 dead receipts await dismissal', async () => {

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -510,6 +510,75 @@ describe('agent queued turn methods', () => {
     ).rejects.toMatchObject({ code: 11000 });
   });
 
+  it('retires and fail-closes duplicate pre-fence admission lanes before index creation', async () => {
+    const first = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'duplicate-admission-first' }),
+    );
+    const second = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'duplicate-admission-second' }),
+    );
+    await Turn.collection.dropIndex('agent_queued_turn_admission_started_lane');
+    for (const [turn, deliveryKey, status] of [
+      [first, 'legacy-duplicate-first', 'dead'],
+      [second, 'legacy-duplicate-second', 'claimed'],
+    ] as const) {
+      await Turn.updateOne(
+        { _id: turn.turn.queuedTurnId },
+        {
+          $set: {
+            status,
+            deliveryKey,
+            deliveryState: 'published',
+            admissionId: deliveryKey,
+            admissionStartedAt: START,
+            ...(status === 'dead' && {
+              terminalReceipt: {
+                outcome: 'dead',
+                settledAt: START,
+                failure: {
+                  code: 'ADMISSION_INDETERMINATE',
+                  message: 'Legacy admission owner disappeared',
+                },
+              },
+            }),
+          },
+        },
+      );
+    }
+
+    await expect(methods.ensureAgentQueuedTurnIndexes()).resolves.toBeUndefined();
+    await expect(
+      Sequence.findOne({ user, tenantId: 'tenant-1', conversationId: 'conversation-1' }).lean(),
+    ).resolves.toMatchObject({ retiredAt: expect.any(Date) });
+    await expect(
+      Turn.find({ _id: { $in: [first.turn.queuedTurnId, second.turn.queuedTurnId] } })
+        .sort({ sequence: 1 })
+        .lean(),
+    ).resolves.toMatchObject([
+      {
+        status: 'dead',
+        terminalReceipt: {
+          failure: { code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE' },
+        },
+      },
+      {
+        status: 'dead',
+        terminalReceipt: {
+          failure: { code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE' },
+        },
+      },
+    ]);
+    await expect(Turn.countDocuments({ admissionStartedAt: { $exists: true } })).resolves.toBe(0);
+    await expect(
+      methods.enqueueAgentQueuedTurn(
+        enqueueInput({ clientRequestId: 'duplicate-admission-follow-up' }),
+      ),
+    ).rejects.toBeInstanceOf(AgentQueuedTurnLaneRetiredError);
+    await expect(
+      Turn.collection.indexExists('agent_queued_turn_admission_started_lane'),
+    ).resolves.toBe(true);
+  });
+
   it('reclaims an expired exact lease but never replays a different claim identity', async () => {
     const queued = await methods.enqueueAgentQueuedTurn(enqueueInput());
     const first = await methods.claimNextAgentQueuedTurn(
@@ -1426,6 +1495,16 @@ describe('agent queued turn methods', () => {
       ),
     ).resolves.toMatchObject({ outcome: 'blocked' });
 
+    /** A protocol-v2 owner created before admission slots existed can already
+     * be in the legacy dead shell when its authoritative source receipt lands. */
+    await Turn.updateOne(
+      { _id: first.turn.queuedTurnId },
+      {
+        $set: { status: 'dead' },
+        $unset: { admissionSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+      },
+    );
+
     await expect(
       methods.markAgentQueuedTurnAdmitted({
         ...claim,
@@ -2049,7 +2128,7 @@ describe('agent queued turn methods', () => {
     expect(repaired?.terminalReceipt?.effectivePredecessorCreatedAt).toBeUndefined();
   });
 
-  it('keeps exact late evidence quarantined when lineage crosses its successor', async () => {
+  it('keeps exact late evidence quarantined behind an ambiguous legacy successor', async () => {
     const target = await methods.enqueueAgentQueuedTurn(
       enqueueInput({ clientRequestId: 'reconcile-target', expectedPredecessorCreatedAt: 10 }),
     );
@@ -2082,7 +2161,6 @@ describe('agent queued turn methods', () => {
             settledAt: LATER,
             generationCreatedAt: 11,
             effectivePredecessorCreatedAt: 10,
-            lineagePredecessorId: target.turn.queuedTurnId,
           },
         },
         $unset: { activeSlot: 1 },

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -624,6 +624,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary' as const,
       generationId: 'generation-1',
       generationCreatedAt: 84,
+      effectivePredecessorCreatedAt: 83,
       settledAt: START,
     };
     await expect(
@@ -638,7 +639,10 @@ describe('agent queued turn methods', () => {
       turn: {
         status: 'admitted',
         deliveryState: 'published',
-        terminalReceipt: { admissionId: 'admission-1' },
+        terminalReceipt: {
+          admissionId: 'admission-1',
+          effectivePredecessorCreatedAt: 83,
+        },
       },
     });
     await expect(
@@ -650,6 +654,7 @@ describe('agent queued turn methods', () => {
         admissionId: 'admission-1',
         generationId: 'generation-1',
         generationCreatedAt: 84,
+        effectivePredecessorCreatedAt: 83,
       }),
     ).resolves.toBe(true);
     await expect(
@@ -661,6 +666,19 @@ describe('agent queued turn methods', () => {
         admissionId: 'admission-1',
         generationId: 'generation-1',
         generationCreatedAt: 85,
+        effectivePredecessorCreatedAt: 83,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      methods.hasAgentQueuedTurnAdmissionReceipt({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        queuedTurnId: admitted.turn.queuedTurnId,
+        admissionId: 'admission-1',
+        generationId: 'generation-1',
+        generationCreatedAt: 84,
+        effectivePredecessorCreatedAt: 82,
       }),
     ).resolves.toBe(false);
     await expect(methods.markAgentQueuedTurnAdmitted(admissionInput)).resolves.toMatchObject({

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -431,6 +431,45 @@ describe('agent queued turn methods', () => {
     ).resolves.toMatchObject({ outcome: 'acquired' });
   });
 
+  it('keeps one durable admission owner after the lane-writer lease is stolen', async () => {
+    const normal = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'durable-owner-normal' }),
+    );
+    await expect(
+      methods.claimNextAgentQueuedTurn(
+        claimInput(normal.turn.queuedTurnId, {
+          claimId: 'durable-owner',
+          leaseUntil: new Date(START.getTime() + 1),
+        }),
+      ),
+    ).resolves.toMatchObject({ outcome: 'acquired' });
+    const priority = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'durable-owner-priority', priority: true }),
+    );
+
+    await Sequence.updateOne(
+      { user, tenantId: 'tenant-1', conversationId: 'conversation-1' },
+      {
+        $set: {
+          writerId: 'stolen-writer',
+          writerUntil: new Date(START.getTime() + 60_000),
+        },
+      },
+    );
+    const otherReplica = createAgentQueuedTurnMethods(mongoose);
+    await expect(
+      otherReplica.claimNextAgentQueuedTurn(
+        claimInput(priority.turn.queuedTurnId, {
+          claimId: 'priority-after-stolen-writer',
+          claimBy: 'worker-2',
+          now: new Date(START.getTime() + 2),
+          leaseUntil: LATER,
+        }),
+      ),
+    ).resolves.toEqual({ outcome: 'blocked', claim: null });
+    await expect(Turn.countDocuments({ admissionSlot: true })).resolves.toBe(1);
+  });
+
   it('reclaims an expired exact lease but never replays a different claim identity', async () => {
     const queued = await methods.enqueueAgentQueuedTurn(enqueueInput());
     const first = await methods.claimNextAgentQueuedTurn(
@@ -706,6 +745,7 @@ describe('agent queued turn methods', () => {
       generationId: 'generation-1',
       generationCreatedAt: 84,
       effectivePredecessorCreatedAt: 83,
+      lineagePredecessorId: 'root',
       settledAt: START,
     };
     await expect(
@@ -866,6 +906,27 @@ describe('agent queued turn methods', () => {
       admissionId: 'delivery-ambiguous-admission',
       startedAt: START,
     });
+    await Turn.updateOne(
+      { _id: queued.turn.queuedTurnId },
+      { $unset: { admissionLineagePredecessorId: 1 } },
+    );
+    const incompleteEvidence = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'ambiguous-admission-evidence' }),
+    );
+    await Turn.updateOne(
+      { _id: incompleteEvidence.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: START,
+            lineagePredecessorId: 'root',
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
 
     await expect(
       methods.claimNextAgentQueuedTurn(
@@ -916,6 +977,22 @@ describe('agent queued turn methods', () => {
         terminalReceipt: { failure: { code: 'ADMISSION_INDETERMINATE' } },
       },
     });
+    const priority = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'priority-behind-indeterminate', priority: true }),
+    );
+    await expect(
+      methods.claimNextAgentQueuedTurn(
+        claimInput(priority.turn.queuedTurnId, {
+          claimId: 'priority-behind-indeterminate',
+          claimBy: 'worker-2',
+          now: LATER,
+          leaseUntil: new Date(LATER.getTime() + 60_000),
+        }),
+      ),
+    ).resolves.toEqual({ outcome: 'blocked', claim: null });
+    await expect(Turn.findOne({ _id: queued.turn.queuedTurnId }).lean()).resolves.toMatchObject({
+      admissionSlot: true,
+    });
     await expect(
       methods.cancelAgentQueuedTurn({
         user,
@@ -939,6 +1016,62 @@ describe('agent queued turn methods', () => {
         targets: [{ conversationId: 'conversation-1', tenantId: 'tenant-1' }],
       }),
     ).rejects.toThrow('admission must settle');
+  });
+
+  it('reconciles a root admission through explicit lineage without a timestamp boundary', async () => {
+    const queued = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'root-lineage-reconciliation' }),
+    );
+    const deliveryKey = 'root-lineage-delivery';
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: queued.turn.queuedTurnId,
+      deliveryKey,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: queued.turn.queuedTurnId,
+      deliveryKey,
+      scheduledAt: START,
+    });
+    const queuedClaim = claimInput(queued.turn.queuedTurnId, { claimId: deliveryKey });
+    await methods.claimNextAgentQueuedTurn(queuedClaim);
+    await expect(
+      methods.beginAgentQueuedTurnAdmission({
+        ...queuedClaim,
+        admissionId: deliveryKey,
+        startedAt: START,
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'started',
+      turn: { admissionLineagePredecessorId: 'root' },
+    });
+    await expect(
+      methods.deadLetterAgentQueuedTurn({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        queuedTurnId: queued.turn.queuedTurnId,
+        deliveryKey,
+        settledAt: LATER,
+        failure: { code: 'ATTEMPTS_EXHAUSTED', message: 'admission result unavailable' },
+        admissionEvidence: { generationId: 'root-generation', generationCreatedAt: 42 },
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'admission_reconciled',
+      turn: {
+        status: 'admitted',
+        terminalReceipt: {
+          generationId: 'root-generation',
+          generationCreatedAt: 42,
+          lineagePredecessorId: 'root',
+        },
+      },
+    });
   });
 
   it('reconstructs a pre-upgrade chained boundary during exact-evidence reconciliation', async () => {
@@ -982,6 +1115,7 @@ describe('agent queued turn methods', () => {
       generationId: 'generation-predecessor',
       generationCreatedAt: 41,
       effectivePredecessorCreatedAt: 40,
+      lineagePredecessorId: 'root',
       settledAt: START,
     });
     await methods.reserveAgentQueuedTurnDelivery({
@@ -1226,6 +1360,7 @@ describe('agent queued turn methods', () => {
         admissionMode: 'ordinary',
         generationId: 'generation-late-proof',
         generationCreatedAt: 44,
+        lineagePredecessorId: 'root',
         settledAt: new Date(claimNow.getTime() + 1),
       }),
     ).resolves.toMatchObject({ outcome: 'admitted', turn: { status: 'admitted' } });
@@ -1268,6 +1403,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 11,
       effectivePredecessorCreatedAt: 10,
+      lineagePredecessorId: 'root',
       settledAt: START,
     });
 
@@ -1279,7 +1415,10 @@ describe('agent queued turn methods', () => {
         sequence: sameRoot.turn.sequence,
         expectedPredecessorCreatedAt: 10,
       }),
-    ).resolves.toBe(11);
+    ).resolves.toEqual({
+      effectivePredecessorCreatedAt: 11,
+      lineagePredecessorId: first.turn.queuedTurnId,
+    });
     await expect(
       methods.getEffectiveAgentQueuedTurnPredecessor({
         user,
@@ -1288,7 +1427,10 @@ describe('agent queued turn methods', () => {
         sequence: laterRoot.turn.sequence,
         expectedPredecessorCreatedAt: 20,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({
+      effectivePredecessorCreatedAt: 20,
+      lineagePredecessorId: 'root',
+    });
 
     await methods.reserveAgentQueuedTurnDelivery({
       user,
@@ -1320,6 +1462,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 12,
       effectivePredecessorCreatedAt: 11,
+      lineagePredecessorId: first.turn.queuedTurnId,
       settledAt: START,
     });
     await expect(
@@ -1331,6 +1474,143 @@ describe('agent queued turn methods', () => {
       }),
     ).resolves.toMatchObject({
       terminalReceipt: { effectivePredecessorCreatedAt: 11 },
+    });
+  });
+
+  it('uses queued-turn identity when consecutive generations share a timestamp', async () => {
+    const first = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'same-timestamp-first', expectedPredecessorCreatedAt: 10 }),
+    );
+    const second = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'same-timestamp-second', expectedPredecessorCreatedAt: 10 }),
+    );
+    const firstDelivery = 'same-timestamp-first-delivery';
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: first.turn.queuedTurnId,
+      deliveryKey: firstDelivery,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: first.turn.queuedTurnId,
+      deliveryKey: firstDelivery,
+      scheduledAt: START,
+    });
+    const firstClaim = claimInput(first.turn.queuedTurnId, { claimId: firstDelivery });
+    await methods.claimNextAgentQueuedTurn(firstClaim);
+    await methods.beginAgentQueuedTurnAdmission({
+      ...firstClaim,
+      admissionId: firstDelivery,
+      startedAt: START,
+    });
+    await methods.markAgentQueuedTurnAdmitted({
+      ...firstClaim,
+      admissionId: firstDelivery,
+      admissionMode: 'ordinary',
+      generationCreatedAt: 10,
+      effectivePredecessorCreatedAt: 10,
+      lineagePredecessorId: 'root',
+      settledAt: START,
+    });
+
+    const secondDelivery = 'same-timestamp-second-delivery';
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: second.turn.queuedTurnId,
+      deliveryKey: secondDelivery,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: second.turn.queuedTurnId,
+      deliveryKey: secondDelivery,
+      scheduledAt: LATER,
+    });
+    const secondClaim = claimInput(second.turn.queuedTurnId, {
+      claimId: secondDelivery,
+      now: LATER,
+      leaseUntil: new Date(LATER.getTime() + 60_000),
+    });
+    await methods.claimNextAgentQueuedTurn(secondClaim);
+    await expect(
+      methods.beginAgentQueuedTurnAdmission({
+        ...secondClaim,
+        admissionId: secondDelivery,
+        startedAt: LATER,
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'started',
+      turn: {
+        admissionEffectivePredecessorCreatedAt: 10,
+        admissionLineagePredecessorId: first.turn.queuedTurnId,
+      },
+    });
+  });
+
+  it('fails closed when an admitted predecessor lacks generation evidence', async () => {
+    const incomplete = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'incomplete-predecessor', expectedPredecessorCreatedAt: 10 }),
+    );
+    const target = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({
+        clientRequestId: 'after-incomplete-predecessor',
+        expectedPredecessorCreatedAt: 10,
+      }),
+    );
+    await Turn.updateOne(
+      { _id: incomplete.turn.queuedTurnId },
+      {
+        $set: {
+          status: 'admitted',
+          terminalReceipt: {
+            outcome: 'admitted',
+            settledAt: START,
+            effectivePredecessorCreatedAt: 10,
+            lineagePredecessorId: 'root',
+          },
+        },
+        $unset: { activeSlot: 1 },
+      },
+    );
+    const deliveryKey = 'after-incomplete-delivery';
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: target.turn.queuedTurnId,
+      deliveryKey,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: target.turn.queuedTurnId,
+      deliveryKey,
+      scheduledAt: START,
+    });
+    const targetClaim = claimInput(target.turn.queuedTurnId, { claimId: deliveryKey });
+    await methods.claimNextAgentQueuedTurn(targetClaim);
+    await expect(
+      methods.beginAgentQueuedTurnAdmission({
+        ...targetClaim,
+        admissionId: deliveryKey,
+        startedAt: START,
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'order_unavailable',
+      turn: {
+        status: 'dead',
+        terminalReceipt: {
+          failure: { code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE' },
+        },
+      },
     });
   });
 
@@ -1378,12 +1658,18 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 11,
       effectivePredecessorCreatedAt: 10,
+      lineagePredecessorId: 'root',
       settledAt: START,
     });
 
     await Turn.updateOne(
       { _id: priority.turn.queuedTurnId },
-      { $unset: { 'terminalReceipt.effectivePredecessorCreatedAt': 1 } },
+      {
+        $unset: {
+          'terminalReceipt.effectivePredecessorCreatedAt': 1,
+          'terminalReceipt.lineagePredecessorId': 1,
+        },
+      },
     );
     await expect(
       methods.getEffectiveAgentQueuedTurnPredecessor({
@@ -1394,10 +1680,18 @@ describe('agent queued turn methods', () => {
         expectedPredecessorCreatedAt: 10,
         allowLegacyPredecessorInference: true,
       }),
-    ).resolves.toBe(11);
+    ).resolves.toEqual({
+      effectivePredecessorCreatedAt: 11,
+      lineagePredecessorId: priority.turn.queuedTurnId,
+    });
     await Turn.updateOne(
       { _id: priority.turn.queuedTurnId },
-      { $set: { 'terminalReceipt.effectivePredecessorCreatedAt': 10 } },
+      {
+        $set: {
+          'terminalReceipt.effectivePredecessorCreatedAt': 10,
+          'terminalReceipt.lineagePredecessorId': 'root',
+        },
+      },
     );
 
     const normalDelivery = 'admission-priority-normal';
@@ -1431,6 +1725,7 @@ describe('agent queued turn methods', () => {
       admissionMode: 'ordinary',
       generationCreatedAt: 12,
       effectivePredecessorCreatedAt: 11,
+      lineagePredecessorId: priority.turn.queuedTurnId,
       settledAt: LATER,
     });
     await Turn.updateOne(
@@ -1451,7 +1746,12 @@ describe('agent queued turn methods', () => {
 
     await Turn.updateMany(
       { _id: { $in: [priority.turn.queuedTurnId, normal.turn.queuedTurnId] } },
-      { $unset: { 'terminalReceipt.effectivePredecessorCreatedAt': 1 } },
+      {
+        $unset: {
+          'terminalReceipt.effectivePredecessorCreatedAt': 1,
+          'terminalReceipt.lineagePredecessorId': 1,
+        },
+      },
     );
     const ambiguous = await methods.enqueueAgentQueuedTurn(
       enqueueInput({ clientRequestId: 'priority-ambiguous', expectedPredecessorCreatedAt: 10 }),
@@ -1598,6 +1898,7 @@ describe('agent queued turn methods', () => {
             settledAt: LATER,
             generationCreatedAt: 11,
             effectivePredecessorCreatedAt: 10,
+            lineagePredecessorId: target.turn.queuedTurnId,
           },
         },
         $unset: { activeSlot: 1 },
@@ -1917,6 +2218,7 @@ describe('agent queued turn methods', () => {
       admissionId: 'delivery-admission-during-delete',
       admissionMode: 'ordinary',
       generationCreatedAt: 42,
+      lineagePredecessorId: 'root',
       settledAt: LATER,
     });
     await expect(

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'node:crypto';
 import mongoose from 'mongoose';
+import { createHash } from 'node:crypto';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import type { Model } from 'mongoose';
 import type {

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -1080,6 +1080,38 @@ describe('agent queued turn methods', () => {
         targets: [{ conversationId: 'conversation-1', tenantId: 'tenant-1' }],
       }),
     ).rejects.toThrow('admission must settle');
+
+    /** A legacy worker changes its owner shell to `dead` when quarantine
+     * begins. It may then claim a successor, but the common started-admission
+     * index must prevent that successor from crossing the provider boundary. */
+    await Turn.updateOne(
+      { _id: queued.turn.queuedTurnId },
+      { $set: { status: 'dead' }, $unset: { admissionSlot: 1 } },
+    );
+    await expect(
+      Turn.updateOne(
+        { _id: priority.turn.queuedTurnId },
+        {
+          $set: {
+            status: 'claimed',
+            claimId: 'legacy-priority-claim',
+            claimBy: 'legacy-worker',
+            claimUntil: new Date(LATER.getTime() + 60_000),
+          },
+        },
+      ),
+    ).resolves.toMatchObject({ modifiedCount: 1 });
+    await expect(
+      Turn.updateOne(
+        { _id: priority.turn.queuedTurnId },
+        {
+          $set: {
+            admissionId: 'legacy-priority-claim',
+            admissionStartedAt: new Date(LATER.getTime() + 1),
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 11000 });
   });
 
   it('reconciles a root admission through explicit lineage without a timestamp boundary', async () => {
@@ -1279,7 +1311,6 @@ describe('agent queued turn methods', () => {
       ...claimInput(first.turn.queuedTurnId, { claimId: deliveryKey }),
       admissionId: deliveryKey,
       startedAt: START,
-      admissionProtocolVersion: 2,
     });
     await methods.deadLetterAgentQueuedTurn({
       user,
@@ -1330,6 +1361,85 @@ describe('agent queued turn methods', () => {
     await expect(
       methods.claimNextAgentQueuedTurn(
         claimInput(successor.turn.queuedTurnId, { claimId: 'successor-delivery' }),
+      ),
+    ).resolves.toMatchObject({ outcome: 'acquired' });
+  });
+
+  it('keeps protocol-v2 job evidence indeterminate until the exact source receipt arrives', async () => {
+    const first = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'source-fenced-evidence' }),
+    );
+    const successor = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({ clientRequestId: 'source-fenced-successor' }),
+    );
+    const deliveryKey = 'source-fenced-delivery';
+    const claim = claimInput(first.turn.queuedTurnId, { claimId: deliveryKey });
+    await methods.reserveAgentQueuedTurnDelivery({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: first.turn.queuedTurnId,
+      deliveryKey,
+    });
+    await methods.markQueuedTurnScheduled({
+      user,
+      tenantId: 'tenant-1',
+      conversationId: 'conversation-1',
+      queuedTurnId: first.turn.queuedTurnId,
+      deliveryKey,
+      scheduledAt: START,
+    });
+    await methods.claimNextAgentQueuedTurn(claim);
+    await methods.beginAgentQueuedTurnAdmission({
+      ...claim,
+      admissionId: deliveryKey,
+      startedAt: START,
+      admissionProtocolVersion: 2,
+    });
+
+    await expect(
+      methods.deadLetterAgentQueuedTurn({
+        user,
+        tenantId: 'tenant-1',
+        conversationId: 'conversation-1',
+        queuedTurnId: first.turn.queuedTurnId,
+        deliveryKey,
+        settledAt: LATER,
+        failure: { code: 'ATTEMPTS_EXHAUSTED', message: 'source receipt unavailable' },
+        admissionEvidence: {
+          generationId: 'transient-job-generation',
+          generationCreatedAt: 43,
+        },
+      }),
+    ).resolves.toMatchObject({
+      outcome: 'admission_indeterminate',
+      turn: {
+        status: 'claimed',
+        admissionProtocolVersion: 2,
+        admissionSlot: true,
+        terminalReceipt: { failure: { code: 'ADMISSION_INDETERMINATE' } },
+      },
+    });
+    await expect(
+      methods.claimNextAgentQueuedTurn(
+        claimInput(successor.turn.queuedTurnId, { claimId: 'source-fenced-successor' }),
+      ),
+    ).resolves.toMatchObject({ outcome: 'blocked' });
+
+    await expect(
+      methods.markAgentQueuedTurnAdmitted({
+        ...claim,
+        admissionId: deliveryKey,
+        admissionMode: 'ordinary',
+        generationId: 'exact-source-generation',
+        generationCreatedAt: 44,
+        lineagePredecessorId: rootLineageId(),
+        settledAt: new Date(LATER.getTime() + 1),
+      }),
+    ).resolves.toMatchObject({ outcome: 'admitted', turn: { status: 'admitted' } });
+    await expect(
+      methods.claimNextAgentQueuedTurn(
+        claimInput(successor.turn.queuedTurnId, { claimId: 'source-fenced-successor' }),
       ),
     ).resolves.toMatchObject({ outcome: 'acquired' });
   });

--- a/packages/data-schemas/src/methods/queuedTurn.spec.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.spec.ts
@@ -517,6 +517,19 @@ describe('agent queued turn methods', () => {
     const second = await methods.enqueueAgentQueuedTurn(
       enqueueInput({ clientRequestId: 'duplicate-admission-second' }),
     );
+    const third = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({
+        conversationId: 'conversation-2',
+        clientRequestId: 'duplicate-claim-first',
+      }),
+    );
+    const fourth = await methods.enqueueAgentQueuedTurn(
+      enqueueInput({
+        conversationId: 'conversation-2',
+        clientRequestId: 'duplicate-claim-second',
+      }),
+    );
+    await Turn.collection.dropIndex('agent_queued_turn_claim_lane');
     await Turn.collection.dropIndex('agent_queued_turn_admission_started_lane');
     for (const [turn, deliveryKey, status] of [
       [first, 'legacy-duplicate-first', 'dead'],
@@ -545,16 +558,58 @@ describe('agent queued turn methods', () => {
         },
       );
     }
+    for (const [turn, deliveryKey] of [
+      [third, 'legacy-claim-first'],
+      [fourth, 'legacy-claim-second'],
+    ] as const) {
+      await Turn.updateOne(
+        { _id: turn.turn.queuedTurnId },
+        {
+          $set: {
+            status: 'claimed',
+            deliveryKey,
+            deliveryState: 'published',
+            claimId: deliveryKey,
+            claimBy: 'legacy-worker',
+            claimUntil: LATER,
+          },
+        },
+      );
+    }
 
     await expect(methods.ensureAgentQueuedTurnIndexes()).resolves.toBeUndefined();
     await expect(
       Sequence.findOne({ user, tenantId: 'tenant-1', conversationId: 'conversation-1' }).lean(),
     ).resolves.toMatchObject({ retiredAt: expect.any(Date) });
     await expect(
-      Turn.find({ _id: { $in: [first.turn.queuedTurnId, second.turn.queuedTurnId] } })
+      Sequence.findOne({ user, tenantId: 'tenant-1', conversationId: 'conversation-2' }).lean(),
+    ).resolves.toMatchObject({ retiredAt: expect.any(Date) });
+    await expect(
+      Turn.find({
+        _id: {
+          $in: [
+            first.turn.queuedTurnId,
+            second.turn.queuedTurnId,
+            third.turn.queuedTurnId,
+            fourth.turn.queuedTurnId,
+          ],
+        },
+      })
         .sort({ sequence: 1 })
         .lean(),
     ).resolves.toMatchObject([
+      {
+        status: 'dead',
+        terminalReceipt: {
+          failure: { code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE' },
+        },
+      },
+      {
+        status: 'dead',
+        terminalReceipt: {
+          failure: { code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE' },
+        },
+      },
       {
         status: 'dead',
         terminalReceipt: {
@@ -574,6 +629,15 @@ describe('agent queued turn methods', () => {
         enqueueInput({ clientRequestId: 'duplicate-admission-follow-up' }),
       ),
     ).rejects.toBeInstanceOf(AgentQueuedTurnLaneRetiredError);
+    await expect(
+      methods.enqueueAgentQueuedTurn(
+        enqueueInput({
+          conversationId: 'conversation-2',
+          clientRequestId: 'duplicate-claim-follow-up',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(AgentQueuedTurnLaneRetiredError);
+    await expect(Turn.collection.indexExists('agent_queued_turn_claim_lane')).resolves.toBe(true);
     await expect(
       Turn.collection.indexExists('agent_queued_turn_admission_started_lane'),
     ).resolves.toBe(true);

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -266,6 +266,7 @@ export interface AgentQueuedTurnMethods {
     input: AgentQueuedTurnConversationScope & {
       sequence: number;
       expectedPredecessorCreatedAt?: number;
+      admittedBefore?: Date;
     },
   ) => Promise<number | undefined>;
   drainAgentQueuedTurns: (
@@ -1025,6 +1026,7 @@ export function createAgentQueuedTurnMethods(
         conversationId: turn.conversationId,
         sequence: turn.sequence,
         expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
+        admittedBefore: turn.terminalReceipt.settledAt,
       })) ?? rootPredecessorCreatedAt;
     await Turn().updateOne(
       {
@@ -2074,6 +2076,7 @@ export function createAgentQueuedTurnMethods(
     input: AgentQueuedTurnConversationScope & {
       sequence: number;
       expectedPredecessorCreatedAt?: number;
+      admittedBefore?: Date;
     },
   ): Promise<number | undefined> {
     if (!Number.isSafeInteger(input.sequence) || input.sequence <= 0) {
@@ -2083,19 +2086,53 @@ export function createAgentQueuedTurnMethods(
     if (rootEpoch == null) {
       return undefined;
     }
-    const predecessor = await Turn()
-      .findOne({
+    if (input.admittedBefore != null && !Number.isFinite(input.admittedBefore.getTime())) {
+      throw new TypeError('Agent queued turn admission cutoff is invalid');
+    }
+    const predecessors = await Turn()
+      .find({
         ...conversationScope(input),
-        sequence: { $lt: input.sequence },
+        sequence: { $ne: input.sequence },
         expectedPredecessorCreatedAt: rootEpoch,
         status: 'admitted',
         'terminalReceipt.outcome': 'admitted',
         'terminalReceipt.generationCreatedAt': { $exists: true },
+        ...(input.admittedBefore != null && {
+          'terminalReceipt.settledAt': { $lte: input.admittedBefore },
+        }),
       })
-      .sort({ sequence: -1 })
-      .select('terminalReceipt.generationCreatedAt')
-      .lean<IAgentQueuedTurn>();
-    return predecessor?.terminalReceipt?.generationCreatedAt;
+      .sort({ 'terminalReceipt.settledAt': 1, sequence: 1 })
+      .select({ sequence: 1, terminalReceipt: 1 })
+      .lean<IAgentQueuedTurn[]>();
+    let effectivePredecessorCreatedAt = rootEpoch;
+    let advanced = false;
+    const remaining = [...predecessors];
+    while (remaining.length > 0) {
+      /** Exact v2 lineage is authoritative and is independent of enqueue
+       * sequence (priority may overtake FIFO). Settled order is used only to
+       * bridge legacy admitted receipts that predate the stored edge. */
+      let nextIndex = remaining.findIndex(
+        (turn) =>
+          normalizePredecessor(turn.terminalReceipt?.effectivePredecessorCreatedAt) ===
+          effectivePredecessorCreatedAt,
+      );
+      if (nextIndex < 0) {
+        nextIndex = remaining.findIndex(
+          (turn) => turn.terminalReceipt?.effectivePredecessorCreatedAt == null,
+        );
+      }
+      if (nextIndex < 0) {
+        break;
+      }
+      const [next] = remaining.splice(nextIndex, 1);
+      const generationCreatedAt = normalizePredecessor(next.terminalReceipt?.generationCreatedAt);
+      if (generationCreatedAt == null) {
+        continue;
+      }
+      effectivePredecessorCreatedAt = generationCreatedAt;
+      advanced = true;
+    }
+    return advanced ? effectivePredecessorCreatedAt : undefined;
   }
 
   async function drainAgentQueuedTurns(

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -2166,6 +2166,7 @@ export function createAgentQueuedTurnMethods(
           expectedPredecessorCreatedAt: 1,
           admissionEffectivePredecessorCreatedAt: 1,
           admissionLineagePredecessorId: 1,
+          admissionProtocolVersion: 1,
         })
         .lean<IAgentQueuedTurn>();
       let effectivePredecessorCreatedAt = normalizePredecessor(
@@ -2204,8 +2205,10 @@ export function createAgentQueuedTurnMethods(
           lineagePredecessorId = resolvedPredecessor.lineagePredecessorId;
         }
       }
+      /** GenerationJob evidence predates the source-receipt protocol. For v2,
+       * only the exact late source callback may prove provider admission. */
       const reconciled =
-        lineagePredecessorId == null
+        admission?.admissionProtocolVersion === 2 || lineagePredecessorId == null
           ? null
           : await Turn()
               .findOneAndUpdate(

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -228,6 +228,7 @@ export interface AgentQueuedTurnMethods {
     input: AgentQueuedTurnClaimFence & {
       admissionId: string;
       startedAt: Date;
+      effectivePredecessorCreatedAt?: number;
       admissionProtocolVersion?: 2;
     },
   ) => Promise<BeginAgentQueuedTurnAdmissionResult>;
@@ -557,6 +558,9 @@ function toRecord(turn: IAgentQueuedTurn): AgentQueuedTurnRecord {
     ...(turn.claimUntil != null && { claimUntil: turn.claimUntil }),
     ...(turn.admissionId != null && { admissionId: turn.admissionId }),
     ...(turn.admissionStartedAt != null && { admissionStartedAt: turn.admissionStartedAt }),
+    ...(turn.admissionEffectivePredecessorCreatedAt != null && {
+      admissionEffectivePredecessorCreatedAt: turn.admissionEffectivePredecessorCreatedAt,
+    }),
     ...(turn.admissionProtocolVersion != null && {
       admissionProtocolVersion: turn.admissionProtocolVersion,
     }),
@@ -1568,10 +1572,12 @@ export function createAgentQueuedTurnMethods(
     input: AgentQueuedTurnClaimFence & {
       admissionId: string;
       startedAt: Date;
+      effectivePredecessorCreatedAt?: number;
       admissionProtocolVersion?: 2;
     },
   ): Promise<BeginAgentQueuedTurnAdmissionResult> {
     const admissionId = requireBoundedString(input.admissionId, 128);
+    const effectivePredecessorCreatedAt = normalizePredecessor(input.effectivePredecessorCreatedAt);
     if (!Number.isFinite(input.startedAt.getTime())) {
       throw new TypeError('Agent queued turn admission start is invalid');
     }
@@ -1646,6 +1652,9 @@ export function createAgentQueuedTurnMethods(
               $set: {
                 admissionId,
                 admissionStartedAt: input.startedAt,
+                ...(effectivePredecessorCreatedAt != null && {
+                  admissionEffectivePredecessorCreatedAt: effectivePredecessorCreatedAt,
+                }),
                 ...(input.admissionProtocolVersion != null && {
                   admissionProtocolVersion: input.admissionProtocolVersion,
                 }),
@@ -1680,7 +1689,8 @@ export function createAgentQueuedTurnMethods(
           current.deliveryState === 'published' &&
           current.laneId === writer.laneId &&
           current.admissionId === admissionId &&
-          current.admissionStartedAt != null
+          current.admissionStartedAt != null &&
+          current.admissionEffectivePredecessorCreatedAt === effectivePredecessorCreatedAt
         ) {
           return { outcome: 'already_started', turn: toRecord(current) };
         }
@@ -1717,6 +1727,9 @@ export function createAgentQueuedTurnMethods(
           deliveryState: 'published',
           admissionId,
           admissionStartedAt: { $exists: true },
+          ...(effectivePredecessorCreatedAt != null
+            ? { admissionEffectivePredecessorCreatedAt: effectivePredecessorCreatedAt }
+            : { admissionEffectivePredecessorCreatedAt: { $exists: false } }),
           $or: [
             {
               status: 'claimed',
@@ -1750,6 +1763,7 @@ export function createAgentQueuedTurnMethods(
             claimUntil: 1,
             admissionId: 1,
             admissionStartedAt: 1,
+            admissionEffectivePredecessorCreatedAt: 1,
             admissionProtocolVersion: 1,
             reconciliationAvailableAt: 1,
             reconciliationClaimId: 1,
@@ -1828,6 +1842,19 @@ export function createAgentQueuedTurnMethods(
       if (generationCreatedAt == null) {
         throw new TypeError('Agent queued turn admission evidence is invalid');
       }
+      const admission = await Turn()
+        .findOne({
+          ...scope,
+          _id: input.queuedTurnId,
+          deliveryKey,
+          admissionId: deliveryKey,
+          admissionStartedAt: { $exists: true },
+        })
+        .select({ admissionEffectivePredecessorCreatedAt: 1 })
+        .lean<IAgentQueuedTurn>();
+      const effectivePredecessorCreatedAt = normalizePredecessor(
+        admission?.admissionEffectivePredecessorCreatedAt,
+      );
       const reconciled = await Turn()
         .findOneAndUpdate(
           {
@@ -1861,6 +1888,9 @@ export function createAgentQueuedTurnMethods(
                 admissionMode: 'ordinary',
                 ...(generationId != null && { generationId }),
                 generationCreatedAt,
+                ...(effectivePredecessorCreatedAt != null && {
+                  effectivePredecessorCreatedAt,
+                }),
               },
             },
             $unset: {
@@ -1870,6 +1900,7 @@ export function createAgentQueuedTurnMethods(
               claimUntil: 1,
               admissionId: 1,
               admissionStartedAt: 1,
+              admissionEffectivePredecessorCreatedAt: 1,
               admissionProtocolVersion: 1,
               reconciliationAvailableAt: 1,
               reconciliationClaimId: 1,

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -141,7 +141,10 @@ export type ClaimAgentQueuedTurnResult =
   | { outcome: 'missing'; claim: null };
 
 export type BeginAgentQueuedTurnAdmissionResult =
-  | { outcome: 'started' | 'already_started' | 'retired'; turn: AgentQueuedTurnRecord }
+  | {
+      outcome: 'started' | 'already_started' | 'retired' | 'order_unavailable';
+      turn: AgentQueuedTurnRecord;
+    }
   | { outcome: 'conflict'; turn: AgentQueuedTurnRecord | null };
 
 export interface AgentQueuedTurnAdmissionEvidence {
@@ -228,7 +231,6 @@ export interface AgentQueuedTurnMethods {
     input: AgentQueuedTurnClaimFence & {
       admissionId: string;
       startedAt: Date;
-      effectivePredecessorCreatedAt?: number;
       admissionProtocolVersion?: 2;
     },
   ) => Promise<BeginAgentQueuedTurnAdmissionResult>;
@@ -267,6 +269,7 @@ export interface AgentQueuedTurnMethods {
       sequence: number;
       expectedPredecessorCreatedAt?: number;
       allowLegacyPredecessorInference?: boolean;
+      targetGenerationCreatedAt?: number;
     },
   ) => Promise<number | null | undefined>;
   drainAgentQueuedTurns: (
@@ -1025,6 +1028,9 @@ export function createAgentQueuedTurnMethods(
       conversationId: turn.conversationId,
       sequence: turn.sequence,
       expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
+      ...(turn.terminalReceipt.generationCreatedAt != null && {
+        targetGenerationCreatedAt: turn.terminalReceipt.generationCreatedAt,
+      }),
     });
     if (resolvedPredecessorCreatedAt === null) {
       return turn;
@@ -1457,96 +1463,130 @@ export function createAgentQueuedTurnMethods(
       throw new TypeError('Agent queued turn lease must end after claim time');
     }
     const scope = conversationScope(input);
-    const replay = await Turn()
-      .findOne({
-        ...scope,
-        _id: input.queuedTurnId,
-        status: 'claimed',
-        claimId,
-        claimBy,
-        claimUntil: { $gt: input.now },
-      })
-      .lean<IAgentQueuedTurn>();
-    const replayedClaim = requireClaim(replay);
-    if (replayedClaim != null) {
-      return { outcome: 'replayed', claim: replayedClaim };
-    }
-
-    const expected = await Turn()
-      .findOne({ ...scope, _id: input.queuedTurnId })
-      .lean<IAgentQueuedTurn>();
-    if (expected == null || (expected.status !== 'queued' && expected.status !== 'claimed')) {
-      return { outcome: 'missing', claim: null };
-    }
-
-    const unfinishedReservation = await Turn().exists({ ...scope, status: 'reserving' });
-    if (unfinishedReservation != null) {
-      return { outcome: 'blocked', claim: null };
-    }
-
-    const head = await Turn()
-      .findOne({ ...scope, status: { $in: ['queued', 'claimed', 'dead'] } })
-      .sort({ priority: -1, sequence: 1 })
-      .lean<IAgentQueuedTurn>();
-    if (head == null) {
-      return { outcome: 'blocked', claim: null };
-    }
-    if (
-      head._id?.toString() !== input.queuedTurnId ||
-      head.availableAt.getTime() > input.now.getTime() ||
-      (head.status === 'claimed' &&
-        head.claimUntil != null &&
-        head.claimUntil.getTime() > input.now.getTime())
-    ) {
-      return { outcome: 'blocked', claim: null };
-    }
-
-    const turn = await Turn()
-      .findOneAndUpdate(
-        {
-          ...scope,
-          _id: input.queuedTurnId,
-          availableAt: { $lte: input.now },
-          $or: [
-            { status: 'queued' },
-            {
-              status: 'claimed',
-              claimUntil: { $lte: input.now },
-              admissionStartedAt: { $exists: false },
-            },
-          ],
-        },
-        {
-          $set: {
+    return serializeLocalLane(input, async () => {
+      let writer: AgentQueuedTurnLaneWriter;
+      try {
+        writer = await acquireLaneWriter(input, false);
+      } catch (error) {
+        if (
+          error instanceof AgentQueuedTurnLaneRetiredError ||
+          error instanceof AgentQueuedTurnLaneMissingError
+        ) {
+          return { outcome: 'missing', claim: null };
+        }
+        throw error;
+      }
+      try {
+        const laneScope = { ...scope, laneId: writer.laneId };
+        const serializedReplay = await Turn()
+          .findOne({
+            ...laneScope,
+            _id: input.queuedTurnId,
             status: 'claimed',
             claimId,
             claimBy,
-            claimUntil: input.leaseUntil,
-          },
-          $inc: { attempts: 1 },
-          $unset: { terminalReceipt: 1 },
-        },
-        { new: true, sort: { priority: -1, sequence: 1 } },
-      )
-      .lean<IAgentQueuedTurn>();
-    const acquired = requireClaim(turn);
-    if (acquired != null) {
-      return { outcome: 'acquired', claim: acquired };
-    }
-    const racedReplay = await Turn()
-      .findOne({
-        ...scope,
-        _id: input.queuedTurnId,
-        status: 'claimed',
-        claimId,
-        claimBy,
-        claimUntil: { $gt: input.now },
-      })
-      .lean<IAgentQueuedTurn>();
-    const racedClaim = requireClaim(racedReplay);
-    return racedClaim == null
-      ? { outcome: 'blocked', claim: null }
-      : { outcome: 'replayed', claim: racedClaim };
+            claimUntil: { $gt: input.now },
+          })
+          .lean<IAgentQueuedTurn>();
+        const serializedClaim = requireClaim(serializedReplay);
+        if (serializedClaim != null) {
+          return { outcome: 'replayed', claim: serializedClaim };
+        }
+
+        const expected = await Turn()
+          .findOne({ ...laneScope, _id: input.queuedTurnId })
+          .lean<IAgentQueuedTurn>();
+        if (expected == null || (expected.status !== 'queued' && expected.status !== 'claimed')) {
+          return { outcome: 'missing', claim: null };
+        }
+
+        const unfinishedReservation = await Turn().exists({
+          ...laneScope,
+          status: 'reserving',
+        });
+        if (unfinishedReservation != null) {
+          return { outcome: 'blocked', claim: null };
+        }
+
+        const competingClaim = await Turn().exists({
+          ...laneScope,
+          _id: { $ne: input.queuedTurnId },
+          status: 'claimed',
+        });
+        if (competingClaim != null) {
+          return { outcome: 'blocked', claim: null };
+        }
+
+        const head =
+          expected.status === 'claimed'
+            ? expected
+            : await Turn()
+                .findOne({ ...laneScope, status: { $in: ['queued', 'dead'] } })
+                .sort({ priority: -1, sequence: 1 })
+                .lean<IAgentQueuedTurn>();
+        if (head == null) {
+          return { outcome: 'blocked', claim: null };
+        }
+        if (
+          head._id?.toString() !== input.queuedTurnId ||
+          head.availableAt.getTime() > input.now.getTime() ||
+          (head.status === 'claimed' &&
+            head.claimUntil != null &&
+            head.claimUntil.getTime() > input.now.getTime())
+        ) {
+          return { outcome: 'blocked', claim: null };
+        }
+
+        const turn = await Turn()
+          .findOneAndUpdate(
+            {
+              ...laneScope,
+              _id: input.queuedTurnId,
+              availableAt: { $lte: input.now },
+              $or: [
+                { status: 'queued' },
+                {
+                  status: 'claimed',
+                  claimUntil: { $lte: input.now },
+                  admissionStartedAt: { $exists: false },
+                },
+              ],
+            },
+            {
+              $set: {
+                status: 'claimed',
+                claimId,
+                claimBy,
+                claimUntil: input.leaseUntil,
+              },
+              $inc: { attempts: 1 },
+              $unset: { terminalReceipt: 1 },
+            },
+            { new: true, sort: { priority: -1, sequence: 1 } },
+          )
+          .lean<IAgentQueuedTurn>();
+        const acquired = requireClaim(turn);
+        if (acquired != null) {
+          return { outcome: 'acquired', claim: acquired };
+        }
+        const racedReplay = await Turn()
+          .findOne({
+            ...laneScope,
+            _id: input.queuedTurnId,
+            status: 'claimed',
+            claimId,
+            claimBy,
+            claimUntil: { $gt: input.now },
+          })
+          .lean<IAgentQueuedTurn>();
+        const racedClaim = requireClaim(racedReplay);
+        return racedClaim == null
+          ? { outcome: 'blocked', claim: null }
+          : { outcome: 'replayed', claim: racedClaim };
+      } finally {
+        await releaseLaneWriter(input, writer.writerId);
+      }
+    });
   }
 
   async function releaseAgentQueuedTurn(
@@ -1623,12 +1663,10 @@ export function createAgentQueuedTurnMethods(
     input: AgentQueuedTurnClaimFence & {
       admissionId: string;
       startedAt: Date;
-      effectivePredecessorCreatedAt?: number;
       admissionProtocolVersion?: 2;
     },
   ): Promise<BeginAgentQueuedTurnAdmissionResult> {
     const admissionId = requireBoundedString(input.admissionId, 128);
-    const effectivePredecessorCreatedAt = normalizePredecessor(input.effectivePredecessorCreatedAt);
     if (!Number.isFinite(input.startedAt.getTime())) {
       throw new TypeError('Agent queued turn admission start is invalid');
     }
@@ -1686,6 +1724,105 @@ export function createAgentQueuedTurnMethods(
         throw error;
       }
       try {
+        const current = await Turn()
+          .findOne({ ...conversationScope(input), _id: input.queuedTurnId })
+          .lean<IAgentQueuedTurn>();
+        if (
+          current?.status === 'claimed' &&
+          current.claimId === input.claimId &&
+          current.claimBy === input.claimBy &&
+          current.deliveryKey === admissionId &&
+          current.deliveryState === 'published' &&
+          current.laneId === writer.laneId &&
+          current.admissionId === admissionId &&
+          current.admissionStartedAt != null
+        ) {
+          return { outcome: 'already_started', turn: toRecord(current) };
+        }
+        if (
+          current?.status === 'claimed' &&
+          current.claimId === input.claimId &&
+          current.claimBy === input.claimBy &&
+          current.admissionStartedAt == null &&
+          current.laneId !== writer.laneId
+        ) {
+          const retired = await retireObsoleteClaim();
+          if (retired != null) {
+            return { outcome: 'retired', turn: retired };
+          }
+        }
+        if (
+          current?.status !== 'claimed' ||
+          current.claimId !== input.claimId ||
+          current.claimBy !== input.claimBy ||
+          current.deliveryKey !== admissionId ||
+          current.deliveryState !== 'published' ||
+          current.laneId !== writer.laneId ||
+          current.admissionId != null ||
+          current.sequence == null
+        ) {
+          return {
+            outcome: 'conflict',
+            turn: current == null ? null : toRecord(current),
+          };
+        }
+
+        const rootPredecessorCreatedAt = normalizePredecessor(current.expectedPredecessorCreatedAt);
+        const resolvedPredecessorCreatedAt = await getEffectiveAgentQueuedTurnPredecessor({
+          user: current.user,
+          ...(current.tenantId != null && { tenantId: current.tenantId }),
+          conversationId: current.conversationId,
+          sequence: current.sequence,
+          ...(rootPredecessorCreatedAt != null && {
+            expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
+          }),
+          allowLegacyPredecessorInference: true,
+        });
+        if (resolvedPredecessorCreatedAt === null) {
+          const dead = await Turn()
+            .findOneAndUpdate(
+              {
+                ...conversationScope(input),
+                _id: input.queuedTurnId,
+                status: 'claimed',
+                claimId: requireBoundedString(input.claimId, 128),
+                claimBy: requireBoundedString(input.claimBy, 256),
+                deliveryKey: admissionId,
+                deliveryState: 'published',
+                laneId: writer.laneId,
+                admissionId: { $exists: false },
+              },
+              {
+                $set: {
+                  status: 'dead',
+                  terminalReceipt: {
+                    outcome: 'dead',
+                    settledAt: input.startedAt,
+                    failure: {
+                      code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE',
+                      message:
+                        'The queued turn admission order could not be reconstructed safely. Review this turn before sending it.',
+                    },
+                  },
+                },
+                $unset: { activeSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+              },
+              { new: true },
+            )
+            .lean<IAgentQueuedTurn>();
+          if (dead != null) {
+            return { outcome: 'order_unavailable', turn: toRecord(dead) };
+          }
+          const conflicted = await Turn()
+            .findOne({ ...conversationScope(input), _id: input.queuedTurnId })
+            .lean<IAgentQueuedTurn>();
+          return {
+            outcome: 'conflict',
+            turn: conflicted == null ? null : toRecord(conflicted),
+          };
+        }
+        const effectivePredecessorCreatedAt =
+          resolvedPredecessorCreatedAt ?? rootPredecessorCreatedAt;
         const turn = await Turn()
           .findOneAndUpdate(
             {
@@ -1717,37 +1854,25 @@ export function createAgentQueuedTurnMethods(
         if (turn != null) {
           return { outcome: 'started', turn: toRecord(turn) };
         }
-        const current = await Turn()
+        const raced = await Turn()
           .findOne({ ...conversationScope(input), _id: input.queuedTurnId })
           .lean<IAgentQueuedTurn>();
         if (
-          current?.status === 'claimed' &&
-          current.claimId === input.claimId &&
-          current.claimBy === input.claimBy &&
-          current.admissionStartedAt == null &&
-          current.laneId !== writer.laneId
+          raced?.status === 'claimed' &&
+          raced.claimId === input.claimId &&
+          raced.claimBy === input.claimBy &&
+          raced.deliveryKey === admissionId &&
+          raced.deliveryState === 'published' &&
+          raced.laneId === writer.laneId &&
+          raced.admissionId === admissionId &&
+          raced.admissionStartedAt != null &&
+          raced.admissionEffectivePredecessorCreatedAt === effectivePredecessorCreatedAt
         ) {
-          const retired = await retireObsoleteClaim();
-          if (retired != null) {
-            return { outcome: 'retired', turn: retired };
-          }
-        }
-        if (
-          current?.status === 'claimed' &&
-          current.claimId === input.claimId &&
-          current.claimBy === input.claimBy &&
-          current.deliveryKey === admissionId &&
-          current.deliveryState === 'published' &&
-          current.laneId === writer.laneId &&
-          current.admissionId === admissionId &&
-          current.admissionStartedAt != null &&
-          current.admissionEffectivePredecessorCreatedAt === effectivePredecessorCreatedAt
-        ) {
-          return { outcome: 'already_started', turn: toRecord(current) };
+          return { outcome: 'already_started', turn: toRecord(raced) };
         }
         return {
           outcome: 'conflict',
-          turn: current == null ? null : toRecord(current),
+          turn: raced == null ? null : toRecord(raced),
         };
       } finally {
         await releaseLaneWriter(input, writer.writerId);
@@ -1923,6 +2048,7 @@ export function createAgentQueuedTurnMethods(
             expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
           }),
           allowLegacyPredecessorInference: true,
+          targetGenerationCreatedAt: generationCreatedAt,
         });
         effectivePredecessorCreatedAt =
           resolvedPredecessorCreatedAt === null
@@ -2083,12 +2209,14 @@ export function createAgentQueuedTurnMethods(
       sequence: number;
       expectedPredecessorCreatedAt?: number;
       allowLegacyPredecessorInference?: boolean;
+      targetGenerationCreatedAt?: number;
     },
   ): Promise<number | null | undefined> {
     if (!Number.isSafeInteger(input.sequence) || input.sequence <= 0) {
       throw new TypeError('Agent queued turn sequence must be a positive integer');
     }
     const rootEpoch = normalizePredecessor(input.expectedPredecessorCreatedAt);
+    const targetGenerationCreatedAt = normalizePredecessor(input.targetGenerationCreatedAt);
     if (rootEpoch == null) {
       return undefined;
     }
@@ -2137,6 +2265,9 @@ export function createAgentQueuedTurnMethods(
     const visited = new Set<number>();
     const advanceExactEdges = () => {
       while (edges.has(effectivePredecessorCreatedAt)) {
+        if (effectivePredecessorCreatedAt === targetGenerationCreatedAt) {
+          return false;
+        }
         if (visited.has(effectivePredecessorCreatedAt)) {
           return false;
         }
@@ -2150,7 +2281,15 @@ export function createAgentQueuedTurnMethods(
       return null;
     }
     if (legacyOutputs.length === 1) {
-      effectivePredecessorCreatedAt = legacyOutputs[0];
+      const legacyOutput = legacyOutputs[0];
+      if (
+        legacyOutput === effectivePredecessorCreatedAt ||
+        visited.has(legacyOutput) ||
+        legacyOutput === targetGenerationCreatedAt
+      ) {
+        return null;
+      }
+      effectivePredecessorCreatedAt = legacyOutput;
       traversed += 1;
       if (!advanceExactEdges()) {
         return null;

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -237,6 +237,7 @@ export interface AgentQueuedTurnMethods {
       admissionMode: 'warm' | 'ordinary';
       generationId?: string;
       generationCreatedAt?: number;
+      effectivePredecessorCreatedAt?: number;
       settledAt: Date;
     },
   ) => Promise<AdmitAgentQueuedTurnResult>;
@@ -246,6 +247,7 @@ export interface AgentQueuedTurnMethods {
       admissionId: string;
       generationId: string;
       generationCreatedAt: number;
+      effectivePredecessorCreatedAt?: number;
     },
   ) => Promise<boolean>;
   deadLetterAgentQueuedTurn: (
@@ -1698,12 +1700,14 @@ export function createAgentQueuedTurnMethods(
       admissionMode: 'warm' | 'ordinary';
       generationId?: string;
       generationCreatedAt?: number;
+      effectivePredecessorCreatedAt?: number;
       settledAt: Date;
     },
   ): Promise<AdmitAgentQueuedTurnResult> {
     const admissionId = requireBoundedString(input.admissionId, 128);
     const generationId = normalizeOptionalString(input.generationId, 256);
     const generationCreatedAt = normalizePredecessor(input.generationCreatedAt);
+    const effectivePredecessorCreatedAt = normalizePredecessor(input.effectivePredecessorCreatedAt);
     const turn = await Turn()
       .findOneAndUpdate(
         {
@@ -1736,6 +1740,7 @@ export function createAgentQueuedTurnMethods(
               admissionMode: input.admissionMode,
               ...(generationId != null && { generationId }),
               ...(generationCreatedAt != null && { generationCreatedAt }),
+              ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
             },
           },
           $unset: {
@@ -1780,9 +1785,11 @@ export function createAgentQueuedTurnMethods(
       admissionId: string;
       generationId: string;
       generationCreatedAt: number;
+      effectivePredecessorCreatedAt?: number;
     },
   ): Promise<boolean> {
     const generationCreatedAt = normalizePredecessor(input.generationCreatedAt);
+    const effectivePredecessorCreatedAt = normalizePredecessor(input.effectivePredecessorCreatedAt);
     if (generationCreatedAt == null) {
       throw new TypeError('Agent queued turn admission generation is invalid');
     }
@@ -1795,6 +1802,9 @@ export function createAgentQueuedTurnMethods(
         'terminalReceipt.admissionId': requireBoundedString(input.admissionId, 128),
         'terminalReceipt.generationId': requireBoundedString(input.generationId, 256),
         'terminalReceipt.generationCreatedAt': generationCreatedAt,
+        ...(effectivePredecessorCreatedAt != null && {
+          'terminalReceipt.effectivePredecessorCreatedAt': effectivePredecessorCreatedAt,
+        }),
       })) != null
     );
   }

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -25,7 +25,9 @@ const LANE_WRITER_RETRY_MS = 5;
 const LANE_WRITER_RETRIES = LANE_WRITER_LEASE_MS / LANE_WRITER_RETRY_MS;
 const RETIRED_LANE_RETENTION_MS = 24 * 60 * 60_000;
 const ROOT_LINEAGE_PREDECESSOR_PREFIX = 'root:';
+const CLAIM_LANE_INDEX = 'agent_queued_turn_claim_lane';
 const ADMISSION_STARTED_LANE_INDEX = 'agent_queued_turn_admission_started_lane';
+const NAMESPACE_EXISTS = 48;
 
 interface DuplicateKeyError {
   code?: number;
@@ -705,7 +707,11 @@ export function createAgentQueuedTurnMethods(
    * unique fence so upgrades remain available without guessing at ordering. */
   async function quarantineDuplicateAdmissionLanes(): Promise<number> {
     const lanes = await Turn().aggregate<DuplicateAdmissionLane>([
-      { $match: { admissionStartedAt: { $exists: true } } },
+      {
+        $match: {
+          $or: [{ status: 'claimed' }, { admissionStartedAt: { $exists: true } }],
+        },
+      },
       {
         $group: {
           _id: {
@@ -787,12 +793,15 @@ export function createAgentQueuedTurnMethods(
   }
 
   async function ensureAgentQueuedTurnIndexes(): Promise<void> {
-    const admissionFenceExists = (
-      await Turn()
-        .listIndexes()
-        .catch(() => [])
-    ).some((index) => index.name === ADMISSION_STARTED_LANE_INDEX);
-    if (!admissionFenceExists) {
+    for (const model of [Turn(), Sequence()]) {
+      await model.createCollection().catch((error: unknown) => {
+        if ((error as DuplicateKeyError).code !== NAMESPACE_EXISTS) {
+          throw error;
+        }
+      });
+    }
+    const indexNames = new Set((await Turn().listIndexes()).map((index) => index.name));
+    if (!indexNames.has(CLAIM_LANE_INDEX) || !indexNames.has(ADMISSION_STARTED_LANE_INDEX)) {
       for (let attempt = 0; ; attempt++) {
         await quarantineDuplicateAdmissionLanes();
         try {
@@ -803,7 +812,7 @@ export function createAgentQueuedTurnMethods(
           if (
             attempt >= 4 ||
             (error as DuplicateKeyError).code !== DUPLICATE_KEY ||
-            !message.includes(ADMISSION_STARTED_LANE_INDEX)
+            (!message.includes(CLAIM_LANE_INDEX) && !message.includes(ADMISSION_STARTED_LANE_INDEX))
           ) {
             throw error;
           }

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -266,9 +266,9 @@ export interface AgentQueuedTurnMethods {
     input: AgentQueuedTurnConversationScope & {
       sequence: number;
       expectedPredecessorCreatedAt?: number;
-      admittedBefore?: Date;
+      allowLegacyPredecessorInference?: boolean;
     },
-  ) => Promise<number | undefined>;
+  ) => Promise<number | null | undefined>;
   drainAgentQueuedTurns: (
     input: AgentQueuedTurnOwnerScope & {
       conversationId?: string;
@@ -1019,15 +1019,17 @@ export function createAgentQueuedTurnMethods(
     if (rootPredecessorCreatedAt == null) {
       return turn;
     }
-    const effectivePredecessorCreatedAt =
-      (await getEffectiveAgentQueuedTurnPredecessor({
-        user: turn.user,
-        ...(turn.tenantId != null && { tenantId: turn.tenantId }),
-        conversationId: turn.conversationId,
-        sequence: turn.sequence,
-        expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
-        admittedBefore: turn.terminalReceipt.settledAt,
-      })) ?? rootPredecessorCreatedAt;
+    const resolvedPredecessorCreatedAt = await getEffectiveAgentQueuedTurnPredecessor({
+      user: turn.user,
+      ...(turn.tenantId != null && { tenantId: turn.tenantId }),
+      conversationId: turn.conversationId,
+      sequence: turn.sequence,
+      expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
+    });
+    if (resolvedPredecessorCreatedAt === null) {
+      return turn;
+    }
+    const effectivePredecessorCreatedAt = resolvedPredecessorCreatedAt ?? rootPredecessorCreatedAt;
     await Turn().updateOne(
       {
         _id: turn._id,
@@ -1912,16 +1914,20 @@ export function createAgentQueuedTurnMethods(
         const rootPredecessorCreatedAt = normalizePredecessor(
           admission.expectedPredecessorCreatedAt,
         );
+        const resolvedPredecessorCreatedAt = await getEffectiveAgentQueuedTurnPredecessor({
+          user: input.user,
+          ...(input.tenantId != null && { tenantId: input.tenantId }),
+          conversationId: input.conversationId,
+          sequence: admission.sequence,
+          ...(rootPredecessorCreatedAt != null && {
+            expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
+          }),
+          allowLegacyPredecessorInference: true,
+        });
         effectivePredecessorCreatedAt =
-          (await getEffectiveAgentQueuedTurnPredecessor({
-            user: input.user,
-            ...(input.tenantId != null && { tenantId: input.tenantId }),
-            conversationId: input.conversationId,
-            sequence: admission.sequence,
-            ...(rootPredecessorCreatedAt != null && {
-              expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
-            }),
-          })) ?? rootPredecessorCreatedAt;
+          resolvedPredecessorCreatedAt === null
+            ? undefined
+            : (resolvedPredecessorCreatedAt ?? rootPredecessorCreatedAt);
       }
       const reconciled =
         effectivePredecessorCreatedAt == null
@@ -2076,18 +2082,15 @@ export function createAgentQueuedTurnMethods(
     input: AgentQueuedTurnConversationScope & {
       sequence: number;
       expectedPredecessorCreatedAt?: number;
-      admittedBefore?: Date;
+      allowLegacyPredecessorInference?: boolean;
     },
-  ): Promise<number | undefined> {
+  ): Promise<number | null | undefined> {
     if (!Number.isSafeInteger(input.sequence) || input.sequence <= 0) {
       throw new TypeError('Agent queued turn sequence must be a positive integer');
     }
     const rootEpoch = normalizePredecessor(input.expectedPredecessorCreatedAt);
     if (rootEpoch == null) {
       return undefined;
-    }
-    if (input.admittedBefore != null && !Number.isFinite(input.admittedBefore.getTime())) {
-      throw new TypeError('Agent queued turn admission cutoff is invalid');
     }
     const predecessors = await Turn()
       .find({
@@ -2097,42 +2100,66 @@ export function createAgentQueuedTurnMethods(
         status: 'admitted',
         'terminalReceipt.outcome': 'admitted',
         'terminalReceipt.generationCreatedAt': { $exists: true },
-        ...(input.admittedBefore != null && {
-          'terminalReceipt.settledAt': { $lte: input.admittedBefore },
-        }),
       })
-      .sort({ 'terminalReceipt.settledAt': 1, sequence: 1 })
       .select({ sequence: 1, terminalReceipt: 1 })
       .lean<IAgentQueuedTurn[]>();
-    let effectivePredecessorCreatedAt = rootEpoch;
-    let advanced = false;
-    const remaining = [...predecessors];
-    while (remaining.length > 0) {
-      /** Exact v2 lineage is authoritative and is independent of enqueue
-       * sequence (priority may overtake FIFO). Settled order is used only to
-       * bridge legacy admitted receipts that predate the stored edge. */
-      let nextIndex = remaining.findIndex(
-        (turn) =>
-          normalizePredecessor(turn.terminalReceipt?.effectivePredecessorCreatedAt) ===
-          effectivePredecessorCreatedAt,
-      );
-      if (nextIndex < 0) {
-        nextIndex = remaining.findIndex(
-          (turn) => turn.terminalReceipt?.effectivePredecessorCreatedAt == null,
-        );
-      }
-      if (nextIndex < 0) {
-        break;
-      }
-      const [next] = remaining.splice(nextIndex, 1);
-      const generationCreatedAt = normalizePredecessor(next.terminalReceipt?.generationCreatedAt);
+    /** Stored v2 edges define admission order without comparing clocks or
+     * enqueue sequence. A single legacy gap is inferable only while the
+     * caller still owns the lane head; every other incomplete/branched graph
+     * returns null so callers preserve explicit fail-closed evidence. */
+    const edges = new Map<number, number>();
+    const legacyOutputs: number[] = [];
+    for (const turn of predecessors) {
+      const generationCreatedAt = normalizePredecessor(turn.terminalReceipt?.generationCreatedAt);
       if (generationCreatedAt == null) {
         continue;
       }
-      effectivePredecessorCreatedAt = generationCreatedAt;
-      advanced = true;
+      const effectivePredecessorCreatedAt = normalizePredecessor(
+        turn.terminalReceipt?.effectivePredecessorCreatedAt,
+      );
+      if (effectivePredecessorCreatedAt == null) {
+        legacyOutputs.push(generationCreatedAt);
+        continue;
+      }
+      if (edges.has(effectivePredecessorCreatedAt)) {
+        return null;
+      }
+      edges.set(effectivePredecessorCreatedAt, generationCreatedAt);
     }
-    return advanced ? effectivePredecessorCreatedAt : undefined;
+    if (
+      legacyOutputs.length > 0 &&
+      (input.allowLegacyPredecessorInference !== true || legacyOutputs.length > 1)
+    ) {
+      return null;
+    }
+    let effectivePredecessorCreatedAt = rootEpoch;
+    let traversed = 0;
+    const visited = new Set<number>();
+    const advanceExactEdges = () => {
+      while (edges.has(effectivePredecessorCreatedAt)) {
+        if (visited.has(effectivePredecessorCreatedAt)) {
+          return false;
+        }
+        visited.add(effectivePredecessorCreatedAt);
+        effectivePredecessorCreatedAt = edges.get(effectivePredecessorCreatedAt) as number;
+        traversed += 1;
+      }
+      return true;
+    };
+    if (!advanceExactEdges()) {
+      return null;
+    }
+    if (legacyOutputs.length === 1) {
+      effectivePredecessorCreatedAt = legacyOutputs[0];
+      traversed += 1;
+      if (!advanceExactEdges()) {
+        return null;
+      }
+    }
+    if (traversed !== predecessors.length) {
+      return null;
+    }
+    return traversed > 0 ? effectivePredecessorCreatedAt : undefined;
   }
 
   async function drainAgentQueuedTurns(

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -25,9 +25,20 @@ const LANE_WRITER_RETRY_MS = 5;
 const LANE_WRITER_RETRIES = LANE_WRITER_LEASE_MS / LANE_WRITER_RETRY_MS;
 const RETIRED_LANE_RETENTION_MS = 24 * 60 * 60_000;
 const ROOT_LINEAGE_PREDECESSOR_PREFIX = 'root:';
+const ADMISSION_STARTED_LANE_INDEX = 'agent_queued_turn_admission_started_lane';
 
 interface DuplicateKeyError {
   code?: number;
+}
+
+interface DuplicateAdmissionLane {
+  _id: {
+    tenantId?: string | null;
+    user: Types.ObjectId;
+    conversationId: string;
+    laneId: string;
+  };
+  count: number;
 }
 
 export class AgentQueuedTurnConflictError extends Error {
@@ -688,8 +699,121 @@ export function createAgentQueuedTurnMethods(
     }
   }
 
+  /** Pre-fence replicas could start two admissions after the first owner moved
+   * to a legacy dead shell. Such a lane has no reconstructible total order.
+   * Retire it and terminalize every nonterminal row before installing the
+   * unique fence so upgrades remain available without guessing at ordering. */
+  async function quarantineDuplicateAdmissionLanes(): Promise<number> {
+    const lanes = await Turn().aggregate<DuplicateAdmissionLane>([
+      { $match: { admissionStartedAt: { $exists: true } } },
+      {
+        $group: {
+          _id: {
+            tenantId: '$tenantId',
+            user: '$user',
+            conversationId: '$conversationId',
+            laneId: '$laneId',
+          },
+          count: { $sum: 1 },
+        },
+      },
+      { $match: { count: { $gt: 1 } } },
+    ]);
+    for (const lane of lanes) {
+      const scopeInput: AgentQueuedTurnConversationScope = {
+        user: lane._id.user,
+        ...(lane._id.tenantId != null && { tenantId: lane._id.tenantId }),
+        conversationId: requireBoundedString(lane._id.conversationId, 256),
+      };
+      const scope = conversationScope(scopeInput);
+      const laneId = requireBoundedString(lane._id.laneId, 128);
+      const settledAt = new Date();
+      await Sequence().updateOne(
+        { _id: laneKey(scopeInput), ...scope },
+        {
+          $set: { retiredAt: settledAt },
+          $setOnInsert: { ...conversationFields(scopeInput), laneId, value: 0 },
+          $unset: {
+            reservationId: 1,
+            writerId: 1,
+            writerUntil: 1,
+            expiresAt: 1,
+          },
+        },
+        { upsert: true },
+      );
+      await Turn().updateMany(
+        {
+          ...scope,
+          laneId,
+          $or: [
+            { status: { $in: ['reserving', 'queued', 'claimed'] } },
+            { admissionStartedAt: { $exists: true } },
+          ],
+        },
+        {
+          $set: {
+            status: 'dead',
+            terminalReceipt: {
+              outcome: 'dead',
+              settledAt,
+              failure: {
+                code: 'QUEUED_TURN_ADMISSION_ORDER_UNAVAILABLE',
+                message:
+                  'Multiple queued turns crossed the admission boundary without a durable order. Delete or replace this conversation before continuing.',
+              },
+            },
+          },
+          $unset: {
+            activeSlot: 1,
+            admissionSlot: 1,
+            claimId: 1,
+            claimBy: 1,
+            claimUntil: 1,
+            admissionId: 1,
+            admissionStartedAt: 1,
+            admissionEffectivePredecessorCreatedAt: 1,
+            admissionLineagePredecessorId: 1,
+            admissionProtocolVersion: 1,
+            reconciliationAvailableAt: 1,
+            reconciliationClaimId: 1,
+            reconciliationClaimBy: 1,
+            reconciliationClaimUntil: 1,
+          },
+        },
+      );
+    }
+    return lanes.length;
+  }
+
   async function ensureAgentQueuedTurnIndexes(): Promise<void> {
-    await Promise.all([createIndexesWithRetry(Turn()), createIndexesWithRetry(Sequence())]);
+    const admissionFenceExists = (
+      await Turn()
+        .listIndexes()
+        .catch(() => [])
+    ).some((index) => index.name === ADMISSION_STARTED_LANE_INDEX);
+    if (!admissionFenceExists) {
+      for (let attempt = 0; ; attempt++) {
+        await quarantineDuplicateAdmissionLanes();
+        try {
+          await createIndexesWithRetry(Turn());
+          break;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (
+            attempt >= 4 ||
+            (error as DuplicateKeyError).code !== DUPLICATE_KEY ||
+            !message.includes(ADMISSION_STARTED_LANE_INDEX)
+          ) {
+            throw error;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 100 * 2 ** attempt));
+        }
+      }
+    } else {
+      await createIndexesWithRetry(Turn());
+    }
+    await createIndexesWithRetry(Sequence());
   }
 
   async function acquireLaneWriter(
@@ -2015,7 +2139,6 @@ export function createAgentQueuedTurnMethods(
           deliveryState: 'published',
           admissionId,
           admissionStartedAt: { $exists: true },
-          admissionSlot: true,
           ...(effectivePredecessorCreatedAt != null
             ? { admissionEffectivePredecessorCreatedAt: effectivePredecessorCreatedAt }
             : { admissionEffectivePredecessorCreatedAt: { $exists: false } }),
@@ -2189,7 +2312,6 @@ export function createAgentQueuedTurnMethods(
           ...(rootPredecessorCreatedAt != null && {
             expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
           }),
-          allowLegacyPredecessorInference: true,
         });
         const lineageConflict =
           resolvedPredecessor === null ||

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -24,7 +24,7 @@ const LANE_WRITER_LEASE_MS = 30_000;
 const LANE_WRITER_RETRY_MS = 5;
 const LANE_WRITER_RETRIES = LANE_WRITER_LEASE_MS / LANE_WRITER_RETRY_MS;
 const RETIRED_LANE_RETENTION_MS = 24 * 60 * 60_000;
-const ROOT_LINEAGE_PREDECESSOR_ID = 'root';
+const ROOT_LINEAGE_PREDECESSOR_PREFIX = 'root:';
 
 interface DuplicateKeyError {
   code?: number;
@@ -158,6 +158,16 @@ export interface AgentQueuedTurnPredecessor {
   effectivePredecessorCreatedAt?: number;
 }
 
+function getRootLineagePredecessorId(parentMessageId: string): string {
+  return `${ROOT_LINEAGE_PREDECESSOR_PREFIX}${createHash('sha256')
+    .update(requireBoundedString(parentMessageId, 256))
+    .digest('base64url')}`;
+}
+
+function isRootLineagePredecessorId(lineagePredecessorId: string): boolean {
+  return lineagePredecessorId.startsWith(ROOT_LINEAGE_PREDECESSOR_PREFIX);
+}
+
 export interface ClaimAgentQueuedTurnReconciliationInput {
   claimId: string;
   claimBy: string;
@@ -275,6 +285,7 @@ export interface AgentQueuedTurnMethods {
   getEffectiveAgentQueuedTurnPredecessor: (
     input: AgentQueuedTurnConversationScope & {
       sequence: number;
+      rootParentMessageId: string;
       expectedPredecessorCreatedAt?: number;
       allowLegacyPredecessorInference?: boolean;
     },
@@ -1032,8 +1043,9 @@ export function createAgentQueuedTurnMethods(
     const rootPredecessorCreatedAt = normalizePredecessor(turn.expectedPredecessorCreatedAt);
     if (
       turn.terminalReceipt.lineagePredecessorId != null &&
-      (rootPredecessorCreatedAt == null ||
-        turn.terminalReceipt.effectivePredecessorCreatedAt != null)
+      (turn.terminalReceipt.effectivePredecessorCreatedAt != null ||
+        (isRootLineagePredecessorId(turn.terminalReceipt.lineagePredecessorId) &&
+          turn.terminalReceipt.rootPredecessor === true))
     ) {
       return turn;
     }
@@ -1042,6 +1054,7 @@ export function createAgentQueuedTurnMethods(
       ...(turn.tenantId != null && { tenantId: turn.tenantId }),
       conversationId: turn.conversationId,
       sequence: turn.sequence,
+      rootParentMessageId: turn.parentMessageId,
       ...(rootPredecessorCreatedAt != null && {
         expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
       }),
@@ -1058,6 +1071,7 @@ export function createAgentQueuedTurnMethods(
         $or: [
           { 'terminalReceipt.effectivePredecessorCreatedAt': { $exists: false } },
           { 'terminalReceipt.lineagePredecessorId': { $exists: false } },
+          { 'terminalReceipt.rootPredecessor': { $exists: false } },
         ],
       },
       {
@@ -1066,6 +1080,10 @@ export function createAgentQueuedTurnMethods(
             'terminalReceipt.effectivePredecessorCreatedAt': effectivePredecessorCreatedAt,
           }),
           'terminalReceipt.lineagePredecessorId': resolvedPredecessor.lineagePredecessorId,
+          ...(effectivePredecessorCreatedAt == null &&
+            isRootLineagePredecessorId(resolvedPredecessor.lineagePredecessorId) && {
+              'terminalReceipt.rootPredecessor': true,
+            }),
         },
       },
     );
@@ -1075,6 +1093,10 @@ export function createAgentQueuedTurnMethods(
         ...turn.terminalReceipt,
         ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
         lineagePredecessorId: resolvedPredecessor.lineagePredecessorId,
+        ...(effectivePredecessorCreatedAt == null &&
+          isRootLineagePredecessorId(resolvedPredecessor.lineagePredecessorId) && {
+            rootPredecessor: true as const,
+          }),
       },
     };
   }
@@ -1309,6 +1331,11 @@ export function createAgentQueuedTurnMethods(
               'terminalReceipt.outcome': 'dead',
               'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
             },
+            {
+              status: 'claimed',
+              'terminalReceipt.outcome': 'dead',
+              'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
+            },
             { status: 'claimed', claimUntil: { $lte: input.now } },
           ],
         },
@@ -1375,7 +1402,7 @@ export function createAgentQueuedTurnMethods(
         ...conversationScope(input),
         _id: input.queuedTurnId,
         deliveryKey: requireBoundedString(input.deliveryKey, 128),
-        status: 'dead',
+        status: { $in: ['claimed', 'dead'] },
         'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
         reconciliationClaimId: requireBoundedString(input.claimId, 128),
         reconciliationClaimBy: requireBoundedString(input.claimBy, 256),
@@ -1845,6 +1872,7 @@ export function createAgentQueuedTurnMethods(
           ...(current.tenantId != null && { tenantId: current.tenantId }),
           conversationId: current.conversationId,
           sequence: current.sequence,
+          rootParentMessageId: current.parentMessageId,
           ...(rootPredecessorCreatedAt != null && {
             expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
           }),
@@ -2005,6 +2033,11 @@ export function createAgentQueuedTurnMethods(
               'terminalReceipt.outcome': 'dead',
               'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
             },
+            {
+              status: 'claimed',
+              'terminalReceipt.outcome': 'dead',
+              'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
+            },
           ],
         },
         {
@@ -2019,6 +2052,11 @@ export function createAgentQueuedTurnMethods(
               ...(generationCreatedAt != null && { generationCreatedAt }),
               ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
               ...(lineagePredecessorId != null && { lineagePredecessorId }),
+              ...(effectivePredecessorCreatedAt == null &&
+                lineagePredecessorId != null &&
+                isRootLineagePredecessorId(lineagePredecessorId) && {
+                  rootPredecessor: true,
+                }),
             },
           },
           $unset: {
@@ -2124,6 +2162,7 @@ export function createAgentQueuedTurnMethods(
         })
         .select({
           sequence: 1,
+          parentMessageId: 1,
           expectedPredecessorCreatedAt: 1,
           admissionEffectivePredecessorCreatedAt: 1,
           admissionLineagePredecessorId: 1,
@@ -2145,6 +2184,7 @@ export function createAgentQueuedTurnMethods(
           ...(input.tenantId != null && { tenantId: input.tenantId }),
           conversationId: input.conversationId,
           sequence: admission.sequence,
+          rootParentMessageId: admission.parentMessageId,
           ...(rootPredecessorCreatedAt != null && {
             expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
           }),
@@ -2204,6 +2244,10 @@ export function createAgentQueuedTurnMethods(
                         effectivePredecessorCreatedAt,
                       }),
                       lineagePredecessorId,
+                      ...(effectivePredecessorCreatedAt == null &&
+                        isRootLineagePredecessorId(lineagePredecessorId) && {
+                          rootPredecessor: true,
+                        }),
                     },
                   },
                   $unset: {
@@ -2274,7 +2318,8 @@ export function createAgentQueuedTurnMethods(
     if (
       current.status === 'claimed' &&
       current.deliveryKey === deliveryKey &&
-      current.admissionStartedAt != null
+      current.admissionStartedAt != null &&
+      current.terminalReceipt?.failure?.code !== 'ADMISSION_INDETERMINATE'
     ) {
       const quarantined = await Turn()
         .findOneAndUpdate(
@@ -2288,7 +2333,7 @@ export function createAgentQueuedTurnMethods(
           },
           {
             $set: {
-              status: 'dead',
+              status: 'claimed',
               reconciliationAvailableAt: input.settledAt,
               reconciliationAttempts: 0,
               terminalReceipt: {
@@ -2316,7 +2361,12 @@ export function createAgentQueuedTurnMethods(
         return { outcome: 'admission_indeterminate', turn: toRecord(quarantined) };
       }
     }
-    if (['admitted', 'cancelled', 'dead'].includes(current.status)) {
+    if (
+      ['admitted', 'cancelled', 'dead'].includes(current.status) ||
+      (current.status === 'claimed' &&
+        current.terminalReceipt?.outcome === 'dead' &&
+        current.terminalReceipt.failure?.code === 'ADMISSION_INDETERMINATE')
+    ) {
       return { outcome: 'already_terminal', turn: toRecord(current) };
     }
     return { outcome: 'conflict', turn: toRecord(current) };
@@ -2325,6 +2375,7 @@ export function createAgentQueuedTurnMethods(
   async function getEffectiveAgentQueuedTurnPredecessor(
     input: AgentQueuedTurnConversationScope & {
       sequence: number;
+      rootParentMessageId: string;
       expectedPredecessorCreatedAt?: number;
       allowLegacyPredecessorInference?: boolean;
     },
@@ -2333,6 +2384,8 @@ export function createAgentQueuedTurnMethods(
       throw new TypeError('Agent queued turn sequence must be a positive integer');
     }
     const rootEpoch = normalizePredecessor(input.expectedPredecessorCreatedAt);
+    const rootParentMessageId = requireBoundedString(input.rootParentMessageId, 256);
+    const rootLineagePredecessorId = getRootLineagePredecessorId(rootParentMessageId);
     const predecessors = await Turn()
       .find({
         ...conversationScope(input),
@@ -2340,6 +2393,7 @@ export function createAgentQueuedTurnMethods(
         ...(rootEpoch == null
           ? { expectedPredecessorCreatedAt: { $exists: false } }
           : { expectedPredecessorCreatedAt: rootEpoch }),
+        parentMessageId: rootParentMessageId,
         status: 'admitted',
         'terminalReceipt.outcome': 'admitted',
       })
@@ -2376,7 +2430,7 @@ export function createAgentQueuedTurnMethods(
     ) {
       return null;
     }
-    let lineagePredecessorId = ROOT_LINEAGE_PREDECESSOR_ID;
+    let lineagePredecessorId = rootLineagePredecessorId;
     let effectivePredecessorCreatedAt = rootEpoch;
     let traversed = 0;
     const visited = new Set<string>();

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -24,6 +24,7 @@ const LANE_WRITER_LEASE_MS = 30_000;
 const LANE_WRITER_RETRY_MS = 5;
 const LANE_WRITER_RETRIES = LANE_WRITER_LEASE_MS / LANE_WRITER_RETRY_MS;
 const RETIRED_LANE_RETENTION_MS = 24 * 60 * 60_000;
+const ROOT_LINEAGE_PREDECESSOR_ID = 'root';
 
 interface DuplicateKeyError {
   code?: number;
@@ -152,6 +153,11 @@ export interface AgentQueuedTurnAdmissionEvidence {
   generationCreatedAt: number;
 }
 
+export interface AgentQueuedTurnPredecessor {
+  lineagePredecessorId: string;
+  effectivePredecessorCreatedAt?: number;
+}
+
 export interface ClaimAgentQueuedTurnReconciliationInput {
   claimId: string;
   claimBy: string;
@@ -241,6 +247,7 @@ export interface AgentQueuedTurnMethods {
       generationId?: string;
       generationCreatedAt?: number;
       effectivePredecessorCreatedAt?: number;
+      lineagePredecessorId?: string;
       settledAt: Date;
     },
   ) => Promise<AdmitAgentQueuedTurnResult>;
@@ -251,6 +258,7 @@ export interface AgentQueuedTurnMethods {
       generationId: string;
       generationCreatedAt: number;
       effectivePredecessorCreatedAt?: number;
+      lineagePredecessorId?: string;
     },
   ) => Promise<boolean>;
   deadLetterAgentQueuedTurn: (
@@ -269,9 +277,8 @@ export interface AgentQueuedTurnMethods {
       sequence: number;
       expectedPredecessorCreatedAt?: number;
       allowLegacyPredecessorInference?: boolean;
-      targetGenerationCreatedAt?: number;
     },
-  ) => Promise<number | null | undefined>;
+  ) => Promise<AgentQueuedTurnPredecessor | null>;
   drainAgentQueuedTurns: (
     input: AgentQueuedTurnOwnerScope & {
       conversationId?: string;
@@ -543,6 +550,7 @@ function toRecord(turn: IAgentQueuedTurn): AgentQueuedTurnRecord {
     ...(turn.laneId != null && { laneId: turn.laneId }),
     sequence: turn.sequence,
     ...(turn.activeSlot != null && { activeSlot: turn.activeSlot }),
+    ...(turn.admissionSlot === true && { admissionSlot: true }),
     status: turn.status,
     priority: turn.priority,
     text: turn.text,
@@ -564,6 +572,9 @@ function toRecord(turn: IAgentQueuedTurn): AgentQueuedTurnRecord {
     ...(turn.admissionStartedAt != null && { admissionStartedAt: turn.admissionStartedAt }),
     ...(turn.admissionEffectivePredecessorCreatedAt != null && {
       admissionEffectivePredecessorCreatedAt: turn.admissionEffectivePredecessorCreatedAt,
+    }),
+    ...(turn.admissionLineagePredecessorId != null && {
+      admissionLineagePredecessorId: turn.admissionLineagePredecessorId,
     }),
     ...(turn.admissionProtocolVersion != null && {
       admissionProtocolVersion: turn.admissionProtocolVersion,
@@ -625,6 +636,7 @@ function requireClaim(turn: IAgentQueuedTurn | null): AgentQueuedTurnClaim | nul
   if (
     turn == null ||
     turn.status !== 'claimed' ||
+    turn.admissionSlot !== true ||
     turn.claimId == null ||
     turn.claimBy == null ||
     turn.claimUntil == null
@@ -1013,39 +1025,47 @@ export function createAgentQueuedTurnMethods(
       turn._id == null ||
       turn.sequence == null ||
       turn.status !== 'admitted' ||
-      turn.terminalReceipt?.outcome !== 'admitted' ||
-      turn.terminalReceipt.effectivePredecessorCreatedAt != null
+      turn.terminalReceipt?.outcome !== 'admitted'
     ) {
       return turn;
     }
     const rootPredecessorCreatedAt = normalizePredecessor(turn.expectedPredecessorCreatedAt);
-    if (rootPredecessorCreatedAt == null) {
+    if (
+      turn.terminalReceipt.lineagePredecessorId != null &&
+      (rootPredecessorCreatedAt == null ||
+        turn.terminalReceipt.effectivePredecessorCreatedAt != null)
+    ) {
       return turn;
     }
-    const resolvedPredecessorCreatedAt = await getEffectiveAgentQueuedTurnPredecessor({
+    const resolvedPredecessor = await getEffectiveAgentQueuedTurnPredecessor({
       user: turn.user,
       ...(turn.tenantId != null && { tenantId: turn.tenantId }),
       conversationId: turn.conversationId,
       sequence: turn.sequence,
-      expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
-      ...(turn.terminalReceipt.generationCreatedAt != null && {
-        targetGenerationCreatedAt: turn.terminalReceipt.generationCreatedAt,
+      ...(rootPredecessorCreatedAt != null && {
+        expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
       }),
     });
-    if (resolvedPredecessorCreatedAt === null) {
+    if (resolvedPredecessor === null) {
       return turn;
     }
-    const effectivePredecessorCreatedAt = resolvedPredecessorCreatedAt ?? rootPredecessorCreatedAt;
+    const effectivePredecessorCreatedAt = resolvedPredecessor.effectivePredecessorCreatedAt;
     await Turn().updateOne(
       {
         _id: turn._id,
         status: 'admitted',
         'terminalReceipt.outcome': 'admitted',
-        'terminalReceipt.effectivePredecessorCreatedAt': { $exists: false },
+        $or: [
+          { 'terminalReceipt.effectivePredecessorCreatedAt': { $exists: false } },
+          { 'terminalReceipt.lineagePredecessorId': { $exists: false } },
+        ],
       },
       {
         $set: {
-          'terminalReceipt.effectivePredecessorCreatedAt': effectivePredecessorCreatedAt,
+          ...(effectivePredecessorCreatedAt != null && {
+            'terminalReceipt.effectivePredecessorCreatedAt': effectivePredecessorCreatedAt,
+          }),
+          'terminalReceipt.lineagePredecessorId': resolvedPredecessor.lineagePredecessorId,
         },
       },
     );
@@ -1053,7 +1073,8 @@ export function createAgentQueuedTurnMethods(
       ...turn,
       terminalReceipt: {
         ...turn.terminalReceipt,
-        effectivePredecessorCreatedAt,
+        ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
+        lineagePredecessorId: resolvedPredecessor.lineagePredecessorId,
       },
     };
   }
@@ -1144,7 +1165,13 @@ export function createAgentQueuedTurnMethods(
             status: 'cancelled',
             terminalReceipt: { outcome: 'cancelled', settledAt },
           },
-          $unset: { activeSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+          $unset: {
+            activeSlot: 1,
+            admissionSlot: 1,
+            claimId: 1,
+            claimBy: 1,
+            claimUntil: 1,
+          },
         },
         { new: true },
       )
@@ -1463,130 +1490,159 @@ export function createAgentQueuedTurnMethods(
       throw new TypeError('Agent queued turn lease must end after claim time');
     }
     const scope = conversationScope(input);
-    return serializeLocalLane(input, async () => {
-      let writer: AgentQueuedTurnLaneWriter;
-      try {
-        writer = await acquireLaneWriter(input, false);
-      } catch (error) {
-        if (
-          error instanceof AgentQueuedTurnLaneRetiredError ||
-          error instanceof AgentQueuedTurnLaneMissingError
-        ) {
-          return { outcome: 'missing', claim: null };
-        }
-        throw error;
-      }
-      try {
-        const laneScope = { ...scope, laneId: writer.laneId };
-        const serializedReplay = await Turn()
-          .findOne({
-            ...laneScope,
-            _id: input.queuedTurnId,
-            status: 'claimed',
-            claimId,
-            claimBy,
-            claimUntil: { $gt: input.now },
-          })
-          .lean<IAgentQueuedTurn>();
-        const serializedClaim = requireClaim(serializedReplay);
-        if (serializedClaim != null) {
-          return { outcome: 'replayed', claim: serializedClaim };
-        }
-
-        const expected = await Turn()
-          .findOne({ ...laneScope, _id: input.queuedTurnId })
-          .lean<IAgentQueuedTurn>();
-        if (expected == null || (expected.status !== 'queued' && expected.status !== 'claimed')) {
-          return { outcome: 'missing', claim: null };
-        }
-
-        const unfinishedReservation = await Turn().exists({
-          ...laneScope,
-          status: 'reserving',
-        });
-        if (unfinishedReservation != null) {
-          return { outcome: 'blocked', claim: null };
-        }
-
-        const competingClaim = await Turn().exists({
-          ...laneScope,
-          _id: { $ne: input.queuedTurnId },
-          status: 'claimed',
-        });
-        if (competingClaim != null) {
-          return { outcome: 'blocked', claim: null };
-        }
-
-        const head =
-          expected.status === 'claimed'
-            ? expected
-            : await Turn()
-                .findOne({ ...laneScope, status: { $in: ['queued', 'dead'] } })
-                .sort({ priority: -1, sequence: 1 })
-                .lean<IAgentQueuedTurn>();
-        if (head == null) {
-          return { outcome: 'blocked', claim: null };
-        }
-        if (
-          head._id?.toString() !== input.queuedTurnId ||
-          head.availableAt.getTime() > input.now.getTime() ||
-          (head.status === 'claimed' &&
-            head.claimUntil != null &&
-            head.claimUntil.getTime() > input.now.getTime())
-        ) {
-          return { outcome: 'blocked', claim: null };
-        }
-
-        const turn = await Turn()
+    const expected = await Turn()
+      .findOne({ ...scope, _id: input.queuedTurnId })
+      .lean<IAgentQueuedTurn>();
+    if (
+      expected == null ||
+      expected.laneId == null ||
+      (expected.status !== 'queued' && expected.status !== 'claimed')
+    ) {
+      return { outcome: 'missing', claim: null };
+    }
+    const laneScope = { ...scope, laneId: expected.laneId };
+    const laneExists = await Sequence().exists({
+      _id: laneKey(input),
+      ...scope,
+      laneId: expected.laneId,
+      retiredAt: { $exists: false },
+    });
+    if (laneExists == null) {
+      return { outcome: 'missing', claim: null };
+    }
+    const competingReservation = await Turn().exists({
+      ...laneScope,
+      _id: { $ne: input.queuedTurnId },
+      $or: [
+        { admissionSlot: true },
+        // Pre-slot replicas and rows still expose their admission owner through
+        // the claimed status. Keep that legacy shell inside the same boundary.
+        { status: 'claimed' },
+        {
+          status: 'dead',
+          'terminalReceipt.outcome': 'dead',
+          'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
+        },
+      ],
+    });
+    if (competingReservation != null) {
+      return { outcome: 'blocked', claim: null };
+    }
+    if (
+      expected.status === 'claimed' &&
+      expected.claimId === claimId &&
+      expected.claimBy === claimBy &&
+      expected.claimUntil != null &&
+      expected.claimUntil.getTime() > input.now.getTime()
+    ) {
+      if (expected.admissionSlot !== true) {
+        const migrated = await Turn()
           .findOneAndUpdate(
             {
               ...laneScope,
               _id: input.queuedTurnId,
-              availableAt: { $lte: input.now },
-              $or: [
-                { status: 'queued' },
-                {
-                  status: 'claimed',
-                  claimUntil: { $lte: input.now },
-                  admissionStartedAt: { $exists: false },
-                },
-              ],
+              status: 'claimed',
+              claimId,
+              claimBy,
+              admissionSlot: { $exists: false },
             },
-            {
-              $set: {
-                status: 'claimed',
-                claimId,
-                claimBy,
-                claimUntil: input.leaseUntil,
-              },
-              $inc: { attempts: 1 },
-              $unset: { terminalReceipt: 1 },
-            },
-            { new: true, sort: { priority: -1, sequence: 1 } },
+            { $set: { admissionSlot: true } },
+            { new: true },
           )
-          .lean<IAgentQueuedTurn>();
-        const acquired = requireClaim(turn);
-        if (acquired != null) {
-          return { outcome: 'acquired', claim: acquired };
-        }
-        const racedReplay = await Turn()
-          .findOne({
-            ...laneScope,
-            _id: input.queuedTurnId,
+          .lean<IAgentQueuedTurn>()
+          .catch((error: unknown) => {
+            if ((error as DuplicateKeyError).code === DUPLICATE_KEY) {
+              return null;
+            }
+            throw error;
+          });
+        const migratedClaim = requireClaim(migrated);
+        return migratedClaim == null
+          ? { outcome: 'blocked', claim: null }
+          : { outcome: 'replayed', claim: migratedClaim };
+      }
+      const replayedClaim = requireClaim(expected);
+      if (replayedClaim != null) {
+        return { outcome: 'replayed', claim: replayedClaim };
+      }
+    }
+
+    const unfinishedReservation = await Turn().exists({ ...laneScope, status: 'reserving' });
+    if (unfinishedReservation != null) {
+      return { outcome: 'blocked', claim: null };
+    }
+    const head =
+      expected.status === 'claimed'
+        ? expected
+        : await Turn()
+            .findOne({ ...laneScope, status: { $in: ['queued', 'dead'] } })
+            .sort({ priority: -1, sequence: 1 })
+            .lean<IAgentQueuedTurn>();
+    if (
+      head == null ||
+      head._id?.toString() !== input.queuedTurnId ||
+      head.availableAt.getTime() > input.now.getTime() ||
+      (head.status === 'claimed' &&
+        head.claimUntil != null &&
+        head.claimUntil.getTime() > input.now.getTime())
+    ) {
+      return { outcome: 'blocked', claim: null };
+    }
+
+    const turn = await Turn()
+      .findOneAndUpdate(
+        {
+          ...laneScope,
+          _id: input.queuedTurnId,
+          availableAt: { $lte: input.now },
+          $or: [
+            { status: 'queued', admissionSlot: { $exists: false } },
+            {
+              status: 'claimed',
+              claimUntil: { $lte: input.now },
+              admissionStartedAt: { $exists: false },
+            },
+          ],
+        },
+        {
+          $set: {
             status: 'claimed',
+            admissionSlot: true,
             claimId,
             claimBy,
-            claimUntil: { $gt: input.now },
-          })
-          .lean<IAgentQueuedTurn>();
-        const racedClaim = requireClaim(racedReplay);
-        return racedClaim == null
-          ? { outcome: 'blocked', claim: null }
-          : { outcome: 'replayed', claim: racedClaim };
-      } finally {
-        await releaseLaneWriter(input, writer.writerId);
-      }
-    });
+            claimUntil: input.leaseUntil,
+          },
+          $inc: { attempts: 1 },
+          $unset: { terminalReceipt: 1 },
+        },
+        { new: true, sort: { priority: -1, sequence: 1 } },
+      )
+      .lean<IAgentQueuedTurn>()
+      .catch((error: unknown) => {
+        if ((error as DuplicateKeyError).code === DUPLICATE_KEY) {
+          return null;
+        }
+        throw error;
+      });
+    const acquired = requireClaim(turn);
+    if (acquired != null) {
+      return { outcome: 'acquired', claim: acquired };
+    }
+    const racedReplay = await Turn()
+      .findOne({
+        ...laneScope,
+        _id: input.queuedTurnId,
+        status: 'claimed',
+        admissionSlot: true,
+        claimId,
+        claimBy,
+        claimUntil: { $gt: input.now },
+      })
+      .lean<IAgentQueuedTurn>();
+    const racedClaim = requireClaim(racedReplay);
+    return racedClaim == null
+      ? { outcome: 'blocked', claim: null }
+      : { outcome: 'replayed', claim: racedClaim };
   }
 
   async function releaseAgentQueuedTurn(
@@ -1615,8 +1671,12 @@ export function createAgentQueuedTurnMethods(
               claimId: 1,
               claimBy: 1,
               claimUntil: 1,
+              admissionSlot: 1,
               admissionId: 1,
               admissionStartedAt: 1,
+              admissionEffectivePredecessorCreatedAt: 1,
+              admissionLineagePredecessorId: 1,
+              admissionProtocolVersion: 1,
               terminalReceipt: 1,
             },
           }
@@ -1634,11 +1694,15 @@ export function createAgentQueuedTurnMethods(
             },
             $unset: {
               activeSlot: 1,
+              admissionSlot: 1,
               claimId: 1,
               claimBy: 1,
               claimUntil: 1,
               admissionId: 1,
               admissionStartedAt: 1,
+              admissionEffectivePredecessorCreatedAt: 1,
+              admissionLineagePredecessorId: 1,
+              admissionProtocolVersion: 1,
             },
           };
     const turn = await Turn()
@@ -1693,7 +1757,13 @@ export function createAgentQueuedTurnMethods(
                 },
               },
             },
-            $unset: { activeSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+            $unset: {
+              activeSlot: 1,
+              admissionSlot: 1,
+              claimId: 1,
+              claimBy: 1,
+              claimUntil: 1,
+            },
           },
           { new: true },
         )
@@ -1731,6 +1801,7 @@ export function createAgentQueuedTurnMethods(
           current?.status === 'claimed' &&
           current.claimId === input.claimId &&
           current.claimBy === input.claimBy &&
+          current.admissionSlot === true &&
           current.deliveryKey === admissionId &&
           current.deliveryState === 'published' &&
           current.laneId === writer.laneId &&
@@ -1755,6 +1826,7 @@ export function createAgentQueuedTurnMethods(
           current?.status !== 'claimed' ||
           current.claimId !== input.claimId ||
           current.claimBy !== input.claimBy ||
+          current.admissionSlot !== true ||
           current.deliveryKey !== admissionId ||
           current.deliveryState !== 'published' ||
           current.laneId !== writer.laneId ||
@@ -1768,7 +1840,7 @@ export function createAgentQueuedTurnMethods(
         }
 
         const rootPredecessorCreatedAt = normalizePredecessor(current.expectedPredecessorCreatedAt);
-        const resolvedPredecessorCreatedAt = await getEffectiveAgentQueuedTurnPredecessor({
+        const resolvedPredecessor = await getEffectiveAgentQueuedTurnPredecessor({
           user: current.user,
           ...(current.tenantId != null && { tenantId: current.tenantId }),
           conversationId: current.conversationId,
@@ -1778,7 +1850,7 @@ export function createAgentQueuedTurnMethods(
           }),
           allowLegacyPredecessorInference: true,
         });
-        if (resolvedPredecessorCreatedAt === null) {
+        if (resolvedPredecessor === null) {
           const dead = await Turn()
             .findOneAndUpdate(
               {
@@ -1787,6 +1859,7 @@ export function createAgentQueuedTurnMethods(
                 status: 'claimed',
                 claimId: requireBoundedString(input.claimId, 128),
                 claimBy: requireBoundedString(input.claimBy, 256),
+                admissionSlot: true,
                 deliveryKey: admissionId,
                 deliveryState: 'published',
                 laneId: writer.laneId,
@@ -1805,7 +1878,13 @@ export function createAgentQueuedTurnMethods(
                     },
                   },
                 },
-                $unset: { activeSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+                $unset: {
+                  activeSlot: 1,
+                  admissionSlot: 1,
+                  claimId: 1,
+                  claimBy: 1,
+                  claimUntil: 1,
+                },
               },
               { new: true },
             )
@@ -1821,8 +1900,7 @@ export function createAgentQueuedTurnMethods(
             turn: conflicted == null ? null : toRecord(conflicted),
           };
         }
-        const effectivePredecessorCreatedAt =
-          resolvedPredecessorCreatedAt ?? rootPredecessorCreatedAt;
+        const effectivePredecessorCreatedAt = resolvedPredecessor.effectivePredecessorCreatedAt;
         const turn = await Turn()
           .findOneAndUpdate(
             {
@@ -1831,6 +1909,7 @@ export function createAgentQueuedTurnMethods(
               status: 'claimed',
               claimId: requireBoundedString(input.claimId, 128),
               claimBy: requireBoundedString(input.claimBy, 256),
+              admissionSlot: true,
               deliveryKey: admissionId,
               deliveryState: 'published',
               laneId: writer.laneId,
@@ -1843,6 +1922,7 @@ export function createAgentQueuedTurnMethods(
                 ...(effectivePredecessorCreatedAt != null && {
                   admissionEffectivePredecessorCreatedAt: effectivePredecessorCreatedAt,
                 }),
+                admissionLineagePredecessorId: resolvedPredecessor.lineagePredecessorId,
                 ...(input.admissionProtocolVersion != null && {
                   admissionProtocolVersion: input.admissionProtocolVersion,
                 }),
@@ -1861,12 +1941,14 @@ export function createAgentQueuedTurnMethods(
           raced?.status === 'claimed' &&
           raced.claimId === input.claimId &&
           raced.claimBy === input.claimBy &&
+          raced.admissionSlot === true &&
           raced.deliveryKey === admissionId &&
           raced.deliveryState === 'published' &&
           raced.laneId === writer.laneId &&
           raced.admissionId === admissionId &&
           raced.admissionStartedAt != null &&
-          raced.admissionEffectivePredecessorCreatedAt === effectivePredecessorCreatedAt
+          raced.admissionEffectivePredecessorCreatedAt === effectivePredecessorCreatedAt &&
+          raced.admissionLineagePredecessorId === resolvedPredecessor.lineagePredecessorId
         ) {
           return { outcome: 'already_started', turn: toRecord(raced) };
         }
@@ -1887,6 +1969,7 @@ export function createAgentQueuedTurnMethods(
       generationId?: string;
       generationCreatedAt?: number;
       effectivePredecessorCreatedAt?: number;
+      lineagePredecessorId?: string;
       settledAt: Date;
     },
   ): Promise<AdmitAgentQueuedTurnResult> {
@@ -1894,6 +1977,7 @@ export function createAgentQueuedTurnMethods(
     const generationId = normalizeOptionalString(input.generationId, 256);
     const generationCreatedAt = normalizePredecessor(input.generationCreatedAt);
     const effectivePredecessorCreatedAt = normalizePredecessor(input.effectivePredecessorCreatedAt);
+    const lineagePredecessorId = normalizeOptionalString(input.lineagePredecessorId, 128);
     const turn = await Turn()
       .findOneAndUpdate(
         {
@@ -1903,9 +1987,13 @@ export function createAgentQueuedTurnMethods(
           deliveryState: 'published',
           admissionId,
           admissionStartedAt: { $exists: true },
+          admissionSlot: true,
           ...(effectivePredecessorCreatedAt != null
             ? { admissionEffectivePredecessorCreatedAt: effectivePredecessorCreatedAt }
             : { admissionEffectivePredecessorCreatedAt: { $exists: false } }),
+          ...(lineagePredecessorId != null
+            ? { admissionLineagePredecessorId: lineagePredecessorId }
+            : { admissionLineagePredecessorId: { $exists: false } }),
           $or: [
             {
               status: 'claimed',
@@ -1930,16 +2018,19 @@ export function createAgentQueuedTurnMethods(
               ...(generationId != null && { generationId }),
               ...(generationCreatedAt != null && { generationCreatedAt }),
               ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
+              ...(lineagePredecessorId != null && { lineagePredecessorId }),
             },
           },
           $unset: {
             activeSlot: 1,
+            admissionSlot: 1,
             claimId: 1,
             claimBy: 1,
             claimUntil: 1,
             admissionId: 1,
             admissionStartedAt: 1,
             admissionEffectivePredecessorCreatedAt: 1,
+            admissionLineagePredecessorId: 1,
             admissionProtocolVersion: 1,
             reconciliationAvailableAt: 1,
             reconciliationClaimId: 1,
@@ -1976,10 +2067,12 @@ export function createAgentQueuedTurnMethods(
       generationId: string;
       generationCreatedAt: number;
       effectivePredecessorCreatedAt?: number;
+      lineagePredecessorId?: string;
     },
   ): Promise<boolean> {
     const generationCreatedAt = normalizePredecessor(input.generationCreatedAt);
     const effectivePredecessorCreatedAt = normalizePredecessor(input.effectivePredecessorCreatedAt);
+    const lineagePredecessorId = normalizeOptionalString(input.lineagePredecessorId, 128);
     if (generationCreatedAt == null) {
       throw new TypeError('Agent queued turn admission generation is invalid');
     }
@@ -1994,6 +2087,9 @@ export function createAgentQueuedTurnMethods(
         'terminalReceipt.generationCreatedAt': generationCreatedAt,
         ...(effectivePredecessorCreatedAt != null && {
           'terminalReceipt.effectivePredecessorCreatedAt': effectivePredecessorCreatedAt,
+        }),
+        ...(lineagePredecessorId != null && {
+          'terminalReceipt.lineagePredecessorId': lineagePredecessorId,
         }),
       })) != null
     );
@@ -2030,16 +2126,21 @@ export function createAgentQueuedTurnMethods(
           sequence: 1,
           expectedPredecessorCreatedAt: 1,
           admissionEffectivePredecessorCreatedAt: 1,
+          admissionLineagePredecessorId: 1,
         })
         .lean<IAgentQueuedTurn>();
       let effectivePredecessorCreatedAt = normalizePredecessor(
         admission?.admissionEffectivePredecessorCreatedAt,
       );
-      if (effectivePredecessorCreatedAt == null && admission?.sequence != null) {
+      let lineagePredecessorId = normalizeOptionalString(
+        admission?.admissionLineagePredecessorId,
+        128,
+      );
+      if (admission?.sequence != null) {
         const rootPredecessorCreatedAt = normalizePredecessor(
           admission.expectedPredecessorCreatedAt,
         );
-        const resolvedPredecessorCreatedAt = await getEffectiveAgentQueuedTurnPredecessor({
+        const resolvedPredecessor = await getEffectiveAgentQueuedTurnPredecessor({
           user: input.user,
           ...(input.tenantId != null && { tenantId: input.tenantId }),
           conversationId: input.conversationId,
@@ -2048,15 +2149,23 @@ export function createAgentQueuedTurnMethods(
             expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
           }),
           allowLegacyPredecessorInference: true,
-          targetGenerationCreatedAt: generationCreatedAt,
         });
-        effectivePredecessorCreatedAt =
-          resolvedPredecessorCreatedAt === null
-            ? undefined
-            : (resolvedPredecessorCreatedAt ?? rootPredecessorCreatedAt);
+        const lineageConflict =
+          resolvedPredecessor === null ||
+          (lineagePredecessorId != null &&
+            lineagePredecessorId !== resolvedPredecessor.lineagePredecessorId) ||
+          (effectivePredecessorCreatedAt != null &&
+            effectivePredecessorCreatedAt !== resolvedPredecessor.effectivePredecessorCreatedAt);
+        if (lineageConflict) {
+          effectivePredecessorCreatedAt = undefined;
+          lineagePredecessorId = undefined;
+        } else {
+          effectivePredecessorCreatedAt = resolvedPredecessor.effectivePredecessorCreatedAt;
+          lineagePredecessorId = resolvedPredecessor.lineagePredecessorId;
+        }
       }
       const reconciled =
-        effectivePredecessorCreatedAt == null
+        lineagePredecessorId == null
           ? null
           : await Turn()
               .findOneAndUpdate(
@@ -2094,16 +2203,19 @@ export function createAgentQueuedTurnMethods(
                       ...(effectivePredecessorCreatedAt != null && {
                         effectivePredecessorCreatedAt,
                       }),
+                      lineagePredecessorId,
                     },
                   },
                   $unset: {
                     activeSlot: 1,
+                    admissionSlot: 1,
                     claimId: 1,
                     claimBy: 1,
                     claimUntil: 1,
                     admissionId: 1,
                     admissionStartedAt: 1,
                     admissionEffectivePredecessorCreatedAt: 1,
+                    admissionLineagePredecessorId: 1,
                     admissionProtocolVersion: 1,
                     reconciliationAvailableAt: 1,
                     reconciliationClaimId: 1,
@@ -2139,7 +2251,13 @@ export function createAgentQueuedTurnMethods(
               },
             },
           },
-          $unset: { activeSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+          $unset: {
+            activeSlot: 1,
+            admissionSlot: 1,
+            claimId: 1,
+            claimBy: 1,
+            claimUntil: 1,
+          },
         },
         { new: true },
       )
@@ -2209,70 +2327,71 @@ export function createAgentQueuedTurnMethods(
       sequence: number;
       expectedPredecessorCreatedAt?: number;
       allowLegacyPredecessorInference?: boolean;
-      targetGenerationCreatedAt?: number;
     },
-  ): Promise<number | null | undefined> {
+  ): Promise<AgentQueuedTurnPredecessor | null> {
     if (!Number.isSafeInteger(input.sequence) || input.sequence <= 0) {
       throw new TypeError('Agent queued turn sequence must be a positive integer');
     }
     const rootEpoch = normalizePredecessor(input.expectedPredecessorCreatedAt);
-    const targetGenerationCreatedAt = normalizePredecessor(input.targetGenerationCreatedAt);
-    if (rootEpoch == null) {
-      return undefined;
-    }
     const predecessors = await Turn()
       .find({
         ...conversationScope(input),
         sequence: { $ne: input.sequence },
-        expectedPredecessorCreatedAt: rootEpoch,
+        ...(rootEpoch == null
+          ? { expectedPredecessorCreatedAt: { $exists: false } }
+          : { expectedPredecessorCreatedAt: rootEpoch }),
         status: 'admitted',
         'terminalReceipt.outcome': 'admitted',
-        'terminalReceipt.generationCreatedAt': { $exists: true },
       })
       .select({ sequence: 1, terminalReceipt: 1 })
       .lean<IAgentQueuedTurn[]>();
-    /** Stored v2 edges define admission order without comparing clocks or
-     * enqueue sequence. A single legacy gap is inferable only while the
-     * caller still owns the lane head; every other incomplete/branched graph
-     * returns null so callers preserve explicit fail-closed evidence. */
-    const edges = new Map<number, number>();
-    const legacyOutputs: number[] = [];
+    /** Queued-turn identities define lineage; timestamps are payload evidence,
+     * never graph nodes. One legacy row may be inserted at the proven tail
+     * while the caller owns admission. Missing output evidence, branches, and
+     * disconnected rows remain fail-closed. */
+    const edges = new Map<string, { queuedTurnId: string; generationCreatedAt: number }>();
+    const legacyRows: { queuedTurnId: string; generationCreatedAt: number }[] = [];
     for (const turn of predecessors) {
+      const queuedTurnId = turn._id?.toString();
       const generationCreatedAt = normalizePredecessor(turn.terminalReceipt?.generationCreatedAt);
-      if (generationCreatedAt == null) {
-        continue;
-      }
-      const effectivePredecessorCreatedAt = normalizePredecessor(
-        turn.terminalReceipt?.effectivePredecessorCreatedAt,
-      );
-      if (effectivePredecessorCreatedAt == null) {
-        legacyOutputs.push(generationCreatedAt);
-        continue;
-      }
-      if (edges.has(effectivePredecessorCreatedAt)) {
+      if (queuedTurnId == null || generationCreatedAt == null) {
         return null;
       }
-      edges.set(effectivePredecessorCreatedAt, generationCreatedAt);
+      const lineagePredecessorId = normalizeOptionalString(
+        turn.terminalReceipt?.lineagePredecessorId,
+        128,
+      );
+      if (lineagePredecessorId == null) {
+        legacyRows.push({ queuedTurnId, generationCreatedAt });
+        continue;
+      }
+      if (edges.has(lineagePredecessorId)) {
+        return null;
+      }
+      edges.set(lineagePredecessorId, { queuedTurnId, generationCreatedAt });
     }
     if (
-      legacyOutputs.length > 0 &&
-      (input.allowLegacyPredecessorInference !== true || legacyOutputs.length > 1)
+      legacyRows.length > 0 &&
+      (input.allowLegacyPredecessorInference !== true || legacyRows.length > 1)
     ) {
       return null;
     }
+    let lineagePredecessorId = ROOT_LINEAGE_PREDECESSOR_ID;
     let effectivePredecessorCreatedAt = rootEpoch;
     let traversed = 0;
-    const visited = new Set<number>();
+    const visited = new Set<string>();
     const advanceExactEdges = () => {
-      while (edges.has(effectivePredecessorCreatedAt)) {
-        if (effectivePredecessorCreatedAt === targetGenerationCreatedAt) {
+      while (edges.has(lineagePredecessorId)) {
+        const edge = edges.get(lineagePredecessorId) as {
+          queuedTurnId: string;
+          generationCreatedAt: number;
+        };
+        if (visited.has(edge.queuedTurnId)) {
           return false;
         }
-        if (visited.has(effectivePredecessorCreatedAt)) {
-          return false;
-        }
-        visited.add(effectivePredecessorCreatedAt);
-        effectivePredecessorCreatedAt = edges.get(effectivePredecessorCreatedAt) as number;
+        visited.add(edge.queuedTurnId);
+        lineagePredecessorId = edge.queuedTurnId;
+        effectivePredecessorCreatedAt = edge.generationCreatedAt;
         traversed += 1;
       }
       return true;
@@ -2280,16 +2399,14 @@ export function createAgentQueuedTurnMethods(
     if (!advanceExactEdges()) {
       return null;
     }
-    if (legacyOutputs.length === 1) {
-      const legacyOutput = legacyOutputs[0];
-      if (
-        legacyOutput === effectivePredecessorCreatedAt ||
-        visited.has(legacyOutput) ||
-        legacyOutput === targetGenerationCreatedAt
-      ) {
+    if (legacyRows.length === 1) {
+      const legacy = legacyRows[0];
+      if (visited.has(legacy.queuedTurnId)) {
         return null;
       }
-      effectivePredecessorCreatedAt = legacyOutput;
+      visited.add(legacy.queuedTurnId);
+      lineagePredecessorId = legacy.queuedTurnId;
+      effectivePredecessorCreatedAt = legacy.generationCreatedAt;
       traversed += 1;
       if (!advanceExactEdges()) {
         return null;
@@ -2298,7 +2415,10 @@ export function createAgentQueuedTurnMethods(
     if (traversed !== predecessors.length) {
       return null;
     }
-    return traversed > 0 ? effectivePredecessorCreatedAt : undefined;
+    return {
+      lineagePredecessorId,
+      ...(effectivePredecessorCreatedAt != null && { effectivePredecessorCreatedAt }),
+    };
   }
 
   async function drainAgentQueuedTurns(
@@ -2329,7 +2449,13 @@ export function createAgentQueuedTurnMethods(
             },
           },
         },
-        $unset: { activeSlot: 1, claimId: 1, claimBy: 1, claimUntil: 1 },
+        $unset: {
+          activeSlot: 1,
+          admissionSlot: 1,
+          claimId: 1,
+          claimBy: 1,
+          claimUntil: 1,
+        },
       },
     );
     await Turn().updateMany(
@@ -2457,6 +2583,7 @@ export function createAgentQueuedTurnMethods(
         },
         $unset: {
           activeSlot: 1,
+          admissionSlot: 1,
           reservationWriterId: 1,
           claimId: 1,
           claimBy: 1,

--- a/packages/data-schemas/src/methods/queuedTurn.ts
+++ b/packages/data-schemas/src/methods/queuedTurn.ts
@@ -1002,6 +1002,52 @@ export function createAgentQueuedTurnMethods(
     return turns.map(toActiveRecord);
   }
 
+  async function ensureEffectiveAdmissionBoundary(
+    turn: IAgentQueuedTurn,
+  ): Promise<IAgentQueuedTurn> {
+    if (
+      turn._id == null ||
+      turn.sequence == null ||
+      turn.status !== 'admitted' ||
+      turn.terminalReceipt?.outcome !== 'admitted' ||
+      turn.terminalReceipt.effectivePredecessorCreatedAt != null
+    ) {
+      return turn;
+    }
+    const rootPredecessorCreatedAt = normalizePredecessor(turn.expectedPredecessorCreatedAt);
+    if (rootPredecessorCreatedAt == null) {
+      return turn;
+    }
+    const effectivePredecessorCreatedAt =
+      (await getEffectiveAgentQueuedTurnPredecessor({
+        user: turn.user,
+        ...(turn.tenantId != null && { tenantId: turn.tenantId }),
+        conversationId: turn.conversationId,
+        sequence: turn.sequence,
+        expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
+      })) ?? rootPredecessorCreatedAt;
+    await Turn().updateOne(
+      {
+        _id: turn._id,
+        status: 'admitted',
+        'terminalReceipt.outcome': 'admitted',
+        'terminalReceipt.effectivePredecessorCreatedAt': { $exists: false },
+      },
+      {
+        $set: {
+          'terminalReceipt.effectivePredecessorCreatedAt': effectivePredecessorCreatedAt,
+        },
+      },
+    );
+    return {
+      ...turn,
+      terminalReceipt: {
+        ...turn.terminalReceipt,
+        effectivePredecessorCreatedAt,
+      },
+    };
+  }
+
   async function listAgentQueuedTurnReceipts(
     input: AgentQueuedTurnConversationScope & { clientRequestIds?: readonly string[] },
   ): Promise<AgentQueuedTurnActiveRecord[]> {
@@ -1038,7 +1084,8 @@ export function createAgentQueuedTurnMethods(
         turns.set(turn._id.toString(), turn);
       }
     }
-    return [...turns.values()]
+    const repaired = await Promise.all([...turns.values()].map(ensureEffectiveAdmissionBoundary));
+    return repaired
       .filter((turn) => turn.sequence != null)
       .sort(
         (left, right) =>
@@ -1057,7 +1104,7 @@ export function createAgentQueuedTurnMethods(
         clientRequestId: requireBoundedString(input.clientRequestId, 128),
       })
       .lean<IAgentQueuedTurn>();
-    return turn == null ? null : toRecord(turn);
+    return turn == null ? null : toRecord(await ensureEffectiveAdmissionBoundary(turn));
   }
 
   async function cancelAgentQueuedTurn(
@@ -1850,67 +1897,89 @@ export function createAgentQueuedTurnMethods(
           admissionId: deliveryKey,
           admissionStartedAt: { $exists: true },
         })
-        .select({ admissionEffectivePredecessorCreatedAt: 1 })
+        .select({
+          sequence: 1,
+          expectedPredecessorCreatedAt: 1,
+          admissionEffectivePredecessorCreatedAt: 1,
+        })
         .lean<IAgentQueuedTurn>();
-      const effectivePredecessorCreatedAt = normalizePredecessor(
+      let effectivePredecessorCreatedAt = normalizePredecessor(
         admission?.admissionEffectivePredecessorCreatedAt,
       );
-      const reconciled = await Turn()
-        .findOneAndUpdate(
-          {
-            ...scope,
-            _id: input.queuedTurnId,
-            deliveryKey,
-            admissionId: deliveryKey,
-            admissionStartedAt: { $exists: true },
-            ...(input.reconciliationClaimId != null && {
-              reconciliationClaimId: requireBoundedString(input.reconciliationClaimId, 128),
+      if (effectivePredecessorCreatedAt == null && admission?.sequence != null) {
+        const rootPredecessorCreatedAt = normalizePredecessor(
+          admission.expectedPredecessorCreatedAt,
+        );
+        effectivePredecessorCreatedAt =
+          (await getEffectiveAgentQueuedTurnPredecessor({
+            user: input.user,
+            ...(input.tenantId != null && { tenantId: input.tenantId }),
+            conversationId: input.conversationId,
+            sequence: admission.sequence,
+            ...(rootPredecessorCreatedAt != null && {
+              expectedPredecessorCreatedAt: rootPredecessorCreatedAt,
             }),
-            ...(input.reconciliationClaimBy != null && {
-              reconciliationClaimBy: requireBoundedString(input.reconciliationClaimBy, 256),
-            }),
-            $or: [
-              { status: 'claimed' },
-              {
-                status: 'dead',
-                'terminalReceipt.outcome': 'dead',
-                'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
-              },
-            ],
-          },
-          {
-            $set: {
-              status: 'admitted',
-              terminalReceipt: {
-                outcome: 'admitted',
-                settledAt: input.settledAt,
-                admissionId: deliveryKey,
-                admissionMode: 'ordinary',
-                ...(generationId != null && { generationId }),
-                generationCreatedAt,
-                ...(effectivePredecessorCreatedAt != null && {
-                  effectivePredecessorCreatedAt,
-                }),
-              },
-            },
-            $unset: {
-              activeSlot: 1,
-              claimId: 1,
-              claimBy: 1,
-              claimUntil: 1,
-              admissionId: 1,
-              admissionStartedAt: 1,
-              admissionEffectivePredecessorCreatedAt: 1,
-              admissionProtocolVersion: 1,
-              reconciliationAvailableAt: 1,
-              reconciliationClaimId: 1,
-              reconciliationClaimBy: 1,
-              reconciliationClaimUntil: 1,
-            },
-          },
-          { new: true },
-        )
-        .lean<IAgentQueuedTurn>();
+          })) ?? rootPredecessorCreatedAt;
+      }
+      const reconciled =
+        effectivePredecessorCreatedAt == null
+          ? null
+          : await Turn()
+              .findOneAndUpdate(
+                {
+                  ...scope,
+                  _id: input.queuedTurnId,
+                  deliveryKey,
+                  admissionId: deliveryKey,
+                  admissionStartedAt: { $exists: true },
+                  ...(input.reconciliationClaimId != null && {
+                    reconciliationClaimId: requireBoundedString(input.reconciliationClaimId, 128),
+                  }),
+                  ...(input.reconciliationClaimBy != null && {
+                    reconciliationClaimBy: requireBoundedString(input.reconciliationClaimBy, 256),
+                  }),
+                  $or: [
+                    { status: 'claimed' },
+                    {
+                      status: 'dead',
+                      'terminalReceipt.outcome': 'dead',
+                      'terminalReceipt.failure.code': 'ADMISSION_INDETERMINATE',
+                    },
+                  ],
+                },
+                {
+                  $set: {
+                    status: 'admitted',
+                    terminalReceipt: {
+                      outcome: 'admitted',
+                      settledAt: input.settledAt,
+                      admissionId: deliveryKey,
+                      admissionMode: 'ordinary',
+                      ...(generationId != null && { generationId }),
+                      generationCreatedAt,
+                      ...(effectivePredecessorCreatedAt != null && {
+                        effectivePredecessorCreatedAt,
+                      }),
+                    },
+                  },
+                  $unset: {
+                    activeSlot: 1,
+                    claimId: 1,
+                    claimBy: 1,
+                    claimUntil: 1,
+                    admissionId: 1,
+                    admissionStartedAt: 1,
+                    admissionEffectivePredecessorCreatedAt: 1,
+                    admissionProtocolVersion: 1,
+                    reconciliationAvailableAt: 1,
+                    reconciliationClaimId: 1,
+                    reconciliationClaimBy: 1,
+                    reconciliationClaimUntil: 1,
+                  },
+                },
+                { new: true },
+              )
+              .lean<IAgentQueuedTurn>();
       if (reconciled != null) {
         return { outcome: 'admission_reconciled', turn: toRecord(reconciled) };
       }

--- a/packages/data-schemas/src/schema/queuedTurn.ts
+++ b/packages/data-schemas/src/schema/queuedTurn.ts
@@ -85,6 +85,7 @@ const queuedTurnSchema: Schema<IAgentQueuedTurnDocument> = new Schema(
     claimUntil: { type: Date },
     admissionStartedAt: { type: Date },
     admissionId: { type: String, maxlength: 128 },
+    admissionEffectivePredecessorCreatedAt: { type: Number, min: 0 },
     admissionProtocolVersion: { type: Number, enum: [2] },
     reconciliationAvailableAt: { type: Date },
     reconciliationClaimId: { type: String, maxlength: 128 },

--- a/packages/data-schemas/src/schema/queuedTurn.ts
+++ b/packages/data-schemas/src/schema/queuedTurn.ts
@@ -36,6 +36,7 @@ const terminalReceiptSchema = new Schema(
     generationCreatedAt: { type: Number, min: 0 },
     effectivePredecessorCreatedAt: { type: Number, min: 0 },
     lineagePredecessorId: { type: String, maxlength: 128 },
+    rootPredecessor: { type: Boolean, enum: [true] },
     failure: { type: failureSchema },
   },
   { _id: false },
@@ -118,6 +119,14 @@ queuedTurnSchema.index(
     name: 'agent_queued_turn_active_capacity',
     unique: true,
     partialFilterExpression: { activeSlot: { $exists: true } },
+  },
+);
+queuedTurnSchema.index(
+  { tenantId: 1, user: 1, conversationId: 1, laneId: 1, status: 1 },
+  {
+    name: 'agent_queued_turn_claim_lane',
+    unique: true,
+    partialFilterExpression: { status: 'claimed' },
   },
 );
 queuedTurnSchema.index(

--- a/packages/data-schemas/src/schema/queuedTurn.ts
+++ b/packages/data-schemas/src/schema/queuedTurn.ts
@@ -34,6 +34,7 @@ const terminalReceiptSchema = new Schema(
     admissionMode: { type: String, enum: ['warm', 'ordinary'] },
     generationId: { type: String, maxlength: 256 },
     generationCreatedAt: { type: Number, min: 0 },
+    effectivePredecessorCreatedAt: { type: Number, min: 0 },
     failure: { type: failureSchema },
   },
   { _id: false },

--- a/packages/data-schemas/src/schema/queuedTurn.ts
+++ b/packages/data-schemas/src/schema/queuedTurn.ts
@@ -35,6 +35,7 @@ const terminalReceiptSchema = new Schema(
     generationId: { type: String, maxlength: 256 },
     generationCreatedAt: { type: Number, min: 0 },
     effectivePredecessorCreatedAt: { type: Number, min: 0 },
+    lineagePredecessorId: { type: String, maxlength: 128 },
     failure: { type: failureSchema },
   },
   { _id: false },
@@ -58,6 +59,7 @@ const queuedTurnSchema: Schema<IAgentQueuedTurnDocument> = new Schema(
     sequence: { type: Number, min: 1 },
     reservationWriterId: { type: String, maxlength: 128 },
     activeSlot: { type: Number, min: 0, max: 99 },
+    admissionSlot: { type: Boolean },
     status: {
       type: String,
       enum: ['reserving', 'queued', 'claimed', 'admitted', 'cancelled', 'dead'],
@@ -86,6 +88,7 @@ const queuedTurnSchema: Schema<IAgentQueuedTurnDocument> = new Schema(
     admissionStartedAt: { type: Date },
     admissionId: { type: String, maxlength: 128 },
     admissionEffectivePredecessorCreatedAt: { type: Number, min: 0 },
+    admissionLineagePredecessorId: { type: String, maxlength: 128 },
     admissionProtocolVersion: { type: Number, enum: [2] },
     reconciliationAvailableAt: { type: Date },
     reconciliationClaimId: { type: String, maxlength: 128 },
@@ -115,6 +118,14 @@ queuedTurnSchema.index(
     name: 'agent_queued_turn_active_capacity',
     unique: true,
     partialFilterExpression: { activeSlot: { $exists: true } },
+  },
+);
+queuedTurnSchema.index(
+  { tenantId: 1, user: 1, conversationId: 1, laneId: 1, admissionSlot: 1 },
+  {
+    name: 'agent_queued_turn_admission_slot',
+    unique: true,
+    partialFilterExpression: { admissionSlot: true },
   },
 );
 queuedTurnSchema.index(

--- a/packages/data-schemas/src/schema/queuedTurn.ts
+++ b/packages/data-schemas/src/schema/queuedTurn.ts
@@ -130,6 +130,17 @@ queuedTurnSchema.index(
   },
 );
 queuedTurnSchema.index(
+  { tenantId: 1, user: 1, conversationId: 1, laneId: 1 },
+  {
+    name: 'agent_queued_turn_admission_started_lane',
+    unique: true,
+    /** `admissionStartedAt` is written by both legacy and current workers and
+     * survives legacy `dead/ADMISSION_INDETERMINATE` quarantine. This is the
+     * cross-version fence after a claim crosses the provider boundary. */
+    partialFilterExpression: { admissionStartedAt: { $exists: true } },
+  },
+);
+queuedTurnSchema.index(
   { tenantId: 1, user: 1, conversationId: 1, laneId: 1, admissionSlot: 1 },
   {
     name: 'agent_queued_turn_admission_slot',

--- a/packages/data-schemas/src/types/queuedTurn.ts
+++ b/packages/data-schemas/src/types/queuedTurn.ts
@@ -37,6 +37,8 @@ export interface AgentQueuedTurnTerminalReceipt {
   admissionMode?: 'warm' | 'ordinary';
   generationId?: string;
   generationCreatedAt?: number;
+  /** Effective predecessor consumed by this admission after queued-turn chaining. */
+  effectivePredecessorCreatedAt?: number;
   failure?: AgentQueuedTurnFailure;
 }
 

--- a/packages/data-schemas/src/types/queuedTurn.ts
+++ b/packages/data-schemas/src/types/queuedTurn.ts
@@ -77,6 +77,8 @@ export interface IAgentQueuedTurn {
   /** Durable proof that ordinary admission may have crossed the HTTP boundary. */
   admissionStartedAt?: Date;
   admissionId?: string;
+  /** Effective predecessor durably fenced before provider admission begins. */
+  admissionEffectivePredecessorCreatedAt?: number;
   /** Version 2 requires accepted and deduplicated execution responses to prove
    * the exact post-invocation source receipt. */
   admissionProtocolVersion?: 2;

--- a/packages/data-schemas/src/types/queuedTurn.ts
+++ b/packages/data-schemas/src/types/queuedTurn.ts
@@ -39,8 +39,10 @@ export interface AgentQueuedTurnTerminalReceipt {
   generationCreatedAt?: number;
   /** Effective predecessor consumed by this admission after queued-turn chaining. */
   effectivePredecessorCreatedAt?: number;
-  /** Durable lineage node: `root` or the predecessor queued-turn identity. */
+  /** Durable lineage node: the root-message identity or predecessor queued-turn identity. */
   lineagePredecessorId?: string;
+  /** This admission consumed no predecessor generation boundary. */
+  rootPredecessor?: true;
   failure?: AgentQueuedTurnFailure;
 }
 

--- a/packages/data-schemas/src/types/queuedTurn.ts
+++ b/packages/data-schemas/src/types/queuedTurn.ts
@@ -39,6 +39,8 @@ export interface AgentQueuedTurnTerminalReceipt {
   generationCreatedAt?: number;
   /** Effective predecessor consumed by this admission after queued-turn chaining. */
   effectivePredecessorCreatedAt?: number;
+  /** Durable lineage node: `root` or the predecessor queued-turn identity. */
+  lineagePredecessorId?: string;
   failure?: AgentQueuedTurnFailure;
 }
 
@@ -59,6 +61,8 @@ export interface IAgentQueuedTurn {
   reservationWriterId?: string;
   /** Bounded active-lane capacity token. Present only while queued/claimed. */
   activeSlot?: number;
+  /** Unique durable admission-order reservation for one conversation lane. */
+  admissionSlot?: boolean;
   status: AgentQueuedTurnStatus;
   priority: boolean;
   text: string;
@@ -79,6 +83,8 @@ export interface IAgentQueuedTurn {
   admissionId?: string;
   /** Effective predecessor durably fenced before provider admission begins. */
   admissionEffectivePredecessorCreatedAt?: number;
+  /** Durable lineage node fenced with the effective predecessor. */
+  admissionLineagePredecessorId?: string;
   /** Version 2 requires accepted and deduplicated execution responses to prove
    * the exact post-invocation source receipt. */
   admissionProtocolVersion?: 2;
@@ -152,6 +158,7 @@ export type AgentQueuedTurnActiveRecord = Pick<
 
 export interface AgentQueuedTurnClaim extends AgentQueuedTurnRecord {
   status: 'claimed';
+  admissionSlot: true;
   claimId: string;
   claimBy: string;
   claimUntil: Date;


### PR DESCRIPTION
## Summary

I moved queued-turn continuation ordering behind one durable admission boundary so queue progress no longer depends on SSE timing, process-local writer leases, millisecond timestamps, or client cache-key churn.

- Preserve monotonic server-admission evidence across delayed POST/GET responses and client queue-drain state.
- Keep one stable client receipt authority per conversation and cancel/refetch it when known reconciliation identities change.
- Treat receipt `revision` as its immutable queue sequence instead of a state mutation clock.
- Centralize claim, predecessor reconstruction, provider admission, settlement, recovery, and reconciliation in the queued-turn lifecycle module.
- Reserve one lane-scoped durable admission slot before reconstructing lineage, and retain it while admission evidence is indeterminate.
- Serialize both current and legacy workers with database-enforced claim and admission-start fences, including legacy `dead/ADMISSION_INDETERMINATE` owners.
- Migrate pre-fence duplicate claim or started-admission owners before index creation by retiring and fail-closing the corrupted lane instead of guessing its order.
- Materialize fresh collections before index inspection so autoCreate-disabled MongoDB/DocumentDB startup remains rejection-free.
- Route already-indeterminate claimed rows through protocol-aware reconciliation instead of repeatedly dead-lettering them.
- Require the exact source receipt to settle protocol-v2 admission; GenerationJob evidence can reconcile only the legacy protocol.
- Accept authoritative late source receipts from pre-slot protocol-v2 owners.
- Identify lineage with queued-turn IDs while retaining generation timestamps only as predecessor-fence evidence.
- Partition equal-timestamp roots by parent-message identity and project explicit no-predecessor admissions to the client.
- Reconstruct one bounded legacy gap only at atomic admission start; historical reconciliation rejects missing-edge ambiguity.
- Preserve priority overtakes, same-timestamp generations, lane deletion fencing, and mixed-version claimed-row blocking.
- Rebase the branch onto the latest `origin/dev`.

Fixes #15391.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran 43 focused data-schema queued-turn lifecycle and migration tests.
- Ran 30 focused API queued-turn HTTP, continuation, and scheduling tests.
- Ran 9 focused data-provider queued-turn contract tests.
- Ran 210 focused client queue-drain, steering, cache-authority, and queued-turn UI tests.
- Ran the data-schema TypeScript check; focused API Jest compilation passed against the changed source.
- Ran the strict Mongo baseline method sweep for `ensureAgentQueuedTurnIndexes`: 21 operations, zero engine rejections.
- Ran targeted ESLint, Prettier, import sorting, and `git diff --check`.
- Rely on the GitHub CI matrix for the broad repository suite.

### **Test Configuration**:

- macOS
- Node.js 24
- Jest 30
- MongoDB Memory Server

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
