### PR TITLE
🧷 fix: Attach to Runs the Server Starts After Your Own Finishes

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -67,6 +67,7 @@ function renderUseResumeOnLoad({
   messages = [],
   getMessages: getMessagesOverride,
   submission = null,
+  isSubmitting = false,
   conversationId = CONVERSATION_ID,
   messagesLoaded = true,
   onSubmission,
@@ -81,6 +82,7 @@ function renderUseResumeOnLoad({
   messages?: TMessage[];
   getMessages?: () => TMessage[] | undefined;
   submission?: TSubmission | null;
+  isSubmitting?: boolean;
   conversationId?: string;
   messagesLoaded?: boolean;
   onSubmission?: (submission: TSubmission | null) => void;
@@ -100,6 +102,7 @@ function renderUseResumeOnLoad({
   const initializeState = (snapshot: MutableSnapshot) => {
     snapshot.set(store.conversationByIndex(0), buildConversation(conversationId));
     snapshot.set(store.submissionByIndex(0), submission);
+    snapshot.set(store.isSubmittingFamily(0), isSubmitting);
     if (submissionStart != null) {
       snapshot.set(store.submissionStartFamily(0), submissionStart);
     }
@@ -642,6 +645,70 @@ describe('useResumeOnLoad', () => {
       });
 
       expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, true);
+    });
+
+    it('attaches to a continuation when the finished run left its submission installed', async () => {
+      const observedSubmissions: Array<TSubmission | null> = [];
+      mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
+
+      /**
+       * The FINAL path never clears the submission atom, so a pane that just
+       * finished a run still holds it. When a background tool dispatch (or any
+       * server-side continuation) then starts the next generation, that stale
+       * bookkeeping is the only thing standing between the announcement and the
+       * attachment — and it is not an attachment: nothing is streaming.
+       */
+      const { rerender } = renderUseResumeOnLoad({
+        submission: buildSubmission(CONVERSATION_ID),
+        isSubmitting: false,
+        messages: [buildUserMessage(CONVERSATION_ID)],
+        onSubmission: (currentSubmission) => observedSubmissions.push(currentSubmission),
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      mockUseStreamStatus.mockClear();
+      mockUseActiveJobs.mockReturnValue({
+        data: { activeJobIds: [CONVERSATION_ID] },
+        dataUpdatedAt: 2,
+      });
+      mockUseStreamStatus.mockReturnValue(ACTIVE_STATUS);
+      rerender();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUseStreamStatus).toHaveBeenCalledWith(CONVERSATION_ID, true);
+      const attached = observedSubmissions[observedSubmissions.length - 1] as
+        | (TSubmission & { resumeStreamId?: string })
+        | null;
+      expect(attached?.resumeStreamId).toBe(CONVERSATION_ID);
+    });
+
+    it('leaves a streaming attachment alone when its own run is announced', async () => {
+      mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
+      const { rerender } = renderUseResumeOnLoad({
+        submission: buildSubmission(CONVERSATION_ID),
+        isSubmitting: true,
+        messages: [buildUserMessage(CONVERSATION_ID)],
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      mockUseStreamStatus.mockClear();
+      /** This pane's own run is what the list is reporting. */
+      mockUseActiveJobs.mockReturnValue({
+        data: { activeJobIds: [CONVERSATION_ID] },
+        dataUpdatedAt: 2,
+      });
+      rerender();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockUseStreamStatus).not.toHaveBeenCalledWith(CONVERSATION_ID, true);
     });
 
     it('does not re-arm for a conversation that is not the one being viewed', async () => {

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.tsx
@@ -68,6 +68,7 @@ function renderUseResumeOnLoad({
   getMessages: getMessagesOverride,
   submission = null,
   isSubmitting = false,
+  attachedGenerationCreatedAt = null,
   conversationId = CONVERSATION_ID,
   messagesLoaded = true,
   onSubmission,
@@ -83,6 +84,7 @@ function renderUseResumeOnLoad({
   getMessages?: () => TMessage[] | undefined;
   submission?: TSubmission | null;
   isSubmitting?: boolean;
+  attachedGenerationCreatedAt?: number | null;
   conversationId?: string;
   messagesLoaded?: boolean;
   onSubmission?: (submission: TSubmission | null) => void;
@@ -103,6 +105,10 @@ function renderUseResumeOnLoad({
     snapshot.set(store.conversationByIndex(0), buildConversation(conversationId));
     snapshot.set(store.submissionByIndex(0), submission);
     snapshot.set(store.isSubmittingFamily(0), isSubmitting);
+    snapshot.set(
+      store.activeGenerationCreatedAtByConvoId(conversationId),
+      attachedGenerationCreatedAt,
+    );
     if (submissionStart != null) {
       snapshot.set(store.submissionStartFamily(0), submissionStart);
     }
@@ -684,6 +690,41 @@ describe('useResumeOnLoad', () => {
         | (TSubmission & { resumeStreamId?: string })
         | null;
       expect(attached?.resumeStreamId).toBe(CONVERSATION_ID);
+    });
+
+    it('leaves a resumed attachment alone before its stream has opened', async () => {
+      const observedSubmissions: Array<TSubmission | null> = [];
+      mockUseStreamStatus.mockReturnValue(INACTIVE_STATUS);
+
+      /**
+       * A resume installs its submission and only reads as submitting once the
+       * stream opens, so between those two points a submission exists with
+       * `isSubmitting` still false. An announcement landing there must not
+       * mistake it for the leftovers of a finished run and tear down the
+       * attachment this hook just built. The epoch is stamped first for exactly
+       * this reason.
+       */
+      const { rerender } = renderUseResumeOnLoad({
+        submission: buildSubmission(CONVERSATION_ID),
+        isSubmitting: false,
+        attachedGenerationCreatedAt: 4242,
+        messages: [buildUserMessage(CONVERSATION_ID)],
+        onSubmission: (currentSubmission) => observedSubmissions.push(currentSubmission),
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      mockUseActiveJobs.mockReturnValue({
+        data: { activeJobIds: [CONVERSATION_ID] },
+        dataUpdatedAt: 2,
+      });
+      rerender();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(observedSubmissions[observedSubmissions.length - 1]).not.toBeNull();
     });
 
     it('leaves a streaming attachment alone when its own run is announced', async () => {

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -250,6 +250,7 @@ export default function useResumeOnLoad(
   const setSubmission = useSetRecoilState(store.submissionByIndex(runIndex));
   const setSubmissionStart = useSetRecoilState(store.submissionStartFamily(runIndex));
   const currentSubmission = useRecoilValue(store.submissionByIndex(runIndex));
+  const isSubmitting = useRecoilValue(store.isSubmittingFamily(runIndex));
   const currentConversation = useRecoilValue(store.conversationByIndex(runIndex));
   const endpoint = currentConversation?.endpoint;
   const endpointType = currentConversation?.endpointType;
@@ -425,6 +426,16 @@ export default function useResumeOnLoad(
     !!currentSubmission && (hasExplicitSubmissionMatch || hasHydratedMessageMatch);
   const hasStaleSubmissionForDifferentConvo =
     !!currentSubmission && submissionConvoId != null && submissionConvoId !== conversationId;
+  /**
+   * A submission only stands in for an attachment while something is actually
+   * streaming. The FINAL path never clears the atom, so a pane that just
+   * finished a run keeps holding the submission it completed — bookkeeping, not
+   * a live stream. `isSubmitting` stays true across reconnect backoff, so this
+   * still reads as attached while recovery is in flight, and `ask` raises it
+   * before installing a submission, so a fresh send has no window where it
+   * looks finished.
+   */
+  const hasLiveSubmissionForThisConvo = hasActiveSubmissionForThisConvo && isSubmitting;
 
   /**
    * A run this pane did not start — another tab, another device, a scheduled
@@ -745,7 +756,7 @@ export default function useResumeOnLoad(
       !resumableEnabled ||
       !hasActiveJobForThisConvo ||
       !conversationId ||
-      hasActiveSubmissionForThisConvo
+      hasLiveSubmissionForThisConvo
     ) {
       if (!hasActiveJobForThisConvo) {
         answeredActiveJobRef.current = null;
@@ -765,6 +776,17 @@ export default function useResumeOnLoad(
     answeredActiveJobRef.current = { conversationId, at: now };
 
     console.log('[ResumeOnLoad] Active job announced without an attachment', { conversationId });
+    /**
+     * A finished submission still installed here is the one thing standing
+     * between this announcement and the attachment: it is what the check below
+     * reads as "already attached", and what disables the status query. The run
+     * it describes is over, so release it — a server-side continuation such as
+     * a background tool dispatch finishing is a different generation, and the
+     * resume path is what owns building the submission for it.
+     */
+    if (hasActiveSubmissionForThisConvo) {
+      setSubmission(null);
+    }
     queryClient.invalidateQueries({ queryKey: streamStatusQueryKey(conversationId) });
     queryClient.invalidateQueries({ queryKey: [QueryKeys.messages, conversationId] });
     processedConvoRef.current = null;
@@ -774,7 +796,9 @@ export default function useResumeOnLoad(
     resumableEnabled,
     hasActiveJobForThisConvo,
     hasActiveSubmissionForThisConvo,
+    hasLiveSubmissionForThisConvo,
     activeJobsUpdatedAt,
+    setSubmission,
     queryClient,
   ]);
 }

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -251,6 +251,9 @@ export default function useResumeOnLoad(
   const setSubmissionStart = useSetRecoilState(store.submissionStartFamily(runIndex));
   const currentSubmission = useRecoilValue(store.submissionByIndex(runIndex));
   const isSubmitting = useRecoilValue(store.isSubmittingFamily(runIndex));
+  const attachedGenerationCreatedAt = useRecoilValue(
+    store.activeGenerationCreatedAtByConvoId(conversationId ?? ''),
+  );
   const currentConversation = useRecoilValue(store.conversationByIndex(runIndex));
   const endpoint = currentConversation?.endpoint;
   const endpointType = currentConversation?.endpointType;
@@ -427,15 +430,22 @@ export default function useResumeOnLoad(
   const hasStaleSubmissionForDifferentConvo =
     !!currentSubmission && submissionConvoId != null && submissionConvoId !== conversationId;
   /**
-   * A submission only stands in for an attachment while something is actually
-   * streaming. The FINAL path never clears the atom, so a pane that just
-   * finished a run keeps holding the submission it completed — bookkeeping, not
-   * a live stream. `isSubmitting` stays true across reconnect backoff, so this
-   * still reads as attached while recovery is in flight, and `ask` raises it
-   * before installing a submission, so a fresh send has no window where it
-   * looks finished.
+   * A submission only stands in for an attachment while one is actually live.
+   * The FINAL path never clears the atom, so a pane that just finished a run
+   * keeps holding the submission it completed — bookkeeping, not a stream.
+   *
+   * Two signals, because neither covers the whole lifetime on its own.
+   * `isSubmitting` is raised by `ask` before a submission is installed and held
+   * across reconnect backoff, so sends and recovery both read as attached. It
+   * is not raised for a resumed attachment until that stream opens, though, and
+   * this effect installs the submission well before then — so an announcement
+   * landing in that window would tear down the attachment it had just built.
+   * The generation epoch closes it: this hook stamps it immediately before
+   * installing a resume submission, `subscribeToStream` stamps it for every
+   * other attachment, and terminal teardown is what clears it.
    */
-  const hasLiveSubmissionForThisConvo = hasActiveSubmissionForThisConvo && isSubmitting;
+  const hasLiveSubmissionForThisConvo =
+    hasActiveSubmissionForThisConvo && (isSubmitting || attachedGenerationCreatedAt != null);
 
   /**
    * A run this pane did not start — another tab, another device, a scheduled
@@ -797,6 +807,7 @@ export default function useResumeOnLoad(
     hasActiveJobForThisConvo,
     hasActiveSubmissionForThisConvo,
     hasLiveSubmissionForThisConvo,
+    attachedGenerationCreatedAt,
     activeJobsUpdatedAt,
     setSubmission,
     queryClient,


### PR DESCRIPTION
## What happens

An agent dispatches a background tool. Its run finishes. The task completes, and the server starts the continuation generation automatically. The pane shows none of it — not the "Background task finished" card, not the generations after it — until a reload. The sidebar spinner *does* show the run, because it reads the active list directly, which is the only reason this is noticeable at all.

#15074 was supposed to cover exactly this: a run this pane did not start. It didn't fire, and the reason is a guard I wrote.

## Why the re-arm skipped it

The FINAL path never clears the submission atom — it writes the run-end signal, closes the stream and clears the stream id, but leaves the completed submission installed. The re-arm treated any submission for the conversation as "already attached", so it returned early; `shouldCheck` reads the same thing, so the status query stayed disabled too.

My tests for #15074 all started from `submission: null` — a pane that had been idle since navigation. That is the two-tab case I had in mind, and it is *not* the common one. A continuation starts for a conversation whose pane almost always just completed the run that dispatched the tool, and that pane is holding a finished submission. The guard was reading bookkeeping as an attachment.

## The fix

A submission stands in for a live stream only while `isSubmitting`. That distinction holds at both ends:

- `isSubmitting` stays true across reconnect backoff, so a pane recovering its own stream still reads as attached and the re-arm keeps its hands off.
- `ask` raises `isSubmitting` before installing a submission, so a fresh send has no window where it looks finished.

When the announcement is answered and a finished submission is still installed, it is released. The run it describes is over, and a server-side continuation is a different generation — building the submission for it is the resume path's job, which the existing re-arm already drives.

Both halves of the report are then covered by the same arm: the messages invalidation brings in the harvested task output that replaced the dispatch handle, and the attachment streams the continuation.

## Testing

Two cases, each mutation-checked in both directions:

- `attaches to a continuation when the finished run left its submission installed` — fails on current dev, and fails again if either the liveness gate or the stale-submission release is removed.
- `leaves a streaming attachment alone when its own run is announced` — fails if the gate is dropped entirely, which is the over-fire this could have caused.

Full client suite: 482 suites / 5949 tests green. eslint and tsc clean.

## Residual

If a background task is harvested with no continuation registered — the message is patched server-side and no run follows — there is no announcement, so nothing prompts a refetch and the output still waits for a reload. That needs a different signal than the active-job list and is out of scope here; worth confirming whether that mode is reachable in practice.
