### PR TITLE
🎯 ci: Retarget Pull Requests Opened Against `main` to `dev`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## 2. Development Notes
 
-1. Before starting work, make sure your main branch has the latest commits with `npm run update`.
+1. Before starting work, make sure your `dev` branch has the latest commits with `npm run update`.
 2. Run linting command to find errors: `npm run lint`. Alternatively, ensure husky pre-commit checks are functioning.
     - `npm install` sets the hooks up for you; set `HUSKY=0` to opt out.
     - The pre-commit hook runs the Static Checks CI job locally, scoped to the files in the commit. Run it by hand with `npm run static-checks`, against a base ref with `npm run static-checks -- --against origin/dev`, or with the slow gates (TypeScript, config migration tests, unused i18n keys, unused npm packages) via `npm run static-checks:full`.
@@ -60,11 +60,11 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 We utilize a GitFlow workflow to manage changes to this project's codebase. Follow these general steps when contributing code:
 
-1. Fork the repository and create a new branch with a descriptive slash-based name (e.g., `new/feature/x`).
+1. Fork the repository and branch off `dev` with a descriptive slash-based name (e.g., `new/feature/x`). All contributions target `dev`; `main` only moves at release time, and pull requests opened against it are retargeted automatically.
 2. Implement your changes and ensure that all tests pass.
 3. Commit your changes using conventional commit messages with GitFlow flags. Begin the commit message with a tag indicating the change type, such as "feat" (new feature), "fix" (bug fix), "docs" (documentation), or "refactor" (code refactoring), followed by a brief summary of the changes (e.g., `feat: Add new feature X to the project`).
-4. Submit a pull request with a clear and concise description of your changes and the reasons behind them.
-5. We will review your pull request, provide feedback as needed, and eventually merge the approved changes into the main branch.
+4. Submit a pull request against `dev` with a clear and concise description of your changes and the reasons behind them.
+5. We will review your pull request, provide feedback as needed, and eventually merge the approved changes into the `dev` branch.
 
 ## 4. Commit Message Format
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,9 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## 2. Development Notes
 
-1. Before starting work, make sure your `dev` branch has the latest commits with `npm run update`.
+1. Before starting work, sync `dev`: `git fetch origin && git checkout dev && git pull origin dev`.
+    - `npm run update` is the self-host deployment updater — it checks out `main` and rebuilds your
+      containers. Do not use it to refresh a development branch.
 2. Run linting command to find errors: `npm run lint`. Alternatively, ensure husky pre-commit checks are functioning.
     - `npm install` sets the hooks up for you; set `HUSKY=0` to opt out.
     - The pre-commit hook runs the Static Checks CI job locally, scoped to the files in the commit. Run it by hand with `npm run static-checks`, against a base ref with `npm run static-checks -- --against origin/dev`, or with the slow gates (TypeScript, config migration tests, unused i18n keys, unused npm packages) via `npm run static-checks:full`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,10 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 ## 2. Development Notes
 
-1. Before starting work, sync `dev`: `git fetch origin && git checkout dev && git pull origin dev`.
+1. Before starting work, sync `dev` from this repository. You are working in a fork, so `origin` is
+   your fork — add the canonical remote once and sync from it:
+    - `git remote add upstream https://github.com/danny-avila/LibreChat.git`
+    - `git fetch upstream dev && git checkout -B dev upstream/dev`
     - `npm run update` is the self-host deployment updater — it checks out `main` and rebuilds your
       containers. Do not use it to refresh a development branch.
 2. Run linting command to find errors: `npm run lint`. Alternatively, ensure husky pre-commit checks are functioning.

--- a/.github/scripts/retarget-prs.sh
+++ b/.github/scripts/retarget-prs.sh
@@ -7,6 +7,7 @@ REPO="${REPO:?REPO is required (owner/name)}"
 RELEASE_BASE="${RELEASE_BASE:-main}"
 TARGET_BASE="${TARGET_BASE:-dev}"
 DRY_RUN="${DRY_RUN:-false}"
+EXPLAIN_MISSING="${EXPLAIN_MISSING:-false}"
 KEEP_LABEL="${KEEP_LABEL:-target: main}"
 THROTTLE_SECONDS="${THROTTLE_SECONDS:-0}"
 MARKER="<!-- librechat:auto-retarget -->"
@@ -17,11 +18,13 @@ if [ "$#" -eq 0 ]; then
 fi
 
 # Branches on the upstream repository that legitimately merge into the release branch.
+# Backport branches are deliberately absent: `main` is kept as a fast-forward of `dev`, so a
+# backport merged straight to `main` would break that invariant. Use the label to exempt one.
 keeps_release_base() {
   local head_repo="$1" head_ref="$2"
   [ "$head_repo" = "$REPO" ] || return 1
   case "$head_ref" in
-    "$TARGET_BASE" | release/* | hotfix/* | backport/* | *-"$RELEASE_BASE") return 0 ;;
+    "$TARGET_BASE" | release/* | hotfix/*) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -52,9 +55,26 @@ Maintainers: apply the \`$KEEP_LABEL\` label and restore the base branch if this
 BODY
 }
 
-retargeted=0
+matched=0
 skipped=0
 failed=0
+unexplained=0
+
+# Posts the explanation unless one is already there. A failure is recorded rather than
+# swallowed: the base edit has already succeeded, so a later run would skip the pull
+# request and the contributor would never receive it.
+post_explanation() {
+  local number="$1"
+  if already_explained "$number"; then
+    echo "#$number: explanation already posted"
+    return 0
+  fi
+  if comment_body | gh pr comment "$number" --repo "$REPO" --body-file -; then
+    return 0
+  fi
+  echo "#$number: FAILED to post the explanation — re-run with EXPLAIN_MISSING=true $number"
+  unexplained=$((unexplained + 1))
+}
 
 for number in "$@"; do
   if ! pr="$(gh api "repos/$REPO/pulls/$number")"; then
@@ -70,6 +90,12 @@ for number in "$@"; do
   if [ "$state" != "open" ]; then
     echo "#$number: skipped — pull request is $state"
     skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$base_ref" = "$TARGET_BASE" ] && [ "$EXPLAIN_MISSING" = "true" ] && [ "$DRY_RUN" != "true" ]; then
+    echo "#$number: already on $TARGET_BASE — posting any missing explanation"
+    post_explanation "$number"
     continue
   fi
 
@@ -93,7 +119,7 @@ for number in "$@"; do
 
   if [ "$DRY_RUN" = "true" ]; then
     echo "#$number: would retarget $RELEASE_BASE -> $TARGET_BASE ($head_repo:$head_ref)"
-    retargeted=$((retargeted + 1))
+    matched=$((matched + 1))
     continue
   fi
 
@@ -103,18 +129,20 @@ for number in "$@"; do
     failed=$((failed + 1))
     continue
   fi
-  if already_explained "$number"; then
-    echo "#$number: explanation already posted"
-  else
-    comment_body | gh pr comment "$number" --repo "$REPO" --body-file - || echo "#$number: comment failed"
-  fi
-  retargeted=$((retargeted + 1))
+  post_explanation "$number"
+  matched=$((matched + 1))
   [ "$THROTTLE_SECONDS" = "0" ] || sleep "$THROTTLE_SECONDS"
 done
 
-echo "retargeted=$retargeted skipped=$skipped failed=$failed"
-if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-  echo "Retargeted **$retargeted** pull request(s) onto \`$TARGET_BASE\`, skipped **$skipped**, failed **$failed**." >> "$GITHUB_STEP_SUMMARY"
+if [ "$DRY_RUN" = "true" ]; then
+  echo "DRY RUN — no pull request was modified. would_retarget=$matched skipped=$skipped failed=$failed"
+  summary="**Dry run — nothing was modified.** Would retarget **$matched**, skip **$skipped**, failed to read **$failed**."
+else
+  echo "retargeted=$matched skipped=$skipped failed=$failed unexplained=$unexplained"
+  summary="Retargeted **$matched** pull request(s) onto \`$TARGET_BASE\`, skipped **$skipped**, failed **$failed**, missing an explanation **$unexplained**."
 fi
 
-[ "$failed" -eq 0 ]
+echo "$summary"
+[ -z "${GITHUB_STEP_SUMMARY:-}" ] || echo "$summary" >> "$GITHUB_STEP_SUMMARY"
+
+[ "$failed" -eq 0 ] && [ "$unexplained" -eq 0 ]

--- a/.github/scripts/retarget-prs.sh
+++ b/.github/scripts/retarget-prs.sh
@@ -29,11 +29,12 @@ keeps_release_base() {
   esac
 }
 
-# Collected before grepping: piping directly into `grep -q` lets SIGPIPE fail the
-# pipeline under `set -o pipefail` and report a false negative.
+# 0 = already explained, 1 = not explained, 2 = the lookup itself failed. The third status
+# matters: treating a failed read as "not explained" would post a duplicate. Bodies are collected
+# before grepping because piping into `grep -q` lets SIGPIPE fail the pipeline under `pipefail`.
 already_explained() {
   local bodies
-  bodies="$(gh api "repos/$REPO/issues/$1/comments" --paginate --jq '.[].body')" || return 1
+  bodies="$(gh api "repos/$REPO/issues/$1/comments" --paginate --jq '.[].body')" || return 2
   grep -qF "$MARKER" <<<"$bodies"
 }
 
@@ -64,9 +65,15 @@ unexplained=0
 # swallowed: the base edit has already succeeded, so a later run would skip the pull
 # request and the contributor would never receive it.
 post_explanation() {
-  local number="$1"
-  if already_explained "$number"; then
+  local number="$1" lookup=0
+  already_explained "$number" || lookup=$?
+  if [ "$lookup" -eq 0 ]; then
     echo "#$number: explanation already posted"
+    return 0
+  fi
+  if [ "$lookup" -eq 2 ]; then
+    echo "#$number: FAILED to read existing comments — not posting, to avoid a duplicate"
+    unexplained=$((unexplained + 1))
     return 0
   fi
   if comment_body | gh pr comment "$number" --repo "$REPO" --body-file -; then

--- a/.github/scripts/retarget-prs.sh
+++ b/.github/scripts/retarget-prs.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Retarget pull requests opened against the release branch onto the development branch.
+# Used by .github/workflows/pr-retarget-dev.yml for both the on-open hook and the manual sweep.
+set -euo pipefail
+
+REPO="${REPO:?REPO is required (owner/name)}"
+RELEASE_BASE="${RELEASE_BASE:-main}"
+TARGET_BASE="${TARGET_BASE:-dev}"
+DRY_RUN="${DRY_RUN:-false}"
+KEEP_LABEL="${KEEP_LABEL:-target: main}"
+THROTTLE_SECONDS="${THROTTLE_SECONDS:-0}"
+MARKER="<!-- librechat:auto-retarget -->"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: REPO=owner/name $0 <pr-number> [pr-number...]" >&2
+  exit 64
+fi
+
+# Branches on the upstream repository that legitimately merge into the release branch.
+keeps_release_base() {
+  local head_repo="$1" head_ref="$2"
+  [ "$head_repo" = "$REPO" ] || return 1
+  case "$head_ref" in
+    "$TARGET_BASE" | release/* | hotfix/* | backport/* | *-"$RELEASE_BASE") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Collected before grepping: piping directly into `grep -q` lets SIGPIPE fail the
+# pipeline under `set -o pipefail` and report a false negative.
+already_explained() {
+  local bodies
+  bodies="$(gh api "repos/$REPO/issues/$1/comments" --paginate --jq '.[].body')" || return 1
+  grep -qF "$MARKER" <<<"$bodies"
+}
+
+comment_body() {
+  cat <<BODY
+$MARKER
+👋 Thanks for the contribution! LibreChat merges all changes into \`$TARGET_BASE\` first — \`$RELEASE_BASE\` only moves at release time — so this pull request's base branch was switched from \`$RELEASE_BASE\` to \`$TARGET_BASE\` automatically.
+
+Nothing is needed from you; your commits, reviews and discussion are unchanged. If the diff now shows files you did not touch, rebase onto \`$TARGET_BASE\`:
+
+\`\`\`bash
+git remote add upstream https://github.com/$REPO.git
+git fetch upstream $TARGET_BASE
+git rebase upstream/$TARGET_BASE
+git push --force-with-lease
+\`\`\`
+
+Maintainers: apply the \`$KEEP_LABEL\` label and restore the base branch if this one genuinely belongs on \`$RELEASE_BASE\`.
+BODY
+}
+
+retargeted=0
+skipped=0
+failed=0
+
+for number in "$@"; do
+  if ! pr="$(gh api "repos/$REPO/pulls/$number")"; then
+    echo "#$number: FAILED to read pull request"
+    failed=$((failed + 1))
+    continue
+  fi
+  state="$(jq -r '.state' <<<"$pr")"
+  base_ref="$(jq -r '.base.ref' <<<"$pr")"
+  head_ref="$(jq -r '.head.ref' <<<"$pr")"
+  head_repo="$(jq -r '.head.repo.full_name // ""' <<<"$pr")"
+
+  if [ "$state" != "open" ]; then
+    echo "#$number: skipped — pull request is $state"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$base_ref" != "$RELEASE_BASE" ]; then
+    echo "#$number: skipped — already based on $base_ref"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if jq -e --arg keep "$KEEP_LABEL" 'any(.labels[]; .name == $keep)' <<<"$pr" >/dev/null; then
+    echo "#$number: skipped — labelled '$KEEP_LABEL'"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if keeps_release_base "$head_repo" "$head_ref"; then
+    echo "#$number: skipped — $head_repo:$head_ref is a release-bound branch"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "#$number: would retarget $RELEASE_BASE -> $TARGET_BASE ($head_repo:$head_ref)"
+    retargeted=$((retargeted + 1))
+    continue
+  fi
+
+  echo "#$number: retargeting $RELEASE_BASE -> $TARGET_BASE ($head_repo:$head_ref)"
+  if ! gh pr edit "$number" --repo "$REPO" --base "$TARGET_BASE"; then
+    echo "#$number: FAILED to change base branch"
+    failed=$((failed + 1))
+    continue
+  fi
+  if already_explained "$number"; then
+    echo "#$number: explanation already posted"
+  else
+    comment_body | gh pr comment "$number" --repo "$REPO" --body-file - || echo "#$number: comment failed"
+  fi
+  retargeted=$((retargeted + 1))
+  [ "$THROTTLE_SECONDS" = "0" ] || sleep "$THROTTLE_SECONDS"
+done
+
+echo "retargeted=$retargeted skipped=$skipped failed=$failed"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "Retargeted **$retargeted** pull request(s) onto \`$TARGET_BASE\`, skipped **$skipped**, failed **$failed**." >> "$GITHUB_STEP_SUMMARY"
+fi
+
+[ "$failed" -eq 0 ]

--- a/.github/workflows/pr-retarget-dev.yml
+++ b/.github/workflows/pr-retarget-dev.yml
@@ -2,7 +2,7 @@ name: Retarget PRs to dev
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -19,8 +19,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Per-pull-request for the hook so a burst of openings runs in parallel; GitHub keeps only one
+# pending job per group, so a single shared group would cancel queued retargets. Every sweep shares
+# one group so two of them cannot process the same pull request at once.
 concurrency:
-  group: pr-retarget-dev-${{ github.event.pull_request.number || github.run_id }}
+  group: pr-retarget-dev-${{ github.event.pull_request.number || 'sweep' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-retarget-dev.yml
+++ b/.github/workflows/pr-retarget-dev.yml
@@ -1,0 +1,76 @@
+name: Retarget PRs to dev
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would change without editing any pull request'
+        type: boolean
+        default: true
+      pr_numbers:
+        description: 'Space-separated PR numbers (default: every open pull request based on main)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-retarget-dev-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  on-open:
+    name: Retarget on open
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # pull_request_target runs with a write token: check out the trusted base
+          # commit only, never the pull request head.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Retarget onto dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/retarget-prs.sh "$PR_NUMBER"
+
+  sweep:
+    name: Sweep open pull requests
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Retarget onto dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+          THROTTLE_SECONDS: '2'
+        run: |
+          numbers="$PR_NUMBERS"
+          if [ -z "$numbers" ]; then
+            numbers="$(gh pr list --repo "$REPO" --base main --state open --limit 500 --json number --jq '.[].number')"
+          fi
+          if [ -z "$numbers" ]; then
+            echo "No open pull requests based on main."
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          .github/scripts/retarget-prs.sh $numbers

--- a/.github/workflows/pr-retarget-dev.yml
+++ b/.github/workflows/pr-retarget-dev.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           numbers="$PR_NUMBERS"
           if [ -z "$numbers" ]; then
-            numbers="$(gh pr list --repo "$REPO" --base main --state open --limit 500 --json number --jq '.[].number')"
+            numbers="$(gh api --paginate "repos/$REPO/pulls?base=main&state=open&per_page=100" --jq '.[].number')"
           fi
           if [ -z "$numbers" ]; then
             echo "No open pull requests based on main."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 See CLAUDE.md.
 
+## Branching and pull requests
+
+Branch off `dev` and target `dev` with every pull request; `gh pr create` defaults to `main`, so
+pass `--base dev` explicitly. `main` is the released branch, kept as a fast-forward of `dev` and
+synced as-is — never open a backport pull request to `main`, because anything merged to `dev`
+reaches it at the next sync. Pull requests opened against `main` are retargeted automatically. See
+the detailed policy in `CLAUDE.md` under "Branching and Pull Requests".
+
 ## Frontend theming and styling
 
 For frontend work, compose existing `@librechat/client` primitives and variants before adding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,18 @@ See CLAUDE.md.
 Branch off `dev` and target `dev` with every pull request; `gh pr create` defaults to `main`, so
 pass `--base dev` explicitly. `main` is the released branch, kept as a fast-forward of `dev` and
 synced as-is — never open a backport pull request to `main`, because anything merged to `dev`
-reaches it at the next sync. Pull requests opened against `main` are retargeted automatically. See
-the detailed policy in `CLAUDE.md` under "Branching and Pull Requests".
+reaches it at the next sync. Pull requests opened against `main` are retargeted automatically.
+`Fixes #N` does not close the issue on a `dev` merge — GitHub honors closing keywords only on the
+default branch, so close linked issues by hand. Worktrees share one stash stack, so never use a bare
+`git stash pop`. See the detailed policy in `CLAUDE.md` under "Branching and Pull Requests".
+
+## Verification
+
+A green build is not a typecheck: `packages/api`, `packages/client` and `packages/data-schemas` build
+with `tsdown`, which emits without checking types. Run `npx tsc --noEmit` in the workspace you
+changed. `packages/client` excludes `*.spec.ts(x)` and `*.test.ts(x)` from typechecking entirely.
+`npm run sort-imports` with no arguments rewrites every source root — pass the paths you touched. See
+`CLAUDE.md` under "Typechecking" and "Formatting".
 
 ## Frontend theming and styling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ The source code for `@librechat/agents` (major backend dependency, same team) li
 
 - **Branch off `dev`, and target `dev` with every pull request.** All work lands on `dev` first.
 - **`main` is the released branch.** It is kept as a fast-forward of `dev` and synced as-is, so it
-  is always a strict ancestor of `dev`.
+  is always an ancestor of `dev` — equal to it right after a sync, behind it otherwise. It never
+  carries a commit that `dev` does not have.
 - **Never open a backport pull request to `main`.** Anything merged to `dev` reaches `main` at the
   next sync; a second pull request for the same change is redundant.
 - **The repository's default branch is `main`**, so `gh pr create` and the GitHub UI target it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,21 @@ The source code for `@librechat/agents` (major backend dependency, same team) li
 
 ---
 
+## Branching and Pull Requests
+
+- **Branch off `dev`, and target `dev` with every pull request.** All work lands on `dev` first.
+- **`main` is the released branch.** It is kept as a fast-forward of `dev` and synced as-is, so it
+  is always a strict ancestor of `dev`.
+- **Never open a backport pull request to `main`.** Anything merged to `dev` reaches `main` at the
+  next sync; a second pull request for the same change is redundant.
+- **The repository's default branch is `main`**, so `gh pr create` and the GitHub UI target it
+  unless told otherwise — always pass `--base dev` explicitly.
+- Pull requests opened against `main` are retargeted to `dev` automatically by
+  `.github/workflows/pr-retarget-dev.yml`. The `target: main` label exempts one, as do release-bound
+  upstream branches (`dev`, `release/*`, `hotfix/*`, `backport/*`, `*-main`).
+
+---
+
 ## Code Style
 
 ### Naming and File Organization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ The source code for `@librechat/agents` (major backend dependency, same team) li
 - Pull requests opened against `main` are retargeted to `dev` automatically by
   `.github/workflows/pr-retarget-dev.yml`. The `target: main` label exempts one, as do release-bound
   upstream branches (`dev`, `release/*`, `hotfix/*`, `backport/*`, `*-main`).
+- **`Fixes #N` does not close the issue.** GitHub honors closing keywords only when a pull request
+  merges into the default branch (`main`). Merging to `dev` does not close anything, and the later
+  fast-forward of `main` is not a merge event either — close linked issues by hand.
+- **Git worktrees share one stash stack.** `refs/stash` lives in the common `.git` directory, so a
+  bare `git stash pop` in one worktree can take work stashed in another. Prefer a throwaway WIP
+  commit; if you must stash, `git stash push -m <tag>` and `apply` that specific entry.
 
 ---
 
@@ -222,6 +228,20 @@ Without it, OpenID JWT request burst caching can serve a stale `req.user` until 
 - Frontend tests: `__tests__` directories alongside components; use `test/layout-test-utils` for rendering.
 - Cover loading, success, and error states for UI/data flows.
 
+### Typechecking
+
+- **A green build is not a typecheck.** `packages/api`, `packages/client` and `packages/data-schemas`
+  build with `tsdown` alone, which emits without checking types. Only `packages/data-provider` runs
+  `tsc` as part of its build.
+- Run `npx tsc --noEmit` in the workspace you changed before calling it done. `client` also exposes
+  it as `npm run typecheck`.
+- `packages/client/tsconfig.json` excludes `*.spec.ts(x)` and `*.test.ts(x)`, so test files there are
+  never typechecked — a type error in a spec surfaces only when the test runs.
+- `npm run static-checks` runs the Static Checks CI job locally against your staged files;
+  `npm run static-checks -- --against origin/dev` reproduces what CI sees for a pull request, and
+  `npm run static-checks:full` adds the slow gates (TypeScript, config migration tests, unused i18n
+  keys, unused npm packages).
+
 ### Philosophy
 
 - **Real logic over mocks.** Exercise actual code paths with real dependencies. Mocking is a last resort.
@@ -236,3 +256,7 @@ Without it, OpenID JWT request burst caching can serve a stale `req.user` until 
 ## Formatting
 
 Fix all formatting lint errors (trailing spaces, tabs, newlines, indentation) using auto-fix when available. All TypeScript/ESLint warnings and errors **must** be resolved.
+
+`npm run sort-imports` with no arguments rewrites every file under `api/`, `client/src` and the four
+`packages/*/src` roots — far beyond what you touched. Always pass explicit paths:
+`npm run sort-imports -- path/to/file.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ The source code for `@librechat/agents` (major backend dependency, same team) li
   unless told otherwise — always pass `--base dev` explicitly.
 - Pull requests opened against `main` are retargeted to `dev` automatically by
   `.github/workflows/pr-retarget-dev.yml`. The `target: main` label exempts one, as do release-bound
-  upstream branches (`dev`, `release/*`, `hotfix/*`, `backport/*`, `*-main`).
+  upstream branches (`dev`, `release/*`, `hotfix/*`). Backport branches are deliberately not exempt —
+  a backport merged straight to `main` is what breaks the fast-forward invariant.
 - **`Fixes #N` does not close the issue.** GitHub honors closing keywords only when a pull request
   merges into the default branch (`main`). Merging to `dev` does not close anything, and the later
   fast-forward of `main` is not a merge event either — close linked issues by hand.


### PR DESCRIPTION
## Summary

Contributions land on `dev`; `main` only moves at release time. But `main` is
the repository's default branch, so pull requests default to it, and the
mismatch gets resolved by hand at merge time. Right now **257 of the 379 open
pull requests are based on `main`** — every one of them a fix or feature that
either gets retargeted manually or waits behind a branch sync.

This adds the retarget as a workflow rather than a merge-time chore.

## Behavior

A pull request opened or reopened against `main` has its base switched to
`dev`, and gets a one-time comment explaining what happened and how to rebase
if the diff looks off. The comment carries a hidden marker and is deduplicated,
so reopening a pull request never re-comments.

Release-bound branches **on this repository** keep `main` as their base:

| Branch | Purpose |
|---|---|
| `dev` | the release pull request |
| `release/*`, `hotfix/*` | release and urgent production work |

The exemptions are scoped to upstream branches deliberately — a fork branch
that happens to be named `hotfix/x` is still retargeted, because a contributor
naming a branch a certain way should not opt them out of the policy.

The `target: main` label exempts any individual pull request. It does not exist
in the repository yet, and the check is simply inert until it is created:

```bash
gh label create "target: main" --repo danny-avila/LibreChat --color 0e8a16 --description "Exempt from automatic retargeting to dev"
```

## Design notes

**This is inert until `main` carries it.** `pull_request_target` reads its
workflow definition from the pull request's base branch, so nothing fires while
the workflow only exists on `dev`. No backport is needed — `main` is a
fast-forward of `dev` here, so the next sync activates it.

**`pull_request_target` runs with a write token**, so the job checks out
`github.event.pull_request.base.sha` — the trusted base commit — and never the
pull request head. No contributor code executes. `persist-credentials: false`
and a sparse checkout of `.github/scripts` keep the surface minimal.

**Retargeting does not re-run checks** that already ran against `main`. A base
change fires the `edited` activity, which no workflow here subscribes to, so
results computed against `main` stand until the next push. This is deliberate:
because `main` is a strict ancestor of `dev`, those results remain
representative, and force-triggering CI would mean 258 simultaneous runs the
moment the backlog sweep is used.

## Backlog sweep

A `workflow_dispatch` job applies the same rules to existing pull requests —
either an explicit list of numbers, or every open pull request based on `main`.
It is **`dry_run: true` by default**: it reports what it would change and
performs no writes. Clearing all 257 notifies every author, so that stays a
deliberate, manual decision rather than something this merge triggers.

Write operations are throttled 2s apart in sweep mode to stay clear of
GitHub's secondary rate limits. A failure on one pull request is isolated and
counted; the sweep continues and exits non-zero.

## Testing

The decision logic was exercised end-to-end against a stubbed `gh` boundary —
the real script, with only the external API faked — over ten cases: a fork
feature branch, upstream `dev`, an upstream `*-main` backport, a fork branch
named `hotfix/*`, a labelled pull request, one already based on `dev`, a closed
one, an upstream `release/*`, one already carrying the marker comment, and a
fork branch literally named `dev`. All ten resolve as designed. Dry-run
performs zero writes; a failing edit and an unreadable pull request are both
isolated and surfaced. `shellcheck` is clean.

Two real bugs surfaced that way and are fixed here: `label` is a reserved word
in jq, so the `target: main` check errored and silently fell through to
retargeting; and piping `gh --paginate` into `grep -q` under `pipefail` can
SIGPIPE into a false negative and double-post the comment.

## Documentation

`CONTRIBUTING.md` told contributors their work would be merged "into the main
branch" — arguably the root cause on the human side. It now says `dev`.

`CLAUDE.md` and `AGENTS.md` never stated the policy at all, which is the root
cause on the agent side: the default branch is `main`, so `gh pr create` and
the GitHub UI target `main` unless told otherwise. Both now record that work
branches off and targets `dev`, that `--base dev` must be passed explicitly,
and that a backport to `main` is never needed because `main` is kept as a
strict ancestor of `dev`.
