### PR TITLE
🪁 fix: Keep Tool Flyouts in View

### DIFF
--- a/client/src/components/Chat/Input/ArtifactsSubMenu.tsx
+++ b/client/src/components/Chat/Input/ArtifactsSubMenu.tsx
@@ -89,8 +89,11 @@ const ArtifactsSubMenu = React.forwardRef<HTMLButtonElement, ArtifactsSubMenuPro
             <Ariakit.Menu
               portal={true}
               unmountOnHide={true}
+              gutter={12}
+              shift={24}
+              flip="left bottom-end top-end"
               className={cn(
-                'animate-popover-left z-40 ml-3 mt-6 flex min-w-[250px] flex-col rounded-xl',
+                'animate-popover-left z-40 flex min-w-[250px] max-w-[calc(100vw-1rem)] flex-col rounded-xl',
                 'border border-border-light bg-surface-secondary shadow-lg',
               )}
             >

--- a/client/src/components/Chat/Input/ArtifactsSubMenu.tsx
+++ b/client/src/components/Chat/Input/ArtifactsSubMenu.tsx
@@ -93,7 +93,7 @@ const ArtifactsSubMenu = React.forwardRef<HTMLButtonElement, ArtifactsSubMenuPro
               shift={24}
               flip="left bottom-end top-end"
               className={cn(
-                'animate-popover-left z-40 flex min-w-[250px] max-w-[calc(100vw-1rem)] flex-col rounded-xl',
+                'animate-popover-left z-40 flex min-w-[min(250px,calc(100vw-1rem))] max-w-[calc(100vw-1rem)] flex-col rounded-xl',
                 'border border-border-light bg-surface-secondary shadow-lg',
               )}
             >

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -93,7 +93,7 @@ const MCPSubMenu = React.forwardRef<HTMLButtonElement, MCPSubMenuProps>(
             flip="left bottom-end top-end"
             aria-label={localize('com_ui_mcp_servers')}
             className={cn(
-              'animate-popover-left z-40 flex min-w-[260px] max-w-[min(320px,calc(100vw-1rem))] flex-col rounded-xl',
+              'animate-popover-left z-40 flex min-w-[min(260px,calc(100vw-1rem))] max-w-[min(320px,calc(100vw-1rem))] flex-col rounded-xl',
               'border border-border-light bg-presentation p-1.5 shadow-lg',
             )}
           >

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -89,9 +89,11 @@ const MCPSubMenu = React.forwardRef<HTMLButtonElement, MCPSubMenuProps>(
           <Ariakit.Menu
             portal={true}
             unmountOnHide={true}
+            gutter={12}
+            flip="left bottom-end top-end"
             aria-label={localize('com_ui_mcp_servers')}
             className={cn(
-              'animate-popover-left z-40 ml-3 flex min-w-[260px] max-w-[320px] flex-col rounded-xl',
+              'animate-popover-left z-40 flex min-w-[260px] max-w-[min(320px,calc(100vw-1rem))] flex-col rounded-xl',
               'border border-border-light bg-presentation p-1.5 shadow-lg',
             )}
           >


### PR DESCRIPTION
## Summary

Fixes #15403.

The `Artifacts` and `MCP Servers` flyouts are pinned to `placement: 'right'` and offset with CSS margins (`ml-3`, plus `mt-6` on Artifacts) that the positioner cannot see, with `flip` left at its default. On a narrow viewport neither side has room for a 250-260px panel, so it is cut off by the right edge of the screen.

- offsets move onto the positioner: `gutter={12}` and `shift={24}`, the same 12px gap and 24px drop the margins provided
- `flip` gets fallback placements, so the panel drops below or above the item when neither side fits
- width is capped to the viewport

No breakpoint is involved — the placement follows the space actually available, which covers phones in either orientation, split screens and small desktop windows. Where there is room, nothing changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified in a standalone repro of the same menu structure on `@ariakit/react` 0.4.15, measuring the panel's bounding rect against the viewport:

| viewport | before | after |
| --- | --- | --- |
| 360x800 | 116px off screen | fully visible, flips to `top-end` |
| 320x568 | clipped | fully visible, flips to `top-end` |
| 800x360 | fits | unchanged, stays `right` |
| 1280x800 | — | identical: 12px gap, 260px wide, `right` |

### **Test Configuration**:

Firefox and Chrome device emulation; `@ariakit/react` 0.4.15.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
