### PR TITLE
👐 ci: Cancel the Playwright E2E Gate With Its Run

### DIFF
--- a/.github/workflows/playwright-mock.yml
+++ b/.github/workflows/playwright-mock.yml
@@ -532,8 +532,13 @@ jobs:
 
   e2e:
     name: e2e
+    # `!cancelled()`, not `always()`: the gate has to survive a failed shard to report it, but a
+    # run superseded by `cancel-in-progress` has nothing to adjudicate. Under `always()` it was
+    # still dispatched onto a fresh runner while every other job went `cancelled`, then read
+    # `needs.e2e_shards.result == 'cancelled'` and exited 1 — so each superseded push left this
+    # required check red instead of cancelled. Matches the two lanes it gates.
     if: >-
-      always() &&
+      !cancelled() &&
       (github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary

I changed the `e2e` fan-in gate in `.github/workflows/playwright-mock.yml` from `always()` to `!cancelled()`, so a superseded run no longer leaves the required `e2e` check red.

- Replaced the gate's job-level `always()` guard, which dispatched it onto a fresh runner even on a run cancelled by `concurrency: cancel-in-progress`. It then read `needs.e2e_shards.result == 'cancelled'`, took the `!= 'success'` branch, and exited 1 — so every superseded push reported a *failing* required check on a run that was never adjudicated, and spent a runner slot to do it.
- Kept the property the gate actually needs: `!cancelled()` still runs when a shard **fails**, which is the reason the default `success()` guard was never an option here. Only the cancelled case is dropped.
- Aligned the gate with the two lanes it gates — `e2e_shards` and `mcp_tool_list_changed` already guard themselves with `!cancelled()`, and this was the only job-level `always()` left in the repository. Every remaining `always()` under `.github/workflows/` is step-level (cleanup and summary steps), where the semantics are correct.
- Documented the choice inline, since `always()` is the obvious-looking thing to write here and reads as equivalent until a run gets cancelled.

Observed on run [33391910258](https://github.com/danny-avila/LibreChat/actions/runs/33391910258), superseded mid-flight: `Codegraph select`, `e2e (${{ matrix.name }})` and `MCP list_changed (${{ matrix.replicas }})` all concluded `cancelled`, while `e2e` waited 1m24s for its own runner and concluded `failure`.

A skipped dependency still reaches the gate under `!cancelled()`. Run [33391962579](https://github.com/danny-avila/LibreChat/actions/runs/33391962579) is the proof already in CI: `codegraph_select` was skipped (non-`synchronize` event), and both `!cancelled()` lanes ran to success anyway.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Parsed the workflow to confirm the `!` survives the `>-` folded scalar as literal expression text rather than a YAML tag, and that the gate's guard now matches its two lanes:

```bash
python3 -c "
import yaml
d = yaml.safe_load(open('.github/workflows/playwright-mock.yml'))
for j in ('e2e_shards', 'mcp_tool_list_changed', 'e2e'):
    print(j, '->', repr(d['jobs'][j]['if'][:30]))
"
```

The behavior itself is only observable against GitHub's scheduler, so it wants confirmation on this PR:

1. Green path — this run's `e2e` should conclude `success` with its single step skipped, exactly as before.
2. Cancelled path — push a second commit while the run is still executing shards. Previously the superseded run's `e2e` concluded `failure`; it should now conclude `cancelled` alongside the shards, and never claim a runner.
3. Failure path (worth checking before merge, since it is the case `always()` was there to serve) — a run with a genuinely failing shard must still reach `exit 1` rather than skipping the gate.

### **Test Configuration**:

No configuration; the change is confined to workflow YAML and needs no local services.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_012jJbt9x1sCu8ggJQmdjoMy)_