### PR TITLE
🧹 fix: Reject Textual Handoff Tool Echoes

### DIFF
--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -37,6 +37,7 @@ const {
   EVENT_ACTOR_DETACHED_COMPLETION_TYPE,
   findAgentEventAppliedAction,
   createAgentEventActionRecorder,
+  isTransferToolEchoText,
   isHITLEnabled,
   agentRequestsAskUserQuestion,
   resolveAgentTurnExecutionPlan,
@@ -50,6 +51,7 @@ const { logViolation } = require('~/cache');
 const { recordScheduleOutcome, isScheduleLive } = require('~/server/services/Schedules');
 const {
   saveMessage,
+  deleteMessages,
   saveConvo,
   getMessages,
   getConvo,
@@ -2731,6 +2733,16 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
               ? 'Terminal response could not be persisted as unfinished'
               : 'Response message could not be persisted before terminal publication',
           );
+        }
+        /** A printed handoff tool name is neither commentary nor a tool call.
+         * The terminal handler records it as failed; remove the synthetic row
+         * here so it cannot become context for a later agent in this thread. */
+        if (eventTaskId != null && isTransferToolEchoText(response.text)) {
+          await deleteMessages({
+            user: userId,
+            conversationId,
+            messageId: response.messageId,
+          });
         }
         if (appliedEventActor != null) {
           const recorded = await recordAgentEventActorReconciliation({

--- a/packages/api/src/agents/triggers/outcome.spec.ts
+++ b/packages/api/src/agents/triggers/outcome.spec.ts
@@ -1632,6 +1632,25 @@ describe('agent event terminal outcomes', () => {
     );
   });
 
+  it('rejects a printed handoff tool name as a failed terminal response', async () => {
+    const settleAgentTriggerHandlingOutcome = jest.fn().mockResolvedValue(true);
+    const handler = createAgentEventTerminalHandler({ settleAgentTriggerHandlingOutcome });
+
+    await handler(
+      'conversation-1',
+      job(),
+      [],
+      [{ type: 'text', text: 'Tool: lc_transfer_to_agent_mateo,' }],
+    );
+
+    expect(settleAgentTriggerHandlingOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        error: 'Agent response contained an unexecuted handoff tool name',
+      }),
+    );
+  });
+
   it('seals a persisted legacy turn from a non-resume terminal owner', async () => {
     const settleAgentTriggerHandlingOutcome = jest.fn().mockResolvedValue(true);
     const completeAgentEventActorLegacyTurn = jest.fn().mockResolvedValue(true);

--- a/packages/api/src/agents/triggers/outcome.ts
+++ b/packages/api/src/agents/triggers/outcome.ts
@@ -31,10 +31,31 @@ interface SettleAgentTriggerHandlingOutcomeInput {
 
 export interface AgentEventRunOutcome {
   status: 'applied' | 'completed_no_action' | 'failed' | 'cancelled';
+  error?: string;
   action?: { toolName: string; toolCallId?: string };
 }
 
 const MAX_RECEIPT_ID_LENGTH = 256;
+const TRANSFER_TOOL_ECHO_PATTERN = /^Tool:\s*lc_transfer_to_agent_[A-Za-z0-9_-]+,?$/;
+const TRANSFER_TOOL_ECHO_ERROR = 'Agent response contained an unexecuted handoff tool name';
+
+export function isTransferToolEchoText(text: unknown): boolean {
+  return typeof text === 'string' && TRANSFER_TOOL_ECHO_PATTERN.test(text.trim());
+}
+
+function isTransferToolEcho(content: Agents.MessageContentComplex[]): boolean {
+  if (content.length === 0) {
+    return false;
+  }
+  let text = '';
+  for (const part of content) {
+    if (!('text' in part) || typeof part.text !== 'string') {
+      return false;
+    }
+    text += part.text;
+  }
+  return isTransferToolEchoText(text);
+}
 
 async function hasDurableAgentEventHistory(input: {
   getMessage: MessageMethods['getMessage'];
@@ -168,6 +189,9 @@ export function classifyAgentEventRunOutcome(
   }
   if (job.status === 'aborted') {
     return { status: 'cancelled' };
+  }
+  if (isTransferToolEcho(content)) {
+    return { status: 'failed', error: TRANSFER_TOOL_ECHO_ERROR };
   }
   return { status: 'completed_no_action' };
 }
@@ -345,7 +369,7 @@ export function createAgentEventTerminalHandler(
     const settledAt = new Date(job.completedAt ?? Date.now());
     const settleCompletionDelivery = async (
       completionOutcome: AgentEventRunOutcome,
-      failureError = receivedJob.error ?? 'Generation failed',
+      failureError = completionOutcome.error ?? receivedJob.error ?? 'Generation failed',
     ): Promise<void> => {
       if (completionDeliveryKey == null) {
         return;
@@ -1109,7 +1133,10 @@ export function createAgentEventTerminalHandler(
       ...(settlementOutcome.status === 'failed' && {
         error: compensated
           ? 'Applied event actor action was explicitly compensated'
-          : (detachedTerminalFailure ?? job.error ?? 'Generation failed'),
+          : (detachedTerminalFailure ??
+            settlementOutcome.error ??
+            job.error ??
+            'Generation failed'),
       }),
       ...(settlementOutcome.action != null && { action: settlementOutcome.action }),
     });
@@ -1120,7 +1147,10 @@ export function createAgentEventTerminalHandler(
       settlementOutcome,
       compensated
         ? 'Applied event actor action was explicitly compensated'
-        : (detachedTerminalFailure ?? receivedJob.error ?? 'Generation failed'),
+        : (detachedTerminalFailure ??
+            settlementOutcome.error ??
+            receivedJob.error ??
+            'Generation failed'),
     );
   };
 }


### PR DESCRIPTION
## Summary

I made textual handoff tool echoes terminal failures and removed them from shared agent history.

- Classify a response consisting only of `Tool: lc_transfer_to_agent_…` as failed with an explicit error.
- Propagate the failure reason to delivery and completion receipts.
- Remove the persisted synthetic assistant message so later agents cannot repeat it from context.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`.
- Ran `npm run build:data-schemas`.
- Ran `npm exec --workspace=@librechat/api -- jest --runInBand src/agents/triggers/outcome.spec.ts`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes