### PR TITLE
🧜‍♀️ chore: Bump `mermaid` to v11.17.2 and `dompurify` to v3.4.14

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -86,7 +86,7 @@
     "mdast-util-from-markdown": "^2.0.1",
     "mdast-util-gfm": "^3.0.0",
     "mdast-util-math": "^3.0.0",
-    "mermaid": "^11.16.1",
+    "mermaid": "^11.17.2",
     "micromark-extension-directive": "^3.0.1",
     "micromark-extension-gfm": "^3.0.0",
     "micromark-extension-llm-math": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -981,7 +981,7 @@
         "mdast-util-from-markdown": "^2.0.1",
         "mdast-util-gfm": "^3.0.0",
         "mdast-util-math": "^3.0.0",
-        "mermaid": "^11.16.1",
+        "mermaid": "^11.17.2",
         "micromark-extension-directive": "^3.0.1",
         "micromark-extension-gfm": "^3.0.0",
         "micromark-extension-llm-math": "^3.1.0",
@@ -11328,9 +11328,9 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
-      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.2"
@@ -24555,9 +24555,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -26182,6 +26182,15 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
       }
     },
     "node_modules/fastq": {
@@ -32438,26 +32447,27 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
-      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "version": "11.17.2",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.2.tgz",
+      "integrity": "sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
+        "dayjs": "^1.11.21",
         "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -39284,6 +39294,12 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
       "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg=="
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "hono": "^4.12.25",
     "@hono/node-server": "^2.0.11",
     "monaco-editor": {
-      "dompurify": "3.4.12"
+      "dompurify": "3.4.14"
     },
     "test-exclude": "^8.0.0",
     "js-yaml": "^4.2.0",


### PR DESCRIPTION
## Summary

Two dependency bumps:

- **`dompurify` 3.4.12 → 3.4.14** — clears Dependabot alert [#326](https://github.com/danny-avila/LibreChat/security/dependabot/326) / [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) (moderate XSS: `IN_PLACE` hook removal leaves a detached subtree executable).
- **`mermaid` 11.16.1 → 11.17.2**.

## Lockfile delta

Deliberately tight — 3 version changes, 2 additions, nothing removed:

| Package | Before | After |
| --- | --- | --- |
| `mermaid` | 11.16.1 | 11.17.2 |
| `@mermaid-js/parser` | 1.2.0 | 1.2.1 |
| `dompurify` | 3.4.12 | 3.4.14 |
| `fastdom` | — | 1.0.12 (new, mermaid dep) |
| `strictdom` | — | 1.0.1 (new, fastdom dep) |

### Why 3.4.14 and not 3.4.13

The pin lives under the `monaco-editor` override because monaco depends on an exact `3.4.8`; the override lifts it to match what the rest of the tree resolves for `^3.4.0` so a single copy stays hoisted. The advisory is fixed in 3.4.13, but pinning 3.4.13 would leave `^3.4.0` resolving to 3.4.14 and install **two** copies. 3.4.14 keeps the single-copy property.

### Why the mermaid floor moves to `^11.17.2`

`^11.16.1` already permitted 11.17.2, so this could have been lockfile-only — but that range also permits **11.17.0 / 11.17.1**, which dropped the `edgePaths` class from rendered SVG and broke the flowchart, block and user-journey stylesheets (restored in 11.17.2). Raising the floor excludes those two.

### katex is not affected

Mermaid 11.17.2 raises its katex floor to `^0.16.47` while we lock 0.16.28. The global `"katex": "^0.16.21"` override supersedes mermaid's request, so nothing cascades, and mermaid only ever calls `katex.renderToString()` — present in 0.16.28. This mismatch is pre-existing (11.16.1 declared `^0.16.45` against the same 0.16.28) and unchanged by this PR.

## Verification

**Unit tests** — 18 suites / 368 tests passing across the mermaid, artifact, diagram-export and markdown-block suites.

Those suites mock the render hooks, so they don't exercise mermaid's actual rendering. To cover that, diagrams were rendered in **real Chromium** through this repo's exact `useMermaid` config (`securityLevel: 'strict'`, `htmlLabels: false`, the `inlineFlowchartConfig` values) and piped through the real `sanitizeMermaidSvg` DOMPurify options, comparing 11.16.1 against 11.17.2 on the selectors our post-processors depend on (`g.node rect` in `roundMermaidNodeCorners`, `g.cluster` in `fixSubgraphTitleContrast`, and `.edgePaths`).

All 9 diagram types (pie, flowchart, subgraph, class, sequence, ER, state, gantt, journey) render and survive sanitization at 98–99% of raw bytes, with **byte-for-byte identical selector counts before and after**:

```
                    11.16.1                        11.17.2
pie         g.node-rect=0 cluster=0 edge=0 | g.node-rect=0 cluster=0 edge=0
flowchart   g.node-rect=7 cluster=0 edge=1 | g.node-rect=7 cluster=0 edge=1
subgraph    g.node-rect=8 cluster=2 edge=1 | g.node-rect=8 cluster=2 edge=1
classDiag   g.node-rect=0 cluster=0 edge=1 | g.node-rect=0 cluster=0 edge=1
sequence    g.node-rect=0 cluster=0 edge=0 | g.node-rect=0 cluster=0 edge=0
er          g.node-rect=6 cluster=0 edge=1 | g.node-rect=6 cluster=0 edge=1
state       g.node-rect=4 cluster=0 edge=1 | g.node-rect=4 cluster=0 edge=1
gantt       g.node-rect=0 cluster=0 edge=0 | g.node-rect=0 cluster=0 edge=0
journey     g.node-rect=0 cluster=0 edge=0 | g.node-rect=0 cluster=0 edge=0
```

Notes on the two upstream changes that looked risky and turned out not to be:

- **`classDiagram` now defaults to the unified (v2) renderer** ([#7812](https://github.com/mermaid-js/mermaid/pull/7812)). No impact here — class diagrams already produced `g.node rect = 0` on 11.16.1, so `roundMermaidNodeCorners` sees exactly what it saw before. (Escape hatch if ever needed: `class: { defaultRenderer: 'dagre-d3' }`.)
- **New `fastdom` dep batches DOM measurements** ([#7951](https://github.com/mermaid-js/mermaid/pull/7951)). Mermaid replaces fastdom's scheduler with `queueMicrotask` (`setTimeout` fallback) rather than `requestAnimationFrame`, so there's no background-tab starvation risk on our detached-render → blob-URL `<img>` path, and it behaves in jsdom.

DOMPurify 3.4.14's changes are hardening plus an allow-list **addition** (SVG `pointer-events` / `vector-effect`), so nothing new is stripped from mermaid output — confirmed by the 98–99% survival above.